### PR TITLE
fix(upgrade): intake-wizard PROJECT_ROOT walk-up + --to-private-poc flag (T1-D)

### DIFF
--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -13,14 +13,45 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/helpers.sh"
 
 # UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
-# (Note: U-G — PROJECT_ROOT being hardcoded to framework even when invoked
-# from a project — is a separate bug deferred to Batch 3.)
 guard_not_in_framework || exit 1
 
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# UAT 2026-04-26 fix (U-G / T1-D): walk up from CWD looking for .claude/.
+# The previous implementation hardcoded PROJECT_ROOT="$SCRIPT_DIR/.." which
+# resolved to the framework dir when invoked via bash $FRAMEWORK/scripts/
+# intake-wizard.sh, breaking --upgrade-deployment / --to-sponsored-poc /
+# --to-private-poc / --resume. Same shape as scripts/upgrade-project.sh's
+# find_project_root().
+find_project_root_for_intake() {
+  local dir="$PWD"
+  while [ "$dir" != "/" ]; do
+    if [ -f "$dir/.claude/phase-state.json" ]; then
+      echo "$dir"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+if PROJECT_ROOT="$(find_project_root_for_intake)"; then
+  :
+else
+  print_fail "Could not find project root (no .claude/phase-state.json in CWD or parents)."
+  print_info "Run intake-wizard.sh from your project directory."
+  exit 1
+fi
+
+# All passthrough exec's below use relative `scripts/...` paths, and several
+# wizard sections write into the project's working files. Anchor CWD to the
+# resolved project root so those paths are unambiguous regardless of where
+# the wizard was invoked from.
+cd "$PROJECT_ROOT"
+
+# Templates ship with the framework, not the project.
+FRAMEWORK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 PROGRESS_FILE="$PROJECT_ROOT/.claude/intake-progress.json"
 INTAKE_FILE="$PROJECT_ROOT/PROJECT_INTAKE.md"
-SUGGESTIONS_DIR="$PROJECT_ROOT/templates/intake-suggestions"
+SUGGESTIONS_DIR="$FRAMEWORK_ROOT/templates/intake-suggestions"
 
 # Project context (loaded from progress file or phase-state.json)
 PROJECT_NAME="${PROJECT_NAME:-}"
@@ -1536,6 +1567,8 @@ main() {
       echo "  --upgrade-to-production Upgrade a POC project to production"
       echo "  --upgrade-track TYPE    Upgrade track (light|standard|full)"
       echo "  --upgrade-deployment T  Upgrade deployment (personal|organizational)"
+      echo "  --to-private-poc        Upgrade Personal -> Private POC"
+      echo "  --to-sponsored-poc      Upgrade Personal/Private POC -> Sponsored POC"
       echo "  --to-sponsored-poc      Convert to sponsored POC"
       echo "  --help                  Show this help"
       exit 0
@@ -1596,6 +1629,14 @@ main() {
     --to-sponsored-poc)
       if [ -x "scripts/upgrade-project.sh" ]; then
         exec bash scripts/upgrade-project.sh --to-sponsored-poc
+      else
+        echo "Error: scripts/upgrade-project.sh not found. Run 'solo init' first."
+        exit 1
+      fi
+      ;;
+    --to-private-poc)
+      if [ -x "scripts/upgrade-project.sh" ]; then
+        exec bash scripts/upgrade-project.sh --to-private-poc
       else
         echo "Error: scripts/upgrade-project.sh not found. Run 'solo init' first."
         exit 1

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -27,6 +27,7 @@ set -euo pipefail
 #   scripts/upgrade-project.sh --deployment organizational  # Deployment upgrade only
 #   scripts/upgrade-project.sh --to-production            # Full upgrade to production
 #   scripts/upgrade-project.sh --to-sponsored-poc         # Personal → Sponsored POC
+#   scripts/upgrade-project.sh --to-private-poc           # Personal → Private POC
 #   scripts/upgrade-project.sh --help
 
 # --- Locate orchestrator and project ---
@@ -58,6 +59,7 @@ VALID_DEPLOYMENTS="personal organizational"
 
 # --- Argument parsing ---
 TARGET_TRACK=""
+TO_PRIVATE_POC=false
 TARGET_DEPLOYMENT=""
 TO_PRODUCTION=false
 TO_SPONSORED_POC=false
@@ -83,6 +85,10 @@ while [ $# -gt 0 ]; do
       ;;
     --to-production)
       TO_PRODUCTION=true
+      shift
+      ;;
+    --to-private-poc)
+      TO_PRIVATE_POC=true
       shift
       ;;
     --to-sponsored-poc)
