### PR TITLE
BL-002: GitHub free-tier 403 graceful degradation

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1853,19 +1853,53 @@ MANIFESTEOF
     host_push_initial main 2>/dev/null || host_push_initial master || { print_fail "Push failed — $remote_url exists but empty"; return 1; }
 
     print_info "Configuring branch protection ($mode mode)..."
-    host_configure_protection main "$mode" || host_configure_protection master "$mode" \
-      || { print_fail "Protection config failed — run 'scripts/check-gate.sh --repair' after troubleshooting"; return 1; }
-
-    print_info "Verifying protection..."
-    if ! host_verify_protection main "$mode" 2>/dev/null && ! host_verify_protection master "$mode"; then
-      # Retry once for API lag
-      sleep 10
-      if ! host_verify_protection main "$mode" 2>/dev/null && ! host_verify_protection master "$mode"; then
-        print_fail "Verification failed — run 'scripts/check-gate.sh --repair'"
-        return 1
-      fi
+    # BL-002: capture exit code 3 for github free-tier 403 (host_configure_protection
+    # detects the "Upgrade to GitHub Pro" pattern). Fall through to the attestation
+    # flow shared with the --git-host other path so init can complete cleanly.
+    local _hcp_rc=0
+    host_configure_protection main "$mode" || _hcp_rc=$?
+    if [ "$_hcp_rc" -ne 0 ] && [ "$_hcp_rc" -ne 3 ]; then
+      _hcp_rc=0
+      host_configure_protection master "$mode" || _hcp_rc=$?
     fi
