### PR TITLE
fix(tests): T5 + T5b in test-bl046-helpers-split now actually test the idempotency guard (closes BL-068)

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1758,3 +1758,28 @@ time bash scripts/lint-tests-registered.sh
 ```
 
 **Related:** PR #122 / BL-038 (introduced the lint — the invariant is correct, only the implementation shape is slow); `scripts/pre-commit-gate.sh` (the caller that pays the cost per commit); `tests/full-project-test-suite.sh` and the other aggregators the lint walks; BL-034 (test-aggregator wiring invariant — this lint is the enforcement arm of that invariant, so keeping it fast is what keeps the invariant credible).
+
+---
+
+## BL-068: T5 + T5b in `tests/test-bl046-helpers-split.sh` are vacuous — idempotency guards have zero regression coverage
+
+**Logged:** 2026-06-30 (PR #125 verifier finding)
+**Category:** Bug / test integrity
+**Severity:** Medium
+**Status:** Closed (2026-06-30, PR #<pending>, this-PR-closes-it)
+
+**What:** The final two subtests of `tests/test-bl046-helpers-split.sh` — T5 (`:205-231`) and T5b (`:233-252`, executed twice: once for `helpers-full.sh`, once for `helpers.sh`) — are tautological. Both claim to prove the `_SOIF_HELPERS_*_LOADED` idempotency guards in `scripts/lib/helpers-{core,full}.sh` + `scripts/lib/helpers.sh` fire on second source. Neither actually does. Mutation experiment: delete the `if [ -n "${_SOIF_HELPERS_CORE_LOADED:-}" ]; then return 0; fi` guard from `helpers-core.sh` and re-run the suite — **all 8 tests still PASS**. Same result for the guards in `helpers-full.sh` and `helpers.sh`. The three guards have zero regression coverage on main.
+
+**Why they're vacuous:**
+- **T5** clears `BOLD=""` between two sources of `helpers-core.sh`, then asserts `BOLD` is empty after the second source ("proof" the guard short-circuited before the color block). But `bash -c "..."` runs in a non-TTY subshell, so `helpers-core.sh`'s `[ -t 1 ]` check takes the ELSE branch and re-assigns `BOLD=''` unconditionally on every source. The assertion passes for the wrong reason. Removing the guard changes nothing.
+- **T5b** captures `first="${sentinel:-}"` after the first source and `still="${sentinel:-}"` after the second, then asserts `first == still`. Each sentinel is assigned to the literal `1` unconditionally at the top of every helper file, so `first=1, still=1` regardless of whether the guard fired. The assertion holds for any file that assigns `X=1` at all, guard-protected or not.
+
+**Impact:** The guards are the entire perf story of BL-046 (avoiding re-parse of the color block, dirname resolution, and function redefinition on nested composition). Without a regression guard, a future refactor that "cleans up" the `_SOIF_HELPERS_*_LOADED` sentinels lands silently, and every short-lived caller pays double parse cost per source. Given how many `check-*.sh` / `validate.sh` callers source helpers-core.sh, that's a real (if small-per-call) tax that compounds under repeated invocation.
+
+**Fix (this PR):** Rewrite T5 and T5b to plant an OBSERVABLE marker in a variable each file assigns AFTER its guard, then assert the marker survives the second source. Concretely:
+- **T5** plants `LOG_FILE="/tmp/bl068-t5-guard-marker-$$"` between sources. `helpers-core.sh` sets `LOG_FILE=""` at line 57 (after the guard at line 18). Guard fires → return before line 57 → marker preserved. Guard removed → marker wiped to empty. Mutation-verified: removing the core guard flips T5 RED.
+- **T5b** plants `MARKER="/tmp/bl068-t5b-guard-marker-$$"` in `$dirvar` (`_SOIF_HELPERS_FULL_DIR` for full, `_SOIF_HELPERS_SHIM_DIR` for shim). Each file recomputes the dirvar from `BASH_SOURCE` after its guard. Guard fires → dirvar untouched. Guard removed → dirvar replaced with real dirname. Mutation-verified: removing each of the two remaining guards independently flips its T5b assertion RED.
+
+**Mutation-proof captured in commit body** (three separate mutations, each restored before the next).
+
+**Related:** PR #125 verifier finding (BL-046 adversarial review); BL-036 (same class — vacuous-by-construction assertions in edge-cases suite); `Reports/2026-06-29-adversarial-certainty-pass.md` (the sweep that catches this defect class).

--- a/tests/test-bl046-helpers-split.sh
+++ b/tests/test-bl046-helpers-split.sh
@@ -195,13 +195,25 @@ fi
 # ── T5: idempotent source ───────────────────────────────────────
 # Sourcing the same file twice in one shell must be a no-op. Idempotency
 # guards use _SOIF_HELPERS_*_LOADED sentinels; if those regress, the
-# second source will still succeed (bash allows redefining functions),
-# but a lot of setup work (color-var reassignment, dirname resolution)
-# will re-run. Assert via $SECONDS delta that the second source is
-# strictly cheaper — but the primary check is "no error". A regression
-# that removes the idempotency guard would still pass "no error", but
-# would defeat the point of the guard. So also assert the sentinel var
-# stays set after the second source (proving the guard fired).
+# second source will still execute the body's assignments AFTER the
+# guard.
+#
+# BL-068 rewrite discipline (2026-06-30, closes BL-068):
+# The prior T5 shape (clear BOLD → assert BOLD stays empty) was
+# VACUOUS: bash -c runs in a non-TTY subshell, so helpers-core.sh's
+# `[ -t 1 ]` branch takes the ELSE and reassigns BOLD="" on every
+# source. The assertion passed for the WRONG reason — deleting the
+# guard entirely did not fail the test (verified by mutation).
+#
+# The rewrite plants an OBSERVABLE marker in a variable the file
+# assigns UNCONDITIONALLY after the guard. helpers-core.sh sets
+# `LOG_FILE=""` at line 57 (well after the line-18 guard). The
+# rewrite plants a sentinel path in LOG_FILE between the two
+# sources: if the guard fires, the second source returns BEFORE
+# the LOG_FILE reset and our sentinel survives. If the guard is
+# removed, the second source runs the LOG_FILE reset and wipes
+# our sentinel to empty. Mutation-verified: removing the guard on
+# helpers-core.sh causes this assertion to FAIL RED.
 t5_out=$(bash -c '
 source "'"$HELPERS_CORE"'"
 # First source set the sentinel.
@@ -210,13 +222,14 @@ if [ -z "$first_sentinel" ]; then
   echo "sentinel not set after first source"
   exit 1
 fi
-# Deliberately clear a color var so we can detect if the second source
-# ran the color-setup block. A working idempotency guard short-circuits
-# BEFORE the color block, leaving BOLD empty.
-BOLD=""
+# Plant a sentinel in LOG_FILE — a variable helpers-core.sh
+# assigns to "" UNCONDITIONALLY after its guard (line 57).
+# A working guard short-circuits BEFORE that reset, preserving
+# the sentinel. A missing guard wipes it.
+LOG_FILE="/tmp/bl068-t5-guard-marker-$$"
 source "'"$HELPERS_CORE"'"
-if [ -n "$BOLD" ]; then
-  echo "second source re-ran color setup (idempotency guard failed)"
+if [ "$LOG_FILE" != "/tmp/bl068-t5-guard-marker-$$" ]; then
+  echo "second source re-ran LOG_FILE reset (guard failed): LOG_FILE=$LOG_FILE"
   exit 1
 fi
 # print_ok must still be callable after two sources.
@@ -225,27 +238,50 @@ exit $?
 ' 2>&1)
 t5_rc=$?
 if [ $t5_rc -eq 0 ]; then
-  pass "T5 idempotent-source: helpers-core.sh sourced twice is a no-op (guard held)"
+  pass "T5 idempotent-source: helpers-core.sh guard holds (LOG_FILE marker preserved)"
 else
   fail_ "T5 idempotent-source" "rc=$t5_rc; output=$t5_out"
 fi
 
-# Repeat T5 for helpers-full.sh and the shim — each has its own guard.
-for lib_pair in "helpers-full.sh:$HELPERS_FULL:_SOIF_HELPERS_FULL_LOADED" \
-                "helpers.sh:$HELPERS_SHIM:_SOIF_HELPERS_SHIM_LOADED"; do
-  IFS=":" read -r libname libpath sentinel <<<"$lib_pair"
+# T5b: same discipline, for helpers-full.sh and helpers.sh (shim).
+#
+# BL-068 rewrite: the prior T5b compared `first="${sentinel:-}"` to
+# `still="${sentinel:-}"` after re-sourcing. But the sentinel is
+# assigned to the literal `1` unconditionally, so first==still even
+# with the guard REMOVED (both times it's just "1"). Verified vacuous
+# by mutation (all 8 tests passed with the core guard deleted).
+#
+# The rewrite plants a marker in a variable the file assigns AFTER
+# its guard:
+#   - helpers-full.sh:   _SOIF_HELPERS_FULL_DIR (line 28)
+#   - helpers.sh (shim): _SOIF_HELPERS_SHIM_DIR (line 36)
+# Both are recomputed from BASH_SOURCE on every un-guarded source.
+# A working guard leaves the planted marker untouched; a missing
+# guard replaces it with the real dirname. Mutation-verified: each
+# guard removal flips its T5b assertion RED.
+for lib_pair in "helpers-full.sh:$HELPERS_FULL:_SOIF_HELPERS_FULL_LOADED:_SOIF_HELPERS_FULL_DIR" \
+                "helpers.sh:$HELPERS_SHIM:_SOIF_HELPERS_SHIM_LOADED:_SOIF_HELPERS_SHIM_DIR"; do
+  IFS=":" read -r libname libpath sentinel dirvar <<<"$lib_pair"
   out=$(bash -c "
     source '$libpath'
     first=\"\${$sentinel:-}\"
     if [ -z \"\$first\" ]; then echo 'sentinel not set'; exit 1; fi
+    # Plant a marker in the dirvar — a variable the file assigns
+    # from BASH_SOURCE unconditionally AFTER its guard. A working
+    # guard leaves this marker untouched; a missing guard replaces
+    # it with the real dirname of the sourced file.
+    MARKER=\"/tmp/bl068-t5b-guard-marker-\$\$\"
+    $dirvar=\"\$MARKER\"
     source '$libpath'
-    still=\"\${$sentinel:-}\"
-    if [ \"\$first\" != \"\$still\" ]; then echo 'sentinel changed'; exit 1; fi
+    if [ \"\${$dirvar}\" != \"\$MARKER\" ]; then
+      echo \"guard did not fire: $dirvar changed from \$MARKER to \${$dirvar}\"
+      exit 1
+    fi
     exit 0
   " 2>&1)
   rc=$?
   if [ $rc -eq 0 ]; then
-    pass "T5b idempotent-source: $libname sentinel $sentinel held across two sources"
+    pass "T5b idempotent-source: $libname guard held ($dirvar marker preserved)"
   else
     fail_ "T5b idempotent-source ($libname)" "rc=$rc; $out"
   fi


### PR DESCRIPTION
## Summary

- PR #125's adversarial verifier found T5 (`:205-231`) and T5b (`:233-252`, executed twice for `helpers-full.sh` and the `helpers.sh` shim) in `tests/test-bl046-helpers-split.sh` were vacuous — mutation experiment (delete each `_SOIF_HELPERS_*_LOADED` guard in turn) left all 8 subtests GREEN. Three idempotency guards had zero regression coverage on `main`.
- **T5** cleared `BOLD=""` and asserted it stayed empty; `bash -c` runs non-TTY so helpers-core.sh's `[ -t 1 ]` ELSE branch reassigns `BOLD=""` on every source. The assertion held for the wrong reason.
- **T5b** compared `first="${sentinel:-}"` to `still="${sentinel:-}"`; the sentinel is assigned to literal `1` unconditionally, so `first==still` regardless of whether the guard fired.
- **Fix**: each rewrite plants an observable marker in a variable each file assigns AFTER its guard. T5 plants `LOG_FILE=/tmp/marker-$$` (wiped to empty by `LOG_FILE=""` at line 57 if the guard doesn't fire). T5b plants `MARKER` in `$dirvar` (`_SOIF_HELPERS_FULL_DIR` / `_SOIF_HELPERS_SHIM_DIR`, both recomputed from `BASH_SOURCE` if the guard doesn't fire).
- Backlog: BL-068 filed AS Closed (this-PR-closes-it — surfaced by PR #125's verifier, remediated here before regression could land). PR# placeholder will be replaced with the real number post-merge (consistent with recent Karl pattern — see git log for BL-053 / BL-046 closer edits).

## Closes

BL-068 (new, filed as part of this PR)

## Test plan

**Red → Green cycle**

Baseline (guards intact, before rewrite): 8 passed / 0 failed.

Rewrite (guards intact): 8 passed / 0 failed.

**Mutation proofs — three independent guard removals, each restored before the next**

1. Removed `helpers-core.sh` guard (lines 18-20):
   ```
   [FAIL] T5 idempotent-source — rc=1; output=second source re-ran LOG_FILE reset (guard failed): LOG_FILE=
   ```
   RED as required. T5b's helpers-full and shim continued to pass, confirming isolation.

2. Restored core guard, removed `helpers-full.sh` guard (lines 21-23):
   ```
   [FAIL] T5b idempotent-source (helpers-full.sh) — rc=1; guard did not fire: _SOIF_HELPERS_FULL_DIR changed from /tmp/bl068-t5b-guard-marker-<pid> to .../scripts/lib
   ```
   RED as required. T5 and T5b-shim continued to pass, confirming isolation.

3. Restored full guard, removed `helpers.sh` shim guard (lines 27-29):
   ```
   [FAIL] T5b idempotent-source (helpers.sh) — rc=1; guard did not fire: _SOIF_HELPERS_SHIM_DIR changed from /tmp/bl068-t5b-guard-marker-<pid> to .../scripts/lib
   ```
   RED as required. T5 and T5b-full continued to pass, confirming isolation.

All three guards restored. Final run: 8 passed / 0 failed. `git diff scripts/lib/` empty at commit time — no source-file changes shipped.

**Failure-path coverage**

Each rewrite plants a marker path via `-$$` (PID) so parallel test runs don't collide, and asserts equality (not just non-empty) against the exact marker. A regression that partially preserves the marker (e.g. keeps the prefix but truncates) still fails RED because the equality check is exact.

**Self-verify lints (all EXIT 0)**

- `bash scripts/lint-counter-antipattern.sh` — OK
- `bash scripts/lint-backlog-references.sh` — OK
- `bash scripts/lint-fix-functions-stderr.sh` — OK
- `bash scripts/lint-raw-read-prompt.sh` — OK
- Skipped: `lint-tests-registered.sh` — BL-067 tracks its runtime issue.

## Coordination note

Files touched:
- `tests/test-bl046-helpers-split.sh` (T5 + T5b rewrites, +57/-21 lines net)
- `solo-orchestrator-backlog.md` (BL-068 entry appended, +25 lines)

No source-file changes. No caller changes. No expected merge conflicts against sibling Wave-C PRs (BL-059 / BL-060 / BL-061 touch different files). If merged after PR #125's follow-up commit that fills in `PR #<pending>` → `PR #125` on BL-046, this PR's BL-068 entry will keep its own `PR #<pending>` placeholder to be filled in post-merge with the real number for THIS PR.

## Worktree note

pwd: `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_42182049-901-4`

Slot: `bl068-tests-bl046-helpers-split-vacuous`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)