### PR TITLE
fix(init): honor NON_INTERACTIVE + AUTO_INSTALL_TOOLS (BL-057)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -730,12 +730,33 @@ resolve_and_install_tools() {
   echo -e "${BOLD}└──────────────────────────────────────────────────────────┘${NC}"
   echo ""
 
-  # Confirm — skip prompt when there is nothing to install
+  # Confirm — skip prompt when there is nothing to install.
+  # BL-057: honor NON_INTERACTIVE + AUTO_INSTALL_TOOLS so the --non-interactive
+  # contract is upheld (closed stdin + `set -euo pipefail` + bare `read -rp`
+  # previously terminated the script silently with rc=1 the moment the resolved
+  # plan included an auto_install or manual_install entry — surfaced as a
+  # Step-5 dogfood DOGFOOD-001 on --platform mobile via Android Studio's
+  # auto_install row).
   local response="Y"
   if [ "$auto_count" -gt 0 ] || [ "$manual_count" -gt 0 ]; then
-    read -rp "$(echo -e "${YELLOW}▶ ${BOLD}Proceed with this plan? [Y/n]${NC}: ")" response # lint-raw-read-prompt: allow init.sh interactive-only tool-install plan; NON_INTERACTIVE path uses AUTO_INSTALL_TOOLS env var rather than this prompt
+    if [ "$NON_INTERACTIVE" = true ]; then
+      response="${AUTO_INSTALL_TOOLS:-Y}"
+    else
+      read -rp "$(echo -e "${YELLOW}▶ ${BOLD}Proceed with this plan? [Y/n]${NC}: ")" response # lint-raw-read-prompt: allow init.sh interactive-only tool-install plan; NON_INTERACTIVE branch above honors AUTO_INSTALL_TOOLS env var
+    fi
   fi
   if [[ "$response" =~ ^[Nn] ]]; then
+    # BL-057: under NON_INTERACTIVE, the user has already expressed an
+    # explicit decline via AUTO_INSTALL_TOOLS=N. Dropping into the
+    # interactive prompt_choice sub-menu (which assumes a TTY) would hang
+    # or surface a confusing EOF diagnostic. Skip the auto-install plan
+    # and let init.sh proceed with whatever is already present — anything
+    # truly required will be re-flagged at the phase-gate check.
+    if [ "$NON_INTERACTIVE" = true ]; then
+      print_info "AUTO_INSTALL_TOOLS=N — skipping tool auto-installation. Missing tools will be re-flagged at the next phase gate."
+      auto_count=0
+      return 0
+    fi
     echo ""
     local config_choice
     config_choice=$(prompt_choice "What would you like to do?" \

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1294,3 +1294,29 @@ PR #87 shipped a minimum-viable WARN that surfaces the risk but does not hard-bl
 **Trigger:** This entry exists as a placeholder in case `wf_c62d9fbe-369` does not close before the next backlog snapshot. If `wf_c62d9fbe-369` ships first, this entry flips to Closed with the PR# citation.
 
 **Related:** `scripts/check-phase-gate.sh:246`; PR #87 (minimum-viable WARN); workflow `wf_c62d9fbe-369` (hard-block in flight); audit code-check-gates-7.
+
+---
+
+## BL-057: init.sh --non-interactive must honor AUTO_INSTALL_TOOLS env var
+
+**Logged:** 2026-06-29
+**Category:** Bug
+**Severity:** High
+**Status:** Closed (2026-06-29, PR #107, commit `a0a4e8d`)
+
+Surfaced by the Step-5 dogfood validation walker (`Reports/2026-06-29-step5-dogfood-validation.md`, DOGFOOD-001) — the only bug found across 38 scenarios. `init.sh:736` called `read -rp "Proceed with this plan? [Y/n]"` UNCONDITIONALLY whenever the resolved tool plan contained any `auto_install` or `manual_install` entries.
+
+The inline `lint-raw-read-prompt: allow` comment at the same line documented the INTENDED bypass — *"NON_INTERACTIVE path uses AUTO_INSTALL_TOOLS env var rather than this prompt"* — but no code in `init.sh` actually read `AUTO_INSTALL_TOOLS`, and the guard immediately above did not check `NON_INTERACTIVE` either. Under `set -euo pipefail` with closed stdin (the documented `--non-interactive` contract), `read` returned non-zero and the script terminated silently with `rc=1`.
+
+Currently surfaced only on `--platform mobile` (Android Studio auto_install row on Darwin hosts without Android Studio installed). Blast radius would grow with every new `auto_install` entry added to `templates/tool-matrix/*.json`.
+
+**Repro (RED on origin/main):**
+
+    init.sh --non-interactive --platform mobile --language typescript \
+            --track full --deployment personal --gov-mode private_poc \
+            --project foo --project-dir <tmp> </dev/null
+    # → prints Tool Installation Plan, then dies silently. rc=1.
+
+**Resolution (PR #107):** Replaced the unconditional `read -rp` with an env-aware branch that mirrors the documented contract — `NON_INTERACTIVE=true` → `response = ${AUTO_INSTALL_TOOLS:-Y}`. Paired with a `NON_INTERACTIVE` short-circuit inside the `[Nn]` decline branch so `AUTO_INSTALL_TOOLS=N` logs *"AUTO_INSTALL_TOOLS=N — skipping tool auto-installation..."* and proceeds, instead of dropping into the interactive `prompt_choice` sub-menu (which would EOF-fail under closed stdin). Regression test at `tests/test-init-non-interactive-mobile-auto-install.sh` covers all three contract cases (default Y, explicit N, explicit Y) and is wired into `tests/full-project-test-suite.sh` as TEST 0c4 per BL-034.
+
+**Related:** `init.sh:733-737` (`resolve_and_install_tools`); Step-5 dogfood walker; BL-034 (test-aggregator wiring invariant); `scripts/lint-raw-read-prompt.sh` (the allowlist marker that documented the bypass that did not exist).

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -181,6 +181,25 @@ else
 fi
 
 # ================================================================
+# TEST 0c4: BL-057 — --non-interactive must honor AUTO_INSTALL_TOOLS env
+# ================================================================
+# Regression suite for BL-057: scripts/init.sh's resolve_and_install_tools
+# called `read -rp` unconditionally when the resolved plan had
+# auto_install/manual_install entries, terminating silently with rc=1
+# under --non-interactive (closed stdin + set -euo pipefail). Surfaced as
+# Step-5 dogfood DOGFOOD-001 on --platform mobile (Android Studio
+# auto_install). Test asserts the post-fix contract:
+#   • default AUTO_INSTALL_TOOLS → Y  → init succeeds (rc=0)
+#   • AUTO_INSTALL_TOOLS=N            → init succeeds (rc=0), no install loop
+#   • AUTO_INSTALL_TOOLS=Y (explicit) → round-trips to default
+section "init.sh --non-interactive honors AUTO_INSTALL_TOOLS (BL-057)"
+if bash "$SCRIPT_DIR/tests/test-init-non-interactive-mobile-auto-install.sh" >/dev/null 2>&1; then
+  pass "init.sh --non-interactive AUTO_INSTALL_TOOLS tests (3/3)"
+else
+  fail "init.sh --non-interactive AUTO_INSTALL_TOOLS tests FAILED (run tests/test-init-non-interactive-mobile-auto-install.sh for details)"
+fi
+
+# ================================================================
 # TEST 0d: BACKLOG-REFERENCES LINT — cycle-7 Slot-5 process backstop
 # ================================================================
 # Sibling of the counter-antipattern lint above; catches drift between

--- a/tests/test-init-non-interactive-mobile-auto-install.sh
+++ b/tests/test-init-non-interactive-mobile-auto-install.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# tests/test-init-non-interactive-mobile-auto-install.sh — regression suite
+# for BL-057: init.sh --non-interactive must honor the AUTO_INSTALL_TOOLS env
+# var instead of issuing a bare `read -rp` on the tool-install plan.
+#
+# DEFECT
+#   scripts/init.sh (resolve_and_install_tools) called:
+#     read -rp "...Proceed with this plan? [Y/n]: " response
+#   unconditionally whenever the resolved plan contained any auto_install or
+#   manual_install entries. Under the documented --non-interactive contract
+#   (closed stdin) and `set -euo pipefail`, `read` returned non-zero and the
+#   script terminated silently with rc=1.
+#
+#   Surfaced by the Step-5 dogfood validation walker (DOGFOOD-001) — the only
+#   bug found across 38 scenarios. Reproducer: --platform mobile +
+#   --language typescript on a Darwin host without Android Studio installed
+#   (the resolver auto-installs Android Studio at Phase 2).
+#
+# CONTRACT (post-fix)
+#   1. NON_INTERACTIVE=true → response = ${AUTO_INSTALL_TOOLS:-Y}; the read
+#      prompt is bypassed.
+#   2. AUTO_INSTALL_TOOLS unset → defaults to Y → installs proceed → rc=0.
+#   3. AUTO_INSTALL_TOOLS=N    → no install commands executed → rc=0.
+#
+# This regression suite asserts (2) and (3). Case (1) — the RED case on
+# origin/main — is documented in the commit body; reproducing it here would
+# require a separate checkout and a network fetch, both out of scope for a
+# fast unit test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT_SH="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build an isolated cwd + project-dir, then invoke init.sh with --platform
+# mobile so the resolver auto-installs Android Studio (the row that hit the
+# bug). stdin is closed (</dev/null) to mirror the dogfood walker.
+#
+# Echoes "EXIT|STDOUT|STDERR" with newlines flattened to spaces.
+run_init_mobile() {
+  local extra_env="${1:-}"
+  local tmpcwd tmpprojdir out rc=0
+  tmpcwd=$(mktemp -d)
+  tmpprojdir=$(mktemp -d)
+  # init.sh refuses to scaffold into an existing dir without --allow-existing-dir.
+  rmdir "$tmpprojdir"
+  if [ -n "$extra_env" ]; then
+    out=$(cd "$tmpcwd" && env "$extra_env" "$INIT_SH" \
+      --non-interactive \
+      --platform mobile \
+      --language typescript \
+      --track full \
+      --deployment personal \
+      --gov-mode private_poc \
+      --project foo \
+      --project-dir "$tmpprojdir" </dev/null 2>&1) || rc=$?
+  else
+    out=$(cd "$tmpcwd" && "$INIT_SH" \
+      --non-interactive \
+      --platform mobile \
+      --language typescript \
+      --track full \
+      --deployment personal \
+      --gov-mode private_poc \
+      --project foo \
+      --project-dir "$tmpprojdir" </dev/null 2>&1) || rc=$?
+  fi
+  # Capture the project-dir so the caller can assert against it before cleanup.
+  echo "$rc|$tmpprojdir|$(printf '%s' "$out" | tr '\n' ' ')"
+  rm -rf "$tmpcwd" "$tmpprojdir"
+}
+
+# ---------------------------------------------------------------------------
+# T1: default AUTO_INSTALL_TOOLS (unset) → Y → init succeeds.
+# This is the GREEN case for the BL-057 fix: the original silent rc=1 must
+# be gone, and the project must be scaffolded.
+# ---------------------------------------------------------------------------
+t1_default_auto_install_y() {
+  local res rc projdir out
+  res=$(run_init_mobile "")
+  rc="${res%%|*}"
+  res="${res#*|}"
+  projdir="${res%%|*}"
+  out="${res#*|}"
+
+  if [ "$rc" != "0" ]; then
+    fail_ "T1" "expected rc=0 with default AUTO_INSTALL_TOOLS, got rc=$rc; tail: ${out: -400}"
+    return
+  fi
+  # Sanity: the Tool Installation Plan section should have rendered.
+  if [[ "$out" != *"Tool Installation Plan"* ]]; then
+    fail_ "T1" "expected plan banner in output; missing"
+    return
+  fi
+  # The fix should NOT short-circuit the BL-057 skip-message on default Y.
+  if [[ "$out" == *"AUTO_INSTALL_TOOLS=N — skipping"* ]]; then
+    fail_ "T1" "default path unexpectedly took the skip branch"
+    return
+  fi
+  pass "T1: --non-interactive --platform mobile (default AUTO_INSTALL_TOOLS) → rc=0, plan rendered, no skip-message"
+}
+
+# ---------------------------------------------------------------------------
+# T2: AUTO_INSTALL_TOOLS=N → init succeeds, no installs executed.
+# The decline branch must NOT drop into the interactive prompt_choice
+# sub-menu (which would EOF-fail with a diagnostic under closed stdin).
+# ---------------------------------------------------------------------------
+t2_auto_install_n_skips_installs() {
+  local res rc projdir out
+  res=$(run_init_mobile "AUTO_INSTALL_TOOLS=N")
+  rc="${res%%|*}"
+  res="${res#*|}"
+  projdir="${res%%|*}"
+  out="${res#*|}"
+
+  if [ "$rc" != "0" ]; then
+    fail_ "T2" "expected rc=0 with AUTO_INSTALL_TOOLS=N, got rc=$rc; tail: ${out: -400}"
+    return
+  fi
+  if [[ "$out" != *"AUTO_INSTALL_TOOLS=N"* ]]; then
+    fail_ "T2" "expected BL-057 skip-message; not found"
+    return
+  fi
+  # The decline branch must not have invoked the interactive sub-menu.
+  if [[ "$out" == *"prompt_choice: stdin closed"* ]] \
+     || [[ "$out" == *"What would you like to do?"* ]]; then
+    fail_ "T2" "decline branch unexpectedly entered interactive sub-menu"
+    return
+  fi
+  # The install loop's "Installing tools..." banner must NOT have fired —
+  # that's the print_step that runs only when auto_count > 0 after the
+  # decline branch.
+  if [[ "$out" == *"[STEP] Installing tools..."* ]]; then
+    fail_ "T2" "AUTO_INSTALL_TOOLS=N did not skip the install loop"
+    return
+  fi
+  pass "T2: AUTO_INSTALL_TOOLS=N → rc=0, skip-message logged, install loop skipped, no interactive prompt"
+}
+
+# ---------------------------------------------------------------------------
+# T3: AUTO_INSTALL_TOOLS=Y → init succeeds (explicit-Y is the documented
+# default and must round-trip identically to the unset case).
+# ---------------------------------------------------------------------------
+t3_auto_install_explicit_y() {
+  local res rc projdir out
+  res=$(run_init_mobile "AUTO_INSTALL_TOOLS=Y")
+  rc="${res%%|*}"
+  res="${res#*|}"
+  projdir="${res%%|*}"
+  out="${res#*|}"
+
+  if [ "$rc" != "0" ]; then
+    fail_ "T3" "expected rc=0 with AUTO_INSTALL_TOOLS=Y, got rc=$rc; tail: ${out: -400}"
+    return
+  fi
+  if [[ "$out" == *"AUTO_INSTALL_TOOLS=N — skipping"* ]]; then
+    fail_ "T3" "explicit-Y path unexpectedly took the skip branch"
+    return
+  fi
+  pass "T3: AUTO_INSTALL_TOOLS=Y → rc=0 (round-trips to default)"
+}
+
+# --- Run all ---
+echo "== tests/test-init-non-interactive-mobile-auto-install.sh =="
+t1_default_auto_install_y
+t2_auto_install_n_skips_installs
+t3_auto_install_explicit_y
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- **Bug:** `init.sh:736` called `read -rp` unconditionally when the resolved tool plan had any `auto_install` / `manual_install` entries. Under `--non-interactive` (closed stdin + `set -euo pipefail`), `read` returned non-zero and the script terminated silently with `rc=1`.
- **Surfaced by:** Step-5 dogfood validation walker (DOGFOOD-001) — the only bug found across 38 scenarios. Reproducer: `--platform mobile` on a Darwin host without Android Studio (the resolver auto-installs Android Studio at Phase 2).
- **Blast radius:** Today, only `mobile`. Grows with every new `auto_install` entry added to the tool matrix.
- **Fix:** Honors the contract the inline lint-suppression comment already documented — `NON_INTERACTIVE=true` → `response = ${AUTO_INSTALL_TOOLS:-Y}`; the `[Nn]` decline branch now also short-circuits to a "skip + log" path under `NON_INTERACTIVE` instead of dropping into the interactive `prompt_choice` sub-menu (which would EOF-fail under closed stdin).
- **Regression test:** New `tests/test-init-non-interactive-mobile-auto-install.sh` (3 cases — default Y, explicit N, explicit Y). Wired into `tests/full-project-test-suite.sh` as TEST 0c4 per BL-034 invariant.

## Bug source

Step-5 dogfood validation walker (DOGFOOD-001 — see `Reports/2026-06-29-step5-dogfood-validation.md`). The only bug found across 38 scenarios. The inline lint-suppression comment at `init.sh:736` documented the intended bypass but no code in the file actually honored it.

## Repro and fix

**RED on `origin/main`:**

    init.sh --non-interactive --platform mobile --language typescript \
            --track full --deployment personal --gov-mode private_poc \
            --project foo --project-dir <tmp> </dev/null

Result: prints the Tool Installation Plan, then dies silently. No diagnostic. `rc=1`.

**Fix in `init.sh` (`resolve_and_install_tools`):**

```bash
local response="Y"
if [ "$auto_count" -gt 0 ] || [ "$manual_count" -gt 0 ]; then
  if [ "$NON_INTERACTIVE" = true ]; then
    response="${AUTO_INSTALL_TOOLS:-Y}"
  else
    read -rp "..." response   # interactive only; lint-allowlisted
  fi
fi
if [[ "$response" =~ ^[Nn] ]]; then
  if [ "$NON_INTERACTIVE" = true ]; then
    print_info "AUTO_INSTALL_TOOLS=N — skipping tool auto-installation..."
    auto_count=0
    return 0
  fi
  # ... existing interactive prompt_choice sub-menu unchanged ...
fi
```

**GREEN (post-fix, same repro):** `rc=0`; project scaffolded; "Installing tools..." banner fires normally.

**GREEN bypass (`AUTO_INSTALL_TOOLS=N`):** `rc=0`; skip-message logged; install loop NOT emitted.

## Test plan

- [x] **RED reproduces on `origin/main`** — `rc=1`, no diagnostic, after the Tool Installation Plan renders. (Verified by stashing the fix and re-running the dogfood walker invocation.)
- [x] **GREEN on this branch** — `tests/test-init-non-interactive-mobile-auto-install.sh` (3 cases): T1 default → Y → `rc=0`; T2 `AUTO_INSTALL_TOOLS=N` → `rc=0`, no install loop; T3 explicit `AUTO_INSTALL_TOOLS=Y` → round-trips to default.
- [x] **No regression on existing non-interactive scenarios** — `tests/test-init-non-interactive.sh` 28/29 (N7 failure pre-existed on `origin/main`; unrelated).
- [x] **Organizational end-to-end intact** — `tests/test-init-organizational.sh` 2/2.
- [x] **All 5 lints green** — `lint-counter-antipattern`, `lint-backlog-references`, `lint-fix-functions-stderr`, `lint-raw-read-prompt` (allowlist marker still on the interactive branch with refreshed rationale), `lint-fixture-envelopes`.
- [x] **Wired into aggregator** — `tests/full-project-test-suite.sh` TEST 0c4 per BL-034 invariant.

## Worktree note

This PR was developed in an isolated worktree at `.claude/worktrees/agent-ab450bf2dfa0333a4` to avoid coupling to other in-flight work. The BL-057 backlog entry is added in a follow-up amend on this branch once the PR number was known (per `scripts/lint-backlog-references.sh`, a Closed entry must cite a PR# or SHA).

**DO NOT merge.** Per the dogfood-walker spec, this PR is staged for review — the reviewer decides ship vs. revise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)