### PR TITLE
fix(check-phase-gate): pipefail-safe pen-test glob detection (T1-E)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -446,7 +446,14 @@ if [ "$current_phase" -ge 3 ]; then
 
   # P3-004: Penetration test check for Standard+ track
   if [ "$track" = "standard" ] || [ "$track" = "full" ]; then
-    if ls docs/test-results/*pen-test* docs/test-results/*pentest* docs/test-results/*penetration* 2>/dev/null | head -1 >/dev/null 2>&1; then
+    # UAT 2026-04-26 fix (T1-E): use compgen instead of `ls glob1 glob2 glob3
+    # | head -1`. Under `set -euo pipefail`, `ls` returns non-zero on any
+    # unmatched glob, propagating through the pipe and failing the if even
+    # when one of the patterns matches a real file. compgen -G tests each
+    # pattern independently and doesn't shell-out to ls.
+    if compgen -G "docs/test-results/*pen-test*" >/dev/null \
+       || compgen -G "docs/test-results/*pentest*" >/dev/null \
+       || compgen -G "docs/test-results/*penetration*" >/dev/null; then
       echo -e "${GREEN}  [OK]${NC} Penetration test results found in docs/test-results/"
     elif [ "$track" = "standard" ] && grep -qi "penetration.*exempted\|pen.*test.*exempted" APPROVAL_LOG.md 2>/dev/null; then
       # Standard track allows IT Security exemption

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1204,7 +1204,7 @@ fi
 
 
 # ================================================================
-section "BL-016: init.sh non-interactive mode — E48-E61"
+section "BL-016: init.sh non-interactive mode — E48-E62"
 
 INIT_SH="$REPO_DIR/init.sh"
 
@@ -1503,6 +1503,50 @@ if [ "$_e61_wizard_rc" = "0" ] && [ "$_e61_poc_mode" = "private_poc" ]; then
   pass "E61: intake-wizard.sh --to-private-poc walks up from project subdir + passthrough works (T1-D regression guard)"
 else
   fail "E61: expected rc=0 poc_mode=private_poc; got rc=$_e61_wizard_rc poc_mode='$_e61_poc_mode'"
+fi
+
+# E62: check-phase-gate.sh detects pen-test artifact under pipefail.
+# Regression guard for T1-E from 2026-04-26 UAT triage. The original
+# `ls glob1 glob2 glob3 2>/dev/null | head -1 >/dev/null 2>&1` returned
+# non-zero under `set -euo pipefail` whenever any one of the three globs
+# had no matches (BSD/GNU ls exits non-zero on missing files; pipefail
+# propagates). Result: full-track production projects were wrongly
+# blocked at Phase 3->4 even with valid pen-test artifacts present.
+# Replaced with compgen -G which tests each pattern independently.
+_e62_dir="$TEST_DIR/e62"
+mkdir -p "$_e62_dir/.claude" "$_e62_dir/docs/test-results"
+cat > "$_e62_dir/.claude/phase-state.json" << 'JSON'
+{
+  "project": "uat-e62",
+  "framework_version": "1.0",
+  "current_phase": 3,
+  "track": "full",
+  "deployment": "personal",
+  "poc_mode": null,
+  "compliance_ready": false,
+  "gates": {
+    "phase_0_to_1": "2026-01-01",
+    "phase_1_to_2": "2026-02-01",
+    "phase_2_to_3": "2026-03-01",
+    "phase_3_to_4": null
+  }
+}
+JSON
+cat > "$_e62_dir/APPROVAL_LOG.md" << 'MD'
+# Approval Log
+
+Phase 0 -> Phase 1: 2026-01-01 approver: Karl
+Phase 1 -> Phase 2: 2026-02-01 approver: Karl
+Phase 2 -> Phase 3: 2026-03-01 approver: Karl
+MD
+# A pen-test artifact that matches *pen-test* but not *pentest* or *penetration*
+# (so the original buggy ls-pipe-head form would fail under pipefail).
+touch "$_e62_dir/docs/test-results/2026-04-26-pen-test-summary.md"
+_e62_out=$(cd "$_e62_dir" && bash "$REPO_DIR/scripts/check-phase-gate.sh" 2>&1) || true
+if echo "$_e62_out" | grep -q "Penetration test results found"; then
+  pass "E62: check-phase-gate.sh detects pen-test artifact under pipefail (T1-E regression guard)"
+else
+  fail "E62: check-phase-gate.sh did not detect pen-test artifact"
 fi
 
 


### PR DESCRIPTION
## Summary

Fixes High-severity bug at `scripts/check-phase-gate.sh:449` surfaced by the 2026-04-26 UAT regression sweep (agent 48).

The original `ls glob1 glob2 glob3 | head -1` form returns non-zero under `set -euo pipefail` whenever any one of the three globs has no matches (BSD/GNU `ls` both error on missing files, the non-zero exit propagates through the pipe). Effect: full-track production projects were wrongly blocked at Phase 3 → 4 with "Full Track requires penetration test" even when valid pen-test artifacts were present — they just only matched one of the three patterns.

## Fix

Replace `ls | head` with `compgen -G` per pattern:

```bash
if compgen -G "docs/test-results/*pen-test*" >/dev/null \
   || compgen -G "docs/test-results/*pentest*" >/dev/null \
   || compgen -G "docs/test-results/*penetration*" >/dev/null; then
```

`compgen -G` tests each glob independently and returns 0/1 directly. No shell-out to `ls`, no pipe.

## Test (E62)

Creates a minimal Phase 3 project state (`current_phase=3`, `track=full`, three dated gates) plus a single pen-test artifact named `2026-04-26-pen-test-summary.md` (matches `*pen-test*` only). Runs `check-phase-gate.sh` and asserts stdout contains "Penetration test results found."

Verified bug→fix:
- Stashed the fix → ran tests → E62 FAIL ("did not detect pen-test artifact")
- Unstashed → ran tests → E62 PASS

## Test plan

- [x] `bash tests/test-init-non-interactive.sh` — 26/26 pass.
- [x] `bash tests/edge-cases-scripts.sh` — 69/69 pass (incl. new E62).

## Triage reference

T1-E in `Reports/uat-2026-04-26/TRIAGE.md`. With this PR, all five Tier-1 (Critical/High) findings from the sweep are addressed (T1-A through T1-E). Next would be the Tier-2 Mediums (T2-A through T2-I) bundled into 2-3 cleanup PRs, plus the post-fix focused regression sweep to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)