### PR TITLE
fix(validate): read gate dates from phase-state.json::gates (BL-059)

### DIFF
--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -270,57 +270,76 @@ fi
 # ================================================================
 print_section "Approval Log"
 
+# BL-059: `.claude/phase-state.json::gates.<gate>` is the live source of
+# truth for gate-passage timestamps — the approval log is a
+# human-readable mirror. Prior versions only greped APPROVAL_LOG.md,
+# emitting a false-negative WARN when the JSON gate was populated but
+# the log had not been mirrored. Fix: read JSON first, fall back to
+# APPROVAL_LOG.md only if the JSON path is absent or malformed
+# (back-compat), and only warn when NEITHER source has a valid date.
+#
+# get_gate_date_from_phase_state <gate_key>
+# - Prints the YYYY-MM-DD gate date from phase-state.json::gates.<key>.
+# - Prints "" if phase-state.json is missing, the key is absent, the
+#   value is null, or the value is not a valid YYYY-MM-DD date.
+# - Uses the same grep+sed extraction shape as check-phase-gate.sh so
+#   the two validators agree on what counts as a recorded gate.
+get_gate_date_from_phase_state() {
+  local gate_key="$1"
+  local state_file=".claude/phase-state.json"
+  [ -f "$state_file" ] || { echo ""; return; }
+  local value
+  value=$(grep -o "\"$gate_key\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" "$state_file" 2>/dev/null \
+            | sed 's/.*: *"//' | sed 's/"//' || echo "")
+  if [ -n "$value" ] && ! echo "$value" | grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'; then
+    echo ""
+    return
+  fi
+  echo "$value"
+}
+
+# check_gate <phase-min> <json-key> <approval-log-header> <label>
+# Precedence: phase-state.json::gates.<json-key> WINS. Falls back to
+# APPROVAL_LOG.md scan for back-compat with older projects that
+# predated the JSON gates block. Warns iff neither source has a valid
+# date AND the project is at or past <phase-min>.
+check_gate() {
+  local phase_min="$1"
+  local json_key="$2"
+  local header="$3"
+  local label="$4"
+
+  [ "$phase" -ge "$phase_min" ] || return 0
+
+  local json_date
+  json_date=$(get_gate_date_from_phase_state "$json_key")
+  if [ -n "$json_date" ]; then
+    print_ok "$label gate: dated entry found ($json_date from phase-state.json)"
+    return 0
+  fi
+
+  if [ -f "APPROVAL_LOG.md" ] && grep -q "$header" APPROVAL_LOG.md; then
+    local log_date
+    log_date=$(grep -A 10 "$header" APPROVAL_LOG.md | grep -i "date" | head -1 || true)
+    if echo "$log_date" | grep -qE "[0-9]{4}-[0-9]{2}-[0-9]{2}"; then
+      print_ok "$label gate: dated entry found (APPROVAL_LOG.md)"
+      return 0
+    fi
+  fi
+
+  warn "$label gate: no date recorded — project appears to be past Phase $((phase_min - 1))"
+}
+
 if [ -f "APPROVAL_LOG.md" ]; then
-  # Check if phase gates have been filled in based on detected phase
-  if [ $phase -ge 1 ]; then
-    if grep -q "Phase 0 → Phase 1" APPROVAL_LOG.md; then
-      # Check if the gate has actual content (not just template)
-      gate_01_date=$(grep -A 10 "Phase 0 → Phase 1" APPROVAL_LOG.md | grep -i "date" | head -1 || true)
-      if echo "$gate_01_date" | grep -qE "[0-9]{4}-[0-9]{2}-[0-9]{2}"; then
-        print_ok "Phase 0→1 gate: dated entry found"
-      else
-        warn "Phase 0→1 gate: no date recorded — project appears to be past Phase 0"
-      fi
-    fi
-  fi
-
-  if [ $phase -ge 2 ]; then
-    if grep -q "Phase 1 → Phase 2" APPROVAL_LOG.md; then
-      gate_12_date=$(grep -A 10 "Phase 1 → Phase 2" APPROVAL_LOG.md | grep -i "date" | head -1 || true)
-      if echo "$gate_12_date" | grep -qE "[0-9]{4}-[0-9]{2}-[0-9]{2}"; then
-        print_ok "Phase 1→2 gate: dated entry found"
-      else
-        warn "Phase 1→2 gate: no date recorded — project appears to be past Phase 1"
-      fi
-    fi
-  fi
-
+  check_gate 1 "phase_0_to_1" "Phase 0 → Phase 1" "Phase 0→1"
+  check_gate 2 "phase_1_to_2" "Phase 1 → Phase 2" "Phase 1→2"
   # code-test-gate-track-resume-validate-1: the Approval Log section had
   # Phase 0→1, 1→2, and 3→4 gate checks but was silently missing the
   # symmetric 2→3 check. A project past Phase 3 without a dated
   # `Phase 2 → Phase 3` entry slipped past validation. Mirrors the 1→2
   # block structure for consistency.
