### PR TITLE
feat: Phase 1→2 hard-block on data_classification + ZDR attestation (closes tier-crosscheck-6 — final S3 finding)

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -815,6 +815,17 @@ When `current_phase >= 2` in `.claude/phase-state.json`:
 - [ ] **`PROJECT_BIBLE.md` exists.**
 - [ ] **`PROJECT_BIBLE.md` has at least 14 numbered sections** (template specifies 16; minimum 14 to pass).
 - [ ] **No placeholder dates in `PROJECT_BIBLE.md`.** Any remaining `YYYY-MM-DD` strings produce a WARN.
+- [ ] **ZDR / data_classification gate (tier-crosscheck-6).** `.claude/process-state.json::phase1_artifacts.data_classification` must be one of `public`, `internal`, `confidential`, `pii`, `financial`, `health`, `regulated`. For any classification above `public`, EITHER `zdr_attested = true` OR a non-empty `zdr_attestation_reason` must be present. Missing or invalid → FAIL (blocking). See docs/governance-framework.md § VII "Mandatory ZDR gate" (invariant #16).
+
+#### Step 1.7: Data Classification & ZDR Attestation (Phase 1→2 invariant — tier-crosscheck-6)
+
+`scripts/intake-wizard.sh` § 5.5 captures `data_classification` + `zdr_attested` and writes them to `.claude/process-state.json::phase1_artifacts`. The Phase 1→2 backstop in `scripts/check-phase-gate.sh` enforces them. When ZDR (Zero Data Retention) is in place, set `zdr_attested = true`. When ZDR is not in place but the deviation has been formally risk-accepted (e.g. a customer SOW that requires retention, or a self-hosted Ollama instance that already controls retention), record the written exception in `zdr_attestation_reason` — the gate honors either evidence shape.
+
+**When ZDR is needed:** Personal/light tier projects handling `public` data only are exempt. Any project handling `internal` or higher data (per docs/governance-framework.md § VII line 297-299) must have ZDR or self-hosted LLM — this includes most organizational projects and any personal project handling PII, financial, health, or regulated data. Setting `zdr_attested = false` without a documented `zdr_attestation_reason` will fail the Phase 1→2 gate.
+
+**Retrofitting an existing project:** Run `bash scripts/reconfigure-project.sh --field data_classification --new <value>` (and optionally `--field zdr_attested --new true|false [--reason "<text>"]`). The reconfigure script appends an audit row to `APPROVAL_LOG.md` and rolls back atomically on failure (PR #57 / PR #93 pattern).
+
+**Personal→Organizational upgrade:** `scripts/upgrade-project.sh --deployment organizational` refuses up-front when `phase1_artifacts.data_classification` is unset — set it first via reconfigure, then re-run the upgrade.
 
 **Save as:** `PROJECT_BIBLE.md`
 

--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -298,6 +298,19 @@ When using Claude or any cloud-hosted LLM, project code and context are transmit
 
 **Mandatory ZDR gate:** Projects with data classified as **Internal or higher** (Internal, Confidential, PII, Financial, Regulated) **must** use the ZDR or self-hosted deployment path. This is a hard gate at Phase 1 — the Orchestrator may not proceed to Phase 2 with a non-ZDR deployment path if the project handles data above Public classification. The Senior Technical Authority must verify the deployment path matches the data classification before approving the Phase 1 → Phase 2 transition.
 
+**Invariant #16 — Enforced (tier-crosscheck-6, closes the final S3 audit finding):** The Mandatory ZDR gate above is enforced as a Phase 1→2 invariant by `scripts/check-phase-gate.sh`. The gate refuses Phase 1→2 (exit 1, `[FAIL]`) unless `.claude/process-state.json::phase1_artifacts` records BOTH:
+
+1. `data_classification` — one of the 7-tier canonical taxonomy values (lowercase): `public`, `internal`, `confidential`, `pii`, `financial`, `health`, `regulated`. This mirrors `templates/project-intake.md` § 5.1 ("Sensitivity classifications: Public, Internal, Confidential, PII, Financial, Health/Medical, Regulated") and `docs/user-guide.md` Section 5.
+2. **Attestation evidence**, in one of two shapes:
+   * `zdr_attested: true` — boolean, indicates ZDR or self-hosted LLM is in place. Sufficient on its own.
+   * `zdr_attestation_reason: "<non-empty text>"` — free-text written exception (e.g. "customer SOW requires retention, risk accepted by CISO Email TKT-42"). Satisfies the gate when ZDR is not attested but the deviation is documented per organizational risk-acceptance policy.
+
+**Exemption:** `data_classification = public` projects are exempt from the attestation requirement — the classification itself is evidence that no sensitive data flows to the LLM provider. The gate emits `[OK]` and skips the attestation check for these projects.
+
+**Where the fields are captured:** Greenfield projects capture both values via `scripts/intake-wizard.sh` § 5.5 (interactive) or via the non-interactive flags `--data-classification VALUE --zdr-attested --zdr-attestation-reason "<text>"`. Retroactive correction uses `scripts/reconfigure-project.sh --field data_classification --new <value>` / `--field zdr_attested --new true|false [--reason "<text>"]`. Personal→Organizational deployment upgrade refuses up-front when `data_classification` is missing — operators must run reconfigure first.
+
+**Audit trail:** Every classification/attestation mutation appends a row to `APPROVAL_LOG.md` (Approval History section) with date, tool, actor, and the new value, preserving the append-only invariant (#8).
+
 **Policy verification cadence:** AI provider terms change. Verify the current data handling policy at the time of adoption and at each biannual review.
 
 ### Data Loss Prevention for AI Prompts

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -487,6 +487,102 @@ if [ "$current_phase" -ge 2 ]; then
   fi
 fi
 
+# --- Phase 1→2 BACKSTOP: data_classification + ZDR attestation (tier-crosscheck-6) ---
+# docs/governance-framework.md §VII line 299 declared a "Mandatory ZDR
+# gate" — projects classified Internal or higher MUST use the ZDR or
+# self-hosted deployment path. The gate was documented but never
+# enforced: no field captured the classification, no field recorded the
+# ZDR attestation, and this script had no backstop reading any such
+# field. tier-crosscheck-6 (the final S3 audit finding) closes the loop
+# by making this an invariant equivalent to the github_free_tier
+# branch-protection backstop above (PR #75).
+#
+# Behavior: when current_phase >= 2, the gate REFUSES (exit 1, FAIL line)
+# unless .claude/process-state.json::phase1_artifacts carries:
+#   * data_classification: one of {public, internal, confidential, pii,
+#     financial, health, regulated} — the 7-tier taxonomy adopted from
+#     templates/project-intake.md:209 + docs/user-guide.md:466.
+#   * AND one of: zdr_attested == true | "true",
+#     OR  zdr_attestation_reason is a non-empty string (written exception
+#     such as a customer-mandated retention clause or a self-hosted LLM).
+#
+# Remediation message points operators at intake-wizard.sh (greenfield)
+# and reconfigure-project.sh --field data_classification (retrofit).
+if [ "$current_phase" -ge 2 ]; then
+  zdr_state_file=".claude/process-state.json"
+  zdr_taxonomy="public internal confidential pii financial health regulated"
+  zdr_classification=""
+  zdr_attested_raw=""
+  zdr_reason=""
+
+  if [ -f "$zdr_state_file" ] && command -v jq >/dev/null 2>&1; then
+    zdr_classification=$(jq -r '.phase1_artifacts.data_classification // ""' "$zdr_state_file" 2>/dev/null || echo "")
+    zdr_attested_raw=$(jq -r '.phase1_artifacts.zdr_attested // ""' "$zdr_state_file" 2>/dev/null || echo "")
+    zdr_reason=$(jq -r '.phase1_artifacts.zdr_attestation_reason // ""' "$zdr_state_file" 2>/dev/null || echo "")
+    # jq returns the string "null" when a key is present but null; normalize.
+    [ "$zdr_classification" = "null" ] && zdr_classification=""
+    [ "$zdr_attested_raw" = "null" ]  && zdr_attested_raw=""
+    [ "$zdr_reason" = "null" ]        && zdr_reason=""
+  fi
+
+  # Normalize classification to lowercase canonical form so the taxonomy
+  # match isn't fooled by stored "Public" vs "public" — both intake and
+  # reconfigure write the canonical lowercase value, but defense-in-
+  # depth covers operators who hand-edit process-state.json.
+  zdr_classification_canon=$(printf '%s' "$zdr_classification" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+  zdr_taxonomy_ok=0
+  if [ -n "$zdr_classification_canon" ]; then
+    for _allowed in $zdr_taxonomy; do
+      if [ "$zdr_classification_canon" = "$_allowed" ]; then
+        zdr_taxonomy_ok=1
+        break
+      fi
+    done
+  fi
+
+  zdr_attest_ok=0
+  case "$zdr_attested_raw" in
+    true|True|TRUE) zdr_attest_ok=1 ;;
+  esac
+  if [ "$zdr_attest_ok" -eq 0 ] && [ -n "$zdr_reason" ]; then
+    zdr_attest_ok=1
+  fi
+
+  if [ -z "$zdr_classification_canon" ]; then
+    echo -e "${RED}[FAIL]${NC} Phase 1→2 ZDR gate: phase1_artifacts.data_classification not set in $zdr_state_file"
+    echo "        Required taxonomy (one of): $zdr_taxonomy"
+    echo "        Remediate: scripts/intake-wizard.sh (greenfield) — OR for retrofit:"
+    echo "                   bash scripts/reconfigure-project.sh --field data_classification --new <value>"
+    echo "        Reference: docs/governance-framework.md § VII (Mandatory ZDR gate, line 299) + invariant #16."
+    issues=$((issues + 1))
+  elif [ "$zdr_taxonomy_ok" -eq 0 ]; then
+    echo -e "${RED}[FAIL]${NC} Phase 1→2 ZDR gate: invalid data_classification '$zdr_classification' (not in taxonomy)"
+    echo "        Allowed (one of): $zdr_taxonomy"
+    echo "        Remediate: bash scripts/reconfigure-project.sh --field data_classification --new <value>"
+    issues=$((issues + 1))
+  elif [ "$zdr_classification_canon" = "public" ]; then
+    # docs/governance-framework.md § VII line 297-299: ZDR is mandatory
+    # for Internal or higher. Public-only projects are exempt from the
+    # attestation requirement — the classification itself is the
+    # evidence that no sensitive data flows to the LLM provider.
+    echo -e "${GREEN}  [OK]${NC} Phase 1→2 ZDR gate: data_classification='public' (ZDR attestation not required for Public-only data)"
+  elif [ "$zdr_attest_ok" -eq 0 ]; then
+    echo -e "${RED}[FAIL]${NC} Phase 1→2 ZDR gate: data_classification='$zdr_classification_canon' but no ZDR attestation evidence"
+    echo "        Required: phase1_artifacts.zdr_attested=true OR a non-empty phase1_artifacts.zdr_attestation_reason."
+    echo "        Remediate: bash scripts/reconfigure-project.sh --field zdr_attested --new true"
+    echo "                   (or --field zdr_attestation_reason --new \"<written exception, e.g. customer retention SOW>\")"
+    echo "        Reference: docs/governance-framework.md § VII (line 297-299) — ZDR mandatory for Internal or higher."
+    issues=$((issues + 1))
+  else
+    if [ -n "$zdr_reason" ] && [ "$zdr_attested_raw" != "true" ] && [ "$zdr_attested_raw" != "True" ] && [ "$zdr_attested_raw" != "TRUE" ]; then
+      echo -e "${GREEN}  [OK]${NC} Phase 1→2 ZDR gate: data_classification='$zdr_classification_canon' (attestation reason: $zdr_reason)"
+    else
+      echo -e "${GREEN}  [OK]${NC} Phase 1→2 ZDR gate: data_classification='$zdr_classification_canon', zdr_attested=true"
+    fi
+  fi
+fi
+
 # Approval field validation: Phase 1→2 (P0-004)
 if [ "$current_phase" -ge 2 ]; then
   validate_approval_fields "Phase 1.*Phase 2" "Phase 1→2"

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -931,8 +931,89 @@ run_section_5() {
   backup=$(prompt_with_suggestions "Backup requirements" "backup_strategy" "Daily automated backups")
   save_answer "backup" "$backup"
 
+  # 5.5 Phase 1 Data Classification & ZDR Attestation (tier-crosscheck-6)
+  #
+  # docs/governance-framework.md § VII line 299 declares a Mandatory ZDR
+  # gate at Phase 1: projects classified Internal or higher MUST use the
+  # ZDR or self-hosted deployment path. The gate was documented but
+  # never enforced; this section captures the two values that
+  # scripts/check-phase-gate.sh now reads as a Phase 1→2 invariant
+  # (the same way it treats github_free_tier branch-protection
+  # attestation, PR #75). 7-tier taxonomy mirrors
+  # templates/project-intake.md:209.
+  if [ ! -f "${_PAUSE_FILE:-/dev/null/sentinel-cannot-exist}" ]; then
+    echo ""
+    print_info "5.5 Data Classification & ZDR Attestation (Phase 1 invariant — tier-crosscheck-6)"
+    echo ""
+    local data_classification
+    data_classification=$(prompt_choice "Highest classification of any data this system handles:" \
+      "public" "internal" "confidential" "pii" "financial" "health" "regulated")
+    save_answer "data_classification" "$data_classification"
+
+    local zdr_attested="false" zdr_attestation_reason=""
+    if [ "$data_classification" = "public" ]; then
+      print_info "  Public data: ZDR not required (governance-framework.md § VII line 297-299)."
+      zdr_attested="false"
+    else
+      if prompt_yes_no "Is ZDR (Zero Data Retention) or self-hosted LLM in place for this project? [Y/n]" "Y"; then
+        zdr_attested="true"
+      else
+        zdr_attested="false"
+        zdr_attestation_reason=$(prompt_input "Documented exception (required when ZDR not attested) — e.g. 'customer SOW requires retention'" "")
+        if [ -z "$zdr_attestation_reason" ]; then
+          print_warn "ZDR not attested AND no documented exception — Phase 1→2 gate will FAIL until this is set."
+          print_warn "Run: bash scripts/reconfigure-project.sh --field zdr_attestation_reason --new \"<text>\""
+        fi
+      fi
+    fi
+    save_answer "zdr_attested" "$zdr_attested"
+    save_answer "zdr_attestation_reason" "$zdr_attestation_reason"
+
+    # Mirror the captured values into .claude/process-state.json so
+    # scripts/check-phase-gate.sh can read them as a Phase 1→2 invariant.
+    # This is the canonical location for Phase 1 artifacts; the
+    # answers/ copy in intake-progress.json is for resume/audit only.
+    persist_phase1_artifacts "$data_classification" "$zdr_attested" "$zdr_attestation_reason"
+  fi
+
   save_section 5
   echo ""
+}
+
+# ================================================================
+# PHASE 1 ARTIFACTS: persist data_classification + ZDR attestation
+# into .claude/process-state.json::phase1_artifacts.
+# ================================================================
+# tier-crosscheck-6: the gate at scripts/check-phase-gate.sh reads from
+# this canonical location. The function is idempotent — re-running with
+# the same values is a no-op write; running with different values
+# overwrites in-place. process-state.json is initialized at init.sh
+# time (.phase2_init etc.); we add phase1_artifacts when absent.
+persist_phase1_artifacts() {
+  local classification="$1"
+  local attested="$2"
+  local reason="$3"
+  local pstate="${PROJECT_ROOT:-.}/.claude/process-state.json"
+  if [ ! -f "$pstate" ]; then
+    print_warn "  $pstate not found — skipping phase1_artifacts persistence."
+    print_info "  Run scripts/init.sh in this project to create it, then re-run intake."
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    print_warn "  jq not available — skipping phase1_artifacts persistence (data captured in intake-progress.json)."
+    return 0
+  fi
+  local jq_bool="false"
+  case "$attested" in
+    true|True|TRUE) jq_bool="true" ;;
+  esac
+  local tmp
+  tmp=$(mktemp)
+  jq --arg c "$classification" --argjson a "$jq_bool" --arg r "$reason" \
+     '.phase1_artifacts = ((.phase1_artifacts // {}) +
+        {data_classification: $c, zdr_attested: $a, zdr_attestation_reason: $r})' \
+     "$pstate" > "$tmp" && mv "$tmp" "$pstate"
+  print_ok "  Phase 1 artifacts persisted to process-state.json (classification=$classification, zdr_attested=$attested)"
 }
 
 # ================================================================
@@ -1881,11 +1962,89 @@ main() {
       echo "  --upgrade-deployment T  Upgrade deployment (personal|organizational)"
       echo "  --to-private-poc        Upgrade Personal -> Private POC"
       echo "  --to-sponsored-poc      Upgrade Personal/Private POC -> Sponsored POC"
-      echo "  --to-sponsored-poc      Convert to sponsored POC"
+      echo ""
+      echo "Phase 1 ZDR/classification non-interactive flags (tier-crosscheck-6):"
+      echo "  --data-classification VALUE        Set data_classification (one of:"
+      echo "                                     public, internal, confidential, pii,"
+      echo "                                     financial, health, regulated)"
+      echo "  --zdr-attested                     Mark zdr_attested=true"
+      echo "  --zdr-attestation-reason \"<text>\"  Record a documented exception"
+      echo ""
       echo "  --help                  Show this help"
       exit 0
       ;;
+    --data-classification|--zdr-attested|--zdr-attestation-reason|--data-classification=*|--zdr-attestation-reason=*)
+      # tier-crosscheck-6 non-interactive write path. Parsed below
+      # (after PROJECT_ROOT is resolved) so the helper can read/write
+      # .claude/process-state.json + .claude/intake-progress.json.
+      ;;
   esac
+
+  # Collect tier-crosscheck-6 CLI flags. We re-scan "$@" so flags can
+  # appear anywhere on the line (and so --resume / --upgrade-* paths
+  # above keep working unchanged).
+  TC6_CLASSIFICATION=""
+  TC6_ATTESTED=""
+  TC6_REASON=""
+  TC6_PROVIDED=0
+  _tc6_args=("$@")
+  _i=0
+  while [ "$_i" -lt "${#_tc6_args[@]}" ]; do
+    case "${_tc6_args[$_i]}" in
+      --data-classification)
+        TC6_CLASSIFICATION="${_tc6_args[$((_i + 1))]:-}"; TC6_PROVIDED=1
+        _i=$((_i + 2)); continue ;;
+      --data-classification=*)
+        TC6_CLASSIFICATION="${_tc6_args[$_i]#--data-classification=}"; TC6_PROVIDED=1
+        _i=$((_i + 1)); continue ;;
+      --zdr-attested)
+        TC6_ATTESTED="true"; TC6_PROVIDED=1
+        _i=$((_i + 1)); continue ;;
+      --zdr-attestation-reason)
+        TC6_REASON="${_tc6_args[$((_i + 1))]:-}"; TC6_PROVIDED=1
+        _i=$((_i + 2)); continue ;;
+      --zdr-attestation-reason=*)
+        TC6_REASON="${_tc6_args[$_i]#--zdr-attestation-reason=}"; TC6_PROVIDED=1
+        _i=$((_i + 1)); continue ;;
+    esac
+    _i=$((_i + 1))
+  done
+  if [ "$TC6_PROVIDED" = "1" ]; then
+    # Validate classification value (if provided).
+    if [ -n "$TC6_CLASSIFICATION" ]; then
+      TC6_CLASSIFICATION_CANON=$(printf '%s' "$TC6_CLASSIFICATION" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+      case "$TC6_CLASSIFICATION_CANON" in
+        public|internal|confidential|pii|financial|health|regulated)
+          TC6_CLASSIFICATION="$TC6_CLASSIFICATION_CANON" ;;
+        *)
+          echo "Error: --data-classification '$TC6_CLASSIFICATION' is not in the 7-tier taxonomy."
+          echo "       Allowed: public, internal, confidential, pii, financial, health, regulated"
+          exit 1 ;;
+      esac
+    fi
+    # When the operator supplies any tier-crosscheck-6 flag, treat it
+    # as a one-shot write to process-state.json and exit cleanly. The
+    # wizard's interactive flow is intentionally NOT entered.
+    if command -v jq >/dev/null 2>&1 && [ -f .claude/process-state.json ]; then
+      _tc6_attested_json="false"
+      [ "$TC6_ATTESTED" = "true" ] && _tc6_attested_json="true"
+      _tc6_tmp=$(mktemp)
+      jq --arg c "$TC6_CLASSIFICATION" --argjson a "$_tc6_attested_json" --arg r "$TC6_REASON" \
+         '.phase1_artifacts = ((.phase1_artifacts // {}) +
+            (if $c != "" then {data_classification: $c} else {} end) +
+            (if $a == true then {zdr_attested: true} else {} end) +
+            (if $r != "" then {zdr_attestation_reason: $r} else {} end))' \
+         .claude/process-state.json > "$_tc6_tmp" && mv "$_tc6_tmp" .claude/process-state.json
+      echo "Phase 1 artifacts updated in .claude/process-state.json:"
+      echo "  data_classification    = '${TC6_CLASSIFICATION:-(unchanged)}'"
+      echo "  zdr_attested           = '${TC6_ATTESTED:-(unchanged)}'"
+      echo "  zdr_attestation_reason = '${TC6_REASON:-(unchanged)}'"
+      exit 0
+    else
+      echo "Error: jq + .claude/process-state.json required for --data-classification / --zdr-* flags."
+      exit 1
+    fi
+  fi
 
   # Check we're in a project directory
   if [ ! -f "$INTAKE_FILE" ]; then

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1009,10 +1009,28 @@ persist_phase1_artifacts() {
   esac
   local tmp
   tmp=$(mktemp)
-  jq --arg c "$classification" --argjson a "$jq_bool" --arg r "$reason" \
-     '.phase1_artifacts = ((.phase1_artifacts // {}) +
-        {data_classification: $c, zdr_attested: $a, zdr_attestation_reason: $r})' \
-     "$pstate" > "$tmp" && mv "$tmp" "$pstate"
+  # PR #105 verifier follow-up: the prior implementation ran
+  # `jq ... > tmp && mv tmp pstate` followed by an unconditional
+  # `print_ok` — a malformed process-state.json produced "Phase 1
+  # artifacts persisted" on stdout and rc=0 even though jq's parse
+  # error went to stderr and the file was unchanged. Capture both
+  # exit codes and refuse to print success unless the chain actually
+  # succeeded.
+  if ! jq --arg c "$classification" --argjson a "$jq_bool" --arg r "$reason" \
+       '.phase1_artifacts = ((.phase1_artifacts // {}) +
+          {data_classification: $c, zdr_attested: $a, zdr_attestation_reason: $r})' \
+       "$pstate" > "$tmp"; then
+    rm -f "$tmp"
+    print_fail "  Phase 1 artifacts persistence failed: jq could not parse $pstate" >&2
+    echo "  Remediation: inspect $pstate for malformed JSON (truncation, stray characters)." >&2
+    echo "  If the file is unrecoverable, restore from a .bak or re-run scripts/init.sh." >&2
+    return 1
+  fi
+  if ! mv "$tmp" "$pstate"; then
+    rm -f "$tmp"
+    print_fail "  Phase 1 artifacts persistence failed: mv into $pstate failed (cross-filesystem? read-only?)" >&2
+    return 1
+  fi
   print_ok "  Phase 1 artifacts persisted to process-state.json (classification=$classification, zdr_attested=$attested)"
 }
 
