### PR TITLE
fix(record-claude-commit): anchored git-commit classifier (closes specs-plans-bl029-bl030-5)

### DIFF
--- a/scripts/hooks/record-claude-commit.sh
+++ b/scripts/hooks/record-claude-commit.sh
@@ -32,12 +32,32 @@ CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
 EXIT=$(echo "$INPUT" | jq -r '.tool_response.exit_code // 1' 2>/dev/null)
 
 # Filter: must be a `git commit` (not `git commit-tree`, etc.) and must have succeeded.
-# Match: 'git commit' or 'git commit ' followed by anything, but not 'git commit-tree'.
-case "$CMD" in
-  *"git commit"*) ;;
-  *) exit 0 ;;
-esac
-echo "$CMD" | grep -qE 'git[[:space:]]+commit-tree' && exit 0
+#
+# Audit finding `specs-plans-bl029-bl030-5` (sibling of BL-020 on the
+# pre-commit-gate side): the previous naive substring match
+# `case "$CMD" in *"git commit"*)` false-positives on innocuous commands
+# whose argv or output happens to contain the literal string `git commit`
+# (e.g., `echo "see git commit later"`, `rg "git commit" docs/`,
+# `cat scripts/pre-commit-gate.sh | grep "git commit"`). Each false-positive
+# polluted the BL-029 ledger with a spurious entry mapped to whatever the
+# current HEAD happened to be, which the out-of-band detector then trusted.
+#
+# Tightened classifier (verbatim from `scripts/pre-commit-gate.sh:81-93`):
+#   `commit` must come immediately after `git` (separated only by whitespace),
+#   and `git` must NOT be preceded by a quote — so `rg "git commit"` is rejected
+#   while `cd /tmp && git commit ...` (preceded by whitespace) is accepted.
+#
+# --amend semantics (option C from the audit response): no special-casing.
+# `git commit --amend` runs the normal flow — the amended commit is recorded
+# as a fresh ledger entry under its new HEAD SHA. The pre-amend entry remains
+# as an orphan SHA in the append-only ledger; this is acceptable because the
+# out-of-band detector matches against ledger membership, so the amended SHA
+# is correctly classified as Claude-issued rather than user-terminal.
+_is_git_commit() {
+  echo "$1" | grep -qE '(^|[^"'\''])git[[:space:]]+commit\b'
+}
+_is_git_commit "$CMD" || exit 0
+echo "$CMD" | grep -qE '(^|[^"'\''])git[[:space:]]+commit-tree\b' && exit 0
 [ "$EXIT" != "0" ] && exit 0
 
 # Capture HEAD SHA. If unreadable, no-op silently.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -629,6 +629,8 @@ Three-tier enforcement level (`no` / `light` / `strict`) configurable at init or
 
 **Audit follow-up:** the v2 audit finding `specs-plans-bl029-bl030-3` ("spec exists; ZERO implementation") is now closed.
 
