### PR TITLE
fix(tests): rewrite 15 major vacuous assertions (closes BL-037)

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -949,7 +949,7 @@ Both branches of the inner if/else call pass(). A regression that silently strip
 **Logged:** 2026-06-28 (test integrity audit)
 **Category:** Bug / test integrity
 **Severity:** High
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #115, commit `359c714`)
 
 15 major-severity findings across edge-cases, verify-install, prompt-install, snapshot-retention, intake-wizard, and self-approval tests use either catch-all `else pass: handled` branches or negative-only oracles (`! grep -q deny`, no positive assertion). Each will silently pass on a crash or on garbage output.
 

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -204,17 +204,33 @@ rm -f "$E12_DIR/CLAUDE.md"
 result=0
 output=$( cd "$E12_DIR" && bash "$E12_DIR/scripts/resume.sh" 2>&1 </dev/null ) || result=$?
 
-# resume.sh should handle missing CLAUDE.md gracefully (not crash)
-# It may still run but show "(not found in CLAUDE.md)" for fields
-if [ "$result" -eq 0 ]; then
-  pass "E12a: resume.sh exits cleanly with missing CLAUDE.md (exit 0)"
-else
-  # Even a non-zero exit is acceptable as long as it didn't crash with a bash error
-  if echo "$output" | grep -qE "unbound variable|syntax error|command not found"; then
-    fail "E12a: resume.sh crashed with bash error when CLAUDE.md missing"
-  else
-    pass "E12a: resume.sh exited non-zero but handled missing CLAUDE.md gracefully (exit $result)"
-  fi
+# BL-037 closure: pre-fix oracle had a three-way structure where the
+# catch-all `else pass` (line 216 pre-fix) accepted any non-zero exit
+# whose stderr lacked the four magic shell-error keywords. A regression
+# where resume.sh silently truncated its prompt output mid-stream still
+# PASSed. Pin the positive contract:
+#   (1) exit 0 (resume.sh has no required-input branch — missing
+#       CLAUDE.md falls through to "(not found in CLAUDE.md)" defaults).
+#   (2) Output contains the prompt template end marker
+#       "End of resume prompt" — proves the script reached the prompt's
+#       tail and did not early-exit silently mid-output.
+#   (3) Output contains "(not found in CLAUDE.md)" — proves the
+#       fallback path actually fired (defaults rendered into prompt).
+e12a_ok=1
+if [ "$result" -ne 0 ]; then
+  fail "E12a: resume.sh must exit 0 with missing CLAUDE.md (got exit $result)"
+  e12a_ok=0
+fi
+if ! echo "$output" | grep -qF "End of resume prompt"; then
+  fail "E12a: resume.sh prompt-template tail marker absent — script bailed mid-output"
+  e12a_ok=0
+fi
+if ! echo "$output" | grep -qF "(not found in CLAUDE.md)"; then
+  fail "E12a: resume.sh missing-CLAUDE fallback string '(not found in CLAUDE.md)' not emitted"
+  e12a_ok=0
+fi
+if [ "$e12a_ok" -eq 1 ]; then
+  pass "E12a: resume.sh exit=0, prompt tail emitted, and (not found in CLAUDE.md) fallback fired"
 fi
 
 # Test with empty CLAUDE.md
@@ -225,10 +241,24 @@ create_test_project "$E12B_DIR"
 result=0
 output=$( cd "$E12B_DIR" && bash "$E12B_DIR/scripts/resume.sh" 2>&1 </dev/null ) || result=$?
 
-if echo "$output" | grep -qE "unbound variable|syntax error|command not found"; then
-  fail "E12b: resume.sh crashed with bash error on empty CLAUDE.md"
-else
-  pass "E12b: resume.sh handles empty CLAUDE.md without crashing"
+# BL-037 closure: empty CLAUDE.md exercises the same fallback as
+# missing CLAUDE.md (grep returns nothing → default placeholder).
+# Same positive contract as E12a.
+e12b_ok=1
+if [ "$result" -ne 0 ]; then
+  fail "E12b: resume.sh must exit 0 with empty CLAUDE.md (got exit $result)"
+  e12b_ok=0
+fi
+if ! echo "$output" | grep -qF "End of resume prompt"; then
+  fail "E12b: resume.sh prompt-template tail marker absent — script bailed mid-output"
+  e12b_ok=0
+fi
+if ! echo "$output" | grep -qF "(not found in CLAUDE.md)"; then
+  fail "E12b: resume.sh empty-CLAUDE fallback string '(not found in CLAUDE.md)' not emitted"
+  e12b_ok=0
+fi
+if [ "$e12b_ok" -eq 1 ]; then
+  pass "E12b: resume.sh exit=0, prompt tail emitted, and (not found in CLAUDE.md) fallback fired"
 fi
 
 
@@ -899,34 +929,79 @@ cat > "$E25_DIR/.claude/phase-state.json" << 'EOF'
 }
 EOF
 
-# Test validate.sh — should not crash
+# BL-037 closure: pre-fix oracle for E25a/b/c was a magic-keyword
+# negative oracle (`grep -qE "unbound variable|syntax error|command not
+# found"`) that PASSed on any output not matching those four strings —
+# including a silent early-bail before phase 99 was ever inspected.
+# Pin POSITIVE substrings that prove the script (a) actually read the
+# phase-state file, (b) recognized the bogus phase 99 value, and (c)
+# reached a known sub-section that depends on the phase value.
+
+# Test validate.sh — should not crash AND must echo the parsed phase 99.
 result=0
 output=$( cd "$E25_DIR" && bash "$E25_DIR/scripts/validate.sh" 2>&1 </dev/null ) || result=$?
 
+e25a_ok=1
 if echo "$output" | grep -qE "unbound variable|syntax error|command not found"; then
   fail "E25a: validate.sh crashed with bash error on phase 99"
-else
-  pass "E25a: validate.sh does not crash with current_phase=99"
+  e25a_ok=0
+fi
+# validate.sh:158 prints `[INFO] Project phase: <N> (source: phase-state.json)`
+# and earlier echoes `[OK] Phase state file found (current_phase: <N>)`.
+# Either is a positive proof that the script read the file and parsed
+# the value as 99.
+if ! echo "$output" | grep -qE "(current_phase:[[:space:]]*99|Project phase:[[:space:]]*99)"; then
+  fail "E25a: validate.sh did not echo parsed current_phase=99 (script did not reach phase-state inspection)"
+  e25a_ok=0
+fi
+if [ "$e25a_ok" -eq 1 ]; then
+  pass "E25a: validate.sh parsed and echoed current_phase=99 without bash error"
 fi
 
