### PR TITLE
T2-A: exempt dep manifests from build_loop gate

### DIFF
--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -797,6 +797,24 @@ show_status() {
   echo ""
 }
 
+# Match common dependency-manifest files by basename (T2-A). These are
+# package-manager artifacts; a pure dep-bump commit should not trigger the
+# Build Loop gate. Match by basename rather than extension because most have
+# no extension or use a non-source extension (.lock, .txt, .sum, .mod).
+_is_dep_manifest() {
+  local base
+  base=$(basename "$1")
+  case "$base" in
+    Pipfile|Pipfile.lock|Gemfile|Gemfile.lock) return 0 ;;
+    Cargo.lock|go.mod|go.sum) return 0 ;;
+    poetry.lock|yarn.lock|pnpm-lock.yaml) return 0 ;;
+    npm-shrinkwrap.json|package-lock.json|pubspec.lock) return 0 ;;
+    Package.resolved|gradle.lockfile|packages.lock.json) return 0 ;;
+    requirements.txt|requirements-*.txt|requirements_*.txt) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
 check_commit_ready() {
   ensure_state_file
 
@@ -847,16 +865,23 @@ check_commit_ready() {
     fi
   done <<< "$staged_files"
 
-  # If not a source commit, check if it's purely docs
+  # If not a source commit, check if it's purely docs or dependency manifests.
+  # Dep manifests (Pipfile.lock, Gemfile.lock, go.sum, etc.) are produced by
+  # package managers; a single dep bump should not require a Build Loop entry
+  # (T2-A, surfaced from lancache 2026-04-26).
   if [ "$is_source" = false ]; then
-    local all_docs=true
+    local all_exempt=true
     while IFS= read -r file; do
-      if ! echo "$file" | grep -qE '\.(md|json|yml|yaml|toml|tmpl)$'; then
-        all_docs=false
-        break
+      if echo "$file" | grep -qE '\.(md|json|yml|yaml|toml|tmpl)$'; then
+        continue
       fi
+      if _is_dep_manifest "$file"; then
+        continue
+      fi
+      all_exempt=false
+      break
     done <<< "$staged_files"
-    if [ "$all_docs" = true ]; then
+    if [ "$all_exempt" = true ]; then
       exit 0
     fi
   fi

--- a/tests/test-process-checklist-classifier.sh
+++ b/tests/test-process-checklist-classifier.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# tests/test-process-checklist-classifier.sh — T2-A regression test.
+# Verifies that scripts/process-checklist.sh --check-commit-ready treats
+# common dependency-manifest files (Pipfile, Pipfile.lock, requirements*.txt,
+# Gemfile, Gemfile.lock, Cargo.lock, go.mod, go.sum, poetry.lock, yarn.lock,
+# pnpm-lock.yaml, etc.) as exempt — same as docs — instead of source.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/process-checklist.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Project state: Phase 2, init verified, no active build_loop. Staging a
+# dep-manifest commit at this point should NOT trigger the build_loop gate.
+setup_project() {
+  TMPDIR_T=$(mktemp -d)
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    mkdir -p .claude
+    cat > .claude/phase-state.json <<'JSON'
+{"current_phase":2,"track":"light","deployment":"personal","phases":{}}
+JSON
+    cat > .claude/process-state.json <<'JSON'
+{"phase2_init":{"verified":true,"steps_completed":["remote_repo_created","branch_protection_configured","ci_pipeline_configured","project_scaffolded","pre_commit_hooks_installed","data_model_applied","initialization_verified"]},"build_loop":{},"uat_session":{"started_at":"null","steps_completed":[]}}
+JSON
+  )
+}
+teardown_project() { rm -rf "$TMPDIR_T"; }
+
+# Stage a single file with given content; commit-ready check should pass.
+stage_and_check() {
+  local label="$1" file="$2"
+  setup_project
+  (
+    cd "$TMPDIR_T"
+    mkdir -p "$(dirname "$file")" 2>/dev/null || true
+    echo "test content" > "$file"
+    git add "$file"
+  )
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --check-commit-ready 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "$label" "expected exit 0 for dep-manifest commit ($file), got rc=$rc out=$out"
+    teardown_project
+    return
+  fi
+  pass "$label: $file commit allowed (exempt as dep-manifest)"
+  teardown_project
+}
+
+# Negative: a real source file should still be blocked.
+stage_and_check_blocked() {
+  local label="$1" file="$2"
+  setup_project
+  (
+    cd "$TMPDIR_T"
+    mkdir -p "$(dirname "$file")" 2>/dev/null || true
+    echo "test content" > "$file"
+    git add "$file"
+  )
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --check-commit-ready 2>&1) || rc=$?
+  if [ "$rc" -eq 0 ]; then
+    fail_ "$label" "expected non-zero exit for source commit ($file), got rc=0 out=$out"
+    teardown_project
+    return
+  fi
+  pass "$label: $file commit blocked (source — build_loop gate active)"
+  teardown_project
+}
+
+echo "== tests/test-process-checklist-classifier.sh =="
+stage_and_check "T1"  "Pipfile"
+stage_and_check "T2"  "Pipfile.lock"
+stage_and_check "T3"  "requirements.txt"
+stage_and_check "T4"  "requirements-dev.txt"
+stage_and_check "T5"  "Gemfile"
+stage_and_check "T6"  "Gemfile.lock"
+stage_and_check "T7"  "Cargo.lock"
+stage_and_check "T8"  "go.mod"
+stage_and_check "T9"  "go.sum"
+stage_and_check "T10" "poetry.lock"
+stage_and_check "T11" "yarn.lock"
+stage_and_check_blocked "T12" "src/main.py"
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- `scripts/process-checklist.sh --check-commit-ready` now treats common dependency-manifest files (`Pipfile.lock`, `Gemfile.lock`, `go.sum`, `requirements*.txt`, `Cargo.lock`, `poetry.lock`, etc.) as exempt from the Phase 2 build_loop gate — same as docs.
- New `_is_dep_manifest()` helper matches by basename (since most have no extension or use `.lock` / `.txt` / `.sum` / `.mod`).
- 12 new test cases in `tests/test-process-checklist-classifier.sh` (11 positives + 1 source-negative regression).

## Why
A pure dep-bump commit (e.g., `pipenv install foo` producing only `Pipfile.lock`) was being blocked with "no Build Loop active" because the file didn't match the docs regex. Surfaced from lancache during BL4 DB-pool work (TRIAGE T2-A).

This is an isolated fix to `process-checklist.sh`. The remaining T2 items in the original bundle (T2-B `--no-remote-creation`, T2-C early manifest.host write) touch `init.sh` in 6+ places and will land in a separate "init.sh manifest hardening" PR.

## Test plan
- [x] `bash tests/test-process-checklist-classifier.sh` → 12/12 pass
- [x] `bash tests/test-pending-approval.sh` → 17/17 (regression)
- [x] `bash tests/test-lint-uat-scenarios.sh` → 12/12 (regression)
- [x] `bash tests/test-check-gate.sh` → 4/4 (regression)
- [ ] In a real project mid-build_loop, `git add Pipfile.lock && git commit -m "build: bump deps"` no longer trips the gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)