### PR TITLE
feat(lint): extend counter-antipattern lint to || true variant + remediate 17 sites

### DIFF
--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -87,8 +87,8 @@ check_file() {
     print_warn "$label: differs from upstream"
     # Show a brief summary of changes
     local added removed
-    added=$(diff "$project_path" "$upstream_path" | grep -c '^>' || true)
-    removed=$(diff "$project_path" "$upstream_path" | grep -c '^<' || true)
+    added=$(diff "$project_path" "$upstream_path" | grep -c '^>' || true) # lint-counter-antipattern: allow value is string-interpolated into a human-readable summary line only, never used in arithmetic or test comparisons; a multi-line "0\n0" value would still render correctly in the echo
+    removed=$(diff "$project_path" "$upstream_path" | grep -c '^<' || true) # lint-counter-antipattern: allow value is string-interpolated into a human-readable summary line only, never used in arithmetic or test comparisons; a multi-line "0\n0" value would still render correctly in the echo
     echo -e "         (+$added lines in upstream, -$removed lines removed from upstream)"
     changes=$((changes + 1))
   fi

--- a/scripts/lint-counter-antipattern.sh
+++ b/scripts/lint-counter-antipattern.sh
@@ -20,23 +20,35 @@
 # This linter is the wave-2 backstop after PRs #67-#71 remediated every
 # known site: it makes the antipattern un-introducible in CI going
 # forward without an explicit allowlist comment justifying the choice.
+# PR #72 (cycle 6) established the baseline regex for `|| echo "0"`.
+# This cycle-8 follow-up extends coverage to the `|| true` and `|| :`
+# variants and remediates the 17 in-tree sites that matched.
 #
 # DELIBERATE SCOPE
-#   • Targets ONLY `|| echo "0"` (or `|| echo 0`) endings on capture
-#     lines that count via `grep -c`, `jq ... length`, or `wc`. These
-#     are the patterns documented in PRs #67-#71 as defect-prone:
-#     non-numeric subshell exit on zero match + numeric fallback that
-#     concatenates rather than replaces.
-#   • DOES NOT target `|| true` or `|| var=0` variants — those have
-#     different failure modes (silent empty-string capture, or
-#     idempotent fallback) and are subject of a separate follow-up
-#     PR. Broadening here would mix unrelated defect classes and
-#     dilute the merge-gate signal.
+#   • Targets `|| echo "0"` (or `|| echo 0`), `|| true`, and `|| :`
+#     endings on capture lines that count via `grep -c`, `jq ... length`,
+#     or `wc`. All three endings collapse the subshell to a non-numeric
+#     or multi-line value when the inner command exits non-zero:
+#       - `|| echo "0"` → "0\n0" concat under zero-match grep -c
+#       - `|| true`     → silent empty-string capture
+#       - `|| :`        → silent empty-string capture (`:` is no-op)
+#     All three break downstream arithmetic identically; PR #72 (cycle 6)
+#     covered the `echo "0"` form, and this cycle-8 follow-up extends
+#     coverage to the `|| true` / `|| :` variants and remediates the
+#     17 in-tree sites that matched.
+#   • DOES NOT target the `var=$(cmd) || var=0` *outer-OR* idiom where
+#     the `||` lives AFTER the subshell's closing `)`. That construction
+#     is structurally distinct: the assignment-exit fires the outer `||`
+#     when grep exits 1, cleanly assigning `var=0` exactly once. It is
+#     the CORRECT idiom and must NOT be flagged. The regex below anchors
+#     `|| <fallback> )` so only IN-subshell fallbacks match. See T6c in
+#     tests/test-lint-counter-antipattern.sh for the regression guard.
 #   • DOES NOT cover multi-line `var=$( cmd \\` captures where the
-#     `|| echo "0"` lives on a continuation line. PR #70 fixed the
-#     known multi-line site in init.sh; future multi-line captures
-#     are out of scope for this regex (a future PR can extend with
-#     a multi-line walker if needed).
+#     fallback lives on a continuation line. PR #70 fixed the known
+#     multi-line site in init.sh; future multi-line captures are out
+#     of scope for this regex (a future PR can extend with a multi-line
+#     walker if needed). Verifier confirmed no in-tree multi-line hits
+#     for this cycle.
 #
 # ALLOWLIST
 #   Append `# lint-counter-antipattern: allow <reason>` to the
@@ -78,10 +90,16 @@ TARGET_GLOBS=(
 )
 
 # Per-line antipattern: extended regex for `grep -E`.
-# Matches:   <leading-ws> IDENT=$( ... grep -c|jq...length|wc ... || echo "0" )
-# Tolerates: -c with extra flags like -cE, -ci, -ciE; quoted/unquoted 0;
-#            trailing whitespace and a `)` after the echo.
-ANTIPATTERN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(.*(grep[[:space:]]+-[a-zA-Z]*c[a-zA-Z]*|jq[[:space:]].*length|[[:space:]]wc[[:space:]]).*\|\|[[:space:]]*echo[[:space:]]+"?0"?[[:space:]]*\)'
+# Matches:   <leading-ws> IDENT=$( ... grep -c|jq...length|wc ... || <fallback> )
+# Where <fallback> ∈ { echo "0", echo 0, true, : }, all of which leave
+# the capture in a non-numeric or empty state on the inner command's
+# non-zero exit. Tolerates: -c with extra flags like -cE, -ci, -ciE;
+# quoted/unquoted 0; trailing whitespace and a `)` after the fallback.
+#
+# The terminating `\)` is load-bearing — it ensures we only match
+# IN-subshell `||` fallbacks. The outer-OR idiom `var=$(...) || var=0`
+# has its `||` AFTER the `)` and is the CORRECT pattern (see T6c).
+ANTIPATTERN_RE='^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=\$\(.*(grep[[:space:]]+-[a-zA-Z]*c[a-zA-Z]*|jq[[:space:]].*length|[[:space:]]wc[[:space:]]).*\|\|[[:space:]]*(echo[[:space:]]+"?0"?|true|:)[[:space:]]*\)'
 
 # Strip a trailing `# lint-counter-antipattern: allow <reason>` and
 # return: VAR_NAME<TAB>ALLOW_REASON_OR_EMPTY<TAB>HAS_MARKER (0|1)

--- a/scripts/lint-uat-scenarios.sh
+++ b/scripts/lint-uat-scenarios.sh
@@ -91,7 +91,7 @@ VIOLATIONS=0
 VIOLATION_LINES=""
 
 # --- File-level check 2: duplicate scenario ids ---
-DUP_IDS=$(echo "$SCENARIOS_JSON" | jq -r '[.[] | .id] | group_by(.) | map(select(length > 1) | .[0]) | .[]' 2>/dev/null || true)
+DUP_IDS=$(echo "$SCENARIOS_JSON" | jq -r '[.[] | .id] | group_by(.) | map(select(length > 1) | .[0]) | .[]' 2>/dev/null || true) # lint-counter-antipattern: allow jq emits a newline-delimited string of duplicate ids (or empty), tested via `[ -n "$DUP_IDS" ]` and then iterated line-by-line; value is never used in arithmetic comparison, so a multi-line capture is the intended shape
 if [ -n "$DUP_IDS" ]; then
   while IFS= read -r id; do
     [ -z "$id" ] && continue

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -67,9 +67,9 @@ VERSION_STATUS="(run scripts/check-versions.sh for details)"
 if [ -x "scripts/check-versions.sh" ]; then
   version_output=$(bash scripts/check-versions.sh 2>&1 </dev/null) || true
   below_min=$(echo "$version_output" | grep -c "BELOW MINIMUM" || true)
-  below_min=${below_min:-0}
+  case "$below_min" in ''|*[!0-9]*) below_min=0 ;; esac
   updates=$(echo "$version_output" | grep -c "available" || true)
