### PR TITLE
fix(check-phase-gate): per-line APPROVAL_LOG.md blame walker (closes code-check-gates-7-followup)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -243,12 +243,57 @@ validate_approval_fields() {
     local approver_name
     approver_name=$(echo "$section" | awk -F'|' '/[Aa]pprover/ && !/Role/ { gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); print $3; exit }' 2>/dev/null || echo "")
     if [ -n "$approver_name" ] && [ "$approver_name" != "[Name]" ] && [ "$approver_name" != "" ]; then
-      local approver_norm git_user git_user_norm commit_author commit_author_norm
+      local approver_norm git_user git_user_norm commit_author commit_author_norm approver_line
       approver_norm=$(printf '%s' "$approver_name" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
       git_user=$(git config user.name 2>/dev/null || echo "")
       git_user_norm=$(printf '%s' "$git_user" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-      # Commit author of the most recent change touching APPROVAL_LOG.md.
-      commit_author=$(git log -n 1 --format='%an' -- "$APPROVAL_LOG" 2>/dev/null || echo "")
+
+      # code-check-gates-7-followup (cycle-7 PR-#87 verifier major #4):
+      # the pre-fix lookup `git log -n 1 --format=%an -- APPROVAL_LOG.md`
+      # returned whoever most recently TOUCHED the file — not who added
+      # the specific gate's Approver row. Attack: Alice commits her own
+      # approval row at gate A (real self-approval — should FAIL); Bob
+      # later commits a typo fix to gate B; `git log -1` returns Bob;
+      # Alice's self-approval silently passes.
+      #
+      # Fix: resolve the line number of the active gate section's
+      # Approver row, then `git blame -L<N>,<N>` to extract the author
+      # of THAT line's most recent change. Compare against approver.
+      #
+      # The awk walker scans for the gate header (case-insensitive
+      # regex match — same shape `grep -A 20 "$gate_name"` uses above),
+      # then within the section walks until the next ## header or `---`
+      # rule, locating the first Approver row that isn't a Role row.
+      # Print its line number and exit.
+      approver_line=$(awk -v gate="$gate_name" '
+        BEGIN { IGNORECASE = 1 }
+        $0 ~ gate && /^## / { in_section = 1; next }
+        in_section && /^## / { exit }
+        in_section && /^---[[:space:]]*$/ { exit }
+        in_section && /[Aa]pprover/ && !/Role/ { print NR; exit }
+      ' "$APPROVAL_LOG" 2>/dev/null || echo "")
+
+      if [ -n "$approver_line" ]; then
+        # `git blame --line-porcelain` prints an `author <name>` line
+        # per blame entry. When the line differs from HEAD (uncommitted
+        # working-tree modification) blame returns "Not Committed Yet".
+        # Both "empty author" and "Not Committed Yet" indicate the
+        # invariant cannot be verified — collapse to the WARN branch.
+        commit_author=$(git blame --line-porcelain \
+                          -L "${approver_line},${approver_line}" \
+                          -- "$APPROVAL_LOG" 2>/dev/null \
+                          | awk '/^author / { sub(/^author /, ""); print; exit }' \
+                          || echo "")
+        if [ "$commit_author" = "Not Committed Yet" ] || [ "$commit_author" = "External file (--contents)" ]; then
+          commit_author=""
+        fi
+      else
+        # awk found neither the gate section nor an Approver row.
+        # Fall back to the file-level lookup so a missing-section case
+        # still has SOME signal (and the WARN branch will fire if it
+        # also returns empty).
+        commit_author=$(git log -n 1 --format='%an' -- "$APPROVAL_LOG" 2>/dev/null || echo "")
+      fi
       commit_author_norm=$(printf '%s' "$commit_author" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
       if [ -n "$commit_author_norm" ] && [ "$commit_author_norm" = "$approver_norm" ]; then
@@ -261,15 +306,15 @@ validate_approval_fields() {
         echo -e "${YELLOW}[WARN]${NC} $gate_label: ambient git user '$git_user' matches approver '$approver_name' but APPROVAL_LOG.md commit author is '$commit_author' — verify the commit author wasn't rewritten"
         issues=$((issues + 1))
       elif [ -z "$commit_author_norm" ] && [ -n "$approver_norm" ]; then
-        # code-check-gates-7-followup (cycle-7 PR-#87 verifier): if
-        # APPROVAL_LOG.md has not yet been committed (or the approver
-        # row was added in the working tree only), `git log -- $APPROVAL_LOG`
-        # returns empty and the self-approval invariant (baseline §5
-        # invariant #9) cannot be verified. Surface this gap as a WARN
-        # so it doesn't silently pass. See backlog entry
-        # `code-check-gates-7-followup` for the per-gate-section blame
-        # fix that would let us verify uncommitted/amended approvals.
-        echo -e "${YELLOW}[WARN]${NC} $gate_label: cannot verify commit author for approver '$approver_name' — APPROVAL_LOG.md not yet committed (or git log returned no author). Commit the approval entry to enable self-approval verification."
+        # code-check-gates-7-followup: cannot verify the per-line blame
+        # author either because (a) the Approver row was added in the
+        # working tree only (uncommitted) — `git blame` returns "Not
+        # Committed Yet", normalized to empty above; (b) the gate
+        # section was not found in APPROVAL_LOG.md and the file-level
+        # fallback also returned empty; or (c) git is unavailable.
+        # Surface as WARN so the silent-pass case never recurs (baseline
+        # §5 invariant #9 audit signal).
+        echo -e "${YELLOW}[WARN]${NC} $gate_label: cannot verify commit author for approver '$approver_name' — APPROVAL_LOG.md row not yet committed (or per-line blame returned no author). Commit the approval entry to enable self-approval verification."
         issues=$((issues + 1))
       fi
     fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -824,7 +824,7 @@ These two gates patch the most damaging clobber surfaces, but the underlying des
 **Logged:** 2026-06-28 (PR #87 cycle-7 verifier major #4)
 **Category:** Bug / governance (precision of self-approval check)
 **Severity:** Major
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #<PR>, commit `06fb186`)
 
 `scripts/check-phase-gate.sh:246` resolves the commit author of an approval via `git log -n 1 --format=%an -- APPROVAL_LOG.md`, which returns whoever most recently touched the file — not who added the specific gate's Approver row. The cycle-7 PR-#87 adversarial verifier (major #4) flagged the resulting attack surface: if Alice committed her own approval row (true self-approval — should FAIL) and Bob later committed a typo fix to a different gate's row, the check passes for Alice because the latest commit author is Bob.
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -321,6 +321,18 @@ if bash "$SCRIPT_DIR/tests/test-check-phase-gate-self-approval.sh" >/dev/null 2>
 else
   fail "tests/test-check-phase-gate-self-approval.sh FAILED (run for details)"
 fi
+# code-check-gates-7-followup (cycle-7 PR-#87 verifier major #4):
+# scripts/check-phase-gate.sh now uses per-line `git blame` (not
+# file-level `git log -1`) to resolve the commit author of the active
+# gate's Approver row. Closes the false-negative attack where Alice
+# self-approves gate A in C1 and Bob later commits a typo fix to gate
+# B in C2 → file-level lookup returned Bob → Alice's self-approval
+# silently passed. The blame-walker tests pin the fix.
+if bash "$SCRIPT_DIR/tests/test-check-phase-gate-blame-walker.sh" >/dev/null 2>&1; then
+  pass "tests/test-check-phase-gate-blame-walker.sh"
+else
+  fail "tests/test-check-phase-gate-blame-walker.sh FAILED (run for details)"
+fi
 
 # ----------------------------------------------------------------
 # TEST 0i: PENDING-APPROVAL RESOLVE-DECISION

--- a/tests/test-check-phase-gate-blame-walker.sh
+++ b/tests/test-check-phase-gate-blame-walker.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# tests/test-check-phase-gate-blame-walker.sh
+#
+# Regression tests for code-check-gates-7-followup (cycle-7 PR #87
+# verifier major #4):
+#   scripts/check-phase-gate.sh::validate_approval_fields used
+#   `git log -n 1 --format=%an -- APPROVAL_LOG.md` to resolve the
+#   commit author for the self-approval check. That returns whoever
+#   most recently TOUCHED the file — NOT who added the specific
+#   gate's Approver row. The result was an exploitable false-negative:
+#
+#     Alice commits her own approval row at gate A (real self-approval
+#     — should FAIL).
+#     Bob later commits a typo fix to gate B's row.
+#     Pre-fix: git log -1 returns Bob → Alice's self-approval silently
+#     passes the check.
+#
+# Fix: resolve the line number of the active gate section's Approver
+# row, then use `git blame -L<N>,<N> --line-porcelain` to extract
+# the author of that specific line's most recent change. Compare
+# THAT author against the approver name.
+#
+# Tests:
+#   T-blame-1: Alice approves gate 0→1 in commit C1; Bob later commits
+#              a typo fix to gate 1→2 row. check-phase-gate.sh MUST
+#              still FAIL on Alice's self-approval at gate 0→1.
+#              (Pre-fix this PASSED silently — RED on origin/main.)
+#   T-blame-2: Alice's row exists in working tree only (uncommitted).
+#              Behavior matches PR #87's WARN: "cannot verify."
+#   T-blame-3: Bob commits Alice's approval row on her behalf
+#              (legitimate organizational approval — Alice is the
+#              approver, Bob is the committer). MUST NOT FAIL.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  ( cd "$PROJ" && git init -q && git config user.email "ambient@example.com" \
+                              && git config user.name  "Ambient" \
+                              && git config commit.gpgsign false )
+}
+teardown() { rm -rf "$TMP"; }
+
+# Phase state — current_phase=2 so BOTH gates (0→1 and 1→2) are checked.
+write_phase_state_org_phase2() {
+  cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"organizational","gates":{"phase_0_to_1":"2026-02-01","phase_1_to_2":"2026-02-15"}}
+JSON
+}
+
+# Phase state — current_phase=1 (single-gate scenarios).
+write_phase_state_org_phase1() {
+  cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1,"deployment":"organizational","gates":{"phase_0_to_1":"2026-02-01"}}
+JSON
+}
+
+# APPROVAL_LOG with two phase-gate sections. The 0→1 section's Approver
+# is supplied; the 1→2 section's Approver is fixed to "Carol".
+write_two_gate_log() {
+  local approver_01="$1"
+  cat > "$PROJ/APPROVAL_LOG.md" <<MD
+# APPROVAL_LOG
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Gate** | Phase 0 → Phase 1 |
+| **Approver** | $approver_01 |
+| **Date** | 2026-02-01 |
+
+---
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| **Gate** | Phase 1 → Phase 2 |
+| **Approver** | Carol Approver |
+| **Date** | 2026-02-15 |
+MD
+}
+
+# Single-gate log (0→1) for T-blame-2.
+write_single_gate_log() {
+  local approver_01="$1"
+  cat > "$PROJ/APPROVAL_LOG.md" <<MD
+# APPROVAL_LOG
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Gate** | Phase 0 → Phase 1 |
+| **Approver** | $approver_01 |
+| **Date** | 2026-02-01 |
+MD
+}
+
+# Commit currently-staged files with a specific author identity.
+git_add_and_commit_as() {
+  local name="$1" email="$2" msg="$3"
+  ( cd "$PROJ" \
+      && git add -A \
+      && GIT_AUTHOR_NAME="$name" GIT_AUTHOR_EMAIL="$email" \
+         GIT_COMMITTER_NAME="$name" GIT_COMMITTER_EMAIL="$email" \
+         git commit -qm "$msg" )
+}
+
+run_gate() {
+  ( cd "$PROJ" && bash "$SCRIPT" 2>&1 ) || true
+}
+
+# ---------------------------------------------------------------------
+# T-blame-1: Alice commits her own approval row at gate 0→1 (real
+# self-approval — MUST FAIL). Bob later commits a typo fix to gate 1→2
+# row. Pre-fix `git log -1 -- APPROVAL_LOG.md` returns Bob, and the
+# self-approval check silently passes (false-negative). The blame-
+# walker fix MUST keep the FAIL on Alice at gate 0→1.
+# ---------------------------------------------------------------------
+echo "T-blame-1: Alice self-approves gate 0→1, Bob later edits gate 1→2 → MUST still FAIL Alice"
+setup
+write_phase_state_org_phase2
+# C1: Alice commits her own approval row.
+write_two_gate_log "Alice Approver"
+git_add_and_commit_as "Alice Approver" "alice@example.com" "alice self-approves gate 0->1"
+# C2: Bob fixes a typo in gate 1→2 only (changes "Carol Approver" → "Carol M. Approver").
+sed -i.bak 's/Carol Approver/Carol M. Approver/' "$PROJ/APPROVAL_LOG.md" && rm -f "$PROJ/APPROVAL_LOG.md.bak"
+git_add_and_commit_as "Bob Editor" "bob@example.com" "typo fix in gate 1->2 row"
+out=$(run_gate)
+# The 0→1 self-approval FAIL must appear in the output. Be strict:
+# require the substring "self-approval" inline with a FAIL marker that
+# clearly cites Phase 0→1.
+if echo "$out" | grep -E "FAIL.*Phase 0.*1.*self-approval|FAIL.*self-approval.*Phase 0" >/dev/null \
+   || echo "$out" | awk '/Phase 0/{ctx=1} ctx && /FAIL.*self-approval/{print; found=1} END{exit !found}' >/dev/null; then
+  pass "T-blame-1: per-line blame correctly fails Alice's self-approval despite Bob's later edit"
+else
+  fail_ "T-blame-1" "expected FAIL on Alice's self-approval at gate 0→1 (per-line blame); output:
+$(echo "$out" | grep -E 'Phase 0|self-approval|FAIL|WARN' | head -20)"
+fi
+teardown
+
+# ---------------------------------------------------------------------
+# T-blame-2: Alice's row exists in the working tree only (never
+# committed). `git blame` on an uncommitted line returns the Not
+# Committed Yet pseudo-author. Behavior MUST match PR #87's WARN:
+# "cannot verify commit author … not yet committed".
+# ---------------------------------------------------------------------
+echo "T-blame-2: approver row uncommitted → WARN 'cannot verify'"
+setup
+write_phase_state_org_phase1
+# Pre-existing commit with a placeholder log (no approver yet).
+write_single_gate_log "[Name]"
+git_add_and_commit_as "Bootstrap" "bootstrap@example.com" "initial empty approval log"
+# Now mutate working tree to add Alice's approver, WITHOUT committing.
+write_single_gate_log "Alice Approver"
+out=$(run_gate)
+if echo "$out" | grep -qE "\[WARN\].*Phase 0.*1.*cannot verify commit author"; then
+  pass "T-blame-2: uncommitted approver row → WARN 'cannot verify commit author'"
+else
+  fail_ "T-blame-2" "expected [WARN] 'cannot verify commit author' for uncommitted approver row; output:
+$(echo "$out" | grep -E 'WARN|FAIL|Phase 0' | head -10)"
+fi
+teardown
+
+# ---------------------------------------------------------------------
+# T-blame-3: Bob legitimately commits Alice's approval row on her
+# behalf (Alice is approver, Bob is committer). Commit author differs
+# from approver — that's the design. MUST NOT FAIL with self-approval.
+# ---------------------------------------------------------------------
+echo "T-blame-3: Bob commits Alice's approval on her behalf → MUST NOT FAIL"
+setup
+write_phase_state_org_phase1
+write_single_gate_log "Alice Approver"
+git_add_and_commit_as "Bob Committer" "bob@example.com" "bob commits alice's approval"
+out=$(run_gate)
+if echo "$out" | grep -qE "FAIL.*self-approval"; then
+  fail_ "T-blame-3" "self-approval FAIL should NOT fire when committer differs from approver; output:
+$(echo "$out" | grep -E 'FAIL|self-approval' | head -10)"
+else
+  pass "T-blame-3: distinct committer + approver → no self-approval FAIL"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- `scripts/check-phase-gate.sh::validate_approval_fields` now uses `git blame --line-porcelain -L<N>,<N> -- APPROVAL_LOG.md` to resolve the commit author of the active gate's Approver row, replacing the prior file-level `git log -n 1 --format=%an -- APPROVAL_LOG.md` lookup that returned whoever most recently touched the file.
- Closes the cycle-7 PR #87 verifier major #4 attack: Alice commits her own approval row at gate A (real self-approval — should FAIL); Bob later commits a typo fix to gate B; pre-fix `git log -1` returned Bob → Alice's self-approval silently passed. Per-line blame on Alice's row now correctly returns Alice and the FAIL persists.
- In-section line resolver implemented with awk (`IGNORECASE=1`, matches the gate header `^## ` then walks until the next `^## ` header or `^---` rule, locating the first non-Role Approver row's line number).
- "Not Committed Yet" / "External file (--contents)" blame pseudo-authors normalize to empty, so PR #87's existing WARN branch ("cannot verify commit author") fires for uncommitted Approver rows (T-blame-2 oracle).
- New `tests/test-check-phase-gate-blame-walker.sh` (3 cases) wired into `tests/full-project-test-suite.sh` TEST 0h alongside the existing PR #87 noninteractive + self-approval tests (BL-034 aggregator-registration invariant).

## Closes

- `code-check-gates-7-followup` (per-gate-section blame for APPROVAL_LOG.md commit-author lookup)

## Test plan

**Red → Green (TDD):**

- T-blame-1 (Alice self-approves gate 0→1, Bob later edits gate 1→2 row):
  - On `origin/main` (pre-fix): RED — `git log -1` returns Bob → Alice's self-approval silently PASSes; new test asserts FAIL → FAILs.
  - With this PR: GREEN — per-line blame returns Alice → FAIL fires → test passes.
- T-blame-2 (Approver row added in working tree only — uncommitted):
  - On `origin/main`: RED — file-level `git log -1` returns the prior commit author; new test asserts the WARN substring is absent.
  - With this PR: GREEN — `git blame` returns "Not Committed Yet" → normalized to empty → existing PR #87 WARN branch fires.
- T-blame-3 (Bob legitimately commits Alice's approval on her behalf):
  - On `origin/main`: PASS (this case wasn't broken).
  - With this PR: PASS — committer ≠ approver, no FAIL.

**Mutation experiment (independent verification):**

- Temporarily replaced the `git blame --line-porcelain -L${approver_line},${approver_line}` invocation with the pre-fix `git log -n 1 --format='%an' -- "$APPROVAL_LOG"` lookup; ran `tests/test-check-phase-gate-blame-walker.sh`:
  - T-blame-1 → RED (Alice's self-approval silently passes)
  - T-blame-2 → RED (uncommitted row not detected)
  - T-blame-3 → GREEN (bug doesn't apply)
- Restored the fix; all 3 + the 5 existing self-approval tests pass.

**Regression cohort confirmed:**

- `bash tests/test-check-phase-gate-self-approval.sh` → 5/5 pass (T1 substring vs token-exact, T2 author=approver FAIL, T3 ambient-mismatch WARN, T4 personal-skip, T5 case-insensitive FAIL).
- `bash tests/test-check-phase-gate-noninteractive.sh` → 3/3 pass.

**Lints (all 4 required):**

- `bash scripts/lint-counter-antipattern.sh` → OK
- `bash scripts/lint-backlog-references.sh` → OK
- `bash scripts/lint-fix-functions-stderr.sh` → OK
- `bash scripts/lint-raw-read-prompt.sh` → OK

## Bonus catches

- The pre-fix WARN branch only fired when `commit_author_norm` was empty AND `approver_norm` was non-empty. The new walker also routes "Not Committed Yet" and "External file (--contents)" blame pseudo-authors into that same WARN branch, so amended/uncommitted approval rows (the exact case PR #87's deferred fix was meant to address) now surface consistently.
- Section walker uses `^## ` + `^---[[:space:]]*$` as terminators so a multi-gate APPROVAL_LOG.md (the canonical org template at upgrade-project.sh:1142-1170) cannot leak the Approver line of an adjacent section.

## Coordination note

- Files touched: `scripts/check-phase-gate.sh`, `tests/test-check-phase-gate-blame-walker.sh` (new), `tests/full-project-test-suite.sh` (1 new test-file invocation in TEST 0h), `solo-orchestrator-backlog.md` (status flip).
- INDEPENDENT of Wave C slots 1+2 (intake/init touchpoints) — should not conflict with sibling PRs.
- Aggregator wiring extends BL-034's TEST 0h block; the same merge will need a single-line rebase if a parallel PR also touches TEST 0h.

## Worktree note

Built and verified in worktree: `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_2a7270ce-74d-3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)