### PR TITLE
fix(reconfigure-project): --field {track,deployment,name} now update APPROVAL_LOG + manifest (3 S3 closures)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1333,7 +1333,7 @@ All scripts live in `scripts/` and can be run with `bash scripts/<name>.sh`. Scr
 | `check-updates.sh` | Framework update availability check | `bash scripts/check-updates.sh` | Any |
 | `intake-wizard.sh` | Interactive project intake questionnaire | `bash scripts/intake-wizard.sh` | Pre-0 |
 | `upgrade-project.sh` | Track/deployment upgrade (Light→Standard, personal→org) | `bash scripts/upgrade-project.sh --help` | Any |
-| `reconfigure-project.sh` | Regenerate CLAUDE.md, Approval Log, .gitignore, CI | `bash scripts/reconfigure-project.sh --help` | Any |
+| `reconfigure-project.sh` | Regenerate CLAUDE.md, APPROVAL_LOG header, intake-progress, CI/release pipelines on name/platform/language change (track/deployment use upgrade-project.sh) | `bash scripts/reconfigure-project.sh --help` | Any |
 | `resolve-tools.sh` | Tool matrix resolution by platform/language/track/phase | `bash scripts/resolve-tools.sh --help` | Any |
 | `resume.sh` | Generate session resume context for copy/paste | `bash scripts/resume.sh` | Any |
 

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -64,9 +64,12 @@ while [ $# -gt 0 ]; do
       echo "Supported fields:"
       echo "  language   — Regenerates CI pipeline, .gitignore language entries, permissions"
       echo "  platform   — Regenerates release pipeline, copies new platform module"
-      echo "  track      — Updates phase-state.json, re-resolves tools"
-      echo "  name       — Updates phase-state.json, CLAUDE.md, Qdrant collection"
-      echo "  deployment — Updates phase-state.json, approval log"
+      echo "  name       — Updates phase-state.json, CLAUDE.md, APPROVAL_LOG.md header,"
+      echo "               intake-progress.json, Qdrant collection, PROJECT_INTAKE.md"
+      echo ""
+      echo "Track and deployment changes are NOT supported here — they require"
+      echo "the governance pre-conditions enforced by scripts/upgrade-project.sh."
+      echo "See audit baseline §4 (lines 431-434) and docs/user-guide.md."
       exit 0
       ;;
     *) echo "Unknown argument: $1" >&2; exit 1 ;;
@@ -405,25 +408,33 @@ reconfigure() {
       fi
       ;;
 
-    track)
-      # Update phase-state.json
-      if [ -f ".claude/phase-state.json" ] && command -v jq &>/dev/null; then
-        local tmp
-        tmp=$(mktemp)
-        jq --arg v "$NEW_VALUE" '.track = $v' ".claude/phase-state.json" > "$tmp" && mv "$tmp" ".claude/phase-state.json"
-        print_ok "Updated track in phase-state.json"
+    track|deployment)
+      # code-verify-reconfigure-3: track and deployment moves require the
+      # governance pre-conditions enforced by scripts/upgrade-project.sh
+      # (baseline §4 lines 431-434: reconfigure "is not a tier/POC upgrade
+      # path and does not change `deployment`, `track`, or `poc_mode`").
+      # Pre-fix this branch wrote .track / .deployment into phase-state
+      # with zero guardrails, silently bypassing:
+      #   * §2.1 six blocking pre-conditions for organizational deployment
+      #   * §3.2 retroactive STA Bible approval on personal→organizational
+      #   * repo-protection bar upgrade
+      #   * biweekly Phase-2 governance checkpoint engagement
+      #   * APPROVAL_LOG.md template swap (code-verify-reconfigure-4)
+      # Refuse and redirect; do not mutate any state.
+      print_fail "scripts/reconfigure-project.sh does not change '$FIELD'."
+      echo "  Reason: track and deployment moves require the governance" >&2
+      echo "          pre-conditions enforced by scripts/upgrade-project.sh." >&2
+      echo "          See audit baseline §4 lines 431-434." >&2
+      echo "" >&2
+      echo "  Action: re-run the change through upgrade-project.sh, e.g.:" >&2
+      if [ "$FIELD" = "track" ]; then
+        echo "          bash scripts/upgrade-project.sh --track $NEW_VALUE" >&2
+      else
+        echo "          bash scripts/upgrade-project.sh --deployment $NEW_VALUE" >&2
       fi
