### PR TITLE
feat(test-gate): unrecord-feature subcommand + CLAUDE.md rollback doc (BL-008)

### DIFF
--- a/docs/superpowers/plans/2026-04-23-unrecord-feature-implementation.md
+++ b/docs/superpowers/plans/2026-04-23-unrecord-feature-implementation.md
@@ -1,0 +1,858 @@
+# Unrecord-Feature Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement `scripts/test-gate.sh --unrecord-feature NAME` per spec `docs/superpowers/specs/2026-04-23-unrecord-feature-design.md`, add a "Recovering from mistakes" subsection to the CLAUDE.md template, and add a self-contained test file covering the state-transform logic.
+
+**Architecture:** One new subcommand in an existing script. State-transform logic lives in a pure `_unrecord_feature_apply()` function (unit-testable). Interactive wrapper `unrecord_feature()` handles tty guard, preview, Y/N prompt, audit log. Source guard added to `test-gate.sh` so tests can source it without triggering dispatch.
+
+**Tech Stack:** Bash 4+, jq, existing solo-orchestrator test conventions (bash assertion scripts).
+
+---
+
+## File Structure
+
+```
+scripts/
+└── test-gate.sh                         # MODIFIED: add _apply + wrapper + parser case + dispatch case + help line + source guard
+
+templates/
+└── generated/
+    └── claude-md.tmpl                   # MODIFIED: add "Recovering from mistakes" subsection
+
+tests/
+└── test-unrecord-feature.sh             # NEW: 7 cases against _unrecord_feature_apply
+```
+
+All changes are in existing files except the new test file. Behavior change is additive — existing subcommands (`--check-batch`, `--record-feature`, etc.) remain unchanged.
+
+---
+
+## Task 1: Make test-gate.sh source-safe
+
+**Files:**
+- Modify: `scripts/test-gate.sh` — wrap argument parsing, validation, and dispatch in a source guard so sourcing the file for tests doesn't trigger the "No action specified" exit.
+
+**Why:** The test file in Task 2 needs to source `test-gate.sh` to call `_unrecord_feature_apply` directly. Without the source guard, sourcing with no arguments would hit the existing `if [ -z "$ACTION" ]; then ... exit 1` block and kill the test process. The `BASH_SOURCE` check makes the dispatch block only fire when the script is run directly, not when sourced.
+
+- [ ] **Step 1: Read current structure of `scripts/test-gate.sh`**
+
+Run: `grep -n '^while\|^if \[ -z "\$ACTION"\|^# --- Dispatch\|^case "\$ACTION"' scripts/test-gate.sh`
+Expected output includes approximately:
+```
+23:while [ $# -gt 0 ]; do
+47:if [ -z "$ACTION" ]; then
+298:# --- Dispatch ---
+299:case "$ACTION" in
+```
+
+Note the exact line numbers; they will vary slightly. Identify the region from the `while [ $# -gt 0 ]; do` loop start through the closing `esac` of the dispatch `case`.
+
+- [ ] **Step 2: Modify test-gate.sh to wrap parsing + dispatch in source guard**
+
+Wrap the entire region from line 23 (`while [ $# -gt 0 ]; do`) through the `esac` that closes the dispatch case. The wrapper:
+
+```bash
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  # --- Argument parsing, validation, dispatch ---
+  # (existing code moves inside this block, indented one level)
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      # ... existing cases ...
+    esac
+  done
+
+  if [ -z "$ACTION" ]; then
+    echo "No action specified. Use --help for usage." >&2
+    exit 1
+  fi
+
+  # --- Dispatch ---
+  case "$ACTION" in
+    # ... existing cases ...
+  esac
+fi
+```
+
+The indentation of the wrapped code changes (add 2 spaces); the logic is unchanged. Function definitions remain outside the guard and are always defined when the file is sourced.
+
+- [ ] **Step 3: Verify existing subcommands still work when run directly**
+
+Run: `bash scripts/test-gate.sh --help`
+Expected: help text prints, exit 0. (If this fails, the source guard wrapping has a syntax error.)
+
+Run: `bash scripts/test-gate.sh`
+Expected: "No action specified. Use --help for usage." exit 1.
+
+- [ ] **Step 4: Verify sourcing the file with no args does NOT exit**
+
+Run: `bash -c 'source scripts/test-gate.sh; echo "sourced ok"; declare -f record_feature >/dev/null && echo "record_feature defined"'`
+Expected output:
+```
+sourced ok
+record_feature defined
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/test-gate.sh
+git commit -m "refactor(test-gate): wrap argument parsing + dispatch in source guard
+
+Enables tests to source test-gate.sh and call its functions directly
+without triggering the 'No action specified' exit that would kill the
+test process. Function definitions remain at top level; only the
+argument parser, validation, and dispatch case are guarded by
+BASH_SOURCE/\$0 equality.
+
+Behavior when run directly is unchanged — verified via --help and
+no-argument invocations."
+```
+
+---
+
+## Task 2: Add state-transform function `_unrecord_feature_apply` (TDD)
+
+**Files:**
+- Create: `tests/test-unrecord-feature.sh` — self-contained bash test file with assertion helpers and 5 state-transform cases
+- Modify: `scripts/test-gate.sh` — add `_unrecord_feature_apply()` function
+
+**Why:** The pure state-transform is the testable core. Writing the 5 state-transform cases first gives a clear contract for the implementation; the tests validate the inverse semantics of `--record-feature` including counter flooring and `testing_required` re-evaluation.
+
+- [ ] **Step 1: Create the test file with 5 failing state-transform tests**
+
+Create `tests/test-unrecord-feature.sh`:
+
+```bash
+#!/usr/bin/env bash
+# tests/test-unrecord-feature.sh — unit tests for _unrecord_feature_apply()
+# Targets the pure state transform; interactive wrapper is manually verified.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Inline assertion helpers (zero-dependency; matches existing tests/*.sh pattern) ---
+
+PASSED=0
+FAILED=0
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="${3:-}"
+  if [ "$expected" != "$actual" ]; then
+    echo "  ASSERT FAIL${msg:+ [$msg]}: expected '$expected', got '$actual'" >&2
+    return 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  ASSERT FAIL${msg:+ [$msg]}: '$haystack' does not contain '$needle'" >&2
+    return 1
+  fi
+}
+
+run_case() {
+  local name="$1"
+  shift
+  if ( set -e; "$@" ); then
+    echo "✓ $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "✗ $name FAILED"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+seed_progress() {
+  # Args: path, array-json, fslt, interval, testing_required, fslhc
+  local path="$1" arr="$2" fslt="$3" interval="$4" testing="$5" fslhc="$6"
+  cat > "$path" <<JSONEOF
+{
+  "features_completed": $arr,
+  "features_since_last_test": $fslt,
+  "test_interval": $interval,
+  "last_test_session": null,
+  "testing_required": $testing,
+  "tester_count": 1,
+  "bug_tracker": "github_issues",
+  "sessions_completed": 0,
+  "features_since_last_health_check": $fslhc
+}
+JSONEOF
+}
+
+# --- Source the script under test ---
+# Task 1's source guard prevents dispatch from running.
+source "$REPO_ROOT/scripts/test-gate.sh"
+
+# --- Test cases ---
+
+case_1_happy_path() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo"]' 1 2 false 1
+    _unrecord_feature_apply "foo"
+    assert_eq "[]" "$(jq -c '.features_completed' .claude/build-progress.json)" "array empty"
+    assert_eq "0" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt 0"
+    assert_eq "0" "$(jq -r '.features_since_last_health_check' .claude/build-progress.json)" "fslhc 0"
+    assert_eq "false" "$(jq -r '.testing_required' .claude/build-progress.json)" "testing_required false"
+  )
+}
+
+case_2_duplicates_first_match() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo","bar","foo"]' 3 2 true 3
+    _unrecord_feature_apply "foo"
+    assert_eq '["bar","foo"]' "$(jq -c '.features_completed' .claude/build-progress.json)" "first 'foo' removed, second preserved"
+  )
+}
+
+case_3_counter_floor_at_zero() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo"]' 0 2 false 0
+    _unrecord_feature_apply "foo"
+    assert_eq "0" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt stays 0"
+    assert_eq "0" "$(jq -r '.features_since_last_health_check' .claude/build-progress.json)" "fslhc stays 0"
+  )
+}
+
+case_4_testing_required_flips_false() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo","bar"]' 2 2 true 2
+    _unrecord_feature_apply "foo"
+    assert_eq "1" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt 1"
+    assert_eq "false" "$(jq -r '.testing_required' .claude/build-progress.json)" "testing_required now false"
+  )
+}
+
+case_5_testing_required_stays_true() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo","bar","baz"]' 3 2 true 3
+    _unrecord_feature_apply "foo"
+    assert_eq "2" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt 2"
+    assert_eq "true" "$(jq -r '.testing_required' .claude/build-progress.json)" "testing_required stays true"
+  )
+}
+
+# --- Run all cases and report ---
+echo "═══ test-unrecord-feature.sh ═══"
+run_case "case 1: happy path"                     case_1_happy_path
+run_case "case 2: duplicates → first match"       case_2_duplicates_first_match
+run_case "case 3: counter floor at 0"             case_3_counter_floor_at_zero
+run_case "case 4: testing_required flips false"   case_4_testing_required_flips_false
+run_case "case 5: testing_required stays true"    case_5_testing_required_stays_true
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "Tests: $PASSED passed, $FAILED failed"
+echo "═══════════════════════════════════════════"
+[ "$FAILED" -eq 0 ]
+```
+
+- [ ] **Step 2: Run tests to verify all 5 fail**
+
+Run: `bash tests/test-unrecord-feature.sh`
+Expected: All 5 cases fail (`_unrecord_feature_apply: command not found` or similar). The aggregate summary shows `0 passed, 5 failed`, exit code 1.
+
+- [ ] **Step 3: Implement `_unrecord_feature_apply()` in test-gate.sh**
+
+Add the following function definition to `scripts/test-gate.sh`, placed **immediately after** the existing `record_feature()` function (for visual symmetry). Functions must be defined outside the source guard added in Task 1.
+
+```bash
+# _unrecord_feature_apply <name>
+# Pure state transform; no tty check, no prompt, no audit log.
+# Inverse of record_feature: removes first occurrence of $name from
+# features_completed, decrements both counters floored at 0, re-evaluates
+# testing_required. Errors if name is not present or build-progress.json
+# is missing. Unit-testable via source.
+_unrecord_feature_apply() {
+  local name="${1:?_unrecord_feature_apply: name required}"
+
+  if [ ! -f "$BUILD_PROGRESS" ]; then
+    echo "_unrecord_feature_apply: $BUILD_PROGRESS does not exist" >&2
+    return 1
+  fi
+
+  # Presence check — errors if name not in features_completed
+  if ! jq --arg name "$name" -e '.features_completed | index($name) != null' "$BUILD_PROGRESS" >/dev/null; then
+    echo "_unrecord_feature_apply: feature '$name' not found in features_completed" >&2
+    return 1
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  jq --arg name "$name" '
+    (.features_completed
+      | (. | index($name)) as $i
+      | .[0:$i] + .[$i+1:]) as $new_arr |
+    .features_completed = $new_arr |
+    .features_since_last_test = ([.features_since_last_test - 1, 0] | max) |
+    .features_since_last_health_check = ([(.features_since_last_health_check // 0) - 1, 0] | max) |
+    .testing_required = (.features_since_last_test >= .test_interval)
+  ' "$BUILD_PROGRESS" > "$tmp" && mv "$tmp" "$BUILD_PROGRESS"
+}
+```
+
+- [ ] **Step 4: Run tests to verify all 5 pass**
+
+Run: `bash tests/test-unrecord-feature.sh`
+Expected output:
+```
+═══ test-unrecord-feature.sh ═══
+✓ case 1: happy path
+✓ case 2: duplicates → first match
+✓ case 3: counter floor at 0
+✓ case 4: testing_required flips false
+✓ case 5: testing_required stays true
+
+═══════════════════════════════════════════
+Tests: 5 passed, 0 failed
+═══════════════════════════════════════════
+```
+
+Exit code 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/test-gate.sh tests/test-unrecord-feature.sh
+git commit -m "feat(test-gate): _unrecord_feature_apply() state transform (BL-008)
+
+Pure state transform that is the inverse of record_feature:
+- Removes first occurrence of NAME from features_completed
+- Decrements features_since_last_test and features_since_last_health_check,
+  floored at 0
+- Re-evaluates testing_required against new counter vs test_interval
+- Errors if NAME not in array or build-progress.json missing
+
+Unit-testable via source (Task 1's guard). 5 cases passing:
+happy path, duplicates → first-match, counter floor at 0,
+testing_required flips false, testing_required stays true."
+```
+
+---
+
+## Task 3: Add error-handling tests for `_apply` (TDD)
+
+**Files:**
+- Modify: `tests/test-unrecord-feature.sh` — add 2 error-path cases
+
+**Why:** Case 6 (feature not found) and Case 7 (missing build-progress.json) are distinct error paths from the state-transform cases. They validate that `_apply` returns non-zero and emits a useful error message in both scenarios. The implementation already handles both cases from Task 2, so this task primarily adds test coverage.
+
+- [ ] **Step 1: Add failing error-handling test cases**
+
+Add these two case functions to `tests/test-unrecord-feature.sh`, immediately before the `# --- Run all cases and report ---` section:
+
+```bash
+case_6_feature_not_found() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo"]' 1 2 false 1
+    set +e
+    local output
+    output=$(_unrecord_feature_apply "bar" 2>&1)
+    local code=$?
+    set -e
+    assert_eq "1" "$code" "exit code 1 on not-found"
+    assert_contains "$output" "not found" "message mentions not found"
+    assert_contains "$output" "bar" "message mentions the specific name"
+  )
+}
+
+case_7_missing_progress_file() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    # No .claude directory, no build-progress.json
+    set +e
+    local output
+    output=$(_unrecord_feature_apply "anything" 2>&1)
+    local code=$?
+    set -e
+    assert_eq "1" "$code" "exit code 1 on missing file"
+    assert_contains "$output" "does not exist" "message mentions file missing"
+  )
+}
+```
+
+Then add these two `run_case` invocations immediately after the existing five, before the `echo ""` separator in the report section:
+
+```bash
+run_case "case 6: feature not found"              case_6_feature_not_found
+run_case "case 7: missing build-progress.json"    case_7_missing_progress_file
+```
+
+- [ ] **Step 2: Run tests to verify all 7 pass**
+
+Run: `bash tests/test-unrecord-feature.sh`
+Expected: 7 cases run, all passing. Exit 0.
+
+The implementation in Task 2 already handles both cases (the presence check and the file-existence check), so these tests should pass without implementation changes.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/test-unrecord-feature.sh
+git commit -m "test(test-gate): error-path cases for _unrecord_feature_apply
+
+Adds case 6 (feature not found) and case 7 (missing build-progress.json)
+to the unrecord-feature test suite. Tests assert exit code 1 and
+specific message content. Implementation from Task 2 already handles
+both paths; this extends the coverage."
+```
+
+---
+
+## Task 4: Add interactive wrapper `unrecord_feature`
+
+**Files:**
+- Modify: `scripts/test-gate.sh` — add `unrecord_feature()` function
+
+**Why:** The interactive wrapper handles the tty guard, state preview, Y/N prompt, and audit-log append. Per the spec, this layer is not unit-tested (tty behavior and `read` are bash primitives); we verify manually at end-of-plan.
+
+- [ ] **Step 1: Add `unrecord_feature()` immediately after `_unrecord_feature_apply()`**
+
+```bash
+# unrecord_feature <name>
+# Interactive wrapper around _unrecord_feature_apply: tty guard,
+# state-change preview, Y/N confirmation, audit-log append.
+# Blocks agent callers (requires an interactive terminal).
+unrecord_feature() {
+  local name="${1:-}"
+
+  if [ -z "$name" ]; then
+    print_fail "Usage: --unrecord-feature NAME (feature name required)"
+    exit 1
+  fi
+
+  if [ ! -t 0 ]; then
+    print_fail "Unrecord requires interactive authorization."
+    echo "The Orchestrator must run this command directly in a terminal:" >&2
+    echo "  scripts/test-gate.sh --unrecord-feature \"$name\"" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$BUILD_PROGRESS" ]; then
+    print_fail "Nothing to unrecord: $BUILD_PROGRESS does not exist."
+    echo "No features have been recorded in this project yet." >&2
+    exit 1
+  fi
+
+  # Presence check + diagnostic output (repeats _apply's check to provide
+  # the current-features list before prompting)
+  if ! jq --arg name "$name" -e '.features_completed | index($name) != null' "$BUILD_PROGRESS" >/dev/null; then
+    print_fail "Feature '$name' not found in features_completed."
+    echo "Currently recorded features:" >&2
+    local features
+    features=$(jq -r '.features_completed[]' "$BUILD_PROGRESS" 2>/dev/null || true)
+    if [ -z "$features" ]; then
+      echo "  (none)" >&2
+    else
+      echo "$features" | sed 's/^/  - /' >&2
+    fi
+    exit 1
+  fi
+
+  # Compute preview values
+  local cur_array cur_fslt cur_fslhc cur_testing interval new_fslt new_fslhc new_testing new_array
+  cur_array=$(jq -c '.features_completed' "$BUILD_PROGRESS")
+  cur_fslt=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS")
+  cur_fslhc=$(jq -r '.features_since_last_health_check // 0' "$BUILD_PROGRESS")
+  cur_testing=$(jq -r '.testing_required' "$BUILD_PROGRESS")
+  interval=$(jq -r '.test_interval' "$BUILD_PROGRESS")
+
+  new_fslt=$(( cur_fslt - 1 < 0 ? 0 : cur_fslt - 1 ))
+  new_fslhc=$(( cur_fslhc - 1 < 0 ? 0 : cur_fslhc - 1 ))
+  if [ "$new_fslt" -ge "$interval" ]; then
+    new_testing="true"
+  else
+    new_testing="false"
+  fi
+  new_array=$(jq --arg name "$name" -c '
+    (.features_completed | (. | index($name)) as $i
+     | .[0:$i] + .[$i+1:])' "$BUILD_PROGRESS")
+
+  # Show preview
+  echo "Unrecord feature '$name'?"
+  echo ""
+  echo "Current state:"
+  echo "  features_completed: $cur_array"
+  echo "  features_since_last_test: $cur_fslt / $interval (testing_required: $cur_testing)"
+  echo "  features_since_last_health_check: $cur_fslhc"
+  echo ""
+  echo "After unrecord:"
+  echo "  features_completed: $new_array"
+  echo "  features_since_last_test: $new_fslt / $interval (testing_required: $new_testing)"
+  echo "  features_since_last_health_check: $new_fslhc"
+  echo ""
+
+  local confirm
+  read -rp "Proceed? [y/N]: " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    print_info "Unrecord cancelled."
+    exit 0
+  fi
+
+  # Apply
+  if ! _unrecord_feature_apply "$name"; then
+    print_fail "Unrecord failed — state unchanged"
+    exit 1
+  fi
+
+  # Audit log
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local audit_entry="[UNRECORD] feature '$name' unrecorded at $now by $(whoami)"
+  mkdir -p .claude
+  echo "$audit_entry" >> ".claude/process-audit.log"
+
+  print_ok "Feature '$name' unrecorded"
+}
+```
+
+- [ ] **Step 2: Verify the function is defined (doesn't exit on source)**
+
+Run: `bash -c 'source scripts/test-gate.sh; declare -f unrecord_feature >/dev/null && echo "defined" || echo "missing"'`
+Expected output: `defined`
+
+- [ ] **Step 3: Verify test suite still passes**
+
+Run: `bash tests/test-unrecord-feature.sh`
+Expected: 7 cases pass (adding the wrapper doesn't affect `_apply` tests).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/test-gate.sh
+git commit -m "feat(test-gate): unrecord_feature interactive wrapper
+
+Adds the interactive wrapper around _unrecord_feature_apply:
+- Validates NAME argument, tty presence, file existence, feature presence
+- Computes and displays state-change preview (current → projected)
+- Y/N confirmation prompt (decline → graceful exit 0 with 'cancelled')
+- Delegates state mutation to _apply
+- Appends [UNRECORD] entry to .claude/process-audit.log
+
+Mirrors the existing reset_process() safety pattern (interactive-only,
+Y/N + preview, audit log). Agent callers are blocked by the [ -t 0 ]
+guard."
+```
+
+---
+
+## Task 5: Wire argument parser, dispatch, and help text
+
+**Files:**
+- Modify: `scripts/test-gate.sh` — add parser case, dispatch case, and help-text line
+
+**Why:** The `unrecord_feature()` function exists but isn't reachable from the CLI yet. This task wires the command-line surface.
+
+- [ ] **Step 1: Add argument parser case**
+
+Find the existing `while [ $# -gt 0 ]; do ... case "$1" in ... esac ... done` block (inside Task 1's source guard) and add a new case **immediately after** the existing `--record-feature)` line. Before:
+
+```bash
+    --record-feature)     ACTION="record-feature"; FEATURE_NAME="$2"; shift 2 ;;
+    --help|-h)
+```
+
+After:
+
+```bash
+    --record-feature)     ACTION="record-feature"; FEATURE_NAME="$2"; shift 2 ;;
+    --unrecord-feature)   ACTION="unrecord-feature"; FEATURE_NAME="$2"; shift 2 ;;
+    --help|-h)
+```
+
+- [ ] **Step 2: Add help-text line**
+
+In the same `--help|-h)` block, find the line matching `--record-feature N  Record a completed feature and increment counter` and add a new help line immediately after. Before:
+
+```bash
+      echo "  --record-feature N  Record a completed feature and increment counter"
+      echo "  --help              Show this help"
+```
+
+After:
+
+```bash
+      echo "  --record-feature N    Record a completed feature and increment counter"
+      echo "  --unrecord-feature N  Un-record a feature recorded in error (interactive; inverse of --record-feature)"
+      echo "  --help                Show this help"
+```
+
+Note: column alignment was adjusted for the longer `--unrecord-feature` option. If the existing help uses a different alignment pattern, match that instead.
+
+- [ ] **Step 3: Add dispatch case**
+
+Find the existing `case "$ACTION" in ... esac` block. Add a new case **immediately after** `record-feature)`:
+
+Before:
+
+```bash
+  record-feature)     record_feature "$FEATURE_NAME" ;;
+esac
+```
+
+After:
+
+```bash
+  record-feature)     record_feature "$FEATURE_NAME" ;;
+  unrecord-feature)   unrecord_feature "$FEATURE_NAME" ;;
+esac
+```
+
+- [ ] **Step 4: Verify help text shows the new option**
+
+Run: `bash scripts/test-gate.sh --help | grep unrecord`
+Expected: one line matching `--unrecord-feature N  Un-record a feature recorded in error ...`
+
+- [ ] **Step 5: Verify command routes correctly (non-interactive → expected error)**
+
+Run: `echo "" | bash scripts/test-gate.sh --unrecord-feature "nonexistent" 2>&1 | head -3`
+Expected output includes:
+```
+[FAIL] Unrecord requires interactive authorization.
+The Orchestrator must run this command directly in a terminal:
+  scripts/test-gate.sh --unrecord-feature "nonexistent"
+```
+This confirms the dispatch reaches `unrecord_feature` and the tty guard fires. Exit code 1.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/test-gate.sh
+git commit -m "feat(test-gate): wire --unrecord-feature CLI surface
+
+Adds argument parser case, dispatch case, and help-text line for the
+new --unrecord-feature NAME subcommand. Command is now reachable via
+the CLI; non-interactive invocations correctly hit the tty guard and
+exit with remediation guidance."
+```
+
+---
+
+## Task 6: CLAUDE.md template "Recovering from mistakes" subsection
+
+**Files:**
+- Modify: `templates/generated/claude-md.tmpl` — add subsection to Testing & Bug Workflow
+
+**Why:** Per spec §Documentation, document the new command and surface existing `--reset uat_session` / `--reset build_loop` commands that were previously undocumented in CLAUDE.md. Placement is inside the Testing & Bug Workflow section (not a new top-level section) so recovery guidance sits next to the operations it recovers.
+
+- [ ] **Step 1: Find the insertion point**
+
+Run: `grep -n 'Severity rules:\|After each feature:' templates/generated/claude-md.tmpl`
+Expected output includes approximately:
+```
+170:- **After each feature:** `scripts/test-gate.sh --record-feature "feature-name"`
+172:- **Severity rules:** SEV-1 cannot be deferred. SEV-2 can be deferred during Phase 2 but must be resolved or feature removed at Phase 2→3 gate.
+```
+
+Note the exact line of the `**Severity rules:**` bullet; we insert immediately after it (inside the same Testing & Bug Workflow bulleted list, before the blank line that ends the section).
+
+- [ ] **Step 2: Insert the "Recovering from mistakes" subsection**
+
+After the `**Severity rules:**` bullet, add the following lines:
+
+```markdown
+- **Recovering from mistakes:**
+  - Un-record a wrongly-recorded feature: `scripts/test-gate.sh --unrecord-feature "name"` (interactive; fully inverses the `--record-feature` counters)
+  - Abort a started UAT session: `scripts/process-checklist.sh --reset uat_session` (interactive)
+  - Abort a started Build Loop: `scripts/process-checklist.sh --reset build_loop` (interactive)
+  - All three require terminal access and Y/N confirmation; each writes an audit entry to `.claude/process-audit.log`. These are **local-state fixes only** — if the state was committed, amend or revert the commit separately.
+```
+
+- [ ] **Step 3: Verify the markdown is well-formed**
+
+Run: `grep -A 6 'Recovering from mistakes:' templates/generated/claude-md.tmpl`
+Expected: the full 5-line subsection appears as a nested list, with no accidental line breaks or indentation errors.
+
+Also verify the section that follows is unchanged:
+
+Run: `grep -n 'Phase 2 Completion Checkpoint\|Phase 3-4 Documentation' templates/generated/claude-md.tmpl | head -2`
+Expected: both sections still present at their original positions (shifted down by the ~6 inserted lines).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/generated/claude-md.tmpl
+git commit -m "docs(claude-md): add 'Recovering from mistakes' subsection (BL-008)
+
+Documents three local-state recovery commands inside the Testing & Bug
+Workflow section:
+- scripts/test-gate.sh --unrecord-feature NAME (new)
+- scripts/process-checklist.sh --reset uat_session (existing)
+- scripts/process-checklist.sh --reset build_loop (existing)
+
+Flags all three as interactive, audit-logged, and local-state-only
+(amend/revert commits separately if already committed)."
+```
+
+---
+
+## Task 7: End-to-end manual smoke test (verification step; no commit)
+
+**Files:**
+- No code changes. This task verifies the full interactive flow against a seeded fixture.
+
+**Why:** Per the spec, the interactive wrapper (tty guard, Y/N prompt, audit log) is not unit-tested. An end-to-end manual verification confirms that all components work together under real terminal conditions.
+
+- [ ] **Step 1: Set up a temporary project workspace**
+
+Run:
+```bash
+TESTPROJ=$(mktemp -d)
+cd "$TESTPROJ"
+mkdir -p .claude
+cat > .claude/build-progress.json <<'JSON'
+{
+  "features_completed": ["alpha", "beta", "charlie"],
+  "features_since_last_test": 2,
+  "test_interval": 2,
+  "last_test_session": null,
+  "testing_required": true,
+  "tester_count": 1,
+  "bug_tracker": "github_issues",
+  "sessions_completed": 0,
+  "features_since_last_health_check": 3
+}
+JSON
+echo "TESTPROJ=$TESTPROJ"
+```
+
+- [ ] **Step 2: Run the command interactively with an existing name**
+
+Run (replace `/path/to/solo-orchestrator` with the actual path; use `$OLDPWD` if you came from the repo root):
+```bash
+bash /path/to/solo-orchestrator/scripts/test-gate.sh --unrecord-feature beta
+```
+
+Expected output:
+```
+Unrecord feature 'beta'?
+
+Current state:
+  features_completed: ["alpha","beta","charlie"]
+  features_since_last_test: 2 / 2 (testing_required: true)
+  features_since_last_health_check: 3
+
+After unrecord:
+  features_completed: ["alpha","charlie"]
+  features_since_last_test: 1 / 2 (testing_required: false)
+  features_since_last_health_check: 2
+
+Proceed? [y/N]:
+```
+
+- [ ] **Step 3: Type `y` and press Enter**
+
+Expected output (after `y`):
+```
+  [OK] Feature 'beta' unrecorded
+```
+
+Verify state:
+```bash
+jq . .claude/build-progress.json
+```
+Expected: `features_completed` is `["alpha","charlie"]`, `features_since_last_test` is `1`, `testing_required` is `false`, `features_since_last_health_check` is `2`.
+
+Verify audit log:
+```bash
+cat .claude/process-audit.log
+```
+Expected: one line matching `[UNRECORD] feature 'beta' unrecorded at <ISO-8601-timestamp> by <username>`.
+
+- [ ] **Step 4: Run again with a name that doesn't exist**
+
+Run: `bash /path/to/solo-orchestrator/scripts/test-gate.sh --unrecord-feature does-not-exist`
+
+Expected output:
+```
+[FAIL] Feature 'does-not-exist' not found in features_completed.
+Currently recorded features:
+  - alpha
+  - charlie
+```
+
+Exit code 1.
+
+- [ ] **Step 5: Run and decline at the Y/N prompt**
+
+Run: `bash /path/to/solo-orchestrator/scripts/test-gate.sh --unrecord-feature alpha`
+
+At the prompt, type `n` (or just press Enter).
+
+Expected:
+```
+  [INFO] Unrecord cancelled.
+```
+
+Verify state is unchanged:
+```bash
+jq '.features_completed' .claude/build-progress.json
+```
+Expected: `["alpha","charlie"]` — unchanged from Step 3.
+
+- [ ] **Step 6: Clean up**
+
+Run: `rm -rf "$TESTPROJ"; unset TESTPROJ`
+
+- [ ] **Step 7: No commit**
+
+This task is a verification-only step. No code changes to commit. If any step fails, diagnose and fix in the appropriate earlier task, then re-run the full manual smoke test.
+
+---
+
+## Plan Self-Review Checklist
+
+**Spec coverage:**
+- [ ] Decision 1 (scope) → Task 2 adds `_apply` in `test-gate.sh`; Task 4 adds wrapper; Task 6 adds doc
+- [ ] Decision 2 (counter semantics) → Task 2 jq transform decrements both counters floored at 0 and re-evaluates `testing_required`; test cases 1, 3, 4, 5 validate
+- [ ] Decision 3 (name matching) → Task 2 implementation uses `index($name)` (first match); test case 2 validates duplicate handling; test case 6 validates not-found
+- [ ] Decision 4 (safety) → Task 4 implements tty guard + Y/N + audit log
+- [ ] Decision 5 (git awareness) → none added (spec's non-goal)
+- [ ] Decision 6 (documentation) → Task 6 adds subsection in Testing & Bug Workflow
+
+**Placeholder scan:**
+- [ ] No "TBD", "TODO", "similar to Task N" anywhere
+- [ ] All code blocks contain actual content
+- [ ] All assertion expected values are concrete
+
+**Type consistency:**
+- [ ] Function names match across tasks: `_unrecord_feature_apply`, `unrecord_feature` (used identically in Tasks 2–5)
+- [ ] Command name consistent: `--unrecord-feature` (used identically in Tasks 4–7)
+- [ ] JSON field names match the schema: `features_completed`, `features_since_last_test`, `features_since_last_health_check`, `testing_required`, `test_interval`
+- [ ] Audit-log format consistent: `[UNRECORD] feature '$name' unrecorded at $timestamp by $(whoami)`

--- a/docs/superpowers/specs/2026-04-23-unrecord-feature-design.md
+++ b/docs/superpowers/specs/2026-04-23-unrecord-feature-design.md
@@ -1,0 +1,226 @@
+# Unrecord-Feature Command + Rollback Documentation
+
+**Date:** 2026-04-23
+**Status:** Design approved, pending spec review
+**Scope:** Framework-level change to solo-orchestrator
+**Implements:** BL-008 from `solo-orchestrator-backlog.md`
+
+## Problem
+
+When `scripts/test-gate.sh --record-feature NAME` is called in error — for example, when a `feat(init):` commit implementing a scaffolding change was recorded as if it were an MVP Cutline feature — there is no sanctioned way to un-record it. Builders currently resort to direct `jq` edits of `.claude/build-progress.json`. This was observed on the lancache project Phase 2 audit on 2026-04-22, where the user is correcting via raw `jq` edit because no command exists for this operation.
+
+Relatedly, `scripts/process-checklist.sh --reset uat_session` (and sibling `--reset <process>` commands) exist and are safe to use, but are not documented in `CLAUDE.md`'s Testing & Bug Workflow section. Builders who need to abort a started UAT session or Build Loop may not discover the existing tooling.
+
+## Goals
+
+- Provide a sanctioned `--unrecord-feature NAME` command as the inverse of `--record-feature NAME`.
+- Document existing `--reset <process>` commands in the CLAUDE.md Testing & Bug Workflow section so builders discover them when they need recovery paths.
+- Apply the same safety envelope as existing `--reset <process>` commands: interactive-terminal requirement, Y/N confirmation with state preview, audit-log entry.
+
+## Non-Goals
+
+- No `--abort-build-loop` command. Redundant with existing `--reset build_loop`.
+- No git-history awareness. Command is a pure local-state operation; help text documents the limitation.
+- No extraction of the shared safety pattern (interactive-terminal guard + Y/N confirm + audit-log append) into a reusable helper. Deferred; file as a new backlog item when a third caller appears and the extraction benefit becomes concrete.
+- No `--all` or `--nth` flags for duplicate handling. First-match-wins is sufficient for the rare duplicate case; YAGNI until we see a real need.
+- No top-level "Rollback / Abort" section in CLAUDE.md. Recovery documentation lives inside the Testing & Bug Workflow section where it's discoverable in context.
+- No changes to `--record-feature` semantics.
+
+## Decisions
+
+| # | Decision | Choice | Rationale |
+|---|----------|--------|-----------|
+| 1 | Scope | New `--unrecord-feature` in `test-gate.sh` + doc existing `--reset <process>` | Small, bounded, observed-gap fix |
+| 2 | Counter semantics | Full inverse of `--record-feature` (remove from array, decrement both counters floored at 0, re-evaluate `testing_required`) | "Undo" mental model; avoids forcing users to know they also need `--reset-counter` |
+| 3 | Name matching | Strict: error on not-found, first-match-wins on duplicates | Catches typos loudly; duplicates are theoretical and rare |
+| 4 | Safety | Mirror `--reset <process>` exactly — interactive-only, Y/N with preview, audit log | Destructive state modification deserves the same safeguards |
+| 5 | Git awareness | Pure local-state fix; help text documents limitation | Command is named for what it does; consistent with `--reset <process>` which also doesn't inspect git |
+| 6 | Documentation | "Recovering from mistakes" subsection added to Testing & Bug Workflow in CLAUDE.md template | Discoverability in context > centralized reference |
+
+## Architecture
+
+One new subcommand in an existing script: `scripts/test-gate.sh --unrecord-feature NAME`, sibling of the existing `--record-feature NAME`. Inverse operation, same file, same jq-based state-transform pattern. No new scripts, no new schemas, no new directories.
+
+**Shape:**
+
+- State mutation lives in `_unrecord_feature_apply()` — pure logic, no I/O beyond file read/write. Unit-testable without tty tricks.
+- Interactive wrapper `unrecord_feature()` handles the tty guard, Y/N prompt with preview, and audit-log append, then delegates state mutation to `_apply`.
+- The wrapper/apply split serves both testability and potential future reuse (e.g., batch operations could call `_apply` directly).
+
+**Documentation component:** new "Recovering from mistakes" subsection in `templates/generated/claude-md.tmpl`'s Testing & Bug Workflow section (currently lines 151–172). Covers:
+
+- `--unrecord-feature NAME` (new)
+- `--reset uat_session` (existing, undocumented in CLAUDE.md)
+- `--reset build_loop` (existing, undocumented in CLAUDE.md)
+
+All three flagged as interactive, audit-logged, and **local-state fixes only**.
+
+## Components
+
+### New files
+
+- `tests/test-unrecord-feature.sh` — ~120 lines, 7 cases, self-contained assertion script.
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `scripts/test-gate.sh` | Add `_unrecord_feature_apply()` + `unrecord_feature()`; add argument parser case `--unrecord-feature)`; add dispatch case; add help-text line |
+| `templates/generated/claude-md.tmpl` | Add "Recovering from mistakes" subsection (~5 lines) inside Testing & Bug Workflow |
+
+### Function split inside `test-gate.sh`
+
+**`_unrecord_feature_apply <name>`** — pure state transform:
+
+- Reads `.claude/build-progress.json`.
+- Validates `name` is present in `features_completed`; exits 1 with error + current-features diagnostic if not.
+- Applies the jq transform (remove first-match, decrement both counters floored at 0, re-evaluate `testing_required`).
+- Writes via `.tmp`-then-`mv` (mirrors existing atomic-write pattern in this file).
+- Returns 0 on success.
+- Does **not** check tty, does **not** prompt, does **not** log. Pure logic; testable with seeded fixtures.
+
+**`unrecord_feature <name>`** — interactive wrapper:
+
+- Validates `name` non-empty.
+- Enforces `[ -t 0 ]` interactive-terminal guard (exits 1 with remediation hint if not interactive).
+- Validates `.claude/build-progress.json` exists (exits 1 if not).
+- Reads current state for the preview.
+- Prints preview (current state → projected state — see Data Flow below).
+- Prompts `[y/N]`; on decline → `print_info "Unrecord cancelled."`, exit 0.
+- Calls `_unrecord_feature_apply "$name"`.
+- Appends `[UNRECORD] feature '$name' unrecorded at $timestamp by $(whoami)` to `.claude/process-audit.log`.
+- Prints success confirmation.
+
+### Argument parser addition
+
+One new case in the existing `while [ $# -gt 0 ]` loop:
+
+```
+--unrecord-feature)   ACTION="unrecord-feature"; FEATURE_NAME="$2"; shift 2 ;;
+```
+
+### Dispatch addition
+
+One new case in the existing `case "$ACTION"` block:
+
+```
+unrecord-feature)   unrecord_feature "$FEATURE_NAME" ;;
+```
+
+### Help-text addition
+
+One new line in the `--help` output, after the existing `--record-feature` line:
+
+```
+  --unrecord-feature N  Un-record a feature recorded in error (interactive; inverse of --record-feature)
+```
+
+### CLAUDE.md template addition
+
+Inserted at the end of the bulleted list in the Testing & Bug Workflow section (after the existing `**After each feature:**` and `**Severity rules:**` bullets):
+
+```markdown
+- **Recovering from mistakes:**
+  - Un-record a wrongly-recorded feature: `scripts/test-gate.sh --unrecord-feature "name"` (interactive; fully inverses the `--record-feature` counters)
+  - Abort a started UAT session: `scripts/process-checklist.sh --reset uat_session` (interactive)
+  - Abort a started Build Loop: `scripts/process-checklist.sh --reset build_loop` (interactive)
+  - All three require terminal access and Y/N confirmation; each writes an audit entry to `.claude/process-audit.log`. These are **local-state fixes only** — if the state was committed, amend or revert the commit separately.
+```
+
+## Data Flow
+
+Linear; one command invocation, one terminal session:
+
+1. **Parse args.** `FEATURE_NAME=$2`, `ACTION="unrecord-feature"`.
+2. **Validate preconditions** (in this order):
+   - `FEATURE_NAME` non-empty → else print usage, exit 1.
+   - `[ -t 0 ]` interactive → else print remediation, exit 1.
+   - `.claude/build-progress.json` exists → else error "nothing to unrecord", exit 1.
+   - `FEATURE_NAME` in `features_completed` → else error "'NAME' not found", list currently-recorded features, exit 1.
+3. **Compute preview.** Read current state; compute projected state (array with first `NAME` removed, counters floored at 0, new `testing_required`).
+4. **Display preview + Y/N.** Format specified in Components §preview. If decline → "Unrecord cancelled", exit 0.
+5. **Apply transform via single jq invocation.** Atomic via `.tmp` + `mv`.
+6. **Append audit-log entry.** `>>` to `.claude/process-audit.log`.
+7. **Print success confirmation.** `print_ok "Feature 'NAME' unrecorded"`.
+8. Exit 0.
+
+**Preview format** (shown at the Y/N prompt):
+
+```
+Unrecord feature 'NAME'?
+
+Current state:
+  features_completed: ["foo", "bar", "NAME"]
+  features_since_last_test: 3 / 2 (testing_required: true)
+  features_since_last_health_check: 5
+
+After unrecord:
+  features_completed: ["foo", "bar"]
+  features_since_last_test: 2 / 2 (testing_required: true)
+  features_since_last_health_check: 4
+
+Proceed? [y/N]:
+```
+
+**Concurrency:** single-user project, no concurrent callers. Read-then-modify-then-write is safe, matches the existing `--record-feature` pattern.
+
+**Idempotency:** second invocation with the same name hits "not found" error and exits 1 without side effects.
+
+**Transaction boundary:** steps 5 and 6 are separate operations. State transform succeeds and audit-log append fails ≈ known limitation; matches `reset_process()` behavior. Acceptable because audit-log failure is rare and recoverable.
+
+## Error Handling
+
+Five handled error cases, each with specific message and exit code:
+
+| # | Condition | Response | Exit |
+|---|-----------|----------|------|
+| 1 | Missing NAME argument | `print_fail "Usage: --unrecord-feature NAME (feature name required)"` | 1 |
+| 2 | Non-interactive invocation | Mirror `reset_process()` exactly: "Unrecord requires interactive authorization" + remediation command on stderr | 1 |
+| 3 | `build-progress.json` missing | "Nothing to unrecord: .claude/build-progress.json does not exist. No features have been recorded in this project yet." | 1 |
+| 4 | Feature not in array | "Feature '$name' not found in features_completed." — then print `Currently recorded features:` with a bulleted list (or `(none)` if array is empty) | 1 |
+| 5 | User declines at Y/N | `print_info "Unrecord cancelled."` | 0 (graceful cancel, not a failure) |
+
+**Audit-log-write failure:** known limitation, not handled. `echo >> file` is best-effort and matches existing `reset_process()` behavior. If this becomes an observed problem, it's cross-cutting and belongs with BL-009's helper extraction.
+
+**jq transform failure:** natural exit 1 via `set -e`. Unlikely in practice; indicates filesystem or JSON-parse issue.
+
+## Testing
+
+**New file:** `tests/test-unrecord-feature.sh` — ~120 lines, 7 cases, self-contained.
+
+**Testability approach:** the wrapper/apply function split enables unit testing without tty tricks. Tests target `_unrecord_feature_apply` directly, skipping the interactive guard that would reject the test runner itself.
+
+**Test cases:**
+
+| # | Case | Setup | Assertion |
+|---|------|-------|-----------|
+| 1 | Happy path: single feature | `features_completed: ["foo"]`, counters at 1 | Array empty, counters at 0, `testing_required: false` |
+| 2 | Duplicates → first match removed | `features_completed: ["foo", "bar", "foo"]` | Array becomes `["bar", "foo"]` |
+| 3 | Counter floor at 0 | `features_completed: ["foo"]`, counters at 0 | Array empty, counters still 0 (no underflow) |
+| 4 | `testing_required` flips false | counters at 2, interval 2, `testing_required: true` | Counter 1, `testing_required: false` |
+| 5 | `testing_required` stays true | counters at 3, interval 2, `testing_required: true` | Counter 2, `testing_required: true` |
+| 6 | Feature not found | `features_completed: ["foo"]`, call with `"bar"` | Exit 1, stderr contains `"not found"` and `"foo"` |
+| 7 | Missing build-progress.json | No file | Exit 1, stderr contains `"does not exist"` |
+
+**Not tested (with rationale):**
+
+- Interactive-guard rejection — tests the tty check, not our logic; low value.
+- Y/N prompt behavior — tests bash's `read`, not our logic.
+- Audit-log append — write-then-read round-trip; mechanical filesystem test.
+- Audit-log failure handling — matches the "known limitation" decision above.
+
+**Test harness:** each case is a self-contained bash function that creates a temp dir, seeds `.claude/build-progress.json`, sources `test-gate.sh`, invokes `_unrecord_feature_apply`, asserts post-state via `jq`, and cleans up. Assertion helpers inlined (zero-dependency, matches existing `tests/*.sh` convention).
+
+**Integration into project test suites:** `tests/test-unrecord-feature.sh` runs standalone via `bash tests/test-unrecord-feature.sh`. No new harness infrastructure needed. Reference in relevant CI templates is optional follow-up; not blocking.
+
+## Open Questions
+
+None. All decisions captured in the Decisions table.
+
+## Related
+
+- Backlog: `solo-orchestrator-backlog.md` BL-008 (this spec's trigger)
+- Related backlog items (not in scope): BL-006 (pre-commit Build Loop enforcement), BL-007 (MVP Cutline Build Loop rule). A future backlog item extracting the shared interactive-auth pattern would be prompted by this spec's non-extraction decision, once a third caller justifies the helper.
+- Surfaced during: lancache project Phase 2 audit, 2026-04-22
+- Existing precedent for safety pattern: `scripts/process-checklist.sh:reset_process()` lines 885–945
+- Existing command for visual symmetry: `scripts/test-gate.sh:record_feature()` lines 91–117

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -20,33 +20,39 @@ BUILD_PROGRESS=".claude/build-progress.json"
 ACTION=""
 FEATURE_NAME=""
 
-while [ $# -gt 0 ]; do
-  case "$1" in
-    --check-batch)        ACTION="check-batch";        shift ;;
-    --check-phase-gate)   ACTION="check-phase-gate";   shift ;;
-    --reset-counter)      ACTION="reset-counter";       shift ;;
-    --reset-health-check) ACTION="reset-health-check"; shift ;;
-    --record-feature)     ACTION="record-feature"; FEATURE_NAME="$2"; shift 2 ;;
-    --help|-h)
-      echo "Usage: scripts/test-gate.sh [--check-batch] [--check-phase-gate] [--reset-counter] [--record-feature NAME]"
-      echo ""
-      echo "Commands:"
-      echo "  --check-batch       Check if testing session is due (exit 0=continue, 1=testing required)"
-      echo "  --check-phase-gate  Check if Phase 2→3 transition is clear (exit 0=clear, 1=blocked, 2=warnings)"
-      echo "  --reset-counter     Reset feature counter after testing session completes"
-      echo "  --record-feature N  Record a completed feature and increment counter"
-      exit 0
-      ;;
-    *)
-      echo "Unknown argument: $1" >&2
-      exit 1
-      ;;
-  esac
-done
+# Source-guard: the argument parser, "no action" check, and dispatch run only
+# when this script is executed directly. When sourced by tests (to call
+# _unrecord_feature_apply or other internal functions in isolation), these
+# blocks are skipped so the test process isn't killed by "No action specified".
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --check-batch)        ACTION="check-batch";        shift ;;
+      --check-phase-gate)   ACTION="check-phase-gate";   shift ;;
+      --reset-counter)      ACTION="reset-counter";       shift ;;
+      --reset-health-check) ACTION="reset-health-check"; shift ;;
+      --record-feature)     ACTION="record-feature"; FEATURE_NAME="$2"; shift 2 ;;
+      --help|-h)
+        echo "Usage: scripts/test-gate.sh [--check-batch] [--check-phase-gate] [--reset-counter] [--record-feature NAME]"
+        echo ""
+        echo "Commands:"
+        echo "  --check-batch       Check if testing session is due (exit 0=continue, 1=testing required)"
+        echo "  --check-phase-gate  Check if Phase 2→3 transition is clear (exit 0=clear, 1=blocked, 2=warnings)"
+        echo "  --reset-counter     Reset feature counter after testing session completes"
+        echo "  --record-feature N  Record a completed feature and increment counter"
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
 
