### PR TITLE
feat(ci): two new lints (fix_*() stderr + raw read -rp) + sweep + pre-commit-gate promotion

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,3 +69,45 @@ jobs:
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bash scripts/lint-backlog-references.sh --base "origin/${BASE_REF}" --list || true
+
+  # Cycle-8 wave-3 Slot-5 sibling: ban `2>/dev/null` and `2>&-`
+  # inside any `fix_*()` function body. See
+  # scripts/lint-fix-functions-stderr.sh header for the defect class
+  # (silenced auto-fix stderr makes failures un-actionable for
+  # operators running under --auto-fix). The PR #92 scrub of
+  # fix_framework_clone / fix_framework_manifest / fix_superpowers
+  # established the precedent; this lint is the merge-time backstop.
+  fix-functions-stderr-lint:
+    name: fix-functions-stderr-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint fix_*() function stderr silencers
+        run: bash scripts/lint-fix-functions-stderr.sh
+
+      - name: Show PASS/FAIL inventory (on failure or on demand)
+        if: always()
+        run: bash scripts/lint-fix-functions-stderr.sh --list || true
+
+  # Cycle-8 wave-3 Slot-5 sibling: ban raw `read -rp` / `read -p`
+  # outside scripts/lib/helpers.sh — the canonical home for the
+  # prompt_input / prompt_yes_no helpers that handle non-interactive
+  # / CI / no-TTY contexts safely. See
+  # scripts/lint-raw-read-prompt.sh header for the defect class
+  # (bare `read -p` hangs unattended invocations or auto-defaults
+  # without operator confirmation).
+  raw-read-prompt-lint:
+    name: raw-read-prompt-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint raw read -rp / read -p sites
+        run: bash scripts/lint-raw-read-prompt.sh
+
+      - name: Show PASS/FAIL inventory (on failure or on demand)
+        if: always()
+        run: bash scripts/lint-raw-read-prompt.sh --list || true

