### PR TITLE
fix(check-phase-gate): parse --gate argv flag; scope check to named gate (BL-060)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -17,6 +17,107 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # BL-046: uses run_with_timeout + prompt_yes_no only — source core subset.
 source "$SCRIPT_DIR/lib/helpers-core.sh"
 
+# ── Argv parser (BL-060) ─────────────────────────────────────────
+# Adversarial cert re-walker-4 surfaced that scenarios invoke this
+# script with `--gate phase_1_to_2` expecting the flag to scope the
+# check to the named gate, but pre-fix the script had no argv parser
+# at all — every arg was silently ignored, and the gate fired only
+# because `current_phase=2` in phase-state.json coincidentally
+# triggered the backstop. A future refactor of the backstop trigger
+# would silently break `--gate` consumers.
+#
+# Contract:
+#   --gate <name>   Force the named gate's checks to run regardless
+#                   of current_phase, AND cap checks at that gate so
+#                   HIGHER-phase gate blocks do not fire (strict scope).
+#                   Valid names: phase_0_to_1, phase_1_to_2,
+#                   phase_2_to_3, phase_3_to_4. Also accepts --gate=<v>.
+#   --help, -h      Print usage and exit 0.
+#
+# Semantics for --gate:
+#   Each gate crossing implies all prior gates have been crossed. So
+#   `--gate phase_1_to_2` verifies Phase 0→1 evidence AND Phase 1→2
+#   evidence, but skips Phase 2→3 and Phase 3→4 checks. Implementation:
+#   override `current_phase` to the gate's TARGET phase.
+#
+# Exit codes:
+#   2 — invalid argv (unknown gate, unknown flag, --gate given twice,
+#       missing value). Diagnostics go to stderr.
+show_check_phase_gate_help() {
+  cat <<'HELP'
+Usage: check-phase-gate.sh [--gate <name>] [--help]
+
+Reads .claude/phase-state.json and verifies APPROVAL_LOG.md has dated
+entries for all completed phase gates.
+
+Options:
+  --gate <name>   Scope the check to the named gate. Forces the gate's
+                  checks to run regardless of current_phase in
+                  phase-state.json; caps at that gate (skips higher
+                  gates). Valid names:
+                    phase_0_to_1, phase_1_to_2,
+                    phase_2_to_3, phase_3_to_4
+                  Also accepts --gate=<name>.
+  --help, -h      Show this message.
+
+Exit codes:
+  0 — all gates consistent (or phase-state.json not found w/o --gate)
+  1 — inconsistency detected (SOIF_PHASE_GATES=warn downgrades to 0),
+      OR --gate was specified but no phase-state.json fixture exists
+  2 — invalid argv (unknown gate, unknown flag, --gate given twice,
+      missing value)
+HELP
+}
+
+GATE_SCOPE=""
+
+_cpg_parse_gate_value() {
+  local val="$1"
+  if [ -n "$GATE_SCOPE" ]; then
+    echo -e "${RED}[FAIL]${NC} --gate specified more than once (already set to '$GATE_SCOPE', received '$val')" >&2
+    exit 2
+  fi
+  if [ -z "$val" ]; then
+    echo -e "${RED}[FAIL]${NC} --gate requires a value (one of: phase_0_to_1, phase_1_to_2, phase_2_to_3, phase_3_to_4)" >&2
+    exit 2
+  fi
+  case "$val" in
+    phase_0_to_1|phase_1_to_2|phase_2_to_3|phase_3_to_4)
+      GATE_SCOPE="$val"
+      ;;
+    *)
+      echo -e "${RED}[FAIL]${NC} Unknown gate: '$val'. Valid gates: phase_0_to_1, phase_1_to_2, phase_2_to_3, phase_3_to_4" >&2
+      exit 2
+      ;;
+  esac
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --gate)
+      if [ $# -lt 2 ]; then
+        echo -e "${RED}[FAIL]${NC} --gate requires a value (one of: phase_0_to_1, phase_1_to_2, phase_2_to_3, phase_3_to_4)" >&2
+        exit 2
+      fi
+      _cpg_parse_gate_value "$2"
+      shift 2
+      ;;
+    --gate=*)
+      _cpg_parse_gate_value "${1#--gate=}"
+      shift
+      ;;
+    --help|-h)
+      show_check_phase_gate_help
+      exit 0
+      ;;
+    *)
+      echo -e "${RED}[FAIL]${NC} Unknown argument: '$1'" >&2
+      echo "Run 'bash scripts/check-phase-gate.sh --help' for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
 # ── Non-interactive prompt guard ─────────────────────────────────
 # code-check-gates-7 (audit v2, S3): the script's header (lines 8-9)
 # advertises CI execution, and baseline §5 invariant #6 ("Phase gate