-  updates=${updates:-0}
+  case "$updates" in ''|*[!0-9]*) updates=0 ;; esac
   if [ "$below_min" -gt 0 ]; then
     VERSION_STATUS="⚠ $below_min tool(s) below minimum version — run scripts/check-versions.sh"
   elif [ "$updates" -gt 0 ]; then

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -95,7 +95,7 @@ print_section "CI/CD Pipelines"
 if [ -f ".github/workflows/release.yml" ]; then
   # Check if release pipeline still has uncommented TODO placeholders
   todo_count=$(grep -cE "# TODO|echo.*TODO" .github/workflows/release.yml 2>/dev/null || true)
-  todo_count=${todo_count:-0}
+  case "$todo_count" in ''|*[!0-9]*) todo_count=0 ;; esac
   if [ "$todo_count" -gt 0 ]; then
     print_ok "Release pipeline (${todo_count} TODOs remaining — configure before first release)"
   else
@@ -343,12 +343,10 @@ print_section "Intake Completeness"
 if [ -f "PROJECT_INTAKE.md" ]; then
   # Count blank table cells (likely unfilled fields)
   blank_cells=$(grep -cE '\| *\|$|\| *$' PROJECT_INTAKE.md 2>/dev/null || true)
-  blank_cells=$(echo "$blank_cells" | tr -d '[:space:]')
-  blank_cells=${blank_cells:-0}
+  case "$blank_cells" in ''|*[!0-9]*) blank_cells=0 ;; esac
   # Count N/A entries (explicitly marked as not applicable — this is fine)
   na_cells=$(grep -ciE '\| *N/?A' PROJECT_INTAKE.md 2>/dev/null || true)
