### PR TITLE
fix: add session-start test gate enforcement hook

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1052,7 +1052,8 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/test-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-versions.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-version-check.sh" scripts/
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh
+  cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-test-gate-check.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions
@@ -1334,21 +1335,30 @@ PERMEOF
         print_warn "Run manually: bash ~/.claude-dev-framework/scripts/init.sh"
       fi
 
-      # Add version check hook to SessionStart (after CDF hooks are in place)
+      # Add orchestrator hooks to SessionStart (after CDF hooks are in place)
       if [ -f ".claude/settings.json" ] && command -v jq &>/dev/null; then
-        local version_hook='bash "$CLAUDE_PROJECT_DIR"/scripts/check-versions.sh'
-        # Check if SessionStart exists and doesn't already have our hook
+        local hooks_added=false
+        # Add version check hook
         if jq -e '.hooks.SessionStart' .claude/settings.json >/dev/null 2>&1; then
-          if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("check-versions.sh"))' .claude/settings.json >/dev/null 2>&1; then
+          if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("session-version-check.sh"))' .claude/settings.json >/dev/null 2>&1; then
             jq '.hooks.SessionStart[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-version-check.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
               && mv .claude/settings.json.tmp .claude/settings.json
+            hooks_added=true
           fi
         else
-          # No SessionStart hook at all — add one
-          jq '.hooks.SessionStart = [{"hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/check-versions.sh"}]}]' .claude/settings.json > .claude/settings.json.tmp \
+          jq '.hooks.SessionStart = [{"hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-version-check.sh"}]}]' .claude/settings.json > .claude/settings.json.tmp \
             && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
         fi
-        print_ok "Session-start version check hook installed"
+        # Add test gate check hook
+        if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("session-test-gate-check.sh"))' .claude/settings.json >/dev/null 2>&1; then
+          jq '.hooks.SessionStart[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-test-gate-check.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
+            && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
+        fi
+        if [ "$hooks_added" = true ]; then
+          print_ok "Session-start hooks installed (version check, test gate)"
+        fi
       fi
     fi
   fi

--- a/scripts/session-test-gate-check.sh
+++ b/scripts/session-test-gate-check.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Solo Orchestrator — SessionStart hook for test gate enforcement
+# Checks if we're in Phase 2 and whether the test gate state is consistent.
+# Only outputs when something needs attention.
+set -euo pipefail
+
+PHASE_STATE=".claude/phase-state.json"
+BUILD_PROGRESS=".claude/build-progress.json"
+
+# Only relevant in Phase 2 (Construction)
+if [ ! -f "$PHASE_STATE" ]; then
+  exit 0
+fi
+
+if ! command -v jq &>/dev/null; then
+  exit 0
+fi
+
+CURRENT_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null)
+if [ "$CURRENT_PHASE" != "2" ]; then
+  exit 0
+fi
+
+# Check build-progress.json exists
+if [ ! -f "$BUILD_PROGRESS" ]; then
+  echo "TEST GATE WARNING: In Phase 2 but .claude/build-progress.json is missing. Run: scripts/test-gate.sh --check-batch"
+  exit 0
+fi
+
+# Read state
+FEATURES_COMPLETED=$(jq -r '.features_completed | length' "$BUILD_PROGRESS" 2>/dev/null || echo "0")
+SINCE_LAST=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS" 2>/dev/null || echo "0")
+INTERVAL=$(jq -r '.test_interval' "$BUILD_PROGRESS" 2>/dev/null || echo "2")
+TESTING_REQUIRED=$(jq -r '.testing_required' "$BUILD_PROGRESS" 2>/dev/null || echo "false")
+
+# Check 1: Testing session is overdue
+if [ "$TESTING_REQUIRED" = "true" ] || [ "$SINCE_LAST" -ge "$INTERVAL" ]; then
+  cat << EOF
+URGENT — TEST GATE BLOCKED. Report this to the Orchestrator IMMEDIATELY as your FIRST response.
+
+Testing session required: $SINCE_LAST features completed since last test (interval is every $INTERVAL).
+Do NOT start the next feature. Run a UAT testing session first.
+Steps: scripts/test-gate.sh --check-batch
+EOF
+  exit 0
+fi
+
+# Check 2: Phase 2 with no features recorded — likely missed --record-feature calls
+# Look for evidence of work: merged PRs, source code commits, test files
+if [ "$FEATURES_COMPLETED" -eq 0 ]; then
+  # Count commits on main since Phase 1→2 gate date
+  PHASE2_DATE=$(jq -r '.gates.phase_1_to_2 // empty' "$PHASE_STATE" 2>/dev/null)
+  COMMIT_COUNT=0
+  if [ -n "$PHASE2_DATE" ]; then
+    COMMIT_COUNT=$(git log --oneline --since="$PHASE2_DATE" --no-merges 2>/dev/null | wc -l | tr -d ' ')
+  fi
+
+  if [ "$COMMIT_COUNT" -gt 5 ]; then
+    cat << EOF
+TEST GATE WARNING: Report this to the Orchestrator as your FIRST response.
+
+Phase 2 has $COMMIT_COUNT commits since Phase 1→2 gate ($PHASE2_DATE) but build-progress.json shows 0 features recorded.
+This likely means scripts/test-gate.sh --record-feature was not called after completing features.
+
+After each feature completion, you MUST run:
+  scripts/test-gate.sh --record-feature "feature-name"
+
+Ask the Orchestrator how many features have been completed so you can record them now.
+EOF
+  fi
+fi


### PR DESCRIPTION
## Summary
- Adds `session-test-gate-check.sh` as a SessionStart hook that enforces test gate compliance during Phase 2
- Catches two failure modes:
  - **UAT overdue**: features completed >= test interval with no test session run — blocks new work
  - **Missed --record-feature**: Phase 2 has commits but build-progress.json shows 0 features — warns agent to reconcile
- Only activates during Phase 2 (Construction). Silent in all other phases.
- Updates `init.sh` to copy the script and inject the hook alongside the existing version check hook

## Context
Discovered during meshscope build: the agent completed 2 features without calling `test-gate.sh --record-feature`, leaving the UAT counter at 0. The CLAUDE.md instruction had no enforcement mechanism. This hook provides that enforcement.

## Test plan
- [x] Tested against meshscope with testing_required=true — correctly outputs UAT blocked warning
- [x] Tested against meshscope with zeroed features — correctly detects 26 commits with 0 features recorded
- [x] Verified script is silent when not in Phase 2
- [x] Syntax check passed on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)