### PR TITLE
fix(bl-029.1): S3/S4/S5 follow-ups from calibration replay

### DIFF
--- a/Reports/uat-2026-04-29-bl029-validation/TRIAGE.md
+++ b/Reports/uat-2026-04-29-bl029-validation/TRIAGE.md
@@ -121,3 +121,26 @@ Estimated time for the subset: 30-60 minutes (regex edits + new tests + verify).
 Full regression: **22/22 PASS** including new T10/T11/T12 detector tests and T10–T18 pattern tests.
 
 Recalibration recommended after the next major UAT sweep. Specific phrasings that fired the relaxations are documented in this TRIAGE — future calibrations should at minimum re-fire them as regression coverage.
+
+## Resolution — BL-029.1 follow-ups (2026-05-04)
+
+The three deferred items shipped on `feature/bl-029-1-followups`.
+
+**S5 fixed** in commit `879d4f5` (`fix(bl-029.1): S5 — remove confirmation phrase from sentinel question text`).
+- `scripts/hooks/bypass-detector.sh` no longer embeds the confirmation phrase in the sentinel's `question` field. Phrase remains in `options[0]` (structurally required for matching). Question now reads "type option A1 verbatim" — directs the user to read options without leaking the phrase into the question itself.
+- `tests/test-bypass-sentinel.sh` T2 assertion flipped (phrase MUST NOT be in question); new T2b locks in that the phrase IS still in options[0]. Integration T3 updated similarly.
+- Residual priming risk: if Claude reads BOTH question and options aloud to the user, the phrase still surfaces. Full mitigation would require not embedding the phrase in JSON at all — out of scope, future work.
+
+**S3 fixed** in commit `e21eac0` (`fix(bl-029.1): S3 — suppress matches inside fenced code blocks`).
+- Detector pre-processes input through `awk` that strips lines between ```` ``` ```` fences before scanning. CHANGELOGs / docstrings / comments wrapping a pattern in a fenced block are descriptive, not advisory — no longer trigger audit rows.
+- Inline single-backtick code (`` `--no-verify` ``) is preserved because Claude typesets active proposals with inline backticks too.
+- Tests T13 (fenced suppressed), T14 (outside-fence still fires), T15 (inline backtick still fires).
+
+**S4 fixed** in commit `7dbed62` (`feat(bl-029.1): S4 — audit-row closer via pending-approval.sh --resolve --decision`).
+- New `bypass_audit_close_pending(<root>, <decision>)` library function in `scripts/lib/bypass-audit.sh`. `decision ∈ {accept, decline}`. Holds the same mkdir lock the append path uses. Idempotent — leaves already-resolved rows alone.
+- `scripts/pending-approval.sh --resolve` gains an optional `--decision` flag. When provided, calls `bypass_audit_close_pending` after deleting the sentinel. Backward compatible.
+- Decision mapping: `accept` → `user_response=accepted, final_outcome=bypassed`; `decline` → `user_response=declined, final_outcome=abandoned`.
+- Tests: 4 new in `test-bypass-audit-lib.sh` (T7-T10) + 4 in `test-pending-approval.sh` (p18-p21).
+- Implicit-abandon detection (sentinel disappears without `--decision`) **deferred** — needs a SessionStart safety-net hook and a wider conversation about inferring decline-by-default. The explicit-decision path covers the load-bearing case.
+
+Full regression after BL-029.1: **22/22 PASS**.

--- a/scripts/hooks/bypass-detector.sh
+++ b/scripts/hooks/bypass-detector.sh
@@ -55,6 +55,21 @@ esac
 
 [ -z "$TEXT" ] && exit 0
 
+# BL-029.1 fix S3 (2026-05-04): strip fenced code blocks before scanning.
+# Documentation / CHANGELOG / docstring text wrapping a bypass pattern in
+# ```...``` is descriptive, not advisory — earlier behavior false-positived
+# on changelog entries that named the patterns. Inline backtick code
+# (`--no-verify`) is preserved because Claude typesets active proposals
+# with inline backticks too. This handles the common doc-FP class without
+# suppressing legitimate proposals.
+TEXT=$(printf '%s\n' "$TEXT" | awk '
+  BEGIN { in_fence = 0 }
+  /^[[:space:]]*```/ { in_fence = !in_fence; next }
+  !in_fence { print }
+')
+
+[ -z "$TEXT" ] && exit 0
+
 # BL-029 + 2026-04-29 calibration fix S1: scan for ALL matched patterns
 # and emit one audit row per match. Without this, an earlier-table
 # normal-severity pattern silently masked refuse_to_recommend severity