@@ -115,6 +121,7 @@ if [ "$SHOW_HELP" = true ]; then
   echo "  scripts/upgrade-project.sh --deployment organizational # Add governance framework"
   echo "  scripts/upgrade-project.sh --to-production            # POC -> Production (upgrade track + remove POC)"
   echo "  scripts/upgrade-project.sh --to-sponsored-poc         # Private POC -> Sponsored POC"
+  echo "  scripts/upgrade-project.sh --to-private-poc           # Personal -> Private POC"
   echo "  scripts/upgrade-project.sh --help                     # This help message"
   echo ""
   echo -e "${BOLD}Flags can be combined:${NC}"
@@ -362,6 +369,27 @@ if [ "$TO_SPONSORED_POC" = true ]; then
   fi
 fi
 
+# --to-private-poc: personal -> organizational/private_poc
+if [ "$TO_PRIVATE_POC" = true ]; then
+  if [ "$CURRENT_DEPLOYMENT" = "organizational" ] && [ "$CURRENT_POC_MODE" = "private_poc" ]; then
+    print_warn "Project is already a Private POC. Nothing to do."
+    exit 0
+  fi
+  if [ "$CURRENT_DEPLOYMENT" = "organizational" ] && [ "$CURRENT_POC_MODE" = "sponsored_poc" ]; then
+    print_fail "Cannot downgrade Sponsored POC to Private POC. POC modes only progress upward."
+    exit 1
+  fi
+  if [ "$CURRENT_DEPLOYMENT" = "organizational" ] && [ -z "$CURRENT_POC_MODE" ]; then
+    print_fail "Project is already organizational/production. Cannot downgrade to Private POC."
+    exit 1
+  fi
+  TARGET_DEPLOYMENT="organizational"
+  # Track stays the same for POC transition
+  if [ -z "$TARGET_TRACK" ]; then
+    TARGET_TRACK="$CURRENT_TRACK"
+  fi
+fi
+
 # Use current values if not specified
 if [ -z "$TARGET_TRACK" ]; then
   TARGET_TRACK="$CURRENT_TRACK"
@@ -406,12 +434,17 @@ if [ -z "$CURRENT_POC_MODE" ] && [ "$TO_SPONSORED_POC" = true ]; then
   print_fail "Cannot downgrade a production project to POC mode."
   exit 1
 fi
+if [ -z "$CURRENT_POC_MODE" ] && [ "$TO_PRIVATE_POC" = true ] && [ "$CURRENT_DEPLOYMENT" = "organizational" ]; then
+  print_fail "Cannot downgrade a production project to POC mode."
+  exit 1
+fi
 
 # Determine what changes
 TRACK_CHANGES=false
 DEPLOYMENT_CHANGES=false
 POC_REMOVED=false
 POC_TO_SPONSORED=false
+POC_TO_PRIVATE=false
 
 if [ "$TARGET_TRACK" != "$CURRENT_TRACK" ]; then
   TRACK_CHANGES=true
@@ -429,9 +462,14 @@ if [ "$TO_SPONSORED_POC" = true ] && [ "$CURRENT_POC_MODE" != "sponsored_poc" ];
   POC_TO_SPONSORED=true
 fi
 
+if [ "$TO_PRIVATE_POC" = true ] && [ "$CURRENT_POC_MODE" != "private_poc" ]; then
+  POC_TO_PRIVATE=true
+fi
+
 # Check if anything actually changes
 if [ "$TRACK_CHANGES" = false ] && [ "$DEPLOYMENT_CHANGES" = false ] && \
