### PR TITLE
test(host-drivers): bitbucket + gitlab unit-test parity (closes BL-005)

### DIFF
--- a/docs/cli-setup-addendum.md
+++ b/docs/cli-setup-addendum.md
@@ -666,13 +666,15 @@ No first-party CLI. Uses `curl` plus a Bitbucket App Password.
 
 1. Generate an App Password at <https://bitbucket.org/account/settings/app-passwords/>
    - Required scopes: `repository:admin`, `project:admin`, `pullrequest:write`
-2. Export credentials:
+2. Export credentials (all three are required — audit code-host-bitbucket-1):
    ```bash
    export BITBUCKET_USER="your-bitbucket-username"
    export BITBUCKET_APP_PASSWORD="your-app-password"
-   # For org workspaces, also:
-   export BITBUCKET_WORKSPACE="org-name"
+   export BITBUCKET_WORKSPACE="your-workspace-slug"
    ```
+   `BITBUCKET_WORKSPACE` is the slug in your `bitbucket.org/<workspace>/` URL.
+   For personal accounts it often (but not always) equals `BITBUCKET_USER`;
+   for org accounts it is the team slug, which differs from any single user.
 3. Add to your shell rc (`.bashrc` / `.zshrc`) for persistence. Ensure mode 600 if any secrets live in it.
 
 ### Other hosts (Gitea, Codeberg, self-hosted)

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -94,13 +94,15 @@ Plan Task 10.3 was deferred during inline execution. `scripts/upgrade-project.sh
 **Logged:** 2026-04-22
 **Category:** Debt
 **Severity:** Low
-**Status:** Open
+**Status:** Resolved (2026-06-28, PR test/bl005-host-driver-parity-final)
 
 Driver-level test coverage varies: GitHub has 8 scenarios (full contract, both modes, drift cases); GitLab has 6 (most of contract, both modes); Bitbucket has 4 (name, require_cli, register_remote, parse_origin only — HTTP logic untested). Bitbucket's `host_configure_protection` and `host_verify_protection` HTTP calls are validated by code review only.
 
 **Scope:** extend `tests/host-drivers/bitbucket.test.sh` with mock-curl fixtures for: configure_protection (personal + org payloads), verify_protection (all restriction types present → pass; missing restrictions → fail with specific messages), drift detection.
 
 **Trigger:** Before the first solo-orchestrator user tries Bitbucket, OR whenever touching `bitbucket.sh`.
+
+**Resolution (cycle 8, 2026-06-28):** Closed via test additions across three files plus one doc + backlog tweak. (1) `tests/host-drivers/bitbucket.test.sh` adds 6 unit-test scenarios — `host_configure_protection` (personal, org) and `host_verify_protection` (personal pass, personal fail, org pass, org fail) — exercising the previously-untested curl payloads under `_bb_curl` / `_bb_curl_no_body`. (2) `tests/host-drivers/gitlab.test.sh` adds 6 parity scenarios surfaced against `github.test.sh`: `host_require_cli` unauthed, `host_create_repo` public + dupe, `host_register_remote` replace existing, `host_configure_protection` org, `host_verify_protection` org pass. (3) `tests/host-drivers/mock-cli.sh` extended with stdin-drain guard (`[ -t 0 ] || cat >/dev/null`) so bitbucket's `--data-binary @-` POSTs don't race against stub exit on the success path; stderr discipline preserved (stub writes stderr only on unmatched-fixture exit 127). (4) `docs/cli-setup-addendum.md` § Bitbucket: `BITBUCKET_WORKSPACE` is now documented as required (not org-only) per audit code-host-bitbucket-1. Full host-drivers run-all + 3 e2e suites remain green.
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -94,7 +94,7 @@ Plan Task 10.3 was deferred during inline execution. `scripts/upgrade-project.sh
 **Logged:** 2026-04-22
 **Category:** Debt
 **Severity:** Low
