### PR TITLE
U-K: defensive defaults in test-gate.sh to avoid integer-cmp crashes

### DIFF
--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -81,9 +81,11 @@ EOF
 check_batch() {
   ensure_progress_file
 
+  # U-K: default missing/null fields so partial state files don't trip
+  # `[: null: integer expression expected` in the comparison below.
   local since_last interval
-  since_last=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS")
-  interval=$(jq -r '.test_interval' "$BUILD_PROGRESS")
+  since_last=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
+  interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")
 
   if [ "$since_last" -ge "$interval" ]; then
     print_fail "Testing session required ($since_last features since last test, interval is $interval)"
@@ -113,9 +115,11 @@ record_feature() {
   health_count=$(jq '.features_since_last_health_check // 0' "$BUILD_PROGRESS")
   jq ".features_since_last_health_check = $((health_count + 1))" "$BUILD_PROGRESS" > "$BUILD_PROGRESS.tmp" && mv "$BUILD_PROGRESS.tmp" "$BUILD_PROGRESS"
 
+  # U-K: default missing/null fields so partial state files don't trip
+  # `[: null: integer expression expected` in the comparison below.
   local since_last interval
-  since_last=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS")
-  interval=$(jq -r '.test_interval' "$BUILD_PROGRESS")
+  since_last=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
+  interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")
 
   print_ok "Feature '$name' recorded ($since_last/$interval until next test session)"
 
@@ -199,11 +203,13 @@ unrecord_feature() {
 
   # Compute preview values
   local cur_array cur_fslt cur_fslhc cur_testing interval new_fslt new_fslhc new_testing new_array
-  cur_array=$(jq -c '.features_completed' "$BUILD_PROGRESS")
-  cur_fslt=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS")
+  # U-K: default missing/null fields so partial state files don't trip
+  # arithmetic and integer-comparison errors below.
+  cur_array=$(jq -c '.features_completed // []' "$BUILD_PROGRESS")
+  cur_fslt=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
   cur_fslhc=$(jq -r '.features_since_last_health_check // 0' "$BUILD_PROGRESS")
-  cur_testing=$(jq -r '.testing_required' "$BUILD_PROGRESS")
-  interval=$(jq -r '.test_interval' "$BUILD_PROGRESS")
+  cur_testing=$(jq -r '.testing_required // false' "$BUILD_PROGRESS")
+  interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")
 
   new_fslt=$(( cur_fslt - 1 < 0 ? 0 : cur_fslt - 1 ))
   new_fslhc=$(( cur_fslhc - 1 < 0 ? 0 : cur_fslhc - 1 ))

--- a/tests/test-test-gate-null-handling.sh
+++ b/tests/test-test-gate-null-handling.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tests/test-test-gate-null-handling.sh — U-K regression test.
+#
+# scripts/test-gate.sh integer comparisons at lines 88/122/210 errored with
+# "integer expression expected" when jq returned null/empty for numeric
+# fields (build-progress.json missing keys or partially populated).
+# Fix: jq -r '... // 0' (or '// 2' for test_interval) default for every
+# numeric read site, so partial state files no longer crash the gate.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/test-gate.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup_with_state() {
+  local state_json="$1"
+  TMPDIR_T=$(mktemp -d)
+  mkdir -p "$TMPDIR_T/.claude"
+  printf '%s' "$state_json" > "$TMPDIR_T/.claude/build-progress.json"
+}
+teardown_project() { rm -rf "$TMPDIR_T"; }
+
+t1_empty_json_check_batch_no_crash() {
+  setup_with_state '{}'
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --check-batch 2>&1) || rc=$?
+  if echo "$out" | grep -q "integer expression expected\|unbound variable"; then
+    fail_ "T1" "shell crash on empty JSON; out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T1" "expected exit 0 (0 features < default interval); rc=$rc out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  pass "T1: --check-batch on empty JSON exits 0 with no shell errors"
+  teardown_project
+}
+
+t2_missing_test_interval_uses_default() {
+  setup_with_state '{"features_since_last_test": 5, "features_completed": []}'
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --check-batch 2>&1) || rc=$?
+  if echo "$out" | grep -q "integer expression expected"; then
+    fail_ "T2" "shell crash; out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  # 5 features >= default interval 2 → testing required → exit 1
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T2" "expected non-zero (5 >= default 2); rc=$rc out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  if ! echo "$out" | grep -q "Testing session required"; then
+    fail_ "T2" "expected 'Testing session required'; out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  pass "T2: missing test_interval defaults to 2 (5 >= 2 → required)"
+  teardown_project
+}
+
+t3_missing_features_since_last_test_uses_default() {
+  setup_with_state '{"test_interval": 3, "features_completed": []}'
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --check-batch 2>&1) || rc=$?
+  if echo "$out" | grep -q "integer expression expected"; then
+    fail_ "T3" "shell crash; out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T3" "expected exit 0 (0 < 3); rc=$rc out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  pass "T3: missing features_since_last_test defaults to 0 (0 < 3 → clear)"
+  teardown_project
+}
+
+t4_record_feature_no_crash_on_partial_state() {
+  setup_with_state '{"features_completed": []}'
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --record-feature "feat-1" 2>&1) || rc=$?
+  if echo "$out" | grep -q "integer expression expected\|unbound variable"; then
+    fail_ "T4" "shell crash on --record-feature; out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  pass "T4: --record-feature on partial state runs without shell errors"
+  teardown_project
+}
+
+t5_populated_state_still_works() {
+  # Regression: ensure normal happy-path state still works.
+  setup_with_state '{"features_completed": [], "features_since_last_test": 0, "test_interval": 2, "testing_required": false, "tester_count": 1, "bug_tracker": "github_issues", "sessions_completed": 0, "last_test_session": null}'
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --check-batch 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T5" "regression: populated state should pass; rc=$rc out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  if ! echo "$out" | grep -q "Clear to continue"; then
+    fail_ "T5" "expected 'Clear to continue'; out:\n$(echo "$out" | head -3)"
+    teardown_project; return
+  fi
+  pass "T5: populated state — 'Clear to continue' (regression)"
+  teardown_project
+}
+
+echo "== tests/test-test-gate-null-handling.sh =="
+t1_empty_json_check_batch_no_crash
+t2_missing_test_interval_uses_default
+t3_missing_features_since_last_test_uses_default
+t4_record_feature_no_crash_on_partial_state
+t5_populated_state_still_works
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Add `// 0` (or `// 2` for `test_interval`, matching `ensure_progress_file`'s bootstrap default) to every numeric `jq` read site in `scripts/test-gate.sh`.
- Adds `// false` for the boolean `testing_required` read and `// []` for the `features_completed` array read in the unrecord preview.
- New `tests/test-test-gate-null-handling.sh` (5 cases): empty JSON, missing test_interval, missing features_since_last_test, --record-feature on partial state, populated regression.

## Why
Three integer comparisons at `scripts/test-gate.sh:88`, `:122`, `:210` errored with `[: null: integer expression expected` and `null: unbound variable` when `jq` returned `"null"` or empty for numeric fields. The trigger is a partially-populated `.claude/build-progress.json` (missing keys after manual edits, schema drift, or merge dropping a field).

`ensure_progress_file` only initializes when the file doesn't exist — it doesn't repair partial state. The defensive defaults handle the "exists but partial" case without changing the bootstrap behavior.

## Test plan
- [x] `bash tests/test-test-gate-null-handling.sh` → 5/5 pass
- [x] `bash tests/test-upgrade-non-interactive.sh` → 7/7 (regression)
- [x] `bash tests/test-process-checklist-classifier.sh` → 12/12 (regression)
- [x] `bash tests/test-pre-commit-gate-classifier.sh` → 6/6 (regression)
- [ ] In a real project: `scripts/test-gate.sh --check-batch` against a partially-populated build-progress.json no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)