-
-      # Update tool-preferences.json
-      if [ -f ".claude/tool-preferences.json" ] && command -v jq &>/dev/null; then
-        local tmp
-        tmp=$(mktemp)
-        jq --arg v "$NEW_VALUE" '.context.track = $v' ".claude/tool-preferences.json" > "$tmp" && mv "$tmp" ".claude/tool-preferences.json"
-        print_ok "Updated track in tool-preferences.json"
-      fi
-
-      print_info "Track changed to $NEW_VALUE. Tool requirements may have changed."
-      print_info "Run: bash scripts/check-phase-gate.sh to verify tool coverage."
+      echo "" >&2
+      echo "  Run scripts/upgrade-project.sh --help for the full transition matrix." >&2
+      exit 1
       ;;
 
     name)
@@ -435,54 +446,145 @@ reconfigure() {
         exit 1
       fi
 
-      # Update phase-state.json
+      # Atomic snapshot/rollback envelope. Sibling of the PR #57 pattern
+      # used by the --enforcement-level path above and the upgrade-project
+      # PR #80 fix. Pre-fix this branch wrote five files with no
+      # transactional safety — SIGINT / disk-full / jq parse error
+      # mid-rename left the project in a half-renamed inconsistent state.
+      # Snapshot every file we might mutate (skip missing ones) into a
+      # tempdir, install a trap, mutate, then drop the trap on success.
+      local snap_dir
+      snap_dir=$(mktemp -d)
+      local _rename_files=(
+        ".claude/phase-state.json"
+        ".claude/tool-preferences.json"
+        ".claude/settings.local.json"
+        ".claude/intake-progress.json"
+        "CLAUDE.md"
+        "PROJECT_INTAKE.md"
+        "APPROVAL_LOG.md"
+      )
+      local f
+      for f in "${_rename_files[@]}"; do
+        if [ -f "$f" ]; then
+          mkdir -p "$snap_dir/$(dirname "$f")"
+          cp "$f" "$snap_dir/$f"
+        fi
+      done
+
+      _rename_rollback() {
+        local reason="${1:-mutation aborted}"
+        local g
+        for g in "${_rename_files[@]}"; do
+          if [ -f "$snap_dir/$g" ]; then
+            mkdir -p "$(dirname "$g")"
+            cp "$snap_dir/$g" "$g"
+          elif [ -f "$g" ]; then
+            # File didn't exist pre-mutation but does now — created during
+            # this run. Remove to restore pre-state.
+            rm -f "$g"
+          fi
+        done
+        rm -rf "$snap_dir"
+        trap - INT TERM ERR
+        print_fail "Rename failed: $reason"
+        echo "  All mutated files have been rolled back to the pre-rename state." >&2
+        exit 1
+      }
+      trap '_rename_rollback "trap fired (INT/TERM/ERR)"' INT TERM ERR
+
+      # Update phase-state.json (.project)
       if [ -f ".claude/phase-state.json" ] && command -v jq &>/dev/null; then
         local tmp
         tmp=$(mktemp)
-        jq --arg v "$new_name" '.project = $v' ".claude/phase-state.json" > "$tmp" && mv "$tmp" ".claude/phase-state.json"
+        jq --arg v "$new_name" '.project = $v' ".claude/phase-state.json" > "$tmp" \
+          && mv "$tmp" ".claude/phase-state.json" \
+          || _rename_rollback "phase-state.json write failed"
         print_ok "Updated project name in phase-state.json"
+      fi
+
+      # code-verify-reconfigure-5: update .claude/intake-progress.json
+      # (.project_name). Pre-fix the wizard's resume would re-introduce
+      # the old name after rename. intake-wizard.sh:259 confirms the key.
+      if [ -f ".claude/intake-progress.json" ] && command -v jq &>/dev/null; then
+        local tmp
+        tmp=$(mktemp)
+        jq --arg v "$new_name" '.project_name = $v' ".claude/intake-progress.json" > "$tmp" \
+          && mv "$tmp" ".claude/intake-progress.json" \
+          || _rename_rollback "intake-progress.json write failed"
+        print_ok "Updated project_name in intake-progress.json"
       fi
 
       # Update Qdrant collection in settings.local.json
       if [ -f ".claude/settings.local.json" ] && command -v jq &>/dev/null; then
         local tmp
         tmp=$(mktemp)
-        jq --arg v "$new_name" '.mcpServers.qdrant.args[-1] = $v' ".claude/settings.local.json" > "$tmp" && mv "$tmp" ".claude/settings.local.json"
+        jq --arg v "$new_name" '.mcpServers.qdrant.args[-1] = $v' ".claude/settings.local.json" > "$tmp" \
+          && mv "$tmp" ".claude/settings.local.json" \
+          || _rename_rollback "settings.local.json write failed"
         print_ok "Updated Qdrant collection to $new_name"
       fi
 
       # Update CLAUDE.md project name
       if [ -f "CLAUDE.md" ]; then
-        sed -i.bak "s|$old_name|$new_name|g" CLAUDE.md
+        sed -i.bak "s|$old_name|$new_name|g" CLAUDE.md \
+          || _rename_rollback "CLAUDE.md sed failed"
         rm -f CLAUDE.md.bak
         print_ok "Updated project name in CLAUDE.md"
       fi
 
       # Update PROJECT_INTAKE.md
       if [ -f "PROJECT_INTAKE.md" ]; then
-        sed -i.bak "s|$old_name|$new_name|g" PROJECT_INTAKE.md
+        sed -i.bak "s|$old_name|$new_name|g" PROJECT_INTAKE.md \
+          || _rename_rollback "PROJECT_INTAKE.md sed failed"
         rm -f PROJECT_INTAKE.md.bak
         print_ok "Updated project name in PROJECT_INTAKE.md"
       fi
-      ;;
 
-    deployment)
-      # Update phase-state.json
-      if [ -f ".claude/phase-state.json" ] && command -v jq &>/dev/null; then
+      # code-verify-reconfigure-5: update APPROVAL_LOG.md YAML front-
+      # matter (`project:` line) and the exact H1 (`# Approval Log — X`).
+      # Anchored substitutions only — DO NOT global-replace the old name
+      # in body content (an attentive operator may have referenced the
+      # old name in dated entry notes; rewriting those would mutate
+      # historical entries and violate invariant 8 append-only). Both
+      # personal and org templates carry these two placeholder sites
+      # (templates/generated/approval-log-{personal,org}.tmpl lines 2,8).
+      if [ -f "APPROVAL_LOG.md" ]; then
         local tmp
         tmp=$(mktemp)
