### PR TITLE
fix: upgrade-project --backfill-only for BL-030; verify-install BL-030 coverage

### DIFF
--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -67,6 +67,11 @@ SHOW_HELP=false
 # BL-018: explicit non-interactive marker (overrides [-t 0] auto-detection) + validate-only.
 NON_INTERACTIVE=false
 VALIDATE_ONLY=false
+# Post-PR #48: --backfill-only runs only the host backfill + BL-030
+# manifest backfill (deployment, poc_mode, enforcement_level) and
+# exits. Lets operators of pre-BL-030 projects upgrade their manifest
+# without choosing a track / deployment / POC transition.
+BACKFILL_ONLY=false
 
 # BL-018: BL-016-style structured error helper (summary + reason + action + context).
 _upgrade_fail() {
@@ -121,6 +126,8 @@ while [ $# -gt 0 ]; do
       esac
       shift 2
       ;;
+    --backfill-only)
+      BACKFILL_ONLY=true; shift; continue ;;
     --to-production)
       TO_PRODUCTION=true
       shift
@@ -197,6 +204,113 @@ if [ "$VALIDATE_ONLY" = true ]; then
       non_interactive:  $non_interactive,
       validate_only:    true
     }'
+  exit 0
+fi
+
+# --- Idempotent manifest backfills (run before target-flag check) ---
+# These migrate pre-existing projects to the current schema without
+# requiring the operator to also pick a track / deployment / POC
+# transition. Idempotent — both block on `! jq -e '.<field>'` so a
+# second run is a no-op.
+( cd "$PROJECT_ROOT"
+  # --- Host-aware migration (spec 2026-04-21) ---
+  # Projects created before the host-aware gate need the flat CI template
+  # layout migrated into per-host subfolders and the manifest backfilled
+  # with a host field. Idempotent on already-migrated projects.
+  if [ -d templates/pipelines/ci ] && [ ! -d templates/pipelines/ci/github ] && ls templates/pipelines/ci/*.yml >/dev/null 2>&1; then
+    print_step "Migrating flat CI template layout → per-host subfolders"
+    mkdir -p templates/pipelines/ci/github templates/pipelines/release/github
+    for f in templates/pipelines/ci/*.yml; do
+      [ -f "$f" ] && (git mv "$f" "templates/pipelines/ci/github/$(basename "$f")" 2>/dev/null || mv "$f" "templates/pipelines/ci/github/$(basename "$f")")
+    done
+    for f in templates/pipelines/release/*.yml; do
+      [ -f "$f" ] && (git mv "$f" "templates/pipelines/release/github/$(basename "$f")" 2>/dev/null || mv "$f" "templates/pipelines/release/github/$(basename "$f")")
+    done
+    print_ok "CI/release templates moved to github/ subfolders"
+  fi
+
+  if [ -f .claude/manifest.json ] && ! jq -e '.host' .claude/manifest.json >/dev/null 2>&1; then
+    print_step "Backfilling manifest.json 'host' field"
+    print_info "Manifest predates the host-aware gate — inferring host from git remote"
+    host_url=$(git remote get-url origin 2>/dev/null || echo "")
+    case "$host_url" in
+      *github.com*)    inferred_host="github" ;;
+      *gitlab*)        inferred_host="gitlab" ;;
+      *bitbucket.org*) inferred_host="bitbucket" ;;
+      *)               inferred_host="other" ;;
+    esac
+    jq --arg h "$inferred_host" '.host = $h' .claude/manifest.json > .claude/manifest.json.tmp \
+      && mv .claude/manifest.json.tmp .claude/manifest.json
+    print_ok "host set to '$inferred_host' (verify via scripts/check-gate.sh --backfill-host if wrong)"
+  fi
+
+  # --- BL-030 manifest backfill (post-PR #48 safety contract) ---
+  # Pre-BL-030 projects have no .enforcement_level / .deployment /
+  # .poc_mode in manifest.json. After PR #48, assert_choosable's jq
+  # default (.deployment // "personal") silently treated those projects
+  # as choosable, letting reconfigure-project.sh --enforcement-level no
+  # bypass baseline §2.5 tier-forcing for organizational/sponsored_poc /
+  # organizational/production projects. This block backfills the three
+  # fields from phase-state.json (canonical post-S2-cluster-4 source),
+  # forces enforcement_level=strict (no auto-relaxation on the upgrade
+  # path), installs the filesystem gate, initializes the detection
+  # baseline, and writes an enforcement_level_set audit row sourced
+  # 'upgrade-backfill' so the lifecycle is traceable.
+  if [ -f .claude/manifest.json ] && ! jq -e '.enforcement_level' .claude/manifest.json >/dev/null 2>&1; then
+    print_step "Backfilling manifest.json BL-030 fields (deployment, poc_mode, enforcement_level)"
+    mig_deployment=""
+    mig_poc=""
+    if [ -f .claude/phase-state.json ]; then
+      mig_deployment=$(jq -r '.deployment // ""' .claude/phase-state.json 2>/dev/null || echo "")
+      mig_poc=$(jq -r '.poc_mode // ""' .claude/phase-state.json 2>/dev/null || echo "")
+      [ "$mig_deployment" = "null" ] && mig_deployment=""
+      [ "$mig_poc" = "null" ] && mig_poc=""
+    fi
+    if [ -z "$mig_deployment" ]; then
+      print_warn "phase-state.json lacks .deployment — assuming 'personal' for backfill."
+      print_warn "If this project is organizational, run after the upgrade completes:"
+      print_warn "  scripts/reconfigure-project.sh --field deployment --old personal --new organizational"
+      mig_deployment="personal"
+    fi
+    if [ -n "$mig_poc" ]; then
+      jq --arg dep "$mig_deployment" --arg pm "$mig_poc" \
+        '. + {deployment: $dep, poc_mode: $pm, enforcement_level: "strict"}' \
+        .claude/manifest.json > .claude/manifest.json.tmp \
+        && mv .claude/manifest.json.tmp .claude/manifest.json
+    else
+      jq --arg dep "$mig_deployment" \
+        '. + {deployment: $dep, poc_mode: null, enforcement_level: "strict"}' \
+        .claude/manifest.json > .claude/manifest.json.tmp \
+        && mv .claude/manifest.json.tmp .claude/manifest.json
+    fi
+    if [ ! -f .claude/last-checked-commit.txt ]; then
+      git rev-parse HEAD 2>/dev/null > .claude/last-checked-commit.txt || true
+    fi
+    if [ -x "scripts/install-filesystem-gates.sh" ]; then
+      bash scripts/install-filesystem-gates.sh --install "$(pwd)" >/dev/null 2>&1 || true
+    fi
+    [ -f .claude/bypass-audit.json ] || echo "[]" > .claude/bypass-audit.json
+    bf_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+    bf_row=$(jq -nc \
+      --arg ts "$bf_ts" \
+      --arg dep "$mig_deployment" \
+      --arg pm "$mig_poc" \
+      '{timestamp:$ts, session_id:null, type:"enforcement_level_set", actor:"framework",
+        enforcement_level_at_event:"strict",
+        details:{level:"strict", deployment:$dep, poc_mode:$pm, source:"upgrade-backfill"},
+        user_response:"n/a", final_outcome:"recorded_only"}')
+    bf_tmp=$(mktemp)
+    jq --argjson r "$bf_row" '. + [$r]' .claude/bypass-audit.json > "$bf_tmp" \
+      && mv "$bf_tmp" .claude/bypass-audit.json
+    print_ok "BL-030 fields backfilled: deployment=$mig_deployment poc_mode=${mig_poc:-null} enforcement_level=strict"
+    print_info "To choose a less strict level (personal/choosable projects only):"
+    print_info "  scripts/reconfigure-project.sh --enforcement-level <light|no> --confirm-pitfalls"
+  fi
+)
+
+# --backfill-only short-circuits here — no track / deployment / POC
+# transition follows.
+if [ "$BACKFILL_ONLY" = true ]; then
   exit 0
 fi
 
@@ -1578,40 +1692,6 @@ fi
 # Projects created before the host-aware gate need the flat CI template layout
 # migrated into per-host subfolders and the manifest backfilled with a host field.
 # This runs idempotently — safe on already-migrated projects.
-
-if [ -d templates/pipelines/ci ] && [ ! -d templates/pipelines/ci/github ] && ls templates/pipelines/ci/*.yml >/dev/null 2>&1; then
-  print_step "Migrating flat CI template layout → per-host subfolders"
-  mkdir -p templates/pipelines/ci/github templates/pipelines/release/github
-  for f in templates/pipelines/ci/*.yml; do
-    [ -f "$f" ] && (git mv "$f" "templates/pipelines/ci/github/$(basename "$f")" 2>/dev/null || mv "$f" "templates/pipelines/ci/github/$(basename "$f")")
-  done
-  for f in templates/pipelines/release/*.yml; do
-    [ -f "$f" ] && (git mv "$f" "templates/pipelines/release/github/$(basename "$f")" 2>/dev/null || mv "$f" "templates/pipelines/release/github/$(basename "$f")")
-  done
-  print_ok "CI/release templates moved to github/ subfolders"
-fi
-
-if [ -f .claude/manifest.json ] && ! jq -e '.host' .claude/manifest.json >/dev/null 2>&1; then
-  print_step "Backfilling manifest.json 'host' field"
-  print_info "Manifest predates the host-aware gate — inferring host from git remote"
-  host_url=$(git remote get-url origin 2>/dev/null || echo "")
-  case "$host_url" in
-    *github.com*)    inferred_host="github" ;;
-    *gitlab*)        inferred_host="gitlab" ;;
-    *bitbucket.org*) inferred_host="bitbucket" ;;
-    *)               inferred_host="other" ;;
-  esac
-  jq --arg h "$inferred_host" '.host = $h' .claude/manifest.json > .claude/manifest.json.tmp \
-    && mv .claude/manifest.json.tmp .claude/manifest.json
-  print_ok "host set to '$inferred_host' (verify via scripts/check-gate.sh --backfill-host if wrong)"
-
-  echo ""
-  print_info "Before your next Phase 1→2 transition, run:"
-  print_info "  bash scripts/check-gate.sh --preflight"
-  print_info "If preflight fails, run:"
-  print_info "  bash scripts/check-gate.sh --repair"
-  echo ""
-fi
 
 # --- UAT template migration (spec 2026-04-23-uat-template-quality-design.md) ---
 # Re-copy updated UAT source templates and per-platform reference pair.

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -262,7 +262,32 @@ check_scripts() {
     "scripts/lint-uat-scenarios.sh"
     "scripts/escalate-to-user.sh"
     "scripts/hooks/bypass-detector.sh"
+    # BL-030 (post-PR #48): detector, installer, recorder hook, and
+    # the fixture-envelope lint that gates the BL-029 hook schema.
+    "scripts/detect-out-of-band-commits.sh"
+    "scripts/install-filesystem-gates.sh"
+    "scripts/hooks/record-claude-commit.sh"
+    "scripts/lint-fixture-envelopes.sh"
   )
+
+  # BL-030 (post-PR #48): sourced libraries — these are not executable
+  # but their presence is load-bearing for enforcement_level reads,
+  # block-message principle lookup, and the reconfigure transition path.
+  local libs=(
+    "scripts/lib/enforcement-level.sh"
+    "scripts/lib/gate-principles.sh"
+  )
+  local lib_name
+  for lib in "${libs[@]}"; do
+    lib_name=$(basename "$lib" .sh)
+    if [ -f "$lib" ]; then
+      register_pass "$lib_name lib present"
+    elif has_source && [ -f "$SOURCE_DIR/$lib" ]; then
+      register_fixable "$lib_name lib missing" "fix_lib_copy_${lib_name}"
+    else
+      register_manual "$lib_name lib missing" "Copy from orchestrator $lib"
+    fi
+  done
 
   for script in "${scripts[@]}"; do
     local name
@@ -354,6 +379,37 @@ check_hooks() {
   else
     register_manual "Stop hook: session-end-qdrant-reminder.sh not registered" \
       "Add session-end-qdrant-reminder.sh to .hooks.Stop in .claude/settings.json"
+  fi
+
+  # BL-029 hooks (PostToolUse + Stop): bypass-detector.sh. Both
+  # registrations are required for the dual-event detection contract.
+  if jq -e '.hooks.PostToolUse[]? | .hooks[]? | select(.command | contains("bypass-detector.sh"))' .claude/settings.json >/dev/null 2>&1; then
+    register_pass "PostToolUse hook: bypass-detector.sh"
+  else
+    register_manual "PostToolUse hook: bypass-detector.sh not registered" \
+      "Add hooks/bypass-detector.sh to .hooks.PostToolUse in .claude/settings.json"
+  fi
+  if jq -e '.hooks.Stop[]? | .hooks[]? | select(.command | contains("bypass-detector.sh"))' .claude/settings.json >/dev/null 2>&1; then
+    register_pass "Stop hook: bypass-detector.sh"
+  else
+    register_manual "Stop hook: bypass-detector.sh not registered" \
+      "Add hooks/bypass-detector.sh to .hooks.Stop in .claude/settings.json"
+  fi
+
+  # BL-030 (post-PR #48): PostToolUse record-claude-commit ledger +
+  # SessionStart out-of-band detector. Both must be registered for the
+  # detection chain that powers the 'no/light/strict' enforcement levels.
+  if jq -e '.hooks.PostToolUse[]? | .hooks[]? | select(.command | contains("record-claude-commit.sh"))' .claude/settings.json >/dev/null 2>&1; then
+    register_pass "PostToolUse hook: record-claude-commit.sh"
+  else
+    register_manual "PostToolUse hook: record-claude-commit.sh not registered" \
+      "Add hooks/record-claude-commit.sh to .hooks.PostToolUse in .claude/settings.json"
+  fi
+  if jq -e '.hooks.SessionStart[]? | .hooks[]? | select(.command | contains("detect-out-of-band-commits.sh"))' .claude/settings.json >/dev/null 2>&1; then
+    register_pass "SessionStart hook: detect-out-of-band-commits.sh"
+  else
+    register_manual "SessionStart hook: detect-out-of-band-commits.sh not registered" \
+      "Add detect-out-of-band-commits.sh to .hooks.SessionStart in .claude/settings.json"
   fi
 }
 
@@ -728,10 +784,16 @@ fix_script() {
 }
 
 # Generate fix functions for each script
-for _s in validate check-phase-gate check-gate check-updates resume intake-wizard resolve-tools upgrade-project reconfigure-project verify-install test-gate check-versions session-version-check session-test-gate-check session-end-qdrant-reminder session-mcp-gate process-checklist pre-commit-gate track-tool-usage pending-approval lint-uat-scenarios escalate-to-user; do
+for _s in validate check-phase-gate check-gate check-updates resume intake-wizard resolve-tools upgrade-project reconfigure-project verify-install test-gate check-versions session-version-check session-test-gate-check session-end-qdrant-reminder session-mcp-gate process-checklist pre-commit-gate track-tool-usage pending-approval lint-uat-scenarios escalate-to-user detect-out-of-band-commits install-filesystem-gates lint-fixture-envelopes; do
   eval "fix_script_chmod_${_s}() { chmod +x 'scripts/${_s}.sh'; }"
   eval "fix_script_copy_${_s}() { fix_script '${_s}.sh'; }"
 done
+# BL-030: hooks live in a subdirectory; chmod + copy paths reflect that.
+eval "fix_script_chmod_record-claude-commit() { chmod +x 'scripts/hooks/record-claude-commit.sh'; }"
+eval "fix_script_copy_record-claude-commit()  { fix_script 'hooks/record-claude-commit.sh'; }"
+# BL-030: sourced libs — no chmod, copy only.
+fix_lib_copy_enforcement-level() { if has_source && [ -f "$SOURCE_DIR/scripts/lib/enforcement-level.sh" ]; then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/enforcement-level.sh" scripts/lib/; else return 1; fi; }
+fix_lib_copy_gate-principles()   { if has_source && [ -f "$SOURCE_DIR/scripts/lib/gate-principles.sh" ];   then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/gate-principles.sh"   scripts/lib/; else return 1; fi; }
 # Hooks live in a subdirectory; chmod + copy paths reflect that. The
 # basename of scripts/hooks/bypass-detector.sh is `bypass-detector`, so
 # the helper names must match (with hyphens, via eval).

--- a/tests/test-upgrade-bl030-backfill.sh
+++ b/tests/test-upgrade-bl030-backfill.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# tests/test-upgrade-bl030-backfill.sh — verify upgrade-project.sh
+# backfills the BL-030 manifest fields (deployment, poc_mode,
+# enforcement_level) on pre-BL-030 projects. Without the backfill,
+# assert_choosable's jq default of 'personal' silently lets an
+# operator relax enforcement_level=no on what should be forced-strict
+# (the safety regression survey #1 called out for PR A).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# init.sh refuses to run from inside the framework repo.
+cd /tmp
+
+# Build a fresh BL-030-era project, then mutate it to LOOK like a
+# pre-BL-030 project: strip enforcement_level / deployment / poc_mode
+# from manifest, remove last-checked-commit.txt, uninstall the
+# filesystem gate, remove the BL-030 audit-log row. This mimics what
+# an operator who initialized before PR #48 would see.
+setup_pre_bl030_personal() {
+  TMP=$(mktemp -d); PROJ="$TMP/p"
+  bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
+    --platform web --language javascript --track light --deployment personal \
+    >/dev/null 2>&1
+  # Strip the BL-030 fields from manifest.
+  tmp=$(mktemp)
+  jq 'del(.enforcement_level, .deployment, .poc_mode)' "$PROJ/.claude/manifest.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/manifest.json"
+  # Strip the BL-030 init artifacts.
+  rm -f "$PROJ/.claude/last-checked-commit.txt"
+  rm -f "$PROJ/.git/hooks/framework-gate.sh"
+  # Remove the marker block from pre-commit.
+  bash "$PROJ/scripts/install-filesystem-gates.sh" --uninstall "$PROJ" >/dev/null 2>&1
+  # Strip the enforcement_level_set rows so we can assert a NEW one is added.
+  tmp=$(mktemp)
+  jq '[.[] | select(.type != "enforcement_level_set")]' "$PROJ/.claude/bypass-audit.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/bypass-audit.json"
+  # Add a phase-state.json deployment field so the backfill can read it.
+  # (phase-state already has these per S2 cluster 4; defensive set here.)
+  tmp=$(mktemp)
+  jq '. + {deployment: "personal", poc_mode: null}' "$PROJ/.claude/phase-state.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/phase-state.json"
+  UPGRADE="$PROJ/scripts/upgrade-project.sh"
+}
+setup_pre_bl030_organizational_production() {
+  TMP=$(mktemp -d); PROJ="$TMP/p"
+  bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
+    --platform web --language javascript --track standard --deployment organizational --gov-mode production \
+    >/dev/null 2>&1
+  tmp=$(mktemp)
+  jq 'del(.enforcement_level, .deployment, .poc_mode)' "$PROJ/.claude/manifest.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/manifest.json"
+  rm -f "$PROJ/.claude/last-checked-commit.txt"
+  rm -f "$PROJ/.git/hooks/framework-gate.sh"
+  bash "$PROJ/scripts/install-filesystem-gates.sh" --uninstall "$PROJ" >/dev/null 2>&1
+  tmp=$(mktemp)
+  jq '[.[] | select(.type != "enforcement_level_set")]' "$PROJ/.claude/bypass-audit.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/bypass-audit.json"
+  UPGRADE="$PROJ/scripts/upgrade-project.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+# T1: pre-BL-030 personal project: upgrade backfills manifest fields.
+echo "T1: pre-BL-030 personal project → enforcement_level=strict, deployment=personal"
+setup_pre_bl030_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+level=$(jq -r '.enforcement_level // empty' "$PROJ/.claude/manifest.json")
+dep=$(jq -r '.deployment // empty' "$PROJ/.claude/manifest.json")
+if [ "$level" = "strict" ] && [ "$dep" = "personal" ]; then
+  pass "T1: manifest now has deployment=personal enforcement_level=strict"
+else
+  fail_ "T1" "got enforcement_level='$level' deployment='$dep'"
+fi
+teardown
+
+# T2: idempotent — running upgrade twice doesn't re-overwrite.
+echo "T2: upgrade is idempotent on already-backfilled projects"
+setup_pre_bl030_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+# Capture timestamp of latest enforcement_level_set row.
+ts1=$(jq -r '[.[] | select(.type=="enforcement_level_set")] | last | .timestamp' "$PROJ/.claude/bypass-audit.json")
+sleep 1
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+ts2=$(jq -r '[.[] | select(.type=="enforcement_level_set")] | last | .timestamp' "$PROJ/.claude/bypass-audit.json")
+# Second run should NOT add a duplicate backfill row.
+if [ "$ts1" = "$ts2" ]; then pass "T2: second upgrade did not re-backfill"; else fail_ "T2" "ts1=$ts1 ts2=$ts2"; fi
+teardown
+
+# T3: pre-BL-030 organizational/production: upgrade backfills with
+# deployment=organizational, NOT personal. This is the load-bearing
+# regression survey #1 called out.
+echo "T3: pre-BL-030 organizational project → deployment=organizational (no silent personal default)"
+setup_pre_bl030_organizational_production
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+dep=$(jq -r '.deployment // empty' "$PROJ/.claude/manifest.json")
+level=$(jq -r '.enforcement_level // empty' "$PROJ/.claude/manifest.json")
+if [ "$dep" = "organizational" ] && [ "$level" = "strict" ]; then
+  pass "T3: org project backfilled correctly (no silent personal-default)"
+else
+  fail_ "T3" "deployment='$dep' enforcement_level='$level' (expected organizational + strict)"
+fi
+teardown
+
+# T4: post-upgrade reconfigure-project --enforcement-level no on org/
+# production project is REJECTED (validate_transition reads correct
+# deployment from backfilled manifest).
+echo "T4: post-upgrade reconfigure to 'no' on org/production is rejected"
+setup_pre_bl030_organizational_production
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+RECONFIG="$PROJ/scripts/reconfigure-project.sh"
+( cd "$PROJ" && bash "$RECONFIG" --enforcement-level no --confirm-pitfalls >/dev/null 2>&1 )
+if [ $? -ne 0 ]; then
+  pass "T4: validate_transition correctly rejected downgrade on org/production"
+else
+  fail_ "T4" "BUG: org/production project was allowed to downgrade to no"
+fi
+teardown
+
+# T5: post-upgrade, filesystem gate IS installed (strict default).
+echo "T5: post-upgrade, .git/hooks/framework-gate.sh + marker block installed"
+setup_pre_bl030_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+if [ -x "$PROJ/.git/hooks/framework-gate.sh" ] \
+   && grep -q "SOIF framework gate" "$PROJ/.git/hooks/pre-commit" 2>/dev/null; then
+  pass "T5: filesystem gate installed by upgrade backfill"
+else
+  fail_ "T5" "gate not installed"
+fi
+teardown
+
+# T6: post-upgrade, enforcement_level_set row added with
+# source='upgrade-backfill' to distinguish from init/reconfigure rows.
+echo "T6: backfill adds an enforcement_level_set row sourced 'upgrade-backfill'"
+setup_pre_bl030_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+sources=$(jq -r '[.[] | select(.type=="enforcement_level_set") | .details.source] | unique | join(",")' "$PROJ/.claude/bypass-audit.json")
+if echo "$sources" | grep -q "upgrade-backfill"; then
+  pass "T6: audit row source='upgrade-backfill' present"
+else
+  fail_ "T6" "sources='$sources' (expected one to be 'upgrade-backfill')"
+fi
+teardown
+
+# T7: post-upgrade, last-checked-commit.txt is initialized so the
+# SessionStart detector has a baseline.
+echo "T7: backfill initializes last-checked-commit.txt"
+setup_pre_bl030_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+if [ -s "$PROJ/.claude/last-checked-commit.txt" ]; then
+  pass "T7: last-checked-commit.txt initialized"
+else
+  fail_ "T7" "last-checked-commit.txt missing or empty"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-verify-install-bl030-coverage.sh
+++ b/tests/test-verify-install-bl030-coverage.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+# tests/test-verify-install-bl030-coverage.sh — verify-install.sh must
+# check the BL-030 scripts, libs, and hook registrations. Without these
+# checks, a hand-edited or pre-BL-030 project passes verify with the
+# BL-030 chain silently broken — exactly the silent-degrade class
+# code-verify-reconfigure-10 was rewritten to prevent.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+cd /tmp
+
+setup_clean_project() {
+  TMP=$(mktemp -d); PROJ="$TMP/p"
+  bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
+    --platform web --language javascript --track light --deployment personal \
+    >/dev/null 2>&1
+  VERIFY="$PROJ/scripts/verify-install.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+# Helper: run verify in check-only mode and capture stdout.
+run_verify() {
+  ( cd "$PROJ" && bash "$VERIFY" --check-only 2>&1 ) || true
+}
+
+# T1: clean project passes BL-030 script checks for the 4 new scripts.
+echo "T1: clean project — verify reports BL-030 scripts present/executable"
+setup_clean_project
+out=$(run_verify)
+fail_count=0
+for s in detect-out-of-band-commits install-filesystem-gates record-claude-commit lint-fixture-envelopes; do
+  if ! echo "$out" | grep -qE "\[OK\] $s present and executable"; then
+    fail_count=$((fail_count + 1))
+    echo "    (missing OK row for $s)"
+  fi
+done
+if [ "$fail_count" = "0" ]; then
+  pass "T1: all 4 BL-030 scripts checked + reported OK"
+else
+  fail_ "T1" "$fail_count of 4 BL-030 scripts not checked by verify-install"
+fi
+teardown
+
+# T2: verify detects missing record-claude-commit.sh (PostToolUse hook script).
+echo "T2: missing record-claude-commit.sh is flagged"
+setup_clean_project
+rm -f "$PROJ/scripts/hooks/record-claude-commit.sh"
+out=$(run_verify)
+if echo "$out" | grep -qE "record-claude-commit (missing|not executable)"; then
+  pass "T2: missing record-claude-commit.sh flagged"
+else
+  fail_ "T2" "no flag for missing record-claude-commit"
+fi
+teardown
+
+# T3: verify detects missing detect-out-of-band-commits.sh.
+echo "T3: missing detect-out-of-band-commits.sh is flagged"
+setup_clean_project
+rm -f "$PROJ/scripts/detect-out-of-band-commits.sh"
+out=$(run_verify)
+if echo "$out" | grep -qE "detect-out-of-band-commits (missing|not executable)"; then
+  pass "T3: missing detect-out-of-band-commits flagged"
+else
+  fail_ "T3" "no flag for missing detect-out-of-band-commits"
+fi
+teardown
+
+# T4: verify detects missing install-filesystem-gates.sh.
+echo "T4: missing install-filesystem-gates.sh is flagged"
+setup_clean_project
+rm -f "$PROJ/scripts/install-filesystem-gates.sh"
+out=$(run_verify)
+if echo "$out" | grep -qE "install-filesystem-gates (missing|not executable)"; then
+  pass "T4: missing install-filesystem-gates flagged"
+else
+  fail_ "T4" "no flag for missing install-filesystem-gates"
+fi
+teardown
+
+# T5: verify detects missing lib/enforcement-level.sh.
+echo "T5: missing lib/enforcement-level.sh is flagged"
+setup_clean_project
+rm -f "$PROJ/scripts/lib/enforcement-level.sh"
+out=$(run_verify)
+if echo "$out" | grep -qE "enforcement-level lib (missing|not present)"; then
+  pass "T5: missing lib/enforcement-level.sh flagged"
+else
+  fail_ "T5" "no flag for missing enforcement-level lib"
+fi
+teardown
+
+# T6: verify detects missing PostToolUse:record-claude-commit hook
+# registration in .claude/settings.json.
+echo "T6: PostToolUse missing record-claude-commit hook is flagged"
+setup_clean_project
+# Strip the registration.
+tmp=$(mktemp)
+jq '(.hooks.PostToolUse // []) |= map(.hooks |= [.[] | select(.command | contains("record-claude-commit.sh") | not)])' \
+  "$PROJ/.claude/settings.json" > "$tmp" && mv "$tmp" "$PROJ/.claude/settings.json"
+out=$(run_verify)
+if echo "$out" | grep -qE "PostToolUse hook: record-claude-commit.*not registered"; then
+  pass "T6: missing PostToolUse:record-claude-commit hook flagged"
+else
+  fail_ "T6" "no flag for missing record-claude-commit hook"
+fi
+teardown
+
+# T7: verify detects missing SessionStart:detect-out-of-band hook.
+echo "T7: SessionStart missing detect-out-of-band hook is flagged"
+setup_clean_project
+tmp=$(mktemp)
+jq '(.hooks.SessionStart // []) |= map(.hooks |= [.[] | select(.command | contains("detect-out-of-band-commits.sh") | not)])' \
+  "$PROJ/.claude/settings.json" > "$tmp" && mv "$tmp" "$PROJ/.claude/settings.json"
+out=$(run_verify)
+if echo "$out" | grep -qE "SessionStart hook: detect-out-of-band.*not registered"; then
+  pass "T7: missing SessionStart:detect-out-of-band hook flagged"
+else
+  fail_ "T7" "no flag for missing detect-out-of-band hook"
+fi
+teardown
+
+# T8: verify detects missing PostToolUse:bypass-detector hook (BL-029
+# regression coverage gap noted by the survey).
+echo "T8: PostToolUse missing bypass-detector hook (BL-029) is flagged"
+setup_clean_project
+tmp=$(mktemp)
+jq '(.hooks.PostToolUse // []) |= map(.hooks |= [.[] | select(.command | contains("bypass-detector.sh") | not)])' \
+  "$PROJ/.claude/settings.json" > "$tmp" && mv "$tmp" "$PROJ/.claude/settings.json"
+out=$(run_verify)
+if echo "$out" | grep -qE "(PostToolUse|Stop) hook: bypass-detector.*not registered"; then
+  pass "T8: missing bypass-detector hook flagged"
+else
+  fail_ "T8" "no flag for missing bypass-detector hook"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

Two fixes that lock in PR #48's BL-030 contract:

1. **Safety regression — pre-BL-030 projects upgrading today.** Without a backfill, `assert_choosable`'s jq default of `personal` silently lets operators run `reconfigure-project.sh --enforcement-level no` on what should be forced-strict (organizational/sponsored_poc or organizational/production). This was the load-bearing finding from the post-merge survey.

2. **Silent-degrade — verify-install was BL-030-blind.** `check_scripts` stopped at bypass-detector and never checked any of the 4 BL-030 scripts. `check_hooks` never asserted the BL-029 bypass-detector or the new BL-030 hook registrations. A hand-edited or pre-BL-030 imported project passed verify with the entire detection chain silently broken.

## `upgrade-project.sh --backfill-only` (post-PR #48 safety contract)

- New `--backfill-only` flag bypasses the no-target-flag requirement so operators can migrate a pre-BL-030 manifest without picking a track / deployment / POC transition.
- Both existing backfills (host + new BL-030) now run BEFORE the no-target-flag check, inside a `( cd "$PROJECT_ROOT" )` subshell. Both idempotent — second run is a no-op.
- BL-030 backfill reads `deployment` / `poc_mode` from `phase-state.json` (canonical post-S2 source), **forces enforcement_level=strict** (no auto-relaxation on the upgrade path — relaxation goes through `reconfigure-project.sh --enforcement-level <X> --confirm-pitfalls` which calls `validate_transition`), installs the filesystem gate, initializes `.claude/last-checked-commit.txt`, appends an audit row sourced `'upgrade-backfill'`.
- When `phase-state.json` lacks `.deployment`, warns the operator and points at `reconfigure-project.sh --field deployment` to correct.

## `verify-install.sh` BL-030 coverage

- `scripts[]` array extended with the 4 BL-030 scripts (`detect-out-of-band-commits`, `install-filesystem-gates`, `record-claude-commit`, `lint-fixture-envelopes`).
- New `libs[]` iteration for `scripts/lib/enforcement-level.sh` and `scripts/lib/gate-principles.sh` (presence-only — no chmod).
- `check_hooks()` gains assertions for BL-029 `bypass-detector` (PostToolUse + Stop) and BL-030 `record-claude-commit` (PostToolUse) + `detect-out-of-band-commits` (SessionStart).
- Eval fix-fn table extended with the 4 scripts + a hyphen-named `record-claude-commit` entry (hooks subdirectory) + lib-only `fix_lib_copy_enforcement-level` and `fix_lib_copy_gate-principles`.

## Verification

| Suite | Result |
|---|---|
| `tests/test-upgrade-bl030-backfill.sh` (new) | 7/7 PASS |
| `tests/test-verify-install-bl030-coverage.sh` (new) | 8/8 PASS |
| `tests/test-bypass-detector.sh` | 15/15 |
| `tests/test-bypass-sentinel.sh` | 5/5 |
| `tests/test-bl029-integration.sh` | 6/6 |
| `tests/test-enforcement-level-lib.sh` | 10/10 |
| `tests/test-record-claude-commit.sh` | 5/5 |
| `tests/test-out-of-band-detector.sh` | 8/8 |
| `tests/test-filesystem-gate-install.sh` | 7/7 |
| `tests/test-pre-commit-gate-terminal-mode.sh` | 3/3 |
| `tests/test-gate-principles.sh` | 3/3 |
| `tests/test-enforcement-level-init.sh` | 8/8 |
| `tests/test-enforcement-level-reconfigure.sh` | 7/7 |
| `tests/test-bypass-audit-schema.sh` | 3/3 |
| `tests/test-bl030-calibration-replay.sh` | 4/4 |
| `tests/test-poc-modes.sh` | 5/5 |
| `tests/test-phase-finalize.sh` | 6/6 |
| `tests/test-upgrade-paths.sh` | 8/8 |
| `tests/test-process-checklist-auto-advance.sh` | 5/5 |
| `tests/test-process-checklist-classifier.sh` | 12/12 |
| `tests/test-lint-uat-scenarios.sh` | 12/12 |
| `scripts/lint-fixture-envelopes.sh` | clean |
| `tests/edge-case-test-suite.sh` | 26 PASS + 1 DOC (T4.4) + 1 pre-existing flake (T2.2 resolve-tools timing, documented in PR #46) |

## Test plan

- [ ] `bash tests/test-upgrade-bl030-backfill.sh` → 7/7 (covers personal + organizational paths, idempotency, the reconfigure-rejected-after-backfill assertion, filesystem-gate install, audit row, baseline init)
- [ ] `bash tests/test-verify-install-bl030-coverage.sh` → 8/8 (covers all 4 BL-030 scripts + 1 lib + 3 hook registrations including BL-029 bypass-detector)
- [ ] Spot-check: migrate a pre-BL-030 project
  ```
  # In any project that init'd before PR #48
  jq 'del(.enforcement_level, .deployment, .poc_mode)' .claude/manifest.json > /tmp/m && mv /tmp/m .claude/manifest.json
  rm -f .git/hooks/framework-gate.sh
  bash scripts/upgrade-project.sh --backfill-only
  jq '{enforcement_level, deployment, poc_mode}' .claude/manifest.json
  # → all three populated; enforcement_level=strict
  [ -x .git/hooks/framework-gate.sh ] && echo "gate installed"
  jq '[.[] | select(.details.source=="upgrade-backfill")] | length' .claude/bypass-audit.json
  # → 1
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)