### PR TITLE
fix(intake-wizard): align section numbering + pause semantics + matrix column

### DIFF
--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -67,7 +67,17 @@ COMPLETED_SECTIONS=""
 # ================================================================
 # UTILITY: Prompt for text input with optional default
 # ================================================================
+# Audit code-intake-wizard-5: every prompt helper short-circuits at
+# entry if the pause sentinel is already set, so once the user types
+# "pause" no further read calls fire in the same section. Combined
+# with the sentinel-check in save_answer, this prevents the empty-
+# string overwrites that the audit cited (one save_answer per
+# remaining prompt corrupting another previously-saved key).
 prompt_input() {
+  if [ -f "${_PAUSE_FILE:-/dev/null/sentinel-cannot-exist}" ]; then
+    echo ""
+    return
+  fi
   local prompt="$1"
   local default="${2:-}"
   local result
@@ -89,6 +99,10 @@ prompt_input() {
 # UTILITY: Prompt for numbered choice
 # ================================================================
 prompt_choice() {
+  if [ -f "${_PAUSE_FILE:-/dev/null/sentinel-cannot-exist}" ]; then
+    echo ""
+    return
+  fi
   local prompt="$1"
   shift
   local options=("$@")
@@ -116,6 +130,10 @@ prompt_choice() {
 # UTILITY: Prompt with ? for suggestions
 # ================================================================
 prompt_with_suggestions() {
+  if [ -f "${_PAUSE_FILE:-/dev/null/sentinel-cannot-exist}" ]; then
+    echo ""
+    return
+  fi
   local prompt="$1"
   local suggestion_key="$2"
   local default="${3:-}"
@@ -382,7 +400,17 @@ render_intake_file() {
 # ================================================================
 # PROGRESS: Save an answer to the progress file
 # ================================================================
+# Audit code-intake-wizard-5: bail out early when the pause sentinel
+# exists. Before this guard, callers like `problem=$(prompt_input ...)`
+# followed by `save_answer "problem_statement" "$problem"` would write
+# the empty string returned by the paused prompt, corrupting whatever
+# the user had previously saved. The guard combined with the early-
+# exit checks in prompt_input/prompt_choice/prompt_with_suggestions
+# makes pause immediate at the granularity of the next prompt.
 save_answer() {
+  if [ -f "${_PAUSE_FILE:-/dev/null/sentinel-cannot-exist}" ]; then
+    return
+  fi
   local key="$1"
   local value="$2"
   if command -v python3 &>/dev/null; then
@@ -896,6 +924,14 @@ run_section_6() {
   print_info "Every honest 'No' adds automated coverage. Every dishonest 'Yes' creates a gap."
   echo ""
 
+  # Audit code-intake-wizard-6: capture the template's third column
+  # ("Automated Tooling Required?") so Phase 3 enforcement and Phase 2
+  # exit peer-review (baseline §3.3 / §3.4 — Security row drives the
+  # organizational peer-review gate) have a recorded source of truth.
+  # For Partially/No answers we present a framework-default tooling
+  # bundle per domain; the operator presses Enter to accept the default
+  # or overrides with free text. Yes answers store "N/A" so the
+  # rendered table is column-complete.
   local domains=("Product/UX Logic" "Frontend Code" "Backend/API Design" "Database Design" "Security" "DevOps/Infrastructure" "Accessibility" "Performance" "Mobile")
   for domain in "${domains[@]}"; do
     local assessment
@@ -908,6 +944,31 @@ run_section_6() {
     local key
     key=$(echo "$domain" | tr '/ ' '_' | tr '[:upper:]' '[:lower:]')
     save_answer "competency_$key" "$assessment"
+
+    # Tooling capture (third column). Skip silently after a pause.
+    if [ -f "${_PAUSE_FILE:-/dev/null/sentinel-cannot-exist}" ]; then
+      continue
+    fi
+    local tooling
+    if [ "$assessment" = "Yes" ]; then
+      tooling="N/A"
+    else
+      local default_tooling
+      case "$key" in
+        product_ux_logic)      default_tooling="UX heuristic review + usability test script" ;;
+        frontend_code)         default_tooling="ESLint + Prettier + axe-core + Playwright" ;;
+        backend_api_design)    default_tooling="OpenAPI contract tests + Postman/Newman + schemathesis" ;;
+        database_design)       default_tooling="SQL linter (sqlfluff) + schema-migration tests + EXPLAIN review" ;;
+        security)              default_tooling="gitleaks + Semgrep + Snyk (SCA + container)" ;;
+        devops_infrastructure) default_tooling="tflint + checkov + IaC plan review + GitHub Actions linter" ;;
+        accessibility)         default_tooling="axe-core + Lighthouse a11y audit + screen-reader smoke test" ;;
+        performance)           default_tooling="Lighthouse perf + k6 (load) + Web Vitals dashboard" ;;
+        mobile)                default_tooling="Detox/XCUITest + device farm (BrowserStack/Sauce) + crash reporting" ;;
+        *)                     default_tooling="Recommended automated tooling (TBD — define before Phase 3)" ;;
+      esac
+      tooling=$(prompt_input "  Automated tooling for $domain" "$default_tooling")
+    fi
+    save_answer "competency_${key}_tooling" "$tooling"
   done
 
   # 6.3 Development Environment