-    print_ok "Protection verified for $mode mode"
+
+    if [ "$_hcp_rc" -eq 3 ]; then
+      print_warn "Branch protection unavailable on this repo (free-tier limit)."
+      print_info "Falling back to attestation flow — see remediation message above."
+      local attest
+      if [ "${BRANCH_PROTECTION_ATTESTED:-false}" = true ]; then
+        attest="yes"
+        print_info "Branch protection attested via --branch-protection-attested flag."
+      else
+        read -rp "Attest that protection will be enforced manually until you upgrade? [type 'yes' to attest]: " attest
+      fi
+      [ "$attest" != "yes" ] && { print_fail "Attestation required — cannot proceed (or upgrade to GitHub Pro)"; return 1; }
+      # Record attestation with the github_free_tier reason so check-gate.sh
+      # --preflight skips the API verify.
+      mkdir -p .claude
+      if [ ! -f .claude/process-state.json ]; then
+        echo '{"phase2_init":{"steps_completed":[],"attestations":{}}}' > .claude/process-state.json
+      fi
+      jq --arg at "$(date -u +%FT%TZ)" \
+         '.phase2_init.attestations.branch_protection = {attested_by: "orchestrator", at: $at, reason: "github_free_tier"}' \
+         .claude/process-state.json > .claude/process-state.json.tmp \
+         && mv .claude/process-state.json.tmp .claude/process-state.json
+      print_ok "Free-tier attestation recorded — check-gate.sh --preflight will honor it."
+    elif [ "$_hcp_rc" -ne 0 ]; then
+      print_fail "Protection config failed — run 'scripts/check-gate.sh --repair' after troubleshooting"
+      return 1
+    else
+      print_info "Verifying protection..."
+      if ! host_verify_protection main "$mode" 2>/dev/null && ! host_verify_protection master "$mode"; then
+        # Retry once for API lag
+        sleep 10
+        if ! host_verify_protection main "$mode" 2>/dev/null && ! host_verify_protection master "$mode"; then
+          print_fail "Verification failed — run 'scripts/check-gate.sh --repair'"
+          return 1
+        fi
+      fi
+      print_ok "Protection verified for $mode mode"
+    fi
   fi
 
   # Write host + mode + remote_url to .claude/manifest.json (create if absent)

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -48,6 +48,21 @@ _require_manifest() {
 cmd_preflight() {
   _require_manifest || return 1
   print_step "Preflight: checking protection status"
+
+  # BL-002: honor a recorded `github_free_tier` (or `other_host_attestation`)
+  # branch-protection attestation from process-state.json. When the project
+  # was init'd against a tier-limited host, host_verify_protection has
+  # nothing to verify — the attestation IS the gate.
+  local attest_reason=""
+  if [ -f .claude/process-state.json ]; then
+    attest_reason=$(jq -r '.phase2_init.attestations.branch_protection.reason // ""' \
+                       .claude/process-state.json 2>/dev/null || echo "")
+  fi
+  if [ "$attest_reason" = "github_free_tier" ]; then
+    print_ok "Ready: branch protection attested (reason: github_free_tier — upgrade to GitHub Pro to enable API enforcement)"
+    return 0
+  fi
+
   # shellcheck disable=SC1090
   source "$SCRIPT_DIR/lib/host.sh"
   host_load_driver || {

--- a/scripts/host-drivers/github.sh
+++ b/scripts/host-drivers/github.sh
@@ -109,8 +109,31 @@ host_configure_protection() {
       ;;
   esac
 
-  if ! gh api -X PUT "repos/$owner_repo/branches/$branch/protection" --input - <<<"$payload" >/dev/null 2>&1; then
+  # BL-002: capture gh stderr so we can detect free-tier 403s. The pattern
+  # `Upgrade to GitHub Pro` (or `make this repository public`) is GitHub's
+  # canonical message when branch protection is unavailable on a free-tier
+  # personal account's private repo. Distinguish from generic 403s (e.g.
+  # insufficient org permissions) which keep returning 2.
+  local gh_err
+  if ! gh_err=$(gh api -X PUT "repos/$owner_repo/branches/$branch/protection" --input - <<<"$payload" 2>&1); then
+    if echo "$gh_err" | grep -qE 'Upgrade to GitHub Pro|make this repository public'; then
+      printf '%s\n' \
+        "github driver: branch protection is unavailable on this repo." \
+        "" \
+        "  GitHub free-tier personal accounts cannot enable branch protection on" \
+        "  private repos. The API responded:" \
+        "" \
+        "$(printf '    %s\n' "$gh_err")" \
+        "" \
+        "  Options:" \
+        "    1. Upgrade to GitHub Pro (\$4/mo) — unlocks protection on private repos." \
+        "    2. Make this repo public — protection works on free-tier public repos." \
+        "    3. Attest manually — accept that protection is enforced by convention," \
+        "       not the API. Re-run with --branch-protection-attested to record this." >&2
+      return 3
+    fi
     echo "github driver: failed to configure protection on $owner_repo#$branch ($mode mode)" >&2
+    [ -n "$gh_err" ] && printf '  %s\n' "$gh_err" >&2
     return 2
   fi
   return 0

--- a/tests/test-check-gate.sh
+++ b/tests/test-check-gate.sh
@@ -108,11 +108,38 @@ t4_yes_flag_before_subcommand() {
   teardown_project
 }
 
+t5_preflight_honors_free_tier_attestation() {
+  # BL-002: check-gate.sh --preflight should pass when a github_free_tier
+  # branch-protection attestation has been recorded in process-state.json,
+  # without invoking host_verify_protection.
+  setup_project
+  jq '.host = "github" | .mode = "personal"' "$TMPDIR_T/.claude/manifest.json" > "$TMPDIR_T/.claude/manifest.json.tmp" \
+    && mv "$TMPDIR_T/.claude/manifest.json.tmp" "$TMPDIR_T/.claude/manifest.json"
+  cat > "$TMPDIR_T/.claude/process-state.json" <<'JSON'
+{"phase2_init":{"steps_completed":[],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-04-27T00:00:00Z","reason":"github_free_tier"}}}}
+JSON
+  local out rc=0
+  out=$(cd "$TMPDIR_T" && "$SCRIPT" --preflight 2>&1) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T5" "expected exit 0 with free-tier attestation, got rc=$rc out=$out"
+    teardown_project
+    return
+  fi
+  if [[ "$out" != *"attested"* ]] && [[ "$out" != *"github_free_tier"* ]]; then
+    fail_ "T5" "expected message mentioning attestation; got: $out"
+    teardown_project
+    return
+  fi
+  pass "T5: --preflight honors github_free_tier attestation (skips API verify)"
+  teardown_project
+}
+
 echo "== tests/test-check-gate.sh =="
 t1_yes_flag_writes_host_non_interactive
 t2_interactive_y_still_works
 t3_interactive_n_aborts
 t4_yes_flag_before_subcommand
+t5_preflight_honors_free_tier_attestation
 
 echo ""
 echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="

--- a/tests/test-github-free-tier-403.sh
+++ b/tests/test-github-free-tier-403.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# tests/test-github-free-tier-403.sh — BL-002 regression test.
+#
+# scripts/host-drivers/github.sh::host_configure_protection swallowed the
+# gh CLI's stderr (`>/dev/null 2>&1`) and printed a generic
+# "failed to configure protection" message. Free-tier accounts trying to
+# enable branch protection on private repos got a cryptic failure with no
+# tier context — even though gh's actual response includes the helpful
+# "Upgrade to GitHub Pro or make this repository public" body.
+#
+# Fix: capture gh's stderr; if the response matches the free-tier 403
+# pattern, return exit code 3 (distinct from 2=other API failure) and
+# emit a structured remediation message. Other failures keep returning 2.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/host-drivers/github.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Set up a tempdir with a fake `gh` on PATH that emits a chosen response
+# body and exit code, plus a git remote that the driver can parse.
+setup_with_fake_gh() {
+  local fake_response="$1"
+  local fake_exit="$2"
+  TMPDIR_T=$(mktemp -d)
+  mkdir -p "$TMPDIR_T/bin"
+  cat > "$TMPDIR_T/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+# Fake gh for BL-002 testing. Always emits the canned response and exit code,
+# regardless of subcommand (api, repo, etc.).
+case "\$*" in
+  *"branches/"*"/protection"*)
+    printf '%s\n' "$fake_response" >&2
+    exit $fake_exit
+    ;;
+  *)
+    # Other gh invocations (e.g. auth status) succeed silently.
+    exit 0
+    ;;
+esac
+GHEOF
+  chmod +x "$TMPDIR_T/bin/gh"
+  # Fake project with a github origin so _github_parse_origin succeeds.
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    git remote add origin https://github.com/test/repo.git
+  )
+}
+teardown_project() { rm -rf "$TMPDIR_T"; }
+
+# Source the driver and call host_configure_protection inside a subshell with
+# fake gh on PATH. Echoes "EXIT|STDERR".
+run_configure() {
+  (
+    cd "$TMPDIR_T"
+    PATH="$TMPDIR_T/bin:$PATH"
+    set +e
+    # shellcheck disable=SC1090
+    source "$DRIVER"
+    out=$(host_configure_protection main personal 2>&1)
+    rc=$?
+    printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+  )
+}
+
+t1_free_tier_403_returns_3_with_remediation() {
+  setup_with_fake_gh 'HTTP 403: Upgrade to GitHub Pro or make this repository public to enable this feature. (https://api.github.com/repos/test/repo/branches/main/protection)' 1
+  local out; out=$(run_configure)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "3" ]; then
+    fail_ "T1" "expected exit 3 for free-tier 403; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"GitHub Pro"* ]] && [[ "$stderr" != *"free-tier"* ]] && [[ "$stderr" != *"tier"* ]]; then
+    fail_ "T1" "expected remediation mentioning tier/Pro; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T1: free-tier 403 → exit 3 + remediation message"
+  teardown_project
+}
+
+t2_success_returns_0() {
+  setup_with_fake_gh '' 0
+  local out; out=$(run_configure)
+  local rc="${out%%|*}"
+  if [ "$rc" != "0" ]; then
+    fail_ "T2" "expected exit 0 on success; got rc=$rc out=$out"
+    teardown_project; return
+  fi
+  pass "T2: gh PUT succeeds → exit 0"
+  teardown_project
+}
+
+t3_generic_403_returns_2() {
+  # Generic 403 (e.g., insufficient permissions on an org repo) should NOT
+  # be classified as the free-tier limitation.
+  setup_with_fake_gh 'HTTP 403: Resource not accessible by integration' 1
+  local out; out=$(run_configure)
+  local rc="${out%%|*}"
+  if [ "$rc" != "2" ]; then
+    fail_ "T3" "expected exit 2 for generic 403; got rc=$rc out=$out"
+    teardown_project; return
+  fi
+  pass "T3: generic 403 → exit 2 (not free-tier)"
+  teardown_project
+}
+
+t4_auth_401_returns_2() {
+  setup_with_fake_gh 'HTTP 401: Bad credentials' 1
+  local out; out=$(run_configure)
+  local rc="${out%%|*}"
+  if [ "$rc" != "2" ]; then
+    fail_ "T4" "expected exit 2 for auth failure; got rc=$rc out=$out"
+    teardown_project; return
+  fi
+  pass "T4: 401 auth failure → exit 2 (existing behavior preserved)"
+  teardown_project
+}
+
+echo "== tests/test-github-free-tier-403.sh =="
+t1_free_tier_403_returns_3_with_remediation
+t2_success_returns_0
+t3_generic_403_returns_2
+t4_auth_401_returns_2
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
GitHub free-tier personal accounts can't enable branch protection on private repos — the API returns 403 "Upgrade to GitHub Pro or make this repository public to enable this feature." Pre-fix, the github driver swallowed `gh`'s stderr and printed a generic failure, init.sh aborted, and the user got a cryptic dead-end.

This PR makes the path graceful end-to-end:

- **`scripts/host-drivers/github.sh`** — `host_configure_protection` captures gh's stderr, detects the free-tier patterns ("Upgrade to GitHub Pro" / "make this repository public"), prints a structured remediation message (three options: upgrade, public, attest), and returns a new exit code **3** (distinct from 2 = other API failure).
- **`init.sh::create_and_protect_remote`** — captures the exit code (instead of swallowing via `||`); on `3`, falls through to the same attestation flow used for `--git-host other`. Honors `--branch-protection-attested` non-interactively. Records the attestation in `.claude/process-state.json` with `reason: "github_free_tier"`.
- **`scripts/check-gate.sh::cmd_preflight`** — reads the attestation reason; when `github_free_tier`, reports attested and exits 0 without calling `host_verify_protection` (which would always fail on the free tier).

Closes BL-002.

## Test plan
- [x] `bash tests/test-github-free-tier-403.sh` → 4/4 (driver detection via fake gh on PATH)
- [x] `bash tests/test-check-gate.sh` → 5/5 (incl. new T5 for attestation honor)
- [x] All 12 adjacent suites green (82 tests total)
- [ ] In a real free-tier project: init.sh completes init.sh, manifest has host=github + remote_url, process-state.json has the attestation, `scripts/check-gate.sh --preflight` reports ready

## Edge cases / non-goals
- Generic 403 (insufficient permissions on an org repo) keeps returning `2` — only the explicit free-tier message triggers exit `3`.
- Existing 401/auth failure path is unchanged (also returns `2`).
- BL-002 spec mentioned similar checks for GitLab/Bitbucket — those tiers don't currently restrict branch protection, so out of scope; can re-open if their behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)