### PR TITLE
fix(init.sh): atomic state writes + clean post-init working tree (code-init-sh-6)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1154,6 +1154,7 @@ create_project() {
   chmod +x scripts/hooks/bypass-detector.sh scripts/escalate-to-user.sh
   cp "$SCRIPT_DIR/scripts/pending-approval.sh" scripts/      # BL-015
   cp "$SCRIPT_DIR/scripts/lint-uat-scenarios.sh" scripts/    # BL-009
+  cp "$SCRIPT_DIR/scripts/lint-fixture-envelopes.sh" scripts/  # BL-030
   # BL-030: enforcement-level lib, gate-principles lib, filesystem-gate
   # installer, PostToolUse Claude-commit recorder, SessionStart out-of-
   # band detector. Required by reconfigure --enforcement-level and by
@@ -1835,6 +1836,20 @@ QDEOF
   print_info "Installing pre-commit hook..."
   install_precommit_hook
 
+  # --- Atomic initial-state preparation (code-init-sh-6) ---
+  # Pre-fix, BL-030 state files (manifest enforcement_level/deployment/poc_mode,
+  # bypass-audit.json init row, filesystem gate) and the host-manifest seed
+  # (host/mode/remote_url) were written AFTER the initial git commit. The chore-
+  # init commit captured none of them, leaving a half-initialized state on every
+  # init (especially severe on create_and_protect_remote failure, since BL-030
+  # writes happened unconditionally on top of the failed-remote state).
+  #
+  # Lay everything down BEFORE the initial commit so a single atomic commit
+  # captures the entire framework-managed state. Post-remote writes (remote_url
+  # update, attestation, phase2_init steps) are captured by finalize_init_commit
+  # below as a second commit when present.
+  prepare_initial_state_for_commit
+
   git add -A
   # Skip hooks for the initial commit — template files trigger false positives
   # in Semgrep/gitleaks. Hooks will enforce on all subsequent commits.
@@ -1844,6 +1859,11 @@ Project: $PROJECT_NAME
 Platform: $PLATFORM
 Track: $TRACK
 Framework: Solo Orchestrator v1.0"
+
+  # Refresh the BL-030 detection baseline to the chore-init commit. The file
+  # is gitignored (templates/generated/gitignore-base.tmpl), so updating it
+  # post-commit does NOT dirty the working tree.
+  ( git rev-parse HEAD 2>/dev/null > .claude/last-checked-commit.txt ) || true
 
   # --- Host-aware repo creation (spec 2026-04-21 host-aware repo gate) ---
   # Reads git_host + repo_visibility from intake-progress.json (set by
@@ -1866,6 +1886,12 @@ Framework: Solo Orchestrator v1.0"
     echo ""
   fi
 
+  # If create_and_protect_remote wrote new state (manifest.remote_url update,
+  # attestation, phase2_init.steps_completed), commit it as a second "finalize"
+  # commit so the working tree stays clean. No-op when nothing changed (e.g.
+  # --no-remote-creation, which set remote_url during prepare_initial_state).
+  finalize_init_commit
+
   echo ""
   print_ok "Project created at $PROJECT_DIR"
 }