-   [ "$POC_REMOVED" = false ] && [ "$POC_TO_SPONSORED" = false ]; then
+   [ "$POC_REMOVED" = false ] && [ "$POC_TO_SPONSORED" = false ] && \
+   [ "$POC_TO_PRIVATE" = false ]; then
   print_warn "No changes needed — project is already at $CURRENT_TRACK/$CURRENT_DEPLOYMENT."
   exit 0
 fi
@@ -458,6 +496,9 @@ if [ "$POC_REMOVED" = true ]; then
 fi
 if [ "$POC_TO_SPONSORED" = true ]; then
   echo -e "  ${BOLD}POC Mode:${NC}   ${CURRENT_POC_MODE:-private poc} -> ${GREEN}Sponsored POC${NC}"
+fi
+if [ "$POC_TO_PRIVATE" = true ]; then
+  echo -e "  ${BOLD}POC Mode:${NC}   ${CURRENT_POC_MODE:-none} -> ${GREEN}Private POC${NC}"
 fi
 
 echo ""
@@ -532,7 +573,7 @@ print_step "Updating .claude/phase-state.json"
 
 # phase-state.json doesn't have a track field by default, but we add one
 # for upgrade tracking. We also preserve existing gates.
-python3 << 'PYEOF' - "$PHASE_STATE" "$TARGET_TRACK" "$POC_REMOVED" "$POC_TO_SPONSORED"
+python3 << 'PYEOF' - "$PHASE_STATE" "$TARGET_TRACK" "$POC_REMOVED" "$POC_TO_SPONSORED" "$POC_TO_PRIVATE" "$TARGET_DEPLOYMENT"
 import json, sys
 from datetime import date
 
@@ -540,11 +581,18 @@ phase_state_path = sys.argv[1]
 new_track = sys.argv[2]
 poc_removed = sys.argv[3] == "true"
 poc_to_sponsored = sys.argv[4] == "true"
+poc_to_private = sys.argv[5] == "true"
+new_deployment = sys.argv[6]
 
 with open(phase_state_path) as f:
     data = json.load(f)
 
 data["track"] = new_track
+# UAT 2026-04-26 fix (U-J / T2-G): write the resolved deployment field on
+# every upgrade. Previously this heredoc only wrote .track, leaving
+# .deployment in phase-state.json out of sync with the upgrade banner and
+# with PROJECT_INTAKE.md / CLAUDE.md (which the later heredocs do update).
+data["deployment"] = new_deployment
 data["last_upgrade"] = str(date.today())
 
 if poc_removed:
@@ -552,6 +600,8 @@ if poc_removed:
         del data["poc_mode"]
 elif poc_to_sponsored:
     data["poc_mode"] = "sponsored_poc"
+elif poc_to_private:
+    data["poc_mode"] = "private_poc"
 
 with open(phase_state_path, 'w') as f:
     json.dump(data, f, indent=2)
@@ -566,7 +616,7 @@ print_ok "Updated phase-state.json"
 if [ -f "$INTAKE_PROGRESS" ]; then
   print_step "Updating .claude/intake-progress.json"
 
-  python3 << 'PYEOF' - "$INTAKE_PROGRESS" "$TARGET_TRACK" "$TARGET_DEPLOYMENT" "$POC_REMOVED" "$POC_TO_SPONSORED"
+  python3 << 'PYEOF' - "$INTAKE_PROGRESS" "$TARGET_TRACK" "$TARGET_DEPLOYMENT" "$POC_REMOVED" "$POC_TO_SPONSORED" "$POC_TO_PRIVATE"
 import json, sys
 
 progress_path = sys.argv[1]
@@ -574,6 +624,7 @@ new_track = sys.argv[2]
 new_deployment = sys.argv[3]
 poc_removed = sys.argv[4] == "true"
 poc_to_sponsored = sys.argv[5] == "true"
+poc_to_private = sys.argv[6] == "true"
 
 with open(progress_path) as f:
     data = json.load(f)
@@ -585,6 +636,8 @@ if poc_removed:
     data["poc_mode"] = None
 elif poc_to_sponsored:
     data["poc_mode"] = "sponsored_poc"
+elif poc_to_private:
+    data["poc_mode"] = "private_poc"
 
 with open(progress_path, 'w') as f:
     json.dump(data, f, indent=2)