@@ -2029,19 +2047,36 @@ main() {
       _tc6_attested_json="false"
       [ "$TC6_ATTESTED" = "true" ] && _tc6_attested_json="true"
       _tc6_tmp=$(mktemp)
-      jq --arg c "$TC6_CLASSIFICATION" --argjson a "$_tc6_attested_json" --arg r "$TC6_REASON" \
-         '.phase1_artifacts = ((.phase1_artifacts // {}) +
-            (if $c != "" then {data_classification: $c} else {} end) +
-            (if $a == true then {zdr_attested: true} else {} end) +
-            (if $r != "" then {zdr_attestation_reason: $r} else {} end))' \
-         .claude/process-state.json > "$_tc6_tmp" && mv "$_tc6_tmp" .claude/process-state.json
+      # PR #105 verifier follow-up: the prior implementation chained
+      # `jq ... > tmp && mv tmp pstate` and then unconditionally printed
+      # "Phase 1 artifacts updated" + exit 0. A malformed
+      # process-state.json produced jq's parse error on stderr, the
+      # success message on stdout, and rc=0 — operator told the write
+      # succeeded when nothing had been written. Surface failure now.
+      if ! jq --arg c "$TC6_CLASSIFICATION" --argjson a "$_tc6_attested_json" --arg r "$TC6_REASON" \
+           '.phase1_artifacts = ((.phase1_artifacts // {}) +
+              (if $c != "" then {data_classification: $c} else {} end) +
+              (if $a == true then {zdr_attested: true} else {} end) +
+              (if $r != "" then {zdr_attestation_reason: $r} else {} end))' \
+           .claude/process-state.json > "$_tc6_tmp"; then
+        rm -f "$_tc6_tmp"
+        echo "[FAIL] intake-wizard.sh: could not update .claude/process-state.json — jq parse failure." >&2
+        echo "  Remediation: inspect .claude/process-state.json for malformed JSON (truncation, stray characters)." >&2
+        echo "  If the file is unrecoverable, restore from a .bak or re-run scripts/init.sh." >&2
+        exit 1
+      fi
+      if ! mv "$_tc6_tmp" .claude/process-state.json; then
+        rm -f "$_tc6_tmp"
+        echo "[FAIL] intake-wizard.sh: mv into .claude/process-state.json failed (cross-filesystem? read-only?)." >&2
+        exit 1
+      fi
       echo "Phase 1 artifacts updated in .claude/process-state.json:"
       echo "  data_classification    = '${TC6_CLASSIFICATION:-(unchanged)}'"
       echo "  zdr_attested           = '${TC6_ATTESTED:-(unchanged)}'"
       echo "  zdr_attestation_reason = '${TC6_REASON:-(unchanged)}'"
       exit 0
     else
-      echo "Error: jq + .claude/process-state.json required for --data-classification / --zdr-* flags."
+      echo "Error: jq + .claude/process-state.json required for --data-classification / --zdr-* flags." >&2
       exit 1
     fi
   fi

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -43,6 +43,10 @@ get_project_context() {
 FIELD=""
 OLD_VALUE=""
 NEW_VALUE=""
+# tier-crosscheck-6: optional companion to `--field zdr_attested --new false`
+# (or as a standalone `--field zdr_attestation_reason --new "<text>"`).
+# Stored as phase1_artifacts.zdr_attestation_reason in process-state.json.
+RECONF_REASON=""
 RECONF_LEVEL=""
 RECONF_CONFIRM=0
 RECONF_RESET_BASELINE=0
@@ -51,6 +55,8 @@ while [ $# -gt 0 ]; do
     --field) FIELD="$2"; shift 2 ;;
     --old) OLD_VALUE="$2"; shift 2 ;;
     --new) NEW_VALUE="$2"; shift 2 ;;
