### PR TITLE
fix(lib,hooks): host.sh date parse + bypass-audit atomicity + bypass-detector session_id (3 S3 closures)

### DIFF
--- a/scripts/hooks/bypass-detector.sh
+++ b/scripts/hooks/bypass-detector.sh
@@ -104,7 +104,15 @@ PATTERNS=$(scan_bypass_patterns_all "$TEXT" || true)
 
 # Build the rows.
 TS=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+# Audit fix code-hooks-bypass-detector-3 (2026-06-28): the Claude Code
+# hook envelope carries .session_id as a documented top-level field;
+# CLAUDE_SESSION_ID is NOT exported by Claude Code, so the previous
+# env-only read landed every row with session_id="unknown" and broke
+# the W7 successor-handoff correlation. Read the envelope first; fall
+# back to $CLAUDE_SESSION_ID (belt-and-suspenders for unexpected
+# envelope shapes), then to "unknown".
+SESSION_ID=$(echo "$INPUT" | jq -r '.session_id // empty' 2>/dev/null)
+[ -z "$SESSION_ID" ] && SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
 LEVEL=$(jq -r '.enforcement_level // "strict"' "$PROJECT_ROOT/.claude/manifest.json" 2>/dev/null)
 FIRST_PATTERN=""
 

--- a/scripts/lib/bypass-audit.sh
+++ b/scripts/lib/bypass-audit.sh
@@ -44,12 +44,21 @@ _bypass_audit_preserve_mode() {
 # bypass_audit_init <project_root>
 # Creates .claude/bypass-audit.json as an empty array if it does not already
 # exist. Idempotent — preserves existing rows.
+#
+# Verifier follow-up (2026-06-28): chmod 600 after creation. The plain
+# `echo "[]" > "$file"` redirect inherits the caller's umask (commonly
+# 0022 → file mode 0644), which leaves the governance ledger world-
+# readable on a default-umask multi-user box. Forcing 0600 here gives
+# _bypass_audit_preserve_mode a sane baseline to copy from on the first
+# append, so an umask-derived leak doesn't perpetuate through later
+# rename cycles.
 bypass_audit_init() {
   local project_root="${1:-.}"
   local file="$project_root/.claude/bypass-audit.json"
   [ -f "$file" ] && return 0
   mkdir -p "$project_root/.claude"
   echo "[]" > "$file"
+  chmod 600 "$file" 2>/dev/null || true
 }
 
 # bypass_audit_append <project_root> <row_json>
@@ -102,21 +111,35 @@ bypass_audit_append() {
   #     either platform.
   # (b) Trap on EXIT/INT/TERM so a signal between mktemp and either
   #     branch doesn't leave an orphan ${file}.XXXXXX littering the
-  #     governance dir. The trap clears itself after successful
-  #     rename so the lock_dir cleanup runs unimpeded.
-  local tmp rc
-  tmp=$(mktemp "${file}.XXXXXX")
-  trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
-  if jq --argjson r "$row" '. + [$r]' "$file" > "$tmp" 2>/dev/null; then
-    _bypass_audit_preserve_mode "$file" "$tmp"
-    mv "$tmp" "$file"
-    rc=0
-  else
-    rm -f "$tmp"
-    echo "[FAIL] bypass_audit_append: jq failed" >&2
-    rc=1
-  fi
-  trap - EXIT INT TERM
+  #     governance dir.
+  #
+  # Verifier follow-up (2026-06-28): wrap the rename window in a
+  # SUBSHELL. bash `trap` is shell-global, not function-local — the
+  # prior `trap '...' EXIT INT TERM` / `trap - EXIT INT TERM` pair at
+  # function scope silently destroyed any pre-existing EXIT trap the
+  # caller had installed. Containing the trap in a subshell means it
+  # only governs that subshell's exit; the caller's trap survives
+  # untouched. tmp/rc must be captured from the subshell's exit code
+  # since locals don't propagate up.
+  local rc=0
+  (
+    tmp=$(mktemp "${file}.XXXXXX") || exit 1
+    trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
+    if jq --argjson r "$row" '. + [$r]' "$file" > "$tmp" 2>/dev/null; then
+      _bypass_audit_preserve_mode "$file" "$tmp"
+      mv "$tmp" "$file" || exit 1
+      # Successful rename: clear the trap so the EXIT path doesn't try
+      # to rm a now-renamed (i.e. nonexistent) tmp path. Also let the
+      # outer caller manage the lock_dir cleanup uniformly.
+      trap - EXIT INT TERM
+      exit 0
+    else
+      rm -f "$tmp"
+      echo "[FAIL] bypass_audit_append: jq failed" >&2
+      trap - EXIT INT TERM
+      exit 1
+    fi
+  ) || rc=1
 
   rmdir "$lock_dir" 2>/dev/null
   return "$rc"
@@ -185,21 +208,28 @@ bypass_audit_close_pending() {
   # Audit fix code-lib-2 (2026-06-28): mirror append's chmod-preserve
   # + EXIT/INT/TERM trap so close_pending doesn't silently downgrade
   # operator-set perms or leave orphan tmp files on signal.
-  local tmp rc
-  tmp=$(mktemp "${file}.XXXXXX")
-  trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
-  if jq --arg ur "$user_resp" --arg fo "$final_out" \
-       '[.[] | if .type == "claude_bypass_proposal" and .user_response == "PENDING" then .user_response = $ur | .final_outcome = $fo else . end]' \
-       "$file" > "$tmp" 2>/dev/null; then
-    _bypass_audit_preserve_mode "$file" "$tmp"
-    mv "$tmp" "$file"
-    rc=0
-  else
-    rm -f "$tmp"
-    echo "[FAIL] bypass_audit_close_pending: jq failed" >&2
-    rc=1
-  fi
-  trap - EXIT INT TERM
+  #
+  # Verifier follow-up (2026-06-28): subshell-isolate the trap (see
+  # bypass_audit_append for rationale). Function-scope traps clobber
+  # the caller's EXIT handler shell-wide; the subshell contains it.
+  local rc=0
+  (
+    tmp=$(mktemp "${file}.XXXXXX") || exit 1
+    trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
+    if jq --arg ur "$user_resp" --arg fo "$final_out" \
+         '[.[] | if .type == "claude_bypass_proposal" and .user_response == "PENDING" then .user_response = $ur | .final_outcome = $fo else . end]' \
+         "$file" > "$tmp" 2>/dev/null; then
+      _bypass_audit_preserve_mode "$file" "$tmp"
+      mv "$tmp" "$file" || exit 1
+      trap - EXIT INT TERM
+      exit 0
+    else
+      rm -f "$tmp"
+      echo "[FAIL] bypass_audit_close_pending: jq failed" >&2
+      trap - EXIT INT TERM
+      exit 1
+    fi
+  ) || rc=1
 
   rmdir "$lock_dir" 2>/dev/null
   return "$rc"

--- a/scripts/lib/bypass-audit.sh
+++ b/scripts/lib/bypass-audit.sh
@@ -20,6 +20,27 @@
 
 # shellcheck shell=bash
 
+# _bypass_audit_preserve_mode <reference_file> <target_file>
+# Copies <reference_file>'s octal mode onto <target_file>. Tries GNU
+# `chmod --reference` first (single syscall path); falls back to
+# `stat`-then-`chmod` covering BSD (macOS) and GNU stat invocations;
+# finally falls back to `chmod 600` (the mktemp default, safe for a
+# governance artifact). Used to preserve operator-set perms across the
+# adjacent-mktemp rename in append / close_pending.
+_bypass_audit_preserve_mode() {
+  local ref="$1" tgt="$2" mode
+  if chmod --reference="$ref" "$tgt" 2>/dev/null; then
+    return 0
+  fi
+  if mode=$(stat -f "%Lp" "$ref" 2>/dev/null) && [ -n "$mode" ]; then
+    chmod "$mode" "$tgt" 2>/dev/null && return 0
+  fi
+  if mode=$(stat -c "%a" "$ref" 2>/dev/null) && [ -n "$mode" ]; then
+    chmod "$mode" "$tgt" 2>/dev/null && return 0
+  fi
+  chmod 600 "$tgt" 2>/dev/null || true
+}
+
 # bypass_audit_init <project_root>
 # Creates .claude/bypass-audit.json as an empty array if it does not already
 # exist. Idempotent — preserves existing rows.
@@ -70,9 +91,24 @@ bypass_audit_append() {
   # file lives on a different filesystem from /tmp/* or $HOME-based
   # project dirs, turning `mv` into copy+unlink. A SIGKILL during the
   # write window can then truncate the append-only ledger.
+  #
+  # Audit fix code-lib-2 (2026-06-28): two residual hardenings.
+  # (a) Preserve target file permissions across the rename. mktemp
+  #     defaults to 0600; if the operator chmod'd the ledger to e.g.
+  #     0640 for a shared-team setup, the post-rename file would
+  #     silently revert. _bypass_audit_preserve_mode tries GNU
+  #     `chmod --reference`, then BSD/GNU `stat`-then-`chmod`, then
+  #     a `chmod 600` fallback — keeps the operator's intent on
+  #     either platform.
+  # (b) Trap on EXIT/INT/TERM so a signal between mktemp and either
+  #     branch doesn't leave an orphan ${file}.XXXXXX littering the
+  #     governance dir. The trap clears itself after successful
+  #     rename so the lock_dir cleanup runs unimpeded.
   local tmp rc
   tmp=$(mktemp "${file}.XXXXXX")
+  trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
   if jq --argjson r "$row" '. + [$r]' "$file" > "$tmp" 2>/dev/null; then
+    _bypass_audit_preserve_mode "$file" "$tmp"
     mv "$tmp" "$file"
     rc=0
   else
@@ -80,6 +116,7 @@ bypass_audit_append() {
     echo "[FAIL] bypass_audit_append: jq failed" >&2
     rc=1
   fi
+  trap - EXIT INT TERM
 
   rmdir "$lock_dir" 2>/dev/null
   return "$rc"
@@ -144,11 +181,17 @@ bypass_audit_close_pending() {
   #
   # D3 fix (post-PR-A): same adjacent-mktemp atomicity fix as
   # bypass_audit_append above.
+  #
+  # Audit fix code-lib-2 (2026-06-28): mirror append's chmod-preserve
+  # + EXIT/INT/TERM trap so close_pending doesn't silently downgrade
+  # operator-set perms or leave orphan tmp files on signal.
   local tmp rc
   tmp=$(mktemp "${file}.XXXXXX")
+  trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
   if jq --arg ur "$user_resp" --arg fo "$final_out" \
        '[.[] | if .type == "claude_bypass_proposal" and .user_response == "PENDING" then .user_response = $ur | .final_outcome = $fo else . end]' \
        "$file" > "$tmp" 2>/dev/null; then
+    _bypass_audit_preserve_mode "$file" "$tmp"
     mv "$tmp" "$file"
     rc=0
   else
@@ -156,6 +199,7 @@ bypass_audit_close_pending() {
     echo "[FAIL] bypass_audit_close_pending: jq failed" >&2
     rc=1
   fi
+  trap - EXIT INT TERM
 
   rmdir "$lock_dir" 2>/dev/null
   return "$rc"

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -78,8 +78,20 @@ _host_define_other_fallbacks() {
     # Check attestation age (90 days)
     local now then days
     now=$(date +%s)
-    # Try GNU date first, then BSD (macOS) date
-    then=$(date -d "$attested" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "$attested" +%s 2>/dev/null || echo "$now")
+    # Try GNU date first, then BSD (macOS) date. Audit fix code-lib-1
+    # (2026-06-28): pre-fix, dual-parser failure silently fell through
+    # via `|| echo "$now"`, which made age=0 days and bypassed the
+    # 90-day staleness check entirely. Now we fail-closed and name the
+    # offending value on stderr so the operator can re-record the
+    # attestation rather than silently waving the W3 backstop.
+    if then=$(date -d "$attested" +%s 2>/dev/null); then
+      :
+    elif then=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$attested" +%s 2>/dev/null); then
+      :
+    else
+      echo "host.sh: unparseable branch_protection attestation timestamp: '$attested'" >&2
+      return 1
+    fi
     days=$(( (now - then) / 86400 ))
     [ "$days" -gt 90 ] && return 1
     return 0

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -76,7 +76,7 @@ _host_define_other_fallbacks() {
     attested=$(jq -r '.phase2_init.attestations.branch_protection.at // empty' "$ps" 2>/dev/null || true)
     [ -z "$attested" ] && return 1
     # Check attestation age (90 days)
-    local now then days
+    local now then_ts days
     now=$(date +%s)
     # Try GNU date first, then BSD (macOS) date. Audit fix code-lib-1
     # (2026-06-28): pre-fix, dual-parser failure silently fell through
@@ -84,15 +84,20 @@ _host_define_other_fallbacks() {
     # 90-day staleness check entirely. Now we fail-closed and name the
     # offending value on stderr so the operator can re-record the
     # attestation rather than silently waving the W3 backstop.
-    if then=$(date -d "$attested" +%s 2>/dev/null); then
+    #
+    # Verifier follow-up (2026-06-28): variable renamed from `then`
+    # to `then_ts`. bash permits `then` as a variable (it's a keyword
+    # only in syntactic position) but several shell linters flag it;
+    # the `_ts` suffix also makes the unit explicit (epoch seconds).
+    if then_ts=$(date -d "$attested" +%s 2>/dev/null); then
       :
-    elif then=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$attested" +%s 2>/dev/null); then
+    elif then_ts=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$attested" +%s 2>/dev/null); then
       :
     else
       echo "host.sh: unparseable branch_protection attestation timestamp: '$attested'" >&2
       return 1
     fi
-    days=$(( (now - then) / 86400 ))
+    days=$(( (now - then_ts) / 86400 ))
     [ "$days" -gt 90 ] && return 1
     return 0
   }

--- a/tests/test-bypass-audit-tmp-hardening.sh
+++ b/tests/test-bypass-audit-tmp-hardening.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# tests/test-bypass-audit-tmp-hardening.sh — regression for code-lib-2.
+#
+# bypass_audit_append + bypass_audit_close_pending already place the
+# mktemp template adjacent to the target file (PR 0d5605e — D3 fix), so
+# `mv` is a same-filesystem rename. Two residual hardenings from the
+# original audit recommendation remain:
+#
+#   (a) Preserve permissions of the target file across the rename. The
+#       audit ledger is a governance artifact; if an operator has
+#       intentionally chmod'd it (e.g. 0640 for a shared-team setup),
+#       the post-rename file silently reverts to mktemp's 0600 default.
+#       Use `chmod --reference="$file" "$tmp" 2>/dev/null || chmod 600
+#       "$tmp"` (GNU + BSD-safe fallback) so the post-rename file
+#       matches the operator's intent, or falls back to a safe default.
+#
+#   (b) Trap on EXIT/INT/TERM to remove orphan tmp files. The current
+#       code only `rm -f "$tmp"` on the jq-failure branch — a SIGTERM
+#       between `mktemp` and either branch leaves a stray ${file}.XXXXXX
+#       in .claude/, polluting the governance directory and confusing
+#       successor agents grepping the dir.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/bypass-audit.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  echo "[]" > "$PROJ/.claude/bypass-audit.json"
+}
+teardown() { rm -rf "$TMP"; }
+
+ROW='{"timestamp":"2026-06-28T00:00:00Z","session_id":null,"type":"claude_bypass_proposal","actor":"claude","enforcement_level_at_event":"strict","details":{"pattern":"x"},"user_response":"PENDING","final_outcome":"recorded_only"}'
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== (a) bypass_audit_append preserves target file permissions ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T1: operator-set 0640 perms survive an append.
+echo "T1: 0640 audit file keeps 0640 after append"
+setup
+chmod 640 "$PROJ/.claude/bypass-audit.json"
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+if [ "$mode" = "640" ]; then
+  pass "T1: post-append mode preserved (was 640, is $mode)"
+else
+  fail_ "T1" "expected 640 after append; got $mode (mktemp 0600 leaked through rename)"
+fi
+teardown
+
+# T2: bypass_audit_close_pending preserves perms too.
+echo "T2: 0640 audit file keeps 0640 after close_pending"
+setup
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+chmod 640 "$PROJ/.claude/bypass-audit.json"
+( source "$LIB" && bypass_audit_close_pending "$PROJ" "accept" >/dev/null 2>&1 )
+mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+if [ "$mode" = "640" ]; then
+  pass "T2: post-close_pending mode preserved"
+else
+  fail_ "T2" "expected 640 after close_pending; got $mode"
+fi
+teardown
+
+# T3: when the source file mode read fails (corner case), we still get
+# a sane default (0600) — never an inherited umask-default (0644 / 0664).
+echo "T3: append on a fresh init produces mode-600 file (not umask default)"
+setup
+# bypass_audit_init writes "[]" via `echo` which honors umask.
+# After the first append, the mode should be 600 (mktemp default) — and
+# the appended file should NOT be world-readable even if umask was 022.
+chmod 644 "$PROJ/.claude/bypass-audit.json"  # simulate a permissive prior
+# Touch fresh, simulating no operator override:
+rm -f "$PROJ/.claude/bypass-audit.json"
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+# When bypass_audit_init creates the file via `echo > file` it inherits
+# umask; the subsequent append's chmod-from-reference will then copy
+# that mode. So this test asserts the file is at most the mode the
+# init created — i.e. NOT silently downgraded to 600 (which would be
+# fine but a behavior change) AND NOT silently upgraded.
+# The contract we care about: after the append, the mode equals the
+# mode the file had just before the append (i.e. no perm churn).
+# Pre-append, init created the file with the inherited umask; we then
+# chmod'd it to a known value during init's mkdir. Read the actual
+# pre-append mode by re-creating via the lib first:
+teardown
+setup
+# Pre-state: file exists with init's umask-derived mode.
+pre_mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+        || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+post_mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+         || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+if [ "$pre_mode" = "$post_mode" ]; then
+  pass "T3: append preserves the pre-existing mode ($pre_mode unchanged)"
+else
+  fail_ "T3" "mode churn: pre=$pre_mode post=$post_mode"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== (b) tmp files are cleaned up on signal / unexpected exit ==="
+# ════════════════════════════════════════════════════════════════════
+
+# T4: source contains a trap that removes the tmp file. Verifies the
+# code shape; a process-killed test is timing-sensitive on CI.
+echo "T4: bypass_audit_append registers an EXIT trap for tmp cleanup"
+append_block=$(awk '/^bypass_audit_append\(\)/,/^}$/' "$LIB")
+if echo "$append_block" | grep -qE "trap.*(rm -f .*\\\$tmp|EXIT|INT|TERM)"; then
+  pass "T4: append has a trap covering tmp cleanup"
+else
+  fail_ "T4" "bypass_audit_append has no EXIT/INT/TERM trap protecting \$tmp"
+fi
+
+# T5: same for close_pending.
+echo "T5: bypass_audit_close_pending registers an EXIT trap for tmp cleanup"
+close_block=$(awk '/^bypass_audit_close_pending\(\)/,/^}$/' "$LIB")
+if echo "$close_block" | grep -qE "trap.*(rm -f .*\\\$tmp|EXIT|INT|TERM)"; then
+  pass "T5: close_pending has a trap covering tmp cleanup"
+else
+  fail_ "T5" "bypass_audit_close_pending has no EXIT/INT/TERM trap protecting \$tmp"
+fi
+
+# T6: no orphan tmp files after a normal successful append cycle.
+# (The trap must not leave the post-rename tmp lying around.)
+echo "T6: no orphan bypass-audit.json.XXXXXX files after a successful append"
+setup
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+orphans=$(find "$PROJ/.claude" -name "bypass-audit.json.*" -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$orphans" = "0" ]; then
+  pass "T6: no orphan tmp files"
+else
+  fail_ "T6" "found $orphans orphan(s) in $PROJ/.claude:"
+  find "$PROJ/.claude" -name "bypass-audit.json.*" -type f 2>/dev/null
+fi
+teardown
+
+# T7: no orphan tmp files after a successful close_pending cycle.
+echo "T7: no orphan bypass-audit.json.XXXXXX files after a successful close_pending"
+setup
+( source "$LIB" \
+  && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 \
+  && bypass_audit_close_pending "$PROJ" "accept" >/dev/null 2>&1 )
+orphans=$(find "$PROJ/.claude" -name "bypass-audit.json.*" -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$orphans" = "0" ]; then
+  pass "T7: no orphan tmp files"
+else
+  fail_ "T7" "found $orphans orphan(s)"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bypass-audit-trap-isolation.sh
+++ b/tests/test-bypass-audit-trap-isolation.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# tests/test-bypass-audit-trap-isolation.sh — regression for verifier
+# follow-up on PR #93.
+#
+# bash `trap '...' EXIT INT TERM` is shell-global, not function-local.
+# The pre-fix bypass_audit_append / bypass_audit_close_pending installed
+# their tmp-cleanup trap at function scope, then did `trap - EXIT INT TERM`
+# unconditionally — silently destroying any pre-existing trap the caller
+# had set. The fix wraps the rename window in a subshell so the trap is
+# contained to that subshell and the caller's trap survives.
+#
+# This is a *latent* defect on main (no current caller of bypass_audit_*
+# also sets an EXIT trap), but it's a library function — the next consumer
+# that adds `trap 'cleanup' EXIT` would have their cleanup silently wiped,
+# which is exactly the silent-bypass class this PR was created to remove.
+#
+# T1: caller sets EXIT trap, then calls bypass_audit_append. After the
+#     call, the caller's trap must still be active. Asserted via two
+#     channels: (a) `trap -p EXIT` still shows the caller's trap;
+#     (b) on subshell exit, the caller's trap body actually fires.
+#
+# T2: caller sets EXIT trap, then triggers a jq-failure path in append
+#     (malformed JSON in the audit file). The internal rollback runs
+#     (rc=1, tmp removed) AND the caller's trap still fires at exit.
+#
+# T3 / T4: same for bypass_audit_close_pending (happy + jq-failure path).
+#
+# T5: bypass_audit_init creates the audit file with mode 600 even under
+#     a permissive umask. Pre-fix `echo "[]" > "$file"` inherited umask,
+#     leaving the governance ledger world-readable on default-022 boxes.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/bypass-audit.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  echo "[]" > "$PROJ/.claude/bypass-audit.json"
+}
+teardown() { rm -rf "$TMP"; }
+
+ROW='{"timestamp":"2026-06-28T00:00:00Z","session_id":null,"type":"claude_bypass_proposal","actor":"claude","enforcement_level_at_event":"strict","details":{"pattern":"x"},"user_response":"PENDING","final_outcome":"recorded_only"}'
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: bypass_audit_append preserves caller's EXIT trap (happy path) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+# Run in a subshell so we can observe the EXIT trap firing as the subshell
+# exits. The marker file is created by the caller's trap; if the trap was
+# wiped by the library, the marker won't exist.
+MARKER="$TMP/caller_trap_fired"
+(
+  source "$LIB"
+  trap 'touch "'"$MARKER"'"' EXIT
+  bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1
+  # Also check trap is still registered post-call (in-process channel).
+  trap_out=$(trap -p EXIT)
+  if echo "$trap_out" | grep -q "caller_trap_fired"; then
+    echo "INPROC_TRAP_PRESENT" > "$TMP/inproc_status"
+  else
+    echo "INPROC_TRAP_WIPED" > "$TMP/inproc_status"
+  fi
+)
+inproc_status=$(cat "$TMP/inproc_status" 2>/dev/null || echo "MISSING")
+if [ "$inproc_status" = "INPROC_TRAP_PRESENT" ]; then
+  pass "T1a: in-process trap -p EXIT still shows caller's trap after append"
+else
+  fail_ "T1a" "in-process trap was wiped by bypass_audit_append (got: $inproc_status)"
+fi
+if [ -f "$MARKER" ]; then
+  pass "T1b: caller's EXIT trap fired at subshell exit (marker created)"
+else
+  fail_ "T1b" "caller's EXIT trap did NOT fire — bypass_audit_append silently cleared it"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: bypass_audit_append preserves caller's EXIT trap (jq-failure path) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+# Corrupt the audit file so jq fails on the append.
+echo "not valid json {{{" > "$PROJ/.claude/bypass-audit.json"
+MARKER="$TMP/caller_trap_fired"
+(
+  source "$LIB"
+  trap 'touch "'"$MARKER"'"' EXIT
+  # Expected to fail (rc=1) because jq cannot parse the file.
+  bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1
+  rc=$?
+  echo "$rc" > "$TMP/append_rc"
+  # Check trap still installed.
+  trap_out=$(trap -p EXIT)
+  if echo "$trap_out" | grep -q "caller_trap_fired"; then
+    echo "INPROC_TRAP_PRESENT" > "$TMP/inproc_status"
+  else
+    echo "INPROC_TRAP_WIPED" > "$TMP/inproc_status"
+  fi
+)
+append_rc=$(cat "$TMP/append_rc" 2>/dev/null || echo "MISSING")
+if [ "$append_rc" = "1" ]; then
+  pass "T2a: append correctly returned rc=1 on jq-failure"
+else
+  fail_ "T2a" "expected append rc=1 on malformed input; got $append_rc"
+fi
+# Verify rollback: no orphan tmp files.
+orphans=$(find "$PROJ/.claude" -name "bypass-audit.json.*" -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$orphans" = "0" ]; then
+  pass "T2b: jq-failure rollback ran — no orphan tmp files"
+else
+  fail_ "T2b" "found $orphans orphan tmp file(s) after jq-failure"
+fi
+inproc_status=$(cat "$TMP/inproc_status" 2>/dev/null || echo "MISSING")
+if [ "$inproc_status" = "INPROC_TRAP_PRESENT" ]; then
+  pass "T2c: caller's trap still registered after jq-failure path"
+else
+  fail_ "T2c" "caller's trap wiped on jq-failure path (got: $inproc_status)"
+fi
+if [ -f "$MARKER" ]; then
+  pass "T2d: caller's EXIT trap fired even after jq-failure rollback"
+else
+  fail_ "T2d" "caller's EXIT trap did NOT fire after jq-failure path"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: bypass_audit_close_pending preserves caller's EXIT trap (happy path) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+# Seed the file with a PENDING row so close_pending has work to do.
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+MARKER="$TMP/caller_trap_fired"
+(
+  source "$LIB"
+  trap 'touch "'"$MARKER"'"' EXIT
+  bypass_audit_close_pending "$PROJ" "accept" >/dev/null 2>&1
+  trap_out=$(trap -p EXIT)
+  if echo "$trap_out" | grep -q "caller_trap_fired"; then
+    echo "INPROC_TRAP_PRESENT" > "$TMP/inproc_status"
+  else
+    echo "INPROC_TRAP_WIPED" > "$TMP/inproc_status"
+  fi
+)
+inproc_status=$(cat "$TMP/inproc_status" 2>/dev/null || echo "MISSING")
+if [ "$inproc_status" = "INPROC_TRAP_PRESENT" ]; then
+  pass "T3a: in-process trap -p EXIT still shows caller's trap after close_pending"
+else
+  fail_ "T3a" "in-process trap was wiped by bypass_audit_close_pending (got: $inproc_status)"
+fi
+if [ -f "$MARKER" ]; then
+  pass "T3b: caller's EXIT trap fired at subshell exit after close_pending"
+else
+  fail_ "T3b" "caller's EXIT trap did NOT fire — bypass_audit_close_pending cleared it"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: bypass_audit_close_pending preserves caller's EXIT trap (jq-failure path) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+# Seed file then corrupt it before close_pending so jq fails inside.
+( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
+echo "not valid json {{{" > "$PROJ/.claude/bypass-audit.json"
+MARKER="$TMP/caller_trap_fired"
+(
+  source "$LIB"
+  trap 'touch "'"$MARKER"'"' EXIT
+  bypass_audit_close_pending "$PROJ" "accept" >/dev/null 2>&1
+  rc=$?
+  echo "$rc" > "$TMP/close_rc"
+  trap_out=$(trap -p EXIT)
+  if echo "$trap_out" | grep -q "caller_trap_fired"; then
+    echo "INPROC_TRAP_PRESENT" > "$TMP/inproc_status"
+  else
+    echo "INPROC_TRAP_WIPED" > "$TMP/inproc_status"
+  fi
+)
+close_rc=$(cat "$TMP/close_rc" 2>/dev/null || echo "MISSING")
+if [ "$close_rc" = "1" ]; then
+  pass "T4a: close_pending correctly returned rc=1 on jq-failure"
+else
+  fail_ "T4a" "expected close_pending rc=1 on malformed input; got $close_rc"
+fi
+orphans=$(find "$PROJ/.claude" -name "bypass-audit.json.*" -type f 2>/dev/null | wc -l | tr -d ' ')
+if [ "$orphans" = "0" ]; then
+  pass "T4b: jq-failure rollback ran — no orphan tmp files"
+else
+  fail_ "T4b" "found $orphans orphan tmp file(s) after close_pending jq-failure"
+fi
+inproc_status=$(cat "$TMP/inproc_status" 2>/dev/null || echo "MISSING")
+if [ "$inproc_status" = "INPROC_TRAP_PRESENT" ]; then
+  pass "T4c: caller's trap still registered after close_pending jq-failure"
+else
+  fail_ "T4c" "caller's trap wiped on close_pending jq-failure (got: $inproc_status)"
+fi
+if [ -f "$MARKER" ]; then
+  pass "T4d: caller's EXIT trap fired even after close_pending jq-failure"
+else
+  fail_ "T4d" "caller's EXIT trap did NOT fire after close_pending jq-failure"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: bypass_audit_init creates file with mode 600 (umask hardening) ==="
+# ════════════════════════════════════════════════════════════════════
+# `echo "[]" > "$file"` inherits umask. On a default-022 umask system the
+# governance ledger ends up world-readable (0644). Audit fix: init should
+# chmod 600 after creation so the preserve-mode helper has a sane baseline.
+setup
+rm -f "$PROJ/.claude/bypass-audit.json"
+# Force a permissive umask so the bug (if any) is visible.
+( umask 022; source "$LIB" && bypass_audit_init "$PROJ" )
+mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+if [ "$mode" = "600" ]; then
+  pass "T5: bypass_audit_init created file with mode 600 (was $mode)"
+else
+  fail_ "T5" "expected mode 600 from bypass_audit_init under umask 022; got $mode (governance artifact left world-readable)"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bypass-detector-session-id.sh
+++ b/tests/test-bypass-detector-session-id.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# tests/test-bypass-detector-session-id.sh — regression for
+# code-hooks-bypass-detector-3.
+#
+# The Claude Code hook envelope carries .session_id as a documented
+# top-level field (per https://code.claude.com/docs/en/hooks). The
+# bypass-detector previously read SESSION_ID from $CLAUDE_SESSION_ID, an
+# undocumented env var that Claude Code does not in fact export — so
+# every audit row was written with session_id="unknown", losing the
+# session-correlation handle the W7 successor-handoff use case depends
+# on.
+#
+# Fix: read .session_id from the envelope; fall back to
+# ${CLAUDE_SESSION_ID:-unknown} only if the field is missing or empty.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/scripts/hooks/bypass-detector.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  mkdir -p "$TMP/.claude"
+  cat > "$TMP/.claude/manifest.json" <<EOF
+{"frameworkVersion":"test","host":"other","mode":"personal","deployment":"personal","enforcement_level":"strict"}
+EOF
+  echo "[]" > "$TMP/.claude/bypass-audit.json"
+}
+teardown() { rm -rf "$TMP"; }
+
+# T1: envelope .session_id is propagated into the audit row.
+echo "T1: envelope .session_id is written to the audit row"
+setup
+unset CLAUDE_SESSION_ID || true
+cat <<'EOF' | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","session_id":"sess-abc-123","tool_input":{"command":"x"},"tool_response":{"output":"use --no-verify"}}
+EOF
+sid=$(jq -r '.[0].session_id' "$TMP/.claude/bypass-audit.json")
+if [ "$sid" = "sess-abc-123" ]; then
+  pass "T1: session_id pulled from envelope"
+else
+  fail_ "T1" "expected 'sess-abc-123'; got '$sid'"
+fi
+teardown
+
+# T2: envelope .session_id wins over $CLAUDE_SESSION_ID env var when both present.
+echo "T2: envelope .session_id wins over CLAUDE_SESSION_ID env var"
+setup
+cat <<'EOF' | CLAUDE_SESSION_ID="env-fallback-id" CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","session_id":"envelope-wins","tool_input":{"command":"x"},"tool_response":{"output":"--no-verify"}}
+EOF
+sid=$(jq -r '.[0].session_id' "$TMP/.claude/bypass-audit.json")
+if [ "$sid" = "envelope-wins" ]; then
+  pass "T2: envelope wins"
+else
+  fail_ "T2" "expected 'envelope-wins'; got '$sid'"
+fi
+teardown
+
+# T3: missing envelope .session_id falls back to $CLAUDE_SESSION_ID.
+echo 'T3: missing envelope .session_id → $CLAUDE_SESSION_ID fallback'
+setup
+cat <<'EOF' | CLAUDE_SESSION_ID="env-fallback-id" CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","tool_input":{"command":"x"},"tool_response":{"output":"--no-verify"}}
+EOF
+sid=$(jq -r '.[0].session_id' "$TMP/.claude/bypass-audit.json")
+if [ "$sid" = "env-fallback-id" ]; then
+  pass "T3: env var fallback used"
+else
+  fail_ "T3" "expected 'env-fallback-id'; got '$sid'"
+fi
+teardown
+
+# T4: both missing → "unknown" final fallback.
+echo "T4: both missing → 'unknown' sentinel"
+setup
+unset CLAUDE_SESSION_ID || true
+cat <<'EOF' | CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","tool_input":{"command":"x"},"tool_response":{"output":"--no-verify"}}
+EOF
+sid=$(jq -r '.[0].session_id' "$TMP/.claude/bypass-audit.json")
+if [ "$sid" = "unknown" ]; then
+  pass "T4: final fallback engaged"
+else
+  fail_ "T4" "expected 'unknown'; got '$sid'"
+fi
+teardown
+
+# T5: empty envelope .session_id ("") still falls back to env var.
+echo "T5: empty envelope .session_id → env var fallback"
+setup
+cat <<'EOF' | CLAUDE_SESSION_ID="env-fallback-when-empty" CLAUDE_PROJECT_DIR="$TMP" bash "$HOOK" >/dev/null 2>&1
+{"hook_event_name":"PostToolUse","session_id":"","tool_input":{"command":"x"},"tool_response":{"output":"--no-verify"}}
+EOF
+sid=$(jq -r '.[0].session_id' "$TMP/.claude/bypass-audit.json")
+if [ "$sid" = "env-fallback-when-empty" ]; then
+  pass "T5: empty-string envelope value treated as missing"
+else
+  fail_ "T5" "expected 'env-fallback-when-empty'; got '$sid'"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-host-verify-protection-date-parse.sh
+++ b/tests/test-host-verify-protection-date-parse.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# tests/test-host-verify-protection-date-parse.sh — regression for code-lib-1.
+#
+# host_verify_protection on the 'other' host reads the attested timestamp
+# from process-state.json. The age check uses GNU date first, then BSD
+# date, then `|| echo "$now"` as a terminal fallback. That fallback
+# silently classifies any unparseable timestamp as "fresh" (age=0 days),
+# which bypasses the 90-day staleness check that drives the W3 backstop.
+#
+# Fail-closed fix: when BOTH parsers fail, emit a stderr warning naming
+# the unparseable value and `return 1` so the caller treats the
+# attestation as not-verified.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOST_LIB="$REPO_ROOT/scripts/lib/host.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup_project() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  ( cd "$PROJ" && git init -q && git config user.email t@t.l && git config user.name t \
+      && echo init > i && git add i && git commit -qm init )
+  cat > "$PROJ/.claude/manifest.json" <<EOF
+{"frameworkVersion":"test","host":"other","mode":"personal","deployment":"personal","enforcement_level":"strict"}
+EOF
+}
+teardown() { rm -rf "$TMP"; }
+
+# Seed process-state.json with a specific attestation timestamp value.
+seed_attestation() {
+  local ts="$1"
+  jq -nc --arg t "$ts" '{phase2_init:{attestations:{branch_protection:{at:$t, attested_by:"orchestrator"}}}}' \
+    > "$PROJ/.claude/process-state.json"
+}
+
+# T1: fresh attestation (today) verifies (sanity check).
+echo "T1: fresh ISO-8601 attestation verifies (returns 0)"
+setup_project
+fresh_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+seed_attestation "$fresh_ts"
+( cd "$PROJ" && source "$HOST_LIB" && _host_define_other_fallbacks && host_verify_protection >/dev/null 2>&1 )
+rc=$?
+if [ "$rc" = "0" ]; then pass "T1"; else fail_ "T1" "expected rc=0, got $rc"; fi
+teardown
+
+# T2: stale attestation (180 days ago) fails verification (sanity check).
+echo "T2: 180-day-old attestation fails verification (returns 1)"
+setup_project
+# 180 days * 86400 = 15552000 seconds
+old_epoch=$(( $(date +%s) - 15552000 ))
+# Use BSD-compatible portable conversion.
+if old_ts=$(date -u -r "$old_epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null); then :; else
+  old_ts=$(date -u -d "@$old_epoch" +"%Y-%m-%dT%H:%M:%SZ")
+fi
+seed_attestation "$old_ts"
+( cd "$PROJ" && source "$HOST_LIB" && _host_define_other_fallbacks && host_verify_protection >/dev/null 2>&1 )
+rc=$?
+if [ "$rc" = "1" ]; then pass "T2"; else fail_ "T2" "expected rc=1 for 180-day-old; got $rc"; fi
+teardown
+
+# T3 (THE REGRESSION): garbage timestamp must fail-closed, not silently
+# count as fresh. Pre-fix: `|| echo "$now"` made then=now, days=0,
+# `[ 0 -gt 90 ]` false, return 0 — silent BYPASS.
+echo "T3: unparseable timestamp returns 1 (fail-closed, not silently fresh)"
+setup_project
+seed_attestation "not-a-timestamp"
+err=$( ( cd "$PROJ" && source "$HOST_LIB" && _host_define_other_fallbacks && host_verify_protection ) 2>&1 )
+rc=$?
+if [ "$rc" != "0" ]; then
+  pass "T3: returned non-zero on unparseable timestamp"
+else
+  fail_ "T3" "expected non-zero (fail-closed); got rc=$rc — silent bypass restored"
+fi
+teardown
+
+# T4: stderr explains the parse failure (operator needs to see the value).
+echo "T4: stderr warning names the unparseable value"
+setup_project
+seed_attestation "garbage-value-xyz"
+err=$( ( cd "$PROJ" && source "$HOST_LIB" && _host_define_other_fallbacks && host_verify_protection ) 2>&1 )
+if echo "$err" | grep -qi "unparseable" && echo "$err" | grep -q "garbage-value-xyz"; then
+  pass "T4: stderr names the value"
+else
+  fail_ "T4" "expected stderr to name 'unparseable' + the value; got: $err"
+fi
+teardown
+
+# T5: GNU-style timestamp ("Sat Jun 28 12:34:56 UTC 2026") still parses
+# via the first parser when GNU date is available. On BSD-only (macOS
+# default), this would fall to the BSD parser; in either case the value
+# is parseable, so the function must NOT trip the fail-closed branch.
+# (We don't seed a value that requires GNU-only; we use ISO-8601 which
+# the BSD parser explicitly handles per the source.)
+echo "T5: ISO-8601 with explicit 'Z' parses cleanly on both GNU and BSD"
+setup_project
+# 30 days ago — well within 90-day window.
+recent_epoch=$(( $(date +%s) - 2592000 ))
+if recent_ts=$(date -u -r "$recent_epoch" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null); then :; else
+  recent_ts=$(date -u -d "@$recent_epoch" +"%Y-%m-%dT%H:%M:%SZ")
+fi
+seed_attestation "$recent_ts"
+( cd "$PROJ" && source "$HOST_LIB" && _host_define_other_fallbacks && host_verify_protection >/dev/null 2>&1 )
+rc=$?
+if [ "$rc" = "0" ]; then pass "T5"; else fail_ "T5" "expected rc=0 for 30-day-old; got $rc"; fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- **code-lib-1**: `host_verify_protection` on the `other`-host fallback chained `date -d` then `date -j -f` then `|| echo "$now"`. The terminal fallback silently classified any unparseable attestation timestamp as fresh (`days=0`), bypassing the 90-day W3 staleness check. Replaced with an explicit dual-parser-failure branch that emits a named-value stderr warning and `return 1` (fail-closed).
- **code-lib-2**: `bypass_audit_append` + `bypass_audit_close_pending` were already using the adjacent-mktemp atomic-rename pattern (PR #46/0d5605e). Added the two residual hardenings from the original recommendation: (a) preserve target file permissions across the rename so operator-set perms (e.g. 0640) don't silently revert to mktemp's 0600 default — portable `_bypass_audit_preserve_mode` helper (GNU `chmod --reference` → BSD/GNU `stat`-then-`chmod` → `chmod 600` fallback); (b) EXIT/INT/TERM trap that removes the tmp file + lockdir if a signal hits between mktemp and the rename, so the governance dir doesn't accumulate orphan `${file}.XXXXXX` litter.
- **code-hooks-bypass-detector-3**: `bypass-detector.sh` line 107 read `${CLAUDE_SESSION_ID:-unknown}` — but Claude Code does NOT export that env var. The documented correlator is the envelope's top-level `.session_id` field. Every audit row was landing with `session_id="unknown"`, breaking W7 successor-handoff correlation. Now reads `$(echo "$INPUT" | jq -r '.session_id // empty')`, falling back to `CLAUDE_SESSION_ID` (belt-and-suspenders for unexpected envelope shapes), then `"unknown"`.

## Findings closed

- code-lib-1 — host.sh::host_verify_protection unparseable timestamp silently fresh
- code-lib-2 — bypass-audit tmp-file hardening (perm-preserve + EXIT trap)
- code-hooks-bypass-detector-3 — session_id read from undocumented env var

## Test plan

### RED (against worktree base, before fixes)

```
$ bash tests/test-host-verify-protection-date-parse.sh
T1: fresh ISO-8601 attestation verifies (returns 0)
  [PASS] T1
T2: 180-day-old attestation fails verification (returns 1)
  [PASS] T2
T3: unparseable timestamp returns 1 (fail-closed, not silently fresh)
  [FAIL] T3 — expected non-zero (fail-closed); got rc=0 — silent bypass restored
T4: stderr warning names the unparseable value
  [FAIL] T4 — expected stderr to name 'unparseable' + the value; got: 
T5: ISO-8601 with explicit 'Z' parses cleanly on both GNU and BSD
  [PASS] T5
Results: 3 passed, 2 failed

$ bash tests/test-bypass-audit-tmp-hardening.sh
T1: 0640 audit file keeps 0640 after append
  [FAIL] T1 — expected 640 after append; got 600 (mktemp 0600 leaked through rename)
T2: 0640 audit file keeps 0640 after close_pending
  [FAIL] T2 — expected 640 after close_pending; got 600
T3: append on a fresh init produces mode-600 file (not umask default)
  [FAIL] T3 — mode churn: pre=644 post=600
T4: bypass_audit_append registers an EXIT trap for tmp cleanup
  [FAIL] T4 — bypass_audit_append has no EXIT/INT/TERM trap protecting $tmp
T5: bypass_audit_close_pending registers an EXIT trap for tmp cleanup
  [FAIL] T5 — bypass_audit_close_pending has no EXIT/INT/TERM trap protecting $tmp
T6: no orphan tmp files after a successful append
  [PASS] T6
T7: no orphan tmp files after a successful close_pending
  [PASS] T7
Results: 2 passed, 5 failed

$ bash tests/test-bypass-detector-session-id.sh
T1: envelope .session_id is written to the audit row
  [FAIL] T1 — expected 'sess-abc-123'; got 'unknown'
T2: envelope .session_id wins over CLAUDE_SESSION_ID env var
  [FAIL] T2 — expected 'envelope-wins'; got 'env-fallback-id'
T3: missing envelope .session_id → $CLAUDE_SESSION_ID fallback
  [PASS] T3
T4: both missing → 'unknown' sentinel
  [PASS] T4
T5: empty envelope .session_id → env var fallback
  [PASS] T5
Results: 3 passed, 2 failed
```

### GREEN (after fixes)

```
$ bash tests/test-host-verify-protection-date-parse.sh
T1 [PASS] | T2 [PASS] | T3 [PASS] | T4 [PASS] | T5 [PASS]
Results: 5 passed, 0 failed

$ bash tests/test-bypass-audit-tmp-hardening.sh
T1 [PASS] (was 640, is 640) | T2 [PASS] | T3 [PASS] (644 unchanged)
T4 [PASS] | T5 [PASS] | T6 [PASS] | T7 [PASS]
Results: 7 passed, 0 failed

$ bash tests/test-bypass-detector-session-id.sh
T1 [PASS] (envelope) | T2 [PASS] (envelope wins) | T3 [PASS] (env fallback)
T4 [PASS] (unknown) | T5 [PASS] (empty → env)
Results: 5 passed, 0 failed
```

### Regressions (all GREEN)

- `tests/test-bypass-audit-lib.sh`           — 10/10
- `tests/test-bypass-audit-integrity.sh`     — 8/8 (D1/D2/D3 sections)
- `tests/test-bypass-audit-schema.sh`        — 3/3
- `tests/test-bypass-detector.sh`            — 15/15
- `tests/test-bypass-sentinel.sh`            — 5/5
- `tests/test-bl029-integration.sh`          — 6/6
- `tests/test-init-other-host-attestation.sh` — 2/2
- `tests/test-check-phase-gate-backstop-attestation.sh` — 3/3

### Lints

```
$ bash scripts/lint-counter-antipattern.sh
OK: no counter-capture antipatterns found.
$ bash scripts/lint-backlog-references.sh
OK: backlog references and Closed-status citations are consistent.
```

## Bonus catches

- `_bypass_audit_preserve_mode` is intentionally extracted as a reusable helper. Adjacent code (`scripts/reconfigure-project.sh`, `scripts/intake-wizard.sh`, `scripts/pending-approval.sh`, `scripts/upgrade-project.sh`) has 20+ `tmp=$(mktemp)` writes that would benefit from the same chmod-preserve + trap discipline; not pulled into this PR (out of scope for the 3-finding bundle) but the helper is in place for a follow-up sweep.
- The detector's `session_id` regression suggests the broader hook-envelope-vs-env-var schema is worth a one-shot grep: any other hook reading `$CLAUDE_*_ID` env vars instead of the documented envelope field is likely similarly broken. Not in this PR's scope; flagging for the cross-cutting Wave 3 sweep slot.

## Worktree note

```
$ pwd
/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_0dedbb55-0f8-4
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)