@@ -117,7 +218,16 @@ APPROVAL_LOG="APPROVAL_LOG.md"
 
 # If no phase state file, this is either a pre-framework project or
 # the file was never created. Exit cleanly — don't block CI.
+#
+# BL-060 edge case: if --gate was explicitly specified but the fixture
+# is missing, the operator asked for a scoped check we cannot perform.
+# Emit a clear error and exit 1 (not 0) — silently succeeding would
+# mask the missing fixture and defeat the point of the scope flag.
 if [ ! -f "$PHASE_STATE" ]; then
+  if [ -n "$GATE_SCOPE" ]; then
+    echo -e "${RED}[FAIL]${NC} --gate $GATE_SCOPE specified but $PHASE_STATE not found — cannot verify gate without a phase-state.json fixture." >&2
+    exit 1
+  fi
   echo "No $PHASE_STATE found — skipping phase gate check."
   exit 0
 fi
@@ -131,6 +241,20 @@ fi
 # This handles the simple flat structure of phase-state.json
 current_phase=$(grep -o '"current_phase"[[:space:]]*:[[:space:]]*"*[0-9][0-9]*"*' "$PHASE_STATE" | grep -o '[0-9][0-9]*' || echo "0")
 case "$current_phase" in ''|*[!0-9]*) current_phase=0 ;; esac