+**Audit follow-up:** the v2 audit finding `specs-plans-bl029-bl030-5` ("naive substring match in `scripts/hooks/record-claude-commit.sh` + missing --amend handling") is now closed. The BL-029 ledger recorder now uses the anchored regex `(^|[^"'\''])git[[:space:]]+commit\b` (verbatim sibling of the BL-020 fix in PR #53 on `scripts/pre-commit-gate.sh:81-93`), rejecting quote-preceded false-positives like `grep "git commit"`. `git commit --amend` is treated as a fresh ledger entry (option C from the audit response) — the amended SHA is recorded so the out-of-band detector classifies it as Claude-issued, and the original entry persists harmlessly as an orphan SHA in the append-only ledger. Regression coverage: `tests/test-record-claude-commit.sh` T6-T9 (9/9 total).
+
 ---
 
 ## BL-031: init.sh:2009 hardcodes GitHub-branded messaging for any driver returning exit 3

--- a/tests/test-record-claude-commit.sh
+++ b/tests/test-record-claude-commit.sh
@@ -123,6 +123,90 @@ EOF
 fi
 rm -rf "$TMP"
 
+# T6-T9: BL-020 sibling — audit finding `specs-plans-bl029-bl030-5`.
+# Pre-fix the classifier used a naive substring match (`*"git commit"*`),
+# which false-positives on innocuous commands whose argv contains the
+# literal `git commit` (echo strings, grep search patterns, etc.). Each
+# false-positive polluted the ledger with HEAD-at-the-time as a spurious
+# Claude-issued entry. Mirrors the BL-020 fix that landed in PR #53 for
+# `scripts/pre-commit-gate.sh`.
+
+# T6: quote-preceded false-positive must NOT record. The literal `git commit`
+# appears immediately after a `"` in a grep search pattern (the regex
+# `[^"']` rejects quote-preceded matches; start-of-line is the only other
+# anchor and doesn't apply here).
+echo "T6: PostToolUse hook ignores 'git commit' inside a quoted grep pattern (piped)"
+setup
+cd "$TMP"
+cat <<'EOF' | bash "$HOOK" >/dev/null 2>&1
+{"tool_input":{"command":"cat scripts/pre-commit-gate.sh | grep \"git commit\""},"tool_response":{"exit_code":0}}
+EOF
+if [ ! -f "$TMP/.claude/claude-commits.jsonl" ]; then
+  pass "T6"
+else
+  fail_ "T6" "ledger created for 'grep \"git commit\"' (quote-preceded false-positive)"
+fi
+teardown
+
+# T7: grep search-string false-positive must NOT record.
+echo "T7: PostToolUse hook ignores 'git commit' inside a grep/rg search pattern"
+setup
+cd "$TMP"
+cat <<'EOF' | bash "$HOOK" >/dev/null 2>&1
+{"tool_input":{"command":"rg \"git commit\" docs/"},"tool_response":{"exit_code":0}}
+EOF
+if [ ! -f "$TMP/.claude/claude-commits.jsonl" ]; then
+  pass "T7"
+else
+  fail_ "T7" "ledger created for 'rg \"git commit\" docs/' (search-string false-positive)"
+fi
+teardown
+
+# T8: cross-cmd-chain happy path — preceded by `&&`, not at line start.
+echo "T8: PostToolUse hook DOES record a chained 'cd foo && git commit ...'"
+setup
+cd "$TMP"
+cat <<EOF | bash "$HOOK" >/dev/null 2>&1
+{"tool_input":{"command":"cd $TMP && git commit --allow-empty -m 'chained'"},"tool_response":{"exit_code":0}}
+EOF
+if [ -f "$TMP/.claude/claude-commits.jsonl" ] && \
+   jq -e --arg sha "$SHA" '.sha == $sha' < "$TMP/.claude/claude-commits.jsonl" >/dev/null 2>&1; then
+  pass "T8"
+else
+  fail_ "T8" "chained 'cd && git commit' should have been recorded"
+fi
+teardown
+
+# T9: --amend handling — option C: record amended commits as a fresh entry.
+# Rationale: keeping the original entry as an orphan SHA is fine (the ledger
+# is append-only). Recording the new HEAD ensures the out-of-band detector
+# sees the amended SHA in the ledger and classifies it as Claude-issued
+# rather than user-terminal. No special-casing needed in the hook — the
+# normal flow handles --amend correctly.
+echo "T9: PostToolUse hook records 'git commit --amend' as a fresh ledger entry (option C)"
+setup
+cd "$TMP"
+# Pre-seed: record the initial commit.
+cat <<EOF | bash "$HOOK" >/dev/null 2>&1
+{"tool_input":{"command":"git commit -m 'first'"},"tool_response":{"exit_code":0}}
+EOF
+ORIG_SHA="$SHA"
+# Now amend: HEAD SHA changes.
+( cd "$TMP" && git commit --amend --no-edit -q 2>/dev/null )
+AMENDED_SHA=$(cd "$TMP" && git rev-parse HEAD)
+cat <<EOF | bash "$HOOK" >/dev/null 2>&1
+{"tool_input":{"command":"git commit --amend --no-edit"},"tool_response":{"exit_code":0}}
+EOF
+if [ -f "$TMP/.claude/claude-commits.jsonl" ] && \
+   [ "$(wc -l < "$TMP/.claude/claude-commits.jsonl" | tr -d ' ')" = "2" ] && \
+   grep -q "$AMENDED_SHA" "$TMP/.claude/claude-commits.jsonl" && \
+   grep -q "$ORIG_SHA" "$TMP/.claude/claude-commits.jsonl"; then
+  pass "T9"
+else
+  fail_ "T9" "expected 2 entries (original + amended SHAs); got: $(cat "$TMP/.claude/claude-commits.jsonl" 2>/dev/null)"
+fi
+teardown
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes audit finding `specs-plans-bl029-bl030-5` on `scripts/hooks/record-claude-commit.sh`. Same defect class as BL-020 on the sister hook `scripts/pre-commit-gate.sh` (fixed in PR #53).

**Defect 1 — naive substring match (line ~37):**

```sh
case "$CMD" in *"git commit"*) ;; *) exit 0 ;; esac
```

False-positives on innocuous commands whose argv contains the literal string `git commit`: `echo "see git commit later"`, `cat scripts/pre-commit-gate.sh | grep "git commit"`, `rg "git commit" docs/`. Each false-positive polluted `.claude/claude-commits.jsonl` with a spurious entry mapped to whatever HEAD happened to be — which the out-of-band detector then trusted as a Claude-issued commit.

**Fix — verbatim copy of `scripts/pre-commit-gate.sh:81-93` (the BL-020 precedent):**

```sh
_is_git_commit() {
  echo "$1" | grep -qE '(^|[^"'"'"'])git[[:space:]]+commit\b'
}
```

`commit` must come immediately after `git` (whitespace-separated); `git` must NOT be preceded by a quote. Start-of-line is allowed; chained `cd /foo && git commit ...` still matches because `git` is preceded by whitespace.

**Defect 2 — `git commit --amend` not handled (line ~44):**

`SHA=$(... && git rev-parse HEAD)` captures HEAD after-the-fact. After `--amend`, HEAD has a new SHA, leaving the original ledger entry pointing at a now-orphan SHA while the new SHA is unrecorded — the out-of-band detector then flags the amended SHA as user-terminal.

**Fix — option C (record amended commits as a fresh entry):**

No special-casing in the hook. The normal flow records the amended commit under its new HEAD SHA. The pre-amend entry persists harmlessly as an orphan SHA in the append-only ledger. The out-of-band detector matches against ledger membership, so the amended SHA is correctly classified as Claude-issued. Options A (skip the hook on --amend, leaves the amended SHA undetected) and B (rewrite the prior entry, requires fragile commit-message matching) were rejected.

## Test plan

- [x] `bash tests/test-record-claude-commit.sh` — **9/9** (T1-T5 unchanged; T6-T9 new)
  - T6: `cat ... | grep "git commit"` (quote-preceded false-positive) — NOT recorded
  - T7: `rg "git commit" docs/` (search-string false-positive) — NOT recorded
  - T8: `cd $TMP && git commit ...` (chained happy path) — recorded
  - T9: `git commit --amend --no-edit` (option C semantics) — recorded as fresh entry, original entry preserved
- [x] `bash tests/test-pre-commit-gate-classifier.sh` — **6/6** (sister suite, unaffected)
- [x] `bash tests/test-out-of-band-detector.sh` — **8/8** (ledger consumer, unaffected by entry shape)
- [x] `bash tests/test-bl030-calibration-replay.sh` — **4/4** (calibration replay)

## Backlog

Closure note added to `solo-orchestrator-backlog.md` under the BL-030 section's existing "Audit follow-up" pattern (parallel to the `specs-plans-bl029-bl030-3` closure).

Generated with Claude Code.