-        jq --arg v "$NEW_VALUE" '.deployment = $v' ".claude/phase-state.json" > "$tmp" && mv "$tmp" ".claude/phase-state.json"
-        print_ok "Updated deployment in phase-state.json"
+        # awk-based: only rewrite the YAML front-matter (between the
+        # first two `---` lines, lines 1..N) and the exact H1. The
+        # front-matter is the only safe place to mutate `project: foo`
+        # because freeform text in entry notes can legitimately contain
+        # `project: foo` as documentation.
+        awk -v old="$old_name" -v new="$new_name" '
+          BEGIN { in_yaml = 0; yaml_done = 0; line = 0 }
+          {
+            line++
+            if (line == 1 && $0 == "---") { in_yaml = 1; print; next }
+            if (in_yaml && $0 == "---")   { in_yaml = 0; yaml_done = 1; print; next }
+            if (in_yaml) {
+              # Match `project:` followed by whitespace then the old name.
+              if ($0 ~ "^project:[[:space:]]+" old "[[:space:]]*$") {
+                print "project: " new; next
+              }
+            }
+            # H1 substitution — exact-match guard so we never touch a
+            # body H1 or H2 that happens to mention the old name.
+            if ($0 == "# Approval Log — " old) {
+              print "# Approval Log — " new; next
+            }
+            print
+          }
+        ' "APPROVAL_LOG.md" > "$tmp" \
+          && mv "$tmp" "APPROVAL_LOG.md" \
+          || _rename_rollback "APPROVAL_LOG.md header rewrite failed"
+        print_ok "Updated APPROVAL_LOG.md header (YAML + H1); historical entries preserved"
       fi
 
