### PR TITLE
docs(closer): 6-doc drift cluster (6 S3 closures)

### DIFF
--- a/docs/extending-platforms.md
+++ b/docs/extending-platforms.md
@@ -22,7 +22,7 @@ The framework is designed for extensibility. Adding a platform requires creating
 
 ## What You Are Creating
 
-Adding a new platform creates up to five components:
+Adding a new platform creates up to six components:
 
 | # | Component | Location | Required? | Purpose |
 |---|---|---|---|---|
@@ -31,6 +31,7 @@ Adding a new platform creates up to five components:
 | 3 | **Release Pipeline** | `templates/pipelines/release/{host}/{platform}.yml` for host ∈ {github, gitlab, bitbucket} | Yes | Per-host release workflow template |
 | 4 | **Intake Suggestions** | `templates/intake-suggestions/{platform}.json` | Recommended | Context-aware suggestions for the intake wizard |
 | 5 | **CI Template Updates** | `templates/pipelines/ci/{host}/*.yml` (line 1 marker) | Yes | Register which languages are available for this platform. `github/` is canonical for language filtering (init.sh:415-417); mirror marker changes to `gitlab/` and `bitbucket/`. |
+| 6 | **UAT References** | `templates/uat/references/{platform}-pre-flight.html` + `templates/uat/references/{platform}-scenario.json` | Recommended (Required for non-`other`) | Per-platform UAT canned reference (pre-flight HTML + scenario JSON). `init.sh` copies them to `tests/uat/examples/` in generated projects so UAT session agents have a worked example. Missing files trigger a `print_warn` fall-back to the `other`-platform co-build protocol. |
 
 **Naming convention:** Use lowercase identifier matching the form accepted by `init.sh --platform <name>`. Snake_case (`mcp_server`) is canonical for multi-word platforms; new platforms should follow the same convention. This name becomes the directory/filename slug used everywhere and appears as a selectable option in `init.sh`.
 
@@ -40,9 +41,9 @@ Adding a new platform creates up to five components:
 
 The init script discovers platforms and languages from the filesystem at runtime. No hardcoded lists.
 
-**Platform discovery** (init.sh lines 275-297):
+**Platform discovery** (init.sh lines 346-368):
 1. Scans `docs/platform-modules/*.md` — each filename (minus `.md`) becomes a platform option
-2. Scans `templates/pipelines/release/*.yml` — adds any platforms not already found
+2. Scans `templates/pipelines/release/github/*.yml` — adds any platforms not already found. The `github/` subtree is canonical for discovery (per spec 2026-04-21, all hosts ship the same platform set, so `init.sh` only reads `github/`)
 3. Appends "other" as a fallback
 
 **Language filtering** (init.sh lines 415-417):
@@ -197,9 +198,19 @@ done
 
 ### Step 3: Release Pipeline
 
-**File:** `templates/pipelines/release/{platform}.yml`
+**File:** `templates/pipelines/release/{host}/{platform}.yml` — one per host ∈ {`github`, `bitbucket`, `gitlab`}.
 
-A GitHub Actions workflow template for releasing projects on this platform. The init script copies this file into the generated project as `.github/workflows/release.yml`.
+A release workflow template for releasing projects on this platform. The init script copies the correct file into the generated project based on the selected `--git-host` (see `generate_release` in init.sh:2584):
+
+| Host | Source path | Output path in generated project |
+|---|---|---|
+| `github` | `templates/pipelines/release/github/{platform}.yml` | `.github/workflows/release.yml` |
+| `bitbucket` | `templates/pipelines/release/bitbucket/{platform}.yml` | `bitbucket-pipelines/release.yml` |
+| `gitlab` | `templates/pipelines/release/gitlab/{platform}.yml` | `.gitlab-ci/release.yml` |
+
+The `github/` subtree is **canonical for platform discovery** — `init.sh` only reads `github/*.yml` when building the platform menu (see init.sh:346-368). Contributors adding a new platform **must** create the release pipeline in all three host directories. At minimum, mirror the github template into `bitbucket/` and `gitlab/`; otherwise users on those hosts hit the `print_info "No release pipeline template for platform … on host …"` branch in `generate_release` (init.sh:2598-2601) and ship with no release pipeline at all.
+
+The GitHub Actions example below is the canonical shape. The bitbucket/gitlab variants follow the host's native pipeline syntax — see existing `templates/pipelines/release/bitbucket/web.yml` and `templates/pipelines/release/gitlab/web.yml` for reference shapes.
 
 **Required structure:**
 
@@ -340,6 +351,40 @@ Each CI template has a platform marker on line 1 that controls which languages a
 
 **Always update `other.yml`** — the "other" template is the catch-all and should list every platform.
 
+### Step 6: UAT Reference Files
+
+**Files:**
+- `templates/uat/references/{platform}-pre-flight.html`
+- `templates/uat/references/{platform}-scenario.json`
+
+These are the platform-specific UAT canned reference pair (per spec 2026-04-23-uat-template-quality-design.md § Flow A). They give the UAT session agent a concrete shape to emulate when generating pre-flight blocks and scenarios for the new platform — without them, UAT quality regresses to the generic `other` co-build protocol.
+
+**What each file contains:**
+
+| File | Contents | Authoring guide reference |
+|---|---|---|
+| `{platform}-pre-flight.html` | Worked example of the pre-flight HTML block: system-under-test description, tooling, accounts, optional dependencies, one-time setup. Should mirror the structure of the existing `web-pre-flight.html` / `desktop-pre-flight.html` / `mobile-pre-flight.html` / `mcp_server-pre-flight.html`. | `docs/uat-authoring-guide.md` §3.1–3.4 |
+| `{platform}-scenario.json` | Worked example of a single scenario (or short scenarios array) showing the platform's typical anchor styles (exact-string match, exit-code, response-shape, on-screen text, etc.). | `docs/uat-authoring-guide.md` §4.1–4.4 |
+
+**How `init.sh` uses them** (init.sh:1187-1207):
+
+```text
+mkdir -p tests/uat/templates tests/uat/sessions tests/uat/examples
+cp .../test-session-template.{md,html} tests/uat/templates/
+if [ "$PLATFORM" != "other" ] && [ -f templates/uat/references/${PLATFORM}-pre-flight.html ] && [ -f templates/uat/references/${PLATFORM}-scenario.json ]; then
+  cp templates/uat/references/${PLATFORM}-pre-flight.html tests/uat/examples/pre-flight-reference.html
+  cp templates/uat/references/${PLATFORM}-scenario.json   tests/uat/examples/scenario-reference.json
+elif [ "$PLATFORM" = "other" ]; then
+  print_info "... no UAT canned reference copied ... co-build Q&A protocol per docs/reference/uat-authoring-guide.md § 5"
+else
+  print_warn "UAT reference files not found for platform '$PLATFORM'. Falling back to 'other'-style co-build protocol; see docs/reference/uat-authoring-guide.md § 5."
+fi
+```
+
+When **both files are present**, they are copied into the generated project at `tests/uat/examples/pre-flight-reference.html` and `tests/uat/examples/scenario-reference.json`. When **either file is missing** for a non-`other` platform, `init.sh` emits the `print_warn` fallback above and the project ships without canned references — the session agent must then run the `other`-style co-build protocol with the Orchestrator.
+
+**Authoring guidance:** Read `docs/uat-authoring-guide.md` §3 (per-platform pre-flight patterns) and §4 (per-platform scenario patterns) before writing the new reference pair. Add a new subsection to each of those §§ describing the platform's pre-flight requirements and scenario shapes — per `docs/uat-authoring-guide.md` §7 (Extending for a new platform), this is one of the three things that must happen for UAT parity when adding a new first-class platform.
+
 ---
 
 ## Validation Checklist
