### PR TITLE
fix(edge-cases-tests): rewrite E31/E32/E39 to invoke real product code (BL-036)

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -920,7 +920,7 @@ Notable orphans (non-exhaustive — full list in `Reports/2026-06-28-test-integr
 **Logged:** 2026-06-28 (test integrity audit)
 **Category:** Bug / test integrity
 **Severity:** Critical
-**Status:** Open
+**Status:** Closed (2026-06-29, PR #110, commit `66da15c`)
 
 Three tests in the edge-cases suite are tautological by construction. The corresponding product behaviors have **zero regression coverage** on `main` — a regression could be merged today with no signal.
 

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1089,9 +1089,15 @@ if ! _uat_real_init_light_impl "$_uat_work" "desktop" "e31-upgrade"; then
 else
   _proj="$_uat_work/e31-upgrade"
   _uat_seed_intake_progress "$_proj" "desktop"
-  # Regression to "pre-migration" state: clobber the source template and
+  # Regression to "pre-migration" state: clobber the source template
+  # with a stub that DOES NOT contain the production placeholder, then
   # delete the reference pair so the upgrade has visible work to do.
-  echo "<!-- OLD TEMPLATE: no __TESTER_PRE_FLIGHT__ placeholder -->" \
+  # BL-036 fix: the prior stub embedded '__TESTER_PRE_FLIGHT__' in its
+  # comment text, which trivially satisfied the post-condition grep
+  # even when upgrade-project.sh's UAT migration block was disabled
+  # (mutation-test escape). The new stub uses a string that cannot
+  # collide with the production marker.
+  echo "OLD STUB TEMPLATE - pre-migration sentinel" \
     > "$_proj/tests/uat/templates/test-session-template.html"
   rm -f "$_proj/tests/uat/examples/pre-flight-reference.html" \
         "$_proj/tests/uat/examples/scenario-reference.json"
@@ -1101,13 +1107,23 @@ else
   ( cd "$_proj" && \
     bash "$REPO_DIR/scripts/upgrade-project.sh" \
         --non-interactive --track standard ) > "$_uat_work/upgrade-e31.log" 2>&1 || true
-  if grep -q '__TESTER_PRE_FLIGHT__' "$_proj/tests/uat/templates/test-session-template.html" && \
+  # Positive assertion: production template is multi-hundred lines and
+  # contains the __TESTER_PRE_FLIGHT__ placeholder at least twice
+  # (canonical shape from templates/uat/test-session-template.html).
+  # BL-036: pin the count, not just presence, so a stub that mentions
+  # the placeholder string once still flips RED.
+  e31_tpl="$_proj/tests/uat/templates/test-session-template.html"
+  e31_count=0
+  if [ -f "$e31_tpl" ]; then
+    e31_count=$(grep -c '__TESTER_PRE_FLIGHT__' "$e31_tpl" 2>/dev/null) || e31_count=0
+  fi
+  if [ "$e31_count" -ge 2 ] && \
      [ -f "$_proj/tests/uat/examples/pre-flight-reference.html" ] && \
      [ -f "$_proj/tests/uat/examples/scenario-reference.json" ] && \
      grep -qi 'terminal\|project root\|venv\|runtime' "$_proj/tests/uat/examples/pre-flight-reference.html"; then
-    pass "E31: real upgrade-project.sh UAT migration refreshes stub template + reference pair"
+    pass "E31: real upgrade-project.sh UAT migration refreshes stub template + reference pair (placeholder count=$e31_count, expected >=2)"
   else
-    fail "E31: upgrade-project.sh UAT migration didn't restore template/refs (log: $_uat_work/upgrade-e31.log)"
+    fail "E31: upgrade-project.sh UAT migration didn't restore template/refs (placeholder count=$e31_count; log: $_uat_work/upgrade-e31.log)"
   fi
 fi
 rm -rf "$_uat_work"

--- a/tests/edge-cases-upgrade-input.sh
+++ b/tests/edge-cases-upgrade-input.sh
@@ -938,42 +938,79 @@ rm -rf "$TEST_DIR/e38_escaped_marker" 2>/dev/null || true
 # ================================================================
 # E39: Newlines in text input
 # ================================================================
+# BL-036 (S1 Critical) closure: the pre-fix version (a) bypassed
+# production save_answer via the SAVE_ANSWER_PY shadow helper, and
+# (b) had both branches of the inner if/else call pass(), so a
+# regression that silently dropped the newline still PASSed.
+#
+# This rewrite sources the production scripts/intake-wizard.sh
+# (made sourceable via the __SOLO_INTAKE_WIZARD_SOURCED__ main-guard at
+# scripts/intake-wizard.sh:30-313) and invokes the real save_answer()
+# at scripts/intake-wizard.sh:463-480. It pins the canonical contract:
+#
+#   In:   $'line1\nline2'       (length 11; embedded LF)
+#   Out:  data['answers']['description'] == 'line1\nline2'
+#         (exact equality — length 11; the LF survives the JSON
+#         round-trip as a real newline, not a stripped char and not
+#         a literal backslash-n).
+#
+# Mutation discipline (BL-036): break save_answer (e.g.
+# `value = value.replace('\n', ' ')` mid-write) and this assertion
+# must flip RED. Restore and it returns GREEN.
 section "E39: Newlines in text input"
 
 E39_DIR="$TEST_DIR/e39"
 create_input_test_env "$E39_DIR"
 
-# Use a Python script to call save_answer with actual newline in value,
-# since bash $'...' passing through sys.argv is the real code path.
-result=0
-python3 "$SAVE_ANSWER_PY" "description" $'line1\nline2' "$E39_DIR/.claude/intake-progress.json" 2>"$TEST_DIR/e39_stderr.txt" || result=$?
+# Subshell-isolated: source the real intake-wizard.sh, set
+# PROGRESS_FILE, and call the production save_answer with an embedded
+# LF. Run/exit code captured via $?.
+(
+  cd "$E39_DIR"
+  # shellcheck disable=SC1091
+  source "$REPO_DIR/scripts/intake-wizard.sh"
+  PROGRESS_FILE="$E39_DIR/.claude/intake-progress.json"
+  save_answer "description" $'line1\nline2'
+) 2>"$TEST_DIR/e39_stderr.txt"
+result=$?
 
-if [ $result -eq 0 ]; then
-  json_valid=0
-  python3 -c "
-import json
-with open('$E39_DIR/.claude/intake-progress.json') as f:
-    json.load(f)
-" 2>/dev/null || json_valid=1
-
-  if [ $json_valid -eq 0 ]; then
-    saved_value=$(python3 -c "
-import json
-with open('$E39_DIR/.claude/intake-progress.json') as f:
-    data = json.load(f)
-v = data['answers'].get('description', 'MISSING')
-print(repr(v))
-" 2>/dev/null || echo "ERROR")
-    if echo "$saved_value" | grep -q "line1"; then
-      pass "E39: Newlines in input preserved in valid JSON: $saved_value"
-    else
-      pass "E39: Newlines in input handled (stored as: $saved_value)"
-    fi
-  else
-    fail "E39: Newlines in input broke JSON validity"
-  fi
+if [ $result -ne 0 ]; then
+  fail "E39: real save_answer crashed on newlines in input (exit $result; stderr: $(cat "$TEST_DIR/e39_stderr.txt"))"
 else
-  fail "E39: save_answer crashed on newlines in input (exit $result)"
+  # Single positive assertion: exact equality on the round-tripped
+  # value. Python compares the parsed in-memory string, so this
+  # catches all three regression classes simultaneously:
+  #   - newline stripped     -> got 'line1line2'      (len 10)
+  #   - newline -> space     -> got 'line1 line2'     (len 11, no LF)
+  #   - newline -> literal \n -> got 'line1\\nline2'  (len 12)
+  # Use --argjson + the canonical Python literal so test failure
+  # output is unambiguous.
+  e39_check=$(python3 - "$E39_DIR/.claude/intake-progress.json" <<'PYEOF'
+import json, sys
+path = sys.argv[1]
+expected = 'line1\nline2'
+try:
+    with open(path) as f:
+        data = json.load(f)
+except Exception as exc:
+    print(f"FAIL|json invalid: {exc}")
+    sys.exit(0)
+v = data.get('answers', {}).get('description')
+if v == expected:
+    # length must be 11 and the 6th char must be a real LF
+    if len(v) == 11 and v[5] == '\n':
+        print("PASS")
+    else:
+        print(f"FAIL|shape mismatch: repr={v!r} len={len(v)}")
+else:
+    print(f"FAIL|value mismatch: repr={v!r} (expected {expected!r})")
+PYEOF
+)
+  if [ "$e39_check" = "PASS" ]; then
+    pass "E39: real save_answer round-trips embedded LF byte-exact (canonical shape: 'line1\\nline2', len=11)"
+  else
+    fail "E39: real save_answer broke newline-preservation contract: ${e39_check#FAIL|}"
+  fi
 fi
 
 # ================================================================


### PR DESCRIPTION
## Summary

- Rewrites three tautological tests in the edge-cases suite (E31, E32, E39) so each one now invokes the real product code path it claims to cover.
- E31 and E32 drive `scripts/upgrade-project.sh`'s real UAT migration block; E39 drives the production `save_answer()` in `scripts/intake-wizard.sh` via the existing main-guard.
- Each rewrite is mutation-proven: a deliberate product-code mutation flips the test RED with an explicit shape diff; restoration returns it to GREEN.
- BL-058 contract (sponsored-POC APPROVAL_LOG = 6 visible rows) is unaffected — these tests don't touch the APPROVAL_LOG path.
- Closes BL-036 (S1 Critical).

## Tests rewritten

**E31 — `tests/edge-cases-scripts.sh` (BL-009 Case 6) — UAT upgrade refreshes templates**

Before: the negative-control stub embedded the literal placeholder string `__TESTER_PRE_FLIGHT__` inside its comment text, so the post-condition `grep -q '__TESTER_PRE_FLIGHT__'` was trivially satisfied even when `upgrade-project.sh`'s UAT template-copy block was disabled — a mutation-test escape on top of the original audit finding.

After: stub reads `OLD STUB TEMPLATE - pre-migration sentinel` (no collision with the production marker). Assertion counts placeholder occurrences and requires `>= 2`, matching the canonical production-template shape at `templates/uat/test-session-template.html`. Counter-capture uses the outer-OR idiom (`var=$(...) || var=0`) per PR #72's canonical pattern, so `lint-counter-antipattern.sh` passes.

**E32 — `tests/edge-cases-scripts.sh` (BL-009 Case 7) — UAT upgrade migration is idempotent**

Assertion shape was already correct (snapshot/diff of project-side `tests/uat` between two real upgrade-project.sh runs — `light→standard` then `standard→full`). Mutation-proven for the first time in this PR. No code change to the test itself; the mutation evidence below is what closes the audit finding for E32.

**E39 — `tests/edge-cases-upgrade-input.sh` — newlines preserved**

Before: bypassed production `save_answer` via the `SAVE_ANSWER_PY` shadow helper; both branches of the inner if/else called `pass()`, so a regression that silently dropped the newline still PASSed via the else-branch `handled (stored as: ...)`.

After: single positive assertion that sources `scripts/intake-wizard.sh` (via the existing `__SOLO_INTAKE_WIZARD_SOURCED__` main-guard) and invokes the production `save_answer` directly. Pins the canonical contract: `$'line1\nline2'` (len 11, embedded LF) -> `data['answers']['description'] == 'line1\nline2'` exact equality. Catches all three regression classes (strip / replace-with-space / replace-with-literal-`\n`) with an unambiguous failure message.

## Mutation proofs

| Test | Mutation applied | RED output excerpt | Restoration |
|------|------------------|--------------------|-------------|
| E31  | Commented out the source-template `cp` block in `scripts/upgrade-project.sh:2156-2162` (UAT migration). | `[FAIL] E31: ... didn't restore template/refs (count=0, log: .../upgrade-e31.log)` | Restored byte-clean (diff against backup empty); E31 back to GREEN with `count=2`. |
| E32  | Appended `echo "<!-- migration-run-stamp: $(date +%s%N) -->" >> tests/uat/templates/test-session-template.html` inside the same migration block (non-idempotent appender). | `[FAIL] E32: ... is NOT idempotent` plus explicit diff: `-<!-- migration-run-stamp: 1782782592467151000 -->` / `+<!-- migration-run-stamp: 1782782620992887000 -->` | Restored byte-clean; E32 back to GREEN. |
| E39  | Added `value = value.replace('\n', ' ')` inside `save_answer`'s Python heredoc at `scripts/intake-wizard.sh:470-479`. | `[FAIL] E39: real save_answer broke newline-preservation contract: value mismatch: repr='line1 line2' (expected 'line1\nline2')` | Restored byte-clean; E39 back to GREEN. |

All four CI lints exit 0 with the production code restored:
- `bash scripts/lint-counter-antipattern.sh` -> OK
- `bash scripts/lint-backlog-references.sh` -> OK
- `bash scripts/lint-fix-functions-stderr.sh` -> OK
- `bash scripts/lint-raw-read-prompt.sh` -> OK

`tests/edge-cases-upgrade-input.sh` -> 19/19 PASS. `tests/edge-cases-scripts.sh` -> E31 PASS (`count=2`), E32 PASS, alongside the pre-existing unrelated E30 FAIL (init.sh `--platform other`) that's already on main.

## Worktree note

This work was done in an isolated git worktree at `.claude/worktrees/wf_a8878e69-3d3-1` (orchestrator-spawned). Mutations were applied and reverted in that worktree only; `scripts/upgrade-project.sh` and `scripts/intake-wizard.sh` are byte-identical to `main` in the final commit. BL-036's `**Status:**` flip in `solo-orchestrator-backlog.md` is deferred to a follow-up commit on this branch so the real PR # and short SHA can be substituted in (the citation-hygiene lint rejects literal placeholder text). DO NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)