### PR TITLE
docs(governance): align pre-condition counts + phase-gate enumeration with canonical (7 sites)

### DIFF
--- a/docs/executive-review.md
+++ b/docs/executive-review.md
@@ -331,6 +331,8 @@ For an organization evaluating this model, expect **4-12 weeks to resolve organi
 7. Scope constraint: internal-only, non-critical, no PII
 8. Exit criteria defined
 9. Orchestrator time allocation approved
+10. Compliance screening completed (Intake §8.4)
+11. Governance enforcement test planned
 
 ### Pilot Timeline
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -263,7 +263,7 @@ If you want to validate the framework before completing all governance approvals
 | Mode | What's Required | What's Deferred |
 |---|---|---|
 | **Sponsored POC** | AI deployment path, project sponsor, time allocation | Insurance, liability entity, ITSM, exit criteria, backup maintainer |
-| **Private POC** | Nothing — personal exploration on your own time | All 8 pre-conditions |
+| **Private POC** | Nothing — personal exploration on your own time | All 6 pre-conditions |
 
 **POC constraints:** No production deployment, no real user data, no external users. All technical work (code, tests, scans, documentation) is production-grade and carries forward unchanged.
 

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1516,7 +1516,7 @@ PROMPTEOF
    - Section 7 (Revenue Model): skip if track is Light or deployment is Personal with internal users
    - Section 8 (Governance): skip if deployment is Personal
 7. For Section 8 (Governance, organizational only): ask which mode — Production Build, Sponsored POC, or Private POC. Explain each:
-   - **Production Build:** All 8 pre-conditions required. Full governance.
+   - **Production Build:** All 6 pre-conditions required. Full governance.
    - **Sponsored POC:** Organization knows. AI deployment path + sponsor + time allocation required. Insurance, liability, ITSM, exit criteria, backup maintainer deferred. Constraints: no production deployment, no real user data, no external users. All technical work is production-grade.
    - **Private POC:** Personal exploration. All pre-conditions deferred. Same constraints as Sponsored POC.
 8. Write completed sections into PROJECT_INTAKE.md progressively as you go.

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -669,6 +669,7 @@ fix_phase_state() {
   "gates": {
     "phase_0_to_1": null,
     "phase_1_to_2": null,
+    "phase_2_to_3": null,
     "phase_3_to_4": null
   }
 }

--- a/templates/generated/approval-log-personal.tmpl
+++ b/templates/generated/approval-log-personal.tmpl
@@ -50,6 +50,19 @@ This document records phase gate reviews for this project. For personal projects
 
 ---
 
+## Phase Gate: Phase 2 → Phase 3
+
+| Field | Value |
+|---|---|
+| **Gate** | Phase 2 → Phase 3 |
+| **Reviewer** | |
+| **Date** | |
+| **Artifacts reviewed** | Construction artifacts (code, tests, ADRs) |
+| **Decision** | Approved / Needs revision |
+| **Notes** | |
+
+---
+
 ## Phase Gate: Phase 3 → Phase 4
 
 | Field | Value |

--- a/templates/generated/claude-md.tmpl
+++ b/templates/generated/claude-md.tmpl
@@ -57,7 +57,7 @@ At the start of every new session, before any other work:
 - The Approval Log (`APPROVAL_LOG.md`) records all phase gate approvals.
 - The phase state file (`.claude/phase-state.json`) tracks the current phase mechanically.
 - **Phase gates are CI-enforced.** If `phase-state.json` and `APPROVAL_LOG.md` are out of sync, CI will block the merge. Keep them consistent.
-- At each phase gate transition (Phase 0→1, Phase 1→2, Phase 3→4):
+- At each phase gate transition (Phase 0→1, Phase 1→2, Phase 2→3, Phase 3→4):
   1. Prompt the Orchestrator: "This phase gate requires approval. Please update APPROVAL_LOG.md with the approver name, date, method, and reference before proceeding to the next phase."
   2. After the Orchestrator confirms, update `.claude/phase-state.json`: set `current_phase` to the new phase number and set the corresponding gate date (e.g., `"phase_0_to_1": "YYYY-MM-DD"`).
   3. Commit both files together.

--- a/templates/project-intake.md
+++ b/templates/project-intake.md
@@ -380,8 +380,8 @@ _Skip this section for personal projects. For organizational deployments, every 
 | **Project sponsor assigned** | Not Started / In Progress / Complete | _Name:_ | Yes |
 | **Backup maintainer designated** | Not Started / In Progress / Complete | _Name:_ | Yes |
 | **ITSM ticket filed / portfolio registered** | Not Started / In Progress / Complete | _Ticket #:_ | Yes |