--- a/scripts/hooks/bypass-detector.sh
+++ b/scripts/hooks/bypass-detector.sh
@@ -112,15 +112,21 @@ done <<< "$PATTERNS"
 # Forces non-trivial confirmation phrase to accept (defends against generic
 # 'OK' / 'yes' / 'proceed' acceptance, per agent-5 spec). One sentinel
 # covers all matched patterns from this proposal.
+#
+# S5 fix (2026-05-04): the confirmation phrase is NO LONGER embedded in the
+# question text. Earlier behavior let Claude/user reading the sentinel
+# copy-paste the phrase out of compliance — defeating the defense. The
+# phrase remains in options[0] (structurally required for matching), and
+# the question instructs the user to read options[0] verbatim.
 SENTINEL="$PROJECT_ROOT/.claude/pending-approval.json"
 if [ ! -f "$SENTINEL" ]; then
   CONFIRM_PHRASE="I have read the proposal at .claude/bypass-audit.json and accept the bypass"
   jq -nc \
-    --arg q "Bypass proposal detected (pattern: $FIRST_PATTERN). Review .claude/bypass-audit.json. To accept, type the confirmation phrase verbatim. To decline, just say 'decline' or describe what you want instead." \
+    --arg q "Bypass proposal detected (pattern: $FIRST_PATTERN). Review .claude/bypass-audit.json before deciding. To accept, type option A1 verbatim. To decline, say 'decline' or describe what you want instead." \
     --arg phrase "$CONFIRM_PHRASE" \
     --arg ts "$TS" \
     '{
-      question: ($q + "\n\nConfirmation phrase: " + $phrase),
+      question: $q,
       options: [
         ("A1: " + $phrase),
         "A2: decline"

--- a/scripts/lib/bypass-audit.sh
+++ b/scripts/lib/bypass-audit.sh
@@ -87,3 +87,60 @@ bypass_audit_count_pending() {
   [ -f "$file" ] || { echo 0; return 0; }
   jq '[.[] | select(.user_response == "PENDING")] | length' "$file" 2>/dev/null || echo 0
 }
+
+# bypass_audit_close_pending <project_root> <decision>
+# Updates every PENDING row to the given decision. decision ∈ {accept, decline}.
+#   accept  → user_response=accepted,  final_outcome=bypassed
+#   decline → user_response=declined,  final_outcome=abandoned
+# Idempotent — leaves already-resolved rows untouched. Holds the same lock
+# bypass_audit_append uses to avoid races. Returns 0 on success, 1 on
+# unknown decision or write failure.
+#
+# S4 fix (2026-05-04): without this, PENDING rows accumulated forever.
+# The W7 successor-handoff use case (audit log as historical governance
+# record) was half-built — a successor reading the log couldn't tell
+# accepted from declined from never-resolved.
+bypass_audit_close_pending() {
+  local project_root="${1:-.}"
+  local decision="${2:-}"
+  local file="$project_root/.claude/bypass-audit.json"
+
+  local user_resp final_out
+  case "$decision" in
+    accept)  user_resp="accepted"; final_out="bypassed" ;;
+    decline) user_resp="declined"; final_out="abandoned" ;;
+    *)
+      echo "[FAIL] bypass_audit_close_pending: unknown decision '$decision' (expected: accept | decline)" >&2
+      return 1
+      ;;
+  esac
+
+  [ -f "$file" ] || return 0
+
+  local lock_dir="$file.lockdir"
+  local attempts=0
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 100 ]; then
+      echo "[FAIL] bypass_audit_close_pending: lock timeout (>10s)" >&2
+      return 1
+    fi
+    sleep 0.1
+  done
+
+  local tmp rc
+  tmp=$(mktemp)
+  if jq --arg ur "$user_resp" --arg fo "$final_out" \
+       '[.[] | if .user_response == "PENDING" then .user_response = $ur | .final_outcome = $fo else . end]' \
+       "$file" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$file"
+    rc=0
+  else
+    rm -f "$tmp"
+    echo "[FAIL] bypass_audit_close_pending: jq failed" >&2
+    rc=1
+  fi
+
+  rmdir "$lock_dir" 2>/dev/null
+  return "$rc"
+}