-# Test check-phase-gate.sh — should not crash
+# Test check-phase-gate.sh — should not crash AND must explicitly
+# reference current_phase=99 in at least one WARN about an unrecorded
+# gate (the script's behavior at phase >=1 echoes the parsed phase
+# back in `Phase N→M: current_phase is <N>` messages).
 result=0
 output=$( cd "$E25_DIR" && bash "$E25_DIR/scripts/check-phase-gate.sh" 2>&1 </dev/null ) || result=$?
 
+e25b_ok=1
 if echo "$output" | grep -qE "unbound variable|syntax error|command not found"; then
   fail "E25b: check-phase-gate.sh crashed with bash error on phase 99"
-else
-  pass "E25b: check-phase-gate.sh does not crash with current_phase=99"
+  e25b_ok=0
+fi
+# check-phase-gate.sh:158 prints `Current phase: <N>` and the
+# Phase 1→2/2→3/3→4 sub-checks each echo `current_phase is 99` when
+# the gate date is missing. Either path proves the script read 99 and
+# routed into the phase>=1 branch.
+if ! echo "$output" | grep -qE "(Current phase:[[:space:]]*99|current_phase is 99)"; then
+  fail "E25b: check-phase-gate.sh did not echo parsed phase 99 (script did not reach gate inspection)"
+  e25b_ok=0
+fi
+if [ "$e25b_ok" -eq 1 ]; then
+  pass "E25b: check-phase-gate.sh parsed phase=99 and routed into gate inspection without bash error"
 fi
 
-# Test resume.sh — should not crash
+# Test resume.sh — should exit 0 AND emit "**Phase:** 99" in the prompt
+# (proves the parsed phase reached the template substitution).
 result=0
 output=$( cd "$E25_DIR" && bash "$E25_DIR/scripts/resume.sh" 2>&1 </dev/null ) || result=$?
 
+e25c_ok=1
 if echo "$output" | grep -qE "unbound variable|syntax error|command not found"; then
   fail "E25c: resume.sh crashed with bash error on phase 99"
-else
-  pass "E25c: resume.sh does not crash with current_phase=99"
+  e25c_ok=0
+fi
+if [ "$result" -ne 0 ]; then
+  fail "E25c: resume.sh must exit 0 on phase 99 (graceful render); got exit $result"
+  e25c_ok=0
+fi
+if ! echo "$output" | grep -qE '\*\*Phase:\*\*[[:space:]]*99'; then
+  fail "E25c: resume.sh did not render '**Phase:** 99' in prompt — value did not reach template"
+  e25c_ok=0
+fi
+if [ "$e25c_ok" -eq 1 ]; then
+  pass "E25c: resume.sh exit=0 and rendered '**Phase:** 99' into the resume prompt"
 fi
 
 
@@ -995,14 +1070,23 @@ else
 fi
 rm -rf "$_uat_work"
 
+# BL-037 closure (E27/E28/E29): the audit flagged asymmetry between
+# E26 (which checks BOTH `pre-flight-reference.html` AND
+# `scenario-reference.json`) and E27/E28/E29 (which only checked
+# `pre-flight-reference.html`). A regression in init.sh's UAT copy
+# block that dropped the scenario-reference.json copy would have left
+# E27/E28/E29 silently green. Each case below now asserts both halves
+# of the reference pair as a hard requirement, mirroring E26's shape.
+
 # Case 2: real init.sh for desktop
 _uat_work=$(mktemp -d)
 if _uat_real_init "$_uat_work" "desktop" "e27-desktop" && \
    [ -f "$_uat_work/e27-desktop/tests/uat/examples/pre-flight-reference.html" ] && \
+   [ -f "$_uat_work/e27-desktop/tests/uat/examples/scenario-reference.json" ] && \
    grep -qi 'terminal\|project root\|venv\|runtime' "$_uat_work/e27-desktop/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E27: real init.sh --platform desktop copies desktop-specific UAT reference pair"
+  pass "E27: real init.sh --platform desktop copies desktop-specific UAT reference pair (BOTH halves: pre-flight-reference.html + scenario-reference.json)"
 else
-  fail "E27: real init.sh --platform desktop failed (log: $_uat_work/init-desktop.log)"
+  fail "E27: real init.sh --platform desktop failed — refs missing (one or both halves of the pair) or pre-flight not desktop-specific (log: $_uat_work/init-desktop.log)"
 fi
 rm -rf "$_uat_work"
 
@@ -1010,10 +1094,11 @@ rm -rf "$_uat_work"
 _uat_work=$(mktemp -d)
 if _uat_real_init "$_uat_work" "mobile" "e28-mobile" && \
    [ -f "$_uat_work/e28-mobile/tests/uat/examples/pre-flight-reference.html" ] && \
+   [ -f "$_uat_work/e28-mobile/tests/uat/examples/scenario-reference.json" ] && \
    grep -qi 'device\|simulator\|testflight\|android' "$_uat_work/e28-mobile/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E28: real init.sh --platform mobile copies mobile-specific UAT reference pair"
+  pass "E28: real init.sh --platform mobile copies mobile-specific UAT reference pair (BOTH halves: pre-flight-reference.html + scenario-reference.json)"
 else
-  fail "E28: real init.sh --platform mobile failed (log: $_uat_work/init-mobile.log)"
+  fail "E28: real init.sh --platform mobile failed — refs missing (one or both halves of the pair) or pre-flight not mobile-specific (log: $_uat_work/init-mobile.log)"
 fi
 rm -rf "$_uat_work"
 
@@ -1021,10 +1106,11 @@ rm -rf "$_uat_work"
 _uat_work=$(mktemp -d)
 if _uat_real_init "$_uat_work" "mcp_server" "e29-mcp" && \
    [ -f "$_uat_work/e29-mcp/tests/uat/examples/pre-flight-reference.html" ] && \
+   [ -f "$_uat_work/e29-mcp/tests/uat/examples/scenario-reference.json" ] && \
    grep -qi 'mcp\|inspector\|json-rpc\|tool call' "$_uat_work/e29-mcp/tests/uat/examples/pre-flight-reference.html"; then
-  pass "E29: real init.sh --platform mcp_server copies mcp-specific UAT reference pair"
+  pass "E29: real init.sh --platform mcp_server copies mcp-specific UAT reference pair (BOTH halves: pre-flight-reference.html + scenario-reference.json)"
 else
-  fail "E29: real init.sh --platform mcp_server failed (log: $_uat_work/init-mcp_server.log)"
+  fail "E29: real init.sh --platform mcp_server failed — refs missing (one or both halves of the pair) or pre-flight not mcp-specific (log: $_uat_work/init-mcp_server.log)"
 fi
 rm -rf "$_uat_work"
 

--- a/tests/edge-cases-upgrade-input.sh
+++ b/tests/edge-cases-upgrade-input.sh
@@ -626,19 +626,28 @@ result=0
 python3 "$SAVE_ANSWER_PY" "project_name" "'; DROP TABLE users; --" "$E33_DIR/.claude/intake-progress.json" 2>"$TEST_DIR/e33_stderr.txt" || result=$?
 
 if [ $result -eq 0 ]; then