-if [ -z "$ACTION" ]; then
-  echo "No action specified. Use --help for usage." >&2
-  exit 1
+  if [ -z "$ACTION" ]; then
+    echo "No action specified. Use --help for usage." >&2
+    exit 1
+  fi
 fi
 
 # --- Ensure build-progress.json exists ---
@@ -293,16 +299,18 @@ check_phase_gate() {
   fi
 }
 
-# --- Dispatch ---
-case "$ACTION" in
-  check-batch)        check_batch ;;
-  check-phase-gate)   check_phase_gate ;;
-  reset-counter)      reset_counter ;;
-  record-feature)     record_feature "$FEATURE_NAME" ;;
-  reset-health-check)
-    ensure_progress_file
-    jq '.features_since_last_health_check = 0' "$BUILD_PROGRESS" > "$BUILD_PROGRESS.tmp" && mv "$BUILD_PROGRESS.tmp" "$BUILD_PROGRESS"
-    echo "Context health check counter reset."
-    exit 0
-    ;;
-esac
+# --- Dispatch (source-guarded to match the argument parser above) ---
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  case "$ACTION" in
+    check-batch)        check_batch ;;
+    check-phase-gate)   check_phase_gate ;;
+    reset-counter)      reset_counter ;;
+    record-feature)     record_feature "$FEATURE_NAME" ;;
+    reset-health-check)
+      ensure_progress_file
+      jq '.features_since_last_health_check = 0' "$BUILD_PROGRESS" > "$BUILD_PROGRESS.tmp" && mv "$BUILD_PROGRESS.tmp" "$BUILD_PROGRESS"
+      echo "Context health check counter reset."
+      exit 0
+      ;;
+  esac
+fi

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -122,6 +122,39 @@ record_feature() {
   fi
 }
 