--- a/scripts/pending-approval.sh
+++ b/scripts/pending-approval.sh
@@ -153,7 +153,15 @@ cmd_offer() {
 # --- Subcommand: --resolve ---
 
 cmd_resolve() {
-  local project_root
+  local project_root decision=""
+  # Parse optional --decision <accept|decline>.
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --decision) decision="${2:-}"; shift 2 ;;
+      *) shift ;;
+    esac
+  done
+
   project_root=$(find_project_root) || {
     print_fail "Not in a Solo project — no .claude/ directory found in \$PWD or any parent."
     return 1
@@ -164,7 +172,26 @@ cmd_resolve() {
     rm -f "$sentinel"
     print_ok "Pending approval resolved."
   else
-    print_ok "No pending approval."
+    print_info "No pending approval."
+  fi
+
+  # BL-029.1 S4 (2026-05-04): if a decision was provided, close any
+  # PENDING claude_bypass_proposal rows in the audit log to match.
+  # Without this, audit rows stay PENDING forever and the W7 successor-
+  # handoff use case (audit log as historical governance record) is
+  # half-built.
+  if [ -n "$decision" ]; then
+    local lib="$SCRIPT_DIR/lib/bypass-audit.sh"
+    if [ -f "$lib" ]; then
+      # shellcheck disable=SC1090
+      source "$lib"
+      if bypass_audit_close_pending "$project_root" "$decision" 2>&1; then
+        print_ok "Audit log closed: pending bypass rows marked $decision."
+      else
+        print_fail "Audit log close failed (decision='$decision')."
+        return 1
+      fi
+    fi
   fi
 }
 
@@ -282,7 +309,10 @@ Commands:
   --offer "QUESTION" --options "A1: ..." "A2: ..." ... --recommendation "A1"
                                   Write a pending-approval sentinel.
                                   Refuses if one already exists.
-  --resolve                       Delete the sentinel (user picked an option).
+  --resolve [--decision X]        Delete the sentinel (user picked an option).
+                                  Optional: --decision accept|decline closes
+                                  any PENDING claude_bypass_proposal rows in
+                                  .claude/bypass-audit.json to match (BL-029.1).
   --clear                         Delete the sentinel (agent abort, semantic alias).
   --status                        Print the current pending question, if any.
   --validate [PATH]               Lint a sentinel file. Default: .claude/pending-approval.json.
@@ -300,7 +330,7 @@ HELP
 
 case "${1:-}" in
   --offer)    shift; cmd_offer "$@" ;;
-  --resolve)  shift; cmd_resolve ;;
+  --resolve)  shift; cmd_resolve "$@" ;;
   --clear)    shift; cmd_clear ;;
   --status)   shift; cmd_status ;;
   --validate) shift; cmd_validate "${1:-}" ;;

--- a/tests/test-bl029-integration.sh
+++ b/tests/test-bl029-integration.sh
@@ -36,12 +36,14 @@ EOF
 rows=$(jq '[.[] | select(.type=="claude_bypass_proposal")] | length' "$PROJ/.claude/bypass-audit.json")
 if [ "$rows" = "1" ]; then pass "T2: claude_bypass_proposal row"; else fail_ "T2" "rows=$rows"; fi
 
-# T3: pending-approval sentinel was written by the detector.
+# T3 (S5 fix 2026-05-04): pending-approval sentinel written; confirmation phrase
+# lives in options[0] only, NOT in question (defeats novice-priming risk).
 if [ -f "$PROJ/.claude/pending-approval.json" ] && \
-   jq -e '.question | contains("I have read the proposal")' "$PROJ/.claude/pending-approval.json" >/dev/null 2>&1; then
-  pass "T3: sentinel + confirmation phrase"
+   jq -e '.options[0] | contains("I have read the proposal")' "$PROJ/.claude/pending-approval.json" >/dev/null 2>&1 && \
+   ! jq -e '.question | contains("I have read the proposal")' "$PROJ/.claude/pending-approval.json" >/dev/null 2>&1; then
+  pass "T3: phrase in options[0] only, not in question"
 else
-  fail_ "T3" "sentinel missing or malformed"
+  fail_ "T3" "sentinel missing, malformed, or phrase leaked into question"
 fi
 
 # T4: escalate-to-user CLI works end-to-end (init a fresh git repo for it).

