### PR TITLE
docs(bl030): close 4 S3 audit findings + amend spec §7.5 to match shipped --confirm-pitfalls semantics

### DIFF
--- a/docs/superpowers/specs/2026-04-28-bl030-enforcement-model-design.md
+++ b/docs/superpowers/specs/2026-04-28-bl030-enforcement-model-design.md
@@ -302,7 +302,7 @@ For `strict`, no banner. The absence of friction is the signal.
 
 ### 7.5 Non-interactive
 
-`init.sh --enforcement-level <level>` for non-interactive callers. If level is `light` or `no` AND mode is choosable, the flag confirms automatically (suppresses pitfall blocks); pair with `--confirm-pitfalls` for explicit-acknowledgment semantics required by automated callers (test suite, BL-025 helpers). If level is `strict` or mode is non-choosable, the flag has no effect beyond setting the value.
+`init.sh --enforcement-level <level>` for non-interactive callers. If level is `light` or `no` AND mode is choosable, both `--enforcement-level=<no|light>` and `--confirm-pitfalls` are required for non-interactive downgrade — there is no "flag confirms automatically" shortcut. Without `--confirm-pitfalls`, the caller refuses with `print_fail` and exits 1 (see `init.sh:3529-3530` and `scripts/reconfigure-project.sh:106`). The same dual-flag requirement applies to `scripts/reconfigure-project.sh --enforcement-level <no|light>`. If level is `strict` or mode is non-choosable, `--confirm-pitfalls` is not required and the level flag has no effect beyond setting the value.
 
 ## 8. Strict-mode integration with `.git/hooks/pre-commit`
 


### PR DESCRIPTION
## Summary

Pure docs / audit-record PR. Zero code touched. Ships S3 cleanup items
**46a** (close 4 truly-subsumed audit findings) and **46b** (amend
BL-030 spec §7.5 to match as-shipped behavior).

Verified each closeout claim against the live tree before committing —
no lies into the audit ledger.

---

## 46a — Audit closeouts (4 of 6 originally proposed)

The cycle 5 survey verifier proposed closing 6 Slice D findings as
subsumed by prior PRs. Only 4 actually are. This PR closes those 4.
The remaining 2 are explicitly deferred (see "Not closed here" below).

### Closed by this PR

| Finding ID | Closing PR | Evidence (file:line) |
| --- | --- | --- |
| `code-escalate-pending-5` | #50 | `scripts/escalate-to-user.sh:96-102` — `bypass_audit_append` failure propagates with `exit 1` + 4-line stderr; the prior `\|\| true` swallow is gone. |
| `code-escalate-pending-6` | #50 | `scripts/lib/bypass-audit.sh:150` — jq filter is now `if .type == "claude_bypass_proposal" and .user_response == "PENDING" then …`, type-scoped so escalation rows are not collateral-closed. |
| `tier-crosscheck-1` | #48 | `enforcement_level` is a real manifest-persisted axis: read at `scripts/lib/enforcement-level.sh:24`, written at `init.sh:3569` (`bl030_finalize_init`), updated at `scripts/reconfigure-project.sh:148`. The "documented but not implemented" predicate is dead. |
| `specs-plans-pending-approval-bl015-6` | #50 | `scripts/escalate-to-user.sh:58-64` delegates sentinel writes to `bash "$SCRIPT_DIR/pending-approval.sh" --offer`, which uses BL-015's atomic mktemp+mv path. |

### Not closed here (deferred to sibling PRs)

- `specs-plans-bl029-bl030-5` — `scripts/record-claude-commit.sh` still
  uses a naive substring match. Sibling agent is shipping the fix on
  branch `fix/record-claude-commit-classifier`; that PR will close this
  finding.
- `code-upgrade-project-8` — `--to-production` pre-condition guard.
  Verifier deferred this to its own PR because it changes the
  success-path semantics, not just a defect cleanup.

---

## 46b — BL-030 spec amendment (closes `specs-plans-bl029-bl030-8`)

`docs/superpowers/specs/2026-04-28-bl030-enforcement-model-design.md`
§7.5 described a non-interactive flow that was never the as-shipped
behavior. Amended to match what `init.sh` and `reconfigure-project.sh`
actually do.

### Before (line 305)

> `init.sh --enforcement-level <level>` for non-interactive callers. If level is `light` or `no` AND mode is choosable, **the flag confirms automatically (suppresses pitfall blocks); pair with `--confirm-pitfalls` for explicit-acknowledgment semantics required by automated callers** (test suite, BL-025 helpers). If level is `strict` or mode is non-choosable, the flag has no effect beyond setting the value.

### After

> `init.sh --enforcement-level <level>` for non-interactive callers. If level is `light` or `no` AND mode is choosable, **both `--enforcement-level=<no\|light>` and `--confirm-pitfalls` are required for non-interactive downgrade — there is no "flag confirms automatically" shortcut. Without `--confirm-pitfalls`, the caller refuses with `print_fail` and exits 1** (see `init.sh:3529-3530` and `scripts/reconfigure-project.sh:106`). The same dual-flag requirement applies to `scripts/reconfigure-project.sh --enforcement-level <no\|light>`. If level is `strict` or mode is non-choosable, `--confirm-pitfalls` is not required and the level flag has no effect beyond setting the value.

### As-shipped behavior (cited)

**`init.sh:3528-3533`** — non-interactive init refuses without `--confirm-pitfalls`:

```bash
light|no)
  if [ "$CONFIRM_PITFALLS" != "1" ]; then
    print_fail "BL-030: non-interactive downgrade to '$ENFORCEMENT_LEVEL' requires --confirm-pitfalls."
    exit 1
  fi
  ;;
```

**`scripts/reconfigure-project.sh:104-111`** — reconfigure refuses identically:

```bash
case "$RECONF_LEVEL" in
  light|no)
    if [ "$RECONF_CONFIRM" != "1" ]; then
      print_fail "Downgrade to '$RECONF_LEVEL' requires --confirm-pitfalls."
      echo "  See docs/superpowers/specs/2026-04-28-bl030-enforcement-model-design.md § 10." >&2
      exit 1
    fi
    ;;
esac
```

---

## Test plan

Pure docs / audit-record PR.

- [x] Diff is exactly 1 file, 1 insertion, 1 deletion (spec §7.5 paragraph)
- [x] No `.sh`, `.bats`, `.json`, hook, or installer file touched
- [x] All 4 closeout claims verified against live `main` tree before commit
- [x] Both closing PRs (#48, #50) confirmed `MERGED` on `main` via `gh pr view`
- [x] Amended §7.5 wording is consistent with `init.sh:3529-3530` and `scripts/reconfigure-project.sh:106`

🤖 Generated with [Claude Code](https://claude.com/claude-code)