+# _unrecord_feature_apply <name>
+# Pure state transform; no tty check, no prompt, no audit log.
+# Inverse of record_feature: removes first occurrence of $name from
+# features_completed, decrements both counters floored at 0, re-evaluates
+# testing_required. Errors if name is not present or build-progress.json
+# is missing. Unit-testable via source.
+_unrecord_feature_apply() {
+  local name="${1:?_unrecord_feature_apply: name required}"
+
+  if [ ! -f "$BUILD_PROGRESS" ]; then
+    echo "_unrecord_feature_apply: $BUILD_PROGRESS does not exist" >&2
+    return 1
+  fi
+
+  # Presence check — errors if name not in features_completed
+  if ! jq --arg name "$name" -e '.features_completed | index($name) != null' "$BUILD_PROGRESS" >/dev/null; then
+    echo "_unrecord_feature_apply: feature '$name' not found in features_completed" >&2
+    return 1
+  fi
+
+  local tmp
+  tmp=$(mktemp)
+  jq --arg name "$name" '
+    (.features_completed
+      | (. | index($name)) as $i
+      | .[0:$i] + .[$i+1:]) as $new_arr |
+    .features_completed = $new_arr |
+    .features_since_last_test = ([.features_since_last_test - 1, 0] | max) |
+    .features_since_last_health_check = ([(.features_since_last_health_check // 0) - 1, 0] | max) |
+    .testing_required = (.features_since_last_test >= .test_interval)
+  ' "$BUILD_PROGRESS" > "$tmp" && mv "$tmp" "$BUILD_PROGRESS"
+}
+
 reset_counter() {
   ensure_progress_file
 

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -155,6 +155,102 @@ _unrecord_feature_apply() {
   ' "$BUILD_PROGRESS" > "$tmp" && mv "$tmp" "$BUILD_PROGRESS"
 }
 
+# unrecord_feature <name>
+# Interactive wrapper around _unrecord_feature_apply: tty guard,
+# state-change preview, Y/N confirmation, audit-log append.
+# Blocks agent callers (requires an interactive terminal).
+unrecord_feature() {
+  local name="${1:-}"
+
+  if [ -z "$name" ]; then
+    print_fail "Usage: --unrecord-feature NAME (feature name required)"
+    exit 1
+  fi
+
+  if [ ! -t 0 ]; then
+    print_fail "Unrecord requires interactive authorization."
+    echo "The Orchestrator must run this command directly in a terminal:" >&2
+    echo "  scripts/test-gate.sh --unrecord-feature \"$name\"" >&2
+    exit 1
+  fi
+
+  if [ ! -f "$BUILD_PROGRESS" ]; then
+    print_fail "Nothing to unrecord: $BUILD_PROGRESS does not exist."
+    echo "No features have been recorded in this project yet." >&2
+    exit 1
+  fi
+
+  # Presence check + diagnostic output (repeats _apply's check to provide
+  # the current-features list before prompting)
+  if ! jq --arg name "$name" -e '.features_completed | index($name) != null' "$BUILD_PROGRESS" >/dev/null; then
+    print_fail "Feature '$name' not found in features_completed."
+    echo "Currently recorded features:" >&2
+    local features
+    features=$(jq -r '.features_completed[]' "$BUILD_PROGRESS" 2>/dev/null || true)
+    if [ -z "$features" ]; then
+      echo "  (none)" >&2
+    else
+      echo "$features" | sed 's/^/  - /' >&2
+    fi
+    exit 1
+  fi
+
+  # Compute preview values
+  local cur_array cur_fslt cur_fslhc cur_testing interval new_fslt new_fslhc new_testing new_array
+  cur_array=$(jq -c '.features_completed' "$BUILD_PROGRESS")
+  cur_fslt=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS")
+  cur_fslhc=$(jq -r '.features_since_last_health_check // 0' "$BUILD_PROGRESS")
+  cur_testing=$(jq -r '.testing_required' "$BUILD_PROGRESS")
+  interval=$(jq -r '.test_interval' "$BUILD_PROGRESS")
+
+  new_fslt=$(( cur_fslt - 1 < 0 ? 0 : cur_fslt - 1 ))
+  new_fslhc=$(( cur_fslhc - 1 < 0 ? 0 : cur_fslhc - 1 ))
+  if [ "$new_fslt" -ge "$interval" ]; then
+    new_testing="true"
+  else
+    new_testing="false"
+  fi
+  new_array=$(jq --arg name "$name" -c '
+    (.features_completed | (. | index($name)) as $i
+     | .[0:$i] + .[$i+1:])' "$BUILD_PROGRESS")
+
+  # Show preview
+  echo "Unrecord feature '$name'?"
+  echo ""
+  echo "Current state:"
+  echo "  features_completed: $cur_array"
+  echo "  features_since_last_test: $cur_fslt / $interval (testing_required: $cur_testing)"
+  echo "  features_since_last_health_check: $cur_fslhc"
+  echo ""
+  echo "After unrecord:"
+  echo "  features_completed: $new_array"
+  echo "  features_since_last_test: $new_fslt / $interval (testing_required: $new_testing)"
+  echo "  features_since_last_health_check: $new_fslhc"
+  echo ""
+
+  local confirm
+  read -rp "Proceed? [y/N]: " confirm
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    print_info "Unrecord cancelled."
+    exit 0
+  fi
+
+  # Apply
+  if ! _unrecord_feature_apply "$name"; then
+    print_fail "Unrecord failed — state unchanged"
+    exit 1
+  fi
+
+  # Audit log
+  local now
+  now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  local audit_entry="[UNRECORD] feature '$name' unrecorded at $now by $(whoami)"
+  mkdir -p .claude
+  echo "$audit_entry" >> ".claude/process-audit.log"
+
+  print_ok "Feature '$name' unrecorded"
+}
+
 reset_counter() {
   ensure_progress_file
 

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -32,14 +32,16 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
       --reset-counter)      ACTION="reset-counter";       shift ;;
       --reset-health-check) ACTION="reset-health-check"; shift ;;
       --record-feature)     ACTION="record-feature"; FEATURE_NAME="$2"; shift 2 ;;
+      --unrecord-feature)   ACTION="unrecord-feature"; FEATURE_NAME="$2"; shift 2 ;;
       --help|-h)
-        echo "Usage: scripts/test-gate.sh [--check-batch] [--check-phase-gate] [--reset-counter] [--record-feature NAME]"
+        echo "Usage: scripts/test-gate.sh [--check-batch] [--check-phase-gate] [--reset-counter] [--record-feature NAME] [--unrecord-feature NAME]"
         echo ""
         echo "Commands:"
-        echo "  --check-batch       Check if testing session is due (exit 0=continue, 1=testing required)"
-        echo "  --check-phase-gate  Check if Phase 2→3 transition is clear (exit 0=clear, 1=blocked, 2=warnings)"
-        echo "  --reset-counter     Reset feature counter after testing session completes"
-        echo "  --record-feature N  Record a completed feature and increment counter"
+        echo "  --check-batch         Check if testing session is due (exit 0=continue, 1=testing required)"
+        echo "  --check-phase-gate    Check if Phase 2→3 transition is clear (exit 0=clear, 1=blocked, 2=warnings)"
+        echo "  --reset-counter       Reset feature counter after testing session completes"
+        echo "  --record-feature N    Record a completed feature and increment counter"
+        echo "  --unrecord-feature N  Un-record a feature recorded in error (interactive; inverse of --record-feature)"
         exit 0
         ;;
       *)
