### PR TITLE
fix: add Qdrant usage guidance and session-end reminder

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1053,7 +1053,8 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/check-versions.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-version-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-test-gate-check.sh
+  cp "$SCRIPT_DIR/scripts/session-end-qdrant-reminder.sh" scripts/
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-test-gate-check.sh scripts/session-end-qdrant-reminder.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions
@@ -1356,8 +1357,20 @@ PERMEOF
             && mv .claude/settings.json.tmp .claude/settings.json
           hooks_added=true
         fi
+        # Add Qdrant reminder to Stop hook
+        if jq -e '.hooks.Stop' .claude/settings.json >/dev/null 2>&1; then
+          if ! jq -e '.hooks.Stop[0].hooks[] | select(.command | contains("session-end-qdrant-reminder.sh"))' .claude/settings.json >/dev/null 2>&1; then
+            jq '.hooks.Stop[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-end-qdrant-reminder.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
+              && mv .claude/settings.json.tmp .claude/settings.json
+            hooks_added=true
+          fi
+        else
+          jq '.hooks.Stop = [{"hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-end-qdrant-reminder.sh"}]}]' .claude/settings.json > .claude/settings.json.tmp \
+            && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
+        fi
         if [ "$hooks_added" = true ]; then
-          print_ok "Session-start hooks installed (version check, test gate)"
+          print_ok "Session hooks installed (version check, test gate, Qdrant reminder)"
         fi
       fi
     fi

--- a/scripts/session-end-qdrant-reminder.sh
+++ b/scripts/session-end-qdrant-reminder.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Solo Orchestrator — Stop hook advisory for Qdrant usage
+# If Qdrant MCP is configured, reminds the agent to store session knowledge.
+# Advisory only — does not block.
+set -euo pipefail
+
+# Check if Qdrant MCP is configured
+QDRANT_CONFIGURED=false
+if command -v jq &>/dev/null; then
+  if [ -f "$HOME/.claude/settings.json" ] && jq -e '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' "$HOME/.claude/settings.json" >/dev/null 2>&1; then
+    QDRANT_CONFIGURED=true
+  elif [ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' "$HOME/.claude.json" >/dev/null 2>&1; then
+    QDRANT_CONFIGURED=true
+  fi
+fi
+
+if [ "$QDRANT_CONFIGURED" = false ]; then
+  exit 0
+fi
+
+cat << 'EOF'
+QDRANT REMINDER: Before ending this session, consider whether anything from this session should be stored in Qdrant for future retrieval. Good candidates:
+- Architecture or design decisions made
+- Non-obvious bugs resolved and their root causes
+- Trade-off discussions with the Orchestrator
+- Integration patterns established
+
+Use qdrant-store with a clear, descriptive document. Skip if nothing significant was decided or discovered.
+EOF

--- a/templates/generated/claude-md.tmpl
+++ b/templates/generated/claude-md.tmpl
@@ -102,6 +102,18 @@ Use `superpowers:dispatching-parallel-agents` for dispatch. Each subagent gets a
 - Documentation generation (follow the templates)
 - Routine security audit checks per Phase 2.4 checklist
 
+### Qdrant Persistent Memory (if configured)
+If the Qdrant MCP server is available (`qdrant-store` and `qdrant-find` tools), use it to persist and retrieve project knowledge across sessions. Store entries at these specific points:
+- **Architecture decisions** — after finalizing a decision in the Project Bible, store the decision and its rationale
+- **Debugging breakthroughs** — after resolving a non-obvious bug, store the root cause and fix
+- **Phase gate transitions** — store a summary of what was accomplished and key lessons from the phase
+- **Trade-off discussions** — when the Orchestrator makes a significant trade-off decision, store the context and reasoning
+- **Integration patterns** — after establishing how components connect, store the pattern for future reference
+
+At the start of each session, use `qdrant-find` to retrieve relevant context for the current work area before diving in.
+
+Do NOT store: routine code changes, test results, obvious patterns, or anything already captured in the Project Bible or CHANGELOG.
+
 ### Upgrade Paths
 This project can be upgraded without losing technical work:
 - **Track upgrade** (light → standard → full): `bash scripts/upgrade-project.sh --track standard`


### PR DESCRIPTION
## Summary
- Add specific Qdrant usage triggers to CLAUDE.md template — tells the agent exactly *when* to call `qdrant-store` (architecture decisions, debugging breakthroughs, phase gates, trade-offs, integration patterns)
- Add `session-end-qdrant-reminder.sh` as a Stop hook — reminds the agent to store session knowledge before ending. Only fires when Qdrant MCP is configured. Advisory, not a gate.
- Updates `init.sh` to copy the script and inject the Stop hook alongside existing CDF stop hooks

## Context
Qdrant MCP was installed, configured, and running on the meshscope project but the agent never called `qdrant-store` — the collection was empty after multiple development sessions. The Dev Framework confirmed Qdrant enforcement is out of scope for mechanical hooks (no clear trigger like Context7's import detection). These changes provide guidance and nudges at the project level instead.

## Test plan
- [x] Verified Qdrant reminder outputs correctly when Qdrant is configured
- [x] Verified reminder is silent when Qdrant is not configured
- [x] Syntax check passed on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)