-      if [ "$NEW_VALUE" = "organizational" ] && [ "$OLD_VALUE" = "personal" ]; then
-        print_warn "Switching to organizational deployment. You may need to:"
-        echo "  1. Complete governance pre-conditions (Section 8 of Intake)"
-        echo "  2. Regenerate APPROVAL_LOG.md with organizational template"
-        echo "  3. Review CLAUDE.md for organizational governance sections"
-      elif [ "$NEW_VALUE" = "personal" ] && [ "$OLD_VALUE" = "organizational" ]; then
-        print_info "Switched to personal deployment. Governance requirements relaxed."
-      fi
+      # Success — drop the trap and clean up the snapshot dir.
+      trap - INT TERM ERR
+      rm -rf "$snap_dir"
       ;;
 
     *)

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -304,8 +304,8 @@ fi
     fi
     if [ -z "$mig_deployment" ]; then
       print_warn "phase-state.json lacks .deployment — assuming 'personal' for backfill."
-      print_warn "If this project is organizational, run after the upgrade completes:"
-      print_warn "  scripts/reconfigure-project.sh --field deployment --old personal --new organizational"
+      print_warn "If this project is organizational, re-run upgrade-project.sh after the backfill:"
+      print_warn "  scripts/upgrade-project.sh --deployment organizational"
       mig_deployment="personal"
     fi
     if [ -n "$mig_poc" ]; then