@@ -435,6 +437,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     check-phase-gate)   check_phase_gate ;;
     reset-counter)      reset_counter ;;
     record-feature)     record_feature "$FEATURE_NAME" ;;
+    unrecord-feature)   unrecord_feature "$FEATURE_NAME" ;;
     reset-health-check)
       ensure_progress_file
       jq '.features_since_last_health_check = 0' "$BUILD_PROGRESS" > "$BUILD_PROGRESS.tmp" && mv "$BUILD_PROGRESS.tmp" "$BUILD_PROGRESS"

--- a/templates/generated/claude-md.tmpl
+++ b/templates/generated/claude-md.tmpl
@@ -170,6 +170,11 @@ At specific phases, adopt specialized personas for higher-quality output. Each p
 - **After each feature:** `scripts/test-gate.sh --record-feature "feature-name"`
 - **Gate enforcement:** Do NOT start the next feature until test-gate.sh --check-batch returns 0.
 - **Severity rules:** SEV-1 cannot be deferred. SEV-2 can be deferred during Phase 2 but must be resolved or feature removed at Phase 2→3 gate.
+- **Recovering from mistakes:**
+  - Un-record a wrongly-recorded feature: `scripts/test-gate.sh --unrecord-feature "name"` (interactive; fully inverses the `--record-feature` counters)
+  - Abort a started UAT session: `scripts/process-checklist.sh --reset uat_session` (interactive)
+  - Abort a started Build Loop: `scripts/process-checklist.sh --reset build_loop` (interactive)
+  - All three require terminal access and Y/N confirmation; each writes an audit entry to `.claude/process-audit.log`. These are **local-state fixes only** — if the state was committed, amend or revert the commit separately.
 
 ### Phase 2 Completion Checkpoint
 Before moving to Phase 3, verify:

--- a/tests/test-unrecord-feature.sh
+++ b/tests/test-unrecord-feature.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# tests/test-unrecord-feature.sh — unit tests for _unrecord_feature_apply()
+# Targets the pure state transform; interactive wrapper is manually verified.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Inline assertion helpers (zero-dependency; matches existing tests/*.sh pattern) ---
+
+PASSED=0
+FAILED=0
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="${3:-}"
+  if [ "$expected" != "$actual" ]; then
+    echo "  ASSERT FAIL${msg:+ [$msg]}: expected '$expected', got '$actual'" >&2
+    return 1
+  fi
+}
+
+assert_contains() {
+  local haystack="$1" needle="$2" msg="${3:-}"
+  if [[ "$haystack" != *"$needle"* ]]; then
+    echo "  ASSERT FAIL${msg:+ [$msg]}: '$haystack' does not contain '$needle'" >&2
+    return 1
+  fi
+}
+
+run_case() {
+  local name="$1"
+  shift
+  if ( set -e; "$@" ); then
+    echo "✓ $name"
+    PASSED=$((PASSED + 1))
+  else
+    echo "✗ $name FAILED"
+    FAILED=$((FAILED + 1))
+  fi
+}
+
+seed_progress() {
+  # Args: path, array-json, fslt, interval, testing_required, fslhc
+  local path="$1" arr="$2" fslt="$3" interval="$4" testing="$5" fslhc="$6"
+  cat > "$path" <<JSONEOF
+{
+  "features_completed": $arr,
+  "features_since_last_test": $fslt,
+  "test_interval": $interval,
+  "last_test_session": null,
+  "testing_required": $testing,
+  "tester_count": 1,
+  "bug_tracker": "github_issues",
+  "sessions_completed": 0,
+  "features_since_last_health_check": $fslhc
+}
+JSONEOF
+}
+
+# --- Source the script under test ---
+# Task 1's source guard prevents dispatch from running.
+source "$REPO_ROOT/scripts/test-gate.sh"
+
+# --- Test cases ---
+
+case_1_happy_path() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo"]' 1 2 false 1
+    _unrecord_feature_apply "foo"
+    assert_eq "[]" "$(jq -c '.features_completed' .claude/build-progress.json)" "array empty"
+    assert_eq "0" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt 0"
+    assert_eq "0" "$(jq -r '.features_since_last_health_check' .claude/build-progress.json)" "fslhc 0"
+    assert_eq "false" "$(jq -r '.testing_required' .claude/build-progress.json)" "testing_required false"
+  )
+}
+
+case_2_duplicates_first_match() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo","bar","foo"]' 3 2 true 3
+    _unrecord_feature_apply "foo"
+    assert_eq '["bar","foo"]' "$(jq -c '.features_completed' .claude/build-progress.json)" "first 'foo' removed, second preserved"
+  )
+}
+
+case_3_counter_floor_at_zero() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo"]' 0 2 false 0
+    _unrecord_feature_apply "foo"
+    assert_eq "0" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt stays 0"
+    assert_eq "0" "$(jq -r '.features_since_last_health_check' .claude/build-progress.json)" "fslhc stays 0"
+  )
+}
+
+case_4_testing_required_flips_false() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo","bar"]' 2 2 true 2
+    _unrecord_feature_apply "foo"
+    assert_eq "1" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt 1"
+    assert_eq "false" "$(jq -r '.testing_required' .claude/build-progress.json)" "testing_required now false"
+  )
+}
+
+case_5_testing_required_stays_true() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo","bar","baz"]' 3 2 true 3
+    _unrecord_feature_apply "foo"
+    assert_eq "2" "$(jq -r '.features_since_last_test' .claude/build-progress.json)" "fslt 2"
+    assert_eq "true" "$(jq -r '.testing_required' .claude/build-progress.json)" "testing_required stays true"
+  )
+}
+
+# --- Run all cases and report ---
+echo "═══ test-unrecord-feature.sh ═══"
+run_case "case 1: happy path"                     case_1_happy_path
+run_case "case 2: duplicates → first match"       case_2_duplicates_first_match
+run_case "case 3: counter floor at 0"             case_3_counter_floor_at_zero
+run_case "case 4: testing_required flips false"   case_4_testing_required_flips_false
+run_case "case 5: testing_required stays true"    case_5_testing_required_stays_true
+
+echo ""
+echo "═══════════════════════════════════════════"
+echo "Tests: $PASSED passed, $FAILED failed"
+echo "═══════════════════════════════════════════"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-unrecord-feature.sh
+++ b/tests/test-unrecord-feature.sh
@@ -134,6 +134,42 @@ case_5_testing_required_stays_true() {
   )
 }
 
