### PR TITLE
fix(init): write-perm preflight runs before framework-repo guard (closes BL-041)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -3707,30 +3707,58 @@ HELPEOF
 
   print_header "$VERSION"
 
-  # UAT 2026-04-25 fix (U-N): refuse to scaffold a project inside the
-  # framework repo itself. (--dry-run is allowed for inspection.)
+  # BL-041 (2026-06-30): the write-permission preflight and the
+  # framework-repo guard share a target-dir resolution step. Compute
+  # _early_target once and feed it to BOTH checks, in the order:
+  #   1. preflight_target_writable  — operator-facing
+  #   2. guard_not_in_framework     — developer-facing
   #
-  # security-audits-1 (S3, 2026-04-26 audit sweep): also pass the resolved
-  # --project-dir target so the guard catches a malicious or honest-mistake
-  # caller that supplies --project-dir=$FRAMEWORK_REPO from a benign cwd.
-  # The legacy bl-016 audit row #10 claimed this was already covered; the
-  # cwd-only guard did NOT actually cover it. The target-aware overload
-  # closes the gap.
+  # Rationale: a real operator who points --project-dir at an unwritable
+  # location should get the relevant permission error, not the framework-
+  # repo refusal. The framework-repo refusal still fires (defense-in-
+  # depth) when the preflight passes, and is the actual right answer for
+  # the developer scenario it was designed for.
+  #
+  # The previous ordering also blocked tests/edge-cases-pre-init.sh E8b:
+  # the harness runs init.sh from inside the framework checkout (cwd is
+  # the framework repo), so the cwd check in guard_not_in_framework fired
+  # before any write-permission probe had a chance. Reordering the two
+  # closes that test gap without weakening either guard.
+  #
+  # --dry-run skips BOTH because it never actually writes anything (the
+  # preview is allowed for inspection from any context, including from
+  # inside the framework repo itself).
   if [ "$DRY_RUN" != true ]; then
     # Resolve the effective target dir: explicit --project-dir wins; non-interactive
     # default is $HOME/Code/$ARG_PROJECT; interactive flow resolves later via prompt
     # (in that path the cwd check is the only signal until prompts run, which is
     # the same scope as before).
-    _gnif_target=""
+    _early_target=""
     if [ -n "${ARG_PROJECT_DIR:-}" ]; then
-      _gnif_target="$ARG_PROJECT_DIR"
+      _early_target="$ARG_PROJECT_DIR"
     elif [ "$NON_INTERACTIVE" = true ] && [ -n "${ARG_PROJECT:-}" ]; then
-      _gnif_target="$HOME/Code/$ARG_PROJECT"
+      _early_target="$HOME/Code/$ARG_PROJECT"
     fi
-    if ! guard_not_in_framework "$_gnif_target"; then
+
+    # 1. Operator-facing: write-permission preflight (BL-041 / audit
+    # recommendation C). Must run BEFORE the framework-repo guard so the
+    # permission failure mode is reachable from any cwd. preflight_target_writable
+    # is a no-op when _early_target is empty (interactive flow resolves
+    # target later; the existing downstream existence check at
+    # collect_inputs_non_interactive::project_dir + create_project's
+    # mkdir surface the same failure mode in that path).
+    if ! preflight_target_writable "$_early_target"; then
       exit 1
     fi
-    unset _gnif_target
+
+    # 2. Developer-facing: framework-repo guard. security-audits-1
+    # (S3, 2026-04-26 audit sweep) added the optional target argument so
+    # this catches a malicious or honest-mistake caller that supplies
+    # --project-dir=$FRAMEWORK_REPO from a benign cwd.
+    if ! guard_not_in_framework "$_early_target"; then
+      exit 1
+    fi
+    unset _early_target
   fi
 
   if [ "$DRY_RUN" = true ]; then

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -271,6 +271,78 @@ guard_not_in_framework() {
   return 0
 }
 