--- a/templates/project-intake.md
+++ b/templates/project-intake.md
@@ -55,7 +55,9 @@ You can fill this out using the **intake wizard** (`bash scripts/intake-wizard.s
 > bash scripts/reconfigure-project.sh --field <field> --old <old_value> --new <new_value>
 > ```
 >
-> Supported fields: `name`, `platform`, `language`, `track`, `deployment`. The intake wizard handles this automatically — manual editing does not.
+> Supported fields: `name`, `platform`, `language`. The intake wizard handles this automatically — manual editing does not.
+>
+> For `track` or `deployment` changes use `scripts/upgrade-project.sh` instead (it enforces the governance pre-conditions; reconfigure-project does not).
 
 ---
 

--- a/tests/test-reconfigure-field-handlers.sh
+++ b/tests/test-reconfigure-field-handlers.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# tests/test-reconfigure-field-handlers.sh — closes S3 findings:
+#
+#   code-verify-reconfigure-3 — `--field track` and `--field deployment`
+#     are back-doors around upgrade-project.sh's governance pre-conditions
+#     (baseline §4 lines 431-434: reconfigure "is not a tier/POC upgrade
+#     path and does not change `deployment`, `track`, or `poc_mode`").
+#
+#   code-verify-reconfigure-4 — `--field deployment` claims (help text +
+#     user-guide.md:1336) to "Update ... approval log" but never touches
+#     APPROVAL_LOG.md. Personal→organizational reconfigure leaves the
+#     project with the wrong (column-missing) personal template while
+#     phase-state reports organizational.
+#
+#   code-verify-reconfigure-5 — `--field name --old foo --new bar` updates
+#     phase-state.json + CLAUDE.md + PROJECT_INTAKE.md but does not touch
+#     APPROVAL_LOG.md (which carries `project: __PROJECT_NAME__` in its
+#     YAML header + `# Approval Log — __PROJECT_NAME__`) or
+#     .claude/intake-progress.json (which carries `.project_name`).
+#
+# Fix (this PR):
+#   * --field track and --field deployment now exit non-zero with a
+#     redirect to scripts/upgrade-project.sh (Option A from the finding;
+#     re-aligns the script with baseline §4 and eliminates the back-door).
+#   * --field name now also updates APPROVAL_LOG.md (anchored to the YAML
+#     front-matter + the exact H1 — never touches historical entries, so
+#     invariant 8 append-only is preserved) and .claude/intake-progress.json.
+#   * APPROVAL_LOG + intake-progress mutations are inside the same
+#     snapshot/rollback envelope as the existing phase-state / CLAUDE.md /
+#     PROJECT_INTAKE.md / settings.local.json writes — PR #57 sibling
+#     pattern. Failure mid-rename restores all files.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RECONFIG="$REPO_ROOT/scripts/reconfigure-project.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build a minimal fixture project that looks plausible to reconfigure-project.sh.
+# We bypass init.sh (and its --non-interactive cost) by hand-rolling the
+# files reconfigure actually reads/writes. PROJECT_ROOT inside the script
+# is derived from `dirname $0/..`, so the script must be invoked from
+# *inside* the fixture's `scripts/` dir — we copy the framework's
+# reconfigure-project.sh + its lib/helpers.sh into the fixture so the
+# script's self-detection lands inside the test fixture rather than the
+# framework repo.
+mk_fixture() {
+  local dir="$1" name="$2" deployment="${3:-personal}" track="${4:-light}"
+
+  mkdir -p "$dir/.claude" "$dir/scripts/lib"
+
+  # Copy the script under test + its required helpers into the fixture.
+  cp "$REPO_ROOT/scripts/reconfigure-project.sh" "$dir/scripts/reconfigure-project.sh"
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" "$dir/scripts/lib/helpers.sh"
+  # enforcement-level.sh is sourced when --enforcement-level is passed;
+  # copied defensively so the script doesn't bail on missing files even
+  # though the field handlers we're testing never hit that code path.
+  if [ -f "$REPO_ROOT/scripts/lib/enforcement-level.sh" ]; then
+    cp "$REPO_ROOT/scripts/lib/enforcement-level.sh" "$dir/scripts/lib/enforcement-level.sh"
+  fi
+
+  # phase-state.json — reconfigure reads .project / .deployment / .track from here.
+  cat > "$dir/.claude/phase-state.json" <<JSON
+{
+  "project": "$name",
+  "framework_version": "1.0",
+  "current_phase": 0,
+  "track": "$track",
+  "deployment": "$deployment",
+  "poc_mode": null
+}
+JSON
+
+  # tool-preferences.json — reconfigure track/language branches write .context.*.
+  cat > "$dir/.claude/tool-preferences.json" <<JSON
+{
+  "context": {
+    "project": "$name",
+    "platform": "web",
+    "language": "javascript",
+    "track": "$track"
+  }
+}
+JSON
+
+  # orchestrator-source.json — required pointer to template directory.
+  cat > "$dir/.claude/orchestrator-source.json" <<JSON
+{ "source_dir": "$REPO_ROOT" }
+JSON
+
+  # intake-progress.json — carries .project_name (intake-wizard.sh:259).
+  cat > "$dir/.claude/intake-progress.json" <<JSON
+{
+  "version": 1,
+  "project_name": "$name",
+  "platform": "web",
+  "track": "$track",
+  "deployment": "$deployment",
+  "language": "javascript",
+  "answers": {}
+}
+JSON
+
+  # settings.local.json — reconfigure name branch writes Qdrant collection arg.
+  cat > "$dir/.claude/settings.local.json" <<JSON
+{
+  "mcpServers": {
+    "qdrant": {
+      "command": "uvx",
+      "args": ["mcp-server-qdrant", "$name"]
+    }
+  }
+}
+JSON
+
+  # CLAUDE.md — reconfigure name branch sed-substitutes.
+  cat > "$dir/CLAUDE.md" <<MD
+# $name — Claude Operator Brief
+
+Project: $name
+MD
+
+  # PROJECT_INTAKE.md — reconfigure name branch sed-substitutes.
+  cat > "$dir/PROJECT_INTAKE.md" <<MD
+# Project Intake — $name
+MD
+
+  # APPROVAL_LOG.md — render the personal template substituting __PROJECT_NAME__.
+  # Seed an existing dated entry to verify it's preserved verbatim by --field name
+  # (invariant 8: APPROVAL_LOG is append-only).
+  sed -e "s|__PROJECT_NAME__|$name|g" -e "s|__TODAY__|2026-06-01|g" \
+    "$REPO_ROOT/templates/generated/approval-log-personal.tmpl" \
+    > "$dir/APPROVAL_LOG.md"
+  # Append a real dated entry under Approval History so we can prove
+  # historical entries are not touched.
+  cat >> "$dir/APPROVAL_LOG.md" <<APP
+| 2026-06-15 | Phase 0 → Phase 1 | Approved | Bible reviewed |
+APP
+
+  # Git init so finalize_reconfigure_commit() can do its work.
+  ( cd "$dir" \
+      && git init -q \
+      && git config user.email t@t.l \
+      && git config user.name t \
+      && git add -A \
+      && git commit -q -m "fixture" ) >/dev/null 2>&1
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: --field track is refused with redirect to upgrade-project.sh ==="
+# ════════════════════════════════════════════════════════════════════
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+track_before=$(jq -r '.track' "$P/.claude/phase-state.json")
+tp_track_before=$(jq -r '.context.track' "$P/.claude/tool-preferences.json")
+
+if ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field track --old light --new standard > "$T/log" 2>&1 ); then
+  fail_ "T1" "reconfigure --field track should have exited non-zero (back-door around upgrade-project.sh governance)"
+else
+  if grep -q "upgrade-project.sh" "$T/log"; then
+    track_after=$(jq -r '.track' "$P/.claude/phase-state.json")
+    tp_track_after=$(jq -r '.context.track' "$P/.claude/tool-preferences.json")
+    if [ "$track_before" = "$track_after" ] && [ "$tp_track_before" = "$tp_track_after" ]; then
+      pass "T1"
+    else
+      fail_ "T1" "phase-state.json or tool-preferences.json mutated despite refusal (state-leak)"
+    fi
+  else
+    fail_ "T1" "error message did not redirect to upgrade-project.sh"
+  fi
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: --field deployment is refused with redirect to upgrade-project.sh ==="
+# ════════════════════════════════════════════════════════════════════
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+dep_before=$(jq -r '.deployment' "$P/.claude/phase-state.json")
+approval_sha_before=$(shasum -a 256 "$P/APPROVAL_LOG.md" | awk '{print $1}')
+
+if ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field deployment --old personal --new organizational > "$T/log" 2>&1 ); then
+  fail_ "T2" "reconfigure --field deployment should have exited non-zero"
+else
+  if grep -q "upgrade-project.sh" "$T/log"; then
+    dep_after=$(jq -r '.deployment' "$P/.claude/phase-state.json")
+    approval_sha_after=$(shasum -a 256 "$P/APPROVAL_LOG.md" | awk '{print $1}')
+    if [ "$dep_before" = "$dep_after" ] && [ "$approval_sha_before" = "$approval_sha_after" ]; then
+      pass "T2"
+    else
+      fail_ "T2" "phase-state.json or APPROVAL_LOG.md mutated despite refusal"
+    fi
+  else
+    fail_ "T2" "error message did not redirect to upgrade-project.sh"
+  fi
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: --help no longer advertises track or deployment ==="
+# ════════════════════════════════════════════════════════════════════
+# Run --help from inside a fixture so guard_not_in_framework passes.
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+help_out=$( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --help 2>&1 )
+# grep -c returns the integer count and exits 0 even on zero matches
+# (regular-file input), so no `|| echo 0` antipattern needed. The
+# sanitizer cases below convert any pathological non-numeric output to
+# 0 — matches lint-counter-antipattern's PASS-marker.
+track_advertised=$(printf '%s\n' "$help_out" | grep -cE '^[[:space:]]*track[[:space:]]+—' || true)
+case "$track_advertised" in '' | *[!0-9]* ) track_advertised=0 ;; esac
+deployment_advertised=$(printf '%s\n' "$help_out" | grep -cE '^[[:space:]]*deployment[[:space:]]+—' || true)
+case "$deployment_advertised" in '' | *[!0-9]* ) deployment_advertised=0 ;; esac
+if [ "$track_advertised" = "0" ] && [ "$deployment_advertised" = "0" ]; then
+  pass "T3"
+else
+  fail_ "T3" "track_advertised=$track_advertised deployment_advertised=$deployment_advertised"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: --field name updates APPROVAL_LOG.md YAML header + H1 ==="
+# ════════════════════════════════════════════════════════════════════
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+
+if ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field name --old foo --new bar > "$T/log" 2>&1 ); then
+  yaml_project=$(grep -m1 '^project:' "$P/APPROVAL_LOG.md" | sed 's/^project:[[:space:]]*//')
+  h1_line=$(grep -m1 '^# Approval Log' "$P/APPROVAL_LOG.md")
+  if [ "$yaml_project" = "bar" ] && [ "$h1_line" = "# Approval Log — bar" ]; then
+    pass "T4"
+  else
+    fail_ "T4" "yaml_project='$yaml_project' h1='$h1_line'"
+  fi
+else
+  fail_ "T4" "reconfigure --field name failed: $(tail -5 "$T/log" 2>/dev/null)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: --field name updates .claude/intake-progress.json ==="
+# ════════════════════════════════════════════════════════════════════
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+
+if ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field name --old foo --new bar > "$T/log" 2>&1 ); then
+  intake_name=$(jq -r '.project_name' "$P/.claude/intake-progress.json")
+  if [ "$intake_name" = "bar" ]; then
+    pass "T5"
+  else
+    fail_ "T5" "intake-progress.json .project_name='$intake_name' (expected 'bar')"
+  fi
+else
+  fail_ "T5" "reconfigure --field name failed"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: --field name preserves prior dated APPROVAL_LOG entries ==="
+# ════════════════════════════════════════════════════════════════════
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+# Capture the seeded entry from mk_fixture.
+seeded_entry='| 2026-06-15 | Phase 0 → Phase 1 | Approved | Bible reviewed |'
+if ! grep -qF "$seeded_entry" "$P/APPROVAL_LOG.md"; then
+  fail_ "T6" "seeded entry missing from fixture — test setup bug"
+elif ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field name --old foo --new bar > "$T/log" 2>&1 ); then
+  if grep -qF "$seeded_entry" "$P/APPROVAL_LOG.md"; then
+    pass "T6"
+  else
+    fail_ "T6" "historical entry mutated/dropped — invariant 8 violation"
+  fi
+else
+  fail_ "T6" "reconfigure --field name failed"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: --field name still updates phase-state.json + CLAUDE.md ==="
+# ════════════════════════════════════════════════════════════════════
+# Regression guard — the existing name-branch behaviors must continue to work.
+T=$(mktemp -d); P="$T/p"
+mk_fixture "$P" "foo" "personal" "light"
+if ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field name --old foo --new bar > "$T/log" 2>&1 ); then
+  ps_name=$(jq -r '.project' "$P/.claude/phase-state.json")
+  claude_has_bar=0
+  grep -q "bar" "$P/CLAUDE.md" && claude_has_bar=1
+  if [ "$ps_name" = "bar" ] && [ "$claude_has_bar" = "1" ]; then
+    pass "T7"
+  else
+    fail_ "T7" "ps_name='$ps_name' claude_has_bar=$claude_has_bar"
+  fi
+else
+  fail_ "T7" "reconfigure --field name failed"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== Results ==="
+# ════════════════════════════════════════════════════════════════════
+echo "  passed: $PASSED"
+echo "  failed: $FAILED"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Closes 3 S3 audit findings against `scripts/reconfigure-project.sh` (auditor: code-verify-reconfigure-{3,4,5}). The script's `--field track` and `--field deployment` handlers were a back-door around `scripts/upgrade-project.sh` — they wrote into `phase-state.json` with zero of the governance pre-conditions that baseline §4 (lines 431-434) explicitly requires for tier/deployment moves. The `--field name` handler updated four files but silently left APPROVAL_LOG.md and `.claude/intake-progress.json` with the stale name, breaking governance metadata + wizard resume.