@@ -600,7 +653,7 @@ fi
 if [ -f "$CLAUDE_MD" ]; then
   print_step "Updating CLAUDE.md"
 
-  python3 << 'PYEOF' - "$CLAUDE_MD" "$TARGET_TRACK" "$TARGET_DEPLOYMENT" "$CURRENT_TRACK" "$CURRENT_DEPLOYMENT" "$POC_REMOVED" "$DEPLOYMENT_CHANGES" "$POC_TO_SPONSORED"
+  python3 << 'PYEOF' - "$CLAUDE_MD" "$TARGET_TRACK" "$TARGET_DEPLOYMENT" "$CURRENT_TRACK" "$CURRENT_DEPLOYMENT" "$POC_REMOVED" "$DEPLOYMENT_CHANGES" "$POC_TO_SPONSORED" "$POC_TO_PRIVATE"
 import re, sys
 
 claude_md_path = sys.argv[1]
@@ -611,6 +664,7 @@ old_deployment = sys.argv[5]
 poc_removed = sys.argv[6] == "true"
 deployment_changes = sys.argv[7] == "true"
 poc_to_sponsored = sys.argv[8] == "true"
+poc_to_private = sys.argv[9] == "true"
 
 with open(claude_md_path) as f:
     content = f.read()
@@ -654,6 +708,10 @@ if poc_to_sponsored:
     content = re.sub(r'private_poc', 'sponsored_poc', content)
     content = re.sub(r'private poc', 'Sponsored POC', content, flags=re.IGNORECASE)
 
+# (POC watermarks for private POC upgrade are added by the governance section
+#  block below when deployment_changes is true; no template-text rewrite is
+#  needed for personal -> private_poc since the source had no POC mention.)
+
 # Update Deployment field if deployment changed
 if deployment_changes:
     content = re.sub(
@@ -691,7 +749,7 @@ fi
 if [ -f "$INTAKE_MD" ]; then
   print_step "Updating PROJECT_INTAKE.md"
 
-  python3 << 'PYEOF' - "$INTAKE_MD" "$TARGET_TRACK" "$TARGET_DEPLOYMENT" "$CURRENT_TRACK" "$CURRENT_DEPLOYMENT" "$POC_REMOVED" "$POC_TO_SPONSORED" "$DEPLOYMENT_CHANGES"
+  python3 << 'PYEOF' - "$INTAKE_MD" "$TARGET_TRACK" "$TARGET_DEPLOYMENT" "$CURRENT_TRACK" "$CURRENT_DEPLOYMENT" "$POC_REMOVED" "$POC_TO_SPONSORED" "$DEPLOYMENT_CHANGES" "$POC_TO_PRIVATE"
 import re, sys
 from datetime import date
 
@@ -703,6 +761,7 @@ old_deployment = sys.argv[5]
 poc_removed = sys.argv[6] == "true"
 poc_to_sponsored = sys.argv[7] == "true"
 deployment_changes = sys.argv[8] == "true"
+poc_to_private = sys.argv[9] == "true"
 
 with open(intake_path) as f:
     content = f.read()
@@ -743,6 +802,12 @@ elif poc_to_sponsored:
         r'\1 Sponsored POC',
         content
     )
+elif poc_to_private:
+    content = re.sub(
+        r'(\*\*Governance Mode:\*\*)\s*.*',
+        r'\1 Private POC',
+        content
+    )
 
 # Add governance section placeholder if moving to organizational and section 8 doesn't exist
 if deployment_changes and new_deployment == "organizational":
@@ -754,7 +819,7 @@ if deployment_changes and new_deployment == "organizational":
 
 _Added during upgrade from personal to organizational deployment on """ + str(date.today()) + """._
 
-**Governance Mode:** """ + ("Production" if poc_removed else ("Sponsored POC" if poc_to_sponsored else "Production")) + """
+**Governance Mode:** """ + ("Production" if poc_removed else ("Sponsored POC" if poc_to_sponsored else ("Private POC" if poc_to_private else "Production"))) + """
 
 ### 8.1 Pre-Conditions
 

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1204,7 +1204,7 @@ fi
 
 
 # ================================================================
