### PR TITLE
fix(init): host-agnostic exit-3 attestation flow (BL-031)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1996,9 +1996,13 @@ create_and_protect_remote() {
     host_push_initial main 2>/dev/null || host_push_initial master || { print_fail "Push failed — $remote_url exists but empty"; return 1; }
 
     print_info "Configuring branch protection ($mode mode)..."
-    # BL-002: capture exit code 3 for github free-tier 403 (host_configure_protection
-    # detects the "Upgrade to GitHub Pro" pattern). Fall through to the attestation
-    # flow shared with the --git-host other path so init can complete cleanly.
+    # BL-002 / BL-031: exit code 3 is the host-agnostic "expected partial
+    # failure — attestation fallback is appropriate" signal. The github driver
+    # returns 3 on free-tier 403; the gitlab driver returns 3 when org-mode
+    # approvals PUT fails; future drivers may use 3 for similar semantics.
+    # The driver itself emits host-specific remediation on stderr BEFORE this
+    # block runs — we echo a host-agnostic summary and route to the shared
+    # attestation flow rather than hardcoding GitHub-Pro wording (BL-031).
     local _hcp_rc=0
     host_configure_protection main "$mode" || _hcp_rc=$?
     if [ "$_hcp_rc" -ne 0 ] && [ "$_hcp_rc" -ne 3 ]; then
@@ -2007,18 +2011,22 @@ create_and_protect_remote() {
     fi
 
     if [ "$_hcp_rc" -eq 3 ]; then
-      print_warn "Branch protection unavailable on this repo (free-tier limit)."
-      print_info "Falling back to attestation flow — see remediation message above."
+      print_warn "Branch protection unavailable via standard API on this $host repo."
+      print_info "Falling back to attestation flow — see $host driver remediation message above."
       local attest
       if [ "${BRANCH_PROTECTION_ATTESTED:-false}" = true ]; then
         attest="yes"
         print_info "Branch protection attested via --branch-protection-attested flag."
       else
-        read -rp "Attest that protection will be enforced manually until you upgrade? [type 'yes' to attest]: " attest
+        read -rp "Attest that protection will be enforced manually? [type 'yes' to attest]: " attest
       fi
-      [ "$attest" != "yes" ] && { print_fail "Attestation required — cannot proceed (or upgrade to GitHub Pro)"; return 1; }
+      [ "$attest" != "yes" ] && { print_fail "Attestation required — cannot proceed (see $host driver remediation above)"; return 1; }
       # Record attestation with the github_free_tier reason so check-gate.sh
-      # --preflight skips the API verify.
+      # --preflight skips the API verify. The reason string is retained for
+      # backward compat with check-gate.sh and tests/test-check-gate.sh::T5;
+      # broadening the reason taxonomy is out of scope for BL-031 (UX-only
+      # fix). Downstream code reads the reason as a "skip API verify" sentinel
+      # regardless of host, so the wording is harmless for non-github paths.
       mkdir -p .claude
       if [ ! -f .claude/process-state.json ]; then
         echo '{"phase2_init":{"steps_completed":[],"attestations":{}}}' > .claude/process-state.json
@@ -2027,7 +2035,7 @@ create_and_protect_remote() {
          '.phase2_init.attestations.branch_protection = {attested_by: "orchestrator", at: $at, reason: "github_free_tier"}' \
          .claude/process-state.json > .claude/process-state.json.tmp \
          && mv .claude/process-state.json.tmp .claude/process-state.json
-      print_ok "Free-tier attestation recorded — check-gate.sh --preflight will honor it."
+      print_ok "Partial-protection attestation recorded — check-gate.sh --preflight will honor it."
     elif [ "$_hcp_rc" -ne 0 ]; then
       print_fail "Protection config failed — run 'scripts/check-gate.sh --repair' after troubleshooting"
       return 1

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -636,19 +636,17 @@ Three-tier enforcement level (`no` / `light` / `strict`) configurable at init or
 **Logged:** 2026-06-27
 **Category:** Bug (UX, cross-driver)
 **Severity:** Medium
+**Status:** Closed — shipped 2026-06-27 (this commit, branch `fix/init-bl031-cross-wiring`).
 
 `scripts/host-drivers/gitlab.sh:120` returns exit 3 from `host_configure_protection` when the org-mode approvals PUT fails. `init.sh:2009` treats `_hcp_rc=3` as the GitHub-free-tier attestation fallback and surfaces a print_warn with the literal string `"Branch protection unavailable on this repo (free-tier limit)"` plus a print_info chain mentioning `"Upgrade to GitHub Pro"`. A GitLab user with partial token scopes lands in the wrong remediation flow with wrong-host messaging.
 
 The exit code 3 was originally a github-specific signal ("free-tier 403 detected — fall back to attestation"). When the gitlab driver was added, exit 3 was reused for a different semantic (gitlab approvals PUT failed) without the init.sh dispatch being updated to disambiguate.
 
-**Scope:**
-1. Either: make exit 3 host-agnostic — rename the message to "Branch protection unavailable on this repo (extended-flow available)" and drop the GitHub-Pro-specific remediation. Drivers stay free to return 3 for their own "expected partial failure" semantics.
-2. Or: require the host driver to emit the host-specific remediation text on stderr and have init.sh echo whatever the driver said.
-3. Update `tests/host-drivers/e2e-init-gitlab.test.sh::T6` to assert the corrected behavior.
+**Resolution:** option 1 (host-agnostic init.sh wording). The init.sh exit-3 branch (lines ~1998-2045) now parameterizes the warn/info on `$host` ("Branch protection unavailable via standard API on this $host repo" / "see $host driver remediation message above") and defers host-specific remediation to the driver's own stderr — which is already emitted before init.sh prints these lines. The driver code (github.sh:120-132, gitlab.sh:120) was deliberately not touched: the exit-3 contract ("I failed in a way you can attest around") is correct; the bug was init.sh interpreting that contract with GitHub-only words. The attestation reason string `github_free_tier` is retained for backward compat with `scripts/check-gate.sh` and `tests/test-check-gate.sh::T5`; broadening the reason taxonomy is out of scope for this fix.
 
-**Detection regression test exists:** `tests/host-drivers/e2e-init-gitlab.test.sh:T6` (added with BL-003a PR) currently asserts the BUGGY GitHub-branded message as a regression guard. The test comment flags it for update once this is fixed.
+**Regression test updated:** `tests/host-drivers/e2e-init-gitlab.test.sh::T6` now asserts the corrected behavior: init exits 0 (U-B contract preserved), log does NOT contain "GitHub Pro" or "free-tier limit", log DOES contain `"on this gitlab repo"` / `"gitlab driver remediation"` plus the gitlab driver's own `"approvals config failed"` stderr.
 
-**Trigger:** opportunistic — fix when next touching init.sh's host dispatch or the host-driver exit-code contract.
+**Verification:** `tests/host-drivers/e2e-init-gitlab.test.sh` 6/6 PASS · `tests/host-drivers/e2e-init.test.sh` 5/5 PASS (github regression) · `tests/test-github-free-tier-403.sh` 4/4 PASS (driver unchanged).
 
 **Related:** BL-003a (introduced the T6 detection test).
 

--- a/tests/host-drivers/e2e-init-gitlab.test.sh
+++ b/tests/host-drivers/e2e-init-gitlab.test.sh
@@ -333,24 +333,28 @@ scenario_teardown
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
-echo "=== T6: gitlab-exit-3 cross-wiring documentation (latent bug) ==="
+echo "=== T6: gitlab-exit-3 host-agnostic attestation flow (BL-031 fix) ==="
 # ════════════════════════════════════════════════════════════════════
 
-# T6 DOCUMENTS a latent cross-wiring bug surfaced by the cycle 5 survey.
-# Gitlab's host_configure_protection returns exit 3 when the org-mode
-# approvals PUT fails (lines 116-120 in scripts/host-drivers/gitlab.sh).
-# init.sh line 2009 treats _hcp_rc=3 as the github-free-tier attestation
-# fallback — a gitlab user lands in a flow whose stderr says
-# "Branch protection unavailable on this repo (free-tier limit)" and
-# "Upgrade to GitHub Pro" — wrong host name and wrong remediation.
+# T6 verifies the BL-031 fix at init.sh:1998-2045: the exit-3 attestation
+# fallback is now host-agnostic. Before BL-031, a gitlab org-mode approvals
+# PUT failure (gitlab.sh:120 returns exit 3) was met with GitHub-branded
+# messaging — "Branch protection unavailable on this repo (free-tier limit)"
+# and "Upgrade to GitHub Pro" — because init.sh:2010-2019 hardcoded those
+# strings against any exit-3 driver return.
 #
-# This test asserts the CURRENT (buggy) observable behavior:
+# Post-fix, init.sh parameterizes the warn/info on $host and defers
+# host-specific remediation to the driver's own stderr (already emitted by
+# gitlab.sh:120 above the init.sh dispatch). The github driver remains
+# unchanged — github e2e T5 + tests/test-github-free-tier-403.sh still pass
+# because the driver's own "GitHub Pro" stderr is what those tests assert.
+#
+# This test now asserts the CORRECTED behavior:
 #   - init.sh exit 0 (U-B contract: warn + continue)
-#   - the GitHub-branded misleading message appears in the log
-#
-# When the cross-wiring is fixed (separate PR — see backlog), this test
-# must be updated to assert the corrected gitlab-aware messaging.
-echo "T6: org approvals PUT fails — DOCUMENTS gitlab-exit-3 cross-wiring at init.sh:2009"
+#   - the log does NOT contain "GitHub Pro" or "free-tier limit"
+#   - the log mentions "gitlab" in the warn/info (host-aware)
+#   - the gitlab driver's own stderr ("approvals config failed") surfaces
+echo "T6: org approvals PUT fails — host-agnostic attestation flow (BL-031 fixed)"
 scenario_setup "https://gitlab.com/e2e-test/approvals-fail.git"
 export MOCK_GL_PROTECT_JSON="$PROTECT_JSON_ORG"
 export MOCK_GL_APPROVALS_JSON="$APPROVALS_JSON_ORG"
@@ -361,13 +365,22 @@ export MOCK_GL_APPROVALS_PUT_ERR='ERROR: 403 — approvals PUT requires premium 
 # DOES on this code path, not block on attestation UX.
 run_init_e2e approvals-fail organizational --gov-mode production --branch-protection-attested
 rc=$?
-# Bug evidence: gitlab user sees GitHub-branded messaging.
+# Fix evidence: no GitHub-branded leak.
 github_branding_seen=no
 grep -qE 'GitHub Pro|free-tier limit' "$TMP/init.log" && github_branding_seen=yes
-if [ "$rc" = "0" ] && [ "$github_branding_seen" = "yes" ]; then
-  pass "T6: gitlab exit-3 → GitHub-branded message (DOCUMENTED CROSS-WIRING BUG — see backlog)"
+# Fix evidence: init.sh's own warn/info names the actual host.
+gitlab_branding_seen=no
+grep -qE 'on this gitlab repo|gitlab driver remediation' "$TMP/init.log" && gitlab_branding_seen=yes
+# Fix evidence: gitlab driver's own stderr surfaces (host-specific context).
+driver_stderr_seen=no
+grep -q 'approvals config failed' "$TMP/init.log" && driver_stderr_seen=yes
+if [ "$rc" = "0" ] \
+   && [ "$github_branding_seen" = "no" ] \
+   && [ "$gitlab_branding_seen" = "yes" ] \
+   && [ "$driver_stderr_seen" = "yes" ]; then
+  pass "T6: gitlab exit-3 → host-agnostic attestation flow with gitlab-aware messaging (BL-031 fixed)"
 else
-  fail_ "T6" "rc=$rc github_branding_seen=$github_branding_seen — cross-wiring not observed as expected; check init.sh:2009 + gitlab.sh:116-120 still match the surveyed shape. log:$(tail -10 "$TMP/init.log")"
+  fail_ "T6" "rc=$rc github_branding_seen=$github_branding_seen gitlab_branding_seen=$gitlab_branding_seen driver_stderr_seen=$driver_stderr_seen log:$(tail -10 "$TMP/init.log")"
 fi
 scenario_teardown
 


### PR DESCRIPTION
## Summary

Fixes the BL-031 cross-wiring bug at `init.sh:~2009`. `host_configure_protection` exit code 3 was a github-specific signal originally (BL-002 free-tier 403 fallback); the gitlab driver later reused exit 3 for a related but distinct semantic ("expected partial failure — attest around it") without the init.sh dispatch being updated. Result: gitlab users whose org-mode approvals PUT failed landed in a flow whose stderr said *"Branch protection unavailable on this repo (free-tier limit)"* + *"Upgrade to GitHub Pro"* — wrong host, wrong remediation.

## Symptoms

- `--git-host gitlab` with `--gov-mode production` and limited token scopes triggers gitlab.sh:120's exit 3 (approvals PUT 403).
- init.sh prints github-branded warn/info even though the host is gitlab.
- Detection test `tests/host-drivers/e2e-init-gitlab.test.sh::T6` (added with BL-003a, PR #59 sibling) was already in place asserting this BUGGY behavior as a regression guard, with a comment flagging it for update once fixed.

## Root cause

`init.sh:2010-2019` hardcoded GitHub-Pro-specific strings against any host driver returning exit 3. The driver code itself is fine — exit 3 is the correct semantic ("I failed in a way you can attest around"), and each driver already emits its own host-specific remediation on stderr (github.sh:120-132, gitlab.sh:120) BEFORE the init.sh dispatch prints these lines.

## Fix approach (option 1 from backlog)

- `init.sh` exit-3 branch now parameterizes the warn/info on `$host` ("Branch protection unavailable via standard API on this `$host` repo" / "see `$host` driver remediation message above") and defers host-specific remediation to the driver's own stderr.
- Driver code (`scripts/host-drivers/github.sh`, `scripts/host-drivers/gitlab.sh`) intentionally untouched — the exit-3 contract is right; only init.sh's interpretation was wrong.
- Attestation reason string `github_free_tier` retained for backward compat with `scripts/check-gate.sh` and `tests/test-check-gate.sh::T5`. Broadening the reason taxonomy is out of scope for this UX-only fix.

## Test changes

`tests/host-drivers/e2e-init-gitlab.test.sh::T6` flipped from documenting the bug to verifying the fix. New T6 asserts:

- init exits 0 (U-B contract preserved — warn + continue).
- Log does NOT contain `"GitHub Pro"` or `"free-tier limit"`.
- Log DOES contain `"on this gitlab repo"` / `"gitlab driver remediation"` (host-aware messaging).
- Gitlab driver's own `"approvals config failed"` stderr surfaces (host-specific context preserved).

`solo-orchestrator-backlog.md` BL-031 flipped Open → Closed with resolution citation and verification log.

## Test plan

- [x] `bash tests/host-drivers/e2e-init-gitlab.test.sh` — 6/6 PASS (T6 now verifies the fix)
- [x] `bash tests/host-drivers/e2e-init.test.sh` — 5/5 PASS (github regression)
- [x] `bash tests/test-github-free-tier-403.sh` — 4/4 PASS (driver-level, unchanged)
- [x] `bash tests/test-init-no-remote-creation.sh` — 3/3 PASS (init.sh adjacent)
- [x] `bash tests/test-init-atomic-finalize.sh` — 8/8 PASS (init.sh-heavy)

Closes BL-031.

🤖 Generated with [Claude Code](https://claude.com/claude-code)