### PR TITLE
fix(upgrade-project): vendored-skills sync + POC_TO_PRIVATE + Manifesto refresh (S3 sweep)

### DIFF
--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -306,6 +306,37 @@ fi
     print_info "To choose a less strict level (personal/choosable projects only):"
     print_info "  scripts/reconfigure-project.sh --enforcement-level <light|no> --confirm-pitfalls"
   fi
+
+  # --- Vendored-skills sync (audit code-upgrade-project-3, S3 sweep) ---
+  # init.sh's skill-install block (init.sh ~line 1239) enumerates each
+  # vendored skill explicitly. Skills shipped after a project was created
+  # (grill-with-docs, session-handoff, sweep-triage, zoom-out) never reach
+  # those projects on re-init. Iterating templates/generated/skills/*/ keeps
+  # the upgrade automatically in sync as new skills are added — no edits
+  # to upgrade-project.sh needed when a new skill lands. Lives inside the
+  # backfill block so --backfill-only picks it up (parallel to BL-030 and
+  # host-aware backfills). Idempotent: cp overwrites identically; the -ef
+  # self-copy guard handles the in-framework-repo invocation.
+  SKILLS_SRC_DIR="$ORCHESTRATOR_ROOT/templates/generated/skills"
+  if [ -d "$SKILLS_SRC_DIR" ]; then
+    mkdir -p .claude/skills
+    for skill_src in "$SKILLS_SRC_DIR"/*/; do
+      [ -d "$skill_src" ] || continue
+      skill_name=$(basename "$skill_src")
+      skill_dest=".claude/skills/$skill_name"
+      # Self-copy guard mirroring the helper-script block at the end of
+      # this script: when invoked from inside the framework repo, source
+      # and destination resolve to the same path and cp would error
+      # under set -euo pipefail.
+      if [ -d "$skill_dest" ] && [ "$skill_src" -ef "$skill_dest/" ]; then
+        continue
+      fi
+      mkdir -p "$skill_dest"
+      [ -f "$skill_src/SKILL.md" ] && cp "$skill_src/SKILL.md" "$skill_dest/"
+      [ -f "$skill_src/NOTICE" ]   && cp "$skill_src/NOTICE"   "$skill_dest/"
+    done
+    print_ok "Vendored skills synced into .claude/skills/ (code-upgrade-project-3)"
+  fi
 )
 
 # --backfill-only short-circuits here — no track / deployment / POC
@@ -1458,20 +1489,21 @@ fi
 # ================================================================
 # 6b. Append upgrade audit entry when no deployment change but POC/track changed
 # ================================================================
-if [ "$DEPLOYMENT_CHANGES" = false ] && { [ "$POC_REMOVED" = true ] || [ "$POC_TO_SPONSORED" = true ] || [ "$TRACK_CHANGES" = true ]; }; then
+if [ "$DEPLOYMENT_CHANGES" = false ] && { [ "$POC_REMOVED" = true ] || [ "$POC_TO_SPONSORED" = true ] || [ "$POC_TO_PRIVATE" = true ] || [ "$TRACK_CHANGES" = true ]; }; then
   if [ -f "$APPROVAL_LOG" ]; then
     print_step "Appending upgrade audit entry to APPROVAL_LOG.md"
 
-    python3 << 'PYEOF' - "$APPROVAL_LOG" "$POC_REMOVED" "$POC_TO_SPONSORED" "$TRACK_CHANGES" "$CURRENT_TRACK" "$TARGET_TRACK"
+    python3 << 'PYEOF' - "$APPROVAL_LOG" "$POC_REMOVED" "$POC_TO_SPONSORED" "$POC_TO_PRIVATE" "$TRACK_CHANGES" "$CURRENT_TRACK" "$TARGET_TRACK"
 import sys
 from datetime import date
 
 log_path = sys.argv[1]
 poc_removed = sys.argv[2] == "true"
 poc_to_sponsored = sys.argv[3] == "true"
-track_changes = sys.argv[4] == "true"
-old_track = sys.argv[5]
-new_track = sys.argv[6]
+poc_to_private = sys.argv[4] == "true"
+track_changes = sys.argv[5] == "true"
+old_track = sys.argv[6]
+new_track = sys.argv[7]
 today = str(date.today())
 
 with open(log_path) as f:
@@ -1482,6 +1514,11 @@ if poc_removed:
     changes.append("POC mode removed (production-ready)")
 if poc_to_sponsored:
     changes.append("upgraded from Private POC to Sponsored POC")
+if poc_to_private:
+    # Audit code-upgrade-project-7 (S3 sweep): the --to-private-poc path
+    # was silently dropped from the audit-entry block, so the markdown
+    # audit trail lost coverage of that transition.
+    changes.append("transitioned to Private POC")
 if track_changes:
     changes.append(f"track upgraded from {old_track} to {new_track}")
 
@@ -1501,6 +1538,56 @@ PYEOF
 
     print_ok "Appended upgrade audit entry to APPROVAL_LOG.md"
   fi
+fi
+
+# ================================================================
+# 6c. Refresh PRODUCT_MANIFESTO.md appendices on track upgrade
+# ================================================================
+# Audit code-upgrade-project-6 (S3 sweep): when a project upgrades from
+# light track to standard/full, Appendix A (Revenue Model & Unit
+# Economics) and Appendix C (Trademark & Legal Pre-Check) may carry
+# "SKIPPED — internal tool, …" markers populated during Phase 0 under
+# the light-track exemption (see docs/builders-guide.md §0.5 / §0.7).
+# Those appendices are required for Standard+, so the upgrade must
+# flag them as PENDING rather than leave the misleading SKIPPED text
+# in place. Rewrite is idempotent: matches the literal "SKIPPED —"
+# Phase-0 marker only, leaves anything else alone, and the second run
+# finds nothing to rewrite.
+PRODUCT_MANIFESTO="$PROJECT_ROOT/PRODUCT_MANIFESTO.md"
+if [ "$TRACK_CHANGES" = true ] && [ "$TARGET_RANK" -gt "$CURRENT_RANK" ] && [ -f "$PRODUCT_MANIFESTO" ]; then
+  print_step "Refreshing PRODUCT_MANIFESTO.md Appendix A/C markers for track upgrade"
+
+  python3 << 'PYEOF' - "$PRODUCT_MANIFESTO" "$CURRENT_TRACK" "$TARGET_TRACK"
+import re, sys
+from datetime import date
+
+manifesto_path = sys.argv[1]
+old_track = sys.argv[2]
+new_track = sys.argv[3]
+today = str(date.today())
+
+with open(manifesto_path) as f:
+    content = f.read()
+
+# Match the Phase-0 light-track SKIPPED marker exactly. The Builder's
+# Guide documents two canonical forms ("SKIPPED — internal tool, no
+# revenue model required" / "SKIPPED — internal tool, no trademark
+# check required"), but operators sometimes append free-form rationale.
+# Anchor on "SKIPPED —" (em dash, U+2014) plus optional ASCII "--"
+# fallback so we catch both typographic conventions.
+pattern = re.compile(r'SKIPPED\s*(?:—|--)\s*[^\n]*')
+replacement = f"PENDING — required by track upgrade {old_track} → {new_track} on {today}"
+
+new_content, n = pattern.subn(replacement, content)
+if n > 0:
+    with open(manifesto_path, 'w') as f:
+        f.write(new_content)
+    print(f"  Rewrote {n} SKIPPED marker(s) → PENDING (track upgrade)")
+else:
+    print("  No SKIPPED markers found — nothing to rewrite.")
+PYEOF
+
+  print_ok "PRODUCT_MANIFESTO.md appendix markers refreshed (if any)"
 fi
 
 # ================================================================
@@ -1601,6 +1688,12 @@ fi
 if [ "$POC_TO_SPONSORED" = true ]; then
   COMMIT_PARTS+=("-> sponsored POC")
 fi
+# Audit code-upgrade-project-7 (S3 sweep): missing POC_TO_PRIVATE branch
+# produced a misleading generic "chore(upgrade):" commit subject when
+# --to-private-poc was the only change.
+if [ "$POC_TO_PRIVATE" = true ]; then
+  COMMIT_PARTS+=("-> private POC")
+fi
 
 COMMIT_SUMMARY=$(IFS=', '; echo "${COMMIT_PARTS[*]}")
 COMMIT_MSG="chore(upgrade): ${COMMIT_SUMMARY}
@@ -1618,6 +1711,11 @@ FILES_TO_STAGE=()
 [ -f "CLAUDE.md" ] && FILES_TO_STAGE+=("CLAUDE.md")
 [ -f "PROJECT_INTAKE.md" ] && FILES_TO_STAGE+=("PROJECT_INTAKE.md")
 [ -f "APPROVAL_LOG.md" ] && FILES_TO_STAGE+=("APPROVAL_LOG.md")
+# Audit code-upgrade-project-6 (S3 sweep): PRODUCT_MANIFESTO.md is
+# rewritten by the Appendix A/C refresh block above when a track
+# upgrade lifts a light-track project to standard/full. Stage it so
+# the rewrite is committed alongside the other upgrade artifacts.
+[ -f "PRODUCT_MANIFESTO.md" ] && FILES_TO_STAGE+=("PRODUCT_MANIFESTO.md")
 
 if [ ${#FILES_TO_STAGE[@]} -gt 0 ]; then
   # Check if there are actual changes to commit
@@ -1764,6 +1862,7 @@ if [ -d scripts ]; then
 else
   print_warn "scripts/ directory not found in project root — skipping helper refresh"
 fi
+
 
 # Run full project validation to surface new track requirements
 if [ -x "scripts/validate.sh" ]; then

--- a/tests/test-upgrade-non-interactive.sh
+++ b/tests/test-upgrade-non-interactive.sh
@@ -147,6 +147,11 @@ t6_no_target_flag_is_error() {
 
 t7_real_upgrade_still_works() {
   # Regression: ensure the existing non-validate path still runs end-to-end.
+  # Per audit code-upgrade-project-1 + tier-crosscheck-3 (2026-06) the
+  # --to-private-poc path resolves to the personal deployment tier — Private
+  # POC is always personal per baseline §2.5. (Pre-audit behavior coerced it
+  # to organizational; the audit fix corrected that. T7 used to assert the
+  # old, incorrect shape — updated here.)
   setup_personal_project
   local out rc=0
   out=$(cd "$TMPDIR_T" && "$SCRIPT" --to-private-poc </dev/null 2>&1) || rc=$?
@@ -155,11 +160,11 @@ t7_real_upgrade_still_works() {
     teardown_project; return
   fi
   local deploy poc; deploy=$(jq -r '.deployment' "$TMPDIR_T/.claude/phase-state.json"); poc=$(jq -r '.poc_mode' "$TMPDIR_T/.claude/phase-state.json")
-  if [ "$deploy" != "organizational" ] || [ "$poc" != "private_poc" ]; then
-    fail_ "T7" "regression: post-upgrade state wrong (deploy=$deploy poc=$poc)"
+  if [ "$deploy" != "personal" ] || [ "$poc" != "private_poc" ]; then
+    fail_ "T7" "regression: post-upgrade state wrong (deploy=$deploy poc=$poc; expected personal/private_poc per audit-1)"
     teardown_project; return
   fi
-  pass "T7: real --to-private-poc upgrade still works (regression check)"
+  pass "T7: real --to-private-poc upgrade still works (regression check; personal/private_poc per audit-1)"
   teardown_project
 }
 

--- a/tests/test-upgrade-paths.sh
+++ b/tests/test-upgrade-paths.sh
@@ -330,5 +330,125 @@ rm -rf "$T"
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
+echo "=== T5: S3 sweep — vendored-skills sync + POC_TO_PRIVATE + Manifesto refresh ==="
+# ════════════════════════════════════════════════════════════════════
+#
+# Three audit-cleanup items shipped together in one PR (S3 sweep):
+#   T5a — code-upgrade-project-3: vendored-skills sync. upgrade-project.sh
+#         previously refreshed only helper scripts; vendored skills shipped
+#         after a project's init never made it into upgraded projects.
+#   T5b — code-upgrade-project-7: --to-private-poc was missing from the
+#         APPROVAL_LOG audit-row condition AND from the COMMIT_PARTS block,
+#         silently dropping audit coverage and producing a misleading
+#         generic commit subject.
+#   T5c — code-upgrade-project-6: PRODUCT_MANIFESTO.md Appendix A/C
+#         "SKIPPED — internal tool, …" markers (light-track Phase-0 exemption)
+#         were never rewritten on track-up to standard/full; appendices
+#         silently stayed marked SKIPPED even though required.
+
+# ── T5a: vendored-skills sync via --backfill-only ──────────────────
+# Old project predates the skill-install block — .claude/skills/ doesn't
+# even exist. After upgrade-project.sh runs, all four vendored skills
+# should land in .claude/skills/<name>/SKILL.md, with NOTICE alongside
+# when the framework ships one. The framework currently vendors:
+# grill-with-docs, session-handoff, sweep-triage, zoom-out.
+T=$(mktemp -d); P="$T/p"
+make_phase_state "$P" "light" "personal" 'null'
+# Ensure the project has NO .claude/skills/ directory (pre-skill projects).
+rm -rf "$P/.claude/skills"
+( cd "$P" && bash "$UPGRADE" --backfill-only --non-interactive ) > "$T/log" 2>&1
+rc=$?
+missing_skills=""
+for s in grill-with-docs session-handoff sweep-triage zoom-out; do
+  if [ ! -f "$P/.claude/skills/$s/SKILL.md" ]; then
+    missing_skills="$missing_skills $s"
+  fi
+done
+# NOTICE check: at least one skill ships a NOTICE in the framework
+# (vendored from mattpocock/skills, MIT). Confirm the copier preserved
+# at least one NOTICE so attribution doesn't silently disappear.
+notice_count=$( find "$P/.claude/skills" -maxdepth 2 -name NOTICE -type f 2>/dev/null | wc -l | tr -d ' ' )
+if [ "$rc" = "0" ] && [ -z "$missing_skills" ] && [ "$notice_count" -ge 1 ]; then
+  pass "T5a: vendored-skills sync — all 4 skills installed with NOTICE attribution preserved"
+else
+  fail_ "T5a" "rc=$rc missing_skills='$missing_skills' notice_count=$notice_count. Log tail: $(tail -10 "$T/log" 2>/dev/null | tr '\n' '|')"
+fi
+rm -rf "$T"
+
+# ── T5b: --to-private-poc commit subject + APPROVAL_LOG audit row ──
+# Setup: personal project with no POC mode. APPROVAL_LOG.md is pre-seeded
+# with an Approval History section so the audit-row branch is reachable
+# (otherwise the audit-write block exits via `[ -f "$APPROVAL_LOG" ]`).
+T=$(mktemp -d); P="$T/p"
+make_phase_state "$P" "light" "personal" 'null'
+cat > "$P/APPROVAL_LOG.md" <<'EOF'
+---
+project: test
+deployment: personal
+---
+
+# Approval Log — test
+
+## Approval History
+
+| Date | Gate / Event | Approver | Role | Decision | Reference |
+|---|---|---|---|---|---|
+EOF
+( cd "$P" && git add APPROVAL_LOG.md && git commit -q -m "seed approval log" ) >/dev/null 2>&1
+( cd "$P" && bash "$UPGRADE" --to-private-poc --non-interactive ) > "$T/log" 2>&1
+rc=$?
+# (a) commit subject contains the new "private POC" branch text
+commit_subject=$( cd "$P" && git log -1 --pretty=%s 2>/dev/null )
+subject_ok=no
+case "$commit_subject" in
+  *"private POC"*) subject_ok=yes ;;
+esac
+# (b) APPROVAL_LOG.md gained a row mentioning Private POC under the
+# Approval History section.
+audit_row_count=$( grep -ci "Private POC" "$P/APPROVAL_LOG.md" 2>/dev/null )
+if [ "$rc" = "0" ] && [ "$subject_ok" = "yes" ] && [ "$audit_row_count" -ge 1 ]; then
+  pass "T5b: --to-private-poc commit subject + APPROVAL_LOG audit row both populated"
+else
+  fail_ "T5b" "rc=$rc commit_subject='$commit_subject' subject_ok=$subject_ok audit_row_count=$audit_row_count. Log tail: $(tail -10 "$T/log" 2>/dev/null | tr '\n' '|')"
+fi
+rm -rf "$T"
+
+# ── T5c: PRODUCT_MANIFESTO.md Appendix A/C refresh on track upgrade ─
+# Light-track project carries SKIPPED markers in Appendix A (Revenue
+# Model) and Appendix C (Trademark & Legal). After --track standard
+# they should be rewritten to PENDING with today's date, and committed
+# alongside the other upgrade artifacts.
+T=$(mktemp -d); P="$T/p"
+make_phase_state "$P" "light" "personal" 'null'
+cat > "$P/PRODUCT_MANIFESTO.md" <<'EOF'
+# Product Manifesto — test
+
+## 1. Product Intent
+Test product.
+
+## Appendix A: Revenue Model & Unit Economics
+
+**Pricing Model:** SKIPPED — internal tool, no revenue model required
+
+## Appendix C: Trademark & Legal Pre-Check
+
+**Trademark Search:** SKIPPED — internal tool, no trademark check required
+EOF
+( cd "$P" && git add PRODUCT_MANIFESTO.md && git commit -q -m "seed manifesto" ) >/dev/null 2>&1
+( cd "$P" && bash "$UPGRADE" --track standard --non-interactive ) > "$T/log" 2>&1
+rc=$?
+skipped_remaining=$( grep -c "SKIPPED" "$P/PRODUCT_MANIFESTO.md" 2>/dev/null )
+pending_added=$(    grep -c "PENDING — required by track upgrade" "$P/PRODUCT_MANIFESTO.md" 2>/dev/null )
+# Verify the rewrite landed in a commit (FILES_TO_STAGE includes Manifesto)
+manifesto_in_log=$( cd "$P" && git log --name-only --pretty=format: 2>/dev/null | grep -c "^PRODUCT_MANIFESTO.md$" )
+if [ "$rc" = "0" ] && [ "$skipped_remaining" = "0" ] && [ "$pending_added" -ge 2 ] && [ "$manifesto_in_log" -ge 1 ]; then
+  pass "T5c: PRODUCT_MANIFESTO.md SKIPPED markers rewritten → PENDING on track-up and committed"
+else
+  fail_ "T5c" "rc=$rc skipped_remaining=$skipped_remaining pending_added=$pending_added manifesto_in_log=$manifesto_in_log. Log tail: $(tail -10 "$T/log" 2>/dev/null | tr '\n' '|')"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

Three additive low-risk fixes in `scripts/upgrade-project.sh` from the S3 audit sweep, shipped together per the cycle-5 verifier's recommendation (low coupling, same file, same review surface). Item 8 (`--to-production` pre-condition guard / code-upgrade-project-8) is intentionally **out of scope** — deferred by cycle-5 verifier; it changes a success path and deserves its own PR with operator-comm note.

### Item 1 — `code-upgrade-project-3`: vendored-skills sync

The helper-script refresh block copied `pending-approval.sh` and `lint-uat-scenarios.sh` into the project but never iterated `templates/generated/skills/*/`. The four post-init skills (`grill-with-docs`, `session-handoff`, `sweep-triage`, `zoom-out`) never reached upgraded projects.

**Fix:** new loop inside the `--backfill-only` block (parallel to BL-030 + host-aware backfills) iterating `templates/generated/skills/*/` and copying each to `.claude/skills/<skill>/` with the same `-ef` self-copy guard the helper-script block uses. Iterating `*/` means new skills added to the framework are automatically picked up — no edits to upgrade-project.sh needed.

### Item 2 — `code-upgrade-project-7`: `POC_TO_PRIVATE` missing branches

Two sites missed the `POC_TO_PRIVATE` branch:

1. **APPROVAL_LOG audit-row condition** (was line 1461): `--to-private-poc` silently dropped from the markdown audit trail.
2. **`COMMIT_PARTS` block** (was line 1591): when `POC_TO_PRIVATE` was the *only* change, `COMMIT_PARTS` stayed empty and `set -u` crashed with `COMMIT_PARTS[*]: unbound variable` at the IFS join. (This crash was masking a latent T7 assertion bug in `tests/test-upgrade-non-interactive.sh` — see "Collateral test fix" below.)

**Fix:** add `POC_TO_PRIVATE` branches to both sites. ~5 lines, 2 sites.

### Item 3 — `code-upgrade-project-6`: PRODUCT_MANIFESTO appendix refresh on track-up

When a project upgrades from light to standard/full, Appendix A (Revenue Model) and Appendix C (Trademark & Legal) may still carry `SKIPPED — internal tool, …` markers populated during Phase 0 under the light-track exemption (per `docs/builders-guide.md` §0.5 / §0.7). Those appendices are required for Standard+ tracks.

**Fix:** new rewriter block that runs when `TRACK_CHANGES=true` AND `TARGET_RANK > CURRENT_RANK`. Scans for `SKIPPED — …` (handles both em-dash and ASCII `--`) and rewrites to `PENDING — required by track upgrade <old> → <new> on <date>`. Adds `PRODUCT_MANIFESTO.md` to `FILES_TO_STAGE`. Idempotent — second run finds no markers to rewrite.

The literal `SKIPPED — Light Track` mentioned in the original task doesn't exist in the template; the canonical Builder's Guide marker is `SKIPPED — internal tool, …` (Phase 0 light-track exemption). The regex anchors on the leading `SKIPPED —` to catch both canonical forms and any operator-added free-form rationale.

### Collateral test fix — `tests/test-upgrade-non-interactive.sh` T7

T7 was already broken on `main` for the wrong reason: the latent unbound-variable crash in `COMMIT_PARTS[*]` aborted `--to-private-poc` before T7's assertion could run, so `T7` failed early without revealing that its assertion (`deploy=organizational`) contradicts `code-upgrade-project-1` (which forces Private POC to `deploy=personal`). Item 2 here fixes the crash, exposing the wrong assertion. T7 updated to expect `personal/private_poc` per audit-1; comment explains the history.

## Test plan

- [x] `bash tests/test-upgrade-paths.sh` — **22/22 PASS** (19 prior + 3 new T5a/b/c)
- [x] `bash tests/test-upgrade-bl030-backfill.sh` — **7/7 PASS**
- [x] `bash tests/test-poc-modes.sh` — **5/5 PASS**
- [x] `bash tests/test-upgrade-non-interactive.sh` — **7/7 PASS** (T7 assertion fixed)
- [x] `bash tests/test-upgrade-personal-to-sponsored-poc.sh` — **3/3 PASS**
- [x] `bash tests/test-upgrade-to-production-warn.sh` — **3/3 PASS**

Audit IDs covered: `code-upgrade-project-3`, `code-upgrade-project-7`, `code-upgrade-project-6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)