@@ -1874,45 +1900,13 @@ Framework: Solo Orchestrator v1.0"
 # Host-Aware Repo Creation (spec 2026-04-21)
 # ================================================================
 create_and_protect_remote() {
-  local host visibility
-  # BL-016: prefer non-interactive top-level variables when set.
-  if [ -n "${GIT_HOST:-}" ]; then
-    host="$GIT_HOST"
-  elif [ -f .claude/intake-progress.json ]; then
-    host=$(jq -r '.answers.git_host // empty' .claude/intake-progress.json 2>/dev/null || echo "")
-  fi
-  if [ -n "${VISIBILITY:-}" ]; then
-    visibility="$VISIBILITY"
-  elif [ -f .claude/intake-progress.json ]; then
-    visibility=$(jq -r '.answers.repo_visibility // empty' .claude/intake-progress.json 2>/dev/null || echo "")
-  fi
-  # Fallback: prompt inline if neither source supplied a value (interactive mode only).
-  [ -z "$host" ]       && host=$(prompt_choice "Git host:" "github" "gitlab" "bitbucket" "other")
-  [ -z "$visibility" ] && visibility=$(prompt_choice "Repository visibility:" "private" "public")
-
-  # Map DEPLOYMENT "organizational" → "org" for consistency with spec
-  local mode="$DEPLOYMENT"
-  [ "$mode" = "organizational" ] && mode="org"
-  # Org forces private
-  if [ "$mode" = "org" ] && [ "$visibility" != "private" ]; then
-    print_warn "Org mode forces private visibility (overriding '$visibility')"
-    visibility="private"
-  fi
-
-  # T2-C: write manifest.host (and mode) early so check-gate.sh --preflight
-  # has a usable host field even if a downstream API call fails (missing CLI,
-  # 403, push failure, fake URL). Late-stage merges below add remote_url and
-  # update host/mode in place.
-  mkdir -p .claude
-  if [ -f .claude/manifest.json ]; then
-    jq --arg h "$host" --arg m "$mode" '.host = $h | .mode = $m' \
-       .claude/manifest.json > .claude/manifest.json.tmp \
-       && mv .claude/manifest.json.tmp .claude/manifest.json
-  else
-    cat > .claude/manifest.json <<MANIFESTEOF
-{"host": "$host", "mode": "$mode"}
-MANIFESTEOF
-  fi
+  # Host/visibility/mode are pre-resolved by prepare_initial_state_for_commit
+  # and exported as _RESOLVED_HOST / _RESOLVED_VISIBILITY / _RESOLVED_MODE so
+  # the manifest can be written BEFORE the chore-init commit. We use those
+  # values here (the manifest.host/manifest.mode are already in HEAD).
+  local host="$_RESOLVED_HOST"
+  local visibility="$_RESOLVED_VISIBILITY"
+  local mode="$_RESOLVED_MODE"
 
   # T2-B: --no-remote-creation skips the host API entirely so UAT/CI runs do
   # not contaminate the user's GitHub/GitLab/Bitbucket account. Manifest already
@@ -3594,45 +3588,90 @@ HELPEOF
   finalize_log
 }
 
