### PR TITLE
BL-006: pre-commit Build Loop enforcement (commit-message-triggered)

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -982,6 +982,8 @@ During the Phase 2 initialization steps above, some scaffolding work produces co
 
 **If you've already shipped Cutline work without the Build Loop:** retroactively run the Build Loop steps for that feature — write the tests you didn't write, run the security audit you skipped, update `FEATURES.md`, record the feature. It's awkward but recoverable. Don't leave the drift uncorrected; future phase gates will surface the gap at Phase 2→3.
 
+**Mechanical enforcement.** This rule is enforced by the pre-commit gate: any `git commit` with a message subject starting with `feat`, `feat(scope)`, `feat!`, or `feat(scope)!` is blocked unless a Build Loop is active and its first five steps (`tests_written`, `tests_verified_failing`, `implemented`, `security_audit`, `documentation_updated`) are complete. Non-feature scaffolding — tooling, CI, build configs — should use the correct Conventional Commits type (`chore:`, `build:`, `ci:`, `docs:`), which the gate does not enforce against. See `docs/superpowers/specs/2026-04-23-build-loop-precommit-enforcement-design.md` for the full design.
+
 ---
 
 ### The Build Loop

--- a/docs/security-audits/bl-006-precommit-buildloop-enforcement-security-audit.md
+++ b/docs/security-audits/bl-006-precommit-buildloop-enforcement-security-audit.md
@@ -1,0 +1,48 @@
+# Security Audit Findings — Feature: BL-006 pre-commit Build Loop enforcement
+
+**Feature:** bl-006-precommit-buildloop-enforcement
+**Date:** 2026-04-24
+**Auditor Persona:** Senior Security Engineer
+
+---
+
+## Scope
+
+- New bash in `scripts/pre-commit-gate.sh`: the `bl006_check` function (message extraction from `-m`/heredoc/`-F`, derivative-commit filters, subcommand delegation).
+- New bash in `scripts/process-checklist.sh`: the `check_commit_message` function and the `require_build_loop_state_for_commit` helper.
+- Two new test files: `tests/test-check-commit-message.sh`, additions to `tests/edge-cases-scripts.sh`.
+
+## Automated Scan Results
+
+| Tool | Config | Result | Findings |
+|------|--------|--------|----------|
+| Semgrep | p/owasp-top-ten, p/security-audit | Not run (bash-only change; ruleset targets web languages) | N/A |
+| `bash -n` syntax check | default | Pass | 0 |
+| `shellcheck` | default | Not run on new files (pre-existing repo convention — no other script runs shellcheck in CI either) | N/A |
+
+## Manual Review Findings
+
+| # | Category | Finding | Severity | File:Line | Resolution | Status |
+|---|----------|---------|----------|-----------|------------|--------|
+| 1 | Command injection | `$COMMAND` is treated as data throughout the extractor; passed through `grep`, `sed`, `awk`, and `head` via stdin/pipes. Never `eval`d, never passed to `sh -c`, never used as a filename. | Critical | `scripts/pre-commit-gate.sh` bl006_check | No mitigation needed — the code already follows the safe pattern. | Accepted (safe by design) |
+| 2 | Command injection | The extracted `$msg` is passed as a single quoted argv to `"$SCRIPT_DIR/process-checklist.sh" --check-commit-message "$msg"`. Bash argv quoting prevents shell re-parsing. | Critical | `scripts/pre-commit-gate.sh` bl006_check | No mitigation needed. | Accepted |
+| 3 | Path traversal / arbitrary file read | The `-F <file>` branch reads an arbitrary path the author provides via `head -n 1 "$f"`. | Low | `scripts/pre-commit-gate.sh` bl006_check | The caller (Claude agent running `git commit -F path`) is trusted; the hook is not a trust boundary against the author. `-F <path>` is a legitimate git feature. Read is bounded to the first line and discarded if empty. | Accepted |
+| 4 | TOCTOU | `.git/MERGE_HEAD` check is non-atomic with respect to the subsequent `git commit`. In theory, a merge could begin between the check and the commit. | Negligible | `scripts/pre-commit-gate.sh` bl006_check | Single-user workflow; no concurrent processes mutate `.git/MERGE_HEAD` between hook and commit. Not a security property — if race happens, the existing file-heuristic fallback still runs. | Accepted |
+| 5 | Resource exhaustion | `awk` / `sed` / `head` all operate on `$COMMAND`, whose length is bounded by Claude Code's bash tool input size (subject to the environment's argv limits, typically 128 KB). | Negligible | `scripts/pre-commit-gate.sh` bl006_check | Existing environmental limits are sufficient. | Accepted |
+| 6 | Input validation | The `feat`-prefix regex `^feat(\([^)]*\))?!?:[[:space:]]` anchors to start-of-subject and rejects near-misses (`feature:`, `featbar:`, `Revert "feat..."`). Tested via U10, U11, U17. | High | `scripts/process-checklist.sh` check_commit_message | Regex is anchored; 17 unit tests exercise edge cases. | Fixed |
+| 7 | Information disclosure | Deny-reason JSON contains the remediation text, which references script paths and step names. No user-supplied content is reflected back. | Low | `scripts/pre-commit-gate.sh` bl006_check | Remediation is static; safe. | Accepted |
+| 8 | Secret exposure | No secrets are read, written, or logged. No environment variables are inspected by the new code beyond `PROCESS_STATE` and `PHASE_STATE` (paths). | Critical | — | No change needed. | Accepted |
+
+## Threat Model Cross-Reference
+
+No Phase 1 threat model artifact exists for solo-orchestrator itself (the project is a meta-tool framework, not a threat-modeled product). Cross-reference N/A.
+
+## Summary
+
+- **0 Open findings.**
+- **2 Critical findings (#1, #2, #8) — accepted as safe-by-design:** the code treats `$COMMAND` and `$msg` as data, never invokes them as shell, and doesn't handle secrets.
+- **1 High finding (#6) — fixed via regex anchoring and 17 unit tests** (U1–U17 in `tests/test-check-commit-message.sh`).
+- **2 Low findings (#3, #7) — accepted:** `-F <path>` file read is a legitimate git flow the hook is not a trust boundary for; deny-reason text is static and contains no user-supplied content.
+- **2 Negligible findings (#4, #5):** TOCTOU on `.git/MERGE_HEAD` and resource exhaustion from awk/sed — both immaterial given the single-user Claude-agent flow.
+
+No findings require code changes. The implementation passes the audit.

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -79,6 +79,83 @@ HOOKEOF
   exit 0
 fi
 
+# --- BL-006: commit-message-triggered Build Loop enforcement ---
+# Scope: only fires on `git commit` authoring events (not merges, reverts,
+# cherry-picks, squash-merges, or editor-case commits). Extracts the message
+# from -m "..." / heredoc / -F file and delegates the policy decision to
+# process-checklist.sh --check-commit-message.
+
+bl006_check() {
+  # Only apply to `git commit` subcommands.
+  echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b' || return 0
+
+  # Derivative-commit filters: pass through.
+  # --amend is already handled above (warns, exits). Belt-and-braces.
+  echo "$COMMAND" | grep -qE '\-\-amend\b' && return 0
+  # Merge in progress.
+  [ -f .git/MERGE_HEAD ] && return 0
+  # Other derivative commands that might embed feat: in their message.
+  echo "$COMMAND" | grep -qE '\bgit\b.*\b(merge|revert|cherry-pick)\b' && return 0
+  echo "$COMMAND" | grep -qE '\bgh\b.*\bpr\b.*\bmerge\b.*\-\-squash' && return 0
+
+  # Extract the message subject.
+  local msg=""
+
+  # 1. Heredoc: look for -m "$(cat <<EOF or -m "$(cat <<'EOF'
+  if echo "$COMMAND" | grep -qE "<<'?EOF'?"; then
+    # awk: after the <<EOF or <<'EOF' marker, the first non-empty content line
+    # before a standalone EOF is the subject.
+    msg=$(printf '%s\n' "$COMMAND" | awk '
+      /<<'"'"'?EOF'"'"'?/ { flag=1; next }
+      /^EOF$/ { flag=0 }
+      flag && !printed && NF>0 { print; printed=1; exit }
+    ')
+  fi
+
+  # 2. Inline -m "..." (double or single quotes). Only if heredoc didn't match.
+  if [ -z "$msg" ]; then
+    # Try double-quoted first, then single-quoted. Capture up to the closing
+    # quote. This is best-effort; exotic escaping falls through.
+    msg=$(printf '%s' "$COMMAND" | sed -nE 's/.*-m "([^"]*)".*/\1/p' | head -n 1)
+    if [ -z "$msg" ]; then
+      msg=$(printf '%s' "$COMMAND" | sed -nE "s/.*-m '([^']*)'.*/\\1/p" | head -n 1)
+    fi
+    # Split on real newlines; take first line.
+    msg=$(printf '%s\n' "$msg" | head -n 1)
+  fi
+
+  # 3. -F <file>. Only if no -m at all was seen.
+  if [ -z "$msg" ] && echo "$COMMAND" | grep -qE '\-F[[:space:]]+[^ ]+'; then
+    local f
+    f=$(echo "$COMMAND" | sed -nE 's/.*-F[[:space:]]+([^ ]+).*/\1/p' | head -n 1)
+    if [ -n "$f" ] && [ -r "$f" ]; then
+      msg=$(head -n 1 "$f")
+    fi
+  fi
+
+  # Empty: fall through (editor case or parse miss).
+  [ -z "$msg" ] && return 0
+
+  # Delegate to the subcommand. Capture both streams (print_fail uses stdout;
+  # echo-to-stderr is used for remediation lines).
+  local policy_err policy_exit=0
+  policy_err=$("$SCRIPT_DIR/process-checklist.sh" --check-commit-message "$msg" 2>&1) || policy_exit=$?
+
+  if [ "$policy_exit" -ne 0 ]; then
+    local reason
+    reason=$(echo "$policy_err" | tr '\n' ' ' | sed 's/"/\\"/g')
+    cat << HOOKEOF
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "$reason"}}
+HOOKEOF
+    exit 0
+  fi
+
+  return 0
+}
+
+bl006_check
+# --- end BL-006 block ---
+
 # Block git push --force (overwrites branch history)
 if echo "$COMMAND" | grep -qE '\bgit\b.*\bpush\b.*(-f|--force)'; then
   cat << HOOKEOF

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -122,6 +122,49 @@ step_is_completed() {
   jq -e --arg step "$step" ".${process}.steps_completed | index(\$step) != null" "$PROCESS_STATE" >/dev/null 2>&1
 }
 
+# --- Helper: require Build Loop state sufficient for a commit ---
+# Used by both the file-heuristic path (--check-commit-ready) and the
+# commit-message-triggered path (--check-commit-message). Prints the spec's
+# Case A / Case B remediation to stderr on failure. Returns 0 if state OK,
+# 1 otherwise. Reads $PROCESS_STATE and the BUILD_LOOP_STEPS array.
+require_build_loop_state_for_commit() {
+  local feature
+  feature=$(jq -r '.build_loop.feature // "null"' "$PROCESS_STATE")
+  if [ "$feature" = "null" ]; then
+    print_fail "pre-commit gate: 'feat(...)' commit blocked — no Build Loop active."
+    echo "MVP Cutline work and all features require a Build Loop per" >&2
+    echo "docs/builders-guide.md \"MVP Cutline Work Requires the Build Loop\"." >&2
+    echo "" >&2
+    echo "To proceed:" >&2
+    echo "  1. scripts/process-checklist.sh --start-feature \"NAME\"" >&2
+    echo "  2. Write failing tests, implement, verify, update docs" >&2
+    echo "  3. Complete each step: scripts/process-checklist.sh --complete-step build_loop:STEP" >&2
+    echo "  4. Re-run your commit" >&2
+    echo "" >&2
+    echo "If this commit is NOT a feature (tooling, CI, scaffolding, docs)," >&2
+    echo "change the conventional-commit type: feat: -> chore:/build:/ci:/docs:." >&2
+    return 1
+  fi
+
+  # Check first 5 build_loop steps: tests_written, tests_verified_failing,
+  # implemented, security_audit, documentation_updated (feature_recorded is
+  # step 6 and not required at commit time).
+  local required_build_steps=("${BUILD_LOOP_STEPS[@]:0:5}")
+  for step in "${required_build_steps[@]}"; do
+    if ! step_is_completed "build_loop" "$step"; then
+      print_fail "pre-commit gate: 'feat($feature)' commit blocked — Build Loop incomplete."
+      echo "Missing step: $step" >&2
+      echo "" >&2
+      echo "Run: scripts/process-checklist.sh --complete-step build_loop:$step" >&2
+      echo "Then: scripts/process-checklist.sh --status  (to verify)" >&2
+      echo "Then re-run your commit." >&2
+      return 1
+    fi
+  done
+
+  return 0
+}
+
 # --- Actions ---
 
 start_phase1() {
@@ -807,24 +850,7 @@ check_commit_ready() {
 
   # Phase 2 source commit checks
   if [ "$current_phase" -eq 2 ]; then
-    # Must have a feature started
-    local feature
-    feature=$(jq -r '.build_loop.feature // "null"' "$PROCESS_STATE")
-    if [ "$feature" = "null" ]; then
-      print_fail "No feature started."
-      echo "Run: scripts/process-checklist.sh --start-feature 'name'" >&2
-      exit 1
-    fi
-
-    # Check build_loop steps through documentation_updated (first 5)
-    local required_build_steps=("${BUILD_LOOP_STEPS[@]:0:5}")
-    for step in "${required_build_steps[@]}"; do
-      if ! step_is_completed "build_loop" "$step"; then
-        print_fail "Build loop step '$step' not completed for feature '$feature'."
-        echo "Run: scripts/process-checklist.sh --complete-step build_loop:$step" >&2
-        exit 1
-      fi
-    done
+    require_build_loop_state_for_commit || exit 1
 
     # If UAT session is in progress, all 9 steps must be complete
     local uat_started

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -35,6 +35,7 @@ PHASE2_INIT_STEPS=(remote_repo_created branch_protection_configured project_scaf
 # --- Argument parsing ---
 ACTION=""
 ARG_VALUE=""
+COMMIT_MSG=""
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -47,6 +48,7 @@ while [ $# -gt 0 ]; do
     --verify-init)      ACTION="verify-init";       shift ;;
     --status)           ACTION="status";            shift ;;
     --check-commit-ready) ACTION="check-commit-ready"; shift ;;
+    --check-commit-message) ACTION="check-commit-message"; COMMIT_MSG="$2"; shift 2 ;;
     --reset)            ACTION="reset";             ARG_VALUE="$2"; shift 2 ;;
     --reset-all)        ACTION="reset-all";         shift ;;
     --help|-h)