@@ -350,10 +395,14 @@ After creating all components, verify your platform works end-to-end:
 
 - [ ] `docs/platform-modules/{platform}.md` exists
 - [ ] `evaluation-prompts/Projects/modules/{platform}.md` exists
-- [ ] `templates/pipelines/release/{platform}.yml` exists
+- [ ] `templates/pipelines/release/github/{platform}.yml` exists (canonical for discovery)
+- [ ] `templates/pipelines/release/bitbucket/{platform}.yml` exists
+- [ ] `templates/pipelines/release/gitlab/{platform}.yml` exists
 - [ ] `templates/intake-suggestions/{platform}.json` exists (recommended)
-- [ ] Relevant `templates/pipelines/ci/*.yml` files updated with platform marker
-- [ ] `templates/pipelines/ci/other.yml` includes your platform in its marker
+- [ ] Relevant `templates/pipelines/ci/{host}/*.yml` files updated with platform marker (all three host trees: github/gitlab/bitbucket)
+- [ ] `templates/pipelines/ci/{host}/other.yml` includes your platform in its marker
+- [ ] `templates/uat/references/{platform}-pre-flight.html` exists (recommended; required for non-`other`)
+- [ ] `templates/uat/references/{platform}-scenario.json` exists (recommended; required for non-`other`)
 
 ### Platform Module Completeness
 

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -198,6 +198,22 @@ For personal projects, gate denial is a self-assessment finding. Record the find
 
 During Phase 2 (Construction, 2-4 weeks), the Orchestrator will make decisions that don't trigger formal escalation but are significant enough to record. Maintain a running decision log capturing: date, decision, rationale, alternatives considered. This log is reviewed at the Phase 3 gate by the Senior Technical Authority.
 
+### Mid-Phase 2 Governance Checkpoint (Organizational)
+
+For organizational deployments, the Orchestrator holds a biweekly (every two weeks) status review with the Senior Technical Authority for the duration of Phase 2. The checkpoint is mandatory for organizational projects; personal deployments may use it at their discretion.
+
+**Scope (30 minutes maximum):**
+
+- Features delivered vs. PROJECT_BIBLE.md scope — call out any drift early.
+- Architectural deviations from the Phase 1 design — note rationale and intent to merge back, refactor, or escalate.
+- Test pass rate trend (unit, integration, E2E) — flag regressions.
+- Unresolved security findings (Semgrep, dependency scanners) — confirm triage and owner.
+- Risk register delta (new risks, changed severity, mitigations in flight).
+
+**Outcomes are recorded as rows in the In-Phase Decision Log** (date, topic, decision, rationale, follow-up). The Senior Technical Authority does not approve or block at this cadence — the checkpoint is course-correction-oriented, not gate-style.
+
+**This checkpoint does not replace the Phase 3 gate.** The Phase 3 gate remains the formal go/no-go decision point for production readiness. The Mid-Phase 2 checkpoint exists so the Phase 3 gate is not the first time the Senior Technical Authority sees the project's state.
+
 ### Escalation Path
 
 The Orchestrator must escalate when:

--- a/docs/uat-authoring-guide.md
+++ b/docs/uat-authoring-guide.md
@@ -32,7 +32,7 @@ Common pre-flight content for web:
 - **Optional tools:** devtools for scenarios that use Network/Console.
 - **One-time setup:** open URL → sign in → confirm no console errors.
 
