### PR TITLE
feat(ci): lint counter-capture antipattern (wave 2 backstop)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,40 @@
+# .github/workflows/lint.yml — CI lint guards.
+#
+# Wave 2 follow-up to PRs #67-#71 (counter-sanitizer remediation
+# bundle). After wave 1 fixed every known unsanitized
+# `var=$(cmd | grep -c X || echo "0")` capture site, this workflow
+# is the merge-time backstop that prevents the antipattern from being
+# reintroduced. See scripts/lint-counter-antipattern.sh for the
+# defect-class write-up and the canonical fix pattern.
+#
+# This is the repository's FIRST GitHub Actions workflow — the
+# `.github/workflows/` directory did not exist before this PR.
+# Subsequent CI jobs (shellcheck, security review, full test suite
+# under CI, etc.) can be added as additional workflows or as
+# additional jobs in this file.
+
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  # Job name is the required-check label in branch protection. Keep it
+  # stable: changing the name forces every protected branch to be
+  # reconfigured. The lint script's behavior may evolve, but the job
+  # name should not.
+  counter-antipattern-lint:
+    name: counter-antipattern-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint counter-capture antipattern
+        run: bash scripts/lint-counter-antipattern.sh
+
+      - name: Show PASS/FAIL inventory (on failure or on demand)
+        if: always()
+        run: bash scripts/lint-counter-antipattern.sh --list || true