--- a/tests/test-bypass-audit-lib.sh
+++ b/tests/test-bypass-audit-lib.sh
@@ -96,6 +96,67 @@ setup_lib_or_skip "T6" && {
 }
 teardown
 
+# ---- S4 fix (2026-05-04): audit-row closer ----
+
+# T7: bypass_audit_close_pending with decision=accept updates PENDING rows.
+echo "T7: close_pending accept updates user_response/final_outcome"
+setup
+setup_lib_or_skip "T7" && {
+  bypass_audit_init "$TMP"
+  bypass_audit_append "$TMP" '{"type":"claude_bypass_proposal","actor":"claude","timestamp":"x","enforcement_level_at_event":"strict","details":{"pattern":"no_verify"},"user_response":"PENDING","final_outcome":"recorded_only"}'
+  bypass_audit_append "$TMP" '{"type":"claude_bypass_proposal","actor":"claude","timestamp":"y","enforcement_level_at_event":"strict","details":{"pattern":"fake_loop"},"user_response":"PENDING","final_outcome":"recorded_only"}'
+  bypass_audit_close_pending "$TMP" "accept"
+  pending=$(bypass_audit_count_pending "$TMP")
+  accepted=$(jq '[.[] | select(.user_response=="accepted")] | length' "$TMP/.claude/bypass-audit.json")
+  bypassed=$(jq '[.[] | select(.final_outcome=="bypassed")] | length' "$TMP/.claude/bypass-audit.json")
+  if [ "$pending" = "0" ] && [ "$accepted" = "2" ] && [ "$bypassed" = "2" ]; then
+    pass "T7"
+  else
+    fail_ "T7" "pending=$pending accepted=$accepted bypassed=$bypassed"
+  fi
+}
+teardown
+
+# T8: bypass_audit_close_pending with decision=decline updates rows.
+echo "T8: close_pending decline updates user_response/final_outcome"
+setup
+setup_lib_or_skip "T8" && {
+  bypass_audit_init "$TMP"
+  bypass_audit_append "$TMP" '{"type":"claude_bypass_proposal","actor":"claude","timestamp":"x","enforcement_level_at_event":"strict","details":{},"user_response":"PENDING","final_outcome":"recorded_only"}'
+  bypass_audit_close_pending "$TMP" "decline"
+  declined=$(jq '[.[] | select(.user_response=="declined")] | length' "$TMP/.claude/bypass-audit.json")
+  abandoned=$(jq '[.[] | select(.final_outcome=="abandoned")] | length' "$TMP/.claude/bypass-audit.json")
+  if [ "$declined" = "1" ] && [ "$abandoned" = "1" ]; then pass "T8"; else fail_ "T8" "declined=$declined abandoned=$abandoned"; fi
+}
+teardown
+
+# T9: close_pending preserves already-resolved rows (won't clobber accepted=>declined).
+echo "T9: close_pending only updates PENDING rows"
+setup
+setup_lib_or_skip "T9" && {
+  bypass_audit_init "$TMP"
+  bypass_audit_append "$TMP" '{"type":"claude_bypass_proposal","actor":"claude","timestamp":"x","enforcement_level_at_event":"strict","details":{},"user_response":"accepted","final_outcome":"committed"}'
+  bypass_audit_append "$TMP" '{"type":"claude_bypass_proposal","actor":"claude","timestamp":"y","enforcement_level_at_event":"strict","details":{},"user_response":"PENDING","final_outcome":"recorded_only"}'
+  bypass_audit_close_pending "$TMP" "decline"
+  accepted=$(jq '[.[] | select(.user_response=="accepted")] | length' "$TMP/.claude/bypass-audit.json")
+  declined=$(jq '[.[] | select(.user_response=="declined")] | length' "$TMP/.claude/bypass-audit.json")
+  if [ "$accepted" = "1" ] && [ "$declined" = "1" ]; then pass "T9"; else fail_ "T9" "accepted=$accepted declined=$declined"; fi
+}
+teardown
+
+# T10: close_pending rejects unknown decision values.
+echo "T10: close_pending rejects unknown decision"
+setup
+setup_lib_or_skip "T10" && {
+  bypass_audit_init "$TMP"
+  if bypass_audit_close_pending "$TMP" "maybe" 2>/dev/null; then
+    fail_ "T10" "expected non-zero return"
+  else
+    pass "T10"
+  fi
+}
+teardown
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]