-  na_cells=$(echo "$na_cells" | tr -d '[:space:]')
-  na_cells=${na_cells:-0}
+  case "$na_cells" in ''|*[!0-9]*) na_cells=0 ;; esac
 
   if [ "$blank_cells" -gt 20 ]; then
     warn "PROJECT_INTAKE.md has ~${blank_cells} blank fields — fill these out before starting Phase 0"
@@ -428,7 +426,7 @@ if [ -f "PROJECT_INTAKE.md" ] && [ -f ".github/workflows/ci.yml" ] && [ $phase -
   if [ $matrix_issues -eq 0 ]; then
     # Check if any rows were actually filled in
     has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || true)
-    has_no=${has_no:-0}
+    case "$has_no" in ''|*[!0-9]*) has_no=0 ;; esac
     if [ "$has_no" -eq 0 ]; then
       print_info "No domains marked 'No' in Competency Matrix (or matrix not yet filled out)"
     fi

--- a/tests/test-lint-counter-antipattern.sh
+++ b/tests/test-lint-counter-antipattern.sh
@@ -151,13 +151,14 @@ teardown
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
-echo "=== T6: '|| true' variant → exit 0 (out-of-scope, deliberate) ==="
+echo "=== T6: '|| true' variant → exit 1 (now in scope, cycle-8 extension) ==="
 # ════════════════════════════════════════════════════════════════════
-# DELIBERATE EXCLUSION: this linter targets only `|| echo \"0\"` (the
-# class with the documented "0\\n0" concat failure mode). The `|| true`
-# variant has a different failure mode (silent empty-string capture)
-# and is scoped to a separate follow-up PR. Keeping these out of scope
-# keeps the merge-gate signal focused on the defect class wave 1 fixed.
+# Cycle 8 follow-up to PR #72: this linter now covers the `|| true` and
+# `|| :` IN-subshell fallback variants in addition to `|| echo "0"`.
+# All three leave the capture in a non-numeric or empty state on the
+# inner command's non-zero exit and break downstream arithmetic
+# identically. The fix pattern is the same canonical case-statement
+# sanitizer on the immediately-following line.
 setup
 cat > "$PROJ/scripts/or-true.sh" <<'SH'
 #!/usr/bin/env bash