@@ -1390,10 +1451,34 @@ run_section_11_5() {
 }
 
 # ================================================================
-# SECTION 12: Agent Initialization Prompt (auto-generated)
+# SECTION 12: Tooling Configuration (auto-populated)
 # ================================================================
+# Audit code-intake-wizard-3: align wizard numbering with the template
+# (templates/project-intake.md §12 = Tooling Configuration, §13 =
+# Agent Initialization Prompt). The wizard previously skipped §12 and
+# called the agent-prompt section "12", which corrupted the section
+# semantics for anyone who paused at "Section 12" and later opened
+# PROJECT_INTAKE.md expecting their work in template §12.
+#
+# This wizard step is informational only — actual content is written
+# by init.sh based on the tool installation matrix (see template
+# §12's auto-populated marker and .claude/tool-preferences.json).
 run_section_12() {
-  print_step "Section 12: Agent Initialization Prompt"
+  print_step "Section 12: Tooling Configuration"
+  print_info "Auto-populated by init.sh from .claude/tool-preferences.json"
+  print_info "and the tool installation matrix — skipping interactive prompts."
+  save_section 12
+  echo ""
+}
+
+# ================================================================
+# SECTION 13: Agent Initialization Prompt (auto-generated)
+# ================================================================
+# Audit code-intake-wizard-3: this used to be `run_section_12` and
+# was labelled "Section 12: Agent Initialization Prompt", which
+# misaligned with templates/project-intake.md (§13 in the template).
+run_section_13() {
+  print_step "Section 13: Agent Initialization Prompt"
   print_info "Auto-generating from your answers..."
 
   # Read accessibility answers for the prompt
@@ -1419,8 +1504,8 @@ PYEOF
 )
   fi
 
-  print_ok "Section 12 auto-generated."
-  save_section 12
+  print_ok "Section 13 auto-generated."
+  save_section 13
   echo ""
 }
 