+
+# BL-060: --gate override. Force current_phase to the gate's TARGET
+# phase so the gate's checks fire (elevate), and cap subsequent
+# threshold comparisons at that phase so HIGHER-gate checks skip
+# (strict scope). Each gate crossing implies prior gates were also
+# crossed, so this preserves prior-gate coverage under scoping.
+if [ -n "$GATE_SCOPE" ]; then
+  case "$GATE_SCOPE" in
+    phase_0_to_1) current_phase=1 ;;
+    phase_1_to_2) current_phase=2 ;;
+    phase_2_to_3) current_phase=3 ;;
+    phase_3_to_4) current_phase=4 ;;
+  esac
+fi
 
 get_gate_date() {
   local gate_key="$1"

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -410,6 +410,25 @@ else
   fail "tests/test-check-phase-gate-blame-walker.sh FAILED (run for details)"
 fi
 
+# BL-060 (adversarial cert re-walker-4): scripts/check-phase-gate.sh
+# must parse `--gate <name>` and scope the check to the named gate.
+# Pre-fix the script had NO argv parsing — scenarios invoking
+# `--gate phase_1_to_2` succeeded coincidentally via `current_phase=2`
+# in phase-state.json triggering the backstop, not because the flag
+# was honored. This suite pins the argv contract:
+#   - --gate <name> forces the gate's checks to fire regardless of
+#     current_phase, and caps at that gate (higher gates skip).
+#   - Unknown gate / unknown flag / --gate given twice → exit 2 with
+#     a clear stderr diagnostic.
+#   - --gate with no phase-state.json fixture → exit 1 + error (never
+#     silently exits 0 the way the pre-fix no-argv path did).
+#   - --help / -h → exit 0 + usage text mentioning `--gate`.
+if bash "$SCRIPT_DIR/tests/test-check-phase-gate-argv-parser.sh" >/dev/null 2>&1; then
+  pass "tests/test-check-phase-gate-argv-parser.sh"
+else
+  fail "tests/test-check-phase-gate-argv-parser.sh FAILED (run for details)"
+fi
+
 # ----------------------------------------------------------------
 # TEST 0i: PENDING-APPROVAL RESOLVE-DECISION
 # ----------------------------------------------------------------

--- a/tests/test-check-phase-gate-argv-parser.sh
+++ b/tests/test-check-phase-gate-argv-parser.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# tests/test-check-phase-gate-argv-parser.sh
+#
+# BL-060 regression: scripts/check-phase-gate.sh must parse `--gate <name>`
+# and scope the check to the named gate.
+#
+# Pre-fix state: the script had NO argv parsing whatsoever. Scenarios
+# invoking `--gate phase_1_to_2` succeeded coincidentally because
+# `current_phase=2` in phase-state.json triggered the backstop — the
+# flag had no effect. A future refactor of the backstop's trigger
+# condition would silently break `--gate` consumers.
+#
+# Post-fix contract:
+#   1. --gate <name> forces the named gate's checks to run regardless
+#      of current_phase (so a fixture with current_phase=1 still fires
+#      the Phase 1→2 checks under --gate phase_1_to_2).
+#   2. --gate <name> caps checking at the named gate — HIGHER-phase
+#      gate blocks do not run (avoids noise from irrelevant gates).
+#   3. Unknown gate → exit 2 + clear diagnostic to stderr.
+#   4. --gate specified twice → exit 2 + clear diagnostic.
+#   5. Unknown flag → exit 2 + clear diagnostic.
+#   6. --gate <name> with no phase-state.json fixture → exit 1 + clear
+#      diagnostic (does NOT crash under `set -euo pipefail`).
+#   7. --help / -h → exit 0 + usage text mentioning `--gate`.
+#
+# Mutation guard (T-mutation): if the argv parser is removed, T-scoped
+# FAILS RED — the Phase 1→2 backstop line does not appear on
+# --gate phase_1_to_2 with current_phase=1.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+}
+teardown() { rm -rf "$TMP"; }
+
+# Run the gate script and capture combined stdout/stderr + exit code
+# without letting `set -e` in the caller propagate a non-zero exit.
+run_gate() {
+  ( cd "$PROJ" && bash "$SCRIPT" "$@" 2>&1 )
+  echo "__EXIT__:$?"
+}
+
+extract_exit() {
+  # Extracts trailing exit code from run_gate output.
+  echo "$1" | awk -F':' '/^__EXIT__:/ { print $2 }' | tail -1
+}
+
+strip_exit() {
+  echo "$1" | sed '/^__EXIT__:/d'
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-scoped: --gate phase_1_to_2 + current_phase=1 → gate fires ==="
+# ════════════════════════════════════════════════════════════════════
+# Without --gate, the Phase 1→2 checks only run when current_phase>=2.
+# With --gate, they must run even when current_phase=1. We assert on
+# the ZDR gate FAIL line because it's the cleanest post-parse signal —
+# the ZDR block requires no external tooling (unlike the branch-
+# protection backstop) and always fires when phase >= 2.
+echo "T-scoped: --gate phase_1_to_2 + current_phase=1 → ZDR gate FAIL appears"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":1,"deployment":"personal","gates":{"phase_0_to_1":"2026-01-01"}}
+JSON
+# APPROVAL_LOG must exist so the script doesn't exit early on line 125.
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Phase 0 → Phase 1
+| Approver | Date |
+| Op | 2026-01-01 |
+MD
+raw=$(run_gate --gate phase_1_to_2)
+exit_code=$(extract_exit "$raw")
+out=$(strip_exit "$raw")
+if echo "$out" | grep -qE "FAIL.*Phase 1.2 ZDR gate.*data_classification"; then
+  pass "T-scoped: ZDR gate FAIL fires under --gate phase_1_to_2 with current_phase=1"
+else
+  fail_ "T-scoped" "expected Phase 1→2 ZDR FAIL; got exit=$exit_code, out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-scoped-caps: --gate phase_1_to_2 caps at phase 2 (no phase 3+ noise) ==="
+# ════════════════════════════════════════════════════════════════════
+# When --gate phase_1_to_2 is passed with a fixture where current_phase=4
+# in phase-state.json, we should NOT see Phase 3→4 checks running (the
+# scope caps at phase_1_to_2). This is what makes the flag "scope" the
+# check rather than merely elevate it.
+echo "T-scoped-caps: --gate phase_1_to_2 + current_phase=4 → no Phase 3→4 lines"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":4,"deployment":"personal","gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01","phase_2_to_3":"2026-03-01","phase_3_to_4":"2026-04-01"}}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Phase 0 → Phase 1
+Approved 2026-01-01
+
+## Phase 1 → Phase 2
+Approved 2026-02-01
+
+## Phase 2 → Phase 3
+Approved 2026-03-01
+
+## Phase 3 → Phase 4
+Approved 2026-04-01
+MD
+raw=$(run_gate --gate phase_1_to_2)
+out=$(strip_exit "$raw")
+# We expect Phase 1→2 lines to appear (positive) and Phase 3→4 to NOT
+# appear (negative). "Phase 2→3" also should not appear under strict
+# scoping, but the primary test is that phase_3_to_4-specific FAILs
+# (like docs/test-results) do not surface.
+if echo "$out" | grep -qE "Phase 3.4:.*(docs/test-results|SECURITY.md|penetration|POC)"; then
+  fail_ "T-scoped-caps" "Phase 3→4 checks ran but scope was phase_1_to_2; out:
+$out"
+elif echo "$out" | grep -qE "Phase 1.2 ZDR gate|Phase 1.2 backstop"; then
+  pass "T-scoped-caps: Phase 1→2 checks ran, Phase 3→4 checks skipped"
+else
+  fail_ "T-scoped-caps" "expected Phase 1→2 activity; out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-unknown-gate: --gate bogus → exit 2 + clear diagnostic ==="
+# ════════════════════════════════════════════════════════════════════
+echo "T-unknown-gate: --gate bogus → exit 2, stderr names 'Unknown gate'"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+MD
+raw=$(run_gate --gate bogus_gate_name)
+exit_code=$(extract_exit "$raw")
+out=$(strip_exit "$raw")
+if [ "$exit_code" != "2" ]; then
+  fail_ "T-unknown-gate" "expected exit 2, got exit=$exit_code; out:
+$out"
+elif echo "$out" | grep -qE "Unknown gate.*bogus_gate_name"; then
+  pass "T-unknown-gate: exit 2 + 'Unknown gate' diagnostic emitted"
+else
+  fail_ "T-unknown-gate" "expected 'Unknown gate' diagnostic; out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-multiple-gates: --gate a --gate b → exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+echo "T-multiple-gates: --gate phase_0_to_1 --gate phase_1_to_2 → exit 2"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+MD
+raw=$(run_gate --gate phase_0_to_1 --gate phase_1_to_2)
+exit_code=$(extract_exit "$raw")
+out=$(strip_exit "$raw")
+if [ "$exit_code" != "2" ]; then
+  fail_ "T-multiple-gates" "expected exit 2 (double --gate), got exit=$exit_code; out:
+$out"
+elif echo "$out" | grep -qiE "gate.*(specified more than once|already set)"; then
+  pass "T-multiple-gates: exit 2 + 'more than once' diagnostic emitted"
+else
+  fail_ "T-multiple-gates" "expected 'specified more than once' diagnostic; out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-unknown-flag: --frobnicate → exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+echo "T-unknown-flag: --frobnicate → exit 2, stderr names 'Unknown argument'"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+MD
+raw=$(run_gate --frobnicate)
+exit_code=$(extract_exit "$raw")
+out=$(strip_exit "$raw")
+if [ "$exit_code" != "2" ]; then
+  fail_ "T-unknown-flag" "expected exit 2, got exit=$exit_code; out:
+$out"
+elif echo "$out" | grep -qE "Unknown argument.*frobnicate"; then
+  pass "T-unknown-flag: exit 2 + 'Unknown argument' diagnostic emitted"
+else
+  fail_ "T-unknown-flag" "expected 'Unknown argument' diagnostic; out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-no-current-phase: --gate with no phase-state.json → clear error ==="
+# ════════════════════════════════════════════════════════════════════
+# Regression guard: the script must NOT crash under `set -euo pipefail`
+# when --gate is specified but phase-state.json is absent. It should
+# emit a clear error and exit non-zero — the operator asked for a scope
+# and we have no fixture to check.
+echo "T-no-current-phase: --gate phase_1_to_2 + no phase-state.json → exit 1, clear error"
+setup
+# No phase-state.json, no APPROVAL_LOG.md
+raw=$(run_gate --gate phase_1_to_2)
+exit_code=$(extract_exit "$raw")
+out=$(strip_exit "$raw")
+if [ "$exit_code" = "0" ]; then
+  fail_ "T-no-current-phase" "expected non-zero exit (--gate requires fixture); got exit=0; out:
+$out"
+elif echo "$out" | grep -qiE "(gate.*specified.*not found|not found.*gate|phase-state\.json.*cannot verify)"; then
+  pass "T-no-current-phase: non-zero exit + clear diagnostic about missing phase-state.json"
+else
+  fail_ "T-no-current-phase" "expected clear error about missing phase-state.json under --gate; got exit=$exit_code; out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-help: --help → exit 0 + usage mentions --gate ==="
+# ════════════════════════════════════════════════════════════════════
+echo "T-help: --help → exit 0, usage names '--gate'"
+setup
+raw=$(run_gate --help)
+exit_code=$(extract_exit "$raw")
+out=$(strip_exit "$raw")
+if [ "$exit_code" != "0" ]; then
+  fail_ "T-help" "expected exit 0, got exit=$exit_code; out:
+$out"
+elif echo "$out" | grep -qE "(Usage|usage).*check-phase-gate" && echo "$out" | grep -q -- "--gate"; then
+  pass "T-help: exit 0 + usage text names --gate"
+else
+  fail_ "T-help" "expected usage text mentioning --gate; out:
+$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-backcompat: no --gate → existing behavior unchanged ==="
+# ════════════════════════════════════════════════════════════════════
+# When no --gate is passed, current_phase from phase-state.json alone
+# determines which checks fire. Regression guard so we don't break the
+# hundreds of callers that never pass --gate.
+echo "T-backcompat: no --gate + current_phase=0 → Phase 1→2 checks don't run"
+setup
+cat > "$PROJ/.claude/phase-state.json" <<'JSON'
+{"current_phase":0,"deployment":"personal"}
+JSON
+cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+MD
+raw=$(run_gate)
+out=$(strip_exit "$raw")
+# The ZDR gate FAIL should NOT appear when current_phase=0 and no --gate
+if echo "$out" | grep -qE "FAIL.*Phase 1.2 ZDR gate"; then
+  fail_ "T-backcompat" "Phase 1→2 ZDR FAIL should not fire at current_phase=0 without --gate; out:
+$out"
+else
+  pass "T-backcompat: no --gate + current_phase=0 → no Phase 1→2 checks"
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## Summary

- Adds an argv parser to `scripts/check-phase-gate.sh` for `--gate <name>` (and `--gate=<name>`), `--help`, and `-h`. Pre-fix the script had no argv parsing whatsoever — scenarios invoking `--gate phase_1_to_2` succeeded coincidentally because `current_phase=2` in phase-state.json triggered the backstop, not because the flag was honored.
- `--gate <name>` **elevates** (forces the named gate's checks to run regardless of the recorded `current_phase`) AND **caps** (skips higher-phase gate blocks) — strict scope. Valid gates: `phase_0_to_1`, `phase_1_to_2`, `phase_2_to_3`, `phase_3_to_4`.
- Failure paths: unknown gate / unknown flag / `--gate` given twice / missing value → exit 2 with clear stderr diagnostic. `--gate` with no `phase-state.json` fixture → exit 1 + explicit error (never silently exit 0).
- New test suite `tests/test-check-phase-gate-argv-parser.sh` (8/8 GREEN) wired into `tests/full-project-test-suite.sh` under the existing "Check-phase-gate noninteractive + self-approval (PR #87)" section.
- All 8 pre-existing `test-check-phase-gate-*.sh` suites still pass unchanged; edge-cases-scripts E25b (parse phase=99) confirms no regression on the no-flag path.

## Closes

- BL-060

## Test plan

**Red → Green:**
- Before adding the parser, `bash tests/test-check-phase-gate-argv-parser.sh` failed 7/8 (T-scoped, T-scoped-caps, T-unknown-gate, T-multiple-gates, T-unknown-flag, T-no-current-phase, T-help). Only T-backcompat passed (existing behavior).
- After adding the parser, 8/8 PASS.

**Failure-path coverage:**
- `T-unknown-gate` — `--gate bogus_gate_name` → exit 2 + `Unknown gate: 'bogus_gate_name'` on stderr.
- `T-multiple-gates` — `--gate phase_0_to_1 --gate phase_1_to_2` → exit 2 + `specified more than once` diagnostic.
- `T-unknown-flag` — `--frobnicate` → exit 2 + `Unknown argument: '--frobnicate'` diagnostic.
- `T-no-current-phase` — `--gate phase_1_to_2` + no phase-state.json → exit 1 + `--gate phase_1_to_2 specified but .claude/phase-state.json not found` (does NOT silently exit 0 under `set -euo pipefail`).

**Mutation proof:**
- Applied mutation: replaced the argv parser's `while` loop body with a bare `shift` (parser now discards every argument).
- Result: `T-scoped, T-scoped-caps, T-unknown-gate, T-multiple-gates, T-unknown-flag, T-no-current-phase, T-help` all fail RED (7/8). `T-backcompat` still passes (as expected — it exercises the no-flag path). This proves the parser is load-bearing for every BL-060 assertion.
- Restored the parser; re-ran the suite → 8/8 GREEN.

**Regression safety:**
- All 8 existing check-phase-gate test suites (`backstop-attestation`, `blame-walker`, `counter-sanitizer`, `noninteractive`, `retroactive-approval`, `self-approval`, `test-check-phase-gate.sh`, `test-init-schema-phase-gate.sh`) still PASS unchanged.
- `edge-cases-scripts.sh` E25b (check-phase-gate.sh parses phase=99) passed without modification.
- Standalone E13-equivalent (current_phase=3, empty APPROVAL_LOG → non-zero exit) reproduced locally — passes.

**Lints (all exit 0):**
- `bash scripts/lint-counter-antipattern.sh`
- `bash scripts/lint-backlog-references.sh`
- `bash scripts/lint-fix-functions-stderr.sh`
- `bash scripts/lint-raw-read-prompt.sh`

## Coordination note

Files touched:
- `scripts/check-phase-gate.sh` — added argv parser (top of file, after `source helpers-core.sh`, before `prompt_yes_no`), added `--gate` override right after `current_phase` parse, added missing-fixture error path when `--gate` is set. Existing check blocks are unchanged.
- `tests/full-project-test-suite.sh` — added a 5-line wiring block registering the new test file under the existing PR-#87 section.
- `tests/test-check-phase-gate-argv-parser.sh` — NEW.

No expected rebase — additive changes only. Sibling S3 Wave-C branches (BL-059, BL-061, BL-068) touch different files; the only overlap risk with BL-055 (per-line APPROVAL_LOG.md blame walker) was mentioned in the BL-060 entry's "Trigger" line, but the blame walker landed in PR #116 pre-fix and this PR does not touch its code. The backlog entry for BL-060 stays `Status: Open` in this PR — standard workflow flips it to `Closed` in a follow-up commit citing this PR number, matching the pattern used for BL-034 (commit `0d209b7` after PR #111 merge).

## Worktree note

pwd: `/Users/karl/Documents/Claude Projects/solo-orchestrator/.claude/worktrees/wf_42182049-901-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)