-section "BL-016: init.sh non-interactive mode — E48-E59"
+section "BL-016: init.sh non-interactive mode — E48-E61"
 
 INIT_SH="$REPO_DIR/init.sh"
 
@@ -1437,6 +1437,72 @@ if [ "$_e59_init_rc" = "0" ] && \
   pass "E59: --non-interactive --platform mcp_server produces all platform-specific files (T1-C regression guard)"
 else
   fail "E59: expected rc=0 + platform module + release.yml + UAT ref; got rc=$_e59_init_rc module=$_e59_module_present release=$_e59_release_present uat_ref=$_e59_uat_ref_present"
+fi
+
+# E60: upgrade-project.sh --to-private-poc takes a personal project to
+# organizational/private_poc. T1-D regression guard for the missing
+# personal -> private_poc CLI path. Before this fix, intake-wizard.sh
+# --upgrade-deployment private_poc was rejected (only personal|organizational
+# accepted) and upgrade-project.sh had no --to-private-poc flag.
+_e60_dir="$TEST_DIR/e60"
+mkdir -p "$_e60_dir"
+_e60_proj="$_e60_dir/uat-e60"
+_e60_init_rc=0
+(cd "$_e60_dir" && "$INIT_SH" --non-interactive \
+  --project uat-e60 --platform web --deployment personal \
+  --language typescript --project-dir "$_e60_proj" \
+  --git-host other --remote-url https://example.com/fake.git \
+  --branch-protection-attested >/dev/null 2>&1) || _e60_init_rc=$?
+_e60_upgrade_rc=0
+if [ "$_e60_init_rc" = "0" ] && [ -d "$_e60_proj/scripts" ]; then
+  (cd "$_e60_proj" && bash scripts/upgrade-project.sh --to-private-poc >/dev/null 2>&1) || _e60_upgrade_rc=$?
+else
+  _e60_upgrade_rc=255
+fi
+_e60_poc_mode=""
+_e60_deployment=""
+if [ -f "$_e60_proj/.claude/phase-state.json" ]; then
+  _e60_poc_mode=$(jq -r '.poc_mode // "null"' "$_e60_proj/.claude/phase-state.json" 2>/dev/null || echo "")
+  _e60_deployment=$(jq -r '.deployment // "null"' "$_e60_proj/.claude/phase-state.json" 2>/dev/null || echo "")
+fi
+if [ "$_e60_upgrade_rc" = "0" ] && \
+   [ "$_e60_poc_mode" = "private_poc" ] && \
+   [ "$_e60_deployment" = "organizational" ]; then
+  pass "E60: upgrade-project.sh --to-private-poc takes personal -> organizational/private_poc (T1-D regression guard)"
+else
+  fail "E60: expected rc=0 poc_mode=private_poc deployment=organizational; got rc=$_e60_upgrade_rc poc_mode='$_e60_poc_mode' deployment='$_e60_deployment'"
+fi
+
+# E61: intake-wizard.sh --to-private-poc from a project subdir, invoked via
+# the framework path. Exercises both T1-D fixes: (a) PROJECT_ROOT walk-up
+# from CWD looking for .claude/, and (b) the new --to-private-poc passthrough.
+# Before the fixes, intake-wizard.sh hardcoded PROJECT_ROOT="$SCRIPT_DIR/.."
+# so framework-path invocation always failed with "PROJECT_INTAKE.md not found."
+_e61_dir="$TEST_DIR/e61"
+mkdir -p "$_e61_dir"
+_e61_proj="$_e61_dir/uat-e61"
+_e61_init_rc=0
+(cd "$_e61_dir" && "$INIT_SH" --non-interactive \
+  --project uat-e61 --platform web --deployment personal \
+  --language typescript --project-dir "$_e61_proj" \
+  --git-host other --remote-url https://example.com/fake.git \
+  --branch-protection-attested >/dev/null 2>&1) || _e61_init_rc=$?
+_e61_subdir="$_e61_proj/docs"
+mkdir -p "$_e61_subdir"
+_e61_wizard_rc=0
+if [ "$_e61_init_rc" = "0" ]; then
+  (cd "$_e61_subdir" && bash "$REPO_DIR/scripts/intake-wizard.sh" --to-private-poc >/dev/null 2>&1) || _e61_wizard_rc=$?
+else
+  _e61_wizard_rc=255
+fi
+_e61_poc_mode=""
+if [ -f "$_e61_proj/.claude/phase-state.json" ]; then
+  _e61_poc_mode=$(jq -r '.poc_mode // "null"' "$_e61_proj/.claude/phase-state.json" 2>/dev/null || echo "")
+fi
+if [ "$_e61_wizard_rc" = "0" ] && [ "$_e61_poc_mode" = "private_poc" ]; then
+  pass "E61: intake-wizard.sh --to-private-poc walks up from project subdir + passthrough works (T1-D regression guard)"
+else
+  fail "E61: expected rc=0 poc_mode=private_poc; got rc=$_e61_wizard_rc poc_mode='$_e61_poc_mode'"
 fi
 
 


