### PR TITLE
fix(init): non-zero exit + structured summary after any [FAIL] (closes BL-064)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -56,6 +56,38 @@ CONFIRM_PITFALLS=0
 
 source "$SCRIPT_DIR/scripts/lib/helpers.sh"
 
+# ────────────────────────────────────────────────────────────────────
+# BL-064: init-failure tracking (silent-success defect class)
+# ────────────────────────────────────────────────────────────────────
+# Adversarial certainty re-walk (re-walker-2, scenario
+# `fresh-org-sponsored-poc-standard-web-ts`) surfaced that init.sh used
+# to exit 0 with the "Setup Complete" banner even after emitting a
+# [FAIL] line for branch protection (or push, or any other
+# create_and_protect_remote step that returns non-zero). Operators who
+# only check the exit code (or scan for the banner) miss the gap —
+# same defect class as PR #105's intake-wizard.sh:2028 silent success.
+#
+# Contract (closes BL-064):
+#   • create_and_protect_remote's failure paths (every print_fail
+#     inside that function feeds `return 1`, which the outer caller
+#     records via `record_init_failure`).
+#   • print_init_failures_summary prints a "Setup INCOMPLETE" banner
+#     with a re-listing of every tracked failure when INIT_FAILURES is
+#     non-empty.
+#   • main() ends with: if [ ${#INIT_FAILURES[@]} -gt 0 ]; then
+#     print_init_failures_summary; return 2; fi.  The non-zero return
+#     propagates as init.sh's exit status.
+#
+# Structural backstop: scripts/lint-fail-emit-exit-status.sh enforces
+# that every print_fail in init.sh either terminates (exit/return 1
+# inline or within 2 lines) or carries a `# lint-fail-emit-exit-status:
+# allow <reason>` annotation justifying continuation. See its header
+# for the regex + allowlist contract.
+INIT_FAILURES=()
+record_init_failure() {
+  INIT_FAILURES+=("$1")
+}
+
 # Audit specs-plans-init-intake-noninteractive-2 (2026-06): the dynamic
 # platform discovery used by the interactive flow at collect_inputs() and
 # the case-statement used by the non-interactive validator had drifted
