### PR TITLE
U-D: auto-advance .current_phase at phase entry

### DIFF
--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -32,6 +32,25 @@ PHASE3_STEPS=(integration_testing security_hardening chaos_testing accessibility
 PHASE4_STEPS=(production_build rollback_tested go_live_verified monitoring_configured handoff_written handoff_tested)
 PHASE2_INIT_STEPS=(remote_repo_created branch_protection_configured project_scaffolded data_model_applied pre_commit_hooks_installed ci_pipeline_configured initialization_verified)
 
+# --- Phase advance helper (U-D) ---
+# Bump .current_phase in PHASE_STATE to at least N. Never downgrades — if
+# the user is already past N (e.g., re-running --start-phase1 from Phase 3),
+# the value is left alone. Silent no-op if PHASE_STATE doesn't exist
+# (pre-framework projects or test fixtures without the file).
+_set_current_phase_min() {
+  local target="$1"
+  [ -f "$PHASE_STATE" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local cur
+  cur=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null || echo "0")
+  case "$cur" in ''|*[!0-9]*) cur=0 ;; esac
+  if [ "$cur" -lt "$target" ]; then
+    jq --argjson p "$target" '.current_phase = $p' "$PHASE_STATE" > "$PHASE_STATE.tmp" \
+      && mv "$PHASE_STATE.tmp" "$PHASE_STATE"
+    print_info "Advanced .current_phase: $cur → $target"
+  fi
+}
+
 # --- Argument parsing ---
 ACTION=""
 ARG_VALUE=""
@@ -183,6 +202,7 @@ start_phase1() {
   fi
 
   print_ok "Phase 1 architecture planning started"
+  _set_current_phase_min 1  # U-D
   print_info "Next step: scripts/process-checklist.sh --complete-step phase1_architecture:architecture_selected"
 }
 