+    --reason) RECONF_REASON="$2"; shift 2 ;;
+    --reason=*) RECONF_REASON="${1#*=}"; shift ;;
     # BL-030 Task 8: enforcement-level transition flags.
     --enforcement-level) RECONF_LEVEL="$2"; shift 2 ;;
     --enforcement-level=*) RECONF_LEVEL="${1#*=}"; shift ;;
@@ -66,6 +72,16 @@ while [ $# -gt 0 ]; do
       echo "  platform   — Regenerates release pipeline, copies new platform module"
       echo "  name       — Updates phase-state.json, CLAUDE.md, APPROVAL_LOG.md header,"
       echo "               intake-progress.json, Qdrant collection, PROJECT_INTAKE.md"
+      echo "  data_classification  — Sets the Phase 1 ZDR/classification gate value"
+      echo "                         (one of: public, internal, confidential, pii,"
+      echo "                          financial, health, regulated). Updates"
+      echo "                          .claude/process-state.json::phase1_artifacts.data_classification"
+      echo "                          + appends an APPROVAL_LOG.md audit row."
+      echo "  zdr_attested         — Sets phase1_artifacts.zdr_attested (--new true|false)."
+      echo "                          When false, also accept --reason \"<text>\" to record"
+      echo "                          phase1_artifacts.zdr_attestation_reason."
+      echo "  zdr_attestation_reason  — Free-text written exception. Sets the reason"
+      echo "                            field directly without flipping zdr_attested."
       echo ""
       echo "Track and deployment changes are NOT supported here — they require"
       echo "the governance pre-conditions enforced by scripts/upgrade-project.sh."
@@ -587,9 +603,177 @@ reconfigure() {
       rm -rf "$snap_dir"
       ;;
 
+    data_classification|zdr_attested|zdr_attestation_reason)
+      # tier-crosscheck-6 (final S3 audit finding): operators must be
+      # able to set the Phase 1 ZDR/classification fields post-intake.
+      # Pre-fix nothing existed — the canonical state lived only in
+      # intake-progress.json::answers and never made it into
+      # process-state.json, so check-phase-gate.sh had nothing to read.
+      # This block writes to .claude/process-state.json::phase1_artifacts
+      # (the field scripts/check-phase-gate.sh consults at Phase 1→2)
+      # and appends an audit row to APPROVAL_LOG.md.
+      #
+      # Atomic envelope: snapshot the two files we mutate (process-
+      # state.json + APPROVAL_LOG.md), install an INT/TERM/ERR trap, do
+      # the work, drop the trap on success. Sibling of the `name`
+      # branch's PR #57 pattern.
+      PSTATE=".claude/process-state.json"
+      APPROVAL_LOG="APPROVAL_LOG.md"
+      if [ ! -f "$PSTATE" ]; then
+        print_fail "$PSTATE not found — initialize the project before setting Phase 1 artifacts."
+        echo "  Run scripts/init.sh first, or scripts/intake-wizard.sh in an initialized project." >&2
+        exit 1
+      fi
+      if ! command -v jq >/dev/null 2>&1; then
+        print_fail "jq is required to mutate $PSTATE — install jq and re-run."
+        exit 1
+      fi
+
+      # Field-specific value validation BEFORE snapshotting (so a bad
+      # input doesn't waste a backup/rollback cycle).
+      case "$FIELD" in
+        data_classification)
+          # Normalize to lowercase canonical form. Accept "Public",
+          # "PUBLIC", "public" → store "public".
+          NEW_VALUE_CANON=$(printf '%s' "$NEW_VALUE" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          # 7-tier taxonomy from templates/project-intake.md:209 +
+          # docs/user-guide.md:466.
+          case "$NEW_VALUE_CANON" in
+            public|internal|confidential|pii|financial|health|regulated) ;;
+            *)
+              print_fail "Invalid data_classification '$NEW_VALUE'"
+              echo "  Allowed (one of): public, internal, confidential, pii, financial, health, regulated" >&2
+              echo "  Reference: templates/project-intake.md:209 / docs/governance-framework.md § VII line 299" >&2
+              exit 1 ;;
+          esac
+          NEW_VALUE="$NEW_VALUE_CANON"
+          ;;
+        zdr_attested)
+          case "$NEW_VALUE" in
+            true|True|TRUE|false|False|FALSE) ;;
+            *)
+              print_fail "Invalid zdr_attested '$NEW_VALUE' (must be true|false)"
+              exit 1 ;;
+          esac
+          # Normalize to canonical lowercase boolean string.
+          case "$NEW_VALUE" in
+            true|True|TRUE) NEW_VALUE="true" ;;
+            *)              NEW_VALUE="false" ;;
+          esac
+          ;;
+        zdr_attestation_reason)
+          if [ -z "$NEW_VALUE" ]; then
+            print_fail "zdr_attestation_reason must be a non-empty string."
+            exit 1
+          fi
+          ;;
+      esac
+
+      # Snapshot the two files we mutate. PR #93's lesson: traps are
+      # shell-global, so wrap the mutation in a subshell whose trap
+      # only fires on failures inside it. We use the subshell exit
+      # status as the rollback trigger; on rc != 0, restore from the
+      # snapshot dir captured in the outer scope.
+      classification_snap_dir=$(mktemp -d)
+      mkdir -p "$classification_snap_dir/.claude"
+      cp "$PSTATE" "$classification_snap_dir/.claude/process-state.json"
+      [ -f "$APPROVAL_LOG" ] && cp "$APPROVAL_LOG" "$classification_snap_dir/APPROVAL_LOG.md"
+
+      _classification_rollback() {
+        local reason="${1:-mutation aborted}"
+        cp "$classification_snap_dir/.claude/process-state.json" "$PSTATE"
+        [ -f "$classification_snap_dir/APPROVAL_LOG.md" ] && cp "$classification_snap_dir/APPROVAL_LOG.md" "$APPROVAL_LOG"
+        rm -rf "$classification_snap_dir"
+        print_fail "data_classification/ZDR mutation failed: $reason"
+        echo "  $PSTATE and APPROVAL_LOG.md rolled back to pre-mutation state." >&2
+        exit 1
+      }
+
+      # Mutate process-state.json. jq's |=  + // {} idiom builds
+      # phase1_artifacts when it's absent.
+      pstate_tmp=$(mktemp)
+      case "$FIELD" in
+        data_classification)
+          jq --arg v "$NEW_VALUE" \
+             '.phase1_artifacts = ((.phase1_artifacts // {}) + {data_classification: $v})' \
+             "$PSTATE" > "$pstate_tmp" \
+            && mv "$pstate_tmp" "$PSTATE" \
+            || _classification_rollback "jq write failed for data_classification"
+          ;;
+        zdr_attested)
+          # Build a JSON bool from the canonical string.
+          if [ "$NEW_VALUE" = "true" ]; then jq_bool="true"; else jq_bool="false"; fi
+          if [ -n "$RECONF_REASON" ]; then
+            jq --argjson b "$jq_bool" --arg r "$RECONF_REASON" \
+               '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attested: $b, zdr_attestation_reason: $r})' \
+               "$PSTATE" > "$pstate_tmp" \
+              && mv "$pstate_tmp" "$PSTATE" \
+              || _classification_rollback "jq write failed for zdr_attested+reason"
+          else
+            jq --argjson b "$jq_bool" \
+               '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attested: $b})' \
+               "$PSTATE" > "$pstate_tmp" \
+              && mv "$pstate_tmp" "$PSTATE" \
+              || _classification_rollback "jq write failed for zdr_attested"
+          fi
+          ;;
+        zdr_attestation_reason)
+          jq --arg r "$NEW_VALUE" \
+             '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attestation_reason: $r})' \
+             "$PSTATE" > "$pstate_tmp" \
+            && mv "$pstate_tmp" "$PSTATE" \
+            || _classification_rollback "jq write failed for zdr_attestation_reason"
+          ;;
+      esac
+      print_ok "Updated $PSTATE::phase1_artifacts.$FIELD"
+
+      # Append audit row to APPROVAL_LOG.md so the governance trail
+      # records the change. Required by tier-crosscheck-6 (compliance
+      # decisions must be auditable in the same log as phase-gate
+      # approvals). Append-only; existing entries are not modified.
+      if [ -f "$APPROVAL_LOG" ]; then
+        today_audit="$(date -u +%Y-%m-%d)"
+        case "$FIELD" in
+          data_classification)
+            audit_line="| $today_audit | data_classification set | reconfigure-project.sh | Orchestrator | Applied | new value: $NEW_VALUE (tier-crosscheck-6) |"
+            ;;
+          zdr_attested)
+            audit_line="| $today_audit | zdr_attested set | reconfigure-project.sh | Orchestrator | Applied | new value: $NEW_VALUE${RECONF_REASON:+ (reason: $RECONF_REASON)} (tier-crosscheck-6) |"
+            ;;
+          zdr_attestation_reason)
+            audit_line="| $today_audit | zdr_attestation_reason set | reconfigure-project.sh | Orchestrator | Applied | reason recorded: $NEW_VALUE (tier-crosscheck-6) |"
+            ;;
+        esac
+        # Insert into the Approval History section if it exists,
+        # otherwise append a new section.
+        if grep -q "^## Approval History" "$APPROVAL_LOG"; then
+          # Append to end of file (append-only — never mutate prior rows).
+          printf '%s\n' "$audit_line" >> "$APPROVAL_LOG" \
+            || _classification_rollback "APPROVAL_LOG.md append failed"
+        else
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## Approval History"
+            echo ""
+            echo "| Date | Gate / Event | Tool | Actor | Status | Details |"
+            echo "|---|---|---|---|---|---|"
+            echo "$audit_line"
+          } >> "$APPROVAL_LOG" \
+            || _classification_rollback "APPROVAL_LOG.md section append failed"
+        fi
+        print_ok "Appended audit row to APPROVAL_LOG.md"
+      fi
+
+      # Success — drop the snapshot.
+      rm -rf "$classification_snap_dir"
+      ;;
+
     *)
       print_fail "Unknown field: $FIELD"
-      echo "Supported: language, platform, track, name, deployment"
+      echo "Supported: language, platform, track, name, deployment,"
+      echo "           data_classification, zdr_attested, zdr_attestation_reason"
       exit 1
       ;;
   esac

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -669,11 +669,18 @@ reconfigure() {
           ;;
       esac
 
-      # Snapshot the two files we mutate. PR #93's lesson: traps are
-      # shell-global, so wrap the mutation in a subshell whose trap
-      # only fires on failures inside it. We use the subshell exit
-      # status as the rollback trigger; on rc != 0, restore from the
-      # snapshot dir captured in the outer scope.
+      # Snapshot the two files we mutate (process-state.json +
+      # APPROVAL_LOG.md) into a tempdir BEFORE installing any trap so
+      # the rollback path can rely on a complete pre-state.
+      #
+      # PR #105 verifier follow-up: the prior implementation here
+      # claimed to install an INT/TERM/ERR trap and subshell-wrap the
+      # mutation block but did neither — a signal arriving between the
+      # process-state.json rewrite and the APPROVAL_LOG.md append left
+      # process-state.json mutated, the audit row missing, and a
+      # snapshot tempdir leaked. This block now actually installs the
+      # trap + subshell envelope (PR #57's `finalize_and_commit` shape;
+      # PR #93's subshell-isolation lesson).
       classification_snap_dir=$(mktemp -d)
       mkdir -p "$classification_snap_dir/.claude"
       cp "$PSTATE" "$classification_snap_dir/.claude/process-state.json"
@@ -681,92 +688,149 @@ reconfigure() {
 
       _classification_rollback() {
         local reason="${1:-mutation aborted}"
-        cp "$classification_snap_dir/.claude/process-state.json" "$PSTATE"
-        [ -f "$classification_snap_dir/APPROVAL_LOG.md" ] && cp "$classification_snap_dir/APPROVAL_LOG.md" "$APPROVAL_LOG"
-        rm -rf "$classification_snap_dir"
-        print_fail "data_classification/ZDR mutation failed: $reason"
+        if [ -f "$classification_snap_dir/.claude/process-state.json" ]; then
+          cp "$classification_snap_dir/.claude/process-state.json" "$PSTATE"
+        fi
+        if [ -f "$classification_snap_dir/APPROVAL_LOG.md" ]; then
+          cp "$classification_snap_dir/APPROVAL_LOG.md" "$APPROVAL_LOG"
+        fi
+        print_fail "data_classification/ZDR mutation failed: $reason" >&2
         echo "  $PSTATE and APPROVAL_LOG.md rolled back to pre-mutation state." >&2
-        exit 1
       }
 
-      # Mutate process-state.json. jq's |=  + // {} idiom builds
-      # phase1_artifacts when it's absent.
-      pstate_tmp=$(mktemp)
-      case "$FIELD" in
-        data_classification)
-          jq --arg v "$NEW_VALUE" \
-             '.phase1_artifacts = ((.phase1_artifacts // {}) + {data_classification: $v})' \
-             "$PSTATE" > "$pstate_tmp" \
-            && mv "$pstate_tmp" "$PSTATE" \
-            || _classification_rollback "jq write failed for data_classification"
-          ;;
-        zdr_attested)
-          # Build a JSON bool from the canonical string.
-          if [ "$NEW_VALUE" = "true" ]; then jq_bool="true"; else jq_bool="false"; fi
-          if [ -n "$RECONF_REASON" ]; then
-            jq --argjson b "$jq_bool" --arg r "$RECONF_REASON" \
-               '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attested: $b, zdr_attestation_reason: $r})' \
-               "$PSTATE" > "$pstate_tmp" \
-              && mv "$pstate_tmp" "$PSTATE" \
-              || _classification_rollback "jq write failed for zdr_attested+reason"
-          else
-            jq --argjson b "$jq_bool" \
-               '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attested: $b})' \
-               "$PSTATE" > "$pstate_tmp" \
-              && mv "$pstate_tmp" "$PSTATE" \
-              || _classification_rollback "jq write failed for zdr_attested"
-          fi
-          ;;
-        zdr_attestation_reason)
-          jq --arg r "$NEW_VALUE" \
-             '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attestation_reason: $r})' \
-             "$PSTATE" > "$pstate_tmp" \
-            && mv "$pstate_tmp" "$PSTATE" \
-            || _classification_rollback "jq write failed for zdr_attestation_reason"
-          ;;
-      esac
-      print_ok "Updated $PSTATE::phase1_artifacts.$FIELD"
+      # Wrap the entire mutation block in a subshell. PR #93's lesson:
+      # `trap` is shell-global — if we installed INT/TERM/ERR in the
+      # outer shell we would clobber any trap a caller (or a sourced
+      # helper) had registered. The subshell isolates our trap so it
+      # only fires for signals/ERR arising inside our mutation window.
+      # The subshell's exit status is the rollback trigger for the
+      # outer shell.
+      (
+        # Inside the subshell: install the trap. On INT/TERM/ERR we
+        # call _classification_rollback (which restores the snapshot)
+        # and then exit non-zero so the outer shell propagates failure.
+        _trap_fire() {
+          local sig="$1"
+          _classification_rollback "trap fired ($sig)"
+          # 130 = 128 + SIGINT(2); 143 = 128 + SIGTERM(15). We use 130
+          # uniformly here so the outer shell can treat any trap exit
+          # as "operator interrupted".
+          exit 130
+        }
+        trap '_trap_fire INT'  INT
+        trap '_trap_fire TERM' TERM
+        trap '_trap_fire ERR'  ERR
 
-      # Append audit row to APPROVAL_LOG.md so the governance trail
-      # records the change. Required by tier-crosscheck-6 (compliance
-      # decisions must be auditable in the same log as phase-gate
-      # approvals). Append-only; existing entries are not modified.
-      if [ -f "$APPROVAL_LOG" ]; then
-        today_audit="$(date -u +%Y-%m-%d)"
+        # Mutate process-state.json. jq's // {} idiom builds
+        # phase1_artifacts when it's absent.
+        pstate_tmp=$(mktemp)
         case "$FIELD" in
           data_classification)
