### PR TITLE
feat(ci): lint enforces every tests/test-*.sh is invoked by an aggregator (closes BL-038)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -111,3 +111,23 @@ jobs:
       - name: Show PASS/FAIL inventory (on failure or on demand)
         if: always()
         run: bash scripts/lint-raw-read-prompt.sh --list || true
+
+  # BL-038 (cycle-9): structural backstop for the BL-034 orphan-test
+  # defect class — refuses to merge a new tests/test-*.sh file unless
+  # an aggregator invokes it (or the file carries an EXEMPT marker
+  # with a non-empty reason). See scripts/lint-tests-registered.sh
+  # header for the contract + KNOWN_ORPHANS_PENDING_BL035 bridge,
+  # and tests/test-lint-tests-registered.sh for the behavior suite.
+  tests-registered-lint:
+    name: tests-registered-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint tests-registered (BL-038 structural backstop)
+        run: bash scripts/lint-tests-registered.sh
+
+      - name: Show PASS/FAIL inventory (on failure or on demand)
+        if: always()
+        run: bash scripts/lint-tests-registered.sh --list || true

--- a/scripts/lint-tests-registered.sh
+++ b/scripts/lint-tests-registered.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# scripts/lint-tests-registered.sh — fail CI if any tests/test-*.sh
+# (or tests/edge-cases-*.sh) file is not invoked by at least one
+# top-level test aggregator. Structural backstop for the BL-034 /
+# BL-038 orphan-test defect class (closes BL-038).
+#
+# THE DEFECT CLASS
+#   Wave 1-4 (PR #103 audit) found 16 of 17 newly-added test files
+#   landed without ever being wired into an aggregator. The tests
+#   passed locally during PR review, then ran ZERO times after merge
+#   — every subsequent regression they would have caught flew silent.
+#   BL-034 retroactively registered the Wave 1-4 cohort; BL-035 will
+#   disposition the pre-existing orphan backlog. BL-038 is the
+#   structural prevention: this lint refuses to merge a new
+#   `tests/test-*.sh` file unless an aggregator invokes it (or the
+#   file carries an explicit EXEMPT marker with a non-empty reason).
+#
+# WHAT COUNTS AS AN AGGREGATOR
+#   Five aggregators are recognised by default; pass --aggregators to
+#   override the list (used by tests/test-lint-tests-registered.sh).
+#     • tests/full-project-test-suite.sh
+#     • tests/edge-case-test-suite.sh
+#     • tests/known-bugs-test-suite.sh
+#     • tests/upgrade-path-tests.sh
+#     • tests/host-drivers/run-all.sh
+#   The host-drivers/run-all.sh entry uses a glob over
+#   `*.test.sh` and `*.selftest.sh`, so any file matching those
+#   patterns under tests/host-drivers/ is implicitly registered.
+#
+# WHAT COUNTS AS A TEST FILE
+#   The walker enumerates:
+#     • tests/test-*.sh
+#     • tests/edge-cases-*.sh
+#     • tests/host-drivers/*.test.sh
+#     • tests/host-drivers/*.selftest.sh
+#   The aggregator files themselves are skipped (they're delegators,
+#   not tests). Files under tests/test-helpers/ (if/when that dir
+#   exists) are skipped as helpers. The lint script itself is skipped.
+#
+# OVERRIDE MECHANISM (per-file EXEMPT marker)
+#   A test file can opt out by placing one of:
+#     # LINT_TEST_REGISTRATION_EXEMPT: <non-empty reason>
+#   …inside the first 40 lines (header). The reason is REQUIRED —
+#   an empty reason fails the lint, matching the allowlist semantics
+#   of scripts/lint-counter-antipattern.sh and siblings. Use this for
+#   genuine manual / network-dependent / slow tests that intentionally
+#   stay out of the aggregator-driven suite.
+#
+# BRIDGE: KNOWN_ORPHANS_PENDING_BL035
+#   ~48 pre-existing test files were already orphaned when BL-038
+#   landed. Editing every one to add an EXEMPT marker would be 48
+#   scattered diffs that have to be unwound when BL-035 dispositions
+#   them. Instead they are listed in KNOWN_ORPHANS_PENDING_BL035
+#   below — a single centralised bridge. The contract is:
+#     • Adding to the list requires a paired BL-035 backlog update.
+#     • Removing from the list requires the test be registered in an
+#       aggregator (or replaced with a real EXEMPT marker if it is
+#       a manual/network-only test).
+#     • When BL-035 closes, this list must be empty.
+#   Test fixtures (tests-dir override) skip the bridge — only the
+#   canonical repo tests dir consults it.
+#
+# EXIT CODES
+#   0 — every test file is registered, EXEMPT, or on the bridge list.
+#   1 — one or more violations found.
+#   2 — invocation / I/O error.
+#
+# USAGE
+#   bash scripts/lint-tests-registered.sh           # quiet pass/fail
+#   bash scripts/lint-tests-registered.sh --list    # PASS/FAIL table
+#   bash scripts/lint-tests-registered.sh \
+#       --tests-dir   /tmp/fixture/tests \
+#       --aggregators /tmp/fixture/tests/myagg.sh
+#       # test-mode: scan an alternate dir + alternate aggregator set
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_PATH="$REPO_ROOT/scripts/lint-tests-registered.sh"
+
+LIST_MODE=0
+TESTS_DIR_OVERRIDE=""
+AGGREGATORS_OVERRIDE=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list) LIST_MODE=1; shift ;;
+    --tests-dir)
+      [ $# -ge 2 ] || { echo "Usage: $0 [--list] [--tests-dir DIR] [--aggregators FILE[,FILE...]]" >&2; exit 2; }
+      TESTS_DIR_OVERRIDE="$2"; shift 2 ;;
+    --aggregators)
+      [ $# -ge 2 ] || { echo "Usage: $0 [--list] [--tests-dir DIR] [--aggregators FILE[,FILE...]]" >&2; exit 2; }
+      AGGREGATORS_OVERRIDE="$2"; shift 2 ;;
+    -h|--help)
+      echo "Usage: $0 [--list] [--tests-dir DIR] [--aggregators FILE[,FILE...]]"; exit 0 ;;
+    *) echo "Usage: $0 [--list] [--tests-dir DIR] [--aggregators FILE[,FILE...]]" >&2; exit 2 ;;
+  esac
+done
+
+TESTS_DIR="${TESTS_DIR_OVERRIDE:-$REPO_ROOT/tests}"
+TEST_MODE=0
+if [ -n "$TESTS_DIR_OVERRIDE" ] || [ -n "$AGGREGATORS_OVERRIDE" ]; then
+  TEST_MODE=1
+fi
+
+# Aggregator list (default vs. --aggregators override).
+declare -a AGGREGATORS
+if [ -n "$AGGREGATORS_OVERRIDE" ]; then
+  IFS=',' read -r -a AGGREGATORS <<< "$AGGREGATORS_OVERRIDE"
+else
+  AGGREGATORS=(
+    "$REPO_ROOT/tests/full-project-test-suite.sh"
+    "$REPO_ROOT/tests/edge-case-test-suite.sh"
+    "$REPO_ROOT/tests/known-bugs-test-suite.sh"
+    "$REPO_ROOT/tests/upgrade-path-tests.sh"
+    "$REPO_ROOT/tests/host-drivers/run-all.sh"
+  )
+fi
+
+# Pre-existing orphan tests (pre-BL-038) tracked by BL-035 for
+# disposition. Bridge mechanism — see header. Remove an entry by:
+#   (a) registering the test in an aggregator, OR
+#   (b) adding a real `# LINT_TEST_REGISTRATION_EXEMPT: <reason>`
+#       marker inside the test file's header.
+# When BL-035 closes this array must be empty.
+KNOWN_ORPHANS_PENDING_BL035=(
+  test-bl029-integration.sh
+  test-bl030-calibration-replay.sh
+  test-bypass-audit-integrity.sh
+  test-bypass-audit-lib.sh
+  test-bypass-audit-schema.sh
+  test-bypass-detector.sh
+  test-bypass-patterns.sh
+  test-bypass-sentinel.sh
+  test-check-changelog-filter.sh
+  test-check-commit-message.sh
+  test-check-gate.sh
+  test-check-phase-gate-counter-sanitizer.sh
+  test-check-phase-gate.sh
+  test-docs-cluster-six-pack.sh
+  test-enforcement-level-init.sh
+  test-enforcement-level-lib.sh
+  test-enforcement-level-reconfigure.sh
+  test-escalate-to-user.sh
+  test-filesystem-gate-install.sh
+  test-gate-principles.sh
+  test-github-free-tier-403.sh
+  test-init-atomic-finalize.sh
+  test-init-no-remote-creation.sh
+  test-init-non-interactive.sh
+  test-init-other-host-attestation.sh
+  test-init-schema-phase-gate.sh
+  test-lint-uat-scenarios.sh
+  test-out-of-band-detector.sh
+  test-pending-approval.sh
+  test-phase-finalize.sh
+  test-platform-security-bugs-closer.sh
+  test-poc-modes.sh
+  test-pre-commit-gate-terminal-mode.sh
+  test-process-checklist-auto-advance.sh
+  test-process-checklist-classifier.sh
+  test-record-claude-commit.sh
+  test-session-test-gate-check-merge.sh
+  test-specs-plans-remaining-quartet.sh
+  test-test-gate-counter-sanitizer.sh
+  test-test-gate-null-handling.sh
+  test-unrecord-feature.sh
+  test-upgrade-bl030-backfill.sh
+  test-upgrade-non-interactive.sh
+  test-upgrade-paths.sh
+  test-upgrade-personal-to-sponsored-poc.sh
+  test-upgrade-to-production-preconditions.sh
+  test-upgrade-to-production-warn.sh
+  test-validate-counter-sanitizer.sh
+  test-vendored-skills-install.sh
+  test-verify-install-bl030-coverage.sh
+)
+
+VIOLATIONS=0
+LIST_ROWS=""
+
+_is_aggregator() {
+  local file="$1"
+  local agg
+  for agg in "${AGGREGATORS[@]}"; do
+    [ "$agg" = "$file" ] && return 0
+  done
+  return 1
+}
+
+_is_known_orphan_bridge() {
+  # Only honour the bridge list when scanning the canonical repo dir.
+  # Fixture-mode scans (--tests-dir override) must see clean lint semantics.
+  [ "$TEST_MODE" -eq 1 ] && return 1
+  local needle="$1"
+  local orphan
+  for orphan in "${KNOWN_ORPHANS_PENDING_BL035[@]}"; do
+    [ "$orphan" = "$needle" ] && return 0
+  done
+  return 1
+}
+
+# host-drivers/run-all.sh globs *.test.sh and *.selftest.sh, so any
+# file matching those extensions under tests/host-drivers/ is
+# implicitly registered as long as run-all.sh appears in the
+# aggregator list.
+_is_host_driver_implicit() {
+  local file="$1"
+  local run_all has_run_all=0 agg
+  for agg in "${AGGREGATORS[@]}"; do
+    case "$agg" in
+      */host-drivers/run-all.sh) has_run_all=1; run_all="$agg"; break ;;
+    esac
+  done
+  [ "$has_run_all" -eq 1 ] || return 1
+  # File must live under the same host-drivers/ directory as run-all.sh.
+  local hd_dir="${run_all%/run-all.sh}"
+  case "$file" in
+    "$hd_dir"/*.test.sh|"$hd_dir"/*.selftest.sh) return 0 ;;
+  esac
+  return 1
+}
+
+# Parse the EXEMPT marker out of the first 40 lines of the file.
+# Emits "<has_marker>\t<reason>" — has_marker is 0 or 1.
+_parse_exempt() {
+  local file="$1"
+  local marker_line reason=""
+  marker_line=$(head -n 40 "$file" 2>/dev/null \
+    | grep -E '^[[:space:]]*#[[:space:]]*LINT_TEST_REGISTRATION_EXEMPT:' \
+    | head -n 1)
+  if [ -z "$marker_line" ]; then
+    printf '0\t\n'
+    return 0
+  fi
+  reason="${marker_line#*LINT_TEST_REGISTRATION_EXEMPT:}"
+  # Trim leading and trailing whitespace.
+  reason="${reason#"${reason%%[![:space:]]*}"}"
+  reason="${reason%"${reason##*[![:space:]]}"}"
+  printf '1\t%s\n' "$reason"
+}
+
+scan_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+
+  local base rel
+  base=$(basename "$file")
+  if [ "$TEST_MODE" -eq 1 ]; then
+    rel="$file"
+  else
+    rel="${file#"$REPO_ROOT"/}"
+  fi
+
+  # Skip the lint script itself (defensive — it's not under tests/).
+  [ "$file" = "$SELF_PATH" ] && return 0
+
+  # Skip aggregators (delegators, not tests).
+  if _is_aggregator "$file"; then
+    LIST_ROWS="${LIST_ROWS}SKIP\t${rel}\taggregator\n"
+    return 0
+  fi
+
+  # Skip tests/test-helpers/* (helpers, not tests). Currently the dir
+  # doesn't exist in the repo, but this future-proofs against helper
+  # libraries landing under that path.
+  case "$file" in
+    */tests/test-helpers/*) LIST_ROWS="${LIST_ROWS}SKIP\t${rel}\ttest-helpers\n"; return 0 ;;
+  esac
+
+  # Skip tests/host-drivers/mock-cli.sh (driver helper invoked by the
+  # other host-driver tests, not a test in its own right). Its
+  # extension doesn't match *.test.sh / *.selftest.sh so it won't be
+  # enumerated anyway, but make the skip explicit.
+  case "$file" in
+    */tests/host-drivers/mock-cli.sh) LIST_ROWS="${LIST_ROWS}SKIP\t${rel}\thost-drivers-helper\n"; return 0 ;;
+  esac
+
+  # EXEMPT marker check.
+  local exempt has_marker reason
+  exempt=$(_parse_exempt "$file")
+  has_marker=$(printf '%s' "$exempt" | cut -f1)
+  reason=$(printf '%s' "$exempt" | cut -f2)
+  if [ "$has_marker" = "1" ]; then
+    if [ -z "$reason" ]; then
+      echo "${rel}: lint-tests-registered: EXEMPT marker present but allowlist requires non-empty reason — append a justification after the colon" >&2
+      VIOLATIONS=$((VIOLATIONS + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\t${rel}\texempt-empty-reason\n"
+    else
+      LIST_ROWS="${LIST_ROWS}PASS\t${rel}\texempt:${reason}\n"
+    fi
+    return 0
+  fi
+
+  # host-drivers glob: *.test.sh and *.selftest.sh under host-drivers/
+  # are implicitly registered via run-all.sh's glob.
+  if _is_host_driver_implicit "$file"; then
+    LIST_ROWS="${LIST_ROWS}PASS\t${rel}\thost-drivers-glob\n"
+    return 0
+  fi
+
+  # Bridge: pre-existing orphan tracked by BL-035 (repo-mode only).
+  if _is_known_orphan_bridge "$base"; then
+    LIST_ROWS="${LIST_ROWS}PASS\t${rel}\torphan-pending-BL-035\n"
+    return 0
+  fi
+
+  # Real registration check: does any aggregator INVOKE this basename
+  # on a non-comment line? A naive substring grep would false-positive
+  # on `# Hook test scaffolding (same shape as test-foo.sh)` comments
+  # in adjacent aggregator headers (caught during BL-038 self-test).
+  # We anchor on a word-boundary-ish neighbourhood and then strip pure
+  # comment lines (`^[whitespace]*#`) from the candidate set before
+  # declaring a match.
+  local agg found=0
+  # Escape the basename's `.` so it doesn't act as a regex wildcard.
+  local base_re="${base//./\\.}"
+  # (^|[^[:alnum:]_-])basename([^[:alnum:]]|$) — matches the basename
+  # as a whole token, allowing trailing quote / paren / EOL but
+  # rejecting substring embeddings like `test-foo.sh.bak`.
+  local re="(^|[^[:alnum:]_-])${base_re}([^[:alnum:]]|\$)"
+  for agg in "${AGGREGATORS[@]}"; do
+    [ -f "$agg" ] || continue
+    # grep candidate lines, then drop pure-comment lines (a leading
+    # `#` after optional whitespace). Any survivor counts as a real
+    # invocation reference.
+    if grep -nE "$re" "$agg" 2>/dev/null | grep -vqE '^[0-9]+:[[:space:]]*#'; then
+      found=1
+      break
+    fi
+  done
+
+  if [ "$found" -eq 1 ]; then
+    LIST_ROWS="${LIST_ROWS}PASS\t${rel}\tregistered\n"
+  else
+    echo "${rel}: lint-tests-registered: test file is not invoked by any aggregator (${AGGREGATORS[*]}). Register it in tests/full-project-test-suite.sh (or another aggregator) following the BL-034 cohort pattern, or add '# LINT_TEST_REGISTRATION_EXEMPT: <reason>' to the file header." >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+    LIST_ROWS="${LIST_ROWS}FAIL\t${rel}\tnot-registered\n"
+  fi
+}
+
+# Enumerate test files under TESTS_DIR. The four globs cover the
+# canonical patterns; missing dirs/no-match cases are skipped via the
+# [ -e ] guard inside scan_file.
+shopt -s nullglob
+declare -a CANDIDATES=()
+for f in "$TESTS_DIR"/test-*.sh; do CANDIDATES+=("$f"); done
+for f in "$TESTS_DIR"/edge-cases-*.sh; do CANDIDATES+=("$f"); done
+for f in "$TESTS_DIR"/host-drivers/*.test.sh; do CANDIDATES+=("$f"); done
+for f in "$TESTS_DIR"/host-drivers/*.selftest.sh; do CANDIDATES+=("$f"); done
+shopt -u nullglob
+
+if [ "${#CANDIDATES[@]}" -eq 0 ]; then
+  if [ "$TEST_MODE" -eq 1 ]; then
+    # Empty fixture dir is legal in test mode (no tests = nothing to lint).
+    [ "$LIST_MODE" -eq 1 ] && printf 'STATUS\tFILE\tDETAIL\n'
+    echo "OK: no test files under $TESTS_DIR."
+    exit 0
+  fi
+  echo "lint-tests-registered: no test files found under $TESTS_DIR — refusing to claim a clean pass" >&2
+  exit 2
+fi
+
+for f in "${CANDIDATES[@]}"; do
+  scan_file "$f"
+done
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS violation(s) found. See scripts/lint-tests-registered.sh header for the registration / EXEMPT-marker contract." >&2
+  exit 1
+fi
+
+echo "OK: every test file is registered with an aggregator (or EXEMPT)."
+exit 0

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -135,6 +135,24 @@ if [ "$TERMINAL_MODE" -eq 1 ]; then
         exit 1
       fi
     fi
+
+    # tests-registered (BL-038): every tests/test-*.sh must be invoked
+    # by an aggregator (or carry an EXEMPT marker). Full-tree scan, no
+    # message dependency. See scripts/lint-tests-registered.sh header.
+    TR_LINT=""
+    for cand in "$PROJECT_ROOT/scripts/lint-tests-registered.sh" \
+                "$SCRIPT_DIR/lint-tests-registered.sh"; do
+      [ -f "$cand" ] && { TR_LINT="$cand"; break; }
+    done
+    if [ -n "$TR_LINT" ]; then
+      if ! tr_out=$(bash "$TR_LINT" 2>&1); then
+        echo "[FRAMEWORK GATE — strict mode] tests-registered lint failed:" >&2
+        echo "$tr_out" >&2
+        echo "" >&2
+        echo "To bypass anyway:  SKIP_LINT=1 git commit ..." >&2
+        exit 1
+      fi
+    fi
   fi
   # --- end cycle-8 slot-5 terminal-mode block ---
 
@@ -494,7 +512,7 @@ lints_check() {
 
   # Escape hatch.
   if [ "${SKIP_LINT:-0}" = "1" ]; then
-    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing counter-antipattern + backlog-references lints" >&2
+    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing counter-antipattern + backlog-references + fix-functions-stderr + raw-read-prompt + tests-registered lints" >&2
     return 0
   fi
 
@@ -504,7 +522,7 @@ lints_check() {
   # still self-checks when run from the framework repo's own working
   # tree. Project root = `git rev-parse --show-toplevel` from the
   # current cwd, since Claude Code invokes the hook from the project.
-  local proj_root ca_lint="" br_lint="" ff_lint="" rr_lint=""
+  local proj_root ca_lint="" br_lint="" ff_lint="" rr_lint="" tr_lint=""
   proj_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
   for cand in "$proj_root/scripts/lint-counter-antipattern.sh" \
               "$SCRIPT_DIR/lint-counter-antipattern.sh"; do
@@ -521,6 +539,10 @@ lints_check() {
   for cand in "$proj_root/scripts/lint-raw-read-prompt.sh" \
               "$SCRIPT_DIR/lint-raw-read-prompt.sh"; do
     [ -n "$cand" ] && [ -f "$cand" ] && { rr_lint="$cand"; break; }
+  done
+  for cand in "$proj_root/scripts/lint-tests-registered.sh" \
+              "$SCRIPT_DIR/lint-tests-registered.sh"; do
+    [ -n "$cand" ] && [ -f "$cand" ] && { tr_lint="$cand"; break; }
   done
 
   # Counter-antipattern: full repo-relative scan, fast.
@@ -562,6 +584,16 @@ lints_check() {
     rr_out=$(bash "$rr_lint" 2>&1) || rr_exit=$?
     if [ "$rr_exit" -ne 0 ]; then
       emit_lint_block "pre-commit gate: scripts/lint-raw-read-prompt.sh failed. ${rr_out} Migrate to prompt_input / prompt_yes_no (scripts/lib/helpers.sh) or append '# lint-raw-read-prompt: allow <reason>'. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
+    fi
+  fi
+
+  # tests-registered (BL-038): structural backstop for orphan tests.
+  # Full repo-relative scan, fast.
+  if [ -n "$tr_lint" ]; then
+    local tr_out tr_exit=0
+    tr_out=$(bash "$tr_lint" 2>&1) || tr_exit=$?
+    if [ "$tr_exit" -ne 0 ]; then
+      emit_lint_block "pre-commit gate: scripts/lint-tests-registered.sh failed. ${tr_out} Register the test in tests/full-project-test-suite.sh (or another aggregator) following the BL-034 cohort pattern, or add '# LINT_TEST_REGISTRATION_EXEMPT: <reason>' to the file header. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
     fi
   fi
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -982,7 +982,7 @@ Both branches of the inner if/else call pass(). A regression that silently strip
 **Logged:** 2026-06-28 (test integrity audit)
 **Category:** Test infrastructure / preventive control
 **Severity:** Medium
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #122, commit 125d6fc)
 
 The pattern of 'PR adds a test file, PR merges, test never runs' is now a systemic risk, not a one-off mistake. 16 of 17 Wave 1-4 test files landed without aggregator registration. Without an automated gate, the next wave will reproduce the same issue.
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -317,6 +317,29 @@ else
   fail "scripts/lint-raw-read-prompt.sh behavior tests FAILED (run tests/test-lint-raw-read-prompt.sh for details)"
 fi
 
+# BL-038: tests/test-lint-tests-registered.sh — behavior suite for the
+# runner-registration backstop. Validates the lint's positive,
+# negative, EXEMPT-marker, mutation, and reverse-mutation paths so a
+# regression in the lint itself (false negative on a new orphan,
+# false positive on a comment-mention) is surfaced at the aggregator.
+if bash "$SCRIPT_DIR/tests/test-lint-tests-registered.sh" >/dev/null 2>&1; then
+  pass "scripts/lint-tests-registered.sh behavior tests"
+else
+  fail "scripts/lint-tests-registered.sh behavior tests FAILED (run tests/test-lint-tests-registered.sh for details)"
+fi
+
+# BL-038: repo-wide lint invocation. Refuses to merge a new
+# tests/test-*.sh file unless an aggregator invokes it or the file
+# carries an EXEMPT marker. See scripts/lint-tests-registered.sh
+# header for the registration contract + KNOWN_ORPHANS_PENDING_BL035
+# bridge.
+section "Tests-registered lint (BL-038 structural backstop)"
+if bash "$SCRIPT_DIR/scripts/lint-tests-registered.sh" >/dev/null 2>&1; then
+  pass "Every tests/test-*.sh is invoked by an aggregator (or EXEMPT)"
+else
+  fail "Tests-registered lint found unregistered test file(s) (see scripts/lint-tests-registered.sh --list)"
+fi
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-lint-tests-registered.sh
+++ b/tests/test-lint-tests-registered.sh
@@ -1,0 +1,308 @@
+#!/usr/bin/env bash
+# tests/test-lint-tests-registered.sh
+#
+# Behavior tests for scripts/lint-tests-registered.sh — the BL-038
+# runner-registration backstop. Each test stages a tmpdir fixture with
+# a fake `tests/` directory plus a fake aggregator, invokes the lint
+# with --tests-dir + --aggregators pointing at the fixture, and asserts
+# on exit code + stderr.
+#
+# Per BL-066 lesson (exercise both success AND failure paths):
+#   • T1 (positive): clean fixture, one registered test → exit 0
+#   • T2 (negative): one unregistered test → exit 1, file named in stderr
+#   • T3 (allowlist marker): unregistered + EXEMPT marker → exit 0
+#   • T4 (empty reason): EXEMPT marker with no reason → exit 1 with
+#       "allowlist requires non-empty reason" diagnostic
+#   • T5 (regression against current repo): real repo invocation → exit 0
+#   • T6 (mutation experiment): comment-out a real registration in
+#       full-project-test-suite.sh, confirm the lint catches it (proves
+#       the lint sees real invocations, not just comment-mention noise)
+#   • T7 (reverse-mutation): no false-positive on existing aggregator
+#       comments that mention test basenames (e.g.
+#       `# Hook test scaffolding (same shape as test-foo.sh)`)
+#
+# Style mirrors tests/test-lint-counter-antipattern.sh (PR #72) and
+# tests/test-lint-fix-functions-stderr.sh (PR #96): set -uo pipefail,
+# mktemp fixtures, pass/fail counters, teardown after each test.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-tests-registered.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build an isolated fixture: $TMP/tests/ with the given file content,
+# plus an aggregator at $TMP/tests/myagg.sh that invokes whatever you
+# pass. Return $TMP via the global TMP variable.
+setup_fixture() {
+  TMP=$(mktemp -d)
+  mkdir -p "$TMP/tests"
+}
+teardown_fixture() { rm -rf "$TMP"; }
+
+# Run the lint pointed at the fixture's tests/ and aggregator file.
+# Args: aggregator-file (relative to $TMP). Captures exit + combined output.
+run_lint_fixture() {
+  local agg="${1:-tests/myagg.sh}"
+  bash "$LINTER" --tests-dir "$TMP/tests" --aggregators "$TMP/$agg" 2>&1
+  return $?
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: clean fixture (one registered test) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/tests/test-registered.sh" <<'SH'
+#!/usr/bin/env bash
+echo "fixture test"
+SH
+cat > "$TMP/tests/myagg.sh" <<SH
+#!/usr/bin/env bash
+bash "$TMP/tests/test-registered.sh"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T1: clean registered fixture exits 0"
+else
+  fail_ "T1" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: unregistered test → exit 1, names file in stderr ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/tests/test-orphan.sh" <<'SH'
+#!/usr/bin/env bash
+echo "this test is never invoked"
+SH
+# Aggregator file exists but does NOT mention test-orphan.sh.
+cat > "$TMP/tests/myagg.sh" <<'SH'
+#!/usr/bin/env bash
+echo "I register nothing"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q "test-orphan.sh" \
+   && echo "$out" | grep -q "not invoked by any aggregator"; then
+  pass "T2: unregistered test exits 1 with file name + diagnostic"
+else
+  fail_ "T2" "expected exit 1 + diagnostic mentioning test-orphan.sh; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: EXEMPT marker with reason → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/tests/test-orphan-exempt.sh" <<'SH'
+#!/usr/bin/env bash
+# LINT_TEST_REGISTRATION_EXEMPT: manual-only smoke test, runs in nightly cron
+echo "exempted orphan"
+SH
+cat > "$TMP/tests/myagg.sh" <<'SH'
+#!/usr/bin/env bash
+echo "I register nothing"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T3: EXEMPT marker with reason exits 0"
+else
+  fail_ "T3" "expected exit 0 with EXEMPT marker; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: EXEMPT marker with empty reason → exit 1 + 'non-empty reason' diagnostic ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/tests/test-orphan-bad-exempt.sh" <<'SH'
+#!/usr/bin/env bash
+# LINT_TEST_REGISTRATION_EXEMPT:
+echo "bad exempt"
+SH
+cat > "$TMP/tests/myagg.sh" <<'SH'
+#!/usr/bin/env bash
+echo "I register nothing"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q "test-orphan-bad-exempt.sh" \
+   && echo "$out" | grep -q "allowlist requires non-empty reason"; then
+  pass "T4: empty-reason EXEMPT marker fails with specific diagnostic"
+else
+  fail_ "T4" "expected exit 1 + 'allowlist requires non-empty reason'; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4b: trailing-whitespace EXEMPT marker still treated as empty ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+# Marker has whitespace after the colon but no actual reason.
+printf '%s\n%s\n%s\n' '#!/usr/bin/env bash' \
+  '# LINT_TEST_REGISTRATION_EXEMPT:   ' \
+  'echo "whitespace-only reason"' > "$TMP/tests/test-orphan-ws-exempt.sh"
+cat > "$TMP/tests/myagg.sh" <<'SH'
+#!/usr/bin/env bash
+echo "I register nothing"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q "allowlist requires non-empty reason"; then
+  pass "T4b: whitespace-only reason rejected"
+else
+  fail_ "T4b" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: real repo state (BL-038 invariant) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# This is the merge gate: the lint must pass on the actual repo HEAD
+# (with the KNOWN_ORPHANS_PENDING_BL035 bridge in place). If it fails,
+# the bridge list is stale OR a Wave 5+ orphan slipped past the gate.
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "T5: repo HEAD is lint-clean (bridge list + Wave 1-4 registration)"
+else
+  fail_ "T5" "current repo HEAD has unregistered tests; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: mutation — comment-out a real aggregator registration ==="
+# ════════════════════════════════════════════════════════════════════
+# Pick a known-registered test, write a fixture that copies it into a
+# tmpdir, and stage an aggregator where the invocation is COMMENTED OUT
+# instead of live. Expect the lint to surface the orphan.
+setup_fixture
+cat > "$TMP/tests/test-mutation-target.sh" <<'SH'
+#!/usr/bin/env bash
+echo "registered in fixture aggregator only via a comment line"
+SH
+# Aggregator mentions the basename but only in a comment — the BL-038
+# defect class. A correct lint must NOT count the comment as a real
+# registration (the false-positive caught during BL-038 self-test:
+# `# Hook test scaffolding (same shape as test-foo.sh)`).
+cat > "$TMP/tests/myagg.sh" <<'SH'
+#!/usr/bin/env bash
+# This comment mentions test-mutation-target.sh but does NOT invoke it.
+echo "real aggregator body"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q "test-mutation-target.sh"; then
+  pass "T6: mutation — comment-mention does NOT count as registration"
+else
+  fail_ "T6" "expected exit 1 (comment shouldn't register); rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: reverse-mutation — live invocation DOES count ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/tests/test-live-invoked.sh" <<'SH'
+#!/usr/bin/env bash
+echo "live"
+SH
+# Aggregator has BOTH a comment mention AND a live invocation. Lint
+# must pass — the live invocation is what counts, the comment is noise.
+cat > "$TMP/tests/myagg.sh" <<SH
+#!/usr/bin/env bash
+# Comment about test-live-invoked.sh that should be ignored
+bash "\$SCRIPT_DIR/tests/test-live-invoked.sh"
+SH
+out=$(run_lint_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "T7: reverse-mutation — live invocation passes despite comment"
+else
+  fail_ "T7" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: aggregator file itself is skipped (not lint-checked as test) ==="
+# ════════════════════════════════════════════════════════════════════
+# The aggregator file might match the test-*.sh pattern itself (e.g.
+# a file named test-aggregator.sh). It must be SKIPPED from the
+# registration check, not flagged as an orphan.
+setup_fixture
+cat > "$TMP/tests/test-aggregator.sh" <<'SH'
+#!/usr/bin/env bash
+echo "I am an aggregator, not a test"
+SH
+cat > "$TMP/tests/test-real.sh" <<'SH'
+#!/usr/bin/env bash
+echo "real test"
+SH
+cat > "$TMP/tests/test-aggregator.sh" <<SH
+#!/usr/bin/env bash
+bash "$TMP/tests/test-real.sh"
+SH
+# Pass test-aggregator.sh AS the aggregator. It should not appear as
+# a violation (it's in the aggregator allowlist).
+out=$(bash "$LINTER" --tests-dir "$TMP/tests" --aggregators "$TMP/tests/test-aggregator.sh" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "T8: aggregator file skipped from registration check"
+else
+  fail_ "T8" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9: --list mode emits PASS/FAIL table ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/tests/test-listed.sh" <<'SH'
+#!/usr/bin/env bash
+echo "fixture"
+SH
+cat > "$TMP/tests/myagg.sh" <<SH
+#!/usr/bin/env bash
+bash "\$SCRIPT_DIR/tests/test-listed.sh"
+SH
+out=$(bash "$LINTER" --tests-dir "$TMP/tests" --aggregators "$TMP/tests/myagg.sh" --list 2>&1); rc=$?
+if [ "$rc" -eq 0 ] \
+   && echo "$out" | grep -q "STATUS" \
+   && echo "$out" | grep -q "test-listed.sh" \
+   && echo "$out" | grep -q "registered"; then
+  pass "T9: --list mode prints STATUS table"
+else
+  fail_ "T9" "expected --list header + row; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: unknown flag returns exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" --bogus-flag 2>&1); rc=$?
+if [ "$rc" -eq 2 ] && echo "$out" | grep -q "Usage:"; then
+  pass "T10: unknown flag rejected with exit 2 + usage"
+else
+  fail_ "T10" "expected exit 2 + usage; rc=$rc; output:\n$out"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds `scripts/lint-tests-registered.sh` — structural backstop preventing the BL-034 / BL-038 orphan-test defect class (Wave 1-4 audit found 16 of 17 newly added tests landed without aggregator wiring → ran zero times after merge).
- Walks `tests/test-*.sh`, `tests/edge-cases-*.sh`, `tests/host-drivers/*.test.sh`, `tests/host-drivers/*.selftest.sh`; greps each aggregator (5 known) on non-comment lines for the basename. Word-boundary regex + comment-line skip prevents both substring collisions and false positives from aggregator-header comments that mention basenames in prose.
- Per-file EXEMPT marker (`# LINT_TEST_REGISTRATION_EXEMPT: <non-empty reason>`) for genuine manual / network-dependent / slow tests; empty reason rejected.
- `KNOWN_ORPHANS_PENDING_BL035` bridge holds the 50 pre-existing orphans tracked by BL-035 (a single centralized allowlist instead of 50 scattered EXEMPT markers; must be empty when BL-035 closes).
- Wired into `.github/workflows/lint.yml` (new `tests-registered-lint` job), `scripts/pre-commit-gate.sh` (both PreToolUse JSON path + `--terminal-mode` branch, honors `SKIP_LINT=1`), and `tests/full-project-test-suite.sh` (TEST 0f registers the behavior suite + full-tree invocation).

## Closes

BL-038

## Test plan

`tests/test-lint-tests-registered.sh` (11 tests, all GREEN) — exercises BOTH success and failure paths per BL-066 lesson:

- [x] **T1 positive**: clean registered fixture → exit 0
- [x] **T2 negative**: unregistered fixture → exit 1 + file named in stderr
- [x] **T3 EXEMPT marker with reason**: → exit 0
- [x] **T4 empty reason**: → exit 1 with literal `allowlist requires non-empty reason`
- [x] **T4b whitespace-only reason**: still rejected (regression guard)
- [x] **T5 real repo HEAD invocation**: → exit 0 (merge gate; proves bridge list + Wave 1-4 registrations are complete)
- [x] **T6 mutation experiment**: a comment that merely *mentions* a test basename does NOT count as registration. Caught the actual bug in the first draft of this lint (`tests/edge-case-test-suite.sh:81` mentions `test-bypass-detector.sh` in prose — a naive `grep -F` would have falsely marked it registered).
- [x] **T7 reverse-mutation**: live `bash …/test-foo.sh` invocation alongside a comment still passes.
- [x] **T8 aggregator file** (matching `test-*.sh` pattern) skipped from registration check.
- [x] **T9 `--list` mode** emits STATUS table.
- [x] **T10 unknown flag** → exit 2 + usage.

### Pre-merge self-verify (all exit 0)

```
$ bash scripts/lint-counter-antipattern.sh   # OK
$ bash scripts/lint-backlog-references.sh    # OK
$ bash scripts/lint-fix-functions-stderr.sh  # OK
$ bash scripts/lint-raw-read-prompt.sh       # OK
$ bash scripts/lint-tests-registered.sh      # OK
$ bash tests/test-lint-tests-registered.sh   # 11 passed, 0 failed
```

### Mutation proofs

| Mutation | Expected | Observed |
|---|---|---|
| Comment-out a fixture aggregator's live `bash …` invocation, leaving only a `# mentions test-foo.sh` comment | lint exits 1 with `test-foo.sh: not invoked` | exits 1, names file (T6) |
| Restore live invocation alongside the comment | lint exits 0 | exits 0 (T7) |
| EXEMPT marker with whitespace-only reason | lint exits 1, `allowlist requires non-empty reason` | exits 1 with expected message (T4b) |
| Drop bridge entry for any orphan still on `KNOWN_ORPHANS_PENDING_BL035` | T5 flips RED | confirmed during first-draft self-test — missing `test-bypass-detector.sh` flagged it, fixed in 125d6fc |

## Coordination note

**Files touched** (independent of slots 2+3 which modify `scripts/init.sh`):

- `.github/workflows/lint.yml` — new job, sibling to existing 4
- `scripts/pre-commit-gate.sh` — extended both lint runners
- `scripts/lint-tests-registered.sh` (NEW)
- `tests/test-lint-tests-registered.sh` (NEW)
- `tests/full-project-test-suite.sh` — registered the new behavior suite + repo-wide lint invocation

No expected rebase conflict with Wave A siblings (BL-040 / BL-041 touch `init.sh`, not the lint surface or pre-commit-gate).

## Worktree note

`pwd` = `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_8bbf1808-203-1`

A second commit will follow on this branch to flip BL-038 to Closed with the PR number — defers per the BL-036 / BL-037 closure pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)