### PR TITLE
fix(host-gitlab): CI status enforcement in org mode + diagnostic stderr + modern approvals API (3 S3 closures)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1996,21 +1996,22 @@ create_and_protect_remote() {
     host_push_initial main 2>/dev/null || host_push_initial master || { print_fail "Push failed — $remote_url exists but empty"; return 1; }
 
     print_info "Configuring branch protection ($mode mode)..."
-    # BL-002 / BL-031: exit code 3 is the host-agnostic "expected partial
-    # failure — attestation fallback is appropriate" signal. The github driver
-    # returns 3 on free-tier 403; the gitlab driver returns 3 when org-mode
-    # approvals PUT fails; future drivers may use 3 for similar semantics.
-    # The driver itself emits host-specific remediation on stderr BEFORE this
-    # block runs — we echo a host-agnostic summary and route to the shared
-    # attestation flow rather than hardcoding GitHub-Pro wording (BL-031).
+    # BL-002 / BL-031 / BL-032: exit codes 3 and 4 are both host-agnostic
+    # "expected partial failure — attestation fallback is appropriate"
+    # signals. The github driver returns 3 on free-tier 403; the gitlab
+    # driver returns 3 on a generic approvals PUT failure and 4 on the
+    # specific Premium-only failure (BL-032 / code-host-gitlab-8). Both
+    # route to the same attestation flow — the driver itself emits host-
+    # specific remediation on stderr BEFORE this block runs, so we echo a
+    # host-agnostic summary and defer detail to the driver (BL-031).
     local _hcp_rc=0
     host_configure_protection main "$mode" || _hcp_rc=$?
-    if [ "$_hcp_rc" -ne 0 ] && [ "$_hcp_rc" -ne 3 ]; then
+    if [ "$_hcp_rc" -ne 0 ] && [ "$_hcp_rc" -ne 3 ] && [ "$_hcp_rc" -ne 4 ]; then
       _hcp_rc=0
       host_configure_protection master "$mode" || _hcp_rc=$?
     fi
 
-    if [ "$_hcp_rc" -eq 3 ]; then
+    if [ "$_hcp_rc" -eq 3 ] || [ "$_hcp_rc" -eq 4 ]; then
       print_warn "Branch protection unavailable via standard API on this $host repo."
       print_info "Falling back to attestation flow — see $host driver remediation message above."
       local attest

--- a/scripts/host-drivers/gitlab.sh
+++ b/scripts/host-drivers/gitlab.sh
@@ -2,6 +2,45 @@
 # scripts/host-drivers/gitlab.sh — GitLab driver.
 # Uses `glab` CLI for creation and authentication, GitLab REST API v4 for protection.
 # Supports both gitlab.com and self-hosted instances.
+#
+# AUDIT-DRIVEN ERROR-CODE CONTRACT (host_configure_protection)
+#   0  success
+#   1  invalid argument / origin parse failure
+#   2  protected_branches POST failed (generic — upstream message surfaced)
+#   3  approvals PUT failed (generic — upstream message surfaced)
+#   4  approvals PUT failed because the feature is Premium-only on gitlab.com
+#      Free tier (matched by the response body). Operators can't fix the API
+#      call from this host/tier combo; the BL-032 remediation message points
+#      them at upgrade / self-hosted / attestation escape-hatch options.
+#   5  project-settings PUT (only_allow_merge_if_pipeline_succeeds) failed
+#      in org mode — upstream message surfaced.
+#
+# WHY GLAB STDERR IS CAPTURED (code-host-gitlab-3)
+#   Pre-fix, both glab api calls used `>/dev/null 2>&1` and emitted only a
+#   generic "failed to configure protection". Operators on gitlab.com Free
+#   org mode would hit a Premium-feature-not-available 403 on the
+#   approvals PUT and see no actionable detail. The github.sh driver
+#   already captures stderr (BL-002 pattern, github.sh:117-138) to detect
+#   free-tier 403s; this driver now mirrors that discipline.
+#
+# WHY THE CI PIPELINE-SUCCESS GATE IS NOW SET (code-host-gitlab-2)
+#   Baseline §3.2 establishes the org protection bar as "1+ PR review + CI
+#   status checks". github.sh sets required_status_checks in org mode and
+#   verifies it; pre-fix gitlab.sh did neither, so org-mode verification
+#   passed silently with no CI gate on main. The org branch now PUTs
+#   `only_allow_merge_if_pipeline_succeeds:true` on projects/:id (paired
+#   with `only_allow_merge_if_all_discussions_are_resolved:true`) and
+#   host_verify_protection asserts the same flag.
+#
+# WHY BL-032 EXISTS (code-host-gitlab-8)
+#   `projects/:id/approvals` with `approvals_before_merge>=1` is a
+#   Premium-tier feature on gitlab.com — Free tier returns 403 with a
+#   "not available on your plan" message. BL-032 in
+#   solo-orchestrator-backlog.md mirrors BL-002 for GitHub free-tier:
+#   document the gap, surface a clear remediation, and track the
+#   attestation escape-hatch as future work. The driver's exit-4 branch
+#   here surfaces the gap loudly with options, instead of returning the
+#   bare exit-3 "approvals config failed" message.
 
 host_name() { echo "gitlab"; }
 
@@ -108,16 +147,67 @@ host_configure_protection() {
 
   local payload
   payload="{\"name\":\"$branch\",\"push_access_level\":$push_access_level,\"merge_access_level\":$merge_access_level,\"allow_force_push\":false,\"code_owner_approval_required\":false}"
-  if ! glab api -X POST "projects/$project/protected_branches" --input - <<<"$payload" >/dev/null 2>&1; then
+
+  # code-host-gitlab-3: capture stderr so failures surface the upstream
+  # glab/API message instead of the pre-fix generic "failed to configure
+  # protection". Mirrors the github.sh BL-002 pattern (lines 117-138).
+  local glab_err
+  if ! glab_err=$(glab api -X POST "projects/$project/protected_branches" --input - <<<"$payload" 2>&1 >/dev/null); then
     echo "gitlab driver: failed to configure protection on $project#$branch ($mode mode)" >&2
+    [ -n "$glab_err" ] && printf '  %s\n' "$glab_err" >&2
     return 2
   fi
 
-  # Org mode: also require approvals on MRs (separate API)
+  # Org mode: also require approvals on MRs (separate API), the CI
+  # pipeline-success gate, and discussion-resolution before merge.
   if [ "$mode" = "org" ]; then
-    glab api -X PUT "projects/$project/approvals" \
-      --input - <<<'{"approvals_before_merge":1,"reset_approvals_on_push":true}' >/dev/null 2>&1 \
-      || { echo "gitlab driver: protected branch set but approvals config failed" >&2; return 3; }
+    # code-host-gitlab-8: capture stderr from the approvals PUT so we can
+    # detect the gitlab.com Free Premium-only failure mode (BL-032). On
+    # Premium-only detection, return a dedicated exit code (4) with a
+    # remediation message; on generic failure, surface the upstream
+    # message and return 3.
+    if ! glab_err=$(glab api -X PUT "projects/$project/approvals" \
+                      --input - <<<'{"approvals_before_merge":1,"reset_approvals_on_push":true}' 2>&1 >/dev/null); then
+      # Premium-only signals from gitlab.com Free responses. The exact
+      # wording has shifted across GitLab releases (the API has used
+      # "premium", "not available on your plan", "feature is not
+      # available", "Ultimate" for some flows); match a broad union so
+      # the detection is resilient to minor message tweaks.
+      if echo "$glab_err" | grep -qiE 'premium|ultimate|not available on your plan|feature is not available|requires.*plan'; then
+        printf '%s\n' \
+          "gitlab driver: required-approvals API is unavailable on this project's plan." \
+          "" \
+          "  \`projects/:id/approvals\` with \`approvals_before_merge\` requires GitLab Premium" \
+          "  on gitlab.com (Free tier rejects the PUT). The API responded:" \
+          "" \
+          "$(printf '    %s\n' "$glab_err")" \
+          "" \
+          "  Options (tracked as BL-032 in solo-orchestrator-backlog.md):" \
+          "    1. Upgrade the project's namespace to GitLab Premium — unlocks required" \
+          "       MR approvals via the API." \
+          "    2. Self-host GitLab CE/EE with an appropriate license — same API surface" \
+          "       without the gitlab.com tier gate." \
+          "    3. Attest manually — accept that approvals are enforced by convention," \
+          "       not the API. Re-run with --approvals-attested to record this once" \
+          "       the BL-032 escape hatch lands (see backlog entry for status)." >&2
+        return 4
+      fi
+      echo "gitlab driver: protected branch set but approvals config failed" >&2
+      [ -n "$glab_err" ] && printf '  %s\n' "$glab_err" >&2
+      return 3
+    fi
+
+    # code-host-gitlab-2: configure the CI pipeline-success gate +
+    # discussion-resolution requirement on the project itself. Pre-fix,
+    # org mode left main with no CI gate, contradicting baseline §3.2.
+    # The github.sh equivalent is required_status_checks (github.sh:104).
+    local settings_payload='{"only_allow_merge_if_pipeline_succeeds":true,"only_allow_merge_if_all_discussions_are_resolved":true}'
+    if ! glab_err=$(glab api -X PUT "projects/$project" \
+                      --input - <<<"$settings_payload" 2>&1 >/dev/null); then
+      echo "gitlab driver: protected branch + approvals set but pipeline-success/settings PUT failed" >&2
+      [ -n "$glab_err" ] && printf '  %s\n' "$glab_err" >&2
+      return 5
+    fi
   fi
   return 0
 }
@@ -156,6 +246,24 @@ host_verify_protection() {
     val=$(echo "$aresp" | jq -r '.approvals_before_merge // 0')
     if [ "$val" = "0" ] || [ "$val" = "null" ]; then
       failures="${failures}approvals_before_merge is 0 (org mode requires at least 1)\n"
+    fi
+
+    # code-host-gitlab-2: parity with github.sh:174-175. Org mode requires
+    # a CI status check on main per baseline §3.2 (1+ PR review + CI). On
+    # GitLab this is `only_allow_merge_if_pipeline_succeeds` on the
+    # project settings. A `false` (or missing) value means a maintainer
+    # can merge without CI green — silent drift from the documented org
+    # protection bar.
+    #
+    # Note the explicit `-X GET` — keeps the call shape distinct from the
+    # other GETs (`projects/:id/approvals`, `projects/:id/protected_branches/*`)
+    # for test fixtures that pattern-match args via substring (mock-cli
+    # would otherwise see ambiguous prefixes).
+    local presp
+    presp=$(glab api -X GET "projects/$project" 2>/dev/null || echo '{}')
+    val=$(echo "$presp" | jq -r '.only_allow_merge_if_pipeline_succeeds // false')
+    if [ "$val" != "true" ]; then
+      failures="${failures}pipeline-success gate not enforced (org mode requires CI status check)\n"
     fi
   fi
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -714,3 +714,27 @@ Operator-visible symptom: `scripts/check-gate.sh --preflight` PASSED (it correct
 **Verification:** new suite 3/3 · `tests/test-check-gate.sh` 5/5 · `tests/test-check-phase-gate-counter-sanitizer.sh` 7/7 · `tests/test-init-other-host-attestation.sh` 2/2 · `tests/test-github-free-tier-403.sh` 4/4. Registered in `tests/full-project-test-suite.sh` (new TEST 0c section after the counter-antipattern lint, to keep the gate-validation backstops co-located).
 
 **Related:** BL-002 (PR #36) introduced the attestation flow; BL-031 (PR #65) generalized cross-host attestation messaging; PR #71 (preflight branch) shipped the canonical pattern this fix mirrors. The case-sanitizer pattern from PR #53 was considered but not needed here — the jq output is used in a string equality test, not arithmetic, so no sanitizer is required.
+
+---
+
+## BL-032: Handle gitlab.com Free org-mode required-approvals 403 gracefully
+
+**Logged:** 2026-06-28
+**Category:** Debt
+**Severity:** Medium
+**Status:** Open
+
+GitLab analog of BL-002. On gitlab.com Free, `PUT projects/:id/approvals` with `approvals_before_merge>=1` is a Premium-tier feature — Free returns HTTP 403 *"This feature is not available on your plan."* (exact wording has varied across GitLab releases — "premium", "ultimate", "not available on your plan", "feature is not available", "requires .* plan"). Organizational deployments on gitlab.com Free cannot clear the Phase 1→2 protection bar because the required-approvals invariant is structurally unavailable.
+
+The driver remediation (this PR, `fix/host-gitlab-ci-status-stderr-approvals`) addresses the operator-recovery side: it pattern-matches the Premium-only response, returns a dedicated exit code (4), and prints a structured remediation listing upgrade / self-hosted / attestation-escape-hatch options. What's still open is the third option — the attestation flow itself.
+
+**Scope:** In `scripts/host-drivers/gitlab.sh` and `scripts/init.sh`:
+1. Add a `--approvals-attested` flag (and `SOLO_APPROVALS_ATTESTED=1` env var) honored by `host_configure_protection`. When set in org mode, skip the approvals PUT and record an attestation in `.claude/process-state.json::phase2_init.attestations.branch_protection.reason = "gitlab_free_tier_approvals"`.
+2. Extend `scripts/check-phase-gate.sh` Phase 1→2 backstop to honor the new attestation reason (mirroring the existing `github_free_tier` branch added in PR #62 — see code-check-gates-1 entry above).
+3. Update `docs/builders-guide.md` § Repository Setup to document the GitLab Free tier limitation alongside the existing GitHub free-tier note (line ~933).
+
+The CI pipeline-success gate (code-host-gitlab-2 / `only_allow_merge_if_pipeline_succeeds`) is NOT Premium-gated on gitlab.com Free, so this BL is scoped strictly to the approvals API.
+
+**Trigger:** Before the first organizational deployment on gitlab.com Free attempts `init.sh` in `org` mode.
+
+**Related:** code-host-gitlab-8 audit finding (the gap that triggered this entry); BL-002 (the GitHub analog this mirrors); code-check-gates-1 (the canonical attestation-honoring backstop pattern this should reuse).

--- a/tests/host-drivers/e2e-init-gitlab.test.sh
+++ b/tests/host-drivers/e2e-init-gitlab.test.sh
@@ -93,6 +93,24 @@ case "$*" in
     fi
     exit 0
     ;;
+  *"api -X PUT projects/"*)
+    # PUT projects/:id (org-mode pipeline-success gate + discussion-
+    # resolution settings — added by audit code-host-gitlab-2).
+    rc="${MOCK_GL_PROJECT_PUT_EXIT:-0}"
+    cat >/dev/null
+    if [ "$rc" -ne 0 ]; then
+      printf '%s\n' "${MOCK_GL_PROJECT_PUT_ERR:-mock glab: project-settings PUT failed}" >&2
+      exit "$rc"
+    fi
+    exit 0
+    ;;
+  *"api -X GET projects/"*)
+    # Explicit GET projects/:id — settings payload for verify (code-host-
+    # gitlab-2). The driver uses `-X GET` here to keep the call shape
+    # distinct from the other GETs for fixture matching.
+    printf '%s\n' "${MOCK_GL_PROJECT_JSON:-{\"only_allow_merge_if_pipeline_succeeds\":true}}"
+    exit 0
+    ;;
   *"api "*protected_branches*)
     # GET protected_branches/<branch>
     printf '%s\n' "${MOCK_GL_PROTECT_JSON:-{}}"
@@ -153,6 +171,7 @@ scenario_teardown() {
   unset MOCK_GL_PROTECT_POST_EXIT MOCK_GL_PROTECT_POST_ERR
   unset MOCK_GL_APPROVALS_PUT_EXIT MOCK_GL_APPROVALS_PUT_ERR
   unset MOCK_GL_PROTECT_JSON MOCK_GL_APPROVALS_JSON MOCK_GL_DELETE_EXIT
+  unset MOCK_GL_PROJECT_PUT_EXIT MOCK_GL_PROJECT_PUT_ERR MOCK_GL_PROJECT_JSON
   unset GIT_CONFIG_GLOBAL GLAB_TOKEN
   case "$PATH" in
     "$MOCK_DIR:"*) PATH="${PATH#"$MOCK_DIR:"}"; export PATH ;;
@@ -359,7 +378,10 @@ scenario_setup "https://gitlab.com/e2e-test/approvals-fail.git"
 export MOCK_GL_PROTECT_JSON="$PROTECT_JSON_ORG"
 export MOCK_GL_APPROVALS_JSON="$APPROVALS_JSON_ORG"
 export MOCK_GL_APPROVALS_PUT_EXIT=1
-export MOCK_GL_APPROVALS_PUT_ERR='ERROR: 403 — approvals PUT requires premium tier'
+# Use a generic 5xx error here so the BL-032 Premium-tier detection
+# (code-host-gitlab-8) does NOT fire — T6 covers the generic exit-3
+# branch; T7 below covers the BL-032 exit-4 branch.
+export MOCK_GL_APPROVALS_PUT_ERR='ERROR: HTTP 500 — internal server error from approvals endpoint'
 # --branch-protection-attested provided so the non-interactive
 # attestation prompt doesn't reject; we want to assert what init.sh
 # DOES on this code path, not block on attestation UX.
@@ -381,6 +403,47 @@ if [ "$rc" = "0" ] \
   pass "T6: gitlab exit-3 → host-agnostic attestation flow with gitlab-aware messaging (BL-031 fixed)"
 else
   fail_ "T6" "rc=$rc github_branding_seen=$github_branding_seen gitlab_branding_seen=$gitlab_branding_seen driver_stderr_seen=$driver_stderr_seen log:$(tail -10 "$TMP/init.log")"
+fi
+scenario_teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: gitlab-exit-4 Premium-only approvals (BL-032 / code-host-gitlab-8) ==="
+# ════════════════════════════════════════════════════════════════════
+#
+# T7 is the BL-032 sibling to T6. When the approvals PUT fails on
+# gitlab.com Free with a Premium-feature-not-available error, the driver
+# now pattern-matches and returns exit 4 with a structured BL-032
+# remediation block (gitlab.sh code-host-gitlab-8 branch). init.sh
+# (BL-031 dispatcher) treats exit 4 identically to exit 3 — routes to
+# the attestation flow with host-aware messaging.
+#
+# Assertions mirror T6 with the BL-032-specific wording substituted for
+# the driver's stderr check.
+echo "T7: org approvals PUT fails with Premium-tier message — BL-032 exit-4 path"
+scenario_setup "https://gitlab.com/e2e-test/premium-only.git"
+export MOCK_GL_PROTECT_JSON="$PROTECT_JSON_ORG"
+export MOCK_GL_APPROVALS_JSON="$APPROVALS_JSON_ORG"
+export MOCK_GL_APPROVALS_PUT_EXIT=1
+export MOCK_GL_APPROVALS_PUT_ERR='HTTP 403: This feature is not available on your plan. Upgrade to Premium to enable required approvals.'
+run_init_e2e premium-only organizational --gov-mode production --branch-protection-attested
+rc=$?
+# No GitHub-branded leak (BL-031 contract — the dispatcher is host-agnostic).
+github_branding_seen=no
+grep -qE 'GitHub Pro|free-tier limit' "$TMP/init.log" && github_branding_seen=yes
+# init.sh's own warn/info names the actual host.
+gitlab_branding_seen=no
+grep -qE 'on this gitlab repo|gitlab driver remediation' "$TMP/init.log" && gitlab_branding_seen=yes
+# BL-032 driver stderr surfaces (Premium-aware remediation).
+bl032_seen=no
+grep -qE 'Premium|BL-032|required-approvals API is unavailable' "$TMP/init.log" && bl032_seen=yes
+if [ "$rc" = "0" ] \
+   && [ "$github_branding_seen" = "no" ] \
+   && [ "$gitlab_branding_seen" = "yes" ] \
+   && [ "$bl032_seen" = "yes" ]; then
+  pass "T7: gitlab exit-4 (BL-032 Premium-only) → attestation flow + Premium-aware remediation"
+else
+  fail_ "T7" "rc=$rc github_branding_seen=$github_branding_seen gitlab_branding_seen=$gitlab_branding_seen bl032_seen=$bl032_seen log:$(tail -10 "$TMP/init.log")"
 fi
 scenario_teardown
 

--- a/tests/host-drivers/gitlab.test.sh
+++ b/tests/host-drivers/gitlab.test.sh
@@ -90,15 +90,19 @@ cd - >/dev/null; rm -rf "$WORK"
 mock_cli_teardown "$MOCK_DIR"; export PATH="$OLD_PATH"
 echo "gitlab.test.sh: host_configure_protection (personal) PASSED"
 
-# host_configure_protection org — POST protected_branches + PUT approvals
-# (gitlab.sh:111-121). Parity with github.test.sh (BL-005). Org mode sets
-# push_access_level=0 (No one) and approvals_before_merge=1.
+# host_configure_protection org — POST protected_branches + PUT approvals +
+# PUT projects/:id pipeline-success gate (gitlab.sh:111-160). Parity with
+# github.test.sh (BL-005). Org mode sets push_access_level=0 (No one),
+# approvals_before_merge=1, and only_allow_merge_if_pipeline_succeeds=true
+# (the latter added by audit code-host-gitlab-2 — CI parity with github.sh's
+# required_status_checks).
 MOCK_DIR=$(mock_cli_setup); export PATH="$MOCK_DIR:$OLD_PATH"
 WORK=$(mktemp -d); cd "$WORK"
 git init -q; git remote add origin "https://gitlab.com/org/repo.git"
 mock_cli_respond glab "api -X DELETE projects/org%2Frepo/protected_branches/main" 0 ""
 mock_cli_respond glab "api -X POST projects/org%2Frepo/protected_branches" 0 '{"id":1,"name":"main"}'
 mock_cli_respond glab "api -X PUT projects/org%2Frepo/approvals" 0 '{"approvals_before_merge":1}'
+mock_cli_respond glab "api -X PUT projects/org%2Frepo" 0 '{"only_allow_merge_if_pipeline_succeeds":true}'
 set +e; host_configure_protection "main" "org"; code=$?; set -e
 assert_exit_code 0 "$code" "org configure succeeds"
 cd - >/dev/null; rm -rf "$WORK"
@@ -119,9 +123,11 @@ set +e; output=$(host_verify_protection "main" "personal" 2>&1); code=$?; set -e
 assert_exit_code 1 "$code" "force-push allowed fails"
 assert_contains "$output" "force-push" "mentions rule"
 
-# org mode requires approvals — fail case
+# org mode requires approvals — fail case. Also fixture the project-settings
+# GET so the new code-host-gitlab-2 CI-gate check has a deterministic response.
 mock_cli_respond glab "api projects/u%2Fp/protected_branches/main" 0 '{"name":"main","allow_force_push":false,"push_access_levels":[{"access_level":40}]}'
 mock_cli_respond glab "api projects/u%2Fp/approvals" 0 '{"approvals_before_merge":0}'
+mock_cli_respond glab "api -X GET projects/u%2Fp" 0 '{"only_allow_merge_if_pipeline_succeeds":true}'
 set +e; output=$(host_verify_protection "main" "org" 2>&1); code=$?; set -e
 assert_exit_code 1 "$code" "org no approvals fails"
 assert_contains "$output" "approval" "mentions approvals"
@@ -139,6 +145,9 @@ git init -q; git remote add origin "https://gitlab.com/org/repo.git"
 mock_cli_respond glab "api projects/org%2Frepo/protected_branches/main" 0 \
   '{"name":"main","allow_force_push":false,"push_access_levels":[{"access_level":0}]}'
 mock_cli_respond glab "api projects/org%2Frepo/approvals" 0 '{"approvals_before_merge":1}'
+# code-host-gitlab-2: pipeline-success gate must be enabled for org-mode
+# verify to pass.
+mock_cli_respond glab "api -X GET projects/org%2Frepo" 0 '{"only_allow_merge_if_pipeline_succeeds":true}'
 set +e; host_verify_protection "main" "org"; code=$?; set -e
 assert_exit_code 0 "$code" "org verify pass"
 cd - >/dev/null; rm -rf "$WORK"

--- a/tests/test-gitlab-ci-status-stderr-approvals.sh
+++ b/tests/test-gitlab-ci-status-stderr-approvals.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# tests/test-gitlab-ci-status-stderr-approvals.sh — regression suite for
+# three GitLab driver S3 audit findings remediated in PR
+# fix/host-gitlab-ci-status-stderr-approvals:
+#
+#   code-host-gitlab-2  Org mode must enforce CI pipeline-success gate
+#                       (PUT projects/:id only_allow_merge_if_pipeline_succeeds)
+#                       and host_verify_protection must fail when the flag
+#                       is false — parity with github.sh required_status_checks.
+#
+#   code-host-gitlab-3  Both glab api calls in host_configure_protection
+#                       must capture stderr and surface the upstream
+#                       message on failure (mirroring github.sh BL-002
+#                       pattern). Otherwise operators see only a generic
+#                       "failed to configure protection" with no detail.
+#
+#   code-host-gitlab-8  Premium-only failure on projects/:id/approvals
+#                       (gitlab.com Free org-mode) must be detected and
+#                       returned as a distinct exit code (4) with a
+#                       BL-032-style remediation message documenting the
+#                       attestation escape hatch.
+#
+# TDD discipline: this file was written BEFORE the driver change and
+# initially failed RED against the baseline gitlab.sh. After the driver
+# was updated, all scenarios pass GREEN.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/host-drivers/gitlab.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build a tempdir with a fake glab on PATH. The fake is driven by env vars
+# the caller sets before invoking the driver:
+#   GLAB_POST_EXIT       — exit code for `glab api -X POST .../protected_branches`
+#   GLAB_POST_STDERR     — stderr emitted on the protected_branches POST
+#   GLAB_PUT_APPR_EXIT   — exit code for `glab api -X PUT .../approvals`
+#   GLAB_PUT_APPR_STDERR — stderr emitted on the approvals PUT
+#   GLAB_PUT_PROJ_EXIT   — exit code for `glab api -X PUT projects/:id` (settings)
+#   GLAB_PUT_PROJ_STDERR — stderr emitted on the project-settings PUT
+#   GLAB_GET_PROJ_BODY   — stdout (JSON) returned by `glab api projects/:id`
+#                          when host_verify_protection inspects settings
+#   GLAB_GET_BRANCH_BODY — stdout (JSON) returned by
+#                          `glab api projects/:id/protected_branches/main`
+#   GLAB_GET_APPR_BODY   — stdout (JSON) returned by
+#                          `glab api projects/:id/approvals`
+setup_with_fake_glab() {
+  TMPDIR_T=$(mktemp -d)
+  mkdir -p "$TMPDIR_T/bin"
+  cat > "$TMPDIR_T/bin/glab" <<'GLAB_EOF'
+#!/usr/bin/env bash
+# Fake glab — pattern-match the invocation and emit the canned response.
+# Drain stdin so piped --input payloads don't SIGPIPE.
+if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
+
+case "$*" in
+  *"-X DELETE"*"/protected_branches/"*)
+    exit 0  # idempotent delete always "succeeds"
+    ;;
+  *"-X POST"*"/protected_branches"*)
+    [ -n "${GLAB_POST_STDERR:-}" ] && printf '%s\n' "$GLAB_POST_STDERR" >&2
+    exit "${GLAB_POST_EXIT:-0}"
+    ;;
+  *"-X PUT"*"/approvals"*)
+    [ -n "${GLAB_PUT_APPR_STDERR:-}" ] && printf '%s\n' "$GLAB_PUT_APPR_STDERR" >&2
+    exit "${GLAB_PUT_APPR_EXIT:-0}"
+    ;;
+  *"-X PUT projects/"*)
+    # PUT projects/:id  (sets only_allow_merge_if_pipeline_succeeds etc.)
+    [ -n "${GLAB_PUT_PROJ_STDERR:-}" ] && printf '%s\n' "$GLAB_PUT_PROJ_STDERR" >&2
+    exit "${GLAB_PUT_PROJ_EXIT:-0}"
+    ;;
+  *"-X GET projects/"*)
+    # Explicit GET projects/:id — settings payload for verify
+    printf '%s' "${GLAB_GET_PROJ_BODY:-{\}}"
+    exit 0
+    ;;
+  *"projects/"*"/protected_branches/"*)
+    printf '%s' "${GLAB_GET_BRANCH_BODY:-{\}}"
+    exit 0
+    ;;
+  *"projects/"*"/approvals"*)
+    printf '%s' "${GLAB_GET_APPR_BODY:-{\}}"
+    exit 0
+    ;;
+  api\ projects/*)
+    # GET projects/:id (bare) — settings payload for verify (fallback)
+    printf '%s' "${GLAB_GET_PROJ_BODY:-{\}}"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+GLAB_EOF
+  chmod +x "$TMPDIR_T/bin/glab"
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    git remote add origin https://gitlab.com/org/repo.git
+  )
+}
+teardown_project() { rm -rf "$TMPDIR_T"; unset GLAB_POST_EXIT GLAB_POST_STDERR \
+  GLAB_PUT_APPR_EXIT GLAB_PUT_APPR_STDERR GLAB_PUT_PROJ_EXIT GLAB_PUT_PROJ_STDERR \
+  GLAB_GET_PROJ_BODY GLAB_GET_BRANCH_BODY GLAB_GET_APPR_BODY; }
+
+run_configure() {
+  local mode="$1"
+  (
+    cd "$TMPDIR_T"
+    PATH="$TMPDIR_T/bin:$PATH"
+    export GLAB_POST_EXIT GLAB_POST_STDERR GLAB_PUT_APPR_EXIT GLAB_PUT_APPR_STDERR \
+           GLAB_PUT_PROJ_EXIT GLAB_PUT_PROJ_STDERR
+    set +e
+    # shellcheck disable=SC1090
+    source "$DRIVER"
+    out=$(host_configure_protection main "$mode" 2>&1)
+    rc=$?
+    printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+  )
+}
+
+run_verify() {
+  local mode="$1"
+  (
+    cd "$TMPDIR_T"
+    PATH="$TMPDIR_T/bin:$PATH"
+    export GLAB_GET_PROJ_BODY GLAB_GET_BRANCH_BODY GLAB_GET_APPR_BODY
+    set +e
+    # shellcheck disable=SC1090
+    source "$DRIVER"
+    out=$(host_verify_protection main "$mode" 2>&1)
+    rc=$?
+    printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+  )
+}
+
+# ─── code-host-gitlab-2 ──────────────────────────────────────────────────────
+
+t1_org_configure_sets_pipeline_succeeds() {
+  # host_configure_protection in org mode must call PUT projects/:id with
+  # only_allow_merge_if_pipeline_succeeds=true (in addition to the existing
+  # protected_branches POST + approvals PUT). We instrument the fake glab to
+  # FAIL on the project-settings PUT specifically and assert that the driver
+  # returns a non-zero exit code attributable to that call — proving the call
+  # was actually attempted.
+  setup_with_fake_glab
+  export GLAB_POST_EXIT=0 GLAB_PUT_APPR_EXIT=0
+  export GLAB_PUT_PROJ_EXIT=1 GLAB_PUT_PROJ_STDERR='HTTP 500: simulated failure'
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" = "0" ]; then
+    fail_ "T1" "expected non-zero rc when project-settings PUT fails (proves driver called it); got rc=0 out=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"pipeline"* ]] && [[ "$stderr" != *"settings"* ]]; then
+    fail_ "T1" "expected error mentioning pipeline/settings; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T1: org configure invokes project-settings PUT (pipeline-succeeds gate)"
+  teardown_project
+}
+
+t2_org_verify_fails_when_pipeline_gate_off() {
+  # host_verify_protection in org mode must GET projects/:id and assert
+  # only_allow_merge_if_pipeline_succeeds=true. When the API reports false,
+  # the gate must fail with the parity error message.
+  setup_with_fake_glab
+  export GLAB_GET_BRANCH_BODY='{"name":"main","allow_force_push":false,"push_access_levels":[{"access_level":0}]}'
+  export GLAB_GET_APPR_BODY='{"approvals_before_merge":1}'
+  export GLAB_GET_PROJ_BODY='{"only_allow_merge_if_pipeline_succeeds":false}'
+  local out; out=$(run_verify org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" = "0" ]; then
+    fail_ "T2" "expected verify to fail when pipeline gate off; got rc=0 out=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"pipeline"* ]]; then
+    fail_ "T2" "expected stderr to mention pipeline gate; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T2: org verify fails with pipeline-gate parity message when API reports false"
+  teardown_project
+}
+
+t3_org_verify_passes_when_pipeline_gate_on() {
+  setup_with_fake_glab
+  export GLAB_GET_BRANCH_BODY='{"name":"main","allow_force_push":false,"push_access_levels":[{"access_level":0}]}'
+  export GLAB_GET_APPR_BODY='{"approvals_before_merge":1}'
+  export GLAB_GET_PROJ_BODY='{"only_allow_merge_if_pipeline_succeeds":true}'
+  local out; out=$(run_verify org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "0" ]; then
+    fail_ "T3" "expected verify pass; got rc=$rc out=$stderr"
+    teardown_project; return
+  fi
+  pass "T3: org verify passes when pipeline gate enabled"
+  teardown_project
+}
+
+# ─── code-host-gitlab-3 ──────────────────────────────────────────────────────
+
+t4_protected_branches_post_surfaces_stderr() {
+  # When the protected_branches POST fails, the driver must capture and
+  # surface the upstream glab error message rather than swallowing it
+  # under a generic "failed to configure protection".
+  setup_with_fake_glab
+  export GLAB_POST_EXIT=1
+  export GLAB_POST_STDERR='HTTP 403: insufficient privileges to write to projects/org%2Frepo/protected_branches'
+  local out; out=$(run_configure personal)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "2" ]; then
+    fail_ "T4" "expected exit 2 for generic POST failure; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"insufficient privileges"* ]]; then
+    fail_ "T4" "expected upstream stderr to be surfaced; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T4: protected_branches POST failure surfaces upstream glab stderr"
+  teardown_project
+}
+
+t5_approvals_put_generic_failure_surfaces_stderr() {
+  setup_with_fake_glab
+  export GLAB_POST_EXIT=0
+  export GLAB_PUT_APPR_EXIT=1
+  export GLAB_PUT_APPR_STDERR='HTTP 500: internal server error on approvals endpoint'
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "3" ]; then
+    fail_ "T5" "expected exit 3 for generic approvals failure; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"internal server error"* ]]; then
+    fail_ "T5" "expected upstream stderr to be surfaced; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T5: approvals PUT generic failure surfaces upstream glab stderr"
+  teardown_project
+}
+
+# ─── code-host-gitlab-8 ──────────────────────────────────────────────────────
+
+t6_approvals_premium_only_returns_distinct_code() {
+  # gitlab.com Free returns a Premium-feature-not-available error on the
+  # approvals PUT. The driver must detect this pattern and return exit
+  # code 4 (distinct from 3=generic-approvals-failure), with a remediation
+  # message naming the BL-032 / Premium tier limitation and the
+  # attestation escape-hatch path.
+  setup_with_fake_glab
+  export GLAB_POST_EXIT=0
+  export GLAB_PUT_APPR_EXIT=1
+  export GLAB_PUT_APPR_STDERR='HTTP 403: 403 Forbidden — This feature is not available on your plan. Upgrade to Premium to enable required approvals.'
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "4" ]; then
+    fail_ "T6" "expected exit 4 for Premium-only approvals; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"Premium"* ]] && [[ "$stderr" != *"premium"* ]]; then
+    fail_ "T6" "expected remediation mentioning Premium tier; stderr=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"BL-032"* ]] && [[ "$stderr" != *"attested"* ]]; then
+    fail_ "T6" "expected remediation mentioning BL-032 / attestation escape hatch; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T6: Premium-only approvals failure → exit 4 + BL-032 remediation"
+  teardown_project
+}
+
+t7_personal_mode_unchanged_on_success() {
+  # Sanity: personal mode (no approvals PUT, no project-settings PUT)
+  # still returns 0 on a clean run. Guards against the refactor breaking
+  # the simple happy path.
+  setup_with_fake_glab
+  export GLAB_POST_EXIT=0
+  local out; out=$(run_configure personal)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "0" ]; then
+    fail_ "T7" "expected exit 0 on personal success; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T7: personal mode happy path returns 0"
+  teardown_project
+}
+
+# ─── backlog-doc parity check ────────────────────────────────────────────────
+
+t8_backlog_has_bl032_entry() {
+  # code-host-gitlab-8 requires a BL-032 entry in the backlog documenting
+  # the gitlab.com Free org-mode approvals graceful-degradation gap,
+  # mirroring BL-002's GitHub free-tier carve-out.
+  local backlog="$REPO_ROOT/solo-orchestrator-backlog.md"
+  if ! grep -qE '^## BL-032:' "$backlog"; then
+    fail_ "T8" "expected BL-032 header in $backlog"
+    return
+  fi
+  if ! grep -q -i 'gitlab' "$backlog"; then
+    fail_ "T8" "expected BL-032 entry to mention GitLab"
+    return
+  fi
+  pass "T8: BL-032 entry exists in backlog (GitLab BL-002 analog)"
+}
+
+echo "== tests/test-gitlab-ci-status-stderr-approvals.sh =="
+t1_org_configure_sets_pipeline_succeeds
+t2_org_verify_fails_when_pipeline_gate_off
+t3_org_verify_passes_when_pipeline_gate_on
+t4_protected_branches_post_surfaces_stderr
+t5_approvals_put_generic_failure_surfaces_stderr
+t6_approvals_premium_only_returns_distinct_code
+t7_personal_mode_unchanged_on_success
+t8_backlog_has_bl032_entry
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **code-host-gitlab-2 — Org-mode CI gate**: Add `only_allow_merge_if_pipeline_succeeds:true` PUT (+ discussion-resolution flag) on `projects/:id`, and a matching GET in `host_verify_protection`. Brings GitLab to parity with `github.sh`'s `required_status_checks` enforcement so org-mode verification can no longer pass silently with no CI gate on main.
- **code-host-gitlab-3 — Diagnostic stderr**: Both `glab api` calls in `host_configure_protection` now capture stderr into `glab_err` and surface the upstream message under the existing generic error. Mirrors the BL-002 pattern in `github.sh:117-138`.
- **code-host-gitlab-8 — BL-032 graceful degradation**: Pattern-match Premium-only response signals on the approvals PUT (`premium|ultimate|not available on your plan|feature is not available|requires .* plan`); return a dedicated exit code 4 with a structured remediation message. `init.sh`'s BL-031 dispatcher now treats exit 4 identically to exit 3 (attestation flow). New BL-032 backlog entry mirrors BL-002 and tracks the attestation flag itself as remaining work.
- **Driver error-code contract documented** in the `gitlab.sh` header (0/1/2/3/4/5).
- **No state-mutating writes** touched, so no snapshot+rollback wrapping was needed — but the new `host_configure_protection` sequence respects the existing return-on-first-failure ordering so a partial protection state is the same as pre-fix (POST succeeds → return 3/4 from approvals failure → init.sh decides; never reaches the project-settings PUT until both prior calls succeed).

## Findings closed

- code-host-gitlab-2 — No CI status-check enforcement in org mode (GitHub parity gap)
- code-host-gitlab-3 — host_configure_protection swallows all glab stderr — opaque failure mode
- code-host-gitlab-8 — Approvals API: gitlab.com Free org-mode no graceful-degradation path

## Test plan

**RED (baseline `tests/test-gitlab-ci-status-stderr-approvals.sh` run BEFORE the driver change, captured during the TDD cycle):**

```
== tests/test-gitlab-ci-status-stderr-approvals.sh ==
  [FAIL] T1 — expected non-zero rc when project-settings PUT fails (proves driver called it); got rc=0 out=
  [FAIL] T2 — expected verify to fail when pipeline gate off; got rc=0 out=
  [PASS] T3: org verify passes when pipeline gate enabled
  [FAIL] T4 — expected upstream stderr to be surfaced; stderr=gitlab driver: failed to configure protection on org%2Frepo#main (personal mode)
  [FAIL] T5 — expected upstream stderr to be surfaced; stderr=gitlab driver: protected branch set but approvals config failed
  [FAIL] T6 — expected exit 4 for Premium-only approvals; got rc=3 stderr=gitlab driver: protected branch set but approvals config failed
  [PASS] T7: personal mode happy path returns 0
  [FAIL] T8 — expected BL-032 header in solo-orchestrator-backlog.md
== Total: 8 | Passed: 2 | Failed: 6 ==
```

**GREEN (post-fix, full suite):**

```
$ bash tests/test-gitlab-ci-status-stderr-approvals.sh
  [PASS] T1: org configure invokes project-settings PUT (pipeline-succeeds gate)
  [PASS] T2: org verify fails with pipeline-gate parity message when API reports false
  [PASS] T3: org verify passes when pipeline gate enabled
  [PASS] T4: protected_branches POST failure surfaces upstream glab stderr
  [PASS] T5: approvals PUT generic failure surfaces upstream glab stderr
  [PASS] T6: Premium-only approvals failure → exit 4 + BL-032 remediation
  [PASS] T7: personal mode happy path returns 0
  [PASS] T8: BL-032 entry exists in backlog (GitLab BL-002 analog)
== Total: 8 | Passed: 8 | Failed: 0 ==

$ bash tests/host-drivers/run-all.sh
... (every host-driver suite green)
Host-driver tests: 9 run, 0 failed

$ bash tests/host-drivers/e2e-init-gitlab.test.sh
Results: 7 passed, 0 failed   # incl. NEW T7 covering BL-032 exit-4 path end-to-end via init.sh

$ bash tests/test-github-free-tier-403.sh        # 4/4 PASS (no regression)
$ bash tests/test-init-other-host-attestation.sh # 2/2 PASS (no regression)

$ bash scripts/lint-counter-antipattern.sh       # OK
$ bash scripts/lint-backlog-references.sh        # OK
```

Adversarial coverage in the new tests:
- T3 (sanity: verify passes when pipeline gate enabled) and T7 (sanity: personal mode happy path) — guard against the refactor breaking the happy path even when the assertion target is unrelated.
- T6 explicitly asserts both exit code 4 AND that the remediation message names "Premium" AND mentions either "BL-032" or "attested" — keeps the driver from regressing to a generic "approvals config failed" if a future cleanup pass refactors the branch.
- The e2e T6/T7 split keeps coverage of both the generic exit-3 attestation flow AND the BL-032 exit-4 flow, so a future change can't collapse them silently.

## Bonus catches

- **e2e mock-glab gap**: the `tests/host-drivers/e2e-init-gitlab.test.sh` mock fell through to its 127-exit unhandled-invocation arm whenever the driver issued the new `glab api -X PUT projects/:id` (settings) or `-X GET projects/:id` (verify) calls. This would have surfaced as a confusing T2/T7 failure for anyone touching the driver in the future. The mock now has dedicated arms for both with their own `MOCK_GL_PROJECT_*` env knobs (mirroring the `MOCK_GL_APPROVALS_*` shape).
- **Substring-collision in mock-cli fixtures**: registering `api projects/:id` (bare) would have matched the longer-suffix `api projects/:id/protected_branches/main` GET via mock-cli's plain substring matcher — that's why the driver uses an explicit `glab api -X GET projects/:id` (and the e2e + unit fixtures key on `api -X GET projects/...`). Documented in the driver comment so the next person adding a project-settings call doesn't trip on it.

## Worktree note

```
/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_dcd1c66b-4ea-2
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)