--- a/init.sh
+++ b/init.sh
@@ -393,7 +393,7 @@ collect_project_info() {
     print_warn "For personal projects, Standard track provides external-user readiness without"
     print_warn "enterprise overhead (pen testing, legal review). You can upgrade later."
     local confirm_full
-    read -rp "$(echo -e "  ${BOLD}Continue with Full track? [y/N]${NC}: ")" confirm_full
+    read -rp "$(echo -e "  ${BOLD}Continue with Full track? [y/N]${NC}: ")" confirm_full # lint-raw-read-prompt: allow init.sh interactive-only wizard (NON_INTERACTIVE=true path bypasses collect_inputs_interactive entirely; see init.sh:3532)
     if [[ ! "$confirm_full" =~ ^[Yy] ]]; then
       TRACK=$(prompt_choice "Project track:" "light" "standard" "full")
       TRACK="${TRACK#"${TRACK%%[![:space:]]*}"}"
@@ -568,7 +568,7 @@ collect_project_info() {
   print_info "Directory: $PROJECT_DIR"
   echo ""
 
-  read -rp "$(echo -e "${BOLD}Continue? [Y/n]${NC}: ")" confirm
+  read -rp "$(echo -e "${BOLD}Continue? [Y/n]${NC}: ")" confirm # lint-raw-read-prompt: allow init.sh interactive-only wizard (NON_INTERACTIVE=true path bypasses collect_inputs_interactive entirely; see init.sh:3532)
   if [[ "$confirm" =~ ^[Nn] ]]; then
     echo ""
     local choice
@@ -733,7 +733,7 @@ resolve_and_install_tools() {
   # Confirm — skip prompt when there is nothing to install
   local response="Y"
   if [ "$auto_count" -gt 0 ] || [ "$manual_count" -gt 0 ]; then
-    read -rp "$(echo -e "${YELLOW}▶ ${BOLD}Proceed with this plan? [Y/n]${NC}: ")" response
+    read -rp "$(echo -e "${YELLOW}▶ ${BOLD}Proceed with this plan? [Y/n]${NC}: ")" response # lint-raw-read-prompt: allow init.sh interactive-only tool-install plan; NON_INTERACTIVE path uses AUTO_INSTALL_TOOLS env var rather than this prompt
   fi
   if [[ "$response" =~ ^[Nn] ]]; then
     echo ""
@@ -778,7 +778,7 @@ resolve_and_install_tools() {
         echo ""
         print_info "Default preferences written to: $PROJECT_DIR/.claude/tool-preferences.json"
         print_info "Edit the file, then press Enter to continue."
-        read -rp ""
+        read -rp "" # lint-raw-read-prompt: allow init.sh interactive-only "press Enter to continue" pause after manual tool-preferences edit; non-interactive path skips this whole branch (PROMPT_EDIT only used when -t 0 above)
         # Re-resolve after manual edit
         resolver_output=$("$SCRIPT_DIR/scripts/resolve-tools.sh" \
           --dev-os "$dev_os" \
@@ -1952,7 +1952,7 @@ create_and_protect_remote() {
     if [ -n "${REMOTE_URL:-}" ]; then
       remote_url="$REMOTE_URL"
     else
-      read -rp "Paste the HTTPS clone URL of the remote repo you've created: " remote_url
+      read -rp "Paste the HTTPS clone URL of the remote repo you've created: " remote_url # lint-raw-read-prompt: allow init.sh interactive-only "other host" URL paste; gated by REMOTE_URL env-var fast-path at line 1952 above for non-interactive callers (BL-016)
     fi
     [ -z "$remote_url" ] && { print_fail "Remote URL required for 'other' host"; return 1; }
     git remote add origin "$remote_url"
@@ -1974,7 +1974,7 @@ create_and_protect_remote() {
       attest="yes"
       print_info "Branch protection attested via --branch-protection-attested flag."
     else
-      read -rp "Has branch protection been configured per the above? [type 'yes' to attest]: " attest
+      read -rp "Has branch protection been configured per the above? [type 'yes' to attest]: " attest # lint-raw-read-prompt: allow init.sh interactive-only attestation; gated by BRANCH_PROTECTION_ATTESTED env-var fast-path at line 1973 above for non-interactive callers (BL-016)
     fi
     [ "$attest" != "yes" ] && { print_fail "Attestation required — cannot proceed to Phase 0"; return 1; }
     # Record attestation in process-state.json (BEFORE push — see BL-024 above).
@@ -2039,7 +2039,7 @@ create_and_protect_remote() {
         attest="yes"
         print_info "Branch protection attested via --branch-protection-attested flag."
       else
-        read -rp "Attest that protection will be enforced manually? [type 'yes' to attest]: " attest
+        read -rp "Attest that protection will be enforced manually? [type 'yes' to attest]: " attest # lint-raw-read-prompt: allow init.sh interactive-only attestation (manual-enforcement branch); gated by BRANCH_PROTECTION_ATTESTED env-var fast-path at line 2038 above for non-interactive callers (BL-016)
       fi
       [ "$attest" != "yes" ] && { print_fail "Attestation required — cannot proceed (see $host driver remediation above)"; return 1; }
       # Record attestation with the github_free_tier reason so check-gate.sh

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -19,6 +19,22 @@ source "$SCRIPT_DIR/lib/helpers.sh" 2>/dev/null || {
   print_info() { echo "[INFO] $*"; }
   print_warn() { echo "[WARN] $*"; }
   log_line()   { :; }
+  # Wave-3 raw-read sweep: prompt_yes_no fallback honors the same
+  # non-interactive hard-N contract as the helpers.sh version. Reached
+  # only in pre-init migration scenarios where lib/helpers.sh is
+  # absent; behavior must match the canonical helper so the manifest
+  # mutation in --backfill-host below stays consistent.
+  prompt_yes_no() {
+    local message="$1" default_answer="${2:-N}"
+    if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+      echo "[WARN] Non-interactive context: skipping prompt (\"$message\") — defaulting to 'N' (caller default '$default_answer' ignored)." >&2
+      return 1
+    fi
+    local reply
+    read -rp "${message}: " reply # lint-raw-read-prompt: allow fallback prompt_yes_no defined inline when lib/helpers.sh is absent (pre-init migration scenario); semantically equivalent to lib/helpers.sh::prompt_yes_no
+    [ -z "$reply" ] && { case "$default_answer" in [Yy]*) return 0 ;; *) return 1 ;; esac; }
+    case "$reply" in [Nn]*) return 1 ;; *) return 0 ;; esac
+  }
 }
 
 usage() {
@@ -99,7 +115,14 @@ cmd_backfill_host() {
     yn="y"
     print_info "Auto-confirmed via --yes."
   else
-    read -rp "Confirm this is correct? [y/N]: " yn
+    # Wave-3 raw-read sweep: prompt_yes_no honors !-t 0 / CI /
+    # SOIF_NONINTERACTIVE and hard-returns N rather than auto-Y'ing
+    # a manifest mutation in CI.
+    if prompt_yes_no "Confirm this is correct? [y/N]" "N"; then
+      yn="y"
+    else
+      yn="n"
+    fi
   fi
   case "$yn" in
     [yY]*)

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -47,7 +47,7 @@ prompt_yes_no() {
   fi
 
   local reply
-  read -rp "$(echo -e "${BOLD}${message}${NC}: ")" reply
+  read -rp "$(echo -e "${BOLD}${message}${NC}: ")" reply # lint-raw-read-prompt: allow internal prompt_yes_no wrapper with TTY/CI hard-N guard above (lines 40-47) — equivalent to lib/helpers.sh::prompt_yes_no, retained here to avoid a cross-script dependency cycle
   if [ -z "$reply" ]; then
     case "$default_answer" in
       [Yy]*) return 0 ;;

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -454,7 +454,7 @@ if [ ${#UPDATES[@]} -gt 0 ] && [ -t 0 ]; then
   echo "  c) Skip for now"
   echo ""
 
-  read -rp "$(echo -e "${BOLD}Choice [a/b/c]${NC}: ")" choice
+  read -rp "$(echo -e "${BOLD}Choice [a/b/c]${NC}: ")" choice # lint-raw-read-prompt: allow multi-letter (a/b/c) choice prompt — prompt_input/prompt_yes_no shape doesn't fit; gated by `-t 0` TTY check at line 444 above; non-interactive branch at line 511 below covers CI/scripted callers
 
   case "$choice" in
     a|A)
@@ -476,7 +476,13 @@ if [ ${#UPDATES[@]} -gt 0 ] && [ -t 0 ]; then
       done
       ;;
     b|B)
-      read -rp "Enter numbers (comma-separated): " selections
+      # Wave-3 raw-read sweep: prompt_input centralizes !-t 0 / CI /
+      # SOIF_NONINTERACTIVE default-return. Empty default means CI
+      # callers get an empty selections list → the `IFS=',' read -ra`
+      # below produces a single empty token, which the bounds check
+      # at "$idx -ge 0 && $idx -lt ${#UPDATE_CMDS[@]}" rejects, so
+      # CI safely skips the update rather than auto-installing.
+      selections=$(prompt_input "Enter numbers (comma-separated)" "")
       IFS=',' read -ra sel_arr <<< "$selections"
       echo ""
       for sel in "${sel_arr[@]}"; do

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1899,6 +1899,23 @@ main() {
       ;;
   esac
 
+  # PR-#96 verifier follow-up: the 8 `read -rp` allowlist entries in
+  # this file (lines 85/88/115/144/146/1658/1774/1923) cite
+  # "interactive-only by design" as the reason. That documented intent,
+  # but until now nothing in the wizard ACTUALLY refused to run without
+  # a TTY — so a CI / piped-stdin invocation would block on the first
+  # prompt or auto-empty-input through every section, corrupting
+  # intake-progress.json. Enforce the contract right before the
+  # interactive mode-selection prompt below, AFTER the flag-driven
+  # passthroughs (--resume / --upgrade-* / --to-*-poc / --help) so
+  # those scripted CI use-cases keep working. Operators driving the
+  # wizard via canned input must opt in via SOIF_NONINTERACTIVE=1.
+  if [ ! -t 0 ] && [ -z "${SOIF_NONINTERACTIVE:-}" ]; then
+    print_fail "intake-wizard requires a TTY on stdin (or set SOIF_NONINTERACTIVE=1 to drive it from a harness)."
+    echo "  Detected non-TTY stdin (CI=${CI:-unset}). The wizard's read prompts would block or auto-empty-input through every section, corrupting .claude/intake-progress.json." >&2
+    exit 1
+  fi
+
   # Mode selection
   echo ""
   echo -e "${BOLD}How would you like to fill out the Project Intake?${NC}"

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -82,10 +82,10 @@ prompt_input() {
   local default="${2:-}"
   local result
   if [ -n "$default" ]; then
-    read -rp "$(echo -e "  ${BOLD}$prompt${NC} [$default]: ")" result
+    read -rp "$(echo -e "  ${BOLD}$prompt${NC} [$default]: ")" result # lint-raw-read-prompt: allow intake-wizard.sh defines its own prompt_input with pause-file semantics (overrides lib/helpers.sh::prompt_input); this IS the wizard's centralized prompt helper
     result="${result:-$default}"
   else
-    read -rp "$(echo -e "  ${BOLD}$prompt${NC}: ")" result
+    read -rp "$(echo -e "  ${BOLD}$prompt${NC}: ")" result # lint-raw-read-prompt: allow intake-wizard.sh defines its own prompt_input with pause-file semantics (overrides lib/helpers.sh::prompt_input); this IS the wizard's centralized prompt helper
   fi
   if [ "$result" = "pause" ] || [ "$result" = "PAUSE" ] || [ "$result" = "Pause" ]; then
     _request_pause
@@ -112,7 +112,7 @@ prompt_choice() {
   done
   local choice
   while true; do
-    read -rp "$(echo -e "  ${BOLD}Select [1-${#options[@]}]${NC}: ")" choice
+    read -rp "$(echo -e "  ${BOLD}Select [1-${#options[@]}]${NC}: ")" choice # lint-raw-read-prompt: allow intake-wizard.sh defines its own prompt_choice with pause-file semantics; this IS the wizard's centralized numbered-choice helper
     if [ "$choice" = "pause" ] || [ "$choice" = "PAUSE" ] || [ "$choice" = "Pause" ]; then
       _request_pause
       echo ""
@@ -141,9 +141,9 @@ prompt_with_suggestions() {
 
   while true; do
     if [ -n "$default" ]; then
-      read -rp "$(echo -e "  ${BOLD}$prompt${NC} [? for suggestions, default: $default]: ")" result
+      read -rp "$(echo -e "  ${BOLD}$prompt${NC} [? for suggestions, default: $default]: ")" result # lint-raw-read-prompt: allow intake-wizard.sh prompt_with_suggestions — wizard-specific helper with `?`-trigger semantics that don't fit lib/helpers.sh shape
     else
-      read -rp "$(echo -e "  ${BOLD}$prompt${NC} [? for suggestions]: ")" result
+      read -rp "$(echo -e "  ${BOLD}$prompt${NC} [? for suggestions]: ")" result # lint-raw-read-prompt: allow intake-wizard.sh prompt_with_suggestions — wizard-specific helper with `?`-trigger semantics that don't fit lib/helpers.sh shape
     fi
 
     if [ "$result" = "pause" ] || [ "$result" = "PAUSE" ] || [ "$result" = "Pause" ]; then
@@ -1655,7 +1655,7 @@ PROMPTEOF
   echo "       When ready: claude \"Read INTAKE_GUIDED_PROMPT.md and begin\""
   echo ""
   local launch_choice
-  read -rp "$(echo -e "  ${BOLD}Select [1-2]${NC}: ")" launch_choice
+  read -rp "$(echo -e "  ${BOLD}Select [1-2]${NC}: ")" launch_choice # lint-raw-read-prompt: allow intake-wizard.sh interactive-only launch-mode choice (1 = launch Claude, 2 = generate prompt file); wizard is interactive-only by design
 
   if [ "$launch_choice" = "1" ]; then
     if command -v claude &>/dev/null; then
@@ -1771,7 +1771,7 @@ ask_project_context() {
     echo "  Deployment: $DEPLOYMENT"
     [ -n "$POC_MODE" ] && echo "  POC Mode:   ${POC_MODE//_/ }"
     echo ""
-    read -rp "$(echo -e "${BOLD}Is this correct? [Y/n]${NC}: ")" confirm
+    read -rp "$(echo -e "${BOLD}Is this correct? [Y/n]${NC}: ")" confirm # lint-raw-read-prompt: allow intake-wizard.sh interactive-only summary confirmation; wizard is interactive-only by design
     if [[ "$confirm" =~ ^[Nn] ]]; then
       print_info "You can change fields in the intake wizard Section 1."
       print_info "Structural changes (platform, language, track) will trigger project reconfiguration."
@@ -1920,7 +1920,7 @@ main() {
   echo ""
 
   local mode
-  read -rp "$(echo -e "${BOLD}Select [1-3]${NC}: ")" mode
+  read -rp "$(echo -e "${BOLD}Select [1-3]${NC}: ")" mode # lint-raw-read-prompt: allow intake-wizard.sh interactive-only mode selection (1=wizard, 2=AI prompt, 3=manual); wizard is interactive-only by design
 
   case "$mode" in
     1)

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -137,10 +137,23 @@ finalize_log() {
 
 # Prompt for text input with optional default value.
 # Usage: result=$(prompt_input "Your name" "default_value")
+#
+# Non-interactive behavior (no TTY on stdin, CI=true, or
+# SOIF_NONINTERACTIVE=true): emits a [WARN] to stderr and returns the
+# default (or empty string if no default). This is the contract that
+# scripts/lint-raw-read-prompt.sh enforces: never call `read -rp`
+# outside this file, because doing so hangs unattended invocations.
 prompt_input() {
   local prompt="$1"
   local default="${2:-}"
   local result
+
+  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: prompt_input(\"$prompt\") returning default '$default' without blocking. Re-run interactively to override." >&2
+    printf '%s' "$default"
+    return 0
+  fi
+
   if [ -n "$default" ]; then
     read -rp "$(echo -e "${BOLD}$prompt${NC} [$default]: ")" result
     echo "${result:-$default}"
@@ -148,6 +161,41 @@ prompt_input() {
     read -rp "$(echo -e "${BOLD}$prompt${NC}: ")" result
     echo "$result"
   fi
+}
+
+# Prompt for yes/no confirmation, returning 0 (yes) or 1 (no).
+# Usage: if prompt_yes_no "Proceed?" "Y"; then ... fi
+#
+# `default_answer` is "Y" or "N" — used ONLY when interactive AND the
+# operator hits Enter without typing a response. In non-interactive
+# contexts (no TTY, CI=true, SOIF_NONINTERACTIVE=true) this function
+# ALWAYS returns N (1) regardless of `default_answer`. This is
+# defense-in-depth: a caller that defaults to Y in interactive use
+# (e.g. "[Y/n]" confirm prompts) must NEVER auto-Y a side-effectful
+# action in CI just because the operator was absent. Mirrors the
+# hard-N policy in scripts/check-phase-gate.sh::prompt_yes_no, which
+# was introduced after the cycle-7 PR #87 unattended-install incident.
+prompt_yes_no() {
+  local message="$1"
+  local default_answer="${2:-N}"
+
+  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: skipping prompt (\"$message\") — defaulting to 'N' (caller default '$default_answer' ignored in non-interactive context)." >&2
+    return 1
+  fi
+
+  local reply
+  read -rp "$(echo -e "${BOLD}${message}${NC}: ")" reply
+  if [ -z "$reply" ]; then
+    case "$default_answer" in
+      [Yy]*) return 0 ;;
+      *)     return 1 ;;
+    esac
+  fi
+  case "$reply" in
+    [Nn]*) return 1 ;;
+    *)     return 0 ;;
+  esac
 }
 
 # Refuse to operate as a project if cwd is the Solo Orchestrator framework

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -279,6 +279,19 @@ prompt_choice() {
 
 # Prompt user to install a missing tool. Returns 0 if installed, 1 if skipped.
 # Usage: prompt_install "tool_name" "install_command" [needs_sudo]
+#
+# Non-interactive behavior (no TTY on stdin, CI=true, or
+# SOIF_NONINTERACTIVE=true): emits a [WARN] to stderr naming the
+# missing tool + install command, and returns 1 (decline install)
+# WITHOUT touching `eval`. Same defense-in-depth contract as
+# prompt_yes_no — a caller in CI / piped invocation must NEVER
+# auto-install a side-effectful command (e.g. `sudo apt install`,
+# `sudo usermod -aG docker $USER`) just because the operator was
+# absent. The PR-#96 adversarial verifier flagged this as the one
+# remaining hole in the lint sweep: scripts/lib/helpers.sh is exempt
+# from scripts/lint-raw-read-prompt.sh (correctly — the prompt
+# helpers themselves must call `read -rp`), so runtime tests are the
+# only safety net. See tests/test-prompt-install-noninteractive.sh.
 prompt_install() {
   local tool_name="$1"
   local install_cmd="$2"
@@ -289,6 +302,13 @@ prompt_install() {
     echo -e "  ${YELLOW}This requires administrator privileges (sudo).${NC}"
   fi
   echo -e "  Install command: ${CYAN}$install_cmd${NC}"
+
+  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: skipping install of '$tool_name' — defaulting to 'N' (no install). Re-run interactively, or run the install manually: $install_cmd" >&2
+    return 1
+  fi
+
+  local response
   read -rp "$(echo -e "  ${BOLD}Install $tool_name now? [Y/n]${NC}: ")" response
   if [[ "$response" =~ ^[Nn] ]]; then
     return 1

--- a/scripts/lint-fix-functions-stderr.sh
+++ b/scripts/lint-fix-functions-stderr.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# scripts/lint-fix-functions-stderr.sh — fail CI when any function
+# whose name starts with `fix_` silences stderr internally via
+# `2>/dev/null` or `2>&-`.
+#
+# THE DEFECT CLASS
+#   fix_*() auto-fix functions in scripts/verify-install.sh (and any
+#   other script that owns operator-facing remediation) silenced their
+#   own stderr. When the underlying command failed (auth prompt,
+#   network error, missing dep, hostile DNS) the operator saw a
+#   "fix returned non-zero" with NO diagnostic — making the issue
+#   un-actionable. See PR #92 (commit 6917fd2f) for the scrub of
+#   fix_framework_clone, fix_framework_manifest, fix_superpowers; the
+#   verifier follow-up on code-verify-reconfigure-14 surfaced the
+#   class. This lint is the wave-3 backstop that keeps the scrub
+#   from regressing.
+#
+# DELIBERATE SCOPE
+#   • Walks scripts/*.sh, scripts/lib/*.sh, scripts/hooks/*.sh,
+#     scripts/host-drivers/*.sh, init.sh — the operator-facing surface
+#     where fix_*() functions actually live.
+#   • Reads each file line by line, tracks bash function nesting by
+#     basename: when a line opens a `fix_<ident>()` function, mark
+#     in-fix and snapshot the depth-zero brace balance; when the
+#     balance returns to zero, exit the fix function.
+#   • Skips lines that are pure comments (leading `#`).
+#   • Skips lines that live inside an open heredoc body (e.g.
+#     `cat > .git/hooks/pre-commit << 'HOOKEOF' ... HOOKEOF`). The
+#     fix function's OWN logic is what we want to lint — the content
+#     of a heredoc body is written to ANOTHER file at runtime and
+#     belongs to that file's lint context, not this one. Heredoc
+#     detection supports `<<DELIM` and `<<'DELIM'` / `<<"DELIM"`
+#     with optional `-` for tab-stripping (`<<-DELIM`).
+#
+# ALLOWLIST
+#   Append `# lint-fix-functions-stderr: allow <reason>` to the
+#   offending line. Reason is REQUIRED — empty reason fails the lint,
+#   matching PR #72's allowlist semantics. Use this when a fix
+#   function intentionally suppresses stderr because the diagnostic
+#   was captured separately upstream (rare — most uses are bugs).
+#
+# EXIT CODES
+#   0 — no violations
+#   1 — one or more violations found
+#   2 — invocation / I/O error
+#
+# USAGE
+#   bash scripts/lint-fix-functions-stderr.sh        # quiet pass/fail
+#   bash scripts/lint-fix-functions-stderr.sh --list # PASS/FAIL table
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_PATH="$REPO_ROOT/scripts/lint-fix-functions-stderr.sh"
+TEST_FIXTURE_PATTERN="test-lint-fix-functions-stderr"
+
+LIST_MODE=0
+if [ "${1:-}" = "--list" ]; then
+  LIST_MODE=1
+elif [ -n "${1:-}" ]; then
+  echo "Usage: $0 [--list]" >&2
+  exit 2
+fi
+
+TARGET_GLOBS=(
+  "$REPO_ROOT/scripts"/*.sh
+  "$REPO_ROOT/scripts/lib"/*.sh
+  "$REPO_ROOT/scripts/hooks"/*.sh
+  "$REPO_ROOT/scripts/host-drivers"/*.sh
+  "$REPO_ROOT/init.sh"
+)
+
+# Match a function-opening line:  fix_<ident>() {
+# Tolerates leading whitespace, optional `function ` prefix, trailing
+# whitespace before the `{`. Captures the function name in group 1.
+FIX_OPEN_RE='^[[:space:]]*(function[[:space:]]+)?(fix_[A-Za-z0-9_-]+)[[:space:]]*\(\)[[:space:]]*\{'
+
+# Match `2>/dev/null` or `2>&-` ANYWHERE on the line (after stripping
+# trailing comments). We strip trailing comments so a line like
+# `cmd  # see also 2>/dev/null discussion` doesn't false-positive.
+STDERR_SILENCER_RE='(2>/dev/null|2>&-)'
+
+VIOLATIONS=0
+LIST_ROWS=""
+
+should_skip_file() {
+  local f="$1"
+  [ "$f" = "$SELF_PATH" ] && return 0
+  case "$(basename "$f")" in
+    "${TEST_FIXTURE_PATTERN}.sh") return 0 ;;
+  esac
+  case "$f" in
+    "$REPO_ROOT"/docs/*|"$REPO_ROOT"/templates/*|"$REPO_ROOT"/Reports/*|"$REPO_ROOT"/.git/*) return 0 ;;
+  esac
+  return 1
+}
+
+# Strip trailing comment (` #...` to EOL) UNLESS the `#` lives inside
+# single or double quotes. Simple pass that scans char-by-char tracking
+# quote state. Good enough for the lint surface.
+strip_trailing_comment() {
+  local line="$1"
+  local out=""
+  local in_squote=0
+  local in_dquote=0
+  local i ch prev=""
+  local len=${#line}
+  for (( i=0; i<len; i++ )); do
+    ch="${line:i:1}"
+    if [ "$in_squote" = "0" ] && [ "$in_dquote" = "0" ] && [ "$ch" = "#" ]; then
+      # only treat as comment if preceded by whitespace or at column 0
+      if [ -z "$prev" ] || [[ "$prev" =~ [[:space:]] ]]; then
+        break
+      fi
+    fi
+    if [ "$in_dquote" = "0" ] && [ "$ch" = "'" ]; then
+      in_squote=$((1 - in_squote))
+    elif [ "$in_squote" = "0" ] && [ "$ch" = '"' ]; then
+      in_dquote=$((1 - in_dquote))
+    fi
+    out="${out}${ch}"
+    prev="$ch"
+  done
+  printf '%s' "$out"
+}
+
+# Extract the (optional) heredoc opening tag from a line. Returns the
+# tag name (without quotes) on stdout if a heredoc is opened, or empty
+# string if not. Supports `<<TAG`, `<<-TAG`, `<<'TAG'`, `<<"TAG"`.
+heredoc_open_tag() {
+  local line="$1"
+  # Strip trailing comment first so `# << ...` isn't confused.
+  line=$(strip_trailing_comment "$line")
+  # Look for the LAST heredoc operator on the line (closest to EOL).
+  # Regex: <<-? optional whitespace, then ('TAG'|"TAG"|TAG)
+  if [[ "$line" =~ \<\<-?[[:space:]]*\'([A-Za-z_][A-Za-z0-9_]*)\' ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  if [[ "$line" =~ \<\<-?[[:space:]]*\"([A-Za-z_][A-Za-z0-9_]*)\" ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  if [[ "$line" =~ \<\<-?[[:space:]]*([A-Za-z_][A-Za-z0-9_]*) ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+    return
+  fi
+  printf ''
+}
+
+# Count `{` minus `}` outside quotes — simple structural counter for
+# tracking when a fix function body ends. Good enough for the shapes
+# the framework actually uses (no embedded brace strings in fix bodies).
+brace_delta() {
+  local line="$1"
+  # Strip trailing comment.
+  line=$(strip_trailing_comment "$line")
+  local i ch in_squote=0 in_dquote=0 open=0 close=0
+  local len=${#line}
+  for (( i=0; i<len; i++ )); do
+    ch="${line:i:1}"
+    if [ "$in_dquote" = "0" ] && [ "$ch" = "'" ]; then
+      in_squote=$((1 - in_squote))
+      continue
+    fi
+    if [ "$in_squote" = "0" ] && [ "$ch" = '"' ]; then
+      in_dquote=$((1 - in_dquote))
+      continue
+    fi
+    if [ "$in_squote" = "0" ] && [ "$in_dquote" = "0" ]; then
+      [ "$ch" = "{" ] && open=$((open + 1))
+      [ "$ch" = "}" ] && close=$((close + 1))
+    fi
+  done
+  printf '%d' $((open - close))
+}
+
+parse_allowlist() {
+  local line="$1"
+  local marker_reason=""
+  local has_marker=0
+  case "$line" in
+    *"# lint-fix-functions-stderr: allow"*)
+      has_marker=1
+      marker_reason="${line##*# lint-fix-functions-stderr: allow}"
+      marker_reason="${marker_reason#"${marker_reason%%[![:space:]]*}"}"
+      marker_reason="${marker_reason%"${marker_reason##*[![:space:]]}"}"
+      ;;
+  esac
+  printf '%d\t%s\n' "$has_marker" "$marker_reason"
+}
+
+scan_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  should_skip_file "$file" && return 0
+
+  local -a LINES=()
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    LINES+=("$line")
+  done < "$file"
+
+  local i n=${#LINES[@]}
+  local in_fix=0
+  local fix_name=""
+  local depth=0
+  local heredoc_tag=""
+
+  for ((i = 0; i < n; i++)); do
+    line="${LINES[i]}"
+    local lineno=$((i + 1))
+    local rel="${file#"$REPO_ROOT"/}"
+
+    # Heredoc termination check.
+    if [ -n "$heredoc_tag" ]; then
+      # Heredoc terminator: the tag alone on a line (optionally with
+      # leading tabs for <<- form). Strip leading tabs only.
+      local stripped="${line#"${line%%[![:space:]]*}"}"
+      # Actually <<- only strips leading tabs not spaces; permissive enough.
+      if [ "$stripped" = "$heredoc_tag" ] || [ "${line//$'\t'/}" = "$heredoc_tag" ] || [ "$line" = "$heredoc_tag" ]; then
+        heredoc_tag=""
+      fi
+      continue
+    fi
+
+    # Pure-comment line: skip detection (but still let brace_delta
+    # handle braces if any — comments have no real braces).
+    local trimmed="${line#"${line%%[![:space:]]*}"}"
+    local is_comment=0
+    case "$trimmed" in
+      '#'*) is_comment=1 ;;
+    esac
+
+    # Detect fix_*() opening BEFORE heredoc handling so a function
+    # whose first line is `fix_foo() { ... <<EOF` correctly marks
+    # both the in-fix state and the heredoc.
+    if [ "$in_fix" = "0" ] && [[ "$line" =~ $FIX_OPEN_RE ]]; then
+      in_fix=1
+      fix_name="${BASH_REMATCH[2]}"
+      depth=$(brace_delta "$line")
+      # A new heredoc might open on the same line.
+      local maybe_tag
+      maybe_tag=$(heredoc_open_tag "$line")
+      [ -n "$maybe_tag" ] && heredoc_tag="$maybe_tag"
+      continue
+    fi
+
+    if [ "$in_fix" = "1" ]; then
+      # Track heredoc opening on this line BEFORE running the violation
+      # check — if the silencer occurs in the SAME line that opens a
+      # heredoc, the silencer is in the host script context (e.g.
+      # `cat > /tmp/x 2>/dev/null << EOF`), which IS a bug. So we
+      # check violations first, then update heredoc state.
+      if [ "$is_comment" = "0" ]; then
+        local stripped_line
+        stripped_line=$(strip_trailing_comment "$line")
+        if printf '%s' "$stripped_line" | grep -Eq "$STDERR_SILENCER_RE"; then
+          # Check allowlist marker.
+          local parsed has_marker allow_reason
+          parsed=$(parse_allowlist "$line")
+          has_marker="$(printf '%s' "$parsed" | cut -f1)"
+          allow_reason="$(printf '%s' "$parsed" | cut -f2)"
+
+          if [ "$has_marker" = "1" ]; then
+            if [ -z "$allow_reason" ]; then
+              echo "${rel}:${lineno}: lint-fix-functions-stderr: allowlist marker present but reason is empty (func=$fix_name)" >&2
+              VIOLATIONS=$((VIOLATIONS + 1))
+              LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\t${fix_name}\tallowlist-empty-reason\n"
+            else
+              LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\t${fix_name}\tallowlist:${allow_reason}\n"
+            fi
+          else
+            echo "${rel}:${lineno}: lint-fix-functions-stderr: stderr silencer inside fix function '${fix_name}' — surface the diagnostic so operators can act on it, or append '# lint-fix-functions-stderr: allow <reason>' with justification" >&2
+            VIOLATIONS=$((VIOLATIONS + 1))
+            LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\t${fix_name}\tstderr-silencer\n"
+          fi
+        fi
+      fi
+
+      # Now track heredoc opening on this line.
+      local maybe_tag
+      maybe_tag=$(heredoc_open_tag "$line")
+      [ -n "$maybe_tag" ] && heredoc_tag="$maybe_tag"
+
+      # Brace balance.
+      local delta
+      delta=$(brace_delta "$line")
+      depth=$((depth + delta))
+      if [ "$depth" -le 0 ]; then
+        in_fix=0
+        fix_name=""
+        depth=0
+      fi
+    fi
+  done
+}
+
+for entry in "${TARGET_GLOBS[@]}"; do
+  [ -e "$entry" ] || continue
+  scan_file "$entry"
+done
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\tFUNC\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS violation(s) found. See scripts/lint-fix-functions-stderr.sh header for the fix pattern." >&2
+  exit 1
+fi
+
+echo "OK: no fix_*() stderr silencers found."
+exit 0

--- a/scripts/lint-raw-read-prompt.sh
+++ b/scripts/lint-raw-read-prompt.sh
@@ -78,15 +78,31 @@ TARGET_GLOBS=(
   "$REPO_ROOT/init.sh"
 )
 
-# Match `read` invocations that include the `-p` flag. Recognize
-# `-p`, `-rp`, `-pr`, `-rsp`, and any other flag bundle containing
-# `p`. We anchor on the `read` command word with a leading word
-# boundary so the substring `bread` etc. doesn't match.
+# Match `read` invocations that include the `-p` flag. Recognize:
+#   • Single-bundle short flags containing `p`: `-p`, `-rp`, `-pr`,
+#     `-rsp`, `-sp`, etc.
+#   • Compact `-p"prompt"` (no space between `-p` and its quoted/raw
+#     value — bash accepts both shapes).
+#   • Multi-flag invocations where `-p` appears in a SEPARATE bundle
+#     from `-r` / `-s`: `read -s -p "..." v`, `read -r -p ...`.
+# We anchor on the `read` command word with a leading word boundary
+# (start-of-line / whitespace / `;` / `!` / `(`) so the substring
+# `bread` etc. doesn't match. We do NOT match `read --long-form`
+# style: bash `read` has no `--silent` / `--prompt` long form
+# (verified against bash 5.2 builtin help), so the verifier's
+# `read --silent -p ...` concern is moot — `bash` would error
+# "read: --: invalid option" before ever reading stdin.
 #
-# The regex below matches `read` followed by whitespace and a `-`
-# option bundle that contains `p`. We intentionally allow either
-# order of `r` and `p` (`-rp`, `-pr`) and any other letters bundled.
-READ_PROMPT_RE='(^|[[:space:]]|;|!|\()read[[:space:]]+-[A-Za-z]*p[A-Za-z]*([[:space:]]|$)'
+# Supported flag-bundle shapes (in order of detection):
+#   1. `read -[A-Za-z]*p[A-Za-z]*` (any bundle containing `p`,
+#      optional whitespace OR a quote/letter for compact `-p"..."`)
+#   2. `read [-s|-r|-rs|-sr]+ -[A-Za-z]*p[A-Za-z]*` (multi-bundle:
+#      another short-flag bundle, whitespace, then a `-p`-bundle)
+#
+# Test fixtures for the wider patterns live in
+# tests/test-lint-raw-read-prompt.sh (N1..N3 added in the PR-#96
+# follow-up).
+READ_PROMPT_RE='(^|[[:space:]]|;|!|\()read[[:space:]]+(-[A-Za-z]*[[:space:]]+)*-[A-Za-z]*p[A-Za-z]*([[:space:]"'"'"']|$)'
 
 VIOLATIONS=0
 LIST_ROWS=""

--- a/scripts/lint-raw-read-prompt.sh
+++ b/scripts/lint-raw-read-prompt.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+# scripts/lint-raw-read-prompt.sh — fail CI when any script outside
+# scripts/lib/helpers.sh calls `read -rp` / `read -p` directly. The
+# centralized prompt helpers (`prompt_input`, `prompt_yes_no`) handle
+# the non-interactive / CI / no-TTY contexts safely; bare `read -p`
+# does not, and hangs unattended invocations or silently proceeds
+# with empty input.
+#
+# THE DEFECT CLASS
+#   read -rp "Proceed? [y/N]: " yn
+#   if [[ "$yn" =~ ^[Yy] ]]; then do_destructive_thing; fi
+#
+# Under unattended invocation, `read` either blocks forever waiting
+# for stdin (when stdin is a pipe with nothing to deliver) or returns
+# immediately with empty `yn` (when stdin reaches EOF). Either way,
+# the operator never confirmed the action, and side-effectful code
+# proceeds with a default that the script author assumed would only
+# fire in interactive use. PR #87 (cycle 7) surfaced this class via
+# check-phase-gate's prompt_yes_no — this lint backstops the wider
+# tree.
+#
+# CANONICAL FIX
+#   if prompt_yes_no "Proceed?" "N"; then do_destructive_thing; fi
+#   # ── or ──
+#   result=$(prompt_input "Enter name" "anon")
+#
+# Both helpers live in scripts/lib/helpers.sh and refuse to block in
+# non-interactive contexts (no TTY on stdin, CI=true,
+# SOIF_NONINTERACTIVE=true), returning the safe default instead.
+#
+# DELIBERATE SCOPE
+#   • Targets `read -p` and `read -rp` (any flag combination that
+#     INCLUDES `-p`, since `-p` is what makes `read` block on a
+#     prompt). `read -r line` without `-p` is the correct portable
+#     idiom for line-by-line file parsing (e.g. inside `while IFS=
+#     read -r line < file`) and stays out of scope.
+#   • EXEMPT FILE: scripts/lib/helpers.sh — the canonical home for
+#     the prompt helpers themselves; they MUST call `read -rp` to
+#     do their job. No other file is exempt by location.
+#
+# ALLOWLIST
+#   Append `# lint-raw-read-prompt: allow <reason>` to the offending
+#   line. Reason is REQUIRED — empty reason fails the lint, matching
+#   PR #72's allowlist semantics. Use this for interactive-only
+#   wizards (e.g. intake-wizard.sh, which is documented as
+#   interactive and gated by upstream TTY checks).
+#
+# EXIT CODES
+#   0 — no violations
+#   1 — one or more violations found
+#   2 — invocation / I/O error
+#
+# USAGE
+#   bash scripts/lint-raw-read-prompt.sh        # quiet pass/fail
+#   bash scripts/lint-raw-read-prompt.sh --list # PASS/FAIL table
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)/.."
+REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
+SELF_PATH="$REPO_ROOT/scripts/lint-raw-read-prompt.sh"
+HELPERS_PATH="$REPO_ROOT/scripts/lib/helpers.sh"
+TEST_FIXTURE_PATTERN="test-lint-raw-read-prompt"
+
+LIST_MODE=0
+if [ "${1:-}" = "--list" ]; then
+  LIST_MODE=1
+elif [ -n "${1:-}" ]; then
+  echo "Usage: $0 [--list]" >&2
+  exit 2
+fi
+
+TARGET_GLOBS=(
+  "$REPO_ROOT/scripts"/*.sh
+  "$REPO_ROOT/scripts/lib"/*.sh
+  "$REPO_ROOT/scripts/hooks"/*.sh
+  "$REPO_ROOT/scripts/host-drivers"/*.sh
+  "$REPO_ROOT/init.sh"
+)
+
+# Match `read` invocations that include the `-p` flag. Recognize
+# `-p`, `-rp`, `-pr`, `-rsp`, and any other flag bundle containing
+# `p`. We anchor on the `read` command word with a leading word
+# boundary so the substring `bread` etc. doesn't match.
+#
+# The regex below matches `read` followed by whitespace and a `-`
+# option bundle that contains `p`. We intentionally allow either
+# order of `r` and `p` (`-rp`, `-pr`) and any other letters bundled.
+READ_PROMPT_RE='(^|[[:space:]]|;|!|\()read[[:space:]]+-[A-Za-z]*p[A-Za-z]*([[:space:]]|$)'
+
+VIOLATIONS=0
+LIST_ROWS=""
+
+should_skip_file() {
+  local f="$1"
+  [ "$f" = "$SELF_PATH" ] && return 0
+  [ "$f" = "$HELPERS_PATH" ] && return 0
+  case "$(basename "$f")" in
+    "${TEST_FIXTURE_PATTERN}.sh") return 0 ;;
+  esac
+  case "$f" in
+    "$REPO_ROOT"/docs/*|"$REPO_ROOT"/templates/*|"$REPO_ROOT"/Reports/*|"$REPO_ROOT"/.git/*) return 0 ;;
+  esac
+  return 1
+}
+
+parse_allowlist() {
+  local line="$1"
+  local marker_reason=""
+  local has_marker=0
+  case "$line" in
+    *"# lint-raw-read-prompt: allow"*)
+      has_marker=1
+      marker_reason="${line##*# lint-raw-read-prompt: allow}"
+      marker_reason="${marker_reason#"${marker_reason%%[![:space:]]*}"}"
+      marker_reason="${marker_reason%"${marker_reason##*[![:space:]]}"}"
+      ;;
+  esac
+  printf '%d\t%s\n' "$has_marker" "$marker_reason"
+}
+
+scan_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  should_skip_file "$file" && return 0
+
+  local -a LINES=()
+  local line
+  while IFS= read -r line || [ -n "$line" ]; do
+    LINES+=("$line")
+  done < "$file"
+
+  local i n=${#LINES[@]}
+  for ((i = 0; i < n; i++)); do
+    line="${LINES[i]}"
+    # Skip pure comment lines.
+    case "${line#"${line%%[![:space:]]*}"}" in
+      '#'*) continue ;;
+    esac
+    if echo "$line" | grep -Eq "$READ_PROMPT_RE"; then
+      local parsed has_marker allow_reason
+      parsed=$(parse_allowlist "$line")
+      has_marker="$(printf '%s' "$parsed" | cut -f1)"
+      allow_reason="$(printf '%s' "$parsed" | cut -f2)"
+
+      local lineno=$((i + 1))
+      local rel="${file#"$REPO_ROOT"/}"
+
+      if [ "$has_marker" = "1" ]; then
+        if [ -z "$allow_reason" ]; then
+          echo "${rel}:${lineno}: lint-raw-read-prompt: allowlist marker present but reason is empty" >&2
+          VIOLATIONS=$((VIOLATIONS + 1))
+          LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\tallowlist-empty-reason\n"
+        else
+          LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\tallowlist:${allow_reason}\n"
+        fi
+      else
+        echo "${rel}:${lineno}: lint-raw-read-prompt: raw 'read -rp' / 'read -p' — migrate to prompt_input / prompt_yes_no (scripts/lib/helpers.sh), or append '# lint-raw-read-prompt: allow <reason>'" >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\traw-read-prompt\n"
+      fi
+    fi
+  done
+}
+
+for entry in "${TARGET_GLOBS[@]}"; do
+  [ -e "$entry" ] || continue
+  scan_file "$entry"
+done
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS violation(s) found. See scripts/lint-raw-read-prompt.sh header for the migration pattern." >&2
+  exit 1
+fi
+
+echo "OK: no raw 'read -rp' / 'read -p' calls outside scripts/lib/helpers.sh."
+exit 0

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -62,10 +62,14 @@ if [ "$TERMINAL_MODE" -eq 1 ]; then
   fi
 
   # --- Cycle-8 slot-5: operator-side lint promotion (terminal-mode) ---
-  # Counter-antipattern + backlog-references lints fire on user-terminal
-  # commits too. SKIP_LINT=1 escape mirrors the PreToolUse path.
+  # All four CI lints fire on user-terminal commits too:
+  #   - counter-antipattern        (PR #72)
+  #   - backlog-references         (PR #76)
+  #   - fix-functions-stderr       (cycle-8 wave-3 slot-5, this PR)
+  #   - raw-read-prompt            (cycle-8 wave-3 slot-5, this PR)
+  # SKIP_LINT=1 escape mirrors the PreToolUse path.
   if [ "${SKIP_LINT:-0}" = "1" ]; then
-    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing counter-antipattern + backlog-references lints" >&2
+    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing all four pre-commit lints (counter-antipattern, backlog-references, fix-functions-stderr, raw-read-prompt)" >&2
   else
     # Counter-antipattern: prefer project-local copy (framework installs
     # the script alongside pre-commit-gate.sh in scripts/), fall back to
@@ -94,6 +98,38 @@ if [ "$TERMINAL_MODE" -eq 1 ]; then
       if ! br_out=$(printf '%s' "$COMMIT_MSG" | bash "$BR_LINT" --pre-commit-mode 2>&1); then
         echo "[FRAMEWORK GATE — strict mode] backlog-references lint failed:" >&2
         echo "$br_out" >&2
+        echo "" >&2
+        echo "To bypass anyway:  SKIP_LINT=1 git commit ..." >&2
+        exit 1
+      fi
+    fi
+
+    # fix-functions-stderr: full-tree scan, no message dependency.
+    FF_LINT=""
+    for cand in "$PROJECT_ROOT/scripts/lint-fix-functions-stderr.sh" \
+                "$SCRIPT_DIR/lint-fix-functions-stderr.sh"; do
+      [ -f "$cand" ] && { FF_LINT="$cand"; break; }
+    done
+    if [ -n "$FF_LINT" ]; then
+      if ! ff_out=$(bash "$FF_LINT" 2>&1); then
+        echo "[FRAMEWORK GATE — strict mode] fix-functions-stderr lint failed:" >&2
+        echo "$ff_out" >&2
+        echo "" >&2
+        echo "To bypass anyway:  SKIP_LINT=1 git commit ..." >&2
+        exit 1
+      fi
+    fi
+
+    # raw-read-prompt: full-tree scan, no message dependency.
+    RR_LINT=""
+    for cand in "$PROJECT_ROOT/scripts/lint-raw-read-prompt.sh" \
+                "$SCRIPT_DIR/lint-raw-read-prompt.sh"; do
+      [ -f "$cand" ] && { RR_LINT="$cand"; break; }
+    done
+    if [ -n "$RR_LINT" ]; then
+      if ! rr_out=$(bash "$RR_LINT" 2>&1); then
+        echo "[FRAMEWORK GATE — strict mode] raw-read-prompt lint failed:" >&2
+        echo "$rr_out" >&2
         echo "" >&2
         echo "To bypass anyway:  SKIP_LINT=1 git commit ..." >&2
         exit 1
@@ -412,12 +448,12 @@ lints_check() {
   fi
 
   # Prefer the project-local copy of each lint (upgrade-project.sh
-  # installs both lints into the project's scripts/ dir alongside
+  # installs the lints into the project's scripts/ dir alongside
   # pre-commit-gate.sh). Fall back to the framework copy so the gate
   # still self-checks when run from the framework repo's own working
   # tree. Project root = `git rev-parse --show-toplevel` from the
   # current cwd, since Claude Code invokes the hook from the project.
-  local proj_root ca_lint="" br_lint=""
+  local proj_root ca_lint="" br_lint="" ff_lint="" rr_lint=""
   proj_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
   for cand in "$proj_root/scripts/lint-counter-antipattern.sh" \
               "$SCRIPT_DIR/lint-counter-antipattern.sh"; do
@@ -426,6 +462,14 @@ lints_check() {
   for cand in "$proj_root/scripts/lint-backlog-references.sh" \
               "$SCRIPT_DIR/lint-backlog-references.sh"; do
     [ -n "$cand" ] && [ -f "$cand" ] && { br_lint="$cand"; break; }
+  done
+  for cand in "$proj_root/scripts/lint-fix-functions-stderr.sh" \
+              "$SCRIPT_DIR/lint-fix-functions-stderr.sh"; do
+    [ -n "$cand" ] && [ -f "$cand" ] && { ff_lint="$cand"; break; }
+  done
+  for cand in "$proj_root/scripts/lint-raw-read-prompt.sh" \
+              "$SCRIPT_DIR/lint-raw-read-prompt.sh"; do
+    [ -n "$cand" ] && [ -f "$cand" ] && { rr_lint="$cand"; break; }
   done
 
   # Counter-antipattern: full repo-relative scan, fast.
@@ -449,6 +493,24 @@ lints_check() {
       if [ "$br_exit" -ne 0 ]; then
         emit_lint_block "pre-commit gate: scripts/lint-backlog-references.sh failed. ${br_out} Add the missing BL entry, fix the typo, or add the citation/allowlist marker. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
       fi
+    fi
+  fi
+
+  # fix-functions-stderr: full repo-relative scan, fast.
+  if [ -n "$ff_lint" ]; then
+    local ff_out ff_exit=0
+    ff_out=$(bash "$ff_lint" 2>&1) || ff_exit=$?
+    if [ "$ff_exit" -ne 0 ]; then
+      emit_lint_block "pre-commit gate: scripts/lint-fix-functions-stderr.sh failed. ${ff_out} Surface the diagnostic (drop the 2>/dev/null) or append '# lint-fix-functions-stderr: allow <reason>' to the offending line. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
+    fi
+  fi
+
+  # raw-read-prompt: full repo-relative scan, fast.
+  if [ -n "$rr_lint" ]; then
+    local rr_out rr_exit=0
+    rr_out=$(bash "$rr_lint" 2>&1) || rr_exit=$?
+    if [ "$rr_exit" -ne 0 ]; then
+      emit_lint_block "pre-commit gate: scripts/lint-raw-read-prompt.sh failed. ${rr_out} Migrate to prompt_input / prompt_yes_no (scripts/lib/helpers.sh) or append '# lint-raw-read-prompt: allow <reason>'. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
     fi
   fi
 

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -443,8 +443,10 @@ complete_step() {
         echo "  Run in your terminal: SOIF_FORCE_STEP=true scripts/process-checklist.sh --complete-step ${process}:${step_id}" >&2
         exit 1
       fi
-      read -rp "Force-complete '${step_id}' without artifact? This is logged. [y/N]: " force_confirm
-      if [[ ! "$force_confirm" =~ ^[Yy]$ ]]; then
+      # Wave-3 raw-read sweep: prompt_yes_no centralizes the !-t 0 / CI
+      # default-N policy. The TTY guard above already returns 1 in
+      # non-interactive contexts; this is defense-in-depth.
+      if ! prompt_yes_no "Force-complete '${step_id}' without artifact? This is logged. [y/N]" "N"; then
         print_info "Force cancelled."
         exit 0
       fi
@@ -1001,9 +1003,10 @@ reset_process() {
     exit 1
   fi
 
-  # Interactive confirmation
-  read -rp "Reset process '$process'? This clears all progress. [y/N]: " confirm
-  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  # Interactive confirmation. Wave-3 raw-read sweep: prompt_yes_no
+  # also returns N in non-interactive contexts (defense-in-depth on
+  # top of the TTY guard above).
+  if ! prompt_yes_no "Reset process '$process'? This clears all progress. [y/N]" "N"; then
     print_info "Reset cancelled."
     exit 0
   fi
@@ -1062,9 +1065,10 @@ reset_all() {
     exit 1
   fi
 
-  # Interactive confirmation
-  read -rp "Reset ALL processes? This clears all progress across all phases. [y/N]: " confirm
-  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  # Interactive confirmation. Wave-3 raw-read sweep: prompt_yes_no
+  # also returns N in non-interactive contexts (defense-in-depth on
+  # top of the TTY guard above).
+  if ! prompt_yes_no "Reset ALL processes? This clears all progress across all phases. [y/N]" "N"; then
     print_info "Reset cancelled."
     exit 0
   fi

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -236,9 +236,9 @@ unrecord_feature() {
   echo "  features_since_last_health_check: $new_fslhc"
   echo ""
 
-  local confirm
-  read -rp "Proceed? [y/N]: " confirm
-  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  # Wave-3 raw-read sweep: prompt_yes_no centralizes the !-t 0 / CI /
+  # SOIF_NONINTERACTIVE non-interactive default-N policy.
+  if ! prompt_yes_no "Proceed? [y/N]" "N"; then
     print_info "Unrecord cancelled."
     exit 0
   fi

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -941,10 +941,16 @@ fi
 echo ""
 
 # --- Interactive confirmation ---
+# Wave-3 raw-read sweep: prompt_yes_no honors !-t 0 / CI /
+# SOIF_NONINTERACTIVE. The interactive default here is Y (the upgrade
+# wizard pre-printed the change plan and the operator typing Enter
+# means "yes proceed"), but in non-interactive contexts prompt_yes_no
+# hard-returns N — so the else-branch's "Non-interactive mode —
+# proceeding with upgrade." auto-Y is preserved explicitly here for
+# CI/scripted callers who already accepted the change plan upstream
+# (e.g. spec-driven upgrades, replay UAT).
 if [ -t 0 ]; then
-  read -rp "$(echo -e "  ${BOLD}Proceed with this upgrade? [Y/n]${NC}: ")" confirm
-  confirm="${confirm:-Y}"
-  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+  if ! prompt_yes_no "$(echo -e "  ${BOLD}Proceed with this upgrade? [Y/n]${NC}")" "Y"; then
     print_info "Upgrade cancelled."
     exit 0
   fi
@@ -1904,9 +1910,11 @@ if [ "$TRACK_CHANGES" = true ] && [ -f "$RESOLVER" ] && [ -d "$MATRIX_DIR" ] && 
       echo ""
 
       if [ "$AUTO_COUNT" -gt 0 ] && [ -t 0 ]; then
-        read -rp "$(echo -e "  ${BOLD}Auto-install $AUTO_COUNT tool(s) now? [Y/n]${NC}: ")" install_confirm
-        install_confirm="${install_confirm:-Y}"
-        if [[ "$install_confirm" =~ ^[Yy]$ ]]; then
+        # Wave-3 raw-read sweep: prompt_yes_no centralizes the
+        # !-t 0 / CI default-N policy. The outer `-t 0` guard
+        # already gates this branch — prompt_yes_no's defense-in-
+        # depth N return here is harmless (we don't enter the block).
+        if prompt_yes_no "$(echo -e "  ${BOLD}Auto-install $AUTO_COUNT tool(s) now? [Y/n]${NC}")" "Y"; then
           echo "$RESOLVER_OUTPUT" | jq -r '.auto_install[] | .install_cmd' | while IFS= read -r cmd; do
             if [ -n "$cmd" ]; then
               print_info "Installing: $cmd"

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -775,11 +775,21 @@ fix_phase_state() {
   poc_value="null"
   if [ -f ".claude/intake-progress.json" ]; then
     local pm
-    # Wave-3 fix-functions-stderr sweep: surface jq diagnostics. A
-    # malformed intake-progress.json should fail loud (the operator
+    # Wave-3 fix-functions-stderr sweep + PR-#96 verifier follow-up:
+    # surface jq diagnostics AND actually fail loud on malformed JSON.
+    # A malformed intake-progress.json should fail loud (the operator
     # then re-runs intake or repairs the file), not silently default
     # to poc_mode=null and write a half-correct phase-state.json.
-    pm=$(jq -r '.answers.poc_mode // empty' .claude/intake-progress.json || echo "")
+    # The previous `|| echo ""` masked jq's exit code (command-
+    # substitution rc isn't propagated under `set -e`); the explicit
+    # if/else here lets jq's stderr through AND refuses to write the
+    # half-filled file, matching the contract the comment describes.
+    if ! pm=$(jq -r '.answers.poc_mode // empty' .claude/intake-progress.json 2>&1); then
+      print_warn "fix_phase_state: jq failed on .claude/intake-progress.json — refusing to write half-filled phase-state.json"
+      register_manual "phase-state.json cannot be auto-fixed: .claude/intake-progress.json is malformed (jq: $pm)" \
+        "Inspect/repair .claude/intake-progress.json, or re-run scripts/intake-wizard.sh"
+      return 1
+    fi
     case "$pm" in
       private_poc|sponsored_poc) poc_value="\"$pm\"" ;;
     esac

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -775,7 +775,11 @@ fix_phase_state() {
   poc_value="null"
   if [ -f ".claude/intake-progress.json" ]; then
     local pm
-    pm=$(jq -r '.answers.poc_mode // empty' .claude/intake-progress.json 2>/dev/null || echo "")
+    # Wave-3 fix-functions-stderr sweep: surface jq diagnostics. A
+    # malformed intake-progress.json should fail loud (the operator
+    # then re-runs intake or repairs the file), not silently default
+    # to poc_mode=null and write a half-correct phase-state.json.
+    pm=$(jq -r '.answers.poc_mode // empty' .claude/intake-progress.json || echo "")
     case "$pm" in
       private_poc|sponsored_poc) poc_value="\"$pm\"" ;;
     esac
@@ -878,7 +882,23 @@ fix_release_pipeline() {
 fix_intake_suggestions() {
   if has_source; then
     mkdir -p templates/intake-suggestions
-    cp "$SOURCE_DIR/templates/intake-suggestions/"*.json templates/intake-suggestions/ 2>/dev/null
+    # Wave-3 fix-functions-stderr sweep: surface cp diagnostics. A
+    # missing source dir, permission error, or path glob mismatch
+    # should fail loud so the operator can act (the prior silent
+    # 2>/dev/null masked all three). Pre-test the glob via bash
+    # nullglob so we don't invoke `cp` with zero source files
+    # (which would emit a real "no such file" stderr under valid
+    # empty-set conditions).
+    local src_dir="$SOURCE_DIR/templates/intake-suggestions"
+    local -a src_files=()
+    if [ -d "$src_dir" ]; then
+      shopt -s nullglob
+      src_files=("$src_dir"/*.json)
+      shopt -u nullglob
+    fi
+    if [ "${#src_files[@]}" -gt 0 ]; then
+      cp "${src_files[@]}" templates/intake-suggestions/
+    fi
   else
     return 1
   fi
@@ -1330,8 +1350,14 @@ run_remediation() {
 
   if [ "$MODE" = "interactive" ]; then
     echo ""
-    read -rp "$(echo -e "${BOLD}Auto-fix $fixable_count issues? [Y/n]${NC}: ")" response
-    if [[ "$response" =~ ^[Nn] ]]; then
+    # Wave-3 raw-read sweep: prompt_yes_no centralizes the !-t 0 / CI
+    # default-N policy. MODE=interactive is only entered when stdin is
+    # a TTY (see MODE selection earlier in this script), so the
+    # interactive default-Y branch is preserved; in degenerate cases
+    # where MODE=interactive but stdin is non-TTY, prompt_yes_no
+    # hard-returns N (defense-in-depth) and the caller falls back to
+    # --auto-fix-or-manual messaging.
+    if ! prompt_yes_no "$(echo -e "${BOLD}Auto-fix $fixable_count issues? [Y/n]${NC}")" "Y"; then
       print_info "Skipping auto-fix. Run with --auto-fix later or fix manually."
       return 1
     fi

--- a/tests/test-check-gate.sh
+++ b/tests/test-check-gate.sh
@@ -49,22 +49,36 @@ t1_yes_flag_writes_host_non_interactive() {
 }
 
 t2_interactive_y_still_works() {
+  # Cycle-8 wave-3 slot-5 contract update: the previous version of this
+  # test piped `echo y` into a non-TTY stdin and expected the bare
+  # `read -rp` to honor the 'y'. After migrating to
+  # lib/helpers.sh::prompt_yes_no, non-TTY stdin contexts (CI, piped
+  # input, `</dev/null`) DELIBERATELY hard-return N — auto-Y'ing a
+  # manifest mutation in CI was the bug the migration closes. The
+  # supported non-interactive confirmation path is the `--yes` flag,
+  # exercised by T1 and T4. This test now confirms the new contract:
+  # piped 'y' WITHOUT `--yes` aborts (no manifest write).
   setup_project
   local out rc=0
   out=$(cd "$TMPDIR_T" && echo y | "$SCRIPT" --backfill-host 2>&1) || rc=$?
-  if [ "$rc" -ne 0 ]; then
-    fail_ "T2" "expected exit 0 with stdin 'y', got rc=$rc out=$out"
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T2" "expected non-zero exit on piped 'y' without --yes (non-TTY hard-N policy); got rc=0 out=$out"
     teardown_project
     return
   fi
   local host
   host=$(jq -r '.host // empty' "$TMPDIR_T/.claude/manifest.json")
-  if [ "$host" != "github" ]; then
-    fail_ "T2" "expected host='github', got host='$host'"
+  if [ -n "$host" ]; then
+    fail_ "T2" "expected host unset on non-interactive abort, got host='$host'"
     teardown_project
     return
   fi
-  pass "T2: --backfill-host with stdin 'y' still writes manifest.host (regression)"
+  if ! printf '%s' "$out" | grep -qE 'Non-interactive context'; then
+    fail_ "T2" "expected WARN diagnostic explaining the non-interactive skip; got: $out"
+    teardown_project
+    return
+  fi
+  pass "T2: piped 'y' WITHOUT --yes is correctly refused (non-TTY hard-N policy; use --yes for non-interactive confirm)"
   teardown_project
 }
 

--- a/tests/test-lint-fix-functions-stderr.sh
+++ b/tests/test-lint-fix-functions-stderr.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+# tests/test-lint-fix-functions-stderr.sh
+#
+# Tests for scripts/lint-fix-functions-stderr.sh — the cycle-8 wave-3
+# CI backstop that bans `2>/dev/null` (and `2>&-`) inside any function
+# body whose name starts with `fix_` across the scripts/ tree.
+#
+# Defect class:
+#   fix_*() auto-fix functions in scripts/verify-install.sh and friends
+#   silenced stderr from their internal commands. When the fix itself
+#   failed (auth prompt, missing dep, hostile DNS) the operator saw a
+#   "fix returned non-zero" with NO diagnostic — making the issue
+#   un-actionable. See PR #92's scrub of fix_framework_clone /
+#   fix_framework_manifest / fix_superpowers for the precedent.
+#
+# Same test-harness convention as tests/test-lint-counter-antipattern.sh:
+# build per-case fixtures under a tmpdir, copy the linter in, run from
+# the fixture root, assert on exit code and stderr.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-fix-functions-stderr.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/repo"
+  mkdir -p "$PROJ/scripts"
+  cp "$LINTER" "$PROJ/scripts/lint-fix-functions-stderr.sh"
+  chmod +x "$PROJ/scripts/lint-fix-functions-stderr.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+run_lint() {
+  ( cd "$PROJ" && bash scripts/lint-fix-functions-stderr.sh 2>&1 )
+  return $?
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: clean fixture (fix_* with no stderr silencer) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/clean.sh" <<'SH'
+#!/usr/bin/env bash
+fix_thing() {
+  git clone -q https://example.invalid/repo.git target
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T1: clean fix_*() body exits 0"
+else
+  fail_ "T1" "expected exit 0, got $rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: fix_*() with 2>/dev/null → exit 1, names file:line + func ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/bad.sh" <<'SH'
+#!/usr/bin/env bash
+fix_silent_clone() {
+  git clone -q https://example.invalid/repo.git target 2>/dev/null
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/bad.sh:3" \
+   && echo "$out" | grep -q "fix_silent_clone"; then
+  pass "T2: bare 2>/dev/null inside fix_*() body is flagged with file:line + func"
+else
+  fail_ "T2" "expected exit 1 + file:line:func; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: fix_*() with 2>&- → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/closefd.sh" <<'SH'
+#!/usr/bin/env bash
+fix_closed_fd() {
+  bash some-installer.sh 2>&-
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/closefd.sh:3" \
+   && echo "$out" | grep -q "fix_closed_fd"; then
+  pass "T3: 2>&- (close-fd) inside fix_*() body is also flagged"
+else
+  fail_ "T3" "expected exit 1 for 2>&-; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: NON-fix_*() function with 2>/dev/null → exit 0 (out of scope) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/check.sh" <<'SH'
+#!/usr/bin/env bash
+check_something() {
+  # Read-only probe; legitimate 2>/dev/null suppression.
+  git rev-parse --git-dir 2>/dev/null
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T4: non-fix_*() functions are out of scope"
+else
+  fail_ "T4" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: 2>/dev/null inside fix_*() but in a COMMENT → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/commented.sh" <<'SH'
+#!/usr/bin/env bash
+fix_explained() {
+  # Drop `2>/dev/null` per the same rationale as fix_framework_clone.
+  git clone -q https://example.invalid/repo.git target
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T5: 2>/dev/null in a comment line is correctly NOT flagged"
+else
+  fail_ "T5" "expected exit 0 for commented occurrence; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: 2>/dev/null inside fix_*() but in a HEREDOC body → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# fix_precommit_hook writes a pre-commit script via heredoc; the
+# generated script's `2>/dev/null` inside `gitleaks ... 2>/dev/null`
+# lives in the .git/hooks/pre-commit file at runtime, NOT in the
+# fix function's own logic. The lint must not flag heredoc bodies.
+setup
+cat > "$PROJ/scripts/heredoc.sh" <<'SH'
+#!/usr/bin/env bash
+fix_precommit_hook() {
+  mkdir -p .git/hooks
+  cat > .git/hooks/pre-commit << 'HOOKEOF'
+#!/usr/bin/env bash
+if ! gitleaks git --staged 2>/dev/null; then
+  echo "[BLOCKED]"
+fi
+HOOKEOF
+  chmod +x .git/hooks/pre-commit
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T6: 2>/dev/null inside a heredoc body is correctly NOT flagged"
+else
+  fail_ "T6" "expected exit 0 for heredoc body; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: allowlist marker WITH reason → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/allowed.sh" <<'SH'
+#!/usr/bin/env bash
+fix_with_reason() {
+  # The diagnostic is captured separately above; intentional silence here.
+  some-command 2>/dev/null # lint-fix-functions-stderr: allow diagnostic already captured upstream
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T7: allowlist marker with reason passes"
+else
+  fail_ "T7" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: allowlist marker WITHOUT reason → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/empty-allow.sh" <<'SH'
+#!/usr/bin/env bash
+fix_empty_reason() {
+  some-command 2>/dev/null # lint-fix-functions-stderr: allow
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -qi "empty\|reason"; then
+  pass "T8: empty-reason allowlist marker fails (justification required)"
+else
+  fail_ "T8" "expected exit 1 with reason-required diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9: MERGE GATE — run linter against current repo HEAD → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Wave-3 acceptance criterion: PR #92 scrubbed every known fix_*()
+# stderr silencer (fix_framework_clone, fix_framework_manifest,
+# fix_superpowers). This test enforces the sweep stays clean.
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T9: current repo HEAD is lint-clean (wave-3 sweep verified)"
+else
+  fail_ "T9" "current repo HEAD has unsilenced fix_*() stderr sites; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: skip-paths — bad fix_*() in Reports/ → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+mkdir -p "$PROJ/Reports"
+cat > "$PROJ/Reports/sample.sh" <<'SH'
+#!/usr/bin/env bash
+fix_ignored() {
+  git clone https://x 2>/dev/null
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T10: bad fix_*() under Reports/ is correctly skipped"
+else
+  fail_ "T10" "expected exit 0 (Reports/ should be skipped); rc=$rc; output:\n$out"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-lint-raw-read-prompt.sh
+++ b/tests/test-lint-raw-read-prompt.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# tests/test-lint-raw-read-prompt.sh
+#
+# Tests for scripts/lint-raw-read-prompt.sh — the cycle-8 wave-3 CI
+# backstop that bans bare `read -rp` (and `read -p`) outside the
+# canonical centralized prompt helpers in scripts/lib/helpers.sh.
+#
+# Defect class:
+#   Scripts call `read -rp "..." var` directly. Under unattended
+#   invocation (CI, AI-agent driven runs, piped input that under-feeds
+#   the prompt) `read` blocks indefinitely on EOF or reads an empty
+#   string into `var`, then proceeds with side-effectful code that
+#   should have been gated on operator confirmation. The remediation
+#   is `prompt_input` / `prompt_yes_no` in scripts/lib/helpers.sh,
+#   which both respect `! -t 0` / `CI=true` / `SOIF_NONINTERACTIVE=true`
+#   and return safe defaults.
+#
+# Same harness pattern as tests/test-lint-fix-functions-stderr.sh.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-raw-read-prompt.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/repo"
+  mkdir -p "$PROJ/scripts/lib"
+  cp "$LINTER" "$PROJ/scripts/lint-raw-read-prompt.sh"
+  chmod +x "$PROJ/scripts/lint-raw-read-prompt.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+run_lint() {
+  ( cd "$PROJ" && bash scripts/lint-raw-read-prompt.sh 2>&1 )
+  return $?
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: clean fixture (no read -rp) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/clean.sh" <<'SH'
+#!/usr/bin/env bash
+result=$(prompt_input "Your name" "anon")
+echo "Hello, $result"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T1: clean fixture exits 0"
+else
+  fail_ "T1" "expected exit 0, got $rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: bare 'read -rp' outside lib/ → exit 1, names file:line ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/bad.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Proceed? [y/N]: " yn
+if [ "$yn" = "y" ]; then echo "ok"; fi
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/bad.sh:2" \
+   && echo "$out" | grep -qi "prompt_input\|prompt_yes_no"; then
+  pass "T2: bare 'read -rp' flagged with migration hint"
+else
+  fail_ "T2" "expected exit 1 + file:line + migration hint; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: bare 'read -p' (no -r) outside lib/ → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/dashp.sh" <<'SH'
+#!/usr/bin/env bash
+read -p "Proceed? " yn
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "scripts/dashp.sh:2"; then
+  pass "T3: 'read -p' (without -r) is also flagged"
+else
+  fail_ "T3" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: 'read -rp' INSIDE lib/helpers.sh → exit 0 (canonical helper home) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/lib/helpers.sh" <<'SH'
+#!/usr/bin/env bash
+prompt_input() {
+  local prompt="$1"
+  read -rp "$prompt: " result
+  echo "$result"
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T4: 'read -rp' inside scripts/lib/helpers.sh is allowed (canonical home)"
+else
+  fail_ "T4" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: 'read -rp' in a COMMENT line → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/commented.sh" <<'SH'
+#!/usr/bin/env bash
+# Previously this used: read -rp "Choice: " reply
+result=$(prompt_input "Choice" "default")
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T5: 'read -rp' in a comment is correctly NOT flagged"
+else
+  fail_ "T5" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: 'read -r' WITHOUT -p → exit 0 (no-prompt form, valid for stdin-stream parsing) ==="
+# ════════════════════════════════════════════════════════════════════
+# `read -r line` reading from stdin (e.g. inside a `while IFS= read -r`
+# loop) is the correct portable form for line-by-line file parsing —
+# we do NOT want to flag it. Only the prompt forms `-p` / `-rp` are
+# in scope.
+setup
+cat > "$PROJ/scripts/parser.sh" <<'SH'
+#!/usr/bin/env bash
+while IFS= read -r line || [ -n "$line" ]; do
+  echo "got: $line"
+done < some-input.txt
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T6: 'read -r' (no -p) is correctly out of scope"
+else
+  fail_ "T6" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: allowlist marker WITH reason → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/allowed.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Proceed? " yn # lint-raw-read-prompt: allow interactive-only wizard path, gated by upstream TTY check
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T7: allowlist marker with reason passes"
+else
+  fail_ "T7" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: allowlist marker WITHOUT reason → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/empty.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Proceed? " yn # lint-raw-read-prompt: allow
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -qi "empty\|reason"; then
+  pass "T8: empty-reason allowlist marker fails (justification required)"
+else
+  fail_ "T8" "expected exit 1 with reason-required diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9: MERGE GATE — run linter against current repo HEAD → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Wave-3 acceptance criterion: every in-tree raw `read -rp` outside
+# scripts/lib/helpers.sh has either been migrated to prompt_input /
+# prompt_yes_no OR carries an allowlist marker with reason. CI fails
+# the merge if a future PR reintroduces an unmarked site.
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T9: current repo HEAD is lint-clean (sweep verified)"
+else
+  fail_ "T9" "current repo HEAD has unmarked raw read -rp sites; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: skip-paths — bare read -rp in Reports/ → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+mkdir -p "$PROJ/Reports"
+cat > "$PROJ/Reports/sample.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Choice: " reply
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T10: bare read -rp under Reports/ is correctly skipped"
+else
+  fail_ "T10" "expected exit 0 (Reports/ should be skipped); rc=$rc; output:\n$out"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-lint-raw-read-prompt.sh
+++ b/tests/test-lint-raw-read-prompt.sh
@@ -230,6 +230,63 @@ else
 fi
 teardown
 
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T11: compact 'read -p\"prompt\"' (no space) → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# PR-#96 verifier regex-blind-spot coverage. Bash accepts `read -p"x"`
+# with no space between `-p` and its value; the previous regex missed
+# this shape because it required `[[:space:]]` after the flag bundle.
+setup
+cat > "$PROJ/scripts/compact.sh" <<'SH'
+#!/usr/bin/env bash
+read -p"name: " name
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "scripts/compact.sh:2"; then
+  pass "T11: compact 'read -p\"...\"' (no space) is flagged"
+else
+  fail_ "T11" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T12: 'read -s -p ...' (separate flag bundles) → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# PR-#96 verifier regex-blind-spot coverage. Multi-bundle invocations
+# where `-p` appears separately from `-s` / `-r` were previously
+# missed (the regex required a SINGLE bundle containing `p`).
+setup
+cat > "$PROJ/scripts/multi.sh" <<'SH'
+#!/usr/bin/env bash
+read -s -p "secret: " secret
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "scripts/multi.sh:2"; then
+  pass "T12: multi-bundle 'read -s -p ...' is flagged"
+else
+  fail_ "T12" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T13: 'read -r -p ...' (separate -r and -p bundles) → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/split.sh" <<'SH'
+#!/usr/bin/env bash
+read -r -p "name: " name
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "scripts/split.sh:2"; then
+  pass "T13: separate '-r' and '-p' bundles are flagged"
+else
+  fail_ "T13" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]

--- a/tests/test-pre-commit-gate-lints.sh
+++ b/tests/test-pre-commit-gate-lints.sh
@@ -25,6 +25,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 GATE="$REPO_ROOT/scripts/pre-commit-gate.sh"
 CA_LINT_SRC="$REPO_ROOT/scripts/lint-counter-antipattern.sh"
 BR_LINT_SRC="$REPO_ROOT/scripts/lint-backlog-references.sh"
+FF_LINT_SRC="$REPO_ROOT/scripts/lint-fix-functions-stderr.sh"
+RR_LINT_SRC="$REPO_ROOT/scripts/lint-raw-read-prompt.sh"
 
 PASSED=0
 FAILED=0
@@ -53,8 +55,12 @@ setup() {
 
   cp "$CA_LINT_SRC" "$PROJ/scripts/lint-counter-antipattern.sh"
   cp "$BR_LINT_SRC" "$PROJ/scripts/lint-backlog-references.sh"
+  cp "$FF_LINT_SRC" "$PROJ/scripts/lint-fix-functions-stderr.sh"
+  cp "$RR_LINT_SRC" "$PROJ/scripts/lint-raw-read-prompt.sh"
   chmod +x "$PROJ/scripts/lint-counter-antipattern.sh"
   chmod +x "$PROJ/scripts/lint-backlog-references.sh"
+  chmod +x "$PROJ/scripts/lint-fix-functions-stderr.sh"
+  chmod +x "$PROJ/scripts/lint-raw-read-prompt.sh"
 
   cp "$REPO_ROOT/scripts/process-checklist.sh" "$PROJ/scripts/"
   cp "$REPO_ROOT/scripts/lib/helpers.sh" "$PROJ/scripts/lib/"
@@ -247,6 +253,122 @@ if [[ "$body" == *'"permissionDecision": "deny"'* ]] && \
   pass "T7: docs-only commit with unknown BL is blocked (lint is structural)"
 else
   fail_ "T7" "expected deny on docs-only commit with unknown BL; got: $out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: PreToolUse — fix-functions-stderr lint blocks unfixed silencer ==="
+# ════════════════════════════════════════════════════════════════════
+# Drop a script with a fix_*() body that silences stderr — the
+# project-local lint copy at scripts/lint-fix-functions-stderr.sh
+# should fire from the gate. Built with single-quoted heredoc so the
+# fixture text does NOT trip the lint scanning THIS test file
+# (tests/*.sh are part of TARGET_GLOBS in some lints).
+setup
+cat > "$PROJ/scripts/has-bad-fix.sh" <<'SH'
+#!/usr/bin/env bash
+fix_silent_thing() {
+  git clone -q https://x.invalid/r.git target 2>/dev/null
+}
+SH
+( cd "$PROJ" && git add scripts/has-bad-fix.sh )
+out=$(run_hook 'git commit -m "docs: trivial (BL-001)"')
+body="${out#*|}"
+if [[ "$body" == *'"permissionDecision": "deny"'* ]] && \
+   [[ "$body" == *"fix-functions-stderr"* ]]; then
+  pass "T8: fix-functions-stderr violation in scripts/ is blocked"
+else
+  fail_ "T8" "expected deny mentioning fix-functions-stderr; got: $out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9: PreToolUse — raw-read-prompt lint blocks raw read -rp ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/has-bare-read.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Proceed? [y/N]: " yn
+echo "$yn"
+SH
+( cd "$PROJ" && git add scripts/has-bare-read.sh )
+out=$(run_hook 'git commit -m "docs: trivial (BL-001)"')
+body="${out#*|}"
+if [[ "$body" == *'"permissionDecision": "deny"'* ]] && \
+   [[ "$body" == *"raw-read-prompt"* ]]; then
+  pass "T9: raw-read-prompt violation in scripts/ is blocked"
+else
+  fail_ "T9" "expected deny mentioning raw-read-prompt; got: $out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: SKIP_LINT=1 bypasses ALL FOUR lints (PreToolUse path) ==="
+# ════════════════════════════════════════════════════════════════════
+# Mirror of T5 but with both new lints in the failure set. SKIP_LINT
+# must bypass all four; the acknowledgement message must NOT contain
+# the per-lint failure prefix.
+setup
+write_bad_script "$PROJ/scripts/bad.sh"
+cat > "$PROJ/scripts/has-bad-fix.sh" <<'SH'
+#!/usr/bin/env bash
+fix_silent_thing() {
+  git clone -q https://x.invalid/r.git target 2>/dev/null
+}
+SH
+cat > "$PROJ/scripts/has-bare-read.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Proceed? [y/N]: " yn
+SH
+( cd "$PROJ" && git add scripts/bad.sh scripts/has-bad-fix.sh scripts/has-bare-read.sh )
+out=$(run_hook_skip_lint 'git commit -m "docs: bypass (BL-999)"')
+body="${out#*|}"
+if [[ "$body" == *"SKIP_LINT=1 set"* ]] && \
+   [[ "$body" != *"lint-counter-antipattern.sh failed"* ]] && \
+   [[ "$body" != *"lint-fix-functions-stderr.sh failed"* ]] && \
+   [[ "$body" != *"lint-raw-read-prompt.sh failed"* ]] && \
+   [[ "$body" != *"unknown BL reference 'BL-999'"* ]]; then
+  pass "T10: SKIP_LINT=1 bypasses all four lints"
+else
+  fail_ "T10" "SKIP_LINT did not bypass all four lints; got: $out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T11: --terminal-mode — new lints fire on framework-installed projects ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/has-bad-fix.sh" <<'SH'
+#!/usr/bin/env bash
+fix_silent_thing() {
+  git clone -q https://x.invalid/r.git target 2>/dev/null
+}
+SH
+( cd "$PROJ" && git add scripts/has-bad-fix.sh )
+echo "docs: trivial (BL-001)" > "$PROJ/.git/COMMIT_EDITMSG"
+out=$( cd "$PROJ" && bash "$GATE" --terminal-mode 2>&1 >/dev/null || true )
+if echo "$out" | grep -qE 'fix-functions-stderr lint failed'; then
+  pass "T11a: --terminal-mode fires fix-functions-stderr lint"
+else
+  fail_ "T11a" "--terminal-mode did not surface fix-functions-stderr lint: $out"
+fi
+rm "$PROJ/scripts/has-bad-fix.sh"
+( cd "$PROJ" && git reset HEAD -- scripts/has-bad-fix.sh >/dev/null 2>&1 || true )
+cat > "$PROJ/scripts/has-bare-read.sh" <<'SH'
+#!/usr/bin/env bash
+read -rp "Proceed? [y/N]: " yn
+SH
+( cd "$PROJ" && git add scripts/has-bare-read.sh )
+echo "docs: trivial (BL-001)" > "$PROJ/.git/COMMIT_EDITMSG"
+out=$( cd "$PROJ" && bash "$GATE" --terminal-mode 2>&1 >/dev/null || true )
+if echo "$out" | grep -qE 'raw-read-prompt lint failed'; then
+  pass "T11b: --terminal-mode fires raw-read-prompt lint"
+else
+  fail_ "T11b" "--terminal-mode did not surface raw-read-prompt lint: $out"
 fi
 teardown
 

--- a/tests/test-prompt-install-noninteractive.sh
+++ b/tests/test-prompt-install-noninteractive.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# tests/test-prompt-install-noninteractive.sh
+#
+# Regression test for the PR-#96 adversarial-verifier MAJOR finding:
+#
+#   scripts/lib/helpers.sh::prompt_install (line ~292) called
+#     read -rp "Install $tool now? [Y/n]: " response
+#     [[ "$response" =~ ^[Nn] ]] && return 1
+#     eval "$install_cmd"
+#
+#   With no `[ -t 0 ]` / `${CI:-}` / `${SOIF_NONINTERACTIVE:-}`
+#   short-circuit, an EOF / piped-stdin invocation caused `read` to
+#   return nonzero with `response=""`, the regex check evaluated
+#   false, and `eval "$install_cmd"` fired UNATTENDED. prompt_install
+#   is invoked from 16 sites in init.sh for `sudo apt install ...`,
+#   Docker daemon install (`usermod -aG docker $USER`), etc. — i.e.
+#   precisely the auto-Y'd side-effectful actions the PR-#96 contract
+#   is supposed to prevent.
+#
+#   The `scripts/lint-raw-read-prompt.sh` lint cannot catch this
+#   because helpers.sh is the only file EXEMPT from that lint (the
+#   prompt helpers themselves must call `read -rp`). That makes a
+#   runtime regression test (this file) the only safety net.
+#
+# Expected behavior after the fix:
+#   prompt_install MUST short-circuit and return 1 (decline install,
+#   do NOT call `eval`) whenever ANY of:
+#     - stdin is not a TTY (`! [ -t 0 ]`)
+#     - $CI is set to a non-empty value
+#     - $SOIF_NONINTERACTIVE is set to a non-empty value
+#
+# Verification strategy:
+#   Source helpers.sh in a harness, mock `eval` as a function that
+#   creates a marker file when called, invoke prompt_install with a
+#   destructive-looking command, then assert (a) the marker is ABSENT
+#   and (b) prompt_install returned nonzero. The marker mechanism
+#   means T1/T2/T3 RED on PR-#96 HEAD (current bug fires `eval`,
+#   creating the marker) and GREEN after the fix (short-circuit
+#   returns 1, eval untouched).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPERS="$REPO_ROOT/scripts/lib/helpers.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build a harness script that:
+#   1. Sources scripts/lib/helpers.sh.
+#   2. Overrides `eval` so that ANY call creates $MARKER (proving the
+#      install command would have fired).
+#   3. Calls prompt_install with a destructive-looking command.
+#   4. Exits with prompt_install's rc.
+#
+# Args: $1 = marker path, $2 = harness path.
+build_harness() {
+  local marker="$1" harness="$2"
+  cat > "$harness" <<HARNESS
+#!/usr/bin/env bash
+set -uo pipefail
+# Disable color escapes so output is greppable.
+YELLOW=""; BOLD=""; NC=""; CYAN=""; GREEN=""; RED=""; BLUE=""
+# Source the real helpers.
+source "$HELPERS"
+# Replace eval with a function stub that records the install attempt.
+# Bash resolves user-defined functions before builtins, so this stub
+# takes precedence inside prompt_install's body. We CANNOT use
+# command substitution to capture args without re-entering eval —
+# just touch the marker and return success so the calling logic
+# proceeds as if install succeeded (irrelevant to the assertion).
+eval() {
+  touch "$marker"
+  return 0
+}
+prompt_install "TestTool" "rm -rf /nonexistent-test-target"
+rc=\$?
+exit "\$rc"
+HARNESS
+  chmod +x "$harness"
+}
+
+# Run the harness with a bounded timeout, stdin redirected per kind,
+# and the supplied env_prefix exported. Records pass/fail by examining
+# (rc, marker presence) — only when the harness short-circuits (no
+# marker AND rc=1) is the test considered PASS.
+#
+# Args:
+#   $1 = test name (T1/T2/T3)
+#   $2 = env prefix (e.g. "CI=true" or "")
+#   $3 = stdin kind: "closed" (</dev/null) | "piped" (empty file)
+run_t() {
+  local name="$1" env_prefix="$2" stdin_kind="$3"
+  local TMP MARKER HARNESS OUT rc
+  TMP=$(mktemp -d)
+  MARKER="$TMP/install-fired"
+  HARNESS="$TMP/harness.sh"
+  OUT="$TMP/out.log"
+  build_harness "$MARKER" "$HARNESS"
+
+  local INFILE="/dev/null"
+  if [ "$stdin_kind" = "piped" ]; then
+    INFILE="$TMP/in"
+    : > "$INFILE"
+  fi
+
+  # Inline bounded-time runner. macOS lacks GNU `timeout(1)`; emulate
+  # via background-PID polling. Same pattern as
+  # tests/test-check-phase-gate-noninteractive.sh::run_bounded.
+  ( env $env_prefix bash "$HARNESS" <"$INFILE" >"$OUT" 2>&1 ) &
+  local pid=$! deadline=$(( $(date +%s) + 15 ))
+  while kill -0 "$pid" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$deadline" ]; then
+      kill -9 "$pid" 2>/dev/null || true
+      wait "$pid" 2>/dev/null || true
+      fail_ "$name" "harness hung past 15s — prompt_install blocked on read instead of short-circuiting"
+      rm -rf "$TMP"
+      return
+    fi
+    sleep 1
+  done
+  wait "$pid"; rc=$?
+
+  local failed=false
+  if [ -e "$MARKER" ]; then
+    fail_ "$name" "install command fired (marker exists) — eval was reached despite non-interactive context"
+    failed=true
+  fi
+  if [ "$rc" = "0" ]; then
+    fail_ "$name" "prompt_install returned 0 — must return nonzero (decline install) in non-interactive context"
+    failed=true
+  fi
+  if [ "$failed" = "false" ]; then
+    pass "$name: prompt_install short-circuited (rc=$rc, no marker, no hang)"
+  fi
+  rm -rf "$TMP"
+}
+
+# ---------------------------------------------------------------------
+# T1: CI=true + piped stdin → MUST refuse install (no eval).
+# ---------------------------------------------------------------------
+echo "T1: CI=true + piped (non-TTY) stdin — prompt_install MUST refuse install"
+run_t "T1" "CI=true" "piped"
+
+# ---------------------------------------------------------------------
+# T2: stdin closed (EOF, ! -t 0) → MUST refuse install (no eval).
+# ---------------------------------------------------------------------
+echo "T2: stdin closed (EOF, ! -t 0) — prompt_install MUST refuse install"
+run_t "T2" "" "closed"
+
+# ---------------------------------------------------------------------
+# T3: SOIF_NONINTERACTIVE=1 → MUST refuse install (no eval).
+# ---------------------------------------------------------------------
+echo "T3: SOIF_NONINTERACTIVE=1 — prompt_install MUST refuse install"
+run_t "T3" "SOIF_NONINTERACTIVE=1" "piped"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- New CI lint **fix-functions-stderr**: bans `2>/dev/null` / `2>&-` inside `fix_*()` function bodies (auto-fix functions must surface diagnostics for operators running under `--auto-fix`). PR #92 scrubbed three sites; this lint locks in the precedent.
- New CI lint **raw-read-prompt**: bans bare `read -rp` / `read -p` outside `scripts/lib/helpers.sh`. Bare `read -p` hangs unattended invocations (CI / AI-agent runs) or silently auto-defaults; centralized `prompt_input` / `prompt_yes_no` honor `! -t 0` / `CI=true` / `SOIF_NONINTERACTIVE=true` with safe-default returns.
- Added `prompt_yes_no` to `scripts/lib/helpers.sh` (mirrors the hard-N policy first introduced in `check-phase-gate.sh` per PR #87).
- Promoted both new lints into `scripts/pre-commit-gate.sh` (PreToolUse path + `--terminal-mode` path) alongside the existing two — same `SKIP_LINT=1` escape hatch.
- Swept every in-tree site: 2 fix-functions-stderr sites migrated, 9 raw-read sites migrated to `prompt_yes_no` / `prompt_input`, 15 raw-read sites allowlisted with non-empty reasons (interactive-only wizards: `init.sh`, `intake-wizard.sh`, `check-versions.sh` numeric-choice prompts, `check-phase-gate.sh`'s own wrapper).


## Breaking changes

- **`check-gate.sh` confirmation semantics**: piped `echo y | scripts/check-gate.sh --backfill-host` invocations (no `--yes`) are now **refused on non-TTY stdin** under the hard-N policy. Wrapper scripts that previously confirmed with a piped `echo y` must migrate to passing `--yes` explicitly. `tests/test-check-gate.sh::T2` was updated to lock in the new contract.
- **`intake-wizard.sh` non-TTY refusal** (added in the verifier follow-up commit): the wizard now exits 1 at the interactive mode-selection prompt when stdin is not a TTY unless `SOIF_NONINTERACTIVE=1` is set. Flag-driven passthroughs (`--resume`, `--upgrade-track`, `--upgrade-deployment`, `--to-private-poc`, `--to-sponsored-poc`, `--upgrade-to-production`, `--help`) continue to work in CI.

## Findings closed

(slot 5 — cross-cutting CI lint sweep, no specific finding IDs)

## Sites swept

### Pattern 1 — `fix_*()` stderr silencer

| File:line | Fix |
|---|---|
| `scripts/verify-install.sh:778` — `fix_phase_state` | Dropped `2>/dev/null` from `jq` read; malformed `intake-progress.json` now fails loud so the operator can repair it (no half-correct `phase-state.json`). |
| `scripts/verify-install.sh:881` — `fix_intake_suggestions` | Replaced `cp ... 2>/dev/null` with `nullglob`+check so `cp` only fires when source files exist; real `cp` errors surface visibly. |

### Pattern 2 — Raw `read -rp` migrated to `prompt_yes_no` / `prompt_input`

| File:line | Fix |
|---|---|
| `scripts/check-gate.sh:102` | `prompt_yes_no` for `--backfill-host` confirm; CI/non-TTY hard-returns N (prevents auto-Y'ing a manifest mutation). |
| `scripts/process-checklist.sh:446` | `prompt_yes_no` for force-complete confirm (defense-in-depth on top of existing TTY guard). |
| `scripts/process-checklist.sh:1005` | `prompt_yes_no` for reset-process confirm. |
| `scripts/process-checklist.sh:1066` | `prompt_yes_no` for reset-all confirm. |
| `scripts/test-gate.sh:240` | `prompt_yes_no` for `--unrecord-feature` confirm. |
| `scripts/upgrade-project.sh:945` | `prompt_yes_no` for upgrade-plan confirm (preserves "non-interactive mode — proceeding" branch explicitly). |
| `scripts/upgrade-project.sh:1907` | `prompt_yes_no` for auto-install confirm (outer `-t 0` guard already gates this branch). |
| `scripts/verify-install.sh:1333` | `prompt_yes_no` for auto-fix confirm (interactive-only `MODE=interactive` branch). |
| `scripts/check-versions.sh:479` | `prompt_input` for comma-separated selection; CI gets empty default → bounds check below safely skips. |

### Pattern 2 — Raw `read -rp` allowlisted with reason

| File:line | Allowlist reason |
|---|---|
| `scripts/check-phase-gate.sh:50` | Inside its own `prompt_yes_no` wrapper with TTY/CI hard-N guard at lines 40-47; equivalent to `lib/helpers.sh::prompt_yes_no`, retained to avoid a cross-script dependency cycle. |
| `scripts/check-versions.sh:457` | Multi-letter (a/b/c) choice; `prompt_input` / `prompt_yes_no` shape doesn't fit; gated by `-t 0` at line 444. |
| `scripts/intake-wizard.sh:85,88,115,144,146` | Wizard defines its own `prompt_input` / `prompt_choice` / `prompt_with_suggestions` with pause-file semantics; this IS the wizard's centralized prompt helper. |
| `scripts/intake-wizard.sh:1658,1774,1923` | Interactive-only wizard prompts (launch-mode choice, summary confirm, mode selection); wizard is interactive-only by design. |
| `init.sh:396,571,736,781,1955,1977,2042` | Interactive-only init wizard; `NON_INTERACTIVE=true` flag (init.sh:3532) bypasses `collect_inputs_interactive` entirely. The post-1955 attestation prompts also have env-var fast-paths (`REMOTE_URL`, `BRANCH_PROTECTION_ATTESTED`) for non-interactive callers (BL-016). |

## New lint behavior (test results)

**Baseline against `main` BEFORE the sweep:**
```
$ bash scripts/lint-fix-functions-stderr.sh
scripts/verify-install.sh:778: ... fix_phase_state ...
scripts/verify-install.sh:881: ... fix_intake_suggestions ...
2 violation(s) found.

$ bash scripts/lint-raw-read-prompt.sh
... 26 violations across check-gate.sh, check-phase-gate.sh, check-versions.sh,
    intake-wizard.sh (8), process-checklist.sh (3), test-gate.sh, upgrade-project.sh (2),
    verify-install.sh, init.sh (7) ...
26 violation(s) found.
```

**After the sweep (current HEAD):**
```
$ bash scripts/lint-fix-functions-stderr.sh
OK: no fix_*() stderr silencers found.

$ bash scripts/lint-raw-read-prompt.sh
OK: no raw 'read -rp' / 'read -p' calls outside scripts/lib/helpers.sh.

$ bash scripts/lint-counter-antipattern.sh
OK: no counter-capture antipatterns found.

$ bash scripts/lint-backlog-references.sh
OK: backlog references and Closed-status citations are consistent.
```

## Test plan

**TDD — RED → GREEN:**

`tests/test-lint-fix-functions-stderr.sh` (10 tests):
- RED confirmed: `FATAL: linter not found at .../scripts/lint-fix-functions-stderr.sh` before the linter was written.
- GREEN after lint + sweep: `Results: 10 passed, 0 failed` (covers clean fixture, bare silencer, `2>&-`, non-`fix_` exemption, comment exemption, heredoc-body exemption, allowlist+reason, allowlist no-reason error, MERGE-GATE against `HEAD`, `Reports/` skip).

`tests/test-lint-raw-read-prompt.sh` (10 tests):
- RED confirmed similarly.
- GREEN: `Results: 10 passed, 0 failed` (clean / `read -rp` / `read -p` / helpers.sh exempt / comment / `read -r` no `-p` / allowlist+reason / allowlist no-reason / MERGE-GATE / `Reports/` skip).

`tests/test-pre-commit-gate-lints.sh` extended from 8 → 13 tests:
- T8: PreToolUse blocks fix-functions-stderr violation.
- T9: PreToolUse blocks raw-read-prompt violation.
- T10: `SKIP_LINT=1` bypasses all four lints.
- T11a/T11b: `--terminal-mode` fires both new lints.
- `Results: 13 passed, 0 failed`.

`tests/test-check-gate.sh::T2` — contract update:
- Old T2: piped `echo y` to expect manifest mutation (the bug the migration closes).
- New T2: piped `echo y` WITHOUT `--yes` is correctly refused under non-TTY hard-N policy. `Results: 5/5 passed`.

**Other impacted suites verified passing:**
- `tests/test-lint-counter-antipattern.sh` — 12/12 (regression guard for the existing lint).
- `tests/test-lint-backlog-references.sh` — 15/15.
- `tests/test-process-checklist-classifier.sh` — 12/12.
- `tests/test-process-checklist-auto-advance.sh` — 5/5.
- `tests/test-check-phase-gate.sh` — 8/8.
- `tests/test-check-phase-gate-noninteractive.sh` — 3/3.
- `tests/test-test-gate-counter-sanitizer.sh` — 5/5.
- `tests/test-test-gate-null-handling.sh` — 5/5.
- `tests/test-upgrade-project-atomic.sh` — 4/4.
- `tests/test-intake-wizard-fixes.sh` — 7/7.

## Bonus catches

- Added `prompt_yes_no` to `scripts/lib/helpers.sh` (mirror of the hard-N pattern from `check-phase-gate.sh`) and tightened `prompt_input` to honor the same non-interactive default-return contract — previously `prompt_input` could block forever on a piped stdin under `set -u`.
- Replaced `cp ... 2>/dev/null` in `fix_intake_suggestions` with a proper `nullglob`-based pre-test so the function no longer silently skips a real `cp` failure when source files exist.
- Added a fallback inline `prompt_yes_no` in `scripts/check-gate.sh` for the pre-init migration scenario where `lib/helpers.sh` isn't yet present (with a justified allowlist marker on the fallback's inline `read -rp`).
- `tests/test-check-gate.sh::T2` updated to lock in the new non-TTY hard-N contract — the previous test was inadvertently asserting the bug.

## Worktree note

```
/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_0dedbb55-0f8-5
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
