### PR TITLE
BL-020 + BL-022: tighten pre-commit-gate classifier + UAT step semantics

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -1230,6 +1230,13 @@ scripts/test-gate.sh --reset-counter
 Mark each UAT step as you complete it: `scripts/process-checklist.sh --complete-step uat_session:STEP_ID`
 Steps in order: `agents_dispatched`, `template_generated`, `orchestrator_notified`, `results_received`, `completeness_verified`, `bugs_consolidated`, `triage_complete`, `remediation_complete`, `gate_passed`.
 
+**Step semantics — read carefully (BL-022).** The last two steps describe **local** state, not "shipped to remote." Mark them when the local conditions are true, then commit. The pre-commit gate at `scripts/process-checklist.sh::check_commit_ready` blocks source commits while `uat_completed < 9` precisely because it expects you to acknowledge the local state via these marks before committing the remediation.
+
+- `remediation_complete` — "all remediation work is written and tested locally." Mark it once you have all fixes implemented, regression tests written, and the full local test suite green. **Do NOT wait for the commit/PR to mark this** — that creates the chicken-and-egg confusion where you can't commit because the step isn't marked, and you (think you) can't mark the step because nothing is committed.
+- `gate_passed` — "test-gate has been re-cleared locally." Mark it after running `scripts/test-gate.sh --reset-counter` and confirming `--check-batch` reports clean. This is local state, not post-merge CI state.
+
+Intended workflow: write fixes → tests green → `--reset-counter` → mark `remediation_complete` → mark `gate_passed` → commit (gate now allows) → push → open PR. CI verification happens after the PR is up; that's when you confirm post-merge state, but `gate_passed` was already truthful at the local-state level when you marked it.
+
 ---
 
 ### Context Health Check (Every 3-4 Features)

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -26,6 +26,20 @@ if [ -z "$COMMAND" ]; then
   exit 0
 fi
 
+# BL-020: classify a Bash command as an actual `git commit` invocation.
+# The previous pattern `\bgit\b.*\bcommit\b` over-matched any command line
+# containing both substrings as words — false-positives on read-only git
+# operations against files whose paths include the word `commit`
+# (e.g., `git diff scripts/pre-commit-gate.sh`, `git log -- scripts/check-commit-message.sh`).
+# Tightened classifier:
+#   - `commit` must come immediately after `git` (separated only by whitespace),
+#     ruling out `git diff <commit-named-path>` etc.
+#   - `git` must NOT be preceded by a quote, ruling out search strings like
+#     `rg "git commit" docs/`. Start-of-line is allowed.
+_is_git_commit() {
+  echo "$1" | grep -qE '(^|[^"'\''])git[[:space:]]+commit\b'
+}
+
 # Block agent-initiated SOIF_FORCE_STEP bypass (match assignment, not diagnostic reads)
 if echo "$COMMAND" | grep -qE 'SOIF_FORCE_STEP='; then
   cat << HOOKEOF
@@ -54,7 +68,7 @@ fi
 # Block git commit if no remote is configured. Solo Orchestrator requires a
 # created-and-protected remote from init onward; commits without a remote
 # indicate either a pre-fix project or drift that needs remediation.
-if echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b' && ! echo "$COMMAND" | grep -qE 'git.*remote'; then
+if _is_git_commit "$COMMAND" && ! echo "$COMMAND" | grep -qE 'git.*remote'; then
   # Only check if we're in a git repo with no remote
   if git rev-parse --git-dir >/dev/null 2>&1; then
     if ! git remote get-url origin >/dev/null 2>&1; then
@@ -67,7 +81,7 @@ HOOKEOF
 fi
 
 # Block --no-verify flag on git commit (bypasses security hooks)
-if echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b.*--no-verify'; then
+if _is_git_commit "$COMMAND" && echo "$COMMAND" | grep -qE -- '--no-verify'; then
   cat << HOOKEOF
 {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "The --no-verify flag bypasses security hooks (gitleaks, Semgrep). Remove --no-verify and commit normally."}}
 HOOKEOF