-# BL-030: finalize init — merge enforcement_level + deployment + poc_mode
-# into manifest, initialize the out-of-band detection baseline, append an
-# enforcement_level_set audit row, install the filesystem gate when strict.
-bl030_finalize_init() {
+# Resolve host/visibility/mode from --git-host / --visibility flags, intake
+# answers, or interactive prompts. Sets globals consumed by both
+# prepare_initial_state_for_commit and create_and_protect_remote so the
+# resolution happens exactly once per init.
+_resolve_host_visibility_mode() {
+  # BL-016: prefer non-interactive top-level variables when set.
+  if [ -n "${GIT_HOST:-}" ]; then
+    _RESOLVED_HOST="$GIT_HOST"
+  elif [ -f .claude/intake-progress.json ]; then
+    _RESOLVED_HOST=$(jq -r '.answers.git_host // empty' .claude/intake-progress.json 2>/dev/null || echo "")
+  fi
+  if [ -n "${VISIBILITY:-}" ]; then
+    _RESOLVED_VISIBILITY="$VISIBILITY"
+  elif [ -f .claude/intake-progress.json ]; then
+    _RESOLVED_VISIBILITY=$(jq -r '.answers.repo_visibility // empty' .claude/intake-progress.json 2>/dev/null || echo "")
+  fi
+  # Fallback: prompt inline if neither source supplied a value (interactive mode only).
+  [ -z "${_RESOLVED_HOST:-}" ]       && _RESOLVED_HOST=$(prompt_choice "Git host:" "github" "gitlab" "bitbucket" "other")
+  [ -z "${_RESOLVED_VISIBILITY:-}" ] && _RESOLVED_VISIBILITY=$(prompt_choice "Repository visibility:" "private" "public")
+
+  # Map DEPLOYMENT "organizational" → "org" for consistency with spec
+  _RESOLVED_MODE="$DEPLOYMENT"
+  [ "$_RESOLVED_MODE" = "organizational" ] && _RESOLVED_MODE="org"
+  # Org forces private
+  if [ "$_RESOLVED_MODE" = "org" ] && [ "$_RESOLVED_VISIBILITY" != "private" ]; then
+    print_warn "Org mode forces private visibility (overriding '$_RESOLVED_VISIBILITY')"
+    _RESOLVED_VISIBILITY="private"
+  fi
+}
+
+# Lay down ALL durable state BEFORE the chore-init commit so it is captured
+# atomically. Combines what used to be (a) create_and_protect_remote's early
+# manifest seed (host/mode), (b) bl030_finalize_init's manifest BL-030 fields
+# + bypass-audit init row + filesystem gate install. The chore-init commit
+# now includes manifest with all fields, bypass-audit.json with the init
+# row, and the filesystem-gate hooks when strict.
+prepare_initial_state_for_commit() {
   [ -d "$PROJECT_DIR" ] || return 0
   command -v jq >/dev/null 2>&1 || return 0
 
-  # Merge BL-030 fields into manifest.json. Existing init code writes host +
-  # mode (and possibly remote_url); this layers on the canonical schema the
-  # enforcement-level library expects.
-  local manifest="$PROJECT_DIR/.claude/manifest.json"
-  local poc_arg
+  _resolve_host_visibility_mode
+
+  mkdir -p .claude
+
+  # Seed manifest with all framework-managed fields. remote_url stays "" until
+  # create_and_protect_remote actually creates the repo; if it doesn't, the
+  # empty value is the documented "no remote" sentinel.
+  local poc_val
   if [ -n "$POC_MODE" ]; then
-    poc_arg="$POC_MODE"
+    poc_val="$POC_MODE"
   else
-    poc_arg=""
+    poc_val=""
   fi
+  local manifest=".claude/manifest.json"
   if [ -f "$manifest" ]; then
     local tmp
     tmp=$(mktemp)
-    if [ -n "$poc_arg" ]; then
-      jq --arg dep "$DEPLOYMENT" --arg pm "$poc_arg" --arg lvl "$ENFORCEMENT_LEVEL" \
-        '. + {deployment: $dep, poc_mode: $pm, enforcement_level: $lvl}' "$manifest" > "$tmp" \
-        && mv "$tmp" "$manifest"
+    if [ -n "$poc_val" ]; then
+      jq --arg h "$_RESOLVED_HOST" --arg m "$_RESOLVED_MODE" \
+         --arg dep "$DEPLOYMENT" --arg pm "$poc_val" --arg lvl "$ENFORCEMENT_LEVEL" \
+         '. + {host:$h, mode:$m, remote_url:"", deployment:$dep, poc_mode:$pm, enforcement_level:$lvl}' \
+         "$manifest" > "$tmp" && mv "$tmp" "$manifest"
     else
-      jq --arg dep "$DEPLOYMENT" --arg lvl "$ENFORCEMENT_LEVEL" \
-        '. + {deployment: $dep, poc_mode: null, enforcement_level: $lvl}' "$manifest" > "$tmp" \
-        && mv "$tmp" "$manifest"
+      jq --arg h "$_RESOLVED_HOST" --arg m "$_RESOLVED_MODE" \
+         --arg dep "$DEPLOYMENT" --arg lvl "$ENFORCEMENT_LEVEL" \
+         '. + {host:$h, mode:$m, remote_url:"", deployment:$dep, poc_mode:null, enforcement_level:$lvl}' \
+         "$manifest" > "$tmp" && mv "$tmp" "$manifest"
+    fi
+  else
+    if [ -n "$poc_val" ]; then
+      jq -n --arg h "$_RESOLVED_HOST" --arg m "$_RESOLVED_MODE" \
+            --arg dep "$DEPLOYMENT" --arg pm "$poc_val" --arg lvl "$ENFORCEMENT_LEVEL" \
+            '{host:$h, mode:$m, remote_url:"", deployment:$dep, poc_mode:$pm, enforcement_level:$lvl}' \
+        > "$manifest"
+    else
+      jq -n --arg h "$_RESOLVED_HOST" --arg m "$_RESOLVED_MODE" \
+            --arg dep "$DEPLOYMENT" --arg lvl "$ENFORCEMENT_LEVEL" \
+            '{host:$h, mode:$m, remote_url:"", deployment:$dep, poc_mode:null, enforcement_level:$lvl}' \
+        > "$manifest"
     fi
   fi
 
-  # Initialize detection baseline.
-  if [ -d "$PROJECT_DIR/.git" ]; then
-    ( cd "$PROJECT_DIR" && git rev-parse HEAD 2>/dev/null > "$PROJECT_DIR/.claude/last-checked-commit.txt" ) || true
-  fi
-  # Ensure bypass-audit.json exists (BL-029 also handles this; defensive).
-  [ -f "$PROJECT_DIR/.claude/bypass-audit.json" ] || echo "[]" > "$PROJECT_DIR/.claude/bypass-audit.json"
-
-  # Append enforcement_level_set audit row.
+  # Seed bypass-audit.json with the init enforcement_level_set row.
+  [ -f .claude/bypass-audit.json ] || echo "[]" > .claude/bypass-audit.json
   local _ts _row _tmp
   _ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   _row=$(jq -nc \
@@ -3644,14 +3683,44 @@ bl030_finalize_init() {
       details:{level:$lvl, confirmed_pitfalls:($confirmed=="1"), source:"init"},
       user_response:"n/a", final_outcome:"recorded_only"}')
   _tmp=$(mktemp)
-  jq --argjson r "$_row" '. + [$r]' "$PROJECT_DIR/.claude/bypass-audit.json" > "$_tmp" \
-    && mv "$_tmp" "$PROJECT_DIR/.claude/bypass-audit.json"
+  jq --argjson r "$_row" '. + [$r]' .claude/bypass-audit.json > "$_tmp" \
+    && mv "$_tmp" .claude/bypass-audit.json
 
-  # Install filesystem gate when strict.
+  # Install filesystem gate when strict (puts the hook in .git/hooks/ before
+  # the chore-init commit so the marker block is consistent with the rest of
+  # the BL-030 surface).
   if [ "$ENFORCEMENT_LEVEL" = "strict" ]; then
     bash "$SCRIPT_DIR/scripts/install-filesystem-gates.sh" --install "$PROJECT_DIR" >/dev/null 2>&1 || \
       print_warn "BL-030: filesystem-gate install failed — strict enforcement degraded."
   fi
+}
+
+# Capture any post-remote state writes (manifest.remote_url update, branch-
+# protection attestation, phase2_init.steps_completed) in a chore-finalize
+# commit so the working tree stays clean after init.sh exits. No-op when
+# nothing changed (e.g. --no-remote-creation, which sets remote_url to the
+# same "" already in HEAD).
+finalize_init_commit() {
+  [ -d "$PROJECT_DIR/.git" ] || return 0
+  if [ -z "$(git status --porcelain 2>/dev/null)" ]; then
+    return 0
+  fi
+  git add -A
+  git commit -q --no-verify -m "chore: record host setup outcome (init finalize)" 2>/dev/null || true
+  # Refresh detection baseline to the finalize commit so subsequent commits
+  # are correctly detected as new work, not as init-time activity.
+  ( git rev-parse HEAD 2>/dev/null > .claude/last-checked-commit.txt ) || true
+}
+
+# Legacy entry point. Pre-fix this function did all the BL-030 state writes
+# (manifest fields, bypass-audit init row, filesystem gate install) AFTER
+# the chore-init commit, leaving them uncommitted. The writes have moved
+# into prepare_initial_state_for_commit so they land in the initial commit.
+# The function is retained as a no-op so any external caller continues to
+# work; the baseline refresh now happens in create_project after each
+# commit point (chore-init + chore-finalize) so this is correctly redundant.
+bl030_finalize_init() {
+  return 0
 }
 
 main "$@"

--- a/templates/generated/gitignore-base.tmpl
+++ b/templates/generated/gitignore-base.tmpl
@@ -57,3 +57,11 @@ terraform.tfvars.json
 # (init.sh removes this after a successful install; ignored as a safety net
 # in case a future flow leaves it behind)
 .claude-backup/
+
+# BL-030 operational state — the detection baseline file. Not project
+# content. Updated by scripts/detect-out-of-band-commits.sh on every
+# SessionStart and by scripts/reconfigure-project.sh / init.sh after
+# state mutations. Tracking it (a) dirtied the working tree on every
+# detector run, and (b) made init.sh impossible to finish with a clean
+# tree, because the file can never point to its own commit hash.
+.claude/last-checked-commit.txt

--- a/tests/test-init-atomic-finalize.sh
+++ b/tests/test-init-atomic-finalize.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# tests/test-init-atomic-finalize.sh — code-init-sh-6 regression.
+#
+# init.sh wrote state files (manifest.host/mode/remote_url, bypass-audit.json,
+# last-checked-commit.txt, process-state.json attestation) AFTER the initial
+# `git commit`. Two consequences:
+#
+#   1) Half-initialized state on remote-creation failure: if
+#      create_and_protect_remote returned 1 (push failure, fake URL, 403,
+#      missing CLI), init left the local repo with manifest fields written
+#      but not committed, no remote, and check-gate.sh --repair had to
+#      reconstruct from a dirty working tree.
+#
+#   2) BL-030 governance surface widened the blast radius: bl030_finalize_init
+#      runs UNCONDITIONALLY after create_project, writing enforcement_level
+#      + deployment + poc_mode + bypass-audit init row + last-checked-commit
+#      — all uncommitted, all sitting on top of whatever create_and_protect_remote
+#      left.
+#
+# Fix: lay down all durable state BEFORE the initial commit so it's captured
+# atomically. The chore-init commit now includes manifest with all fields,
+# bypass-audit.json with the init row, and the filesystem gate. Anything
+# create_and_protect_remote subsequently writes (remote_url, attestation)
+# is captured by a `finalize_init_commit` second commit; if nothing dirty,
+# skipped. last-checked-commit.txt is gitignored so its post-commit update
+# doesn't dirty the working tree.
+#
+# Invariant: after init.sh exits (with or without remote success),
+# `git status --porcelain` is empty.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# init.sh refuses to scaffold inside the framework repo — work from /tmp.
+cd /tmp
+
+run_init_no_remote() {
+  local proj="$1"; shift
+  bash "$INIT" --non-interactive \
+    --project x \
+    --project-dir "$proj" \
+    --platform web \
+    --language javascript \
+    --deployment personal \
+    --track light \
+    --git-host github \
+    --visibility private \
+    --no-remote-creation "$@" >/dev/null 2>&1
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Clean working tree after init (no remote case) ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T1: --no-remote-creation must leave the project with `git status` clean.
+# Pre-fix, manifest BL-030 fields, bypass-audit.json, last-checked-commit.txt,
+# and process-state.json updates were uncommitted after init exited.
+echo "T1: --no-remote-creation → clean working tree"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  dirty=$( cd "$PROJ" && git status --porcelain 2>/dev/null )
+  if [ -z "$dirty" ]; then
+    pass "T1: working tree clean post-init"
+  else
+    fail_ "T1" "dirty files post-init:\n$dirty"
+  fi
+else
+  fail_ "T1" "init failed"
+fi
+rm -rf "$TMP"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== BL-030 + host state captured atomically in initial commit ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T2: initial commit contains manifest.json with BL-030 fields populated.
+# Pre-fix the initial commit had NO manifest.json (bl030_finalize_init
+# created it post-commit).
+echo "T2: initial commit includes manifest.enforcement_level/deployment"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  # Use git show to read manifest.json AT the initial commit, not from the
+  # working tree.
+  manifest_at_init=$( cd "$PROJ" && git show HEAD:.claude/manifest.json 2>/dev/null )
+  enf=$( echo "$manifest_at_init" | jq -r '.enforcement_level // empty' )
+  dep=$( echo "$manifest_at_init" | jq -r '.deployment // empty' )
+  if [ "$enf" = "strict" ] && [ "$dep" = "personal" ]; then
+    pass "T2: initial commit manifest has enforcement_level=strict + deployment=personal"
+  else
+    fail_ "T2" "initial commit manifest missing fields: enf='$enf' dep='$dep'"
+  fi
+else
+  fail_ "T2" "init failed"
+fi
+rm -rf "$TMP"
+
+# T3: initial commit contains bypass-audit.json with the enforcement_level_set
+# init row. Pre-fix bypass-audit was written by bl030_finalize_init AFTER
+# the chore-init commit, so the init row was uncommitted.
+echo "T3: initial commit includes bypass-audit.json init row"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  audit_at_init=$( cd "$PROJ" && git show HEAD:.claude/bypass-audit.json 2>/dev/null )
+  rows=$( echo "$audit_at_init" | jq '[.[] | select(.type=="enforcement_level_set")] | length' 2>/dev/null || echo "0" )
+  if [ "$rows" -ge "1" ]; then
+    pass "T3: bypass-audit.json has the init enforcement_level_set row in initial commit"
+  else
+    fail_ "T3" "init row missing from initial commit's bypass-audit.json (rows=$rows)"
+  fi
+else
+  fail_ "T3" "init failed"
+fi
+rm -rf "$TMP"
+
+# T4: initial commit contains manifest.host = the resolved host (not just
+# a placeholder), even without remote creation.
+echo "T4: initial commit includes manifest.host=github"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  manifest_at_init=$( cd "$PROJ" && git show HEAD:.claude/manifest.json 2>/dev/null )
+  host=$( echo "$manifest_at_init" | jq -r '.host // empty' )
+  if [ "$host" = "github" ]; then
+    pass "T4: initial commit manifest.host=github (pre-resolved)"
+  else
+    fail_ "T4" "initial commit manifest.host='$host' (expected github)"
+  fi
+else
+  fail_ "T4" "init failed"
+fi
+rm -rf "$TMP"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== last-checked-commit.txt is gitignored (not project content) ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T5: .gitignore lists .claude/last-checked-commit.txt. The file is
+# operational state (the BL-030 detection baseline), not project content.
+# Tracking it caused two problems: (a) it dirtied the working tree on every
+# detector run, (b) it could never point to its own commit (chicken-and-egg).
+echo "T5: .gitignore excludes .claude/last-checked-commit.txt"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  if grep -q '\.claude/last-checked-commit\.txt' "$PROJ/.gitignore" 2>/dev/null; then
+    pass "T5: .claude/last-checked-commit.txt is gitignored"
+  else
+    fail_ "T5" "gitignore missing last-checked-commit.txt"
+  fi
+else
+  fail_ "T5" "init failed"
+fi
+rm -rf "$TMP"
+
+# T6: last-checked-commit.txt is initialized to a valid commit hash (the
+# initial commit). Regression guard — must still work post-fix.
+echo "T6: last-checked-commit.txt = HEAD post-init"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  baseline=$( cat "$PROJ/.claude/last-checked-commit.txt" 2>/dev/null )
+  head=$( cd "$PROJ" && git rev-parse HEAD 2>/dev/null )
+  if [ -n "$baseline" ] && [ "$baseline" = "$head" ]; then
+    pass "T6: last-checked-commit.txt = HEAD"
+  else
+    fail_ "T6" "baseline='$baseline' HEAD='$head'"
+  fi
+else
+  fail_ "T6" "init failed"
+fi
+rm -rf "$TMP"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Single atomic commit (no half-init second commit) ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T7: with --no-remote-creation there is no remote work to record, so init
+# should produce exactly ONE commit. A second "finalize" commit only exists
+# if create_and_protect_remote actually wrote something (remote_url,
+# attestation). Pre-fix this was muddied because state writes weren't
+# atomic with the commit.
+echo "T7: --no-remote-creation → exactly 1 commit, working tree clean"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  commit_count=$( cd "$PROJ" && git rev-list --count HEAD 2>/dev/null )
+  if [ "$commit_count" = "1" ]; then
+    pass "T7: exactly 1 commit (no superfluous finalize commit)"
+  else
+    fail_ "T7" "expected 1 commit, got $commit_count"
+  fi
+else
+  fail_ "T7" "init failed"
+fi
+rm -rf "$TMP"
+
+# T8: filesystem gate install still happens for strict (regression guard;
+# the install now runs before the initial commit so the hook is captured).
+echo "T8: strict init installs filesystem-gate (regression guard)"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+if run_init_no_remote "$PROJ"; then
+  if [ -x "$PROJ/.git/hooks/framework-gate.sh" ] \
+     && grep -q "SOIF framework gate" "$PROJ/.git/hooks/pre-commit" 2>/dev/null; then
+    pass "T8: framework-gate.sh + pre-commit marker block present"
+  else
+    fail_ "T8" "filesystem gate not installed for strict mode"
+  fi
+else
+  fail_ "T8" "init failed"
+fi
+rm -rf "$TMP"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- **Atomic initial state**: hoist BL-030 manifest fields + bypass-audit init row + filesystem-gate install + host/mode resolution into `prepare_initial_state_for_commit`, called BEFORE the chore-init commit. The initial commit now captures the complete framework-managed state.
- **Half-init prevention**: new `finalize_init_commit` captures any post-remote writes (manifest.remote_url update, attestation, phase2_init.steps_completed) in a second commit only when changes exist. `--no-remote-creation` produces exactly one commit.
- **Operational state isolation**: `.claude/last-checked-commit.txt` is now gitignored. It's the BL-030 detection baseline, not project content — tracking it dirtied the working tree on every detector run and made the file unable to point at its own commit hash.
- **Missed copy**: `scripts/lint-fixture-envelopes.sh` was missing from init's framework-script copy list, so `verify-install.sh --auto-fix` copied it post-commit (leaving an untracked stray). Added to the copy list.

## Why this matters more post-BL-030

Pre-BL-030, the half-init state was limited to manifest.host/mode/remote_url and a process-state attestation. BL-030 added `bl030_finalize_init` as a second unconditional post-commit writer (enforcement_level + deployment + poc_mode merge, bypass-audit init row, last-checked-commit.txt baseline, filesystem-gate install). Every init left those uncommitted, and on `create_and_protect_remote` failure the user got a project where the governance surface (audit-row, baseline, gate) was layered on top of a failed-remote state with no clean recovery.

## Invariant

After `init.sh` exits — with or without remote success — `git status --porcelain` is empty.

## Scope correction from the survey verifier

The original finding framed this as "move the git commit." That's incomplete — BL-030 added a second post-commit writer (`bl030_finalize_init`) that runs unconditionally after `create_and_protect_remote`. A naive reorder would have left those writes uncommitted. The fix pulls both writers into one pre-commit helper.

Sibling bug in `scripts/reconfigure-project.sh:93-118` (manifest + bypass-audit + gate install with no rollback) is intentionally NOT in this PR — different code path, lower priority, should reuse the same finalize_and_commit pattern once this lands.

## New regression test — `tests/test-init-atomic-finalize.sh` (8/8)

| # | What |
| - | - |
| T1 | --no-remote-creation → `git status --porcelain` empty |
| T2 | initial commit includes manifest.enforcement_level + deployment |
| T3 | initial commit includes bypass-audit.json with init row |
| T4 | initial commit includes manifest.host=github (pre-resolved) |
| T5 | .claude/last-checked-commit.txt is gitignored |
| T6 | last-checked-commit.txt = HEAD post-init (regression guard) |
| T7 | --no-remote-creation produces exactly 1 commit (no superfluous finalize) |
| T8 | strict init installs filesystem-gate (regression guard) |

## Test plan
- [x] tests/test-init-atomic-finalize.sh (8/8 — new)
- [x] tests/test-enforcement-level-init.sh (8/8)
- [x] tests/test-init-no-remote-creation.sh (3/3)
- [x] tests/test-init-other-host-attestation.sh (2/2)
- [x] tests/test-enforcement-level-reconfigure.sh (7/7)
- [x] tests/test-bl030-calibration-replay.sh (4/4)
- [x] tests/test-bypass-audit-schema.sh (3/3)
- [x] tests/test-out-of-band-detector.sh (8/8)
- [x] tests/test-record-claude-commit.sh (5/5)
- [x] tests/test-filesystem-gate-install.sh (7/7)
- [x] tests/test-upgrade-bl030-backfill.sh (7/7)
- [x] tests/test-verify-install-bl030-coverage.sh (8/8)
- [x] tests/test-bypass-detector.sh (15/15)
- [x] tests/test-bypass-audit-integrity.sh (8/8)
- [x] tests/test-bypass-audit-lib.sh (10/10)
- [x] tests/test-session-test-gate-check-merge.sh (7/7)
- [x] tests/test-pre-commit-gate-terminal-mode.sh (3/3)
- [x] tests/test-gate-principles.sh (3/3)
- [x] tests/test-check-gate.sh (5/5)
- [x] tests/test-phase-finalize.sh (6/6)
- [x] tests/test-poc-modes.sh (5/5)
- [x] tests/test-upgrade-paths.sh (8/8)
- [x] tests/test-process-checklist-classifier.sh (12/12)
- [x] tests/test-pre-commit-gate-classifier.sh (6/6)
- [x] tests/test-lint-uat-scenarios.sh (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)