### PR TITLE
docs(contributing): Commit conventions + Local development setup + close code-check-gates-3

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,6 +76,52 @@ By making a contribution to this project, I certify that:
 4. Ensure all commits include DCO sign-off (`git commit -s`)
 5. Open a pull request against `main`
 
+## Commit conventions
+
+This project follows [Conventional Commits](https://www.conventionalcommits.org/) for commit subject lines. Use one of the following prefixes:
+
+- `feat` — a new feature or capability
+- `fix` — a bug fix
+- `docs` — documentation-only changes
+- `test` — adding or correcting tests
+- `refactor` — code change that neither fixes a bug nor adds a feature
+- `chore` — tooling, build configuration, or repository maintenance
+
+An optional scope in parentheses narrows the subject (e.g., `fix(init): handle missing CDF clone`). The subject should be imperative and under ~72 characters; longer rationale belongs in the commit body.
+
+### Docs-only bypass
+
+Commits whose staged files all match documentation extensions (`.md`, `.json`, `.yml`, `.yaml`, `.toml`, `.tmpl`) skip the Build Loop gate. The classifier lives in `scripts/process-checklist.sh` (function `check_commit_ready`, regex `\.(md|json|yml|yaml|toml|tmpl)$`); a matching commit does not need to be tied to an open Build Loop step. Mixed commits (any staged source file alongside docs) fall back to full Build Loop enforcement — split them if you want the docs portion to land without the gate.
+
+Dependency manifests (`Pipfile.lock`, `Gemfile.lock`, `go.sum`, etc.) are also exempt via the `_is_dep_manifest` helper in the same script.
+
+## Local development setup
+
+The framework lives in two repositories — both must be cloned for the test suite and `init.sh` to function end-to-end.
+
+1. Clone the framework:
+   ```bash
+   git clone https://github.com/kraulerson/solo-orchestrator.git
+   ```
+2. Clone the Claude Dev Framework to the path `init.sh` expects:
+   ```bash
+   git clone https://github.com/kraulerson/claude-dev-framework.git ~/.claude-dev-framework
+   ```
+   The `~/.claude-dev-framework` location is required; see `docs/cli-setup-addendum.md` §3 ("Development Guardrails for Claude Code") for the rationale.
+3. Run the test suites directly to validate a working checkout (faster than running `init.sh` against a scratch project):
+   ```bash
+   bash tests/full-project-test-suite.sh
+   bash tests/host-drivers/run-all.sh
+   ```
+   Alternatively, run `bash init.sh` from a throwaway directory to exercise the full installer flow.
+4. Install the pre-commit gate locally (`init.sh` does this for user projects; contributors working on the framework itself must install it manually):
+   ```bash
+   cp scripts/pre-commit-gate.sh .git/hooks/pre-commit
+   chmod +x .git/hooks/pre-commit
+   ```
+
+For deeper setup — MCP servers, profiles, CLAUDE.md authoring, host CLI installation — see `docs/cli-setup-addendum.md` and `docs/user-guide.md`.
+
 ## What Not to Contribute
 
 - Changes to the core methodology (Builder's Guide phases, governance structure) without prior discussion in an issue


### PR DESCRIPTION
## Summary

Cycle 6, Slot 4. Scoped down from a 10-finding slice (full scope deferred to cycle 7) to focus cycle 6 bandwidth on real bugs. Two docs additions to `CONTRIBUTING.md` plus one audit closeout recorded in this PR body.

## Changes

### 1. `CONTRIBUTING.md` — new section "Commit conventions"

Cites [Conventional Commits](https://www.conventionalcommits.org/) and enumerates the recommended subject prefixes (`feat`, `fix`, `docs`, `test`, `refactor`, `chore`). Documents the docs-only bypass rule honored by `scripts/process-checklist.sh` (function `check_commit_ready`, regex `\.(md|json|yml|yaml|toml|tmpl)$` at line 896) and notes the dependency-manifest exemption via `_is_dep_manifest`.

Closes audit finding `contributing-readme-personal-1`.

### 2. `CONTRIBUTING.md` — new section "Local development setup"

Half-page setup guide for framework contributors:

1. Clone `solo-orchestrator`.
2. Clone `claude-dev-framework` to `~/.claude-dev-framework` (path required by `init.sh`; see `docs/cli-setup-addendum.md` §3).
3. Run the test suites: `tests/full-project-test-suite.sh` and `tests/host-drivers/run-all.sh`.
4. Manual pre-commit hook install for framework contributors (`init.sh` handles this for user projects).

Defers deeper setup to `docs/cli-setup-addendum.md` and `docs/user-guide.md`.

Closes audit finding `contributing-readme-personal-2`.

## Audit closeout — `code-check-gates-3` (durable record)

This PR body is the durable record for the closeout, following the cycle 5 PR #63 pattern. No new ledger file is created.

**Finding:** Unbound arithmetic comparisons in `scripts/check-phase-gate.sh` when `grep -c` returns empty or non-numeric output.

**Status:** **FULLY REMEDIATED by PR #53.** Reconfirmed in the current `scripts/check-phase-gate.sh` (lines 317-325):

```bash
317:    placeholder_dates=$(grep -c "YYYY-MM-DD" PROJECT_BIBLE.md 2>/dev/null || echo "0")
318:    case "$placeholder_dates" in ''|*[!0-9]*) placeholder_dates=0 ;; esac
319:    if [ "$placeholder_dates" -gt 0 ]; then
...
324:    bible_sections=$(grep -cE "^## [0-9]+\." PROJECT_BIBLE.md 2>/dev/null || echo "0")
325:    case "$bible_sections" in ''|*[!0-9]*) bible_sections=0 ;; esac
326:    if [ "$bible_sections" -lt 14 ]; then
```

Both sites cited by the finding (`placeholder_dates`, `bible_sections`) carry the `case "$var" in ''|*[!0-9]*) var=0 ;; esac` sanitizer immediately before the `-gt` / `-lt` arithmetic comparison. Empty and non-numeric values are coerced to `0` before evaluation, eliminating the unbound-comparison failure mode the finding cited.

## Test plan

- [x] Docs-only change — no test suite changes required.
- [x] Only `CONTRIBUTING.md` staged; no stray untracked files included.
- [x] Commit signed off (DCO).
- [x] `code-check-gates-3` line citations re-verified against `scripts/check-phase-gate.sh` in this PR's tree.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>