### PR TITLE
fix(session-hook): merge tool-usage.json on /resume /compact /clear; only overwrite on startup

### DIFF
--- a/scripts/session-test-gate-check.sh
+++ b/scripts/session-test-gate-check.sh
@@ -7,6 +7,32 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# ── Parse SessionStart envelope ──────────────────────────────────
+# Claude Code passes a SessionStart envelope on stdin with a `source`
+# field whose value is one of:
+#   "startup" — first session of the project (or a new conversation)
+#   "resume"  — `claude --resume`, picking up a prior session
+#   "compact" — `/compact` invocation mid-session
+#   "clear"   — `/clear` invocation mid-session
+#
+# Pre-fix, this hook destructively overwrote .claude/tool-usage.json on
+# every invocation, zeroing the calls array and the
+# commits_since_last_context7 counter — re-arming the MCP gate and
+# erasing in-flight Context7 / Qdrant history mid-Build-Loop on every
+# /compact. Now we only do the destructive init on startup (or when the
+# envelope is missing — legacy compatibility for non-Claude-Code
+# invocations); the other three sources merge into the existing file.
+SESSION_SOURCE="startup"
+if [ ! -t 0 ]; then
+  ENVELOPE=$(cat 2>/dev/null || echo "")
+  if [ -n "$ENVELOPE" ] && command -v jq >/dev/null 2>&1; then
+    parsed=$(echo "$ENVELOPE" | jq -r '.source // ""' 2>/dev/null || echo "")
+    case "$parsed" in
+      startup|resume|compact|clear) SESSION_SOURCE="$parsed" ;;
+    esac
+  fi
+fi
+
 # ── MCP Server Discovery ─────────────────────────────────────────
 # Detect which MCP servers are configured and set up enforcement requirements.
 # Known servers (set up by init.sh): context7, qdrant
@@ -49,15 +75,36 @@ if command -v jq &>/dev/null; then
   done <<< "$ALL_MCP_SERVERS"
 fi
 
-# ── Initialize Tool Usage Tracking ────────────────────────────────
+# ── Initialize / merge Tool Usage Tracking ───────────────────────
 TOOL_USAGE=".claude/tool-usage.json"
 if command -v jq &>/dev/null; then
   SESSION_ID=$(date -u +%Y-%m-%dT%H:%M:%SZ)
   mkdir -p .claude
 
-  # Build additional_required array from unknown servers (empty for now —
-  # the agent will ask the user about these, and the user can add them)
-  cat > "$TOOL_USAGE" << TUEOF
+  if [ "$SESSION_SOURCE" != "startup" ] && [ -f "$TOOL_USAGE" ]; then
+    # Merge path: preserve in-flight ledger state (calls, counters,
+    # flags, operator-added additional_required), refresh session_id
+    # so the boundary is visible to a successor, and re-derive the
+    # MCP requirements in case the user added or removed servers
+    # between sessions.
+    tmp=$(mktemp "${TOOL_USAGE}.XXXXXX")
+    if jq \
+        --arg sid "$SESSION_ID" \
+        --argjson qreq "$QDRANT_CONFIGURED" \
+        --argjson creq "$CONTEXT7_CONFIGURED" \
+        '. as $orig |
+         $orig
+         | .session_id = $sid
+         | .mcp_requirements.qdrant_required = $qreq
+         | .mcp_requirements.context7_required = $creq
+         | .mcp_requirements.additional_required = ($orig.mcp_requirements.additional_required // [])' \
+        "$TOOL_USAGE" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$TOOL_USAGE"
+    else
+      # If jq fails (malformed prior file, etc.), fall through to a
+      # fresh write so the gate is not left wedged.
+      rm -f "$tmp"
+      cat > "$TOOL_USAGE" << TUEOF
 {
   "session_id": "$SESSION_ID",
   "calls": [],
@@ -73,6 +120,26 @@ if command -v jq &>/dev/null; then
   }
 }
 TUEOF
