### PR TITLE
fix(check-phase-gate): sanitize counter captures (code-check-gates-4)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -85,6 +85,7 @@ fi
 # Parse phase state using lightweight JSON extraction (no jq dependency)
 # This handles the simple flat structure of phase-state.json
 current_phase=$(grep -o '"current_phase"[[:space:]]*:[[:space:]]*"*[0-9][0-9]*"*' "$PHASE_STATE" | grep -o '[0-9][0-9]*' || echo "0")
+case "$current_phase" in ''|*[!0-9]*) current_phase=0 ;; esac
 
 get_gate_date() {
   local gate_key="$1"
@@ -150,6 +151,7 @@ validate_manifesto_content() {
   if grep -qi "Status:[[:space:]]*Open" "$file" 2>/dev/null; then
     local open_count
     open_count=$(grep -ci "Status:[[:space:]]*Open" "$file" 2>/dev/null || echo "0")
+    case "$open_count" in ''|*[!0-9]*) open_count=0 ;; esac
     echo -e "${RED}[FAIL]${NC} PRODUCT_MANIFESTO.md: $open_count unresolved Open Question(s) — resolve before Phase 1"
     issues=$((issues + 1))
   fi
@@ -201,6 +203,7 @@ if [ "$deployment" = "organizational" ] && [ "$current_phase" -ge 0 ]; then
     # Full organizational — all 6 pre-conditions required
     if grep -q "Pre-Phase 0" "$APPROVAL_LOG" 2>/dev/null; then
       local_precond_count=$(grep -A 30 "Pre-Phase 0" "$APPROVAL_LOG" 2>/dev/null | grep -cE "[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])" || echo "0")
+      case "$local_precond_count" in ''|*[!0-9]*) local_precond_count=0 ;; esac
       if [ "$local_precond_count" -lt 6 ]; then
         echo -e "${YELLOW}[WARN]${NC} Pre-Phase 0: Organizational deployment — only $local_precond_count pre-condition date(s) recorded (6 required)"
         issues=$((issues + 1))
@@ -312,12 +315,14 @@ if [ "$current_phase" -ge 2 ]; then
     echo -e "${GREEN}  [OK]${NC} PROJECT_BIBLE.md exists"
     # Check for placeholder dates (YYYY-MM-DD) indicating unfilled sections
     placeholder_dates=$(grep -c "YYYY-MM-DD" PROJECT_BIBLE.md 2>/dev/null || echo "0")
+    case "$placeholder_dates" in ''|*[!0-9]*) placeholder_dates=0 ;; esac
     if [ "$placeholder_dates" -gt 0 ]; then
       echo -e "${YELLOW}[WARN]${NC} PROJECT_BIBLE.md has $placeholder_dates placeholder date(s) — update Last Updated markers"
       issues=$((issues + 1))
     fi
     # Check key sections exist (numbered 1-16 per template)
     bible_sections=$(grep -cE "^## [0-9]+\." PROJECT_BIBLE.md 2>/dev/null || echo "0")
+    case "$bible_sections" in ''|*[!0-9]*) bible_sections=0 ;; esac
     if [ "$bible_sections" -lt 14 ]; then
       echo -e "${YELLOW}[WARN]${NC} PROJECT_BIBLE.md has only $bible_sections numbered sections (template specifies 16, minimum 14)"
       issues=$((issues + 1))
@@ -472,6 +477,7 @@ if [ "$current_phase" -ge 3 ]; then
   # P3-007: Cross-reference process-state.json for Phase 3 completion
   if [ -f ".claude/process-state.json" ] && command -v jq &>/dev/null; then
     p3_steps_done=$(jq '.phase3_validation.steps_completed | length' .claude/process-state.json 2>/dev/null || echo "0")
+    case "$p3_steps_done" in ''|*[!0-9]*) p3_steps_done=0 ;; esac
     if [ "$p3_steps_done" -ge 9 ]; then
       echo -e "${GREEN}  [OK]${NC} Phase 3 process checklist: $p3_steps_done steps completed"
     elif [ "$p3_steps_done" -gt 0 ]; then
@@ -487,6 +493,7 @@ if [ "$current_phase" -ge 3 ]; then
   if [ -f "$MANIFEST" ]; then
     if command -v jq &>/dev/null; then
       review_count=$(jq '.reviews | length' "$MANIFEST" 2>/dev/null || echo "0")
+      case "$review_count" in ''|*[!0-9]*) review_count=0 ;; esac
       review_commit=$(jq -r '.commit // "unknown"' "$MANIFEST" 2>/dev/null)
       echo -e "${GREEN}  [OK]${NC} Review manifest: $review_count review(s) recorded (commit: ${review_commit:0:8})"
     else

