### PR TITLE
UAT 2026-04-25 Batch 2 (small) — EOF guard, framework-self guard, init.sh fake-remote tolerance

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1687,7 +1687,21 @@ Framework: Solo Orchestrator v1.0"
   # intake-wizard.sh). If absent, prompts inline. Creates remote, registers
   # origin, pushes initial commit, configures branch protection, verifies.
   # Writes host/mode/remote_url to .claude/manifest.json.
-  create_and_protect_remote
+  #
+  # UAT 2026-04-25 fix (U-B): if remote creation fails (push to fake URL,
+  # missing CLI, API 403, etc.) DO NOT abort init.sh via set -e. Continue
+  # to verify-install + print_next_steps so the project is still usable
+  # and the orchestrator gets clear remediation guidance via check-gate.sh.
+  if ! create_and_protect_remote; then
+    echo ""
+    print_warn "Remote setup did not complete cleanly."
+    print_info "Project files are in place; remote push/protection is the gap."
+    print_info "Remediate when ready:"
+    print_info "  scripts/check-gate.sh --backfill-host    # if .claude/manifest.json lacks 'host'"
+    print_info "  scripts/check-gate.sh --repair           # to re-create remote and protection"
+    print_info "  scripts/check-gate.sh --preflight        # to verify the remote is correctly set up"
+    echo ""
+  fi
 
   echo ""
   print_ok "Project created at $PROJECT_DIR"

