### PR TITLE
T2-F + T2-H: track-bump warning + template placeholder collision (closes T2-D + T2-I as can-not-reproduce)

### DIFF
--- a/Reports/uat-2026-04-26/TRIAGE.md
+++ b/Reports/uat-2026-04-26/TRIAGE.md
@@ -120,15 +120,22 @@ Or alternatively: keep hyphen in files, normalize at lookup with `${PLATFORM//_/
 **Effect:** `check-gate.sh --preflight` keeps failing because manifest lacks the host key.
 **Fix:** Have init.sh write `manifest.host` whenever `--git-host` is provided.
 
-### T2-D — Several scripts print `[FAIL]` but `exit 0`
+### T2-D — Several scripts print `[FAIL]` but `exit 0` — **CLOSED: could-not-reproduce (2026-04-26)**
 
-**Severity:** Medium
-**Affected scripts:**
+**Severity:** Medium → ~~Resolved~~ (no bug found)
+**Originally claimed:**
 - `scripts/check-gate.sh --preflight` (cmd_preflight returns 1 internally; outer dispatcher case discards)
 - `scripts/pending-approval.sh --validate` (prints schema error, exit 0)
 - `scripts/lint-uat-scenarios.sh` on missing-scenarios input (prints "no scenarios block found", exit 0 ... or exit 2 inconsistently)
-**Confirmation:** ~5 agents reported variants.
-**Fix at each:** Return non-zero on `[FAIL]` paths; lint should distinguish "no input" (usage error, exit 2) from "violations found" (exit 1) from "clean" (exit 0).
+
+**Investigation (2026-04-26):** Direct reproduction attempts on all three scripts returned the documented non-zero exit codes:
+- `check-gate.sh --preflight` with no manifest → `[FAIL]` + RC=1
+- `pending-approval.sh --validate` on bad schema → `[FAIL]` + RC=1 (already covered by `tests/test-pending-approval.sh::p15`)
+- `lint-uat-scenarios.sh` on missing-scenarios block → RC=2; on no arg → RC=2; on placeholder violations → RC=1; on clean → RC=0
+
+Existing test suites (`tests/test-pending-approval.sh` 17/17, `tests/test-lint-uat-scenarios.sh` 11/11) already lock these exit codes in. Agent reports cite `exit 0` but reproductions show RC=1; agent-12's "exits 0" claim contradicts `lint-uat-scenarios.sh:10` (`exit 2`) and the passing test. The one real exit-code-adjacent symptom (agent-20's `--backfill-host` non-interactive) is **T2-E**, not T2-D.
+
+**Resolution:** Closed. Existing tests guard the behavior.
 
 ### T2-E — `check-gate.sh --backfill-host` interactive-only
 
@@ -153,10 +160,17 @@ Or alternatively: keep hyphen in files, normalize at lookup with `${PLATFORM//_/
 **Affected file:** `templates/uat/test-session-template.html:142` (the comment that documents the placeholder syntax).
 **Fix:** Skip lines inside HTML comments; or rename the placeholder example.
 
-### T2-I — `process-checklist.sh --verify-init` non-idempotent (U-L, prior-sweep open)
+### T2-I — `process-checklist.sh --verify-init` non-idempotent — **CLOSED: could-not-reproduce as framed (2026-04-26)**
 
-**Severity:** Medium
-**First call:** "Cannot auto-verify"; **Second call:** silently auto-marks. Confusing UX. Confirmed by agent 13.
+**Severity:** Medium → ~~Resolved~~ (TRIAGE summary did not match the code)
+
+**Originally claimed:** First call "Cannot auto-verify"; second call silently auto-marks.
+
+**Investigation (2026-04-26):** Two consecutive `--verify-init` calls against an identical state produce identical output and identical state — `verify_init()` at `scripts/process-checklist.sh:562` is idempotent for any fixed prerequisite-completion set. The "first/second call" transition only happens when the user manually marks `data_model_applied` between the calls, which is the documented workflow (the script tells the user to do exactly that).
+
+Agent-13's actual report is a separate complaint: `pre-commit-gate` re-demands `--verify-init` after Phase 2 work has progressed. That's a `pre-commit-gate` signal-checking bug, not a `verify_init` idempotency bug. Tracking it as a new entry if it reproduces post-T2 cleanup.
+
+**Resolution:** Closed as written. If agent-13's symptom reproduces, file as a new bug under `pre-commit-gate.sh` (not `process-checklist.sh`).
 
 ## Tier 3 — Prior-sweep open, still confirmed (no change)
 

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -119,7 +119,7 @@ if [ "$SHOW_HELP" = true ]; then
   echo "  scripts/upgrade-project.sh --track standard           # Track upgrade (light->standard, etc.)"
   echo "  scripts/upgrade-project.sh --track full               # Track upgrade to full"
   echo "  scripts/upgrade-project.sh --deployment organizational # Add governance framework"
-  echo "  scripts/upgrade-project.sh --to-production            # POC -> Production (upgrade track + remove POC)"
+  echo "  scripts/upgrade-project.sh --to-production            # POC -> Production (auto-bumps track to standard if light; remove POC)"
   echo "  scripts/upgrade-project.sh --to-sponsored-poc         # Private POC -> Sponsored POC"
   echo "  scripts/upgrade-project.sh --to-private-poc           # Personal -> Private POC"
   echo "  scripts/upgrade-project.sh --help                     # This help message"
@@ -337,6 +337,9 @@ if [ "$TO_PRODUCTION" = true ]; then
   if [ -z "$TARGET_TRACK" ]; then
     if [ "$(track_rank "$CURRENT_TRACK")" -lt "$(track_rank "standard")" ]; then
       TARGET_TRACK="standard"
+      print_warn "Track will auto-bump from $CURRENT_TRACK -> standard."
+      print_warn "  --to-production requires standard or higher (release-pipeline policy)."
+      print_warn "  Pass --track light to keep current track, or --track full to upgrade further."
     else
       TARGET_TRACK="$CURRENT_TRACK"
     fi

--- a/templates/uat/test-session-template.html
+++ b/templates/uat/test-session-template.html
@@ -139,7 +139,8 @@ __FEATURE_SECTIONS__
 // AGENT INSTRUCTIONS: Replace __SCENARIOS_JSON__ with a JavaScript array.
 // Each element MUST be an object with ALL of the following fields.
 // Do not omit any field. Do not add fields not listed here.
-// Do not modify any code outside the __PLACEHOLDER__ tokens.
+// Do not modify any code outside the placeholder tokens (the ALL_CAPS
+// identifiers wrapped in double underscores, like the SCENARIOS_JSON one above).
 //
 // SCHEMA:
 // [

--- a/tests/test-lint-uat-scenarios.sh
+++ b/tests/test-lint-uat-scenarios.sh
@@ -192,6 +192,20 @@ HTML
   assert_contains "$out" "parse failed" "mentions parse failure"
 }
 