-Reference file: `templates/uat/references/web-pre-flight.html`.
+Reference file (framework source): `templates/uat/references/web-pre-flight.html`; in a generated project: `tests/uat/examples/pre-flight-reference.html` (copied by init.sh:1187-1207 when the project's platform is `web`).
 
 ### 3.2 desktop
 
@@ -45,7 +45,7 @@ Common pre-flight content for desktop:
 - **Required tools:** `git`, `jq`, `python`/`node`/`cargo`/`go` per stack.
 - **One-time setup:** three lines max — `cd`, activate, version check.
 
-Reference file: `templates/uat/references/desktop-pre-flight.html`.
+Reference file (framework source): `templates/uat/references/desktop-pre-flight.html`; in a generated project: `tests/uat/examples/pre-flight-reference.html` (copied by init.sh:1187-1207 when the project's platform is `desktop`).
 
 ### 3.3 mobile
 
@@ -58,7 +58,7 @@ Common pre-flight content for mobile:
 - **Optional tools:** screen recording for scenarios that benefit from tap-sequence capture.
 - **One-time setup:** install, launch, onboard, sign in, confirm home.
 
-Reference file: `templates/uat/references/mobile-pre-flight.html`.
+Reference file (framework source): `templates/uat/references/mobile-pre-flight.html`; in a generated project: `tests/uat/examples/pre-flight-reference.html` (copied by init.sh:1187-1207 when the project's platform is `mobile`).
 
 ### 3.4 mcp_server
 
@@ -71,7 +71,7 @@ Common pre-flight content for mcp_server:
 - **Auth:** env var exports (e.g., `MCP_API_KEY`).
 - **One-time setup:** export env → start Inspector against server → confirm connection.
 
-Reference file: `templates/uat/references/mcp_server-pre-flight.html`.
+Reference file (framework source): `templates/uat/references/mcp_server-pre-flight.html`; in a generated project: `tests/uat/examples/pre-flight-reference.html` (copied by init.sh:1187-1207 when the project's platform is `mcp_server`).
 
 ## 4. Per-platform scenario patterns
 
@@ -84,7 +84,7 @@ Example anchor styles:
 - "The /items list shows the new record at the top with category 'general'."
 - "After deletion, GET /api/items/<id> would return 404."
 
-Reference file: `templates/uat/references/web-scenario.json`.
+Reference file (framework source): `templates/uat/references/web-scenario.json`; in a generated project: `tests/uat/examples/scenario-reference.json` (copied by init.sh:1187-1207 when the project's platform is `web`).
 
 ### 4.2 desktop
 
@@ -95,7 +95,7 @@ Example anchor styles:
 - "`git diff --exit-code` returns 0 and prints 'RESTORED'."
 - "Output contains `total=42` on a single line."
 
-Reference file: `templates/uat/references/desktop-scenario.json`.
+Reference file (framework source): `templates/uat/references/desktop-scenario.json`; in a generated project: `tests/uat/examples/scenario-reference.json` (copied by init.sh:1187-1207 when the project's platform is `desktop`).
 
 ### 4.3 mobile
 
@@ -106,7 +106,7 @@ Example anchor styles:
 - "Sync indicator appears for ≥1 second, then disappears; post appears in the list."
 - "No crash dialog. App does not return to the home screen."
 
-Reference file: `templates/uat/references/mobile-scenario.json`.
+Reference file (framework source): `templates/uat/references/mobile-scenario.json`; in a generated project: `tests/uat/examples/scenario-reference.json` (copied by init.sh:1187-1207 when the project's platform is `mobile`).
 
 ### 4.4 mcp_server
 
@@ -117,7 +117,7 @@ Example anchor styles:
 - "`response.result.total` is the integer 25."
 - "Response does not contain an `error` field at the top level."
 
-Reference file: `templates/uat/references/mcp_server-scenario.json`.
+Reference file (framework source): `templates/uat/references/mcp_server-scenario.json`; in a generated project: `tests/uat/examples/scenario-reference.json` (copied by init.sh:1187-1207 when the project's platform is `mcp_server`).
 
 ## 5. Co-build protocol for 'other' platform
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1029,6 +1029,7 @@ If any check fails, return to the Build Loop. Do not proceed to Phase 3.
 
 | Your Action | Personal | Organizational |
 |---|---|---|
+| If `poc_mode` is set, run `scripts/upgrade-project.sh --to-production` first (see §1.2). Phase 4 is hard-blocked otherwise at both `check-phase-gate.sh` and `process-checklist.sh --start-phase4`. | Required | Required |
 | Verify production build on all target platforms | Same | Same |
 | Configure secrets in CI/CD (API keys, signing certs, deployment credentials) | Same | Same |
 | Review incident response playbook (INCIDENT_RESPONSE.md) | Self-review | Same — share with backup maintainer |

--- a/init.sh
+++ b/init.sh
@@ -1114,6 +1114,13 @@ create_project() {
   cp "$SCRIPT_DIR/docs/cli-setup-addendum.md" docs/reference/
   cp "$SCRIPT_DIR/docs/user-guide.md" docs/reference/
   cp "$SCRIPT_DIR/docs/security-scan-guide.md" docs/reference/
+  # Audit uat-authoring-guide-2 (2026-06): the UAT authoring guide is
+  # referenced by init.sh's UAT-references fallback print_* strings AND
+  # by templates/uat/test-session-template.html line ~95. Without copying
+  # it into the generated project, those references resolve to nothing
+  # once the operator leaves the framework repo. Mirrors the pattern for
+  # the six sibling docs above.
+  cp "$SCRIPT_DIR/docs/uat-authoring-guide.md" docs/reference/
 
   # Copy evaluation prompts (project-level reviews for Phase 3 validation)
   print_info "Copying evaluation prompts..."
@@ -1201,9 +1208,9 @@ create_project() {
   elif [ "$PLATFORM" = "other" ]; then
     print_info "Platform is 'other' — no UAT canned reference copied."
     print_info "When starting a UAT session, the agent will run the co-build Q&A"
-    print_info "protocol with you per docs/uat-authoring-guide.md § 5."
+    print_info "protocol with you per docs/reference/uat-authoring-guide.md § 5."
   else
-    print_warn "UAT reference files not found for platform '$PLATFORM'. Falling back to 'other'-style co-build protocol; see docs/uat-authoring-guide.md § 5."
+    print_warn "UAT reference files not found for platform '$PLATFORM'. Falling back to 'other'-style co-build protocol; see docs/reference/uat-authoring-guide.md § 5."
   fi
 
   # Copy the correct platform module (auto-discovered)

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -2121,17 +2121,17 @@ if [ -d tests/uat/templates ] || [ -d tests/uat ]; then
     print_ok "UAT reference pair copied for platform '$uat_platform'"
   elif [ "$uat_platform" = "other" ]; then
     print_info "Platform is 'other' — UAT reference is co-build protocol."
-    print_info "See docs/uat-authoring-guide.md § 5 next time you start a UAT session."
+    print_info "See docs/reference/uat-authoring-guide.md § 5 next time you start a UAT session."
   else
-    print_warn "UAT platform unknown (intake-progress.json missing or lacks 'platform' field). Skipping reference copy; see docs/uat-authoring-guide.md."
+    print_warn "UAT platform unknown (intake-progress.json missing or lacks 'platform' field). Skipping reference copy; see docs/reference/uat-authoring-guide.md."
   fi
 
   echo ""
   print_info "UAT quality guardrails now active. Next UAT session should:"
-  print_info "  1. Read templates/uat/test-session-template.html's embedded checklist"
+  print_info "  1. Read tests/uat/templates/test-session-template.html's embedded checklist"
   print_info "  2. Use tests/uat/examples/ as shape references (first-class platforms)"
   print_info "  3. Run scripts/lint-uat-scenarios.sh <populated-file> before saving"
-  print_info "See docs/uat-authoring-guide.md for details."
+  print_info "See docs/reference/uat-authoring-guide.md for details."
   echo ""
 fi
 

--- a/templates/generated/claude-md.tmpl
+++ b/templates/generated/claude-md.tmpl
@@ -183,7 +183,7 @@ At specific phases, adopt specialized personas for higher-quality output. Each p
   1a. Start the UAT checklist: `scripts/process-checklist.sh --start-uat N` (where N is the session number)
   2. If blocked: dispatch parallel test agents (automated suite, exploratory, cross-platform)
   3. Generate test template for human tester(s) and wait for results
-  3a. **Quality gate:** run `scripts/lint-uat-scenarios.sh <populated-file>` on the generated template. Must exit 0 before dispatch. If exit 1: read violations, revise scenarios, re-run. If exit 2: investigate file/JSON integrity. See `docs/uat-authoring-guide.md § 6` for details.
+  3a. **Quality gate:** run `scripts/lint-uat-scenarios.sh <populated-file>` on the generated template. Must exit 0 before dispatch. If exit 1: read violations, revise scenarios, re-run. If exit 2: investigate file/JSON integrity. See `docs/reference/uat-authoring-guide.md § 6` for details.
   4. Verify submission completeness — list incomplete scenarios, ask to continue or finish
   5. Consolidate all results into bug tracker
   6. Triage with Orchestrator (Fix Now / Defer / Won't Fix / Post-MVP)
@@ -204,7 +204,7 @@ At specific phases, adopt specialized personas for higher-quality output. Each p
   - Abort a started Build Loop: `scripts/process-checklist.sh --reset build_loop` (interactive)
   - All three require terminal access and Y/N confirmation; each writes an audit entry to `.claude/process-audit.log`. These are **local-state fixes only** — if the state was committed, amend or revert the commit separately.
 - **UAT authoring:**
-  - Full per-platform guidance + co-build protocol for 'other' platforms: `docs/uat-authoring-guide.md`
+  - Full per-platform guidance + co-build protocol for 'other' platforms: `docs/reference/uat-authoring-guide.md`
   - Quality linter: `scripts/lint-uat-scenarios.sh <populated-file>`
   - Platform-specific reference examples: `tests/uat/examples/` (populated by init.sh based on your project's platform)
 

--- a/templates/uat/test-session-template.html
+++ b/templates/uat/test-session-template.html
@@ -92,7 +92,7 @@
   worked example (populated by init.sh based on your project's platform).
   If your project's platform is 'other', the reference file is NOT provided
   — ask the Orchestrator the co-build questions in
-  docs/uat-authoring-guide.md § "Co-build protocol for 'other' platform"
+  docs/reference/uat-authoring-guide.md § "Co-build protocol for 'other' platform"
   before generating this block.
 -->
 __TESTER_PRE_FLIGHT__

--- a/templates/uat/test-session-template.md
+++ b/templates/uat/test-session-template.md
@@ -26,7 +26,7 @@ _Every UAT test must begin with a clear statement of the test environment and on
 - **Required tools:** _list._ Optional: _list, with scenario numbers that require each_
 - **One-time setup:** _the commands or steps you ran once before starting_
 
-For richer per-platform guidance — including quality checklist, anti-patterns, reference examples, and the co-build protocol for 'other' platforms — see `templates/uat/test-session-template.html` and `docs/uat-authoring-guide.md`.
+For richer per-platform guidance — including quality checklist, anti-patterns, reference examples, and the co-build protocol for 'other' platforms — see `tests/uat/templates/test-session-template.html` and `docs/reference/uat-authoring-guide.md` (both copied into the project at init time).
 
 ---
 

--- a/tests/test-docs-cluster-six-pack.sh
+++ b/tests/test-docs-cluster-six-pack.sh
@@ -1,0 +1,415 @@
+#!/usr/bin/env bash
+# tests/test-docs-cluster-six-pack.sh
+#
+# Docs/code-lint tests for six S3 audit findings closed by
+# PR docs/cluster-six-pack-closer:
+#
+#   T1 (user-guide-3): docs/user-guide.md §5 Phase 4 user-actions table
+#       must include a POC precondition row directing operators to run
+#       scripts/upgrade-project.sh --to-production first when poc_mode
+#       is set. The row must be marked Required for both Personal and
+#       Organizational columns.
+#
+#   T2 (governance-framework-4): docs/governance-framework.md §V must
+#       include a 'Mid-Phase 2 Governance Checkpoint' subsection covering
+#       the biweekly Senior-Technical-Authority status review (org-only,
+#       30-min cap, recorded in the In-Phase Decision Log, does not
+#       replace the Phase 3 gate).
+#
+#   T3 (extending-platforms-1): docs/extending-platforms.md release-pipeline
+#       references must use the per-host path templates/pipelines/release/
+#       {host}/{platform}.yml, name all three hosts (github/bitbucket/gitlab),
+#       and document that github is canonical for discovery. The legacy
+#       flat-dir path templates/pipelines/release/{platform}.yml must be
+#       gone from the file-table row, Step 3 'File:' line, and the
+#       Auto-Discovery section. Step 3 must instruct contributors to add
+#       per-host copies.
+#
+#   T4 (extending-platforms-5): docs/extending-platforms.md 'What You Are
+#       Creating' table must list six components, with a row for UAT
+#       References (templates/uat/references/{platform}-pre-flight.html +
+#       {platform}-scenario.json). A 'Step 6: UAT Reference Files' section
+#       must exist documenting both files, init.sh's copy to
+#       tests/uat/examples/, the print_warn fallback, and pointer to
+#       docs/uat-authoring-guide.md.
+#
+#   T5 (uat-authoring-guide-1): docs/uat-authoring-guide.md §§3.1–3.4
+#       and §§4.1–4.3 'Reference file:' lines must cite BOTH the
+#       framework-source path (templates/uat/references/...) AND the
+#       post-init path (tests/uat/examples/...), so the agent gets the
+#       correct path regardless of which repo they're in.
+#
+#   T6 (uat-authoring-guide-2): init.sh's project-bootstrap doc copy
+#       block must include docs/uat-authoring-guide.md. The two init.sh
+#       print_* fallback strings that reference the guide must point at
+#       docs/reference/uat-authoring-guide.md § 5. Likewise
+#       templates/uat/test-session-template.html line ~95 must reference
+#       the in-project path.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+USER_GUIDE="$REPO_ROOT/docs/user-guide.md"
+GOV_FRAMEWORK="$REPO_ROOT/docs/governance-framework.md"
+EXT_PLATFORMS="$REPO_ROOT/docs/extending-platforms.md"
+UAT_GUIDE="$REPO_ROOT/docs/uat-authoring-guide.md"
+INIT_SH="$REPO_ROOT/init.sh"
+UAT_HTML_TMPL="$REPO_ROOT/templates/uat/test-session-template.html"
+
+for f in "$USER_GUIDE" "$GOV_FRAMEWORK" "$EXT_PLATFORMS" "$UAT_GUIDE" "$INIT_SH" "$UAT_HTML_TMPL"; do
+  if [ ! -f "$f" ]; then
+    echo "FATAL: required file not found: $f" >&2
+    exit 2
+  fi
+done
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ----------------------------------------------------------------
+# T1 (user-guide-3): Phase 4 user-actions table has a POC precondition
+# row pointing at upgrade-project.sh --to-production.
+# ----------------------------------------------------------------
+echo ""
+echo "T1 (user-guide-3): Phase 4 user-actions table has POC precondition row"
+
+# The Phase 4 section starts at the '### Phase 4: Release & Maintenance'
+# heading and ends at the next '### ' heading (or the Phase 4 details
+# block). Extract just that span and look inside for the POC row.
+phase4_block=$(awk '
+  /^### Phase 4:/ { capture=1 }
+  capture && /^### / && !/^### Phase 4:/ { exit }
+  capture { print }
+' "$USER_GUIDE")
+
+if [ -z "$phase4_block" ]; then
+  fail_ "T1-pre" "Could not isolate Phase 4 section in user-guide.md"
+else
+  # Row must explicitly call out poc_mode AND the upgrade-project.sh
+  # --to-production command AND be Required in both columns.
+  if printf '%s\n' "$phase4_block" \
+       | grep -qE '\|.*poc_mode.*upgrade-project\.sh.*--to-production.*\|.*Required.*\|.*Required.*\|'; then
+    pass "T1: Phase 4 table has POC precondition row (poc_mode + upgrade-project.sh --to-production + Required/Required)"
+  else
+    fail_ "T1" "Phase 4 user-actions table does not contain a POC precondition row matching '| ... poc_mode ... upgrade-project.sh --to-production ... | Required | Required |'"
+  fi
+fi
+
+# ----------------------------------------------------------------
+# T2 (governance-framework-4): §V has a 'Mid-Phase 2 Governance
+# Checkpoint' subsection with the required content.
+# ----------------------------------------------------------------
+echo ""
+echo "T2 (governance-framework-4): §V has Mid-Phase 2 Governance Checkpoint subsection"
+
+# Find the subsection heading. Must be inside §V (between '## V.' and
+# the next '## ' heading).
+section_v_block=$(awk '
+  /^## V\. / { capture=1 }
+  capture && /^## / && !/^## V\. / { exit }
+  capture { print }
+' "$GOV_FRAMEWORK")
+
+if [ -z "$section_v_block" ]; then
+  fail_ "T2-pre" "Could not isolate §V in governance-framework.md"
+else
+  if printf '%s\n' "$section_v_block" | grep -qE '^### Mid-Phase 2 Governance Checkpoint'; then
+    pass "T2a: §V has 'Mid-Phase 2 Governance Checkpoint' subsection heading"
+  else
+    fail_ "T2a" "§V missing '### Mid-Phase 2 Governance Checkpoint' subsection heading"
+  fi
+
+  # The body must mention biweekly cadence, Senior Technical Authority,
+  # 30 minutes (or 30-min) cap, and the In-Phase Decision Log linkage.
+  mp2_body=$(printf '%s\n' "$section_v_block" | awk '
+    /^### Mid-Phase 2 Governance Checkpoint/ { capture=1; next }
+    capture && /^### / { exit }
+    capture { print }
+  ')
+
+  if printf '%s\n' "$mp2_body" | grep -qiE 'biweekly|every two weeks|every 2 weeks'; then
+    pass "T2b: Mid-Phase 2 body specifies biweekly cadence"
+  else
+    fail_ "T2b" "Mid-Phase 2 body does not specify biweekly cadence"
+  fi
+
+  if printf '%s\n' "$mp2_body" | grep -q 'Senior Technical Authority'; then
+    pass "T2c: Mid-Phase 2 body names Senior Technical Authority"
+  else
+    fail_ "T2c" "Mid-Phase 2 body does not name Senior Technical Authority"
+  fi
+
+  if printf '%s\n' "$mp2_body" | grep -qiE '30[- ]min|30 minutes'; then
+    pass "T2d: Mid-Phase 2 body specifies 30-minute duration cap"
+  else
+    fail_ "T2d" "Mid-Phase 2 body does not specify a 30-minute duration cap"
+  fi
+
+  if printf '%s\n' "$mp2_body" | grep -q 'In-Phase Decision Log'; then
+    pass "T2e: Mid-Phase 2 body references the In-Phase Decision Log"
+  else
+    fail_ "T2e" "Mid-Phase 2 body does not reference the In-Phase Decision Log"
+  fi
+
+  # The checkpoint must NOT replace the Phase 3 gate; spell that out.
+  if printf '%s\n' "$mp2_body" | grep -qiE 'does not replace|not a replacement for|in addition to'; then
+    pass "T2f: Mid-Phase 2 body states the checkpoint does not replace the Phase 3 gate"
+  else
+    fail_ "T2f" "Mid-Phase 2 body does not explicitly state it does not replace the Phase 3 gate"
+  fi
+fi
+
+# ----------------------------------------------------------------
+# T3 (extending-platforms-1): per-host release-pipeline path is used
+# in the file-table row, Step 3 'File:' line, and Auto-Discovery.
+# ----------------------------------------------------------------
+echo ""
+echo "T3 (extending-platforms-1): release-pipeline references use per-host path"
+
+# T3a: the Step 3 'File:' line must NOT be the flat-dir path.
+if grep -qE '^\*\*File:\*\*\s+`templates/pipelines/release/\{platform\}\.yml`' "$EXT_PLATFORMS"; then
+  fail_ "T3a" "Step 3 'File:' line still uses the flat-dir path templates/pipelines/release/{platform}.yml (should be per-host: {host}/{platform}.yml)"
+else
+  pass "T3a: Step 3 'File:' line no longer uses the flat-dir templates/pipelines/release/{platform}.yml path"
+fi
+
+# T3b: Step 3 'File:' line uses the per-host path.
+if grep -qE '^\*\*File:\*\*\s+`templates/pipelines/release/\{host\}/\{platform\}\.yml`' "$EXT_PLATFORMS"; then
+  pass "T3b: Step 3 'File:' line uses the per-host path templates/pipelines/release/{host}/{platform}.yml"
+else
+  fail_ "T3b" "Step 3 'File:' line does not use the per-host path templates/pipelines/release/{host}/{platform}.yml"
+fi
+
+# T3c: Auto-Discovery section must name the github subdirectory, not
+# the flat templates/pipelines/release/*.yml path.
+autodisc_block=$(awk '
+  /^## Auto-Discovery/ { capture=1 }
+  capture && /^## / && !/^## Auto-Discovery/ { exit }
+  capture { print }
+' "$EXT_PLATFORMS")
+
+if printf '%s\n' "$autodisc_block" | grep -qE 'templates/pipelines/release/github/\*\.yml'; then
+  pass "T3c: Auto-Discovery references the github subdirectory (canonical for discovery)"
+else
+  fail_ "T3c" "Auto-Discovery does not reference templates/pipelines/release/github/*.yml as the canonical discovery tree"
+fi
+
+# T3d: the legacy flat 'Scans templates/pipelines/release/*.yml' bullet
+# (without the github subdir) must be gone — that path is misleading.
+if printf '%s\n' "$autodisc_block" | grep -qE 'Scans\s+\`templates/pipelines/release/\*\.yml\`'; then
+  fail_ "T3d" "Auto-Discovery still says 'Scans templates/pipelines/release/*.yml' (flat dir — wrong; the actual scan is github/ only)"
+else
+  pass "T3d: Auto-Discovery no longer cites the flat templates/pipelines/release/*.yml path"
+fi
+
+# T3e: 'What You Are Creating' table row 3 (Release Pipeline) uses the
+# per-host path and names all three hosts (github/bitbucket/gitlab).
+table_block=$(awk '
+  /^## What You Are Creating/ { capture=1 }
+  capture && /^## / && !/^## What You Are Creating/ { exit }
+  capture { print }
+' "$EXT_PLATFORMS")
+
+if printf '%s\n' "$table_block" | grep -qE 'templates/pipelines/release/\{host\}/\{platform\}\.yml' \
+   && printf '%s\n' "$table_block" | grep -q 'github' \
+   && printf '%s\n' "$table_block" | grep -q 'bitbucket' \
+   && printf '%s\n' "$table_block" | grep -q 'gitlab'; then
+  pass "T3e: 'What You Are Creating' table row 3 uses per-host path and names github/bitbucket/gitlab"
+else
+  fail_ "T3e" "'What You Are Creating' table row 3 does not use per-host path or does not name all three hosts (github/bitbucket/gitlab)"
+fi
+
+# T3f: Step 3 body must instruct contributors to add per-host copies
+# (or at minimum mention all three host directories explicitly).
+step3_block=$(awk '
+  /^### Step 3: Release Pipeline/ { capture=1 }
+  capture && /^### Step 4/ { exit }
+  capture { print }
+' "$EXT_PLATFORMS")
+
+if printf '%s\n' "$step3_block" | grep -qE 'bitbucket' \
+   && printf '%s\n' "$step3_block" | grep -qE 'gitlab' \
+   && printf '%s\n' "$step3_block" | grep -qE 'github'; then
+  pass "T3f: Step 3 body names all three host directories (github/bitbucket/gitlab)"
+else
+  fail_ "T3f" "Step 3 body does not name all three host directories"
+fi
+
+# ----------------------------------------------------------------
+# T4 (extending-platforms-5): table lists six components with UAT
+# References row, and Step 6 section exists.
+# ----------------------------------------------------------------
+echo ""
+echo "T4 (extending-platforms-5): table has UAT References row + Step 6 section exists"
+
+# T4a: 'What You Are Creating' table includes a row referencing
+# templates/uat/references/{platform}-pre-flight.html and -scenario.json.
+if printf '%s\n' "$table_block" \
+     | grep -qE 'templates/uat/references/\{platform\}-pre-flight\.html'; then
+  pass "T4a: 'What You Are Creating' table includes UAT References row (pre-flight.html)"
+else
+  fail_ "T4a" "'What You Are Creating' table missing UAT References row (templates/uat/references/{platform}-pre-flight.html)"
+fi
+
+if printf '%s\n' "$table_block" \
+     | grep -qE 'templates/uat/references/\{platform\}-scenario\.json'; then
+  pass "T4b: 'What You Are Creating' table includes UAT References row (scenario.json)"
+else
+  fail_ "T4b" "'What You Are Creating' table missing UAT References row (templates/uat/references/{platform}-scenario.json)"
+fi
+
+# T4c: numbered row 6 in the table exists (six rows total).
+if printf '%s\n' "$table_block" | grep -qE '^\|\s*6\s*\|'; then
+  pass "T4c: 'What You Are Creating' table has a 6th numbered row"
+else
+  fail_ "T4c" "'What You Are Creating' table does not have a 6th numbered row"
+fi
+
+# T4d: a 'Step 6: UAT Reference Files' section exists.
+if grep -qE '^### Step 6: UAT Reference Files' "$EXT_PLATFORMS"; then
+  pass "T4d: 'Step 6: UAT Reference Files' section exists"
+else
+  fail_ "T4d" "Missing '### Step 6: UAT Reference Files' section"
+fi
+
+# T4e: Step 6 body mentions both files, the tests/uat/examples copy
+# target, the print_warn fallback, and points at the UAT authoring guide.
+step6_block=$(awk '
+  /^### Step 6: UAT Reference Files/ { capture=1 }
+  capture && /^### / && !/^### Step 6/ { exit }
+  capture && /^## / && !/^### Step 6/ { exit }
+  capture { print }
+' "$EXT_PLATFORMS")
+
+if printf '%s\n' "$step6_block" | grep -q 'tests/uat/examples'; then
+  pass "T4e1: Step 6 body mentions tests/uat/examples copy target"
+else
+  fail_ "T4e1" "Step 6 body does not mention tests/uat/examples"
+fi
+
+if printf '%s\n' "$step6_block" | grep -qE 'print_warn|fallback'; then
+  pass "T4e2: Step 6 body mentions the print_warn fallback"
+else
+  fail_ "T4e2" "Step 6 body does not mention the print_warn fallback"
+fi
+
+if printf '%s\n' "$step6_block" | grep -q 'uat-authoring-guide'; then
+  pass "T4e3: Step 6 body points at docs/uat-authoring-guide.md"
+else
+  fail_ "T4e3" "Step 6 body does not point at docs/uat-authoring-guide.md"
+fi
+
+# ----------------------------------------------------------------
+# T5 (uat-authoring-guide-1): §§3.1–3.4 and §§4.1–4.3 'Reference file'
+# lines cite BOTH source and post-init paths.
+# ----------------------------------------------------------------
+echo ""
+echo "T5 (uat-authoring-guide-1): Reference-file lines cite both source and post-init paths"
+
+# Count 'Reference file' lines that mention the framework source path.
+src_refs=$(grep -cE 'Reference file.*templates/uat/references' "$UAT_GUIDE" || true)
+case "$src_refs" in ''|*[!0-9]*) src_refs=0 ;; esac
+# Count 'Reference file' lines that mention the post-init project path.
+post_refs=$(grep -cE 'Reference file.*tests/uat/examples' "$UAT_GUIDE" || true)
+case "$post_refs" in ''|*[!0-9]*) post_refs=0 ;; esac
+
+# There are 7 reference-file lines total (4 pre-flight + 3 scenario);
+# every one must cite both paths. Use a tight equality assertion.
+if [ "$src_refs" -ge 7 ]; then
+  pass "T5a: at least 7 'Reference file' lines cite the framework source path (got $src_refs)"
+else
+  fail_ "T5a" "fewer than 7 'Reference file' lines cite templates/uat/references (got $src_refs)"
+fi
+
+if [ "$post_refs" -ge 7 ]; then
+  pass "T5b: at least 7 'Reference file' lines cite the post-init path (got $post_refs)"
+else
+  fail_ "T5b" "fewer than 7 'Reference file' lines cite tests/uat/examples (got $post_refs)"
+fi
+
+# T5c: §3.1 specifically must cite both — anchor on the web pre-flight.
+sec31_block=$(awk '
+  /^### 3\.1 web/ { capture=1; next }
+  capture && /^### / { exit }
+  capture { print }
+' "$UAT_GUIDE")
+
+if printf '%s\n' "$sec31_block" | grep -qE 'templates/uat/references/web-pre-flight\.html' \
+   && printf '%s\n' "$sec31_block" | grep -qE 'tests/uat/examples/pre-flight-reference\.html'; then
+  pass "T5c: §3.1 web cites both source (templates/uat/references/web-pre-flight.html) and post-init (tests/uat/examples/pre-flight-reference.html) paths"
+else
+  fail_ "T5c" "§3.1 web does not cite both source and post-init pre-flight paths"
+fi
+
+# ----------------------------------------------------------------
+# T6 (uat-authoring-guide-2): init.sh copies the guide into projects;
+# print_* and the HTML template reference the in-project path.
+# ----------------------------------------------------------------
+echo ""
+echo "T6 (uat-authoring-guide-2): init.sh copies uat-authoring-guide.md + in-project path used"
+
+# T6a: init.sh's docs/reference/ copy block (right after the user-guide
+# cp) must include uat-authoring-guide.md.
+if grep -qE 'cp\s+"\$SCRIPT_DIR/docs/uat-authoring-guide\.md"\s+docs/reference/' "$INIT_SH"; then
+  pass "T6a: init.sh copies docs/uat-authoring-guide.md into docs/reference/"
+else
+  fail_ "T6a" "init.sh does not copy docs/uat-authoring-guide.md into docs/reference/"
+fi
+
+# T6b: the two init.sh print_* lines that previously pointed at
+# docs/uat-authoring-guide.md must now point at the in-project path
+# docs/reference/uat-authoring-guide.md. We anchor on '§ 5' which is
+# the original section reference, ensuring we caught both call sites.
+ref_print_count=$(grep -cE 'docs/reference/uat-authoring-guide\.md\s+§\s*5' "$INIT_SH" || true)
+case "$ref_print_count" in ''|*[!0-9]*) ref_print_count=0 ;; esac
+
+if [ "$ref_print_count" -ge 2 ]; then
+  pass "T6b: init.sh has >= 2 print_* lines pointing at docs/reference/uat-authoring-guide.md § 5 (got $ref_print_count)"
+else
+  fail_ "T6b" "init.sh does not have >= 2 print_* lines pointing at docs/reference/uat-authoring-guide.md § 5 (got $ref_print_count)"
+fi
+
+# T6c: the legacy docs/uat-authoring-guide.md path must NOT remain in
+# init.sh's print_* fallback strings (the source-of-truth in the
+# framework repo is fine; we're checking that no print_info/print_warn
+# string still cites the un-prefixed path that won't resolve in a
+# generated project).
+stale_print_lines=$(grep -nE 'print_(info|warn).*"[^"]*docs/uat-authoring-guide\.md' "$INIT_SH" || true)
+if [ -n "$stale_print_lines" ]; then
+  fail_ "T6c" "init.sh still has print_* fallback strings citing the un-prefixed docs/uat-authoring-guide.md path:
+$stale_print_lines"
+else
+  pass "T6c: no init.sh print_* fallback strings still cite the un-prefixed docs/uat-authoring-guide.md path"
+fi
+
+# T6d: templates/uat/test-session-template.html must reference the
+# in-project path (docs/reference/uat-authoring-guide.md), not the
+# pre-init source path.
+if grep -qE 'docs/reference/uat-authoring-guide\.md' "$UAT_HTML_TMPL"; then
+  pass "T6d: test-session-template.html references docs/reference/uat-authoring-guide.md"
+else
+  fail_ "T6d" "test-session-template.html does not reference docs/reference/uat-authoring-guide.md"
+fi
+
+# T6e: the legacy un-prefixed docs/uat-authoring-guide.md path must
+# NOT remain in the HTML template (that string ships to user projects
+# where docs/uat-authoring-guide.md does not exist; only
+# docs/reference/uat-authoring-guide.md is in-project).
+if grep -qE '(^|[^/])docs/uat-authoring-guide\.md' "$UAT_HTML_TMPL"; then
+  fail_ "T6e" "test-session-template.html still references the un-prefixed docs/uat-authoring-guide.md (won't resolve in generated projects)"
+else
+  pass "T6e: test-session-template.html no longer references the un-prefixed docs/uat-authoring-guide.md"
+fi
+
+# ----------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------
+echo ""
+echo "=================================================="
+echo "Results: $PASSED passed, $FAILED failed"
+echo "=================================================="
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

- Closes a 6-finding cluster of S3 doc-drift / incomplete-step findings spanning four docs (`user-guide.md`, `governance-framework.md`, `extending-platforms.md`, `uat-authoring-guide.md`).
- Adds a POC precondition row to the Phase 4 user-actions table so operators see the hard-block enforcement points (`check-phase-gate.sh` + `process-checklist.sh --start-phase4`) inline with the rest of their Phase 4 actions.
- Documents the Mid-Phase 2 biweekly Senior-Technical-Authority checkpoint that was missing from §V — explicitly orthogonal to the Phase 3 gate.
- Fixes the release-pipeline path drift (flat dir → per-host `templates/pipelines/release/{host}/{platform}.yml`) in three places, names all three hosts (github/bitbucket/gitlab), and points contributors at canonical-github discovery (`init.sh:346-368`).
- Adds Step 6 + UAT-References row to extending-platforms.md so the platform-extension recipe matches what `init.sh` actually requires.
- Cites both framework-source AND post-init paths in every `Reference file:` line of uat-authoring-guide.md, and copies the guide into `docs/reference/` so the dead-link self-references in `init.sh` print_* and the HTML template now resolve.

## Findings closed

| ID | File:line citation |
|---|---|
| `user-guide-3` | `docs/user-guide.md:1032` (new POC precondition row above the existing Phase 4 user-actions table) |
| `governance-framework-4` | `docs/governance-framework.md:201` (new `### Mid-Phase 2 Governance Checkpoint (Organizational)` subsection between In-Phase Decision Log and Escalation Path) |
| `extending-platforms-1` | `docs/extending-platforms.md:43-48` (Auto-Discovery `github/*.yml` path); `docs/extending-platforms.md:202-218` (Step 3 'File:' line + per-host source-path table + contributor-must-add-three warning); `docs/extending-platforms.md:399-402` (Validation Checklist per-host rows) |
| `extending-platforms-5` | `docs/extending-platforms.md:34` (6th 'UAT References' row in 'What You Are Creating' table); `docs/extending-platforms.md:345-378` (new `### Step 6: UAT Reference Files` section) |
| `uat-authoring-guide-1` | `docs/uat-authoring-guide.md:35,48,61,74,87,98,109,120` (8 'Reference file' lines updated to cite both source + post-init path) |
| `uat-authoring-guide-2` | `init.sh:1117-1124` (cp into `docs/reference/`); `init.sh:1204,1206` (two print_* strings → `docs/reference/uat-authoring-guide.md § 5`); `templates/uat/test-session-template.html:95` (in-project path) |

## Test plan

New test file: `tests/test-docs-cluster-six-pack.sh` — 28 assertions across 6 finding groups (T1..T6). Every assertion is anchored on load-bearing content (table-cell pattern, subsection heading, specific path string, line-count threshold of 7 reference-file lines, etc.) — none are catch-all greps of substrings that appear in success output.

### RED proof (against `origin/main`)

Captured by stashing only the production-file changes (keeping the new test in place) and re-running:

```text
$ git stash push -- docs/user-guide.md docs/governance-framework.md \
                    docs/extending-platforms.md docs/uat-authoring-guide.md \
                    init.sh templates/uat/test-session-template.html \
                    templates/uat/test-session-template.md \
                    templates/generated/claude-md.tmpl scripts/upgrade-project.sh
$ bash tests/test-docs-cluster-six-pack.sh; echo "exit=$?"
...
T1 (user-guide-3): Phase 4 user-actions table has POC precondition row
  [FAIL] T1 — Phase 4 user-actions table does not contain a POC precondition row matching '| ... poc_mode ... upgrade-project.sh --to-production ... | Required | Required |'

T2 (governance-framework-4): §V has Mid-Phase 2 Governance Checkpoint subsection
  [FAIL] T2a — §V missing '### Mid-Phase 2 Governance Checkpoint' subsection heading
  [FAIL] T2b — Mid-Phase 2 body does not specify biweekly cadence
  [FAIL] T2c — Mid-Phase 2 body does not name Senior Technical Authority
  [FAIL] T2d — Mid-Phase 2 body does not specify a 30-minute duration cap
  [FAIL] T2e — Mid-Phase 2 body does not reference the In-Phase Decision Log
  [FAIL] T2f — Mid-Phase 2 body does not explicitly state it does not replace the Phase 3 gate

T3 (extending-platforms-1): release-pipeline references use per-host path
  [FAIL] T3a — Step 3 'File:' line still uses the flat-dir path templates/pipelines/release/{platform}.yml
  [FAIL] T3b — Step 3 'File:' line does not use the per-host path templates/pipelines/release/{host}/{platform}.yml
  [FAIL] T3c — Auto-Discovery does not reference templates/pipelines/release/github/*.yml as the canonical discovery tree
  [FAIL] T3d — Auto-Discovery still says 'Scans templates/pipelines/release/*.yml' (flat dir — wrong; the actual scan is github/ only)
  [PASS] T3e: 'What You Are Creating' table row 3 uses per-host path and names github/bitbucket/gitlab
  [FAIL] T3f — Step 3 body does not name all three host directories

T4 (extending-platforms-5): table has UAT References row + Step 6 section exists
  [FAIL] T4a — 'What You Are Creating' table missing UAT References row (templates/uat/references/{platform}-pre-flight.html)
  [FAIL] T4b — 'What You Are Creating' table missing UAT References row (templates/uat/references/{platform}-scenario.json)
  [FAIL] T4c — 'What You Are Creating' table does not have a 6th numbered row
  [FAIL] T4d — Missing '### Step 6: UAT Reference Files' section
  [FAIL] T4e1 — Step 6 body does not mention tests/uat/examples
  [FAIL] T4e2 — Step 6 body does not mention the print_warn fallback
  [FAIL] T4e3 — Step 6 body does not point at docs/uat-authoring-guide.md

T5 (uat-authoring-guide-1): Reference-file lines cite both source and post-init paths
  [PASS] T5a: at least 7 'Reference file' lines cite the framework source path (got 8)
  [FAIL] T5b — fewer than 7 'Reference file' lines cite tests/uat/examples (got 0)
  [FAIL] T5c — §3.1 web does not cite both source and post-init pre-flight paths

T6 (uat-authoring-guide-2): init.sh copies uat-authoring-guide.md + in-project path used
  [FAIL] T6a — init.sh does not copy docs/uat-authoring-guide.md into docs/reference/
  [FAIL] T6b — init.sh does not have >= 2 print_* lines pointing at docs/reference/uat-authoring-guide.md § 5 (got 0)
  [FAIL] T6c — init.sh still has print_* fallback strings citing the un-prefixed docs/uat-authoring-guide.md path:
1204:    print_info "protocol with you per docs/uat-authoring-guide.md § 5."
1206:    print_warn "UAT reference files not found for platform '$PLATFORM'. Falling back to 'other'-style co-build protocol; see docs/uat-authoring-guide.md § 5."
  [FAIL] T6d — test-session-template.html does not reference docs/reference/uat-authoring-guide.md
  [FAIL] T6e — test-session-template.html still references the un-prefixed docs/uat-authoring-guide.md (won't resolve in generated projects)

==================================================
Results: 2 passed, 26 failed
==================================================
exit=1
```

(The two pre-existing PASSes are T3e — the file-row table already had the per-host path from PR #71-ish — and T5a — the framework-source paths were already cited; only the post-init mirrors were missing.)

### GREEN after fixes

```text
$ bash tests/test-docs-cluster-six-pack.sh; echo "exit=$?"
...
==================================================
Results: 28 passed, 0 failed
==================================================
exit=0
```

### Lints (all four exit 0)

```text
$ bash scripts/lint-counter-antipattern.sh
OK: no counter-capture antipatterns found.
$ bash scripts/lint-backlog-references.sh
OK: backlog references and Closed-status citations are consistent.
$ bash scripts/lint-fix-functions-stderr.sh
OK: no fix_*() stderr silencers found.
$ bash scripts/lint-raw-read-prompt.sh
OK: no raw 'read -rp' / 'read -p' calls outside scripts/lib/helpers.sh.
```

### Adjacent existing tests (unchanged baseline)

- `bash tests/test-poc-modes.sh` — 5/5 passed.
- `bash tests/test-lint-uat-scenarios.sh` — 12/12 passed.
- `bash tests/test-init-non-interactive.sh` — 25/26 passed; the one fail (`N7`) is pre-existing on `origin/main` (confirmed by re-running with my changes stashed) and is unrelated to this PR.

## Bonus catches

Same root cause as `uat-authoring-guide-2` (the framework references the guide via the un-prefixed `docs/uat-authoring-guide.md` path, which only resolves in the framework repo — not in user-generated projects). The brief named the two init.sh strings + the HTML template; my grep across all surfaces that ship to projects turned up four more dead-link sites that this PR also fixes:

- `templates/generated/claude-md.tmpl:186,207` — UAT step 3a quality-gate hint + 'UAT authoring' index pointer. Every generated project's CLAUDE.md would have rendered both lines as dangling references.
- `templates/uat/test-session-template.md:29` — markdown variant of the UAT session template. Repointed at `tests/uat/templates/test-session-template.html` (the in-project copy) plus the new `docs/reference/uat-authoring-guide.md` path.
- `scripts/upgrade-project.sh:2124,2126,2131,2134` — four print_* / print_info strings emitted during `--enable-uat-quality-guardrails`-style upgrades. Same fix pattern. Also repointed the `templates/uat/test-session-template.html` reference to `tests/uat/templates/...` for consistency.
- `docs/extending-platforms.md` Validation Checklist — bumped the file-existence list from flat to per-host paths and added the two UAT-references rows so the checklist matches the new Step 6.

Additional polish (no separate finding ID — surfaced while rewriting):

- Auto-Discovery line-number citation in extending-platforms.md updated from the stale `init.sh lines 275-297` to the current `init.sh lines 346-368` (where the platform-discovery loop actually lives today).

## Breaking changes

None. All changes are doc text, doc-template strings, and one additive `cp` line in `init.sh`'s project bootstrap (copies `docs/uat-authoring-guide.md` into `docs/reference/`). No caller-facing behavior shifts; no script flags added or removed; no schema changes.

Two print_* string changes in `init.sh` and four in `scripts/upgrade-project.sh` change the path printed to the operator (`docs/uat-authoring-guide.md` → `docs/reference/uat-authoring-guide.md`). Operators who had memorized the old path now get the in-project resolvable path, which is the intended fix.

## Worktree note

```text
/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_22ccde10-1af-1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)