-  if [ $phase -ge 3 ]; then
-    if grep -q "Phase 2 → Phase 3" APPROVAL_LOG.md; then
-      gate_23_date=$(grep -A 10 "Phase 2 → Phase 3" APPROVAL_LOG.md | grep -i "date" | head -1 || true)
-      if echo "$gate_23_date" | grep -qE "[0-9]{4}-[0-9]{2}-[0-9]{2}"; then
-        print_ok "Phase 2→3 gate: dated entry found"
-      else
-        warn "Phase 2→3 gate: no date recorded — project appears to be past Phase 2"
-      fi
-    fi
-  fi
-
-  if [ $phase -ge 4 ]; then
-    if grep -q "Phase 3 → Phase 4" APPROVAL_LOG.md; then
-      gate_34_date=$(grep -A 10 "Phase 3 → Phase 4" APPROVAL_LOG.md | grep -i "date" | head -1 || true)
-      if echo "$gate_34_date" | grep -qE "[0-9]{4}-[0-9]{2}-[0-9]{2}"; then
-        print_ok "Phase 3→4 gate: dated entry found"
-      else
-        warn "Phase 3→4 gate: no date recorded — project appears to be past Phase 3"
-      fi
-    fi
-  fi
+  check_gate 3 "phase_2_to_3" "Phase 2 → Phase 3" "Phase 2→3"
+  check_gate 4 "phase_3_to_4" "Phase 3 → Phase 4" "Phase 3→4"
 else
   fail "APPROVAL_LOG.md missing"
 fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -1397,7 +1397,7 @@ grep -c '^| [0-9] |' foo/APPROVAL_LOG.md   # → 6
 **Logged:** 2026-06-29
 **Category:** Bug
 **Severity:** Medium
