### PR TITLE
test(harness): correct stale --language args for --platform other + e2e tests (closes BL-065 + BL-066)

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1530,7 +1530,7 @@ The adversarial certainty re-walk (re-walker-2, scenario `fresh-org-sponsored-po
 **Logged:** 2026-06-30
 **Category:** Bug
 **Severity:** Trivial
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #121, commit fb843a9)
 
 When PR #111 wired `tests/edge-cases-scripts.sh` into `full-project-test-suite.sh` (TEST 0r), the aggregator-registration commit (`cc1e532`) documented the file as `known-RED (BL-039 + BL-009 follow-up)` and gated it behind a new `SKIP_KNOWN_FAILING` env var so the suite stays green for local iteration loops while the underlying defects are tracked separately. The cited BLs cover E50 (BL-039) and the UAT-template guardrails (BL-009 follow-up), but the RED state in `tests/edge-cases-scripts.sh` also covers **E30** — the `init.sh --platform other` case at `tests/edge-cases-scripts.sh:1031-1041` — which has no backlog entry today. E30 asserts that `init.sh --platform other` skips the UAT reference-pair copy while leaving `tests/uat/templates/test-session-template.html` in place (the documented escape hatch for unsupported platforms); the failure mode (whether the template is missing, the reference files are present anyway, the script exits non-zero, or something else) is not characterized in the PR #111 commit message or in any current report.
 
@@ -1614,7 +1614,7 @@ No production code change is needed in `init.sh`, the UAT-copy section, or the p
 **Logged:** 2026-06-30
 **Category:** Bug
 **Severity:** Trivial
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #121, commit fb843a9)
 
 When PR #111 wired `tests/host-drivers/run-all.sh` into `full-project-test-suite.sh` (TEST 0s), the aggregator-registration commit (`cc1e532`) documented the file as `known-RED (e2e-init-* trio)` and gated it behind `SKIP_KNOWN_FAILING` so the suite stays green for local iteration loops. The "trio" comprises `tests/host-drivers/e2e-init.test.sh` (github), `tests/host-drivers/e2e-init-gitlab.test.sh`, and `tests/host-drivers/e2e-init-bitbucket.test.sh` — the three end-to-end init.sh tests that exercise the full host-driver path against a mocked host CLI / `curl` stub (per BL-003, BL-003a, BL-003b, all closed). The other six children of `run-all.sh` (`github.test.sh`, `gitlab.test.sh`, `bitbucket.test.sh`, `regressions.test.sh`, `mock-cli.selftest.sh`, `dispatcher.test.sh`) are all GREEN; only the e2e trio is RED, and the specific failure modes are not characterized in the PR #111 commit message or in any current report. Whether all three e2e tests share a single root cause (e.g. a regression in `init.sh`'s host-driver invocation path), or each fails for a distinct host-specific reason, is unknown today.
 

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1040,6 +1040,16 @@ section "BL-009: UAT template quality + platform-aware authoring"
 _uat_real_init() {
   local work="$1" platform="$2" project="$3"
   local logfile="$work/init-${platform}.log"
+  # init.sh's Pass-2 platform×language validator (init.sh:3447) walks
+  # templates/pipelines/ci/github/*.yml and reads each file's
+  # `# solo-orchestrator: platforms=` marker. Only `other.yml` lists
+  # `other` in its marker, so `--platform other` must pair with
+  # `--language other`; `typescript.yml` (web/desktop/mobile/mcp_server)
+  # is correct for every other platform we exercise here. Without this
+  # gate, E30 trips Pass-2 with rc=1 before the UAT branch ever runs
+  # (BL-065 characterization, 2026-06-30).
+  local language=typescript
+  [ "$platform" = other ] && language=other
   # Feed a finite stream of "Y" answers from process substitution so
   # init.sh's "Proceed with this plan?" / install confirms auto-pass
   # without breaking `set -o pipefail` (yes(1) gets SIGPIPE and the
@@ -1049,7 +1059,7 @@ _uat_real_init() {
         --project "$project" \
         --platform "$platform" \
         --deployment personal \
-        --language typescript \
+        --language "$language" \
         --git-host github \
         --visibility private \
         --no-remote-creation \

--- a/tests/host-drivers/e2e-init-bitbucket.test.sh
+++ b/tests/host-drivers/e2e-init-bitbucket.test.sh
@@ -235,7 +235,7 @@ run_init_e2e() {
       --project "$pname" \
       --project-dir "$PROJ" \
       --platform web \
-      --language javascript \
+      --language typescript \
       --track light \
       --deployment "$deployment" \
       --git-host bitbucket \
@@ -303,8 +303,9 @@ echo ""
 echo "=== Failure paths (T3 push, T4 repo-exists, T5 protection 403) ==="
 # ════════════════════════════════════════════════════════════════════
 
-# T3: push fails (insteadOf points to a non-existent bare repo). init.sh's
-# U-B contract: warn + continue, NOT abort (same as github/gitlab T3).
+# T3: push fails (insteadOf points to a non-existent bare repo). post-BL-064
+# (PR #118, commit 443b50a): warn + emit [FAIL] summary → rc=2 (was
+# rc=0+warn pre-BL-064). Same as github/gitlab T3.
 echo "T3: curl repo create succeeds but git push fails (no bare repo)"
 TMP=$(mktemp -d)
 PROJ="$TMP/proj"
@@ -328,10 +329,10 @@ grep -q "Remote setup did not complete cleanly" "$TMP/init.log" && warn_seen=yes
 url=$( jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 host=$( jq -r '.host // ""'      "$PROJ/.claude/manifest.json" 2>/dev/null )
 steps=$( jq -r '.phase2_init.steps_completed | length' "$PROJ/.claude/process-state.json" 2>/dev/null )
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$host" = "bitbucket" ] && [ "$url" = "" ] \
    && [ "$steps" = "1" ]; then
-  pass "T3: push failure → init.sh warns + continues; manifest.host set, remote_url empty, partial steps=1 (remote_repo_created)"
+  pass "T3: push failure → init.sh warns + exits rc=2 (post-BL-064); manifest.host set, remote_url empty, partial steps=1 (remote_repo_created)"
 else
   fail_ "T3" "rc=$rc warn_seen=$warn_seen host=$host url=$url steps=$steps log:$(tail -8 "$TMP/init.log")"
 fi
@@ -358,10 +359,10 @@ host=$( jq -r '.host // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 url=$(  jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 origin_set=no
 ( cd "$PROJ" && git remote get-url origin >/dev/null 2>&1 ) && origin_set=yes
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$host" = "bitbucket" ] && [ "$url" = "" ] \
    && [ "$origin_set" = "no" ]; then
-  pass "T4: slug-already-exists → warn + continue; no origin, manifest.host=bitbucket"
+  pass "T4: slug-already-exists → warn + rc=2 (post-BL-064); no origin, manifest.host=bitbucket"
 else
   fail_ "T4" "rc=$rc warn_seen=$warn_seen host=$host url=$url origin_set=$origin_set log:$(tail -8 "$TMP/init.log")"
 fi
@@ -369,13 +370,14 @@ scenario_teardown
 
 # T5: first branch-restrictions POST fails with HTTP 403 — likely cause
 # is an App Password missing repository:admin scope. host_configure_
-# protection returns 2 → create_and_protect_remote returns 1 → init.sh
-# U-B contract: warn + continue. Origin IS registered (push succeeded
-# before protection). Unlike github there is no "free-tier" branch for
-# bitbucket (the free Bitbucket Cloud plan permits branch-restrictions
-# API access), so the failure is unconditional → init.sh:2031 prints
-# "Protection config failed", not the free-tier attestation path.
-# manifest.remote_url stays "" (late write at init.sh:2054 unreached).
+# protection returns 2 → create_and_protect_remote returns 1 → post-BL-064
+# (PR #118, commit 443b50a): init.sh warns + emits [FAIL] summary → rc=2
+# (was rc=0+warn pre-BL-064). Origin IS registered (push succeeded before
+# protection). Unlike github there is no "free-tier" branch for bitbucket
+# (the free Bitbucket Cloud plan permits branch-restrictions API access),
+# so the failure is unconditional → init.sh:2031 prints "Protection config
+# failed", not the free-tier attestation path. manifest.remote_url stays
+# "" (late write at init.sh:2054 unreached).
 echo "T5: branch-restrictions POST fails with HTTP 403 (no free-tier branch on bitbucket)"
 scenario_setup "https://bitbucket.org/test-ws/protect-fail.git"
 export MOCK_BB_PROTECT_POST_EXIT=22  # curl --fail HTTP-error
@@ -391,11 +393,11 @@ origin_set=no
 url=$(  jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 host=$( jq -r '.host // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 steps=$( jq -r '.phase2_init.steps_completed | length' "$PROJ/.claude/process-state.json" 2>/dev/null )
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$origin_set" = "yes" ] \
    && [ "$host" = "bitbucket" ] && [ "$url" = "" ] \
    && [ "$steps" = "2" ]; then
-  pass "T5: protection 403 → warn + continue; origin registered, partial steps=2 (remote_repo_created + pushed_initial)"
+  pass "T5: protection 403 → warn + rc=2 (post-BL-064); origin registered, partial steps=2 (remote_repo_created + pushed_initial)"
 else
   fail_ "T5" "rc=$rc warn_seen=$warn_seen origin_set=$origin_set host=$host url=$url steps=$steps log:$(tail -8 "$TMP/init.log")"
 fi

--- a/tests/host-drivers/e2e-init-gitlab.test.sh
+++ b/tests/host-drivers/e2e-init-gitlab.test.sh
@@ -198,7 +198,7 @@ run_init_e2e() {
       --project "$pname" \
       --project-dir "$PROJ" \
       --platform web \
-      --language javascript \
+      --language typescript \
       --track light \
       --deployment "$deployment" \
       --git-host gitlab \
@@ -263,8 +263,9 @@ echo ""
 echo "=== Failure paths (T3 push, T4 repo-exists, T5 protection 403) ==="
 # ════════════════════════════════════════════════════════════════════
 
-# T3: push fails (insteadOf to a non-existent bare repo). init.sh's U-B
-# contract: warn + continue, NOT abort. Mirror of github e2e T3.
+# T3: push fails (insteadOf to a non-existent bare repo). post-BL-064
+# (PR #118, commit 443b50a): warn + emit [FAIL] summary → rc=2 (was
+# rc=0+warn pre-BL-064). Mirror of github e2e T3.
 echo "T3: glab repo create succeeds but git push fails (no bare repo)"
 TMP=$(mktemp -d)
 PROJ="$TMP/proj"
@@ -285,10 +286,10 @@ grep -q "Remote setup did not complete cleanly" "$TMP/init.log" && warn_seen=yes
 url=$( jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 host=$( jq -r '.host // ""'      "$PROJ/.claude/manifest.json" 2>/dev/null )
 steps=$( jq -r '.phase2_init.steps_completed | length' "$PROJ/.claude/process-state.json" 2>/dev/null )
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$host" = "gitlab" ] && [ "$url" = "" ] \
    && [ "$steps" = "1" ]; then
-  pass "T3: push failure → init.sh warns + continues; manifest.host set, remote_url empty, partial steps=1 (remote_repo_created)"
+  pass "T3: push failure → init.sh warns + exits rc=2 (post-BL-064); manifest.host set, remote_url empty, partial steps=1 (remote_repo_created)"
 else
   fail_ "T3" "rc=$rc warn_seen=$warn_seen host=$host url=$url steps=$steps log:$(tail -8 "$TMP/init.log")"
 fi
@@ -311,10 +312,10 @@ host=$( jq -r '.host // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 url=$(  jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 origin_set=no
 ( cd "$PROJ" && git remote get-url origin >/dev/null 2>&1 ) && origin_set=yes
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$host" = "gitlab" ] && [ "$url" = "" ] \
    && [ "$origin_set" = "no" ]; then
-  pass "T4: name-already-taken → warn + continue; no origin, manifest.host=gitlab"
+  pass "T4: name-already-taken → warn + rc=2 (post-BL-064); no origin, manifest.host=gitlab"
 else
   fail_ "T4" "rc=$rc warn_seen=$warn_seen host=$host url=$url origin_set=$origin_set log:$(tail -8 "$TMP/init.log")"
 fi
@@ -323,9 +324,10 @@ scenario_teardown
 # T5: glab api -X POST protected_branches fails with a generic 403.
 # Unlike github there is no free-tier branch (gitlab.com free tier
 # permits the protected-branches API), so the driver always returns 2 →
-# init.sh prints "Protection config failed" → warn + continue. Origin
-# IS registered (push succeeded before protection); manifest remote_url
-# stays "" (late write at init.sh:2054 didn't run).
+# init.sh prints "Protection config failed" → warn + emit [FAIL] summary
+# → rc=2 (post-BL-064 / PR #118, commit 443b50a; was rc=0+warn pre-BL-064).
+# Origin IS registered (push succeeded before protection); manifest
+# remote_url stays "" (late write at init.sh:2054 didn't run).
 echo "T5: protection POST fails with generic 403 (no free-tier branch on gitlab)"
 scenario_setup "https://gitlab.com/e2e-test/protect-fail.git"
 export MOCK_GL_PROTECT_POST_EXIT=1
@@ -340,11 +342,11 @@ origin_set=no
 url=$(  jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 host=$( jq -r '.host // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 steps=$( jq -r '.phase2_init.steps_completed | length' "$PROJ/.claude/process-state.json" 2>/dev/null )
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$origin_set" = "yes" ] \
    && [ "$host" = "gitlab" ] && [ "$url" = "" ] \
    && [ "$steps" = "2" ]; then
-  pass "T5: protection 403 → warn + continue; origin registered, partial steps=2 (remote_repo_created + pushed_initial)"
+  pass "T5: protection 403 → warn + rc=2 (post-BL-064); origin registered, partial steps=2 (remote_repo_created + pushed_initial)"
 else
   fail_ "T5" "rc=$rc warn_seen=$warn_seen origin_set=$origin_set host=$host url=$url steps=$steps log:$(tail -8 "$TMP/init.log")"
 fi

--- a/tests/host-drivers/e2e-init.test.sh
+++ b/tests/host-drivers/e2e-init.test.sh
@@ -176,7 +176,7 @@ run_init_e2e() {
       --project "$pname" \
       --project-dir "$PROJ" \
       --platform web \
-      --language javascript \
+      --language typescript \
       --track light \
       --deployment "$deployment" \
       --git-host github \
@@ -246,11 +246,15 @@ echo "=== Failure paths (T3 push, T4 repo-exists, T5 protection 403) ==="
 # ════════════════════════════════════════════════════════════════════
 
 # T3: push fails (insteadOf points to a non-existent bare repo).
-# init.sh's U-B contract (line 1858 wrapper) says push failure does NOT
-# abort init — print warn, surface remediation, keep going. Working tree
-# stays clean post-fix (finalize_init_commit is a no-op when nothing
-# changed; only host_register_remote's .git/config edit happened, and
-# .git/config is untracked).
+# post-BL-064 (PR #118, commit 443b50a): push failure warns + emits the
+# [FAIL] summary at end of init → rc=2 (was rc=0+warn-and-continue
+# pre-BL-064). Project files are still in place and host_register_remote's
+# .git/config edit still happened (warn-and-continue semantics preserved);
+# only the exit status flipped from 0 to 2 so wrapper scripts can observe
+# the partial-success state. Working tree stays clean post-fix
+# (finalize_init_commit is a no-op when nothing changed; only
+# host_register_remote's .git/config edit happened, and .git/config is
+# untracked).
 #
 # Post-finding specs-plans-host-aware-2: phase2_init.steps_completed is
 # written incrementally. host_register_remote succeeds before the push
@@ -273,7 +277,9 @@ export MOCK_GH_REPO_URL="$REPO_URL"
 export MOCK_GH_PROTECT_JSON="$PROTECT_JSON_PERSONAL"
 run_init_e2e push-fail personal
 rc=$?
-# init.sh's U-B contract: push failure is warn-and-continue, NOT abort.
+# post-BL-064: push failure warns + emits [FAIL] summary → rc=2 (PR #118,
+# commit 443b50a). The warn line is still emitted (warn-and-continue
+# semantics intact); only the exit code flipped from 0 to 2.
 warn_seen=no
 grep -q "Remote setup did not complete cleanly" "$TMP/init.log" && warn_seen=yes
 # host_register_remote ran before push, so origin is set, but the late
@@ -283,10 +289,10 @@ grep -q "Remote setup did not complete cleanly" "$TMP/init.log" && warn_seen=yes
 url=$( jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 host=$( jq -r '.host // ""'      "$PROJ/.claude/manifest.json" 2>/dev/null )
 steps=$( jq -r '.phase2_init.steps_completed | length' "$PROJ/.claude/process-state.json" 2>/dev/null )
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$host" = "github" ] && [ "$url" = "" ] \
    && [ "$steps" = "1" ]; then
-  pass "T3: push failure → init.sh warns + continues; manifest.host set, remote_url empty, partial steps=1 (remote_repo_created)"
+  pass "T3: push failure → init.sh warns + exits rc=2 (post-BL-064); manifest.host set, remote_url empty, partial steps=1 (remote_repo_created)"
 else
   fail_ "T3" "rc=$rc warn_seen=$warn_seen host=$host url=$url steps=$steps log:$(tail -8 "$TMP/init.log")"
 fi
@@ -296,7 +302,8 @@ rm -rf "$TMP"
 
 # T4: gh repo create fails (repo already exists). host_create_repo
 # returns 1 → create_and_protect_remote prints "Repo creation failed"
-# → returns 1. init.sh U-B contract: warn + continue. Nothing was
+# → returns 1. post-BL-064 (PR #118, commit 443b50a): init.sh warns +
+# emits [FAIL] summary → rc=2 (was rc=0+warn pre-BL-064). Nothing was
 # committed to remote, no origin was registered.
 echo "T4: gh repo create fails (repo-already-exists scenario)"
 scenario_setup "https://github.com/e2e-test/exists.git"
@@ -310,10 +317,10 @@ host=$( jq -r '.host // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 url=$(  jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 origin_set=no
 ( cd "$PROJ" && git remote get-url origin >/dev/null 2>&1 ) && origin_set=yes
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$host" = "github" ] && [ "$url" = "" ] \
    && [ "$origin_set" = "no" ]; then
-  pass "T4: repo-already-exists → warn + continue; no origin, manifest.host=github"
+  pass "T4: repo-already-exists → warn + rc=2 (post-BL-064); no origin, manifest.host=github"
 else
   fail_ "T4" "rc=$rc warn_seen=$warn_seen host=$host url=$url origin_set=$origin_set log:$(tail -8 "$TMP/init.log")"
 fi
@@ -323,8 +330,9 @@ scenario_teardown
 # free-tier branch is gated by the substring 'Upgrade to GitHub Pro'
 # in stderr (BL-002); without that substring, host_configure_protection
 # returns 2 → create_and_protect_remote prints "Protection config
-# failed" → returns 1. init.sh U-B contract: warn + continue. By the
-# time this fires, gh repo create succeeded + push succeeded, so the
+# failed" → returns 1. post-BL-064 (PR #118, commit 443b50a): init.sh
+# warns + emits [FAIL] summary → rc=2 (was rc=0+warn pre-BL-064). By
+# the time this fires, gh repo create succeeded + push succeeded, so the
 # origin remote IS registered, but the late manifest write at
 # init.sh:2054 still didn't run — remote_url stays "".
 #
@@ -347,11 +355,11 @@ origin_set=no
 url=$(  jq -r '.remote_url // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 host=$( jq -r '.host // ""' "$PROJ/.claude/manifest.json" 2>/dev/null )
 steps=$( jq -r '.phase2_init.steps_completed | length' "$PROJ/.claude/process-state.json" 2>/dev/null )
-if [ "$rc" = "0" ] && [ "$warn_seen" = "yes" ] \
+if [ "$rc" = "2" ] && [ "$warn_seen" = "yes" ] \
    && [ "$origin_set" = "yes" ] \
    && [ "$host" = "github" ] && [ "$url" = "" ] \
    && [ "$steps" = "2" ]; then
-  pass "T5: protection 403 → warn + continue; origin registered, partial steps=2 (remote_repo_created + pushed_initial)"
+  pass "T5: protection 403 → warn + rc=2 (post-BL-064); origin registered, partial steps=2 (remote_repo_created + pushed_initial)"
 else
   fail_ "T5" "rc=$rc warn_seen=$warn_seen origin_set=$origin_set host=$host url=$url steps=$steps log:$(tail -8 "$TMP/init.log")"
 fi


### PR DESCRIPTION
## Summary

- Test-harness-only fix per BL-065 + BL-066 characterizations in PR #120; no production-code change.
- BL-065: `_uat_real_init` helper in `tests/edge-cases-scripts.sh` hardcoded `--language typescript`, but `--platform other` requires `--language other` (only `templates/pipelines/ci/github/other.yml` whitelists `other` in its `platforms=` marker). Fix special-cases the helper at :1052 with `[ "$platform" = other ] && language=other` (Option b per task — keeps the helper API stable for E26-E29 web/desktop/mobile/mcp_server callers).
- BL-066: three drifts in the host-driver e2e suite. (1) Stale `--language javascript` in each `run_init_e2e` helper — no `javascript.yml` template exists, so PR #99's strict Pass-2 validator (`73da7c9`) rejected every scenario. (2) T3/T4/T5 in all three files asserted the pre-BL-064 `rc=0`+warn contract; PR #118's BL-064 closure (`443b50a`) changed init.sh so any `[FAIL]` line produces `rc=2`+structured INCOMPLETE summary. T6/T7 in `e2e-init-gitlab.test.sh` (BL-031 attestation flow / BL-032 Premium-tier path) genuinely still return rc=0 — the BL-031 dispatcher routes gitlab exit-3/4 to attestation without emitting a `[FAIL]` line — so T6/T7 assertions are unchanged.
- Worktree note: the second drift (rc=0 → rc=2 contract) was NOT in the PR #120 BL-066 characterization. Caught + reported during TDD verification; coordinator approved Option 1 (update tests to match canonical post-BL-064 contract; `warn_seen=yes` check preserved, only the rc clause flipped).
- All 4 CI lints exit 0 (`lint-counter-antipattern`, `lint-fix-functions-stderr`, `lint-raw-read-prompt`, `lint-backlog-references --base origin/main`).

## Closes

- BL-065
- BL-066

## Files changed

1. `tests/edge-cases-scripts.sh` — `_uat_real_init` helper picks `language=other` when `platform=other`; everything else stays `typescript` (BL-065).
2. `tests/host-drivers/e2e-init.test.sh` — `--language javascript` → `--language typescript` in `run_init_e2e`; T3/T4/T5 assertions flipped `rc=0` → `rc=2` with updated U-B-contract comments (BL-066 github).
3. `tests/host-drivers/e2e-init-gitlab.test.sh` — same shape (BL-066 gitlab); T6/T7 unchanged because BL-031 attestation flow still legitimately returns rc=0.
4. `tests/host-drivers/e2e-init-bitbucket.test.sh` — same shape (BL-066 bitbucket).

## Test plan

Pre-fix (origin/main, baseline RED capture):
- `bash tests/host-drivers/run-all.sh` → 9 run, 3 failed (e2e-init / e2e-init-gitlab / e2e-init-bitbucket). All three RED with the same stderr: `[FAIL] init.sh non-interactive: language 'javascript' is not supported for platform 'web'`.
- `SKIP_KNOWN_FAILING=0 bash tests/edge-cases-scripts.sh` → `[FAIL] E30: real init.sh --platform other produced wrong state` (template missing because init.sh aborted at Pass-2).

Mid-fix (only `--language javascript`→`typescript` swap applied, rc=2 assertion fix pending — captured during TDD to expose the second drift):
- `bash tests/host-drivers/run-all.sh` → still 9 run, 3 failed.
  - e2e-init.test.sh: 2 passed (T1+T2), 3 failed (T3+T4+T5).
  - e2e-init-gitlab.test.sh: 4 passed (T1+T2+T6+T7), 3 failed (T3+T4+T5).
  - e2e-init-bitbucket.test.sh: 2 passed (T1+T2), 3 failed (T3+T4+T5).
- T3/T4/T5 RED with `[FAIL] T3 — rc=2 warn_seen=yes ...` (BL-064 contract met an obsolete assertion).

Post-fix (this PR head):
- `bash tests/host-drivers/run-all.sh` → 9 run, 0 failed. Per-child: e2e-init 5/5, e2e-init-gitlab 7/7, e2e-init-bitbucket 5/5.
- `SKIP_KNOWN_FAILING=0 bash tests/edge-cases-scripts.sh` → `[PASS] E30: real init.sh --platform other skips ref copy, keeps source templates`.
- All 4 lints exit 0.

## Worktree note

Done in `.claude/worktrees/agent-aca4842ef07037926/` (worktree-agent-aca4842ef07037926 → branch `test(harness)/bl065-bl066-stale-language-args`). DO NOT MERGE per task instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)