+case_12_seed_template_no_placeholder_collision() {
+  # T2-H regression: the seed template must not contain literal __PLACEHOLDER__
+  # in comments, because that token matches the linter's `__[A-Z][A-Z_]*__`
+  # placeholder pattern and false-flags every populated copy that retains the
+  # comment.
+  local template="$REPO_ROOT/templates/uat/test-session-template.html"
+  if grep -q '__PLACEHOLDER__' "$template"; then
+    local hit; hit=$(grep -n '__PLACEHOLDER__' "$template" | head -1)
+    echo "  Seed template contains literal __PLACEHOLDER__ at: $hit" >&2
+    echo "  This will false-flag the linter on every populated UAT HTML." >&2
+    return 1
+  fi
+}
+
 case_11_multiple_violations() {
   local work; work=$(mktemp -d); trap "rm -rf '$work'" RETURN
   seed_html "$work/bad.html" '[
@@ -219,6 +233,7 @@ run_case "case 8: duplicate scenario IDs"            case_8_duplicate_ids
 run_case "case 9: missing input file"                case_9_missing_file
 run_case "case 10: malformed JSON"                   case_10_malformed_json
 run_case "case 11: multiple violations"              case_11_multiple_violations
+run_case "case 12: seed template no __PLACEHOLDER__" case_12_seed_template_no_placeholder_collision
 
 echo ""
 echo "═══════════════════════════════════════════"

--- a/tests/test-upgrade-to-production-warn.sh
+++ b/tests/test-upgrade-to-production-warn.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# tests/test-upgrade-to-production-warn.sh — T2-F regression test.
+# Verifies that scripts/upgrade-project.sh --to-production emits a [WARN]
+# line when the project's track is auto-bumped (e.g., light -> standard).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/upgrade-project.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup_project() {
+  TMPDIR_T=$(mktemp -d)
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git remote add origin https://github.com/example/foo.git
+    mkdir -p .claude
+    cat > .claude/manifest.json <<'JSON'
+{"frameworkVersion":"test","mode":"personal","host":"github"}
+JSON
+    cat > .claude/phase-state.json <<'JSON'
+{"track":"light","deployment":"organizational","poc_mode":"private_poc","current_phase":1,"phases":{}}
+JSON
+    cat > .claude/tool-preferences.json <<'JSON'
+{"context":{"track":"light","platform":"web","os":"darwin"},"preferences":{}}
+JSON
+    cat > .claude/intake-progress.json <<'JSON'
+{"track":"light","deployment":"organizational"}
+JSON
+  )
+}
+
+teardown_project() { rm -rf "$TMPDIR_T"; }
+
+t1_warn_emitted_on_track_bump_light_to_standard() {
+  setup_project
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --to-production </dev/null 2>&1) || rc=$?
+  if ! echo "$out" | grep -qE '\[WARN\].*track.*(light|standard)'; then
+    fail_ "T1" "expected [WARN] line about track bump (light->standard); rc=$rc out:\n$out"
+    teardown_project
+    return
+  fi
+  pass "T1: --to-production emits [WARN] when track auto-bumps light->standard"
+  teardown_project
+}
+
+t2_no_warn_when_track_already_standard() {
+  setup_project
+  jq '.track = "standard"' "$TMPDIR_T/.claude/phase-state.json" > "$TMPDIR_T/.claude/phase-state.json.tmp" \
+    && mv "$TMPDIR_T/.claude/phase-state.json.tmp" "$TMPDIR_T/.claude/phase-state.json"
+  jq '.context.track = "standard"' "$TMPDIR_T/.claude/tool-preferences.json" > "$TMPDIR_T/.claude/tool-preferences.json.tmp" \
+    && mv "$TMPDIR_T/.claude/tool-preferences.json.tmp" "$TMPDIR_T/.claude/tool-preferences.json"
+  jq '.track = "standard"' "$TMPDIR_T/.claude/intake-progress.json" > "$TMPDIR_T/.claude/intake-progress.json.tmp" \
+    && mv "$TMPDIR_T/.claude/intake-progress.json.tmp" "$TMPDIR_T/.claude/intake-progress.json"
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --to-production </dev/null 2>&1) || rc=$?
+  if echo "$out" | grep -qE '\[WARN\].*track.*bump'; then
+    fail_ "T2" "should not emit track-bump [WARN] when already standard; out:\n$out"
+    teardown_project
+    return
+  fi
+  pass "T2: --to-production does NOT emit track-bump [WARN] when already standard"
+  teardown_project
+}
+
+t3_help_documents_track_bump() {
+  local out
+  out=$("$SCRIPT" --help 2>&1)
+  if ! echo "$out" | grep -qiE 'to-production.*(track|bump|light.*standard|auto)'; then
+    fail_ "T3" "--help should mention track auto-bump for --to-production; got:\n$out"
+    return
+  fi
+  pass "T3: --help mentions track auto-bump for --to-production"
+}
+
+echo "== tests/test-upgrade-to-production-warn.sh =="
+t1_warn_emitted_on_track_bump_light_to_standard
+t2_no_warn_when_track_already_standard
+t3_help_documents_track_bump
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **T2-F** — `scripts/upgrade-project.sh --to-production` now emits a `[WARN]` line when it auto-bumps the track (e.g., `light` → `standard`) and explains the override (`--track light` / `--track full`). `--help` updated to mention the auto-bump. Two rev1 agents (37, 40) flagged the silent re-track as surprising.
- **T2-H** — `templates/uat/test-session-template.html:142` had the literal `__PLACEHOLDER__` inside a JS comment as a generic stand-in. The lint regex `__[A-Z_]+__` matched it on every populated copy, false-flagging one extra violation per output. Comment rephrased.
- **T2-D + T2-I** — closed in `Reports/uat-2026-04-26/TRIAGE.md` as **could-not-reproduce**:
  - T2-D: `check-gate.sh --preflight`, `pending-approval.sh --validate`, `lint-uat-scenarios.sh` all return correct non-zero exit codes on every failure path I tested. Existing `tests/test-pending-approval.sh::p15` and `tests/test-lint-uat-scenarios.sh` already lock the behavior in.
  - T2-I: `--verify-init` is idempotent across two consecutive calls. Agent-13's actual symptom was a `pre-commit-gate` re-demand, which is a different surface; will track separately if it reproduces.

## Test plan
- [x] `bash tests/test-upgrade-to-production-warn.sh` → 3/3 pass (T1 warn emitted on bump, T2 no warn when already standard, T3 --help mentions bump)
- [x] `bash tests/test-lint-uat-scenarios.sh` → 12/12 pass (new case_12 asserts seed template has no `__PLACEHOLDER__` collision)
- [x] `bash tests/test-pending-approval.sh` → 17/17 pass (regression)
- [x] `bash tests/test-check-gate.sh` → 4/4 pass (regression)
- [x] `bash scripts/lint-uat-scenarios.sh templates/uat/test-session-template.html` → 0 hits on `__PLACEHOLDER__` (was 1 pre-fix)
- [ ] Run `--to-production` against a real project and confirm WARN appears in the upgrade-plan output

🤖 Generated with [Claude Code](https://claude.com/claude-code)