-**Status:** Open
+**Status:** Open (fix in flight on branch `fix/bl059-validate-sh-phase-state-gates`; will be flipped to the terminal status with PR# + commit SHA in a follow-up docs commit after merge per defer-to-second-commit pattern)
 
 The adversarial certainty re-walk (re-walker-4, scenario `migration-track-standard-to-full`) surfaced that `scripts/validate.sh:281` emits `Phase 0->1 gate: no date recorded` even when `phase-state.json::gates.phase_0_to_1` is populated. Root cause: the checker greps `APPROVAL_LOG.md` only, while the live state file (`phase-state.json::gates`) is the actual source of truth for gate-passage timestamps. Cross-source inconsistency between the live state file and the validator.
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -591,6 +591,21 @@ else
 fi
 
 # ----------------------------------------------------------------
+# TEST 0p2: VALIDATE READS PHASE-STATE.JSON::GATES (BL-059)
+# ----------------------------------------------------------------
+# BL-059: scripts/validate.sh's Approval Log section previously
+# greped APPROVAL_LOG.md only, emitting a false-negative "no date
+# recorded" WARN when phase-state.json::gates.<gate> was populated
+# but the log had not been mirrored. Fix reads JSON first, falls
+# back to APPROVAL_LOG.md for back-compat.
+section "validate.sh reads phase-state.json::gates (BL-059)"
+if bash "$SCRIPT_DIR/tests/test-validate-phase-state-gates.sh" >/dev/null 2>&1; then
+  pass "tests/test-validate-phase-state-gates.sh"
+else
+  fail "tests/test-validate-phase-state-gates.sh FAILED (run for details)"
+fi
+
+# ----------------------------------------------------------------
 # TEST 0q: SPECS+PLANS HOST-AWARE QUARTET
 # ----------------------------------------------------------------
 # PR #97: docs/superpowers/specs+plans host-aware quartet rendering

--- a/tests/test-validate-phase-state-gates.sh
+++ b/tests/test-validate-phase-state-gates.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# tests/test-validate-phase-state-gates.sh — BL-059.
+#
+# validate.sh's Approval Log gate-date checks previously greped
+# APPROVAL_LOG.md only. The live source of truth for gate-passage
+# timestamps is .claude/phase-state.json::gates.<gate>. Operators saw
+# false negatives ("no date recorded") on projects whose gate was in
+# phase-state.json but not (yet) mirrored to APPROVAL_LOG.md.
+#
+# Fix: validate.sh reads phase-state.json::gates.<gate> FIRST. If the
+# JSON path is absent or malformed, it falls back to APPROVAL_LOG.md
+# (back-compat). If neither has a valid date, it warns "no date
+# recorded".
+#
+# T1 (happy path):     JSON has valid date, APPROVAL_LOG lacks header
+#                      → NO "no date recorded" warning; OK line present.
+# T2 (fallback):       JSON gates absent, APPROVAL_LOG has valid date
+#                      → OK line (back-compat).
+# T3 (both sources):   JSON has valid date + APPROVAL_LOG has valid
+#                      date → JSON wins (no warn; OK line present).
+# T4 (neither):        JSON gates empty + APPROVAL_LOG lacks header
+#                      → "no date recorded" warning emitted.
+# T5 (mutation guard): The JSON-first read helper must be present in
+#                      validate.sh so that reverting the JSON path
+#                      would flip T1 red.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+VALIDATE="$REPO_ROOT/scripts/validate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build a minimal Phase-1+ project that validate.sh will accept.
+setup_project() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude" "$PROJ/docs/reference"
+  (
+    cd "$PROJ"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    cat > CLAUDE.md <<'MD'
+- **Project:** test
+- **Platform:** cli
+- **Track:** light
+- **Primary Language:** typescript
+MD
+    cat > PROJECT_INTAKE.md <<'MD'
+intake
+MD
+    cat > "docs/reference/builders-guide.md" <<'MD'
+guide
+MD
+    cat > "docs/reference/user-guide.md" <<'MD'
+user
+MD
+    cat > "docs/reference/governance-framework.md" <<'MD'
+gov
+MD
+    cat > "docs/reference/cli-setup-addendum.md" <<'MD'
+cli
+MD
+    touch .gitignore
+    mkdir -p .github/workflows
+    cat > .github/workflows/ci.yml <<'YML'
+name: ci
+on: push
+YML
+  )
+}
+teardown_project() { rm -rf "$TMP"; }
+
+# --------------------------------------------------------------------
+# T1: JSON gate populated, APPROVAL_LOG.md has NO Phase 0 → Phase 1
+# header at all. The pre-fix behavior emitted the false-negative WARN
+# from the header-scan path. Post-fix: JSON is consulted first and the
+# gate is recognized without needing APPROVAL_LOG mirroring.
+# --------------------------------------------------------------------
+echo "T1: JSON gate set, APPROVAL_LOG lacks header → OK, no false-negative WARN"
+setup_project
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1,"gates":{"phase_0_to_1":"2026-01-15","phase_1_to_2":null,"phase_2_to_3":null,"phase_3_to_4":null}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+(no gate entries yet)
+MD
+out=$(cd "$PROJ" && bash "$VALIDATE" 2>&1) || true
+if echo "$out" | grep -qE "Phase 0.*1 gate.*no date"; then
+  fail_ "T1" "false-negative WARN emitted despite JSON gate populated; out:
+$out"
+elif echo "$out" | grep -qE "Phase 0.*1 gate: dated"; then
+  pass "T1: JSON gate recognized; OK line present, no false-negative WARN"
+else
+  fail_ "T1" "no OK line for Phase 0→1 gate when JSON had a valid date; out:
+$out"
+fi
+teardown_project
+
+# --------------------------------------------------------------------
+# T2: JSON has no gates block (back-compat with older projects).
+# APPROVAL_LOG.md has a valid dated Phase 0 → Phase 1 entry. Post-fix
+# must fall through to the APPROVAL_LOG scan and emit OK.
+# --------------------------------------------------------------------
+echo "T2: JSON gates absent, APPROVAL_LOG dated → fallback OK"
+setup_project
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+## Phase 0 → Phase 1
+- Date: 2026-01-15
+- Approver: alice
+MD
+out=$(cd "$PROJ" && bash "$VALIDATE" 2>&1) || true
+if echo "$out" | grep -qE "Phase 0.*1 gate.*no date"; then
+  fail_ "T2" "APPROVAL_LOG fallback path failed; out:
+$out"
+elif echo "$out" | grep -qE "Phase 0.*1 gate: dated"; then
+  pass "T2: APPROVAL_LOG fallback recognized dated entry (back-compat)"
+else
+  fail_ "T2" "no OK line for Phase 0→1 gate under fallback path; out:
+$out"
+fi
+teardown_project
+
+# --------------------------------------------------------------------
+# T3: Both sources populated with DIFFERENT valid dates. JSON must
+# win — the OK line must reference JSON's date, not APPROVAL_LOG's.
+# --------------------------------------------------------------------
+echo "T3: JSON + APPROVAL_LOG both populated → JSON date wins"
+setup_project
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1,"gates":{"phase_0_to_1":"2026-01-15","phase_1_to_2":null,"phase_2_to_3":null,"phase_3_to_4":null}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+## Phase 0 → Phase 1
+- Date: 2026-05-05
+- Approver: bob
+MD
+out=$(cd "$PROJ" && bash "$VALIDATE" 2>&1) || true
+# Strict: the OK message must observably quote the JSON date so a
+# future refactor that inverts precedence (APPROVAL_LOG-first) trips
+# the test. Emitting JSON's date in the OK message is the observable
+# precedence signal.
+if echo "$out" | grep -qE "Phase 0.*1 gate.*no date"; then
+  fail_ "T3" "false-negative WARN when both sources populated; out:
+$out"
+elif echo "$out" | grep -qE "Phase 0.*1 gate: dated.*2026-05-05"; then
+  fail_ "T3" "APPROVAL_LOG date shown instead of JSON date (precedence inverted); out:
+$out"
+elif echo "$out" | grep -qE "Phase 0.*1 gate: dated.*2026-01-15"; then
+  pass "T3: JSON date wins (2026-01-15 preferred over APPROVAL_LOG 2026-05-05)"
+else
+  fail_ "T3" "OK line does not quote the JSON date — precedence is silent, so a future refactor that flips priority would go undetected; out:
+$out"
+fi
+teardown_project
+
+# --------------------------------------------------------------------
+# T4: Neither source has a valid date. WARN must fire (the operator
+# needs to know the gate is unrecorded).
+# --------------------------------------------------------------------
+echo "T4: no JSON gate, no APPROVAL_LOG entry → WARN 'no date recorded'"
+setup_project
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1,"gates":{"phase_0_to_1":null,"phase_1_to_2":null,"phase_2_to_3":null,"phase_3_to_4":null}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+(no gate entries yet)
+MD
+out=$(cd "$PROJ" && bash "$VALIDATE" 2>&1) || true
+if echo "$out" | grep -qE "Phase 0.*1 gate.*no date"; then
+  pass "T4: WARN fired for genuinely unrecorded gate"
+else
+  fail_ "T4" "expected 'no date recorded' WARN when neither source has a date; out:
+$out"
+fi
+teardown_project
+
+# --------------------------------------------------------------------
+# T5 (mutation guard): the JSON-first helper must exist in validate.sh
+# so that reverting it (deleting the JSON read call) would flip T1
+# red. A grep-anchor is faster than a full mutation replay; if the
+# canonical helper name changes, update this anchor.
+# --------------------------------------------------------------------
+echo "T5: mutation guard — JSON gate-date read is present in validate.sh"
+if grep -qE 'get_gate_date_from_(phase_)?state|phase-state\.json.*gates|gates\.phase_0_to_1' "$VALIDATE"; then
+  pass "T5: JSON gate-date read anchor present in validate.sh"
+else
+  fail_ "T5" "no JSON gate-date read anchor found in validate.sh — a revert would leave T1 as the only guard, which relies on absence of a WARN line (weaker than a positive anchor)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-validate-phase-state-gates.sh
+++ b/tests/test-validate-phase-state-gates.sh
@@ -23,6 +23,14 @@
 # T5 (mutation guard): The JSON-first read helper must be present in
 #                      validate.sh so that reverting the JSON path
 #                      would flip T1 red.
