### PR TITLE
fix(specs-plans): PR-gate Build Loop + check-versions uname shadow + verify-install pipeline + phase-audit tier-blindness (4 S3)

### DIFF
--- a/docs/superpowers/plans/2026-04-08-phase-audit.md
+++ b/docs/superpowers/plans/2026-04-08-phase-audit.md
@@ -87,6 +87,35 @@ Read ALL of these files thoroughly:
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/scripts/check-phase-gate.sh
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/evaluation-prompts/Projects/bases/ (all files in this directory)
 
+## Tier-Tuple Pre-Audit Gating (Mandatory)
+
+BEFORE grading any finding, compute the project's tier tuple
+(deployment, poc_mode, track, enforcement_level) and cross-reference
+the graceful-degradation baseline:
+
+1. Read `.claude/phase-state.json` for `.deployment`, `.poc_mode`,
+   `.track`. Read `.claude/manifest.json` for `.enforcement_level`.
+   If a field is missing, fall back to `manifest.json` for
+   deployment/poc_mode and treat enforcement_level as `strict`.
+2. Cross-reference `.audit-baseline-v2.md` §6 (Intentional Graceful
+   Degradation) and §7 (Cross-Tier Behavior Matrix). A behavior that
+   LOOKS like a gap may be an intentional carve-out for the project's
+   tier tuple (e.g. branch protection skipped on `deployment=personal`,
+   Phase 3 SAST skipped on `track=light`). If the baseline file is
+   missing, note this in §1 Scope and proceed treating all tiers as
+   strict.
+3. Every finding row in §2 MUST include a **tier_context** field
+   stating which tier combinations the finding applies to. Example
+   values: `applies to all tiers` | `organizational + strict only` |
+   `personal — graceful degradation, NOT a gap`. A finding without
+   `tier_context` is malformed and will be rejected during
+   consolidation. Use the new severity flag `tier_misalignment` for
+   findings where the bug is divergence from expected tier-tuple
+   behavior rather than absence of behavior.
+
+Record the computed tier tuple in §1 Scope & Methodology of your
+report.
+
 ## Evaluation Rubric
 For EVERY prescribed action in Phase 0, evaluate against these 12 criteria:
 1. Instructions — Is there a clear, unambiguous instruction? Can someone new follow it?
@@ -133,8 +162,9 @@ Produce your report in EXACTLY this Markdown structure:
 For each finding use this EXACT format:
 
 ### Finding P0-NNN: [Title]
-- **Severity:** Critical | Major | Minor | Observation
+- **Severity:** Critical | Major | Minor | Observation | tier_misalignment
 - **Category:** Missing Template | Missing Enforcement | Missing Documentation | Missing Storage | Missing Validation | Workflow Gap | Audit Trail Gap | Bypass Risk
+- **tier_context:** [REQUIRED — see Tier-Tuple Pre-Audit Gating; e.g. "applies to all tiers" | "organizational + strict only" | "personal — graceful degradation, NOT a gap"]
 - **Evidence:** [file:line or "not found"]
 - **Enterprise Expectation:** [What a production software company would require]
 - **Current State:** [What the framework actually does]
@@ -148,6 +178,7 @@ Severity definitions:
 - Major: Process works but produces inconsistent/unverifiable results
 - Minor: Gap exists but workaround is obvious or impact is low
 - Observation: Not a gap but an improvement opportunity
+- tier_misalignment: Framework behavior diverges from the expected behavior for this project's tier tuple (e.g. branch protection fires on personal deployment, or strict mode auto-relaxes)
 
 ## 3. Remediation Plan
 
@@ -206,6 +237,35 @@ Read ALL of these files thoroughly:
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/desktop.md
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/mobile.md
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/evaluation-prompts/Projects/bases/ (all files)
+
+## Tier-Tuple Pre-Audit Gating (Mandatory)
+
+BEFORE grading any finding, compute the project's tier tuple
+(deployment, poc_mode, track, enforcement_level) and cross-reference
+the graceful-degradation baseline:
+
+1. Read `.claude/phase-state.json` for `.deployment`, `.poc_mode`,
+   `.track`. Read `.claude/manifest.json` for `.enforcement_level`.
+   If a field is missing, fall back to `manifest.json` for
+   deployment/poc_mode and treat enforcement_level as `strict`.
+2. Cross-reference `.audit-baseline-v2.md` §6 (Intentional Graceful
+   Degradation) and §7 (Cross-Tier Behavior Matrix). A behavior that
+   LOOKS like a gap may be an intentional carve-out for the project's
+   tier tuple (e.g. branch protection skipped on `deployment=personal`,
+   Phase 3 SAST skipped on `track=light`). If the baseline file is
+   missing, note this in §1 Scope and proceed treating all tiers as
+   strict.
+3. Every finding row in §2 MUST include a **tier_context** field
+   stating which tier combinations the finding applies to. Example
+   values: `applies to all tiers` | `organizational + strict only` |
+   `personal — graceful degradation, NOT a gap`. A finding without
+   `tier_context` is malformed and will be rejected during
+   consolidation. Use the new severity flag `tier_misalignment` for
+   findings where the bug is divergence from expected tier-tuple
+   behavior rather than absence of behavior.
+
+Record the computed tier tuple in §1 Scope & Methodology of your
+report.
 
 ## Evaluation Rubric
 For EVERY prescribed action in Phase 1, evaluate against these 12 criteria:
@@ -275,6 +335,35 @@ Read ALL of these files thoroughly:
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/templates/uat-test-template.md
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/init.sh — read the Phase 2 initialization and hook registration sections
 
+## Tier-Tuple Pre-Audit Gating (Mandatory)
+
+BEFORE grading any finding, compute the project's tier tuple
+(deployment, poc_mode, track, enforcement_level) and cross-reference
+the graceful-degradation baseline:
+
+1. Read `.claude/phase-state.json` for `.deployment`, `.poc_mode`,
+   `.track`. Read `.claude/manifest.json` for `.enforcement_level`.
+   If a field is missing, fall back to `manifest.json` for
+   deployment/poc_mode and treat enforcement_level as `strict`.
+2. Cross-reference `.audit-baseline-v2.md` §6 (Intentional Graceful
+   Degradation) and §7 (Cross-Tier Behavior Matrix). A behavior that
+   LOOKS like a gap may be an intentional carve-out for the project's
+   tier tuple (e.g. branch protection skipped on `deployment=personal`,
+   Phase 3 SAST skipped on `track=light`). If the baseline file is
+   missing, note this in §1 Scope and proceed treating all tiers as
+   strict.
+3. Every finding row in §2 MUST include a **tier_context** field
+   stating which tier combinations the finding applies to. Example
+   values: `applies to all tiers` | `organizational + strict only` |
+   `personal — graceful degradation, NOT a gap`. A finding without
+   `tier_context` is malformed and will be rejected during
+   consolidation. Use the new severity flag `tier_misalignment` for
+   findings where the bug is divergence from expected tier-tuple
+   behavior rather than absence of behavior.
+
+Record the computed tier tuple in §1 Scope & Methodology of your
+report.
+
 ## Evaluation Rubric
 For EVERY prescribed action in Phase 2, evaluate against these 12 criteria:
 1. Instructions — Is there a clear, unambiguous instruction? Can someone new follow it?
@@ -341,6 +430,35 @@ Read ALL of these files thoroughly:
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/desktop.md — read Phase 3 sections
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/mobile.md — read Phase 3 sections
 
+## Tier-Tuple Pre-Audit Gating (Mandatory)
+
+BEFORE grading any finding, compute the project's tier tuple
+(deployment, poc_mode, track, enforcement_level) and cross-reference
+the graceful-degradation baseline:
+
+1. Read `.claude/phase-state.json` for `.deployment`, `.poc_mode`,
+   `.track`. Read `.claude/manifest.json` for `.enforcement_level`.
+   If a field is missing, fall back to `manifest.json` for
+   deployment/poc_mode and treat enforcement_level as `strict`.
+2. Cross-reference `.audit-baseline-v2.md` §6 (Intentional Graceful
+   Degradation) and §7 (Cross-Tier Behavior Matrix). A behavior that
+   LOOKS like a gap may be an intentional carve-out for the project's
+   tier tuple (e.g. branch protection skipped on `deployment=personal`,
+   Phase 3 SAST skipped on `track=light`). If the baseline file is
+   missing, note this in §1 Scope and proceed treating all tiers as
+   strict.
+3. Every finding row in §2 MUST include a **tier_context** field
+   stating which tier combinations the finding applies to. Example
+   values: `applies to all tiers` | `organizational + strict only` |
+   `personal — graceful degradation, NOT a gap`. A finding without
+   `tier_context` is malformed and will be rejected during
+   consolidation. Use the new severity flag `tier_misalignment` for
+   findings where the bug is divergence from expected tier-tuple
+   behavior rather than absence of behavior.
+
+Record the computed tier tuple in §1 Scope & Methodology of your
+report.
+
 ## Evaluation Rubric
 For EVERY prescribed action in Phase 3, evaluate against these 12 criteria:
 1. Instructions — Is there a clear, unambiguous instruction? Can someone new follow it?
