### PR TITLE
fix(init): handle gitlab.com Free org-mode required-approvals 403 gracefully (closes BL-032)

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -958,6 +958,13 @@ Workarounds:
 
 For organizational deployments: GitHub Team or Enterprise includes branch protection on private repos by default, so this limitation does not apply to org projects.
 
+**GitLab Free-tier limitation — organizational deployments.** On gitlab.com Free, the `projects/:id/approvals` API is Premium-only. When `init.sh` runs with `--git-host=gitlab --deployment=organizational`, the driver's default flow tries to `PUT /projects/:id/approvals` with `approvals_before_merge=1`, which returns HTTP 403: *"This feature is not available on your plan."* (exact wording has varied across GitLab releases — the driver matches a broad union of Premium-only signals). Two escape hatches:
+
+- **Reactive (interactive):** The driver returns exit 4 with a structured remediation message. `init.sh` prompts you to attest that approvals will be enforced by convention. On `yes`, an attestation is recorded and check-gate.sh honors it.
+- **Proactive (non-interactive):** Pass `--approvals-attested` to `init.sh` (or export `SOLO_APPROVALS_ATTESTED=1`). The driver skips the approvals PUT entirely and emits a `[WARN]` pointing you at **Settings > Merge requests > Merge request approvals** to set the value manually. init.sh records the attestation with reason `gitlab_free_tier_approvals`, and `scripts/check-gate.sh --preflight` + the `scripts/check-phase-gate.sh` Phase 1→2 backstop honor it as the load-bearing gate — same pattern as `github_free_tier` for the GitHub analog. Upgrade the namespace to GitLab Premium (or self-host GitLab CE/EE with an appropriate license) to enable API-level enforcement.
+
+Tracked as BL-032 in `solo-orchestrator-backlog.md`.
+
 **3. Initialize the project with the AI agent:**
 
 Provide the Project Bible and direct the agent to:

--- a/init.sh
+++ b/init.sh
@@ -37,6 +37,14 @@ ARG_GIT_HOST=""
 ARG_VISIBILITY=""
 ARG_REMOTE_URL=""
 ARG_BRANCH_PROTECTION_ATTESTED=false
+# BL-032: proactive attestation for gitlab.com Free org-mode approvals
+# API (Premium-only). When set, init.sh exports SOLO_APPROVALS_ATTESTED=1
+# to host_configure_protection, which skips the approvals PUT and emits
+# a WARN with the operator-actionable manual-setup hint. Post-success
+# init.sh records the corresponding attestation in process-state.json
+# with reason `gitlab_free_tier_approvals` (honored by check-gate.sh +
+# check-phase-gate.sh, mirroring the `github_free_tier` reactive path).
+ARG_APPROVALS_ATTESTED=false
 ARG_ALLOW_EXISTING_DIR=false
 ARG_NO_REMOTE_CREATION=false
 # BL-030: enforcement-level flags (non-interactive). Default empty so
@@ -49,6 +57,7 @@ GIT_HOST=""
 VISIBILITY=""
 REMOTE_URL=""
 BRANCH_PROTECTION_ATTESTED=false
+APPROVALS_ATTESTED=false
 ALLOW_EXISTING_DIR=false
 NO_REMOTE_CREATION=false
 ENFORCEMENT_LEVEL=""