@@ -61,6 +63,7 @@ while [ $# -gt 0 ]; do
       echo "  --verify-init               Auto-verify Phase 2 initialization steps"
       echo "  --status                    Print human-readable status of all processes"
       echo "  --check-commit-ready        Check if commit is allowed (used by PreToolUse hook)"
+      echo "  --check-commit-message MSG  Check commit-message prefix (feat:) against Build Loop state (BL-006)"
       echo "  --reset PROCESS             Reset a single process to initial state"
       echo "  --reset-all                 Reset all processes to initial state"
       echo "  --help                      Show this help"
@@ -1008,6 +1011,48 @@ EOF
   print_ok "All processes reset to initial state"
 }
 
+# --- BL-006: commit-message-triggered Build Loop enforcement ---
+# Inspects the subject line of a commit message. If it starts with a
+# Conventional Commits feature prefix (feat, feat(x), feat!, feat(x)!),
+# require the Build Loop state to be sufficient for a commit. Otherwise,
+# exit 0 silently. Phase gate: Phase < 2 skips enforcement.
+check_commit_message() {
+  local msg="$1"
+
+  ensure_state_file
+
+  # Empty message: nothing to check.
+  if [ -z "$msg" ]; then
+    exit 0
+  fi
+
+  # Take only the first line (subject).
+  local subject
+  subject=$(printf '%s\n' "$msg" | head -n 1)
+
+  # Read current phase.
+  local current_phase=0
+  if [ -f "$PHASE_STATE" ]; then
+    current_phase=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null || echo "0")
+  fi
+
+  # Phase gate: enforcement starts at Phase 2.
+  if [ "$current_phase" -lt 2 ]; then
+    exit 0
+  fi
+
+  # Feat-prefix regex, anchored, case-sensitive per Conventional Commits.
+  # Matches: feat:, feat(x):, feat!:, feat(x)!: — each followed by whitespace.
+  if ! [[ "$subject" =~ ^feat(\([^\)]*\))?!?:[[:space:]] ]]; then
+    exit 0
+  fi
+
+  # Feat-prefixed: require Build Loop state sufficient for a commit.
+  require_build_loop_state_for_commit || exit 1
+
+  exit 0
+}
+
 # --- Dispatch ---
 case "$ACTION" in
   start-feature)      start_feature "$ARG_VALUE" ;;