@@ -165,10 +166,68 @@ silent_count=$(grep -c "X" file.txt 2>/dev/null || true)
 echo "$silent_count"
 SH
 out=$(run_lint); rc=$?
-if [ $rc -eq 0 ]; then
-  pass "T6: '|| true' variant is out of scope (passes)"
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/or-true.sh:2" \
+   && echo "$out" | grep -q "silent_count"; then
+  pass "T6: '|| true' in-subshell fallback is now flagged with file:line + var"
 else
-  fail_ "T6" "expected exit 0 for out-of-scope variant; rc=$rc; output:\n$out"
+  fail_ "T6" "expected exit 1 + file:line:var for '|| true'; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6b: '|| true' variant + sanitizer on next line → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Confirms the SAME canonical case-statement sanitizer that fixes the
+# `|| echo "0"` form also satisfies the lint for the `|| true` and
+# `|| :` forms. This is the documented fix pattern at every cycle-8
+# remediation site (scripts/validate.sh, scripts/resume.sh, etc.).
+setup
+cat > "$PROJ/scripts/or-true-fixed.sh" <<'SH'
+#!/usr/bin/env bash
+silent_count=$(grep -c "X" file.txt 2>/dev/null || true)
+case "$silent_count" in ''|*[!0-9]*) silent_count=0 ;; esac
+colon_count=$(grep -c "Y" file.txt 2>/dev/null || :)
+case "$colon_count" in ''|*[!0-9]*) colon_count=0 ;; esac
+echo "$silent_count $colon_count"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T6b: sanitized '|| true' and '|| :' captures pass"
+else
+  fail_ "T6b" "expected exit 0 for sanitized variants; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6c: outer-OR idiom 'var=\$(cmd) || var=0' → exit 0 (regression guard) ==="
+# ════════════════════════════════════════════════════════════════════
+# REGRESSION GUARD for the structurally-distinct outer-OR idiom used
+# at scripts/check-phase-gate.sh:427. Here the `||` lives AFTER the
+# subshell's closing `)`, NOT inside it. Bash semantics: when grep -c
+# exits 1 on zero matches, the assignment statement inherits that
+# non-zero exit, which fires the outer `||`, which cleanly assigns
+# `var=0` exactly once. There is no "0\n0" concat, no silent empty
+# capture, no broken arithmetic — this is the CORRECT idiom and the
+# lint must NEVER flag it. The cycle-8 regex extension preserved the
+# `\) $` anchor on the in-subshell match precisely to keep this site
+# out of scope; T6c locks that property in.
+setup
+cat > "$PROJ/scripts/outer-or.sh" <<'SH'
+#!/usr/bin/env bash
+# This is the exact shape at scripts/check-phase-gate.sh:427.
+todo_count=$(grep -c "TODO" .github/workflows/release.yml 2>/dev/null) || todo_count=0
+if [ "$todo_count" -gt 0 ]; then
+  echo "warn: $todo_count TODOs remain"
+fi
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T6c: outer-OR idiom is correctly NOT flagged"
+else
+  fail_ "T6c" "REGRESSION: outer-OR idiom was flagged (must stay out of scope); rc=$rc; output:\n$out"
 fi
 teardown
 

--- a/tests/test-pending-approval.sh
+++ b/tests/test-pending-approval.sh
@@ -209,9 +209,12 @@ p17_atomic_write_code_shape() {
   # rather than literals, so accept both shapes.
   local has_mktemp has_mv has_direct_write
   has_mktemp=$(grep -cE 'mktemp.*pending-approval\.[A-Z0-9]+\.tmp' "$SCRIPT" || true)
+  case "$has_mktemp" in ''|*[!0-9]*) has_mktemp=0 ;; esac
   has_mv=$(grep -cE '^[[:space:]]*mv[[:space:]]+["$]' "$SCRIPT" || true)