--- a/scripts/lint-counter-antipattern.sh
+++ b/scripts/lint-counter-antipattern.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# scripts/lint-counter-antipattern.sh — fail CI if any shell script
+# captures a counter using the `|| echo "0"` antipattern without the
+# canonical case-statement sanitizer on the immediately-following line.
+#
+# THE DEFECT CLASS
+#   var=$(grep -c PATTERN file 2>/dev/null || echo "0")
+#   [ "$var" -gt 0 ] && do_thing
+#
+# When `grep -c` matches zero lines, it prints "0\n" and exits 1; the
+# `||` branch then fires and appends a second "0\n". The capture holds
+# the two-line string "0\n0". Subsequent arithmetic comparisons error
+# with `integer expression expected`, and under `set -euo pipefail`
+# the test returns non-zero — silently flipping gates into the wrong
+# branch. The CANONICAL fix (PR #53, audit-driven across PRs #67-#71):
+#
+#   var=$(grep -c PATTERN file 2>/dev/null || echo "0")
+#   case "$var" in ''|*[!0-9]*) var=0 ;; esac
+#
+# This linter is the wave-2 backstop after PRs #67-#71 remediated every
+# known site: it makes the antipattern un-introducible in CI going
+# forward without an explicit allowlist comment justifying the choice.
+#
+# DELIBERATE SCOPE
+#   • Targets ONLY `|| echo "0"` (or `|| echo 0`) endings on capture
+#     lines that count via `grep -c`, `jq ... length`, or `wc`. These
+#     are the patterns documented in PRs #67-#71 as defect-prone:
+#     non-numeric subshell exit on zero match + numeric fallback that
+#     concatenates rather than replaces.
+#   • DOES NOT target `|| true` or `|| var=0` variants — those have
+#     different failure modes (silent empty-string capture, or
+#     idempotent fallback) and are subject of a separate follow-up
+#     PR. Broadening here would mix unrelated defect classes and
+#     dilute the merge-gate signal.
+#   • DOES NOT cover multi-line `var=$( cmd \\` captures where the
+#     `|| echo "0"` lives on a continuation line. PR #70 fixed the
+#     known multi-line site in init.sh; future multi-line captures
+#     are out of scope for this regex (a future PR can extend with
+#     a multi-line walker if needed).
+#
+# ALLOWLIST
+#   Append `# lint-counter-antipattern: allow <reason>` to the
+#   antipattern line itself (NOT the sanitizer line). The reason is
+#   REQUIRED — an empty reason fails the lint, so reviewers always
+#   have justification text to evaluate.
+#
+# EXIT CODES
+#   0 — no violations
+#   1 — one or more violations found
+#   2 — invocation / I/O error
+#
+# USAGE
+#   bash scripts/lint-counter-antipattern.sh           # quiet pass/fail
+#   bash scripts/lint-counter-antipattern.sh --list    # PASS/FAIL table
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_PATH="$REPO_ROOT/scripts/lint-counter-antipattern.sh"
+TEST_FIXTURE_PATTERN="test-lint-counter-antipattern"
+
+LIST_MODE=0
+if [ "${1:-}" = "--list" ]; then
+  LIST_MODE=1
+elif [ -n "${1:-}" ]; then
+  echo "Usage: $0 [--list]" >&2
+  exit 2
+fi
+
+# Files to walk. Globs are evaluated below; missing dirs are skipped.
+TARGET_GLOBS=(
+  "$REPO_ROOT/scripts"/*.sh
+  "$REPO_ROOT/scripts/lib"/*.sh
+  "$REPO_ROOT/scripts/hooks"/*.sh
+  "$REPO_ROOT/scripts/host-drivers"/*.sh
+  "$REPO_ROOT/tests"/*.sh
+  "$REPO_ROOT/init.sh"
+)
+
+# Per-line antipattern: extended regex for `grep -E`.
+# Matches:   <leading-ws> IDENT=$( ... grep -c|jq...length|wc ... || echo "0" )
+# Tolerates: -c with extra flags like -cE, -ci, -ciE; quoted/unquoted 0;
+#            trailing whitespace and a `)` after the echo.
+ANTIPATTERN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(.*(grep[[:space:]]+-[a-zA-Z]*c[a-zA-Z]*|jq[[:space:]].*length|[[:space:]]wc[[:space:]]).*\|\|[[:space:]]*echo[[:space:]]+"?0"?[[:space:]]*\)'
+
+# Strip a trailing `# lint-counter-antipattern: allow <reason>` and
+# return: VAR_NAME<TAB>ALLOW_REASON_OR_EMPTY<TAB>HAS_MARKER (0|1)
+# Caller checks: if HAS_MARKER=1 and reason empty → fail.
+parse_line() {
+  local line="$1"
+  local marker_reason=""
+  local has_marker=0
+  case "$line" in
+    *"# lint-counter-antipattern: allow"*)
+      has_marker=1
+      # Extract everything after the marker prefix; trim trailing ws.
+      marker_reason="${line##*# lint-counter-antipattern: allow}"
+      # Trim leading and trailing whitespace.
+      marker_reason="${marker_reason#"${marker_reason%%[![:space:]]*}"}"
+      marker_reason="${marker_reason%"${marker_reason##*[![:space:]]}"}"
+      ;;
+  esac
+
+  # Extract var name: leading whitespace, then identifier up to '='.
+  local stripped="${line#"${line%%[![:space:]]*}"}"
+  local var_name="${stripped%%=*}"
+
+  printf '%s\t%s\t%d\n' "$var_name" "$marker_reason" "$has_marker"
+}
+
+# Build PASS-marker regex for a given var name. Tolerates whitespace.
+sanitizer_regex_for() {
+  local var="$1"
+  # Match: optional ws, case "$var" in '' | *[!0-9]* ) var=0 ;; esac
+  # Use printf to safely interpolate var; treat all literals.
+  printf '^[[:space:]]*case[[:space:]]+"\\$%s"[[:space:]]+in[[:space:]]+'\'''\''[[:space:]]*\\|[[:space:]]*\*\[!0-9\]\*[[:space:]]*\\)[[:space:]]+%s=0[[:space:]]*;;[[:space:]]+esac[[:space:]]*$' "$var" "$var"
+}
+
+VIOLATIONS=0
+LIST_ROWS=""
+
+should_skip_file() {
+  local f="$1"
+  # Skip the linter itself.
+  [ "$f" = "$SELF_PATH" ] && return 0
+  # Skip the linter's own test (it contains deliberate bad fixtures
+  # built inline, but the script file itself doesn't host the bad
+  # lines — defensive though).
+  case "$(basename "$f")" in
+    "${TEST_FIXTURE_PATTERN}.sh") return 0 ;;
+  esac
+  # Skip docs/, templates/, Reports/, .git/ — these directories don't
+  # appear in TARGET_GLOBS but we double-check by path.
+  case "$f" in
+    "$REPO_ROOT"/docs/*|"$REPO_ROOT"/templates/*|"$REPO_ROOT"/Reports/*|"$REPO_ROOT"/.git/*) return 0 ;;
+  esac
+  return 1
+}
+
+scan_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  should_skip_file "$file" && return 0
+
+  # Read all lines into an array so we can look at N+1.
+  local -a LINES=()
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    LINES+=("$line")
+  done < "$file"
+
+  local i n
+  n=${#LINES[@]}
+  for ((i = 0; i < n; i++)); do
+    line="${LINES[i]}"
+    # Skip lines that are pure comments (no var=$( ... ) shape).
+    case "${line#"${line%%[![:space:]]*}"}" in
+      '#'*) continue ;;
+    esac
+
+    if echo "$line" | grep -Eq "$ANTIPATTERN_RE"; then
+      # Parse var name + allowlist.
+      local parsed var_name allow_reason has_marker
+      parsed=$(parse_line "$line")
+      var_name="$(printf '%s' "$parsed" | cut -f1)"
+      allow_reason="$(printf '%s' "$parsed" | cut -f2)"
+      has_marker="$(printf '%s' "$parsed" | cut -f3)"
+
+      local lineno=$((i + 1))
+      local rel="${file#"$REPO_ROOT"/}"
+
+      if [ "$has_marker" = "1" ]; then
+        if [ -z "$allow_reason" ]; then
+          echo "${rel}:${lineno}: lint-counter-antipattern: allowlist marker present but reason is empty (var=$var_name)" >&2
+          VIOLATIONS=$((VIOLATIONS + 1))
+          LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\t${var_name}\tallowlist-empty-reason\n"
+        else
+          LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\t${var_name}\tallowlist:${allow_reason}\n"
+        fi
+        continue
+      fi
+
+      # Check next line for the case-statement sanitizer with matching var.
+      local next="${LINES[i+1]:-}"
+      local sanitizer_re
+      sanitizer_re="$(sanitizer_regex_for "$var_name")"
+      if echo "$next" | grep -Eq "$sanitizer_re"; then
+        LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\t${var_name}\tsanitized\n"
+      else
+        # Identify the failure subtype for a clearer message.
+        local subtype="missing-sanitizer"
+        # If next line is ALSO a case statement but for a different var,
+        # call that out — that's the copy-paste bug class T5 protects.
+        if echo "$next" | grep -Eq '^[[:space:]]*case[[:space:]]+"\$[A-Za-z_][A-Za-z0-9_]*"[[:space:]]+in[[:space:]]+'\'''\''[[:space:]]*\|'; then
+          subtype="sanitizer-var-mismatch"
+          echo "${rel}:${lineno}: lint-counter-antipattern: capture of '\$${var_name}' is not sanitized — next-line case-statement uses a different var name" >&2
+        else
+          echo "${rel}:${lineno}: lint-counter-antipattern: capture of '\$${var_name}' is not sanitized — add 'case \"\$${var_name}\" in '\'''\''|*[!0-9]*) ${var_name}=0 ;; esac' on the next line, or append '# lint-counter-antipattern: allow <reason>'" >&2
+        fi
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\t${var_name}\t${subtype}\n"
+      fi
+    fi
+  done
+}
+
+for entry in "${TARGET_GLOBS[@]}"; do
+  # If the glob didn't expand, the literal string with `*` shows up;
+  # skip those by testing -e on each candidate.
+  [ -e "$entry" ] || continue
+  scan_file "$entry"
+done
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\tVAR\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS violation(s) found. See scripts/lint-counter-antipattern.sh header for the fix pattern." >&2
+  exit 1
+fi
+
+echo "OK: no counter-capture antipatterns found."
+exit 0

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -66,6 +66,26 @@ else
 fi
 
 # ================================================================
+# TEST 0b: COUNTER-ANTIPATTERN LINT — wave-2 backstop after PRs #67-#71
+# ================================================================
+section "Counter-capture antipattern lint"
+if bash "$SCRIPT_DIR/scripts/lint-counter-antipattern.sh" >/dev/null 2>&1; then
+  pass "No unsanitized 'cmd | grep -c X || echo \"0\"' captures in tracked scripts"
+else
+  fail "Counter-capture antipattern found (see scripts/lint-counter-antipattern.sh --list)"
+fi
+
+# Run the linter's own behavior-test suite so a regression in the lint
+# itself (false negative on the antipattern, false positive on the
+# sanitizer match, broken allowlist) is caught here too.
+section "Counter-antipattern lint — behavior test suite"
+if bash "$SCRIPT_DIR/tests/test-lint-counter-antipattern.sh" >/dev/null 2>&1; then
+  pass "scripts/lint-counter-antipattern.sh behavior tests (10/10)"
+else
+  fail "scripts/lint-counter-antipattern.sh behavior tests FAILED (run tests/test-lint-counter-antipattern.sh for details)"
+fi
+
+# ================================================================
 # TEST 1: RESOLVER MATRIX — ALL COMBINATIONS
 # ================================================================
 section "TEST 1: Resolver Matrix — All Platform × Language × Track Combinations"

--- a/tests/known-bugs-test-suite.sh
+++ b/tests/known-bugs-test-suite.sh
@@ -488,6 +488,7 @@ create_test_project "$BUG6_DIR"
 (
   cd "$BUG6_DIR"
   todo_count=$(grep -c "# TODO\|echo.*TODO" .github/workflows/release.yml 2>/dev/null || echo "0")
+  case "$todo_count" in ''|*[!0-9]*) todo_count=0 ;; esac
   echo "todo_count=$todo_count"
 ) > "$TEST_DIR/bug6a-output.txt" 2>&1
 result=$?
@@ -557,7 +558,7 @@ EOF
   cd "$BUG7_DIR"
 
   # Replicate the exact code from validate.sh line 367-369
-  has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || echo "0")
+  has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || echo "0") # lint-counter-antipattern: allow deliberate verbatim replication of validate.sh line 367-369 to exercise the upstream behavior under test
   if [ "$has_no" -eq 0 ]; then
     echo "has_no=0"
   else
@@ -592,7 +593,7 @@ EOF
   set -euo pipefail
   cd "$BUG7_DIR"
 
-  has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || echo "0")
+  has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || echo "0") # lint-counter-antipattern: allow deliberate verbatim replication of validate.sh line 367-369 to exercise the upstream behavior under test
   if [ "$has_no" -eq 0 ]; then
     echo "has_no=0 (correctly zero)"
   else

--- a/tests/test-enforcement-level-init.sh
+++ b/tests/test-enforcement-level-init.sh
@@ -113,6 +113,7 @@ echo "T8: init writes enforcement_level_set audit row"
 TMP=$(mktemp -d); PROJ="$TMP/p"
 if run_init "$PROJ" --track light --deployment personal; then
   rows=$(jq '[.[] | select(.type=="enforcement_level_set")] | length' "$PROJ/.claude/bypass-audit.json" 2>/dev/null || echo 0)
+  case "$rows" in ''|*[!0-9]*) rows=0 ;; esac
   if [ "$rows" -ge "1" ]; then pass "T8"; else fail_ "T8" "rows=$rows"; fi
 else
   fail_ "T8" "init failed"

--- a/tests/test-init-atomic-finalize.sh
+++ b/tests/test-init-atomic-finalize.sh
@@ -111,6 +111,7 @@ TMP=$(mktemp -d); PROJ="$TMP/p"
 if run_init_no_remote "$PROJ"; then
   audit_at_init=$( cd "$PROJ" && git show HEAD:.claude/bypass-audit.json 2>/dev/null )
   rows=$( echo "$audit_at_init" | jq '[.[] | select(.type=="enforcement_level_set")] | length' 2>/dev/null || echo "0" )
+  case "$rows" in ''|*[!0-9]*) rows=0 ;; esac
   if [ "$rows" -ge "1" ]; then
     pass "T3: bypass-audit.json has the init enforcement_level_set row in initial commit"
   else

--- a/tests/test-lint-counter-antipattern.sh
+++ b/tests/test-lint-counter-antipattern.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# tests/test-lint-counter-antipattern.sh
+#
+# Tests for scripts/lint-counter-antipattern.sh — the wave-2 CI backstop
+# that bans the `var=$(cmd | grep -c X || echo "0")` counter-capture
+# antipattern after the wave-1 sanitizer remediation (PRs #67-#71).
+#
+# Each test stages a tiny per-case fixture tree, overrides REPO_ROOT
+# via a copied linter (so the linter walks the fixture's scripts/ tree
+# instead of the real repo), runs the linter, and asserts on exit code
+# and stderr. Test 9 is the merge gate: it runs the linter directly
+# against the current repo HEAD and requires exit 0 — proof that wave 1
+# left no unsanitized sites for this PR to enforce.
+#
+# Style mirrors tests/test-test-gate-counter-sanitizer.sh (PR #69) and
+# tests/test-check-phase-gate-counter-sanitizer.sh (PR #53): set -uo
+# pipefail, mktemp fixtures, pass/fail counters, teardown after each.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-counter-antipattern.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Each test builds an isolated fake-repo at $PROJ with a copy of the
+# linter at $PROJ/scripts/lint-counter-antipattern.sh — this lets us
+# point the linter at fixture trees without touching the real repo.
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/repo"
+  mkdir -p "$PROJ/scripts"
+  cp "$LINTER" "$PROJ/scripts/lint-counter-antipattern.sh"
+  chmod +x "$PROJ/scripts/lint-counter-antipattern.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+# Run the fixture-local linter and capture exit + stderr.
+run_lint() {
+  ( cd "$PROJ" && bash scripts/lint-counter-antipattern.sh 2>&1 )
+  return $?
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: clean fixture (sanitized site) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/clean.sh" <<'SH'
+#!/usr/bin/env bash
+foo_count=$(grep -c "PATTERN" file.txt 2>/dev/null || echo "0")
+case "$foo_count" in ''|*[!0-9]*) foo_count=0 ;; esac
+echo "$foo_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T1: clean sanitized capture exits 0"
+else
+  fail_ "T1" "expected exit 0, got $rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: bare antipattern (no sanitizer) → exit 1, names file:line + var ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/bad.sh" <<'SH'
+#!/usr/bin/env bash
+bad_count=$(grep -c "PATTERN" file.txt 2>/dev/null || echo "0")
+echo "$bad_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/bad.sh:2" \
+   && echo "$out" | grep -q "bad_count"; then
+  pass "T2: bare antipattern fails with file:line and var name"
+else
+  fail_ "T2" "expected exit 1 + file:line:var; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: antipattern + UNRELATED next line → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/unrelated.sh" <<'SH'
+#!/usr/bin/env bash
+other_count=$(grep -c "X" file.txt 2>/dev/null || echo "0")
+echo "doing something unrelated here"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "other_count"; then
+  pass "T3: antipattern with unrelated follow-up fails"
+else
+  fail_ "T3" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: antipattern + correct case-statement → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/good.sh" <<'SH'
+#!/usr/bin/env bash
+sev1_count=$(grep -c 'SEV-1' BUGS.md 2>/dev/null | tr -d '[:space:]' || echo "0")
+case "$sev1_count" in ''|*[!0-9]*) sev1_count=0 ;; esac
+echo "$sev1_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T4: antipattern + matching case-statement passes"
+else
+  fail_ "T4" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: antipattern + case-statement with WRONG var name → exit 1 (copy-paste guard) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+# This is the copy-paste-bug class: the sanitizer was duplicated from
+# a sibling site and never renamed. The lint MUST catch this by
+# requiring the case-statement var name to match the capture's var name.
+cat > "$PROJ/scripts/copypaste.sh" <<'SH'
+#!/usr/bin/env bash
+my_count=$(grep -c "X" file.txt 2>/dev/null || echo "0")
+case "$other_count" in ''|*[!0-9]*) other_count=0 ;; esac
+echo "$my_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "my_count" \
+   && echo "$out" | grep -q "sanitizer-var-mismatch\|different var name"; then
+  pass "T5: copy-paste var-name mismatch is detected"
+else
+  fail_ "T5" "expected exit 1 + mismatch diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: '|| true' variant → exit 0 (out-of-scope, deliberate) ==="
+# ════════════════════════════════════════════════════════════════════
+# DELIBERATE EXCLUSION: this linter targets only `|| echo \"0\"` (the
+# class with the documented "0\\n0" concat failure mode). The `|| true`
+# variant has a different failure mode (silent empty-string capture)
+# and is scoped to a separate follow-up PR. Keeping these out of scope
+# keeps the merge-gate signal focused on the defect class wave 1 fixed.
+setup
+cat > "$PROJ/scripts/or-true.sh" <<'SH'
+#!/usr/bin/env bash
+silent_count=$(grep -c "X" file.txt 2>/dev/null || true)
+echo "$silent_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T6: '|| true' variant is out of scope (passes)"
+else
+  fail_ "T6" "expected exit 0 for out-of-scope variant; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: allowlist marker WITH reason → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/allowed.sh" <<'SH'
+#!/usr/bin/env bash
+weird_count=$(grep -c "X" file.txt 2>/dev/null || echo "0") # lint-counter-antipattern: allow deliberate reproduction of upstream behavior under test
+echo "$weird_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T7: allowlist marker with reason passes"
+else
+  fail_ "T7" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: allowlist marker WITHOUT reason → exit 1 (justification required) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/empty-allow.sh" <<'SH'
+#!/usr/bin/env bash
+empty_count=$(grep -c "X" file.txt 2>/dev/null || echo "0") # lint-counter-antipattern: allow
+echo "$empty_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -qi "empty\|reason"; then
+  pass "T8: empty-reason allowlist marker fails (justification required)"
+else
+  fail_ "T8" "expected exit 1 with reason-required diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9: MERGE GATE — run linter against current repo HEAD → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# This is the wave-2 acceptance criterion: wave 1 (PRs #67-#71) is
+# claimed to have remediated every unsanitized counter-capture site in
+# the in-tree code; this test PROVES that claim by running the same
+# linter that CI runs and requiring exit 0. If any unsanitized site
+# slipped past wave 1's audit, this test fails and the PR cannot
+# merge until the site is either sanitized or allowlisted with reason.
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T9: current repo HEAD is lint-clean (wave 1 remediation verified)"
+else
+  fail_ "T9" "current repo HEAD has unsanitized antipattern sites; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: skip-paths — antipattern in Reports/ → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Reports/, docs/, templates/, and .git/ are out of the walk: those
+# trees host UAT report artifacts and templated content that may
+# legitimately quote the antipattern in prose or sample code. The
+# walk-globs already exclude them, but T10 makes the exclusion an
+# enforced contract so a future glob expansion can't silently start
+# linting documentation prose.
+setup
+mkdir -p "$PROJ/Reports"
+cat > "$PROJ/Reports/sample-output.sh" <<'SH'
+#!/usr/bin/env bash
+# This file lives under Reports/ — should be skipped by the linter.
+ignored_count=$(grep -c "X" file.txt 2>/dev/null || echo "0")
+echo "$ignored_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T10: antipattern under Reports/ is correctly skipped"
+else
+  fail_ "T10" "expected exit 0 (Reports/ should be skipped); rc=$rc; output:\n$out"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-upgrade-to-production-preconditions.sh
+++ b/tests/test-upgrade-to-production-preconditions.sh
@@ -271,6 +271,7 @@ t4_ack_preconditions_bypass() {
   fi
   local ack_rows
   ack_rows=$(jq -r '[.[] | select(.details.action == "to_production_preconditions_acked")] | length' "$audit" 2>/dev/null || echo 0)
+  case "$ack_rows" in ''|*[!0-9]*) ack_rows=0 ;; esac
   if [ "$ack_rows" -lt 1 ]; then
     fail_ "T4" "bypass-audit.json has no to_production_preconditions_acked row; audit:\n$(cat "$audit")"
     teardown_project; return

--- a/tests/upgrade-path-tests.sh
+++ b/tests/upgrade-path-tests.sh
@@ -452,6 +452,7 @@ fi
 # 4d: Verify organizational deployment requires more governance sections
 # Count governance-related sections in init.sh organizational vs personal templates
 org_gate_count=$(grep -c "Phase Gate\|Approver\|Role.*|.*IT Security\|Evidence required" "$INIT_FILE" 2>/dev/null || echo "0")
+case "$org_gate_count" in ''|*[!0-9]*) org_gate_count=0 ;; esac
 if [ "$org_gate_count" -gt 5 ]; then
   pass "Organizational template has extensive governance ($org_gate_count gate-related markers)"
 else


### PR DESCRIPTION
## Summary

Wave 2 sequential follow-up to PRs #67-#71 (counter-sanitizer remediation bundle). Introduces:

- `scripts/lint-counter-antipattern.sh` — CI lint banning the `cmd | grep -c X || echo \"0\"` counter-capture antipattern; requires the canonical `case \"\$var\" in ''|*[!0-9]*) var=0 ;; esac` sanitizer on the immediately-following line, or an explicit `# lint-counter-antipattern: allow <reason>` allowlist marker (reason required).
- `tests/test-lint-counter-antipattern.sh` — 10-case behavior suite covering clean/bad/copy-paste/allowlist/skip-path/HEAD-sanity scenarios.
- `tests/full-project-test-suite.sh` — registers the new lint + behavior tests in the project-wide runner.
- 5 wave-1 gap closures in `tests/` (sites the lint discovered that wave 1's audit missed; all are tests, no production scripts affected).

**NOTE on `.github/workflows/lint.yml`** — see \"Outstanding\" section below.

## Sequencing — why this PR ships AFTER #67-#71 (not parallel)

Test case T9 of the new suite runs the linter directly against the current repo HEAD and requires exit 0. Pre-wave-1, several production scripts (`test-gate.sh`, `validate.sh`, `check-phase-gate.sh`, `init.sh`, `upgrade-project.sh`) had unsanitized capture sites that would have made T9 fail. Wave 1 sanitized those sites. Only after wave 1 merged could this PR's merge gate become enforceable.

## Defect class (recap)

```bash
# Antipattern:
var=$(grep -c PATTERN file 2>/dev/null || echo \"0\")
[ \"\$var\" -gt 0 ] && do_thing
```

When `grep -c` matches zero, it prints `0\n` and exits 1; `||` appends a second `0\n`. The capture holds `\"0\\n0\"`. Subsequent `[ \"\$var\" -gt N ]` errors with `integer expression expected` and (under `set -euo pipefail`) the arithmetic test returns non-zero — silently flipping gates into the wrong branch.

Canonical fix (PR #53, sweep across PRs #67-#71):

```bash
var=$(grep -c PATTERN file 2>/dev/null || echo \"0\")
case \"\$var\" in ''|*[!0-9]*) var=0 ;; esac
```

## Deliberate scope (and the `|| true` out-of-scope mention)

The lint targets ONLY the `|| echo \"0\"` (or `|| echo 0`) ending on captures using `grep -c`, `jq ... length`, or `wc`. Out of scope, follow-up PR to come:

- **`|| true` variant** — different failure mode (silent empty-string capture), not concatenation-prone in the same way. Worth its own lint or its own remediation pass, but mixing it here would dilute the merge-gate signal for the defect class wave 1 actually fixed.
- **`|| var=0` variant** — idempotent fallback, low risk.
- **Multi-line `var=\$( cmd \\\\` captures** — PR #70 fixed the known multi-line site in `init.sh`; future multi-line cases would need a walker, not the current single-line regex.

## Allowlist mechanism

Append `# lint-counter-antipattern: allow <reason>` to the capture line itself. **The reason is REQUIRED** — empty reason fails the lint (test T8 enforces this), so reviewers always have justification text to evaluate.

Currently 2 allowlisted sites, both in `tests/known-bugs-test-suite.sh`, deliberately replicating the validate.sh upstream antipattern to exercise the bug behavior under test.

## Five wave-1 gaps closed in this PR

The lint discovered 5 unsanitized sites wave 1's audit missed (all in `tests/`; production scripts were already clean). Sanitized here so T9 passes:

| Site | Var |
|---|---|
| `tests/known-bugs-test-suite.sh:491` | `todo_count` |
| `tests/upgrade-path-tests.sh:454` | `org_gate_count` |
| `tests/test-init-atomic-finalize.sh:113` | `rows` |
| `tests/test-enforcement-level-init.sh:115` | `rows` |
| `tests/test-upgrade-to-production-preconditions.sh:273` | `ack_rows` |

## Test plan

- [x] New suite: `bash tests/test-lint-counter-antipattern.sh` → 10/10 pass
- [x] `bash scripts/lint-counter-antipattern.sh` → exit 0 on this branch HEAD (the merge gate)
- [x] `bash scripts/lint-counter-antipattern.sh --list` shows ~25 PASS rows, 0 FAIL, 2 allowlisted-with-reason
- [x] Adjacent counter-sanitizer suites still green:
  - `tests/test-check-phase-gate-counter-sanitizer.sh` → 7/7
  - `tests/test-test-gate-counter-sanitizer.sh` → 5/5
  - `tests/test-validate-counter-sanitizer.sh` → 5/5
  - `tests/test-init-schema-phase-gate.sh` → 8/8
- [ ] **CI smoke (post-workflow-add)**: open a throwaway PR that introduces a fresh antipattern → the `counter-antipattern-lint` check must fail. (Cannot be exercised until the workflow file lands — see Outstanding.)

## Outstanding — `.github/workflows/lint.yml` (NOT in this push)

The workflow YAML was written and locally validated, but the push of `.github/workflows/*` requires the GitHub OAuth token to carry the `workflow` scope. The current credentials lack it, and the agent declined to tunnel around the boundary via the Contents API (correctly — that's the user's scope to grant, not the agent's).

The workflow content is stashed at `scratchpad/lint.yml` (1.4 KB) and ready to commit. To complete this PR, one of:

1. **Grant `workflow` scope locally** then push the workflow file as a follow-up commit on this branch:
   ```sh
   gh auth refresh -h github.com -s workflow   # browser flow
   # then copy scratchpad/lint.yml → .github/workflows/lint.yml, commit, push
   ```
2. **Create the file via GitHub web UI** on this branch (drag-drop or \"Add file → Create new file\" into `.github/workflows/lint.yml`).
3. **Use a PAT with `workflow` scope** in the git credential helper, then push the local commit.

Workflow contents (already locally validated against the spec):

```yaml
name: lint

on:
  push:
    branches: [main]
  pull_request:

jobs:
  counter-antipattern-lint:
    name: counter-antipattern-lint
    runs-on: ubuntu-latest
    steps:
      - name: Checkout repository
        uses: actions/checkout@v4
      - name: Lint counter-capture antipattern
        run: bash scripts/lint-counter-antipattern.sh
      - name: Show PASS/FAIL inventory (on failure or on demand)
        if: always()
        run: bash scripts/lint-counter-antipattern.sh --list || true
```

The job name `counter-antipattern-lint` is intentionally stable so it can be added to branch protection as a required check without future lint-script churn breaking the label.

## Local dev impact

None. The lint is CI-only — NOT added to `scripts/pre-commit-gate.sh`. Promotion to pre-commit is a candidate follow-up after the rule cooks in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)