+# T6 (wired-ness):     phase_2_to_3 branch executes (fixture current_phase=3,
+#                      JSON gate populated) and quotes the JSON date +
+#                      "from phase-state.json" source annotation. Proves the
+#                      check_gate call for phase_2_to_3 is not dead code.
+# T7 (regex guard):    a malformed JSON date is REJECTED — validate.sh must
+#                      fall back to APPROVAL_LOG.md rather than blindly
+#                      trusting a value like "March 1, 2026". Mutation-proof
+#                      against a weakened date regex.
 
 set -uo pipefail
 
@@ -190,15 +198,100 @@ teardown_project
 # --------------------------------------------------------------------
 # T5 (mutation guard): the JSON-first helper must exist in validate.sh
 # so that reverting it (deleting the JSON read call) would flip T1
-# red. A grep-anchor is faster than a full mutation replay; if the
-# canonical helper name changes, update this anchor.
+# red. Anchored on the function DEFINITION at beginning-of-line, not
+# on any mention of the name — a prior looser regex matched comment
+# lines describing the helper, so deleting the body while leaving the
+# comments alone would still pass. If the canonical helper name
+# changes, update this anchor.
 # --------------------------------------------------------------------
-echo "T5: mutation guard — JSON gate-date read is present in validate.sh"
-if grep -qE 'get_gate_date_from_(phase_)?state|phase-state\.json.*gates|gates\.phase_0_to_1' "$VALIDATE"; then
-  pass "T5: JSON gate-date read anchor present in validate.sh"
+echo "T5: mutation guard — JSON gate-date read function is defined in validate.sh"
+if grep -qE '^get_gate_date_from_phase_state\(\)' "$VALIDATE"; then
+  pass "T5: get_gate_date_from_phase_state() function definition present in validate.sh"
 else