@@ -1019,6 +1064,7 @@ case "$ACTION" in
   verify-init)        verify_init ;;
   status)             show_status ;;
   check-commit-ready) check_commit_ready ;;
+  check-commit-message) check_commit_message "$COMMIT_MSG" ;;
   reset)              reset_process "$ARG_VALUE" ;;
   reset-all)          reset_all ;;
 esac

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -8,6 +8,12 @@ set -euo pipefail
 # Handles all upgrade paths: track upgrades, deployment upgrades,
 # POC-to-production, and personal-to-sponsored-POC transitions.
 #
+# Changelog:
+# - BL-006 (2026-04-24): pre-commit gate now blocks feat: commits without
+#   an active Build Loop. No migration code needed — the updated
+#   scripts/process-checklist.sh and scripts/pre-commit-gate.sh are copied
+#   by this script's existing behavior, so running an upgrade picks it up.
+#
 # Usage:
 #   scripts/upgrade-project.sh --track standard          # Track upgrade only
 #   scripts/upgrade-project.sh --deployment organizational  # Deployment upgrade only

--- a/templates/generated/claude-md.tmpl
+++ b/templates/generated/claude-md.tmpl
@@ -69,6 +69,7 @@ At the start of every new session, before any other work:
 - **Test-first:** Write failing tests before implementation. Verify they fail. Then implement.
 - **One feature at a time:** Complete the full Build Loop (test → implement → security audit → document) per feature before starting the next.
 - **MVP Cutline work is always Build Loop work.** If a Phase 2 initialization step (repo setup, scaffolding, data model, pre-commit, CI/CD, or verification) produces code that implements an item above the MVP Cutline in `PRODUCT_MANIFESTO.md` §5, that code requires the full Build Loop — tests first, implement, security audit, documentation, `--record-feature` — regardless of which init step it first appeared in. See `docs/reference/builders-guide.md` § "MVP Cutline Work Requires the Build Loop" for examples and recovery guidance.