@@ -2126,6 +2135,16 @@ create_and_protect_remote() {
     # route to the same attestation flow — the driver itself emits host-
     # specific remediation on stderr BEFORE this block runs, so we echo a
     # host-agnostic summary and defer detail to the driver (BL-031).
+    #
+    # BL-032 proactive attestation: when --approvals-attested is set (or
+    # the SOLO_APPROVALS_ATTESTED=1 env var is exported by an outer
+    # harness), the gitlab driver skips the approvals PUT entirely and
+    # emits a WARN pointing operators at Settings > Merge requests.
+    # host_configure_protection returns 0, so we take the success branch
+    # below and record the `gitlab_free_tier_approvals` reason separately.
+    if [ "${APPROVALS_ATTESTED:-false}" = true ]; then
+      export SOLO_APPROVALS_ATTESTED=1
+    fi
     local _hcp_rc=0
     host_configure_protection main "$mode" || _hcp_rc=$?
     if [ "$_hcp_rc" -ne 0 ] && [ "$_hcp_rc" -ne 3 ] && [ "$_hcp_rc" -ne 4 ]; then
@@ -2168,6 +2187,27 @@ create_and_protect_remote() {
       return 1
     else
       _record_phase2_step "branch_protection_configured"
+      # BL-032 proactive path: when the operator pre-attested with
+      # --approvals-attested AND we're on gitlab in org mode, the driver
+      # took the SOLO_APPROVALS_ATTESTED shortcircuit (skipped the
+      # approvals PUT + emitted a WARN). Record the
+      # `gitlab_free_tier_approvals` attestation so check-gate.sh +
+      # check-phase-gate.sh honor it as the gate-pass. The
+      # host_verify_protection call below would still succeed on gitlab
+      # for the protected_branches half of the config, but the
+      # attestation IS the load-bearing gate on the approvals half —
+      # match the reactive-path discipline.
+      if [ "${APPROVALS_ATTESTED:-false}" = true ] && [ "$host" = "gitlab" ] && [ "$mode" = "org" ]; then
+        mkdir -p .claude
+        if [ ! -f .claude/process-state.json ]; then
+          echo '{"phase2_init":{"steps_completed":[],"attestations":{}}}' > .claude/process-state.json
+        fi
+        jq --arg at "$(date -u +%FT%TZ)" \
+           '.phase2_init.attestations.branch_protection = {attested_by: "orchestrator", at: $at, reason: "gitlab_free_tier_approvals"}' \
+           .claude/process-state.json > .claude/process-state.json.tmp \
+           && mv .claude/process-state.json.tmp .claude/process-state.json
+        print_ok "GitLab Free tier approvals attestation recorded (reason: gitlab_free_tier_approvals) — check-gate.sh --preflight will honor it."
+      fi
       print_info "Verifying protection..."
       if ! host_verify_protection main "$mode" 2>/dev/null && ! host_verify_protection master "$mode"; then
         # Retry once for API lag
@@ -3066,6 +3106,14 @@ Required flags (conditional):
                            Boolean flag (presence = true). Confirms branch
                            protection is configured on the remote.
                            REQUIRED when --git-host=other.
+  --approvals-attested     Boolean flag (presence = true). Skips the
+                           gitlab.com Free-tier `projects/:id/approvals` PUT
+                           (Premium-only) and records a
+                           `gitlab_free_tier_approvals` attestation. Only
+                           meaningful for --git-host=gitlab + --deployment
+                           =organizational; ignored otherwise. Equivalent to
+                           SOLO_APPROVALS_ATTESTED=1 in the environment.
+                           See BL-032 in solo-orchestrator-backlog.md.
 
 Optional flags (with defaults):
   --description TEXT       One-sentence project description. Default: "".
@@ -3109,6 +3157,7 @@ JSON config schema (snake_case keys; all fields optional, missing → use flag/d
   "visibility": "private",
   "remote_url": null,
   "branch_protection_attested": false,
+  "approvals_attested": false,
   "allow_existing_dir": false,
   "no_remote_creation": false
 }
@@ -3176,7 +3225,7 @@ collect_inputs_non_interactive() {
     fi
 
     # Warn on unknown fields (forward-compat per spec § 5.4).
-    local known_fields="project description platform track deployment gov_mode language project_dir git_host visibility remote_url branch_protection_attested allow_existing_dir no_remote_creation"
+    local known_fields="project description platform track deployment gov_mode language project_dir git_host visibility remote_url branch_protection_attested approvals_attested allow_existing_dir no_remote_creation"
     local field
     for field in $(jq -r 'keys[]' "$CONFIG_FILE"); do
       if ! echo " $known_fields " | grep -q " $field "; then
@@ -3206,6 +3255,13 @@ collect_inputs_non_interactive() {
       local cfg_attest
       cfg_attest=$(cfg_get branch_protection_attested)
       [ "$cfg_attest" = "true" ] && ARG_BRANCH_PROTECTION_ATTESTED=true
+    fi
+    # BL-032: honor approvals_attested from config file (parity with
+    # branch_protection_attested above; flag wins on conflict).
+    if [ "$ARG_APPROVALS_ATTESTED" != true ]; then
+      local cfg_appr_attest
+      cfg_appr_attest=$(cfg_get approvals_attested)
+      [ "$cfg_appr_attest" = "true" ] && ARG_APPROVALS_ATTESTED=true
     fi
     if [ "$ARG_ALLOW_EXISTING_DIR" != true ]; then
       local cfg_allow
@@ -3569,6 +3625,7 @@ collect_inputs_non_interactive() {
   VISIBILITY="$ARG_VISIBILITY"
   REMOTE_URL="$ARG_REMOTE_URL"
   BRANCH_PROTECTION_ATTESTED="$ARG_BRANCH_PROTECTION_ATTESTED"
+  APPROVALS_ATTESTED="$ARG_APPROVALS_ATTESTED"
   ALLOW_EXISTING_DIR="$ARG_ALLOW_EXISTING_DIR"
   NO_REMOTE_CREATION="$ARG_NO_REMOTE_CREATION"
 
@@ -3594,6 +3651,7 @@ collect_inputs_non_interactive() {
       --arg visibility "$VISIBILITY" \
       --arg remote_url "$REMOTE_URL" \
       --argjson attested "$([ "$BRANCH_PROTECTION_ATTESTED" = true ] && echo true || echo false)" \
+      --argjson approvals_attested "$([ "$APPROVALS_ATTESTED" = true ] && echo true || echo false)" \
       --argjson allow_dir "$([ "$ALLOW_EXISTING_DIR" = true ] && echo true || echo false)" \
       --argjson no_remote "$([ "$NO_REMOTE_CREATION" = true ] && echo true || echo false)" \
       '{
@@ -3611,6 +3669,7 @@ collect_inputs_non_interactive() {
         visibility: $visibility,
         remote_url: (if $remote_url == "" then null else $remote_url end),
         branch_protection_attested: $attested,
+        approvals_attested: $approvals_attested,
         allow_existing_dir: $allow_dir,
         no_remote_creation: $no_remote
       }'
@@ -3681,6 +3740,9 @@ main() {
         ARG_REMOTE_URL="${1#*=}"; shift ;;
       --branch-protection-attested)
         ARG_BRANCH_PROTECTION_ATTESTED=true; shift ;;
+      --approvals-attested)
+        # BL-032: proactive gitlab.com Free approvals attestation.
+        ARG_APPROVALS_ATTESTED=true; shift ;;
       --allow-existing-dir)
         ARG_ALLOW_EXISTING_DIR=true; shift ;;
       --no-remote-creation)

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -71,6 +71,12 @@ cmd_preflight() {
   # branch-protection attestation from process-state.json. When the project
   # was init'd against a tier-limited host, host_verify_protection has
   # nothing to verify — the attestation IS the gate.
+  #
+  # BL-032: `gitlab_free_tier_approvals` is the GitLab analog — set when
+  # the operator pre-attests via --approvals-attested for gitlab.com Free
+  # org-mode projects (approvals PUT is Premium-only). Honored here the
+  # same way `github_free_tier` is: the attestation IS the gate, no API
+  # verify possible.
   local attest_reason=""
   if [ -f .claude/process-state.json ]; then
     attest_reason=$(jq -r '.phase2_init.attestations.branch_protection.reason // ""' \
@@ -78,6 +84,10 @@ cmd_preflight() {
   fi
   if [ "$attest_reason" = "github_free_tier" ]; then
     print_ok "Ready: branch protection attested (reason: github_free_tier — upgrade to GitHub Pro to enable API enforcement)"
+    return 0
+  fi
+  if [ "$attest_reason" = "gitlab_free_tier_approvals" ]; then
+    print_ok "Ready: branch protection attested (reason: gitlab_free_tier_approvals — set required-approvals manually via GitLab Settings > Merge requests, or upgrade to Premium for API enforcement)"
     return 0
   fi
 
@@ -205,6 +215,14 @@ cmd_repair() {
      && _step_done "remote_repo_created" \
      && _step_done "pushed_initial"; then
     print_ok "Repair: nothing to do — branch protection attested (reason: github_free_tier)"
+    return 0
+  fi
+  # BL-032: same short-circuit for the GitLab Free tier approvals
+  # attestation reason.
+  if [ "$attest_reason" = "gitlab_free_tier_approvals" ] \
+     && _step_done "remote_repo_created" \
+     && _step_done "pushed_initial"; then
+    print_ok "Repair: nothing to do — branch protection attested (reason: gitlab_free_tier_approvals)"
     return 0
   fi
 

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -675,6 +675,12 @@ if [ "$current_phase" -ge 2 ]; then
     fi
     if [ "$backstop_attest_reason" = "github_free_tier" ]; then
       echo -e "${GREEN}  [OK]${NC} Phase 1→2 backstop: branch protection attested (reason: github_free_tier — upgrade to GitHub Pro to enable API enforcement)"
+    elif [ "$backstop_attest_reason" = "gitlab_free_tier_approvals" ]; then
+      # BL-032 close: honor the GitLab Free-tier approvals attestation
+      # (proactive --approvals-attested / SOLO_APPROVALS_ATTESTED=1 flow).
+      # On gitlab.com Free the projects/:id/approvals PUT is Premium-only,
+      # so the attestation IS the gate — there is nothing to verify.
+      echo -e "${GREEN}  [OK]${NC} Phase 1→2 backstop: branch protection attested (reason: gitlab_free_tier_approvals — set required-approvals manually via GitLab Settings > Merge requests, or upgrade to Premium)"
     else
       # shellcheck disable=SC1090
       source "$host_dispatcher"

--- a/scripts/host-drivers/gitlab.sh
+++ b/scripts/host-drivers/gitlab.sh
@@ -161,12 +161,44 @@ host_configure_protection() {
   # Org mode: also require approvals on MRs (separate API), the CI
   # pipeline-success gate, and discussion-resolution before merge.
   if [ "$mode" = "org" ]; then
+    # ── BL-032-SHORTCIRCUIT-BEGIN (proactive attestation escape hatch) ──
+    # SOLO_APPROVALS_ATTESTED=1 is the operator-side pre-attestation
+    # channel wired up by init.sh's `--approvals-attested` flag. On
+    # gitlab.com Free tier the `projects/:id/approvals` PUT is
+    # Premium-only and always returns 403 — the reactive exit-4 branch
+    # below catches this, but non-interactive runs (CI, dogfood
+    # harnesses, scripted org setup) need a way to declare up front
+    # "I know approvals will be enforced by convention, don't try the
+    # API call." When set, skip the PUT entirely and emit a WARN with
+    # the operator-actionable hint pointing at Settings > Merge
+    # requests. init.sh records the corresponding attestation with
+    # reason `gitlab_free_tier_approvals` in process-state.json;
+    # scripts/check-gate.sh + scripts/check-phase-gate.sh honor that
+    # reason as a valid gate-pass alongside `github_free_tier`.
+    #
+    # STRUCTURE: this block ONLY sets `_bl032_skip_approvals=1` so that
+    # the block is well-formed under marker-based mutation
+    # (tests/test-bl032-gitlab-free-approvals-attestation.sh::T7 strips
+    # everything between BL-032-SHORTCIRCUIT-BEGIN and -END and the
+    # remainder must still parse). The approvals-PUT block below then
+    # honors the flag.
+    local _bl032_skip_approvals=0
+    if [ "${SOLO_APPROVALS_ATTESTED:-0}" = "1" ]; then
+      printf '%s\n' \
+        '[WARN] gitlab driver: skipping required-approvals API PUT — SOLO_APPROVALS_ATTESTED=1.' \
+        '       Set required-approvals manually via Settings > Merge requests >' \
+        '       Merge request approvals if this is not the gitlab.com Free tier.' \
+        '       (BL-032 escape hatch — see docs/builders-guide.md § Repository Setup.)' >&2
+      _bl032_skip_approvals=1
+    fi
+    # ── BL-032-SHORTCIRCUIT-END ──
+
     # code-host-gitlab-8: capture stderr from the approvals PUT so we can
     # detect the gitlab.com Free Premium-only failure mode (BL-032). On
     # Premium-only detection, return a dedicated exit code (4) with a
     # remediation message; on generic failure, surface the upstream
     # message and return 3.
-    if ! glab_err=$(glab api -X PUT "projects/$project/approvals" \
+    if [ "${_bl032_skip_approvals:-0}" != "1" ] && ! glab_err=$(glab api -X PUT "projects/$project/approvals" \
                       --input - <<<'{"approvals_before_merge":1,"reset_approvals_on_push":true}' 2>&1 >/dev/null); then
       # Premium-only signals from gitlab.com Free responses. The exact
       # wording has shifted across GitLab releases (the API has used
@@ -187,9 +219,8 @@ host_configure_protection() {
           "       MR approvals via the API." \
           "    2. Self-host GitLab CE/EE with an appropriate license — same API surface" \
           "       without the gitlab.com tier gate." \
-          "    3. Attest manually — accept that approvals are enforced by convention," \
-          "       not the API. Re-run with --approvals-attested to record this once" \
-          "       the BL-032 escape hatch lands (see backlog entry for status)." >&2
+          "    3. Attest manually via --approvals-attested (BL-032 escape hatch)" \
+          "       to record this — see docs/builders-guide.md § Repository Setup." >&2
         return 4
       fi
       echo "gitlab driver: protected branch set but approvals config failed" >&2
@@ -241,11 +272,22 @@ host_verify_protection() {
       failures="${failures}push_access_level=$val on $branch (org mode requires 0 = No one)\n"
     fi
 
-    local aresp
-    aresp=$(glab api "projects/$project/approvals" 2>/dev/null || echo '{}')
-    val=$(echo "$aresp" | jq -r '.approvals_before_merge // 0')
-    if [ "$val" = "0" ] || [ "$val" = "null" ]; then
-      failures="${failures}approvals_before_merge is 0 (org mode requires at least 1)\n"
+    # BL-032: when SOLO_APPROVALS_ATTESTED=1 the operator has pre-attested
+    # that approvals are enforced by convention on gitlab.com Free (the
+    # `projects/:id/approvals` PUT is Premium-only, so the API check
+    # below would always report `approvals_before_merge=0` and false-fail
+    # this verify pass). host_configure_protection took the same
+    # shortcircuit; parity here so verify doesn't undo the attestation
+    # discipline. The attestation itself is written by init.sh with
+    # reason=gitlab_free_tier_approvals and honored by check-gate.sh +
+    # check-phase-gate.sh as the load-bearing gate.
+    if [ "${SOLO_APPROVALS_ATTESTED:-0}" != "1" ]; then
+      local aresp
+      aresp=$(glab api "projects/$project/approvals" 2>/dev/null || echo '{}')
+      val=$(echo "$aresp" | jq -r '.approvals_before_merge // 0')
+      if [ "$val" = "0" ] || [ "$val" = "null" ]; then
+        failures="${failures}approvals_before_merge is 0 (org mode requires at least 1)\n"
+      fi
     fi
 
     # code-host-gitlab-2: parity with github.sh:174-175. Org mode requires

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -724,7 +724,7 @@ Operator-visible symptom: `scripts/check-gate.sh --preflight` PASSED (it correct
 **Logged:** 2026-06-28
 **Category:** Debt
 **Severity:** Medium
-**Status:** Open
+**Status:** Closed (2026-07-01, PR TBD, commit d85a084) — proactive `--approvals-attested` / `SOLO_APPROVALS_ATTESTED=1` shortcircuit shipped alongside the existing exit-4 reactive path; `gitlab_free_tier_approvals` attestation reason honored by `scripts/check-gate.sh` (--preflight, --repair) + `scripts/check-phase-gate.sh` Phase 1→2 backstop; `docs/builders-guide.md` § Repository Setup documents both escape hatches. Test coverage: `tests/test-bl032-gitlab-free-approvals-attestation.sh` (7 cases including mutation proof), wired into `tests/full-project-test-suite.sh` per BL-034.
 
 GitLab analog of BL-002. On gitlab.com Free, `PUT projects/:id/approvals` with `approvals_before_merge>=1` is a Premium-tier feature — Free returns HTTP 403 *"This feature is not available on your plan."* (exact wording has varied across GitLab releases — "premium", "ultimate", "not available on your plan", "feature is not available", "requires .* plan"). Organizational deployments on gitlab.com Free cannot clear the Phase 1→2 protection bar because the required-approvals invariant is structurally unavailable.
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -485,6 +485,14 @@ if bash "$SCRIPT_DIR/tests/test-gitlab-ci-status-stderr-approvals.sh" >/dev/null
 else
   fail "tests/test-gitlab-ci-status-stderr-approvals.sh FAILED (run for details)"
 fi
+# BL-032 close: proactive gitlab.com Free approvals attestation
+# (--approvals-attested / SOLO_APPROVALS_ATTESTED=1) — mirrors BL-002's
+# github_free_tier attestation for the GitLab analog.
+if bash "$SCRIPT_DIR/tests/test-bl032-gitlab-free-approvals-attestation.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl032-gitlab-free-approvals-attestation.sh"
+else
+  fail "tests/test-bl032-gitlab-free-approvals-attestation.sh FAILED (run for details)"
+fi
 
 # ----------------------------------------------------------------
 # TEST 0l: VERIFY-INSTALL + PROMPT-INSTALL FIX-FUNCTIONS

--- a/tests/test-bl032-gitlab-free-approvals-attestation.sh
+++ b/tests/test-bl032-gitlab-free-approvals-attestation.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# tests/test-bl032-gitlab-free-approvals-attestation.sh — BL-032 close
+#
+# BL-032 backlog scope (solo-orchestrator-backlog.md):
+#   Add a `--approvals-attested` flag (and `SOLO_APPROVALS_ATTESTED=1` env
+#   var) honored by `host_configure_protection`. When set in org mode,
+#   skip the approvals PUT and record an attestation in
+#   `.claude/process-state.json::phase2_init.attestations.branch_protection.reason
+#   = "gitlab_free_tier_approvals"`. Extend `scripts/check-phase-gate.sh`
+#   Phase 1→2 backstop to honor the new attestation reason.
+#
+# Test coverage (mirrors BL-036 + BL-066 lessons — failure paths +
+# mutation proof):
+#   T1  SOLO_APPROVALS_ATTESTED=1 + org mode + 403 Premium response
+#       → driver skips the approvals PUT entirely and returns 0 with a
+#         specific WARN. Attestation-attempt shortcircuit is what makes
+#         a 403-serving mock a green run.
+#   T2  Without SOLO_APPROVALS_ATTESTED + 403 Premium response → driver
+#       still returns exit 4 (existing BL-032 reactive path unchanged).
+#   T3  T1's WARN message contains the operator-actionable hint pointing
+#       at "Settings > Merge requests" — not just a generic
+#       "approvals skipped".
+#   T4  SOLO_APPROVALS_ATTESTED=1 does NOT swallow non-403 failures on
+#       other API calls (project-settings PUT 500 still returns exit 5).
+#   T5  scripts/check-phase-gate.sh Phase 1→2 backstop honors reason
+#       `gitlab_free_tier_approvals` — passes without invoking
+#       host_verify_protection.
+#   T6  scripts/check-gate.sh --preflight honors reason
+#       `gitlab_free_tier_approvals` — mirrors T5 for the operator-facing
+#       preflight subcommand.
+#   T7  Mutation proof: with the SOLO_APPROVALS_ATTESTED shortcircuit
+#       removed from the driver, T1's scenario returns rc=4 instead of
+#       rc=0. Proves the shortcircuit is what makes T1 green (not some
+#       adjacent behavior).
+#
+# TDD discipline: this file was written BEFORE the driver + check-gate
+# changes landed; the mutation test (T7) explicitly guards against a
+# regression where the shortcircuit is removed and the test still passes
+# via a non-load-bearing path.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/host-drivers/gitlab.sh"
+CHECK_GATE="$REPO_ROOT/scripts/check-gate.sh"
+CHECK_PHASE_GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ── Fake glab setup (mirrors test-gitlab-ci-status-stderr-approvals.sh) ──
+setup_with_fake_glab() {
+  TMPDIR_T=$(mktemp -d)
+  mkdir -p "$TMPDIR_T/bin"
+  cat > "$TMPDIR_T/bin/glab" <<'GLAB_EOF'
+#!/usr/bin/env bash
+# Fake glab — pattern-match the invocation and emit the canned response.
+# The `APPROVALS_PUT_CALLED` file is touched IFF the approvals PUT is
+# actually invoked; tests read it to prove the shortcircuit did/didn't fire.
+if [ ! -t 0 ]; then cat >/dev/null 2>&1 || true; fi
+
+case "$*" in
+  *"-X DELETE"*"/protected_branches/"*)
+    exit 0
+    ;;
+  *"-X POST"*"/protected_branches"*)
+    [ -n "${GLAB_POST_STDERR:-}" ] && printf '%s\n' "$GLAB_POST_STDERR" >&2
+    exit "${GLAB_POST_EXIT:-0}"
+    ;;
+  *"-X PUT"*"/approvals"*)
+    # Track that this call actually happened — the SOLO_APPROVALS_ATTESTED
+    # shortcircuit is expected to skip it.
+    [ -n "${APPROVALS_PUT_TRACKER:-}" ] && touch "$APPROVALS_PUT_TRACKER"
+    [ -n "${GLAB_PUT_APPR_STDERR:-}" ] && printf '%s\n' "$GLAB_PUT_APPR_STDERR" >&2
+    exit "${GLAB_PUT_APPR_EXIT:-0}"
+    ;;
+  *"-X PUT projects/"*)
+    [ -n "${GLAB_PUT_PROJ_STDERR:-}" ] && printf '%s\n' "$GLAB_PUT_PROJ_STDERR" >&2
+    exit "${GLAB_PUT_PROJ_EXIT:-0}"
+    ;;
+  *"-X GET projects/"*)
+    printf '%s' "${GLAB_GET_PROJ_BODY:-{\}}"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+GLAB_EOF
+  chmod +x "$TMPDIR_T/bin/glab"
+  (
+    cd "$TMPDIR_T"
+    git init -q
+    git config user.email "test@test.local"
+    git config user.name "test"
+    git remote add origin https://gitlab.com/org/repo.git
+  )
+}
+teardown_project() {
+  rm -rf "$TMPDIR_T"
+  unset GLAB_POST_EXIT GLAB_POST_STDERR GLAB_PUT_APPR_EXIT GLAB_PUT_APPR_STDERR \
+        GLAB_PUT_PROJ_EXIT GLAB_PUT_PROJ_STDERR GLAB_GET_PROJ_BODY \
+        APPROVALS_PUT_TRACKER SOLO_APPROVALS_ATTESTED
+}
+
+run_configure() {
+  local mode="$1"
+  (
+    cd "$TMPDIR_T"
+    PATH="$TMPDIR_T/bin:$PATH"
+    export GLAB_POST_EXIT GLAB_POST_STDERR GLAB_PUT_APPR_EXIT GLAB_PUT_APPR_STDERR \
+           GLAB_PUT_PROJ_EXIT GLAB_PUT_PROJ_STDERR APPROVALS_PUT_TRACKER \
+           SOLO_APPROVALS_ATTESTED
+    set +e
+    # shellcheck disable=SC1090
+    source "$DRIVER"
+    out=$(host_configure_protection main "$mode" 2>&1)
+    rc=$?
+    printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+  )
+}
+
+# ─── T1: shortcircuit skips approvals PUT ──────────────────────────────────
+
+t1_shortcircuit_skips_approvals_put() {
+  setup_with_fake_glab
+  export SOLO_APPROVALS_ATTESTED=1
+  export GLAB_POST_EXIT=0
+  # If the driver's shortcircuit works, we NEVER reach the approvals PUT.
+  # Set the fake to fail with a Premium 403 so a regression (driver still
+  # calls PUT) surfaces via exit 4 rather than silently passing.
+  export GLAB_PUT_APPR_EXIT=1
+  export GLAB_PUT_APPR_STDERR='HTTP 403: 403 Forbidden — This feature is not available on your plan. Upgrade to Premium to enable required approvals.'
+  export APPROVALS_PUT_TRACKER="$TMPDIR_T/approvals_put_was_called"
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}"
+  if [ "$rc" != "0" ]; then
+    fail_ "T1" "expected exit 0 with SOLO_APPROVALS_ATTESTED=1; got rc=$rc"
+    teardown_project; return
+  fi
+  if [ -f "$APPROVALS_PUT_TRACKER" ]; then
+    fail_ "T1" "approvals PUT was invoked despite SOLO_APPROVALS_ATTESTED=1 (shortcircuit missing)"
+    teardown_project; return
+  fi
+  pass "T1: SOLO_APPROVALS_ATTESTED=1 → driver skips approvals PUT and returns 0"
+  teardown_project
+}
+
+# ─── T2: reactive path unchanged when flag absent ──────────────────────────
+
+t2_reactive_path_unchanged() {
+  setup_with_fake_glab
+  # SOLO_APPROVALS_ATTESTED unset — driver should still hit the 403 and
+  # return the existing exit 4 (BL-032 reactive path).
+  export GLAB_POST_EXIT=0
+  export GLAB_PUT_APPR_EXIT=1
+  export GLAB_PUT_APPR_STDERR='HTTP 403: 403 Forbidden — This feature is not available on your plan. Upgrade to Premium to enable required approvals.'
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}"
+  if [ "$rc" != "4" ]; then
+    fail_ "T2" "expected exit 4 without SOLO_APPROVALS_ATTESTED (reactive path); got rc=$rc"
+    teardown_project; return
+  fi
+  pass "T2: unset SOLO_APPROVALS_ATTESTED preserves BL-032 reactive path (exit 4)"
+  teardown_project
+}
+
+# ─── T3: WARN message contains operator-actionable hint ────────────────────
+
+t3_warn_message_has_actionable_hint() {
+  setup_with_fake_glab
+  export SOLO_APPROVALS_ATTESTED=1
+  export GLAB_POST_EXIT=0
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" != "0" ]; then
+    fail_ "T3" "expected exit 0; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  # The WARN must mention "Settings" so the operator knows where to
+  # click, not just a generic "approvals skipped".
+  if [[ "$stderr" != *"Settings"* ]] && [[ "$stderr" != *"settings"* ]]; then
+    fail_ "T3" "WARN missing operator hint ('Settings'); stderr=$stderr"
+    teardown_project; return
+  fi
+  if [[ "$stderr" != *"Merge request"* ]] && [[ "$stderr" != *"merge request"* ]] && [[ "$stderr" != *"MR"* ]]; then
+    fail_ "T3" "WARN missing MR context; stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T3: WARN message contains 'Settings > Merge requests' hint"
+  teardown_project
+}
+
+# ─── T4: shortcircuit does NOT swallow non-approvals failures ──────────────
+
+t4_shortcircuit_preserves_other_failures() {
+  setup_with_fake_glab
+  export SOLO_APPROVALS_ATTESTED=1
+  export GLAB_POST_EXIT=0
+  # project-settings PUT still fails — this is NOT the approvals PUT,
+  # so the shortcircuit must not swallow it.
+  export GLAB_PUT_PROJ_EXIT=1
+  export GLAB_PUT_PROJ_STDERR='HTTP 500: internal server error on project settings'
+  local out; out=$(run_configure org)
+  local rc="${out%%|*}" stderr="${out#*|}"
+  if [ "$rc" = "0" ]; then
+    fail_ "T4" "shortcircuit swallowed a project-settings PUT failure (would mask real bugs); rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  if [ "$rc" != "5" ]; then
+    fail_ "T4" "expected exit 5 for project-settings failure; got rc=$rc stderr=$stderr"
+    teardown_project; return
+  fi
+  pass "T4: SOLO_APPROVALS_ATTESTED=1 preserves non-approvals failure paths (exit 5 for project-settings 500)"
+  teardown_project
+}
+
+# ─── T5: check-phase-gate.sh honors gitlab_free_tier_approvals reason ──────
+
+t5_check_phase_gate_honors_new_reason() {
+  # E2E execution of check-phase-gate.sh requires ~a dozen preseeded
+  # artifacts (APPROVAL_LOG.md, PROJECT_BIBLE.md, PRODUCT_MANIFESTO.md,
+  # phase-state.json with gates, PATH-stubbed gh/glab, etc.) — the
+  # existing test-check-phase-gate-backstop-attestation.sh already
+  # exercises that shape for `github_free_tier`. Rather than duplicate
+  # the sandbox, T5 is a source-level attestation: the backstop MUST
+  # contain a branch that handles `gitlab_free_tier_approvals` — same
+  # discipline as T6, but for check-phase-gate.sh rather than
+  # check-gate.sh. This catches "the reason was added to check-gate.sh
+  # but missed on check-phase-gate.sh" — the exact drift that leaked
+  # BL-002 into the code-check-gates-1 audit finding.
+  local backstop_line
+  # The backstop lives in a block gated by `if [ "$current_phase" -ge 2 ]`.
+  # Grep for the new reason in the same file.
+  if ! grep -q 'gitlab_free_tier_approvals' "$CHECK_PHASE_GATE"; then
+    fail_ "T5" "$CHECK_PHASE_GATE has no branch handling reason 'gitlab_free_tier_approvals' — the Phase 1→2 backstop will FAIL for legitimately-attested GitLab Free projects (same drift class as code-check-gates-1)"
+    return
+  fi
+  # Also assert the branch is adjacent to the existing github_free_tier
+  # handler (not just a stray comment somewhere).
+  backstop_line=$(grep -n 'gitlab_free_tier_approvals' "$CHECK_PHASE_GATE" | head -1 | cut -d: -f1)
+  if [ -z "$backstop_line" ]; then
+    fail_ "T5" "grep returned no line number for gitlab_free_tier_approvals in $CHECK_PHASE_GATE"
+    return
+  fi
+  # sanity: the reason must appear as an equality comparison (an if/elif
+  # test), not just a comment.
+  if ! grep -qE '(=|==)[[:space:]]*"gitlab_free_tier_approvals"' "$CHECK_PHASE_GATE"; then
+    fail_ "T5" "gitlab_free_tier_approvals in $CHECK_PHASE_GATE is not in an equality branch — likely a stray comment, not an actual gate handler"
+    return
+  fi
+  pass "T5: check-phase-gate.sh has a branch handling reason 'gitlab_free_tier_approvals' (line $backstop_line)"
+}
+
+# ─── T6: check-gate.sh --preflight honors gitlab_free_tier_approvals ───────
+
+t6_check_gate_preflight_honors_new_reason() {
+  local sandbox
+  sandbox=$(mktemp -d)
+  (
+    cd "$sandbox"
+    mkdir -p .claude
+    cat > .claude/manifest.json <<MANIFEST_EOF
+{"host": "gitlab", "mode": "org", "remote_url": "https://gitlab.com/org/repo.git"}
+MANIFEST_EOF
+    cat > .claude/process-state.json <<STATE_EOF
+{
+  "phase2_init": {
+    "attestations": {
+      "branch_protection": {
+        "attested_by": "orchestrator",
+        "at": "2026-06-30T12:00:00Z",
+        "reason": "gitlab_free_tier_approvals"
+      }
+    }
+  }
+}
+STATE_EOF
+    out=$(bash "$CHECK_GATE" --preflight 2>&1)
+    rc=$?
+    if [ "$rc" != "0" ]; then
+      echo "$out" > "$sandbox/preflight_out.log"
+      return 1
+    fi
+    if ! echo "$out" | grep -q "gitlab_free_tier_approvals"; then
+      echo "$out" > "$sandbox/preflight_out.log"
+      return 2
+    fi
+    return 0
+  )
+  local rc=$?
+  if [ "$rc" != "0" ]; then
+    fail_ "T6" "check-gate.sh --preflight did not honor gitlab_free_tier_approvals reason (rc=$rc); see $sandbox/preflight_out.log"
+    return
+  fi
+  rm -rf "$sandbox"
+  pass "T6: check-gate.sh --preflight honors gitlab_free_tier_approvals reason"
+}
+
+# ─── T7: Mutation proof — remove intercept, T1 must fail ───────────────────
+
+t7_mutation_proof_intercept_is_load_bearing() {
+  # Copy the driver to a tempdir, strip the SOLO_APPROVALS_ATTESTED
+  # shortcircuit, then re-run T1's scenario. It MUST now fail (rc=4)
+  # because the driver falls through to the approvals PUT that gets a
+  # Premium 403.
+  #
+  # RED-BEFORE-IMPLEMENTATION contract: this test asserts the driver
+  # ACTUALLY CONTAINS SOLO_APPROVALS_ATTESTED before mutation. Absent
+  # this guard, T7 would pass vacuously against a baseline driver that
+  # naturally returns 4 (nothing to mutate). Once implementation lands
+  # the guard becomes a smoke test that the shortcircuit is present at
+  # source-level, and the mutation validates it's load-bearing.
+  if ! grep -q "SOLO_APPROVALS_ATTESTED" "$DRIVER"; then
+    fail_ "T7" "driver missing SOLO_APPROVALS_ATTESTED shortcircuit — implementation incomplete (mutation proof would be vacuous)"
+    return
+  fi
+  local mutant_dir mutant_driver
+  mutant_dir=$(mktemp -d)
+  mutant_driver="$mutant_dir/gitlab.sh"
+  # Strip any line that references SOLO_APPROVALS_ATTESTED (both the
+  # env-var check AND any WARN block that fires because of it). The
+  # cleanest surgical mutation: drop every line between the marker
+  # tokens if they exist; otherwise sed out the env-var check itself.
+  awk '
+    /BL-032-SHORTCIRCUIT-BEGIN/ { skip = 1; next }
+    /BL-032-SHORTCIRCUIT-END/   { skip = 0; next }
+    !skip { print }
+  ' "$DRIVER" > "$mutant_driver"
+  # Sanity: mutant must NOT still contain the shortcircuit inside
+  # host_configure_protection (the function under test in T1). Other
+  # BL-032 references (e.g., inside host_verify_protection) are outside
+  # the T1 code path and don't invalidate the mutation.
+  local baseline_hits mutant_hits
+  baseline_hits=$(grep -c '"${SOLO_APPROVALS_ATTESTED:-0}"' "$DRIVER" || echo 0)
+  case "$baseline_hits" in ''|*[!0-9]*) baseline_hits=0 ;; esac
+  mutant_hits=$(grep -c '"${SOLO_APPROVALS_ATTESTED:-0}"' "$mutant_driver" || echo 0)
+  case "$mutant_hits" in ''|*[!0-9]*) mutant_hits=0 ;; esac
+  if [ "$mutant_hits" -ge "$baseline_hits" ]; then
+    fail_ "T7" "mutation did not reduce SOLO_APPROVALS_ATTESTED occurrences (baseline=$baseline_hits, mutant=$mutant_hits) — BL-032-SHORTCIRCUIT markers missing or misplaced in $DRIVER"
+    rm -rf "$mutant_dir"; return
+  fi
+
+  setup_with_fake_glab
+  export SOLO_APPROVALS_ATTESTED=1
+  export GLAB_POST_EXIT=0
+  export GLAB_PUT_APPR_EXIT=1
+  export GLAB_PUT_APPR_STDERR='HTTP 403: 403 Forbidden — This feature is not available on your plan. Upgrade to Premium to enable required approvals.'
+  local out
+  out=$(
+    cd "$TMPDIR_T"
+    PATH="$TMPDIR_T/bin:$PATH"
+    export GLAB_POST_EXIT GLAB_PUT_APPR_EXIT GLAB_PUT_APPR_STDERR SOLO_APPROVALS_ATTESTED
+    set +e
+    # shellcheck disable=SC1090
+    source "$mutant_driver"
+    out2=$(host_configure_protection main org 2>&1)
+    rc=$?
+    printf '%s' "$rc"
+  )
+  rm -rf "$mutant_dir"
+  if [ "$out" = "0" ]; then
+    fail_ "T7" "mutation (shortcircuit removed) still returned 0 — T1 was passing by accident, not because of the intercept"
+    teardown_project; return
+  fi
+  if [ "$out" != "4" ]; then
+    fail_ "T7" "expected mutant to hit reactive path (rc=4); got rc=$out — mutation may have broken adjacent code"
+    teardown_project; return
+  fi
+  pass "T7: mutation proof — removing the SOLO_APPROVALS_ATTESTED shortcircuit fails T1's scenario (rc=4)"
+  teardown_project
+}
+
+echo "== tests/test-bl032-gitlab-free-approvals-attestation.sh =="
+t1_shortcircuit_skips_approvals_put
+t2_reactive_path_unchanged
+t3_warn_message_has_actionable_hint
+t4_shortcircuit_preserves_other_failures
+t5_check_phase_gate_honors_new_reason
+t6_check_gate_preflight_honors_new_reason
+t7_mutation_proof_intercept_is_load_bearing
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-bl032-gitlab-free-approvals-attestation.sh
+++ b/tests/test-bl032-gitlab-free-approvals-attestation.sh
@@ -299,6 +299,80 @@ STATE_EOF
   pass "T6: check-gate.sh --preflight honors gitlab_free_tier_approvals reason"
 }
 
+# ─── T4b: check-gate.sh --repair honors gitlab_free_tier_approvals ─────────
+
+t4b_check_gate_repair_honors_new_reason() {
+  # PR #134 verifier follow-up: the cmd_repair branch in
+  # scripts/check-gate.sh lines ~222-227 short-circuits with an OK line
+  # when the recorded attestation reason is `gitlab_free_tier_approvals`
+  # AND both `remote_repo_created` + `pushed_initial` steps are marked
+  # completed. Parallel to T6 (which covers --preflight for the same
+  # reason), this test covers --repair for the same reason so both
+  # entrypoints are exercised.
+  #
+  # Fixture requires:
+  #   * .claude/manifest.json (host=gitlab, mode=org — matches BL-032 scope)
+  #   * .claude/process-state.json with:
+  #       phase2_init.steps_completed = ["remote_repo_created", "pushed_initial"]
+  #       phase2_init.attestations.branch_protection.reason = "gitlab_free_tier_approvals"
+  #
+  # Assertions: rc=0 AND stdout contains a Repair OK line that names
+  # gitlab_free_tier_approvals — proves it was the new elif branch that
+  # fired, not the github_free_tier branch or the full-repair fallthrough.
+  #
+  # Mutation-proven: stripping the cmd_repair branch at
+  # scripts/check-gate.sh:222-227 makes this test fail RED (either rc!=0
+  # from the fallthrough hitting missing host driver stubs, or the
+  # gitlab_free_tier_approvals OK line is absent).
+  local sandbox
+  sandbox=$(mktemp -d)
+  (
+    cd "$sandbox"
+    git init -q >/dev/null 2>&1
+    git remote add origin https://gitlab.com/org/repo.git
+    mkdir -p .claude
+    cat > .claude/manifest.json <<MANIFEST_EOF
+{"host": "gitlab", "mode": "org", "remote_url": "https://gitlab.com/org/repo.git"}
+MANIFEST_EOF
+    cat > .claude/process-state.json <<STATE_EOF
+{
+  "phase2_init": {
+    "steps_completed": ["remote_repo_created", "pushed_initial"],
+    "attestations": {
+      "branch_protection": {
+        "attested_by": "orchestrator",
+        "at": "2026-06-30T12:00:00Z",
+        "reason": "gitlab_free_tier_approvals"
+      }
+    }
+  }
+}
+STATE_EOF
+    out=$(bash "$CHECK_GATE" --repair 2>&1)
+    rc=$?
+    if [ "$rc" != "0" ]; then
+      printf '%s' "$out" > "$sandbox/repair_out.log"
+      return 1
+    fi
+    if ! printf '%s' "$out" | grep -q "gitlab_free_tier_approvals"; then
+      printf '%s' "$out" > "$sandbox/repair_out.log"
+      return 2
+    fi
+    if ! printf '%s' "$out" | grep -qE "Repair.*(nothing to do|attested)"; then
+      printf '%s' "$out" > "$sandbox/repair_out.log"
+      return 3
+    fi
+    return 0
+  )
+  local rc=$?
+  if [ "$rc" != "0" ]; then
+    fail_ "T4b" "check-gate.sh --repair did not honor gitlab_free_tier_approvals reason (rc=$rc); see $sandbox/repair_out.log"
+    return
+  fi
+  rm -rf "$sandbox"
+  pass "T4b: check-gate.sh --repair honors gitlab_free_tier_approvals reason"
+}
+
 # ─── T7: Mutation proof — remove intercept, T1 must fail ───────────────────
 
 t7_mutation_proof_intercept_is_load_bearing() {
@@ -380,6 +454,7 @@ t3_warn_message_has_actionable_hint
 t4_shortcircuit_preserves_other_failures
 t5_check_phase_gate_honors_new_reason
 t6_check_gate_preflight_honors_new_reason
+t4b_check_gate_repair_honors_new_reason
 t7_mutation_proof_intercept_is_load_bearing
 
 echo ""

--- a/tests/test-check-phase-gate-backstop-attestation.sh
+++ b/tests/test-check-phase-gate-backstop-attestation.sh
@@ -182,6 +182,45 @@ else
   fail_ "T3" "tests/test-check-gate.sh suite failed — possible cross-script regression"
 fi
 
+# T4 (positive — BL-032 backstop analog): mirrors T1 for the new
+# `gitlab_free_tier_approvals` attestation reason introduced by PR #134.
+# The Phase 1→2 backstop in scripts/check-phase-gate.sh acquired an
+# `elif` branch at ~line 678-683 that emits an OK line and short-circuits
+# host_verify_protection when the reason equals gitlab_free_tier_approvals
+# (gitlab.com Free-tier org-mode projects — approvals PUT is Premium-only,
+# so the attestation IS the gate). This test proves that branch fires:
+#   1. Preseed process-state.json with reason = gitlab_free_tier_approvals.
+#   2. Run check-phase-gate.sh under the same PATH-stubbed setup as T1
+#      (gh stub returns 403 on protection GET — proves the elif skipped
+#      host driver dispatch, because otherwise the stub 403 would surface
+#      as a backstop FAIL).
+#   3. Assert rc=0 AND the specific gitlab_free_tier_approvals OK line is
+#      emitted (not merely "attested" — the branch-specific message must
+#      appear so we know it was THIS elif, not the github_free_tier if
+#      or a fallthrough).
+#
+# Mutation-proven: replacing the elif body at check-phase-gate.sh:678-683
+# with `false  # deliberately break` makes this test fail RED (rc != 0
+# because `set -euo pipefail` propagates the `false`).
+echo "T4: gitlab_free_tier_approvals attestation → backstop honors it, exits 0"
+setup_phase2_project
+cat > "$PROJ/.claude/process-state.json" <<'JSON'
+{"phase2_init":{"steps_completed":[],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-06-30T12:00:00Z","reason":"gitlab_free_tier_approvals"}}},
+ "phase1_artifacts":{"data_classification":"public","zdr_attested":false}}
+JSON
+out=$(run_gate)
+rc=$?
+if [ "$rc" -ne 0 ]; then
+  fail_ "T4" "expected exit 0 with gitlab_free_tier_approvals attestation, got rc=$rc out:\n$out"
+elif echo "$out" | grep -q "Phase 1→2 backstop: protection verification failed"; then
+  fail_ "T4" "backstop FAIL emitted despite gitlab_free_tier_approvals attestation; out:\n$(echo "$out" | grep -i backstop)"
+elif ! echo "$out" | grep -qE "backstop.*gitlab_free_tier_approvals"; then
+  fail_ "T4" "expected backstop OK line mentioning gitlab_free_tier_approvals; out:\n$(echo "$out" | grep -i backstop)"
+else
+  pass "T4: backstop honors gitlab_free_tier_approvals attestation (skips API verify)"
+fi
+teardown_project
+
 echo ""
 echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
 [ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- **Proactive escape hatch**: adds `--approvals-attested` flag (and `SOLO_APPROVALS_ATTESTED=1` env var) to `init.sh` — honored by `scripts/host-drivers/gitlab.sh::host_configure_protection`, which skips the `projects/:id/approvals` PUT entirely (Premium-only on gitlab.com Free) and emits a `[WARN]` pointing operators at Settings > Merge requests > Merge request approvals.
- **Reactive path preserved**: without the flag, the existing exit-4 remediation (interactive attestation) continues to fire — no behavior change for the interactive flow.
- **New attestation reason `gitlab_free_tier_approvals`**: recorded by init.sh in `process-state.json::phase2_init.attestations.branch_protection`. Honored by `scripts/check-gate.sh` (`--preflight`, `--repair`) AND `scripts/check-phase-gate.sh` Phase 1→2 backstop — mirrors the `github_free_tier` handlers shipped in PR #36 (BL-002) / PR #62 (code-check-gates-1). Prevents the "preflight PASS but backstop FAIL" contradictory-signals drift class.
- **Verify parity**: `host_verify_protection` also honors `SOLO_APPROVALS_ATTESTED=1` so the API GET on `projects/:id/approvals` (which returns `approvals_before_merge=0` by default on Free) doesn't false-fail verification after the attestation was recorded.
- **Docs**: `docs/builders-guide.md` § Repository Setup gains a GitLab Free-tier callout mirroring the existing GitHub free-tier note, documenting both escape hatches.

## Closes
BL-032

## Test plan
New test file: `tests/test-bl032-gitlab-free-approvals-attestation.sh` (7 cases; all RED before implementation → GREEN after).

- **T1** `SOLO_APPROVALS_ATTESTED=1` + org mode + 403 mock → driver skips the approvals PUT (proven via fake-glab tracker file, not just exit code) and returns 0.
- **T2** Without the flag + 403 mock → driver still returns exit 4 (existing BL-032 reactive path unchanged).
- **T3** WARN message contains the operator-actionable hint "Settings > Merge requests" — not a generic "approvals skipped".
- **T4** Failure-path guard: with the flag set, a non-approvals API failure (project-settings PUT HTTP 500) still returns exit 5 — the shortcircuit does NOT swallow real failures.
- **T5** `scripts/check-phase-gate.sh` has an equality branch handling reason `gitlab_free_tier_approvals` (source-level; the E2E sandbox pattern already lives in `test-check-phase-gate-backstop-attestation.sh`).
- **T6** `scripts/check-gate.sh --preflight` honors the new reason end-to-end.
- **T7 (mutation proof)** `BL-032-SHORTCIRCUIT-BEGIN`/`END` markers bracket the load-bearing lines; T7 strips that block and asserts T1's scenario now returns rc=4. Baseline guard: mutation must actually reduce `SOLO_APPROVALS_ATTESTED` occurrences vs. the un-mutated driver.

### Adjacent-suite regression checks (all clean)
- `tests/test-gitlab-ci-status-stderr-approvals.sh` — 8/8 pass (existing exit-4 reactive path unchanged)
- `tests/test-check-gate.sh` — 5/5 pass (existing `github_free_tier` T5 preserved)
- `tests/test-check-phase-gate-backstop-attestation.sh` — 3/3 pass (existing backstop tests preserved)
- `tests/test-github-free-tier-403.sh` — 4/4 pass (BL-002 pattern unchanged)

### Lints (all exit 0)
- `scripts/lint-counter-antipattern.sh`
- `scripts/lint-backlog-references.sh`
- `scripts/lint-fix-functions-stderr.sh`
- `scripts/lint-raw-read-prompt.sh`
- `scripts/lint-fail-emit-exit-status.sh` (init.sh has new print_fail-adjacent code)

### Init.sh validate-only smoke test
`bash init.sh --non-interactive --validate-only ... --approvals-attested` correctly emits `"approvals_attested": true` in the resolved JSON.

## Coordination note
Files touched:
- `init.sh` (+59/-1) — new flag, config field, resolver wiring, exports `SOLO_APPROVALS_ATTESTED` before host_configure_protection, records `gitlab_free_tier_approvals` reason on the proactive-flag success path.
- `scripts/host-drivers/gitlab.sh` (+52/-8) — `SOLO_APPROVALS_ATTESTED=1` shortcircuit in `host_configure_protection` (marker-bracketed for mutation proof) and `host_verify_protection`.
- `scripts/check-gate.sh` (+17/-1) — honors `gitlab_free_tier_approvals` in `cmd_preflight` + `cmd_repair`.
- `scripts/check-phase-gate.sh` (+6/-0) — honors `gitlab_free_tier_approvals` in Phase 1→2 backstop.
- `docs/builders-guide.md` (+7/-0) — GitLab Free-tier callout.
- `tests/full-project-test-suite.sh` (+8/-0) — BL-034 test-aggregator wiring.
- `tests/test-bl032-gitlab-free-approvals-attestation.sh` (new, 387 LOC).

## Worktree note
Developed in `.claude/worktrees/wf_b4228f71-f2c-1` (isolated worktree; changes do not affect main working tree).

Backlog status flip (`Open` → `Closed`) landed as a separate commit per the defer-status-flip pattern. PR # will be backfilled on the citation post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)