-            audit_line="| $today_audit | data_classification set | reconfigure-project.sh | Orchestrator | Applied | new value: $NEW_VALUE (tier-crosscheck-6) |"
+            if ! jq --arg v "$NEW_VALUE" \
+                 '.phase1_artifacts = ((.phase1_artifacts // {}) + {data_classification: $v})' \
+                 "$PSTATE" > "$pstate_tmp"; then
+              _classification_rollback "jq write failed for data_classification"
+              exit 1
+            fi
+            if ! mv "$pstate_tmp" "$PSTATE"; then
+              _classification_rollback "mv into $PSTATE failed (data_classification)"
+              exit 1
+            fi
             ;;
           zdr_attested)
-            audit_line="| $today_audit | zdr_attested set | reconfigure-project.sh | Orchestrator | Applied | new value: $NEW_VALUE${RECONF_REASON:+ (reason: $RECONF_REASON)} (tier-crosscheck-6) |"
+            if [ "$NEW_VALUE" = "true" ]; then jq_bool="true"; else jq_bool="false"; fi
+            if [ -n "$RECONF_REASON" ]; then
+              if ! jq --argjson b "$jq_bool" --arg r "$RECONF_REASON" \
+                   '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attested: $b, zdr_attestation_reason: $r})' \
+                   "$PSTATE" > "$pstate_tmp"; then
+                _classification_rollback "jq write failed for zdr_attested+reason"
+                exit 1
+              fi
+            else
+              if ! jq --argjson b "$jq_bool" \
+                   '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attested: $b})' \
+                   "$PSTATE" > "$pstate_tmp"; then
+                _classification_rollback "jq write failed for zdr_attested"
+                exit 1
+              fi
+            fi
+            if ! mv "$pstate_tmp" "$PSTATE"; then
+              _classification_rollback "mv into $PSTATE failed (zdr_attested)"
+              exit 1
+            fi
             ;;
           zdr_attestation_reason)
-            audit_line="| $today_audit | zdr_attestation_reason set | reconfigure-project.sh | Orchestrator | Applied | reason recorded: $NEW_VALUE (tier-crosscheck-6) |"
+            if ! jq --arg r "$NEW_VALUE" \
+                 '.phase1_artifacts = ((.phase1_artifacts // {}) + {zdr_attestation_reason: $r})' \
+                 "$PSTATE" > "$pstate_tmp"; then
+              _classification_rollback "jq write failed for zdr_attestation_reason"
+              exit 1
+            fi
+            if ! mv "$pstate_tmp" "$PSTATE"; then
+              _classification_rollback "mv into $PSTATE failed (zdr_attestation_reason)"
+              exit 1
+            fi
             ;;
         esac
-        # Insert into the Approval History section if it exists,
-        # otherwise append a new section.
-        if grep -q "^## Approval History" "$APPROVAL_LOG"; then
-          # Append to end of file (append-only — never mutate prior rows).
-          printf '%s\n' "$audit_line" >> "$APPROVAL_LOG" \
-            || _classification_rollback "APPROVAL_LOG.md append failed"
-        else
-          {
-            echo ""
-            echo "---"
-            echo ""
-            echo "## Approval History"
-            echo ""
-            echo "| Date | Gate / Event | Tool | Actor | Status | Details |"
-            echo "|---|---|---|---|---|---|"
-            echo "$audit_line"
-          } >> "$APPROVAL_LOG" \
-            || _classification_rollback "APPROVAL_LOG.md section append failed"
+        print_ok "Updated $PSTATE::phase1_artifacts.$FIELD"
+
+        # Append audit row to APPROVAL_LOG.md so the governance trail
+        # records the change. Required by tier-crosscheck-6 (compliance
+        # decisions must be auditable in the same log as phase-gate
+        # approvals). Append-only; existing entries are not modified.
+        if [ -f "$APPROVAL_LOG" ]; then
+          today_audit="$(date -u +%Y-%m-%d)"
+          case "$FIELD" in
+            data_classification)
+              audit_line="| $today_audit | data_classification set | reconfigure-project.sh | Orchestrator | Applied | new value: $NEW_VALUE (tier-crosscheck-6) |"
+              ;;
+            zdr_attested)
+              audit_line="| $today_audit | zdr_attested set | reconfigure-project.sh | Orchestrator | Applied | new value: $NEW_VALUE${RECONF_REASON:+ (reason: $RECONF_REASON)} (tier-crosscheck-6) |"
+              ;;
+            zdr_attestation_reason)
+              audit_line="| $today_audit | zdr_attestation_reason set | reconfigure-project.sh | Orchestrator | Applied | reason recorded: $NEW_VALUE (tier-crosscheck-6) |"
+              ;;
+          esac
+          # Insert into the Approval History section if it exists,
+          # otherwise append a new section.
+          if grep -q "^## Approval History" "$APPROVAL_LOG"; then
+            if ! printf '%s\n' "$audit_line" >> "$APPROVAL_LOG"; then
+              _classification_rollback "APPROVAL_LOG.md append failed"
+              exit 1
+            fi
+          else
+            if ! {
+              echo ""
+              echo "---"
+              echo ""
+              echo "## Approval History"
+              echo ""
+              echo "| Date | Gate / Event | Tool | Actor | Status | Details |"
+              echo "|---|---|---|---|---|---|"
+              echo "$audit_line"
+            } >> "$APPROVAL_LOG"; then
+              _classification_rollback "APPROVAL_LOG.md section append failed"
+              exit 1
+            fi
+          fi
+          print_ok "Appended audit row to APPROVAL_LOG.md"
         fi
-        print_ok "Appended audit row to APPROVAL_LOG.md"
+
+        # Subshell success — drop the traps and exit 0 so the outer
+        # shell discards the snapshot.
+        trap - INT TERM ERR
+        exit 0
+      )
+      classification_rc=$?
+      if [ "$classification_rc" -ne 0 ]; then
+        # The subshell already restored the snapshot via its trap +
+        # rollback path. Clean up the snapshot dir in the outer scope
+        # and propagate the failure.
+        rm -rf "$classification_snap_dir"
+        exit "$classification_rc"
       fi
 
-      # Success — drop the snapshot.
+      # Success — drop the snapshot dir.
       rm -rf "$classification_snap_dir"
       ;;
 

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -779,6 +779,42 @@ if [ "$TARGET_DEPLOYMENT" != "$CURRENT_DEPLOYMENT" ]; then
   DEPLOYMENT_CHANGES=true
 fi
 
+# tier-crosscheck-6 (final S3 audit finding): personal→organizational
+# deployment changes Phase 1→2 from a self-attested invariant into one
+# under STA governance, including the Mandatory ZDR gate
+# (docs/governance-framework.md § VII line 299). If the project's
+# .claude/process-state.json::phase1_artifacts has no data_classification,
+# this upgrade leaves an unenforceable promise behind: check-phase-gate.sh
+# will FAIL Phase 1→2 backstop until the operator runs reconfigure-
+# project.sh. Refuse the upgrade upfront with a clear pointer.
+#
+# Behavior contract:
+#   * Non-interactive (CI=true / SOIF_NONINTERACTIVE=1 / no TTY) →
+#     hard refuse with the remediation command.
+#   * Interactive → also refuse for now; the wizard-driven prompt path
+#     lives in scripts/intake-wizard.sh. Interactive operators are
+#     redirected there. (A later release may add an in-place prompt
+#     here once the lib/helpers.sh prompt_choice helper is wired
+#     through this script's flag-parsing layer — out of scope for the
+#     hard-block PR.)
+if [ "$DEPLOYMENT_CHANGES" = true ] && \
+   [ "$CURRENT_DEPLOYMENT" = "personal" ] && \
+   [ "$TARGET_DEPLOYMENT" = "organizational" ]; then
+  _zdr_pstate="$PROJECT_ROOT/.claude/process-state.json"
+  _zdr_classification=""
+  if [ -f "$_zdr_pstate" ] && command -v jq >/dev/null 2>&1; then
+    _zdr_classification=$(jq -r '.phase1_artifacts.data_classification // ""' "$_zdr_pstate" 2>/dev/null || echo "")
+    [ "$_zdr_classification" = "null" ] && _zdr_classification=""
+  fi
+  if [ -z "$_zdr_classification" ]; then
+    _upgrade_fail "--deployment organizational blocked — data_classification not set (tier-crosscheck-6)" \
+                  "Personal→Organizational upgrade activates the Phase 1→2 ZDR gate (docs/governance-framework.md § VII line 299). The project's $_zdr_pstate has no phase1_artifacts.data_classification, so check-phase-gate.sh would FAIL Phase 1→2 backstop immediately after this upgrade." \
+                  "set data_classification BEFORE upgrading, e.g.: bash scripts/reconfigure-project.sh --field data_classification --new <public|internal|confidential|pii|financial|health|regulated>. Then set the ZDR attestation: bash scripts/reconfigure-project.sh --field zdr_attested --new true. Then re-run this upgrade." \
+                  "deployment_change=personal->organizational; classification=(unset); pstate=$_zdr_pstate"
+    exit 1
+  fi
+fi
+
 # code-upgrade-project-8: Pre-Phase-0 pre-condition gate for --to-production.
 # Per docs/governance-framework.md:230, Sponsored POC defers 3 of the 6
 # governance pre-conditions (insurance, liability, ITSM, backup

--- a/templates/project-intake.md
+++ b/templates/project-intake.md
@@ -208,6 +208,18 @@ _What data does the user provide or the system ingest?_
 
 **Sensitivity classifications:** Public, Internal, Confidential, PII, Financial, Health/Medical, Regulated
 
+#### 5.1.1 Project-Level Data Classification (Phase 1 Gate — tier-crosscheck-6)
+
+The **highest** classification across all rows in §5.1 is the project-level `data_classification`. It is recorded in `.claude/process-state.json::phase1_artifacts` and enforced as a Phase 1→2 hard gate by `scripts/check-phase-gate.sh`. Per docs/governance-framework.md § VII (Mandatory ZDR gate, line 299), projects classified **Internal or higher** must use a ZDR or self-hosted LLM deployment path — `phase1_artifacts.zdr_attested` (or a documented `phase1_artifacts.zdr_attestation_reason` exception) is required before Phase 1→2.
+
+| Field | Value (one of) |
+|---|---|
+| **Project-level data_classification** | `public` / `internal` / `confidential` / `pii` / `financial` / `health` / `regulated` |
+| **ZDR attested (Zero Data Retention or self-hosted LLM)** | `true` / `false` |
+| **ZDR attestation reason** _(required when `zdr_attested=false` AND classification > public)_ | _Free text: written exception (e.g. "Customer SOW requires retention, risk accepted by CISO Email TKT-42")_ |
+
+These three fields are captured by `scripts/intake-wizard.sh` Section 5.5, and can be corrected after-the-fact with `scripts/reconfigure-project.sh --field data_classification --new <value>` / `--field zdr_attested --new true|false`.
+
 ### 5.2 Data Outputs
 
 _What does the user receive from the system?_

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -131,6 +131,31 @@ else
 fi
 
 # ================================================================
