### PR TITLE
docs(v2): MCP server architecture + auto-discovery extensibility concepts

### DIFF
--- a/evaluation-prompts/v2-concepts/auto-discovery-extensibility.md
+++ b/evaluation-prompts/v2-concepts/auto-discovery-extensibility.md
@@ -1,0 +1,131 @@
+# Auto-Discovery + Schema-Based Checker for Extensibility — v2 Concept
+
+## Problem Statement
+
+Solo Orchestrator V1 is partially extensible: drop-in points exist for platforms (`templates/platforms/<name>.md`), CI templates (`templates/pipelines/ci/<host>/<lang>.yml`), tool matrices (`templates/tool-matrix/<name>.json`), host drivers (`scripts/host-drivers/<name>.sh`), and intake suggestions. But adding any of these requires editing **central plumbing** in addition to dropping in the file:
+
+- **Hardcoded validation in `init.sh`:** `case "$ARG_PLATFORM" in desktop|mobile|web|mcp_server) ;; *) fail ;;`. Adding `cli` as a platform requires editing this case statement.
+- **Hardcoded UI lists in wizards:** `prompt_choice "Platform:" "desktop" "mobile" "web" "mcp_server"`. Adding `cli` requires editing this prompt.
+- **Hardcoded validation in `--validate-only` JSON output**, `--help` text, error messages, test fixtures.
+- **Multiple files to update for a single new option** — adding a platform means: drop the markdown, edit init.sh validation, edit wizard prompt, edit help text, possibly edit upgrade-project.sh and intake-wizard.sh, possibly edit tool-matrix referencing.
+
+The drop-in promise is partial. Real extensibility requires modifying core code, which means contributors need to understand the framework's plumbing, and updates to the framework risk breaking external extensions.
+
+## Proposed Direction (V2)
+
+**Auto-discover everything from the filesystem; validate via schemas; never hardcode option lists in core code.**
+
+### The pattern
+
+For each extension type, the framework reads `<extension-dir>/` and uses whatever it finds:
+
+```bash
+# OLD (V1):
+prompt_choice "Platform" "desktop" "mobile" "web" "mcp_server"
+case "$ARG_PLATFORM" in
+  desktop|mobile|web|mcp_server) ;;
+  *) fail "invalid --platform" ;;
+esac
+
+# NEW (V2):
+PLATFORMS=$(ls templates/platforms/*.md 2>/dev/null | xargs -I{} basename {} .md)
+prompt_choice "Platform" $PLATFORMS
+case " $PLATFORMS " in
+  *" $ARG_PLATFORM "*) ;;
+  *) fail "invalid --platform '$ARG_PLATFORM' — see templates/platforms/" ;;
+esac
+```
+
+Drop in `templates/platforms/cli.md` and "cli" appears as a platform choice **everywhere it's relevant**. No core code edits.
+
+### Schema-based Checker
+
+Auto-discovery without validation is dangerous: invalid drop-ins can crash the framework. The Checker validates every drop-in against a schema:
+
+- Per extension type: `<extension-dir>/_schema.json` defines what fields must exist, types, valid values.
+- For markdown extensions (platform docs), use **frontmatter** + frontmatter schema:
+  ```markdown
+  ---
+  name: cli
+  languages: [rust, go, python]
+  test_pattern: "test_*.py"
+  ---
+  
+  (rest of the markdown is human docs, not validated)
+  ```
+- For JSON extensions (tool-matrix, methodologies, gates, etc.), validate the whole file against the schema.
+- For shell extensions (host drivers, hooks), define a **contract test** — a script that exercises the extension against a known scenario and asserts expected behavior.
+
+The Checker:
+- Runs on every drop-in **at init time** (refuses to start if any extension is invalid).
+- Is **invokable on-demand** via `scripts/validate-extension.sh <path>`.
+- Returns **structured errors** identifying which file failed, which schema rule was violated, and how to fix it.
+- Is **referenced from CI** so the framework's own tests catch breakage when shipping.
+
+### Where to apply
+
+Solo V1 has hardcoded lists in many places. V2 replaces all of them with discovery:
+
+| V1 location | V2 replacement |
+|---|---|
+| `init.sh` `case "$ARG_PLATFORM" in desktop\|mobile\|web\|mcp_server)` | `case " $(ls templates/platforms/) " in *" $ARG_PLATFORM.md "*)` |
+| `intake-wizard.sh` `prompt_choice "Platform:" "desktop" "mobile" "web" "mcp_server"` | `prompt_choice "Platform:" $(discover_platforms)` |
+| `init.sh` validation of `--track` (light/standard/full) | Discover from `configs/tracks/<name>.json` |
+| `init.sh` validation of `--gov-mode` (production/sponsored_poc/private_poc) | Discover from `configs/gov-modes/<name>.json` |
+| `upgrade-project.sh` validation of `--track` and `--deployment` | Same — discovery |
+| `init.sh` `--validate-only` JSON output reflecting valid options | Reflect discovery |
+| `--help` text listing valid options | Generate from discovery |
+| Test fixtures naming valid platforms | Reflect discovery |
+| Tool matrix referencing platforms | Verify each `templates/tool-matrix/<name>.json` corresponds to a `templates/platforms/<name>.md` (cross-reference validation in Checker) |
+
+This is mechanical but pervasive. Done right, the framework's hardcoded knowledge collapses into "what types of extensions exist" (a small finite list at the source level) rather than "what specific options exist within each type" (open-ended).
+
+## Key Design Questions
+
+1. **Discovery cache vs filesystem read on every prompt.** Is filesystem performance a concern? For a wizard with 12 sections each prompting from auto-discovery, that's potentially 12 directory scans. Probably fine on local filesystems but worth measuring. Cache invalidation on extension drop-in is the alternative.
+
+2. **Schema authoring complexity.** Schemas are themselves files developers may need to read or modify. Are JSON Schema (V1's existing format) sufficient? Or use TypeSpec / Protobuf for richer types? JSON Schema is more universal and AI-readable.
+
+3. **Cross-reference validation.** Some extensions reference others (tool-matrix points at platforms; methodology points at gates). The Checker should validate these cross-references, not just per-file schemas. Adds complexity but catches real bugs.
+
+4. **Markdown frontmatter schema enforcement.** Markdown is permissive by design. Frontmatter validation is straightforward but the markdown body itself is descriptive — should the Checker even attempt to validate body content? Probably not; let humans write whatever helps them.
+
+5. **Extension authoring documentation.** Even with auto-discovery, contributors need to know what fields to put in their drop-in. V2 ships hand-authoring docs (`docs/extension-authoring/<type>.md`) showing how to write each extension type by reading the schema and following examples. Good error messages from the Checker reduce documentation burden.
+
+6. **Versioning of extensions.** What if a future framework version changes the schema? Extensions need a `schema_version` field; the Checker validates against the current version and warns on outdated extensions. Migration tooling for "upgrade this extension to the new schema" is a future need.
+
+7. **Extension priority / shadowing.** What if a project drops in a custom `templates/platforms/web.md` to override the framework's? Should that be allowed (project-local override) or refused (one source of truth)? Probably allow with a `[OVERRIDE]` warning so it's visible.
+
+## Pairs with the Extensible Creator (separate concept, deferred)
+
+Auto-discovery + Checker enables the Extensible Creator wizard: a guided tool that walks an extension author through producing a valid drop-in. The wizard reads the schema, prompts for each field, validates the input, and writes the file. Without auto-discovery + Checker, the Creator can't exist; with them, the Creator is a natural follow-on but not load-bearing for V2 itself.
+
+## Why this is V2, not a refactor of V1
+
+The V1 architecture works. Refactoring to discovery throughout V1 is a major change that touches dozens of files. Pairing this with the MCP server architecture migration (separate v2 concept) is the natural time to do it: a major version boundary where the rewrite is justified by other factors.
+
+V2 candidates that pair naturally with auto-discovery:
+- MCP server architecture (separate concept) — same major-version event
+- Post-MVP feature development cycle (separate concept) — needs discovery for "feature templates" and "validation profiles"
+- Principal Engineer Guardian (separate concept) — runs cleaner if it can discover review profiles from `configs/`
+
+## Risks
+
+1. **Filesystem performance** if discovery is uncached and wizard does N prompts. Probably negligible but worth measuring.
+2. **Schema design complexity.** Getting the schemas right means understanding what each extension type actually needs. V2 should ship with 2-3 reference extensions per type to validate the schema.
+3. **Backward compatibility.** Existing V1 platforms (web, desktop, mobile, mcp_server) need to be re-expressed as auto-discoverable extensions. They already are (markdown files in `templates/platforms/`); the work is adding frontmatter to match the V2 schema.
+4. **Cross-reference validation is hard.** Naive validation says "this tool-matrix references platform X; does X exist?" Sophisticated validation says "does X define the languages this tool-matrix expects?" V2 should do naive first; sophisticated is a future iteration.
+5. **Bash discovery patterns are fragile.** `ls *.md | xargs basename` chains break on filenames with spaces, special chars, etc. V2 should use safer patterns (`find` with null-terminated output, or move to a real implementation language). Pairs naturally with the MCP server / language migration.
+
+## Trigger
+
+Adopt for Solo V2 when at least one of these is true:
+- A community contributor adds an extension and asks "do I also need to edit the framework code?" — that's the user-visible pain.
+- A new platform / methodology / track is added to V1 and the central-plumbing edits become a real source of merge conflicts.
+- The MCP server architecture migration (separate v2 concept) is being planned, since auto-discovery is a natural pairing for that effort.
+
+Until one of those triggers, V1's hardcoded lists continue to serve. The pain is real but contained.
+
+## Reference
+
+- Team-Orchestrator (sibling project, designed 2026-04-27) is committing to auto-discovery + Checker from V1 because its broader extension surface (methodologies, gates, roles, phase models, in addition to Solo's existing types) demands true drop-in extensibility. Solo's existing V1 customers tolerate the central-plumbing model; Team-Orchestrator's customers won't. Team-Orchestrator's V1 implementation will be the reference for whether the auto-discovery pattern is production-ready; Solo V2 can adopt the same patterns once they're validated.

--- a/evaluation-prompts/v2-concepts/mcp-server-architecture.md
+++ b/evaluation-prompts/v2-concepts/mcp-server-architecture.md
@@ -1,0 +1,113 @@
+# MCP Server Architecture — v2 Concept
+
+## Problem Statement
+
+Solo Orchestrator V1 is implemented as bash scripts + markdown files + Claude Code hooks. This architecture has structural limitations:
+
+1. **Bash-only execution.** Scripts run only where bash is available. This excludes Claude Desktop entirely (no shell), and most IDE plugins are limited or sandboxed in ways that make bash invocation fragile. The Orchestrator is effectively locked into Claude Code CLI.
+2. **Unstructured AI invitation.** The AI is told via CLAUDE.md and builders-guide to run scripts like `process-checklist.sh --start-feature`, but the scripts are presented as bash commands with shell args. The AI has no schema, no validation, no structured invitation. It can call them or not; it can pass malformed args; it has to parse stdout text to interpret results. Claude is meaningfully better at calling structured tools than bash scripts.
+3. **No cross-session state coordination.** Scripts are single-invocation. Each `process-checklist.sh --check-commit-ready` is a fresh process reading state files. There's no long-running coordination layer; multi-actor coordination (which Team-Orchestrator needs) cannot be cleanly implemented this way.
+4. **Bash as the long-term implementation language.** Bash works for scripts of moderate complexity but degrades fast as logic grows. Solo's `init.sh` is already 3000+ lines of bash; `process-checklist.sh` is 1100+ lines. Maintenance, refactoring, and testing all become harder. Real type systems, real testing frameworks, real libraries are unavailable.
+
+The Solo Orchestrator methodology (Phase 0–4, Build Loop, governance attestations, drop-in extensibility) is solid. The implementation surface is the limit.
+
+## Proposed Direction (V2)
+
+Reimplement Solo Orchestrator's tool surface as an **MCP server** while preserving the existing hook layer for non-bypassable enforcement.
+
+### Three-layer architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ AI Client (CC CLI / Desktop / IDE)                      │
+└─────────────────┬─────────────────────────┬─────────────┘
+                  │                         │
+                  │ MCP                     │ Hooks
+                  │ (tools, resources)      │ (PreToolUse, etc.)
+                  │                         │
+        ┌─────────▼──────────┐    ┌────────▼──────────┐
+        │  MCP Server        │    │  Hook scripts     │
+        │  (Rust or Python)  │    │  (bash, current)  │
+        │                    │    │                   │
+        │  - start_feature   │    │  - pre-commit-gate│
+        │  - complete_step   │    │  - config-guard   │
+        │  - check_status    │    │  - session-checks │
+        │  - request_approval│    │                   │
+        └─────────┬──────────┘    └────────┬──────────┘
+                  │                         │
+                  └──────────┬──────────────┘
+                             │
+                  ┌──────────▼──────────┐
+                  │  File-based state   │
+                  │  (.claude/*.json)   │
+                  │  + configs/         │
+                  │  + docs/ (markdown) │
+                  └─────────────────────┘
+```
+
+- **MCP server** exposes structured tools the AI invokes voluntarily (start_feature, complete_step, query status, request approval, etc.). Cross-client compatible.
+- **Hook layer** remains as-is for non-bypassable enforcement (pre-commit-gate, config-guard, session checks).
+- **File-based state** is the substrate. Both layers operate on the same JSON files.
+- **Markdown docs** stay as AI context.
+
+### Why MCP, not "rewrite scripts in Python/Rust"
+
+The MCP protocol is what makes this cross-client. A Rust binary that runs as a CLI tool would still need bash hooks to invoke it; an MCP server is a long-running process that the AI client connects to directly via the protocol. Claude Code, Claude Desktop, Cursor, Continue, and future Anthropic-aware clients all speak MCP. None speak "your project's bash scripts."
+
+### What MCP does NOT replace
+
+- **Hooks.** PreToolUse / PostToolUse / Stop hooks are how non-bypassable enforcement happens. MCP tools are voluntarily called by the AI. Hooks fire whether the AI wants them to or not.
+- **File-based state.** `.claude/process-state.json`, `phase-state.json`, audit logs — these stay as JSON files on disk. They're the substrate.
+- **Markdown documentation.** CLAUDE.md, builders-guide, intake suggestions remain. The AI reads them as context.
+- **Configuration files.** Drop-in extensions for platforms, methodologies, gates, etc. continue as files.
+
+The MCP server adds a structured tool layer; it doesn't replace the existing architecture.
+
+## Key Design Questions
+
+1. **Implementation language.** Rust (single static binary, type safety, distribution simplicity) vs Python (faster iteration, official Anthropic SDK) vs TypeScript. Each has real trade-offs. For Solo's use case (single-developer projects, maintained alongside other work), iteration speed may matter more than distribution simplicity.
+
+2. **Tool surface granularity.** Chunky workflow tools (one tool per common workflow: `complete_phase_2_gate`) vs many fine-grained tools (one per state transition: `mark_step_complete`, `verify_init`, etc.). Trade-off: fewer tools easier to use; more tools more composable.
+
+3. **Tool surface per script.** Solo's scripts each have multiple subcommands (`--start-feature`, `--complete-step`, `--check-commit-ready`, etc.). Mapping: one MCP tool per subcommand? Or grouped by workflow? Or per script with parameters? Affects AI usability.
+
+4. **Resources.** Should the server expose resources (file-like data the AI reads): `phase-state.json`, `process-state.json`, audit log? Or have the AI use bash to read them as it does today? Resources give better introspection.
+
+5. **Prompts.** Should the server expose prompts (predefined templates): "Start a new feature," "Resume from where we left off," "Pre-commit checklist"? These complement tools.
+
+6. **Hook compatibility.** The hooks need to operate on the same state the MCP server operates on. They're currently bash; can stay bash. But if the MCP server is doing atomic writes with locks and the hooks are doing naive `jq`-edit-and-rewrite, there's a coordination problem. Options: bash hooks call MCP server's state-mutation API; or hooks get rewritten alongside.
+
+7. **Distribution and installation.** MCP server is a long-running process. Solo currently ships as `git clone`-and-run scripts. MCP-based Solo ships as `cargo install` or `pip install` plus per-client configuration ("point your AI at this server"). Different operational model. Per-project or per-user installation?
+
+8. **Backward compatibility with V1 projects.** Existing Solo V1 projects have `.claude/*.json` state files. V2 must read those without forcing migration. State shape stays the same; only the tool surface changes.
+
+## Why this is V2, not a refactor of V1
+
+V1's implementation works. The methodology is proven. Refactoring V1 to MCP would be a major undertaking (5-7 weeks per the Team-Orchestrator estimate) for marginal benefit to existing V1 users (who are CC CLI natives). The right time to adopt MCP is at a major version boundary where the implementation rewrite is justified by other factors.
+
+V2 candidates that pair naturally with MCP:
+- This concept (cross-client + structured tools)
+- Auto-discovery + Checker for extensibility (separate concept doc) — drops the hardcoded list pattern from init.sh, wizards, validators
+- Post-MVP feature development cycle (separate concept doc) — pairs with MCP because the MCP tool surface for "ongoing development" is different from "linear Phase 0-4 progression"
+- Principal Engineer Guardian (separate concept doc) — runs cleaner as an MCP-aware hook than as a separate bash hook
+
+## Risks
+
+1. **MCP protocol churn.** The protocol is stable but evolving. Over 18-24 months, expect minor breakages or feature additions. V2 commits to riding that wave.
+2. **Distribution complexity.** Solo V1's "git clone and use" is part of its appeal. MCP-based V2 has a more involved setup. Worth designing the install story carefully (Homebrew tap? cargo install? per-client setup wizard?).
+3. **Lock-in to MCP.** If the AI tooling ecosystem fragments away from MCP, Solo V2 is harder to port. As of 2026-04, MCP is widely adopted across Anthropic-compatible clients; this risk is low but real.
+4. **Bash vs MCP-server feature parity at V2 launch.** V1 has 5 years (or however long) of bash logic. V2 must reproduce all of it. Time-cost real.
+5. **Operational debugging.** When a bash script fails, the script is the artifact. When an MCP server fails, it's a daemon with logs, IPC, version mismatches. Higher operational complexity for users debugging their own setup.
+
+## Reference
+
+- Team-Orchestrator (sibling project, designed 2026-04-27) is being built MCP-native from V1 because its targeted customer (2-10 dev teams) needs cross-client compatibility from day one. Solo's existing V1 customers are CC CLI natives; the cross-client need is less urgent. Team-Orchestrator's V1 implementation will be the reference for whether MCP is the right architecture; Solo V2 can adopt the same patterns once Team-Orchestrator validates them in production.
+
+## Trigger
+
+Adopt for Solo V2 when at least one of these is true:
+- A meaningful number of Solo V1 users want to run Solo against Claude Desktop or IDE plugins (validated by support requests / GitHub issues).
+- Team-Orchestrator's MCP architecture validates as production-quality and the patterns are stable.
+- The maintenance burden of bash logic (process-checklist.sh, init.sh, etc.) becomes painful enough that a rewrite is warranted regardless of MCP.
+
+Until one of those triggers, V1's bash architecture continues to serve.


### PR DESCRIPTION
## Summary
Two new V2 concept docs captured from the Team-Orchestrator design session on 2026-04-27. Both apply patterns being adopted for Team-Orchestrator V1 back to Solo's V2 roadmap as candidate improvements when the major-version rewrite is justified.

- **`mcp-server-architecture.md`** — Reimplement Solo's tool surface as an MCP server while keeping the hook layer. Cross-client (CC CLI + Desktop + IDE), structured tool interface, better implementation language. Pairs with the auto-discovery concept.
- **`auto-discovery-extensibility.md`** — Replace V1's hardcoded option lists in `init.sh`, `intake-wizard.sh`, validators, and help text with filesystem-based auto-discovery + a schema-based Checker. Closes the partial-extensibility gap where adding a platform / track / gov-mode requires editing central plumbing in addition to dropping in the file.

Both are honest about why they're V2 and not V1 refactors: V1 works; the rewrite cost is justified only at a major version boundary. Both reference each other and existing V2 concepts (`post-mvp-feature-development`, `principal-engineer-guardian`, `in-flight-project-ingestion`).

## Why
The Team-Orchestrator design conversation surfaced architectural patterns that solve real Solo V1 limitations. Capturing them in `evaluation-prompts/v2-concepts/` ensures they're part of the V2 conversation when it eventually starts.

Triggers for adoption documented in each file. Until those triggers fire, V1's architecture continues to serve.

## Test plan
- [x] No code changes — docs only
- [x] Both files follow the existing v2-concepts format pattern (`# Concept — v2 Concept`, Problem Statement, Proposed Direction, Key Design Questions, Risks, Trigger)
- [x] Cross-references between the two new docs and to the existing v2 concepts are present and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)