+# Verify the calling process can create files at $1.
+#
+# Why this exists (BL-041 closer, 2026-06-30):
+#   init.sh historically only learned that the target directory was
+#   unwritable AFTER hundreds of lines of setup — by which point it had
+#   already side-effected logs, mkdir'd partial scaffolds, and bailed in
+#   the middle of an inconsistent install. Worse, the framework-repo
+#   guard (guard_not_in_framework above) used to fire BEFORE any write-
+#   permission check, so test harnesses running from inside the
+#   framework checkout could not exercise the read-only failure path
+#   at all (tests/edge-cases-pre-init.sh E8b was SKIPped).
+#
+#   This preflight is the operator-facing write-permission probe. It
+#   MUST run before guard_not_in_framework so that:
+#     • a real operator who points --project-dir at an unwritable
+#       location gets a clear permission error (not the developer-
+#       facing framework-repo refusal that is irrelevant to them);
+#     • test harnesses running from any cwd can deliberately exercise
+#       the read-only assertion without first being short-circuited
+#       by the framework-repo guard.
+#
+# Contract:
+#   • returns 0 if the target can be created/written; 1 otherwise.
+#   • empty $1 returns 0 (caller has no resolvable target yet — interactive
+#     flows resolve via prompts after this preflight; the project_dir-
+#     existence check downstream handles that path).
+#   • when target does not exist, the deepest existing ancestor is probed.
+#   • emits a self-contained operator-facing error on failure (no caller
+#     post-message needed).
+preflight_target_writable() {
+  local target="${1:-}"
+  [ -n "$target" ] || return 0
+
+  # Normalize to absolute (no realpath dependency — POSIX only).
+  case "$target" in
+    /*) ;;
+    *)  target="$(pwd)/$target" ;;
+  esac
+
+  # Walk up to deepest existing ancestor. We need a path that exists
+  # before we can answer "is it writable?".
+  local probe="$target"
+  while [ ! -e "$probe" ]; do
+    local parent
+    parent="$(dirname "$probe")"
+    if [ "$parent" = "$probe" ]; then
+      # Walked all the way to the filesystem root and nothing exists.
+      # This is a different failure mode (path is in a non-existent
+      # filesystem) — defer to the downstream existence check.
+      return 0
+    fi
+    probe="$parent"
+  done
+
+  if [ ! -w "$probe" ]; then
+    print_fail "Cannot create project directory: write permission denied."
+    echo "  Target:           $target" >&2
+    echo "  Unwritable path:  $probe" >&2
+    echo "" >&2
+    echo "  init.sh needs to write under the resolved target path, but" >&2
+    echo "  the existing ancestor '$probe' is not writable by the" >&2
+    echo "  current user ($(whoami))." >&2
+    echo "" >&2
+    echo "  Fix one of:" >&2
+    echo "    - chmod the parent to grant write access (e.g. chmod u+w '$probe')" >&2
+    echo "    - pick a different --project-dir under a writable parent" >&2
+    echo "    - re-run as a user that owns the parent directory" >&2
+    return 1
+  fi
+  return 0
+}
+
 # Prompt for a numbered choice from a list of options.
 # Usage: result=$(prompt_choice "Pick one:" "option1" "option2" "option3")
 #

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1056,7 +1056,7 @@ E2 in `tests/edge-cases-pre-init.sh` is left as SKIP because `scripts/init.sh:27
 **Logged:** 2026-06-28 (test integrity audit)
 **Category:** Bug / live product defect (test-harness blocker)
 **Severity:** Medium
-**Status:** Closed (2026-06-30, commit `64e8c85`)
+**Status:** Closed (2026-06-30, PR #123, commit `64e8c85`)
 
 The framework-repo guard at `scripts/init.sh:3494` runs before the write-permission preflight. When the test harness invokes init.sh from inside the framework checkout (which is how `tests/edge-cases-pre-init.sh` is structured), the guard refuses any non-dry-run invocation before the preflight can fire. E8b is SKIPed as a consequence — there is no way to exercise the write-permission failure path under the current layering.
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1056,7 +1056,7 @@ E2 in `tests/edge-cases-pre-init.sh` is left as SKIP because `scripts/init.sh:27
 **Logged:** 2026-06-28 (test integrity audit)
 **Category:** Bug / live product defect (test-harness blocker)
 **Severity:** Medium
-**Status:** Open
+**Status:** Closed (2026-06-30, commit `64e8c85`)
 
 The framework-repo guard at `scripts/init.sh:3494` runs before the write-permission preflight. When the test harness invokes init.sh from inside the framework checkout (which is how `tests/edge-cases-pre-init.sh` is structured), the guard refuses any non-dry-run invocation before the preflight can fire. E8b is SKIPed as a consequence — there is no way to exercise the write-permission failure path under the current layering.
 

--- a/tests/edge-cases-pre-init.sh
+++ b/tests/edge-cases-pre-init.sh
@@ -467,15 +467,15 @@ fi
 # behavior of init.sh was never exercised.
 #
 # Honest reframe: dry-run cannot exercise mkdir, so it cannot prove the
-# read-only-handling contract. Rewrite this section to only assert what
-# dry-run can honestly verify — preview completes and is non-destructive —
-# and emit a SKIP for the real-write read-only case (it would require
-# either a write-permission pre-flight in init.sh per audit recommendation
-# C, or running the heavy real-run install path from outside the framework
-# repo since init.sh refuses to scaffold inside its own repo). The skip
-# surfaces the gap explicitly rather than hiding it inside a catch-all
-# PASS cascade. See solo-orchestrator-backlog.md for the follow-up to add
-# a write-permission pre-flight.
+# read-only-handling contract. Split into:
+#   - E8a: --dry-run honestly verifies preview completes and is non-
+#     destructive even when target parent is unwritable.
+#   - E8b: --non-interactive real-run probe of the BL-041 write-permission
+#     preflight. Was SKIPped pre-BL-041 because init.sh's framework-repo
+#     guard fired first and masked the permission failure path. After
+#     PR for BL-041 the preflight runs BEFORE the framework-repo guard,
+#     so this case is now exercisable from the test harness even when
+#     cwd is the framework repo.
 # ================================================================
 section "E8: Read-Only Directory"
 
@@ -506,13 +506,34 @@ else
   fail "E8a: dry-run created $E8_DIR/project — non-destructive invariant violated"
 fi
 
-# E8b: real-run read-only assertion is intentionally not exercised here.
-# init.sh's framework-repo guard (init.sh:3494) blocks all non-dry-run
-# invocations from within the framework repo, including --validate-only,
-# so we cannot run a real-write probe from the test harness location.
-# A future pre-flight write-permission check in init.sh (audit
-# recommendation C) would let this case be tested via --dry-run + probe.
-skip "E8b: real-run read-only assertion needs init.sh write-permission pre-flight (audit option C) — see solo-orchestrator-backlog.md"
+# E8b: real-run read-only assertion — verifies the BL-041 write-perm
+# preflight. POSIX 0444 does not deny root; skip when running as root
+# so we don't false-pass.
+if [ "$(id -u)" = "0" ]; then
+  skip "E8b: skipped under root (POSIX 0444 doesn't deny root; preflight cannot be exercised)"
+else
+  echo ""
+  echo "  E8b: Testing init.sh --non-interactive with read-only --project-dir parent"
+  e8b_exit=0
+  e8b_output=$( bash "$REPO_DIR/init.sh" --non-interactive \
+                  --project e8b-readonly \
+                  --platform web \
+                  --deployment personal \
+                  --language typescript \
+                  --git-host github \
+                  --visibility private \
+                  --project-dir "$E8_DIR/project" \
+                  --no-remote-creation 2>&1 ) || e8b_exit=$?
+  if [ "$e8b_exit" -eq 0 ]; then
+    fail "E8b: expected non-zero exit (write-perm preflight); got rc=0"
+  elif ! echo "$e8b_output" | grep -qE "write permission denied|Cannot create project directory"; then
+    fail "E8b: did not emit write-permission marker (rc=$e8b_exit). Tail: $(echo "$e8b_output" | tail -5)"
+  elif echo "$e8b_output" | grep -q "Refusing to operate inside the Solo Orchestrator framework repo"; then
+    fail "E8b: framework-repo guard fired first (BL-041 layering regressed). Tail: $(echo "$e8b_output" | tail -5)"
+  else
+    pass "E8b: write-perm preflight fires before framework-repo guard (BL-041 layering active)"
+  fi
+fi
 
 # Restore permissions for cleanup
 chmod 755 "$E8_DIR"

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -233,6 +233,26 @@ else
 fi
 
 # ================================================================
+# TEST 0c5: BL-041 — write-permission preflight runs BEFORE framework-repo guard
+# ================================================================
+# Regression suite for BL-041 (LB-3): the framework-repo guard
+# (guard_not_in_framework) historically ran BEFORE any write-permission
+# probe, so a real operator who pointed --project-dir at an unwritable
+# location saw the irrelevant developer-facing framework-repo refusal
+# instead of a permission error, and tests/edge-cases-pre-init.sh E8b
+# could not be exercised at all from inside the framework checkout.
+# Fix: preflight_target_writable in scripts/lib/helpers.sh, wired into
+# init.sh BEFORE guard_not_in_framework. Tests pin the layering both
+# ways (preflight wins when target is unwritable; guard wins when
+# preflight passes; neither false-positives outside the framework).
+section "init.sh write-perm preflight before framework-repo guard (BL-041)"
+if bash "$SCRIPT_DIR/tests/test-init-write-perm-preflight.sh" >/dev/null 2>&1; then
+  pass "init.sh BL-041 layering tests (3/3)"
+else
+  fail "init.sh BL-041 layering tests FAILED (run tests/test-init-write-perm-preflight.sh for details)"
+fi
+
+# ================================================================
 # TEST 0d: BACKLOG-REFERENCES LINT — cycle-7 Slot-5 process backstop
 # ================================================================
 # Sibling of the counter-antipattern lint above; catches drift between

--- a/tests/test-init-write-perm-preflight.sh
+++ b/tests/test-init-write-perm-preflight.sh
@@ -1,0 +1,166 @@
+#!/usr/bin/env bash
+# tests/test-init-write-perm-preflight.sh — BL-041 closer.
+#
+# Verifies the layering fix for the init.sh write-permission preflight vs.
+# the framework-repo guard. Before this fix, the framework-repo guard ran
+# FIRST when cwd was inside the framework checkout, masking any write-
+# permission failure path and forcing tests/edge-cases-pre-init.sh E8b to
+# be SKIPped (see solo-orchestrator-backlog.md::BL-041).
+#
+# Test matrix
+#   T1 — write-perm preflight fires BEFORE framework-repo guard.
+#        cwd = framework repo, --project-dir points at a read-only parent
+#        OUTSIDE the framework. Expect: init.sh exits non-zero AND emits
+#        the write-permission error, NOT the framework-repo refusal.
+#   T2 — framework-repo guard still fires when preflight passes.
+#        cwd = framework repo, --project-dir under a WRITABLE parent.
+#        Expect: init.sh exits non-zero AND emits the framework-repo
+#        refusal (defense-in-depth preserved).
+#   T3 — clean tmp dir OUTSIDE framework: neither check false-positives.
+#        cwd = tmp dir OUTSIDE framework, --project-dir under writable
+#        parent. Expect: --validate-only exits 0 (preflight + guard pass).
+#   T-mutation — verified by the operator manually reverting the reorder
+#        block in init.sh and re-running T1; documented in the PR body
+#        rather than scripted here (the script would have to mutate
+#        committed source, which is fragile under CI).
+#
+# Self-verify (must exit 0 after fix):
+#   bash tests/test-init-write-perm-preflight.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT_SH="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Refuse to run as root — chmod 0444 won't actually deny root write
+# (root bypasses POSIX permission bits), so the preflight assertion would
+# false-pass. This matches the same guard used in other read-only tests.
+if [ "$(id -u)" = "0" ]; then
+  echo "  [SKIP] running as root — POSIX 0444 doesn't deny root; preflight cannot be exercised"
+  exit 0
+fi
+
+# --- T1: write-perm preflight fires BEFORE framework-repo guard ---
+t1_preflight_runs_before_framework_guard() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local ro_parent="$tmpdir/ro-parent"
+  local proj_target="$ro_parent/proj"
+  mkdir -p "$ro_parent"
+  chmod 0555 "$ro_parent"     # read+execute, NO write
+
+  local rc=0 out
+  # cwd intentionally set to REPO_ROOT — that is the framework checkout,
+  # which historically triggered guard_not_in_framework BEFORE any
+  # write-permission check. After the BL-041 fix, the preflight must
+  # fire first and short-circuit with a write-permission error.
+  out=$( cd "$REPO_ROOT" && "$INIT_SH" --non-interactive \
+           --project bl041-t1 \
+           --platform web \
+           --deployment personal \
+           --language typescript \
+           --git-host github \
+           --visibility private \
+           --project-dir "$proj_target" \
+           --no-remote-creation 2>&1 ) || rc=$?
+
+  # Restore permissions so cleanup can rm -rf
+  chmod 0755 "$ro_parent" 2>/dev/null || true
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T1" "expected non-zero exit (write-perm preflight); got rc=0; tail: $(echo "$out" | tail -5)"
+    return
+  fi
+  # Preflight MUST win — look for its distinctive marker.
+  if ! echo "$out" | grep -qE "write permission denied|Cannot create project directory"; then
+    fail_ "T1" "missing write-permission marker; tail: $(echo "$out" | tail -10)"
+    return
+  fi
+  # Framework-repo guard MUST NOT have produced its refusal banner.
+  # (If it had, the preflight didn't run first and the layering is wrong.)
+  if echo "$out" | grep -q "Refusing to operate inside the Solo Orchestrator framework repo"; then
+    fail_ "T1" "framework-repo guard fired first (layering not fixed); tail: $(echo "$out" | tail -10)"
+    return
+  fi
+  pass "T1: write-perm preflight fires before framework-repo guard (cwd=framework, target parent ro)"
+}
+
+# --- T2: framework-repo guard still fires when preflight passes ---
+t2_framework_guard_still_fires() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj_target="$tmpdir/proj"   # parent writable, target doesn't exist
+
+  local rc=0 out
+  # cwd = framework checkout, target writable. Preflight passes (writable
+  # parent), then the framework-repo guard cwd check fires. Confirms
+  # defense-in-depth is preserved.
+  out=$( cd "$REPO_ROOT" && "$INIT_SH" --non-interactive \
+           --project bl041-t2 \
+           --platform web \
+           --deployment personal \
+           --language typescript \
+           --git-host github \
+           --visibility private \
+           --project-dir "$proj_target" \
+           --no-remote-creation 2>&1 ) || rc=$?
+
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -eq 0 ]; then
+    fail_ "T2" "expected non-zero exit (framework-repo guard); got rc=0; tail: $(echo "$out" | tail -5)"
+    return
+  fi
+  if ! echo "$out" | grep -q "Refusing to operate inside the Solo Orchestrator framework repo"; then
+    fail_ "T2" "framework-repo guard did not fire when preflight passed; tail: $(echo "$out" | tail -10)"
+    return
+  fi
+  pass "T2: framework-repo guard still fires when preflight passes (defense-in-depth preserved)"
+}
+
+# --- T3: clean tmpdir OUTSIDE framework — neither check false-positives ---
+t3_non_framework_fresh_create_succeeds() {
+  local tmpdir; tmpdir=$(mktemp -d)
+  local proj_target="$tmpdir/proj"
+
+  local rc=0 out
+  # cwd = tmp dir (NOT the framework repo) and target is writable.
+  # --validate-only is enough to prove both guards passed without paying
+  # for the full project scaffold (which is exercised end-to-end in
+  # other suites). --validate-only exits 0 after the resolved-JSON dump
+  # only when no pre-resolution check (incl. the new preflight) fails.
+  out=$( cd "$tmpdir" && "$INIT_SH" --non-interactive --validate-only \
+           --project bl041-t3 \
+           --platform web \
+           --deployment personal \
+           --language typescript \
+           --git-host github \
+           --visibility private \
+           --project-dir "$proj_target" \
+           --no-remote-creation 2>&1 ) || rc=$?
+
+  rm -rf "$tmpdir"
+
+  if [ "$rc" -ne 0 ]; then
+    fail_ "T3" "expected exit 0 outside framework with writable target; got rc=$rc; tail: $(echo "$out" | tail -5)"
+    return
+  fi
+  if echo "$out" | grep -qE "write permission denied|Refusing to operate inside the Solo Orchestrator framework repo"; then
+    fail_ "T3" "preflight or framework guard false-positive; tail: $(echo "$out" | tail -10)"
+    return
+  fi
+  pass "T3: outside-framework + writable target → neither guard false-positives"
+}
+
+echo "== tests/test-init-write-perm-preflight.sh =="
+t1_preflight_runs_before_framework_guard
+t2_framework_guard_still_fires
+t3_non_framework_fresh_create_succeeds
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary

- Adds `preflight_target_writable()` helper to `scripts/lib/helpers.sh` — operator-facing write-permission probe that walks to the deepest existing ancestor of the target dir and verifies it is writable.
- Wires the new preflight into `init.sh` to run **BEFORE** the existing `guard_not_in_framework` check, so an operator who points `--project-dir` at an unwritable parent now sees a clear permission error instead of the irrelevant developer-facing framework-repo refusal.
- Restores `tests/edge-cases-pre-init.sh` E8b (was SKIPped since the 2026-06-28 test-integrity audit because no preflight existed and the framework-repo guard masked any real-write probe from inside the framework checkout).
- New regression suite `tests/test-init-write-perm-preflight.sh` pins the layering both ways: preflight wins when target is unwritable, guard wins when preflight passes, neither false-positives outside the framework.
- Aggregator registration: new suite registered in `tests/full-project-test-suite.sh` (TEST 0c5) so a future regression surfaces in the full-suite gate.

## Closes

BL-041 (LB-3 — `init.sh:3494` framework-repo guard layering)

## Test plan

- [x] **RED on pre-fix code.** Ran the new suite against the original ordering: T1 fails with "missing write-permission marker" because `guard_not_in_framework` printed the framework-repo refusal first. T2/T3 pass even pre-fix (T2 doesn't depend on the preflight existing; T3 has no failure path to mask).
- [x] **GREEN after fix.** All 3 tests in `tests/test-init-write-perm-preflight.sh` pass.
- [x] **Mutation experiment.** Manually swapped the two `if !` blocks back to guard-first ordering and re-ran the suite. T1 failed RED again (same shape as the pre-fix run), proving the reorder is load-bearing. Restored the fix and verified T1 GREEN.
- [x] **Failure-path coverage** (both branches exercised).
  - **Success path** = preflight blocks the install (T1 / E8b): rc=1, output contains `Cannot create project directory` / `write permission denied`, output does NOT contain `Refusing to operate inside the Solo Orchestrator framework repo`.
  - **Defense-in-depth path** = preflight passes, guard fires (T2): rc=1, output contains the framework-repo refusal banner.
  - **No-false-positive path** (T3): clean tmpdir outside framework + writable target dir → `--validate-only` exits 0.
- [x] **E8b restored** in `tests/edge-cases-pre-init.sh`. Full-suite run of `tests/edge-cases-pre-init.sh` shows 28 PASS / 3 FAIL / 1 SKIP — E8b is now PASS, and the 3 remaining FAILs (E1×2 + E4) are pre-existing apostrophe/dry-run-name-preservation regressions tracked by BL-040 (sibling slot).
- [x] **Adjacent regressions ruled out.** `tests/test-platform-security-bugs-closer.sh` 7/7 PASS (exercises `guard_not_in_framework` directly + every script that depends on it). `tests/test-init-no-remote-creation.sh` 3/3 PASS (exercises the same init.sh pre-resolution path).
- [x] **All four self-verify lints pass:** `lint-counter-antipattern.sh`, `lint-backlog-references.sh`, `lint-fix-functions-stderr.sh`, `lint-raw-read-prompt.sh`.

### mutation_proofs

| Mutation | Tests catching it | Result |
|---|---|---|
| Swap `preflight_target_writable` and `guard_not_in_framework` so guard fires first again | T1 in `tests/test-init-write-perm-preflight.sh` + E8b in `tests/edge-cases-pre-init.sh` | RED (framework-repo refusal masks the permission error) |

## Coordination note

This PR touches `init.sh` and `tests/edge-cases-pre-init.sh`. **Sibling slot BL-040** ALSO touches both files (different sections: BL-040 edits `dry_run_summary` near init.sh:2781 and E2 in `edge-cases-pre-init.sh`; BL-041 edits the `print_header` block near init.sh:3708 and E8b in `edge-cases-pre-init.sh`). The diffs are in non-overlapping ranges so the merge should be syntactic, but a rebase is likely on whichever lands second.

This PR also touches:
- `scripts/lib/helpers.sh` — adds `preflight_target_writable` between `guard_not_in_framework` and `prompt_choice`. No conflict expected with other slots.
- `tests/full-project-test-suite.sh` — adds TEST 0c5 block after TEST 0c4. No conflict expected.

## Worktree note

Worked in `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_8bbf1808-203-3` (slot `bl041-framework-repo-guard-layering`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)