### PR TITLE
fix(init): clear poc_mode for --gov-mode production (T1-A)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3214,7 +3214,13 @@ HELPEOF
       exit 0
     fi
     # Derive POC_MODE from GOV_MODE for downstream consumers (existing code uses POC_MODE).
-    POC_MODE="$GOV_MODE"
+    # The interactive flow at init.sh:381 maps "Production" -> POC_MODE="" because Production
+    # is the absence of POC, not a POC mode itself. Mirror that here — process-checklist.sh
+    # start_phase4 treats any non-null poc_mode as a POC and blocks Phase 4.
+    case "$GOV_MODE" in
+      production) POC_MODE="" ;;
+      *)          POC_MODE="$GOV_MODE" ;;
+    esac
     # Pass 3 of collect_inputs_non_interactive already verified required tools.
   else
     if [ -n "$CONFIG_FILE" ]; then

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1204,7 +1204,7 @@ fi
 
 
 # ================================================================
-section "BL-016: init.sh non-interactive mode — E48-E56"
+section "BL-016: init.sh non-interactive mode — E48-E57"
 
 INIT_SH="$REPO_DIR/init.sh"
 
@@ -1349,6 +1349,31 @@ if [ "$_e56_rc" = "0" ] && \
   pass "E56: --non-interactive end-to-end writes all project files (TEST_INTERVAL regression guard)"
 else
   fail "E56: end-to-end run incomplete (rc=$_e56_rc, test_interval='$_e56_test_interval'). Missing one or more of: CLAUDE.md, APPROVAL_LOG.md, .gitignore, .github/workflows/ci.yml, .claude/build-progress.json, .claude/process-state.json"
+fi
+
+# E57: --non-interactive --gov-mode production must clear poc_mode in phase-state.json.
+# Regression guard for the production poc_mode bug (T1-A from 2026-04-26 UAT triage).
+# init.sh's interactive flow correctly maps Production -> POC_MODE="" (init.sh:381),
+# but the non-interactive driver was setting POC_MODE="production" verbatim, which
+# then caused process-checklist.sh start_phase4 to block every production project
+# (it rejects any non-null poc_mode as a POC).
+_e57_dir="$TEST_DIR/e57"
+mkdir -p "$_e57_dir"
+_e57_proj="$_e57_dir/uat-e57"
+_e57_rc=0
+(cd "$_e57_dir" && "$INIT_SH" --non-interactive \
+  --project uat-e57 --platform web --deployment organizational --gov-mode production \
+  --language typescript --project-dir "$_e57_proj" \
+  --git-host other --remote-url https://example.com/fake.git \
+  --branch-protection-attested >/dev/null 2>&1) || _e57_rc=$?
+_e57_poc=""
+if [ -f "$_e57_proj/.claude/phase-state.json" ]; then
+  _e57_poc=$(jq -r '.poc_mode' "$_e57_proj/.claude/phase-state.json" 2>/dev/null || echo "missing")
+fi
+if [ "$_e57_rc" = "0" ] && [ "$_e57_poc" = "null" ]; then
+  pass "E57: --non-interactive --gov-mode production clears poc_mode (T1-A regression guard)"
+else
+  fail "E57: expected rc=0 and phase-state.json .poc_mode=null, got rc=$_e57_rc poc_mode='$_e57_poc'"
 fi
 
 


### PR DESCRIPTION
## Summary

- Fixes Critical regression in PR #19 (BL-016) surfaced by the 2026-04-26 UAT regression sweep.
- `init.sh --non-interactive --gov-mode production` was writing `poc_mode="production"` to `.claude/phase-state.json`. The interactive flow at `init.sh:381` correctly maps Production → `POC_MODE=""` because Production is the absence of POC, not a POC mode itself.
- Effect: every non-interactive production project was blocked at Phase 4 by `process-checklist.sh:540 start_phase4` (rejects any non-null poc_mode). The upgrade-to-production path was unaffected because `upgrade-project.sh` clears poc_mode entirely as part of the upgrade.

## Confirmation in sweep

10 of 12 base-production agents in `Reports/uat-2026-04-26/` reproduced this. The 2 that didn't either (a) used track=light and never reached the Phase 4 check (37) or (b) graded the bug at Medium rather than Critical (44). Production-target upgrade agents passed because they took the upgrade path.

## Fix

Case statement in `collect_inputs_non_interactive()` mirroring the interactive mapping:
```bash
case "$GOV_MODE" in
  production) POC_MODE="" ;;
  *)          POC_MODE="$GOV_MODE" ;;
esac
```

## Test (E57)

New integration test in `tests/edge-cases-scripts.sh` drives a real `--non-interactive --gov-mode production` end-to-end and asserts `.claude/phase-state.json .poc_mode == null`. Reproduces the bug on unfixed code (`poc_mode='production'`); passes after the fix. Closes the gap that the 26 unit tests + 8 prior integration tests left because they all used `--validate-only` or non-production gov modes.

## Test plan

- [x] `bash tests/test-init-non-interactive.sh` — 26/26 pass
- [x] `bash tests/edge-cases-scripts.sh` — 64/64 pass (including new E57)
- [x] Reproduced bug on `main` (HEAD `d66e8f2`) before the fix; same command produced `poc_mode='production'`. Fix removes that.

## Triage reference

T1-A in `Reports/uat-2026-04-26/TRIAGE.md`. Next up: T1-B (`upgrade-project.sh` self-copy guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)