### PR TITLE
T2-E: --yes flag for check-gate.sh --backfill-host

### DIFF
--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -23,13 +23,18 @@ source "$SCRIPT_DIR/lib/helpers.sh" 2>/dev/null || {
 
 usage() {
   cat <<'EOM'
-Usage: check-gate.sh <subcommand>
+Usage: check-gate.sh <subcommand> [--yes]
 
 Subcommands:
   --preflight       Dry-run: check current protection status without modifying anything.
                     Exits 0 if ready to cross Phase 1→2, non-zero if blocked.
   --repair          Re-run repo setup from last successful step (idempotent).
   --backfill-host   Infer host from git remote URL and write to manifest.
+
+Flags:
+  --yes, -y         Skip confirmation prompts (for non-interactive use,
+                    e.g. CI or scripted setup). Currently honored by
+                    --backfill-host.
 EOM
 }
 
@@ -75,7 +80,12 @@ cmd_backfill_host() {
   esac
   print_info "Inferred host '$inferred' from origin URL: $url"
   local yn
-  read -rp "Confirm this is correct? [y/N]: " yn
+  if [ "${ASSUME_YES:-0}" = "1" ]; then
+    yn="y"
+    print_info "Auto-confirmed via --yes."
+  else
+    read -rp "Confirm this is correct? [y/N]: " yn
+  fi
   case "$yn" in
     [yY]*)
       jq --arg h "$inferred" '.host = $h' .claude/manifest.json > .claude/manifest.json.tmp \
@@ -132,6 +142,16 @@ cmd_repair() {
   fi
   print_ok "Repair complete"
 }
+
+ASSUME_YES=0
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --yes|-y) ASSUME_YES=1 ;;
+    *)        ARGS+=("$arg") ;;
+  esac
+done
+set -- ${ARGS[@]+"${ARGS[@]}"}
 
 case "${1:-}" in
   --preflight)     shift || true; cmd_preflight "$@" ;;

--- a/tests/test-check-gate.sh
+++ b/tests/test-check-gate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tests/test-check-gate.sh — unit tests for scripts/check-gate.sh.
+# Currently covers --backfill-host (T2-E: --yes flag for non-interactive use).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-gate.sh"
+
+PASSED=0
+FAILED=0
+
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup_project() {
+  TMPDIR_T=$(mktemp -d)
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git remote add origin https://github.com/example/foo.git
+    mkdir -p .claude
+    echo '{"frameworkVersion":"test","mode":"personal"}' > .claude/manifest.json
+  )
+}
+
+teardown_project() {
+  rm -rf "$TMPDIR_T"
+}
+
+t1_yes_flag_writes_host_non_interactive() {
+  setup_project
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --backfill-host --yes </dev/null 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T1" "expected exit 0 with --yes, got rc=$rc out=$out"
+    teardown_project
+    return
+  fi
+  local host
+  host=$(jq -r '.host // empty' "$TMPDIR_T/.claude/manifest.json")
+  if [ "$host" != "github" ]; then
+    fail_ "T1" "expected host='github', got host='$host'"
+    teardown_project
+    return
+  fi
+  pass "T1: --backfill-host --yes writes manifest.host non-interactively"
+  teardown_project
+}
+
+t2_interactive_y_still_works() {
+  setup_project
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && echo y | "$SCRIPT" --backfill-host 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T2" "expected exit 0 with stdin 'y', got rc=$rc out=$out"
+    teardown_project
+    return
+  fi
+  local host
+  host=$(jq -r '.host // empty' "$TMPDIR_T/.claude/manifest.json")
+  if [ "$host" != "github" ]; then
+    fail_ "T2" "expected host='github', got host='$host'"
+    teardown_project
+    return
+  fi
+  pass "T2: --backfill-host with stdin 'y' still writes manifest.host (regression)"
+  teardown_project
+}
+
+t3_interactive_n_aborts() {
+  setup_project
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && echo n | "$SCRIPT" --backfill-host 2>&1) || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T3" "expected non-zero exit on 'n', got rc=0 out=$out"
+    teardown_project
+    return
+  fi
+  local host
+  host=$(jq -r '.host // empty' "$TMPDIR_T/.claude/manifest.json")
+  if [ -n "$host" ]; then
+    fail_ "T3" "expected host unset on abort, got host='$host'"
+    teardown_project
+    return
+  fi
+  pass "T3: --backfill-host with stdin 'n' aborts (regression, host not written)"
+  teardown_project
+}
+
+t4_yes_flag_before_subcommand() {
+  setup_project
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --yes --backfill-host </dev/null 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T4" "expected exit 0 with --yes before --backfill-host, got rc=$rc out=$out"
+    teardown_project
+    return
+  fi
+  local host
+  host=$(jq -r '.host // empty' "$TMPDIR_T/.claude/manifest.json")
+  if [ "$host" != "github" ]; then
+    fail_ "T4" "expected host='github', got host='$host'"
+    teardown_project
+    return
+  fi
+  pass "T4: --yes accepted before --backfill-host"
+  teardown_project
+}
+
+echo "== tests/test-check-gate.sh =="
+t1_yes_flag_writes_host_non_interactive
+t2_interactive_y_still_works
+t3_interactive_n_aborts
+t4_yes_flag_before_subcommand
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Add top-level `--yes`/`-y` flag to `scripts/check-gate.sh` so `--backfill-host` can run non-interactively (CI, scripted setup) without aborting on closed stdin.
- Pre-parsed before subcommand dispatch — flag works in either position (`--backfill-host --yes` or `--yes --backfill-host`).
- New `tests/test-check-gate.sh` (4 cases): `--yes` writes manifest non-interactively, interactive `y` still writes (regression), interactive `n` still aborts (regression), `--yes` accepted before subcommand.

## Why
Surfaced by rev1 sweep agent-20 (`Reports/uat-2026-04-26/`). Without `--yes`, scripted setup scripts can't backfill `manifest.host` after init: `read -rp` fails on closed stdin, `set -euo pipefail` aborts the script, the manifest is left without a host field, and the next `--preflight` keeps failing. The user then has to either run an interactive shell or hand-edit JSON. Closes T2-E from `Reports/uat-2026-04-26/TRIAGE.md`.

## Test plan
- [x] `bash tests/test-check-gate.sh` → 4/4 pass
- [x] `bash tests/test-pending-approval.sh` → 17/17 pass (no regression)
- [x] `bash tests/test-lint-uat-scenarios.sh` → 11/11 pass (no regression)
- [x] `bash scripts/check-gate.sh --help` shows new `--yes` flag
- [ ] Interactive `bash scripts/check-gate.sh --backfill-host` against a real github project still prompts and writes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)