+# TEST 0c2c: PHASE 1→2 ZDR / DATA_CLASSIFICATION HARD GATE (tier-crosscheck-6)
+# ================================================================
+# Regression suite for the FINAL S3 audit finding (tier-crosscheck-6):
+# docs/governance-framework.md § VII line 299 declared a Mandatory ZDR
+# gate ("Internal or higher must use ZDR or self-hosted"). Pre-fix the
+# gate was documented but never enforced — no field captured the
+# classification, no field recorded the ZDR attestation, and
+# scripts/check-phase-gate.sh had no Phase 1→2 backstop reading any
+# such field. This PR closes the loop end-to-end:
+#   * intake-wizard.sh prompts for + persists the two fields.
+#   * scripts/check-phase-gate.sh adds a Phase 1→2 ZDR backstop that
+#     FAILs when the data is missing or invalid.
+#   * scripts/reconfigure-project.sh --field data_classification /
+#     --field zdr_attested / --field zdr_attestation_reason let
+#     operators correct post-intake (atomic snapshot + APPROVAL_LOG audit row).
+#   * scripts/upgrade-project.sh personal→organizational refuses up-
+#     front when the classification is missing, redirecting to reconfigure.
+section "Phase 1→2 ZDR / data_classification hard gate (tier-crosscheck-6)"
+if bash "$SCRIPT_DIR/tests/test-tier-crosscheck-6-zdr-gate.sh" >/dev/null 2>&1; then
+  pass "tier-crosscheck-6 ZDR/data_classification hard gate tests (7/7)"
+else
+  fail "tier-crosscheck-6 ZDR/data_classification hard gate tests FAILED (run tests/test-tier-crosscheck-6-zdr-gate.sh for details)"
+fi
+
+# ================================================================
 # TEST 0c3: ORGANIZATIONAL END-TO-END INIT (tests-init-host-attestation-4)
 # ================================================================
 # Regression suite for the audit tests-init-host-attestation-4 closure:

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -150,9 +150,20 @@ fi
 #     front when the classification is missing, redirecting to reconfigure.
 section "Phase 1→2 ZDR / data_classification hard gate (tier-crosscheck-6)"
 if bash "$SCRIPT_DIR/tests/test-tier-crosscheck-6-zdr-gate.sh" >/dev/null 2>&1; then
-  pass "tier-crosscheck-6 ZDR/data_classification hard gate tests (7/7)"
+  pass "tier-crosscheck-6 ZDR/data_classification hard gate tests (8/8)"
 else
   fail "tier-crosscheck-6 ZDR/data_classification hard gate tests FAILED (run tests/test-tier-crosscheck-6-zdr-gate.sh for details)"
+fi
+
+# tier-crosscheck-6 follow-up: atomicity + jq-failure regression suite
+# (adversarial verifier follow-up on PR #105). Three tests covering the
+# defects the original suite did not catch: SIGTERM mid-mutation in
+# reconfigure-project.sh, silent-success on jq failure in
+# intake-wizard.sh's --data-classification path and persist_phase1_artifacts().
+if bash "$SCRIPT_DIR/tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh" >/dev/null 2>&1; then
+  pass "tier-crosscheck-6 follow-up (atomicity + jq surfacing) tests (3/3)"
+else
+  fail "tier-crosscheck-6 follow-up tests FAILED (run tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh for details)"
 fi
 
 # ================================================================

--- a/tests/test-check-phase-gate-backstop-attestation.sh
+++ b/tests/test-check-phase-gate-backstop-attestation.sh
@@ -128,10 +128,18 @@ echo ""
 # T1 (positive — primary): attestation present → backstop must skip
 # host_verify_protection (the stub would fail it), exit 0, and the
 # output must mention the attestation.
+#
+# tier-crosscheck-6 cross-cutting update: process-state.json fixture
+# now also carries phase1_artifacts (data_classification + zdr_attested)
+# so the NEW Phase 1→2 ZDR backstop doesn't fail and mask this test's
+# signal. The classification value is "public" because this fixture
+# isn't testing the ZDR gate — we want it green so we can isolate the
+# branch-protection-attestation behavior under test.
 echo "T1: attestation present → backstop honors it, exits 0"
 setup_phase2_project
 cat > "$PROJ/.claude/process-state.json" <<'JSON'
