### PR TITLE
fix(init): repair --non-interactive contract path surfaced by E50 (BL-039)

### DIFF
--- a/docs/superpowers/specs/2026-04-25-init-sh-non-interactive-design.md
+++ b/docs/superpowers/specs/2026-04-25-init-sh-non-interactive-design.md
@@ -374,7 +374,7 @@ Existing variables that the interactive flow sets but non-interactive doesn't ne
 |---|---|
 | E48 | Full non-interactive run: web + personal + standard + typescript → project skeleton at `$TEST_DIR/e48` |
 | E49 | E48 with `--validate-only` added → exit 0, JSON to stdout, project NOT created |
-| E50 | Mobile + organizational + private_poc + kotlin → poc_mode in phase-state.json |
+| E50 | Mobile + organizational + sponsored_poc + kotlin → exit 0, JSON has gov_mode=sponsored_poc + visibility=private (org→private force). Companion E50b: same shape with `--gov-mode=private_poc` → exit 1 per baseline §2.5 (`organizational/private_poc` is not a valid tier — see `docs/governance-framework.md:257`; original 2026-04-25 spec row used private_poc but that combination is rejected, so the test was reconciled to the actual contract in PR closing BL-039). |
 | E51 | Web + organizational + production + git-host=other + fake remote-url + attested → exit 0 with soft-fail remediation (per UAT C-fix B) |
 | E52 | `--config $TEST_DIR/cfg.json --project-dir $TEST_DIR/e52` (config has all required) → project created |
 | E53 | `--config $TEST_DIR/cfg.json --track full` (config has track=light, flag overrides) → phase-state shows track=full |

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1007,7 +1007,7 @@ Add self-test `tests/test-lint-tests-registered.sh` covering: (a) all-registered
 **Logged:** 2026-06-28 (test integrity audit)
 **Category:** Bug / live product defect
 **Severity:** High
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #117, commit 2888fa2)
 
 E50 in `tests/edge-cases-scripts.sh` (BL-016 init.sh non-interactive suite) is acknowledged as failing on `main` per the PR #89 implementer note. The assistant who added the test did not fix the underlying bug nor remove the assertion. The product code path (`init.sh --non-interactive`) does not satisfy the contract E50 pins.
 
