### PR TITLE
feat: vendored skills + session-handoff (PR #1 of 4 from mattpocock/skills)

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -838,6 +838,16 @@ If the Superpowers plugin is installed (see CLI Setup Addendum, Section 1), it s
 
 **Without Superpowers:** The Build Loop below works as written — the agent executes sequentially with the Orchestrator directing each step. Superpowers is recommended but not required.
 
+### Vendored Skills (`.claude/skills/`)
+
+Every project initialized by `init.sh` receives a `.claude/skills/` directory containing project-scoped Claude Code skills the framework ships out of the box. Skills installed here activate at the project level alongside any user-level skills the Orchestrator has installed (Superpowers, mattpocock/skills, etc.).
+
+| Skill | Purpose | Source |
+|---|---|---|
+| `session-handoff` | Compact the current conversation into a session-boundary handoff document at `docs/handoffs/YYYY-MM-DD-<topic>.md`. Use before a hard context break, machine reboot, or operator change. Distinct from Solo's Phase 4 production `HANDOFF.md`. | Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT) — see `.claude/skills/session-handoff/NOTICE`. |
+
+Each vendored skill ships with a `NOTICE` file preserving the upstream author's copyright and documenting the adaptations made for Solo Orchestrator. Upstream updates are not automatic; vendored skills are versioned with the framework.
+
 ### Using a Different AI Coding Agent
 
 The Builder's Guide methodology (phases, decision gates, Build Loop, test-first) works with any AI coding agent that can read files, write code, and run commands. Superpowers and the CLI Setup Addendum are optimized for Claude Code but are not required. If using a different agent:

--- a/init.sh
+++ b/init.sh
@@ -1154,6 +1154,20 @@ create_project() {
   cp "$SCRIPT_DIR/templates/generated/bugs.tmpl" templates/generated/
   cp "$SCRIPT_DIR/templates/generated/release-notes.tmpl" templates/generated/
 
+  # Install vendored skills (project-level, .claude/skills/<name>/).
+  # Skills are markdown SKILL.md files with NOTICE-attribution preserved.
+  # Adding a new skill: drop it under templates/generated/skills/<name>/
+  # and append a line to the loop below.
+  mkdir -p .claude/skills
+  for skill in session-handoff; do
+    if [ -d "$SCRIPT_DIR/templates/generated/skills/$skill" ]; then
+      mkdir -p ".claude/skills/$skill"
+      cp "$SCRIPT_DIR/templates/generated/skills/$skill/SKILL.md" ".claude/skills/$skill/"
+      [ -f "$SCRIPT_DIR/templates/generated/skills/$skill/NOTICE" ] \
+        && cp "$SCRIPT_DIR/templates/generated/skills/$skill/NOTICE" ".claude/skills/$skill/"
+    fi
+  done
+
   # Copy starter files from templates (empty until agent populates)
   cp "$SCRIPT_DIR/templates/generated/features.tmpl" FEATURES.md
   cp "$SCRIPT_DIR/templates/generated/changelog.tmpl" CHANGELOG.md

--- a/templates/generated/skills/session-handoff/NOTICE
+++ b/templates/generated/skills/session-handoff/NOTICE
@@ -1,0 +1,44 @@
+This skill is adapted from the `handoff` skill in the mattpocock/skills
+repository (https://github.com/mattpocock/skills), licensed under the
+MIT License.
+
+Original copyright:
+
+  MIT License
+
+  Copyright (c) Matt Pocock
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+Adaptations made for Solo Orchestrator:
+
+- Renamed `handoff` → `session-handoff` to disambiguate from Solo's Phase 4
+  production HANDOFF.md (templates/generated/handoff.tmpl).
+- Save path changed from `mktemp` to `docs/handoffs/YYYY-MM-DD-<topic-slug>.md`
+  so handoff documents live with the project as auditable artifacts
+  (Solo's W7 handoff-readiness principle).
+- Expanded body with required sections (Where we are / Just shipped /
+  Blocked / Next / References / Resume prompt) and composition guidance
+  for Solo's existing artifacts (plans, TRIAGEs, process-state,
+  pending-approval sentinels).
+- Added When / When-not-to-use guidance and a self-check section.
+
+Original content was a 4-paragraph SKILL.md; the adapted version preserves
+the original intent (handoff document, references-not-duplications,
+tailor-to-args) while adding Solo-specific structure.

--- a/templates/generated/skills/session-handoff/SKILL.md
+++ b/templates/generated/skills/session-handoff/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: session-handoff
+description: Compact the current conversation into a session-boundary handoff document for another agent to pick up. Use at session end (or before a planned interruption like a machine reboot, hard context-window break, or hand-off to a different operator).
+argument-hint: "What will the next session be used for?"
+---
+
+# Session Handoff
+
+> **Attribution.** This skill is adapted with permission from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, © Matt Pocock). The original skill (`handoff`) was written to be lightweight and tool-agnostic. This Solo Orchestrator-adapted version writes to `docs/handoffs/` so the handoff lives with the project as an auditable artifact (Solo's W7 handoff-readiness principle), and is named `session-handoff` to disambiguate from Solo's Phase 4 production HANDOFF.md (`templates/generated/handoff.tmpl`). See `NOTICE` for full attribution and license.
+
+## When to use
+
+Use **before** any of:
+- Hard context-window break (the next reply might roll context out of memory).
+- Machine reboot or planned shutdown.
+- Switching to a different agent or operator mid-task.
+- End-of-day stop when work is mid-flight and you want to resume cleanly tomorrow.
+
+Do **not** use this skill for:
+- Phase 4 production handoff to operations — that goes in `HANDOFF.md` via the project's existing `templates/generated/handoff.tmpl`. They are different artifacts with different audiences.
+- Single-task summaries inside a session — write those inline.
+
+## What it produces
+
+Write a markdown document summarizing the current conversation so a fresh agent (or future-you) can continue cleanly. Save it to:
+
+```
+docs/handoffs/YYYY-MM-DD-<topic-slug>.md
+```
+
+(Create `docs/handoffs/` if it does not exist.)
+
+The handoff document MUST include:
+
+1. **Where we are** — one-paragraph status of the work in progress: current branch, current PR (if any), current task on the implementation plan, current test-gate state.
+2. **What just shipped this session** — bullet list of commits / PRs / artifacts produced. Link to file paths and PR URLs, do not duplicate content.
+3. **What's blocked / waiting** — anything paused on user review, external state (CI, deploys), or unanswered design questions.
+4. **What's next** — the specific next concrete action. If multiple options exist, list them with the recommendation.
+5. **References** — paths to PRDs, plans, ADRs, specs, TRIAGE docs, calibration reports the next session will need. Use repo-relative paths.
+6. **Resume prompt** — a single paragraph the user can paste into the next session (or have an agent re-enter with) that re-establishes context. Should be self-contained: "Continuing from <date> handoff at <path>. <One-line recap of decision-state>. <Specific next action>."
+
+If the user passed an argument describing the next session's focus, tailor the document to that focus.
+
+## What NOT to do
+
+- **Do not duplicate content** already captured in artifacts. The handoff is a pointer document, not a re-creation. If a decision lives in an ADR, link to it. If a plan lives in `docs/superpowers/plans/`, link to it.
+- **Do not write the handoff as a narrative log.** This is not a journal. Lead with "where we are now" and "what's next" — those are what the resumer needs.
+- **Do not skip the resume prompt.** Without it, the next session has to re-derive context. The prompt is the difference between "useful" and "load-bearing."
+- **Do not invent followup items.** Only record items the conversation actually surfaced.
+
+## Composition with Solo's existing artifacts
+
+- If a feature is mid-implementation, link to its implementation plan (`docs/superpowers/plans/...`) and identify the current task by number.
+- If a calibration / UAT sweep is mid-flight, link to the TRIAGE.md and identify which findings are addressed vs. deferred.
+- If `process-state.json` reflects in-flight Build Loop / Phase work, mention the current step and what step is next.
+- If a `pending-approval.json` sentinel exists (BL-015 / BL-029), call this out prominently — the next session must address it before proceeding.
+
+## Self-check before saving
+
+Read the document you just wrote. Ask:
+1. If I, with no other context, started a session and was given only this document, could I resume cleanly?
+2. Did I link to canonical artifacts rather than re-quoting them?
+3. Is the resume prompt at the bottom usable as a literal first message?
+
+If any answer is no, fix it before saving.

--- a/tests/test-vendored-skills-install.sh
+++ b/tests/test-vendored-skills-install.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# tests/test-vendored-skills-install.sh — verify init.sh installs vendored skills.
+#
+# Vendored skills live under templates/generated/skills/<name>/ in the framework
+# repo and are copied into .claude/skills/<name>/ on project init. Each skill
+# must ship its SKILL.md and (when applicable) a NOTICE attribution file.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Run init from /tmp to avoid the framework's "refuse to operate inside framework repo" guard.
+run_init() {
+  local proj="$1"
+  ( cd /tmp && bash "$REPO_ROOT/init.sh" --non-interactive \
+      --project skillstest --project-dir "$proj" --no-remote-creation \
+      --platform web --language typescript \
+      --deployment personal --git-host other \
+      --remote-url https://example.com/x.git --branch-protection-attested \
+      --allow-existing-dir >/dev/null 2>&1 )
+}
+
+# T1: session-handoff SKILL.md exists in the framework repo.
+echo "T1: framework ships templates/generated/skills/session-handoff/SKILL.md"
+if [ -f "$REPO_ROOT/templates/generated/skills/session-handoff/SKILL.md" ]; then
+  pass "T1"
+else
+  fail_ "T1" "vendored SKILL.md missing"
+fi
+
+# T2: session-handoff NOTICE exists in the framework repo (MIT attribution).
+echo "T2: framework ships templates/generated/skills/session-handoff/NOTICE"
+if [ -f "$REPO_ROOT/templates/generated/skills/session-handoff/NOTICE" ]; then
+  pass "T2"
+else
+  fail_ "T2" "vendored NOTICE missing"
+fi
+
+# T3: NOTICE references the upstream repo and MIT license.
+echo "T3: NOTICE preserves attribution + MIT terms"
+if grep -q "mattpocock/skills" "$REPO_ROOT/templates/generated/skills/session-handoff/NOTICE" \
+   && grep -q "MIT License" "$REPO_ROOT/templates/generated/skills/session-handoff/NOTICE"; then
+  pass "T3"
+else
+  fail_ "T3" "attribution incomplete"
+fi
+
+# T4: init.sh copies the skill into a freshly-init'd project.
+echo "T4: init.sh installs .claude/skills/session-handoff/"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+run_init "$PROJ"
+if [ -f "$PROJ/.claude/skills/session-handoff/SKILL.md" ] \
+   && [ -f "$PROJ/.claude/skills/session-handoff/NOTICE" ]; then
+  pass "T4"
+else
+  fail_ "T4" "skill not installed at .claude/skills/session-handoff/ — SKILL.md=$([ -f "$PROJ/.claude/skills/session-handoff/SKILL.md" ] && echo yes || echo no) NOTICE=$([ -f "$PROJ/.claude/skills/session-handoff/NOTICE" ] && echo yes || echo no)"
+fi
+rm -rf "$TMP"
+
+# T5: SKILL.md frontmatter has the expected name and an argument-hint.
+echo "T5: SKILL.md frontmatter has name=session-handoff + argument-hint"
+if head -10 "$REPO_ROOT/templates/generated/skills/session-handoff/SKILL.md" | grep -q "^name: session-handoff$" \
+   && head -10 "$REPO_ROOT/templates/generated/skills/session-handoff/SKILL.md" | grep -q "^argument-hint:"; then
+  pass "T5"
+else
+  fail_ "T5" "frontmatter missing or wrong"
+fi
+
+# T6: SKILL.md body disambiguates from Solo's Phase 4 HANDOFF.md.
+echo "T6: SKILL.md body clarifies vs Phase 4 production HANDOFF.md"
+if grep -q "Phase 4 production HANDOFF.md\|production handoff" "$REPO_ROOT/templates/generated/skills/session-handoff/SKILL.md"; then
+  pass "T6"
+else
+  fail_ "T6" "disambiguation missing"
+fi
+
+# T7: SKILL.md body requires the resume-prompt section (load-bearing for the
+# 'paste this into next session' use case).
+echo "T7: SKILL.md mandates a resume prompt"
+if grep -qi "resume prompt" "$REPO_ROOT/templates/generated/skills/session-handoff/SKILL.md"; then
+  pass "T7"
+else
+  fail_ "T7" "resume prompt section missing"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

First of four PRs integrating selected skills from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, © Matt Pocock) into Solo Orchestrator. Each skill ships independently so any one can be rolled back without affecting the others.

**This PR introduces:**

1. **The `.claude/skills/` namespace** — project-scoped Claude Code skills shipped by the framework, distinct from user-level plugins (Superpowers, etc.). Skills here activate at the project level and survive operator handoff (W7 principle).

2. **`session-handoff` skill** — adapted from mattpocock/skills' `handoff`. Produces a session-boundary handoff document at `docs/handoffs/YYYY-MM-DD-<topic>.md` for use before hard context-window breaks, machine reboots, or operator changes.

3. **Attribution / vendoring policy** — every vendored skill ships with a `NOTICE` file preserving upstream copyright + license, documenting the adaptations made for Solo Orchestrator.

## Solo adaptations from upstream

- **Renamed `handoff` → `session-handoff`** to disambiguate from Solo's Phase 4 production `HANDOFF.md` (`templates/generated/handoff.tmpl`). Same word, very different artifacts.
- **Save path:** `mktemp` → `docs/handoffs/YYYY-MM-DD-<topic>.md` so handoffs live with the project as auditable artifacts.
- **Required sections** added to the skill body: *Where we are*, *What just shipped*, *Blocked / waiting*, *What's next*, *References*, *Resume prompt*.
- **Solo-specific composition guidance** — how to reference implementation plans, TRIAGEs, `process-state.json`, and `pending-approval.json` sentinels from the handoff.
- **When-to-use / when-not-to-use** guidance and a self-check section.

## Future PRs in this series

| PR | Skill | Why |
|---|---|---|
| #1 (this) | `session-handoff` | Direct W7 fit; no Solo equivalent. |
| #2 | `triage` | Codifies the TRIAGE.md shape Karl already hand-rolls for UAT sweeps. |
| #3 | `zoom-out` | Periodic step-back; W4 self-discipline complement. |
| #4 | `grill-with-docs` | Periodic doc audit; needs adaptation to Solo's `CLAUDE.md` / `PROJECT_BIBLE.md` / ADR layout (no `CONTEXT.md` in Solo). |

Skills the upstream ships that we deliberately skip: `tdd`, `diagnose`, `write-a-skill`, `caveman` (duplicate Superpowers); `improve-codebase-architecture`, `prototype`, `to-prd`, `to-issues`, `grill-me` (conflict with Solo's phase-audit / POC track / intake-wizard / brainstorming).

## Test Plan

- [x] `bash tests/test-vendored-skills-install.sh` — 7/7 (skill presence, attribution preservation, init copy behavior, frontmatter structure, disambiguation from HANDOFF.md, resume-prompt requirement)
- [x] Full regression suite: **23/23 PASS** (22 baseline + 1 new test file)
- [x] Smoke test: fresh `init.sh --non-interactive` produces `.claude/skills/session-handoff/SKILL.md` and `NOTICE` in the new project

## Attribution preserved

- `templates/generated/skills/session-handoff/NOTICE` — full MIT text + © Matt Pocock + adaptation log
- `templates/generated/skills/session-handoff/SKILL.md` — opens with an attribution paragraph linking upstream

🤖 Generated with [Claude Code](https://claude.com/claude-code)