### PR TITLE
fix(init): non-interactive TEST_INTERVAL default + E56 regression test

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3041,6 +3041,12 @@ collect_inputs_non_interactive() {
   BRANCH_PROTECTION_ATTESTED="$ARG_BRANCH_PROTECTION_ATTESTED"
   ALLOW_EXISTING_DIR="$ARG_ALLOW_EXISTING_DIR"
 
+  # The interactive language_prompt() sets TEST_INTERVAL=2 mid-flow; the
+  # non-interactive driver bypasses that prompt, so set the same default
+  # here. Consumed at line ~1582 (build-progress.json heredoc) and ~2012
+  # (template substitution) under set -u.
+  TEST_INTERVAL=2
+
   if [ "$VALIDATE_ONLY" = true ]; then
     # Build the resolved JSON via jq for proper escaping.
     jq -n \

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1204,7 +1204,7 @@ fi
 
 
 # ================================================================
-section "BL-016: init.sh non-interactive mode — E48-E55"
+section "BL-016: init.sh non-interactive mode — E48-E56"
 
 INIT_SH="$REPO_DIR/init.sh"
 
@@ -1316,6 +1316,39 @@ if [ "$_e55_first_rc" = "1" ] && [ "$_e55_second_rc" = "0" ]; then
   pass "E55: existing dir without --allow-existing-dir fails; with the flag succeeds"
 else
   fail "E55: expected first run to fail and second to succeed; got first=$_e55_first_rc second=$_e55_second_rc"
+fi
+
+# E56: real (non-validate-only) end-to-end run completes the file-write path.
+# Regression guard for the TEST_INTERVAL unbound-variable bug surfaced by the
+# 2026-04-26 UAT sweep. Drives init.sh through .claude/build-progress.json
+# generation (line 1577 heredoc) and template substitution (line 2012), both
+# of which read $TEST_INTERVAL. Uses --git-host other so no real CLI/API call
+# is made; the push to a fake URL fails by design and PR #18's tolerance
+# allows init to continue past it.
+_e56_dir="$TEST_DIR/e56"
+mkdir -p "$_e56_dir"
+_e56_proj="$_e56_dir/uat-e56"
+_e56_rc=0
+(cd "$_e56_dir" && "$INIT_SH" --non-interactive \
+  --project uat-e56 --platform web --deployment personal --language typescript \
+  --project-dir "$_e56_proj" \
+  --git-host other --remote-url https://example.com/fake.git \
+  --branch-protection-attested >/dev/null 2>&1) || _e56_rc=$?
+_e56_test_interval=""
+if [ -f "$_e56_proj/.claude/build-progress.json" ]; then
+  _e56_test_interval=$(jq -r '.test_interval // empty' "$_e56_proj/.claude/build-progress.json" 2>/dev/null || echo "")
+fi
+if [ "$_e56_rc" = "0" ] && \
+   [ -f "$_e56_proj/CLAUDE.md" ] && \
+   [ -f "$_e56_proj/APPROVAL_LOG.md" ] && \
+   [ -f "$_e56_proj/.gitignore" ] && \
+   [ -f "$_e56_proj/.github/workflows/ci.yml" ] && \
+   [ -f "$_e56_proj/.claude/build-progress.json" ] && \
+   [ -f "$_e56_proj/.claude/process-state.json" ] && \
+   [ "$_e56_test_interval" = "2" ]; then
+  pass "E56: --non-interactive end-to-end writes all project files (TEST_INTERVAL regression guard)"
+else
+  fail "E56: end-to-end run incomplete (rc=$_e56_rc, test_interval='$_e56_test_interval'). Missing one or more of: CLAUDE.md, APPROVAL_LOG.md, .gitignore, .github/workflows/ci.yml, .claude/build-progress.json, .claude/process-state.json"
 fi
 
 


### PR DESCRIPTION
## Summary

- Fixes Critical regression in PR #19 (BL-016): `init.sh --non-interactive` crashed under `set -u` at line 1582 on `TEST_INTERVAL: unbound variable`, leaving every non-interactive project skeleton half-built.
- Root cause: `TEST_INTERVAL=2` is assigned inside the interactive `language_prompt()` flow (init.sh:494). The non-interactive driver bypasses that prompt and never sets the variable. Lines 1582 (build-progress.json heredoc) and 2012 (template substitution) read `$TEST_INTERVAL` unconditionally.
- Fix: one-line default in `collect_inputs_non_interactive()` immediately after the global-variable assignment block. Same default value (2) as the interactive path.
- Adds E56 integration test that drives a real `--non-interactive` end-to-end (not `--validate-only`), proves the bug is caught, and guards against future regression.

## Why E56 is the right shape

The 26 unit tests + 8 existing integration tests (E48–E55) all use `--validate-only`, which returns before reaching line 1582. That's why the bug shipped — no test exercised the file-write path. E56 uses `--git-host=other --remote-url=https://example.com/fake.git --branch-protection-attested` so it walks the full file-generation block without making real network calls; PR #18's fake-remote tolerance lets init complete past the synthetic push failure.

## Surfaced by

The 2026-04-26 UAT regression sweep — agents 1, 2, 3 (base/personal/desktop × light/standard/full) all reproduced 3-of-3 with identical signatures.

## Test plan

- [x] `bash tests/test-init-non-interactive.sh` — 26 unit tests pass
- [x] `bash tests/edge-cases-scripts.sh` — 63 tests pass including new E56
- [x] Manual end-to-end: `init.sh --non-interactive --project x --platform web --deployment personal --language typescript --project-dir /tmp/x --git-host other --remote-url https://example.com/fake.git --branch-protection-attested` → exit 0, all expected files present, `test_interval=2` in `.claude/build-progress.json`
- [x] Reproduced bug on `main` (HEAD `43ade85`) before the fix; same command exited 1 with `TEST_INTERVAL: unbound variable`

## Follow-up

After this lands, the 2026-04-26 UAT sweep resumes from agent 4 against fixed code (paused at `Reports/uat-2026-04-26/dispatch-state.json`). A separate backlog item should be filed for adding `--test-interval N` flag to `init.sh --non-interactive` for full feature parity with the intake-configurable default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)