@@ -118,7 +132,7 @@ EOF
 pa_check() {
   # Only applies to git commit or gh pr create. Other commands fall through.
   local is_commit=false is_pr=false
-  echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b' && is_commit=true
+  _is_git_commit "$COMMAND" && is_commit=true
   echo "$COMMAND" | grep -qE '\bgh\b.*\bpr\b.*\bcreate\b' && is_pr=true
   [ "$is_commit" = false ] && [ "$is_pr" = false ] && return 0
 
@@ -147,7 +161,7 @@ pa_check
 # --- end BL-015 block ---
 
 # Warn on git commit --amend (rewrites commit history, bypasses build loop for amended content)
-if echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b.*--amend'; then
+if _is_git_commit "$COMMAND" && echo "$COMMAND" | grep -qE -- '--amend'; then
   cat << HOOKEOF
 {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow", "permissionDecisionReason": "WARNING: git commit --amend rewrites the previous commit. Ensure the amended content has been through the full Build Loop. If this amend adds new source code, consider a new commit instead."}}
 HOOKEOF
@@ -162,7 +176,7 @@ fi
 
 bl006_check() {
   # Only apply to `git commit` subcommands.
-  echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b' || return 0
+  _is_git_commit "$COMMAND" || return 0
 
   # Derivative-commit filters: pass through.
   # --amend is already handled above (warns, exits). Belt-and-braces.
@@ -250,7 +264,7 @@ fi
 # Only gate git commit and gh pr create for process checklist enforcement
 IS_COMMIT=false
 IS_PR=false
-if echo "$COMMAND" | grep -qE '\bgit\b.*\bcommit\b'; then
+if _is_git_commit "$COMMAND"; then
   IS_COMMIT=true
 elif echo "$COMMAND" | grep -qE '\bgh\b.*\bpr\b.*\bcreate\b'; then
   IS_PR=true

--- a/tests/test-pre-commit-gate-classifier.sh
+++ b/tests/test-pre-commit-gate-classifier.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# tests/test-pre-commit-gate-classifier.sh — BL-020 regression test.
+#
+# scripts/pre-commit-gate.sh:253 classifies a Bash command as "git commit"
+# via a regex. Pre-fix the regex was `\bgit\b.*\bcommit\b`, which matches
+# any command containing both substrings as words anywhere — false-positive
+# on read-only git invocations like `git diff scripts/pre-commit-gate.sh`
+# (path contains the word `commit`). Tightened to require `commit` to come
+# immediately after `git` (separated only by whitespace) AND for `git` to
+# be at command start (line start or after `;`/`&&`/`|`). Still catches
+# real `git commit` invocations including chained ones (`cd /foo && git commit`).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/scripts/pre-commit-gate.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Set up a tempdir project where current_phase=2 with UAT in progress
+# (uat_completed < uat_total). In this state the gate WILL block any
+# command classified as `git commit` once a source file is staged.
+setup_uat_blocking_state() {
+  TMPDIR_T=$(mktemp -d)
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    git remote add origin https://example.com/fake.git
+    mkdir -p .claude
+    cat > .claude/manifest.json <<'JSON'
+{"frameworkVersion":"test","mode":"personal","host":"other"}
+JSON
+    cat > .claude/phase-state.json <<'JSON'
+{"current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"phases":{}}
+JSON
+    cat > .claude/process-state.json <<'JSON'
+{
+  "phase2_init":{"verified":true,"steps_completed":["remote_repo_created","branch_protection_configured","ci_pipeline_configured","project_scaffolded","pre_commit_hooks_installed","data_model_applied","initialization_verified"]},
+  "build_loop":{"feature":null,"step":0,"steps_completed":[]},
+  "uat_session":{"session_id":"test","step":7,"steps_completed":["agents_dispatched","template_generated","orchestrator_notified","results_received","completeness_verified","bugs_consolidated","triage_complete"],"started_at":"2026-04-26T00:00:00Z"}
+}
+JSON
+    # Stage a source file so the classifier reaches the source-commit branch.
+    echo "stub" > src.py
+    git add src.py
+  )
+}
+teardown_project() { rm -rf "$TMPDIR_T"; }
+
+# Feed a JSON tool_input.command to the hook, return its output (stdout+stderr merged) and exit code.
+# Echo: "EXIT|OUTPUT_ONE_LINE"
+run_hook() {
+  local cmd="$1"
+  local input out rc=0
+  input=$(jq -n --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  out=$(cd "$TMPDIR_T" && printf '%s' "$input" | "$HOOK" 2>&1) || rc=$?
+  echo "$rc|$(printf '%s' "$out" | tr '\n' ' ')"
+}
+
+# True git commit invocations should be classified and (in this UAT state) BLOCKED.
+t1_real_git_commit_classified() {
+  setup_uat_blocking_state
+  local out; out=$(run_hook 'git commit -m "test"')
+  if [[ "${out#*|}" != *'"permissionDecision": "deny"'* ]]; then
+    fail_ "T1" "expected deny for real 'git commit'; got: $out"
+    teardown_project; return
+  fi
+  pass "T1: 'git commit -m \"test\"' classified as commit (blocked under UAT)"
+  teardown_project
+}
+
+t2_chained_git_commit_classified() {
+  setup_uat_blocking_state
+  local out; out=$(run_hook 'cd /tmp && git commit -m "x"')
+  if [[ "${out#*|}" != *'"permissionDecision": "deny"'* ]]; then
+    fail_ "T2" "expected deny for chained 'cd && git commit'; got: $out"
+    teardown_project; return
+  fi
+  pass "T2: 'cd /tmp && git commit ...' classified as commit (chained invocation)"
+  teardown_project
+}
+
+# Read-only git operations on files whose paths contain the word `commit` MUST NOT be classified.
+t3_git_diff_on_commit_named_file_not_classified() {
+  setup_uat_blocking_state
+  local out; out=$(run_hook 'git diff scripts/pre-commit-gate.sh')
+  if [[ "${out#*|}" == *'"permissionDecision": "deny"'* ]]; then
+    fail_ "T3" "false-positive: 'git diff <commit-path>' classified as commit; got: $out"
+    teardown_project; return
+  fi
+  pass "T3: 'git diff scripts/pre-commit-gate.sh' NOT classified as commit (read-only)"
+  teardown_project
+}
+
+t4_git_log_on_commit_named_file_not_classified() {
+  setup_uat_blocking_state
+  local out; out=$(run_hook 'git log -- scripts/check-commit-message.sh')
+  if [[ "${out#*|}" == *'"permissionDecision": "deny"'* ]]; then
+    fail_ "T4" "false-positive: 'git log <commit-path>' classified as commit; got: $out"
+    teardown_project; return
+  fi
+  pass "T4: 'git log -- scripts/check-commit-message.sh' NOT classified as commit"
+  teardown_project
+}
+
+t5_git_blame_on_commit_named_file_not_classified() {
+  setup_uat_blocking_state
+  local out; out=$(run_hook 'git blame scripts/pre-commit-gate.sh')
+  if [[ "${out#*|}" == *'"permissionDecision": "deny"'* ]]; then
+    fail_ "T5" "false-positive: 'git blame <commit-path>' classified as commit; got: $out"
+    teardown_project; return
+  fi
+  pass "T5: 'git blame scripts/pre-commit-gate.sh' NOT classified as commit"
+  teardown_project
+}
+
+# Commands that mention 'git commit' inside quotes (e.g., grep search strings) MUST NOT be classified.
+t6_grep_for_string_not_classified() {
+  setup_uat_blocking_state
+  local out; out=$(run_hook 'rg "git commit" docs/')
+  if [[ "${out#*|}" == *'"permissionDecision": "deny"'* ]]; then
+    fail_ "T6" "false-positive: 'rg \"git commit\" docs/' classified as commit; got: $out"
+    teardown_project; return
+  fi
+  pass "T6: 'rg \"git commit\" docs/' NOT classified as commit (search string)"
+  teardown_project
+}
+
+echo "== tests/test-pre-commit-gate-classifier.sh =="
+t1_real_git_commit_classified
+t2_chained_git_commit_classified
+t3_git_diff_on_commit_named_file_not_classified
+t4_git_log_on_commit_named_file_not_classified
+t5_git_blame_on_commit_named_file_not_classified
+t6_grep_for_string_not_classified
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **BL-020** (hook fix) — `scripts/pre-commit-gate.sh` classified Bash commands as `git commit` invocations via `\bgit\b.*\bcommit\b` at 6 call sites. The pattern over-matched any command line containing both substrings as words. Refactored to a shared `_is_git_commit()` helper using `(^|[^"'])git[[:space:]]+commit\b` — requires `commit` to come immediately after `git` AND `git` to not be preceded by a quote. New `tests/test-pre-commit-gate-classifier.sh` (6 cases: 2 positives + 4 false-positive regressions) all pass.
- **BL-022** (docs) — `docs/builders-guide.md` UAT_STEPS section now clarifies that `remediation_complete` and `gate_passed` describe **local** state, not "shipped to remote." Documents the intended sequence to prevent the chicken-and-egg framing that drove the lancache handoff-theater incident.

## Why
Both BL-020 and BL-022 surfaced from the lancache UAT-2 session 2026-04-26 where an agent spent ~19 minutes in handoff theater. BL-020 made `git diff scripts/pre-commit-gate.sh` and similar read-only operations on commit-named files appear blocked; BL-022 made the framework's intended marking sequence look like a logical contradiction.

Edge case: `bash -c "git commit"` is no longer classified by the new pattern. Rare and non-idiomatic for agents — acceptable trade-off.

## Test plan
- [x] `bash tests/test-pre-commit-gate-classifier.sh` → 6/6 pass (T1/T2 positives, T3-T6 regressions for `git diff`, `git log`, `git blame`, and `rg "git commit"`)
- [x] `bash tests/test-pending-approval.sh` → 17/17 (regression — pending-approval also goes through the classifier)
- [x] `bash tests/test-process-checklist-classifier.sh` → 12/12 (regression — adjacent gate)
- [ ] In a real project mid-UAT: `git diff scripts/pre-commit-gate.sh` no longer trips the gate; `git commit` still does

🤖 Generated with [Claude Code](https://claude.com/claude-code)