@@ -109,7 +141,7 @@ check_prerequisites() {
   if command -v git &>/dev/null; then
     print_ok "Git $(git --version | awk '{print $3}')"
   else
-    print_fail "Git not found"
+    print_fail "Git not found"  # lint-fail-emit-exit-status: allow check_prerequisites accumulator pattern — missing tools are collected into missing_required[] and a single `exit 1` at the function tail (see line near print_fail "Missing required prerequisites" below) fires only when at least one required tool is absent; interactive install path may install the tool before that check, in which case the [FAIL] line is a status diagnostic only.
     local git_installed=false
     if [ "$interactive" = true ]; then
       if [ "$os_type" = "Darwin" ]; then
@@ -516,7 +548,7 @@ collect_project_info() {
     esac
     if [ -n "$os_block_reason" ]; then
       echo ""
-      print_fail "Incompatible OS/language combination: $LANGUAGE on $OS_TYPE"
+      print_fail "Incompatible OS/language combination: $LANGUAGE on $OS_TYPE"  # lint-fail-emit-exit-status: allow interactive prompt_choice recovery — the while-true loop below re-prompts for a compatible language and re-validates; init proceeds normally once the operator picks a valid combination, so the [FAIL] line is a status diagnostic that does NOT survive past the recovery loop.
       print_warn "$os_block_reason"
       echo ""
       print_info "Valid languages for $PLATFORM on $OS_TYPE:"
@@ -1932,6 +1964,16 @@ Framework: Solo Orchestrator v1.0"
     print_info "  scripts/check-gate.sh --repair           # to re-create remote and protection"
     print_info "  scripts/check-gate.sh --preflight        # to verify the remote is correctly set up"
     echo ""
+    # BL-064: record the host-setup failure so main()'s exit-time check
+    # prints "Setup INCOMPLETE" instead of "Setup Complete" and returns
+    # non-zero. Without this, the print_fail lines emitted inside
+    # create_and_protect_remote would be silently absorbed by `if !` and
+    # the operator would see rc=0 + a success banner. The summary cites
+    # the phase rather than each individual [FAIL] message — the lines
+    # themselves are already on stdout above; the summary's job is to
+    # surface that at least one phase failed so an operator scanning only
+    # the tail of the log still sees the gap.
+    record_init_failure "Host repo setup (create_and_protect_remote) — see [FAIL] lines above; remediate with scripts/check-gate.sh --repair"
   fi
 
   # If create_and_protect_remote wrote new state (manifest.remote_url update,
@@ -2861,6 +2903,52 @@ print_next_steps() {
 }
 
 # ================================================================
+# BL-064: Setup-INCOMPLETE summary (silent-success defect class)
+# ================================================================
+# Printed in place of "Setup Complete" when INIT_FAILURES is non-empty.
+# Re-lists every tracked failure so an operator scanning only the tail of
+# the log still sees the gap, regardless of whether they checked the exit
+# code. main() calls this and returns 2 when failures occurred.
+#
+# Failure categorisation:
+#   • Currently tracked: host repo setup (create_and_protect_remote
+#     return-1 paths — push fail, attestation missing, host CLI missing,
+#     protection config fail, verification fail).
+#   • NOT tracked (terminal-exit paths): missing prerequisites (line
+#     112-area + 322), incompatible OS/language (519, interactive
+#     recovery), --enforcement-level validation (3693, 3698). All of
+#     these already terminate via `exit 1` before reaching main()'s
+#     completion path, so no Setup-Complete banner can appear.
+#
+# See scripts/lint-fail-emit-exit-status.sh for the structural backstop
+# that prevents new print_fail sites from regressing this contract.
+print_init_failures_summary() {
+  local n="${#INIT_FAILURES[@]}"
+  echo ""
+  echo -e "${BOLD}${RED}╔══════════════════════════════════════════════════════════╗${NC}"
+  echo -e "${BOLD}${RED}║                   Setup INCOMPLETE                       ║${NC}"
+  echo -e "${BOLD}${RED}╚══════════════════════════════════════════════════════════╝${NC}"
+  echo ""
+  echo -e "${BOLD}${RED}${n} failure(s) occurred during init:${NC}"
+  local i=1
+  local msg
+  for msg in "${INIT_FAILURES[@]}"; do
+    echo -e "  ${RED}${i}.${NC} ${msg}"
+    i=$((i + 1))
+  done
+  echo ""
+  echo -e "${BOLD}Project files are in place; some setup steps did NOT complete.${NC}"
+  echo ""
+  echo "Typical remediation (consult the [FAIL] lines above for specifics):"
+  echo "  scripts/check-gate.sh --backfill-host    # if .claude/manifest.json lacks 'host'"
+  echo "  scripts/check-gate.sh --repair           # re-create remote + branch protection"
+  echo "  scripts/check-gate.sh --preflight        # verify the remote is set up correctly"
+  echo ""
+  echo "Exit status: 2 (init produced [FAIL] line(s) — wrapper scripts must observe)"
+  echo ""
+}
+
+# ================================================================
 dry_run_summary() {
   echo ""
   print_step "DRY RUN SUMMARY"
@@ -3745,6 +3833,17 @@ HELPEOF
     fi
 
     bash "$PROJECT_DIR/scripts/verify-install.sh" --auto-fix || true
+    # BL-064: if any tracked failure occurred during the run, replace the
+    # "Setup Complete" banner with "Setup INCOMPLETE" and surface a
+    # non-zero exit so wrapper scripts that gate downstream actions on
+    # init.sh succeeding observe the gap. record_init_failure callers
+    # (currently the create_and_protect_remote outer wrap) populate the
+    # INIT_FAILURES array; see init.sh header block for the contract.
+    if [ "${#INIT_FAILURES[@]}" -gt 0 ]; then
+      print_init_failures_summary
+      finalize_log
+      return 2
+    fi
     print_next_steps
   fi
 

--- a/scripts/lint-fail-emit-exit-status.sh
+++ b/scripts/lint-fail-emit-exit-status.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# scripts/lint-fail-emit-exit-status.sh — BL-064 structural backstop.
+#
+# THE DEFECT CLASS (silent-success after [FAIL])
+#   init.sh emits a `[FAIL]` line via `print_fail "..."` and then keeps
+#   running through to the "Setup Complete" banner with rc=0. Operators
+#   who only check the exit code (or scan for the banner) miss the gap
+#   entirely — exactly the scenario branch protection / push verification
+#   exists to prevent. See solo-orchestrator-backlog.md BL-064 and
+#   Reports/2026-06-29-adversarial-certainty-pass.md § Tailoring signals
+#   catalog S-7 for the full history. PR #105 fixed the same defect
+#   shape in scripts/intake-wizard.sh:2028.
+#
+# WHAT THIS LINT ENFORCES IN init.sh
+#   Every `print_fail "..."` line in init.sh must, on its own line, be
+#   one of:
+#     (a) terminated inline:        `; exit ` or `; return `
+#     (b) followed within 2 lines:  `exit ` or `return 1` (or `return $N`)
+#     (c) followed within 2 lines:  `record_init_failure ...` (BL-064 helper)
+#     (d) explicitly allowed:       a same-line `# lint-fail-emit-exit-
+#         status: allow <reason>` annotation with a non-empty <reason>.
+#
+#   The structural rule is: every [FAIL] emit must either propagate to
+#   the script's exit status (via terminal exit/return) OR be explicitly
+#   commented as a recoverable / non-fatal status diagnostic.
+#
+# WHAT THIS LINT DOES NOT ENFORCE
+#   • Other scripts that use print_fail — those have their own callers
+#     and exit-status contracts. The silent-success defect that BL-064
+#     remediates was specific to init.sh's "Setup Complete" banner.
+#     Future expansion to other operator-facing scripts is welcome but
+#     out of BL-064 scope.
+#   • Heredocs that contain the literal string "[FAIL]" (e.g. the
+#     non-interactive help block in init.sh). The regex anchors on
+#     `print_fail` invocations, not on `[FAIL]` strings, so this is
+#     a non-issue.
+#
+# ALLOWLIST FORMAT
+#   Append `# lint-fail-emit-exit-status: allow <reason>` to the
+#   `print_fail` line itself (NOT a sibling line). Empty reason fails
+#   the lint so reviewers always have justification text to evaluate.
+#
+# EXIT CODES
+#   0 — no violations
+#   1 — one or more violations found
+#   2 — invocation / I/O error
+#
+# USAGE
+#   bash scripts/lint-fail-emit-exit-status.sh           # quiet pass/fail
+#   bash scripts/lint-fail-emit-exit-status.sh --list    # PASS/FAIL table
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TARGET_FILE="$REPO_ROOT/init.sh"
+
+LIST_MODE=0
+if [ "${1:-}" = "--list" ]; then
+  LIST_MODE=1
+elif [ -n "${1:-}" ]; then
+  echo "Usage: $0 [--list]" >&2
+  exit 2
+fi
+
+if [ ! -f "$TARGET_FILE" ]; then
+  echo "lint-fail-emit-exit-status: $TARGET_FILE not found" >&2
+  exit 2
+fi
+
+# Match a `print_fail "..."` invocation anywhere on the line. init.sh
+# embeds print_fail in three syntactic shapes:
+#   1. Indented statement:                   `    print_fail "..."`
+#   2. Same-line compound statement:         `... && { print_fail "..."; return 1; }`
+#   3. Short-circuit after `||`:             `cmd || { print_fail "..."; return 1; }`
+# The regex requires a word-boundary character (start-of-line, whitespace,
+# `{`, `;`, `|`, `&`) immediately before `print_fail` so it doesn't match
+# substrings inside identifiers. It also requires a following whitespace +
+# `"` so heredoc/comment mentions of the literal word `print_fail` don't
+# false-trigger.
+PRINT_FAIL_RE='(^|[[:space:]{;|&])print_fail[[:space:]]+"'
+
+# Same-line terminators (matches in any position on the line).
+INLINE_TERMINATOR_RE=';[[:space:]]*(exit|return)([[:space:]]|$)'
+
+# Same-line allow marker.
+ALLOW_MARKER_RE='# lint-fail-emit-exit-status:[[:space:]]*allow[[:space:]]+'
+
+# Next/next-next line acceptable forms (no leading-content constraint;
+# bash/zsh allows arbitrary indentation).
+NEXT_LINE_RE='^[[:space:]]*(exit([[:space:]]|$)|return([[:space:]]|$)|record_init_failure([[:space:](]|$))'
+
+VIOLATIONS=0
+LIST_ROWS=""
+
+declare -a LINES=()
+while IFS= read -r line || [ -n "$line" ]; do
+  LINES+=("$line")
+done < "$TARGET_FILE"
+
+n=${#LINES[@]}
+for ((i = 0; i < n; i++)); do
+  line="${LINES[i]}"
+
+  # Skip lines that don't invoke print_fail.
+  echo "$line" | grep -Eq "$PRINT_FAIL_RE" || continue
+
+  lineno=$((i + 1))
+
+  # ── (a) inline terminator on this line ──────────────────────────
+  if echo "$line" | grep -Eq "$INLINE_TERMINATOR_RE"; then
+    LIST_ROWS="${LIST_ROWS}PASS\tinit.sh:${lineno}\tinline-terminator\n"
+    continue
+  fi
+
+  # ── (d) explicit allow marker on this line ──────────────────────
+  if echo "$line" | grep -Eq "$ALLOW_MARKER_RE"; then
+    # Extract reason: everything after the marker prefix.
+    reason="${line##*# lint-fail-emit-exit-status: allow}"
+    # Trim leading/trailing whitespace.
+    reason="${reason#"${reason%%[![:space:]]*}"}"
+    reason="${reason%"${reason##*[![:space:]]}"}"
+    if [ -z "$reason" ]; then
+      echo "init.sh:${lineno}: lint-fail-emit-exit-status: allowlist marker present but reason is empty" >&2
+      VIOLATIONS=$((VIOLATIONS + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\tinit.sh:${lineno}\tallowlist-empty-reason\n"
+    else
+      LIST_ROWS="${LIST_ROWS}PASS\tinit.sh:${lineno}\tallowlist:${reason}\n"
+    fi
+    continue
+  fi
+
+  # ── (b)/(c) check next two non-blank lines ──────────────────────
+  matched=0
+  for offset in 1 2; do
+    j=$((i + offset))
+    [ "$j" -lt "$n" ] || break
+    candidate="${LINES[j]}"
+    if echo "$candidate" | grep -Eq "$NEXT_LINE_RE"; then
+      matched=1
+      break
+    fi
+  done
+  if [ "$matched" -eq 1 ]; then
+    LIST_ROWS="${LIST_ROWS}PASS\tinit.sh:${lineno}\tnext-line-terminator\n"
+    continue
+  fi
+
+  echo "init.sh:${lineno}: lint-fail-emit-exit-status: print_fail does not propagate to exit status" >&2
+  echo "  Add 'exit 1' / 'return 1' / 'record_init_failure ...' within 2 lines," >&2
+  echo "  or append '# lint-fail-emit-exit-status: allow <reason>' to this line." >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+  LIST_ROWS="${LIST_ROWS}FAIL\tinit.sh:${lineno}\tno-terminator-no-allow\n"
+done
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS violation(s) found. See scripts/lint-fail-emit-exit-status.sh header for the fix pattern." >&2
+  exit 1
+fi
+
+echo "OK: every print_fail in init.sh propagates to exit status (or is annotated)."
+exit 0

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1502,7 +1502,7 @@ The adversarial certainty re-walk (re-walker-5, scenarios `edge-phase-3-to-4-poc
 **Logged:** 2026-06-29
 **Category:** Bug
 **Severity:** Major
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #118, commit 443b50a)
 
 The adversarial certainty re-walk (re-walker-2, scenario `fresh-org-sponsored-poc-standard-web-ts`) surfaced that `init.sh` exits `0` with the `Setup Complete` banner even after emitting a `[FAIL]` line for branch protection. Operators who only check the exit code (or scan for the banner) miss the gap entirely — the script claims success while having printed a failure diagnostic. This is the same silent-success defect shape that PR #105 fixed in `intake-wizard.sh:2028` (and the same defect class addressed by recent retroactive lint additions for `[FAIL]`-followed-by-`exit 0` patterns).
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -181,6 +181,39 @@ else
 fi
 
 # ================================================================
+# TEST 0c3b: BL-064 — init.sh non-zero exit + Setup INCOMPLETE banner after [FAIL]
+# ================================================================
+# Regression suite for BL-064: init.sh used to exit 0 with the
+# "Setup Complete" banner even after emitting a [FAIL] line for
+# create_and_protect_remote (push, branch protection, host CLI). The
+# silent-success defect bypassed any wrapper script that gated on the
+# init exit code. Fix: INIT_FAILURES array + record_init_failure helper
+# + print_init_failures_summary in init.sh; non-zero exit propagates.
+# See solo-orchestrator-backlog.md BL-064 + adversarial-certainty-pass
+# report § S-7 for full context.
+section "init.sh non-zero exit + Setup INCOMPLETE after [FAIL] (BL-064)"
+if bash "$SCRIPT_DIR/tests/test-init-fail-status-propagation.sh" >/dev/null 2>&1; then
+  pass "init.sh BL-064 silent-success-after-FAIL tests (5/5)"
+else
+  fail "init.sh BL-064 silent-success-after-FAIL tests FAILED (run tests/test-init-fail-status-propagation.sh for details)"
+fi
+
+# ================================================================
+# TEST 0c3c: BL-064 — structural backstop lint for new print_fail sites
+# ================================================================
+# Sibling of lint-counter-antipattern.sh: enforces that every print_fail
+# invocation in init.sh either terminates (exit/return inline or within
+# 2 lines), routes through record_init_failure, or carries an explicit
+# `# lint-fail-emit-exit-status: allow <reason>` annotation. Prevents
+# regression of the BL-064 silent-success-after-FAIL defect class.
+section "Fail-emit exit-status propagation lint (BL-064 structural backstop)"
+if bash "$SCRIPT_DIR/scripts/lint-fail-emit-exit-status.sh" >/dev/null 2>&1; then
+  pass "Every print_fail in init.sh propagates to exit status (or is annotated)"
+else
+  fail "Fail-emit lint found a print_fail without exit-status propagation (see scripts/lint-fail-emit-exit-status.sh --list)"
+fi
+
+# ================================================================
 # TEST 0c4: BL-057 — --non-interactive must honor AUTO_INSTALL_TOOLS env
 # ================================================================
 # Regression suite for BL-057: scripts/init.sh's resolve_and_install_tools

--- a/tests/test-init-fail-status-propagation.sh
+++ b/tests/test-init-fail-status-propagation.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# tests/test-init-fail-status-propagation.sh — BL-064 regression test.
+#
+# BL-064 (Major, 2026-06-29 adversarial certainty pass): init.sh exits 0
+# with the "Setup Complete" banner even after emitting a [FAIL] line for
+# branch protection (or push, or any other create_and_protect_remote step
+# that returns non-zero). Operators who only check the exit code (or scan
+# for the banner) miss the gap entirely — same silent-success defect class
+# that PR #105 fixed in intake-wizard.sh:2028.
+#
+# The fix (see init.sh::record_init_failure + print_init_failures_summary):
+#   1. create_and_protect_remote's failure is tracked in INIT_FAILURES.
+#   2. main() checks INIT_FAILURES after verify-install:
+#        - empty → prints "Setup Complete" banner, returns 0
+#        - non-empty → prints "Setup INCOMPLETE" summary re-listing every
+#          tracked [FAIL], returns 2.
+#   3. The exit code propagates to the script's exit status so wrapper
+#      scripts that gate downstream actions on init.sh succeeding observe
+#      the failure.
+#
+# This test is the regression guard: with a controlled push-failure trigger
+# (fake remote URL), init.sh must exit non-zero AND must NOT print the
+# unconditional "Setup Complete" banner AND must re-list the failure in a
+# structured summary.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT_SH="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Helper: run init.sh against a fake URL (push always fails) and capture
+# rc + full output. Used by both T1 (propagation) and T2 (summary content).
+_run_init_with_fake_url() {
+  local tmpdir="$1"
+  local proj="$tmpdir/proj"
+  local rc=0
+  ( cd "$tmpdir" && "$INIT_SH" --non-interactive \
+        --project bl064-trace \
+        --platform web \
+        --deployment personal \
+        --language typescript \
+        --project-dir "$proj" \
+        --git-host other \
+        --remote-url https://example.invalid/fake.git \
+        --branch-protection-attested \
+        --visibility private \
+        --allow-existing-dir > "$tmpdir/out" 2>&1 ) || rc=$?
+  echo "$rc"
+}
+
+# T1: rc must be non-zero when create_and_protect_remote emits [FAIL].
+t1_rc_nonzero_after_create_and_protect_remote_fail() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local rc; rc=$(_run_init_with_fake_url "$tmpdir")
+
+  # Sanity: the test's trigger relies on the fake URL producing a push [FAIL].
+  if ! grep -q "Push failed" "$tmpdir/out"; then
+    fail_ "T1" "trigger broken — expected [FAIL] 'Push failed' in output; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # The actual contract: rc must be non-zero so wrapper scripts see the gap.
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T1" "BL-064 silent-success regression: init.sh exited 0 despite [FAIL] line; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  pass "T1: init.sh exits non-zero (rc=$rc) when create_and_protect_remote emits [FAIL]"
+  rm -rf "$tmpdir"
+}
+
+# T2: the unconditional "Setup Complete" banner must NOT print on the failure
+# path. Either the banner is suppressed entirely or it is replaced by an
+# explicit "Setup INCOMPLETE" banner that re-lists the failures.
+t2_setup_complete_banner_suppressed_on_failure() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  _run_init_with_fake_url "$tmpdir" > /dev/null
+
+  if ! grep -q "Push failed" "$tmpdir/out"; then
+    fail_ "T2" "trigger broken — expected [FAIL] 'Push failed' in output"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # The defect signature: a bare "Setup Complete" line appears even after
+  # [FAIL]. After the fix, that banner must not appear; an explicit
+  # "Setup INCOMPLETE" banner takes its place.
+  if grep -Eq '^[^|]*Setup Complete' "$tmpdir/out" && ! grep -q "Setup INCOMPLETE" "$tmpdir/out"; then
+    fail_ "T2" "BL-064 silent-success regression: 'Setup Complete' banner printed without 'Setup INCOMPLETE' override; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  if ! grep -q "Setup INCOMPLETE" "$tmpdir/out"; then
+    fail_ "T2" "expected 'Setup INCOMPLETE' banner on failure path; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  pass "T2: 'Setup Complete' banner suppressed; 'Setup INCOMPLETE' replaces it on failure path"
+  rm -rf "$tmpdir"
+}
+
+# T3: the exit-time summary must re-list the tracked failure so an operator
+# scanning only the tail of the log still sees the gap.
+t3_exit_summary_relists_failure() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  _run_init_with_fake_url "$tmpdir" > /dev/null
+
+  if ! grep -q "Push failed" "$tmpdir/out"; then
+    fail_ "T3" "trigger broken — expected [FAIL] 'Push failed' in output"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # The structured summary must contain a re-listing of the tracked failure.
+  # We anchor on the summary section keyword and the host-setup phase token
+  # that record_init_failure cites; the exact wording is informational only.
+  if ! grep -qi "failure(s) occurred during init" "$tmpdir/out"; then
+    fail_ "T3" "expected exit-time summary keyword 'failure(s) occurred during init'; tail:\n$(tail -25 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+  if ! grep -qi "Host repo setup" "$tmpdir/out"; then
+    fail_ "T3" "expected summary to cite 'Host repo setup' phase; tail:\n$(tail -25 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  pass "T3: exit-time summary re-lists the host-setup failure"
+  rm -rf "$tmpdir"
+}
+
+# T4: BL-024 invariant preservation — the attestation MUST still be recorded
+# even though init.sh now exits non-zero. The BL-024 fix recorded attestation
+# BEFORE push so a push failure cannot drop the operator's commitment; BL-064
+# must not regress that.
+t4_attestation_still_recorded_under_new_contract() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/proj"
+  _run_init_with_fake_url "$tmpdir" > /dev/null
+
+  if [ ! -f "$proj/.claude/process-state.json" ]; then
+    fail_ "T4" "process-state.json missing — BL-024 attestation invariant regressed"
+    rm -rf "$tmpdir"; return
+  fi
+  local attested_by
+  attested_by=$(jq -r '.phase2_init.attestations.branch_protection.attested_by // "MISSING"' "$proj/.claude/process-state.json")
+  if [ "$attested_by" != "orchestrator" ]; then
+    fail_ "T4" "BL-024 regression: expected attested_by=orchestrator; got '$attested_by'"
+    rm -rf "$tmpdir"; return
+  fi
+
+  pass "T4: BL-024 attestation recorded under BL-064 non-zero-exit contract"
+  rm -rf "$tmpdir"
+}
+
+# T5: clean-path invariant — when create_and_protect_remote succeeds (here
+# via --no-remote-creation, which skips the API entirely), init.sh must
+# still exit 0 with the unmodified "Setup Complete" banner. This pins the
+# negative side of the new contract — the BL-064 fix must not flag every
+# init as INCOMPLETE.
+t5_clean_path_still_setup_complete() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj="$tmpdir/proj"
+  local rc=0
+  ( cd "$tmpdir" && "$INIT_SH" --non-interactive \
+        --project bl064-clean \
+        --platform web \
+        --deployment personal \
+        --language typescript \
+        --project-dir "$proj" \
+        --git-host github \
+        --visibility private \
+        --no-remote-creation \
+        --allow-existing-dir > "$tmpdir/out" 2>&1 ) || rc=$?
+
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T5" "BL-064 over-flag regression: clean-path init exited rc=$rc; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+  if ! grep -q "Setup Complete" "$tmpdir/out"; then
+    fail_ "T5" "clean-path init missing 'Setup Complete' banner; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+  if grep -q "Setup INCOMPLETE" "$tmpdir/out"; then
+    fail_ "T5" "clean-path init wrongly printed 'Setup INCOMPLETE'; tail:\n$(tail -20 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  pass "T5: clean-path init still produces 'Setup Complete' with rc=0"
+  rm -rf "$tmpdir"
+}
+
+echo "== tests/test-init-fail-status-propagation.sh =="
+t1_rc_nonzero_after_create_and_protect_remote_fail
+t2_setup_complete_banner_suppressed_on_failure
+t3_exit_summary_relists_failure
+t4_attestation_still_recorded_under_new_contract
+t5_clean_path_still_setup_complete
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-init-other-host-attestation.sh
+++ b/tests/test-init-other-host-attestation.sh
@@ -1,16 +1,29 @@
 #!/usr/bin/env bash
-# tests/test-init-other-host-attestation.sh — BL-024 regression test.
+# tests/test-init-other-host-attestation.sh — BL-024 + BL-064 regression test.
 #
-# init.sh::create_and_protect_remote on the --git-host other path used to
-# perform `git push` BEFORE the --branch-protection-attested attestation
-# block. When the push failed (fake URL, corporate firewall, connectivity
-# blip), `return 1` aborted the function and the attestation was silently
-# dropped — even though the operator had explicitly passed
-# --branch-protection-attested.
-#
-# The fix reorders the attestation block to run BEFORE push, since
+# BL-024 (fixed earlier): init.sh::create_and_protect_remote on the
+# --git-host other path used to perform `git push` BEFORE the
+# --branch-protection-attested attestation block. When the push failed
+# (fake URL, corporate firewall, connectivity blip), `return 1` aborted
+# the function and the attestation was silently dropped — even though
+# the operator had explicitly passed --branch-protection-attested.
+# The BL-024 fix reorders the attestation block to run BEFORE push, since
 # attestation is a forward-looking commitment by the operator and is
 # independent of push success.
+#
+# BL-064 (Major, 2026-06-30): init.sh used to exit 0 with the
+# "Setup Complete" banner even after emitting a [FAIL] line for push
+# (or branch protection, or any other create_and_protect_remote step
+# that returns non-zero). Operators who only check the exit code missed
+# the gap — same silent-success defect class as PR #105's intake-wizard.sh
+# fix. The BL-064 fix tracks create_and_protect_remote's failure in
+# INIT_FAILURES and exits the script with rc=2 + a "Setup INCOMPLETE"
+# banner that re-lists the failure.
+#
+# T1 below covers BOTH contracts on the same fixture:
+#   • BL-064: rc must be non-zero (was rc=0 before BL-064 fix).
+#   • BL-064: "Setup INCOMPLETE" banner replaces "Setup Complete".
+#   • BL-024: attestation must STILL be recorded despite the push fail.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -40,9 +53,13 @@ t1_attestation_recorded_when_push_fails_to_fake_url() {
         --visibility private \
         --allow-existing-dir > "$tmpdir/out" 2>&1 ) || rc=$?
 
-  # init.sh continues past push failure (BL-016/U-B fix), so it should exit 0.
-  if [ "$rc" -ne 0 ]; then
-    fail_ "T1" "expected init exit 0; rc=$rc tail:\n$(tail -10 "$tmpdir/out")"
+  # BL-064: init.sh now exits non-zero (rc=2) when create_and_protect_remote
+  # emits [FAIL]. Pre-BL-064, rc was 0 with the unconditional "Setup Complete"
+  # banner — the silent-success defect closed by BL-064. The script still
+  # writes attestation + project files (BL-024 invariant, asserted below);
+  # only the exit code and banner change.
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T1" "BL-064 silent-success regression: expected non-zero rc on push failure; got rc=0; tail:\n$(tail -15 "$tmpdir/out")"
     rm -rf "$tmpdir"; return
   fi
 
@@ -52,18 +69,25 @@ t1_attestation_recorded_when_push_fails_to_fake_url() {
     rm -rf "$tmpdir"; return
   fi
 
-  # The attestation MUST be recorded despite the push failure.
+  # BL-064: the "Setup INCOMPLETE" banner must replace "Setup Complete" on
+  # the failure path so an operator scanning only the tail sees the gap.
+  if ! grep -q "Setup INCOMPLETE" "$tmpdir/out"; then
+    fail_ "T1" "BL-064: expected 'Setup INCOMPLETE' banner; tail:\n$(tail -15 "$tmpdir/out")"
+    rm -rf "$tmpdir"; return
+  fi
+
+  # BL-024 invariant: the attestation MUST be recorded despite the push failure.
   if [ ! -f "$proj/.claude/process-state.json" ]; then
-    fail_ "T1" "process-state.json missing"
+    fail_ "T1" "BL-024 regression: process-state.json missing"
     rm -rf "$tmpdir"; return
   fi
   local attested_by
   attested_by=$(jq -r '.phase2_init.attestations.branch_protection.attested_by // "MISSING"' "$proj/.claude/process-state.json")
   if [ "$attested_by" != "orchestrator" ]; then
-    fail_ "T1" "expected attested_by=orchestrator; got '$attested_by'"
+    fail_ "T1" "BL-024 regression: expected attested_by=orchestrator; got '$attested_by'"
     rm -rf "$tmpdir"; return
   fi
-  pass "T1: --branch-protection-attested recorded despite push-to-fake-URL failure"
+  pass "T1: --branch-protection-attested recorded (BL-024) + rc=2 + Setup INCOMPLETE banner (BL-064)"
   rm -rf "$tmpdir"
 }
 


### PR DESCRIPTION
## Summary

- **Defect class**: silent-success after `[FAIL]` — same shape as PR #105's `intake-wizard.sh:2028` fix. `init.sh` used to exit `0` with the "Setup Complete" banner even after emitting `[FAIL]` for branch protection, push, host CLI, repo creation, or verification. Operators who only check the exit code (or scan for the banner) missed the gap entirely.
- **Fix**: `INIT_FAILURES` array + `record_init_failure` helper track every phase-level failure (populated at the `create_and_protect_remote` outer wrap). `print_init_failures_summary` replaces the "Setup Complete" banner with "Setup INCOMPLETE" + a re-listing of every tracked failure when any are present. Script exits with `rc=2` so wrapper scripts that gate on init succeeding observe the gap.
- **Comment justifications**: lines 144 (`Git not found` — accumulator pattern with `exit 1` at function tail) and 551 (incompatible OS/language — interactive `prompt_choice` recovery loop) carry explicit `# lint-fail-emit-exit-status: allow <reason>` annotations.
- **Structural backstop**: `scripts/lint-fail-emit-exit-status.sh` enforces that every `print_fail` in `init.sh` either terminates (exit/return inline or within 2 lines), routes through `record_init_failure`, or carries an allow annotation. Prevents regression when new `print_fail` sites are added.
- **Test wiring**: per BL-034 invariant, the new test + the new lint are wired into `tests/full-project-test-suite.sh` (TEST 0c3b + 0c3c).

## Closes

BL-064

## Test plan

**RED on origin/main** (defect confirmed):
```
[FAIL] T1 — BL-064 silent-success regression: init.sh exited 0 despite [FAIL] line
[FAIL] T2 — BL-064 silent-success regression: 'Setup Complete' banner printed without 'Setup INCOMPLETE' override
[FAIL] T3 — expected exit-time summary keyword 'failure(s) occurred during init'
[PASS] T4: BL-024 attestation recorded under BL-064 non-zero-exit contract
[PASS] T5: clean-path init still produces 'Setup Complete' with rc=0
```

**GREEN after fix** (5/5 pass):
```
[PASS] T1: init.sh exits non-zero (rc=2) when create_and_protect_remote emits [FAIL]
[PASS] T2: 'Setup Complete' banner suppressed; 'Setup INCOMPLETE' replaces it on failure path
[PASS] T3: exit-time summary re-lists the host-setup failure
[PASS] T4: BL-024 attestation recorded under BL-064 non-zero-exit contract
[PASS] T5: clean-path init still produces 'Setup Complete' with rc=0
```

**Mutation experiment 1** (revert `record_init_failure` invocation, leave the rest):
```
[FAIL] T1 — BL-064 silent-success regression: init.sh exited 0 despite [FAIL] line
[FAIL] T2 — BL-064 silent-success regression: 'Setup Complete' banner printed without 'Setup INCOMPLETE' override
[FAIL] T3 — expected exit-time summary keyword 'failure(s) occurred during init'
[PASS] T4: BL-024 attestation recorded under BL-064 non-zero-exit contract
[PASS] T5: clean-path init still produces 'Setup Complete' with rc=0
```
Confirms T1-T3 catch the regression while T4-T5 (independent invariants) stay GREEN.

**Mutation experiment 2** (remove `return 1` after `print_fail "Push failed — verify URL and credentials"` at init.sh:2087):
```
init.sh:2087: lint-fail-emit-exit-status: print_fail does not propagate to exit status
1 violation(s) found.
```
Confirms the new lint catches a regression in the structural contract.

**Sibling tests still pass**:
- `tests/test-init-other-host-attestation.sh` (BL-024 + BL-064 combined): 2/2
- `tests/test-init-organizational.sh`: 2/2
- `tests/test-init-no-remote-creation.sh`: 3/3
- All four required lints + counter-antipattern behavior tests: 12/12

## Bonus catches

- None this pass — kept scope strictly to BL-064.

## Coordination note

**Files touched**: `init.sh` (BL-064 region: top-of-file helper + create_and_protect_remote outer wrap + main() exit check + Setup-INCOMPLETE summary function + 2 print_fail allowlist comments), `scripts/lint-fail-emit-exit-status.sh` (new), `tests/test-init-fail-status-propagation.sh` (new), `tests/test-init-other-host-attestation.sh` (T1 contract update for BL-064), `tests/full-project-test-suite.sh` (2 new sections wired), `solo-orchestrator-backlog.md` (BL-064 status flip — second commit).

**Expected rebase with Wave C sibling PRs**: BL-039 (`fix/bl039-...`) also touches `init.sh`, but in a different region (non-interactive contract, not the exit-status + print_fail audit covered here). Trivial textual conflict unlikely; semantic conflict ruled out (different functions, different concerns). Land order does not matter.

## Worktree note

`/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_2a7270ce-74d-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)