--- a/tests/test-bypass-detector.sh
+++ b/tests/test-bypass-detector.sh
@@ -183,6 +183,45 @@ EOF
 fi
 teardown
 
+# T13 (S3 fix 2026-05-04): pattern matches inside fenced code blocks are suppressed.
+# Documentation / CHANGELOG / docstring text wrapping a pattern in ```...``` is
+# descriptive, not advisory — should not trigger the detector.
+echo "T13: fenced code block content is stripped before scanning"
+setup
+if [ ! -f "$HOOK" ]; then fail_ "T13" "hook missing"; else
+  CLAUDE_PROJECT_DIR="$TMP" cat <<'EOF' | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","tool_input":{"command":"x"},"tool_result":{"output":"# CHANGELOG\n\n## Added\n\n- Detection for the following bypass patterns:\n```\n--no-verify\nSOIF_FORCE_STEP=\n```\n\nNo behavior change for users."}}
+EOF
+  rows=$(jq '[.[] | select(.type=="claude_bypass_proposal")] | length' "$TMP/.claude/bypass-audit.json")
+  if [ "$rows" = "0" ]; then pass "T13"; else fail_ "T13" "false positive: rows=$rows"; fi
+fi
+teardown
+
+# T14: pattern OUTSIDE fenced blocks still fires (regression for T13 fix).
+echo "T14: fenced-stripping does not suppress matches outside the fence"
+setup
+if [ ! -f "$HOOK" ]; then fail_ "T14" "hook missing"; else
+  CLAUDE_PROJECT_DIR="$TMP" cat <<'EOF' | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","tool_input":{"command":"x"},"tool_result":{"output":"You can use --no-verify here.\n\n```\nthis fenced block has no patterns\n```\n\nThe --no-verify suggestion above is a real proposal."}}
+EOF
+  rows=$(jq '[.[] | select(.type=="claude_bypass_proposal")] | length' "$TMP/.claude/bypass-audit.json")
+  if [ "$rows" -ge "1" ]; then pass "T14"; else fail_ "T14" "rows=$rows — outside-fence match was suppressed"; fi
+fi
+teardown
+
+# T15: inline single-backtick code (`...`) is NOT stripped — Claude often
+# typesets ACTIVE proposals using inline backticks ("run `git commit --no-verify`").
+echo "T15: inline backtick code is scanned (not stripped)"
+setup
+if [ ! -f "$HOOK" ]; then fail_ "T15" "hook missing"; else
+  CLAUDE_PROJECT_DIR="$TMP" cat <<'EOF' | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","tool_input":{"command":"x"},"tool_result":{"output":"You can run `git commit --no-verify` to skip the gate."}}
+EOF
+  rows=$(jq '[.[] | select(.type=="claude_bypass_proposal")] | length' "$TMP/.claude/bypass-audit.json")
+  if [ "$rows" -ge "1" ]; then pass "T15"; else fail_ "T15" "inline-backtick match was suppressed"; fi
+fi
+teardown
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]

--- a/tests/test-bypass-sentinel.sh
+++ b/tests/test-bypass-sentinel.sh
@@ -33,8 +33,13 @@ EOF
 fi
 teardown
 
-# T2: sentinel question contains the required confirmation phrase.
-echo "T2: sentinel embeds confirmation phrase"
+# T2 (S5 fix 2026-05-04): sentinel question does NOT embed the confirmation
+# phrase verbatim. Earlier behavior leaked the phrase into the question text,
+# which let Claude/user reading the sentinel copy-paste the phrase out of
+# compliance — defeating the "non-trivial confirmation" defense. The phrase
+# still lives in options[0] (structurally required for matching) but the
+# question text uses a generic pointer.
+echo "T2: sentinel question does NOT embed the confirmation phrase"
 setup
 if [ ! -f "$HOOK" ]; then fail_ "T2" "hook missing"; else
   CLAUDE_PROJECT_DIR="$TMP" cat <<EOF | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
@@ -42,9 +47,25 @@ if [ ! -f "$HOOK" ]; then fail_ "T2" "hook missing"; else
 EOF
   q=$(jq -r '.question' "$TMP/.claude/pending-approval.json")
   if echo "$q" | grep -q "I have read the proposal at .claude/bypass-audit.json and accept the bypass"; then
-    pass "T2"
+    fail_ "T2" "phrase still in question — priming risk: $q"
   else