+case_6_feature_not_found() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    mkdir -p .claude
+    seed_progress .claude/build-progress.json '["foo"]' 1 2 false 1
+    set +e
+    local output
+    output=$(_unrecord_feature_apply "bar" 2>&1)
+    local code=$?
+    set -e
+    assert_eq "1" "$code" "exit code 1 on not-found"
+    assert_contains "$output" "not found" "message mentions not found"
+    assert_contains "$output" "bar" "message mentions the specific name"
+  )
+}
+
+case_7_missing_progress_file() {
+  local work
+  work=$(mktemp -d)
+  trap "rm -rf '$work'" RETURN
+  (
+    cd "$work"
+    # No .claude directory, no build-progress.json
+    set +e
+    local output
+    output=$(_unrecord_feature_apply "anything" 2>&1)
+    local code=$?
+    set -e
+    assert_eq "1" "$code" "exit code 1 on missing file"
+    assert_contains "$output" "does not exist" "message mentions file missing"
+  )
+}
+
 # --- Run all cases and report ---
 echo "═══ test-unrecord-feature.sh ═══"
 run_case "case 1: happy path"                     case_1_happy_path
@@ -141,6 +177,8 @@ run_case "case 2: duplicates → first match"       case_2_duplicates_first_matc
 run_case "case 3: counter floor at 0"             case_3_counter_floor_at_zero
 run_case "case 4: testing_required flips false"   case_4_testing_required_flips_false
 run_case "case 5: testing_required stays true"    case_5_testing_required_stays_true