-{"phase2_init":{"steps_completed":[],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-04-27T00:00:00Z","reason":"github_free_tier"}}}}
+{"phase2_init":{"steps_completed":[],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-04-27T00:00:00Z","reason":"github_free_tier"}}},
+ "phase1_artifacts":{"data_classification":"public","zdr_attested":false}}
 JSON
 out=$(run_gate)
 rc=$?

--- a/tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
+++ b/tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
+#
+# Regression suite for the PR #105 adversarial-verifier follow-up. Two
+# defects the verifier surfaced that the original suite did not catch:
+#
+#   F1 (atomicity) — scripts/reconfigure-project.sh's
+#       data_classification|zdr_attested|zdr_attestation_reason handler
+#       claimed to install an INT/TERM/ERR trap and subshell-wrap the
+#       mutation block but did neither. A SIGINT arriving between the
+#       process-state.json rewrite and the APPROVAL_LOG.md append left
+#       process-state.json mutated, the audit row missing, and the
+#       snapshot tempdir leaked. F1 mirrors PR #57's `finalize_and_commit`
+#       crash-safety contract on the same script.
+#
+#   F2 (silent jq failure) — scripts/intake-wizard.sh's --data-classification
+#       / --zdr-attested non-interactive path AND persist_phase1_artifacts()
+#       did `jq ... > tmp && mv tmp pstate` followed by an unconditional
+#       success line + exit 0, regardless of whether jq+mv succeeded.
+#       Feeding a malformed process-state.json reproduced: jq prints a
+#       parse error to stderr, success message prints to stdout, file is
+#       unchanged, operator is told the write succeeded.
+#
+# Both fixtures construct minimal project scaffolds, exercise the
+# defective code path, and assert the post-fix invariants.
+
+set -u
+[[ "${BASH_VERSION:-}" ]] || { echo "bash required"; exit 1; }
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# --------------------------------------------------------------------
+# Test scaffolding (mirrors the style of test-tier-crosscheck-6-zdr-gate.sh)
+# --------------------------------------------------------------------
+PASS=0
+FAIL=0
+FAILED_TESTS=()
+
+pass() { echo "  [PASS] $1"; PASS=$((PASS + 1)); }
+fail_() {
+  echo "  [FAIL] $1"
+  echo "        $2"
+  FAIL=$((FAIL + 1))
+  FAILED_TESTS+=("$1")
+}
+
+# Always restore PATH between cases so the mv-shim from F1 doesn't bleed
+# into subsequent fixtures.
+ORIG_PATH="$PATH"
+
+# ════════════════════════════════════════════════════════════════════
+# F1: Signal mid-mutation in reconfigure-project.sh leaves NO torn state.
+#
+# Strategy: shim `mv` so that immediately AFTER the mv that commits
+# process-state.json into place we send a SIGTERM to the script-bash
+# parent. The mv shim then sleeps briefly so the signal has time to
+# deliver before mv exits 0 (which would let the script continue to the
+# APPROVAL_LOG append). SIGTERM rather than SIGINT because non-
+# interactive bash absorbs externally-delivered SIGINT but exits on
+# SIGTERM (and SIGTERM is part of the trap contract the PR body claims:
+# INT/TERM/ERR). The atomicity defect is signal-class-agnostic.
+#
+# Verified RED on PR head (44ee984): pstate mutated, APPROVAL_LOG
+# unchanged, snapshot dir leaked.
+#
+# Assertions on GREEN:
+#   * process-state.json is byte-identical to the pre-mutation snapshot
+#   * APPROVAL_LOG.md is byte-identical to the pre-mutation snapshot
+#     (or both files mutated — strict atomicity)
+#   * exit code is non-zero
+# A torn state (post-fix violation) is pstate mutated AND approval not.
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "F1: signal mid-mutation in reconfigure-project.sh produces no torn state"
+T1=$(mktemp -d); P1="$T1/p"
+
+# Build minimal project that reconfigure-project.sh can operate on.
+mkdir -p "$P1/.claude" "$P1/scripts/lib" "$T1/bin"
+cp "$REPO_ROOT/scripts/reconfigure-project.sh" "$P1/scripts/reconfigure-project.sh"
+cp "$REPO_ROOT/scripts/lib/helpers.sh" "$P1/scripts/lib/helpers.sh"
+[ -f "$REPO_ROOT/scripts/lib/enforcement-level.sh" ] && cp "$REPO_ROOT/scripts/lib/enforcement-level.sh" "$P1/scripts/lib/enforcement-level.sh"
+
+cat > "$P1/.claude/phase-state.json" <<'JSON'
+{"project":"t","framework_version":"1.0","current_phase":1,"track":"light","deployment":"personal","poc_mode":null}
+JSON
+cat > "$P1/.claude/tool-preferences.json" <<'JSON'
+{"context":{"project":"t","platform":"web","language":"javascript","track":"light"}}
+JSON
+cat > "$P1/.claude/orchestrator-source.json" <<JSON
+{ "source_dir": "$REPO_ROOT" }
+JSON
+cat > "$P1/.claude/process-state.json" <<'JSON'
+{"phase1_artifacts":{"existing":"value"}}
+JSON
+echo "# t — Operator Brief" > "$P1/CLAUDE.md"
+echo "# Project Intake — t" > "$P1/PROJECT_INTAKE.md"
+cat > "$P1/APPROVAL_LOG.md" <<'MD'
+---
+project: t
+deployment: personal
+---
+
+# Approval Log — t
+
+## Approval History
+| Date | Gate / Event | Approver | Role | Decision | Reference |
+|---|---|---|---|---|---|
+MD
+
+( cd "$P1" \
+    && git init -q \
+    && git config user.email t@t.l \
+    && git config user.name t \
+    && git add -A \
+    && git commit -q -m "fixture" ) >/dev/null 2>&1
+
+# Snapshot pre-state for byte-comparison after the signal.
+cp "$P1/.claude/process-state.json" "$T1/pstate.pre"
+cp "$P1/APPROVAL_LOG.md" "$T1/approval.pre"
+
+# Shim `mv` to inject a signal into the script-bash parent right after
+# committing the process-state.json move but before the script returns
+# control to its caller — which would otherwise immediately append to
+# APPROVAL_LOG.md.
+#
+# Sending the signal from *inside* the script's own process tree
+# matters: bash absorbs SIGINT delivered from outside in non-interactive
+# mode, but SIGTERM kills it regardless. The atomicity contract claims
+# INT/TERM/ERR, so SIGTERM is a valid driver for the same trap path.
+cat > "$T1/bin/mv" <<SHIM
+#!/usr/bin/env bash
+# Find the real mv (PATH was prepended for the shim).
+real_mv=""
+for cand in /bin/mv /usr/bin/mv; do
+  if [ -x "\$cand" ]; then real_mv="\$cand"; break; fi
+done
+[ -z "\$real_mv" ] && { echo "shim: cannot find real mv" >&2; exit 1; }
+
+"\$real_mv" "\$@"
+rc=\$?
+
+# Only wedge the SPECIFIC mv that commits process-state.json. Last
+# argument is the destination — match the path tail.
+dest="\${@: -1}"
+if [[ "\$dest" == *".claude/process-state.json" ]] && [ "\$rc" -eq 0 ]; then
+  : > "$T1/mv-done"
+  # Signal the script-bash parent. PPID is the bash process that ran
+  # the script via \`bash scripts/reconfigure-project.sh ...\`.
+  kill -TERM \$PPID 2>/dev/null || true
+  # Give the signal time to deliver before mv exits and the script
+  # would otherwise resume execution.
+  sleep 0.3
+fi
+exit \$rc
+SHIM
+chmod +x "$T1/bin/mv"
+
+F1_LOG="$T1/f1.log"
+# Run synchronously — the shim handles the wedge. Use `exec` inside the
+# subshell so PPID inside the shim maps cleanly to the script-bash.
+# `set +m` and the explicit redirect suppress bash's "Terminated: 15"
+# job-control message that would otherwise leak to our stderr when the
+# subshell dies from SIGTERM.
+set +m
+{
+  ( cd "$P1" && PATH="$T1/bin:$ORIG_PATH" exec bash "$P1/scripts/reconfigure-project.sh" --field data_classification --new internal ) > "$F1_LOG" 2>&1
+  F1_RC=$?
+} 2>/dev/null
+
+if [ ! -f "$T1/mv-done" ]; then
+  fail_ "F1" "wedge marker never appeared — shim was not invoked. rc=$F1_RC, Log:\n$(cat "$F1_LOG")"
+else
+  pstate_now_sha=$(shasum "$P1/.claude/process-state.json" | awk '{print $1}')
+  pstate_pre_sha=$(shasum "$T1/pstate.pre" | awk '{print $1}')
+  approval_now_sha=$(shasum "$P1/APPROVAL_LOG.md" | awk '{print $1}')
+  approval_pre_sha=$(shasum "$T1/approval.pre" | awk '{print $1}')
+
+  pstate_changed="NO"; approval_changed="NO"
+  [ "$pstate_now_sha"   != "$pstate_pre_sha"   ] && pstate_changed="YES"
+  [ "$approval_now_sha" != "$approval_pre_sha" ] && approval_changed="YES"
+
+  fail_reason=""
+  # Atomicity contract: pstate and approval are either both pre-state
+  # (rollback fired) or both committed (success). The torn state
+  # (pstate changed AND approval unchanged) is what the verifier
+  # reproduced on PR HEAD.
+  if [ "$pstate_changed" = "YES" ] && [ "$approval_changed" = "NO" ]; then
+    fail_reason="TORN state: process-state.json mutated but APPROVAL_LOG.md unchanged (rc=$F1_RC). pstate=${pstate_pre_sha}->${pstate_now_sha} approval=$approval_pre_sha (unchanged)"
+  elif [ "$pstate_changed" = "NO" ] && [ "$approval_changed" = "YES" ]; then
+    fail_reason="TORN state: APPROVAL_LOG.md mutated but process-state.json unchanged (rc=$F1_RC). approval=${approval_pre_sha}->${approval_now_sha}"
+  fi
+
+  if [ -z "$fail_reason" ]; then
+    pass "F1: signal mid-mutation produced atomic outcome (rc=$F1_RC, pstate_changed=$pstate_changed approval_changed=$approval_changed)"
+  else
+    fail_ "F1" "$fail_reason. Log:\n$(cat "$F1_LOG")"
+  fi
+fi
+rm -rf "$T1"
+
+# ════════════════════════════════════════════════════════════════════
+# F2: intake-wizard.sh non-interactive --data-classification refuses to
+# print success when the underlying jq+mv chain failed.
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "F2: intake-wizard.sh --data-classification surfaces jq failure (no silent success)"
+T2=$(mktemp -d); P2="$T2/p"
+
+mkdir -p "$P2/.claude"
+# Malformed process-state.json — jq will choke parsing this.
+printf '%s' '{not valid json' > "$P2/.claude/process-state.json"
+printf '%s' '{"project":"t","current_phase":1,"deployment":"personal"}' > "$P2/.claude/phase-state.json"
+touch "$P2/PROJECT_INTAKE.md"
+
+cp "$P2/.claude/process-state.json" "$T2/pstate.pre"
+
+F2_STDOUT="$T2/stdout"
+F2_STDERR="$T2/stderr"
+( cd "$P2" && bash "$REPO_ROOT/scripts/intake-wizard.sh" \
+    --data-classification internal --zdr-attested ) > "$F2_STDOUT" 2> "$F2_STDERR"
+F2_RC=$?
+
+# Assertions:
+#   1. Exit code must be non-zero (the operator must know the write failed).
+#   2. STDOUT must NOT contain the "Phase 1 artifacts updated" success line.
+#   3. Some error indication must reach the operator (stderr OR stdout).
+#   4. The file must be byte-identical to the pre-state (no partial write).
+f2_fail=""
+if [ "$F2_RC" -eq 0 ]; then
+  f2_fail="exit code was 0 despite jq parse failure (silent success). STDOUT:\n$(cat "$F2_STDOUT")\nSTDERR:\n$(cat "$F2_STDERR")"
+elif grep -q "Phase 1 artifacts updated" "$F2_STDOUT"; then
+  f2_fail="stdout claims 'Phase 1 artifacts updated' but the write failed. STDOUT:\n$(cat "$F2_STDOUT")"
+elif ! { grep -qi "error\|fail" "$F2_STDERR" || grep -qi "error\|fail\|\[FAIL\]" "$F2_STDOUT"; }; then
+  f2_fail="no error indication surfaced to the operator. STDOUT:\n$(cat "$F2_STDOUT")\nSTDERR:\n$(cat "$F2_STDERR")"
+elif ! cmp -s "$P2/.claude/process-state.json" "$T2/pstate.pre"; then
+  f2_fail="process-state.json was partially mutated despite the jq parse failure."
+fi
+
+if [ -z "$f2_fail" ]; then
+  pass "F2: jq failure surfaces as non-zero exit + no success line + file unchanged"
+else
+  fail_ "F2" "$f2_fail"
+fi
+rm -rf "$T2"
+
+# ════════════════════════════════════════════════════════════════════
+# F3: persist_phase1_artifacts() (the interactive-wizard helper used by
+# section 5.5) must also surface jq failure. We exercise it by sourcing
+# helpers.sh + the function directly and calling it against a malformed
+# process-state.json.
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "F3: persist_phase1_artifacts() surfaces jq failure (no silent success)"
+T3=$(mktemp -d); P3="$T3/p"
+
+mkdir -p "$P3/.claude"
+printf '%s' '{not valid json' > "$P3/.claude/process-state.json"
+cp "$P3/.claude/process-state.json" "$T3/pstate.pre"
+
+# Source the function out of intake-wizard.sh and call it. We extract
+# just the function body via a small bash wrapper that sources the
+# script's prelude (helpers.sh) and the function definition.
+F3_STDOUT="$T3/stdout"
+F3_STDERR="$T3/stderr"
+
+# Run a tiny harness that loads helpers + extracts persist_phase1_artifacts
+# from intake-wizard.sh and calls it. We don't source intake-wizard.sh in
+# full because that would trigger its argv parsing.
+cat > "$T3/harness.sh" <<HARNESS
+#!/usr/bin/env bash
+set -u
+cd "$P3"
+source "$REPO_ROOT/scripts/lib/helpers.sh"
+
+# Pull the function definition out of intake-wizard.sh by sed-extracting
+# the lines between 'persist_phase1_artifacts()' and the next top-level
+# function start.
+fn_src=\$(awk '
+  /^persist_phase1_artifacts\(\) {/ { in_fn = 1 }
+  in_fn { print }
+  in_fn && /^}/ { exit }
+' "$REPO_ROOT/scripts/intake-wizard.sh")
+eval "\$fn_src"
+
+PROJECT_ROOT="$P3"
+persist_phase1_artifacts "internal" "true" ""
+HARNESS
+
+bash "$T3/harness.sh" > "$F3_STDOUT" 2> "$F3_STDERR"
+F3_RC=$?
+
+f3_fail=""
+if [ "$F3_RC" -eq 0 ]; then
+  f3_fail="exit code was 0 despite jq parse failure (silent success). STDOUT:\n$(cat "$F3_STDOUT")\nSTDERR:\n$(cat "$F3_STDERR")"
+elif grep -q "Phase 1 artifacts persisted" "$F3_STDOUT"; then
+  f3_fail="stdout claims 'Phase 1 artifacts persisted' but the write failed. STDOUT:\n$(cat "$F3_STDOUT")"
+elif ! { grep -qi "error\|fail" "$F3_STDERR" || grep -qi "error\|fail\|\[FAIL\]" "$F3_STDOUT"; }; then
+  f3_fail="no error indication surfaced to the operator. STDOUT:\n$(cat "$F3_STDOUT")\nSTDERR:\n$(cat "$F3_STDERR")"
+elif ! cmp -s "$P3/.claude/process-state.json" "$T3/pstate.pre"; then
+  f3_fail="process-state.json was partially mutated despite the jq parse failure."
+fi
+
+if [ -z "$f3_fail" ]; then
+  pass "F3: persist_phase1_artifacts() surfaces jq failure"
+else
+  fail_ "F3" "$f3_fail"
+fi
+rm -rf "$T3"
+
+# --------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------
+echo ""
+echo "════════════════════════════════════════════════════════════════════"
+echo "tier-crosscheck-6 follow-up suite: Passed: $PASS | Failed: $FAIL"
+if [ "$FAIL" -gt 0 ]; then
+  echo "Failures: ${FAILED_TESTS[*]}"
+  exit 1
+fi
+exit 0

--- a/tests/test-tier-crosscheck-6-zdr-gate.sh
+++ b/tests/test-tier-crosscheck-6-zdr-gate.sh
@@ -1,0 +1,448 @@
+#!/usr/bin/env bash
+# tests/test-tier-crosscheck-6-zdr-gate.sh — closes the final S3 audit
+# finding `tier-crosscheck-6` (Phase 1→2 ZDR / data-classification gate).
+#
+# Audit context:
+#   docs/governance-framework.md:299 declares a "Mandatory ZDR gate":
+#     "Projects with data classified as Internal or higher (Internal,
+#     Confidential, PII, Financial, Regulated) must use the ZDR or
+#     self-hosted deployment path. This is a hard gate at Phase 1 — the
+#     Orchestrator may not proceed to Phase 2 with a non-ZDR deployment
+#     path."
+#   The gate was declared but nothing enforced it: no field captured the
+#   classification, no field recorded the ZDR attestation, and
+#   check-phase-gate.sh had no Phase 1→2 backstop reading any such field.
+#
+# Fix (this PR):
+#   * intake-wizard.sh prompts for data_classification + zdr_attested (+
+#     optional zdr_attestation_reason when not attested).
+#   * Both are persisted under
+#     .claude/process-state.json::phase1_artifacts.{data_classification,
+#       zdr_attested, zdr_attestation_reason}.
+#   * scripts/check-phase-gate.sh refuses Phase 1→2 when
+#     current_phase >= 2 AND (data_classification missing/invalid OR
+#     no attestation evidence). Mirrors the github_free_tier backstop
+#     pattern at scripts/check-phase-gate.sh:445-488 (PR #75).
+#   * scripts/reconfigure-project.sh --field data_classification and
+#     --field zdr_attested let operators correct post-intake (with
+#     APPROVAL_LOG.md audit row + atomic snapshot/rollback).
+#   * scripts/upgrade-project.sh refuses personal→organizational when
+#     data_classification missing, redirecting to reconfigure.
+#
+# Taxonomy (7-tier, canonical lowercase form — adopted from
+# templates/project-intake.md:209 and docs/user-guide.md:466):
+#   public, internal, confidential, pii, financial, health, regulated
+#
+# Attestation shape:
+#   zdr_attested: boolean. true means ZDR (or self-hosted) deployment
+#     is in place. Required for any data_classification > public.
+#   zdr_attestation_reason: free text (non-empty). Documents a written
+#     exception (e.g. "customer requires retention", "self-hosted Ollama").
+#     Either zdr_attested=true OR a non-empty reason satisfies the gate.
+#
+# RED→GREEN evidence — each T# below was confirmed RED on origin/main
+# before implementing the fix. Verification command for each:
+#   git stash && bash tests/test-tier-crosscheck-6-zdr-gate.sh
+# Expected: every assertion FAILS on main (no gate exists).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECK_GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+RECONFIGURE="$REPO_ROOT/scripts/reconfigure-project.sh"
+UPGRADE="$REPO_ROOT/scripts/upgrade-project.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build a Phase-2 project that's syntactically clean for every OTHER
+# check in check-phase-gate.sh so the only signal we measure is the
+# ZDR/classification gate. Mirrors the fixture shape used by
+# tests/test-check-phase-gate-backstop-attestation.sh.
+mk_phase2_project() {
+  local proj="$1"
+  local classification="${2:-}"
+  local zdr_attested="${3:-}"     # "true", "false", or "" (omit)
+  local zdr_reason="${4:-}"       # free text, or "" (omit)
+
+  mkdir -p "$proj/.claude"
+
+  cat > "$proj/.claude/manifest.json" <<'JSON'
+{"frameworkVersion":"test","host":"github","mode":"personal","enforcement_level":"strict"}
+JSON
+
+  cat > "$proj/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal","track":"light",
+ "gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"},
+ "phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"}
+JSON
+
+  # process-state.json — base shape from the canonical seed in
+  # scripts/init.sh + the github_free_tier attestation so the existing
+  # Phase 1→2 backstop doesn't fail and mask our signal.
+  local pstate
+  pstate=$(jq -nc \
+    --arg cls "$classification" \
+    --arg att "$zdr_attested" \
+    --arg rsn "$zdr_reason" \
+    '{
+      phase2_init: {
+        steps_completed: [],
+        verified: false,
+        attestations: {
+          branch_protection: {
+            attested_by: "orchestrator",
+            at: "2026-04-27T00:00:00Z",
+            reason: "github_free_tier"
+          }
+        }
+      },
+      phase1_artifacts: (
+        ({} as $base
+        | (if $cls != "" then $base + {data_classification: $cls} else $base end)
+        | (if $att != "" then . + {zdr_attested: ($att == "true")} else . end)
+        | (if $rsn != "" then . + {zdr_attestation_reason: $rsn} else . end))
+      )
+    }')
+  echo "$pstate" > "$proj/.claude/process-state.json"
+
+  # APPROVAL_LOG.md with dated Phase 0→1 and Phase 1→2 entries so the
+  # gate-date / approval-field checks don't accumulate issues.
+  cat > "$proj/APPROVAL_LOG.md" <<'MD'
+---
+project: t
+deployment: personal
+created: 2026-01-01
+framework: Solo Orchestrator v1.0
+---
+
+# Approval Log — t
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Approver** | Karl |
+| **Role** | Sponsor |
+| **Date** | 2026-01-01 |
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| **Approver** | Karl |
+| **Role** | STA |
+| **Date** | 2026-02-01 |
+MD
+
+  # PRODUCT_MANIFESTO.md — 8 numbered sections with content.
+  {
+    echo "# PRODUCT_MANIFESTO"
+    for i in 1 2 3 4 5 6 7 8; do
+      echo "## ${i}. Section ${i}"
+      echo "Content for section ${i}."
+      echo ""
+    done
+  } > "$proj/PRODUCT_MANIFESTO.md"
+
+  # PROJECT_BIBLE.md — 14 numbered sections.
+  {
+    echo "# PROJECT_BIBLE"
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do
+      echo "## ${i}. Section ${i}"
+      echo "Content."
+      echo ""
+    done
+  } > "$proj/PROJECT_BIBLE.md"
+}
+
+run_gate() {
+  ( cd "$1" && bash "$CHECK_GATE" 2>&1 ); return $?
+}
+
+# Run check-phase-gate.sh and capture both output and exit code.
+# We can't share rc through subshell exit because we want both.
+run_gate_capture() {
+  local proj="$1"
+  local out
+  out=$(cd "$proj" && bash "$CHECK_GATE" 2>&1)
+  local rc=$?
+  printf '%s\n--RC=%d' "$out" "$rc"
+}
+
+# Assert the captured output contains the ZDR/classification FAIL line
+# AND the exit code is non-zero.
+assert_gate_fails_with_classification_msg() {
+  local label="$1" captured="$2"
+  local rc="${captured##*--RC=}"
+  local out="${captured%--RC=*}"
+  if [ "$rc" = "0" ]; then
+    fail_ "$label" "expected non-zero exit; got rc=0. Output tail:\n$(echo "$out" | tail -20)"
+    return 1
+  fi
+  if ! echo "$out" | grep -qiE "data_classification|zdr"; then
+    fail_ "$label" "expected FAIL line mentioning data_classification or ZDR; got:\n$(echo "$out" | tail -20)"
+    return 1
+  fi
+  if ! echo "$out" | grep -qE "\[FAIL\].*Phase 1.*2.*ZDR|\[FAIL\].*ZDR|\[FAIL\].*data_classification"; then
+    fail_ "$label" "expected a [FAIL]-prefixed line tied to the ZDR gate; got:\n$(echo "$out" | grep -E '\[FAIL\]')"
+    return 1
+  fi
+  return 0
+}
+
+assert_gate_passes_classification() {
+  local label="$1" captured="$2"
+  local out="${captured%--RC=*}"
+  if echo "$out" | grep -qE '\[FAIL\].*(ZDR|data_classification)'; then
+    fail_ "$label" "did not expect ZDR/classification FAIL; got:\n$(echo "$out" | grep -E '\[FAIL\]')"
+    return 1
+  fi
+  if ! echo "$out" | grep -qE '\[OK\].*Phase 1.*2.*(ZDR|data_classification|classification|attestation)'; then
+    fail_ "$label" "expected an [OK] confirmation line for the ZDR gate; got tail:\n$(echo "$out" | tail -10)"
+    return 1
+  fi
+  return 0
+}
+
+echo "== tests/test-tier-crosscheck-6-zdr-gate.sh =="
+echo ""
+
+# ════════════════════════════════════════════════════════════════════
+# T1: positive — each valid classification with zdr_attested=true passes
+# ════════════════════════════════════════════════════════════════════
+echo "T1: each valid data_classification value + zdr_attested=true passes"
+T1_FAILED=0
+for cls in public internal confidential pii financial health regulated; do
+  T=$(mktemp -d); P="$T/p"
+  mk_phase2_project "$P" "$cls" "true" ""
+  cap=$(run_gate_capture "$P")
+  if ! assert_gate_passes_classification "T1[$cls]" "$cap"; then
+    T1_FAILED=$((T1_FAILED + 1))
+  fi
+  rm -rf "$T"
+done
+if [ "$T1_FAILED" -eq 0 ]; then
+  pass "T1: all 7 taxonomy values pass with zdr_attested=true (public, internal, confidential, pii, financial, health, regulated)"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+# T2: negative — classification absent → Phase 1→2 fails
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T2: missing data_classification → Phase 1→2 fails"
+T=$(mktemp -d); P="$T/p"
+mk_phase2_project "$P" "" "true" ""   # no classification, has attestation
+cap=$(run_gate_capture "$P")
+assert_gate_fails_with_classification_msg "T2" "$cap" && pass "T2"
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+# T3: negative — classification set but neither attested nor reason → fails
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T3: classification set, no zdr_attested, no reason → Phase 1→2 fails"
+T=$(mktemp -d); P="$T/p"
+mk_phase2_project "$P" "internal" "" ""   # classification only
+cap=$(run_gate_capture "$P")
+assert_gate_fails_with_classification_msg "T3" "$cap" && pass "T3"
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+# T4: attestation-reason path — zdr_attested=false but reason present → passes
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T4: zdr_attested=false but zdr_attestation_reason='customer requires retention' → passes"
+T=$(mktemp -d); P="$T/p"
+mk_phase2_project "$P" "confidential" "false" "customer requires retention per signed SOW 2026-03-15"
+cap=$(run_gate_capture "$P")
+assert_gate_passes_classification "T4" "$cap" && pass "T4"
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+# T5: invalid value — data_classification="bogus" → fails
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T5: data_classification='bogus' → fails with taxonomy-mismatch message"
+T=$(mktemp -d); P="$T/p"
+mk_phase2_project "$P" "bogus" "true" ""
+cap=$(run_gate_capture "$P")
+rc="${cap##*--RC=}"
+out="${cap%--RC=*}"
+if [ "$rc" = "0" ]; then
+  fail_ "T5" "expected non-zero exit for invalid classification; got rc=0"
+elif echo "$out" | grep -qiE "invalid.*classification|not.*(one of|in).*(public|taxonomy)|bogus"; then
+  pass "T5"
+else
+  fail_ "T5" "expected message identifying the invalid value; got:\n$(echo "$out" | grep -iE 'classification|zdr' | head -3)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+# T6: reconfigure-project.sh --field data_classification writes back
+#     correctly and adds an APPROVAL_LOG.md audit row.
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T6: reconfigure-project.sh --field data_classification --new <value> updates state + audit"
+T=$(mktemp -d); P="$T/p"
+
+# Build a minimal project that reconfigure-project.sh can operate on.
+mkdir -p "$P/.claude" "$P/scripts/lib"
+cp "$REPO_ROOT/scripts/reconfigure-project.sh" "$P/scripts/reconfigure-project.sh"
+cp "$REPO_ROOT/scripts/lib/helpers.sh" "$P/scripts/lib/helpers.sh"
+[ -f "$REPO_ROOT/scripts/lib/enforcement-level.sh" ] && cp "$REPO_ROOT/scripts/lib/enforcement-level.sh" "$P/scripts/lib/enforcement-level.sh"
+
+cat > "$P/.claude/phase-state.json" <<'JSON'
+{"project":"t","framework_version":"1.0","current_phase":1,"track":"light","deployment":"personal","poc_mode":null}
+JSON
+cat > "$P/.claude/tool-preferences.json" <<'JSON'
+{"context":{"project":"t","platform":"web","language":"javascript","track":"light"}}
+JSON
+cat > "$P/.claude/orchestrator-source.json" <<JSON
+{ "source_dir": "$REPO_ROOT" }
+JSON
+echo '{}' > "$P/.claude/process-state.json"
+echo "# t — Operator Brief" > "$P/CLAUDE.md"
+echo "# Project Intake — t" > "$P/PROJECT_INTAKE.md"
+cat > "$P/APPROVAL_LOG.md" <<'MD'
+---
+project: t
+deployment: personal
+---
+
+# Approval Log — t
+
+## Approval History
+| Date | Gate / Event | Approver | Role | Decision | Reference |
+|---|---|---|---|---|---|
+MD
+
+( cd "$P" \
+    && git init -q \
+    && git config user.email t@t.l \
+    && git config user.name t \
+    && git add -A \
+    && git commit -q -m "fixture" ) >/dev/null 2>&1
+
+if ( cd "$P" && bash "$P/scripts/reconfigure-project.sh" --field data_classification --new confidential > "$T/log" 2>&1 ); then
+  cls_after=$(jq -r '.phase1_artifacts.data_classification // ""' "$P/.claude/process-state.json")
+  if [ "$cls_after" != "confidential" ]; then
+    fail_ "T6" "process-state.json did not record data_classification=confidential (got '$cls_after'). Log:\n$(cat "$T/log")"
+  elif ! grep -qE "data_classification|classification" "$P/APPROVAL_LOG.md"; then
+    fail_ "T6" "APPROVAL_LOG.md did not get a classification audit row. Tail:\n$(tail -20 "$P/APPROVAL_LOG.md")"
+  else
+    pass "T6"
+  fi
+else
+  fail_ "T6" "reconfigure-project.sh --field data_classification exited non-zero. Log:\n$(cat "$T/log")"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+# T7: upgrade-project.sh personal→organizational refuses when
+#     data_classification missing (non-interactive context).
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T7: upgrade-project.sh --deployment organizational (non-interactive) refuses without data_classification"
+T=$(mktemp -d); P="$T/p"
+
+# Hand-rolled fixture so we don't pay the full init.sh cost. Mirrors the
+# fixture pattern used by tests/test-upgrade-project-retroactive-section.sh.
+mkdir -p "$P/.claude" "$P/scripts/lib" "$P/scripts/host-drivers" "$P/scripts/hooks"
+cp "$REPO_ROOT/scripts/upgrade-project.sh" "$P/scripts/upgrade-project.sh"
+cp "$REPO_ROOT/scripts/lib/helpers.sh" "$P/scripts/lib/helpers.sh"
+[ -f "$REPO_ROOT/scripts/lib/host.sh" ] && cp "$REPO_ROOT/scripts/lib/host.sh" "$P/scripts/lib/host.sh"
+[ -f "$REPO_ROOT/scripts/host-drivers/github.sh" ] && cp "$REPO_ROOT/scripts/host-drivers/github.sh" "$P/scripts/host-drivers/github.sh"
+
+cat > "$P/.claude/manifest.json" <<'JSON'
+{"frameworkVersion":"test","host":"github","mode":"personal","enforcement_level":"strict","deployment":"personal","poc_mode":null}
+JSON
+cat > "$P/.claude/phase-state.json" <<'JSON'
+{"project":"t","framework_version":"1.0","current_phase":2,"track":"light","deployment":"personal","poc_mode":null,
+ "phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"}
+JSON
+cat > "$P/.claude/tool-preferences.json" <<'JSON'
+{"context":{"project":"t","platform":"web","language":"javascript","track":"light","dev_os":"darwin"}}
+JSON
+cat > "$P/.claude/orchestrator-source.json" <<JSON
+{ "source_dir": "$REPO_ROOT" }
+JSON
+# Intentionally NO data_classification in process-state.json.
+echo '{"phase2_init":{"steps_completed":[],"verified":false}}' > "$P/.claude/process-state.json"
+
+# Minimal personal APPROVAL_LOG (org template fields will be regenerated).
+cat > "$P/APPROVAL_LOG.md" <<'MD'
+---
+project: t
+deployment: personal
+---
+
+# Approval Log — t
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Approver** | Karl |
+| **Role** | Sponsor |
+| **Date** | 2026-01-01 |
+MD
+
+# Minimal CLAUDE.md / PROJECT_INTAKE.md
+echo "# t" > "$P/CLAUDE.md"
+echo "# Project Intake — t" > "$P/PROJECT_INTAKE.md"
+# bypass-audit.json so upgrade's BL-030 backfill is a no-op write.
+echo "[]" > "$P/.claude/bypass-audit.json"
+
+( cd "$P" \
+    && git init -q \
+    && git config user.email t@t.l \
+    && git config user.name t \
+    && git add -A \
+    && git commit -q -m "fixture" ) >/dev/null 2>&1
+
+# Run upgrade with --non-interactive so the missing-classification check
+# refuses (rather than prompting). Expect non-zero exit + a message that
+# names data_classification and points the operator at reconfigure.
+if ( cd "$P" && SOIF_NONINTERACTIVE=1 bash "$P/scripts/upgrade-project.sh" --deployment organizational --non-interactive > "$T/log" 2>&1 ); then
+  fail_ "T7" "upgrade-project.sh succeeded without data_classification (expected refusal). Log tail:\n$(tail -30 "$T/log")"
+else
+  if grep -qiE "data_classification" "$T/log"; then
+    if grep -qE "reconfigure-project|--field data_classification" "$T/log"; then
+      pass "T7"
+    else
+      fail_ "T7" "refused but did not point to reconfigure-project.sh / --field data_classification. Log:\n$(tail -30 "$T/log")"
+    fi
+  else
+    fail_ "T7" "refused for unrelated reason — log does not mention data_classification. Tail:\n$(tail -30 "$T/log")"
+  fi
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+# T8: public-data exemption — Public doesn't need ZDR attestation.
+# docs/governance-framework.md § VII line 297-299 makes ZDR mandatory
+# for "Internal or higher". Public is the explicit exemption — there
+# is no sensitive data to retain, so no attestation is needed. Verify
+# the gate honors this by passing with classification='public' and
+# NO attestation at all (no zdr_attested, no reason).
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "T8: data_classification='public' with no attestation evidence → passes (governance-framework.md § VII line 297-299 exemption)"
+T=$(mktemp -d); P="$T/p"
+mk_phase2_project "$P" "public" "" ""   # no attestation, no reason
+cap=$(run_gate_capture "$P")
+out="${cap%--RC=*}"
+rc="${cap##*--RC=}"
+if [ "$rc" != "0" ]; then
+  fail_ "T8" "expected exit 0 with public data + no attestation; got rc=$rc. Tail:\n$(echo "$out" | tail -10)"
+elif ! echo "$out" | grep -qE "\[OK\].*public.*not required|\[OK\].*ZDR.*public"; then
+  fail_ "T8" "expected [OK] line mentioning public exemption; got:\n$(echo "$out" | grep -E '\[OK\].*ZDR' | head -3)"
+else
+  pass "T8"
+fi
+rm -rf "$T"
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-upgrade-paths.sh
+++ b/tests/test-upgrade-paths.sh
@@ -33,6 +33,15 @@ make_phase_state() {
   "gates": {"phase_0_to_1": null, "phase_1_to_2": null, "phase_3_to_4": null}
 }
 JSON
+  # tier-crosscheck-6 cross-cutting update: process-state.json carries
+  # phase1_artifacts so personal→organizational upgrades don't hit the
+  # new ZDR/data_classification refusal. Seeded with 'internal' +
+  # zdr_attested=true so the upgrade-project.sh gate is happy. Tests
+  # that specifically need to exercise the refusal create their own
+  # fixture without phase1_artifacts (see test-tier-crosscheck-6-zdr-gate.sh T7).
+  cat > "$dir/.claude/process-state.json" <<'JSON'
+{"phase1_artifacts":{"data_classification":"internal","zdr_attested":true,"zdr_attestation_reason":""}}
+JSON
   ( cd "$dir" && git init -q && git config user.email t@t.l && git config user.name t \
       && git add -A && git commit -q -m "init" ) >/dev/null 2>&1
 }

--- a/tests/test-upgrade-personal-to-sponsored-poc.sh
+++ b/tests/test-upgrade-personal-to-sponsored-poc.sh
@@ -40,6 +40,12 @@ JSON
     cat > .claude/intake-progress.json <<'JSON'
 {"track":"light","deployment":"personal"}
 JSON
+    # tier-crosscheck-6: seed phase1_artifacts so the personal→
+    # organizational refusal (in --to-sponsored-poc which flips
+    # deployment) doesn't fire.
+    cat > .claude/process-state.json <<'JSON'
+{"phase1_artifacts":{"data_classification":"internal","zdr_attested":true}}
+JSON
   )
 }
 