@@ -402,6 +520,35 @@ Read ALL of these files thoroughly:
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/web.md — read release/distribution sections
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/desktop.md — read release/distribution sections
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/docs/platform-modules/mobile.md — read release/distribution sections
+
+## Tier-Tuple Pre-Audit Gating (Mandatory)
+
+BEFORE grading any finding, compute the project's tier tuple
+(deployment, poc_mode, track, enforcement_level) and cross-reference
+the graceful-degradation baseline:
+
+1. Read `.claude/phase-state.json` for `.deployment`, `.poc_mode`,
+   `.track`. Read `.claude/manifest.json` for `.enforcement_level`.
+   If a field is missing, fall back to `manifest.json` for
+   deployment/poc_mode and treat enforcement_level as `strict`.
+2. Cross-reference `.audit-baseline-v2.md` §6 (Intentional Graceful
+   Degradation) and §7 (Cross-Tier Behavior Matrix). A behavior that
+   LOOKS like a gap may be an intentional carve-out for the project's
+   tier tuple (e.g. branch protection skipped on `deployment=personal`,
+   Phase 3 SAST skipped on `track=light`). If the baseline file is
+   missing, note this in §1 Scope and proceed treating all tiers as
+   strict.
+3. Every finding row in §2 MUST include a **tier_context** field
+   stating which tier combinations the finding applies to. Example
+   values: `applies to all tiers` | `organizational + strict only` |
+   `personal — graceful degradation, NOT a gap`. A finding without
+   `tier_context` is malformed and will be rejected during
+   consolidation. Use the new severity flag `tier_misalignment` for
+   findings where the bug is divergence from expected tier-tuple
+   behavior rather than absence of behavior.
+
+Record the computed tier tuple in §1 Scope & Methodology of your
+report.
 
 ## Evaluation Rubric
 For EVERY prescribed action in Phase 4, evaluate against these 12 criteria:
@@ -466,6 +613,35 @@ Read ALL of these files thoroughly:
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/templates/pipelines/ci/typescript.yml
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/evaluation-prompts/Framework/ (all files)
 - /Users/karl/Documents/Claude Projects/solo-orchestrator/evaluation-prompts/Projects/ (README.md, compose.sh, run-reviews.sh, bases/)
+
+## Tier-Tuple Pre-Audit Gating (Mandatory)
+
+BEFORE grading any finding, compute the project's tier tuple
+(deployment, poc_mode, track, enforcement_level) and cross-reference
+the graceful-degradation baseline:
+
+1. Read `.claude/phase-state.json` for `.deployment`, `.poc_mode`,
+   `.track`. Read `.claude/manifest.json` for `.enforcement_level`.
+   If a field is missing, fall back to `manifest.json` for
+   deployment/poc_mode and treat enforcement_level as `strict`.
+2. Cross-reference `.audit-baseline-v2.md` §6 (Intentional Graceful
+   Degradation) and §7 (Cross-Tier Behavior Matrix). A behavior that
+   LOOKS like a gap may be an intentional carve-out for the project's
+   tier tuple (e.g. branch protection skipped on `deployment=personal`,
+   Phase 3 SAST skipped on `track=light`). If the baseline file is
+   missing, note this in §1 Scope and proceed treating all tiers as
+   strict.
+3. Every finding row in §2 MUST include a **tier_context** field
+   stating which tier combinations the finding applies to. Example
+   values: `applies to all tiers` | `organizational + strict only` |
+   `personal — graceful degradation, NOT a gap`. A finding without
+   `tier_context` is malformed and will be rejected during
+   consolidation. Use the new severity flag `tier_misalignment` for
+   findings where the bug is divergence from expected tier-tuple
+   behavior rather than absence of behavior.
+
+Record the computed tier tuple in §1 Scope & Methodology of your
+report.
 
 ## Evaluation Rubric
 For EVERY script, hook, CI check, governance mechanism, and infrastructure component, evaluate against these 12 criteria:

--- a/docs/superpowers/specs/2026-04-08-phase-audit-design.md
+++ b/docs/superpowers/specs/2026-04-08-phase-audit-design.md
@@ -205,6 +205,71 @@ Real-world usage on the meshscope project exposed specific gaps (UAT step skippi
 
 ---
 
+## 2.0 Tier-Tuple Gating (Pre-Audit, Mandatory)
+
+**Amendment landed for finding specs-plans-phase-audit-docs-remediation-1.**
+
+Every auditor MUST complete this step BEFORE grading any finding. The
+prior version of this spec was tier-blind: auditors graded findings
+without knowledge of the project's (deployment, poc_mode, track,
+enforcement_level) tuple, so intentional graceful-degradation
+behaviors (e.g. branch protection skipped on `personal` deployments,
+sentinel auto-skipped under `track=light`) surfaced as severity
+inflations or false-positive "Missing Enforcement" findings.
+
+### Step 2.0.1 — Compute the tier tuple
+
+Read the project's classification from canonical state files:
+
+```
+deployment        ← .claude/phase-state.json:.deployment   (personal | organizational)
+poc_mode          ← .claude/phase-state.json:.poc_mode     (null | private_poc | sponsored_poc | production)
+track             ← .claude/phase-state.json:.track        (light | standard | full)
+enforcement_level ← .claude/manifest.json:.enforcement_level (advisory | recommended | strict)
+```
+
+If any field is missing or null, fall back to `manifest.json` for
+deployment/poc_mode (post-BL-030 backfill canonical) and record the
+fallback in the report's §1 Scope & Methodology block.
+
+### Step 2.0.2 — Cross-reference the graceful-degradation matrix
+
+Before grading a finding, consult `.audit-baseline-v2.md` §6
+(Intentional Graceful Degradation) and §7 (Cross-Tier Behavior Matrix).
+A behavior that LOOKS like a gap may be an intentional carve-out for
+the project's tier tuple. Examples:
+
+- Branch protection enforcement is intentionally absent on `deployment=personal`.
+- Phase 3 SAST scans are intentionally skipped on `track=light`.
+- BL-006 commit-message Build-Loop enforcement runs in `recommended`
+  mode (warn-not-block) when `enforcement_level=advisory`.
+
+If `.audit-baseline-v2.md` is missing from the repo (pre-baseline
+projects), treat all tiers as `strict` and note the missing reference
+in §1.
+
+### Step 2.0.3 — Carry `tier_context` on every finding
+
+Every finding row in §2 MUST include a `tier_context` field stating
+which tier combinations the finding applies to. Example values:
+
+- `tier_context: applies to all tiers` (genuine universal gap)
+- `tier_context: organizational + strict only` (gap only when both enforcement and deployment are high)
+- `tier_context: personal — graceful degradation, NOT a gap` (use this to record an investigated-but-rejected finding)
+
+A finding without `tier_context` is a malformed finding and MUST be
+rejected by the consolidating summary in §4.3 below.
+
+### Step 2.0.4 — `tier_misalignment` severity flag
+
+Add a new severity flag for findings where the bug is that the
+framework's behavior diverges from the expected tier-tuple behavior
+(rather than missing entirely). Example: "branch protection enforcement
+fires on `deployment=personal` (should be skipped per baseline §6)" is
+a `tier_misalignment` finding even if no other criterion is violated.
+
+---
+
 ## 2. Standardized Report Template
 
 Every auditor produces a report with this structure:
@@ -217,6 +282,7 @@ Every auditor produces a report with this structure:
 **Date:** 2026-04-08
 **Framework Version:** Solo Orchestrator v1.0 (post-PR #6, #7)
 **Files Evaluated:** [list of every file read]
+**Tier Tuple:** deployment=[...] poc_mode=[...] track=[...] enforcement_level=[...]
 
 ---
 
@@ -225,14 +291,19 @@ Every auditor produces a report with this structure:
 [What was evaluated, what enterprise standard was the benchmark,
 what questions drove the evaluation]
 
+[Record the tier tuple computed in §2.0.1 here, including any fallback
+sources used and whether `.audit-baseline-v2.md` was available.]
+
 ## 2. Findings
 
 ### Finding [PHASE]-[NNN]: [Title]
 
-- **Severity:** Critical | Major | Minor | Observation
+- **Severity:** Critical | Major | Minor | Observation | tier_misalignment
 - **Category:** Missing Template | Missing Enforcement | Missing Documentation |
                Missing Storage | Missing Validation | Workflow Gap |
                Audit Trail Gap | Bypass Risk
+- **tier_context:** [REQUIRED — see §2.0.3; e.g. "applies to all tiers" |
+               "organizational + strict only" | "personal — graceful degradation, NOT a gap"]
 - **Evidence:** [file:line or "not found"]
 - **Enterprise Expectation:** [What a production software company would require]
 - **Current State:** [What the framework actually does]

--- a/docs/superpowers/specs/2026-04-08-process-enforcement-design.md
+++ b/docs/superpowers/specs/2026-04-08-process-enforcement-design.md
@@ -235,7 +235,7 @@ For all other commands, it exits immediately with no output (allow).
 
 1. Same as git commit checks
 2. Additionally: verify no UAT session is in progress with incomplete steps
-3. Additionally: verify process-state build_loop is at step 0 or fully complete (no partial features)
+3. Additionally: verify process-state `build_loop` is at step 0 OR steps 1–5 (tests_written, tests_verified_failing, implemented, security_audit, documentation_updated) are complete. Per baseline invariant #14, the build/test/commit cycle is steps 1–5 only — step 6 (`feature_recorded`) is post-PR bookkeeping recorded via `scripts/test-gate.sh --record-feature` after merge. Requiring `feature_recorded` pre-PR would be a process inversion (you cannot record the merged PR before the PR exists). This matches `scripts/process-checklist.sh:require_build_loop_state_for_commit`, which also requires only the first 5 steps.
 
 **Auto-detection of commit type:**
 

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -274,6 +274,16 @@ echo ""
 BELOW_MIN=()
 UPDATES=()
 UPDATE_CMDS=()
+# UPDATE_NAMES tracks the verbatim tool name (with whitespace preserved)
+# in parallel with UPDATES[]/UPDATE_CMDS[]. The pre-fix code reconstructed
+# the name by parsing the display-string entry from UPDATES via
+# `${var%% *}` (single-space split), which truncated multi-word tool
+# names (e.g. "Claude Code" → "Claude") in the interactive selection
+# loops AND printed the entire display string verbatim in the
+# non-interactive branch. The parallel array decouples display
+# formatting from the canonical name and is the recommendation
+# recorded against finding specs-plans-tool-matrix-versions-1.
+UPDATE_NAMES=()
 PASS_COUNT=0
 CURRENT_CATEGORY=""
 
@@ -363,10 +373,12 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       BELOW_MIN+=("$NAME")
       UPDATES+=("$NAME $INSTALLED → latest (BELOW MINIMUM)")
       UPDATE_CMDS+=("${UPDATE_CHECK_CMD:-}")
+      UPDATE_NAMES+=("$NAME")
     elif [ "$UPDATE_CHECK_STATUS" = "behind" ]; then
       print_warn "$NAME: ${INSTALLED:-configured} — $UPDATE_CHECK_MSG"
       UPDATES+=("$NAME — $UPDATE_CHECK_MSG")
       UPDATE_CMDS+=("${UPDATE_CHECK_CMD:-}")
+      UPDATE_NAMES+=("$NAME")
     elif [ "$UPDATE_CHECK_STATUS" = "self_updating" ]; then
       print_ok "$NAME: ${INSTALLED:-configured} — $UPDATE_CHECK_MSG"
       PASS_COUNT=$((PASS_COUNT + 1))
@@ -409,6 +421,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       fi
       UPDATES+=("$NAME $INSTALLED → ${LATEST:-latest} (BELOW MINIMUM)")
       UPDATE_CMDS+=("$local_update_cmd")
+      UPDATE_NAMES+=("$NAME")
     elif [ -n "$LATEST" ] && ! version_gte "$INSTALLED" "$LATEST"; then
       print_ok "$NAME: $INSTALLED$MIN_DISPLAY$LATEST_DISPLAY"
       # Find update command
@@ -421,6 +434,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       fi
       UPDATES+=("$NAME $INSTALLED → $LATEST")
       UPDATE_CMDS+=("$local_update_cmd")
+      UPDATE_NAMES+=("$NAME")
       PASS_COUNT=$((PASS_COUNT + 1))
     else
       print_ok "$NAME: ${INSTALLED:-configured}$MIN_DISPLAY$LATEST_DISPLAY"
@@ -461,17 +475,20 @@ if [ ${#UPDATES[@]} -gt 0 ] && [ -t 0 ]; then
       echo ""
       for idx in "${!UPDATE_CMDS[@]}"; do
         cmd="${UPDATE_CMDS[$idx]}"
-        uname="${UPDATES[$idx]%%  *}"
-        uname="${uname%% *}"
+        # specs-plans-tool-matrix-versions-1: pull the verbatim name
+        # from UPDATE_NAMES[] (parallel array). Pre-fix code parsed
+        # UPDATES[] with `${var%% *}` (one-space split), which
+        # truncated multi-word tool names AND shadowed uname(1).
+        tool_name="${UPDATE_NAMES[$idx]}"
         if [ -n "$cmd" ] && [ "$cmd" != "null" ]; then
-          print_info "Updating $uname..."
+          print_info "Updating $tool_name..."
           if eval "$cmd" 2>/dev/null; then
-            print_ok "$uname updated"
+            print_ok "$tool_name updated"
           else
-            print_fail "Could not update $uname. Run manually: $cmd"
+            print_fail "Could not update $tool_name. Run manually: $cmd"
           fi
         else
-          print_warn "$uname: no auto-update command available"
+          print_warn "$tool_name: no auto-update command available"
         fi
       done
       ;;
@@ -490,14 +507,15 @@ if [ ${#UPDATES[@]} -gt 0 ] && [ -t 0 ]; then
         idx=$((sel - 1))
         if [ "$idx" -ge 0 ] && [ "$idx" -lt ${#UPDATE_CMDS[@]} ]; then
           cmd="${UPDATE_CMDS[$idx]}"
-          uname="${UPDATES[$idx]%%  *}"
-          uname="${uname%% *}"
+          # specs-plans-tool-matrix-versions-1 — see comment in the a/A
+          # branch above; UPDATE_NAMES[] preserves whitespace verbatim.
+          tool_name="${UPDATE_NAMES[$idx]}"
           if [ -n "$cmd" ] && [ "$cmd" != "null" ]; then
-            print_info "Updating $uname..."
+            print_info "Updating $tool_name..."
             if eval "$cmd" 2>/dev/null; then
-              print_ok "$uname updated"
+              print_ok "$tool_name updated"
             else
-              print_fail "Could not update $uname. Run manually: $cmd"
+              print_fail "Could not update $tool_name. Run manually: $cmd"
             fi
           fi
         fi
@@ -508,18 +526,24 @@ if [ ${#UPDATES[@]} -gt 0 ] && [ -t 0 ]; then
         echo ""
         echo "Manual update commands:"
         for idx in "${!UPDATES[@]}"; do
-          echo "  ${UPDATES[$idx]%%  *}: ${UPDATE_CMDS[$idx]}"
+          # specs-plans-tool-matrix-versions-1 — UPDATE_NAMES[] is the
+          # canonical tool name (whitespace preserved). Pre-fix used
+          # `${UPDATES[$idx]%%  *}` (two-space split) which left the
+          # whole display string ("Claude Code 0.0.1 → latest (BELOW
+          # MINIMUM)") in front of the colon.
+          echo "  ${UPDATE_NAMES[$idx]}: ${UPDATE_CMDS[$idx]}"
         done
       fi
       ;;
   esac
 elif [ ${#UPDATES[@]} -gt 0 ]; then
-  # Non-interactive: just print commands
+  # Non-interactive: just print commands. Same rationale as the c/C
+  # branch above — UPDATE_NAMES[] preserves whitespace; the prior
+  # `${UPDATES[$idx]%%  *}` parse-out-of-display-string was lossy.
   echo ""
   echo "Update commands (run manually):"
   for idx in "${!UPDATES[@]}"; do
-    uname="${UPDATES[$idx]%%  *}"
-    echo "  $uname: ${UPDATE_CMDS[$idx]}"
+    echo "  ${UPDATE_NAMES[$idx]}: ${UPDATE_CMDS[$idx]}"
   done
 fi
 

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -633,13 +633,21 @@ HOOKEOF
       fi
     fi
 
-    # Check build_loop is at step 0 or fully complete
+    # Check build_loop is at step 0 or steps 1–5 complete. Per baseline
+    # invariant #14, the build/test/commit cycle is steps 1–5
+    # (tests_written, tests_verified_failing, implemented, security_audit,
+    # documentation_updated). Step 6 (feature_recorded) is bookkeeping
+    # that runs AFTER the PR/merge via `test-gate.sh --record-feature`;
+    # requiring it pre-PR is a process inversion that contradicts
+    # invariant #14. Match the commit-side rule in
+    # scripts/process-checklist.sh:require_build_loop_state_for_commit
+    # (which already requires only the first 5 steps).
     BUILD_FEATURE=$(jq -r '.build_loop.feature // empty' "$PROCESS_STATE" 2>/dev/null)
     if [ -n "$BUILD_FEATURE" ]; then
       BUILD_STEPS_DONE=$(jq -r '.build_loop.steps_completed | length' "$PROCESS_STATE" 2>/dev/null)
-      if [ "$BUILD_STEPS_DONE" -gt 0 ] && [ "$BUILD_STEPS_DONE" -lt 6 ]; then
+      if [ "$BUILD_STEPS_DONE" -gt 0 ] && [ "$BUILD_STEPS_DONE" -lt 5 ]; then
         cat << HOOKEOF
-{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Feature '$BUILD_FEATURE' has incomplete Build Loop ($BUILD_STEPS_DONE/6 steps). Complete the feature or reset before creating a PR."}}
+{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "Feature '$BUILD_FEATURE' has incomplete Build Loop ($BUILD_STEPS_DONE/5 steps). Complete steps 1–5 (tests_written … documentation_updated) before creating a PR. Step 6 (feature_recorded) is post-PR bookkeeping — record it via scripts/test-gate.sh --record-feature after merge."}}
 HOOKEOF
         exit 0
       fi

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -189,22 +189,58 @@ check_project_structure() {
     fi
   fi
 
-  # CI pipeline
-  if [ -f ".github/workflows/ci.yml" ]; then
-    register_pass "CI pipeline exists"
+  # CI pipeline — host-aware. The CI destination depends on the SCM
+  # host: github → .github/workflows/ci.yml, bitbucket →
+  # bitbucket-pipelines.yml at repo root, gitlab → .gitlab-ci.yml at
+  # repo root. Mirrors the same detection logic encoded in
+  # _detect_pipeline_host (used by the fix_*_pipeline functions later
+  # in this file); kept inline here because the existence check runs
+  # during context gathering and we want to surface the right
+  # destination in the fail message.
+  local _ci_host=""
+  if [ -f .claude/manifest.json ] && command -v jq &>/dev/null; then
+    _ci_host=$(jq -r '.host // empty' .claude/manifest.json 2>/dev/null)
+  fi
+  if [ -z "$_ci_host" ] || [ "$_ci_host" = "null" ]; then
+    case "$(git remote get-url origin 2>/dev/null)" in
+      *github.com*)    _ci_host="github" ;;
+      *gitlab*)        _ci_host="gitlab" ;;
+      *bitbucket.org*) _ci_host="bitbucket" ;;
+      *)               _ci_host="other" ;;
+    esac
+  fi
+  local _ci_dest=""
+  case "$_ci_host" in
+    github)    _ci_dest=".github/workflows/ci.yml" ;;
+    bitbucket) _ci_dest="bitbucket-pipelines.yml" ;;
+    gitlab)    _ci_dest=".gitlab-ci.yml" ;;
+  esac
+  if [ -n "$_ci_dest" ] && [ -f "$_ci_dest" ]; then
+    register_pass "CI pipeline exists ($_ci_dest)"
+  elif [ -z "$_ci_dest" ]; then
+    register_manual "CI pipeline missing" "Unsupported SCM host '$_ci_host' — no canonical CI destination; configure manually"
   elif has_source && has_context; then
-    register_fixable "CI pipeline missing" "fix_ci_pipeline"
+    register_fixable "CI pipeline missing ($_ci_dest)" "fix_ci_pipeline"
   else
-    register_manual "CI pipeline missing" "Copy from orchestrator templates/pipelines/ci/"
+    register_manual "CI pipeline missing ($_ci_dest)" "Copy from orchestrator templates/pipelines/ci/$_ci_host/"
   fi
 
-  # Release pipeline
-  if [ -n "$PLATFORM" ] && has_source && [ -f "$SOURCE_DIR/templates/pipelines/release/${PLATFORM}.yml" ]; then
-    if [ -f ".github/workflows/release.yml" ]; then
-      register_pass "Release pipeline exists"
-    else
-      register_fixable "Release pipeline missing" "fix_release_pipeline"
-    fi
+  # Release pipeline — same host routing. bitbucket/gitlab carry
+  # release steps in their unified pipeline file (no separate
+  # release.yml); register a manual entry so the warning surfaces.
+  if [ -n "$PLATFORM" ] && has_source && [ -f "$SOURCE_DIR/templates/pipelines/release/$_ci_host/${PLATFORM}.yml" ]; then
+    case "$_ci_host" in
+      github)
+        if [ -f ".github/workflows/release.yml" ]; then
+          register_pass "Release pipeline exists"
+        else
+          register_fixable "Release pipeline missing" "fix_release_pipeline"
+        fi
+        ;;
+      bitbucket|gitlab)
+        register_manual "Release pipeline (host=$_ci_host)" "Integrate release steps from templates/pipelines/release/$_ci_host/${PLATFORM}.yml into the unified pipeline file"
+        ;;
+    esac
   fi
 
   # Intake suggestions
@@ -862,6 +898,37 @@ fix_platform_module() {
   fi
 }
 
+# Detect the project's CI host from .claude/manifest.json (.host),
+# falling back to `git remote get-url origin` parsing (same case-switch
+# used by scripts/upgrade-project.sh:253-281 for the BL-008 host-aware
+# backfill). Returns one of: github | bitbucket | gitlab | other.
+#
+# specs-plans-uat-bugs-verify-install-uat-quality-3 — the pre-fix
+# fix_ci_pipeline / fix_release_pipeline functions hardcoded both
+# (a) the source layout (pre-BL-008 flat `templates/pipelines/ci/<lang>.yml`)
+# and (b) the destination (`.github/workflows/{ci,release}.yml`), so they
+# could never run successfully on bitbucket- or gitlab-hosted projects
+# AND silently failed even on github after the BL-008 per-host subfolder
+# migration. The detector below routes both source AND destination by
+# host, restoring the auto-fix path for all three SCM hosts.
+_detect_pipeline_host() {
+  local h=""
+  if [ -f .claude/manifest.json ] && command -v jq &>/dev/null; then
+    h=$(jq -r '.host // empty' .claude/manifest.json 2>/dev/null)
+  fi
+  if [ -z "$h" ] || [ "$h" = "null" ]; then
+    local url
+    url=$(git remote get-url origin 2>/dev/null || echo "")
+    case "$url" in
+      *github.com*)    h="github" ;;
+      *gitlab*)        h="gitlab" ;;
+      *bitbucket.org*) h="bitbucket" ;;
+      *)               h="other" ;;
+    esac
+  fi
+  printf '%s' "$h"
+}
+
 fix_ci_pipeline() {
   if ! has_source || ! has_context; then return 1; fi
   local ci_template
@@ -871,22 +938,59 @@ fix_ci_pipeline() {
     java) ci_template="java.yml" ;;
     *) ci_template="${LANGUAGE}.yml" ;;
   esac