-  fail_ "T5" "no JSON gate-date read anchor found in validate.sh — a revert would leave T1 as the only guard, which relies on absence of a WARN line (weaker than a positive anchor)"
+  fail_ "T5" "no get_gate_date_from_phase_state() function definition found in validate.sh — a revert (deleting the helper) would leave T1 as the only guard, which relies on absence of a WARN line (weaker than a positive anchor)"
 fi
+
+# --------------------------------------------------------------------
+# T6 (wired-ness for phase_2_to_3): T1-T5 all use current_phase=1, so
+# check_gate's early-return guard `[ "$phase" -ge "$phase_min" ] || return 0`
+# means the phase_1_to_2 / phase_2_to_3 / phase_3_to_4 branches are
+# never exercised. Renaming the phase_2_to_3 key in the check_gate call
+# would still leave T1-T5 green. T6 builds a fixture with
+# current_phase=3 and populates gates.phase_2_to_3 so the branch
+# actually runs; the assertion targets the OK line for the 2→3 gate
+# quoting the JSON date + "from phase-state.json" source annotation.
+# --------------------------------------------------------------------
+echo "T6: current_phase=3 + JSON gate populated → OK line for Phase 2→3 with JSON date + source annotation"
+setup_project
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":3,"gates":{"phase_0_to_1":"2026-01-15","phase_1_to_2":"2026-02-01","phase_2_to_3":"2026-03-01","phase_3_to_4":null}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+(gates recorded in phase-state.json)
+MD
+out=$(cd "$PROJ" && bash "$VALIDATE" 2>&1) || true
+# The assertion has to fire specifically on the 2→3 line — with
+# current_phase=3, all three of 0→1, 1→2, and 2→3 will emit OK
+# lines. We anchor on the label AND the JSON date AND the source
+# annotation so a mutation renaming the phase_2_to_3 key would drop
+# just this line to a WARN and be caught.
+if echo "$out" | grep -qE "Phase 2.*3 gate: dated entry found \(2026-03-01 from phase-state\.json\)"; then
+  pass "T6: phase_2_to_3 check_gate call is wired (OK line quotes JSON date + source)"
+elif echo "$out" | grep -qE "Phase 2.*3 gate.*no date"; then
+  fail_ "T6" "phase_2_to_3 gate WARN'd even though JSON gate was populated — check_gate call likely mis-wired or key mismatched; out:
+$out"
+else
+  fail_ "T6" "no OK line for Phase 2→3 gate with expected JSON date + source annotation; out:
+$out"
+fi
+teardown_project
+
+# --------------------------------------------------------------------
+# T7 (regex guard for malformed JSON dates): validate.sh's
+# get_gate_date_from_phase_state helper regex-validates the value
+# before returning it, so a garbage value like "March 1, 2026" in
+# gates.phase_0_to_1 should be rejected and the fallback (APPROVAL_LOG)
+# should carry the gate. If the regex were weakened (e.g. to `.`), the
+# malformed string would leak through and be printed as the gate date.
+#
+# Shape T7a (chosen): APPROVAL_LOG.md has a valid dated entry, so the
+# fallback path fires and the OK line contains the "APPROVAL_LOG.md"
+# source annotation. Under a mutation that weakens the regex, the
+# helper would instead return "March 1, 2026" and the OK line would
+# say "(March 1, 2026 from phase-state.json)" — no APPROVAL_LOG.md
+# substring — so the assertion below would flip red.
+# --------------------------------------------------------------------
+echo "T7: malformed JSON date rejected → falls back to APPROVAL_LOG (annotation quoted)"
+setup_project
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1,"gates":{"phase_0_to_1":"March 1, 2026","phase_1_to_2":null,"phase_2_to_3":null,"phase_3_to_4":null}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+## Phase 0 → Phase 1
+- Date: 2026-01-15
+- Approver: alice
+MD
+out=$(cd "$PROJ" && bash "$VALIDATE" 2>&1) || true
+# The OK message under fallback is "$label gate: dated entry found
+# (APPROVAL_LOG.md)". If the regex mutation lets the malformed value
+# through, the OK line becomes "(March 1, 2026 from phase-state.json)"
+# — which contains neither "APPROVAL_LOG.md" nor a well-formed date.
+# We assert on the fallback annotation directly.
+if echo "$out" | grep -qE "Phase 0.*1 gate: dated entry found \(APPROVAL_LOG\.md\)"; then
+  pass "T7: malformed JSON date skipped; APPROVAL_LOG fallback used (source annotation present)"
+elif echo "$out" | grep -qE "Phase 0.*1 gate: dated entry found \(March 1, 2026"; then
+  fail_ "T7" "malformed JSON date 'March 1, 2026' was accepted as a valid gate date — regex guard is not effective; out:
+$out"
+elif echo "$out" | grep -qE "Phase 0.*1 gate.*no date"; then
+  fail_ "T7" "expected APPROVAL_LOG fallback to carry the gate after malformed JSON was rejected, but WARN fired; out:
+$out"
+else
+  fail_ "T7" "no OK line with (APPROVAL_LOG.md) source annotation for Phase 0→1 gate under malformed-JSON scenario; out:
+$out"
+fi
+teardown_project
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"