--- a/tests/test-upgrade-project-retroactive-section.sh
+++ b/tests/test-upgrade-project-retroactive-section.sh
@@ -57,6 +57,12 @@ seed_personal_phase_state() {
   "gates": {"phase_0_to_1": "2026-04-01", "phase_1_to_2": "2026-04-15", "phase_3_to_4": null}
 }
 JSON
+  # tier-crosscheck-6: seed phase1_artifacts so the upgrade-project
+  # personal→organizational refusal doesn't fire (we're testing the
+  # retroactive STA section stamping, not the new ZDR gate).
+  cat > "$dir/.claude/process-state.json" <<'JSON'
+{"phase1_artifacts":{"data_classification":"internal","zdr_attested":true}}
+JSON
 }
 
 # Seed a personal APPROVAL_LOG.md (deployment: personal frontmatter) so


### PR DESCRIPTION
## Summary

- **Taxonomy chosen** (existing, documented in templates/project-intake.md:209 + docs/user-guide.md:466 + governance-framework.md § VII line 299): 7-tier canonical lowercase form — `public`, `internal`, `confidential`, `pii`, `financial`, `health`, `regulated`. Hand-edited mixed-case values are normalized.
- **Hard-block scope**: `scripts/check-phase-gate.sh` Phase 1→2 backstop refuses (`[FAIL]`, exit 1) when `.claude/process-state.json::phase1_artifacts` is missing/invalid. Mirrors the existing `github_free_tier` branch-protection backstop pattern (PR #75).
- **Intake + reconfigure + upgrade reach**: `intake-wizard.sh § 5.5` captures both fields (interactive + non-interactive flags); `reconfigure-project.sh --field data_classification | zdr_attested | zdr_attestation_reason` lets operators correct post-intake (atomic snapshot/rollback + `APPROVAL_LOG.md` audit row); `upgrade-project.sh --deployment organizational` refuses up-front when classification missing.
- **Doc updates**: governance-framework.md § VII gains Invariant #16 (taxonomy, attestation shape, exemption, capture surfaces); builders-guide.md gains Phase 1→2 gate row + new Step 1.7; templates/project-intake.md § 5.1.1 adds the project-level field table.
- **Test wiring**: new `tests/test-tier-crosscheck-6-zdr-gate.sh` (8 tests, 448 LOC) wired into `tests/full-project-test-suite.sh` (TEST 0c2c block) per BL-034.

## Finding closed

- `tier-crosscheck-6` (the final S3 audit finding) — gate enforced at `scripts/check-phase-gate.sh:489-585` (Phase 1→2 ZDR backstop block). Pre-fix the governance framework declared a "Mandatory ZDR gate" (`docs/governance-framework.md:299`) but no field captured the classification, no field recorded the attestation, and `check-phase-gate.sh` had no reader. This PR closes the loop end-to-end.

## Classification taxonomy

| Value | Use case | ZDR required? |
|---|---|---|
| `public` | Intentionally public content | No (exempt) |
| `internal` | Business data, internal reports | Yes |
| `confidential` | Financial, trade secrets, strategic plans | Yes |
| `pii` | Names, emails, government IDs, addresses | Yes |
| `financial` | Payment data, account numbers, transaction history | Yes |
| `health` | PHI, medical records | Yes |
| `regulated` | Subject to specific regulatory frameworks (GDPR, HIPAA, PCI-DSS) | Yes |

**Rationale**: adopted from the documented baseline in `templates/project-intake.md:209` + `docs/user-guide.md:466` (line: "Public, Internal, Confidential, PII, Financial, Health/Medical, Regulated") to maintain doc consistency. Stored canonical form is lowercase; the gate accepts mixed-case input but normalizes before validation/storage.

## Attestation shape

Two distinct shapes (caller picks whichever fits):

- **`zdr_attested: true`** — boolean. Indicates ZDR or self-hosted LLM is in place. Sufficient on its own.
- **`zdr_attestation_reason: "<non-empty text>"`** — free-text written exception. Documents a deviation from ZDR that has been formally risk-accepted (e.g. "Customer SOW requires retention, risk accepted by CISO Email TKT-42").

The gate honors **either** shape. `public` classification is exempt from attestation entirely (the classification itself is evidence that no sensitive data flows to the LLM provider).

## Test plan

All 8 tests in `tests/test-tier-crosscheck-6-zdr-gate.sh` were proven RED on `bcaa43a` (origin/main) before the implementation. Mutation testing was applied to confirm each assertion has bite. (PR #105 verifier follow-up: T1's "mutation tested" column previously misattributed the `zdr_taxonomy_ok` mutation to T1 — it's actually **T5** that catches that mutation, since T5 is the invalid-value case. Reattributed below.)

| # | Assertion | RED-on-main evidence | GREEN evidence | Mutation tested |
|---|---|---|---|---|
| T1 | All 7 taxonomy values pass with `zdr_attested=true` | Gate doesn't exist; no `[OK] ZDR` line emitted | `[OK] Phase 1→2 ZDR gate: data_classification='<v>', zdr_attested=true` | n/a (positive-path case; T5 is the detector for the `zdr_taxonomy_ok` mutation) |
| T2 | Missing classification → `[FAIL]` | Gate doesn't fire | `[FAIL] Phase 1→2 ZDR gate: phase1_artifacts.data_classification not set` | n/a (covered by T1 inverse) |
| T3 | Classification set, no attestation evidence → `[FAIL]` | Gate doesn't fire | `[FAIL] Phase 1→2 ZDR gate: data_classification='internal' but no ZDR attestation evidence` | Set `zdr_attest_ok=1` always → T3 FAILS |
| T4 | `zdr_attested=false` + non-empty reason → passes | Gate doesn't exist | `[OK] Phase 1→2 ZDR gate: data_classification='confidential' (attestation reason: customer requires retention...)` | n/a (covered by mutation on attest_ok) |
| T5 | `data_classification='bogus'` → `[FAIL]` with taxonomy message | No validation; succeeds | `[FAIL] Phase 1→2 ZDR gate: invalid data_classification 'bogus' (not in taxonomy)` | Set `zdr_taxonomy_ok=1` always → T5 FAILS |
| T6 | `reconfigure --field data_classification --new confidential` writes back + audit row | Handler doesn't exist (`Unknown field`) | `phase1_artifacts.data_classification='confidential'` + audit row in `APPROVAL_LOG.md` | n/a (handler-existence binary) |
| T7 | `upgrade-project.sh --deployment organizational --non-interactive` refuses without classification | Succeeds with rc=0 | `[FAIL] upgrade-project.sh: --deployment organizational blocked — data_classification not set (tier-crosscheck-6)` with pointer to reconfigure | Replace guard with `if false; then` → T7 FAILS |
| T8 | `public` classification with NO attestation evidence → passes (exemption) | Pre-mutation gate would have failed | `[OK] Phase 1→2 ZDR gate: data_classification='public' (ZDR attestation not required for Public-only data)` | Disable `elif public` branch → T8 FAILS |

Adjacent test bundles that exercise the changed surfaces — all GREEN post-fix:

- `tests/test-check-phase-gate.sh` (8/8)
- `tests/test-check-phase-gate-backstop-attestation.sh` (3/3) — fixture updated
- `tests/test-check-phase-gate-retroactive-approval.sh` (3/3)
- `tests/test-check-phase-gate-self-approval.sh` (5/5)
- `tests/test-check-phase-gate-counter-sanitizer.sh` (7/7)
- `tests/test-check-phase-gate-noninteractive.sh` (3/3)
- `tests/test-reconfigure-field-handlers.sh` (7/7)
- `tests/test-upgrade-non-interactive.sh` (7/7)
- `tests/test-upgrade-paths.sh` (24/24) — fixture updated
- `tests/test-upgrade-project-retroactive-section.sh` (2/2) — fixture updated
- `tests/test-upgrade-personal-to-sponsored-poc.sh` (3/3) — fixture updated
- `tests/test-upgrade-project-atomic.sh` (4/4)
- `tests/test-init-organizational.sh` (2/2)
- `tests/test-intake-wizard-fixes.sh` (9/9)

All 4 anti-pattern lints pass:

- `bash scripts/lint-counter-antipattern.sh` → OK
- `bash scripts/lint-backlog-references.sh` → OK
- `bash scripts/lint-fix-functions-stderr.sh` → OK
- `bash scripts/lint-raw-read-prompt.sh` → OK
- `bash scripts/lint-fixture-envelopes.sh tests/` → OK

## Breaking changes

Existing projects with `current_phase >= 2` in `.claude/phase-state.json` but no `phase1_artifacts.data_classification` in `.claude/process-state.json` will **fail** Phase 1→2 backstop until the operator runs:

```bash
bash scripts/reconfigure-project.sh --field data_classification --new <public|internal|confidential|pii|financial|health|regulated>
bash scripts/reconfigure-project.sh --field zdr_attested --new true
```

The reconfigure script appends an audit row to `APPROVAL_LOG.md` per BL-034 governance trail invariant; rollback is atomic on failure.

This is **intentional** — the field is the new Phase 1 invariant declared by `docs/governance-framework.md § VII` (Mandatory ZDR gate) + Invariant #16 of governance framework v1.1.

## Verifier follow-up (post-initial-review)

The PR #105 adversarial verifier surfaced two MAJOR defects + two MINORs in the initial commit. Addressed in a follow-up commit on this branch:

1. **MAJOR — atomicity claim was false.** The data_classification/ZDR handler in `scripts/reconfigure-project.sh` commented that it installed an INT/TERM/ERR trap and subshell-wrapped the mutation block, but did neither. A SIGTERM/SIGINT mid-mutation left process-state.json mutated, the audit row missing, and the snapshot tempdir leaked. **Fixed**: the entire mutation block is now wrapped in `( ... )` with `trap '_trap_fire INT|TERM|ERR' INT TERM ERR` installed inside; on any of those signals (or any failed inner step) the rollback restores both files to the pre-mutation snapshot. Regression test: `tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh::F1` reproduces the torn state (RED on PR head) and asserts atomic outcome (GREEN after fix). The shell-global trap concern (PR #93's lesson) is respected — the trap lives inside the subshell.
2. **MAJOR — silent success on jq failure.** Both `scripts/intake-wizard.sh::persist_phase1_artifacts` (line ~1015) and the non-interactive `--data-classification` / `--zdr-attested` path (line ~2028) chained `jq ... > tmp && mv tmp pstate` and then unconditionally printed `"Phase 1 artifacts updated/persisted"` + exited 0 regardless of whether jq+mv succeeded. A malformed process-state.json reproduced: jq parse error on stderr, success message on stdout, rc=0, file unchanged. **Fixed**: jq exit code and mv exit code are now both captured; failure surfaces as `[FAIL]`, prints operator-actionable remediation (inspect, restore from .bak, re-run init.sh), and exits non-zero. Regression tests: `tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh::F2` (non-interactive flag path) and `::F3` (persist_phase1_artifacts function).
3. **MINOR — count drift.** `tests/full-project-test-suite.sh:153` previously reported `(7/7)` but the file has 8 tests. **Fixed** to `(8/8)`.
4. **MINOR — mutation-test attribution.** The T1 row of the test plan above misattributed the `zdr_taxonomy_ok` mutation to T1; T5 is the actual detector. **Fixed** in the test-plan table above.

The verifier also noted two out-of-scope items (audit-trail divergence between non-interactive intake and reconfigure paths; `init.sh` not seeding `phase1_artifacts`). These are documented as known limitations — operators who advance via `init.sh` + manual phase bump without going through intake will trip the new gate at the next CI check, which is the intended behavior (the gate exists precisely to catch unattended phase advances without classification capture).

## Worktree note

Implemented in isolated git worktree at `.claude/worktrees/wf_c62d9fbe-369-1` (separate working copy from the main repo). Changes do not affect parallel worktrees or the main working directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