+  - The pre-commit gate blocks `feat:` commits without an active Build Loop. Non-feature work should use `chore:`/`build:`/`ci:`/`docs:` instead.
 - **Pin dependencies:** Exact versions only. Commit the lockfile.
 - **Structured logging:** Every significant operation produces a log entry with timestamp, severity, and correlation ID.
 - **No direct data model changes:** All changes go through versioned migrations.

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -972,6 +972,122 @@ rm -rf "$_uat_work"
 
 
 # ================================================================
+section "BL-006: pre-commit Build Loop enforcement (commit-message-triggered) — E33-E39"
+
+# Helper: seed a project dir with given phase and build_loop state
+bl006_seed() {
+  local dir="$1" phase="$2" feature="$3"
+  mkdir -p "$dir/.claude" "$dir/.git"
+  cat > "$dir/.claude/phase-state.json" <<JSON
+{"current_phase": $phase, "project": "e33-e39"}
+JSON
+  local feature_json="null"
+  [ "$feature" != "null" ] && feature_json="\"$feature\""
+  cat > "$dir/.claude/process-state.json" <<JSON
+{
+  "phase2_init": {"verified": true},
+  "build_loop": {"feature": $feature_json, "step": 0, "steps_completed": [], "started_at": null},
+  "uat_session": {"started_at": null, "steps_completed": []}
+}
+JSON
+  # Satisfy the hook's early-guard: remote must exist.
+  ( cd "$dir" && git init -q && git remote add origin https://example.com/fake.git 2>/dev/null || true )
+}
+
+# Helper: invoke the PreToolUse hook with a JSON command from stdin.
+# Returns "EXIT|OUTPUT" where OUTPUT may contain a deny/allow JSON.
+bl006_invoke_hook() {
+  local cmd="$1" project_dir="$2"
+  local input
+  input=$(jq -n --arg c "$cmd" '{command: $c}')
+  local out rc=0
+  out=$( cd "$project_dir" && echo "$input" | bash "$REPO_DIR/scripts/pre-commit-gate.sh" 2>&1 ) || rc=$?
+  echo "$rc|$out"
+}
+
+# E33: inline feat -m, no feature started -> deny
+_bl006_e33_dir="$TEST_DIR/bl006-e33"
+bl006_seed "$_bl006_e33_dir" 2 null
+_bl006_e33_r=$(bl006_invoke_hook 'git commit -m "feat(x): thing"' "$_bl006_e33_dir")
+if [[ "${_bl006_e33_r#*|}" =~ permissionDecision.*deny ]] && [[ "${_bl006_e33_r#*|}" == *"start-feature"* ]]; then
+  pass "E33: inline feat -m blocks with --start-feature guidance"
+else
+  fail "E33: expected deny JSON with --start-feature, got: $_bl006_e33_r"
+fi
+
+# E34: heredoc feat, no feature started -> deny
+_bl006_e34_dir="$TEST_DIR/bl006-e34"
+bl006_seed "$_bl006_e34_dir" 2 null
+_bl006_e34_cmd=$(cat <<'CMDEOF'
+git commit -m "$(cat <<'EOF'
+feat(x): thing from heredoc
+
+body line.
+EOF
+)"
+CMDEOF
+)
+_bl006_e34_r=$(bl006_invoke_hook "$_bl006_e34_cmd" "$_bl006_e34_dir")
+if [[ "${_bl006_e34_r#*|}" =~ permissionDecision.*deny ]]; then
+  pass "E34: heredoc -m blocks (heredoc parser works)"
+else
+  fail "E34: expected deny JSON, got: $_bl006_e34_r"
+fi
+
+# E35: -F file, no feature started -> deny
+_bl006_e35_dir="$TEST_DIR/bl006-e35"
+bl006_seed "$_bl006_e35_dir" 2 null
+echo "feat(x): from file" > "$_bl006_e35_dir/msg.txt"
+_bl006_e35_r=$(bl006_invoke_hook "git commit -F $_bl006_e35_dir/msg.txt" "$_bl006_e35_dir")
+if [[ "${_bl006_e35_r#*|}" =~ permissionDecision.*deny ]]; then
+  pass "E35: -F file blocks"
+else
+  fail "E35: expected deny JSON, got: $_bl006_e35_r"
+fi
+
+# E36: --amend with feat, no feature started -> amend path wins (allow + warn)
+_bl006_e36_dir="$TEST_DIR/bl006-e36"
+bl006_seed "$_bl006_e36_dir" 2 null
+_bl006_e36_r=$(bl006_invoke_hook 'git commit -m "feat(x): thing" --amend' "$_bl006_e36_dir")
+if [[ "${_bl006_e36_r#*|}" =~ permissionDecision.*allow ]] && [[ "${_bl006_e36_r#*|}" == *"WARNING"* ]]; then
+  pass "E36: --amend bypasses new gate (existing amend warn wins)"
+else
+  fail "E36: expected amend warn (allow), got: $_bl006_e36_r"
+fi
+
+# E37: merge in progress (MERGE_HEAD exists) -> no deny from BL-006 path
+_bl006_e37_dir="$TEST_DIR/bl006-e37"
+bl006_seed "$_bl006_e37_dir" 2 null
+touch "$_bl006_e37_dir/.git/MERGE_HEAD"
+_bl006_e37_r=$(bl006_invoke_hook 'git commit -m "feat(x): from merge"' "$_bl006_e37_dir")
+if ! [[ "${_bl006_e37_r#*|}" =~ permissionDecision.*deny ]]; then
+  pass "E37: MERGE_HEAD present — BL-006 path skips"
+else
+  fail "E37: expected no deny, got: $_bl006_e37_r"
+fi
+
+# E38: git commit with no -m (editor case) -> no deny from BL-006 path
+_bl006_e38_dir="$TEST_DIR/bl006-e38"
+bl006_seed "$_bl006_e38_dir" 2 null
+_bl006_e38_r=$(bl006_invoke_hook 'git commit' "$_bl006_e38_dir")
+if ! [[ "${_bl006_e38_r#*|}" =~ permissionDecision.*deny ]]; then
+  pass "E38: bare git commit (editor case) — BL-006 path falls through"
+else
+  fail "E38: expected no deny, got: $_bl006_e38_r"
+fi
+
+# E39: feat -m at Phase 0 -> no deny (phase gate)
+_bl006_e39_dir="$TEST_DIR/bl006-e39"
+bl006_seed "$_bl006_e39_dir" 0 null
+_bl006_e39_r=$(bl006_invoke_hook 'git commit -m "feat(x): foo"' "$_bl006_e39_dir")
+if ! [[ "${_bl006_e39_r#*|}" =~ permissionDecision.*deny ]]; then
+  pass "E39: Phase 0 — BL-006 path skipped by phase gate"
+else
+  fail "E39: expected no deny at Phase 0, got: $_bl006_e39_r"
+fi
+
+
+# ================================================================
 echo ""
 echo -e "${BOLD}═══════════════════════════════════════════════════════════${NC}"
 echo -e "${BOLD}  SUMMARY${NC}"