+  case "$has_mv" in ''|*[!0-9]*) has_mv=0 ;; esac
   # Direct write: any non-comment line that does `> $sentinel` or `> ".../.claude/pending-approval.json"`.
   has_direct_write=$(grep -cE '^[[:space:]]*[^#]*>[[:space:]]+("?\$?\{?[A-Za-z_]*\}?/?\.claude/pending-approval\.json"?|"\$sentinel")' "$SCRIPT" || true)
+  case "$has_direct_write" in ''|*[!0-9]*) has_direct_write=0 ;; esac
 
   if [ "$has_mktemp" -ge 1 ] && [ "$has_mv" -ge 1 ] && [ "$has_direct_write" = "0" ]; then
     pass "P17: helper uses atomic write (mktemp + mv); no direct '> sentinel' patterns"

--- a/tests/test-test-gate-counter-sanitizer.sh
+++ b/tests/test-test-gate-counter-sanitizer.sh
@@ -224,6 +224,7 @@ cat > "$PROJ/BUGS.md" <<'MD'
 MD
 out=$(run_gate)
 ok_count=$(echo "$out" | grep -c 'No open SEV-1\|No open SEV-2 fix-now\|No deferred SEV-2\|No open SEV-3' || true)
+case "$ok_count" in ''|*[!0-9]*) ok_count=0 ;; esac
 if echo "$out" | grep -q "integer expression expected"; then
   fail_ "T4" "integer leak on zero-bug scenario; out:\n$(echo "$out" | grep -i integer)"
 elif [ "$ok_count" -ge 4 ]; then

--- a/tests/upgrade-path-tests.sh
+++ b/tests/upgrade-path-tests.sh
@@ -626,9 +626,9 @@ names_light=$(get_all_tool_names "$output_light_all")
 names_standard=$(get_all_tool_names "$output_standard_all")
 names_full=$(get_all_tool_names "$output_full_all")
 
-count_light=$(echo "$names_light" | grep -c . || true)
-count_standard=$(echo "$names_standard" | grep -c . || true)
-count_full=$(echo "$names_full" | grep -c . || true)
+count_light=$(echo "$names_light" | grep -c . || true) # lint-counter-antipattern: allow value is echoed for human inspection in the upgrade-path diagnostic output only, never used in arithmetic or test gating
+count_standard=$(echo "$names_standard" | grep -c . || true) # lint-counter-antipattern: allow value is echoed for human inspection in the upgrade-path diagnostic output only, never used in arithmetic or test gating
+count_full=$(echo "$names_full" | grep -c . || true) # lint-counter-antipattern: allow value is echoed for human inspection in the upgrade-path diagnostic output only, never used in arithmetic or test gating
 
 echo "  web/typescript tool counts: light=$count_light, standard=$count_standard, full=$count_full"
 echo ""


### PR DESCRIPTION
## Summary

Cycle 8 follow-up to PR #72 (cycle 6). PR #72 established the counter-capture antipattern lint for the `|| echo "0"` form; its DELIBERATE SCOPE block explicitly deferred `|| true` / `|| :` coverage to a follow-up. This is that follow-up — bundled lint extension + 17-site remediation in a single PR per verifier recommendation.

## Lint extension

`scripts/lint-counter-antipattern.sh` ANTIPATTERN_RE now matches three in-subshell fallbacks:

- `|| echo "0"` (PR #72 baseline) — produces `"0\n0"` concat on zero-match `grep -c`
- `|| true` (this PR) — produces silent empty-string capture
- `|| :` (this PR) — produces silent empty-string capture (`:` is no-op)

All three break downstream arithmetic identically; the canonical `case "$var" in ''|*[!0-9]*) var=0 ;; esac` sanitizer fixes all three.

## The `|| var=0` outer-OR idiom is NOT flagged (T6c regression guard)

`scripts/check-phase-gate.sh:427` uses the structurally distinct outer-OR idiom:

```bash
todo_count=$(grep -c "TODO" .github/workflows/release.yml 2>/dev/null) || todo_count=0
```

Here the `||` lives **after** the subshell's closing `)`. When `grep -c` exits 1 on zero matches, the assignment-statement inherits that non-zero exit, the outer `||` fires, and `todo_count=0` is assigned cleanly exactly once. No multi-line concat, no silent empty capture, no broken arithmetic — this is the CORRECT idiom and must NEVER be flagged.

The cycle-8 regex preserves the `\| <fallback> )` anchor precisely to keep this form out of scope. **T6c locks this in as a regression guard.**

## Site classification (17 sites — verifier-supplied)

| Category | Count | Action | Sites |
|----------|-------|--------|-------|
| EXPLOITABLE | 8 | Canonical case-statement sanitizer | `scripts/validate.sh:97` (todo_count, -gt), `scripts/validate.sh:430` (has_no, -eq), `scripts/resume.sh:69` (below_min, -gt), `scripts/resume.sh:71` (updates, -gt), `tests/test-test-gate-counter-sanitizer.sh:226` (ok_count, -ge 4), `tests/test-pending-approval.sh:211` (has_mktemp, -ge 1), `tests/test-pending-approval.sh:212` (has_mv, -ge 1), `tests/test-pending-approval.sh:214` (has_direct_write, equality) |
| STDERR_LEAK / armored | 2 | Sanitizer for consistency (replaces `tr -d` + `${var:-0}` pair) | `scripts/validate.sh:345` (blank_cells), `scripts/validate.sh:349` (na_cells) |
| BENIGN | 6 | Allowlist with substantive reason | `scripts/check-updates.sh:90,91` (added/removed — string-only summary), `tests/upgrade-path-tests.sh:629-631` (count_light/standard/full — echoed for human inspection), `scripts/lint-uat-scenarios.sh:94` (DUP_IDS — jq newline-list tested with `-n`) |
| EXEMPT | 1 | Inside `<<'SH'` heredoc; repurposed by T6 inversion | `tests/test-lint-counter-antipattern.sh:164` |

## Test changes

- **T6 INVERTED**: was "expect exit 0 (out-of-scope)", now "expect exit 1 + names `silent_count`" since `|| true` is now in scope.
- **T6b ADDED**: sanitized `|| true` AND `|| :` captures pass — confirms the same canonical case-statement fixes both forms.
- **T6c ADDED**: outer-OR idiom regression guard — must NEVER be flagged. Fixture replicates the exact shape at `scripts/check-phase-gate.sh:427`.

## Verification

- `bash scripts/lint-counter-antipattern.sh` against HEAD → **exit 0** (T9 merge gate satisfied; all 17 sites sanitized/allowlisted/exempt)
- `bash tests/test-lint-counter-antipattern.sh` → **12/12 pass** (T1-T5, T6, T6b, T6c, T7-T10)
- Adjacent regression suites green:
  - `tests/test-test-gate-counter-sanitizer.sh` → 5/5
  - `tests/test-check-phase-gate-counter-sanitizer.sh` → 7/7
  - `tests/test-pending-approval.sh` → 21/21
  - `tests/test-validate-counter-sanitizer.sh` → 5/5

## Sequencing note

**Merge this PR BEFORE the slot 5 PR** (pre-commit-gate lint promotion). The slot 5 PR will invoke `scripts/lint-counter-antipattern.sh` from a pre-commit gate; merging this first ensures that gate inherits the extended `|| true` / `|| :` coverage from the moment it's promoted. Merging in the reverse order would gate against the old narrower regex and let the new variants slip into local commits.

## Test plan

- [x] T6 inverted — was expect-0, now expect-1 with diagnostic
- [x] T6b added — sanitized `|| true` and `|| :` pass
- [x] T6c added — outer-OR idiom NOT flagged
- [x] 10 sanitizer fixes applied (8 EXPLOITABLE + 2 STDERR_LEAK)
- [x] 6 allowlist comments applied with substantive reasons
- [x] T9 HEAD-sanity merge gate exits 0
- [x] 4 adjacent suites green

🤖 Generated with [Claude Code](https://claude.com/claude-code)