### PR TITLE
perf(lib): split helpers.sh into core + full (BL-046)

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1185,7 +1185,16 @@ create_project() {
   # Copy utility scripts into the project (self-contained after init)
   print_info "Copying utility scripts..."
   mkdir -p scripts/lib
-  cp "$SCRIPT_DIR/scripts/lib/helpers.sh" scripts/lib/
+  # BL-046: helpers.sh split into a backwards-compat shim + core + full.
+  # All three files must be copied — the shim (helpers.sh) sources
+  # helpers-full.sh, which sources helpers-core.sh. Short-lived
+  # scripts (check-*, validate, test-gate, resume) source helpers-core.sh
+  # directly; long-running callers (init.sh, upgrade-project.sh,
+  # intake-wizard.sh, reconfigure-project.sh, verify-install.sh) source
+  # helpers.sh (which transitively loads full + core).
+  cp "$SCRIPT_DIR/scripts/lib/helpers.sh"       scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/helpers-core.sh"  scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/helpers-full.sh"  scripts/lib/
   cp "$SCRIPT_DIR/scripts/validate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-phase-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-gate.sh" scripts/

--- a/scripts/check-changelog.sh
+++ b/scripts/check-changelog.sh
@@ -16,8 +16,11 @@ set -euo pipefail
 #   1 — source changed without changelog (only when SOIF_STRICT_CHANGELOG=true)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$SCRIPT_DIR/lib/helpers.sh" ]; then
-  source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: sources helpers-core.sh (subset) instead of helpers.sh (full)
+# — uses print_ok / print_warn only. Skips the ~110 lines of init_log +
+# MCP-detection helpers in helpers-full.sh to shave parse cost.
+if [ -f "$SCRIPT_DIR/lib/helpers-core.sh" ]; then
+  source "$SCRIPT_DIR/lib/helpers-core.sh"
 else
   # Minimal fallback if helpers not available
   print_warn() { echo "[WARN] $1"; }

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -10,8 +10,10 @@
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+# BL-046: uses print_step/ok/fail/info/warn + log_line + prompt_yes_no
+# only — source core subset. Fallback still triggers when lib is missing.
 # shellcheck disable=SC1090
-source "$SCRIPT_DIR/lib/helpers.sh" 2>/dev/null || {
+source "$SCRIPT_DIR/lib/helpers-core.sh" 2>/dev/null || {
   # Minimal fallback if helpers not available (e.g., pre-init migration scenario)
   print_step() { echo "[STEP] $*"; }
   print_ok()   { echo "  [OK] $*"; }
@@ -20,9 +22,9 @@ source "$SCRIPT_DIR/lib/helpers.sh" 2>/dev/null || {
   print_warn() { echo "[WARN] $*"; }
   log_line()   { :; }
   # Wave-3 raw-read sweep: prompt_yes_no fallback honors the same
-  # non-interactive hard-N contract as the helpers.sh version. Reached
-  # only in pre-init migration scenarios where lib/helpers.sh is
-  # absent; behavior must match the canonical helper so the manifest
+  # non-interactive hard-N contract as the helpers-core.sh version.
+  # Reached only in pre-init migration scenarios where lib/helpers-core.sh
+  # is absent; behavior must match the canonical helper so the manifest
   # mutation in --backfill-host below stays consistent.
   prompt_yes_no() {
     local message="$1" default_answer="${2:-N}"
@@ -31,7 +33,7 @@ source "$SCRIPT_DIR/lib/helpers.sh" 2>/dev/null || {
       return 1
     fi
     local reply
-    read -rp "${message}: " reply # lint-raw-read-prompt: allow fallback prompt_yes_no defined inline when lib/helpers.sh is absent (pre-init migration scenario); semantically equivalent to lib/helpers.sh::prompt_yes_no
+    read -rp "${message}: " reply # lint-raw-read-prompt: allow fallback prompt_yes_no defined inline when lib/helpers-core.sh is absent (pre-init migration scenario); semantically equivalent to lib/helpers-core.sh::prompt_yes_no
     [ -z "$reply" ] && { case "$default_answer" in [Yy]*) return 0 ;; *) return 1 ;; esac; }
     case "$reply" in [Nn]*) return 1 ;; *) return 0 ;; esac
   }

--- a/scripts/check-maintenance.sh
+++ b/scripts/check-maintenance.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 #   2 — could not determine (missing data)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_info / print_ok / print_warn only — source core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 echo -e "${BOLD}Maintenance Cadence Check${NC}"
 echo ""

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -14,7 +14,8 @@ set -euo pipefail
 #   1 — inconsistency detected (blocked). Set SOIF_PHASE_GATES=warn to downgrade.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses run_with_timeout + prompt_yes_no only — source core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 # ── Non-interactive prompt guard ─────────────────────────────────
 # code-check-gates-7 (audit v2, S3): the script's header (lines 8-9)

--- a/scripts/check-session-state.sh
+++ b/scripts/check-session-state.sh
@@ -18,8 +18,9 @@ set -euo pipefail
 #   1 — CLAUDE.md is stale (only when SOIF_STRICT_SESSION=true)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$SCRIPT_DIR/lib/helpers.sh" ]; then
-  source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_ok / print_warn only — source core subset.
+if [ -f "$SCRIPT_DIR/lib/helpers-core.sh" ]; then
+  source "$SCRIPT_DIR/lib/helpers-core.sh"
 else
   print_warn() { echo "[WARN] $1"; }
   print_ok()   { echo "  [OK] $1"; }

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 # If no path is provided, attempts to clone the latest version to a temp dir.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_info/ok/warn only — source core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 # Verify we're in a Solo Orchestrator project
 if [ ! -f "CLAUDE.md" ]; then

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -18,8 +18,9 @@ if [ -n "$BREW_PREFIX" ] && [ -d "$BREW_PREFIX/bin" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-if [ -f "$SCRIPT_DIR/lib/helpers.sh" ]; then
-  source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_fail/info/ok/warn + prompt_input/yes_no only — core subset.
+if [ -f "$SCRIPT_DIR/lib/helpers-core.sh" ]; then
+  source "$SCRIPT_DIR/lib/helpers-core.sh"
 else
   if [ -t 1 ]; then
     RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'

--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# Solo Orchestrator — Core Shared Script Helpers (perf-optimized subset)
+#
+# This is the MINIMUM helper set every short-lived caller needs:
+#   - Colors + print_* family
+#   - LOG_FILE + log_line/log_section (print_* delegate to log_line)
+#   - prompt_input / prompt_yes_no / prompt_choice / prompt_install
+#   - run_with_timeout
+#   - guard_not_in_framework
+#
+# The heavier "full" surface (init_log/finalize_log log-file rotation
+# and MCP-detection helpers) lives in scripts/lib/helpers-full.sh.
+#
+# Idempotent-source guard: sourcing twice is a no-op (function defs
+# from bash are naturally idempotent, but this short-circuits the
+# color setup and re-parse when the same script is sourced multiple
+# times via nested composition).
+if [ -n "${_SOIF_HELPERS_CORE_LOADED:-}" ]; then
+  return 0
+fi
+_SOIF_HELPERS_CORE_LOADED=1
+#
+# Usage:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/helpers-core.sh"
+
+# Colors (disabled if not a terminal)
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; CYAN=''; BOLD=''; NC=''
+fi
+
+# --- Print helpers ---
+print_header() {
+  local version="${1:-1.0.0}"
+  echo ""
+  echo -e "${BOLD}╔══════════════════════════════════════════════════════════╗${NC}"
+  echo -e "${BOLD}║         Solo Orchestrator — Project Init v${version}          ║${NC}"
+  echo -e "${BOLD}╚══════════════════════════════════════════════════════════╝${NC}"
+  echo ""
+}
+
+print_step() { echo -e "${CYAN}[STEP]${NC} $1"; log_line "[STEP] $1"; }
+print_ok()   { echo -e "${GREEN}  [OK]${NC} $1"; log_line "  [OK] $1"; }
+print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; log_line "[WARN] $1"; }
+print_fail() { echo -e "${RED}[FAIL]${NC} $1"; log_line "[FAIL] $1"; }
+print_info() { echo -e "${BLUE}[INFO]${NC} $1"; log_line "[INFO] $1"; }
+
+# ── Logging (light) ──────────────────────────────────────────────
+# print_* delegate to log_line, so log_line must live in core.
+# init_log / finalize_log (which actually create + close the log
+# file) are heavier and only used by init.sh — they live in
+# helpers-full.sh. When a short-lived caller sources only
+# helpers-core.sh, LOG_FILE stays empty and log_line is a no-op.
+LOG_FILE=""
+
+log_line() {
+  if [ -n "$LOG_FILE" ]; then
+    echo "$1" | sed 's/\x1b\[[0-9;]*m//g' >> "$LOG_FILE"
+  fi
+}
+
+log_section() {
+  if [ -n "$LOG_FILE" ]; then
+    echo -e "\n── $1 ──────────────────────────────────" >> "$LOG_FILE"
+  fi
+}
+
+# Run a command with a timeout (portable, no coreutils needed).
+# Usage: run_with_timeout <seconds> <command...>
+# Returns 0 on success, 1 on timeout or failure.
+run_with_timeout() {
+  local _rto_secs="$1"; shift
+  "$@" &
+  local _rto_pid=$!
+  local _rto_elapsed=0
+  while kill -0 "$_rto_pid" 2>/dev/null; do
+    if [ "$_rto_elapsed" -ge "$_rto_secs" ]; then
+      kill "$_rto_pid" 2>/dev/null || true
+      wait "$_rto_pid" 2>/dev/null || true
+      return 1
+    fi
+    sleep 1
+    _rto_elapsed=$((_rto_elapsed + 1))
+  done
+  wait "$_rto_pid" 2>/dev/null
+}
+
+# --- Prompt helpers ---
+
+# Prompt for text input with optional default value.
+# Usage: result=$(prompt_input "Your name" "default_value")
+#
+# Non-interactive behavior (no TTY on stdin, CI=true, or
+# SOIF_NONINTERACTIVE=true): emits a [WARN] to stderr and returns the
+# default (or empty string if no default). This is the contract that
+# scripts/lint-raw-read-prompt.sh enforces: never call `read -rp`
+# outside this file, because doing so hangs unattended invocations.
+prompt_input() {
+  local prompt="$1"
+  local default="${2:-}"
+  local result
+
+  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: prompt_input(\"$prompt\") returning default '$default' without blocking. Re-run interactively to override." >&2
+    printf '%s' "$default"
+    return 0
+  fi
+
+  if [ -n "$default" ]; then
+    read -rp "$(echo -e "${BOLD}$prompt${NC} [$default]: ")" result
+    echo "${result:-$default}"
+  else
+    read -rp "$(echo -e "${BOLD}$prompt${NC}: ")" result
+    echo "$result"
+  fi
+}
+
+# Prompt for yes/no confirmation, returning 0 (yes) or 1 (no).
+# Usage: if prompt_yes_no "Proceed?" "Y"; then ... fi
+#
+# `default_answer` is "Y" or "N" — used ONLY when interactive AND the
+# operator hits Enter without typing a response. In non-interactive
+# contexts (no TTY, CI=true, SOIF_NONINTERACTIVE=true) this function
+# ALWAYS returns N (1) regardless of `default_answer`. This is
+# defense-in-depth: a caller that defaults to Y in interactive use
+# (e.g. "[Y/n]" confirm prompts) must NEVER auto-Y a side-effectful
+# action in CI just because the operator was absent. Mirrors the
+# hard-N policy in scripts/check-phase-gate.sh::prompt_yes_no, which
+# was introduced after the cycle-7 PR #87 unattended-install incident.
+prompt_yes_no() {
+  local message="$1"
+  local default_answer="${2:-N}"
+
+  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: skipping prompt (\"$message\") — defaulting to 'N' (caller default '$default_answer' ignored in non-interactive context)." >&2
+    return 1
+  fi
+
+  local reply
+  read -rp "$(echo -e "${BOLD}${message}${NC}: ")" reply
+  if [ -z "$reply" ]; then
+    case "$default_answer" in
+      [Yy]*) return 0 ;;
+      *)     return 1 ;;
+    esac
+  fi
+  case "$reply" in
+    [Nn]*) return 1 ;;
+    *)     return 0 ;;
+  esac
+}
+
+# Refuse to operate as a project if cwd OR an explicit target directory is
+# the Solo Orchestrator framework repo itself. Every project-targeted script
+# (init.sh, verify-install.sh, process-checklist.sh, upgrade-project.sh,
+# intake-wizard.sh, pending-approval.sh, reconfigure-project.sh) must call
+# this BEFORE any file writes.
+#
+# Usage:
+#   guard_not_in_framework               # checks $(pwd) only (legacy / default)
+#   guard_not_in_framework "$target_dir" # checks $(pwd) AND "$target_dir"
+#
+# The optional target-dir argument was added for security-audits-1
+# (S3, 2026-04-26 audit sweep): init.sh accepts --project-dir=PATH and
+# proceeds to write into PATH even if PATH is the framework repo. The
+# cwd-only check missed that vector because the cwd could be a benign
+# tempdir while --project-dir pointed at the framework. Callers that
+# accept any "write into this dir" arg (init.sh, upgrade-project.sh, ...)
+# MUST pass it as $1 so this guard can lint both surfaces.
+#
+# UAT 2026-04-25 fix (U-N + U-O): a UAT agent's cwd was the framework dir
+# (instead of their tempdir), so verify-install.sh + indirectly CDF init
+# scattered .claude/, .claude-backup/, gates/, hooks/, rules/, and
+# APPROVAL_LOG.md into the framework root. None tracked, but contaminates
+# the workspace and can sneak into commits.
+#
+# Detection signature: the framework has a top-level init.sh whose header
+# contains "Solo Orchestrator — Project Initialization Script" — a string
+# that's specific to this framework and won't appear in arbitrary projects'
+# init.sh files. Also check for templates/generated/ to triple-confirm.
+guard_not_in_framework() {
+  local target="${1:-}"
+  local cwd
+  cwd="$(pwd)"
+
+  # Helper: returns 0 if $1 looks like the framework repo root.
+  _gnif_dir_is_framework() {
+    local d="$1"
+    [ -n "$d" ] || return 1
+    [ -f "$d/init.sh" ] || return 1
+    grep -q "Solo Orchestrator — Project Initialization Script" "$d/init.sh" 2>/dev/null || return 1
+    [ -d "$d/templates/generated" ] || return 1
+    return 0
+  }
+
+  _gnif_emit_refusal() {
+    local where="$1"     # human label: "cwd" or "--project-dir"
+    local detected="$2"  # the resolved path
+    print_fail "Refusing to operate inside the Solo Orchestrator framework repo."
+    echo "  Detected framework signature ($where): $detected" >&2
+    echo "" >&2
+    echo "  This script targets a project, not the framework itself." >&2
+    echo "  Move to your project directory and re-run:" >&2
+    echo "    cd /path/to/your-project" >&2
+    echo "" >&2
+    echo "  If this directory IS your project (i.e., you cloned solo-orchestrator" >&2
+    echo "  AS a project), the framework is mis-installed — clone solo-orchestrator" >&2
+    echo "  separately and run init.sh from inside an empty project directory." >&2
+  }
+
+  # 1. cwd check (preserves legacy behavior — callers that don't pass a target).
+  if _gnif_dir_is_framework "$cwd"; then
+    _gnif_emit_refusal "cwd" "$cwd"
+    return 1
+  fi
+
+  # 2. target-dir check (security-audits-1). Only runs when caller supplies $1.
+  if [ -n "$target" ] && _gnif_dir_is_framework "$target"; then
+    _gnif_emit_refusal "--project-dir / target" "$target"
+    return 1
+  fi
+
+  return 0
+}
+
+# Prompt for a numbered choice from a list of options.
+# Usage: result=$(prompt_choice "Pick one:" "option1" "option2" "option3")
+#
+# UAT 2026-04-25 fix (agent 12): EOF guard. The original loop had no exit
+# condition for stdin EOF — `read` returns non-zero on EOF, but the loop
+# kept retrying and re-printing "Invalid choice", spinning the CPU and
+# producing megabytes of output until killed. Affected ANY scripted
+# invocation of init.sh (or any caller of prompt_choice) when canned
+# answers were under-fed.
+#
+# Fix: detect read's non-zero return (EOF). On EOF, print a clear failure
+# to stderr and return 1 (caller can decide whether to abort or default).
+# Bonus: cap retries at 100 so even a malformed-but-non-EOF input stream
+# doesn't burn forever.
+prompt_choice() {
+  local prompt="$1"
+  shift
+  local options=("$@")
+  echo -e "${BOLD}$prompt${NC}" >&2
+  for i in "${!options[@]}"; do
+    echo "  $((i+1)). ${options[$i]}" >&2
+  done
+  local choice
+  local retries=0
+  local max_retries=100
+  while [ "$retries" -lt "$max_retries" ]; do
+    if ! read -rp "$(echo -e "${BOLD}Select [1-${#options[@]}]${NC}: ")" choice; then
+      echo "" >&2
+      echo "  prompt_choice: stdin closed (EOF) before a valid choice was supplied." >&2
+      echo "  This usually means a scripted/heredoc invocation under-fed the prompt." >&2
+      return 1
+    fi
+    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
+      echo "${options[$((choice-1))]}"
+      return 0
+    fi
+    echo "  Invalid choice. Enter a number between 1 and ${#options[@]}." >&2
+    retries=$((retries + 1))
+  done
+  echo "  prompt_choice: $max_retries invalid attempts; aborting to prevent loop." >&2
+  return 1
+}
+
+# Prompt user to install a missing tool. Returns 0 if installed, 1 if skipped.
+# Usage: prompt_install "tool_name" "install_command" [needs_sudo]
+#
+# Non-interactive behavior (no TTY on stdin, CI=true, or
+# SOIF_NONINTERACTIVE=true): emits a [WARN] to stderr naming the
+# missing tool + install command, and returns 1 (decline install)
+# WITHOUT touching `eval`. Same defense-in-depth contract as
+# prompt_yes_no — a caller in CI / piped invocation must NEVER
+# auto-install a side-effectful command (e.g. `sudo apt install`,
+# `sudo usermod -aG docker $USER`) just because the operator was
+# absent. The PR-#96 adversarial verifier flagged this as the one
+# remaining hole in the lint sweep: scripts/lib/helpers.sh is exempt
+# from scripts/lint-raw-read-prompt.sh (correctly — the prompt
+# helpers themselves must call `read -rp`), so runtime tests are the
+# only safety net. See tests/test-prompt-install-noninteractive.sh.
+prompt_install() {
+  local tool_name="$1"
+  local install_cmd="$2"
+  local needs_sudo="${3:-false}"
+
+  echo ""
+  if [ "$needs_sudo" = true ]; then
+    echo -e "  ${YELLOW}This requires administrator privileges (sudo).${NC}"
+  fi
+  echo -e "  Install command: ${CYAN}$install_cmd${NC}"
+
+  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: skipping install of '$tool_name' — defaulting to 'N' (no install). Re-run interactively, or run the install manually: $install_cmd" >&2
+    return 1
+  fi
+
+  local response
+  read -rp "$(echo -e "  ${BOLD}Install $tool_name now? [Y/n]${NC}: ")" response
+  if [[ "$response" =~ ^[Nn] ]]; then
+    return 1
+  fi
+
+  if eval "$install_cmd"; then
+    print_ok "$tool_name installed"
+    return 0
+  else
+    print_warn "Installation failed. You can try manually: $install_cmd"
+    return 1
+  fi
+}

--- a/scripts/lib/helpers-full.sh
+++ b/scripts/lib/helpers-full.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# Solo Orchestrator — Full Shared Script Helpers (heavy surface)
+#
+# Loads helpers-core.sh (print_*, prompt_*, log_line, run_with_timeout,
+# guard_not_in_framework) then adds the heavier helpers that only the
+# long-running callers need:
+#   - init_log / finalize_log (log-file rotation)
+#   - is_context7_mcp_registered / is_qdrant_mcp_registered
+#   - is_qdrant_container_running / register_qdrant_mcp
+#
+# Only long-running callers should source this file directly:
+#   init.sh, upgrade-project.sh, intake-wizard.sh,
+#   reconfigure-project.sh, verify-install.sh.
+# Short-lived scripts (check-*.sh, validate.sh, test-gate.sh, ...)
+# should source helpers-core.sh instead to skip the extra parse.
+#
+# Every existing caller that still does `source scripts/lib/helpers.sh`
+# transitively lands here via the backwards-compat shim in helpers.sh.
+#
+# Idempotent-source guard.
+if [ -n "${_SOIF_HELPERS_FULL_LOADED:-}" ]; then
+  return 0
+fi
+_SOIF_HELPERS_FULL_LOADED=1
+
+# Load the core helpers first (idempotent-guarded on its own).
+# Fast-path dirname via parameter expansion (no subshell / no dirname fork).
+_SOIF_HELPERS_FULL_DIR="${BASH_SOURCE[0]%/*}"
+[ "$_SOIF_HELPERS_FULL_DIR" = "${BASH_SOURCE[0]}" ] && _SOIF_HELPERS_FULL_DIR="."
+# shellcheck source=./helpers-core.sh
+source "$_SOIF_HELPERS_FULL_DIR/helpers-core.sh"
+
+# ── Logging ──────────────────────────────────────────────────────
+# Call init_log() early in init.sh to enable file logging.
+# All print_* functions in helpers-core.sh automatically log when
+# LOG_FILE is set (they call log_line, which is a no-op until then).
+
+init_log() {
+  local log_dir="$1"
+  mkdir -p "$log_dir"
+  LOG_FILE="$log_dir/init-$(date +%Y%m%d-%H%M%S).log"
+  {
+    echo "═══════════════════════════════════════════════════════════"
+    echo "Solo Orchestrator Init Log"
+    echo "Started: $(date '+%Y-%m-%d %H:%M:%S %Z')"
+    echo "OS: $(uname -s) $(uname -r) ($(uname -m))"
+    echo "Shell: $BASH_VERSION"
+    echo "User: $(whoami)@$(hostname)"
+    echo "Working directory: $(pwd)"
+    echo "═══════════════════════════════════════════════════════════"
+    echo ""
+  } > "$LOG_FILE"
+}
+
+finalize_log() {
+  if [ -n "$LOG_FILE" ]; then
+    {
+      echo ""
+      echo "═══════════════════════════════════════════════════════════"
+      echo "Completed: $(date '+%Y-%m-%d %H:%M:%S %Z')"
+      echo "Duration: ${SECONDS}s"
+      echo "═══════════════════════════════════════════════════════════"
+    } >> "$LOG_FILE"
+    # Print log location (to both stdout and log)
+    echo ""
+    echo -e "${BLUE}[INFO]${NC} Init log saved to: $LOG_FILE"
+  fi
+}
+
+# ── MCP Detection Helpers ────────────────────────────────────────
+# Check both ~/.claude/settings.json and ~/.claude.json for MCP server registration.
+
+is_context7_mcp_registered() {
+  command -v jq &>/dev/null || return 1
+  # Direct MCP registration in either user config file
+  ([ -f "$HOME/.claude/settings.json" ] && jq -e '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty' "$HOME/.claude/settings.json" >/dev/null 2>&1) || \
+  ([ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty' "$HOME/.claude.json" >/dev/null 2>&1) || \
+  # Plugin-installed Context7 (surfaces as mcp__plugin_context7_context7__*; registered under .enabledPlugins, not .mcpServers)
+  ([ -f "$HOME/.claude/settings.json" ] && jq -e '.enabledPlugins | to_entries[] | select(.key | test("^context7"; "i")) | select(.value == true)' "$HOME/.claude/settings.json" >/dev/null 2>&1)
+}
+
+is_qdrant_mcp_registered() {
+  command -v jq &>/dev/null || return 1
+  ([ -f "$HOME/.claude/settings.json" ] && jq -e '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' "$HOME/.claude/settings.json" >/dev/null 2>&1) || \
+  ([ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' "$HOME/.claude.json" >/dev/null 2>&1)
+}
+
+# Check if a Qdrant container is running via docker ps (5s timeout, no docker info).
+is_qdrant_container_running() {
+  command -v docker &>/dev/null || return 1
+  local _ps_out
+  _ps_out=$(run_with_timeout 5 docker ps --format '{{.Names}}' 2>/dev/null) || return 1
+  echo "$_ps_out" | grep -q "^qdrant$"
+}
+
+# Register Qdrant MCP with Claude Code (30s timeout).
+# Usage: register_qdrant_mcp [collection_name]
+register_qdrant_mcp() {
+  local collection="${1:-claude-memory}"
+  run_with_timeout 30 bash -c "echo y | claude mcp add -s user -e QDRANT_URL=http://localhost:6333 -e COLLECTION_NAME=$collection qdrant -- uvx --python 3.13 mcp-server-qdrant >/dev/null 2>&1"
+}

--- a/scripts/lib/helpers.sh
+++ b/scripts/lib/helpers.sh
@@ -1,361 +1,39 @@
 #!/usr/bin/env bash
-# Solo Orchestrator — Shared Script Helpers
-# Source this file from any script:
-#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-#   source "$SCRIPT_DIR/lib/helpers.sh"
-# Or from init.sh (repo root):
-#   source "$SCRIPT_DIR/scripts/lib/helpers.sh"
-
-# Colors (disabled if not a terminal)
-if [ -t 1 ]; then
-  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
-  BLUE='\033[0;34m'; CYAN='\033[0;36m'; BOLD='\033[1m'; NC='\033[0m'
-else
-  RED=''; GREEN=''; YELLOW=''; BLUE=''; CYAN=''; BOLD=''; NC=''
-fi
-
-# --- Print helpers ---
-print_header() {
-  local version="${1:-1.0.0}"
-  echo ""
-  echo -e "${BOLD}╔══════════════════════════════════════════════════════════╗${NC}"
-  echo -e "${BOLD}║         Solo Orchestrator — Project Init v${version}          ║${NC}"
-  echo -e "${BOLD}╚══════════════════════════════════════════════════════════╝${NC}"
-  echo ""
-}
-
-print_step() { echo -e "${CYAN}[STEP]${NC} $1"; log_line "[STEP] $1"; }
-print_ok()   { echo -e "${GREEN}  [OK]${NC} $1"; log_line "  [OK] $1"; }
-print_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; log_line "[WARN] $1"; }
-print_fail() { echo -e "${RED}[FAIL]${NC} $1"; log_line "[FAIL] $1"; }
-print_info() { echo -e "${BLUE}[INFO]${NC} $1"; log_line "[INFO] $1"; }
-
-# ── Logging ──────────────────────────────────────────────────────
-# Call init_log() early in init.sh to enable file logging.
-# All print_* functions automatically log when LOG_FILE is set.
-LOG_FILE=""
-
-init_log() {
-  local log_dir="$1"
-  mkdir -p "$log_dir"
-  LOG_FILE="$log_dir/init-$(date +%Y%m%d-%H%M%S).log"
-  {
-    echo "═══════════════════════════════════════════════════════════"
-    echo "Solo Orchestrator Init Log"
-    echo "Started: $(date '+%Y-%m-%d %H:%M:%S %Z')"
-    echo "OS: $(uname -s) $(uname -r) ($(uname -m))"
-    echo "Shell: $BASH_VERSION"
-    echo "User: $(whoami)@$(hostname)"
-    echo "Working directory: $(pwd)"
-    echo "═══════════════════════════════════════════════════════════"
-    echo ""
-  } > "$LOG_FILE"
-}
-
-# Strip ANSI escape codes and write to log file
-log_line() {
-  if [ -n "$LOG_FILE" ]; then
-    echo "$1" | sed 's/\x1b\[[0-9;]*m//g' >> "$LOG_FILE"
-  fi
-}
-
-log_section() {
-  if [ -n "$LOG_FILE" ]; then
-    echo -e "\n── $1 ──────────────────────────────────" >> "$LOG_FILE"
-  fi
-}
-
-# Run a command with a timeout (portable, no coreutils needed).
-# Usage: run_with_timeout <seconds> <command...>
-# Returns 0 on success, 1 on timeout or failure.
-run_with_timeout() {
-  local _rto_secs="$1"; shift
-  "$@" &
-  local _rto_pid=$!
-  local _rto_elapsed=0
-  while kill -0 "$_rto_pid" 2>/dev/null; do
-    if [ "$_rto_elapsed" -ge "$_rto_secs" ]; then
-      kill "$_rto_pid" 2>/dev/null || true
-      wait "$_rto_pid" 2>/dev/null || true
-      return 1
-    fi
-    sleep 1
-    _rto_elapsed=$((_rto_elapsed + 1))
-  done
-  wait "$_rto_pid" 2>/dev/null
-}
-
-# ── MCP Detection Helpers ────────────────────────────────────────
-# Check both ~/.claude/settings.json and ~/.claude.json for MCP server registration.
-
-is_context7_mcp_registered() {
-  command -v jq &>/dev/null || return 1
-  # Direct MCP registration in either user config file
-  ([ -f "$HOME/.claude/settings.json" ] && jq -e '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty' "$HOME/.claude/settings.json" >/dev/null 2>&1) || \
-  ([ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty' "$HOME/.claude.json" >/dev/null 2>&1) || \
-  # Plugin-installed Context7 (surfaces as mcp__plugin_context7_context7__*; registered under .enabledPlugins, not .mcpServers)
-  ([ -f "$HOME/.claude/settings.json" ] && jq -e '.enabledPlugins | to_entries[] | select(.key | test("^context7"; "i")) | select(.value == true)' "$HOME/.claude/settings.json" >/dev/null 2>&1)
-}
-
-is_qdrant_mcp_registered() {
-  command -v jq &>/dev/null || return 1
-  ([ -f "$HOME/.claude/settings.json" ] && jq -e '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' "$HOME/.claude/settings.json" >/dev/null 2>&1) || \
-  ([ -f "$HOME/.claude.json" ] && jq -e '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' "$HOME/.claude.json" >/dev/null 2>&1)
-}
-
-# Check if a Qdrant container is running via docker ps (5s timeout, no docker info).
-is_qdrant_container_running() {
-  command -v docker &>/dev/null || return 1
-  local _ps_out
-  _ps_out=$(run_with_timeout 5 docker ps --format '{{.Names}}' 2>/dev/null) || return 1
-  echo "$_ps_out" | grep -q "^qdrant$"
-}
-
-# Register Qdrant MCP with Claude Code (30s timeout).
-# Usage: register_qdrant_mcp [collection_name]
-register_qdrant_mcp() {
-  local collection="${1:-claude-memory}"
-  run_with_timeout 30 bash -c "echo y | claude mcp add -s user -e QDRANT_URL=http://localhost:6333 -e COLLECTION_NAME=$collection qdrant -- uvx --python 3.13 mcp-server-qdrant >/dev/null 2>&1"
-}
-
-finalize_log() {
-  if [ -n "$LOG_FILE" ]; then
-    {
-      echo ""
-      echo "═══════════════════════════════════════════════════════════"
-      echo "Completed: $(date '+%Y-%m-%d %H:%M:%S %Z')"
-      echo "Duration: ${SECONDS}s"
-      echo "═══════════════════════════════════════════════════════════"
-    } >> "$LOG_FILE"
-    # Print log location (to both stdout and log)
-    echo ""
-    echo -e "${BLUE}[INFO]${NC} Init log saved to: $LOG_FILE"
-  fi
-}
-
-# --- Prompt helpers ---
-
-# Prompt for text input with optional default value.
-# Usage: result=$(prompt_input "Your name" "default_value")
+# Solo Orchestrator — Shared Script Helpers (backwards-compat shim)
 #
-# Non-interactive behavior (no TTY on stdin, CI=true, or
-# SOIF_NONINTERACTIVE=true): emits a [WARN] to stderr and returns the
-# default (or empty string if no default). This is the contract that
-# scripts/lint-raw-read-prompt.sh enforces: never call `read -rp`
-# outside this file, because doing so hangs unattended invocations.
-prompt_input() {
-  local prompt="$1"
-  local default="${2:-}"
-  local result
-
-  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
-    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: prompt_input(\"$prompt\") returning default '$default' without blocking. Re-run interactively to override." >&2
-    printf '%s' "$default"
-    return 0
-  fi
-
-  if [ -n "$default" ]; then
-    read -rp "$(echo -e "${BOLD}$prompt${NC} [$default]: ")" result
-    echo "${result:-$default}"
-  else
-    read -rp "$(echo -e "${BOLD}$prompt${NC}: ")" result
-    echo "$result"
-  fi
-}
-
-# Prompt for yes/no confirmation, returning 0 (yes) or 1 (no).
-# Usage: if prompt_yes_no "Proceed?" "Y"; then ... fi
+# BL-046 (PR #<N>, 2026-06-30): helpers.sh was split into two files
+# to give short-lived callers (check-versions.sh, check-updates.sh,
+# check-changelog.sh, check-session-state.sh, validate.sh,
+# check-gate.sh, ...) a smaller parse cost per invocation:
+#   - scripts/lib/helpers-core.sh — print_*, prompt_*, log_line,
+#     run_with_timeout, guard_not_in_framework (the minimum set
+#     every caller uses).
+#   - scripts/lib/helpers-full.sh — init_log/finalize_log +
+#     MCP-detection helpers (only long-running init.sh /
+#     upgrade-project.sh / intake-wizard.sh /
+#     reconfigure-project.sh / verify-install.sh need these).
 #
-# `default_answer` is "Y" or "N" — used ONLY when interactive AND the
-# operator hits Enter without typing a response. In non-interactive
-# contexts (no TTY, CI=true, SOIF_NONINTERACTIVE=true) this function
-# ALWAYS returns N (1) regardless of `default_answer`. This is
-# defense-in-depth: a caller that defaults to Y in interactive use
-# (e.g. "[Y/n]" confirm prompts) must NEVER auto-Y a side-effectful
-# action in CI just because the operator was absent. Mirrors the
-# hard-N policy in scripts/check-phase-gate.sh::prompt_yes_no, which
-# was introduced after the cycle-7 PR #87 unattended-install incident.
-prompt_yes_no() {
-  local message="$1"
-  local default_answer="${2:-N}"
-
-  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
-    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: skipping prompt (\"$message\") — defaulting to 'N' (caller default '$default_answer' ignored in non-interactive context)." >&2
-    return 1
-  fi
-
-  local reply
-  read -rp "$(echo -e "${BOLD}${message}${NC}: ")" reply
-  if [ -z "$reply" ]; then
-    case "$default_answer" in
-      [Yy]*) return 0 ;;
-      *)     return 1 ;;
-    esac
-  fi
-  case "$reply" in
-    [Nn]*) return 1 ;;
-    *)     return 0 ;;
-  esac
-}
-
-# Refuse to operate as a project if cwd OR an explicit target directory is
-# the Solo Orchestrator framework repo itself. Every project-targeted script
-# (init.sh, verify-install.sh, process-checklist.sh, upgrade-project.sh,
-# intake-wizard.sh, pending-approval.sh, reconfigure-project.sh) must call
-# this BEFORE any file writes.
+# This shim exists so every existing caller that sources
+# `scripts/lib/helpers.sh` — including third-party / user scripts,
+# pinned CDF installs, and older cached copies — continues to
+# receive the FULL API without any code change. Short-lived callers
+# were migrated in the same PR to source helpers-core.sh directly.
 #
-# Usage:
-#   guard_not_in_framework               # checks $(pwd) only (legacy / default)
-#   guard_not_in_framework "$target_dir" # checks $(pwd) AND "$target_dir"
-#
-# The optional target-dir argument was added for security-audits-1
-# (S3, 2026-04-26 audit sweep): init.sh accepts --project-dir=PATH and
-# proceeds to write into PATH even if PATH is the framework repo. The
-# cwd-only check missed that vector because the cwd could be a benign
-# tempdir while --project-dir pointed at the framework. Callers that
-# accept any "write into this dir" arg (init.sh, upgrade-project.sh, ...)
-# MUST pass it as $1 so this guard can lint both surfaces.
-#
-# UAT 2026-04-25 fix (U-N + U-O): a UAT agent's cwd was the framework dir
-# (instead of their tempdir), so verify-install.sh + indirectly CDF init
-# scattered .claude/, .claude-backup/, gates/, hooks/, rules/, and
-# APPROVAL_LOG.md into the framework root. None tracked, but contaminates
-# the workspace and can sneak into commits.
-#
-# Detection signature: the framework has a top-level init.sh whose header
-# contains "Solo Orchestrator — Project Initialization Script" — a string
-# that's specific to this framework and won't appear in arbitrary projects'
-# init.sh files. Also check for templates/generated/ to triple-confirm.
-guard_not_in_framework() {
-  local target="${1:-}"
-  local cwd
-  cwd="$(pwd)"
+# Do NOT add new function definitions here. Add them to
+# helpers-core.sh (if they're small + universally used) or
+# helpers-full.sh (if they're heavy or narrowly needed).
 
-  # Helper: returns 0 if $1 looks like the framework repo root.
-  _gnif_dir_is_framework() {
-    local d="$1"
-    [ -n "$d" ] || return 1
-    [ -f "$d/init.sh" ] || return 1
-    grep -q "Solo Orchestrator — Project Initialization Script" "$d/init.sh" 2>/dev/null || return 1
-    [ -d "$d/templates/generated" ] || return 1
-    return 0
-  }
-
-  _gnif_emit_refusal() {
-    local where="$1"     # human label: "cwd" or "--project-dir"
-    local detected="$2"  # the resolved path
-    print_fail "Refusing to operate inside the Solo Orchestrator framework repo."
-    echo "  Detected framework signature ($where): $detected" >&2
-    echo "" >&2
-    echo "  This script targets a project, not the framework itself." >&2
-    echo "  Move to your project directory and re-run:" >&2
-    echo "    cd /path/to/your-project" >&2
-    echo "" >&2
-    echo "  If this directory IS your project (i.e., you cloned solo-orchestrator" >&2
-    echo "  AS a project), the framework is mis-installed — clone solo-orchestrator" >&2
-    echo "  separately and run init.sh from inside an empty project directory." >&2
-  }
-
-  # 1. cwd check (preserves legacy behavior — callers that don't pass a target).
-  if _gnif_dir_is_framework "$cwd"; then
-    _gnif_emit_refusal "cwd" "$cwd"
-    return 1
-  fi
-
-  # 2. target-dir check (security-audits-1). Only runs when caller supplies $1.
-  if [ -n "$target" ] && _gnif_dir_is_framework "$target"; then
-    _gnif_emit_refusal "--project-dir / target" "$target"
-    return 1
-  fi
-
+# Idempotent-source guard (in addition to the guards in core+full).
+if [ -n "${_SOIF_HELPERS_SHIM_LOADED:-}" ]; then
   return 0
-}
+fi
+_SOIF_HELPERS_SHIM_LOADED=1
 
-# Prompt for a numbered choice from a list of options.
-# Usage: result=$(prompt_choice "Pick one:" "option1" "option2" "option3")
-#
-# UAT 2026-04-25 fix (agent 12): EOF guard. The original loop had no exit
-# condition for stdin EOF — `read` returns non-zero on EOF, but the loop
-# kept retrying and re-printing "Invalid choice", spinning the CPU and
-# producing megabytes of output until killed. Affected ANY scripted
-# invocation of init.sh (or any caller of prompt_choice) when canned
-# answers were under-fed.
-#
-# Fix: detect read's non-zero return (EOF). On EOF, print a clear failure
-# to stderr and return 1 (caller can decide whether to abort or default).
-# Bonus: cap retries at 100 so even a malformed-but-non-EOF input stream
-# doesn't burn forever.
-prompt_choice() {
-  local prompt="$1"
-  shift
-  local options=("$@")
-  echo -e "${BOLD}$prompt${NC}" >&2
-  for i in "${!options[@]}"; do
-    echo "  $((i+1)). ${options[$i]}" >&2
-  done
-  local choice
-  local retries=0
-  local max_retries=100
-  while [ "$retries" -lt "$max_retries" ]; do
-    if ! read -rp "$(echo -e "${BOLD}Select [1-${#options[@]}]${NC}: ")" choice; then
-      echo "" >&2
-      echo "  prompt_choice: stdin closed (EOF) before a valid choice was supplied." >&2
-      echo "  This usually means a scripted/heredoc invocation under-fed the prompt." >&2
-      return 1
-    fi
-    if [[ "$choice" =~ ^[0-9]+$ ]] && [ "$choice" -ge 1 ] && [ "$choice" -le "${#options[@]}" ]; then
-      echo "${options[$((choice-1))]}"
-      return 0
-    fi
-    echo "  Invalid choice. Enter a number between 1 and ${#options[@]}." >&2
-    retries=$((retries + 1))
-  done
-  echo "  prompt_choice: $max_retries invalid attempts; aborting to prevent loop." >&2
-  return 1
-}
-
-# Prompt user to install a missing tool. Returns 0 if installed, 1 if skipped.
-# Usage: prompt_install "tool_name" "install_command" [needs_sudo]
-#
-# Non-interactive behavior (no TTY on stdin, CI=true, or
-# SOIF_NONINTERACTIVE=true): emits a [WARN] to stderr naming the
-# missing tool + install command, and returns 1 (decline install)
-# WITHOUT touching `eval`. Same defense-in-depth contract as
-# prompt_yes_no — a caller in CI / piped invocation must NEVER
-# auto-install a side-effectful command (e.g. `sudo apt install`,
-# `sudo usermod -aG docker $USER`) just because the operator was
-# absent. The PR-#96 adversarial verifier flagged this as the one
-# remaining hole in the lint sweep: scripts/lib/helpers.sh is exempt
-# from scripts/lint-raw-read-prompt.sh (correctly — the prompt
-# helpers themselves must call `read -rp`), so runtime tests are the
-# only safety net. See tests/test-prompt-install-noninteractive.sh.
-prompt_install() {
-  local tool_name="$1"
-  local install_cmd="$2"
-  local needs_sudo="${3:-false}"
-
-  echo ""
-  if [ "$needs_sudo" = true ]; then
-    echo -e "  ${YELLOW}This requires administrator privileges (sudo).${NC}"
-  fi
-  echo -e "  Install command: ${CYAN}$install_cmd${NC}"
-
-  if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
-    echo -e "${YELLOW}[WARN]${NC} Non-interactive context: skipping install of '$tool_name' — defaulting to 'N' (no install). Re-run interactively, or run the install manually: $install_cmd" >&2
-    return 1
-  fi
-
-  local response
-  read -rp "$(echo -e "  ${BOLD}Install $tool_name now? [Y/n]${NC}: ")" response
-  if [[ "$response" =~ ^[Nn] ]]; then
-    return 1
-  fi
-
-  if eval "$install_cmd"; then
-    print_ok "$tool_name installed"
-    return 0
-  else
-    print_warn "Installation failed. You can try manually: $install_cmd"
-    return 1
-  fi
-}
+# Fast-path dirname via parameter expansion (no subshell / no dirname fork).
+# ${BASH_SOURCE[0]%/*} strips the trailing "/helpers.sh". If BASH_SOURCE
+# has no slash (unlikely — happens only when sourced by exact filename
+# from cwd), fall back to "." which resolves against the caller's cwd.
+_SOIF_HELPERS_SHIM_DIR="${BASH_SOURCE[0]%/*}"
+[ "$_SOIF_HELPERS_SHIM_DIR" = "${BASH_SOURCE[0]}" ] && _SOIF_HELPERS_SHIM_DIR="."
+# shellcheck source=./helpers-full.sh
+source "$_SOIF_HELPERS_SHIM_DIR/helpers-full.sh"

--- a/scripts/lint-raw-read-prompt.sh
+++ b/scripts/lint-raw-read-prompt.sh
@@ -59,7 +59,18 @@ set -uo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")" && pwd)/.."
 REPO_ROOT="$(cd "$REPO_ROOT" && pwd)"
 SELF_PATH="$REPO_ROOT/scripts/lint-raw-read-prompt.sh"
-HELPERS_PATH="$REPO_ROOT/scripts/lib/helpers.sh"
+# BL-046: helpers.sh was split into three files (shim, core, full).
+# All three must be exempt from the raw-read check. In practice only
+# helpers-core.sh actually contains raw `read -rp` calls today (the
+# prompt_* helpers live there), but the shim and full-set are kept
+# exempt for future safety: they're the canonical prompt-helper
+# surface, and exempting the whole family avoids a future refactor
+# accidentally tripping the lint if a raw read moves back into them.
+HELPERS_PATHS=(
+  "$REPO_ROOT/scripts/lib/helpers.sh"
+  "$REPO_ROOT/scripts/lib/helpers-core.sh"
+  "$REPO_ROOT/scripts/lib/helpers-full.sh"
+)
 TEST_FIXTURE_PATTERN="test-lint-raw-read-prompt"
 
 LIST_MODE=0
@@ -110,7 +121,9 @@ LIST_ROWS=""
 should_skip_file() {
   local f="$1"
   [ "$f" = "$SELF_PATH" ] && return 0
-  [ "$f" = "$HELPERS_PATH" ] && return 0
+  for _hp in "${HELPERS_PATHS[@]}"; do
+    [ "$f" = "$_hp" ] && return 0
+  done
   case "$(basename "$f")" in
     "${TEST_FIXTURE_PATTERN}.sh") return 0 ;;
   esac

--- a/scripts/pending-approval.sh
+++ b/scripts/pending-approval.sh
@@ -21,14 +21,16 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if [ -f "$SCRIPT_DIR/lib/helpers.sh" ]; then
-  source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_ok/fail/info + guard_not_in_framework only — core subset.
+if [ -f "$SCRIPT_DIR/lib/helpers-core.sh" ]; then
+  source "$SCRIPT_DIR/lib/helpers-core.sh"
 else
   print_ok()   { echo "[OK] $1"; }
   print_fail() { echo "[FAIL] $1" >&2; }
   print_info() { echo "[INFO] $1"; }
-  # When helpers.sh is unavailable (vendored stub install), no-op the framework
-  # guard: there's nothing to source. The full Solo install always ships helpers.
+  # When helpers-core.sh is unavailable (vendored stub install), no-op the
+  # framework guard: there's nothing to source. The full Solo install always
+  # ships helpers.
   guard_not_in_framework() { return 0; }
 fi
 

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -19,7 +19,9 @@ set -euo pipefail
 #   scripts/process-checklist.sh --help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_ok/warn/fail/info + prompt_yes_no + guard_not_in_framework
+# only — source core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 # security-audits-2 (S3, 2026-04-26 audit sweep): the helpers.sh docstring at
 # guard_not_in_framework names scripts/process-checklist.sh as a script that

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -7,7 +7,8 @@ set -euo pipefail
 # Usage: bash scripts/resume.sh
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses only color vars (BOLD/CYAN/NC) — source core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 echo -e "${BOLD}Generating session resume prompt...${NC}"
 echo ""

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -12,7 +12,8 @@ set -euo pipefail
 #   scripts/test-gate.sh --help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_fail/info/ok/warn + prompt_yes_no only — core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 BUILD_PROGRESS=".claude/build-progress.json"
 

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -2196,6 +2196,32 @@ fi
 # pending-approval.sh), existing projects can't pick them up by re-running
 # init. This block syncs the post-BL-009/BL-015 helper set into the project's
 # scripts/ directory. Idempotent: cp overwrites existing files identically.
+#
+# BL-046 (helpers.sh core/full split, 2026-06-30): existing projects have
+# only scripts/lib/helpers.sh (the pre-split monolith). The refreshed
+# short-lived scripts (check-versions.sh, check-updates.sh, etc.) source
+# scripts/lib/helpers-core.sh directly. Without the two new sibling files
+# they'd fall through to the inline fallback (which is functional but
+# suboptimal) or, in a couple of scripts that hard-source without a
+# fallback (check-maintenance.sh, check-phase-gate.sh, check-updates.sh,
+# validate.sh, test-gate.sh, resume.sh, process-checklist.sh), they'd
+# error out with "file not found." Ship the two new files before the
+# script refresh below, so the refreshed callers find them on next run.
+if [ -d scripts/lib ]; then
+  for lib_file in helpers-core.sh helpers-full.sh; do
+    src="$SCRIPT_DIR/lib/$lib_file"
+    dst="scripts/lib/$lib_file"
+    if [ -f "$src" ]; then
+      if [ "$src" -ef "$dst" ]; then
+        : # no-op (same file)
+      else
+        cp "$src" "$dst"
+        print_ok "scripts/lib/$lib_file installed (BL-046 helpers.sh split)"
+      fi
+    fi
+  done
+fi
+
 print_step "Refreshing framework helper scripts (BL-009, BL-015)"
 if [ -d scripts ]; then
   for helper in pending-approval.sh lint-uat-scenarios.sh; do

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -11,7 +11,8 @@ set -euo pipefail
 #    or: bash /path/to/solo-orchestrator/scripts/validate.sh (from any project)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$SCRIPT_DIR/lib/helpers.sh"
+# BL-046: uses print_fail/info/ok/warn only — source core subset.
+source "$SCRIPT_DIR/lib/helpers-core.sh"
 
 print_section() { echo ""; echo -e "${BOLD}── $1 ──${NC}"; }
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1126,7 +1126,7 @@ This matters because the >600 s suite runtime is the primary reason the CI workf
 **Logged:** 2026-06-29
 **Category:** Performance
 **Severity:** Medium
-**Status:** Open
+**Status:** Closed (2026-06-30, PR #<pending>, commit `16f5c9b`)
 
 `lib/helpers.sh` is sourced by ~15 short-lived script callers. Each source incurs a 30–40 ms parse+exec cost (Step 4 recon profiling) regardless of which helpers the caller actually uses. Compounded across the CLI surface this is visible latency on the per-script TUI flow.
 
@@ -1134,7 +1134,22 @@ This matters because the >600 s suite runtime is the primary reason the CI workf
 
 **Trigger:** When CLI latency becomes user-visible OR when adding the next big helper that would push `lib/helpers.sh` parse time over a perceptible threshold.
 
-**Related:** `Reports/2026-06-28-step4-dead-code-perf-eval.md` §5, §7 item 2; `lib/helpers.sh`; all `source lib/helpers.sh` call sites under `scripts/`.
+**Resolution (2026-06-30):** Landed as a two-file split (not the four-file per-domain split proposed in the original scope) because caller-usage analysis showed a clean bimodal cut, not a domain-based one. Every short-lived caller (check-*, validate, test-gate, resume, pending-approval, process-checklist) uses a common minimum set: print_*, prompt_*, log_line, run_with_timeout, guard_not_in_framework. Only long-running callers (init.sh, upgrade-project.sh, intake-wizard.sh, reconfigure-project.sh, verify-install.sh) additionally need init_log/finalize_log + MCP-detection helpers. So:
+
+  - `scripts/lib/helpers-core.sh` — 316 lines, the minimum set.
+  - `scripts/lib/helpers-full.sh` — 101 lines, transitively sources core, adds init_log/finalize_log/MCP helpers.
+  - `scripts/lib/helpers.sh` — thin backwards-compat shim; sources full (which sources core).
+
+Each file has an idempotent-source sentinel guard (`_SOIF_HELPERS_*_LOADED`) so a shell that ends up sourcing multiple entry points (e.g. shim → full → core via composition) still parses each file exactly once.
+
+**Measured savings** (500-iteration amortized loop, Darwin bash 3.2, M-series Mac):
+  - helpers.sh via shim: 1.101 ms per source
+  - helpers-core.sh direct: 0.823 ms per source
+  - **Per-source reduction: 0.278 ms (25%)**
+
+The absolute savings are smaller than the Step 4 report's 30–40 ms projection — that scout likely measured on slower hardware or included non-source-cost latency. The parse-cost *ratio* holds (~25% reduction), so on slower CI/Intel hardware where per-source is ~10× higher, the delta should scale proportionally.
+
+**Related:** `Reports/2026-06-28-step4-dead-code-perf-eval.md` §5, §7 item 2; `tests/test-bl046-helpers-split.sh` (T1-T5b contracts); PR #<pending>.
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1126,7 +1126,7 @@ This matters because the >600 s suite runtime is the primary reason the CI workf
 **Logged:** 2026-06-29
 **Category:** Performance
 **Severity:** Medium
-**Status:** Closed (2026-06-30, PR #<pending>, commit `16f5c9b`)
+**Status:** Closed (2026-06-30, PR #125, commit `16f5c9b`)
 
 `lib/helpers.sh` is sourced by ~15 short-lived script callers. Each source incurs a 30–40 ms parse+exec cost (Step 4 recon profiling) regardless of which helpers the caller actually uses. Compounded across the CLI surface this is visible latency on the per-script TUI flow.
 
@@ -1149,7 +1149,7 @@ Each file has an idempotent-source sentinel guard (`_SOIF_HELPERS_*_LOADED`) so 
 
 The absolute savings are smaller than the Step 4 report's 30–40 ms projection — that scout likely measured on slower hardware or included non-source-cost latency. The parse-cost *ratio* holds (~25% reduction), so on slower CI/Intel hardware where per-source is ~10× higher, the delta should scale proportionally.
 
-**Related:** `Reports/2026-06-28-step4-dead-code-perf-eval.md` §5, §7 item 2; `tests/test-bl046-helpers-split.sh` (T1-T5b contracts); PR #<pending>.
+**Related:** `Reports/2026-06-28-step4-dead-code-perf-eval.md` §5, §7 item 2; `tests/test-bl046-helpers-split.sh` (T1-T5b contracts); PR #125.
 
 ---
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -605,6 +605,24 @@ else
 fi
 
 # ----------------------------------------------------------------
+# TEST 0r-bl046: HELPERS.SH CORE/FULL SPLIT CONTRACT (BL-046)
+# ----------------------------------------------------------------
+# tests/test-bl046-helpers-split.sh proves the five contracts of the
+# BL-046 split: core-only callers get the minimum surface, full
+# callers get both surfaces via delegation, the boundary is enforced
+# (T3: init_log absent from core), the shim retains full backwards
+# compatibility, and each file is idempotent-source-guarded.
+# Registered here per BL-038 discipline: every test-*.sh needs an
+# aggregator wire so a silent regression can't slip past
+# `full-project-test-suite.sh`.
+section "BL-046 helpers.sh core/full split contract"
+if bash "$SCRIPT_DIR/tests/test-bl046-helpers-split.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl046-helpers-split.sh (T1..T5b)"
+else
+  fail "tests/test-bl046-helpers-split.sh FAILED (run for details)"
+fi
+
+# ----------------------------------------------------------------
 # TEST 0s: HOST-DRIVER AGGREGATOR
 # ----------------------------------------------------------------
 # tests/host-drivers/run-all.sh wraps the per-host unit tests

--- a/tests/test-bl046-helpers-split.sh
+++ b/tests/test-bl046-helpers-split.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# tests/test-bl046-helpers-split.sh
+#
+# BL-046: split scripts/lib/helpers.sh into helpers-core.sh (subset used
+# by every short-lived caller) + helpers-full.sh (init_log / finalize_log
+# + MCP-detection helpers only long-running callers need). helpers.sh
+# stays as a backwards-compat shim that transitively loads full → core.
+#
+# This test proves five contracts. Each corresponds to a paragraph in the
+# BL-046 PR body's "Test plan" section and is designed so the RED-first
+# failure of any individual assertion pinpoints a specific defect:
+#
+#   T1  core-only-callers-work
+#         Sourcing helpers-core.sh exposes every core helper the
+#         short-lived callers (check-versions.sh, check-updates.sh, ...)
+#         actually invoke. Calling one of them succeeds without error.
+#
+#   T2  full-only-callers-still-work
+#         Sourcing helpers-full.sh exposes both the core and full APIs.
+#         Calling init_log/finalize_log via helpers-full.sh writes a
+#         real log file, proving the delegation chain works.
+#
+#   T3  missing-function-error
+#         Sourcing helpers-core.sh does NOT expose init_log / finalize_log
+#         / MCP-detection functions. Invoking any of them errors out
+#         with rc != 0 (command not found). This proves the boundary is
+#         real — the split isn't just an alias.
+#
+#   T4  shim-backwards-compat
+#         Sourcing scripts/lib/helpers.sh (the pre-split entry point
+#         every existing caller uses) still exposes the FULL API. No
+#         caller breaks.
+#
+#   T5  idempotent-source
+#         Sourcing helpers-core.sh twice in the same shell does not
+#         fail, does not re-run the color setup, and does not create
+#         duplicate function definitions. Same for helpers-full.sh
+#         and helpers.sh.
+#
+# Verification strategy: build a small harness per T-case that sources
+# the target file, invokes the assertion, and exits with rc that
+# encodes pass/fail. Colours are disabled so grep-based assertions on
+# the output are stable.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB_DIR="$REPO_ROOT/scripts/lib"
+HELPERS_SHIM="$LIB_DIR/helpers.sh"
+HELPERS_CORE="$LIB_DIR/helpers-core.sh"
+HELPERS_FULL="$LIB_DIR/helpers-full.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Preconditions — the three files exist.
+[ -f "$HELPERS_SHIM" ] || { echo "PRECONDITION FAIL: $HELPERS_SHIM missing"; exit 99; }
+[ -f "$HELPERS_CORE" ] || { echo "PRECONDITION FAIL: $HELPERS_CORE missing"; exit 99; }
+[ -f "$HELPERS_FULL" ] || { echo "PRECONDITION FAIL: $HELPERS_FULL missing"; exit 99; }
+
+echo "── BL-046: helpers.sh core/full split contract tests ──"
+echo ""
+
+# ── T1: core-only callers work ──────────────────────────────────
+# Every short-lived caller (per Step 4 dead-code-perf-eval report) uses
+# some subset of: print_ok/warn/fail/info/step/header, log_line,
+# log_section, run_with_timeout, prompt_input, prompt_yes_no,
+# prompt_choice, prompt_install, guard_not_in_framework. All must be
+# defined after sourcing helpers-core.sh alone.
+CORE_EXPECTED_FUNCS=(
+  print_header print_step print_ok print_warn print_fail print_info
+  log_line log_section run_with_timeout
+  prompt_input prompt_yes_no prompt_choice prompt_install
+  guard_not_in_framework
+)
+t1_out=$(bash -c "
+source '$HELPERS_CORE'
+missing=0
+for f in ${CORE_EXPECTED_FUNCS[*]}; do
+  declare -F \"\$f\" >/dev/null || { echo \"MISSING \$f\"; missing=1; }
+done
+# Also invoke one to prove it actually runs (print_ok writes to stdout).
+print_ok 't1-invocation-check' > /dev/null
+exit \$missing
+" 2>&1)
+t1_rc=$?
+if [ $t1_rc -eq 0 ]; then
+  pass "T1 core-only-callers-work: all ${#CORE_EXPECTED_FUNCS[@]} core functions defined and callable"
+else
+  fail_ "T1 core-only-callers-work" "rc=$t1_rc; output=$t1_out"
+fi
+
+# ── T2: full callers still work ─────────────────────────────────
+# Sourcing helpers-full.sh must expose both the full-set functions
+# AND (transitively) every core function. Verify init_log actually
+# writes a log by pointing it at a tempdir and checking the file
+# contents.
+FULL_EXPECTED_FUNCS=(
+  init_log finalize_log
+  is_context7_mcp_registered is_qdrant_mcp_registered
+  is_qdrant_container_running register_qdrant_mcp
+)
+tmp_t2=$(mktemp -d)
+t2_out=$(bash -c "
+source '$HELPERS_FULL'
+missing=0
+# Full set
+for f in ${FULL_EXPECTED_FUNCS[*]}; do
+  declare -F \"\$f\" >/dev/null || { echo \"MISSING FULL \$f\"; missing=1; }
+done
+# Core set (transitively loaded)
+for f in ${CORE_EXPECTED_FUNCS[*]}; do
+  declare -F \"\$f\" >/dev/null || { echo \"MISSING CORE \$f\"; missing=1; }
+done
+# Invoke init_log for real — it should create a log file in the tempdir.
+init_log '$tmp_t2'
+if [ -z \"\${LOG_FILE:-}\" ] || [ ! -f \"\$LOG_FILE\" ]; then
+  echo 'init_log did not create a log file'
+  missing=1
+fi
+# Invoke a print_ helper — should append (via log_line) to LOG_FILE.
+print_ok 'test-line' > /dev/null
+if ! grep -q 'test-line' \"\$LOG_FILE\" 2>/dev/null; then
+  echo 'print_ok did not route through log_line to LOG_FILE'
+  missing=1
+fi
+exit \$missing
+" 2>&1)
+t2_rc=$?
+rm -rf "$tmp_t2"
+if [ $t2_rc -eq 0 ]; then
+  pass "T2 full-callers-still-work: full+core surface + init_log/log_line integration"
+else
+  fail_ "T2 full-callers-still-work" "rc=$t2_rc; output=$t2_out"
+fi
+
+# ── T3: missing-function-error (boundary enforcement) ──────────
+# helpers-core.sh must NOT define the full-set functions. Attempting to
+# call one of them must fail (rc=127, "command not found").
+t3_out=$(bash -c "
+source '$HELPERS_CORE'
+# Try to call init_log. If the split boundary is broken (init_log
+# leaked into core), this succeeds and rc=0. That's a boundary defect.
+init_log /tmp/should-not-be-created-bl046-t3 2>/dev/null
+exit \$?
+")
+t3_rc=$?
+if [ $t3_rc -eq 127 ]; then
+  pass "T3 missing-function-error: init_log absent from core (rc=127 command-not-found)"
+else
+  fail_ "T3 missing-function-error" "expected rc=127 (command not found); got rc=$t3_rc — init_log leaked into helpers-core.sh"
+fi
+
+# Second half of T3: verify each full-set function is absent from core.
+t3b_out=$(bash -c "
+source '$HELPERS_CORE'
+leaked=0
+for f in ${FULL_EXPECTED_FUNCS[*]}; do
+  if declare -F \"\$f\" >/dev/null; then
+    echo \"LEAKED \$f\"
+    leaked=1
+  fi
+done
+exit \$leaked
+" 2>&1)
+t3b_rc=$?
+if [ $t3b_rc -eq 0 ]; then
+  pass "T3b none of the ${#FULL_EXPECTED_FUNCS[@]} full-set functions leak into helpers-core.sh"
+else
+  fail_ "T3b full-set leak into core" "$t3b_out"
+fi
+
+# ── T4: shim backwards compat ──────────────────────────────────
+# Every existing caller sources scripts/lib/helpers.sh (the shim).
+# After sourcing, both core AND full APIs must be present — the shim
+# must transitively load helpers-full.sh (which loads helpers-core.sh).
+t4_out=$(bash -c "
+source '$HELPERS_SHIM'
+missing=0
+for f in ${CORE_EXPECTED_FUNCS[*]} ${FULL_EXPECTED_FUNCS[*]}; do
+  declare -F \"\$f\" >/dev/null || { echo \"MISSING \$f\"; missing=1; }
+done
+exit \$missing
+" 2>&1)
+t4_rc=$?
+if [ $t4_rc -eq 0 ]; then
+  pass "T4 shim-backwards-compat: helpers.sh exposes all $(( ${#CORE_EXPECTED_FUNCS[@]} + ${#FULL_EXPECTED_FUNCS[@]} )) functions"
+else
+  fail_ "T4 shim-backwards-compat" "rc=$t4_rc; output=$t4_out"
+fi
+
+# ── T5: idempotent source ───────────────────────────────────────
+# Sourcing the same file twice in one shell must be a no-op. Idempotency
+# guards use _SOIF_HELPERS_*_LOADED sentinels; if those regress, the
+# second source will still succeed (bash allows redefining functions),
+# but a lot of setup work (color-var reassignment, dirname resolution)
+# will re-run. Assert via $SECONDS delta that the second source is
+# strictly cheaper — but the primary check is "no error". A regression
+# that removes the idempotency guard would still pass "no error", but
+# would defeat the point of the guard. So also assert the sentinel var
+# stays set after the second source (proving the guard fired).
+t5_out=$(bash -c '
+source "'"$HELPERS_CORE"'"
+# First source set the sentinel.
+first_sentinel="${_SOIF_HELPERS_CORE_LOADED:-}"
+if [ -z "$first_sentinel" ]; then
+  echo "sentinel not set after first source"
+  exit 1
+fi
+# Deliberately clear a color var so we can detect if the second source
+# ran the color-setup block. A working idempotency guard short-circuits
+# BEFORE the color block, leaving BOLD empty.
+BOLD=""
+source "'"$HELPERS_CORE"'"
+if [ -n "$BOLD" ]; then
+  echo "second source re-ran color setup (idempotency guard failed)"
+  exit 1
+fi
+# print_ok must still be callable after two sources.
+print_ok "idempotent" > /dev/null
+exit $?
+' 2>&1)
+t5_rc=$?
+if [ $t5_rc -eq 0 ]; then
+  pass "T5 idempotent-source: helpers-core.sh sourced twice is a no-op (guard held)"
+else
+  fail_ "T5 idempotent-source" "rc=$t5_rc; output=$t5_out"
+fi
+
+# Repeat T5 for helpers-full.sh and the shim — each has its own guard.
+for lib_pair in "helpers-full.sh:$HELPERS_FULL:_SOIF_HELPERS_FULL_LOADED" \
+                "helpers.sh:$HELPERS_SHIM:_SOIF_HELPERS_SHIM_LOADED"; do
+  IFS=":" read -r libname libpath sentinel <<<"$lib_pair"
+  out=$(bash -c "
+    source '$libpath'
+    first=\"\${$sentinel:-}\"
+    if [ -z \"\$first\" ]; then echo 'sentinel not set'; exit 1; fi
+    source '$libpath'
+    still=\"\${$sentinel:-}\"
+    if [ \"\$first\" != \"\$still\" ]; then echo 'sentinel changed'; exit 1; fi
+    exit 0
+  " 2>&1)
+  rc=$?
+  if [ $rc -eq 0 ]; then
+    pass "T5b idempotent-source: $libname sentinel $sentinel held across two sources"
+  else
+    fail_ "T5b idempotent-source ($libname)" "rc=$rc; $out"
+  fi
+done
+
+# ── Summary ─────────────────────────────────────────────────────
+echo ""
+echo "── Summary ──"
+echo "  Passed: $PASSED"
+echo "  Failed: $FAILED"
+if [ "$FAILED" -gt 0 ]; then
+  exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Splits `scripts/lib/helpers.sh` (~360 lines) into `helpers-core.sh` (~316 lines: print_*, prompt_*, log_line, run_with_timeout, guard_not_in_framework) and `helpers-full.sh` (~101 lines: init_log/finalize_log + MCP-detection helpers, transitively loads core).
- `scripts/lib/helpers.sh` remains as a thin backwards-compat shim — every existing caller keeps working unchanged. Twelve short-lived callers migrated to source `helpers-core.sh` directly (check-changelog, check-gate, check-maintenance, check-phase-gate, check-session-state, check-updates, check-versions, pending-approval, process-checklist, resume, test-gate, validate).
- Fast-path dirname via `${BASH_SOURCE[0]%/*}` (no subshell fork) — a naive `$(cd ... && pwd)` shim would have regressed full-caller path by ~4 ms per source on Darwin bash 3.2.
- Idempotent-source sentinels (`_SOIF_HELPERS_*_LOADED`) prevent double-parsing when scripts compose (shim → full → core).
- `init.sh` copies all three files into new projects; `upgrade-project.sh` backfills the two new siblings into pre-BL-046 projects before refreshing helper scripts (otherwise refreshed check-*.sh callers would hit "file not found" when sourcing `helpers-core.sh`).
- `scripts/lint-raw-read-prompt.sh` HELPERS_PATH → HELPERS_PATHS[] so all three helper files stay exempt from the raw-read check.

## Closes

BL-046

## Wall-clock measurement

Method: 500-iteration amortized loop, Darwin bash 3.2, M-series Mac (macOS 25.4). Warmup 3 runs discarded; median of 15 samples.

```
bash -c "for i in $(seq 1 500); do (source scripts/lib/helpers.sh); done"
bash -c "for i in $(seq 1 500); do (source scripts/lib/helpers-core.sh); done"
```

| Target | Total (500x) | Per-source | Delta |
|---|---|---|---|
| helpers.sh (shim -> full -> core) | 550.5 ms median | **1.101 ms** | baseline |
| helpers-core.sh (core only) | 411.4 ms median | **0.823 ms** | **-0.278 ms (-25%)** |

Single-source measurement (60 samples, `bash -c "source <file>"`):

| Target | Median | Min | p90 |
|---|---|---|---|
| bash startup only | 2.18 ms | 1.92 ms | 2.36 ms |
| helpers.sh (shim) | 2.78 ms | 2.51 ms | 3.02 ms |
| helpers-full.sh | 2.73 ms | 2.51 ms | 3.00 ms |
| helpers-core.sh | 2.47 ms | 2.31 ms | 2.77 ms |

The Step 4 report projected 30-40 ms per short-lived caller — my Mac measures ~0.3 ms. Two honest reads:

1. The scout that produced the projection likely measured on slower hardware (Intel Mac / Linux CI). Parse cost scales roughly with CPU speed for bash 3.2's synchronous parser, so an ~10x slower box would see a ~3 ms delta — order-of-magnitude closer to the projection but still an over-estimate.
2. The 25% *ratio* is the durable win. On any host, sourcing helpers-core.sh costs roughly 3/4 of sourcing helpers.sh. That compounds across the ~15 short-lived callers on the hot path.

The split still delivers a measurable improvement (25% source-cost reduction) with modest complexity cost (three files + shim + idempotency guards), and the shim keeps backwards compatibility bulletproof. Not aborting.

## Test plan

**New test:** `tests/test-bl046-helpers-split.sh` — five contract tests + boundary sub-tests:

- [x] **T1 core-only-callers-work** — sourcing `helpers-core.sh` alone exposes all 14 core functions; `print_ok` actually runs.
- [x] **T2 full-only-callers-still-work** — sourcing `helpers-full.sh` exposes both full+core (20 functions), `init_log` creates a real file, `print_ok` routes through `log_line` to the log.
- [x] **T3 missing-function-error** — sourcing `helpers-core.sh` and calling `init_log` returns rc=127 (command not found). Proves the boundary is real.
- [x] **T3b** — none of the 6 full-set functions leak into `helpers-core.sh`.
- [x] **T4 shim-backwards-compat** — sourcing the `helpers.sh` shim exposes all 20 functions.
- [x] **T5 idempotent-source** — sourcing `helpers-core.sh` twice does not re-run color setup; sentinel `_SOIF_HELPERS_CORE_LOADED` held.
- [x] **T5b** — same for `helpers-full.sh` and `helpers.sh` sentinels.

Result: **8/8 PASS**.

**Mutation proofs (RED-first evidence)** — each experiment removes/moves one thing and confirms the intended test fires RED, proving the tests are non-vacuous:

- Removed `init_log()` from `helpers-full.sh` → T2 FAIL, T4 FAIL (as expected: `MISSING FULL init_log`).
- Appended `init_log() { ... }` stub to `helpers-core.sh` → T3 FAIL (`init_log leaked into helpers-core.sh`), T3b FAIL (`LEAKED init_log`).
- Rewired the shim to source `helpers-core.sh` instead of `helpers-full.sh` → T4 FAIL (`MISSING init_log finalize_log is_context7_mcp_registered is_qdrant_mcp_registered is_qdrant_container_running register_qdrant_mcp`).

**Regression coverage** for callers touched by the migration:

- [x] `bash tests/test-check-gate.sh` — 5/5 PASS.
- [x] `bash tests/test-lint-raw-read-prompt.sh` — 13/13 PASS.
- [x] `bash tests/test-check-phase-gate.sh` — 8/8 PASS.
- [x] `bash tests/test-check-phase-gate-noninteractive.sh` — 3/3 PASS.
- [x] `bash tests/test-prompt-install-noninteractive.sh` — 3/3 PASS.
- [x] `bash tests/test-check-changelog-filter.sh` — 8/8 PASS.

**Self-verify lints (all exit 0):**

- [x] `bash scripts/lint-counter-antipattern.sh` — OK.
- [x] `bash scripts/lint-backlog-references.sh` — OK (BL-046 Closed with cited SHA).
- [x] `bash scripts/lint-fix-functions-stderr.sh` — OK.
- [x] `bash scripts/lint-raw-read-prompt.sh` — OK (HELPERS_PATHS[] exempts all three).

**Aggregator registration:** `tests/full-project-test-suite.sh` gained a `TEST 0r-bl046` block wiring `tests/test-bl046-helpers-split.sh` under the existing BL-034 discipline (no `|| true`; fails loudly).

## Coordination note

Files touched:

- `scripts/lib/helpers.sh` (shim rewrite; entire file body replaced with ~20 lines).
- `scripts/lib/helpers-core.sh` (new, 316 lines).
- `scripts/lib/helpers-full.sh` (new, 101 lines).
- `init.sh` (line ~1188: added 2 `cp` lines for the new helper files).
- `scripts/upgrade-project.sh` (added ~25-line backfill block just before the BL-009/BL-015 helper-refresh block near line ~2193).
- Twelve short-lived scripts (single-line source-target changes each): check-changelog, check-gate, check-maintenance, check-phase-gate, check-session-state, check-updates, check-versions, pending-approval, process-checklist, resume, test-gate, validate.
- `scripts/lint-raw-read-prompt.sh` (HELPERS_PATH → HELPERS_PATHS[] array + should_skip_file loop).
- `tests/full-project-test-suite.sh` (new TEST 0r-bl046 block, ~15 lines).

**Slot 2 (BL-050)** touches `scripts/verify-install.sh`, which sources `scripts/lib/helpers.sh` (unchanged by this PR — long-running caller, stays on the shim). No direct file overlap. Rebase risk is low.

**Slot 3 (BL-053)** unknown but likely test-suite parallelism — no expected overlap.

## Worktree note

`/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_960c732d-fa0-1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)