### PR DESCRIPTION
## Summary

- **Bug (BL-059):** `scripts/validate.sh`'s Approval Log section greped `APPROVAL_LOG.md` only, emitting a false-negative "no date recorded" WARN even when `phase-state.json::gates.<gate>` was populated. The live source of truth is `phase-state.json::gates`; the log is a human-readable mirror.
- **Fix:** New `get_gate_date_from_phase_state()` helper reads JSON first (mirrors the grep+sed extraction shape used in `scripts/check-phase-gate.sh` for consistency). New `check_gate()` helper collapses the four inline gate blocks, gives them uniform JSON-first / APPROVAL_LOG-fallback behavior, and only WARNs when neither source has a valid `YYYY-MM-DD` date.
- **Observability:** When JSON wins, the OK line quotes the date **and** its source ("… from phase-state.json") so precedence is visible to reviewers — a future refactor that flips priority is immediately noticeable in the output.
- **Back-compat:** Projects with no `gates` block in `phase-state.json` (older projects) still succeed via the APPROVAL_LOG.md fallback.
- **BL-034 invariant:** New test wired into `tests/full-project-test-suite.sh`.

## Closes

- BL-059

## Test plan

**Red → green (all 5 T-cases in `tests/test-validate-phase-state-gates.sh`):**
- **T1 (happy):** JSON gate populated + APPROVAL_LOG lacks header → OK line, no false-negative WARN. RED pre-fix, GREEN post-fix.
- **T2 (fallback):** JSON gates absent + APPROVAL_LOG dated → OK line via back-compat scan. GREEN both pre and post (regression guard for back-compat).
- **T3 (both sources):** JSON `2026-01-15` + APPROVAL_LOG `2026-05-05` → OK line quotes `2026-01-15` (JSON wins). RED pre-fix (no date quoted), GREEN post-fix.
- **T4 (neither):** JSON gates null + APPROVAL_LOG lacks header → WARN "no date recorded". RED pre-fix (current code emitted nothing at all when header was missing), GREEN post-fix.
- **T5 (mutation guard):** `validate.sh` must contain a JSON gate-date read anchor; grep-asserted so a `git revert` of the JSON helper leaves T1 as the only defense (weaker than a positive anchor).