### PR DESCRIPTION
## Summary

Resolves the personal → private_poc upgrade gap surfaced by the 2026-04-26 UAT regression sweep. Two related fixes plus a folded-in Medium (U-J).

### D1: intake-wizard.sh PROJECT_ROOT walk-up

`scripts/intake-wizard.sh` hardcoded `PROJECT_ROOT="\$SCRIPT_DIR/.."` (the framework dir when invoked via the framework path). Every `--upgrade-deployment` / `--to-sponsored-poc` / `--to-private-poc` / `--resume` invocation via `bash \$FRAMEWORK/scripts/intake-wizard.sh ...` aborted with "PROJECT_INTAKE.md not found."

Walk up from CWD looking for `.claude/phase-state.json` (same shape as `upgrade-project.sh`'s `find_project_root`), then `cd "\$PROJECT_ROOT"` so passthrough exec's that use relative `scripts/...` paths resolve correctly regardless of invocation cwd.

**Confirmation:** agents 49, 50, 51, 53, 55, 59 in `Reports/uat-2026-04-26/`.

### D2: upgrade-project.sh --to-private-poc

Before this fix there was no scripted CLI path from personal → private_poc:
- `intake-wizard.sh --upgrade-deployment private_poc` rejected (only `personal|organizational` accepted).
- `upgrade-project.sh` had `--to-sponsored-poc` and `--to-production` but no `--to-private-poc`.

Adds `--to-private-poc` flag paralleling `--to-sponsored-poc`. Plumbs `POC_TO_PRIVATE` through the four existing python heredocs (phase-state.json, intake-progress.json, CLAUDE.md, PROJECT_INTAKE.md) alongside `POC_TO_SPONSORED`. Adds `intake-wizard.sh --to-private-poc` passthrough.

**Confirmation:** agents 49, 51, 56, 57, 59, 60.

### U-J fold-in (T2-G in TRIAGE)

Without it, `--to-private-poc` would leave `.claude/phase-state.json .deployment` stuck at "personal" while CLAUDE.md / PROJECT_INTAKE.md correctly reflected the new "organizational" value (state drift). The phase-state heredoc previously only wrote `.track` and `.last_upgrade`; now also writes `.deployment`.

**Confirmation in sweep:** ~5 upgrade agents.

## Tests

- **E60**: `bash scripts/upgrade-project.sh --to-private-poc` on a personal/web/light project produces `deployment=organizational` and `poc_mode=private_poc` in phase-state.json.
- **E61**: `bash \$FRAMEWORK/scripts/intake-wizard.sh --to-private-poc` invoked from a project subdir (`CWD=\$PROJECT/docs/`) walks up to the project root, exec's the upgrade, and produces `poc_mode=private_poc`. Exercises both D1 and D2 in one go.

## Test plan

- [x] `bash tests/test-init-non-interactive.sh` — 26/26 pass.
- [x] `bash tests/edge-cases-scripts.sh` — 68/68 pass (incl. new E60, E61).

## Triage reference

T1-D in `Reports/uat-2026-04-26/TRIAGE.md` (and folds in T2-G / U-J). Next up: T1-E (`check-phase-gate.sh` pipefail-safe glob check for full-track pen-test detection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)