--- a/tests/test-check-phase-gate-counter-sanitizer.sh
+++ b/tests/test-check-phase-gate-counter-sanitizer.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# tests/test-check-phase-gate-counter-sanitizer.sh
+#
+# Regression: scripts/check-phase-gate.sh used the antipattern
+#   var=$(cmd_that_may_exit_nonzero || echo "0")
+# where `cmd_that_may_exit_nonzero` was `grep -c` (which exits 1 on zero
+# matches). When the grep exited 1 it had already printed "0\n", so the
+# `||` appended a second "0" — the variable then held the two-line
+# string "0\n0". Subsequent `[ "$var" -lt N ]` errored with
+# "integer expression expected" and (under set -euo pipefail) the
+# arithmetic test returned non-zero, sending control to the OK branch
+# at five sites and silently bypassing hard gates.
+#
+# The most severe site was the Pre-Phase 0 organizational pre-condition
+# gate (line ~203): when APPROVAL_LOG.md had the "Pre-Phase 0" section
+# header but ZERO ISO dates in it, the script printed
+#   [OK] Pre-Phase 0 pre-conditions recorded (0
+#   0 entries)
+# instead of WARNing about a missing pre-condition gate.
+#
+# Fix: capture into a temp var, then sanitize via the case-statement
+# pattern already in scripts/process-checklist.sh:45-46
+#   case "$var" in ''|*[!0-9]*) var=0 ;; esac
+# so the arithmetic always sees a single non-negative integer.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+}
+teardown() { rm -rf "$TMP"; }
+
+run_gate() {
+  ( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Primary site: Pre-Phase 0 organizational pre-conditions ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T1: APPROVAL_LOG has the "Pre-Phase 0" section header but zero ISO
+# dates in it. Pre-fix this hit the OK branch (false success). Post-fix
+# the WARN branch fires.
+echo "T1: Pre-Phase 0 header present, 0 dates → WARN (not [OK])"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":0,"deployment":"organizational"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Pre-Phase 0
+
+(intentionally no dates here — operator forgot to fill in)
+MD
+out=$(run_gate)
+if echo "$out" | grep -q "OK.*Pre-Phase 0 pre-conditions recorded"; then
+  fail_ "T1" "still emits false [OK]; out:\n$(echo "$out" | grep Pre-Phase)"
+elif echo "$out" | grep -qE "WARN.*Pre-Phase 0.*only 0 pre-condition"; then
+  pass "T1: WARN fires when 0 dates recorded"
+else
+  fail_ "T1" "neither expected line present; out:\n$(echo "$out" | grep -i pre-phase)"
+fi
+teardown
+
+# T2: APPROVAL_LOG has the section + 6 valid ISO dates. Post-fix the OK
+# branch must still fire (regression guard for the happy path).
+echo "T2: Pre-Phase 0 header + 6 dates → [OK]"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":0,"deployment":"organizational"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Pre-Phase 0
+
+- ITSM registration recorded 2026-01-15
+- SSO enrollment recorded 2026-01-16
+- Centralized logging recorded 2026-01-17
+- Portfolio review recorded 2026-01-18
+- Budget approval recorded 2026-01-19
+- Security review recorded 2026-01-20
+MD
+out=$(run_gate)
+if echo "$out" | grep -qE "OK.*Pre-Phase 0 pre-conditions recorded \(6 entries\)"; then
+  pass "T2: [OK] fires when 6 valid dates present"
+else
+  fail_ "T2" "expected '[OK] ... (6 entries)'; out:\n$(echo "$out" | grep -i pre-phase)"
+fi
+teardown
+
+# T3: APPROVAL_LOG missing the "Pre-Phase 0" section entirely. The
+# secondary WARN branch must fire (this branch was already correct
+# pre-fix; regression guard).
+echo "T3: No Pre-Phase 0 section → WARN (no pre-conditions section found)"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":0,"deployment":"organizational"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+(section header intentionally absent)
+MD
+out=$(run_gate)
+if echo "$out" | grep -qE "WARN.*Pre-Phase 0.*no pre-conditions section found"; then
+  pass "T3: WARN fires when section absent"
+else
+  fail_ "T3" "expected 'no pre-conditions section found'; out:\n$(echo "$out" | grep -i pre-phase)"
+fi
+teardown
+
+# T4: POC-mode org deployment — entire Pre-Phase 0 block is skipped
+# (sponsored_poc and private_poc both have poc_mode set, which bypasses
+# the full-org 6-precondition rule).
+echo "T4: poc_mode=sponsored_poc → Pre-Phase 0 block skipped entirely"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":0,"deployment":"organizational","poc_mode":"sponsored_poc"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+(no Pre-Phase 0 section needed in POC mode)
+MD
+out=$(run_gate)
+if echo "$out" | grep -qi "Pre-Phase 0"; then
+  fail_ "T4" "Pre-Phase 0 block should be skipped in POC mode; out:\n$(echo "$out" | grep -i pre-phase)"
+else
+  pass "T4: Pre-Phase 0 block correctly skipped in POC mode"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Secondary site: PROJECT_BIBLE.md numbered sections ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T5: PROJECT_BIBLE.md has zero numbered sections. The `< 14 sections`
+# WARN must fire — pre-fix this took the silent OK path because
+# `[ "0\n0" -lt 14 ]` failed the arithmetic test.
+echo "T5: PROJECT_BIBLE.md with 0 numbered sections → WARN (< 14 sections)"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal","gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Phase 0 → Phase 1
+Approved 2026-01-01
+
+## Phase 1 → Phase 2
+Approved 2026-02-01
+MD
+# Empty PROJECT_BIBLE.md — no headers, no placeholders.
+: > "$PROJ/PROJECT_BIBLE.md"
+out=$(run_gate)
+if echo "$out" | grep -qE "WARN.*PROJECT_BIBLE.*has only 0 numbered sections"; then
+  pass "T5: WARN fires when 0 numbered sections (was silently OK pre-fix)"
+else
+  fail_ "T5" "expected 'has only 0 numbered sections'; out:\n$(echo "$out" | grep -i 'project_bible\|numbered')"
+fi
+teardown
+
+# T6: PROJECT_BIBLE.md with 14 numbered sections → no [WARN] about
+# section count (regression guard for happy path).
+echo "T6: PROJECT_BIBLE.md with 14 numbered sections → no section-count WARN"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal","gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Phase 0 → Phase 1
+Approved 2026-01-01
+
+## Phase 1 → Phase 2
+Approved 2026-02-01
+MD
+{
+  for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do
+    echo "## ${i}. Section ${i}"
+    echo ""
+  done
+} > "$PROJ/PROJECT_BIBLE.md"
+out=$(run_gate)
+if echo "$out" | grep -qE "WARN.*PROJECT_BIBLE.*numbered sections"; then
+  fail_ "T6" "should not WARN with 14 sections; out:\n$(echo "$out" | grep -i 'numbered')"
+else
+  pass "T6: 14 sections → no section-count WARN (regression guard)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Defect-class verification: no 'integer expression expected' ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T7: No matter what zero-match scenario, the script must NOT print
+# bash's 'integer expression expected' error to stderr. Pre-fix this
+# leaked on multiple sites; post-fix the sanitizer absorbs them all.
+echo "T7: Zero-match scenarios do not leak 'integer expression expected'"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"organizational","gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Pre-Phase 0
+
+(no dates)
+
+## Phase 0 → Phase 1
+Approved 2026-01-01
+
+## Phase 1 → Phase 2
+Approved 2026-02-01
+MD
+: > "$PROJ/PROJECT_BIBLE.md"
+out=$(run_gate)
+if echo "$out" | grep -q "integer expression expected"; then
+  fail_ "T7" "bash 'integer expression expected' leaked; out:\n$(echo "$out" | grep -i integer)"
+else
+  pass "T7: no 'integer expression expected' leaked across multiple zero-match sites"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- Sanitize the 7 `var=$(... || echo "0")` capture sites in `scripts/check-phase-gate.sh` so a `grep -c` returning 0 on no-match (exit 1) no longer produces the two-line string `"0\n0"` that broke downstream `[ -lt ]`/`[ -gt ]` arithmetic tests and silently flipped hard gates into their OK branch.
- Smoking gun: Pre-Phase 0 organizational pre-condition gate (line 203). When `APPROVAL_LOG.md` contained the `Pre-Phase 0` header but zero ISO dates, the script printed `[OK] Pre-Phase 0 pre-conditions recorded (0\n0 entries)` instead of the WARN that should fire — silently bypassing a hard organizational pre-condition gate.
- Fix follows the precedent already in `scripts/process-checklist.sh:45-46`: `case "$var" in ''|*[!0-9]*) var=0 ;; esac`. Narrower than swapping to project-wide `set -o pipefail`, which would surface unrelated latent bugs.

## Sites touched

| Line | Variable | Severity |
| --- | --- | --- |
| 87  | current_phase | latent (grep -o is usually safe) |
| 152 | open_count | defensive (already gated by `grep -qi`) |
| 203 | local_precond_count | **PRIMARY — silent hard-gate bypass** |
| 314 | placeholder_dates | benign (false-OK matched correct outcome by coincidence) |
| 320 | bible_sections | **silent OK on 0-section PROJECT_BIBLE** |
| 474 | p3_steps_done | latent (jq usually returns single value) |
| 489 | review_count | latent |

## New regression test — `tests/test-check-phase-gate-counter-sanitizer.sh` (7/7)

- T1 Pre-Phase 0 header + 0 dates → WARN (the smoking gun)
- T2 Pre-Phase 0 header + 6 dates → [OK] (happy-path regression guard)
- T3 No Pre-Phase 0 section → WARN
- T4 `poc_mode=sponsored_poc` → block skipped (regression guard)
- T5 PROJECT_BIBLE 0 numbered sections → WARN (was silently OK pre-fix)
- T6 PROJECT_BIBLE 14 numbered sections → no section-count WARN (regression guard)
- T7 No `integer expression expected` leakage across multiple zero-match sites

## Test plan
- [x] `tests/test-check-phase-gate-counter-sanitizer.sh` (7/7)
- [x] `tests/test-check-gate.sh` (5/5)
- [x] `tests/test-process-checklist-auto-advance.sh` (5/5)
- [x] `tests/test-process-checklist-classifier.sh` (12/12)
- [x] `tests/test-phase-finalize.sh` (6/6)
- [x] `tests/test-poc-modes.sh` (5/5)
- [x] `tests/test-test-gate-null-handling.sh` (5/5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)