-**Status:** Resolved (2026-06-28, PR test/bl005-host-driver-parity-final)
+**Status:** Resolved (2026-06-28, PR #81)
 
 Driver-level test coverage varies: GitHub has 8 scenarios (full contract, both modes, drift cases); GitLab has 6 (most of contract, both modes); Bitbucket has 4 (name, require_cli, register_remote, parse_origin only — HTTP logic untested). Bitbucket's `host_configure_protection` and `host_verify_protection` HTTP calls are validated by code review only.
 

--- a/tests/host-drivers/bitbucket.test.sh
+++ b/tests/host-drivers/bitbucket.test.sh
@@ -46,4 +46,108 @@ assert_eq "ws/repo" "$(_bb_parse_origin)" "parse_origin"
 cd - >/dev/null; rm -rf "$WORK"
 echo "bitbucket.test.sh: _bb_parse_origin PASSED"
 
+# ════════════════════════════════════════════════════════════════════
+# host_configure_protection — BL-005 closure (cycle 8). The driver invokes
+# curl 2-7 times per call (1 GET idempotency scan, 0-N DELETEs, 2 POSTs
+# personal / 5 POSTs org). mock-cli's stub matches on a substring of the
+# full argv; both POSTs share the `/branch-restrictions` URL so a single
+# fixture serves all kinds. The idempotency GET uses
+# `branch-restrictions?pattern=main` — distinct substring → distinct fixture.
+# Bitbucket credentials are required by the driver's `_bb_curl` (-u flag)
+# but never validated by the stub; export sentinels so the auth assembly
+# doesn't error.
+# ════════════════════════════════════════════════════════════════════
+
+# host_configure_protection personal — 2 POSTs (force + delete), no idempotency hits
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="ws"
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://bitbucket.org/ws/repo.git"
+# Idempotency scan returns no existing restrictions → no DELETE issued.
+mock_cli_respond curl "branch-restrictions?pattern=main" 0 '{"values":[]}'
+# POST creates restrictions; one fixture serves all kinds (force, delete in personal).
+mock_cli_respond curl "-X POST" 0 '{"id":1,"kind":"force"}'
+set +e; host_configure_protection "main" "personal"; code=$?; set -e
+assert_exit_code 0 "$code" "personal configure succeeds"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
+echo "bitbucket.test.sh: host_configure_protection (personal) PASSED"
+
+# host_configure_protection org — 5 POSTs total (force, delete, push, approvals, builds).
+# One curl POST fixture serves all five since they share the URL substring.
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="orgws"
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://bitbucket.org/orgws/orgrepo.git"
+mock_cli_respond curl "branch-restrictions?pattern=main" 0 '{"values":[]}'
+mock_cli_respond curl "-X POST" 0 '{"id":1}'
+set +e; host_configure_protection "main" "org"; code=$?; set -e
+assert_exit_code 0 "$code" "org configure succeeds"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
+echo "bitbucket.test.sh: host_configure_protection (org) PASSED"
+
+# host_verify_protection personal pass — both force + delete restrictions present.
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="ws"
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://bitbucket.org/ws/repo.git"
+mock_cli_respond curl "branch-restrictions?pattern=main" 0 \
+  '{"values":[{"id":1,"kind":"force","pattern":"main"},{"id":2,"kind":"delete","pattern":"main"}]}'
+set +e; host_verify_protection "main" "personal"; code=$?; set -e
+assert_exit_code 0 "$code" "personal verify pass"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
+echo "bitbucket.test.sh: host_verify_protection (personal pass) PASSED"
+
+# host_verify_protection personal fail — force-push restriction missing.
+# Driver returns 1 + prints "force-push not restricted" on stderr.
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="ws"
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://bitbucket.org/ws/repo.git"
+# Only the delete kind present — force missing → personal failure path.
+mock_cli_respond curl "branch-restrictions?pattern=main" 0 \
+  '{"values":[{"id":2,"kind":"delete","pattern":"main"}]}'
+set +e; output=$(host_verify_protection "main" "personal" 2>&1); code=$?; set -e
+assert_exit_code 1 "$code" "personal verify fail (force missing)"
+assert_contains "$output" "force-push" "mentions force-push rule"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
+echo "bitbucket.test.sh: host_verify_protection (personal fail) PASSED"
+
+# host_verify_protection org pass — all 5 kinds present, approvals + builds value>=1.
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="orgws"
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://bitbucket.org/orgws/orgrepo.git"
+mock_cli_respond curl "branch-restrictions?pattern=main" 0 \
+  '{"values":[{"id":1,"kind":"force","pattern":"main"},{"id":2,"kind":"delete","pattern":"main"},{"id":3,"kind":"push","pattern":"main"},{"id":4,"kind":"require_approvals_to_merge","pattern":"main","value":1},{"id":5,"kind":"require_passing_builds_to_merge","pattern":"main","value":1}]}'
+set +e; host_verify_protection "main" "org"; code=$?; set -e
+assert_exit_code 0 "$code" "org verify pass"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
+echo "bitbucket.test.sh: host_verify_protection (org pass) PASSED"
+
+# host_verify_protection org fail — push restriction missing (force+delete+approvals+builds OK).
+# Driver reports specific missing org-mode rules on stderr.
+export BITBUCKET_USER="testuser" BITBUCKET_APP_PASSWORD="testpass" BITBUCKET_WORKSPACE="orgws"
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://bitbucket.org/orgws/orgrepo.git"
+mock_cli_respond curl "branch-restrictions?pattern=main" 0 \
+  '{"values":[{"id":1,"kind":"force","pattern":"main"},{"id":2,"kind":"delete","pattern":"main"},{"id":4,"kind":"require_approvals_to_merge","pattern":"main","value":1},{"id":5,"kind":"require_passing_builds_to_merge","pattern":"main","value":1}]}'
+set +e; output=$(host_verify_protection "main" "org" 2>&1); code=$?; set -e
+assert_exit_code 1 "$code" "org verify fail (push missing)"
+assert_contains "$output" "push" "mentions push restriction"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+unset BITBUCKET_USER BITBUCKET_APP_PASSWORD BITBUCKET_WORKSPACE
+echo "bitbucket.test.sh: host_verify_protection (org fail) PASSED"
+
 echo "bitbucket.test.sh: all tests PASSED"

--- a/tests/host-drivers/gitlab.test.sh
+++ b/tests/host-drivers/gitlab.test.sh
@@ -22,21 +22,61 @@ export PATH="$OLD_PATH"
 mock_cli_teardown "$MOCK_DIR"
 echo "gitlab.test.sh: host_require_cli (missing) PASSED"
 
-# host_create_repo
+# host_require_cli — glab present but unauthed. Parity with github.test.sh
+# (BL-005 closure, cycle 8). gitlab.sh distinguishes missing-binary (rc=1,
+# install guidance) from auth-failure (rc=2, `glab auth login` guidance).
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+mock_cli_respond glab "auth status" 1 "not logged in"
+mock_cli_respond glab "--version" 0 "glab 1.0"
+set +e; output=$(host_require_cli 2>&1); code=$?; set -e
+assert_exit_code 2 "$code" "unauth'd glab returns 2"
+assert_contains "$output" "authenticated" "mentions auth"
+export PATH="$OLD_PATH"; mock_cli_teardown "$MOCK_DIR"
+echo "gitlab.test.sh: host_require_cli (unauthed) PASSED"
+
+# host_create_repo private
 MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
 mock_cli_respond glab "repo create my-repo --private" 0 "https://gitlab.com/user/my-repo"
 url=$(host_create_repo "my-repo" "private")
 assert_eq "https://gitlab.com/user/my-repo" "$url" "create private"
 mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
-echo "gitlab.test.sh: host_create_repo PASSED"
+echo "gitlab.test.sh: host_create_repo (private) PASSED"
 
-# host_register_remote
+# host_create_repo public — parity with github.test.sh (BL-005).
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+mock_cli_respond glab "repo create pub-repo --public" 0 "https://gitlab.com/user/pub-repo"
+url=$(host_create_repo "pub-repo" "public")
+assert_eq "https://gitlab.com/user/pub-repo" "$url" "create public"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+echo "gitlab.test.sh: host_create_repo (public) PASSED"
+
+# host_create_repo dupe — already-exists path returns non-zero + surfaces glab's stderr.
+# Parity with github.test.sh (BL-005).
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+mock_cli_respond glab "repo create dupe --private" 1 "repository already exists"
+set +e; output=$(host_create_repo "dupe" "private" 2>&1); code=$?; set -e
+assert_exit_code 1 "$code" "existing repo returns non-zero"
+assert_contains "$output" "already exists" "surfaces underlying error"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+echo "gitlab.test.sh: host_create_repo (dupe) PASSED"
+
+# host_register_remote — fresh init.
 WORK=$(mktemp -d); cd "$WORK"
 git init -q
 host_register_remote "https://gitlab.com/u/r.git"
 assert_eq "https://gitlab.com/u/r.git" "$(git remote get-url origin)" "register sets origin"
 cd - >/dev/null; rm -rf "$WORK"
-echo "gitlab.test.sh: host_register_remote PASSED"
+echo "gitlab.test.sh: host_register_remote (fresh) PASSED"
+
+# host_register_remote — replaces existing origin idempotently. Parity with
+# github.test.sh (BL-005).
+WORK=$(mktemp -d); cd "$WORK"
+git init -q
+git remote add origin "https://example.com/old.git"
+host_register_remote "https://gitlab.com/u/r.git"
+assert_eq "https://gitlab.com/u/r.git" "$(git remote get-url origin)" "register replaces existing"
+cd - >/dev/null; rm -rf "$WORK"
+echo "gitlab.test.sh: host_register_remote (replace) PASSED"
 
 # host_configure_protection personal
 MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
@@ -49,6 +89,21 @@ assert_exit_code 0 "$code" "personal configure succeeds"
 cd - >/dev/null; rm -rf "$WORK"
 mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
 echo "gitlab.test.sh: host_configure_protection (personal) PASSED"
+
+# host_configure_protection org — POST protected_branches + PUT approvals
+# (gitlab.sh:111-121). Parity with github.test.sh (BL-005). Org mode sets
+# push_access_level=0 (No one) and approvals_before_merge=1.
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://gitlab.com/org/repo.git"
+mock_cli_respond glab "api -X DELETE projects/org%2Frepo/protected_branches/main" 0 ""
+mock_cli_respond glab "api -X POST projects/org%2Frepo/protected_branches" 0 '{"id":1,"name":"main"}'
+mock_cli_respond glab "api -X PUT projects/org%2Frepo/approvals" 0 '{"approvals_before_merge":1}'
+set +e; host_configure_protection "main" "org"; code=$?; set -e
+assert_exit_code 0 "$code" "org configure succeeds"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+echo "gitlab.test.sh: host_configure_protection (org) PASSED"
 
 # host_verify_protection — personal pass
 MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
@@ -73,4 +128,19 @@ assert_contains "$output" "approval" "mentions approvals"
 
 cd - >/dev/null; rm -rf "$WORK"
 mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
-echo "gitlab.test.sh: host_verify_protection PASSED"
+echo "gitlab.test.sh: host_verify_protection (personal pass / personal fail / org fail) PASSED"
+
+# host_verify_protection — org pass. Parity with github.test.sh (BL-005).
+# Org mode requires push_access_level=0 (No one) AND approvals_before_merge>=1
+# AND force-push disabled (gitlab.sh:144-159).
+MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
+WORK=$(mktemp -d); cd "$WORK"
+git init -q; git remote add origin "https://gitlab.com/org/repo.git"
+mock_cli_respond glab "api projects/org%2Frepo/protected_branches/main" 0 \
+  '{"name":"main","allow_force_push":false,"push_access_levels":[{"access_level":0}]}'
+mock_cli_respond glab "api projects/org%2Frepo/approvals" 0 '{"approvals_before_merge":1}'
+set +e; host_verify_protection "main" "org"; code=$?; set -e
+assert_exit_code 0 "$code" "org verify pass"
+cd - >/dev/null; rm -rf "$WORK"
+mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
+echo "gitlab.test.sh: host_verify_protection (org pass) PASSED"

--- a/tests/host-drivers/mock-cli.sh
+++ b/tests/host-drivers/mock-cli.sh
@@ -27,11 +27,29 @@ mock_cli_respond() {
   mkdir -p "$dir/.fixtures"
 
   # Each stub writes its arg-line, consults fixtures, and exits.
+  # Stdin discipline: drain any piped payload before exiting. The bitbucket
+  # driver pipes JSON to `curl --data-binary @-`; the gitlab driver pipes
+  # JSON to `glab api ... --input -`. Without draining, the producer can
+  # race against stub exit (SIGPIPE) or leave bytes in the pipe buffer.
+  # `cat >/dev/null` is a no-op when nothing is piped (read returns EOF
+  # immediately), so this is safe for all callers.
+  #
+  # Stderr discipline: stubs MUST NOT write to stderr on the success path —
+  # the bitbucket driver merges stderr into stdout via `curl ... 2>&1`, so
+  # any stray diagnostic gets folded into the response body and crashes jq
+  # downstream. Stderr is only emitted from the unmatched-fixture branch
+  # (intentional failure mode, exit 127).
   cat > "$stub" <<'STUB_EOF'
 #!/usr/bin/env bash
 fixture_dir="$(dirname "$0")/.fixtures"
 cli="$(basename "$0")"
 args="$*"
+# Drain stdin if data is piped in (POST/PUT bodies). Stdin from a terminal
+# would block read; check first via `[ -t 0 ]`. When a pipe/file is on stdin
+# (`[ -t 0 ]` false), read+discard everything.
+if [ ! -t 0 ]; then
+  cat >/dev/null 2>&1 || true
+fi
 # Find first matching fixture file: <cli>.<hash-of-pattern>
 for f in "$fixture_dir/$cli".*; do
   [ -f "$f" ] || continue


### PR DESCRIPTION
## Summary

Closes the final stretch of BL-005 — driver-level test coverage parity
across github / gitlab / bitbucket. Bitbucket's `host_configure_protection`
and `host_verify_protection` HTTP payloads had ZERO unit-test coverage
(validated by e2e only); gitlab.test.sh had several gaps vs github.test.sh.

- **bitbucket.test.sh**: +6 scenarios (configure personal/org, verify personal pass/fail + org pass/fail)
- **gitlab.test.sh**: +6 parity scenarios (require_cli unauthed, create_repo public + dupe, register_remote replace, configure org, verify org pass)
- **mock-cli.sh**: stdin-drain guard for bitbucket `--data-binary @-` POSTs (backward compatible no-op when no payload piped); stderr discipline preserved
- **cli-setup-addendum.md** § Bitbucket: `BITBUCKET_WORKSPACE` documented as required (not org-only) per audit code-host-bitbucket-1
- **solo-orchestrator-backlog.md** BL-005: flipped Open → Resolved with this PR cited

No production driver code touched (`scripts/host-drivers/*.sh` untouched). Strictly test additions + 1 doc paragraph + 1 backlog flip.

## Verification

`bash tests/host-drivers/run-all.sh`: **9 run, 0 failed**

| Suite | Result |
|---|---|
| bitbucket.test.sh | 10 PASS (4 pre-existing + 6 new) |
| gitlab.test.sh | 12 PASS (6 pre-existing + 6 new) |
| github.test.sh | unchanged (green) |
| dispatcher.test.sh, regressions.test.sh, mock-cli.selftest.sh | green |
| e2e-init.test.sh | 5 passed, 0 failed |
| e2e-init-gitlab.test.sh | 6 passed, 0 failed |
| e2e-init-bitbucket.test.sh | 5 passed, 0 failed |

## Test plan

- [x] Run `bash tests/host-drivers/run-all.sh` — all 9 suites green
- [x] Confirm bitbucket curl payloads exercised: configure (1 GET + 2-5 POST), verify (1 GET)
- [x] Confirm gitlab parity additions exercise all gaps vs github.test.sh
- [x] Confirm mock-cli stdin-drain guard does not regress existing stubs (bitbucket + gitlab e2e suites green)
- [x] Confirm backlog BL-005 flip is the only backlog entry edited

🤖 Generated with [Claude Code](https://claude.com/claude-code)