@@ -1439,11 +1524,17 @@ run_script_mode() {
   print_info "Type '?' at prompts marked with [? for suggestions] to see options."
   echo ""
 
-  # Section IDs: 1..11, 115 (Testing & Bug Tracking), 12.
+  # Section IDs: 1..11, 115 (Testing & Bug Tracking), 12, 13.
   # The 115 ID encodes "between 11 and 12" while keeping the value an
   # integer for save_section / is_section_complete; the runner maps it
   # back to function name run_section_11_5 below.
-  local sections=(1 2 3 4 5 6 7 8 9 10 11 115 12)
+  #
+  # Audit code-intake-wizard-3: §12 (Tooling Configuration, auto-
+  # populated) and §13 (Agent Initialization Prompt, auto-generated)
+  # are now distinct wizard steps that mirror the template's
+  # numbering, instead of the old single "Section 12" that ran §13's
+  # content.
+  local sections=(1 2 3 4 5 6 7 8 9 10 11 115 12 13)
   for section in "${sections[@]}"; do
     if [ "$section" -lt "$start_section" ]; then
       continue
@@ -1507,7 +1598,7 @@ PROMPTEOF
 
 ## Instructions
 
-1. Walk through PROJECT_INTAKE.md section by section (Sections 1-12).
+1. Walk through PROJECT_INTAKE.md section by section (Sections 1-13).
 2. Section 1 is mostly pre-filled from context above — confirm and fill remaining fields (target platforms, codename, repo URL).
 3. For each field, explain its purpose briefly, then ask the question.
 4. When the user says "I'm not sure" or asks for help, offer 2-3 options ranked by fit for their project type ($PLATFORM, $LANGUAGE, $TRACK), with a one-sentence explanation of why each fits.
@@ -1516,12 +1607,13 @@ PROMPTEOF
    - Section 7 (Revenue Model): skip if track is Light or deployment is Personal with internal users
    - Section 8 (Governance): skip if deployment is Personal
 7. For Section 8 (Governance, organizational only): ask which mode — Production Build, Sponsored POC, or Private POC. Explain each:
-   - **Production Build:** All 6 pre-conditions required. Full governance.
+   - **Production Build:** All 8 pre-conditions required. Full governance.
    - **Sponsored POC:** Organization knows. AI deployment path + sponsor + time allocation required. Insurance, liability, ITSM, exit criteria, backup maintainer deferred. Constraints: no production deployment, no real user data, no external users. All technical work is production-grade.
    - **Private POC:** Personal exploration. All pre-conditions deferred. Same constraints as Sponsored POC.
 8. Write completed sections into PROJECT_INTAKE.md progressively as you go.
-9. Section 12 (Agent Initialization Prompt): auto-generate from the answers. Do not ask the user to write this.
-10. At the end, summarize what was filled in and flag any fields left blank.
+9. Section 12 (Tooling Configuration) is auto-populated by `init.sh` from `.claude/tool-preferences.json` — do not prompt the user; confirm the section is recorded and move on.
+10. Section 13 (Agent Initialization Prompt): auto-generate from the answers. Do not ask the user to write this.
+11. At the end, summarize what was filled in and flag any fields left blank.
 
 ## Suggestion Data
 

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# tests/test-intake-wizard-fixes.sh
+#
+# Tests for the three S3 fixes in scripts/intake-wizard.sh:
+#   - code-intake-wizard-3: wizard section numbering aligns with template
+#   - code-intake-wizard-5: pause is immediate (no further save_answer writes)
+#   - code-intake-wizard-6: Competency Matrix captures the
+#       "Automated Tooling Required?" third column
+#
+# Plus a regression guard for the wizard's print_step / Claude-mode prompt
+# section count drift (bonus catch: "All 8 pre-conditions", "Sections 1-13").
+#
+# Style mirrors tests/test-lint-counter-antipattern.sh: set -uo pipefail,
+# isolated fixtures, per-case pass/fail counters, RED-before-GREEN
+# verification by inspection (no shared state between cases).
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+WIZARD="$REPO_ROOT/scripts/intake-wizard.sh"
+TEMPLATE="$REPO_ROOT/templates/project-intake.md"
+
+if [ ! -f "$WIZARD" ]; then
+  echo "FATAL: intake-wizard.sh not found at $WIZARD" >&2
+  exit 2
+fi
+if [ ! -f "$TEMPLATE" ]; then
+  echo "FATAL: project-intake.md template not found at $TEMPLATE" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ----------------------------------------------------------------
+# T1 (code-intake-wizard-3): wizard print_step labels must match
+# the template's `## N. Title` headings for every numbered section.
+# ----------------------------------------------------------------
+echo ""
+echo "T1: wizard section labels match template headings"
+
+# Extract template section number → title map (skip 11.5 — printed
+# separately by run_section_11_5 in the wizard).
+template_pairs=$(awk -F': ' '
+  /^##[[:space:]]+[0-9]+\.[[:space:]]/ {
+    sub(/^##[[:space:]]+/, "")
+    # Trim trailing parenthetical qualifiers like "(Standard+ Track ...)"
+    sub(/[[:space:]]+\(.*\)$/, "")
+    print
+  }
+' "$TEMPLATE")
+
+# Pull every print_step "Section N: Title" line from the wizard.
+wizard_pairs=$(grep -oE 'print_step "Section [0-9]+(\.[0-9]+)?: [^"]+"' "$WIZARD" \
+  | sed -e 's/^print_step "Section //' -e 's/"$//')
+
+drift_found=0
+while IFS= read -r tpl_line; do
+  tpl_num="${tpl_line%%.*}"
+  tpl_title=$(echo "$tpl_line" | sed -E 's/^[0-9]+\.[[:space:]]*//')
+  # Find wizard line for this section.
+  wiz_line=$(echo "$wizard_pairs" | awk -v n="$tpl_num" -F': ' '
+    $1 == n { print; exit }
+  ')
+  if [ -z "$wiz_line" ]; then
+    # 11 has no template heading qualifier; the only sections without a
+    # matching print_step in the wizard are §12 (auto-populated, no prompt).
+    # Don't flag this as drift — it's wired in run_section_12 by design.
+    if [ "$tpl_num" = "12" ]; then
+      continue
+    fi
+    fail_ "T1" "wizard missing print_step for template Section $tpl_num ($tpl_title)"
+    drift_found=1
+    continue
+  fi
+  wiz_title=$(echo "$wiz_line" | sed -E 's/^[0-9]+:[[:space:]]*//')
+  # Loose title comparison: template title is canonical, wizard may shorten.
+  # Hard requirement: numbers must match.
+  if [ "${wiz_line%%:*}" != "$tpl_num" ]; then
+    fail_ "T1" "wizard section number drift at template §$tpl_num: wizard shows '$wiz_line'"
+    drift_found=1
+  fi
+done <<<"$template_pairs"
+
+# Also: the wizard's section-12 label must match template §12
+# (Tooling Configuration), not "Agent Initialization Prompt".
+if grep -qE 'print_step "Section 12: Agent Initialization Prompt"' "$WIZARD"; then
+  fail_ "T1" "wizard §12 still labelled 'Agent Initialization Prompt' (should be Tooling Configuration; that label belongs to §13)"
+  drift_found=1
+fi
+
+# And: a §13 label for Agent Initialization Prompt must exist.
+if ! grep -qE 'print_step "Section 13: Agent Initialization Prompt"' "$WIZARD"; then
+  fail_ "T1" "wizard missing 'Section 13: Agent Initialization Prompt' label (template §13)"
+  drift_found=1
+fi
+
+if [ "$drift_found" -eq 0 ]; then
+  pass "T1: wizard print_step labels align with template Section numbers"
+fi
+
+# ----------------------------------------------------------------
+# T2 (code-intake-wizard-3, ancillary): the Claude-mode generated
+# prompt must reference the correct section range (1-13, not 1-12).
+# ----------------------------------------------------------------
+echo ""
+echo "T2: Claude-mode prompt section range matches template"
+if grep -qE 'Walk through PROJECT_INTAKE.md section by section \(Sections 1-12\)' "$WIZARD"; then
+  fail_ "T2" "Claude-mode prompt still says 'Sections 1-12' (should be 1-13)"
+elif grep -qE 'Walk through PROJECT_INTAKE.md section by section \(Sections 1-13\)' "$WIZARD"; then
+  pass "T2: Claude-mode prompt covers Sections 1-13"
+else
+  fail_ "T2" "Claude-mode 'Walk through ... Sections N-M' line not found in wizard"
+fi
+
+# ----------------------------------------------------------------
+# T3 (bonus): "All 6 pre-conditions required" — the preconditions
+# array has 8 items; the count must match.
+# ----------------------------------------------------------------
+echo ""
+echo "T3: Production-Build pre-condition count matches preconditions array"
+precond_count=$(awk '
+  /^  local preconditions=\(/ { inside=1; next }
+  inside && /^  \)/ { inside=0 }
+  inside && /^[[:space:]]+"/ { count++ }
+  END { print count+0 }
+' "$WIZARD")
+if [ "${precond_count:-0}" -ne 8 ]; then
+  fail_ "T3" "expected 8 preconditions in run_section_8 array, found ${precond_count:-0}"
+elif grep -qE '\*\*Production Build:\*\* All 6 pre-conditions required' "$WIZARD"; then
+  fail_ "T3" "wizard Claude-mode says 'All 6 pre-conditions' but the array has 8 entries"
+elif grep -qE '\*\*Production Build:\*\* All 8 pre-conditions required' "$WIZARD"; then
+  pass "T3: Production-Build prompt correctly references all 8 pre-conditions"
+else
+  fail_ "T3" "Claude-mode 'Production Build' pre-condition count line not found"
+fi
+
+# ----------------------------------------------------------------
+# T4 (code-intake-wizard-5): pause is immediate — once "pause" is
+# typed at a prompt, no further save_answer writes happen in that
+# section. We exercise prompt_input + save_answer in a sourced
+# subshell with stdin pre-loaded with "pause".
+# ----------------------------------------------------------------
+echo ""
+echo "T4: pause short-circuits prompt_input and skips save_answer writes"
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  [SKIP] T4 — python3 unavailable"
+else
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"' EXIT
+  PROG="$TMP/intake-progress.json"
+  python3 -c "
+import json
+data = {
+  'version': 1, 'started_at': '2026-01-01T00:00:00Z',
+  'last_section': 0, 'completed_sections': [],
+  'project_name': 'TestProject', 'platform': 'web', 'track': 'standard',
+  'deployment': 'personal', 'language': 'typescript',
+  'description': 'A test', 'poc_mode': None,
+  'answers': {'preexisting': 'kept'}
+}
+with open('$PROG', 'w') as f:
+    json.dump(data, f)
+"
+
+  # Source the wizard's helper functions only (avoid running main).
+  # We extract prompt_input, save_answer, _request_pause,
+  # check_pause_requested into a runnable script with overridden
+  # PROGRESS_FILE and stubbed print_* helpers.
+  TEST_SCRIPT="$TMP/test.sh"
+  cat > "$TEST_SCRIPT" << EOF
+#!/usr/bin/env bash
+set -uo pipefail
+PROGRESS_FILE="$PROG"
+_PAUSE_FILE="$TMP/.pause-sentinel"
+BOLD=''; NC=''; CYAN=''; GREEN=''; BLUE=''; YELLOW=''; RED=''
+print_info() { :; }
+print_ok()   { :; }
+print_warn() { :; }
+print_fail() { :; }
+print_step() { :; }
+log_line()   { :; }
+
+EOF
+  # Extract the wizard functions we need. Use awk to grab each
+  # function block by name (BSD-awk compatible).
+  for fn in prompt_input prompt_choice prompt_with_suggestions _request_pause check_pause_requested save_answer; do
+    awk -v fn="$fn" '
+      $0 ~ ("^" fn "\\(\\) \\{") { inside=1 }
+      inside { print; if ($0 == "}") { inside=0; print ""; exit } }
+    ' "$WIZARD" >> "$TEST_SCRIPT"
+  done
+
+  cat >> "$TEST_SCRIPT" << 'EOF'
+
+# Simulate run_section_2 sequence: ask for two real answers, then "pause",
+# then attempt three more prompts/saves. After fix, "pause" must cause
+# every subsequent save_answer to be a no-op (sentinel guards it).
+answer1=$(prompt_input "Q1" "")
+save_answer "q1" "$answer1"
+
+answer2=$(prompt_input "Q2" "")
+save_answer "q2" "$answer2"
+
+answer3=$(prompt_input "Q3" "")
+save_answer "q3" "$answer3"
+
+# These should also not write — sentinel is set after Q3's "pause".
+answer4=$(prompt_input "Q4" "")
+save_answer "q4" "$answer4"
+
+answer5=$(prompt_input "Q5" "")
+save_answer "q5" "$answer5"
+
+# Verify what got written.
+python3 -c "
+import json, sys
+with open('$PROGRESS_FILE') as f:
+    data = json.load(f)
+ans = data.get('answers', {})
+# Pre-existing key must be preserved.
+assert ans.get('preexisting') == 'kept', f'preexisting was clobbered: {ans}'
+# q1 + q2 are real, q3 was 'pause' and q4/q5 came after pause.
+# After fix: q3, q4, q5 keys must NOT exist (or must be empty/unchanged).
+assert ans.get('q1') == 'first',  f'q1 mismatch: {ans.get(\"q1\")}'
+assert ans.get('q2') == 'second', f'q2 mismatch: {ans.get(\"q2\")}'
+assert 'q3' not in ans, f'q3 was written after pause: {ans.get(\"q3\")!r}'
+assert 'q4' not in ans, f'q4 was written after pause: {ans.get(\"q4\")!r}'
+assert 'q5' not in ans, f'q5 was written after pause: {ans.get(\"q5\")!r}'
+print('PAUSE_OK')
+"
+EOF
+  chmod +x "$TEST_SCRIPT"
+
+  # Feed answers: first, second, pause, then anything (should not be read).
+  out=$(printf 'first\nsecond\npause\nignored1\nignored2\n' | bash "$TEST_SCRIPT" 2>&1) || true
+  if echo "$out" | grep -q "PAUSE_OK"; then
+    pass "T4: pause prevents save_answer writes for q3/q4/q5"
+  else
+    fail_ "T4" "pause should short-circuit save_answer: $out"
+  fi
+
+  rm -rf "$TMP"
+  trap - EXIT
+fi
+
+# ----------------------------------------------------------------
+# T5 (code-intake-wizard-6): Competency Matrix saves a tooling
+# answer for each domain — competency_${key}_tooling.
+# ----------------------------------------------------------------
+echo ""
+echo "T5: Competency Matrix captures 'Automated Tooling Required?' column"
+
+# Static-source check: run_section_6 must save competency_${key}_tooling
+# (one per domain). We verify the source has the save call.
+if ! grep -qE 'save_answer "competency_\$\{?key\}?_tooling"' "$WIZARD"; then
+  fail_ "T5" "run_section_6 does not save 'competency_\${key}_tooling' for any domain"
+else
+  pass "T5a: run_section_6 saves competency_\${key}_tooling"
+fi
+
+# Domains list must be unchanged length (9).
+domains_count=$(awk '
+  /local domains=\(/ {
+    line=$0
+    sub(/.*domains=\(/, "", line)
+    sub(/\).*/, "", line)
+    # Count quoted strings.
+    n=gsub(/"[^"]*"/, "&", line)
+    print n; exit
+  }
+' "$WIZARD")
+if [ "${domains_count:-0}" -ne 9 ]; then
+  fail_ "T5" "expected 9 competency domains, found ${domains_count:-0}"
+else
+  pass "T5b: 9 competency domains still defined"
+fi
+
+# Functional test: drive run_section_6's matrix loop with scripted
+# answers and assert the JSON has competency_security_tooling populated
+# when Security == "No".
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "  [SKIP] T5c — python3 unavailable"
+else
+  TMP=$(mktemp -d)
+  trap 'rm -rf "$TMP"' EXIT
+  PROG="$TMP/intake-progress.json"
+  python3 -c "
+import json
+data = {
+  'version': 1, 'started_at': '2026-01-01T00:00:00Z',
+  'last_section': 0, 'completed_sections': [],
+  'project_name': 'TestProject', 'platform': 'web', 'track': 'standard',
+  'deployment': 'personal', 'language': 'typescript',
+  'description': 'A test', 'poc_mode': None, 'answers': {}
+}
+with open('$PROG', 'w') as f:
+    json.dump(data, f)
+"
+
+  TEST_SCRIPT="$TMP/test.sh"
+  cat > "$TEST_SCRIPT" << EOF
+#!/usr/bin/env bash
+set -uo pipefail
+PROGRESS_FILE="$PROG"
+_PAUSE_FILE="$TMP/.pause-sentinel"
+BOLD=''; NC=''; CYAN=''; GREEN=''; BLUE=''; YELLOW=''; RED=''
+print_info() { :; }
+print_ok()   { :; }
+print_warn() { :; }
+print_fail() { :; }
+print_step() { :; }
+log_line()   { :; }
+
+EOF
+  for fn in prompt_input prompt_choice prompt_with_suggestions _request_pause check_pause_requested save_answer show_suggestions parse_suggestions; do
+    awk -v fn="$fn" '
+      $0 ~ ("^" fn "\\(\\) \\{") { inside=1 }
+      inside { print; if ($0 == "}") { inside=0; print ""; exit } }
+    ' "$WIZARD" >> "$TEST_SCRIPT"
+  done
+
+  # Emit only the matrix loop from run_section_6, wrapped in a
+  # function so `local` keywords inside the loop stay valid.
+  echo 'run_matrix() {' >> "$TEST_SCRIPT"
+  awk '
+    /local domains=\("Product\/UX Logic"/ { capture=1 }
+    capture { print }
+    capture && /^  done$/ { exit }
+  ' "$WIZARD" >> "$TEST_SCRIPT"
+  echo '}' >> "$TEST_SCRIPT"
+  echo 'run_matrix' >> "$TEST_SCRIPT"
+
+  cat >> "$TEST_SCRIPT" << 'EOF'
+
+python3 -c "
+import json
+with open('$PROGRESS_FILE') as f:
+    data = json.load(f)
+ans = data.get('answers', {})
+# Assert: every domain has a corresponding _tooling key.
+domains = ['product_ux_logic', 'frontend_code', 'backend_api_design',
+           'database_design', 'security', 'devops_infrastructure',
+           'accessibility', 'performance', 'mobile']
+missing = [d for d in domains if f'competency_{d}_tooling' not in ans]
+assert not missing, f'missing tooling keys for: {missing}'
+# Security was 'No' — tooling answer must be non-empty (the default or
+# user-supplied value).
+sec_tool = ans.get('competency_security_tooling', '')
+assert sec_tool and sec_tool != 'N/A', \
+  f'competency_security_tooling must be non-empty for a \"No\" answer, got {sec_tool!r}'
+print('MATRIX_OK')
+"
+EOF
+  chmod +x "$TEST_SCRIPT"
+
+  # Feed: 9 prompt_choice answers (1=Yes, 2=Partially, 3=No), and for
+  # any Partially/No, accept the default tooling by pressing Enter.
+  # Order: Product/UX=1, Frontend=1, Backend=1, Database=1, Security=3,
+  # DevOps=2, Accessibility=3, Performance=2, Mobile=1.
+  # Defaults accepted for the 4 non-Yes answers (Security, DevOps,
+  # Accessibility, Performance).
+  out=$(printf '1\n1\n1\n1\n3\n\n2\n\n3\n\n2\n\n1\n' | bash "$TEST_SCRIPT" 2>&1) || true
+  if echo "$out" | grep -q "MATRIX_OK"; then
+    pass "T5c: Competency Matrix saves _tooling answer for each domain (Security has framework default)"
+  else
+    fail_ "T5c" "Competency Matrix tooling capture missing: $out"
+  fi
+
+  rm -rf "$TMP"
+  trap - EXIT
+fi
+
+# ----------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------
+echo ""
+echo "==============================="
+echo "Passed: $PASSED   Failed: $FAILED"
+echo "==============================="
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary
- Renumber wizard sections to match `templates/project-intake.md` (§12 = Tooling Configuration, §13 = Agent Initialization Prompt). Adds a no-op `run_section_12` and renames the existing `run_section_12` → `run_section_13`. Extends the section runner array and Claude-mode prompt accordingly.
- Make `pause` immediate. Adds sentinel-file early-exit guards to `prompt_input` / `prompt_choice` / `prompt_with_suggestions` and to `save_answer`, so once the user types "pause" no further prompts fire and no subsequent `save_answer` writes overwrite previously-saved keys with the empty strings the paused prompts return.
- Capture the Competency Matrix's third "Automated Tooling Required?" column. The matrix loop now saves `competency_${key}_tooling` per domain — `Yes` answers store `N/A`, `Partially`/`No` answers prompt for tooling with a framework-default bundle per domain (Security → gitleaks + Semgrep + Snyk, Accessibility → axe + Lighthouse + screen-reader smoke, etc.).

## Findings closed
- `code-intake-wizard-3` — Section numbering misalignment: wizard's "Section 12" was template's §13.
- `code-intake-wizard-5` — `prompt_input` pause ran the rest of the section before pausing (corrupting answers).
- `code-intake-wizard-6` — Competency Matrix never captured the "Automated Tooling Required?" column from template §6.2.

## Test plan
- [x] `bash tests/test-intake-wizard-fixes.sh` — 7 cases, all GREEN (RED before fix). Covers numbering alignment, Claude-mode prompt range, pre-condition count, pause short-circuit (q3/q4/q5 must NOT be written after `pause` at q3), and matrix tooling capture (default-accept path).
- [x] `bash tests/edge-cases-scripts.sh` — existing intake-wizard cases E19/E20/E21 still pass (apostrophe handling, `--resume` with no progress file, resume-next-section computation).
- [x] `bash tests/test-poc-modes.sh` — 5/5 pass (POC reachability + `--to-private-poc` target deployment).
- [x] `bash tests/test-lint-counter-antipattern.sh` — 12/12 pass.
- [x] `bash scripts/lint-counter-antipattern.sh` — clean.
- [x] `bash scripts/lint-backlog-references.sh` — clean.
- [x] `bash -n scripts/intake-wizard.sh` — syntax OK.

## Bonus catches
- Claude-mode prompt said "**Production Build:** All 6 pre-conditions required" but the `preconditions=(...)` array in `run_section_8` has 8 items (Exit criteria + Orchestrator time allocation were added after the original "6" was written). Fixed to "All 8 pre-conditions required" so the operator-facing prompt matches the loop's actual iteration count and the template's §8.1 row count.
- Updated Claude-mode prompt step ordering: §12 (Tooling Configuration) is now explicitly documented as auto-populated by `init.sh`, and §13 (Agent Initialization Prompt) gets its own auto-generate step. Renumbered the trailing "summarize" step to keep the list contiguous.

## Worktree note
Developed in an isolated git worktree at `.claude/worktrees/agent-a276eb3ffca291d2a` so the change doesn't disturb the main checkout. BL-016 non-interactive paths are preserved: the new `save_answer` sentinel guard is a no-op when the pause file is absent (the default), and the new `run_section_12` is print-only with no `read` calls, so `/dev/null` stdin completes cleanly through both the new step and `run_section_13`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)