Fix:
- Remove `--field track` and `--field deployment` from reconfigure entirely; exit non-zero with a redirect to `upgrade-project.sh` and the equivalent flag spelled out (Option A from the finding).
- Implement `APPROVAL_LOG.md` header rewrite (anchored awk over the YAML front-matter + exact H1, so historical entries are never touched — invariant 8 append-only preserved) and `intake-progress.json` update inside the `--field name` handler.
- Wrap the full `--field name` mutation block (now seven files) in a snapshot/rollback envelope matching the PR #57 / PR #80 atomic-finalize precedent: SIGINT / disk-full / parse error mid-rename restores every file.
- Scrub docs and templates of the now-removed `track` / `deployment` reconfigure fields; redirect operators to `upgrade-project.sh`.

## Findings closed

- `code-verify-reconfigure-3` — `--field track` / `--field deployment` were a governance back-door around `upgrade-project.sh`. Now refused with a redirect.
- `code-verify-reconfigure-4` — `--field deployment` advertised APPROVAL_LOG regeneration but never touched the file. Implicitly closed by removing the deployment branch; operators are routed through `upgrade-project.sh`, which does the org-template swap with a personal-history backup (`scripts/upgrade-project.sh:1459-1505`).
- `code-verify-reconfigure-5` — `--field name` did not update APPROVAL_LOG.md header or `intake-progress.json`. Now does both; historical APPROVAL_LOG entries are preserved verbatim.

