### PR TITLE
fix(upgrade-project): tighten POC-mode regex to prevent list/heading swallow

### DIFF
--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -1102,14 +1102,30 @@ if poc_removed:
     filtered = []
     skip_block = False
     for line in lines:
-        # Skip POC-specific warning blocks
-        if re.search(r'POC (MODE|mode|Mode|constraints|Constraints)', line, re.IGNORECASE):
+        # Skip POC-specific warning blocks. Audit code-upgrade-project-4
+        # (2026-06): the regex must NOT match identifiers like
+        # POC_MODE_FOO (word boundary required), AND skip_block must
+        # terminate not only on blank lines but also on a markdown
+        # heading or list-item line — otherwise a mid-paragraph "POC
+        # mode" / "POC constraints" mention inside a numbered list or
+        # right before a heading silently swallows the trailing items /
+        # the heading + body. Operator-customized CLAUDE.md only;
+        # default templates have no POC prose, so this is a real bug
+        # with a narrow but data-loss blast radius.
+        if re.search(r'POC (mode|constraints)\b', line, re.IGNORECASE):
             skip_block = True
             continue
-        if skip_block and line.strip() == '':
+        if skip_block and (
+            line.strip() == ''
+            or line.lstrip().startswith('#')
+            or re.match(r'^\s*[-*+]\s|^\s*\d+\.\s', line)
+        ):
             skip_block = False
-            continue
-        if skip_block:
+            # fall through — preserve the terminator line (heading or
+            # list item); only blank lines are dropped (continue below).
+            if line.strip() == '':
+                continue
+        elif skip_block:
             continue
         # Remove individual POC watermark lines
         if re.search(r'no production deployment.*no real user data.*no external users', line, re.IGNORECASE):

