### PR TITLE
BL-024: record attestation before push on --git-host other

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1807,10 +1807,13 @@ MANIFESTEOF
     fi
     [ -z "$remote_url" ] && { print_fail "Remote URL required for 'other' host"; return 1; }
     git remote add origin "$remote_url"
-    if ! git push -u origin main 2>/dev/null && ! git push -u origin master 2>/dev/null; then
-      print_fail "Push failed — verify URL and credentials"
-      return 1
-    fi
+
+    # BL-024: record attestation BEFORE the push attempt. Attestation is a
+    # forward-looking commitment ("I will configure protection on this remote")
+    # — it does not depend on push success. Pre-fix, push happened first and
+    # any push failure (corporate firewall, fake URL for testing, connectivity
+    # blip) returned 1 before attestation was written, silently dropping the
+    # operator's commitment.
     echo ""
     echo "Since 'other' host is not API-verifiable, attest branch protection:"
     echo "  - Force-push disabled on main"
@@ -1825,7 +1828,7 @@ MANIFESTEOF
       read -rp "Has branch protection been configured per the above? [type 'yes' to attest]: " attest
     fi
     [ "$attest" != "yes" ] && { print_fail "Attestation required — cannot proceed to Phase 0"; return 1; }
-    # Record attestation in process-state.json
+    # Record attestation in process-state.json (BEFORE push — see BL-024 above).
     mkdir -p .claude
     if [ ! -f .claude/process-state.json ]; then
       echo '{"phase2_init":{"steps_completed":[],"attestations":{}}}' > .claude/process-state.json
@@ -1834,6 +1837,17 @@ MANIFESTEOF
        '.phase2_init.attestations.branch_protection = {attested_by: "orchestrator", at: $at}' \
        .claude/process-state.json > .claude/process-state.json.tmp \
        && mv .claude/process-state.json.tmp .claude/process-state.json
+
+    # Push happens AFTER attestation so a push failure cannot drop the
+    # attestation. The outer init.sh wraps create_and_protect_remote in
+    # `if ! ...; then warn ...` (BL-016/U-B fix at init.sh:1717-1730), so
+    # `return 1` here surfaces the push failure as a remediation prompt
+    # without aborting init.sh — and the attestation we just wrote
+    # persists for check-gate.sh --repair / --preflight to honor.
+    if ! git push -u origin main 2>/dev/null && ! git push -u origin master 2>/dev/null; then
+      print_fail "Push failed — verify URL and credentials"
+      return 1
+    fi
   else
     # First-class host: dispatcher + driver
     # shellcheck disable=SC1090

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -513,7 +513,9 @@ Apply to any future runbook templates as well; the existing rev1/rev2 runbooks h
 **Logged:** 2026-04-27
 **Category:** Debt (real bug)
 **Severity:** Medium
