### PR TITLE
fix(reconfigure-project): atomic enforcement-level transition + rollback (sibling to PR #54)

### DIFF
--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -73,6 +73,25 @@ while [ $# -gt 0 ]; do
   esac
 done
 
+# Sibling of PR #54 (init.sh atomic finalize). Commit any post-mutation
+# state into a chore-finalize commit so the working tree stays clean
+# after reconfigure exits. No-op when nothing changed (defensive). The
+# detection baseline is refreshed to the new HEAD so the BL-030 detector
+# does not flag the reconfigure commit as out-of-band on the next
+# SessionStart.
+finalize_reconfigure_commit() {
+  local subject="$1"
+  [ -d "$PROJECT_ROOT/.git" ] || return 0
+  if [ -z "$( cd "$PROJECT_ROOT" && git status --porcelain 2>/dev/null )" ]; then
+    return 0
+  fi
+  ( cd "$PROJECT_ROOT" \
+      && git add -A \
+      && git commit -q --no-verify -m "$subject" 2>/dev/null \
+      && git rev-parse HEAD 2>/dev/null > .claude/last-checked-commit.txt \
+  ) || return 1
+}
+
 # BL-030 Task 8: --enforcement-level <no|light|strict> transition.
 if [ -n "$RECONF_LEVEL" ]; then
   # shellcheck disable=SC1091
@@ -90,10 +109,46 @@ if [ -n "$RECONF_LEVEL" ]; then
       fi
       ;;
   esac
+
+  # Sibling of PR #54 (init.sh atomic finalize). Pre-fix this block
+  # wrote manifest.json + bypass-audit.json + ran install-filesystem-
+  # gates.sh with `|| true` swallowing the installer exit code. On
+  # installer failure (read-only .git/hooks/, malformed sibling hook,
+  # missing /bin/bash on a stripped container) the manifest claimed
+  # the new level while no SOIF marker had been installed — a silent-
+  # bypass security defect where the audit log lied about strict
+  # enforcement being active. The reverse (strict->light with a
+  # failed uninstall) left the manifest saying light while the gate
+  # kept blocking. Both cases now snapshot the pre-state, run the
+  # installer with failure propagation, and roll back on failure.
+  MANIFEST_FILE="$PROJECT_ROOT/.claude/manifest.json"
+  AUDIT_FILE="$PROJECT_ROOT/.claude/bypass-audit.json"
+  manifest_backup=$(mktemp)
+  cp "$MANIFEST_FILE" "$manifest_backup"
+  audit_backup=$(mktemp)
+  if [ -f "$AUDIT_FILE" ]; then
+    cp "$AUDIT_FILE" "$audit_backup"
+  else
+    echo "[]" > "$audit_backup"
+  fi
+
+  rollback_reconfigure() {
+    local reason="$1"
+    cp "$manifest_backup" "$MANIFEST_FILE"
+    cp "$audit_backup" "$AUDIT_FILE"
+    rm -f "$manifest_backup" "$audit_backup"
+    print_fail "Enforcement-level transition failed: $reason"
+    echo "  Manifest and audit log rolled back to pre-transition state." >&2
+    echo "  Manifest: $MANIFEST_FILE (still: $current)" >&2
+    echo "  Audit:    $AUDIT_FILE (no new row appended)" >&2
+    exit 1
+  }
+
   tmp=$(mktemp)
-  jq --arg lvl "$RECONF_LEVEL" '.enforcement_level = $lvl' "$PROJECT_ROOT/.claude/manifest.json" > "$tmp" \
-    && mv "$tmp" "$PROJECT_ROOT/.claude/manifest.json"
-  [ -f "$PROJECT_ROOT/.claude/bypass-audit.json" ] || echo "[]" > "$PROJECT_ROOT/.claude/bypass-audit.json"
+  jq --arg lvl "$RECONF_LEVEL" '.enforcement_level = $lvl' "$MANIFEST_FILE" > "$tmp" \
+    && mv "$tmp" "$MANIFEST_FILE" \
+    || rollback_reconfigure "manifest write failed"
+  [ -f "$AUDIT_FILE" ] || echo "[]" > "$AUDIT_FILE"
   ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   row=$(jq -nc \
     --arg ts "$ts" --arg lvl "$RECONF_LEVEL" --arg from "$current" \
@@ -102,20 +157,35 @@ if [ -n "$RECONF_LEVEL" ]; then
       details:{level:$lvl, from:$from, source:"reconfigure"},
       user_response:"n/a", final_outcome:"recorded_only"}')
   tmp=$(mktemp)
-  jq --argjson r "$row" '. + [$r]' "$PROJECT_ROOT/.claude/bypass-audit.json" > "$tmp" \
-    && mv "$tmp" "$PROJECT_ROOT/.claude/bypass-audit.json"
+  jq --argjson r "$row" '. + [$r]' "$AUDIT_FILE" > "$tmp" \
+    && mv "$tmp" "$AUDIT_FILE" \
+    || rollback_reconfigure "audit-row append failed"
+
   # Install or uninstall the filesystem gate to match the new level.
-  # PROJECT_ROOT is the canonical install target.
-  INSTALLER="$SCRIPT_DIR/install-filesystem-gates.sh"
-  if [ "$RECONF_LEVEL" = "strict" ]; then
-    bash "$INSTALLER" --install "$PROJECT_ROOT" >/dev/null 2>&1 || true
+  # PROJECT_ROOT is the canonical install target. Prefer the project-
+  # local copy so the lookup honors any rollback / migration the
+  # project has applied; fall back to the framework copy when absent.
+  if [ -x "$PROJECT_ROOT/scripts/install-filesystem-gates.sh" ]; then
+    INSTALLER="$PROJECT_ROOT/scripts/install-filesystem-gates.sh"
   else
-    bash "$INSTALLER" --uninstall "$PROJECT_ROOT" >/dev/null 2>&1 || true
+    INSTALLER="$SCRIPT_DIR/install-filesystem-gates.sh"
   fi
+  if [ "$RECONF_LEVEL" = "strict" ]; then
+    if ! bash "$INSTALLER" --install "$PROJECT_ROOT" >/dev/null 2>&1; then
+      rollback_reconfigure "filesystem-gate install failed (installer: $INSTALLER)"
+    fi
+  else
+    if ! bash "$INSTALLER" --uninstall "$PROJECT_ROOT" >/dev/null 2>&1; then
+      rollback_reconfigure "filesystem-gate uninstall failed (installer: $INSTALLER)"
+    fi
+  fi
+
+  rm -f "$manifest_backup" "$audit_backup"
   if [ ! -f "$PROJECT_ROOT/.claude/last-checked-commit.txt" ]; then
     ( cd "$PROJECT_ROOT" && git rev-parse HEAD 2>/dev/null > .claude/last-checked-commit.txt ) || true
   fi
-  print_ok "Enforcement level: $current → $RECONF_LEVEL"
+  finalize_reconfigure_commit "chore: enforcement-level ${current} -> ${RECONF_LEVEL} (reconfigure)" || true
+  print_ok "Enforcement level: $current -> $RECONF_LEVEL"
   exit 0
 fi
 
@@ -132,6 +202,7 @@ if [ "$RECONF_RESET_BASELINE" = "1" ]; then
   tmp=$(mktemp)
   jq --argjson r "$row" '. + [$r]' "$PROJECT_ROOT/.claude/bypass-audit.json" > "$tmp" \
     && mv "$tmp" "$PROJECT_ROOT/.claude/bypass-audit.json"
+  finalize_reconfigure_commit "chore: reset detection baseline (reconfigure)" || true
   print_ok "Detection baseline reset to current HEAD."
   exit 0
 fi

--- a/tests/test-enforcement-level-reconfigure.sh
+++ b/tests/test-enforcement-level-reconfigure.sh
@@ -92,15 +92,130 @@ if [ "$after" = "$((initial + 1))" ]; then pass "T6"; else fail_ "T6" "rows: $in
 teardown
 
 # T7: --reset-detection-baseline writes current HEAD.
+# Post-fix (atomic finalize): the reset path commits the audit-row write, so
+# baseline tracks the new chore-finalize HEAD, not the pre-call HEAD.
 echo "T7: --reset-detection-baseline updates last-checked-commit.txt"
 setup_personal
 ( cd "$PROJ" && echo z > z && git add z && git commit -qm z )
-expected=$(cd "$PROJ" && git rev-parse HEAD)
 if ( cd "$PROJ" && bash "$RECONFIG" --reset-detection-baseline >/dev/null 2>&1 ); then
+  expected=$(cd "$PROJ" && git rev-parse HEAD)
   actual=$(cat "$PROJ/.claude/last-checked-commit.txt")
   if [ "$actual" = "$expected" ]; then pass "T7"; else fail_ "T7" "$expected vs $actual"; fi
 else
   fail_ "T7" "reconfigure failed"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Atomic finalize + rollback (sibling to PR #54) ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T8: after a successful --enforcement-level transition, the working
+# tree is clean (parity with the PR #54 init.sh invariant).
+# Pre-fix the reconfigure left manifest.json + bypass-audit.json
+# modifications uncommitted.
+echo "T8: --enforcement-level → working tree clean"
+setup_personal
+if ( cd "$PROJ" && bash "$RECONFIG" --enforcement-level light --confirm-pitfalls >/dev/null 2>&1 ); then
+  dirty=$( cd "$PROJ" && git status --porcelain 2>/dev/null )
+  if [ -z "$dirty" ]; then
+    pass "T8: working tree clean post-reconfigure"
+  else
+    fail_ "T8" "dirty:\n$dirty"
+  fi
+else
+  fail_ "T8" "reconfigure failed"
+fi
+teardown
+
+# T9: the commit emitted by the reconfigure has a chore subject naming
+# the transition. Lets a reader (or W7 successor) reconstruct what the
+# operator did from `git log --oneline`.
+echo "T9: --enforcement-level emits 'chore: enforcement-level ... reconfigure' commit"
+setup_personal
+if ( cd "$PROJ" && bash "$RECONFIG" --enforcement-level light --confirm-pitfalls >/dev/null 2>&1 ); then
+  subject=$( cd "$PROJ" && git log -1 --format='%s' )
+  if echo "$subject" | grep -qE '^chore: enforcement-level (strict|light|no) -> (strict|light|no) \(reconfigure\)$'; then
+    pass "T9: commit subject: '$subject'"
+  else
+    fail_ "T9" "unexpected commit subject: '$subject'"
+  fi
+else
+  fail_ "T9" "reconfigure failed"
+fi
+teardown
+
+# T10: install-filesystem-gates.sh FAILURE on light→strict.
+# Pre-fix: the installer was invoked with `|| true`, so the failure was
+# swallowed, the manifest had already been written claiming strict, the
+# audit row claimed strict, but no SOIF marker was installed in
+# .git/hooks/pre-commit — silent-bypass security defect.
+# Post-fix: failure propagates, manifest + audit are rolled back, exit
+# non-zero. The pre-call manifest level + audit row count are preserved.
+echo "T10: light→strict installer FAILURE rolls back manifest + audit"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
+  --platform web --language javascript --track light --deployment personal \
+  --enforcement-level light --confirm-pitfalls >/dev/null 2>&1
+RECONFIG="$PROJ/scripts/reconfigure-project.sh"
+# Replace the project-local installer with a stub that exits 1.
+printf '#!/usr/bin/env bash\nexit 1\n' > "$PROJ/scripts/install-filesystem-gates.sh"
+chmod +x "$PROJ/scripts/install-filesystem-gates.sh"
+before_level=$(jq -r '.enforcement_level' "$PROJ/.claude/manifest.json")
+before_rows=$(jq '[.[] | select(.type=="enforcement_level_set")] | length' "$PROJ/.claude/bypass-audit.json")
+( cd "$PROJ" && bash "$RECONFIG" --enforcement-level strict >/dev/null 2>&1 )
+rc=$?
+after_level=$(jq -r '.enforcement_level' "$PROJ/.claude/manifest.json")
+after_rows=$(jq '[.[] | select(.type=="enforcement_level_set")] | length' "$PROJ/.claude/bypass-audit.json")
+marker_present=no
+if grep -q "SOIF framework gate" "$PROJ/.git/hooks/pre-commit" 2>/dev/null; then marker_present=yes; fi
+if [ "$rc" -ne 0 ] && [ "$after_level" = "$before_level" ] && [ "$after_rows" = "$before_rows" ] && [ "$marker_present" = "no" ]; then
+  pass "T10: rollback complete (rc=$rc level=$after_level rows=$after_rows marker=$marker_present)"
+else
+  fail_ "T10" "rc=$rc level=${before_level}->${after_level} rows=${before_rows}->${after_rows} marker=$marker_present"
+fi
+teardown
+
+# T11: install-filesystem-gates.sh FAILURE on strict→light.
+# Mirror of T10. Pre-fix: manifest got rewritten to "light" while the
+# SOIF marker stayed in place — surprise blocks on commits the user
+# thought they had freed. Post-fix: rollback, manifest stays strict,
+# marker stays present, audit row count unchanged.
+echo "T11: strict→light installer FAILURE rolls back"
+setup_personal
+printf '#!/usr/bin/env bash\nexit 1\n' > "$PROJ/scripts/install-filesystem-gates.sh"
+chmod +x "$PROJ/scripts/install-filesystem-gates.sh"
+before_level=$(jq -r '.enforcement_level' "$PROJ/.claude/manifest.json")
+before_rows=$(jq '[.[] | select(.type=="enforcement_level_set")] | length' "$PROJ/.claude/bypass-audit.json")
+( cd "$PROJ" && bash "$RECONFIG" --enforcement-level light --confirm-pitfalls >/dev/null 2>&1 )
+rc=$?
+after_level=$(jq -r '.enforcement_level' "$PROJ/.claude/manifest.json")
+after_rows=$(jq '[.[] | select(.type=="enforcement_level_set")] | length' "$PROJ/.claude/bypass-audit.json")
+marker_present=no
+if grep -q "SOIF framework gate" "$PROJ/.git/hooks/pre-commit" 2>/dev/null; then marker_present=yes; fi
+if [ "$rc" -ne 0 ] && [ "$after_level" = "strict" ] && [ "$after_rows" = "$before_rows" ] && [ "$marker_present" = "yes" ]; then
+  pass "T11: rollback complete (rc=$rc level=$after_level rows=$after_rows marker=$marker_present)"
+else
+  fail_ "T11" "rc=$rc level=${before_level}->${after_level} rows=${before_rows}->${after_rows} marker=$marker_present"
+fi
+teardown
+
+# T12: --reset-detection-baseline also leaves the tree clean (parity
+# with --enforcement-level). The audit-row write that the reset path
+# performs now lands in a commit, not as drift.
+echo "T12: --reset-detection-baseline → working tree clean"
+setup_personal
+( cd "$PROJ" && echo zz > zz && git add zz && git commit -qm zz )
+if ( cd "$PROJ" && bash "$RECONFIG" --reset-detection-baseline >/dev/null 2>&1 ); then
+  dirty=$( cd "$PROJ" && git status --porcelain 2>/dev/null )
+  if [ -z "$dirty" ]; then
+    pass "T12: working tree clean post-baseline-reset"
+  else
+    fail_ "T12" "dirty:\n$dirty"
+  fi
+else
+  fail_ "T12" "reconfigure failed"
 fi
 teardown
 


### PR DESCRIPTION
## Summary

Silent-bypass security defect: `scripts/reconfigure-project.sh --enforcement-level <X>` wrote `manifest.json` + `bypass-audit.json` + invoked `install-filesystem-gates.sh` with `|| true` swallowing the installer's exit code. On installer failure the manifest claimed the new level and the audit log carried an attesting row — but no SOIF marker was installed in `.git/hooks/pre-commit`. The framework-gate never ran on subsequent user-terminal commits while the manifest and audit log lied about strict enforcement being active. Zero user feedback; only surfaces when something the operator expected to be blocked slips through.

Same family as PR #54 (init.sh atomic finalize). Naive port of that pattern: snapshot → write → run installer with failure propagation → on failure rollback + exit 1 → on success finalize_commit + refresh baseline.

## What changed

- **`finalize_reconfigure_commit` helper** — commits any post-mutation state with a chore subject, refreshes `.claude/last-checked-commit.txt` to new HEAD so BL-030 detector doesn't flag the reconfigure as out-of-band.
- **`--enforcement-level` path** — snapshots both files to adjacent mktemp before any write; drops `|| true` on installer call; `rollback_reconfigure` restores both files + exits 1 with a 4-line stderr explaining what was rolled back. Success path emits a commit subject `chore: enforcement-level <old> -> <new> (reconfigure)` so a reader can reconstruct the transition from `git log --oneline`.
- **Installer lookup** — prefers project-local `scripts/install-filesystem-gates.sh` over the framework copy. Honors any rollback/migration state and lets tests inject a fake installer without touching the framework repo.
- **`--reset-detection-baseline` path** — now finalize-commits its audit-row write so the working tree stays clean (parity with `--enforcement-level`). Subject: `chore: reset detection baseline (reconfigure)`.

## Tests

T1–T7 preserved as regression guards. T7's expected-baseline assertion moved from pre-call to post-call because the reset path now advances HEAD by one commit; baseline correctly tracks the finalize commit.

**New T8–T12 in `tests/test-enforcement-level-reconfigure.sh`:**
- T8 — `--enforcement-level` → `git status --porcelain` empty
- T9 — commit subject matches `chore: enforcement-level X -> Y (reconfigure)`
- T10 — **light→strict installer failure** rolls back (manifest unchanged, no audit row, no SOIF marker, exit non-zero)
- T11 — **strict→light installer failure** rolls back (manifest still strict, no audit row, SOIF marker still present, exit non-zero)
- T12 — `--reset-detection-baseline` → working tree clean

## Scope correction from the survey verifier

The shared `apply_enforcement_transition()` helper extraction into `scripts/lib/enforcement-level.sh` was deliberately NOT done. The init.sh and reconfigure-project.sh call sites diverge meaningfully (init seeds 5+ manifest fields pre-first-commit; reconfigure mutates one field in an established repo with rollback needs). Pattern stays local. Can extract if a third caller emerges.

## Test plan
- [x] `tests/test-enforcement-level-reconfigure.sh` (12/12 — extends 7 → 12)
- [x] `tests/test-enforcement-level-init.sh` (8/8)
- [x] `tests/test-enforcement-level-lib.sh` (10/10)
- [x] `tests/test-init-atomic-finalize.sh` (8/8)
- [x] `tests/test-init-no-remote-creation.sh` (3/3)
- [x] `tests/test-init-other-host-attestation.sh` (2/2)
- [x] `tests/test-bl030-calibration-replay.sh` (4/4)
- [x] `tests/test-bypass-audit-schema.sh` (3/3)
- [x] `tests/test-bypass-audit-integrity.sh` (8/8)
- [x] `tests/test-bypass-audit-lib.sh` (10/10)
- [x] `tests/test-bypass-detector.sh` (15/15)
- [x] `tests/test-out-of-band-detector.sh` (8/8)
- [x] `tests/test-record-claude-commit.sh` (5/5)
- [x] `tests/test-filesystem-gate-install.sh` (7/7)
- [x] `tests/test-pre-commit-gate-terminal-mode.sh` (3/3)
- [x] `tests/test-gate-principles.sh` (3/3)
- [x] `tests/test-session-test-gate-check-merge.sh` (7/7)
- [x] `tests/test-poc-modes.sh` (5/5)
- [x] `tests/test-upgrade-paths.sh` (8/8)
- [x] `tests/test-upgrade-bl030-backfill.sh` (7/7)
- [x] `tests/test-verify-install-bl030-coverage.sh` (8/8)
- [x] `tests/test-check-gate.sh` (5/5)
- [x] `tests/test-check-phase-gate-counter-sanitizer.sh` (7/7)
- [x] `tests/test-phase-finalize.sh` (6/6)
- [x] `tests/test-process-checklist-classifier.sh` (12/12)
- [x] `tests/test-pre-commit-gate-classifier.sh` (6/6)

🤖 Generated with [Claude Code](https://claude.com/claude-code)