+  # BL-037 closure: the pre-fix oracle had a catch-all `else pass`
+  # ("was sanitized to: ...") that accepted ANY non-empty/non-MISSING
+  # value as success. A regression that silently truncated the payload
+  # to a single character (e.g. "'") would have PASSed. The helper
+  # SAVE_ANSWER_PY does NO sanitization — it assigns the raw string
+  # to data['answers'][key] and serializes via json.dump. JSON's
+  # string-quoting handles the apostrophe / semicolons safely.
+  # The pinned contract is therefore EXACT round-trip equality:
+  # input bytes == stored bytes. Any drift (truncation, partial
+  # sanitization, mojibake) flips RED.
   saved_value=$(python3 -c "
 import json
 with open('$E33_DIR/.claude/intake-progress.json') as f:
     data = json.load(f)
-print(data['answers'].get('project_name', 'MISSING'))
+v = data['answers'].get('project_name', 'MISSING')
+print(v)
 " 2>/dev/null || echo "JSON_PARSE_ERROR")
 
   if [ "$saved_value" = "'; DROP TABLE users; --" ]; then
-    pass "E33: SQL injection payload stored literally (no injection, JSON safe)"
-  elif [ "$saved_value" = "MISSING" ] || [ "$saved_value" = "JSON_PARSE_ERROR" ]; then
-    fail "E33: SQL injection payload corrupted JSON or was not stored"
+    pass "E33: SQL injection payload stored byte-exact (input bytes == stored bytes, JSON-quoting safe)"
   else
-    pass "E33: SQL injection payload was sanitized to: '$saved_value'"
+    fail "E33: SQL injection payload not stored byte-exact — got: '$saved_value' (expected literal \"'; DROP TABLE users; --\")"
   fi
 else
   fail "E33: save_answer crashed on SQL injection payload (exit $result)"
@@ -658,6 +667,12 @@ result=0
 python3 "$SAVE_ANSWER_PY" "description" "$LONG_DESC" "$E34_DIR/.claude/intake-progress.json" 2>"$TEST_DIR/e34_stderr.txt" || result=$?
 
 if [ $result -eq 0 ]; then
+  # BL-037 closure: pre-fix `elif [ "$saved_len" -gt 0 ]` catch-all
+  # would PASS on truncation to a single character. Pin the exact
+  # length: SAVE_ANSWER_PY does no truncation (no documented cap on
+  # description length in the helper), so the contract is byte-exact
+  # preservation. Also assert byte-exact first/last chars to catch a
+  # regression that happens to preserve length but corrupts content.
   saved_len=$(python3 -c "
 import json
 with open('$E34_DIR/.claude/intake-progress.json') as f:
@@ -665,12 +680,20 @@ with open('$E34_DIR/.claude/intake-progress.json') as f:
 print(len(data['answers'].get('description', '')))
 " 2>/dev/null || echo "0")
 
-  if [ "$saved_len" = "10000" ]; then
-    pass "E34: 10,000-char description stored in full ($saved_len chars)"
-  elif [ "$saved_len" -gt 0 ] 2>/dev/null; then
-    pass "E34: 10,000-char description truncated gracefully to $saved_len chars"
+  saved_signature=$(python3 -c "
+import json
+with open('$E34_DIR/.claude/intake-progress.json') as f:
+    data = json.load(f)
+v = data['answers'].get('description', '')
+# First/last chars + uniform-A check: input is 10000 'A's; any mutation
+# (truncate, partial-corrupt) flips the signature.
+print('len={} first={} last={} all_A={}'.format(len(v), v[:1] or 'EMPTY', v[-1:] or 'EMPTY', all(c == 'A' for c in v) if v else False))
+" 2>/dev/null || echo "SIGNATURE_ERROR")
+
+  if [ "$saved_len" = "10000" ] && [ "$saved_signature" = "len=10000 first=A last=A all_A=True" ]; then
+    pass "E34: 10,000-char description stored byte-exact (len=10000, all 'A' bytes preserved)"
   else
-    fail "E34: 10,000-char description lost or corrupted"
+    fail "E34: 10,000-char description not stored byte-exact — len=$saved_len signature='$saved_signature' (expected len=10000, all-A)"
   fi
 else
   fail "E34: save_answer crashed on 10,000-char description (exit $result)"
@@ -789,19 +812,36 @@ result=0
 python3 "$SAVE_ANSWER_PY" "project_name" "プロジェクト" "$E36_DIR/.claude/intake-progress.json" 2>"$TEST_DIR/e36_stderr.txt" || result=$?
 
 if [ $result -eq 0 ]; then
-  saved_value=$(python3 -c "
-import json
-with open('$E36_DIR/.claude/intake-progress.json') as f:
-    data = json.load(f)
-print(data['answers'].get('project_name', 'MISSING'))
-" 2>/dev/null || echo "ERROR")
-
-  if [ "$saved_value" = "プロジェクト" ]; then
-    pass "E36: Unicode project name stored correctly"
-  elif [ "$saved_value" = "MISSING" ] || [ "$saved_value" = "ERROR" ]; then
-    fail "E36: Unicode project name was lost or corrupted"
+  # BL-037 closure: pre-fix catch-all `else pass: handled (stored as:
+  # ...)` allowed mojibake or any non-empty/non-MISSING/non-ERROR
+  # string to PASS — a regression that encoded as 0xE3,0x83,0x97 with
+  # a stripped suffix would still PASS. Pin the EXACT UTF-8 roundtrip.
+  # Read via python3 directly with explicit unicode comparison so the
+  # bash string layer cannot mask byte-level corruption.
+  e36_check=$(python3 - "$E36_DIR/.claude/intake-progress.json" <<'PYEOF'
+import json, sys
+expected = 'プロジェクト'
+expected_bytes = expected.encode('utf-8')
+try:
+    with open(sys.argv[1], 'rb') as f:
+        raw = f.read()
+    data = json.loads(raw.decode('utf-8'))
+except Exception as exc:
+    print(f"FAIL|json invalid: {exc}")
+    sys.exit(0)
+v = data.get('answers', {}).get('project_name')
+if v != expected:
+    print(f"FAIL|value mismatch: repr={v!r} (expected {expected!r})")
+elif v.encode('utf-8') != expected_bytes:
+    print(f"FAIL|utf-8 mismatch: bytes={v.encode('utf-8')!r} (expected {expected_bytes!r})")
+else:
+    print("PASS")
+PYEOF
+)
+  if [ "$e36_check" = "PASS" ]; then
+    pass "E36: Unicode project name stored byte-exact (UTF-8 roundtrip == 'プロジェクト')"
   else
-    pass "E36: Unicode project name handled (stored as: '$saved_value')"
+    fail "E36: Unicode roundtrip broken: ${e36_check#FAIL|}"
   fi
 else
   fail "E36: save_answer crashed on Unicode project name (exit $result)"
@@ -819,19 +859,35 @@ result=0
 python3 "$SAVE_ANSWER_PY" "description" "Build a 🚀 app" "$E37_DIR/.claude/intake-progress.json" 2>"$TEST_DIR/e37_stderr.txt" || result=$?
 
 if [ $result -eq 0 ]; then
-  saved_value=$(python3 -c "
-import json
-with open('$E37_DIR/.claude/intake-progress.json') as f:
-    data = json.load(f)
-print(data['answers'].get('description', 'MISSING'))
-" 2>/dev/null || echo "ERROR")
-
-  if [ "$saved_value" = "Build a 🚀 app" ]; then
-    pass "E37: Emoji in description stored literally"
-  elif [ "$saved_value" = "MISSING" ] || [ "$saved_value" = "ERROR" ]; then
-    fail "E37: Emoji in description was lost"
+  # BL-037 closure: pre-fix catch-all `else pass: handled (stored as:
+  # ...)` accepted any non-empty/non-MISSING/non-ERROR string. The
+  # 4-byte UTF-8 emoji is the regression-prone case (surrogate-pair
+  # mishandling, mojibake, byte truncation to U+0001F680 → "?"). Pin
+  # the EXACT UTF-8 roundtrip via python3 byte comparison.
+  e37_check=$(python3 - "$E37_DIR/.claude/intake-progress.json" <<'PYEOF'
+import json, sys
+expected = 'Build a 🚀 app'
+expected_bytes = expected.encode('utf-8')
+try:
+    with open(sys.argv[1], 'rb') as f:
+        raw = f.read()
+    data = json.loads(raw.decode('utf-8'))
+except Exception as exc:
+    print(f"FAIL|json invalid: {exc}")
+    sys.exit(0)
+v = data.get('answers', {}).get('description')
+if v != expected:
+    print(f"FAIL|value mismatch: repr={v!r} (expected {expected!r})")
+elif v.encode('utf-8') != expected_bytes:
+    print(f"FAIL|utf-8 mismatch: bytes={v.encode('utf-8')!r} (expected {expected_bytes!r})")
+else:
+    print("PASS")
+PYEOF
+)
+  if [ "$e37_check" = "PASS" ]; then
+    pass "E37: Emoji in description stored byte-exact (UTF-8 roundtrip preserves 4-byte 🚀)"
   else
-    pass "E37: Emoji in description handled (stored as: '$saved_value')"
+    fail "E37: Emoji roundtrip broken: ${e37_check#FAIL|}"
   fi
 else
   fail "E37: save_answer crashed on emoji in description (exit $result)"
@@ -1021,8 +1077,12 @@ section "E40: NUL bytes in text input"
 E40_DIR="$TEST_DIR/e40"
 create_input_test_env "$E40_DIR"
 
-# NUL bytes are stripped by bash before reaching sys.argv, so this becomes "testdata".
-# We verify the function handles this gracefully and produces valid JSON.
+# Bash's $'...\x00...' literal expansion produces a C-string that the
+# kernel's exec() truncates at the embedded NUL when building argv —
+# python3's sys.argv[1] therefore receives "test" (the prefix), not
+# "testdata" or "test\0data". The documented sanitization for E40 is
+# therefore: saved_value == "test". Pre-fix oracle's `grep -q "test"`
+# catch-all matched "tes", "best test", "test123abc", etc.
 result=0
 python3 "$SAVE_ANSWER_PY" "description" $'test\x00data' "$E40_DIR/.claude/intake-progress.json" 2>"$TEST_DIR/e40_stderr.txt" || result=$?
 
@@ -1035,18 +1095,23 @@ with open('$E40_DIR/.claude/intake-progress.json') as f:
 " 2>/dev/null || json_valid=1
 
   if [ $json_valid -eq 0 ]; then
+    # BL-037 closure: pre-fix catch-all `elif echo "$saved_value" | grep -q
+    # "test"` matched 'tes', 'best test', 'test123abc', etc. — silently
+    # accepting partial corruption. Bash strips NUL bytes from $'...\\x00...'
+    # literals before exec, so the documented sanitization is
+    # "stored == 'testdata'" (NUL byte removed by bash, JSON valid).
+    # Pin EXACT equality; anything else is corruption.
     saved_value=$(python3 -c "
 import json
 with open('$E40_DIR/.claude/intake-progress.json') as f:
     data = json.load(f)
-print(data['answers'].get('description', 'MISSING'))
-" 2>/dev/null || echo "ERROR")
-    if [ "$saved_value" = "testdata" ]; then
-      pass "E40: NUL byte stripped by shell -- 'testdata' stored, JSON valid"
-    elif echo "$saved_value" | grep -q "test"; then
-      pass "E40: NUL byte handled -- stored as: '$saved_value', JSON valid"
+v = data['answers'].get('description', 'MISSING')
+print(repr(v))
+" 2>/dev/null || echo "'ERROR'")
+    if [ "$saved_value" = "'test'" ]; then
+      pass "E40: kernel NUL-truncated argv — saved_value == 'test' byte-exact (documented sanitization)"
     else
-      fail "E40: NUL byte corrupted value: '$saved_value'"
+      fail "E40: NUL byte input did not produce documented 'test' result — got $saved_value"
     fi
   else
     fail "E40: NUL byte input broke JSON validity"

--- a/tests/test-check-phase-gate-self-approval.sh
+++ b/tests/test-check-phase-gate-self-approval.sh
@@ -130,15 +130,31 @@ write_phase_state_org
 write_log_with_approver "Karl Raulerson"
 commit_log_as "Jane Approver" "jane@example.com"
 out=$(run_gate_with_git_user "Karl Raulerson")
+# BL-037 closure: pre-fix oracle had a both-branches-pass shape — the
+# elif matched WARN output; the else (line 138-141) ALSO passed on
+# absence-of-message ("Acceptable: no message at all"). A regression
+# that silently dropped the WARN entirely still PASSed T3, leaving
+# the operator with no audit signal when ambient git user matches
+# approver but commit author does not (the exact "rewrote author
+# metadata" case baseline §5 invariant #9 cares about).
+#
+# scripts/check-phase-gate.sh:259-262 explicitly emits the WARN with
+# substring "ambient git user '<X>' matches approver '<X>'" whenever
+# git_user_norm == approver_norm AND commit_author_norm differs.
+# Pin that as a HARD requirement (no else-pass branch).
+t3_ok=1
 if echo "$out" | grep -qE "FAIL.*self-approval"; then
   fail_ "T3" "should not FAIL — commit author is different; out:
 $(echo "$out" | grep -E 'self-approval|Phase 0')"
-elif echo "$out" | grep -qE "WARN.*self-approval|WARN.*ambient.*git user"; then
-  pass "T3: WARN fires for ambient mismatch without FAIL"
-else
-  # Acceptable: no message at all (commit author authoritative). The
-  # WARN is a nice-to-have; primary requirement is no FAIL.
-  pass "T3: no FAIL emitted (commit-author authoritative)"
+  t3_ok=0
+fi
+if ! echo "$out" | grep -qE "\[WARN\].*ambient git user.*matches approver"; then
+  fail_ "T3" "expected [WARN] 'ambient git user ... matches approver ...' substring (audit signal for rewritten-author detection); not found in:
+$(echo "$out" | grep -E 'WARN|Phase 0' | head -10)"
+  t3_ok=0
+fi
+if [ "$t3_ok" -eq 1 ]; then
+  pass "T3: ambient-mismatch path emits [WARN] 'ambient git user ... matches approver ...' AND no FAIL (baseline §5 invariant #9 signal preserved)"
 fi
 teardown
 

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -76,11 +76,43 @@ while IFS= read -r tpl_line; do
     continue
   fi
   wiz_title=$(echo "$wiz_line" | sed -E 's/^[0-9]+:[[:space:]]*//')
-  # Loose title comparison: template title is canonical, wizard may shorten.
-  # Hard requirement: numbers must match.
+  # BL-037 closure: the pre-fix oracle compared `${wiz_line%%:*}` (i.e.
+  # the number prefix) to `$tpl_num` — but `wiz_line` was selected by
+  # awk's `$1 == n` filter, so by construction the number prefix is
+  # `$tpl_num`. The comparison was a tautology and the `wiz_title`
+  # variable computed on the line above was never consumed. A wizard
+  # entry like `print_step "Section 4: Compliance Audit"` against
+  # template `## 4. Features & Requirements` (number preserved, title
+  # corrupted) silently passed.
+  #
+  # New assertion: pin BOTH halves of the pair.
+  #   (a) Number prefix matches (preserves the pre-fix sanity check
+  #       — even though it was structurally redundant, future refactors
+  #       might change the awk filter).
+  #   (b) Title alignment: template title is canonical, wizard may
+  #       shorten the trailing qualifier (e.g. tpl "Distribution &
+  #       Operations Preferences" vs wiz "Distribution & Operations").
+  #       Accept iff (case-insensitive) the wizard title is a non-empty
+  #       prefix of the template title OR vice-versa. Any unrelated
+  #       drift (different leading words, swapped section bodies) fails.
   if [ "${wiz_line%%:*}" != "$tpl_num" ]; then
     fail_ "T1" "wizard section number drift at template §$tpl_num: wizard shows '$wiz_line'"
     drift_found=1
+  fi
+  if [ -z "$wiz_title" ]; then
+    fail_ "T1" "wizard §$tpl_num has empty title (template title: '$tpl_title')"
+    drift_found=1
+  else
+    wiz_title_lc=$(printf '%s' "$wiz_title" | tr '[:upper:]' '[:lower:]')
+    tpl_title_lc=$(printf '%s' "$tpl_title" | tr '[:upper:]' '[:lower:]')
+    # Case-insensitive bidirectional prefix match handles the wizard's
+    # documented shortening (e.g. drop trailing "Preferences"). Pure
+    # substring would over-match; require prefix.
+    if [ "${tpl_title_lc#"$wiz_title_lc"}" = "$tpl_title_lc" ] && \
+       [ "${wiz_title_lc#"$tpl_title_lc"}" = "$wiz_title_lc" ]; then
+      fail_ "T1" "wizard §$tpl_num title drift: wizard='$wiz_title' template='$tpl_title' (neither is a case-insensitive prefix of the other)"
+      drift_found=1
+    fi
   fi
 done <<<"$template_pairs"
 

--- a/tests/test-prompt-install-noninteractive.sh
+++ b/tests/test-prompt-install-noninteractive.sh
@@ -66,6 +66,21 @@ set -uo pipefail
 YELLOW=""; BOLD=""; NC=""; CYAN=""; GREEN=""; RED=""; BLUE=""
 # Source the real helpers.
 source "$HELPERS"
+# BL-037 closure: before sourcing helpers.sh, the prompt_install
+# invocation below would resolve to "command not found" (bash rc=127)
+# if helpers.sh (a) silently failed to source or (b) ever drops the
+# prompt_install function definition. The pre-fix oracle asserted
+# rc != 0 only, which silently accepted 127 as the "decline" code —
+# meaning a regression that removed prompt_install entirely PASSed
+# T1/T2/T3 vacuously. Guard with a hard precondition: prompt_install
+# MUST be defined as a function in the sourced helpers.sh.
+# Note: this comment intentionally avoids backticks because the heredoc
+# is unquoted (<<HARNESS) and bash would treat \`...\` as command
+# substitution during expansion, executing the wrapped tokens.
+if ! type prompt_install 2>/dev/null | grep -qE '^prompt_install is a function'; then
+  echo "HARNESS_PRECONDITION_FAIL: prompt_install is not a function after sourcing helpers.sh — exit 99 (this rules out the bash 127 case the pre-fix oracle accepted as success)"
+  exit 99
+fi
 # Replace eval with a function stub that records the install attempt.
 # Bash resolves user-defined functions before builtins, so this stub
 # takes precedence inside prompt_install's body. We CANNOT use
@@ -129,12 +144,24 @@ run_t() {
     fail_ "$name" "install command fired (marker exists) — eval was reached despite non-interactive context"
     failed=true
   fi
-  if [ "$rc" = "0" ]; then
-    fail_ "$name" "prompt_install returned 0 — must return nonzero (decline install) in non-interactive context"
+  # BL-037 closure: tighten `rc != 0` (which silently accepted bash's
+  # 127 "command not found" — the exact failure mode of a regression
+  # that removed prompt_install entirely) to `rc == 1` — the documented
+  # decline-install return code. Combined with the harness's
+  # type-check (which would have exit-99'd before reaching this assert
+  # if prompt_install was undefined), this gives us a precise refusal
+  # contract: function exists, was invoked, and returned the
+  # documented decline rc.
+  if [ "$rc" = "99" ]; then
+    fail_ "$name" "harness precondition failed (prompt_install not defined in helpers.sh) — see HARNESS_PRECONDITION_FAIL line in $OUT"
+    failed=true
+  fi
+  if [ "$rc" != "1" ]; then
+    fail_ "$name" "prompt_install rc=$rc; required rc==1 (documented decline-install return code). rc=0 means install ran; rc=127 means function missing; any other rc means an unrelated failure path."
     failed=true
   fi
   if [ "$failed" = "false" ]; then
-    pass "$name: prompt_install short-circuited (rc=$rc, no marker, no hang)"
+    pass "$name: prompt_install short-circuited cleanly (function defined, rc=1 decline, no marker, no hang)"
   fi
   rm -rf "$TMP"
 }

--- a/tests/test-upgrade-interruption.sh
+++ b/tests/test-upgrade-interruption.sh
@@ -216,6 +216,20 @@ t1_unwritable_approval_log_preserves_state() {
 # "always snapshot before mutation" invariant from PR #54/#57/#80 —
 # even when the run fails, the snapshot dir is retained so an operator
 # can audit what state existed at the moment of failure.
+#
+# BL-037 closure: the pre-fix T2 wrapped the snapshot-children
+# assertion in `if [ -d "$TMPDIR_T/.claude/upgrade-snapshots" ]; then
+# ... fi`. If `upgrade-project.sh`'s snapshot creation was completely
+# broken and never created the dir, the conditional was skipped and
+# `pass T2` fired unconditionally. The "always snapshot before
+# mutation" invariant is precisely what T2 is supposed to guard —
+# guarding it conditionally guards nothing. Per audit BL-037:
+# "remove the `if [ -d ... ]` wrap on the snapshot dir assertion;
+# make the dir's presence a hard requirement." This rewrite makes
+# (a) directory presence and (b) at least one child snapshot HARD
+# requirements identical to T1's assertion 4 — so a regression that
+# disables the snapshot-pre-mutation block flips both T1 and T2 RED
+# (no single-assertion silent-pass quadrant remains).
 t2_snapshot_dir_retained_on_failure() {
   setup_org_sponsored_dated
   chmod 0444 "$TMPDIR_T/APPROVAL_LOG.md"
@@ -229,33 +243,41 @@ t2_snapshot_dir_retained_on_failure() {
     teardown_project; return
   fi
 
-  # The snapshot dir may or may not exist depending on whether the run
-  # reached the snapshot phase before failing. If the rollback path
-  # fired (snapshot existed), the dir must be retained per
-  # _upgrade_rollback's "Snapshot retained for forensics" contract.
-  # If the failure tripped before the snapshot dir was created, the
-  # dir tree is allowed to be absent — but if the root exists with
-  # any subdirectory, at least one snapshot must be retained (no
-  # silent pruning under failure).
-  if [ -d "$TMPDIR_T/.claude/upgrade-snapshots" ]; then
-    local count
-    # `grep -c .` exits 1 on zero matches — `|| true` keeps `set -e` from
-    # killing the test before the assertion runs.
-    count=$(find "$TMPDIR_T/.claude/upgrade-snapshots" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | grep -c . || true)
-    case "$count" in ''|*[!0-9]*) count=0 ;; esac
-    # If the dir was created, we expect at least one snapshot child
-    # (pre-mutation snapshot is what the rollback restores from).
-    # The keep-3 retention prune only runs after success per
-    # _upgrade_prune_snapshots's header note, so a failure run that
-    # produced the dir but pruned all children is a regression — the
-    # operator loses forensic state at exactly the moment they need it.
-    if [ "$count" -lt 1 ]; then
-      fail_ "T2" "upgrade-snapshots dir exists but is empty (forensic history pruned under failure)"
-      teardown_project; return
-    fi
+  # Hard requirement (1): the snapshot directory MUST exist. The
+  # fault-injection (read-only APPROVAL_LOG.md) is triggered in the
+  # mutation block at scripts/upgrade-project.sh:2062+, which runs
+  # AFTER _upgrade_snapshot_pre_mutation (line 1110) and AFTER `trap
+  # _upgrade_rollback` (line 1111). Either path leaves the snapshot
+  # root present:
+  #   * Rollback fires → _upgrade_rollback prints "Snapshot retained
+  #     for forensics" and the dir lives on (no rm).
+  #   * Even pre-rollback-fire failures hit the trap, which only
+  #     restores files in-place from the snapshot — it does not
+  #     remove the snapshot dir.
+  # If the dir is absent, the snapshot-pre-mutation block has been
+  # disabled or the fault tripped before the snapshot phase — both
+  # regressions invalidate every downstream rollback invariant.
+  if [ ! -d "$TMPDIR_T/.claude/upgrade-snapshots" ]; then
+    fail_ "T2" "snapshot dir absent after fault-injection — the always-snapshot-before-mutation invariant is broken (or the failure tripped before snapshot phase; either way, rollback path is uncovered)"
+    teardown_project; return
   fi
 
-  pass "T2: snapshot infrastructure preserves forensic state under failure"
+  # Hard requirement (2): the snapshot dir must hold at least one
+  # child snapshot. _upgrade_prune_snapshots only runs after success
+  # per its header note, so a failure run that produced the root but
+  # pruned all children is a regression — the operator loses
+  # forensic state at exactly the moment they need it.
+  local count
+  # `grep -c .` exits 1 on zero matches — `|| true` keeps `set -e` from
+  # killing the test before the assertion runs.
+  count=$(find "$TMPDIR_T/.claude/upgrade-snapshots" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | grep -c . || true)
+  case "$count" in ''|*[!0-9]*) count=0 ;; esac
+  if [ "$count" -lt 1 ]; then
+    fail_ "T2" "upgrade-snapshots dir exists but is empty (forensic history pruned under failure, or pre-mutation snapshot was never captured)"
+    teardown_project; return
+  fi
+
+  pass "T2: snapshot infrastructure preserves forensic state under failure (dir present AND $count child snapshot(s) retained — both hard-required)"
   teardown_project
 }
 

--- a/tests/test-verify-install-fix-functions.sh
+++ b/tests/test-verify-install-fix-functions.sh
@@ -65,12 +65,12 @@ setup_clean_project() {
   # rather than build an array.)
   if [ "$deployment" = "organizational" ]; then
     bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-      --platform web --language javascript --track light --deployment "$deployment" \
+      --platform web --language typescript --track light --deployment "$deployment" \
       --gov-mode sponsored_poc \
       >/dev/null 2>&1
   else
     bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-      --platform web --language javascript --track light --deployment "$deployment" \
+      --platform web --language typescript --track light --deployment "$deployment" \
       >/dev/null 2>&1
   fi
   VERIFY="$PROJ/scripts/verify-install.sh"
@@ -114,7 +114,7 @@ else
   grep -q "^- \*\*Project:\*\* x"               "$PROJ/CLAUDE.md" || missing="$missing project"
   grep -q "^- \*\*Platform:\*\* web"            "$PROJ/CLAUDE.md" || missing="$missing platform"
   grep -q "^- \*\*Track:\*\* light"             "$PROJ/CLAUDE.md" || missing="$missing track"
-  grep -q "^- \*\*Primary Language:\*\* javascript" "$PROJ/CLAUDE.md" || missing="$missing language"
+  grep -q "^- \*\*Primary Language:\*\* typescript" "$PROJ/CLAUDE.md" || missing="$missing language"
   if [ -n "$missing" ]; then
     fail_ "T2" "missing substituted identity fields:$missing"
   else
@@ -188,16 +188,44 @@ teardown
 # and executable bit of the hook scripts referenced in settings.json.
 # ============================================================
 
+# BL-037 closure (T6-T10): the pre-fix oracles were negative-only
+# (`! grep -qE "[OK] <hook>"`). If verify-install.sh crashed before
+# the hook-check section, or changed the [OK] label format, the
+# absence-of-OK still satisfied the negation — T6-T10 silently PASSed.
+# Mirror T5's tightened oracle: require a POSITIVE remediation row for
+# the affected hook (via register_manual, which print_warn-emits the
+# string `[WARN] <hook> ... (manual)`).
+#
+# verify-install.sh's _check_hooks_hook_pair (scripts/verify-install.sh:393)
+# emits register_manual with one of:
+#   "<label> registered but on-disk script missing (<path>)"
+#   "<label> registered but on-disk script not executable (<path>)"
+# All three patterns are valid remediation rows; we accept any of them.
+
+# Convenience pattern: positive hook-remediation row for a given basename
+# script. Mirrors T5's auto-fixable|missing|manual|REFUSED phrasing.
+_hook_remediation_re='(missing|not executable|REFUSED|auto-fixable|registered but on-disk script)'
+
 echo "T6: missing on-disk pre-commit-gate.sh is reported despite intact settings.json"
 setup_clean_project personal
 # Settings reference is intact; the on-disk file is gone.
 rm -f "$PROJ/scripts/pre-commit-gate.sh"
 out=$(run_verify_check)
-# The hook check must NOT print a green OK line for pre-commit-gate.sh.
+t6_failed=""
+# Negative: must not report green OK for the missing-script hook.
 if echo "$out" | grep -qE "\[OK\] PreToolUse hook: pre-commit-gate\.sh"; then
-  fail_ "T6" "verify reported green OK for hook despite missing on-disk script"
+  t6_failed="verify reported green OK for hook despite missing on-disk script"
+fi
+# Positive: must emit a [WARN] remediation row that names pre-commit-gate.sh
+# and the (manual) suffix register_manual adds. This is the assertion
+# that flips RED if verify-install crashes before hook-check runs.
+if ! echo "$out" | grep -qE "\[WARN\].*pre-commit-gate\.sh.*${_hook_remediation_re}.*\(manual\)"; then
+  t6_failed="${t6_failed:+$t6_failed; }no positive [WARN] (manual) remediation row for pre-commit-gate.sh"
+fi
+if [ -n "$t6_failed" ]; then
+  fail_ "T6" "$t6_failed"
 else
-  pass "T6: hook with missing on-disk script no longer reported as PASS"
+  pass "T6: missing pre-commit-gate.sh produces [WARN] (manual) remediation row AND no green OK"
 fi
 teardown
 
@@ -205,10 +233,17 @@ echo "T7: non-executable pre-commit-gate.sh on disk is reported"
 setup_clean_project personal
 chmod -x "$PROJ/scripts/pre-commit-gate.sh"
 out=$(run_verify_check)
+t7_failed=""
 if echo "$out" | grep -qE "\[OK\] PreToolUse hook: pre-commit-gate\.sh"; then
-  fail_ "T7" "verify reported green OK for hook despite non-executable on-disk script"
+  t7_failed="verify reported green OK for hook despite non-executable on-disk script"
+fi
+if ! echo "$out" | grep -qE "\[WARN\].*pre-commit-gate\.sh.*${_hook_remediation_re}.*\(manual\)"; then
+  t7_failed="${t7_failed:+$t7_failed; }no positive [WARN] (manual) remediation row for non-executable pre-commit-gate.sh"
+fi
+if [ -n "$t7_failed" ]; then
+  fail_ "T7" "$t7_failed"
 else
-  pass "T7: hook with non-executable on-disk script no longer reported as PASS"
+  pass "T7: non-executable pre-commit-gate.sh produces [WARN] (manual) remediation row AND no green OK"
 fi
 teardown
 
@@ -216,10 +251,17 @@ echo "T8: missing on-disk track-tool-usage.sh is reported"
 setup_clean_project personal
 rm -f "$PROJ/scripts/track-tool-usage.sh"
 out=$(run_verify_check)
+t8_failed=""
 if echo "$out" | grep -qE "\[OK\] PostToolUse hook: track-tool-usage\.sh"; then
-  fail_ "T8" "verify reported green OK for hook despite missing track-tool-usage.sh"
+  t8_failed="verify reported green OK for hook despite missing track-tool-usage.sh"
+fi
+if ! echo "$out" | grep -qE "\[WARN\].*track-tool-usage\.sh.*${_hook_remediation_re}.*\(manual\)"; then
+  t8_failed="${t8_failed:+$t8_failed; }no positive [WARN] (manual) remediation row for track-tool-usage.sh"
+fi
+if [ -n "$t8_failed" ]; then
+  fail_ "T8" "$t8_failed"
 else
-  pass "T8: PostToolUse track-tool-usage with missing on-disk script no longer PASS"
+  pass "T8: missing track-tool-usage.sh produces [WARN] (manual) remediation row AND no green OK"
 fi
 teardown
 
@@ -228,10 +270,19 @@ setup_clean_project personal
 rm -f "$PROJ/scripts/session-version-check.sh"
 out=$(run_verify_check)
 # The SessionStart row covers two scripts together — both must be on disk.
+# Per scripts/verify-install.sh:488, the WARN message format is
+# "SessionStart hooks registered but on-disk scripts incomplete: <list>".
+t9_failed=""
 if echo "$out" | grep -qE "\[OK\] SessionStart hooks: version check \+ test gate"; then
-  fail_ "T9" "verify reported green OK for SessionStart hooks despite missing session-version-check.sh"
+  t9_failed="verify reported green OK for SessionStart hooks despite missing session-version-check.sh"
+fi
+if ! echo "$out" | grep -qE "\[WARN\].*SessionStart.*session-version-check\.sh.*(missing|not executable|incomplete).*\(manual\)"; then
+  t9_failed="${t9_failed:+$t9_failed; }no positive [WARN] (manual) remediation row naming session-version-check.sh"
+fi
+if [ -n "$t9_failed" ]; then
+  fail_ "T9" "$t9_failed"
 else
-  pass "T9: SessionStart hooks no longer PASS when on-disk script is missing"
+  pass "T9: missing session-version-check.sh produces [WARN] (manual) SessionStart row AND no green OK"
 fi
 teardown
 
@@ -239,10 +290,17 @@ echo "T10: missing on-disk session-end-qdrant-reminder.sh is reported"
 setup_clean_project personal
 rm -f "$PROJ/scripts/session-end-qdrant-reminder.sh"
 out=$(run_verify_check)
+t10_failed=""
 if echo "$out" | grep -qE "\[OK\] Stop hook: session-end-qdrant-reminder\.sh"; then
-  fail_ "T10" "verify reported green OK for Stop hook despite missing on-disk script"
+  t10_failed="verify reported green OK for Stop hook despite missing on-disk script"
+fi
+if ! echo "$out" | grep -qE "\[WARN\].*session-end-qdrant-reminder\.sh.*${_hook_remediation_re}.*\(manual\)"; then
+  t10_failed="${t10_failed:+$t10_failed; }no positive [WARN] (manual) remediation row for session-end-qdrant-reminder.sh"
+fi
+if [ -n "$t10_failed" ]; then
+  fail_ "T10" "$t10_failed"
 else
-  pass "T10: Stop hook session-end-qdrant-reminder no longer PASS when on-disk script is missing"
+  pass "T10: missing session-end-qdrant-reminder.sh produces [WARN] (manual) Stop-hook row AND no green OK"
 fi
 teardown
 


### PR DESCRIPTION
## Summary

- Closes 15 major-severity vacuous-assertion findings flagged by `Reports/2026-06-28-test-integrity-audit.md` §3 across 7 orphan test files (edge-cases, verify-install, prompt-install, snapshot-retention, intake-wizard, self-approval).
- Replaces each catch-all `else pass: handled` / negative-only `! grep -q OK` / tautological branch with a POSITIVE-substring assertion that requires actual emission from the product code.
- Mirrors BL-036's TDD precedent: each rewrite proven RED-under-mutation, GREEN-when-restored.

## Closes

BL-037

## Test plan

### Baseline GREEN (post-rewrite, unmutated)

- [x] `bash tests/edge-cases-upgrade-input.sh` → 19/19 PASS (E33, E34, E36, E37, E40 covered; sibling E26-E32, E35, E38, E39 untouched).
- [x] `bash tests/edge-cases-scripts.sh` → E12a, E12b, E25a, E25b, E25c, E27, E28, E29 all PASS.
- [x] `bash tests/test-verify-install-fix-functions.sh` → T6, T7, T8, T9, T10 all PASS (after `javascript → typescript` setup fix; init.sh deprecated javascript+web combo).
- [x] `bash tests/test-prompt-install-noninteractive.sh` → 3/3 PASS.
- [x] `bash tests/test-upgrade-interruption.sh` → 2/2 PASS.
- [x] `bash tests/test-intake-wizard-fixes.sh` → 9/9 PASS.
- [x] `bash tests/test-check-phase-gate-self-approval.sh` → 5/5 PASS.
- [x] All four self-verify lints clean: `lint-counter-antipattern.sh`, `lint-backlog-references.sh`, `lint-fix-functions-stderr.sh`, `lint-raw-read-prompt.sh`.

### Mutation proofs (end-to-end verified RED)

| Test | Mutation applied | Result |
|---|---|---|
| E33 (SQL injection) | `data['answers'][key] = value[:1]` in SAVE_ANSWER_PY | FAIL: "not stored byte-exact — got: `'''`" |
| E34 (10K-char) | `data['answers'][key] = value[:100]` | FAIL: "len=100 signature='len=100 first=A last=A all_A=True'" |
| T1/T2/T3 prompt_install | rename `prompt_install` → `prompt_install_DISABLED` in helpers.sh | 6/6 FAIL (HARNESS_PRECONDITION_FAIL + rc=99) |
| T3 self-approval | comment out the `[WARN] ambient git user ... matches approver` echo branch in check-phase-gate.sh | FAIL: "expected [WARN] 'ambient git user ... matches approver ...' substring" |
| T1+T2 upgrade-interruption | `_upgrade_snapshot_pre_mutation() { return 0; ... }` (no-op) in upgrade-project.sh | T1 FAIL: "files diverged from pre-run snapshot"; T2 FAIL: "snapshot dir absent after fault-injection" |

### Contract-proven by code inspection (mutation strategy documented)

- **E36 / E37 (Unicode + emoji)**: pre-fix catch-all `else pass: handled (stored as: ...)` accepted any non-MISSING/non-ERROR value; new byte-exact UTF-8 equality requires actual roundtrip. Mutation `data['answers'][key] = '?'` flips RED.
- **E40 (NUL)**: pre-fix `grep -q "test"` matched `tes`, `best test`, `test123abc`; new exact `'test'` requires kernel argv-truncation behavior. Mutation `value + '_corrupt'` flips RED.
- **E12a/b (resume.sh)**: pre-fix accepted any output not containing 4 magic shell-error keywords; new requires "End of resume prompt" tail + "(not found in CLAUDE.md)" fallback. Early-exit mutation flips RED.
- **E25a/b/c (phase=99)**: pre-fix magic-keyword negative oracle; new requires positive phase-99 echo. Mutation `**Phase:** $PHASE` → `**Phase:** 0` in resume.sh flips E25c RED.
- **E27/E28/E29 (UAT reference pair)**: pre-fix only checked `pre-flight-reference.html`; new requires both halves. Disabling init.sh's `scenario-reference.json` copy flips RED.
- **T6-T10 (verify-install hooks)**: pre-fix `! grep -q [OK]` accepted check_hooks crashing entirely; new requires `[WARN] (manual)` row. Disabling `register_manual` in `_check_hooks_hook_pair` flips RED.
- **T1 intake-wizard**: pre-fix `${wiz_line%%:*} != $tpl_num` was tautological (awk filter pre-equated them); new title comparison flips RED on `Section 4: Compliance Audit` vs template `4. Features & Requirements`.

## Coordination note

Touches 7 test files + 1 backlog file. No sibling PR conflicts expected:
- Wave B BL-044 / BL-045 / BL-065 / BL-066 are unrelated paths.
- Wave A BL-034 (orphan test registration) is parallel and already merged via PR #111 — these tightened tests will run on CI/pre-commit because the BL-034 work registered them in `tests/full-project-test-suite.sh` (per audit §5 "(vacuous) × (unregistered)" worst-quadrant fix).

Setup-fix sub-change in `tests/test-verify-install-fix-functions.sh`: `--language javascript` → `--language typescript` (init.sh's web platform CI templates dropped javascript support in an earlier wave — see `templates/pipelines/ci/github/`). T2's grep assertion updated to match. Without this, T1/T2/T4/T5 setup phase silently aborted on `main` and T6-T10 vacuously passed because their pre-fix `! grep -q [OK]` accepted the no-output crash state. Restoring T6-T10's hook coverage required restoring init.sh setup.

Branch is rebased onto current `origin/main` (122e57c, PR #114).

## Worktree note

Worked in `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_e9c99065-57e-1` (isolated worktree, slot `bl037-vacuous-assertions`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)