@@ -1022,6 +1022,8 @@ Because E50 is in an orphan test file (`edge-cases-scripts.sh` is not invoked by
 4. Verify E50 GREEN before closing.
 
 **Dependencies:** BL-034 must register `edge-cases-scripts.sh` in an aggregator so the GREEN state is enforced going forward. Land BL-034 first (with E50 marked expected-fail), then this BL flips it to expected-pass.
+
+**Resolution:** Investigated 2026-06-30 against `init.sh:3262-3268` and `docs/governance-framework.md:257`. The contract E50 was pinning (organizational + private_poc → success with visibility=private) is **wrong** — baseline §2.5 explicitly rejects the `organizational/private_poc` tier shape, and `init.sh` correctly returns exit 1 with the audit code-init-sh-4 / tier-crosscheck-2 rejection message. The 2026-04-25 BL-016 spec table 6.6 row E50 was authored before the tier-crosscheck-2 audit landed and was never reconciled. Rewrote E50 to use `sponsored_poc` (the gov_mode that IS valid for organizational deployments) preserving the org→visibility=private force assertion on mobile+kotlin, and added E50b as a positive rejection test for the actual contract so a future regression that re-permits the invalid combination surfaces loudly. Updated `docs/superpowers/specs/2026-04-25-init-sh-non-interactive-design.md` §8.2 to reflect the actual contract. Narrowed the `SKIP_KNOWN_FAILING` gate in `tests/full-project-test-suite.sh` TEST 0r to track only BL-065 (E30 `--platform other`) — the BL-039 component is lifted. `init.sh` source unchanged; mutation experiment verified E50b would catch a regression (replaced rejection block with `:`, init.sh accepted the invalid combo → E50b would flip RED).
 
 **Related:** `Reports/2026-06-28-test-integrity-audit.md` §2 (LB-1), §7 Slot 5. PR #89 implementer note.
 

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1519,17 +1519,45 @@ else
   fail "E49: --validate-only created project dir (should not have)"
 fi
 
-# E50: Mobile + organizational + private_poc + kotlin → forces visibility=private.
+# E50: Mobile + organizational + sponsored_poc + kotlin → forces visibility=private.
+# (Originally written against organizational+private_poc, which is rejected
+#  per docs/governance-framework.md §2.5 line 257 + BL-016 spec §6.2 line 217.
+#  Rewritten 2026-06-30 to use sponsored_poc — the gov_mode that IS valid for
+#  organizational deployments — so the assertion still exercises the
+#  organizational→visibility=private force on the mobile+kotlin combo it pins.
+#  Closes BL-039; companion E50b below pins the rejection contract directly.)
 _e50_dir="$TEST_DIR/e50"
 mkdir -p "$_e50_dir"
 _e50_out=$(cd "$_e50_dir" && "$INIT_SH" --non-interactive --validate-only \
-  --project uat-e50 --platform mobile --deployment organizational --gov-mode private_poc --language kotlin \
+  --project uat-e50 --platform mobile --deployment organizational --gov-mode sponsored_poc --language kotlin \
   --project-dir "$_e50_dir/proj" 2>&1)
 _e50_rc=$?
-if [ "$_e50_rc" = "0" ] && echo "$_e50_out" | grep -q '"gov_mode": "private_poc"' && echo "$_e50_out" | grep -q '"visibility": "private"'; then
-  pass "E50: organizational + private_poc forces visibility=private"
+if [ "$_e50_rc" = "0" ] && echo "$_e50_out" | grep -q '"gov_mode": "sponsored_poc"' && echo "$_e50_out" | grep -q '"visibility": "private"'; then
+  pass "E50: mobile + organizational + sponsored_poc forces visibility=private"
 else
-  fail "E50: expected gov_mode=private_poc and visibility=private, got: $_e50_out"
+  fail "E50: expected exit 0 with gov_mode=sponsored_poc and visibility=private, got rc=$_e50_rc out=$_e50_out"
+fi
+
+# E50b: Mobile + organizational + private_poc → rejected (baseline §2.5 tier rule).
+# Pins the contract from docs/governance-framework.md:257 ("The
+# organizational/private_poc shape is not a valid tier; init.sh rejects it in
+# non-interactive mode") so a future regression that re-permits this combo
+# surfaces here instead of silently scaffolding an invalid tier.
+_e50b_dir="$TEST_DIR/e50b"
+mkdir -p "$_e50b_dir"
+# Wrap in `if/else` so `set -e` does not abort the suite — the rejection IS
+# the contract we're pinning, so init.sh's non-zero exit is the GREEN path.
+if _e50b_out=$(cd "$_e50b_dir" && "$INIT_SH" --non-interactive --validate-only \
+  --project uat-e50b --platform mobile --deployment organizational --gov-mode private_poc --language kotlin \
+  --project-dir "$_e50b_dir/proj" 2>&1); then
+  _e50b_rc=0
+else
+  _e50b_rc=$?
+fi
+if [ "$_e50b_rc" != "0" ] && echo "$_e50b_out" | grep -q 'gov-mode=private_poc is not valid for --deployment=organizational'; then
+  pass "E50b: organizational + private_poc rejected with baseline §2.5 message"
+else
+  fail "E50b: expected non-zero exit with baseline §2.5 rejection, got rc=$_e50b_rc out=$_e50b_out"
 fi
 
 # E51: git-host=other + remote-url + attested → validate succeeds.

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -516,8 +516,11 @@ fi
 #     in init.sh name sanitization + dry-run name preservation;
 #     tracked by BL-040 / LB-2 init.sh:2781 dry_run_summary).
 #   • edge-cases-scripts.sh     — RED (E30: --platform other refs/
-#     template handling; E50: init.sh --non-interactive contract
-#     mismatch; tracked by BL-009 follow-up + BL-039 / LB-1).
+#     template handling; tracked by BL-065 / BL-009 follow-up).
+#     (E50 / BL-039 was repaired in the PR that closed BL-039: the
+#     test was reconciled to the actual baseline §2.5 tier contract
+#     — organizational+private_poc is rejected, not accepted — and
+#     E50 + new E50b now pass on main.)
 #   • edge-cases-upgrade-input.sh — GREEN.
 #
 # All three are gated together because they share BL-034 status.
@@ -537,15 +540,17 @@ else
   fi
 fi
 if [ "$SKIP_KNOWN_FAILING" = "1" ]; then
-  warn "SKIP_KNOWN_FAILING=1 — skipping tests/edge-cases-scripts.sh (known-RED, BL-039 + BL-009 follow-up)"
+  warn "SKIP_KNOWN_FAILING=1 — skipping tests/edge-cases-scripts.sh (known-RED, BL-065 / BL-009 follow-up: E30 --platform other)"
 else
-  # Status: known-RED on main pending BL-039 (E50 init.sh --non-
-  # interactive contract) + BL-009 follow-up (E30 --platform other).
+  # Status: known-RED on main pending BL-065 (E30 --platform other
+  # refs/template handling — BL-009 follow-up). BL-039 (E50) was
+  # closed in the PR that landed this gate-narrowing — E50 + new
+  # E50b now reflect the actual baseline §2.5 tier contract.
   # Do NOT `|| true`. SKIP_KNOWN_FAILING=1 to bypass locally.
   if bash "$SCRIPT_DIR/tests/edge-cases-scripts.sh" >/dev/null 2>&1; then
     pass "tests/edge-cases-scripts.sh"
   else
-    fail "tests/edge-cases-scripts.sh FAILED — known-RED on main, tracked by BL-039 (E50) + BL-009 follow-up (E30 --platform other). SKIP_KNOWN_FAILING=1 to bypass during local iteration."
+    fail "tests/edge-cases-scripts.sh FAILED — known-RED on main, tracked by BL-065 (E30 --platform other / BL-009 follow-up). SKIP_KNOWN_FAILING=1 to bypass during local iteration."
   fi
 fi
 if bash "$SCRIPT_DIR/tests/edge-cases-upgrade-input.sh" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- E50 in `tests/edge-cases-scripts.sh` was RED on `main` because it asserted that `--platform mobile --deployment organizational --gov-mode private_poc` would succeed, but that tier combination is explicitly rejected by `init.sh:3262-3268` per baseline §2.5 (`docs/governance-framework.md:257` — "The `organizational/private_poc` shape is not a valid tier; init.sh rejects it in non-interactive mode").
- Test goalposts (not `init.sh`) were wrong. The BL-016 design spec table 6.6 row E50 (`docs/superpowers/specs/2026-04-25-init-sh-non-interactive-design.md:377`) was authored 2026-04-25 before the tier-crosscheck-2 audit tightened the tier rules and was never reconciled.
- Rewrote E50 to use `sponsored_poc` — the gov_mode that IS valid for organizational deployments — so the assertion still exercises the mobile+kotlin+organizational happy path AND the org→visibility=private force the original test row intended to pin.
- Added E50b: a positive rejection test for the contract (organizational+private_poc → exit 1 with the baseline §2.5 message) so a future regression that re-permits the invalid combination surfaces loudly instead of silently scaffolding an invalid tier.
- Narrowed the `SKIP_KNOWN_FAILING` gate in `tests/full-project-test-suite.sh` TEST 0r to track only BL-065 (E30 `--platform other`), since E50/BL-039 is now GREEN.

`init.sh` source unchanged — the rejection logic at `init.sh:3262-3268` was already correct per the audit code-init-sh-4 / tier-crosscheck-2 (2026-06) decision and the governance framework.

## Closes

- BL-039 — Resolve LB-1 (fix the underlying bug behind E50)

## Test plan

**RED-on-main evidence** (captured before the fix):

```
$ cd /tmp/e50-repro && "$INIT_SH" --non-interactive --validate-only \
    --project uat-e50 --platform mobile --deployment organizational \
    --gov-mode private_poc --language kotlin --project-dir /tmp/e50-repro/proj
[FAIL] init.sh non-interactive: --gov-mode=private_poc is not valid for --deployment=organizational
  Reason: Private POC is always a personal deployment (baseline §2.5).
  Action: use --deployment=personal --gov-mode=private_poc, or --deployment=organizational --gov-mode=sponsored_poc.
  Context: --deployment=organizational, --gov-mode=private_poc
---RC=1---
```

**GREEN-after-fix evidence** (isolation harness with `set -euo pipefail`):

```
  [PASS] E50: mobile + organizational + sponsored_poc forces visibility=private
  [PASS] E50b: organizational + private_poc rejected with baseline §2.5 message
  [POST-CHECK] Suite still alive after E50b — set -e propagation contained ✓
PASS=2 FAIL=0 RC=0
```

**Mutation proof for E50b** (verifies the test actually pins the contract):

Temporarily replaced the rejection block at `init.sh:3262-3268` with a no-op (`:`); re-ran the new E50b combination:

```
$ "$INIT_SH" --non-interactive --validate-only --project uat-e50b --platform mobile \
    --deployment organizational --gov-mode private_poc --language kotlin --project-dir /tmp/e50b-mutated/proj
{
  "_validated": true,
  ...
  "gov_mode": "private_poc",
  "visibility": "private",
  ...
}
RC=0
```

E50b would correctly flip RED on this mutation (`_e50b_rc=0` instead of non-zero + missing rejection grep). Restored `init.sh` before commit; `diff init.sh.bak init.sh` returned no differences.

**Lint self-verify** (all exit 0):

```
$ bash scripts/lint-counter-antipattern.sh   -> OK: no counter-capture antipatterns found.
$ bash scripts/lint-backlog-references.sh    -> OK: backlog references and Closed-status citations are consistent.
$ bash scripts/lint-fix-functions-stderr.sh  -> OK: no fix_*() stderr silencers found.
$ bash scripts/lint-raw-read-prompt.sh       -> OK: no raw 'read -rp' / 'read -p' calls outside scripts/lib/helpers.sh.
```

## Bonus catches

- `set -euo pipefail` propagation gap in `tests/edge-cases-scripts.sh`: any new test whose subject command exits non-zero must wrap the substitution in `if … then _rc=0; else _rc=$?; fi`, or `set -e` will abort the suite on the assignment. Existing E48–E55 happy-path tests are immune (init.sh returns 0) so this bear-trap was latent; E50b would have hit it. Documented inline in the test alongside E50b.

## Coordination note

Files touched in this PR:
- `tests/edge-cases-scripts.sh` (E50 rewrite + E50b addition)
- `tests/full-project-test-suite.sh` (narrow SKIP_KNOWN_FAILING gate comment/message — TEST 0r region only)
- `docs/superpowers/specs/2026-04-25-init-sh-non-interactive-design.md` (E50 row in §8.2 table)

**Sibling Wave C PR (BL-064)** touches `init.sh` (exit-code path), a different code region from this PR's non-interactive contract path. `init.sh` is **unchanged** in this PR — only tests + docs/spec — so no `init.sh` rebase conflict is expected. Rebase risk is limited to the `full-project-test-suite.sh` TEST 0r section if BL-064's PR also touches an aggregator gate; trivial to reconcile.

## Worktree note

`/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_2a7270ce-74d-1`

## DO NOT merge.

This PR is part of the Wave C cohort; merge ordering will be handled by the orchestrator after the BL-064 + code-check-gates-7 siblings land and aggregator gates are reconciled. The backlog status-flip commit for BL-039 will follow in a second commit per the BL-036 / BL-037 discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)