-  if [ -f "$SOURCE_DIR/templates/pipelines/ci/$ci_template" ]; then
-    mkdir -p .github/workflows
-    cp "$SOURCE_DIR/templates/pipelines/ci/$ci_template" .github/workflows/ci.yml
-  else
+  local host
+  host=$(_detect_pipeline_host)
+  local src="$SOURCE_DIR/templates/pipelines/ci/$host/$ci_template"
+  if [ ! -f "$src" ]; then
+    print_warn "fix_ci_pipeline: no CI template for host=$host language=$LANGUAGE at $src"
     return 1
   fi
+  case "$host" in
+    github)
+      mkdir -p .github/workflows
+      cp "$src" .github/workflows/ci.yml
+      ;;
+    bitbucket)
+      cp "$src" bitbucket-pipelines.yml
+      ;;
+    gitlab)
+      cp "$src" .gitlab-ci.yml
+      ;;
+    *)
+      print_warn "fix_ci_pipeline: unsupported host '$host' — no canonical CI destination"
+      return 1
+      ;;
+  esac
 }
 
 fix_release_pipeline() {
   if ! has_source || [ -z "$PLATFORM" ]; then return 1; fi
-  if [ -f "$SOURCE_DIR/templates/pipelines/release/${PLATFORM}.yml" ]; then
-    mkdir -p .github/workflows
-    cp "$SOURCE_DIR/templates/pipelines/release/${PLATFORM}.yml" .github/workflows/release.yml
-  else
+  local host
+  host=$(_detect_pipeline_host)
+  local src="$SOURCE_DIR/templates/pipelines/release/$host/${PLATFORM}.yml"
+  if [ ! -f "$src" ]; then
+    print_warn "fix_release_pipeline: no release template for host=$host platform=$PLATFORM at $src"
     return 1
   fi
+  case "$host" in
+    github)
+      mkdir -p .github/workflows
+      cp "$src" .github/workflows/release.yml
+      ;;
+    bitbucket|gitlab)
+      # bitbucket and gitlab carry release steps inside the single
+      # bitbucket-pipelines.yml / .gitlab-ci.yml respectively — there
+      # is no separate release file at repo root. Surface a
+      # non-blocking warning rather than silently writing to
+      # .github/workflows/release.yml (the pre-fix bug).
+      print_warn "fix_release_pipeline: host '$host' carries release steps in the unified pipeline file; manual integration required (template at $src)"
+      return 1
+      ;;
+    *)
+      print_warn "fix_release_pipeline: unsupported host '$host' — no canonical release destination"
+      return 1
+      ;;
+  esac
 }
 
 fix_intake_suggestions() {

--- a/tests/test-specs-plans-remaining-quartet.sh
+++ b/tests/test-specs-plans-remaining-quartet.sh
@@ -1,0 +1,468 @@
+#!/usr/bin/env bash
+# tests/test-specs-plans-remaining-quartet.sh
+#
+# Coverage for four S3 audit findings landed together in PR
+# `fix/specs-plans-remaining-quartet`. Each block is a self-contained
+# red→green oracle:
+#
+#   T-PR-GATE — specs-plans-process-enforcement-2
+#     pre-commit-gate.sh's gh-pr-create branch must allow PR creation
+#     once Build-Loop steps 1–5 (tests_written … documentation_updated)
+#     are complete. The pre-fix threshold of `-lt 6` requires step 6
+#     (feature_recorded) which is post-PR bookkeeping; baseline
+#     invariant #14 prescribes 5/6. RED on origin/main: gate DENIES at
+#     5/6. GREEN: gate ALLOWS at 5/6 and still DENIES at 1/6..4/6.
+#
+#   T-CV-MULTIWORD — specs-plans-tool-matrix-versions-1
+#     check-versions.sh truncated multi-word tool names ("Claude Code")
+#     to their first word in update output by parsing the display string
+#     UPDATES[] entry with `${var%% *}`. Now driven from a parallel
+#     UPDATE_NAMES[] array so the printed name matches the matrix
+#     verbatim. RED on origin/main: "Claude" only appears in command-list
+#     line. GREEN: "Claude Code" appears verbatim.
+#
+#   T-VI-PIPELINE — specs-plans-uat-bugs-verify-install-uat-quality-3
+#     verify-install.sh's fix_ci_pipeline / fix_release_pipeline read
+#     from pre-BL-008 flat-layout paths and write to .github/workflows
+#     hardcoded — broken for bitbucket/gitlab hosts and broken even on
+#     github after the BL-008 per-host subfolder migration. Now reads
+#     host from .claude/manifest.json (.host) with `git remote get-url
+#     origin` fallback and routes to the matching host destination.
+#     RED on origin/main: bitbucket-pipelines.yml is never created.
+#     GREEN: bitbucket-pipelines.yml is created from
+#     templates/pipelines/ci/bitbucket/<lang>.yml.
+#
+#   T-PA-TIERAWARE — specs-plans-phase-audit-docs-remediation-1
+#     The phase-audit spec and plan were tier-blind: auditors graded
+#     findings without knowledge of (deployment, poc_mode, track,
+#     enforcement_level) so intentional graceful-degradation behaviors
+#     surfaced as severity inflations. Spec §2.0 and the six agent
+#     prompts must require auditors to compute the project's tier
+#     tuple and carry a `tier_context` field on every finding. RED on
+#     origin/main: the spec and plan do not mention `tier_context` or
+#     §2.0 tier-tuple gating. GREEN: both files contain the tier-aware
+#     amendment markers.
+#
+# Test harness conventions mirror tests/test-pre-commit-gate-classifier.sh
+# and tests/test-verify-install-fix-functions.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GATE="$REPO_ROOT/scripts/pre-commit-gate.sh"
+CV="$REPO_ROOT/scripts/check-versions.sh"
+VI="$REPO_ROOT/scripts/verify-install.sh"
+SPEC="$REPO_ROOT/docs/superpowers/specs/2026-04-08-phase-audit-design.md"
+PLAN="$REPO_ROOT/docs/superpowers/plans/2026-04-08-phase-audit.md"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ════════════════════════════════════════════════════════════════════
+# T-PR-GATE — specs-plans-process-enforcement-2
+# ════════════════════════════════════════════════════════════════════
+
+setup_pr_fixture() {
+  local steps_done="$1"  # integer 0..6
+  TMP_PR=$(mktemp -d)
+  (
+    cd "$TMP_PR"
+    git init -q -b main
+    git config user.email "t@t.l"
+    git config user.name  "t"
+    git remote add origin https://example.com/x.git
+    mkdir -p .claude
+    cat > .claude/manifest.json <<'JSON'
+{"frameworkVersion":"test","mode":"personal","host":"other","deployment":"personal","enforcement_level":"strict"}
+JSON
+    cat > .claude/phase-state.json <<'JSON'
+{"current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"phases":{}}
+JSON
+  )
+
+  # Build a build_loop.steps_completed list of the requested length using
+  # the canonical ordering from process-checklist.sh:BUILD_LOOP_STEPS.
+  local all=(tests_written tests_verified_failing implemented security_audit documentation_updated feature_recorded)
+  local steps_json="[]"
+  if [ "$steps_done" -gt 0 ]; then
+    local slice=()
+    local i
+    for (( i=0; i<steps_done; i++ )); do
+      slice+=("${all[$i]}")
+    done
+    steps_json=$(printf '%s\n' "${slice[@]}" | jq -R . | jq -s .)
+  fi
+  jq -n --argjson s "$steps_json" '
+    {
+      phase2_init:{verified:true,steps_completed:["remote_repo_created","branch_protection_configured","ci_pipeline_configured","project_scaffolded","pre_commit_hooks_installed","data_model_applied","initialization_verified"]},
+      build_loop:{feature:"demo",step:($s|length),steps_completed:$s,started_at:"2026-04-26T00:00:00Z"},
+      uat_session:{},
+      phase3_validation:{},
+      phase4_release:{}
+    }' > "$TMP_PR/.claude/process-state.json"
+}
+teardown_pr() { rm -rf "${TMP_PR:-}"; }
+
+# Pipe a JSON tool_input.command into the gate. Echo "EXIT|STDOUT".
+# SKIP_LINT=1 bypasses the counter-antipattern + backlog-references
+# lints, which are scoped to the repo we're being invoked from and add
+# tens of seconds per invocation; they are not under test here.
+run_gate() {
+  local cmd="$1"
+  local input out rc=0
+  input=$(jq -n --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  out=$(cd "$TMP_PR" && printf '%s' "$input" | SKIP_LINT=1 bash "$GATE" 2>&1) || rc=$?
+  echo "$rc|$(printf '%s' "$out" | tr '\n' ' ')"
+}
+
+# T-PR-GATE-A: 5/6 steps done (documentation_updated last) → gate must ALLOW.
+# RED on main: gate DENIES (the `-lt 6` branch fires at 5/6).
+echo "T-PR-GATE-A: gh pr create with Build-Loop 5/6 complete is ALLOWED"
+setup_pr_fixture 5
+out=$(run_gate 'gh pr create --title "x" --body "y"')
+if [[ "${out#*|}" == *'"permissionDecision": "deny"'*'incomplete Build Loop'* ]]; then
+  fail_ "T-PR-GATE-A" "gate DENIED PR creation at 5/6 (should ALLOW per baseline invariant #14)"
+else
+  pass "T-PR-GATE-A: 5/6 build_loop steps allows PR creation"
+fi
+teardown_pr
+
+# T-PR-GATE-B: 3/6 steps done (partial) → gate must still DENY.
+# This is the non-vacuous companion: confirms the lowered threshold did
+# not collapse to "always allow". RED on main: also DENIES (different
+# message internals). GREEN: still DENIES with "$BUILD_STEPS_DONE/5".
+echo "T-PR-GATE-B: gh pr create with Build-Loop 3/6 complete is still DENIED"
+setup_pr_fixture 3
+out=$(run_gate 'gh pr create --title "x" --body "y"')
+if [[ "${out#*|}" != *'"permissionDecision": "deny"'* ]]; then
+  fail_ "T-PR-GATE-B" "gate ALLOWED PR creation at 3/6 (should DENY — partial Build Loop)"
+elif [[ "${out#*|}" != *'incomplete Build Loop'* ]]; then
+  fail_ "T-PR-GATE-B" "gate DENIED but for the wrong reason (expected 'incomplete Build Loop'); got: ${out#*|}"
+else
+  pass "T-PR-GATE-B: 3/6 build_loop steps still denies PR creation"
+fi
+teardown_pr
+
+# T-PR-GATE-C: 0/6 steps done with feature unset → no build_loop block at all.
+# Confirms the gate's existing step-0 carve-out still works (no regression
+# on the "between features" case). RED on main: ALLOWS (so does GREEN);
+# this is anti-regression armor for the carve-out.
+echo "T-PR-GATE-C: gh pr create with build_loop feature unset is ALLOWED"
+TMP_PR=$(mktemp -d)
+(
+  cd "$TMP_PR"
+  git init -q -b main
+  git config user.email "t@t.l"; git config user.name "t"
+  git remote add origin https://example.com/x.git
+  mkdir -p .claude
+  cat > .claude/manifest.json <<'JSON'
+{"frameworkVersion":"test","mode":"personal","host":"other","deployment":"personal","enforcement_level":"strict"}
+JSON
+  cat > .claude/phase-state.json <<'JSON'
+{"current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"phases":{}}
+JSON
+  cat > .claude/process-state.json <<'JSON'
+{"phase2_init":{"verified":true,"steps_completed":["remote_repo_created","branch_protection_configured","ci_pipeline_configured","project_scaffolded","pre_commit_hooks_installed","data_model_applied","initialization_verified"]},"build_loop":{"feature":null,"step":0,"steps_completed":[]},"uat_session":{},"phase3_validation":{},"phase4_release":{}}
+JSON
+)
+out=$(run_gate 'gh pr create --title "x" --body "y"')
+if [[ "${out#*|}" == *'"permissionDecision": "deny"'*'incomplete Build Loop'* ]]; then
+  fail_ "T-PR-GATE-C" "gate DENIED PR creation with no in-flight feature (should ALLOW — step-0 carve-out)"
+else
+  pass "T-PR-GATE-C: no in-flight build_loop allows PR creation"
+fi
+teardown_pr
+
+# ════════════════════════════════════════════════════════════════════
+# T-CV-MULTIWORD — specs-plans-tool-matrix-versions-1
+#   check-versions.sh shadows uname(1) by reusing the name `uname` for
+#   a string variable AND parses the display string to recover it.
+#   When the matrix name has whitespace ("Claude Code"), the display
+#   parser truncates to "Claude". The non-interactive branch (lines
+#   516–524) prints `<name>: <cmd>` for every UPDATES[] entry — this is
+#   the surface we drive in the test.
+# ════════════════════════════════════════════════════════════════════
+
+setup_cv_fixture() {
+  TMP_CV=$(mktemp -d)
+  mkdir -p "$TMP_CV/templates/tool-matrix" "$TMP_CV/scripts/lib"
+  # Single tool with a multi-word name. min_version > installed (echo 0.0.1)
+  # forces the BELOW MINIMUM branch which unconditionally pushes onto
+  # UPDATES[] / UPDATE_CMDS[] regardless of network availability.
+  # check-versions.sh loads common.json directly; we place our single
+  # multi-word tool there.
+  cat > "$TMP_CV/templates/tool-matrix/common.json" <<'JSON'
+{
+  "tools": [
+    {
+      "name": "Claude Code",
+      "category": "ai_agent",
+      "required": true,
+      "min_version": "99.0.0",
+      "description": "Claude Code CLI",
+      "check_command": "true",
+      "version_command": "echo 0.0.1",
+      "tracks": ["light", "standard", "full"],
+      "languages": ["all"],
+      "platforms": ["all"],
+      "dev_os": ["darwin", "linux"],
+      "install": { "darwin_brew": "brew install claude-fake" }
+    }
+  ]
+}
+JSON
+  # Minimal helpers stub. The real helpers.sh provides print_* + colour
+  # vars; we provide just enough for check-versions.sh to source cleanly.
+  cat > "$TMP_CV/scripts/lib/helpers.sh" <<'BASH'
+BOLD=""; NC=""; YELLOW=""; CYAN=""; GREEN=""; RED=""
+print_ok()   { echo "[OK] $*"; }
+print_warn() { echo "[WARN] $*"; }
+print_fail() { echo "[FAIL] $*"; }
+print_info() { echo "[INFO] $*"; }
+print_step() { echo "[STEP] $*"; }
+prompt_input() { echo "${2:-}"; }
+prompt_yes_no() { echo "n"; }
+BASH
+  cp "$CV" "$TMP_CV/scripts/check-versions.sh"
+  chmod +x "$TMP_CV/scripts/check-versions.sh"
+}
+teardown_cv() { rm -rf "${TMP_CV:-}"; }
+
+echo "T-CV-MULTIWORD: multi-word tool name 'Claude Code' is printed verbatim in update output"
+setup_cv_fixture
+# Invoke from inside the fixture so templates/tool-matrix is discovered
+# relative to the script (matches normal invocation). Non-interactive
+# (stdin not a TTY) is achieved by piping /dev/null in.
+out=$(cd "$TMP_CV" && bash scripts/check-versions.sh </dev/null 2>&1 || true)
+# The non-interactive "Update commands (run manually):" block prints one
+# line per UPDATES[] entry as `  <name>: <cmd>`. We assert the multi-word
+# name survives intact AND is not truncated to its first word.
+if echo "$out" | grep -qE '^[[:space:]]*Claude Code:[[:space:]]+brew install claude-fake$'; then
+  pass "T-CV-MULTIWORD: 'Claude Code' surfaces with full multi-word name (no version garbage)"
+else
+  fail_ "T-CV-MULTIWORD" "expected '  Claude Code: brew install claude-fake' line; output: $out"
+fi
+teardown_cv
+
+# ════════════════════════════════════════════════════════════════════
+# T-VI-PIPELINE — specs-plans-uat-bugs-verify-install-uat-quality-3
+#   fix_ci_pipeline / fix_release_pipeline must route source AND dest
+#   by host (.claude/manifest.json:.host, fallback to `git remote get-url
+#   origin`). We test the bitbucket path explicitly because it is the
+#   one that is guaranteed-broken on main (no .github/workflows on
+#   bitbucket; .github/workflows/ci.yml is never the right destination).
+# ════════════════════════════════════════════════════════════════════
+
+setup_vi_fixture() {
+  local host="$1"  # github|bitbucket|gitlab
+  TMP_VI=$(mktemp -d)
+  SRC_VI="$TMP_VI/src"
+  PROJ_VI="$TMP_VI/proj"
+  mkdir -p "$SRC_VI/templates/pipelines/ci/github" \
+           "$SRC_VI/templates/pipelines/ci/bitbucket" \
+           "$SRC_VI/templates/pipelines/ci/gitlab" \
+           "$SRC_VI/templates/pipelines/release/github" \
+           "$SRC_VI/templates/pipelines/release/bitbucket" \
+           "$SRC_VI/templates/pipelines/release/gitlab"
+  # Distinguishable sentinel content per host so we can confirm the
+  # right SOURCE file was copied (not just "some file appeared").
+  printf 'CI:GITHUB:TS\n'    > "$SRC_VI/templates/pipelines/ci/github/typescript.yml"
+  printf 'CI:BITBUCKET:TS\n' > "$SRC_VI/templates/pipelines/ci/bitbucket/typescript.yml"
+  printf 'CI:GITLAB:TS\n'    > "$SRC_VI/templates/pipelines/ci/gitlab/typescript.yml"
+  printf 'REL:GITHUB:WEB\n'    > "$SRC_VI/templates/pipelines/release/github/web.yml"
+  printf 'REL:BITBUCKET:WEB\n' > "$SRC_VI/templates/pipelines/release/bitbucket/web.yml"
+  printf 'REL:GITLAB:WEB\n'    > "$SRC_VI/templates/pipelines/release/gitlab/web.yml"
+
+  mkdir -p "$PROJ_VI/.claude" "$PROJ_VI/scripts"
+  cat > "$PROJ_VI/.claude/manifest.json" <<JSON
+{"frameworkVersion":"test","mode":"personal","host":"$host","deployment":"personal","enforcement_level":"strict"}
+JSON
+  cat > "$PROJ_VI/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"phases":{}}
+JSON
+  cat > "$PROJ_VI/.claude/orchestrator-source.json" <<JSON
+{"source_dir":"$SRC_VI"}
+JSON
+  cp "$VI" "$PROJ_VI/scripts/verify-install.sh"
+  mkdir -p "$PROJ_VI/scripts/lib"
+  if [ -f "$REPO_ROOT/scripts/lib/helpers.sh" ]; then
+    cp "$REPO_ROOT/scripts/lib/helpers.sh" "$PROJ_VI/scripts/lib/"
+  fi
+  chmod +x "$PROJ_VI/scripts/verify-install.sh"
+}
+teardown_vi() { rm -rf "${TMP_VI:-}"; }
+
+# Helper: extract just fix_ci_pipeline / fix_release_pipeline + their
+# host-detection dependency from scripts/verify-install.sh, source it
+# in an isolated subshell with the necessary surface variables, and
+# invoke directly. This avoids the autorun-main path's
+# guard_not_in_framework + has_source/has_context plumbing.
+_invoke_fix_pipeline() {
+  local fn="$1"        # fix_ci_pipeline | fix_release_pipeline
+  local lang="$2"
+  local platform="$3"
+  local extract
+  extract=$(mktemp)
+
+  # Pass 1 — post-fix layout: a `_detect_pipeline_host()` helper is
+  # defined above the fix functions. Grab from the helper's opening
+  # through the target fix function's closing brace. This gives us a
+  # self-contained, sourceable extract.
+  awk -v fn="$fn" '
+    /^_detect_pipeline_host\(\) \{/ { capture=1 }
+    capture { print }
+    capture && /^\}$/ && !inside_fn {
+      # Helper closed; keep going so we can also capture the target fn
+      # AND any sibling helpers between the two.
+      next
+    }
+    $0 ~ "^"fn"\\(\\) \\{" { inside_fn=1 }
+    inside_fn && /^\}$/ { print "# end-extract"; exit }
+  ' "$PROJ_VI/scripts/verify-install.sh" > "$extract"
+
+  # Pass 2 fallback — origin/main has no detector helper. Extract just
+  # the bare target function body.
+  if ! grep -q "^$fn()" "$extract"; then
+    awk -v fn="$fn" '
+      $0 ~ "^"fn"\\(\\) \\{" { flag=1 }
+      flag { print }
+      flag && /^\}$/ { print "# end-extract"; exit }
+    ' "$PROJ_VI/scripts/verify-install.sh" > "$extract"
+  fi
+
+  (
+    cd "$PROJ_VI"
+    SOURCE_DIR="$SRC_VI"
+    LANGUAGE="$lang"
+    PLATFORM="$platform"
+    export SOURCE_DIR LANGUAGE PLATFORM
+    print_fail() { echo "[FAIL] $*"; }
+    print_info() { echo "[INFO] $*"; }
+    print_warn() { echo "[WARN] $*"; }
+    has_source()  { [ -d "$SOURCE_DIR" ]; }
+    has_context() { [ -f .claude/manifest.json ]; }
+    # shellcheck disable=SC1090
+    source "$extract"
+    "$fn"
+    printf "EXIT=%s\n" "$?"
+  ) 2>&1
+  rm -f "$extract"
+}
+
+# T-VI-PIPELINE-CI-BITBUCKET: CI auto-fix on a bitbucket-hosted project
+# must (a) read the source from templates/pipelines/ci/bitbucket/<lang>.yml
+# and (b) write to bitbucket-pipelines.yml at repo root. RED on
+# origin/main: .github/workflows/ci.yml created (wrong destination).
+echo "T-VI-PIPELINE-CI-BITBUCKET: fix_ci_pipeline routes by host (bitbucket)"
+setup_vi_fixture bitbucket
+_invoke_fix_pipeline fix_ci_pipeline typescript web >/dev/null 2>&1
+ok=1
+if [ ! -f "$PROJ_VI/bitbucket-pipelines.yml" ]; then
+  ok=0; reason="bitbucket-pipelines.yml was NOT created at repo root"
+elif ! grep -q '^CI:BITBUCKET:TS' "$PROJ_VI/bitbucket-pipelines.yml" 2>/dev/null; then
+  ok=0; reason="bitbucket-pipelines.yml content is not the bitbucket source (got: $(head -1 "$PROJ_VI/bitbucket-pipelines.yml" 2>/dev/null || echo MISSING))"
+fi
+if [ "$ok" -eq 1 ]; then
+  pass "T-VI-PIPELINE-CI-BITBUCKET: bitbucket-pipelines.yml created from bitbucket source"
+else
+  fail_ "T-VI-PIPELINE-CI-BITBUCKET" "$reason"
+fi
+teardown_vi
+
+# T-VI-PIPELINE-CI-GITLAB: gitlab path writes .gitlab-ci.yml at repo root
+# from templates/pipelines/ci/gitlab/<lang>.yml.
+echo "T-VI-PIPELINE-CI-GITLAB: fix_ci_pipeline routes by host (gitlab)"
+setup_vi_fixture gitlab
+_invoke_fix_pipeline fix_ci_pipeline typescript web >/dev/null 2>&1
+ok=1
+if [ ! -f "$PROJ_VI/.gitlab-ci.yml" ]; then
+  ok=0; reason=".gitlab-ci.yml was NOT created at repo root"
+elif ! grep -q '^CI:GITLAB:TS' "$PROJ_VI/.gitlab-ci.yml" 2>/dev/null; then
+  ok=0; reason=".gitlab-ci.yml content is not the gitlab source (got: $(head -1 "$PROJ_VI/.gitlab-ci.yml" 2>/dev/null || echo MISSING))"
+fi
+if [ "$ok" -eq 1 ]; then
+  pass "T-VI-PIPELINE-CI-GITLAB: .gitlab-ci.yml created from gitlab source"
+else
+  fail_ "T-VI-PIPELINE-CI-GITLAB" "$reason"
+fi
+teardown_vi
+
+# T-VI-PIPELINE-CI-GITHUB: anti-regression — github path STILL writes
+# .github/workflows/ci.yml and reads from the github/ subfolder (post
+# BL-008 layout). Origin/main writes to the right destination but
+# reads from the wrong (flat) source path, so this asserts both legs.
+echo "T-VI-PIPELINE-CI-GITHUB: fix_ci_pipeline reads github/<lang>.yml not flat"
+setup_vi_fixture github
+_invoke_fix_pipeline fix_ci_pipeline typescript web >/dev/null 2>&1
+ok=1
+if [ ! -f "$PROJ_VI/.github/workflows/ci.yml" ]; then
+  ok=0; reason=".github/workflows/ci.yml was NOT created"
+elif ! grep -q '^CI:GITHUB:TS' "$PROJ_VI/.github/workflows/ci.yml" 2>/dev/null; then
+  ok=0; reason="ci.yml content is not the github source (got: $(head -1 "$PROJ_VI/.github/workflows/ci.yml" 2>/dev/null || echo MISSING))"
+fi
+if [ "$ok" -eq 1 ]; then
+  pass "T-VI-PIPELINE-CI-GITHUB: github CI sourced from github/ subfolder"
+else
+  fail_ "T-VI-PIPELINE-CI-GITHUB" "$reason"
+fi
+teardown_vi
+
+# T-VI-PIPELINE-RELEASE-BITBUCKET: release pipeline parallel to CI.
+# Bitbucket has no separate release file (releases run in same
+# bitbucket-pipelines.yml). Test that the function either writes the
+# right release destination for the host OR returns 1 (no destination
+# defined) — must NOT silently create .github/workflows/release.yml.
+echo "T-VI-PIPELINE-RELEASE-BITBUCKET: fix_release_pipeline does not write .github on bitbucket"
+setup_vi_fixture bitbucket
+_invoke_fix_pipeline fix_release_pipeline typescript web >/dev/null 2>&1
+ok=1
+if [ -f "$PROJ_VI/.github/workflows/release.yml" ]; then
+  ok=0; reason=".github/workflows/release.yml was created on a bitbucket-hosted project (wrong destination)"
+fi
+if [ "$ok" -eq 1 ]; then
+  pass "T-VI-PIPELINE-RELEASE-BITBUCKET: no .github/workflows/release.yml on bitbucket"
+else
+  fail_ "T-VI-PIPELINE-RELEASE-BITBUCKET" "$reason"
+fi
+teardown_vi
+
+# ════════════════════════════════════════════════════════════════════
+# T-PA-TIERAWARE — specs-plans-phase-audit-docs-remediation-1
+#   The spec/plan amendment is doc-only. The oracle is the presence of
+#   the new content blocks: (a) §2.0 in the spec mentioning
+#   tier-tuple gating, (b) `tier_context` field in the finding schema,
+#   and (c) each of the six auditor prompts in the plan referencing
+#   the tier tuple before grading. RED on main: none of these markers
+#   exist. GREEN: all markers present.
+# ════════════════════════════════════════════════════════════════════
+
+echo "T-PA-TIERAWARE-SPEC: spec contains §2.0 tier-tuple step"
+if ! grep -qE '^## 2\.0 ' "$SPEC"; then
+  fail_ "T-PA-TIERAWARE-SPEC" "spec is missing a §2.0 heading (pre-§2.1 tier-tuple step)"
+elif ! grep -qE 'tier_context' "$SPEC"; then
+  fail_ "T-PA-TIERAWARE-SPEC" "spec does not introduce the 'tier_context' finding field"
+elif ! grep -qiE 'deployment.*poc_mode.*track.*enforcement_level|tier (tuple|context)' "$SPEC"; then
+  fail_ "T-PA-TIERAWARE-SPEC" "spec §2.0 does not enumerate the four tier dimensions"
+else
+  pass "T-PA-TIERAWARE-SPEC: §2.0 tier-tuple gating present with tier_context field"
+fi
+
+echo "T-PA-TIERAWARE-PLAN: plan's six auditor prompts each reference tier_context"
+# Count distinct dispatch blocks that mention tier_context. The plan
+# has 6 prompts (Phase 0..4 + Cross-Cutting). We require ALL six to
+# embed the tier-aware instruction — a partial sprinkle would leave
+# auditors mis-graded for the unamended phases.
+mentions=$(grep -c 'tier_context' "$PLAN" 2>/dev/null || echo "0")
+case "$mentions" in ''|*[!0-9]*) mentions=0 ;; esac
+if [ "$mentions" -lt 6 ]; then
+  fail_ "T-PA-TIERAWARE-PLAN" "expected 'tier_context' in all 6 auditor prompts; found $mentions occurrences"
+else
+  pass "T-PA-TIERAWARE-PLAN: all six auditor prompts reference tier_context"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- Wave-4 slot-3 — closes four S3 audit findings under `fix/specs-plans-remaining-quartet`.
- **pre-commit-gate** lowers gh-pr-create Build-Loop threshold from 6/6 to 5/6 (step 6 is post-PR bookkeeping per baseline invariant #14); spec amended to match.
- **check-versions.sh** introduces parallel `UPDATE_NAMES[]` array; multi-word tool names (`Claude Code`) no longer truncated by the `${var%% *}` display-string parse, and `uname(1)` is no longer shadowed.
- **verify-install.sh** host-routes both source and destination of CI/release auto-fix via new `_detect_pipeline_host` (manifest.json:.host with `git remote get-url origin` fallback). Bitbucket + gitlab now write the right files at repo root; github reads from the post-BL-008 `github/` subfolder.
- **phase-audit spec + plan** gain a §2.0 Tier-Tuple Pre-Audit Gating block + `tier_context` field on every finding + `tier_misalignment` severity flag. All six auditor prompts in the plan embed the gating.

## Findings closed

- `specs-plans-process-enforcement-2` — scripts/pre-commit-gate.sh:640 condition lowered to `-lt 5`; docs/superpowers/specs/2026-04-08-process-enforcement-design.md §3.1 amended.
- `specs-plans-tool-matrix-versions-1` — scripts/check-versions.sh:lines 273–289 (UPDATE_NAMES decl + 4 push sites) + lines 462–476, 488–504, 516–532 (3 consumer loops).
- `specs-plans-uat-bugs-verify-install-uat-quality-3` — scripts/verify-install.sh:lines 192–243 (CI/release existence check, host-aware) + lines 891–977 (`_detect_pipeline_host` + `fix_ci_pipeline` + `fix_release_pipeline`).
- `specs-plans-phase-audit-docs-remediation-1` — docs/superpowers/specs/2026-04-08-phase-audit-design.md (new §2.0 + finding template update) + docs/superpowers/plans/2026-04-08-phase-audit.md (Tier-Tuple Pre-Audit Gating block × 6 auditor prompts + tier_context in finding format).

## Test plan

New test file: `tests/test-specs-plans-remaining-quartet.sh`.

**RED on `origin/main`** (confirmed against the merge base `8bfe51c` which is HEAD of `origin/main`):

```
$ bash tests/test-specs-plans-remaining-quartet.sh 2>&1 | grep -E "T-|PASS|FAIL|Results"
T-PR-GATE-A: gh pr create with Build-Loop 5/6 complete is ALLOWED
  [FAIL] T-PR-GATE-A — gate DENIED PR creation at 5/6 (should ALLOW per baseline invariant #14)
T-PR-GATE-B: gh pr create with Build-Loop 3/6 complete is still DENIED
  [PASS] T-PR-GATE-B: 3/6 build_loop steps still denies PR creation
T-PR-GATE-C: gh pr create with build_loop feature unset is ALLOWED
  [PASS] T-PR-GATE-C: no in-flight build_loop allows PR creation
T-CV-MULTIWORD: multi-word tool name 'Claude Code' is printed verbatim in update output
  [FAIL] T-CV-MULTIWORD — expected '  Claude Code: brew install claude-fake' line; output:
T-VI-PIPELINE-CI-BITBUCKET: fix_ci_pipeline routes by host (bitbucket)
  [FAIL] T-VI-PIPELINE-CI-BITBUCKET — bitbucket-pipelines.yml was NOT created at repo root
T-VI-PIPELINE-CI-GITLAB: fix_ci_pipeline routes by host (gitlab)
  [FAIL] T-VI-PIPELINE-CI-GITLAB — .gitlab-ci.yml was NOT created at repo root
T-VI-PIPELINE-CI-GITHUB: fix_ci_pipeline reads github/<lang>.yml not flat
  [FAIL] T-VI-PIPELINE-CI-GITHUB — .github/workflows/ci.yml was NOT created
T-VI-PIPELINE-RELEASE-BITBUCKET: fix_release_pipeline does not write .github on bitbucket
  [PASS] T-VI-PIPELINE-RELEASE-BITBUCKET: no .github/workflows/release.yml on bitbucket
T-PA-TIERAWARE-SPEC: spec contains §2.0 tier-tuple step
  [FAIL] T-PA-TIERAWARE-SPEC — spec is missing a §2.0 heading (pre-§2.1 tier-tuple step)
T-PA-TIERAWARE-PLAN: plan's six auditor prompts each reference tier_context
  [FAIL] T-PA-TIERAWARE-PLAN — expected 'tier_context' in all 6 auditor prompts; found 0 occurrences
Results: 3 passed, 7 failed
```

7 RED + 3 anti-regression PASS armor on origin/main.

**GREEN on this branch**:

```
$ bash tests/test-specs-plans-remaining-quartet.sh 2>&1 | tail -3
  [PASS] T-PA-TIERAWARE-PLAN: all six auditor prompts reference tier_context

Results: 10 passed, 0 failed
```

**Adjacent existing tests** (no regression):

- `tests/test-pre-commit-gate-classifier.sh` — 13/13 PASS
- `tests/test-pre-commit-gate-lints.sh` — 13/13 PASS
- `tests/test-pre-commit-gate-terminal-mode.sh` — 3/3 PASS
- `tests/test-check-commit-message.sh` — 18/18 PASS
- `tests/test-verify-install-fix-functions.sh` — 15/15 PASS
- `tests/test-verify-install-bl030-coverage.sh` — 8/8 PASS

**Self-verify lints** (all OK):

- `scripts/lint-counter-antipattern.sh` — OK: no counter-capture antipatterns found.
- `scripts/lint-backlog-references.sh` — OK: backlog references and Closed-status citations are consistent.
- `scripts/lint-fix-functions-stderr.sh` — OK: no fix_*() stderr silencers found.
- `scripts/lint-raw-read-prompt.sh` — OK: no raw 'read -rp' / 'read -p' calls outside scripts/lib/helpers.sh.

## Bonus catches

- `verify-install.sh` `check_project_structure()`'s CI/release existence check was *also* hardcoded to `.github/workflows/{ci,release}.yml` regardless of host (paired bug — would have reported "CI pipeline exists" on a bitbucket project that has no such file, or "missing" + `fix_ci_pipeline` would have copied the wrong-host source). Host-routed inline using the same detection logic.
- `verify-install.sh` `fix_release_pipeline` now surfaces a non-blocking warning on bitbucket/gitlab (release steps live in the unified pipeline file there) instead of silently writing to `.github/workflows/release.yml`.
- spec finding template gains explicit `tier_misalignment` severity flag (covers a genus of bugs the prior 4-tier severity didn't capture: behavior diverges from expected per tier tuple, e.g. branch protection fires on personal).

## Breaking changes

None for direct callers, but two operator-visible behavior shifts:

1. `gh pr create` is now permitted at Build-Loop step 5/5 (was blocked at 5/6). Callers relying on the prior gate to block PR creation until `feature_recorded` will see the gate pass earlier. The block at steps 1–4 is unchanged.
2. `scripts/verify-install.sh --auto-fix` on bitbucket-hosted projects now writes `bukbucket-pipelines.yml` at repo root (previously: silently wrote `.github/workflows/ci.yml`, useless). Operators with both files staged should remove the stale `.github/workflows/ci.yml`.

## Worktree note

```
$ pwd
/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_22ccde10-1af-3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)