-**Status:** Open
+**Status:** Resolved (2026-04-27, PR #38)
+
+**Resolution:** `init.sh::create_and_protect_remote` reordered so the attestation prompt + record block runs BEFORE `git push` on the `--git-host other` path. Push failure no longer drops the attestation. New `tests/test-init-other-host-attestation.sh` covers the regression (2 cases: attestation persists on push failure, regression check that the flag is still required).
 
 `init.sh::create_and_protect_remote` for the `--git-host other` path has the wrong order of operations relative to `--branch-protection-attested`. The flow at `init.sh:1768-1836`:
 

--- a/tests/test-init-other-host-attestation.sh
+++ b/tests/test-init-other-host-attestation.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# tests/test-init-other-host-attestation.sh — BL-024 regression test.
+#
+# init.sh::create_and_protect_remote on the --git-host other path used to
+# perform `git push` BEFORE the --branch-protection-attested attestation
+# block. When the push failed (fake URL, corporate firewall, connectivity
+# blip), `return 1` aborted the function and the attestation was silently
+# dropped — even though the operator had explicitly passed
+# --branch-protection-attested.
+#
+# The fix reorders the attestation block to run BEFORE push, since
+# attestation is a forward-looking commitment by the operator and is
+# independent of push success.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT_SH="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Run init.sh against a fake URL so push fails. With --branch-protection-attested,
+# attestation must still be recorded despite the push failure.
+t1_attestation_recorded_when_push_fails_to_fake_url() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/proj"
+  local rc=0
+  ( cd "$tmpdir" && "$INIT_SH" --non-interactive \
+        --project bl024-trace \
+        --platform web \
+        --deployment personal \
+        --language typescript \
+        --project-dir "$proj" \
+        --git-host other \
+        --remote-url https://example.com/fake.git \
+        --branch-protection-attested \
+        --visibility private \
+        --allow-existing-dir > "$tmpdir/out" 2>&1 ) || rc=$?
+
+  # init.sh continues past push failure (BL-016/U-B fix), so it should exit 0.
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T1" "expected init exit 0; rc=$rc tail:\n$(tail -10 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # The push failure should still be visible in the log.
+  if ! grep -q "Push failed" "$tmpdir/out"; then
+    fail_ "T1" "expected to see 'Push failed' in output (this test relies on the fake URL failing); not present"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # The attestation MUST be recorded despite the push failure.
+  if [ ! -f "$proj/.claude/process-state.json" ]; then
+    fail_ "T1" "process-state.json missing"
+    rm -rf "$tmpdir"; return
+  fi
+  local attested_by
+  attested_by=$(jq -r '.phase2_init.attestations.branch_protection.attested_by // "MISSING"' "$proj/.claude/process-state.json")
+  if [ "$attested_by" != "orchestrator" ]; then
+    fail_ "T1" "expected attested_by=orchestrator; got '$attested_by'"
+    rm -rf "$tmpdir"; return
+  fi
+  pass "T1: --branch-protection-attested recorded despite push-to-fake-URL failure"
+  rm -rf "$tmpdir"
+}
+
+# Negative: without the attestation flag, push failure must NOT silently record an attestation.
+t2_no_attestation_when_flag_absent() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/proj"
+  # --git-host other REQUIRES --branch-protection-attested in non-interactive mode
+  # (init.sh validates this and would exit 1 before reaching create_and_protect_remote).
+  # So we test by checking that the attestation only appears when the flag was passed —
+  # i.e., the recording is gated on the flag, not on push success.
+  local rc=0
+  ( cd "$tmpdir" && "$INIT_SH" --non-interactive \
+        --project bl024-neg \
+        --platform web \
+        --deployment personal \
+        --language typescript \
+        --project-dir "$proj" \
+        --git-host other \
+        --remote-url https://example.com/fake.git \
+        --visibility private \
+        --allow-existing-dir > "$tmpdir/out" 2>&1 ) || rc=$?
+
+  # Without --branch-protection-attested, init.sh should fail validation early.
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T2" "expected init validation failure without --branch-protection-attested; got rc=0"
+    rm -rf "$tmpdir"; return
+  fi
+  pass "T2: --git-host other without --branch-protection-attested fails validation (regression)"
+  rm -rf "$tmpdir"
+}
+
+echo "== tests/test-init-other-host-attestation.sh =="
+t1_attestation_recorded_when_push_fails_to_fake_url
+t2_no_attestation_when_flag_absent
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
Reorder `init.sh::create_and_protect_remote` so the `--branch-protection-attested` attestation block runs BEFORE `git push` on the `--git-host other` path. Push failure no longer drops the attestation. New `tests/test-init-other-host-attestation.sh` covers the regression.

## Why
Pre-fix, the push at `init.sh:1810` ran before the attestation block at `:1814-1836`. Any push failure (corporate firewall, fake URL for testing, connectivity blip) returned 1 and silently bypassed the attestation despite the operator having explicitly passed `--branch-protection-attested`. The dropped attestation cascades: post-PR-#36, `check-gate.sh --preflight` honors `phase2_init.attestations.branch_protection.reason` for tier-limited setups; without the attestation having been written, `--preflight` falls through to API verification that has nothing to verify.

Reproduced 2026-04-27 from rev3 sweep agent 2's doc gap. Filed as BL-024 in PR #37 (just merged).

Closes BL-024.

## Why this order is correct
Attestation is a **forward-looking commitment** by the operator ("I will configure protection on this remote") — it does not depend on push success. The push still runs and `return 1`s on failure (so the operator sees the network/auth issue and the U-B fix at `init.sh:1717-1730` surfaces it as a remediation prompt), but the attestation written above persists for `check-gate.sh --repair` and `--preflight` to honor.

## Test plan
- [x] `bash tests/test-init-other-host-attestation.sh` → 2/2 (T1 attestation persists despite fake-URL push failure; T2 regression that the flag is still required)
- [x] All 14 adjacent suites green: test-init-non-interactive (26), test-init-no-remote-creation (3), test-check-gate (5), test-github-free-tier-403 (4), test-pending-approval (17), test-process-checklist-classifier (12), test-process-checklist-auto-advance (5), test-test-gate-null-handling (5), test-pre-commit-gate-classifier (6), test-upgrade-non-interactive (7), test-upgrade-personal-to-sponsored-poc (3), test-upgrade-to-production-warn (3), test-lint-uat-scenarios (12), and the new test (2). 110 tests total.
- [ ] In a real `--git-host other` setup with a real remote URL: attestation still recorded on success path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)