### PR TITLE
fix(upgrade): guard helper-refresh against same-file cp (T1-B)

### DIFF
--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -1470,9 +1470,17 @@ print_step "Refreshing framework helper scripts (BL-009, BL-015)"
 if [ -d scripts ]; then
   for helper in pending-approval.sh lint-uat-scenarios.sh; do
     if [ -f "$SCRIPT_DIR/$helper" ]; then
-      cp "$SCRIPT_DIR/$helper" "scripts/$helper"
-      chmod +x "scripts/$helper"
-      print_ok "scripts/$helper refreshed from framework"
+      # When invoked as `bash scripts/upgrade-project.sh` from the project root,
+      # $SCRIPT_DIR resolves to scripts/ — the source and destination are the
+      # same file. BSD cp returns non-zero on identical source/dest, which under
+      # `set -euo pipefail` would abort the upgrade. Skip the no-op.
+      if [ "$SCRIPT_DIR/$helper" -ef "scripts/$helper" ]; then
+        print_info "scripts/$helper already at framework version (no-op)"
+      else
+        cp "$SCRIPT_DIR/$helper" "scripts/$helper"
+        chmod +x "scripts/$helper"
+        print_ok "scripts/$helper refreshed from framework"
+      fi
     fi
   done
 else

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1204,7 +1204,7 @@ fi
 
 
 # ================================================================
-section "BL-016: init.sh non-interactive mode — E48-E57"
+section "BL-016: init.sh non-interactive mode — E48-E58"
 
 INIT_SH="$REPO_DIR/init.sh"
 
@@ -1374,6 +1374,35 @@ if [ "$_e57_rc" = "0" ] && [ "$_e57_poc" = "null" ]; then
   pass "E57: --non-interactive --gov-mode production clears poc_mode (T1-A regression guard)"
 else
   fail "E57: expected rc=0 and phase-state.json .poc_mode=null, got rc=$_e57_rc poc_mode='$_e57_poc'"
+fi
+
+# E58: project-local invocation of upgrade-project.sh must exit rc=0.
+# Regression guard for T1-B from 2026-04-26 UAT triage. The BL-009/BL-015
+# helper-refresh block at scripts/upgrade-project.sh:1471 did
+# `cp $SCRIPT_DIR/$helper scripts/$helper` where $SCRIPT_DIR resolved to the
+# project's own scripts/ dir when invoked as `bash scripts/upgrade-project.sh`
+# from the project root. BSD cp returns non-zero on identical source/dest,
+# and `set -euo pipefail` aborted before "Upgrade complete." State changes
+# succeeded but the wrapper signaled failure.
+_e58_dir="$TEST_DIR/e58"
+mkdir -p "$_e58_dir"
+_e58_proj="$_e58_dir/uat-e58"
+_e58_init_rc=0
+(cd "$_e58_dir" && "$INIT_SH" --non-interactive \
+  --project uat-e58 --platform web --deployment organizational --gov-mode private_poc \
+  --language typescript --project-dir "$_e58_proj" \
+  --git-host other --remote-url https://example.com/fake.git \
+  --branch-protection-attested >/dev/null 2>&1) || _e58_init_rc=$?
+_e58_upgrade_rc=0
+if [ "$_e58_init_rc" = "0" ] && [ -d "$_e58_proj/scripts" ]; then
+  (cd "$_e58_proj" && bash scripts/upgrade-project.sh --to-sponsored-poc >/dev/null 2>&1) || _e58_upgrade_rc=$?
+else
+  _e58_upgrade_rc=255
+fi
+if [ "$_e58_upgrade_rc" = "0" ]; then
+  pass "E58: project-local upgrade-project.sh --to-sponsored-poc exits 0 (T1-B regression guard)"
+else
+  fail "E58: expected rc=0 from project-local upgrade-project.sh, got rc=$_e58_upgrade_rc (init_rc=$_e58_init_rc)"
 fi
 
 


### PR DESCRIPTION
## Summary

- Fixes Critical bug in PR #17 (BL-009/BL-015 helper-refresh) surfaced by the 2026-04-26 UAT regression sweep.
- The trailing helper-refresh block at `scripts/upgrade-project.sh:1471` did `cp \"\$SCRIPT_DIR/\$helper\" \"scripts/\$helper\"` where `\$SCRIPT_DIR` resolves to the project's own `scripts/` when invoked as `bash scripts/upgrade-project.sh ...` from the project root (the documented invocation). BSD `cp` returns non-zero on same-file source/dest, and `set -euo pipefail` aborted the script before "Upgrade complete." Functional state mutations all completed; only RC=1 was wrong.

## Confirmation in sweep

12 upgrade agents in `Reports/uat-2026-04-26/`: 50, 53, 56, 57, 60, 64, 66, 70, 72, 80, 81, 83. Agents that invoked via the framework path (`\$FRAMEWORK/scripts/upgrade-project.sh`) were unaffected.

## Fix

Same-file guard with `[ -ef ]` test before the cp. When source and destination resolve to the same inode, skip the no-op copy and emit an informational line.

```bash
if [ "\$SCRIPT_DIR/\$helper" -ef "scripts/\$helper" ]; then
  print_info "scripts/\$helper already at framework version (no-op)"
else
  cp "\$SCRIPT_DIR/\$helper" "scripts/\$helper"
  chmod +x "scripts/\$helper"
  print_ok "scripts/\$helper refreshed from framework"
fi
```

The framework-path invocation continues to refresh helpers as before.

## Test (E58)

New integration test in `tests/edge-cases-scripts.sh`:
1. Init a `private_poc/web/light` baseline via `--non-interactive`
2. Invoke `bash scripts/upgrade-project.sh --to-sponsored-poc` from the project root (the project-local copy, the bug-triggering form)
3. Assert RC=0

Reproduces the bug on unfixed code (rc=1); passes after the fix.

## Test plan

- [x] `bash tests/test-init-non-interactive.sh` — 26/26 pass
- [x] `bash tests/edge-cases-scripts.sh` — 65/65 pass (including new E58)
- [x] Reproduced bug on `main` (HEAD `28ca041`) before the fix; same command produced rc=1.

## Triage reference

T1-B in `Reports/uat-2026-04-26/TRIAGE.md`. Next up: T1-C (`mcp_server` hyphen/underscore unification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)