--- a/init.sh
+++ b/init.sh
@@ -2567,6 +2567,14 @@ main() {
 
   print_header "$VERSION"
 
+  # UAT 2026-04-25 fix (U-N): refuse to scaffold a project inside the
+  # framework repo itself. (--dry-run is allowed for inspection.)
+  if [ "$DRY_RUN" != true ]; then
+    if ! guard_not_in_framework; then
+      exit 1
+    fi
+  fi
+
   if [ "$DRY_RUN" = true ]; then
     echo -e "${YELLOW}${BOLD}DRY RUN MODE — no changes will be made${NC}"
     echo ""

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -12,6 +12,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/helpers.sh"
 
+# UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
+# (Note: U-G — PROJECT_ROOT being hardcoded to framework even when invoked
+# from a project — is a separate bug deferred to Batch 3.)
+guard_not_in_framework || exit 1
+
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 PROGRESS_FILE="$PROJECT_ROOT/.claude/intake-progress.json"
 INTAKE_FILE="$PROJECT_ROOT/PROJECT_INTAKE.md"

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -152,6 +152,18 @@ prompt_input() {
 
 # Prompt for a numbered choice from a list of options.
 # Usage: result=$(prompt_choice "Pick one:" "option1" "option2" "option3")
+#
+# UAT 2026-04-25 fix (agent 12): EOF guard. The original loop had no exit
+# condition for stdin EOF — `read` returns non-zero on EOF, but the loop
+# kept retrying and re-printing "Invalid choice", spinning the CPU and
+# producing megabytes of output until killed. Affected ANY scripted
+# invocation of init.sh (or any caller of prompt_choice) when canned
+# answers were under-fed.
+#
+# Fix: detect read's non-zero return (EOF). On EOF, print a clear failure
+# to stderr and return 1 (caller can decide whether to abort or default).
+# Bonus: cap retries at 100 so even a malformed-but-non-EOF input stream
+# doesn't burn forever.
 prompt_choice() {
   local prompt="$1"
   shift
@@ -161,14 +173,24 @@ prompt_choice() {
     echo "  $((i+1)). ${options[$i]}" >&2
   done
   local choice
-  while true; do
-    read -rp "$(echo -e "${BOLD}Select [1-${#options[@]}]${NC}: ")" choice
+  local retries=0
+  local max_retries=100
+  while [ "$retries" -lt "$max_retries" ]; do
+    if ! read -rp "$(echo -e "${BOLD}Select [1-${#options[@]}]${NC}: ")" choice; then
+      echo "" >&2
+      echo "  prompt_choice: stdin closed (EOF) before a valid choice was supplied." >&2
+      echo "  This usually means a scripted/heredoc invocation under-fed the prompt." >&2
+      return 1
+    fi
     if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
       echo "${options[$((choice-1))]}"
-      return
+      return 0
     fi
     echo "  Invalid choice. Enter a number between 1 and ${#options[@]}." >&2
+    retries=$((retries + 1))
   done
+  echo "  prompt_choice: $max_retries invalid attempts; aborting to prevent loop." >&2
+  return 1
 }
 
 # Prompt user to install a missing tool. Returns 0 if installed, 1 if skipped.

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -150,6 +150,42 @@ prompt_input() {
   fi
 }
 
+# Refuse to operate as a project if cwd is the Solo Orchestrator framework
+# repo itself. Every project-targeted script (init.sh, verify-install.sh,
+# process-checklist.sh, upgrade-project.sh, intake-wizard.sh,
+# pending-approval.sh) must call this BEFORE any file writes.
+#
+# UAT 2026-04-25 fix (U-N + U-O): a UAT agent's cwd was the framework dir
+# (instead of their tempdir), so verify-install.sh + indirectly CDF init
+# scattered .claude/, .claude-backup/, gates/, hooks/, rules/, and
+# APPROVAL_LOG.md into the framework root. None tracked, but contaminates
+# the workspace and can sneak into commits.
+#
+# Detection signature: the framework has a top-level init.sh whose header
+# contains "Solo Orchestrator — Project Initialization Script" — a string
+# that's specific to this framework and won't appear in arbitrary projects'
+# init.sh files. Also check for templates/generated/ to triple-confirm.
+guard_not_in_framework() {
+  local cwd
+  cwd="$(pwd)"
+  if [ -f "$cwd/init.sh" ] \
+     && grep -q "Solo Orchestrator — Project Initialization Script" "$cwd/init.sh" 2>/dev/null \
+     && [ -d "$cwd/templates/generated" ]; then
+    print_fail "Refusing to operate inside the Solo Orchestrator framework repo."
+    echo "  Detected framework signature at: $cwd" >&2
+    echo "" >&2
+    echo "  This script targets a project, not the framework itself." >&2
+    echo "  Move to your project directory and re-run:" >&2
+    echo "    cd /path/to/your-project" >&2
+    echo "" >&2
+    echo "  If this directory IS your project (i.e., you cloned solo-orchestrator" >&2
+    echo "  AS a project), the framework is mis-installed — clone solo-orchestrator" >&2
+    echo "  separately and run init.sh from inside an empty project directory." >&2
+    return 1
+  fi
+  return 0
+}
+
 # Prompt for a numbered choice from a list of options.
 # Usage: result=$(prompt_choice "Pick one:" "option1" "option2" "option3")
 #

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -152,6 +152,9 @@ if ! command -v python3 &>/dev/null; then
   exit 1
 fi
 
+# UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
+guard_not_in_framework || exit 1
+
 # --- BL-015 pending-approval sentinel respect (UAT 2026-04-25 fix C5) ---
 # If the agent has offered structured options to the user via
 # scripts/pending-approval.sh, refuse to advance an irreversible upgrade.

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -14,6 +14,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/helpers.sh"
 
+# UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
+# verify-install.sh's auto-create-stub-artifacts behavior was the root cause
+# of the framework-self-contamination incident.
+guard_not_in_framework || exit 1
+
 # --- Parse arguments ---
 MODE="interactive"  # interactive | check-only | auto-fix
 while [ $# -gt 0 ]; do


### PR DESCRIPTION
## Summary

Three small UAT-driven fixes following PR #17 (5 critical fixes). Each is independent, well-bounded, and ships with zero new dependencies.

## Fixes

| Commit | Fix | Triage ID | Confirmations |
|---|---|---|---|
| `b206ed4` | `prompt_choice` EOF guard — no more infinite-CPU loop on stdin EOF (max 100 retries + EOF detection) | (UAT) | agent 12 (11.4MB of "Invalid choice" output before SIGKILL) |
| `b57f560` | New `helpers.sh::guard_not_in_framework` + wired into `init.sh::main`, `verify-install.sh`, `upgrade-project.sh`, `intake-wizard.sh`. Refuses to operate when cwd matches the framework signature. | U-N + U-O | post-PR-#17 cleanup discovery |
| `2402c56` | `init.sh` tolerates `create_and_protect_remote` failure — wraps the call in `if !`, prints check-gate.sh remediation, continues to verify-install + print_next_steps. | U-B | agents 1, 14, 78, 80, 9 |

## Test results

- `tests/test-pending-approval.sh` — 17/17
- `tests/test-check-commit-message.sh` — 18/18
- `tests/edge-cases-scripts.sh` — 54/54
- `tests/test-unrecord-feature.sh` — 7/7
- `tests/known-bugs-test-suite.sh` — 22/22
- `tests/test-lint-uat-scenarios.sh` — 11/11

Smoke-tests for both new behaviors (EOF guard fires correctly; framework guard fires inside framework, passes outside).

## Skipped (deferred to later batches per triage plan)

- **U-A** (init.sh `--non-interactive` mode) — own PR after this lands; needs full brainstorm/spec/plan because it's a feature, not a fix (~15 input flags, prompt-flow refactor).
- **U-G** (intake-wizard.sh PROJECT_ROOT hardcoded to framework dir) — Batch 3.
- **U-D** (no script advances current_phase) — Batch 3.
- **U-K, U-L, U-I, U-J, U-M** — Batch 3 cleanup.
- **U-C** (BL-006 bypass via direct shell) — Batch 4 (BL-010 commit-msg git hook).

## References

- Triage: `Reports/uat-2026-04-25/TRIAGE.md` (incl. addendum for U-N/O)
- Per-agent reports: `Reports/uat-2026-04-25/results/agent-*.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)