-    fail_ "T2" "phrase missing from question: $q"
+    pass "T2"
+  fi
+fi
+teardown
+
+# T2b (S5 fix): confirmation phrase IS preserved in options[0].
+echo "T2b: confirmation phrase is in options[0]"
+setup
+if [ ! -f "$HOOK" ]; then fail_ "T2b" "hook missing"; else
+  CLAUDE_PROJECT_DIR="$TMP" cat <<EOF | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","tool_input":{"command":"x"},"tool_result":{"output":"--no-verify path"}}
+EOF
+  opt0=$(jq -r '.options[0]' "$TMP/.claude/pending-approval.json")
+  if echo "$opt0" | grep -q "I have read the proposal at .claude/bypass-audit.json and accept the bypass"; then
+    pass "T2b"
+  else
+    fail_ "T2b" "phrase missing from options[0]: $opt0"
   fi
 fi
 teardown

--- a/tests/test-pending-approval.sh
+++ b/tests/test-pending-approval.sh
@@ -240,6 +240,80 @@ p15_validate_malformed
 p16_help
 p17_atomic_write_code_shape
 
+# ---- BL-029.1 S4 (2026-05-04): --resolve --decision closes audit rows ----
+
+p18_resolve_decision_accept_closes_audit_rows() {
+  echo "[TEST] --resolve --decision accept updates PENDING bypass rows to accepted/bypassed"
+  setup_project
+  # Seed an audit log with a PENDING row + a sentinel.
+  echo '[{"timestamp":"x","session_id":null,"type":"claude_bypass_proposal","actor":"claude","enforcement_level_at_event":"strict","details":{"pattern":"no_verify"},"user_response":"PENDING","final_outcome":"recorded_only"}]' > "$TMPDIR_T/.claude/bypass-audit.json"
+  echo '{"question":"q","options":["A1: x","A2: y"],"recommendation":"A2","offered_at":"x"}' > "$TMPDIR_T/.claude/pending-approval.json"
+
+  run_in_project --resolve --decision accept >/dev/null
+
+  user_resp=$(jq -r '.[0].user_response' "$TMPDIR_T/.claude/bypass-audit.json")
+  final_out=$(jq -r '.[0].final_outcome' "$TMPDIR_T/.claude/bypass-audit.json")
+  if [ "$user_resp" = "accepted" ] && [ "$final_out" = "bypassed" ]; then
+    pass "p18 accept closes row"
+  else
+    fail_ "p18 accept closes row" "user_response=$user_resp final_outcome=$final_out"
+  fi
+  teardown_project
+}
+p18_resolve_decision_accept_closes_audit_rows
+
+p19_resolve_decision_decline_closes_audit_rows() {
+  echo "[TEST] --resolve --decision decline updates PENDING bypass rows to declined/abandoned"
+  setup_project
+  echo '[{"timestamp":"x","session_id":null,"type":"claude_bypass_proposal","actor":"claude","enforcement_level_at_event":"strict","details":{"pattern":"fake_loop"},"user_response":"PENDING","final_outcome":"recorded_only"}]' > "$TMPDIR_T/.claude/bypass-audit.json"
+  echo '{"question":"q","options":["A1: x","A2: y"],"recommendation":"A2","offered_at":"x"}' > "$TMPDIR_T/.claude/pending-approval.json"
+
+  run_in_project --resolve --decision decline >/dev/null
+
+  user_resp=$(jq -r '.[0].user_response' "$TMPDIR_T/.claude/bypass-audit.json")
+  final_out=$(jq -r '.[0].final_outcome' "$TMPDIR_T/.claude/bypass-audit.json")
+  if [ "$user_resp" = "declined" ] && [ "$final_out" = "abandoned" ]; then
+    pass "p19 decline closes row"
+  else
+    fail_ "p19 decline closes row" "user_response=$user_resp final_outcome=$final_out"
+  fi
+  teardown_project
+}
+p19_resolve_decision_decline_closes_audit_rows
+
+p20_resolve_without_decision_leaves_audit_alone() {
+  echo "[TEST] --resolve (no --decision) deletes sentinel but does NOT modify audit rows"
+  setup_project
+  echo '[{"timestamp":"x","session_id":null,"type":"claude_bypass_proposal","actor":"claude","enforcement_level_at_event":"strict","details":{},"user_response":"PENDING","final_outcome":"recorded_only"}]' > "$TMPDIR_T/.claude/bypass-audit.json"
+  echo '{"question":"q","options":["A1: x","A2: y"],"recommendation":"A2","offered_at":"x"}' > "$TMPDIR_T/.claude/pending-approval.json"
+
+  run_in_project --resolve >/dev/null
+
+  user_resp=$(jq -r '.[0].user_response' "$TMPDIR_T/.claude/bypass-audit.json")
+  if [ "$user_resp" = "PENDING" ] && [ ! -f "$TMPDIR_T/.claude/pending-approval.json" ]; then
+    pass "p20 backward compat (no --decision)"
+  else
+    fail_ "p20 backward compat" "user_response=$user_resp sentinel_still_present=$([ -f "$TMPDIR_T/.claude/pending-approval.json" ] && echo yes || echo no)"
+  fi
+  teardown_project
+}
+p20_resolve_without_decision_leaves_audit_alone
+
+p21_resolve_decision_unknown_fails() {
+  echo "[TEST] --resolve --decision <unknown> fails"
+  setup_project
+  echo '[]' > "$TMPDIR_T/.claude/bypass-audit.json"
+  echo '{"question":"q","options":["A1: x","A2: y"],"recommendation":"A2","offered_at":"x"}' > "$TMPDIR_T/.claude/pending-approval.json"
+
+  out=$(run_in_project --resolve --decision maybe 2>&1 || true)
+  case "$out" in
+    *FAIL*|*"unknown decision"*) pass "p21 unknown decision fails" ;;
+    *) fail_ "p21 unknown decision fails" "got '$out'" ;;
+  esac
+  teardown_project
+}
+p21_resolve_decision_unknown_fails
+
 echo ""
 echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
 [ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Ships the three deferred items from `Reports/uat-2026-04-29-bl029-validation/TRIAGE.md`. All identified during the BL-029 calibration replay; none merge-blocking on their own, but together they close the loop on the calibration findings.

- **S5 — Remove confirmation phrase from sentinel question** (`879d4f5`).
  Earlier behavior embedded the phrase in the question text, letting Claude/user reading the sentinel copy-paste it out of compliance. Phrase now lives in `options[0]` only; question directs the user to "type option A1 verbatim."
- **S3 — Suppress matches inside fenced code blocks** (`e21eac0`).
  Documentation/CHANGELOG/docstring mentions of `--no-verify` were false-positiving. Detector now strips `` ``` `` fenced blocks before scanning. Inline single-backtick code (`` `--no-verify` ``) is preserved because Claude typesets active proposals with inline backticks.
- **S4 — Audit-row closer via `pending-approval.sh --resolve --decision`** (`7dbed62`).
  PENDING claude_bypass_proposal rows accumulated forever. New `bypass_audit_close_pending(<root>, <decision>)` library function + `--decision <accept|decline>` flag on `pending-approval.sh --resolve`. Backward compatible — `--resolve` without `--decision` behaves exactly as before.

## Deferred (still)

- **Implicit-abandon detection** for S4: sentinel disappearing without `--decision` (legacy `--clear` or external `rm`). Requires a SessionStart safety-net hook and a wider design conversation about inferring decline-by-default. The explicit-decision path covers the load-bearing case (Claude calls `--resolve --decision` when user picks).
- **Stronger S5 mitigation** (phrase not embedded in JSON at all): would need a different verification mechanism. Documented as future work.

## Test Plan

- [x] `bash tests/test-bypass-audit-lib.sh` — 10/10 (6 original + 4 new for `bypass_audit_close_pending`)
- [x] `bash tests/test-bypass-detector.sh` — 15/15 (12 original + 3 new for fenced-block suppression: T13/T14/T15)
- [x] `bash tests/test-bypass-sentinel.sh` — 5/5 (T2 assertion flipped per S5; new T2b locks phrase-in-options[0])
- [x] `bash tests/test-pending-approval.sh` — 21/21 (17 original + 4 new for `--decision` flag: p18-p21)
- [x] `bash tests/test-bl029-integration.sh` — 6/6 (T3 updated to assert phrase in options[0] only)
- [x] Full regression suite: **22/22 PASS**

## TRIAGE.md updated

Resolution section appended to `Reports/uat-2026-04-29-bl029-validation/TRIAGE.md` with commit references and behavior summaries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)