### PR TITLE
fix(init): dry_run_summary echoes project description (closes BL-040)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -2956,6 +2956,18 @@ dry_run_summary() {
 
   echo -e "${BOLD}Project:${NC}"
   echo "  Name:      $PROJECT_NAME"
+  # BL-040 (2026-06-30): echo the operator-supplied description so the
+  # dry-run preview reflects every input that will be persisted to
+  # PROJECT_INTAKE.md / manifest. Omit the line entirely when the value
+  # is empty (keeps the summary clean for the "no description provided"
+  # default). Newlines and tabs are collapsed to spaces so a multi-line
+  # value reachable through --description $'foo\nbar' doesn't break the
+  # one-line-per-field column layout below.
+  if [ -n "${PROJECT_DESCRIPTION:-}" ]; then
+    local _summary_desc
+    _summary_desc=$(printf '%s' "$PROJECT_DESCRIPTION" | tr '\n\t' '  ')
+    echo "  Description: $_summary_desc"
+  fi
   echo "  Platform:  $PLATFORM"
   echo "  Track:     $TRACK"
   echo "  Language:  $LANGUAGE"

--- a/tests/edge-cases-pre-init.sh
+++ b/tests/edge-cases-pre-init.sh
@@ -198,32 +198,116 @@ else
   pass "E2: backtick command substitution was NOT executed"
 fi
 
-# Audit finding tests-edge-cases-2: the original block had both branches
-# call pass(), so the assertion added 1 to the count regardless of whether
-# the literal "$(whoami)" appeared in the dry-run output. The audit's
-# recommended option A (require the literal to be echoed back) does not
-# match init.sh's actual dry-run contract — dry_run_summary (init.sh:2781)
-# prints project name, platform, track, language and directory but NOT
-# the description (the description is stored in state/manifest only).
-# So a positive-assertion for $(whoami) in dry-run output would fail not
-# because of an injection regression but because dry-run was never
-# designed to echo description back.
-#
-# Adopt audit recommendation B instead: delete the vacuous literal-text
-# block entirely. Injection-resistance is already covered by the uid=
-# check above (init.sh:154) and the DRY RUN completion check below
-# (init.sh:169). Replace the vacuous PASS with a SKIP that explicitly
-# names why this case isn't asserted, so a future change adding the
-# description to dry-run output surfaces a follow-up to wire a real
-# positive grep here.
-# (Closes audit finding tests-edge-cases-2.)
-skip "E2: dry-run does not echo description back — no surface to assert literal \$(whoami) preservation (see init.sh:2781)"
+# BL-040 (2026-06-30) restored assertion: dry_run_summary now echoes
+# the operator-supplied description, so the literal "$(whoami)" and
+# "`id`" from the malicious input must appear verbatim in the dry-run
+# preview. The original E2 stdin-piped harness CANNOT verify this
+# because scripts/lib/helpers.sh:prompt_input() returns the default
+# (empty string) whenever stdin is not a TTY — the piped malicious
+# description never reaches PROJECT_DESCRIPTION, so a regression that
+# silently dropped the description would still "PASS" the stdin path.
+# Use the non-interactive --description flag instead; the value lands
+# in PROJECT_DESCRIPTION via ARG_DESCRIPTION (init.sh:3540), bypassing
+# the TTY-gated prompt. Fails RED on origin/main (no Description line
+# in summary), GREEN after the dry_run_summary fix. Grep with -F so
+# the $( and ` metacharacters are matched literally, not as regex.
+E2_NI_DIR="$TEST_DIR/e2-ni-project"
+e2_ni_output=$(bash "$REPO_DIR/init.sh" \
+  --dry-run \
+  --non-interactive \
+  --project "e2-injection-ni" \
+  --description "$E2_MALICIOUS_DESC" \
+  --platform web \
+  --deployment personal \
+  --language python \
+  --project-dir "$E2_NI_DIR" 2>&1) || true
 
-# If dry-run completed without crashing, that's a good sign
+if echo "$e2_ni_output" | grep -qF '$(whoami)' \
+   && echo "$e2_ni_output" | grep -qF '`id`'; then
+  pass "E2: non-interactive dry-run echoes malicious description as literal text"
+else
+  fail "E2: non-interactive dry-run did not echo literal '\$(whoami) \`id\`' (BL-040 regression)"
+fi
+
+# Belt-and-suspenders: even on the non-interactive path, neither
+# command substitution should fire — no uid= or root: leaking into
+# the summary output.
+if echo "$e2_ni_output" | grep -qE 'uid=|root:'; then
+  fail "E2: command substitution leaked into non-interactive dry-run output"
+else
+  pass "E2: non-interactive dry-run treats description as literal (no command substitution)"
+fi
+
+# If interactive dry-run completed without crashing, that's a good sign
 if echo "$e2_output" | grep -qi "DRY RUN"; then
   pass "E2: init.sh completed dry-run with malicious description"
 else
   fail "E2: init.sh did not complete dry-run with malicious description"
+fi
+
+# ----------------------------------------------------------------
+# E2b: Empty description renders cleanly in dry-run summary
+# Expected: dry_run_summary omits the "Description:" line when the
+# value is empty (operator-friendly: no blank label).
+# ----------------------------------------------------------------
+E2B_DIR="$TEST_DIR/e2b-project"
+e2b_input=$(build_dryrun_input "e2b-empty-desc" "" 4 2 1 6 "$E2B_DIR" "Y")
+e2b_output=$(printf '%s\n' "$e2b_input" | bash "$REPO_DIR/init.sh" --dry-run 2>&1) || true
+
+# Must still complete dry-run when description is empty
+if echo "$e2b_output" | grep -qi "DRY RUN SUMMARY"; then
+  pass "E2b: dry-run completes with empty description"
+else
+  fail "E2b: dry-run did NOT complete with empty description"
+fi
+
+# Description label must be omitted entirely (no dangling "Description: " line)
+if echo "$e2b_output" | grep -q "^  Description:"; then
+  fail "E2b: empty description should be omitted from summary (found dangling label)"
+else
+  pass "E2b: dry-run summary omits Description label when value is empty"
+fi
+
+# ----------------------------------------------------------------
+# E2c: Multi-line description normalizes to a single summary line
+# Expected: dry_run_summary collapses embedded newlines/tabs into
+# spaces so the summary stays one-line-per-field. Multi-line input
+# is reachable through the non-interactive --description flag
+# (interactive prompt_input is a single read -rp).
+# ----------------------------------------------------------------
+E2C_DIR="$TEST_DIR/e2c-project"
+# shellcheck disable=SC2034
+E2C_DESC=$'line-one-marker\nline-two-marker'
+
+e2c_output=$(bash "$REPO_DIR/init.sh" \
+  --dry-run \
+  --non-interactive \
+  --project "e2c-multiline" \
+  --description "$E2C_DESC" \
+  --platform web \
+  --deployment personal \
+  --language python \
+  --project-dir "$E2C_DIR" 2>&1) || true
+
+# Both halves of the multi-line value must appear in the dry-run
+# output (proves the whole description survived the echo).
+if echo "$e2c_output" | grep -qF "line-one-marker" \
+   && echo "$e2c_output" | grep -qF "line-two-marker"; then
+  pass "E2c: dry-run echoes both halves of multi-line description"
+else
+  fail "E2c: dry-run dropped part of multi-line description"
+fi
+
+# Both markers must land on the SAME line after newline normalization
+# (the description should not bleed across multiple summary lines and
+# break the column layout). awk is shell-safe across BSD and GNU.
+if echo "$e2c_output" | awk '
+  /line-one-marker/ && /line-two-marker/ { found=1; exit }
+  END { exit !found }
+'; then
+  pass "E2c: multi-line description rendered on a single summary line"
+else
+  fail "E2c: multi-line description not collapsed onto a single summary line"
 fi
 
 # ================================================================


### PR DESCRIPTION
## Summary

- `init.sh:dry_run_summary` now prints the operator-supplied `PROJECT_DESCRIPTION` between Name and Platform, so the dry-run preview reflects every input that will be persisted to `PROJECT_INTAKE.md` / manifest.
- Empty descriptions are omitted entirely (no dangling label), and embedded newlines/tabs are collapsed to spaces so a multi-line `--description $'foo\nbar'` value stays on a single summary line.
- `tests/edge-cases-pre-init.sh` E2 drops the SKIP and lands three covering assertions through the non-interactive `--description` flag — the interactive stdin path returns the default for description because `helpers.sh:prompt_input()` short-circuits on a non-TTY stdin, so a stdin-piped malicious value never actually reaches `PROJECT_DESCRIPTION` and the previous assertion would have been vacuous.

## Closes

- BL-040

## Test plan

- [x] TDD red → green for `tests/edge-cases-pre-init.sh` E2 / E2b / E2c.
- [x] Failure-path coverage (BL-066 lesson): T-empty asserts the `Description:` label is omitted when value is empty (no dangling label); T-multiline asserts newline normalization so the column layout doesn't break.
- [x] Mutation experiment: reverting just the `dry_run_summary` diff turns E2 BL-040 + E2c (both assertions) RED while E2b still PASSes (empty case was always correct because there was no Description line at all). Restoring the fix returns all six new assertions to GREEN.
  - RED log: `/private/tmp/claude-501/-Users-karl-Documents-Claude-Projects-solo-orchestrator/7492d236-9edf-4ad1-845b-634f9df45abf/scratchpad/mutation-run.log`
  - GREEN log: `/private/tmp/claude-501/-Users-karl-Documents-Claude-Projects-solo-orchestrator/7492d236-9edf-4ad1-845b-634f9df45abf/scratchpad/green-run-v2.log` (33 PASS / 3 pre-existing FAIL — E1 ×2 and E4 — on origin/main, unrelated to this PR / 1 pre-existing SKIP for E8b waiting on BL-041).
- [x] Belt-and-suspenders: `E2: non-interactive dry-run treats description as literal (no command substitution)` — asserts neither `uid=` nor `root:` leak into the dry-run output even on the non-interactive path.
- [x] All four required lints pass (`scripts/lint-counter-antipattern.sh`, `scripts/lint-backlog-references.sh`, `scripts/lint-fix-functions-stderr.sh`, `scripts/lint-raw-read-prompt.sh`).

## Coordination note

Files touched: `init.sh` (added a 12-line block inside `dry_run_summary` near line 2956) + `tests/edge-cases-pre-init.sh` (E2 / E2b / E2c rewrite).

S3 Wave A Slot 3 (BL-041) ALSO touches `init.sh` but in a different region — the framework-repo guard around line 3494 (vs. `dry_run_summary` near line 2956). Conflicts are extremely unlikely, but a textual rebase may still be needed if the sibling PR introduces nearby line shifts. BL-040 lands first by design (BL-041 verification removes E8b SKIP, which currently sits below the E2 region we modified).

## Worktree note

`pwd`: `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_8bbf1808-203-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)