### PR TITLE
test(bitbucket): export BITBUCKET_WORKSPACE in driver unit test

### DIFF
--- a/tests/host-drivers/bitbucket.test.sh
+++ b/tests/host-drivers/bitbucket.test.sh
@@ -12,17 +12,22 @@ source "$REPO_ROOT/scripts/host-drivers/bitbucket.sh"
 assert_eq "bitbucket" "$(host_name)" "host_name"
 echo "bitbucket.test.sh: host_name PASSED"
 
-# host_require_cli — no creds
-unset BITBUCKET_USER BITBUCKET_APP_PASSWORD
+# host_require_cli — no creds. Defensively unset all three vars so an
+# inherited test env doesn't satisfy the check accidentally.
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
 set +e; output=$(host_require_cli 2>&1); code=$?; set -e
 assert_exit_code 1 "$code" "no creds fails"
 assert_contains "$output" "BITBUCKET_USER" "mentions env var"
 
-# with creds
-export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass"
+# with creds — driver requires all three vars (audit code-host-bitbucket-1
+# added BITBUCKET_WORKSPACE alongside USER + APP_PASSWORD). Pre-fix the
+# test exported only USER + APP_PASSWORD, so host_require_cli fell into
+# its "missing var" branch and emitted the App-Password help text +
+# returned 1 — ASSERT FAIL "with creds passes".
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="testws"
 set +e; host_require_cli; code=$?; set -e
 assert_exit_code 0 "$code" "with creds passes"
-unset BITBUCKET_USER BITBUCKET_APP_PASSWORD
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
 echo "bitbucket.test.sh: host_require_cli PASSED"
 
 # host_register_remote


### PR DESCRIPTION
## Summary

Stale-test fix. `scripts/host-drivers/bitbucket.sh::host_require_cli` requires all three of `BITBUCKET_USER`, `BITBUCKET_APP_PASSWORD`, and `BITBUCKET_WORKSPACE` per audit `code-host-bitbucket-1`. The driver was updated; its unit test on line 22 still only exported the first two. The "with creds passes" assertion fell into the no-creds branch and emitted the App-Password help text — ASSERT FAIL on any contributor checkout without real BITBUCKET_* env vars.

This was the lone failing suite in `tests/host-drivers/run-all.sh` on clean clones since the audit fix shipped (flagged during cycle 4 regression sweeps).

## Change

1-line fix on the export, plus env hygiene (extended the `unset` on lines 16 + 25 to also clear `BITBUCKET_WORKSPACE`). No production code touched.

## Scope correction

Cycle 5 survey verifier corrected the original framing of this as a "curl-stub rework" sibling to BL-003b. The file **never calls curl** — the four assertion blocks exercise:
- `host_name` (pure)
- `host_require_cli` (env-var inspection only)
- `host_register_remote` (git ops)
- `_bb_parse_origin` (git ops)

No mock-infra rework needed. BL-003b's curl-stub work proceeds independently.

## Test plan
- [x] `tests/host-drivers/bitbucket.test.sh` (4/4)
- [x] `tests/host-drivers/run-all.sh` (7 run, 0 failed — first time green on clean clone since the audit fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)