--- a/tests/test-upgrade-paths.sh
+++ b/tests/test-upgrade-paths.sh
@@ -482,5 +482,91 @@ rm -rf "$T"
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
+echo "=== T6: CLAUDE.md POC-mode strip preserves surrounding prose (code-upgrade-project-4) ==="
+# ════════════════════════════════════════════════════════════════════
+#
+# Audit code-upgrade-project-4 regression: the python heredoc that
+# strips POC watermarks from CLAUDE.md when --to-production runs uses a
+# skip_block state that terminates ONLY on a blank line. A mid-paragraph
+# mention of "POC mode" or "POC constraints" inside a numbered list or
+# right before a markdown heading therefore swallows the trailing list
+# items / the heading and its body. Operator-customized CLAUDE.md files
+# can lose data silently. Default templated CLAUDE.md has no POC prose
+# so blast radius is operator-edits only — still a real correctness bug.
+#
+# Fix: broaden skip_block termination to also close on a markdown
+# heading line (starts with #) or a list-item line (-, *, +, or
+# numbered N.). T6a covers the list-item case; T6b covers the heading.
+
+# ── T6a: numbered list — items after a mid-list POC mention survive ──
+T=$(mktemp -d); P="$T/p"
+make_phase_state "$P" "standard" "organizational" '"sponsored_poc"'
+seed_approval_log_org_filled "$P"
+cat > "$P/CLAUDE.md" <<'EOF'
+# Project Identity
+
+**Track:** Standard
+**Deployment:** Organizational
+
+## Operating Checklist
+
+1. Review the project intake before each phase gate.
+2. POC mode is documented in section 4 below for context.
+3. CANARY-LIST-ITEM-THREE must be preserved.
+4. CANARY-LIST-ITEM-FOUR must be preserved.
+
+## Next Section
+
+CANARY-NEXT-SECTION-BODY must be preserved.
+EOF
+( cd "$P" && git add APPROVAL_LOG.md CLAUDE.md && git commit -q -m "seed approval log + claude.md" ) >/dev/null 2>&1
+( cd "$P" && bash "$UPGRADE" --to-production --non-interactive --ack-preconditions=1,2,3,4,5,6 ) > "$T/log" 2>&1
+rc=$?
+have_three=$(grep -c "CANARY-LIST-ITEM-THREE" "$P/CLAUDE.md" 2>/dev/null); have_three=${have_three:-0}
+have_four=$(grep -c "CANARY-LIST-ITEM-FOUR"  "$P/CLAUDE.md" 2>/dev/null); have_four=${have_four:-0}
+have_next=$(grep -c "CANARY-NEXT-SECTION-BODY" "$P/CLAUDE.md" 2>/dev/null); have_next=${have_next:-0}
+if [ "$rc" = "0" ] && [ "$have_three" -ge 1 ] && [ "$have_four" -ge 1 ] && [ "$have_next" -ge 1 ]; then
+  pass "T6a: numbered-list items after mid-list POC mention preserved through --to-production strip"
+else
+  fail_ "T6a" "rc=$rc have_three=$have_three have_four=$have_four have_next=$have_next. Log tail: $(tail -10 "$T/log" 2>/dev/null | tr '\n' '|')"
+fi
+rm -rf "$T"
+
+# ── T6b: heading after a "POC constraints" line is preserved ────────
+T=$(mktemp -d); P="$T/p"
+make_phase_state "$P" "standard" "organizational" '"sponsored_poc"'
+seed_approval_log_org_filled "$P"
+cat > "$P/CLAUDE.md" <<'EOF'
+# Project Identity
+
+**Track:** Standard
+**Deployment:** Organizational
+
+POC constraints apply during pilot.
+## Configuration
+
+CANARY-CONFIG-BODY must be preserved.
+
+## Deployment Notes
+
+CANARY-DEPLOY-BODY must be preserved.
+EOF
+( cd "$P" && git add APPROVAL_LOG.md CLAUDE.md && git commit -q -m "seed approval log + claude.md" ) >/dev/null 2>&1
+( cd "$P" && bash "$UPGRADE" --to-production --non-interactive --ack-preconditions=1,2,3,4,5,6 ) > "$T/log" 2>&1
+rc=$?
+have_config_head=$(grep -c "^## Configuration"  "$P/CLAUDE.md" 2>/dev/null); have_config_head=${have_config_head:-0}
+have_config_body=$(grep -c "CANARY-CONFIG-BODY" "$P/CLAUDE.md" 2>/dev/null); have_config_body=${have_config_body:-0}
+have_deploy_head=$(grep -c "^## Deployment Notes" "$P/CLAUDE.md" 2>/dev/null); have_deploy_head=${have_deploy_head:-0}
+have_deploy_body=$(grep -c "CANARY-DEPLOY-BODY" "$P/CLAUDE.md" 2>/dev/null); have_deploy_body=${have_deploy_body:-0}
+if [ "$rc" = "0" ] && [ "$have_config_head" -ge 1 ] && [ "$have_config_body" -ge 1 ] \
+   && [ "$have_deploy_head" -ge 1 ] && [ "$have_deploy_body" -ge 1 ]; then
+  pass "T6b: heading + body after 'POC constraints' line preserved through --to-production strip"
+else
+  fail_ "T6b" "rc=$rc config_head=$have_config_head config_body=$have_config_body deploy_head=$have_deploy_head deploy_body=$have_deploy_body. Log tail: $(tail -10 "$T/log" 2>/dev/null | tr '\n' '|')"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- **Bug:** `scripts/upgrade-project.sh` CLAUDE.md POC-watermark stripper terminates `skip_block` only on blank lines, so a mid-paragraph "POC mode" / "POC constraints" mention inside a numbered list silently swallows trailing items, and one right before a `## Heading` swallows the heading + body. Operator-customized CLAUDE.md files lose data on `--to-production` upgrades with no warning. Default templated CLAUDE.md has no POC prose so blast radius is operator-customized files only — still a real correctness bug.
- **Fix:** (1) regex `r'POC (MODE|mode|Mode|constraints|Constraints)'` → `r'POC (mode|constraints)\b'` — `re.IGNORECASE` covers casing; `\b` prevents matches inside identifiers like `POC_MODE_FOO`. (2) `skip_block` termination broadened to also close on a markdown heading (`#`-prefix) or a list-item line (`-`, `*`, `+`, or numbered `N.`). Terminator lines are preserved verbatim so the heading/item itself survives.
- **Tests:** T6a (numbered list — items 3, 4 + next section survive) and T6b (`## Configuration` heading + body after "POC constraints apply." line survives) added to `tests/test-upgrade-paths.sh`. Both FAIL on main (RED), PASS with the fix (GREEN). All adjacent regression suites stay green (55/55 total across 7 suites).

## Slice B deferred

The cycle-7 plan flagged an atomicity wrap (trap/snapshot/rollback around the heredoc chain, ~80-120 LOC) as Slice B. Per verifier split recommendation (same-file conflict, focused review attention needed, same precedent as PR #54 / PR #57), Slice B is **deferred to cycle 8**. The stretch suggestion of switching templates to fenced `<!-- POC-START --> / <!-- POC-END -->` markers is also deferred — needs template + emitter changes.

## Test plan

- [x] T6a + T6b confirmed RED on main, GREEN after fix (TDD signal)
- [x] `tests/test-upgrade-paths.sh` — 24/24 (was 22)
- [x] `tests/test-upgrade-bl030-backfill.sh` — 7/7
- [x] `tests/test-poc-modes.sh` — 5/5
- [x] `tests/test-upgrade-non-interactive.sh` — 7/7
- [x] `tests/test-upgrade-to-production-preconditions.sh` — 6/6
- [x] `tests/test-upgrade-personal-to-sponsored-poc.sh` — 3/3
- [x] `tests/test-upgrade-to-production-warn.sh` — 3/3

Closes audit item **code-upgrade-project-4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)