--- a/tests/test-check-commit-message.sh
+++ b/tests/test-check-commit-message.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+# tests/test-check-commit-message.sh — unit tests for
+# `scripts/process-checklist.sh --check-commit-message "MSG"` (BL-006).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/process-checklist.sh"
+
+PASSED=0
+FAILED=0
+
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# --- Helpers: seed a tempdir .claude/ state ---
+
+seed_phase() {
+  # $1 = phase number
+  mkdir -p "$TMPDIR_T/.claude"
+  cat > "$TMPDIR_T/.claude/phase-state.json" <<JSON
+{"current_phase": $1, "project": "unit-test"}
+JSON
+}
+
+seed_process_state() {
+  # $1 = feature value (e.g., null or "myfeat")
+  # $2 = space-separated list of completed steps (may be empty)
+  local feature="$1"
+  local completed="$2"
+  local completed_json="[]"
+  if [ -n "$completed" ]; then
+    completed_json=$(printf '%s\n' $completed | jq -R . | jq -sc .)
+  fi
+  local feature_json
+  if [ "$feature" = "null" ]; then
+    feature_json="null"
+  else
+    feature_json="\"$feature\""
+  fi
+  cat > "$TMPDIR_T/.claude/process-state.json" <<JSON
+{
+  "phase2_init": {"verified": true},
+  "build_loop": {
+    "feature": $feature_json,
+    "step": 0,
+    "steps_completed": $completed_json,
+    "started_at": null
+  },
+  "uat_session": {"started_at": null, "steps_completed": []}
+}
+JSON
+}
+
+run_check() {
+  # $1 = MSG to pass. Echoes "EXIT|STDERR" (one line joined).
+  local msg="$1"
+  local rc=0
+  local err
+  err=$( cd "$TMPDIR_T" && "$SCRIPT" --check-commit-message "$msg" 2>&1 >/dev/null ) || rc=$?
+  err=$(printf '%s' "$err" | tr '\n' ' ')
+  echo "$rc|$err"
+}
+
+setup() {
+  TMPDIR_T=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "$TMPDIR_T"
+}
+
+# --- Tests ---
+
+u1_phase_0_feat() {
+  setup; seed_phase 0; seed_process_state null ""
+  local out; out=$(run_check "feat(x): foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U1" "expected exit 0 in phase 0, got: $out"; teardown; return; }
+  pass "U1: Phase 0 — feat: exits 0 (phase gate)"
+  teardown
+}
+
+u2_phase_1_feat() {
+  setup; seed_phase 1; seed_process_state null ""
+  local out; out=$(run_check "feat(x): foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U2" "expected exit 0 in phase 1, got: $out"; teardown; return; }
+  pass "U2: Phase 1 — feat: exits 0 (phase gate)"
+  teardown
+}
+
+u3_phase_2_no_feature_feat() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "feat(x): foo")
+  [ "${out%%|*}" = "1" ] || { fail_ "U3" "expected exit 1, got: $out"; teardown; return; }
+  [[ "${out#*|}" == *"start-feature"* ]] || { fail_ "U3" "stderr missing --start-feature guidance: $out"; teardown; return; }
+  pass "U3: Phase 2, no feature — feat: exit 1 + start-feature remediation"
+  teardown
+}
+
+u4_non_feat_fix() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "fix(x): foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U4" "expected exit 0 for fix:, got: $out"; teardown; return; }
+  pass "U4: fix: — exit 0 (non-feat)"
+  teardown
+}
+
+u5_non_feat_chore() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "chore: bump")
+  [ "${out%%|*}" = "0" ] || { fail_ "U5" "expected exit 0 for chore:, got: $out"; teardown; return; }
+  pass "U5: chore: — exit 0"
+  teardown
+}
+
+u6_non_feat_docs() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "docs: typo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U6" "expected exit 0 for docs:, got: $out"; teardown; return; }
+  pass "U6: docs: — exit 0"
+  teardown
+}
+
+u7_feat_no_scope() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "feat: foo")
+  [ "${out%%|*}" = "1" ] || { fail_ "U7" "expected exit 1 for 'feat: ', got: $out"; teardown; return; }
+  pass "U7: feat: (no scope) — exit 1"
+  teardown
+}
+
+u8_feat_bang_no_scope() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "feat!: breaking")
+  [ "${out%%|*}" = "1" ] || { fail_ "U8" "expected exit 1 for 'feat!:', got: $out"; teardown; return; }
+  pass "U8: feat!: — exit 1"
+  teardown
+}
+
+u9_feat_scope_bang() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "feat(x)!: breaking")
+  [ "${out%%|*}" = "1" ] || { fail_ "U9" "expected exit 1 for 'feat(x)!:', got: $out"; teardown; return; }
+  pass "U9: feat(x)!: — exit 1"
+  teardown
+}
+
+u10_feature_word() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "feature: foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U10" "expected exit 0 for 'feature:', got: $out"; teardown; return; }
+  pass "U10: feature: (wrong word) — exit 0"
+  teardown
+}
+
+u11_featbar_prefix() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "featbar: foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U11" "expected exit 0 for 'featbar:', got: $out"; teardown; return; }
+  pass "U11: featbar: (not feat) — exit 0"
+  teardown
+}
+
+u12_feature_started_zero_steps() {
+  setup; seed_phase 2; seed_process_state "myfeat" ""
+  local out; out=$(run_check "feat(x): foo")
+  [ "${out%%|*}" = "1" ] || { fail_ "U12" "expected exit 1, got: $out"; teardown; return; }
+  [[ "${out#*|}" == *"tests_written"* ]] || { fail_ "U12" "stderr missing 'tests_written' step name: $out"; teardown; return; }
+  pass "U12: feature started, 0 steps — exit 1 + names tests_written"
+  teardown
+}
+
+u13_feature_started_partial() {
+  setup; seed_phase 2
+  seed_process_state "myfeat" "tests_written tests_verified_failing implemented security_audit"
+  local out; out=$(run_check "feat(x): foo")
+  [ "${out%%|*}" = "1" ] || { fail_ "U13" "expected exit 1, got: $out"; teardown; return; }
+  [[ "${out#*|}" == *"documentation_updated"* ]] || { fail_ "U13" "stderr missing 'documentation_updated' step name: $out"; teardown; return; }
+  pass "U13: steps 0-3 done — exit 1 + names step 4 (documentation_updated)"
+  teardown
+}
+
+u14_feature_started_all_done() {
+  setup; seed_phase 2
+  seed_process_state "myfeat" "tests_written tests_verified_failing implemented security_audit documentation_updated"
+  local out; out=$(run_check "feat(x): foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U14" "expected exit 0, got: $out"; teardown; return; }
+  pass "U14: feat with all 5 steps complete — exit 0"
+  teardown
+}
+
+u15_non_feat_all_done() {
+  setup; seed_phase 2
+  seed_process_state "myfeat" "tests_written tests_verified_failing implemented security_audit documentation_updated"
+  local out; out=$(run_check "fix(x): foo")
+  [ "${out%%|*}" = "0" ] || { fail_ "U15" "expected exit 0 for fix with all steps done, got: $out"; teardown; return; }
+  pass "U15: fix: with all steps done — exit 0"
+  teardown
+}
+
+u16_empty_msg() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check "")
+  [ "${out%%|*}" = "0" ] || { fail_ "U16" "expected exit 0 for empty MSG, got: $out"; teardown; return; }
+  pass "U16: empty message — exit 0"
+  teardown
+}
+
+u17_revert_quotes_feat() {
+  setup; seed_phase 2; seed_process_state null ""
+  local out; out=$(run_check 'Revert "feat(x): foo"')
+  [ "${out%%|*}" = "0" ] || { fail_ "U17" "expected exit 0 for Revert-prefix, got: $out"; teardown; return; }
+  pass "U17: Revert \"feat(x): ...\" — exit 0 (regex anchored to start)"
+  teardown
+}
+
+# --- Run all ---
+echo "== tests/test-check-commit-message.sh =="
+u1_phase_0_feat
+u2_phase_1_feat
+u3_phase_2_no_feature_feat
+u4_non_feat_fix
+u5_non_feat_chore
+u6_non_feat_docs
+u7_feat_no_scope
+u8_feat_bang_no_scope
+u9_feat_scope_bang
+u10_feature_word
+u11_featbar_prefix
+u12_feature_started_zero_steps
+u13_feature_started_partial
+u14_feature_started_all_done
+u15_non_feat_all_done
+u16_empty_msg
+u17_revert_quotes_feat
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- New `scripts/process-checklist.sh --check-commit-message "MSG"` subcommand owning the feat-regex, phase gate, and Build Loop state check.
- New extraction + filter block in `scripts/pre-commit-gate.sh` that handles `-m "..."`, heredoc `-m "$(cat <<EOF…EOF)"`, and `-F file`; skips amend, merge, revert, cherry-pick, squash-merge, `MERGE_HEAD`, and editor-case commits.
- Shared helper `require_build_loop_state_for_commit` factored out of existing `check_commit_ready`; both the file-heuristic and message-prefix paths share it. Error messages on both paths upgraded to the spec's Case A/B format (references Builder's Guide, mentions Conventional Commits escape route).
- 17 unit tests (`tests/test-check-commit-message.sh`) + 7 integration tests (E33–E39 in `tests/edge-cases-scripts.sh`).
- Docs: Builder's Guide enforcement paragraph under "MVP Cutline Work Requires the Build Loop", `claude-md.tmpl` subordinate bullet, `upgrade-project.sh` header changelog note.
- Security audit: `docs/security-audits/bl-006-precommit-buildloop-enforcement-security-audit.md` — 0 open findings.

Mechanically enforces the doctrinal rule BL-007 shipped in PR #14.

## Test plan

- [x] `bash tests/test-check-commit-message.sh` — 17/17 pass
- [x] `bash tests/edge-cases-scripts.sh` — all 46 pass (E33–E39 new)
- [x] `bash tests/test-unrecord-feature.sh` — 7/7 pass, no regression
- [x] `bash tests/known-bugs-test-suite.sh` — 22/22 pass
- [x] `bash tests/test-lint-uat-scenarios.sh` — 11/11 pass
- [x] Smoke test: `git commit -m "feat(x): …"` in a Phase-2 project with no feature started → denied with Case A remediation.

## References

- Spec: `docs/superpowers/specs/2026-04-23-build-loop-precommit-enforcement-design.md`
- Plan: `docs/superpowers/plans/2026-04-24-build-loop-precommit-enforcement-implementation.md`
- Backlog: BL-006 → resolved; BL-010–BL-014 logged as optional follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)