-| **Exit criteria defined** | Not Started / In Progress / Complete | | Yes |
-| **Orchestrator time allocation approved** | Not Started / In Progress / Complete | _Hours/week, blocked or interleaved_ | Yes |
+| **Exit criteria defined** | Not Started / In Progress / Complete | _See Section 8.5 below_ | Required (not blocking — pilot prep, see Governance Framework §XIV) |
+| **Orchestrator time allocation approved** | Not Started / In Progress / Complete | _Hours/week, blocked or interleaved_ | Required (not blocking — pilot prep, see Governance Framework §XIV) |
 
 ### 8.2 Approval Authorities
 


### PR DESCRIPTION
## Summary

Aligns 7 drifted sites with the canonical source `docs/governance-framework.md:896-911` (6 blocking + 5 additional pilot prep = 11 pilot items, with Phase 2→3 as a tracked gate).

- **Counts:** `All 8 pre-conditions` → `All 6 pre-conditions` (correct blocking count) in `docs/user-guide.md`, `scripts/intake-wizard.sh`.
- **Enumerations:** Appended canonical items 10-11 (Compliance Screening, Governance Enforcement Test) to `docs/executive-review.md` §X; added Phase 2→3 to `templates/generated/claude-md.tmpl` enumeration + `templates/generated/approval-log-personal.tmpl` section + `scripts/verify-install.sh` phase-state.json initializer.
- **Blocking column:** Relabeled rows 7-8 in `templates/project-intake.md` §8.1 from `Yes` → `Required (not blocking — pilot prep, see Governance Framework §XIV)` to match canonical's split between 6 blocking and 5 additional.

## Changes (docs first, then templates, then scripts)

| # | File | Drift | Fix |
|---|---|---|---|
| 1 | `docs/user-guide.md:266` | `All 8 pre-conditions` (same doc says 6 elsewhere) | `All 6 pre-conditions` |
| 2 | `docs/executive-review.md:325-333` | 9 items, missing canonical 10-11 | Appended Compliance Screening + Governance Enforcement Test |
| 3 | `templates/project-intake.md:383-384` | Rows 7-8 marked Blocking=Yes | Relabeled to "Required (not blocking — pilot prep)" |
| 4 | `templates/generated/claude-md.tmpl:60` | Enumeration missing Phase 2→3 | Added Phase 2→3 (matches `check-phase-gate.sh`, `governance-framework.md:169`) |
| 5 | `templates/generated/approval-log-personal.tmpl` | Missing Phase 2→3 section | Inserted using lightweight Field/Value shape consistent with surrounding sections |
| 6 | `scripts/intake-wizard.sh:1519` (BONUS) | Operator-facing prompt: `All 8 pre-conditions required` | `All 6 pre-conditions required` |
| 7 | `scripts/verify-install.sh:670-672` (BONUS) | phase-state.json initializer missing `phase_2_to_3` | Added `"phase_2_to_3": null` |

Bonus sites (6, 7) surfaced by cycle 7 verifier, same drift family.

Closes audit findings: `user-guide-1`, `templates-intake-and-suggestions-1`, `executive-review-2`, `templates-generated-3`, `templates-generated-4`.

## Verification (grep guards — ran locally, both pass)

```
$ grep -rn 'All 8 pre-conditions\|8 pre-conditions required' docs/ templates/ scripts/ \
    | grep -v superpowers/plans | grep -v superpowers/specs
ZERO HITS

$ grep -n '(Phase 0→1' templates/generated/claude-md.tmpl
60:- At each phase gate transition (Phase 0→1, Phase 1→2, Phase 2→3, Phase 3→4):
```

Render-sanity (`bash scripts/init.sh --non-interactive ...`) skipped — sandbox didn't permit. Template edit is verbatim text insertion; render path is well-trodden by existing init tests.

## Test plan

- [ ] CI lint passes (phase-gate workflow, link checker)
- [ ] Manual: render an org-mode project via `init.sh` and confirm generated `APPROVAL_LOG.md` includes a `Phase 2 → Phase 3` section
- [ ] Manual: render a personal-mode project and confirm generated `CLAUDE.md` enumeration includes `Phase 2→3`
- [ ] Spot-check `docs/executive-review.md` §X renders with 11 numbered items

🤖 Generated with [Claude Code](https://claude.com/claude-code)