+    fi
+  else
+    # startup (or missing envelope, or file absent) — fresh init.
+    cat > "$TOOL_USAGE" << TUEOF
+{
+  "session_id": "$SESSION_ID",
+  "calls": [],
+  "commits_since_last_context7": 0,
+  "qdrant_find_called": false,
+  "qdrant_store_called": false,
+  "context7_called": false,
+  "mcp_gate_satisfied": false,
+  "mcp_requirements": {
+    "qdrant_required": $QDRANT_CONFIGURED,
+    "context7_required": $CONTEXT7_CONFIGURED,
+    "additional_required": []
+  }
+}
+TUEOF
+  fi
 fi
 
 # ── Report Unknown MCP Servers ────────────────────────────────────

--- a/tests/test-session-test-gate-check-merge.sh
+++ b/tests/test-session-test-gate-check-merge.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# tests/test-session-test-gate-check-merge.sh — session-test-gate-check.sh
+# must not destructively overwrite .claude/tool-usage.json on resume /
+# compact / clear. Pre-fix, every SessionStart invocation re-wrote the
+# file with counters zeroed, re-arming the MCP gate and zeroing the
+# Context7 counter mid-Build-Loop. After BL-030 added more SessionStart
+# hooks (out-of-band-commits detector), the destructive overwrite hits
+# the user's flow more often, so the fix is now-higher-impact.
+#
+# Hook contract (Claude Code): SessionStart envelope on stdin has a
+# 'source' field with values "startup" | "resume" | "compact" | "clear".
+# Fresh init only on startup; merge on the other three.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/scripts/session-test-gate-check.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d); PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  # Seed a tool-usage.json with accumulated in-flight state.
+  cat > "$PROJ/.claude/tool-usage.json" <<'JSON'
+{
+  "session_id": "2026-04-28T00:00:00Z",
+  "calls": [
+    {"tool": "context7", "ts": "2026-04-28T00:01:00Z"},
+    {"tool": "qdrant_find", "ts": "2026-04-28T00:02:00Z"}
+  ],
+  "commits_since_last_context7": 4,
+  "qdrant_find_called": true,
+  "qdrant_store_called": true,
+  "context7_called": true,
+  "mcp_gate_satisfied": true,
+  "mcp_requirements": {
+    "qdrant_required": true,
+    "context7_required": true,
+    "additional_required": ["custom-server"]
+  }
+}
+JSON
+}
+teardown() { rm -rf "$TMP"; }
+
+run_hook_with_source() {
+  local src="$1"
+  if [ -z "$src" ]; then
+    ( cd "$PROJ" && bash "$HOOK" </dev/null >/dev/null 2>&1 ) || true
+  else
+    ( cd "$PROJ" && printf '{"hook_event_name":"SessionStart","source":"%s"}' "$src" \
+        | bash "$HOOK" >/dev/null 2>&1 ) || true
+  fi
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Non-startup sources (resume / compact / clear) must MERGE ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T1: source=resume preserves the counters.
+echo "T1: source=resume preserves calls / counters / flags"
+setup
+run_hook_with_source "resume"
+calls_len=$(jq '.calls | length' "$PROJ/.claude/tool-usage.json")
+commits_counter=$(jq '.commits_since_last_context7' "$PROJ/.claude/tool-usage.json")
+context7_flag=$(jq -r '.context7_called' "$PROJ/.claude/tool-usage.json")
+add_req=$(jq -r '.mcp_requirements.additional_required | length' "$PROJ/.claude/tool-usage.json")
+if [ "$calls_len" = "2" ] && [ "$commits_counter" = "4" ] \
+   && [ "$context7_flag" = "true" ] && [ "$add_req" = "1" ]; then
+  pass "T1: resume merge preserved calls=2 counter=4 context7=true add_req=1"
+else
+  fail_ "T1" "calls=$calls_len counter=$commits_counter context7=$context7_flag add_req=$add_req"
+fi
+teardown
+
+# T2: source=compact preserves the counters.
+echo "T2: source=compact preserves calls / counters / flags"
+setup
+run_hook_with_source "compact"
+calls_len=$(jq '.calls | length' "$PROJ/.claude/tool-usage.json")
+commits_counter=$(jq '.commits_since_last_context7' "$PROJ/.claude/tool-usage.json")
+mcp_gate=$(jq -r '.mcp_gate_satisfied' "$PROJ/.claude/tool-usage.json")
+if [ "$calls_len" = "2" ] && [ "$commits_counter" = "4" ] && [ "$mcp_gate" = "true" ]; then
+  pass "T2: compact merge preserved calls=2 counter=4 mcp_gate=true"
+else
+  fail_ "T2" "calls=$calls_len counter=$commits_counter mcp_gate=$mcp_gate"
+fi
+teardown
+
+# T3: source=clear preserves the counters too. /clear semantically
+# means "drop history" but the documented semantics in Claude Code
+# are about CONVERSATION history, not framework state. Erasing the
+# tool-usage ledger mid-Build-Loop would be surprising; preserve.
+echo "T3: source=clear preserves calls / counters / flags"
+setup
+run_hook_with_source "clear"
+calls_len=$(jq '.calls | length' "$PROJ/.claude/tool-usage.json")
+if [ "$calls_len" = "2" ]; then
+  pass "T3: clear merge preserved calls=2"
+else
+  fail_ "T3" "calls=$calls_len (expected 2)"
+fi
+teardown
+
+# T4: each non-startup invocation refreshes session_id even though the
+# counters are preserved (so a successor reading the file can see the
+# session boundary).
+echo "T4: non-startup invocation refreshes session_id"
+setup
+original_id=$(jq -r '.session_id' "$PROJ/.claude/tool-usage.json")
+sleep 1   # ensure date timestamps differ
+run_hook_with_source "resume"
+new_id=$(jq -r '.session_id' "$PROJ/.claude/tool-usage.json")
+if [ "$new_id" != "$original_id" ] && [ -n "$new_id" ]; then
+  pass "T4: session_id refreshed (was '$original_id', now '$new_id')"
+else
+  fail_ "T4" "session_id unchanged ('$original_id' → '$new_id')"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== source=startup (and missing envelope) initializes fresh ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T5: source=startup writes a fresh tool-usage.json with the counters
+# zeroed (current behavior, must not regress).
+echo "T5: source=startup writes a fresh tool-usage.json"
+setup
+run_hook_with_source "startup"
+calls_len=$(jq '.calls | length' "$PROJ/.claude/tool-usage.json")
+commits_counter=$(jq '.commits_since_last_context7' "$PROJ/.claude/tool-usage.json")
+context7_flag=$(jq -r '.context7_called' "$PROJ/.claude/tool-usage.json")
+if [ "$calls_len" = "0" ] && [ "$commits_counter" = "0" ] && [ "$context7_flag" = "false" ]; then
+  pass "T5: startup fresh-init zeros calls/counter/flags"
+else
+  fail_ "T5" "calls=$calls_len counter=$commits_counter context7=$context7_flag (expected 0/0/false)"
+fi
+teardown
+
+# T6: invocation with NO envelope on stdin (legacy / unknown caller)
+# defaults to startup behavior — backwards compat.
+echo "T6: invocation with no envelope defaults to startup (legacy compat)"
+setup
+run_hook_with_source ""
+calls_len=$(jq '.calls | length' "$PROJ/.claude/tool-usage.json")
+if [ "$calls_len" = "0" ]; then
+  pass "T6: missing envelope → fresh init"
+else
+  fail_ "T6" "calls=$calls_len (expected 0)"
+fi
+teardown
+
+# T7: even on merge paths, the mcp_requirements get re-derived so
+# users who add/remove MCP servers between sessions see the updated
+# requirements. (We can't easily simulate adding servers in test, so
+# this asserts the keys exist; the re-derivation logic is sourced
+# from the same MCP-discovery block the startup path uses.)
+echo "T7: merge path preserves mcp_requirements schema"
+setup
+run_hook_with_source "resume"
+qreq=$(jq -r '.mcp_requirements.qdrant_required' "$PROJ/.claude/tool-usage.json")
+creq=$(jq -r '.mcp_requirements.context7_required' "$PROJ/.claude/tool-usage.json")
+if [ "$qreq" != "null" ] && [ "$creq" != "null" ]; then
+  pass "T7: mcp_requirements re-derived (qdrant=$qreq context7=$creq)"
+else
+  fail_ "T7" "qdrant_required=$qreq context7_required=$creq"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

`session-test-gate-check.sh`'s SessionStart hook destructively rewrote `.claude/tool-usage.json` on every invocation, zeroing the calls array and the `commits_since_last_context7` counter. That **re-armed the MCP gate** and **erased in-flight Context7 / Qdrant history mid-Build-Loop on every `/compact`**. Now-higher-impact post-PR #48 because BL-030 added more SessionStart hooks, so this fix lands while the surface is warm.

## Hook contract

Claude Code's SessionStart envelope carries a `source` field on stdin:

| `source` | Meaning |
|---|---|
| `startup` | First session of the project (or a new conversation) |
| `resume`  | `claude --resume`, picking up a prior session |
| `compact` | `/compact` mid-session |
| `clear`   | `/clear` mid-session |

The fix branches on this value: fresh init only on `startup` (and when the envelope is missing, for legacy compat); merge into the existing file on the other three.

## What the merge preserves vs. refreshes

| Field | resume/compact/clear |
|---|---|
| `.calls` | **preserved** |
| `.commits_since_last_context7` | **preserved** |
| `.qdrant_find_called` / `.qdrant_store_called` / `.context7_called` | **preserved** |
| `.mcp_gate_satisfied` | **preserved** |
| `.mcp_requirements.additional_required` | **preserved** (operator-added entries don't get nuked) |
| `.session_id` | **refreshed** (so successors can see the session boundary in the file) |
| `.mcp_requirements.qdrant_required` / `.context7_required` | **re-derived** (so users who add/remove MCP servers between sessions see the updated requirements) |

Merge uses `jq` + atomic-rename via `mktemp "${TOOL_USAGE}.XXXXXX"` so a failed jq run never leaves the file partially written. If jq does fail (malformed prior file, etc.), the script falls through to a fresh write so the gate is not left wedged.

## Verification

| Suite | Result |
|---|---|
| `tests/test-session-test-gate-check-merge.sh` (new, 7 tests) | 7/7 PASS |
| `tests/test-test-gate-null-handling.sh` | 5/5 |
| `scripts/lint-fixture-envelopes.sh` | clean |
| `tests/test-bypass-detector.sh` | 15/15 |
| `tests/test-bl029-integration.sh` | 6/6 |

New test sections:

- **Non-startup sources merge (T1–T4):** `resume`, `compact`, `clear` each preserve a seeded 2-entry calls array, the `commits_since_last_context7=4` counter, the boolean flags, and a 1-entry `additional_required`. `session_id` refreshes on every non-startup invocation.
- **`startup` + missing envelope still init fresh (T5–T6):** existing behavior preserved.
- **mcp_requirements re-derivation (T7):** merge path correctly carries through the qdrant/context7 booleans from the discovery block.

## Test plan

- [ ] `bash tests/test-session-test-gate-check-merge.sh` → 7/7
- [ ] Spot-check the merge live:
  ```
  # In any initialized project:
  jq '.calls = [{tool:"context7",ts:"x"}] | .commits_since_last_context7 = 3' .claude/tool-usage.json > /tmp/t && mv /tmp/t .claude/tool-usage.json
  printf '{"hook_event_name":"SessionStart","source":"compact"}' | bash scripts/session-test-gate-check.sh
  jq '{calls_len: (.calls | length), counter: .commits_since_last_context7}' .claude/tool-usage.json
  # → calls_len=1, counter=3 (preserved)
  ```
- [ ] Regression: `tests/test-test-gate-null-handling.sh` 5/5, BL-029 hook suites still green.

## Why now

This was item #5 in the post-audit survey synthesis. Three reasons it warranted attention before opening new fronts:

1. Higher-impact post-BL-030 (more SessionStart hooks → more `/compact` re-arms).
2. Mid-Build-Loop friction during the freshly-stabilized governance loop.
3. Bundles thematically with PR #49's `verify-install` hook coverage — that PR added the assertion that the BL-030 SessionStart hook is registered; this PR fixes the destructive behavior in the sibling SessionStart hook the registration sits next to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)