+run_case "case 6: feature not found"              case_6_feature_not_found
+run_case "case 7: missing build-progress.json"    case_7_missing_progress_file
 
 echo ""
 echo "═══════════════════════════════════════════"


### PR DESCRIPTION
## Summary

Implements BL-008 — sanctioned path to un-record a wrongly-recorded feature. Surfaced during the lancache Phase 2 audit (2026-04-22), where the user was about to correct via raw `jq` edit of `.claude/build-progress.json` because no command existed. Also documents existing `--reset uat_session` / `--reset build_loop` commands that were previously undocumented in CLAUDE.md's Testing & Bug Workflow section.

- **New command:** `scripts/test-gate.sh --unrecord-feature NAME`. Full inverse of `--record-feature`: removes first occurrence from `features_completed`, decrements both counters floored at 0, re-evaluates `testing_required`. Strict name matching (errors on not-found). Mirrors the existing `--reset <process>` safety envelope: interactive-terminal requirement, Y/N confirmation with state-change preview, audit-log entry `[UNRECORD] ...` appended to `.claude/process-audit.log`. Pure local-state fix — no git history awareness.
- **Wrapper/apply split:** `_unrecord_feature_apply()` is the pure state transform (no I/O beyond file read/write); `unrecord_feature()` is the interactive wrapper (tty guard + preview + Y/N + audit). The split enables unit testing of the logic without tty tricks.
- **Source-guard refactor to `test-gate.sh`:** wrapped the argument parser and dispatch in `if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then ... fi` so tests can source the file without triggering the "No action specified" exit. Function definitions remain at top level; behavior when run directly is unchanged.
- **Docs:** new "Recovering from mistakes" subsection in `templates/generated/claude-md.tmpl`'s Testing & Bug Workflow section, covering the new command plus existing `--reset uat_session` / `--reset build_loop`.
- **Tests:** `tests/test-unrecord-feature.sh` — 7 cases, all passing. Happy path, duplicate handling, counter-floor at 0, `testing_required` flipping false, `testing_required` staying true, feature-not-found, missing build-progress.json.

