### PR TITLE
feat(skills): sweep-triage (Solo-original, PR #2 of the skills integration series)

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -845,8 +845,9 @@ Every project initialized by `init.sh` receives a `.claude/skills/` directory co
 | Skill | Purpose | Source |
 |---|---|---|
 | `session-handoff` | Compact the current conversation into a session-boundary handoff document at `docs/handoffs/YYYY-MM-DD-<topic>.md`. Use before a hard context break, machine reboot, or operator change. Distinct from Solo's Phase 4 production `HANDOFF.md`. | Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT) — see `.claude/skills/session-handoff/NOTICE`. |
+| `sweep-triage` | Consolidate findings from a sweep (UAT calibration, multi-agent validation, manual audit) into a `Reports/<sweep-id>/TRIAGE.md` with S1-S5 severity ranking and a single ship decision. Codifies the format the framework would otherwise hand-roll. Distinct from per-issue triage in an issue tracker. | Solo-original. See `Related work` in the SKILL.md for the spiritually-related upstream pattern. |
 
-Each vendored skill ships with a `NOTICE` file preserving the upstream author's copyright and documenting the adaptations made for Solo Orchestrator. Upstream updates are not automatic; vendored skills are versioned with the framework.
+Each vendored skill with adapted content ships a `NOTICE` file preserving the upstream author's copyright and documenting the adaptations made for Solo Orchestrator. Solo-original skills carry no NOTICE — claiming MIT inheritance for original work would overclaim dependency. Upstream updates are not automatic; vendored skills are versioned with the framework.
 
 ### Using a Different AI Coding Agent
 

--- a/init.sh
+++ b/init.sh
@@ -1159,7 +1159,7 @@ create_project() {
   # Adding a new skill: drop it under templates/generated/skills/<name>/
   # and append a line to the loop below.
   mkdir -p .claude/skills
-  for skill in session-handoff; do
+  for skill in session-handoff sweep-triage; do
     if [ -d "$SCRIPT_DIR/templates/generated/skills/$skill" ]; then
       mkdir -p ".claude/skills/$skill"
       cp "$SCRIPT_DIR/templates/generated/skills/$skill/SKILL.md" ".claude/skills/$skill/"

--- a/templates/generated/skills/sweep-triage/SKILL.md
+++ b/templates/generated/skills/sweep-triage/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: sweep-triage
+description: Consolidate findings from a sweep (UAT calibration, multi-agent validation, manual audit) into a TRIAGE.md document with severity ranking and ship recommendations. Use when a sweep has produced multiple findings that need to be triaged together to make a single ship/no-ship decision.
+argument-hint: "Path to the sweep directory (e.g., Reports/uat-2026-MM-DD-foo/) OR a description of the sweep being triaged."
+---
+
+# Sweep Triage
+
+> **What this is.** A skill for consolidating findings from a sweep into one decision-grade document. A sweep is any activity that surfaces multiple findings at once: a multi-agent UAT run, a manual audit pass, a security review, a calibration replay. Each finding needs severity, a fix recommendation, and the whole set needs an overall ship recommendation.
+>
+> **What this is NOT.** This skill is not for per-issue triage in an issue tracker (working through GitHub Issues or Linear one at a time, applying state-machine labels). That is a different workflow. If you want issue-tracker triage, see the related work below.
+>
+> **Canonical example.** `Reports/uat-2026-04-29-bl029-validation/TRIAGE.md` (committed to this repo) is the output shape this skill produces. Read it before writing your first TRIAGE — it shows the per-agent verdict table, severity-ranked issue list, and the Resolution section appended after fixes shipped.
+
+## When to use
+
+- A multi-agent UAT sweep just finished and you have N agent reports in `Reports/<sweep-id>/results/agent-*.json`.
+- A manual audit (security review, accessibility pass, code review) produced multiple findings.
+- A calibration replay (cf. BL-029 / BL-030 work) produced verdicts across scenarios and personas.
+- You're about to make a ship / no-ship decision and have more than 2-3 findings to weigh.
+
+## When NOT to use
+
+- Single-finding issues — write the fix or file the BL item directly.
+- Per-issue triage in an issue tracker — that's a different workflow (state machine + labels, not severity tiers + ship decisions). See *Related work* below.
+- Trivial sweeps (everything green, no findings) — no document needed; the green test output is the artifact.
+
+## Output
+
+The skill produces a markdown document at:
+
+```
+Reports/<sweep-id>/TRIAGE.md
+```
+
+Where `<sweep-id>` is the directory the sweep already lives in (e.g., `uat-2026-04-29-bl029-validation`). If there is no sweep directory yet, create one at `Reports/<sweep-id>/` first.
+
+### Required sections
+
+The TRIAGE.md MUST contain, in this order:
+
+1. **Header.** Date, sweep name, target branch/HEAD, wave structure (if multi-wave dispatch), and a one-line per-agent or per-source verdict summary.
+2. **Per-agent verdicts table** (or per-source equivalent). One row per agent / per audit source. Columns: identifier, scope, headline verdict (e.g., `ship | fix-then-ship | block-merge`), headline finding.
+3. **Issues, ranked by severity.** Use severity tiers `S1` (critical / merge-blocker) through `S5` (low / nice-to-have). Each issue gets:
+   - One-line headline
+   - Source(s) — which agent(s) / audit step surfaced it
+   - Description (what's broken, what's the scope, what's at stake)
+   - Recommended action: `fix-in-branch | defer-to-followup | accept-as-is | block-merge`
+   - Fix complexity estimate (small / medium / large)
+4. **"What demonstrably works"** section. Non-findings — list properties of the work that the sweep CONFIRMED rather than just failed to disprove. This is the section that prevents people from reading a TRIAGE as "everything is broken" when actually most things work and N specific things don't.
+5. **Ship decision.** One paragraph: ship | fix-then-ship | block-merge, with reasoning. If fix-then-ship, list the specific subset to fix in this branch and what defers. If block-merge, list the specific blockers and what closes them.
+
+### Optional but recommended
+
+6. **Resolution section** (appended AFTER the recommended fixes ship). Records what was actually done vs. deferred, with commit references. Lets a future reader trace from the original finding to the fix commit without git archaeology.
+
+## Workflow
+
+1. **Locate or create the sweep directory.** If the user passed `Reports/<sweep-id>/`, use it. Otherwise infer from context (current sweep in flight) or ask.
+
+2. **Gather findings.** Inspect everything in the sweep directory that produces signal:
+   - Agent JSON reports (`results/agent-*.json`) — each typically has a `ship_recommendation` field and a list of findings.
+   - Manual notes from the user.
+   - Test output, GitHub issues, ADRs touched during the sweep.
+
+3. **Cluster duplicate findings.** When multiple agents report the same underlying issue with different framings, merge them into one issue with all sources cited. Don't list the same problem 3 times.
+
+4. **Assign severity.** Use the ladder:
+   - **S1 (critical):** merge-blocker; the framework's stated invariant is violated. Examples: silent dropping of `refuse_to_recommend` audit rows (BL-029 calibration S1); secret leakage; data loss path.
+   - **S2 (high):** ship-blocker under strict reading; the calibration scenarios surfaced exactly this phrasing and it's the reason the sweep was run. Examples: regex narrowness on canonical bypass language (BL-029 calibration S2).
+   - **S3 (medium):** real but post-merge OK; bounded blast radius. Examples: documentation false positives (BL-029 calibration S3).
+   - **S4 (medium):** feature gap that prevents a use case from completing, but the use case isn't critical-path for this ship. Examples: missing audit-row closer for W7 utility (BL-029 calibration S4).
+   - **S5 (low):** UX edge or polish. Examples: sentinel priming risk (BL-029 calibration S5).
+
+5. **Recommend per-issue action.** For each issue, pick: `fix-in-branch` (do it now), `defer-to-followup` (file a BL item), `accept-as-is` (document why and move on), `block-merge` (don't ship until this is fixed).
+
+6. **Recommend overall ship decision.** Bias toward shipping with a clear deferred list over blocking everything. Block-merge should be rare — only when an S1 is unresolved or a cluster of S2s collectively crosses the credibility threshold.
+
+7. **Write "What demonstrably works."** This is the section that prevents misreading. Examples: "Confirmation phrase defeats novice acceptance (agent 4 confirmed in-character)" or "Severity elevation routes through correctly when patterns DO match."
+
+8. **Save the TRIAGE.md.** Commit it as part of the sweep evidence, not as a transient artifact.
+
+9. **After fixes ship — append Resolution.** Once the recommended fixes are in, return to the TRIAGE and append a Resolution section recording exactly what was done (commit refs) and what was deferred (BL items). This converts the TRIAGE from a snapshot into a permanent record.
+
+## Self-check before saving
+
+Read the document with fresh eyes. Ask:
+
+1. If someone read only this TRIAGE (not the agent reports), could they decide ship / fix / block?
+2. Did I cluster duplicate findings, or is the issue list inflated with restatements?
+3. Did I include "What demonstrably works"? If not, add it — readers will infer "everything is broken" otherwise.
+4. Is every recommended action concrete (`fix-in-branch this subset`, `defer-to-followup as BL-029.1`) or vague (`investigate`)?
+5. Is the ship decision a clear one-line verdict, or a hedge?
+
+If any answer is no, fix it before saving.
+
+## Composition with Solo's existing artifacts
+
+- **Backlog (`solo-orchestrator-backlog.md`):** `defer-to-followup` items should be filed as BL items. Cite the BL number in the TRIAGE so the reader can trace.
+- **Implementation plans (`docs/superpowers/plans/`):** if a `fix-in-branch` cluster is large enough to warrant a plan, write one. The TRIAGE points to the plan; the plan points back to the TRIAGE.
+- **Calibration / UAT reports (`Reports/<sweep-id>/`):** the TRIAGE lives in the same directory as the agent reports it triages.
+- **Pending-approval sentinel:** if the sweep surfaced an open question for the user, use `scripts/escalate-to-user.sh` (BL-029) to write a structured pending-approval rather than burying the question in the TRIAGE.
+
+## Related work
+
+- **`mattpocock/skills` `triage`** ([upstream](https://github.com/mattpocock/skills/tree/main/skills/engineering/triage), MIT, © Matt Pocock) — a spiritually-related but differently-scoped skill for per-issue triage in an issue tracker (GitHub Issues, Linear). State machine model with `needs-triage` / `needs-info` / `ready-for-agent` labels. Use that if you're working through a backlog of incoming issues one at a time; use this skill if you're consolidating a sweep into a single ship decision.
+- **`session-handoff`** (Solo, adapted from mattpocock) — what to do when the work is mid-flight and the session is ending. Different artifact; different purpose.

--- a/tests/test-vendored-skills-install.sh
+++ b/tests/test-vendored-skills-install.sh
@@ -88,6 +88,80 @@ else
   fail_ "T7" "resume prompt section missing"
 fi
 
+# ---- sweep-triage (PR #2 — Solo-original, no NOTICE) ----
+
+# T8: sweep-triage SKILL.md exists.
+echo "T8: framework ships templates/generated/skills/sweep-triage/SKILL.md"
+if [ -f "$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md" ]; then
+  pass "T8"
+else
+  fail_ "T8" "vendored SKILL.md missing"
+fi
+
+# T9: sweep-triage has NO NOTICE file. Skill is Solo-original — nothing was
+# adapted from upstream, so claiming MIT inheritance would overclaim
+# dependency. A NOTICE here would be a bug.
+echo "T9: sweep-triage has NO NOTICE (Solo-original, no upstream adaptation)"
+if [ ! -f "$REPO_ROOT/templates/generated/skills/sweep-triage/NOTICE" ]; then
+  pass "T9"
+else
+  fail_ "T9" "NOTICE present — overclaims upstream dependency for a Solo-original skill"
+fi
+
+# T10: init.sh installs sweep-triage into a freshly-init'd project.
+echo "T10: init.sh installs .claude/skills/sweep-triage/"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+run_init "$PROJ"
+if [ -f "$PROJ/.claude/skills/sweep-triage/SKILL.md" ]; then
+  pass "T10"
+else
+  fail_ "T10" "skill not installed"
+fi
+rm -rf "$TMP"
+
+# T11: sweep-triage frontmatter name + argument-hint present.
+echo "T11: sweep-triage frontmatter"
+if head -10 "$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md" | grep -q "^name: sweep-triage$" \
+   && head -10 "$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md" | grep -q "^argument-hint:"; then
+  pass "T11"
+else
+  fail_ "T11" "frontmatter missing or wrong"
+fi
+
+# T12: SKILL.md disambiguates from issue-tracker triage workflow.
+echo "T12: sweep-triage clarifies vs per-issue triage workflow"
+if grep -q "per-issue triage\|issue tracker" "$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md"; then
+  pass "T12"
+else
+  fail_ "T12" "disambiguation from per-issue triage missing"
+fi
+
+# T13: SKILL.md cites the canonical BL-029 calibration TRIAGE as the example
+# (so readers see a real artifact, not just a template).
+echo "T13: sweep-triage cites canonical example artifact"
+if grep -q "uat-2026-04-29-bl029-validation/TRIAGE.md\|BL-029 calibration" "$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md"; then
+  pass "T13"
+else
+  fail_ "T13" "canonical example missing"
+fi
+
+# T14: SKILL.md defines the S1-S5 severity ladder.
+echo "T14: sweep-triage defines severity ladder S1-S5"
+body="$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md"
+if grep -q "S1" "$body" && grep -q "S2" "$body" && grep -q "S3" "$body" && grep -q "S5" "$body"; then
+  pass "T14"
+else
+  fail_ "T14" "severity ladder incomplete"
+fi
+
+# T15: SKILL.md links to mattpocock's triage as related work.
+echo "T15: sweep-triage 'Related work' references mattpocock/skills triage"
+if grep -q "mattpocock/skills.*triage\|mattpocock.*triage" "$REPO_ROOT/templates/generated/skills/sweep-triage/SKILL.md"; then
+  pass "T15"
+else
+  fail_ "T15" "related-work reference missing"
+fi
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

Second in the skills integration series. **Solo-original** — codifies the `TRIAGE.md` consolidation format the framework would otherwise hand-roll, modeled on `Reports/uat-2026-04-29-bl029-validation/TRIAGE.md` from the BL-029 calibration sweep.

## Why this departs from the "4 PRs from mattpocock" framing

I was initially going to vendor [mattpocock/skills' `triage`](https://github.com/mattpocock/skills/tree/main/skills/engineering/triage) for PR #2. On closer reading, that skill is a state machine for working through an *issue tracker* (`needs-triage` / `needs-info` / `ready-for-agent` labels, one issue at a time). It does NOT produce the sweep-findings consolidation document we hand-roll for UAT calibration and multi-agent validation work.

After clarification, the decision was to write a **Solo-original** skill that does what we actually want — and link mattpocock's `triage` under "Related work" for readers who arrived looking for issue-tracker workflow. No content is adapted from upstream, so this skill carries **no NOTICE file**. Claiming MIT inheritance for original work would overclaim dependency.

The 4-PR series remains the rest of the original plan (zoom-out next, then grill-with-docs).

## What sweep-triage produces

```
Reports/<sweep-id>/TRIAGE.md
```

Required sections:
- Header + per-agent verdicts table
- Severity-ranked issue list — **S1 critical / S2 high / S3 medium / S4 medium / S5 low**, with per-issue recommended action: `fix-in-branch | defer-to-followup | accept-as-is | block-merge` and fix complexity (small / medium / large)
- **"What demonstrably works"** section — non-findings the sweep CONFIRMED. Prevents the "everything is broken" misreading
- Single ship decision: `ship | fix-then-ship | block-merge` with reasoning
- Optional Resolution section appended after fixes ship (commit references)

## Composition with existing artifacts

- `solo-orchestrator-backlog.md` — defer-to-followup items get filed there with BL numbers cited
- `docs/superpowers/plans/` — fix-in-branch clusters large enough to need a plan get one; bidirectional links
- `scripts/escalate-to-user.sh` (BL-029) — open user-judgment questions go through structured pending-approvals, not buried in the TRIAGE

## Test Plan

- [x] `bash tests/test-vendored-skills-install.sh` — 15/15 (7 from PR #1 + 8 new sweep-triage assertions: presence, no-NOTICE invariant, init copy, frontmatter, disambiguation from per-issue triage, canonical example citation, severity ladder coverage, related-work link)
- [x] Full regression suite: **23/23 PASS**
- [x] Smoke: `init.sh --non-interactive` produces `.claude/skills/sweep-triage/SKILL.md` in the new project

## Attribution policy clarified

builders-guide.md "Vendored Skills" section now spells out the two cases:
- **Adapted skills** (e.g., `session-handoff`) — ship a NOTICE preserving upstream copyright + license + adaptation log
- **Solo-original skills** (e.g., `sweep-triage`) — no NOTICE; falsely claiming inheritance would overclaim dependency

## Future PRs

| PR | Skill | Source | Status |
|---|---|---|---|
| #1 | `session-handoff` | mattpocock (MIT) | merged (#42) |
| #2 (this) | `sweep-triage` | Solo-original | this PR |
| #3 | `zoom-out` | mattpocock (MIT) | next |
| #4 | `grill-with-docs` | mattpocock (MIT) | after #3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)