### PR TITLE
fix(check-phase-gate): WARN-not-fallback on missing gate section + Bootstrap T-blame-1 + scrub placeholder (post-merge follow-up on PR #116)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -260,39 +260,80 @@ validate_approval_fields() {
       # Approver row, then `git blame -L<N>,<N>` to extract the author
       # of THAT line's most recent change. Compare against approver.
       #
-      # The awk walker scans for the gate header (case-insensitive
-      # regex match — same shape `grep -A 20 "$gate_name"` uses above),
-      # then within the section walks until the next ## header or `---`
-      # rule, locating the first Approver row that isn't a Role row.
-      # Print its line number and exit.
+      # The awk walker scans for the gate header, then within the
+      # section walks until the next ## header or `---` rule, locating
+      # the first Approver row that isn't a Role row. It emits one of:
+      #
+      #   <integer>   the approver row's 1-based line number
+      #   NO_APPROVER gate header found but no Approver row inside
+      #   NO_SECTION  no `## ` header matching the gate at all
+      #
+      # PR #116 follow-up (post-merge verifier MINOR #2): the previous
+      # implementation silently fell back to the pre-fix file-level
+      # `git log -1` lookup when the walker found no line — reinstating
+      # the exact self-approval evasion this PR was meant to close, for
+      # any malformed/non-canonical APPROVAL_LOG.md. The fallback is
+      # removed: missing section OR missing approver row → operator-
+      # visible WARN + early return, never a silent file-level lookup.
+      #
+      # Headers and gate_name are both capitalized (canonical template
+      # uses "## Phase Gate: Phase 0 → Phase 1"), so case-sensitive
+      # matching is sufficient and matches the prior `grep -A 20` shape
+      # (also case-sensitive). `IGNORECASE = 1` is a gawk extension
+      # silently ignored on BSD/macOS awk — removed as dead code.
       approver_line=$(awk -v gate="$gate_name" '
-        BEGIN { IGNORECASE = 1 }
-        $0 ~ gate && /^## / { in_section = 1; next }
+        BEGIN { found_section = 0; found_approver = 0; approver_nr = 0 }
+        $0 ~ gate && /^## / { in_section = 1; found_section = 1; next }
         in_section && /^## / { exit }
         in_section && /^---[[:space:]]*$/ { exit }
-        in_section && /[Aa]pprover/ && !/Role/ { print NR; exit }
+        in_section && /[Aa]pprover/ && !/Role/ {
+          if (!found_approver) { approver_nr = NR; found_approver = 1 }
+          exit
+        }
+        END {
+          if (found_approver) print approver_nr
+          else if (found_section) print "NO_APPROVER"
+          else print "NO_SECTION"
+        }
       ' "$APPROVAL_LOG" 2>/dev/null || echo "")
 
-      if [ -n "$approver_line" ]; then
-        # `git blame --line-porcelain` prints an `author <name>` line
-        # per blame entry. When the line differs from HEAD (uncommitted
-        # working-tree modification) blame returns "Not Committed Yet".
-        # Both "empty author" and "Not Committed Yet" indicate the
-        # invariant cannot be verified — collapse to the WARN branch.
-        commit_author=$(git blame --line-porcelain \
-                          -L "${approver_line},${approver_line}" \
-                          -- "$APPROVAL_LOG" 2>/dev/null \
-                          | awk '/^author / { sub(/^author /, ""); print; exit }' \
-                          || echo "")
-        if [ "$commit_author" = "Not Committed Yet" ] || [ "$commit_author" = "External file (--contents)" ]; then
-          commit_author=""
-        fi
-      else
-        # awk found neither the gate section nor an Approver row.
-        # Fall back to the file-level lookup so a missing-section case
-        # still has SOME signal (and the WARN branch will fire if it
-        # also returns empty).
-        commit_author=$(git log -n 1 --format='%an' -- "$APPROVAL_LOG" 2>/dev/null || echo "")
+      case "$approver_line" in
+        NO_SECTION)
+          # Canonical `## ` header not present — silent fallback to
+          # `git log -1` would reintroduce the self-approval evasion.
+          # Surface as WARN so the malformed file becomes audit signal.
+          echo -e "${YELLOW}[WARN]${NC} $gate_label: APPROVAL_LOG.md has no '## ' header matching gate — cannot verify self-approval (malformed file?). Refusing silent file-level fallback; restore canonical '## Phase Gate: …' header."
+          issues=$((issues + 1))
+          return 0
+          ;;
+        NO_APPROVER)
+          # Gate section found but contains no Approver row — same
+          # silent-pass risk if we fell back to file-level lookup.
+          echo -e "${YELLOW}[WARN]${NC} $gate_label: APPROVAL_LOG.md gate section found but no Approver row — cannot verify self-approval. Add an 'Approver' row to the gate section."
+          issues=$((issues + 1))
+          return 0
+          ;;
+        ''|*[!0-9]*)
+          # awk script failed entirely (unexpected — defensive).
+          echo -e "${YELLOW}[WARN]${NC} $gate_label: APPROVAL_LOG.md gate-section walker produced no result — cannot verify self-approval."
+          issues=$((issues + 1))
+          return 0
+          ;;
+      esac
+
+      # approver_line is a numeric line number — run per-line blame.
+      # `git blame --line-porcelain` prints an `author <name>` line per
+      # entry. When the line differs from HEAD (uncommitted working-
+      # tree modification) blame returns "Not Committed Yet". Both
+      # empty-author and "Not Committed Yet" mean the invariant cannot
+      # be verified — collapse to the WARN branch below.
+      commit_author=$(git blame --line-porcelain \
+                        -L "${approver_line},${approver_line}" \
+                        -- "$APPROVAL_LOG" 2>/dev/null \
+                        | awk '/^author / { sub(/^author /, ""); print; exit }' \
+                        || echo "")
+      if [ "$commit_author" = "Not Committed Yet" ] || [ "$commit_author" = "External file (--contents)" ]; then
+        commit_author=""
       fi
       commit_author_norm=$(printf '%s' "$commit_author" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
 
@@ -307,13 +348,13 @@ validate_approval_fields() {
         issues=$((issues + 1))
       elif [ -z "$commit_author_norm" ] && [ -n "$approver_norm" ]; then
         # code-check-gates-7-followup: cannot verify the per-line blame
-        # author either because (a) the Approver row was added in the
-        # working tree only (uncommitted) — `git blame` returns "Not
-        # Committed Yet", normalized to empty above; (b) the gate
-        # section was not found in APPROVAL_LOG.md and the file-level
-        # fallback also returned empty; or (c) git is unavailable.
-        # Surface as WARN so the silent-pass case never recurs (baseline
-        # §5 invariant #9 audit signal).
+        # author because (a) the Approver row was added in the working
+        # tree only (uncommitted) — `git blame` returns "Not Committed
+        # Yet", normalized to empty above; or (b) git is unavailable.
+        # The missing-section / no-approver-row cases never reach this
+        # branch — the case-statement above returns early with a louder
+        # WARN. Surface as WARN so the silent-pass case never recurs
+        # (baseline §5 invariant #9 audit signal).
         echo -e "${YELLOW}[WARN]${NC} $gate_label: cannot verify commit author for approver '$approver_name' — APPROVAL_LOG.md row not yet committed (or per-line blame returned no author). Commit the approval entry to enable self-approval verification."
         issues=$((issues + 1))
       fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -824,7 +824,7 @@ These two gates patch the most damaging clobber surfaces, but the underlying des
 **Logged:** 2026-06-28 (PR #87 cycle-7 verifier major #4)
 **Category:** Bug / governance (precision of self-approval check)
 **Severity:** Major
-**Status:** Closed (2026-06-30, PR #<PR>, commit `06fb186`)
+**Status:** Closed (2026-06-30, PR #116, commit `06fb186`)
 
 `scripts/check-phase-gate.sh:246` resolves the commit author of an approval via `git log -n 1 --format=%an -- APPROVAL_LOG.md`, which returns whoever most recently touched the file — not who added the specific gate's Approver row. The cycle-7 PR-#87 adversarial verifier (major #4) flagged the resulting attack surface: if Alice committed her own approval row (true self-approval — should FAIL) and Bob later committed a typo fix to a different gate's row, the check passes for Alice because the latest commit author is Bob.
 

--- a/tests/test-check-phase-gate-blame-walker.sh
+++ b/tests/test-check-phase-gate-blame-walker.sh
@@ -30,6 +30,14 @@
 #   T-blame-3: Bob commits Alice's approval row on her behalf
 #              (legitimate organizational approval — Alice is the
 #              approver, Bob is the committer). MUST NOT FAIL.
+#   T-blame-4: Malformed APPROVAL_LOG.md (gate header is `### ` h3
+#              instead of canonical `## ` h2). The PR #116 awk walker
+#              fails to match, and the pre-followup code silently fell
+#              back to file-level `git log -1 -- APPROVAL_LOG.md` — re-
+#              introducing the very evasion the per-line walker closes.
+#              The follow-up MUST WARN ("gate section not found") and
+#              MUST NOT silently fall back. Confirms the silent-pass
+#              class is closed for non-canonical files.
 
 set -uo pipefail
 
@@ -130,7 +138,18 @@ run_gate() {
 echo "T-blame-1: Alice self-approves gate 0→1, Bob later edits gate 1→2 → MUST still FAIL Alice"
 setup
 write_phase_state_org_phase2
-# C1: Alice commits her own approval row.
+# C0 (Bootstrap): scaffolds the APPROVAL_LOG.md with `[Name]` placeholders
+# for BOTH gates. Authored by a third identity ("Bootstrap"). This
+# tailoring tightening (PR #116 verifier minor #1) ensures every line
+# in the file is initially blamed to Bootstrap — NOT to Alice — so a
+# wrong fix like `git blame -L 1,1` would return Bootstrap, fail to
+# match approver "Alice Approver", and the test correctly FAILs RED.
+# Without this commit, Alice's C1 would author the entire file and
+# `-L 1,1` would coincidentally produce the expected FAIL.
+write_two_gate_log "[Name]"
+git_add_and_commit_as "Bootstrap" "bootstrap@example.com" "scaffold approval log"
+# C1: Alice rewrites HER OWN approver row only (gate 0→1). The single
+# changed line is blamed to Alice; every other line stays Bootstrap.
 write_two_gate_log "Alice Approver"
 git_add_and_commit_as "Alice Approver" "alice@example.com" "alice self-approves gate 0->1"
 # C2: Bob fixes a typo in gate 1→2 only (changes "Carol Approver" → "Carol M. Approver").
@@ -188,6 +207,59 @@ if echo "$out" | grep -qE "FAIL.*self-approval"; then
 $(echo "$out" | grep -E 'FAIL|self-approval' | head -10)"
 else
   pass "T-blame-3: distinct committer + approver → no self-approval FAIL"
+fi
+teardown
+
+# ---------------------------------------------------------------------
+# T-blame-4: Malformed APPROVAL_LOG.md uses `### ` h3 instead of the
+# canonical `## ` h2 for the gate header. PR #116's awk walker only
+# matches `^## `, so it returns no line number, and the silent-fallback
+# branch ran `git log -1 -- APPROVAL_LOG.md` — which returned Bob (the
+# latest committer, unrelated to Alice's self-approval row). Alice's
+# true self-approval silently passed.
+#
+# Follow-up requirement: WARN + return — never silently fall back.
+# Operator MUST see "cannot verify" (or equivalent) so the malformed
+# file becomes an audit signal instead of an exploit surface.
+# ---------------------------------------------------------------------
+echo "T-blame-4: malformed APPROVAL_LOG.md (h3 header) → MUST WARN, not silently pass"
+setup
+write_phase_state_org_phase1
+# Inline the malformed file — gate name appears in prose AND under an
+# `### ` h3 header (not `## ` h2). grep -A 20 still finds it (so the
+# approver_name extraction sees "Alice Approver"), but the awk walker
+# requires `^## ` and returns no line number.
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+This log records approvals for Phase 0 → Phase 1 transitions.
+
+### Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Gate** | Phase 0 → Phase 1 |
+| **Approver** | Alice Approver |
+| **Date** | 2026-02-01 |
+MD
+# C1: Alice commits her own approval row (true self-approval).
+git_add_and_commit_as "Alice Approver" "alice@example.com" "alice self-approves (malformed log)"
+# C2: Bob commits an unrelated prose-line typo fix. With pre-followup
+# code, `git log -1` returns Bob → no name match → silent pass.
+sed -i.bak 's/records approvals/records the approvals/' "$PROJ/APPROVAL_LOG.md" \
+  && rm -f "$PROJ/APPROVAL_LOG.md.bak"
+git_add_and_commit_as "Bob Editor" "bob@example.com" "prose typo fix"
+out=$(run_gate)
+# Operator-visible audit signal: either a self-approval FAIL (caught
+# Alice via some other path) OR a WARN that explicitly cites the
+# malformed/non-canonical gate section. The forbidden outcome is a
+# silent pass — no FAIL and no WARN about commit-author/gate-section.
+if echo "$out" | grep -qE "\[WARN\].*Phase 0.*1.*(cannot verify|gate section not found|no '## '|malformed)"; then
+  pass "T-blame-4: malformed APPROVAL_LOG.md surfaces WARN — silent-fallback closed"
+elif echo "$out" | grep -qE "FAIL.*Phase 0.*1.*self-approval"; then
+  pass "T-blame-4: malformed APPROVAL_LOG.md still caught self-approval via FAIL"
+else
+  fail_ "T-blame-4" "silent-pass: expected [WARN] (cannot verify | gate section not found) or FAIL self-approval; output:
+$(echo "$out" | grep -E 'WARN|FAIL|Phase 0' | head -10)"
 fi
 teardown
 


### PR DESCRIPTION
## Summary

Post-merge follow-up on **PR #116** (per-line APPROVAL_LOG.md blame walker for self-approval evasion). The adversarial verifier (claude-opus-4-7, Wave C / code-check-gates-7-followup-blame-walker) flagged four findings on PR #116; see `gh pr view 116 --comments`. PR #116 merged at `06fb186` before these were addressed inline. This PR closes all four.

### 1. SUBSTANTIVE (verifier graded MINOR — major in practice): silent-pass fallback re-opens the bug PR #116 was meant to close

`scripts/check-phase-gate.sh` (around the per-line blame block) silently fell back to the pre-fix file-level `git log -n 1 --format='%an' -- "$APPROVAL_LOG"` whenever the awk walker didn't find a `^## ` header matching `$gate_name`. For any malformed / non-canonical APPROVAL_LOG.md (e.g. `### ` h3 header, gate name in prose only, custom section format), the original self-approval evasion reappeared via the back door.

**Fix.** Replaced the silent fallback. Awk now emits one of three sentinels via an `END` block (`<integer> | NO_APPROVER | NO_SECTION`). A bash `case` dispatches:
- `<integer>`   → per-line blame as before (unchanged path)
- `NO_APPROVER` → operator-visible `WARN` + `issues++` + `return 0`
- `NO_SECTION`  → operator-visible `WARN` + `issues++` + `return 0`

WARN signals are direct echoes (no `SOIF_QUIET` gating). Malformed file becomes audit signal instead of exploit surface.

### 2. MINOR: T-blame-1 setup tailoring (Bootstrap commit)

Original T-blame-1 committed the entire APPROVAL_LOG.md in C1 under Alice's identity, so a wrong fix like `git blame -L 1,1` coincidentally produced the expected FAIL (line 1's author == approver). Added a Bootstrap C0 commit (third identity) that scaffolds the file with `[Name]` placeholders before Alice's approver-row addition. `-L 1,1` now returns Bootstrap, not Alice → no name match → test correctly fails RED.

### 3. NIT: removed dead `IGNORECASE = 1`

Was a gawk extension silently ignored on BSD/macOS awk. The original bonus claim that it "mirrors `grep -A 20`" was incorrect (grep is case-sensitive by default). Headers + `gate_name` are both canonically capitalized, so case-sensitive matching is sufficient and now consistent with the prior grep shape. Comment updated.

### 4. NIT: backlog placeholder

`solo-orchestrator-backlog.md:827` patched from `PR #<PR>` to `PR #116` so `lint-backlog-references.sh` stays green long-term.

## Mutation proofs

- **M1**: revert per-line blame to `-L 1,1` → `T-blame-1` failed RED with the Bootstrap-tightened fixture (Bootstrap-authored line 1 no longer coincides with Alice). Restored fix → GREEN.
- **M2**: revert WARN-and-return to silent `return 0` (no message) → `T-blame-4` failed RED (regression test detects the silent-pass class). Restored fix → GREEN.

## Test plan

- [x] `tests/test-check-phase-gate-blame-walker.sh` — 4/4 (added T-blame-4 for malformed `### ` h3 header)
- [x] `tests/test-check-phase-gate-self-approval.sh` — 5/5 (unchanged regression cohort)
- [x] `tests/test-check-phase-gate-noninteractive.sh` — 3/3
- [x] `tests/test-check-phase-gate.sh` — 8/8
- [x] `tests/test-check-phase-gate-retroactive-approval.sh` — 3/3
- [x] `tests/test-check-phase-gate-backstop-attestation.sh` — 3/3
- [x] `tests/test-check-phase-gate-counter-sanitizer.sh` — 7/7
- [x] `scripts/lint-counter-antipattern.sh` — OK
- [x] `scripts/lint-fix-functions-stderr.sh` — OK
- [x] `scripts/lint-raw-read-prompt.sh` — OK
- [x] `scripts/lint-backlog-references.sh --base origin/main` — OK

## Files touched

- `scripts/check-phase-gate.sh` — awk walker + sentinel dispatch + WARN messages
- `tests/test-check-phase-gate-blame-walker.sh` — Bootstrap C0 in T-blame-1 + new T-blame-4
- `solo-orchestrator-backlog.md` — placeholder scrub

Citation per the defer-to-second-commit pattern (BL-036, BL-037, BL-039): `PR #<this PR>` + commit `601417f` will be appended to backlog once this PR merges.

Generated with [Claude Code](https://claude.com/claude-code)