### PR TITLE
test(closer): real init.sh in BL-009 + idempotency real-test + org-host integration + known-bugs dedup + Personal→Org retroactive reapproval (5 S3)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -516,6 +516,44 @@ if [ "$current_phase" -ge 2 ]; then
   fi
 fi
 
+# audit tier-crosscheck-5 closure: Personal → Organizational upgrade
+# retroactive STA approval. baseline §4 row 5 / builders-guide.md line
+# 807 require that any project upgraded from personal to organizational
+# have its existing Project Bible retroactively reviewed and approved
+# by a Senior Technical Authority. Pre-fix nothing enforced this — the
+# upgrade-project.sh APPROVAL_LOG.md restructure didn't even surface
+# a row for the retroactive sign-off, so check-phase-gate.sh had
+# nothing to validate.
+#
+# Behavior: when the APPROVAL_LOG.md frontmatter carries
+# `upgraded_from: personal` AND current_phase >= 2, parse the
+# `Retroactive Phase 1 → Phase 2 STA Approval` section. If the
+# Approver or Date is blank, emit a non-blocking WARN (does NOT
+# increment $issues — this is a recurring nudge, not a gate-block,
+# per the audit recommendation). When the section is missing entirely
+# we WARN too (for projects upgraded before this row was added).
+if [ "$current_phase" -ge 2 ] && [ -f "$APPROVAL_LOG" ] && \
+   grep -q '^upgraded_from: personal' "$APPROVAL_LOG" 2>/dev/null; then
+  # Slice out the Retroactive section header and the next ~15 lines.
+  retro_section=$(grep -A 15 "Retroactive Phase 1.*Phase 2.*STA" "$APPROVAL_LOG" 2>/dev/null || echo "")
+  if [ -z "$retro_section" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Phase 1→2 retroactive: project upgraded from personal but APPROVAL_LOG.md has no 'Retroactive Phase 1 → Phase 2 STA Approval' section."
+    echo "        Required by docs/builders-guide.md § Phase 1 (line 807). Re-run scripts/upgrade-project.sh"
+    echo "        to regenerate the section, or add it manually with Approver + Date."
+  else
+    # Extract Approver and Date values from the Field/Value table.
+    retro_approver=$(echo "$retro_section" | grep -E '\*\*Approver\*\*' | head -1 | sed -E 's/.*\*\*Approver\*\*[[:space:]]*\|[[:space:]]*//; s/[[:space:]]*\|.*$//')
+    retro_date=$(echo "$retro_section" | grep -E '\*\*Date\*\*' | head -1 | sed -E 's/.*\*\*Date\*\*[[:space:]]*\|[[:space:]]*//; s/[[:space:]]*\|.*$//')
+    if [ -z "$retro_approver" ] || [ -z "$retro_date" ]; then
+      echo -e "${YELLOW}[WARN]${NC} Phase 1→2 retroactive: project upgraded from personal but Retroactive STA Approval row is incomplete (Approver='$retro_approver' Date='$retro_date')."
+      echo "        Required by docs/builders-guide.md § Phase 1 (line 807). Have the Senior Technical"
+      echo "        Authority retroactively review the Project Bible and fill in the Approver + Date."
+    else
+      echo -e "${GREEN}  [OK]${NC} Phase 1→2 retroactive: STA approval recorded ($retro_approver, $retro_date)"
+    fi
+  fi
+fi
+
 # Check: if current_phase >= 3, gate 2→3 should have a date
 if [ "$current_phase" -ge 3 ]; then
   if [ -n "$gate_2_to_3" ]; then

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -21,10 +21,16 @@ source "$SCRIPT_DIR/lib/helpers.sh"
 # replicating save_answer / init_progress / save_section / _request_pause
 # inline; the tests can now source the file and exercise the real
 # functions, closing the regression-coverage gap the audit cited.
-_intake_wizard_sourced=0
-(return 0 2>/dev/null) && _intake_wizard_sourced=1
+#
+# PR #104 verifier follow-up (Wave 4 minor #4): the probe was previously
+# the unscoped global `_intake_wizard_sourced`, which leaked into the
+# caller's variable namespace. Renamed to `__SOLO_INTAKE_WIZARD_SOURCED__`
+# (caps + double-underscore prefix is the project convention for
+# module-private globals).
+__SOLO_INTAKE_WIZARD_SOURCED__=0
+(return 0 2>/dev/null) && __SOLO_INTAKE_WIZARD_SOURCED__=1
 
-if [ "$_intake_wizard_sourced" -ne 1 ]; then
+if [ "$__SOLO_INTAKE_WIZARD_SOURCED__" -ne 1 ]; then
   # UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
   guard_not_in_framework || exit 1
 
@@ -261,6 +267,21 @@ PYEOF
 
 # Pause detection: prompt functions write a sentinel file when the user
 # types "pause". The section runner checks for this file after each prompt.
+#
+# PR #104 verifier follow-up (Wave 4 major #3): the verifier flagged
+# both `_PAUSE_FILE` allocation and the EXIT trap as module-load-time
+# side effects. The allocation is kept unconditional because:
+#   (a) it's a pure variable assignment — no /tmp file is created until
+#       _request_pause() touches it, which only the wizard's prompt loop
+#       calls; sourcing the file alone does NOT touch the filesystem.
+#   (b) the `$$` interpolation captures the sourcing process's PID, so
+#       parallel test runs cannot collide.
+#   (c) tests/known-bugs-test-suite.sh:615 (BUG-8) sources this file
+#       under `set -u` and reads $_PAUSE_FILE directly; gating the
+#       allocation would force every sourced caller to fallback-default
+#       it, undermining the source-real-functions rewrite that closed
+#       tests-full-known-bugs-2.
+# The real clobber risk is the EXIT trap (see below) — that IS gated.
 _PAUSE_FILE="/tmp/.solo-intake-pause-$$"
 
 _request_pause() {
@@ -278,8 +299,20 @@ check_pause_requested() {
   fi
 }
 
-# Clean up pause file on exit
-trap 'rm -f "$_PAUSE_FILE"' EXIT
+# Clean up pause file on exit.
+#
+# PR #104 verifier follow-up (Wave 4 major #3): the trap is gated on
+# __SOLO_INTAKE_WIZARD_SOURCED__ -ne 1. Pre-fix the trap ran at
+# module-load time even when sourced and silently clobbered any pre-
+# existing EXIT trap in the caller's shell — same defect class as the
+# original BUG-8 the main-guard pattern (lines 27, 2009) was added to
+# fix. Tests escaped today only because each `source` lives inside its
+# own `( ... )` subshell. Gating the trap eliminates the clobber surface
+# for any future caller that does not subshell-wrap. Sourced callers
+# that want pause-file cleanup must register their own trap.
+if [ "${__SOLO_INTAKE_WIZARD_SOURCED__:-0}" -ne 1 ]; then
+  trap 'rm -f "$_PAUSE_FILE"' EXIT
+fi
 
 # ================================================================
 # PROGRESS: Initialize progress file
@@ -2001,6 +2034,6 @@ main() {
   esac
 }
 
-if [ "${_intake_wizard_sourced:-0}" -ne 1 ]; then
+if [ "${__SOLO_INTAKE_WIZARD_SOURCED__:-0}" -ne 1 ]; then
   main "$@"
 fi

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -12,45 +12,65 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/lib/helpers.sh"
 
-# UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
-guard_not_in_framework || exit 1
+# audit tests-full-known-bugs-2 (closure): allow this file to be sourced
+# by tests without triggering the wizard's project-root discovery,
+# CWD anchor, and main() loop. The guard `return 0 2>/dev/null` succeeds
+# only when the script is being sourced — in normal `bash intake-wizard.sh`
+# invocations it errors out, the negation flips, and the original setup
+# block runs unchanged. This unblocks tests/known-bugs-test-suite.sh from
+# replicating save_answer / init_progress / save_section / _request_pause
+# inline; the tests can now source the file and exercise the real
+# functions, closing the regression-coverage gap the audit cited.
+_intake_wizard_sourced=0
+(return 0 2>/dev/null) && _intake_wizard_sourced=1
 
-# UAT 2026-04-26 fix (U-G / T1-D): walk up from CWD looking for .claude/.
-# The previous implementation hardcoded PROJECT_ROOT="$SCRIPT_DIR/.." which
-# resolved to the framework dir when invoked via bash $FRAMEWORK/scripts/
-# intake-wizard.sh, breaking --upgrade-deployment / --to-sponsored-poc /
-# --to-private-poc / --resume. Same shape as scripts/upgrade-project.sh's
-# find_project_root().
-find_project_root_for_intake() {
-  local dir="$PWD"
-  while [ "$dir" != "/" ]; do
-    if [ -f "$dir/.claude/phase-state.json" ]; then
-      echo "$dir"
-      return 0
-    fi
-    dir="$(dirname "$dir")"
-  done
-  return 1
-}
-if PROJECT_ROOT="$(find_project_root_for_intake)"; then
-  :
-else
-  print_fail "Could not find project root (no .claude/phase-state.json in CWD or parents)."
-  print_info "Run intake-wizard.sh from your project directory."
-  exit 1
+if [ "$_intake_wizard_sourced" -ne 1 ]; then
+  # UAT 2026-04-25 fix (U-N): refuse to operate inside the framework repo.
+  guard_not_in_framework || exit 1
+
+  # UAT 2026-04-26 fix (U-G / T1-D): walk up from CWD looking for .claude/.
+  # The previous implementation hardcoded PROJECT_ROOT="$SCRIPT_DIR/.." which
+  # resolved to the framework dir when invoked via bash $FRAMEWORK/scripts/
+  # intake-wizard.sh, breaking --upgrade-deployment / --to-sponsored-poc /
+  # --to-private-poc / --resume. Same shape as scripts/upgrade-project.sh's
+  # find_project_root().
+  find_project_root_for_intake() {
+    local dir="$PWD"
+    while [ "$dir" != "/" ]; do
+      if [ -f "$dir/.claude/phase-state.json" ]; then
+        echo "$dir"
+        return 0
+      fi
+      dir="$(dirname "$dir")"
+    done
+    return 1
+  }
+  if PROJECT_ROOT="$(find_project_root_for_intake)"; then
+    :
+  else
+    print_fail "Could not find project root (no .claude/phase-state.json in CWD or parents)."
+    print_info "Run intake-wizard.sh from your project directory."
+    exit 1
+  fi
+
+  # All passthrough exec's below use relative `scripts/...` paths, and several
+  # wizard sections write into the project's working files. Anchor CWD to the
+  # resolved project root so those paths are unambiguous regardless of where
+  # the wizard was invoked from.
+  cd "$PROJECT_ROOT"
 fi
 
-# All passthrough exec's below use relative `scripts/...` paths, and several
-# wizard sections write into the project's working files. Anchor CWD to the
-# resolved project root so those paths are unambiguous regardless of where
-# the wizard was invoked from.
-cd "$PROJECT_ROOT"
-
-# Templates ship with the framework, not the project.
+# Templates ship with the framework, not the project. Defining this
+# outside the sourced/standalone branch keeps the constant available
+# to functions that tests may reach for (e.g. render_intake_file).
 FRAMEWORK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
-PROGRESS_FILE="$PROJECT_ROOT/.claude/intake-progress.json"
-INTAKE_FILE="$PROJECT_ROOT/PROJECT_INTAKE.md"
+# When sourced for unit tests PROJECT_ROOT isn't resolved (no walk to a
+# .claude/phase-state.json from the test's CWD). Default to empty so the
+# top-level assignment doesn't trip `set -u` in the test harness; tests
+# override PROGRESS_FILE/INTAKE_FILE before calling save_answer etc.
+PROGRESS_FILE="${PROJECT_ROOT:-}/.claude/intake-progress.json"
+INTAKE_FILE="${PROJECT_ROOT:-}/PROJECT_INTAKE.md"
 SUGGESTIONS_DIR="$FRAMEWORK_ROOT/templates/intake-suggestions"
 
 # Project context (loaded from progress file or phase-state.json)
@@ -1981,4 +2001,6 @@ main() {
   esac
 }
 
-main "$@"
+if [ "${_intake_wizard_sourced:-0}" -ne 1 ]; then
+  main "$@"
+fi

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -1607,6 +1607,25 @@ These pre-conditions must be completed before Phase 0 begins. See Governance Fra
 
 ---
 
+## Retroactive Phase 1 → Phase 2 STA Approval
+
+**Required because:** This project was upgraded from personal to organizational on {today}. Per docs/builders-guide.md § Phase 1 (line 807) and Governance Framework Section V, the Senior Technical Authority must retroactively review and approve the existing Project Bible before further phase gate work proceeds. scripts/check-phase-gate.sh emits a non-blocking WARN until the Approver + Date below are filled in.
+
+| Field | Value |
+|---|---|
+| **Gate** | Retroactive Phase 1 → Phase 2 (STA) |
+| **Approver** | |
+| **Role** | Senior Technical Authority |
+| **Date** | |
+| **Method** | Email / Ticket / Document |
+| **Reference** | docs/builders-guide.md § Phase 1 (line 807) |
+| **Artifacts reviewed** | PROJECT_BIBLE.md (as-of upgrade), Architecture Decision Records, Threat Model |
+| **Decision** | Approved / Approved with conditions / Rejected |
+| **Conditions (if any)** | |
+| **Notes** | |
+
+---
+
 ## Approval History
 
 _Append additional approvals here for post-launch changes, maintenance reviews, or re-approvals._

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -765,6 +765,58 @@ Note: `docker.install.linux_apt` uses `sudo apt install ... && sudo usermod ...`
 
 ---
 
+## BL-042: init.sh `prompt_install` interaction with pipefail when stdin is closed
+
+**Logged:** 2026-06-29 (PR #104 verifier follow-up — Wave 4 risk note 2)
+**Category:** Bug / non-interactive UX (test-only workaround in tree)
+**Severity:** Low (workaround in place; affects test ergonomics, not user-facing behavior)
+**Status:** Open
+
+When `init.sh --non-interactive` is invoked from a test harness with a piped/heredoc stdin (e.g. `printf 'Y\n...' | bash init.sh ...`), the `prompt_install` helper at `scripts/lib/helpers.sh:295-324` interacts poorly with `set -o pipefail` in two ways:
+
+1. `prompt_install` checks `[ ! -t 0 ]` at line 306 to detect non-interactive context and returns 1 (no install). When stdin is a `printf`-fed pipe rather than a tty, the gate fires correctly — but the *test* expects the install to proceed (or be silently skipped without error).
+2. Some upstream callers chain `printf | bash init.sh` directly. Under `pipefail`, if init.sh exits before consuming the full stdin, the upstream `printf` receives SIGPIPE and exits 141 — which propagates through the pipeline and fails the parent command. Tests work around this by using process substitution (`< <(printf 'Y\nY\n...')`) so each program reads its own fd without a true pipe.
+
+**Current workaround (test-side, in tree):**
+- `tests/test-init-organizational.sh:50,146` — `< <(printf 'Y\nY\nY\nY\nY\nY\nY\nY\nY\nY\n')` feeds finite stdin.
+- `tests/edge-cases-scripts.sh:983,1083` — same shape.
+- The PR-#104 body explicitly notes this as a worked-around bonus catch.
+
+**Proposed source fix (deferred):**
+- Audit `prompt_install` and its callers so the non-interactive path is the *only* path that runs when `CI=1`, `SOIF_NONINTERACTIVE=1`, or `--non-interactive` is passed, and the function NEVER attempts a `read -rp` on a closed-stdin stream. Today the `-t 0` test at line 306 catches the pipe-stdin case, but the broader question is whether `bash init.sh --non-interactive < /dev/null` (genuinely closed stdin, no fed input) is well-defined for callers that don't want even the `[WARN]` chatter on lines 307.
+- Add a `tests/test-init-prompt-install-closed-stdin.sh` regression to fix the boundary so future tests don't need the printf-fed workaround.
+
+**Why deferred (not in PR #104 fix-commit):** the workaround is local to tests, the user-facing behavior of `init.sh --non-interactive` (which the gate at `prompt_install:306` handles correctly) is sound, and the source audit touches multiple helpers + their callers. Capturing as a backlog item per the Wave 4 retrospective so it does not become a "silent backlog" item.
+
+**Related:** PR #104 (test-singletons-and-tier-crosscheck-5), `scripts/lib/helpers.sh:295-324`, `init.sh:117-249` (all the `prompt_install` callsites), Wave 4 retrospective risk note 2.
+
+---
+
+## BL-043: intake-wizard.sh module-load side effects justify a `main()` extraction refactor
+
+**Logged:** 2026-06-29 (PR #104 verifier follow-up — Wave 4 risk note 2)
+**Category:** Debt / sourceability hardening
+**Severity:** Low (current main-guard + trap-guard handle the surface; refactor improves hygiene)
+**Status:** Open
+
+PR #104 added two main-guard gates to `scripts/intake-wizard.sh`:
+1. Lines 27 + 2009 (PR #104 base): block the project-root discovery + `main "$@"` call when sourced.
+2. Lines 290 + 314 (PR #104 verifier follow-up): block the EXIT trap that cleans up `_PAUSE_FILE` when sourced, so it does not clobber the caller's pre-existing EXIT trap.
+
+These two gates patch the most damaging clobber surfaces, but the underlying design is still that intake-wizard.sh runs side-effects at module-load time (helpers sourced at line 13, `_PAUSE_FILE` allocated at line 273, function definitions, etc.). A cleaner shape would be:
+- All side-effect setup (CWD anchor, `_PAUSE_FILE`, trap, project-root discovery, `main "$@"`) lives inside an explicit `main()` body.
+- The module-load section contains only `set -euo pipefail`, `SCRIPT_DIR=…`, `source lib/helpers.sh`, and function definitions.
+- The main-guard at the bottom becomes a single `if [ "${BASH_SOURCE[0]}" = "${0}" ]; then main "$@"; fi`.
+
+**Proposed scope:**
+- ~50-100 LOC moved, no new behavior — but every test that currently subshell-wraps `source scripts/intake-wizard.sh` should still pass without the wrapper. Add a `tests/test-intake-wizard-sourceable-no-side-effects.sh` regression that sources the file at the top level of a test process and verifies (a) no trap registered, (b) no `_PAUSE_FILE` written, (c) the caller's CWD unchanged.
+
+**Why deferred (not in PR #104 fix-commit):** the gates already close the verifier-flagged risks for the current call shapes; the refactor is a hygiene improvement that touches the wizard's structure rather than its behavior. Schedule for a focused refactor PR so the diff is reviewable.
+
+**Related:** PR #104 verifier follow-up (Wave 4 majors #3 + #4), `scripts/intake-wizard.sh:24-27` (sourced-probe), `scripts/intake-wizard.sh:273-321` (pause-file + trap), `scripts/intake-wizard.sh:2009-2011` (main-guard).
+
+---
+
 ## code-check-gates-7-followup: per-gate-section blame for APPROVAL_LOG.md commit-author lookup
 
 **Logged:** 2026-06-28 (PR #87 cycle-7 verifier major #4)

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -937,136 +937,220 @@ fi
 # ================================================================
 section "BL-009: UAT template quality + platform-aware authoring"
 
-_uat_run_init_copy_block() {
-  # Args: work-dir, platform
-  # Source helpers and execute just the UAT copy block of init.sh against the
-  # work dir. Extracting the subset keeps the test fast; full init.sh run
-  # would require mocking prerequisites and a full intake flow.
-  local work="$1" platform="$2"
-  (
-    cd "$work"
-    # shellcheck disable=SC1091
-    source "$REPO_DIR/scripts/lib/helpers.sh"
-    export SCRIPT_DIR="$REPO_DIR"
-    export PLATFORM="$platform"
-    mkdir -p tests/uat/templates tests/uat/sessions tests/uat/examples
-    cp "$SCRIPT_DIR/templates/uat/test-session-template.md"   tests/uat/templates/test-session-template.md
-    cp "$SCRIPT_DIR/templates/uat/test-session-template.html" tests/uat/templates/test-session-template.html
-    if [ "$PLATFORM" != "other" ] && \
-       [ -f "$SCRIPT_DIR/templates/uat/references/${PLATFORM}-pre-flight.html" ] && \
-       [ -f "$SCRIPT_DIR/templates/uat/references/${PLATFORM}-scenario.json" ]; then
-      cp "$SCRIPT_DIR/templates/uat/references/${PLATFORM}-pre-flight.html" \
-         tests/uat/examples/pre-flight-reference.html
-      cp "$SCRIPT_DIR/templates/uat/references/${PLATFORM}-scenario.json" \
-         tests/uat/examples/scenario-reference.json
-    fi
-  )
+# audit tests-edge-cases-22 / tests-edge-cases-23 (closure):
+# Pre-fix this section called _uat_run_init_copy_block, an in-test
+# duplicate of init.sh's UAT copy block. The shadow helper meant E26-E32
+# never exercised init.sh / upgrade-project.sh — if init.sh deleted its
+# entire UAT copy block, every E26-E32 case still passed. Verified RED
+# on origin/main by removing init.sh:1187-1207 — all 7 cases still
+# returned [PASS].
+#
+# The rewrite below drives the real init.sh --non-interactive code path
+# (E26-E30) and the real scripts/upgrade-project.sh UAT migration block
+# (E31, E32). That removes the shadow code and gives the BL-009 spec
+# real regression coverage: deleting init.sh's copy block or breaking
+# upgrade-project.sh's UAT migration now flips E26-E32 to FAIL.
+
+# Helper: run real init.sh --non-interactive for the given platform into
+# the supplied --project-dir. Uses --no-remote-creation so the test never
+# touches a real GitHub/GitLab/Bitbucket account. Captures stderr on
+# failure so the diagnostic survives the assertion below.
+#
+# Note: init.sh's "Proceed with this plan?" prompt only fires when a tool
+# in the install plan is missing on the test host (e.g. mobile platform
+# needs Android Studio). With closed stdin and `set -e`, the `read -rp`
+# at init.sh:736 would EOF and abort. We pipe a stream of "Y" answers so
+# the plan proceeds regardless of host state — this isolates the test
+# from the test host's tool inventory.
+_uat_real_init() {
+  local work="$1" platform="$2" project="$3"
+  local logfile="$work/init-${platform}.log"
+  # Feed a finite stream of "Y" answers from process substitution so
+  # init.sh's "Proceed with this plan?" / install confirms auto-pass
+  # without breaking `set -o pipefail` (yes(1) gets SIGPIPE and the
+  # 141 exit code propagates through pipefail; printf does not).
+  ( cd "$work" && \
+    bash "$REPO_DIR/init.sh" --non-interactive \
+        --project "$project" \
+        --platform "$platform" \
+        --deployment personal \
+        --language typescript \
+        --git-host github \
+        --visibility private \
+        --no-remote-creation \
+        --project-dir "$work/$project" \
+        --allow-existing-dir \
+        < <(printf 'Y\nY\nY\nY\nY\nY\nY\nY\nY\nY\n') ) > "$logfile" 2>&1
 }
 
-# Case 1: init for web platform copies web reference pair
+# Case 1: real init.sh for web platform copies web reference pair
 _uat_work=$(mktemp -d)
-_uat_run_init_copy_block "$_uat_work" "web"
-if [ -f "$_uat_work/tests/uat/examples/pre-flight-reference.html" ] && \
-   [ -f "$_uat_work/tests/uat/examples/scenario-reference.json" ] && \
-   grep -qi 'browser\|devtools\|app url' "$_uat_work/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E26: UAT init for 'web' copies web-specific reference pair"
+if _uat_real_init "$_uat_work" "web" "e26-web" && \
+   [ -f "$_uat_work/e26-web/tests/uat/examples/pre-flight-reference.html" ] && \
+   [ -f "$_uat_work/e26-web/tests/uat/examples/scenario-reference.json" ] && \
+   grep -qi 'browser\|devtools\|app url' "$_uat_work/e26-web/tests/uat/examples/pre-flight-reference.html"; then
+  pass "E26: real init.sh --platform web copies web-specific UAT reference pair"
 else
-  fail "E26: UAT init for 'web' failed — refs missing or not web-specific"
+  fail "E26: real init.sh --platform web failed — refs missing or not web-specific (log: $_uat_work/init-web.log)"
 fi
 rm -rf "$_uat_work"
 
-# Case 2: init for desktop
+# Case 2: real init.sh for desktop
 _uat_work=$(mktemp -d)
-_uat_run_init_copy_block "$_uat_work" "desktop"
-if [ -f "$_uat_work/tests/uat/examples/pre-flight-reference.html" ] && \
-   grep -qi 'terminal\|project root\|venv\|runtime' "$_uat_work/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E27: UAT init for 'desktop' copies desktop-specific reference pair"
+if _uat_real_init "$_uat_work" "desktop" "e27-desktop" && \
+   [ -f "$_uat_work/e27-desktop/tests/uat/examples/pre-flight-reference.html" ] && \
+   grep -qi 'terminal\|project root\|venv\|runtime' "$_uat_work/e27-desktop/tests/uat/examples/pre-flight-reference.html"; then
+  pass "E27: real init.sh --platform desktop copies desktop-specific UAT reference pair"
 else
-  fail "E27: UAT init for 'desktop' failed"
+  fail "E27: real init.sh --platform desktop failed (log: $_uat_work/init-desktop.log)"
 fi
 rm -rf "$_uat_work"
 
-# Case 3: init for mobile
+# Case 3: real init.sh for mobile
 _uat_work=$(mktemp -d)
-_uat_run_init_copy_block "$_uat_work" "mobile"
-if [ -f "$_uat_work/tests/uat/examples/pre-flight-reference.html" ] && \
-   grep -qi 'device\|simulator\|testflight\|android' "$_uat_work/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E28: UAT init for 'mobile' copies mobile-specific reference pair"
+if _uat_real_init "$_uat_work" "mobile" "e28-mobile" && \
+   [ -f "$_uat_work/e28-mobile/tests/uat/examples/pre-flight-reference.html" ] && \
+   grep -qi 'device\|simulator\|testflight\|android' "$_uat_work/e28-mobile/tests/uat/examples/pre-flight-reference.html"; then
+  pass "E28: real init.sh --platform mobile copies mobile-specific UAT reference pair"
 else
-  fail "E28: UAT init for 'mobile' failed"
+  fail "E28: real init.sh --platform mobile failed (log: $_uat_work/init-mobile.log)"
 fi
 rm -rf "$_uat_work"
 
-# Case 4: init for mcp_server
+# Case 4: real init.sh for mcp_server
 _uat_work=$(mktemp -d)
-_uat_run_init_copy_block "$_uat_work" "mcp_server"
-if [ -f "$_uat_work/tests/uat/examples/pre-flight-reference.html" ] && \
-   grep -qi 'mcp\|inspector\|json-rpc\|tool call' "$_uat_work/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E29: UAT init for 'mcp_server' copies mcp-specific reference pair"
+if _uat_real_init "$_uat_work" "mcp_server" "e29-mcp" && \
+   [ -f "$_uat_work/e29-mcp/tests/uat/examples/pre-flight-reference.html" ] && \
+   grep -qi 'mcp\|inspector\|json-rpc\|tool call' "$_uat_work/e29-mcp/tests/uat/examples/pre-flight-reference.html"; then
+  pass "E29: real init.sh --platform mcp_server copies mcp-specific UAT reference pair"
 else
-  fail "E29: UAT init for 'mcp_server' failed"
+  fail "E29: real init.sh --platform mcp_server failed (log: $_uat_work/init-mcp_server.log)"
 fi
 rm -rf "$_uat_work"
 
-# Case 5: init for 'other' skips reference copy
+# Case 5: real init.sh for 'other' skips reference copy but keeps templates
 _uat_work=$(mktemp -d)
-_uat_run_init_copy_block "$_uat_work" "other"
-if [ -f "$_uat_work/tests/uat/templates/test-session-template.html" ] && \
-   [ ! -f "$_uat_work/tests/uat/examples/pre-flight-reference.html" ] && \
-   [ ! -f "$_uat_work/tests/uat/examples/scenario-reference.json" ]; then
-  pass "E30: UAT init for 'other' skips ref copy, keeps source templates"
+if _uat_real_init "$_uat_work" "other" "e30-other" && \
+   [ -f "$_uat_work/e30-other/tests/uat/templates/test-session-template.html" ] && \
+   [ ! -f "$_uat_work/e30-other/tests/uat/examples/pre-flight-reference.html" ] && \
+   [ ! -f "$_uat_work/e30-other/tests/uat/examples/scenario-reference.json" ]; then
+  pass "E30: real init.sh --platform other skips ref copy, keeps source templates"
 else
-  fail "E30: UAT init for 'other' incorrect state (ref files present or template missing)"
+  fail "E30: real init.sh --platform other produced wrong state (refs present or template missing) (log: $_uat_work/init-other.log)"
 fi
 rm -rf "$_uat_work"
 
-# Case 6: upgrade refreshes templates on pre-migration layout
-_uat_work=$(mktemp -d)
-mkdir -p "$_uat_work/.claude" "$_uat_work/tests/uat/templates"
-cat > "$_uat_work/.claude/intake-progress.json" <<JSON
-{"answers": {"platform": "desktop", "project_name": "uat-upgrade-test"}}
+# Helper: seed intake-progress.json with the platform key that
+# upgrade-project.sh's UAT migration block reads. init.sh writes
+# tool-preferences.json but not intake-progress.json (audit-trail gap
+# tracked in code-upgrade-project; not the focus of this audit closure).
+# This keeps the E31/E32 cases focused on the BL-009 UAT migration
+# contract, not the unrelated intake-progress drift.
+_uat_seed_intake_progress() {
+  local proj="$1" platform="$2"
+  mkdir -p "$proj/.claude"
+  cat > "$proj/.claude/intake-progress.json" <<JSON
+{
+  "version": 1,
+  "started_at": "2026-04-23T00:00:00Z",
+  "answers": {"platform": "$platform", "project_name": "$(basename "$proj")"}
+}
 JSON
-echo "<!-- OLD TEMPLATE, no __TESTER_PRE_FLIGHT__ placeholder -->" \
-  > "$_uat_work/tests/uat/templates/test-session-template.html"
-(
-  cd "$_uat_work"
-  cp "$REPO_DIR/templates/uat/test-session-template.html" \
-     tests/uat/templates/test-session-template.html
-  cp "$REPO_DIR/templates/uat/test-session-template.md" \
-     tests/uat/templates/test-session-template.md
-  mkdir -p tests/uat/examples
-  cp "$REPO_DIR/templates/uat/references/desktop-pre-flight.html" \
-     tests/uat/examples/pre-flight-reference.html
-  cp "$REPO_DIR/templates/uat/references/desktop-scenario.json" \
-     tests/uat/examples/scenario-reference.json
-)
-if grep -q '__TESTER_PRE_FLIGHT__' "$_uat_work/tests/uat/templates/test-session-template.html" && \
-   [ -f "$_uat_work/tests/uat/examples/pre-flight-reference.html" ]; then
-  pass "E31: UAT upgrade refreshes source templates with new placeholder"
+}
+
+# Case 6: real upgrade-project.sh UAT migration refreshes a pre-migration tree.
+# Initialize via real init.sh (with --track light so the subsequent
+# upgrade-project.sh --track standard does real work and reaches the UAT
+# migration block at scripts/upgrade-project.sh:2093). Then simulate a
+# pre-BL-009 project by overwriting the source template with stub content
+# and removing the reference pair. The upgrade-project.sh UAT migration
+# block must restore them.
+_uat_real_init_light_impl() {
+  local work="$1" platform="$2" project="$3"
+  local logfile="$work/init-${platform}-light.log"
+  ( cd "$work" && \
+    bash "$REPO_DIR/init.sh" --non-interactive \
+        --project "$project" \
+        --platform "$platform" \
+        --deployment personal \
+        --language typescript \
+        --track light \
+        --git-host github \
+        --visibility private \
+        --no-remote-creation \
+        --project-dir "$work/$project" \
+        --allow-existing-dir \
+        < <(printf 'Y\nY\nY\nY\nY\nY\nY\nY\nY\nY\n') ) > "$logfile" 2>&1
+}
+
+_uat_work=$(mktemp -d)
+if ! _uat_real_init_light_impl "$_uat_work" "desktop" "e31-upgrade"; then
+  fail "E31: setup init.sh failed (log: $_uat_work/init-desktop-light.log)"
 else
-  fail "E31: UAT upgrade didn't refresh templates or copy references"
+  _proj="$_uat_work/e31-upgrade"
+  _uat_seed_intake_progress "$_proj" "desktop"
+  # Regression to "pre-migration" state: clobber the source template and
+  # delete the reference pair so the upgrade has visible work to do.
+  echo "<!-- OLD TEMPLATE: no __TESTER_PRE_FLIGHT__ placeholder -->" \
+    > "$_proj/tests/uat/templates/test-session-template.html"
+  rm -f "$_proj/tests/uat/examples/pre-flight-reference.html" \
+        "$_proj/tests/uat/examples/scenario-reference.json"
+  # Drive the real upgrade-project.sh UAT migration block.
+  # --track light → standard is a real upgrade target so the script
+  # reaches the post-validation sweep that includes UAT migration.
+  ( cd "$_proj" && \
+    bash "$REPO_DIR/scripts/upgrade-project.sh" \
+        --non-interactive --track standard ) > "$_uat_work/upgrade-e31.log" 2>&1 || true
+  if grep -q '__TESTER_PRE_FLIGHT__' "$_proj/tests/uat/templates/test-session-template.html" && \
+     [ -f "$_proj/tests/uat/examples/pre-flight-reference.html" ] && \
+     [ -f "$_proj/tests/uat/examples/scenario-reference.json" ] && \
+     grep -qi 'terminal\|project root\|venv\|runtime' "$_proj/tests/uat/examples/pre-flight-reference.html"; then
+    pass "E31: real upgrade-project.sh UAT migration refreshes stub template + reference pair"
+  else
+    fail "E31: upgrade-project.sh UAT migration didn't restore template/refs (log: $_uat_work/upgrade-e31.log)"
+  fi
 fi
 rm -rf "$_uat_work"
 
-# Case 7: upgrade is idempotent
+# Case 7: E32 — UAT migration is idempotent. Drive the real UAT migration
+# block twice against the same tree (via two upgrade-project.sh runs that
+# each reach the migration block) and verify the resulting trees are
+# byte-identical. The pre-fix version asserted cp's idempotency
+# (tautology); the new version asserts the framework's idempotency by
+# comparing run-1 output to run-2 output.
 _uat_work=$(mktemp -d)
-mkdir -p "$_uat_work/.claude"
-cat > "$_uat_work/.claude/intake-progress.json" <<JSON
-{"answers": {"platform": "desktop"}}
-JSON
-for _i in 1 2; do
-  (
-    cd "$_uat_work"
-    mkdir -p tests/uat/templates tests/uat/examples
-    cp "$REPO_DIR/templates/uat/test-session-template.html" tests/uat/templates/test-session-template.html
-    cp "$REPO_DIR/templates/uat/references/desktop-pre-flight.html" tests/uat/examples/pre-flight-reference.html
-  )
-done
-if diff -q "$_uat_work/tests/uat/templates/test-session-template.html" \
-           "$REPO_DIR/templates/uat/test-session-template.html" >/dev/null 2>&1; then
-  pass "E32: UAT upgrade migration is idempotent"
+if ! _uat_real_init_light_impl "$_uat_work" "desktop" "e32-idem"; then
+  fail "E32: setup init.sh failed (log: $_uat_work/init-desktop-light.log)"
 else
-  fail "E32: UAT upgrade migration produced diverging content on re-run"
+  _proj="$_uat_work/e32-idem"
+  _uat_seed_intake_progress "$_proj" "desktop"
+  # Snapshot UAT subtree after a forced "pre-migration" state to ensure
+  # the first upgrade-project.sh has real work.
+  echo "<!-- OLD TEMPLATE -->" > "$_proj/tests/uat/templates/test-session-template.html"
+  rm -f "$_proj/tests/uat/examples/"*.html "$_proj/tests/uat/examples/"*.json 2>/dev/null || true
+  # Run 1: light → standard. This runs the migration block.
+  ( cd "$_proj" && \
+    bash "$REPO_DIR/scripts/upgrade-project.sh" \
+        --non-interactive --track standard ) > "$_uat_work/upgrade-run1.log" 2>&1 || true
+  _snap1="$_uat_work/snap1"
+  mkdir -p "$_snap1"
+  cp -R "$_proj/tests/uat" "$_snap1/"
+  # Run 2: standard → full. Different target so upgrade-project.sh
+  # again reaches the post-validation sweep (UAT migration). Anything
+  # the migration does on this second invocation that mutates the UAT
+  # subtree differently from run-1 is drift.
+  ( cd "$_proj" && \
+    bash "$REPO_DIR/scripts/upgrade-project.sh" \
+        --non-interactive --track full ) > "$_uat_work/upgrade-run2.log" 2>&1 || true
+  _snap2="$_uat_work/snap2"
+  mkdir -p "$_snap2"
+  cp -R "$_proj/tests/uat" "$_snap2/"
+  # Compare snapshots — they must be byte-identical for idempotency.
+  if diff -ru "$_snap1/uat" "$_snap2/uat" > "$_uat_work/snapshot.diff" 2>&1; then
+    pass "E32: upgrade-project.sh UAT migration is idempotent (run-1 and run-2 produce identical trees)"
+  else
+    fail "E32: upgrade-project.sh UAT migration is NOT idempotent — run-2 diverged from run-1 (see $_uat_work/snapshot.diff)"
+  fi
 fi
 rm -rf "$_uat_work"
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -113,6 +113,24 @@ else
 fi
 
 # ================================================================
+# TEST 0c2b: PHASE 1→2 RETROACTIVE STA — UPGRADE-PROJECT STAMPING HALF
+# ================================================================
+# PR #104 verifier follow-up (Wave 4): the check-phase-gate.sh half of
+# tier-crosscheck-5 was already exercised above (test 0c2). The other
+# half — scripts/upgrade-project.sh:1610-1626, which actually stamps the
+# Retroactive Phase 1 → Phase 2 STA Approval section into the
+# regenerated APPROVAL_LOG.md during personal→organizational upgrade —
+# had no automated coverage. This sibling suite runs the real upgrade
+# end-to-end and inspects the resulting log for the section header +
+# field rows that check-phase-gate.sh depends on.
+section "upgrade-project.sh stamps retroactive STA section on personal→org upgrade"
+if bash "$SCRIPT_DIR/tests/test-upgrade-project-retroactive-section.sh" >/dev/null 2>&1; then
+  pass "scripts/upgrade-project.sh retroactive section stamping tests (2/2)"
+else
+  fail "scripts/upgrade-project.sh retroactive section stamping tests FAILED (run tests/test-upgrade-project-retroactive-section.sh for details)"
+fi
+
+# ================================================================
 # TEST 0c3: ORGANIZATIONAL END-TO-END INIT (tests-init-host-attestation-4)
 # ================================================================
 # Regression suite for the audit tests-init-host-attestation-4 closure:

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -99,6 +99,34 @@ else
 fi
 
 # ================================================================
+# TEST 0c2: PHASE 1→2 RETROACTIVE STA APPROVAL (tier-crosscheck-5)
+# ================================================================
+# Regression suite for the audit tier-crosscheck-5 closure:
+# scripts/check-phase-gate.sh must emit a non-blocking WARN when
+# APPROVAL_LOG.md has `upgraded_from: personal` AND current_phase >= 2
+# AND the Retroactive Phase 1 → Phase 2 STA Approval row is incomplete.
+section "Phase 1→2 retroactive STA approval surfaces WARN on personal→org upgrades"
+if bash "$SCRIPT_DIR/tests/test-check-phase-gate-retroactive-approval.sh" >/dev/null 2>&1; then
+  pass "scripts/check-phase-gate.sh retroactive STA approval tests (3/3)"
+else
+  fail "scripts/check-phase-gate.sh retroactive STA approval tests FAILED (run tests/test-check-phase-gate-retroactive-approval.sh for details)"
+fi
+
+# ================================================================
+# TEST 0c3: ORGANIZATIONAL END-TO-END INIT (tests-init-host-attestation-4)
+# ================================================================
+# Regression suite for the audit tests-init-host-attestation-4 closure:
+# init.sh --non-interactive --deployment organizational must produce the
+# organizational APPROVAL_LOG.md template + record deployment in
+# manifest/phase-state + honor --no-remote-creation.
+section "init.sh organizational end-to-end coverage"
+if bash "$SCRIPT_DIR/tests/test-init-organizational.sh" >/dev/null 2>&1; then
+  pass "init.sh organizational end-to-end tests (2/2)"
+else
+  fail "init.sh organizational end-to-end tests FAILED (run tests/test-init-organizational.sh for details)"
+fi
+
+# ================================================================
 # TEST 0d: BACKLOG-REFERENCES LINT — cycle-7 Slot-5 process backstop
 # ================================================================
 # Sibling of the counter-antipattern lint above; catches drift between

--- a/tests/known-bugs-test-suite.sh
+++ b/tests/known-bugs-test-suite.sh
@@ -182,28 +182,18 @@ with open('$BUG1_DIR/.claude/intake-progress.json', 'w') as f:
 "
 
 # Test: save_answer with a value containing single quotes
+# audit tests-full-known-bugs-2 (closure): pre-fix this block re-declared
+# save_answer inline, which meant editing the real save_answer in
+# scripts/intake-wizard.sh (e.g. by reverting the single-quote-safe
+# python3-via-argv approach to a shell-interpolated heredoc) would not
+# flip this test red. The rewrite below sources the real
+# scripts/intake-wizard.sh (now sourceable via the main-guard added in
+# the same PR) and exercises the production save_answer directly.
 (
   cd "$BUG1_DIR"
-  source scripts/lib/helpers.sh
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/scripts/intake-wizard.sh"
   PROGRESS_FILE="$BUG1_DIR/.claude/intake-progress.json"
-
-  # Source save_answer from intake-wizard.sh (extract the function)
-  save_answer() {
-    local key="$1"
-    local value="$2"
-    if command -v python3 &>/dev/null; then
-      python3 -c "
-import json, sys
-key, value, path = sys.argv[1], sys.argv[2], sys.argv[3]
-with open(path) as f:
-    data = json.load(f)
-data['answers'][key] = value
-with open(path, 'w') as f:
-    json.dump(data, f, indent=2)
-" "$key" "$value" "$PROGRESS_FILE"
-    fi
-  }
-
   save_answer "api_type" "it's a REST API"
 )
 result=$?
@@ -233,9 +223,13 @@ section "BUG-2: init_progress with single quotes"
 BUG2_DIR="$TEST_DIR/bug2"
 create_test_project "$BUG2_DIR"
 
+# audit tests-full-known-bugs-2 (closure): sources real intake-wizard.sh
+# init_progress instead of re-declaring it inline. The production
+# function is at scripts/intake-wizard.sh:267-290.
 (
   cd "$BUG2_DIR"
-  source scripts/lib/helpers.sh
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/scripts/intake-wizard.sh"
   PROGRESS_FILE="$BUG2_DIR/.claude/intake-progress.json"
 
   PROJECT_NAME="Derek's Cool App"
@@ -244,32 +238,6 @@ create_test_project "$BUG2_DIR"
   TRACK="standard"
   DEPLOYMENT="personal"
   LANGUAGE="typescript"
-
-  # Extract init_progress function
-  init_progress() {
-    mkdir -p "$(dirname "$PROGRESS_FILE")"
-    if command -v python3 &>/dev/null; then
-      python3 -c "
-import json, sys
-data = {
-    'version': 1,
-    'started_at': sys.argv[1],
-    'last_section': 0,
-    'completed_sections': [],
-    'project_name': sys.argv[2],
-    'platform': sys.argv[3],
-    'track': sys.argv[4],
-    'deployment': sys.argv[5],
-    'language': sys.argv[6],
-    'description': sys.argv[7],
-    'poc_mode': None,
-    'answers': {}
-}
-with open(sys.argv[8], 'w') as f:
-    json.dump(data, f, indent=2)
-" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT_NAME" "$PLATFORM" "$TRACK" "$DEPLOYMENT" "$LANGUAGE" "$PROJECT_DESCRIPTION" "$PROGRESS_FILE"
-    fi
-  }
 
   init_progress
 )
@@ -329,9 +297,15 @@ with open('$BUG3_DIR/.claude/intake-progress.json', 'w') as f:
 # Clean up any previous injection marker
 rm -f /tmp/solo-test-injection
 
+# audit tests-full-known-bugs-2 (closure): sources real intake-wizard.sh
+# load_progress (scripts/intake-wizard.sh:432-463) so reverting the
+# shlex-quoted python3-via-tmpfile guard to an eval-based loader would
+# allow the injection marker to land and flip this test red. The pre-fix
+# inline copy would have shielded any such regression.
 (
   cd "$BUG3_DIR"
-  source scripts/lib/helpers.sh
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/scripts/intake-wizard.sh"
   PROGRESS_FILE="$BUG3_DIR/.claude/intake-progress.json"
   PROJECT_ROOT="$BUG3_DIR"
   PROJECT_NAME=""
@@ -343,35 +317,6 @@ rm -f /tmp/solo-test-injection
   POC_MODE=""
   LAST_SECTION=0
   COMPLETED_SECTIONS=""
-
-  load_progress() {
-    if [ ! -f "$PROGRESS_FILE" ]; then
-      print_warn "No progress file found."
-      return 1
-    fi
-    if command -v python3 &>/dev/null; then
-      local tmpfile
-      tmpfile=$(mktemp)
-      python3 -c "
-import json, sys, shlex
-with open(sys.argv[1]) as f:
-    data = json.load(f)
-print(f\"LAST_SECTION={data['last_section']}\")
-print(f\"PROJECT_NAME={shlex.quote(data['project_name'])}\")
-print(f\"PLATFORM={shlex.quote(data['platform'])}\")
-print(f\"TRACK={shlex.quote(data['track'])}\")
-print(f\"DEPLOYMENT={shlex.quote(data['deployment'])}\")
-print(f\"LANGUAGE={shlex.quote(data['language'])}\")
-print(f\"PROJECT_DESCRIPTION={shlex.quote(data['description'])}\")
-poc = data.get('poc_mode') or ''
-print(f\"POC_MODE={shlex.quote(poc)}\")
-completed = ' '.join(str(s) for s in data.get('completed_sections', []))
-print(f\"COMPLETED_SECTIONS={shlex.quote(completed)}\")
-" "$PROGRESS_FILE" > "$tmpfile"
-      source "$tmpfile"
-      rm -f "$tmpfile"
-    fi
-  }
 
   load_progress
 )
@@ -566,35 +511,60 @@ cat > "$BUG7_DIR/.claude/phase-state.json" << 'EOF'
 }
 EOF
 
-# Test the has_no computation directly
+# audit tests-full-known-bugs-2 (closure): the pre-fix BUG-7 test
+# *replicated* the validate.sh line 367-369 idiom inline (with the same
+# `|| echo "0"` shape that the audit identified as the underlying bug)
+# and then asserted that the duplicated copy produced a usable number.
+# That meant validate.sh could regress from the safe form to a broken
+# form (e.g. drop the case-statement sanitizer added later, or revert
+# to a |[!0-9]| crash under `set -e`) without the inline test caring.
+#
+# Option-B fix: keep the behavioral check but anchor it on the REAL
+# scripts/validate.sh by running validate.sh against a seeded
+# PROJECT_INTAKE.md with at least one matching "| No |" row, and
+# additionally grep-assert the post-fix idiom shape (`|| true` plus
+# `case "$has_no" in ''|*[!0-9]*) has_no=0 ;; esac` sanitizer) is
+# present in validate.sh. Reverting to the pre-fix `|| echo "0"` shape
+# now flips the literal-idiom assertion red.
 (
   set -euo pipefail
   cd "$BUG7_DIR"
-
-  # Replicate the exact code from validate.sh line 367-369
-  has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || echo "0") # lint-counter-antipattern: allow deliberate verbatim replication of validate.sh line 367-369 to exercise the upstream behavior under test
-  if [ "$has_no" -eq 0 ]; then
-    echo "has_no=0"
-  else
-    echo "has_no=$has_no"
-  fi
-) > "$TEST_DIR/bug7-output.txt" 2>&1
-result=$?
-
-if [ $result -eq 0 ]; then
-  has_no_val=$(grep -o 'has_no=[0-9]*' "$TEST_DIR/bug7-output.txt" | head -1 | grep -o '[0-9]*' || echo "MISSING")
-  if [ "$has_no_val" = "MISSING" ]; then
-    fail "BUG-7: has_no computation produced no usable output"
-  else
-    pass "BUG-7: has_no computation works correctly (value=$has_no_val)"
-  fi
+  # validate.sh exits non-zero in Phase 0 (artifacts not ready) but
+  # should not crash under set -e on the has_no computation. We probe
+  # stderr+stdout for a Python/bash crash signature; the absence of one
+  # is the assertion. Stdout/stderr capture lets us inspect failures.
+  bash "$REPO_DIR/scripts/validate.sh" > "$TEST_DIR/bug7-output.txt" 2>&1 || true
+  # The has_no path runs only when current_phase >= 2; we need to set
+  # that. Re-create the phase-state and re-run.
+  cat > .claude/phase-state.json <<JSON
+{"current_phase": 2, "project": "TestProject"}
+JSON
+  bash "$REPO_DIR/scripts/validate.sh" >> "$TEST_DIR/bug7-output.txt" 2>&1 || true
+)
+# A crash would surface as "set -e" bash output / unbound variable /
+# integer expression expected. The post-fix sanitizer produces clean
+# WARN/OK lines instead.
+if grep -qE "integer expression expected|unbound variable|line [0-9]+: \[: " "$TEST_DIR/bug7-output.txt"; then
+  fail "BUG-7: real validate.sh crashed on the has_no path (suspect: counter sanitizer regression)"
+  echo "    Output tail: $(tail -10 "$TEST_DIR/bug7-output.txt")"
 else
-  fail "BUG-7: has_no computation crashed under set -e (exit $result)"
-  # Show the error
-  echo "    Output: $(cat "$TEST_DIR/bug7-output.txt")"
+  pass "BUG-7: real scripts/validate.sh does not crash on the has_no path under set -e"
 fi
 
-# Test 7b: PROJECT_INTAKE.md with NO "No" entries (forces grep -c to return 0)
+# BUG-7 literal-idiom guard (Option B): the bug pre-fix form was
+# `... | grep -ciE ... || echo "0"`. The post-fix form is
+# `... | grep -ciE ... || true` followed by a case-statement sanitizer
+# `case "$has_no" in ''|*[!0-9]*) has_no=0 ;; esac`. Assert the
+# post-fix form is still in validate.sh.
+if grep -qE 'has_no=\$\(grep -i "\| \*No \*\|" PROJECT_INTAKE\.md \| grep -ciE "Security\|Accessibility\|Performance\|Database" \|\| true\)' "$REPO_DIR/scripts/validate.sh" \
+   && grep -qE 'case "\$has_no" in .* has_no=0' "$REPO_DIR/scripts/validate.sh"; then
+  pass "BUG-7: validate.sh keeps the safe '|| true' + case-statement sanitizer idiom"
+else
+  fail "BUG-7: validate.sh has regressed away from the post-fix idiom (counter sanitizer missing or '|| echo \"0\"' reintroduced)"
+fi
+
+# BUG-7b: PROJECT_INTAKE.md with NO "No" entries (forces grep -c to
+# return 0). Same Option-B shape: run real validate.sh, ensure no crash.
 cat > "$BUG7_DIR/PROJECT_INTAKE.md" << 'EOF'
 # Project Intake
 | Domain | Self-Assessment | Notes |
@@ -606,21 +576,13 @@ EOF
 (
   set -euo pipefail
   cd "$BUG7_DIR"
-
-  has_no=$(grep -i "| *No *|" PROJECT_INTAKE.md | grep -ciE "Security|Accessibility|Performance|Database" || echo "0") # lint-counter-antipattern: allow deliberate verbatim replication of validate.sh line 367-369 to exercise the upstream behavior under test
-  if [ "$has_no" -eq 0 ]; then
-    echo "has_no=0 (correctly zero)"
-  else
-    echo "has_no=$has_no"
-  fi
-) > "$TEST_DIR/bug7b-output.txt" 2>&1
-result=$?
-
-if [ $result -eq 0 ]; then
-  pass "BUG-7b: has_no works when no 'No' entries exist"
-else
-  fail "BUG-7b: has_no crashes when no 'No' entries exist (exit $result)"
+  bash "$REPO_DIR/scripts/validate.sh" > "$TEST_DIR/bug7b-output.txt" 2>&1 || true
+)
+if grep -qE "integer expression expected|unbound variable|line [0-9]+: \[: " "$TEST_DIR/bug7b-output.txt"; then
+  fail "BUG-7b: real validate.sh crashes when no 'No' entries exist"
   echo "    Output: $(cat "$TEST_DIR/bug7b-output.txt")"
+else
+  pass "BUG-7b: real validate.sh handles zero matching 'No' entries without crashing"
 fi
 
 # ================================================================
@@ -631,41 +593,37 @@ section "BUG-8: Pause detection via file sentinel"
 BUG8_DIR="$TEST_DIR/bug8"
 create_test_project "$BUG8_DIR"
 
-# The fix uses a file-based sentinel. Test that _request_pause creates the file
-# and check_pause_requested detects it.
+# audit tests-full-known-bugs-2 (closure): sources real intake-wizard.sh
+# _request_pause + check_pause_requested. Pre-fix the test re-declared
+# both functions with the file-sentinel approach, so removing the file
+# sentinel from production (e.g. by reverting to an exported variable
+# that loses its value crossing a `$(...)` subshell boundary) would not
+# flip this test red. The rewrite below sources the real functions and
+# exercises them across a $(...) subshell boundary — the exact failure
+# mode the bug captured.
+#
+# check_pause_requested exits 0 when no pause is set; on pause it
+# *exits* the shell (not just returns), so we wrap it in a subshell.
 (
   cd "$BUG8_DIR"
-  source scripts/lib/helpers.sh
-
-  _PAUSE_FILE="/tmp/.solo-intake-pause-$$"
-  trap 'rm -f "$_PAUSE_FILE"' EXIT
-
-  _request_pause() {
-    touch "$_PAUSE_FILE"
-  }
-
-  check_pause_requested() {
-    if [ -f "$_PAUSE_FILE" ]; then
-      rm -f "$_PAUSE_FILE"
-      echo "PAUSE_DETECTED"
-      return 0
-    fi
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/scripts/intake-wizard.sh"
+  # _PAUSE_FILE is set by intake-wizard.sh to /tmp/.solo-intake-pause-$$
+  # (line 264). The trap on EXIT cleans it up after this subshell.
+  # Simulate: prompt function called in $() subshell requests pause.
+  _unused=$(_request_pause && echo "pause_requested")
+  if [ -f "$_PAUSE_FILE" ]; then
+    echo "PAUSE_DETECTED"
+  else
     echo "NO_PAUSE"
-    return 0
-  }
-
-  # Simulate: prompt function called in $() subshell requests pause
-  result=$(_request_pause && echo "pause_requested")
-
-  # Now check from the parent shell — the file should exist
-  check_pause_requested
+  fi
 ) > "$TEST_DIR/bug8-output.txt" 2>&1
-result=$?
 
 if grep -q "PAUSE_DETECTED" "$TEST_DIR/bug8-output.txt"; then
-  pass "BUG-8: File sentinel pause detection works across subshells"
+  pass "BUG-8: real intake-wizard.sh file sentinel survives \$(...) subshell"
 else
-  fail "BUG-8: File sentinel pause not detected across subshells"
+  fail "BUG-8: file sentinel did NOT survive subshell — pause cannot be detected from parent"
+  echo "    Output: $(cat "$TEST_DIR/bug8-output.txt")"
 fi
 
 # ================================================================

--- a/tests/known-bugs-test-suite.sh
+++ b/tests/known-bugs-test-suite.sh
@@ -544,11 +544,27 @@ JSON
 # A crash would surface as "set -e" bash output / unbound variable /
 # integer expression expected. The post-fix sanitizer produces clean
 # WARN/OK lines instead.
+#
+# PR #104 verifier follow-up (Wave 4 minor #5): tightened to also
+# require that the `Competency Matrix Coverage` section header was
+# actually reached. validate.sh has `set -euo pipefail` and may exit on
+# earlier checks (phase state mismatch, missing artifacts) BEFORE the
+# has_no path at scripts/validate.sh:428 runs. The previous behavioral
+# block masked early exits via `|| true`, so a regression that prevents
+# the has_no codepath from ever executing still passed silently. Now
+# the test grep-asserts the `── Competency Matrix Coverage ──` section
+# header (emitted by scripts/validate.sh:396 only when phase >= 2 AND
+# PROJECT_INTAKE.md AND .github/workflows/ci.yml all exist — i.e. the
+# gate that fronts the has_no computation). A regression that skips the
+# whole section now flips this assertion red.
 if grep -qE "integer expression expected|unbound variable|line [0-9]+: \[: " "$TEST_DIR/bug7-output.txt"; then
   fail "BUG-7: real validate.sh crashed on the has_no path (suspect: counter sanitizer regression)"
   echo "    Output tail: $(tail -10 "$TEST_DIR/bug7-output.txt")"
+elif ! grep -qE "Competency Matrix Coverage" "$TEST_DIR/bug7-output.txt"; then
+  fail "BUG-7: validate.sh exited before reaching the 'Competency Matrix Coverage' section — the has_no path at scripts/validate.sh:428 was never executed, so the behavioral assertion was vacuous (suspect: phase-2 gate at scripts/validate.sh:395 broke, or an earlier check fataled before line 396)"
+  echo "    Output tail: $(tail -10 "$TEST_DIR/bug7-output.txt")"
 else
-  pass "BUG-7: real scripts/validate.sh does not crash on the has_no path under set -e"
+  pass "BUG-7: real scripts/validate.sh reaches Competency Matrix Coverage section and does not crash on the has_no path under set -e"
 fi
 
 # BUG-7 literal-idiom guard (Option B): the bug pre-fix form was
@@ -581,8 +597,14 @@ EOF
 if grep -qE "integer expression expected|unbound variable|line [0-9]+: \[: " "$TEST_DIR/bug7b-output.txt"; then
   fail "BUG-7b: real validate.sh crashes when no 'No' entries exist"
   echo "    Output: $(cat "$TEST_DIR/bug7b-output.txt")"
+elif ! grep -qE "Competency Matrix Coverage" "$TEST_DIR/bug7b-output.txt"; then
+  # PR #104 verifier follow-up (Wave 4 minor #5): same strengthening
+  # as BUG-7 above — require the section header was reached so the
+  # has_no=0 sanitizer path was actually executed.
+  fail "BUG-7b: validate.sh exited before reaching the 'Competency Matrix Coverage' section — the has_no=0 sanitizer at scripts/validate.sh:429 was never executed (vacuous behavioral assertion)"
+  echo "    Output: $(cat "$TEST_DIR/bug7b-output.txt")"
 else
-  pass "BUG-7b: real validate.sh handles zero matching 'No' entries without crashing"
+  pass "BUG-7b: real validate.sh reaches Competency Matrix Coverage section and handles zero matching 'No' entries without crashing"
 fi
 
 # ================================================================

--- a/tests/test-check-phase-gate-retroactive-approval.sh
+++ b/tests/test-check-phase-gate-retroactive-approval.sh
@@ -164,38 +164,65 @@ t1_upgraded_blank_retroactive_emits_warn() {
   teardown
 }
 
-# T2: upgraded_from=personal + filled retroactive rows → no Retroactive WARN.
-t2_upgraded_filled_retroactive_no_warn() {
+# T2: upgraded_from=personal + filled retroactive rows → positive `[OK]`
+# line emitted by scripts/check-phase-gate.sh:552.
+#
+# PR-#104 verifier (Wave 4) flagged the prior assertion as vacuous: it
+# only asserted ABSENCE of a WARN, which passes trivially on origin/main
+# where the entire retroactive code block at scripts/check-phase-gate.sh:
+# 519-555 does not exist. Tightened to grep-assert the positive line
+# emitted at scripts/check-phase-gate.sh:552:
+#   `[OK] Phase 1→2 retroactive: STA approval recorded ($approver, $date)`
+# Confirmed RED on origin/main (line :552 absent) → GREEN on PR branch.
+t2_upgraded_filled_retroactive_emits_ok() {
   setup
   write_upgraded_log "true"
   local output
   output=$( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
-  if echo "$output" | grep -qiE "WARN.*retroactive: project upgraded from personal but.*incomplete|WARN.*retroactive: project upgraded from personal but APPROVAL_LOG\.md has no"; then
-    fail_ "T2" "expected NO Retroactive WARN when approver+date filled; got:\n$output"
+  # The `[OK]` token in check-phase-gate.sh output includes ANSI color
+  # escapes; strip them so the regex matches the human-readable line.
+  local stripped
+  stripped=$(echo "$output" | sed -E $'s/\x1b\\[[0-9;]*m//g')
+  if echo "$stripped" | grep -qE 'Phase 1.+2 retroactive: STA approval recorded \(Jane Doe, 2026-04-20\)'; then
+    pass "T2: upgraded_from=personal + Approver+Date filled → check-phase-gate.sh emits positive [OK] retroactive line (Jane Doe, 2026-04-20)"
   else
-    pass "T2: upgraded_from=personal + Approver+Date filled → no Retroactive WARN"
+    fail_ "T2" "expected positive [OK] retroactive line citing 'Jane Doe, 2026-04-20'; got:\n$output"
   fi
   teardown
 }
 
-# T3: NOT upgraded_from=personal → check must skip the retroactive WARN.
-t3_non_upgraded_no_retroactive_warn() {
+# T3: NOT upgraded_from=personal → check-phase-gate.sh must NOT emit ANY
+# retroactive output (neither WARN nor [OK] nor any other 'retroactive'
+# mention).
+#
+# PR-#104 verifier (Wave 4) flagged the prior assertion as vacuous: it
+# only asserted absence of two specific WARN strings, which passed
+# trivially on origin/main (no retroactive code at all) AND would still
+# pass if a future refactor introduced an unconditional `[OK] retroactive`
+# emission. Tightened to assert absence of ANY 'retroactive' mention
+# (case-insensitive) — this fails RED if the upgraded-from branch ever
+# starts firing on non-upgraded projects (e.g. a regression that removes
+# or weakens the `grep -q '^upgraded_from: personal'` gate at
+# scripts/check-phase-gate.sh:536). T1 (RED-on-main proven) and T2
+# (positive emission, RED-on-main proven) anchor the suite; T3 is the
+# precision guard against false positives.
+t3_non_upgraded_no_retroactive_output() {
   setup
   write_non_upgraded_org_log
   local output
   output=$( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
-  if echo "$output" | grep -qiE "WARN.*retroactive: project upgraded from personal but.*incomplete|WARN.*retroactive: project upgraded from personal but APPROVAL_LOG\.md has no"; then
-    fail_ "T3" "expected NO Retroactive WARN when not upgraded_from=personal; got:\n$output"
+  if echo "$output" | grep -qiE "retroactive"; then
+    fail_ "T3" "expected NO retroactive output (no WARN, no OK, no mention) when not upgraded_from=personal; got:\n$output"
   else
-    pass "T3: non-upgraded organizational project does NOT trigger Retroactive WARN"
+    pass "T3: non-upgraded organizational project produces NO retroactive output of any kind (neither WARN nor [OK] nor any mention)"
   fi
   teardown
 }
 
 echo "== tests/test-check-phase-gate-retroactive-approval.sh =="
 t1_upgraded_blank_retroactive_emits_warn
-t2_upgraded_filled_retroactive_no_warn
-t3_non_upgraded_no_retroactive_warn
+t2_upgraded_filled_retroactive_emits_ok
+t3_non_upgraded_no_retroactive_output
 
 echo ""
 echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="

--- a/tests/test-check-phase-gate-retroactive-approval.sh
+++ b/tests/test-check-phase-gate-retroactive-approval.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# tests/test-check-phase-gate-retroactive-approval.sh
+#
+# Regression test for tier-crosscheck-5 (audit S3 closure):
+#   The Personal → Organizational upgrade path in
+#   scripts/upgrade-project.sh restructures APPROVAL_LOG.md and stamps
+#   the frontmatter with `upgraded_from: personal`. Baseline §4
+#   (docs/builders-guide.md line 807) requires that, after such an
+#   upgrade, the Senior Technical Authority retroactively review and
+#   approve the existing Project Bible — yet nothing in the code
+#   enforces this. The previous APPROVAL_LOG.md template didn't even
+#   carry a row for the retroactive approver/date.
+#
+# Fix (option B from the audit recommendation):
+#   1. upgrade-project.sh's organizational APPROVAL_LOG.md restructure
+#      now includes a dedicated "Retroactive Phase 1 → Phase 2 STA
+#      Approval" section with Approver/Date fields.
+#   2. scripts/check-phase-gate.sh detects this state — frontmatter
+#      `upgraded_from: personal` AND current_phase >= 2 — and emits a
+#      non-blocking WARN when the Retroactive Approver or Date is
+#      blank, citing builders-guide.md § Phase 1 (line 807).
+#
+# This test exercises check-phase-gate.sh against three scenarios:
+#   T1: upgraded project with current_phase >= 2 and blank retroactive
+#       approval rows → must emit WARN that mentions "Retroactive".
+#   T2: same scenario but with Approver + Date filled in → no WARN
+#       about retroactive approval.
+#   T3: project NOT upgraded from personal (no `upgraded_from` key) →
+#       check-phase-gate.sh must NOT emit the retroactive WARN even
+#       when current_phase >= 2.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  ( cd "$PROJ" && git init -q \
+      && git config user.email "ops@example.com" \
+      && git config user.name "Ops" )
+  # Phase state — current_phase 2 so the new check fires.
+  cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{
+  "current_phase": 2,
+  "project": "tier-crosscheck-5-fixture",
+  "deployment": "organizational",
+  "gates": {"phase_0_to_1": "2026-04-01", "phase_1_to_2": "2026-04-15"}
+}
+JSON
+  # Minimal PROJECT_BIBLE.md (so the Phase 1→2 artifact check passes
+  # and we observe only the retroactive WARN).
+  printf '## 1. one\n## 2. two\n## 3. three\n## 4. four\n## 5. five\n## 6. six\n## 7. seven\n## 8. eight\n## 9. nine\n## 10. ten\n## 11. eleven\n## 12. twelve\n## 13. thirteen\n## 14. fourteen\n' > "$PROJ/PROJECT_BIBLE.md"
+  # Minimal PRODUCT_MANIFESTO.md (Phase 0→1 artifact).
+  cat > "$PROJ/PRODUCT_MANIFESTO.md" <<'MANIFESTO'
+# Product Manifesto
+
+## Problem Statement
+A real problem.
+
+## Compliance Screening
+Required by IT Security.
+
+## Cost & Maintenance Discussion
+Acknowledged.
+
+## Stakeholder Map
+Sponsor, Owner.
+MANIFESTO
+}
+teardown() { rm -rf "$TMP"; }
+
+# Build an upgraded-from-personal APPROVAL_LOG.md. The flag toggles
+# whether the Retroactive Approver/Date rows are filled in.
+write_upgraded_log() {
+  local fill_retroactive="$1"
+  local approver date
+  if [ "$fill_retroactive" = "true" ]; then
+    approver="Jane Doe"; date="2026-04-20"
+  else
+    approver=""; date=""
+  fi
+  cat > "$PROJ/APPROVAL_LOG.md" <<MD
+---
+project: tier-crosscheck-5-fixture
+deployment: organizational
+created: 2026-04-15
+upgraded_from: personal
+framework: Solo Orchestrator v1.0
+---
+
+# Approval Log
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Gate** | Phase 0 → Phase 1 |
+| **Approver** | Sponsor |
+| **Date** | 2026-04-01 |
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| **Gate** | Phase 1 → Phase 2 |
+| **Approver** | Sponsor |
+| **Date** | 2026-04-15 |
+
+## Retroactive Phase 1 → Phase 2 STA Approval
+| Field | Value |
+|---|---|
+| **Gate** | Retroactive Phase 1 → Phase 2 (STA) |
+| **Approver** | $approver |
+| **Date** | $date |
+| **Reference** | See docs/builders-guide.md § Phase 1 (line 807) |
+MD
+}
+
+write_non_upgraded_org_log() {
+  cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+---
+project: tier-crosscheck-5-fixture
+deployment: organizational
+created: 2026-04-15
+framework: Solo Orchestrator v1.0
+---
+
+# Approval Log
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Gate** | Phase 0 → Phase 1 |
+| **Approver** | Sponsor |
+| **Date** | 2026-04-01 |
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| **Gate** | Phase 1 → Phase 2 |
+| **Approver** | Sponsor |
+| **Date** | 2026-04-15 |
+MD
+}
+
+# T1: upgraded_from=personal + blank retroactive rows → WARN emitted.
+t1_upgraded_blank_retroactive_emits_warn() {
+  setup
+  write_upgraded_log "false"
+  local output
+  output=$( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
+  if echo "$output" | grep -qiE "WARN.*retroactive|Retroactive STA Approval"; then
+    pass "T1: upgraded_from=personal + blank retroactive rows → check-phase-gate.sh emits Retroactive WARN"
+  else
+    fail_ "T1" "expected WARN mentioning 'retroactive'; got:\n$output"
+  fi
+  teardown
+}
+
+# T2: upgraded_from=personal + filled retroactive rows → no Retroactive WARN.
+t2_upgraded_filled_retroactive_no_warn() {
+  setup
+  write_upgraded_log "true"
+  local output
+  output=$( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
+  if echo "$output" | grep -qiE "WARN.*retroactive: project upgraded from personal but.*incomplete|WARN.*retroactive: project upgraded from personal but APPROVAL_LOG\.md has no"; then
+    fail_ "T2" "expected NO Retroactive WARN when approver+date filled; got:\n$output"
+  else
+    pass "T2: upgraded_from=personal + Approver+Date filled → no Retroactive WARN"
+  fi
+  teardown
+}
+
+# T3: NOT upgraded_from=personal → check must skip the retroactive WARN.
+t3_non_upgraded_no_retroactive_warn() {
+  setup
+  write_non_upgraded_org_log
+  local output
+  output=$( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
+  if echo "$output" | grep -qiE "WARN.*retroactive: project upgraded from personal but.*incomplete|WARN.*retroactive: project upgraded from personal but APPROVAL_LOG\.md has no"; then
+    fail_ "T3" "expected NO Retroactive WARN when not upgraded_from=personal; got:\n$output"
+  else
+    pass "T3: non-upgraded organizational project does NOT trigger Retroactive WARN"
+  fi
+  teardown
+}
+
+echo "== tests/test-check-phase-gate-retroactive-approval.sh =="
+t1_upgraded_blank_retroactive_emits_warn
+t2_upgraded_filled_retroactive_no_warn
+t3_non_upgraded_no_retroactive_warn
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-init-organizational.sh
+++ b/tests/test-init-organizational.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# tests/test-init-organizational.sh — audit tests-init-host-attestation-4 closure.
+#
+# Pre-fix coverage gap: tests/test-init-no-remote-creation.sh and
+# tests/test-init-other-host-attestation.sh both ran init.sh end-to-end
+# but only with --deployment personal. Nothing exercised the
+# --deployment organizational + --gov-mode path against the real init.sh
+# code (the only org-flow coverage was --validate-only at
+# tests/edge-cases-scripts.sh E50/E51, which exits before file writes
+# and before bl030_finalize_init runs). That left a real regression hole:
+# breaking the org branch of init.sh's create_project / phase-state
+# writer / governance scaffolding would not flip any test red.
+#
+# This file fills the gap with a single integration test that runs
+# init.sh --non-interactive --deployment organizational --gov-mode
+# production end-to-end (using --no-remote-creation so the test never
+# touches a real host), then asserts the organizational markers landed
+# correctly in the resulting project.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT_SH="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# T1: end-to-end organizational init writes manifest deployment field +
+# APPROVAL_LOG.md governance scaffolding.
+t1_organizational_e2e_writes_governance_scaffolding() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/org-proj"
+  local rc=0
+  # cd to tmpdir so the framework-self-guard doesn't refuse.
+  # < <(printf 'Y\nY\n...) feeds finite stdin so any install confirms
+  # auto-accept without breaking pipefail (yes(1) gets SIGPIPE → 141).
+  ( cd "$tmpdir" && \
+    "$INIT_SH" --non-interactive \
+        --project test-org \
+        --platform web \
+        --deployment organizational \
+        --gov-mode production \
+        --language typescript \
+        --git-host github \
+        --visibility private \
+        --project-dir "$proj" \
+        --no-remote-creation \
+        < <(printf 'Y\nY\nY\nY\nY\nY\nY\nY\nY\nY\n') \
+        > "$tmpdir/init.log" 2>&1 ) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T1" "expected init exit 0; rc=$rc tail:\n$(tail -15 "$tmpdir/init.log")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # T1a: manifest.json records deployment=organizational. Pre-fix
+  # nothing asserted this against a real run.
+  if [ ! -f "$proj/.claude/manifest.json" ]; then
+    fail_ "T1" "manifest.json not written"
+    rm -rf "$tmpdir"; return
+  fi
+  local manifest_deployment
+  manifest_deployment=$(jq -r '.deployment // empty' "$proj/.claude/manifest.json")
+  if [ "$manifest_deployment" != "organizational" ]; then
+    fail_ "T1" "expected manifest.deployment='organizational'; got '$manifest_deployment'"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # T1b: manifest.json records the host correctly even on the
+  # --no-remote-creation path (same T2-C invariant as the personal
+  # test). Organizational deployments must not silently lose this.
+  local manifest_host
+  manifest_host=$(jq -r '.host // empty' "$proj/.claude/manifest.json")
+  if [ "$manifest_host" != "github" ]; then
+    fail_ "T1" "expected manifest.host='github'; got '$manifest_host'"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # T1c: APPROVAL_LOG.md exists and is the ORGANIZATIONAL template, not
+  # the personal one. The organizational template carries the
+  # 'deployment: organizational' frontmatter key and the
+  # Pre-Phase 0 Organizational Pre-Conditions section. The personal
+  # template carries neither. This is what proves init's org branch
+  # actually picked the right template.
+  if [ ! -f "$proj/APPROVAL_LOG.md" ]; then
+    fail_ "T1" "APPROVAL_LOG.md not written"
+    rm -rf "$tmpdir"; return
+  fi
+  if ! grep -q '^deployment: organizational' "$proj/APPROVAL_LOG.md"; then
+    fail_ "T1" "APPROVAL_LOG.md missing 'deployment: organizational' frontmatter; head:\n$(head -10 "$proj/APPROVAL_LOG.md")"
+    rm -rf "$tmpdir"; return
+  fi
+  if ! grep -q "Pre-Phase 0.*Organizational Pre-Conditions" "$proj/APPROVAL_LOG.md"; then
+    fail_ "T1" "APPROVAL_LOG.md missing 'Pre-Phase 0: Organizational Pre-Conditions' section"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # T1d: phase-state.json records deployment=organizational + (because
+  # gov-mode=production) poc_mode is null. POC modes carry a non-null
+  # poc_mode; production must be the explicit absence.
+  local ps_deploy ps_poc
+  ps_deploy=$(jq -r '.deployment // empty' "$proj/.claude/phase-state.json" 2>/dev/null || echo "")
+  ps_poc=$(jq -r '.poc_mode // "null"' "$proj/.claude/phase-state.json" 2>/dev/null || echo "")
+  if [ "$ps_deploy" != "organizational" ]; then
+    fail_ "T1" "expected phase-state.deployment='organizational'; got '$ps_deploy'"
+    rm -rf "$tmpdir"; return
+  fi
+  if [ "$ps_poc" != "null" ] && [ -n "$ps_poc" ]; then
+    fail_ "T1" "expected phase-state.poc_mode=null for production gov-mode; got '$ps_poc'"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # T1e: --no-remote-creation contract still holds — no real origin
+  # remote was added. This catches any future regression where the
+  # organizational branch accidentally bypasses the no-remote-creation
+  # guard.
+  if (cd "$proj" && git remote get-url origin >/dev/null 2>&1); then
+    local url; url=$(cd "$proj" && git remote get-url origin)
+    fail_ "T1" "expected NO origin remote (--no-remote-creation); got: $url"
+    rm -rf "$tmpdir"; return
+  fi
+
+  pass "T1: organizational end-to-end init writes deployment=organizational manifest + org APPROVAL_LOG.md + null poc_mode + no remote"
+  rm -rf "$tmpdir"
+}
+
+# T2: end-to-end organizational + sponsored_poc init records poc_mode
+# correctly. Asserts the POC-mode branch of init.sh's organizational
+# path, which is otherwise only covered at --validate-only level.
+t2_organizational_sponsored_poc_records_poc_mode() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/poc-proj"
+  local rc=0
+  ( cd "$tmpdir" && \
+    "$INIT_SH" --non-interactive \
+        --project test-poc \
+        --platform web \
+        --deployment organizational \
+        --gov-mode sponsored_poc \
+        --language typescript \
+        --git-host github \
+        --visibility private \
+        --project-dir "$proj" \
+        --no-remote-creation \
+        < <(printf 'Y\nY\nY\nY\nY\nY\nY\nY\nY\nY\n') \
+        > "$tmpdir/init.log" 2>&1 ) || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T2" "expected init exit 0; rc=$rc tail:\n$(tail -15 "$tmpdir/init.log")"
+    rm -rf "$tmpdir"; return
+  fi
+  local ps_poc
+  ps_poc=$(jq -r '.poc_mode // empty' "$proj/.claude/phase-state.json" 2>/dev/null || echo "")
+  if [ "$ps_poc" != "sponsored_poc" ]; then
+    fail_ "T2" "expected phase-state.poc_mode='sponsored_poc'; got '$ps_poc'"
+    rm -rf "$tmpdir"; return
+  fi
+  pass "T2: organizational + sponsored_poc writes phase-state.poc_mode='sponsored_poc'"
+  rm -rf "$tmpdir"
+}
+
+echo "== tests/test-init-organizational.sh =="
+t1_organizational_e2e_writes_governance_scaffolding
+t2_organizational_sponsored_poc_records_poc_mode
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-upgrade-project-retroactive-section.sh
+++ b/tests/test-upgrade-project-retroactive-section.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# tests/test-upgrade-project-retroactive-section.sh
+#
+# Regression test for the upgrade-project.sh half of tier-crosscheck-5
+# (audit S3 closure): when a project is upgraded from personal to
+# organizational, scripts/upgrade-project.sh:1610-1626 stamps a new
+# "Retroactive Phase 1 → Phase 2 STA Approval" section into the
+# regenerated APPROVAL_LOG.md. This section is the artifact that
+# scripts/check-phase-gate.sh (lines 519-555) reads to emit the
+# non-blocking WARN governed by tests/test-check-phase-gate-retroactive-
+# approval.sh.
+#
+# PR #104 verifier (Wave 4) flagged that the original closure only
+# tested the check-phase-gate.sh half — the stamping logic in
+# upgrade-project.sh was verified only by hand-rolling the section into
+# a fixture. Deleting upgrade-project.sh:1610-1626 left the suite green.
+#
+# This test runs the REAL scripts/upgrade-project.sh against a fresh
+# personal project end-to-end and inspects the resulting APPROVAL_LOG.md
+# for the new retroactive section header + frontmatter key
+# (`upgraded_from: personal`) + the four field rows the
+# check-phase-gate.sh parser depends on (Gate / Approver / Date /
+# Reference).
+#
+# RED-on-main / GREEN-on-PR evidence:
+#   - On origin/main, scripts/upgrade-project.sh does not emit the
+#     "Retroactive Phase 1 → Phase 2 STA Approval" header at all (the
+#     stamping block at lines 1610-1626 does not exist), so T1 fails.
+#   - On PR #104, the stamping block is present and the section header
+#     + four rows land in the regenerated log → T1 passes.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+UPGRADE="$REPO_ROOT/scripts/upgrade-project.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Seed a personal-deployment phase-state.json matching init.sh:1601-1616
+# schema. Caller passes the project dir.
+seed_personal_phase_state() {
+  local dir="$1"
+  mkdir -p "$dir/.claude"
+  cat > "$dir/.claude/phase-state.json" <<'JSON'
+{
+  "project": "test-retroactive-section",
+  "framework_version": "1.0",
+  "current_phase": 2,
+  "track": "standard",
+  "deployment": "personal",
+  "poc_mode": null,
+  "compliance_ready": false,
+  "gates": {"phase_0_to_1": "2026-04-01", "phase_1_to_2": "2026-04-15", "phase_3_to_4": null}
+}
+JSON
+}
+
+# Seed a personal APPROVAL_LOG.md (deployment: personal frontmatter) so
+# upgrade-project.sh:1467-1472 detects it as a personal-format log and
+# triggers the organizational restructure that stamps the retroactive
+# section. Without this seed, the upgrade-project.sh path skips the
+# restructure entirely.
+seed_personal_approval_log() {
+  local dir="$1"
+  cat > "$dir/APPROVAL_LOG.md" <<'MD'
+---
+project: test-retroactive-section
+deployment: personal
+created: 2026-04-01
+framework: Solo Orchestrator v1.0
+---
+
+# Approval Log (Personal Deployment)
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Gate** | Phase 0 → Phase 1 |
+| **Reviewer** | Self |
+| **Date** | 2026-04-01 |
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| **Gate** | Phase 1 → Phase 2 |
+| **Reviewer** | Self |
+| **Date** | 2026-04-15 |
+MD
+}
+
+# T1: run scripts/upgrade-project.sh --deployment organizational
+# end-to-end and verify the regenerated APPROVAL_LOG.md carries the
+# new "Retroactive Phase 1 → Phase 2 STA Approval" section.
+t1_personal_to_org_stamps_retroactive_section() {
+  local T; T=$(mktemp -d); local P="$T/p"
+  mkdir -p "$P"
+  ( cd "$P" && git init -q \
+      && git config user.email t@t.l \
+      && git config user.name t ) >/dev/null 2>&1
+  seed_personal_phase_state "$P"
+  seed_personal_approval_log "$P"
+  ( cd "$P" && git add -A && git commit -q -m "personal seed" ) >/dev/null 2>&1
+
+  local rc=0
+  ( cd "$P" && bash "$UPGRADE" --deployment organizational --non-interactive ) > "$T/log" 2>&1 || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T1" "upgrade-project.sh --deployment organizational returned rc=$rc; log tail:\n$(tail -15 "$T/log")"
+    rm -rf "$T"; return
+  fi
+
+  if [ ! -f "$P/APPROVAL_LOG.md" ]; then
+    fail_ "T1" "APPROVAL_LOG.md missing after upgrade"
+    rm -rf "$T"; return
+  fi
+
+  # T1a — frontmatter: deployment flipped to organizational AND the
+  # upgraded_from key is stamped. The frontmatter key is what
+  # check-phase-gate.sh:536 grep-matches to activate the retroactive WARN.
+  if ! grep -q '^deployment: organizational' "$P/APPROVAL_LOG.md"; then
+    fail_ "T1a" "APPROVAL_LOG.md missing 'deployment: organizational' frontmatter; head:\n$(head -8 "$P/APPROVAL_LOG.md")"
+    rm -rf "$T"; return
+  fi
+  if ! grep -q '^upgraded_from: personal' "$P/APPROVAL_LOG.md"; then
+    fail_ "T1a" "APPROVAL_LOG.md missing 'upgraded_from: personal' frontmatter (check-phase-gate.sh:536 gate would not fire); head:\n$(head -8 "$P/APPROVAL_LOG.md")"
+    rm -rf "$T"; return
+  fi
+
+  # T1b — the new Retroactive section header is present. This is the
+  # exact string scripts/upgrade-project.sh:1610 stamps and
+  # scripts/check-phase-gate.sh:538 greps for via "Retroactive Phase 1.*Phase 2.*STA".
+  if ! grep -qE "Retroactive Phase 1.*Phase 2.*STA Approval" "$P/APPROVAL_LOG.md"; then
+    fail_ "T1b" "APPROVAL_LOG.md missing 'Retroactive Phase 1 → Phase 2 STA Approval' section header (scripts/upgrade-project.sh:1610 stamping regression); APPROVAL_LOG tail:\n$(tail -30 "$P/APPROVAL_LOG.md")"
+    rm -rf "$T"; return
+  fi
+
+  # T1c — the four field rows the check-phase-gate.sh parser depends
+  # on are present (Gate / Approver / Date / Reference). Without these
+  # the WARN/OK emission at scripts/check-phase-gate.sh:545-552 cannot
+  # extract Approver and Date values from the table.
+  local retro_section
+  retro_section=$(grep -A 16 "Retroactive Phase 1.*Phase 2.*STA Approval" "$P/APPROVAL_LOG.md")
+  local missing=""
+  echo "$retro_section" | grep -qE '\*\*Gate\*\*[[:space:]]*\|[[:space:]]*Retroactive Phase 1' \
+    || missing="$missing Gate"
+  echo "$retro_section" | grep -qE '\*\*Approver\*\*[[:space:]]*\|' \
+    || missing="$missing Approver"
+  echo "$retro_section" | grep -qE '\*\*Date\*\*[[:space:]]*\|' \
+    || missing="$missing Date"
+  echo "$retro_section" | grep -qE '\*\*Reference\*\*[[:space:]]*\|.*builders-guide\.md.*Phase 1.*807' \
+    || missing="$missing Reference"
+
+  if [ -n "$missing" ]; then
+    fail_ "T1c" "Retroactive section missing required field row(s):$missing. Section dump:\n$retro_section"
+    rm -rf "$T"; return
+  fi
+
+  pass "T1: scripts/upgrade-project.sh --deployment organizational stamps Retroactive Phase 1→2 STA Approval section (header + Gate/Approver/Date/Reference rows + upgraded_from frontmatter)"
+
+  # T2 — the personal log is preserved as APPROVAL_LOG.md.personal-backup
+  # (scripts/upgrade-project.sh:1474). This is part of the same stamping
+  # block; if the backup vanishes the upgrade has regressed away from
+  # the audit-mandated preservation behavior.
+  if [ ! -f "$P/APPROVAL_LOG.md.personal-backup" ]; then
+    fail_ "T2" "APPROVAL_LOG.md.personal-backup missing (scripts/upgrade-project.sh:1474 backup regression); files in dir:\n$(ls "$P/")"
+    rm -rf "$T"; return
+  fi
+  if ! grep -q '^deployment: personal' "$P/APPROVAL_LOG.md.personal-backup"; then
+    fail_ "T2" "APPROVAL_LOG.md.personal-backup is not the original personal-deployment log"
+    rm -rf "$T"; return
+  fi
+  pass "T2: original personal APPROVAL_LOG.md preserved as APPROVAL_LOG.md.personal-backup"
+
+  rm -rf "$T"
+}
+
+echo "== tests/test-upgrade-project-retroactive-section.sh =="
+t1_personal_to_org_stamps_retroactive_section
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

Wave 4 closer slot 6 — five tightly-related S3 audit closures that each share the same defect class (test reproduces production code inline instead of exercising it). The PR rewires the tests so the regressions they were designed to catch would actually fail when reintroduced, plus wires one new check-phase-gate.sh enforcement promised by the baseline but never implemented.

- **BL-009 E26-E32** now drive the real `init.sh --non-interactive` and `scripts/upgrade-project.sh` UAT migration paths. Deleting init.sh's UAT copy block now flips E26-E30 to FAIL (it didn't before).
- **`tests/test-init-organizational.sh`** new — fills the SDLC gap that `tests/test-init-no-remote-creation.sh` + `tests/test-init-other-host-attestation.sh` only covered `--deployment personal`.
- **`tests/known-bugs-test-suite.sh`** BUG-1/2/3/8 now source `scripts/intake-wizard.sh` directly (sourceable via a new main-guard); BUG-7 grep-asserts the post-fix idiom shape so `|| echo "0"` reintroduction flips RED.
- **Personal → Organizational retroactive STA approval** (baseline §4 row 5 / `docs/builders-guide.md` line 807) is now enforced: `scripts/upgrade-project.sh` stamps a 'Retroactive Phase 1 → Phase 2 STA Approval' section into the regenerated `APPROVAL_LOG.md`, and `scripts/check-phase-gate.sh` emits a non-blocking WARN when the Approver/Date are blank.

## Findings closed

- **tests-edge-cases-22** — `tests/edge-cases-scripts.sh:940-1021` BL-009 E26-E30 rewrite (shadow `_uat_run_init_copy_block` → real `init.sh --non-interactive --no-remote-creation --platform <X>` per case).
- **tests-edge-cases-23** — `tests/edge-cases-scripts.sh:1051-1156` E31, E32 rewrite (inline `cp` loop → two real `scripts/upgrade-project.sh` runs + snapshot-diff for idempotency).
- **tests-init-host-attestation-4** — new file `tests/test-init-organizational.sh` (T1 organizational+production, T2 organizational+sponsored_poc).
- **tests-full-known-bugs-2** — `tests/known-bugs-test-suite.sh:184-208` (BUG-1), `:228-247` (BUG-2), `:286-308` (BUG-3), `:546-622` (BUG-7), `:630-664` (BUG-8) all switched to source the real production functions; `scripts/intake-wizard.sh:16-66, 1990-1992` made sourceable via main-guard.
- **tier-crosscheck-5** — `scripts/check-phase-gate.sh:519-555` (new retroactive WARN block), `scripts/upgrade-project.sh:1610-1626` (new Retroactive STA Approval section in regenerated APPROVAL_LOG.md), `tests/test-check-phase-gate-retroactive-approval.sh` (new T1/T2/T3 coverage).

## Test plan

### RED proof against `origin/main`

**BL-009 E26-E32** — delete `init.sh`'s UAT copy block (lines 1187-1207) and re-run the pre-fix tests:

```
$ cp init.sh /tmp/init.sh.original
$ sed -i.bak '1187,1207d' init.sh
$ awk '/^section "BL-009/,/^section "BL-006/' tests/edge-cases-scripts.sh > /tmp/bl009-section.sh
$ bash -c 'set -euo pipefail; REPO_DIR="..."; pass(){...}; fail(){...}; section(){...}; . /tmp/bl009-section.sh'
== BL-009: UAT template quality + platform-aware authoring ==
[PASS] E26: UAT init for 'web' copies web-specific reference pair
[PASS] E27: UAT init for 'desktop' copies desktop-specific reference pair
[PASS] E28: UAT init for 'mobile' copies mobile-specific reference pair
[PASS] E29: UAT init for 'mcp_server' copies mcp-specific reference pair
[PASS] E30: UAT init for 'other' skips ref copy, keeps source templates
[PASS] E31: UAT upgrade refreshes source templates with new placeholder
[PASS] E32: UAT upgrade migration is idempotent
```

All 7 pre-fix tests still pass with init.sh's UAT block deleted — proving they never exercised init.sh. After the rewrite, the same sabotage flips E26-E30 to FAIL:

```
[FAIL] E26: real init.sh --platform web failed — refs missing or not web-specific
[FAIL] E27: real init.sh --platform desktop failed
[FAIL] E28: real init.sh --platform mobile failed
[FAIL] E29: real init.sh --platform mcp_server failed
[FAIL] E30: real init.sh --platform other produced wrong state (refs present or template missing)
```

**tests-init-host-attestation-4** — sabotage init.sh's APPROVAL_LOG.md branch (`[ "$DEPLOYMENT" = "organizational" ] → false && [ "$DEPLOYMENT" = "organizational" ]`):

```
$ sed -i.bak 's|if \[ "$DEPLOYMENT" = "organizational" \]|if false \&\& [ "$DEPLOYMENT" = "organizational" ]|' init.sh
$ bash tests/test-init-organizational.sh
  [FAIL] T1 — APPROVAL_LOG.md missing 'deployment: organizational' frontmatter
  [PASS] T2: organizational + sponsored_poc writes phase-state.poc_mode='sponsored_poc'
```

T1 RED'd. After restore, both T1+T2 GREEN.

**tests-full-known-bugs-2** — sabotage scripts/intake-wizard.sh save_answer to write `'WRONG_VALUE'` + sabotage init_progress to write `'WRONG_NAME'` / `'WRONG_DESC'`:

```
[FAIL] BUG-1: save_answer corrupted value: got 'WRONG_VALUE'
[FAIL] BUG-2: init_progress corrupted values: name='WRONG_NAME' desc='WRONG_DESC'
```

Plus sabotage `scripts/validate.sh` to revert `|| true` → `|| echo "0"`:

```
[FAIL] BUG-7: validate.sh has regressed away from the post-fix idiom (counter sanitizer missing or '|| echo "0"' reintroduced)
```

**tier-crosscheck-5** — revert `scripts/check-phase-gate.sh` to origin/main and re-run new test:

```
$ git show origin/main:scripts/check-phase-gate.sh > scripts/check-phase-gate.sh
$ bash tests/test-check-phase-gate-retroactive-approval.sh
  [FAIL] T1 — expected WARN mentioning 'retroactive'; ...
  [PASS] T2: upgraded_from=personal + Approver+Date filled → no Retroactive WARN
  [PASS] T3: non-upgraded organizational project does NOT trigger Retroactive WARN
```

T1 RED'd. After restore, all three GREEN.

### GREEN (post-fix on this branch)

```
$ bash scripts/lint-counter-antipattern.sh
OK: no counter-capture antipatterns found.
$ bash scripts/lint-backlog-references.sh
OK: backlog references and Closed-status citations are consistent.
$ bash scripts/lint-fix-functions-stderr.sh
OK: no fix_*() stderr silencers found.
$ bash scripts/lint-raw-read-prompt.sh
OK: no raw 'read -rp' / 'read -p' calls outside scripts/lib/helpers.sh.

$ bash tests/test-init-organizational.sh
  [PASS] T1: organizational end-to-end init writes deployment=organizational manifest + org APPROVAL_LOG.md + null poc_mode + no remote
  [PASS] T2: organizational + sponsored_poc writes phase-state.poc_mode='sponsored_poc'
== Total: 2 | Passed: 2 | Failed: 0 ==

$ bash tests/test-check-phase-gate-retroactive-approval.sh
  [PASS] T1: upgraded_from=personal + blank retroactive rows → check-phase-gate.sh emits Retroactive WARN
  [PASS] T2: upgraded_from=personal + Approver+Date filled → no Retroactive WARN
  [PASS] T3: non-upgraded organizational project does NOT trigger Retroactive WARN
== Total: 3 | Passed: 3 | Failed: 0 ==

$ bash tests/known-bugs-test-suite.sh
...
  Passed:  23
  Failed:  0

$ # BL-009 isolated subsection re-run
[PASS] E26: real init.sh --platform web copies web-specific UAT reference pair
[PASS] E27: real init.sh --platform desktop copies desktop-specific UAT reference pair
[PASS] E28: real init.sh --platform mobile copies mobile-specific UAT reference pair
[PASS] E29: real init.sh --platform mcp_server copies mcp-specific UAT reference pair
[PASS] E30: real init.sh --platform other skips ref copy, keeps source templates
[PASS] E31: real upgrade-project.sh UAT migration refreshes stub template + reference pair
[PASS] E32: upgrade-project.sh UAT migration is idempotent (run-1 and run-2 produce identical trees)
```

Adjacent regression checks (passed): `test-check-phase-gate.sh`, `test-check-phase-gate-self-approval.sh`, `test-check-phase-gate-backstop-attestation.sh`, `test-check-phase-gate-noninteractive.sh`, `test-check-phase-gate-counter-sanitizer.sh`, `test-init-no-remote-creation.sh`, `test-init-other-host-attestation.sh`, `test-intake-wizard-fixes.sh`, `test-prompt-install-noninteractive.sh`, `test-poc-modes.sh`, `test-reconfigure-field-handlers.sh`, `test-platform-mobile-mcp-docs.sh`, `test-upgrade-paths.sh`, `test-upgrade-non-interactive.sh`, `test-upgrade-project-atomic.sh`.

## Bonus catches

- **`init.sh`'s install-plan `read -rp` aborts under pipefail with closed stdin.** Discovered while wiring BL-009 E28 (mobile) — when init.sh runs into Android Studio in the "Will install now" list, the `read -rp` prompt at `init.sh:736` consumes stdin. With `set -o pipefail` + closed stdin in tests, that abort cascades. Worked around in the test helper by feeding a finite `printf 'Y\n...\n'` process substitution. A follow-up audit item could promote the prompt to honor `SOIF_NONINTERACTIVE` directly so the `NON_INTERACTIVE=true` path skips it entirely.
- **`scripts/intake-wizard.sh` was not sourceable** because top-level statements ran setup unconditionally. Added a sourced/standalone branch guard (`(return 0 2>/dev/null) && _intake_wizard_sourced=1`) that lets tests reach the real functions without triggering project-root discovery, CWD anchor, or `main`. This pattern is reusable for any future test wanting to exercise wizard internals.
- **Registered the two new test files in `tests/full-project-test-suite.sh`** so they run in the same gate as the existing `check-phase-gate` backstop tests. This is the same pattern PR #67-#71 used to integrate the lint-test-suite — keeps the new coverage from drifting out of the standard gate.

## Breaking changes

None. The wire-ups are additive:

- New `scripts/check-phase-gate.sh` WARN emits only when the new condition triggers; existing projects without `upgraded_from: personal` are untouched.
- `scripts/intake-wizard.sh` main-guard only affects the sourced path; normal `bash scripts/intake-wizard.sh` invocations run exactly as before (verified by re-running `bash scripts/intake-wizard.sh --help` against the framework guard).
- `scripts/upgrade-project.sh` adds a new section to the regenerated APPROVAL_LOG.md; existing org-format logs with no `upgraded_from` field are unchanged.
- Test rewrites preserve all original assertion intent; the new behavior is strictly _more_ regression coverage.

## Worktree note

```
$ pwd
/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_22ccde10-1af-6
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)