### PR TITLE
fix: version check track filtering, brew PATH, update prompts

### DIFF
--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -9,6 +9,14 @@ set -euo pipefail
 #   scripts/check-versions.sh       # Full check + update prompt
 #   scripts/check-versions.sh --help
 
+# Prefer brew-installed tools over system defaults (e.g., macOS ships
+# outdated Python, Git, Ruby at /usr/bin). This ensures version checks
+# find the user-installed version, not the Xcode/system stub.
+BREW_PREFIX="$(brew --prefix 2>/dev/null || true)"
+if [ -n "$BREW_PREFIX" ] && [ -d "$BREW_PREFIX/bin" ]; then
+  export PATH="$BREW_PREFIX/bin:$PATH"
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [ -f "$SCRIPT_DIR/lib/helpers.sh" ]; then
   source "$SCRIPT_DIR/lib/helpers.sh"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -247,6 +247,14 @@ if [ -n "$LANGUAGE" ]; then
   )]')
 fi
 
+# Filter by track (skip tools that require a higher track)
+if [ -n "$TRACK" ]; then
+  ALL_TOOLS=$(echo "$ALL_TOOLS" | jq --arg track "$TRACK" '[.[] | select(
+    .tracks == null or
+    (.tracks | index($track)) != null
+  )]')
+fi
+
 # Only check tools that have a version_command (skip presence-only tools like Android Keystore)
 CHECKABLE_TOOLS=$(echo "$ALL_TOOLS" | jq '[.[] | select(.version_command != null and .version_command != "" and .check_command != null)]')
 

--- a/scripts/session-version-check.sh
+++ b/scripts/session-version-check.sh
@@ -16,13 +16,12 @@ WARN_LINES=$(echo "$VERSION_OUTPUT" | grep "^\[WARN\]" | grep -v "^$" || true)
 
 # Extract update commands section
 UPDATE_CMDS=$(echo "$VERSION_OUTPUT" | sed -n '/^Update commands/,$ p' || true)
-# Also check for manual update commands format
 if [ -z "$UPDATE_CMDS" ]; then
   UPDATE_CMDS=$(echo "$VERSION_OUTPUT" | sed -n '/^Manual update commands/,$ p' || true)
 fi
 
 # Only output when something needs attention
-if [ "$VERSION_EXIT" -ne 0 ]; then
+if [ -n "$BELOW_MIN_LINES" ] 2>/dev/null || [ "$VERSION_EXIT" -ne 0 ]; then
   cat << EOF
 URGENT — VERSION CHECK FAILED. Report this to the Orchestrator IMMEDIATELY as your FIRST response before any other work.
 
@@ -32,16 +31,20 @@ $WARN_LINES
 ${UPDATE_CMDS:+$UPDATE_CMDS
 
 }Do NOT proceed with any work until the Orchestrator addresses these version issues.
+Ask the Orchestrator: "The following tools are outdated. Would you like me to run the update commands now?"
+Then list each update command and wait for approval before running them.
 EOF
-elif [ -n "$WARN_LINES" ]; then
+elif [ -n "$WARN_LINES" ] || [ -n "$UPDATE_CMDS" ]; then
   cat << EOF
 VERSION CHECK: Report the following to the Orchestrator as your FIRST response before any other work.
 
+${WARN_LINES:+Warnings:
 $WARN_LINES
 
-${UPDATE_CMDS:+$UPDATE_CMDS
+}${UPDATE_CMDS:+$UPDATE_CMDS
 
-}Ask the Orchestrator if they want to update now or skip.
+}You MUST ask the Orchestrator: "Would you like me to run these updates now, or skip for this session?"
+List each update command explicitly and wait for their answer. Do NOT skip this question.
 EOF
 fi
 # If everything is up to date: output nothing. No noise.

--- a/templates/tool-matrix/common.json
+++ b/templates/tool-matrix/common.json
@@ -346,7 +346,7 @@
       "platforms": ["all"],
       "languages": ["python"],
       "check_command": "command -v python3 || command -v python",
-      "version_command": "$(brew --prefix 2>/dev/null)/bin/python3 --version 2>/dev/null | awk '{print $2}' || python3 --version 2>/dev/null | awk '{print $2}' || python --version 2>/dev/null | awk '{print $2}'",
+      "version_command": "python3 --version 2>/dev/null | awk '{print $2}' || python --version 2>/dev/null | awk '{print $2}'",
       "min_version": "3.10.0",
       "latest_check": null,
       "install": {

--- a/templates/tool-matrix/common.json
+++ b/templates/tool-matrix/common.json
@@ -346,7 +346,7 @@
       "platforms": ["all"],
       "languages": ["python"],
       "check_command": "command -v python3 || command -v python",
-      "version_command": "python3 --version 2>/dev/null | awk '{print $2}' || python --version 2>/dev/null | awk '{print $2}'",
+      "version_command": "$(brew --prefix 2>/dev/null)/bin/python3 --version 2>/dev/null | awk '{print $2}' || python3 --version 2>/dev/null | awk '{print $2}' || python --version 2>/dev/null | awk '{print $2}'",
       "min_version": "3.10.0",
       "latest_check": null,
       "install": {


### PR DESCRIPTION
## Summary
- **Track filtering**: `check-versions.sh` now filters tools by project track — light track projects no longer see standard/full-only tools (Apple Developer Program, EV cert)
- **Universal brew PATH priority**: Prepend brew's bin directory to PATH at the top of `check-versions.sh` so all version checks find brew-installed tools over macOS system stubs (Python 3.9.6 vs 3.14.3, etc.). Works on any system — skipped when brew isn't installed.
- **Directive update prompts**: Session-start hook now explicitly instructs the agent to ask the Orchestrator whether to run updates, listing each command. Previously the agent presented results as informational without offering to act.

## Context
Discovered during meshscope testing: Python showed 3.9.6 (Xcode system stub) instead of 3.14.3 (brew), Apple Developer Program appeared for a light track project, and the agent didn't offer to run available updates.

## Test plan
- [x] Python detected as 3.14.3 (brew) not 3.9.6 (system)
- [x] Apple Developer Program and EV cert filtered out for light track
- [x] Version check silent when all tools current (session-version-check.sh)
- [x] Syntax check passed on all modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)