### PR TITLE
docs(bl058): clarify Sponsored POC APPROVAL_LOG.md canonical shape — no product change

### DIFF
--- a/docs/governance-framework.md
+++ b/docs/governance-framework.md
@@ -243,7 +243,7 @@ The Solo Orchestrator framework supports three governance modes, set at project 
 | Mode | Deployment | Phase 0 entry requires | Deferred until upgrade | Phase 4 |
 |---|---|---|---|---|
 | **Production Build** | personal or organizational | All 6 pre-conditions (AI deployment path, sponsor, insurance, liability, ITSM, exit criteria, backup maintainer) | None | Allowed |
-| **Sponsored POC** | organizational only | AI deployment path approved, sponsor assigned, time-boxed exit criteria documented (3 of 6) | Insurance clearance, liability entity, ITSM integration, backup maintainer (5 of 6 minus the 3 required = the remainder) | **Blocked** until `scripts/upgrade-project.sh --to-production` clears the deferred items |
+| **Sponsored POC** | organizational only | AI deployment path approved + project sponsor assigned (2 of the 6 blocking pre-conditions in §XIV). Time-boxed exit criteria (§XIV item #8, tracked outside `APPROVAL_LOG.md`) must also be documented upfront. | Insurance clearance, liability entity, ITSM integration, backup maintainer (the remaining 4 of 6 blocking pre-conditions). `APPROVAL_LOG.md` retains all 6 rows; deferred rows are left blank until `--to-production`. | **Blocked** until `scripts/upgrade-project.sh --to-production` clears the deferred items |
 | **Private POC** | personal only | None — all governance is deferred for exploratory work | All 6 pre-conditions deferred | **Blocked** until upgrade to Sponsored POC (rare) or Production |
 
 **Constraints common to all POC modes:**

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -885,7 +885,7 @@ if [ "$TO_PRODUCTION" = true ] && [ -n "$CURRENT_POC_MODE" ]; then
 
     if [ -n "$_missing_rows" ]; then
       _upgrade_fail "--to-production blocked — Pre-Phase-0 pre-conditions not cleared" \
-                    "APPROVAL_LOG.md rows [$_missing_rows] lack a dated approval (and were not acknowledged via --ack-preconditions). Per docs/governance-framework.md:230 Production requires all 6 pre-conditions; Sponsored POC deferred 3 and Private POC deferred all 6 — they must be cleared before the upgrade." \
+                    "APPROVAL_LOG.md rows [$_missing_rows] lack a dated approval (and were not acknowledged via --ack-preconditions). Per docs/governance-framework.md §V Production requires all 6 pre-conditions cleared; Sponsored POC requires rows 1,4 (AI deployment path, sponsor) upfront and defers rows 2,3,5,6 (insurance, liability, backup, ITSM); Private POC defers all 6. Deferred rows must be cleared before --to-production." \
                     "fill in the Date column for the missing rows in APPROVAL_LOG.md (see Pre-Phase 0 section), OR re-run with --non-interactive --ack-preconditions=<N1,N2,...> after recording the equivalent approvals out-of-band." \
                     "missing_rows=[$_missing_rows]; missing_labels=[$_missing_labels]; approval_log=$APPROVAL_LOG"
       exit 1

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1294,3 +1294,51 @@ PR #87 shipped a minimum-viable WARN that surfaces the risk but does not hard-bl
 **Trigger:** This entry exists as a placeholder in case `wf_c62d9fbe-369` does not close before the next backlog snapshot. If `wf_c62d9fbe-369` ships first, this entry flips to Closed with the PR# citation.
 
 **Related:** `scripts/check-phase-gate.sh:246`; PR #87 (minimum-viable WARN); workflow `wf_c62d9fbe-369` (hard-block in flight); audit code-check-gates-7.
+
+---
+
+## BL-058: Sponsored POC `APPROVAL_LOG.md` canonical shape — doc/matrix wording clarified (no product change)
+
+**Logged:** 2026-06-29
+**Category:** Documentation
+**Severity:** Low
+**Status:** Won't Fix — documentation aligned with product behavior. Doc tightening shipped in the same PR.
+
+**What:** The adversarial dogfood re-walker (2026-06-29) flagged `migration-private-poc-personal-to-sponsored-poc-org` as `partial`. The matrix's `expected_terminal_state` said: "APPROVAL_LOG restructured with the 3 Sponsored-required rows visible." After `bash scripts/upgrade-project.sh --to-sponsored-poc --non-interactive` the resulting `APPROVAL_LOG.md` contains all 6 Pre-Phase-0 rows. The re-walker read "3 rows visible" as a restructure-to-3 contract; that reading is incorrect — the product behavior is the canonical contract.
+
+**Why (canonical contract — file:line citations):**
+- `templates/generated/approval-log-org.tmpl:20-27` — the organizational APPROVAL_LOG template has all 6 Pre-Phase-0 rows in the table. The template is shape-only; the 6 rows are always present regardless of POC mode.
+- `scripts/upgrade-project.sh:1551-1562` — the personal→organizational APPROVAL_LOG restructure emits all 6 rows in the new org-format table. There is no POC-mode-conditional row filter, and the contract does not call for one.
+- `tests/test-upgrade-to-production-preconditions.sh:90-134` (`_write_approval_log_org`) — the canonical sponsored-POC fixture seeds all 6 rows. The deferred-vs-upfront distinction is *which rows have dates*, not which rows are present.
+- `docs/governance-framework.md` §V — Sponsored POC requires rows 1 (AI deployment path) and 4 (project sponsor) dated upfront; defers rows 2 (insurance), 3 (liability), 5 (backup), 6 (ITSM) until `--to-production` clears them via dated approval or `--ack-preconditions=2,3,5,6`. Exit criteria is §XIV item #8, tracked outside `APPROVAL_LOG.md`.
+- `docs/governance-framework.md` §V (pre-clarify wording, original): said "3 of 6" upfront + "5 of 6 minus the 3 required = the remainder". The "3 of 6" count counted exit-criteria as one of the 6, which §XIV does not; "5 of 6 minus 3" was nonsense arithmetic. This PR rewrites §V row 246 to spell out "2 of 6 blocking from §XIV upfront (rows 1,4); 4 of 6 deferred (rows 2,3,5,6); exit criteria is §XIV #8 tracked outside the table; all 6 rows remain visible."
+
+**Scope:**
+- `docs/governance-framework.md` §V row 246 — re-worded as above to remove "5 of 6 minus 3" gibberish and explicitly state "all 6 rows remain visible in `APPROVAL_LOG.md`."
+- `scripts/upgrade-project.sh:888` — error message tightened from "Sponsored POC deferred 3" to "Sponsored POC requires rows 1,4 upfront and defers rows 2,3,5,6" so operators hitting the `--to-production` gate read the correct row numbers.
+- `tests/test-upgrade-to-production-preconditions.sh:10-15` — comment rewritten to match the corrected canonical split.
+- Scratchpad `dogfood-matrix.json` — the `migration-private-poc-personal-to-sponsored-poc-org` and `migration-sponsored-poc-to-production-org-ack-bypass` entries had the same "3 Sponsored-required" wording. Updated to "rows 1,4 dated (the 2 Sponsored-required) and rows 2,3,5,6 still TBD" so future dogfood passes don't re-misread the contract.
+
+**No product code change** — `scripts/upgrade-project.sh` already implements the canonical contract correctly.
+
+**Trigger:** Doc-only PR; ships immediately. No follow-up work required unless a separate investigation determines that the dogfood walker's failure to verify the actual canonical contract (rows 1,4 dated, 2,3,5,6 blank) is itself a walker-coverage gap worth filing — that would be a separate ticket about adversarial-walk assertion depth, not this one.
+
+**Related:** Adversarial re-walk verdict 2026-06-29 (`partial`); `docs/governance-framework.md:246` (pre-clarify); `scripts/upgrade-project.sh:1503-1672` (restructure logic, unchanged); `templates/generated/approval-log-org.tmpl`; `tests/test-upgrade-to-production-preconditions.sh`; closed audit `code-upgrade-project-8` (which introduced the original "3 of 6" wording and the deferred-pre-condition gate).
+
+**Reproduction (confirms the canonical 6-row shape is correct):**
+```
+# Outside the framework repo:
+bash $REPO/init.sh --non-interactive --project foo --deployment personal \
+  --gov-mode private_poc --platform mcp_server --language typescript \
+  --track standard --project-dir "$PWD/foo" --git-host other \
+  --remote-url https://example.com/foo.git --branch-protection-attested \
+  --no-remote-creation
+# Set data_classification + zdr_attested in .claude/process-state.json
+jq '. + {"phase1_artifacts":{"data_classification":"internal","zdr_attested":true}}' \
+  foo/.claude/process-state.json > /tmp/p.json && mv /tmp/p.json foo/.claude/process-state.json
+( cd foo && bash $REPO/scripts/upgrade-project.sh --to-sponsored-poc --non-interactive )
+# Expect: APPROVAL_LOG.md contains 6 Pre-Phase-0 rows in org format.
+# Sponsored-required rows (1=AI deployment, 4=sponsor) are left BLANK in the
+# template — the operator fills them by hand or via subsequent approvals.
+grep -c '^| [0-9] |' foo/APPROVAL_LOG.md   # → 6
+```

--- a/tests/test-upgrade-to-production-preconditions.sh
+++ b/tests/test-upgrade-to-production-preconditions.sh
@@ -7,12 +7,15 @@
 # pre-conditions in APPROVAL_LOG.md are dated (or an operator
 # acknowledges them via --ack-preconditions in non-interactive mode).
 #
-# Canonical pre-condition split per docs/governance-framework.md:230 —
-# Sponsored POC defers 3 of 6 governance items (insurance, liability,
-# ITSM, backup maintainer; sponsor/AI-path/exit-criteria upfront).
-# Private POC defers all 6. Production requires all 6 cleared. Personal
-# deployments auto-fill the 6 rows via templates/generated/
-# approval-log-personal.tmpl and are exempt from the gate.
+# Canonical pre-condition split per docs/governance-framework.md §V —
+# Of the 6 blocking pre-conditions in APPROVAL_LOG.md Pre-Phase 0,
+# Sponsored POC requires rows 1,4 (AI deployment path, project sponsor)
+# upfront and defers rows 2,3,5,6 (insurance, liability, backup
+# maintainer, ITSM). Exit criteria (§XIV item #8) is tracked separately
+# outside this table. Private POC defers all 6. Production requires all
+# 6 cleared. Personal deployments auto-fill the 6 rows via
+# templates/generated/approval-log-personal.tmpl and are exempt from
+# the gate.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"


### PR DESCRIPTION
## Summary

- Adversarial dogfood re-walk (2026-06-29) flagged `migration-private-poc-personal-to-sponsored-poc-org` as `partial`. The matrix's expected_terminal_state said "APPROVAL_LOG restructured with the 3 Sponsored-required rows visible" but the actual file contains all 6 rows.
- Investigation: **interpretation #2 (documentation inconsistency)**. The product behaviour is the canonical contract; the matrix wording (and a thin trail of doc/code/test-comment citations) carried the confused "3 of 6 / deferred 3" framing from §V row 246.
- This PR tightens the wording in the canonical doc, the upgrade-blocked error message, and the test comment block. No product-code change. Filed BL-058 as Won't Fix.

## What the canonical contract actually is

- `APPROVAL_LOG.md` Pre-Phase-0 table is always **6 rows** in org-format (matches `templates/generated/approval-log-org.tmpl:20-27`).
- Sponsored POC requires **rows 1, 4** (AI deployment path, sponsor) dated upfront — 2 of the 6 blocking pre-conditions from §XIV.
- Sponsored POC defers **rows 2, 3, 5, 6** (insurance, liability, backup, ITSM) until `--to-production` clears them.
- Exit criteria is §XIV item #8 and is tracked outside the `APPROVAL_LOG.md` table.

## Changes

| File | Change |
|---|---|
| `docs/governance-framework.md` §V row 246 | Rewrite Sponsored POC cell to remove "5 of 6 minus the 3 required = the remainder" gibberish and state explicitly: rows 1,4 upfront, rows 2,3,5,6 deferred, exit criteria outside the table, all 6 rows visible. |
| `scripts/upgrade-project.sh:888` | Tighten `--to-production` blocked error from "Sponsored POC deferred 3" to "Sponsored POC requires rows 1,4 upfront and defers rows 2,3,5,6" so operators read the correct row numbers. |
| `tests/test-upgrade-to-production-preconditions.sh:10-15` | Rewrite the comment block to match the canonical split. Comment-only — no functional change, test still passes 6/6. |
| `solo-orchestrator-backlog.md` | File BL-058 (Won't Fix). Body includes file:line citations to the org template, the upgrade restructure block, the test fixture, and §V, plus a reproducer command. |

## What was NOT changed

`scripts/upgrade-project.sh:1503-1672` (the personal→organizational APPROVAL_LOG restructure block) is unchanged because it already implements the canonical contract — it writes all 6 rows in org format.

## Test plan

- [x] `bash tests/test-upgrade-to-production-preconditions.sh` — 6/6 PASS (comment change only).
- [x] `bash scripts/lint-counter-antipattern.sh` — OK.
- [x] `bash scripts/lint-backlog-references.sh --base origin/main` — OK (BL-058 entry follows the canonical schema).
- [x] `bash scripts/lint-fix-functions-stderr.sh` — OK.
- [x] `bash scripts/lint-raw-read-prompt.sh` — OK.
- [x] `bash scripts/lint-fixture-envelopes.sh tests` — OK.
- [x] Manual reproducer (in BL-058 body) — confirmed `APPROVAL_LOG.md` has 6 rows after `--to-sponsored-poc`, matching the new wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)