**Mutation proof (verified locally before commit):**
- Neutralized the JSON read in `check_gate` (`local json_date=""` in place of the helper call). T1 and T3 flipped RED. Restored → all 5 GREEN.

**Failure-path coverage:**
- T4 exercises the WARN path (previously silent when the APPROVAL_LOG header was missing entirely — this fix tightens the check so at-or-past-phase projects can no longer slip through silently).
- Malformed-date paths are already covered by `tests/test-validate-phase-2-3-gate.sh::T3` (mirrored logic; no re-test needed).

**Adjacent-test regressions (all GREEN post-fix):**
- `tests/test-validate-phase-2-3-gate.sh` — 4/4 pass (existing 2→3 behavior preserved).
- `tests/test-validate-counter-sanitizer.sh` — 5/5 pass.
- `tests/known-bugs-test-suite.sh` — 23/23 pass (BUG-4 and BUG-7 both exercise `validate.sh`).
- `tests/edge-cases-scripts.sh` — E11 (validate.sh outside project), E25a-c (phase 99 handling), E26-E28 (init.sh UAT copies) all pass.

**Linters:**
- `bash scripts/lint-counter-antipattern.sh` → OK
- `bash scripts/lint-backlog-references.sh` → OK
- `bash scripts/lint-fix-functions-stderr.sh` → OK
- `bash scripts/lint-raw-read-prompt.sh` → OK

## Coordination note

**Files touched:**
- `scripts/validate.sh` — new `get_gate_date_from_phase_state()` + `check_gate()` helpers; the four inline gate blocks collapse into 4 calls.
- `tests/test-validate-phase-state-gates.sh` — new file (205 lines, 5 T-cases).
- `tests/full-project-test-suite.sh` — new aggregator entry `TEST 0p2` right after `TEST 0p` (`test-validate-phase-2-3-gate.sh`).
- `solo-orchestrator-backlog.md` — BL-059 status annotated with "fix in flight" pointer per defer-to-second-commit pattern.

**Expected rebase / conflicts:** low. `scripts/validate.sh` conflicts only if another PR is also editing the Approval Log section (unlikely — the only other recent touch was PR #101 for the 2→3 gate, which is preserved verbatim here). Sibling backlog PRs (BL-060, BL-061, BL-068 per S3 Wave C) touch different scripts.

**Post-merge:** a follow-up docs commit will flip `BL-059` status from "Open" to "Closed" with the PR# + commit SHA cited (defer-to-second-commit pattern — same shape as `0d209b7` for BL-034).

## Worktree note

Fix implemented in isolated worktree:
`/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_42182049-901-1` (slot `bl059-validate-sh-source-of-truth`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)