@@ -453,6 +473,7 @@ complete_step() {
   if [ "$process" = "phase2_init" ] && [ "$new_step_num" -eq "${#steps[@]}" ]; then
     jq '.phase2_init.verified = true' "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"
     print_ok "Phase 2 initialization auto-verified (all ${#steps[@]} steps complete)"
+    _set_current_phase_min 2  # U-D
   fi
 
   # Auto-reset build_loop when feature_recorded lands — the previous feature's
@@ -498,15 +519,11 @@ start_phase3() {
   local now
   now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-  # P3-012: Verify Phase 2 prerequisites before allowing Phase 3 entry
-  local phase_state=".claude/phase-state.json"
-  if [ -f "$phase_state" ]; then
-    local current_phase
-    current_phase=$(grep -o '"current_phase"[[:space:]]*:[[:space:]]*"*[0-9]*"*' "$phase_state" | grep -o '[0-9]*' || echo "0")
-    if [ "$current_phase" -lt 3 ] 2>/dev/null; then
-      print_warn "current_phase is $current_phase (expected >= 3). Update phase-state.json before starting Phase 3."
-    fi
-  fi
+  # P3-012 + U-D: enforce Phase 2 → 3 prerequisites and auto-advance
+  # current_phase. Pre-fix this only WARNED if current_phase < 3, leaving
+  # the operator to manually `jq` patch phase-state.json. We now do the
+  # advance ourselves at the end of this function (after the bug-gate
+  # check passes).
 
   # Check bug gate status
   local test_gate="$SCRIPT_DIR/test-gate.sh"
@@ -527,6 +544,7 @@ start_phase3() {
   ' "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"
 
   print_ok "Phase 3 validation started"
+  _set_current_phase_min 3  # U-D
   print_info "Next step: scripts/process-checklist.sh --complete-step phase3_validation:integration_testing"
 }
 
@@ -556,6 +574,7 @@ start_phase4() {
   ' "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"
 
   print_ok "Phase 4 release started"
+  _set_current_phase_min 4  # U-D
   print_info "Next step: scripts/process-checklist.sh --complete-step phase4_release:production_build"
 }
 
@@ -677,6 +696,7 @@ verify_init() {
     fi
     jq '.phase2_init.verified = true' "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"
     print_ok "Phase 2 initialization fully verified ($total/$total steps complete)"
+    _set_current_phase_min 2  # U-D
   else
     print_warn "Phase 2 initialization incomplete ($prereq_done/$prereq_total prerequisite steps)"
     echo ""

--- a/tests/test-process-checklist-auto-advance.sh
+++ b/tests/test-process-checklist-auto-advance.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# tests/test-process-checklist-auto-advance.sh — U-D regression test.
+#
+# Before this fix, scripts/process-checklist.sh wrote phase progress into
+# .claude/process-state.json (start-phaseN markers, --verify-init flips,
+# auto-verify on the final --complete-step) but NEVER updated
+# .claude/phase-state.json::current_phase. The user had to `jq` patch
+# current_phase manually between phases.
+#
+# Fix: each phase-entry path also calls _set_current_phase_min(N), which
+# bumps .current_phase to at least N (never downgrades).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/process-checklist.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup_phase_zero_project() {
+  TMPDIR_T=$(mktemp -d)
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    git remote add origin https://example.com/fake.git
+    mkdir -p .claude
+    cat > .claude/manifest.json <<'JSON'
+{"frameworkVersion":"test","mode":"personal","host":"other"}
+JSON
+    cat > .claude/phase-state.json <<'JSON'
+{"current_phase":0,"track":"light","deployment":"personal","poc_mode":null,"phases":{}}
+JSON
+    cat > .claude/process-state.json <<'JSON'
+{
+  "phase1_architecture":{"steps_completed":[],"started_at":null},
+  "phase2_init":{"verified":false,"steps_completed":[],"started_at":null},
+  "phase3_validation":{"steps_completed":[],"started_at":null},
+  "phase4_release":{"steps_completed":[],"started_at":null},
+  "build_loop":{"feature":null,"step":0,"steps_completed":[]},
+  "uat_session":{"session_id":null,"step":0,"steps_completed":[],"started_at":null}
+}
+JSON
+  )
+}
+teardown_project() { rm -rf "$TMPDIR_T"; }
+
+current_phase_in() { jq -r '.current_phase' "$1/.claude/phase-state.json"; }
+
+t1_start_phase1_advances_to_1() {
+  setup_phase_zero_project
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --start-phase1 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T1" "expected exit 0; rc=$rc out:\n$out"
+    teardown_project; return
+  fi
+  local got; got=$(current_phase_in "$TMPDIR_T")
+  if [ "$got" != "1" ]; then
+    fail_ "T1" "expected current_phase=1 after --start-phase1, got $got"
+    teardown_project; return
+  fi
+  pass "T1: --start-phase1 advances .current_phase 0 → 1"
+  teardown_project
+}
+
+t2_verify_init_advances_to_2() {
+  setup_phase_zero_project
+  # Pre-condition: phase 1 done, ready to verify-init. Set up so verify_init
+  # can auto-mark phase2_init.verified — easier path is to mark all 6 prereq
+  # steps directly via jq, then run --verify-init which checks them.
+  jq '.current_phase = 1' "$TMPDIR_T/.claude/phase-state.json" > "$TMPDIR_T/.claude/phase-state.json.tmp" && mv "$TMPDIR_T/.claude/phase-state.json.tmp" "$TMPDIR_T/.claude/phase-state.json"
+  jq '.phase2_init.steps_completed = ["remote_repo_created","branch_protection_configured","ci_pipeline_configured","project_scaffolded","pre_commit_hooks_installed","data_model_applied"]' "$TMPDIR_T/.claude/process-state.json" > "$TMPDIR_T/.claude/process-state.json.tmp" && mv "$TMPDIR_T/.claude/process-state.json.tmp" "$TMPDIR_T/.claude/process-state.json"
+  # Provide the artifacts verify_init checks for.
+  (
+    cd "$TMPDIR_T"
+    mkdir -p .github/workflows .git/hooks
+    echo "stub" > .github/workflows/ci.yml
+    echo "stub" > package-lock.json
+    echo "#!/bin/sh" > .git/hooks/pre-commit
+    chmod +x .git/hooks/pre-commit
+  )
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --verify-init 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T2" "expected exit 0; rc=$rc out:\n$out"
+    teardown_project; return
+  fi
+  local got; got=$(current_phase_in "$TMPDIR_T")
+  if [ "$got" -lt 2 ]; then
+    fail_ "T2" "expected current_phase >= 2 after --verify-init success, got $got"
+    teardown_project; return
+  fi
+  pass "T2: --verify-init success advances .current_phase to ≥ 2 (got $got)"
+  teardown_project
+}
+
+t3_start_phase3_advances_to_3() {
+  setup_phase_zero_project
+  jq '.current_phase = 2' "$TMPDIR_T/.claude/phase-state.json" > "$TMPDIR_T/.claude/phase-state.json.tmp" && mv "$TMPDIR_T/.claude/phase-state.json.tmp" "$TMPDIR_T/.claude/phase-state.json"
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --start-phase3 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T3" "expected exit 0; rc=$rc out:\n$out"
+    teardown_project; return
+  fi
+  local got; got=$(current_phase_in "$TMPDIR_T")
+  if [ "$got" != "3" ]; then
+    fail_ "T3" "expected current_phase=3 after --start-phase3, got $got"
+    teardown_project; return
+  fi
+  pass "T3: --start-phase3 advances .current_phase 2 → 3"
+  teardown_project
+}
+
+t4_start_phase4_advances_to_4() {
+  setup_phase_zero_project
+  jq '.current_phase = 3' "$TMPDIR_T/.claude/phase-state.json" > "$TMPDIR_T/.claude/phase-state.json.tmp" && mv "$TMPDIR_T/.claude/phase-state.json.tmp" "$TMPDIR_T/.claude/phase-state.json"
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --start-phase4 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T4" "expected exit 0; rc=$rc out:\n$out"
+    teardown_project; return
+  fi
+  local got; got=$(current_phase_in "$TMPDIR_T")
+  if [ "$got" != "4" ]; then
+    fail_ "T4" "expected current_phase=4 after --start-phase4, got $got"
+    teardown_project; return
+  fi
+  pass "T4: --start-phase4 advances .current_phase 3 → 4"
+  teardown_project
+}
+
+t5_no_downgrade_when_already_advanced() {
+  # Regression: if user has manually advanced past N, don't downgrade them.
+  setup_phase_zero_project
+  jq '.current_phase = 3' "$TMPDIR_T/.claude/phase-state.json" > "$TMPDIR_T/.claude/phase-state.json.tmp" && mv "$TMPDIR_T/.claude/phase-state.json.tmp" "$TMPDIR_T/.claude/phase-state.json"
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --start-phase1 2>&1) || rc=$?
+  local got; got=$(current_phase_in "$TMPDIR_T")
+  if [ "$got" != "3" ]; then
+    fail_ "T5" "regression — --start-phase1 downgraded current_phase from 3 to $got"
+    teardown_project; return
+  fi
+  pass "T5: re-running --start-phase1 with current_phase=3 does NOT downgrade"
+  teardown_project
+}
+
+echo "== tests/test-process-checklist-auto-advance.sh =="
+t1_start_phase1_advances_to_1
+t2_verify_init_advances_to_2
+t3_start_phase3_advances_to_3
+t4_start_phase4_advances_to_4
+t5_no_downgrade_when_already_advanced
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- New `_set_current_phase_min N` helper in `scripts/process-checklist.sh` bumps `.claude/phase-state.json::current_phase` to at least `N`. Never downgrades; silent no-op when `PHASE_STATE` doesn't exist.
- Hooked at five insertion points so phase transitions update both `process-state.json` AND `phase-state.json`:
  - `start_phase1()` → ≥1
  - `--complete-step phase2_init` final-step auto-verify → ≥2
  - `verify_init()` success path → ≥2
  - `start_phase3()` → ≥3 (replaces the prior warn-only "expected >= 3" message)
  - `start_phase4()` → ≥4
- New `tests/test-process-checklist-auto-advance.sh` (5 cases): one per transition + no-downgrade regression check.

## Why
Pre-fix, no script ever wrote `.current_phase`. Every UAT runbook since rev1 worked around this with explicit `jq '.current_phase = N'` lines, and live operators had to remember the manual patch between phases. Closes U-D from `Reports/uat-2026-04-26/TRIAGE.md` tier-3 (still confirmed at the rev3 sweep but explicitly out-of-scope for the regression-only re-sweep).

## Test plan
- [x] `bash tests/test-process-checklist-auto-advance.sh` → 5/5 pass
- [x] `bash tests/test-process-checklist-classifier.sh` → 12/12 (regression)
- [x] `bash tests/test-test-gate-null-handling.sh` → 5/5 (regression)
- [x] `bash tests/test-pre-commit-gate-classifier.sh` → 6/6 (regression)
- [x] `bash tests/test-pending-approval.sh` → 17/17 (regression)
- [ ] In a real project: `--start-phase1` then `cat .claude/phase-state.json` shows `current_phase: 1` without manual `jq`

🤖 Generated with [Claude Code](https://claude.com/claude-code)