## Test Plan

- [x] `bash tests/test-unrecord-feature.sh` — 7/7 passing
- [x] `bash scripts/test-gate.sh --help` — shows new `--unrecord-feature` line, exit 0
- [x] `bash scripts/test-gate.sh --unrecord-feature NAME` piped (non-tty) — correctly fires the interactive-authorization guard with remediation hint, exit 1
- [x] End-to-end state transform + audit-log write verified via bash harness (seeded build-progress.json → sourced function → manual wrapper-equivalent audit append → assertions on post-state)
- [x] Source guard verified: `bash scripts/test-gate.sh` direct invocation still exits with "No action specified"; `source scripts/test-gate.sh` in bash works without exit
- [ ] **Before merge — manual interactive smoke test in a real terminal:**
  ```bash
  TESTPROJ=$(mktemp -d) && cd "$TESTPROJ" && mkdir -p .claude && cat > .claude/build-progress.json <<'JSON'
  {"features_completed":["alpha","beta","charlie"],"features_since_last_test":2,"test_interval":2,"last_test_session":null,"testing_required":true,"tester_count":1,"bug_tracker":"github_issues","sessions_completed":0,"features_since_last_health_check":3}
  JSON
  # From a terminal (not piped):
  bash /path/to/solo-orchestrator/scripts/test-gate.sh --unrecord-feature beta
  # Expect: preview shown, Y/N prompt. Accept 'y', verify state change + audit log.
  # Then: retry with does-not-exist name (expect not-found error + features list)
  # Then: retry with existing name and answer 'n' (expect "Unrecord cancelled.")
  cd / && rm -rf "$TESTPROJ"
  ```
- [ ] Review 6 commits for clean history, commit message quality, no unintended changes

## Spec decisions implemented

| # | Decision | Choice |
|---|----------|--------|
| 1 | Scope | New `--unrecord-feature` in test-gate.sh + document existing `--reset <process>` |
| 2 | Counter semantics | Full inverse of `--record-feature` |
| 3 | Name matching | Strict, first-match-wins on duplicates |
| 4 | Safety | Mirror `--reset <process>` pattern exactly |
| 5 | Git awareness | Pure local-state fix; documented limitation |
| 6 | Documentation | Scoped subsection in Testing & Bug Workflow |

## Related

- Backlog: closes BL-008 in `solo-orchestrator-backlog.md`
- Spec: `docs/superpowers/specs/2026-04-23-unrecord-feature-design.md`
- Plan: `docs/superpowers/plans/2026-04-23-unrecord-feature-implementation.md`
- Surfaced during: lancache project Phase 2 audit, 2026-04-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)