## Test plan

`tests/test-reconfigure-field-handlers.sh` (new, 7 cases, runs in ~3s against fixture projects — no `init.sh` cost):
- T1 — `--field track` refused, redirects to `upgrade-project.sh`, no state leak
- T2 — `--field deployment` refused, redirects, no state leak
- T3 — `--help` no longer advertises `track` or `deployment`
- T4 — `--field name` rewrites APPROVAL_LOG YAML header (`project:`) + H1 (`# Approval Log — X`)
- T5 — `--field name` rewrites `intake-progress.json` (`.project_name`)
- T6 — `--field name` preserves prior dated APPROVAL_LOG entries (invariant 8 append-only)
- T7 — `--field name` regression: `phase-state.json` + `CLAUDE.md` still update

Verification on main (pre-fix, RED):
```
=== Results ===  passed: 2  failed: 5
```
Verification on this branch (GREEN):
```
=== Results ===  passed: 7  failed: 0
```

Other tests confirmed clean:
- `tests/test-enforcement-level-reconfigure.sh` — 12/12 pass (no regression in `--enforcement-level` / `--reset-detection-baseline` paths).
- `scripts/lint-counter-antipattern.sh` — clean.
- `scripts/lint-backlog-references.sh` — clean.

## Bonus catches

- Pre-fix `--field name` had no transactional safety despite mutating five files; this PR snapshots the full envelope (now seven files: `phase-state.json`, `tool-preferences.json`, `settings.local.json`, `intake-progress.json`, `CLAUDE.md`, `PROJECT_INTAKE.md`, `APPROVAL_LOG.md`) and installs `trap INT TERM ERR _rename_rollback` matching PR #57.
- `scripts/upgrade-project.sh:308` recommended the removed back-door in a print_warn (`reconfigure-project.sh --field deployment --old personal --new organizational`); now redirects operators to `upgrade-project.sh --deployment organizational`.
- `docs/user-guide.md` Quick Reference scripts table listed reconfigure as regenerating "Approval Log" generically — updated to specify only the header on rename and note `track` / `deployment` belong to `upgrade-project.sh`.
- `templates/project-intake.md`'s "If editing manually" callout listed `track` / `deployment` as supported reconfigure fields — corrected.

## Worktree note

Authored from `.claude/worktrees/agent-abc2bdea2ebc9c277` against branch `fix/reconfigure-field-handlers-approval-log`. No stray staging; only the five files in `--stat` were touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)