### PR TITLE
T2-B + T2-C: init.sh --no-remote-creation + early manifest.host

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -38,6 +38,7 @@ ARG_VISIBILITY=""
 ARG_REMOTE_URL=""
 ARG_BRANCH_PROTECTION_ATTESTED=false
 ARG_ALLOW_EXISTING_DIR=false
+ARG_NO_REMOTE_CREATION=false
 # Resolved variables produced by either input path (consumed by downstream functions)
 GOV_MODE=""
 GIT_HOST=""
@@ -45,6 +46,7 @@ VISIBILITY=""
 REMOTE_URL=""
 BRANCH_PROTECTION_ATTESTED=false
 ALLOW_EXISTING_DIR=false
+NO_REMOTE_CREATION=false
 
 source "$SCRIPT_DIR/scripts/lib/helpers.sh"
 
@@ -1762,6 +1764,36 @@ create_and_protect_remote() {
     visibility="private"
   fi
 
+  # T2-C: write manifest.host (and mode) early so check-gate.sh --preflight
+  # has a usable host field even if a downstream API call fails (missing CLI,
+  # 403, push failure, fake URL). Late-stage merges below add remote_url and
+  # update host/mode in place.
+  mkdir -p .claude
+  if [ -f .claude/manifest.json ]; then
+    jq --arg h "$host" --arg m "$mode" '.host = $h | .mode = $m' \
+       .claude/manifest.json > .claude/manifest.json.tmp \
+       && mv .claude/manifest.json.tmp .claude/manifest.json
+  else
+    cat > .claude/manifest.json <<MANIFESTEOF
+{"host": "$host", "mode": "$mode"}
+MANIFESTEOF
+  fi
+
+  # T2-B: --no-remote-creation skips the host API entirely so UAT/CI runs do
+  # not contaminate the user's GitHub/GitLab/Bitbucket account. Manifest already
+  # has host + mode from the T2-C block above; record empty remote_url and
+  # tell the user how to attach a remote later.
+  if [ "${NO_REMOTE_CREATION:-false}" = true ]; then
+    print_step "Skipping remote creation (--no-remote-creation)"
+    print_info "No remote will be created on $host."
+    print_info "Project files are scaffolded; .claude/manifest.json records host='$host', mode='$mode'."
+    print_info "When ready, attach a remote and apply protection with:"
+    print_info "  scripts/check-gate.sh --repair"
+    jq --arg u "" '.remote_url = $u' .claude/manifest.json > .claude/manifest.json.tmp \
+       && mv .claude/manifest.json.tmp .claude/manifest.json
+    return 0
+  fi
+
   print_step "Creating git repository on $host"
 
   local remote_url=""
@@ -2626,6 +2658,13 @@ Optional flags (with defaults):
                            NOTE: organizational deployments force private.
   --allow-existing-dir     Boolean flag. Allow init into an existing directory
                            (otherwise: exit 1 if --project-dir already exists).
+  --no-remote-creation     Boolean flag. Skip the host_create_repo / push /
+                           branch-protection API calls. Project files are
+                           scaffolded and .claude/manifest.json is written
+                           with the host field. The remote can be added
+                           later with `scripts/check-gate.sh --repair`.
+                           Useful for UAT/CI runs that must NOT contaminate
+                           a real GitHub/GitLab/Bitbucket account.
 
 Mode flags:
   --non-interactive        Required to enable this mode. Without it, all input
@@ -2652,7 +2691,8 @@ JSON config schema (snake_case keys; all fields optional, missing → use flag/d
   "visibility": "private",
   "remote_url": null,
   "branch_protection_attested": false,
-  "allow_existing_dir": false
+  "allow_existing_dir": false,
+  "no_remote_creation": false
 }
 
 Examples:
@@ -2718,7 +2758,7 @@ collect_inputs_non_interactive() {
     fi
 
     # Warn on unknown fields (forward-compat per spec § 5.4).
-    local known_fields="project description platform track deployment gov_mode language project_dir git_host visibility remote_url branch_protection_attested allow_existing_dir"
+    local known_fields="project description platform track deployment gov_mode language project_dir git_host visibility remote_url branch_protection_attested allow_existing_dir no_remote_creation"
     local field
     for field in $(jq -r 'keys[]' "$CONFIG_FILE"); do
       if ! echo " $known_fields " | grep -q " $field "; then
@@ -2753,6 +2793,11 @@ collect_inputs_non_interactive() {
       local cfg_allow
       cfg_allow=$(cfg_get allow_existing_dir)
       [ "$cfg_allow" = "true" ] && ARG_ALLOW_EXISTING_DIR=true
+    fi
+    if [ "$ARG_NO_REMOTE_CREATION" != true ]; then
+      local cfg_no_remote
+      cfg_no_remote=$(cfg_get no_remote_creation)
+      [ "$cfg_no_remote" = "true" ] && ARG_NO_REMOTE_CREATION=true
     fi
   fi
 
@@ -3040,6 +3085,7 @@ collect_inputs_non_interactive() {
   REMOTE_URL="$ARG_REMOTE_URL"
   BRANCH_PROTECTION_ATTESTED="$ARG_BRANCH_PROTECTION_ATTESTED"
   ALLOW_EXISTING_DIR="$ARG_ALLOW_EXISTING_DIR"
+  NO_REMOTE_CREATION="$ARG_NO_REMOTE_CREATION"
 
   # The interactive language_prompt() sets TEST_INTERVAL=2 mid-flow; the
   # non-interactive driver bypasses that prompt, so set the same default
@@ -3064,6 +3110,7 @@ collect_inputs_non_interactive() {
       --arg remote_url "$REMOTE_URL" \
       --argjson attested "$([ "$BRANCH_PROTECTION_ATTESTED" = true ] && echo true || echo false)" \
       --argjson allow_dir "$([ "$ALLOW_EXISTING_DIR" = true ] && echo true || echo false)" \
+      --argjson no_remote "$([ "$NO_REMOTE_CREATION" = true ] && echo true || echo false)" \
       '{
         _validated: true,
         _resolved_at: $ts,
@@ -3079,7 +3126,8 @@ collect_inputs_non_interactive() {
         visibility: $visibility,
         remote_url: (if $remote_url == "" then null else $remote_url end),
         branch_protection_attested: $attested,
-        allow_existing_dir: $allow_dir
+        allow_existing_dir: $allow_dir,
+        no_remote_creation: $no_remote
       }'
   fi
   return 0
@@ -3150,6 +3198,8 @@ main() {
         ARG_BRANCH_PROTECTION_ATTESTED=true; shift ;;
       --allow-existing-dir)
         ARG_ALLOW_EXISTING_DIR=true; shift ;;
+      --no-remote-creation)
+        ARG_NO_REMOTE_CREATION=true; shift ;;
       --help-non-interactive)
         print_help_non_interactive
         exit 0 ;;

--- a/tests/test-init-no-remote-creation.sh
+++ b/tests/test-init-no-remote-creation.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# tests/test-init-no-remote-creation.sh — T2-B + T2-C regression tests.
+#
+# T2-B: init.sh --non-interactive --no-remote-creation must skip the
+#       host_create_repo / push / protection API calls so UAT runs do
+#       not contaminate the user's GitHub account, while still writing
+#       a usable manifest.
+#
+# T2-C: .claude/manifest.json must contain `host` after init, even when
+#       --no-remote-creation prevents the late "all-success" manifest write
+#       from running.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT_SH="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# --- Validate-only tests (cheap, just exercise CLI parsing) ---
+
+run_validate() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local out err rc=0
+  out=$(cd "$tmpdir" && "$INIT_SH" --non-interactive --validate-only "$@" 2>/tmp/init-no-remote-err) || rc=$?
+  err=$(cat /tmp/init-no-remote-err 2>/dev/null || true)
+  rm -rf "$tmpdir" /tmp/init-no-remote-err
+  echo "$rc|$(printf '%s' "$out" | tr '\n' ' ')|$(printf '%s' "$err" | tr '\n' ' ')"
+}
+
+t1_flag_accepted_validate_only() {
+  local out; out=$(run_validate \
+    --project p \
+    --platform web \
+    --deployment personal \
+    --language typescript \
+    --git-host github \
+    --no-remote-creation)
+  if [ "${out%%|*}" != "0" ]; then
+    fail_ "T1" "expected exit 0, got: $out"
+    return
+  fi
+  local stdout="${out#*|}"; stdout="${stdout%%|*}"
+  if [[ "$stdout" != *'"no_remote_creation": true'* ]]; then
+    fail_ "T1" "stdout missing no_remote_creation:true; got: $stdout"
+    return
+  fi
+  pass "T1: --no-remote-creation accepted; resolved JSON shows no_remote_creation=true"
+}
+
+t2_flag_default_false_validate_only() {
+  local out; out=$(run_validate \
+    --project p \
+    --platform web \
+    --deployment personal \
+    --language typescript)
+  if [ "${out%%|*}" != "0" ]; then
+    fail_ "T2" "expected exit 0, got: $out"
+    return
+  fi
+  local stdout="${out#*|}"; stdout="${stdout%%|*}"
+  if [[ "$stdout" != *'"no_remote_creation": false'* ]]; then
+    fail_ "T2" "stdout missing no_remote_creation:false default; got: $stdout"
+    return
+  fi
+  pass "T2: --no-remote-creation absent → resolves to false"
+}
+
+# --- Integration test (real init run; covers T2-B effect + T2-C invariant) ---
+
+t3_integration_skips_api_writes_manifest() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/proj"
+  local out err rc=0
+  # cd to tmpdir so the framework-self-guard (helpers.sh:guard_not_in_framework)
+  # doesn't refuse — it checks pwd, not --project-dir.
+  out=$( cd "$tmpdir" && "$INIT_SH" --non-interactive \
+           --project test-no-remote \
+           --platform web \
+           --deployment personal \
+           --language typescript \
+           --git-host github \
+           --visibility private \
+           --project-dir "$proj" \
+           --no-remote-creation 2>"$tmpdir/err" ) || rc=$?
+  err=$(cat "$tmpdir/err" 2>/dev/null || true)
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T3" "expected exit 0; got rc=$rc; stderr tail: $(echo "$err" | tail -10)"
+    rm -rf "$tmpdir"; return
+  fi
+  if [ ! -f "$proj/.claude/manifest.json" ]; then
+    fail_ "T3" "manifest.json not written"
+    rm -rf "$tmpdir"; return
+  fi
+  local host; host=$(jq -r '.host // empty' "$proj/.claude/manifest.json")
+  if [ "$host" != "github" ]; then
+    fail_ "T3" "expected manifest.host='github'; got '$host'"
+    rm -rf "$tmpdir"; return
+  fi
+  # Assert no real remote was added.
+  if (cd "$proj" && git remote get-url origin >/dev/null 2>&1); then
+    local url; url=$(cd "$proj" && git remote get-url origin)
+    fail_ "T3" "expected NO origin remote (--no-remote-creation); got: $url"
+    rm -rf "$tmpdir"; return
+  fi
+  pass "T3: --no-remote-creation produces project with manifest.host='github' and no origin remote"
+  rm -rf "$tmpdir"
+}
+
+echo "== tests/test-init-no-remote-creation.sh =="
+t1_flag_accepted_validate_only
+t2_flag_default_false_validate_only
+t3_integration_skips_api_writes_manifest
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **T2-B** — new `--no-remote-creation` CLI flag (and JSON config field `no_remote_creation`) on `init.sh --non-interactive`. When set, the host_create_repo / push / branch-protection chain is skipped entirely; the manifest is still written with `host` + `mode`. Use case: UAT/CI runs that must NOT contaminate a real GitHub/GitLab/Bitbucket account. Three rev1 contamination repos (`uat-agent-{1,2,3}`) motivated this.
- **T2-C** — `.claude/manifest.json` now gets its `host` + `mode` written **early** in `create_and_protect_remote`, before any failure-prone API call. Previously, a single push/CLI/403 failure would leave the manifest without `host`, forcing the user into the `--backfill-host` flow. The late-stage write at the function tail still runs on success and adds `remote_url`.
- New test file `tests/test-init-no-remote-creation.sh`: 3 cases (validate-only flag accepted, validate-only default-false, integration test that runs init in a tempdir and asserts manifest + no origin remote).

## Why
Both are gaps that surfaced in rev1 sweep (TRIAGE T2-B and T2-C). T2-C also chains into the workflow PR #26 unblocked: with `host` written early, `--preflight` works on the first try and `--backfill-host --yes` becomes a recovery tool, not a routine step.

## Test plan
- [x] `bash tests/test-init-no-remote-creation.sh` → 3/3 pass (T3 is a real init run in a tempdir)
- [x] `bash tests/test-init-non-interactive.sh` → 26/26 (regression, including new field in resolved JSON)
- [x] `bash tests/test-pending-approval.sh` → 17/17 (regression)
- [x] `bash tests/test-lint-uat-scenarios.sh` → 12/12 (regression)
- [x] `bash tests/test-check-gate.sh` → 4/4 (regression)
- [x] `bash tests/test-process-checklist-classifier.sh` → 12/12 (regression)
- [x] `bash tests/test-upgrade-to-production-warn.sh` → 3/3 (regression)
- [ ] In a real project: `init.sh --non-interactive ... --no-remote-creation`, then `scripts/check-gate.sh --preflight` reports the manifest is missing remote_url (not host) → `scripts/check-gate.sh --repair` attaches a real remote later

🤖 Generated with [Claude Code](https://claude.com/claude-code)