### PR TITLE
fix(tests): scaffold full helpers shim chain in fixtures (BL-074)

### DIFF
--- a/tests/test-helpers/scaffold-libs.sh
+++ b/tests/test-helpers/scaffold-libs.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# tests/test-helpers/scaffold-libs.sh — shared fixture-scaffold helper.
+#
+# BL-074: the BL-046 helpers split (PR #125) turned scripts/lib/helpers.sh
+# into a backwards-compat SHIM that sources helpers-full.sh, which in turn
+# sources helpers-core.sh. The real product path copies all three into
+# every generated project (init.sh:1221-1223), so shipping projects are
+# fine. But hand-rolled test fixtures that copied ONLY helpers.sh died at
+# helpers.sh:39 with "helpers-full.sh: No such file or directory" the
+# moment a scaffolded script (reconfigure-project.sh, upgrade-project.sh,
+# intake-wizard.sh, ...) sourced the shim.
+#
+# Route every fixture that needs the helpers through this one function so
+# the copy set can never drift out of sync with the shim chain again. If a
+# future split adds another sibling, it gets added HERE, in one place.
+#
+# Usage:
+#   source "$REPO_ROOT/tests/test-helpers/scaffold-libs.sh"
+#   scaffold_helpers_libs "$P/scripts/lib"              # repo inferred
+#   scaffold_helpers_libs "$P/scripts/lib" "$REPO_ROOT" # repo explicit
+#
+# bash-3.2 safe (macOS /bin/bash): no associative arrays, no mapfile, no
+# process substitution required.
+
+# Resolve this helper's own repo root once (tests/test-helpers -> ../..).
+# Callers may still pass an explicit repo root as arg 2 to override.
+_SCAFFOLD_LIBS_SELF_DIR="${BASH_SOURCE[0]%/*}"
+[ "$_SCAFFOLD_LIBS_SELF_DIR" = "${BASH_SOURCE[0]}" ] && _SCAFFOLD_LIBS_SELF_DIR="."
+_SCAFFOLD_LIBS_DEFAULT_REPO="$(cd "$_SCAFFOLD_LIBS_SELF_DIR/../.." && pwd)"
+
+# The full shim chain, in the order init.sh copies it. Keep in lockstep
+# with init.sh:1221-1223. helpers.sh sources helpers-full.sh, which
+# sources helpers-core.sh — all three MUST land together.
+_SCAFFOLD_HELPERS_CHAIN="helpers.sh helpers-core.sh helpers-full.sh"
+
+# scaffold_helpers_libs <dest_scripts_lib_dir> [repo_root]
+#
+# Copies the complete helpers shim chain into <dest_scripts_lib_dir>
+# (created if absent). Returns non-zero — and prints to stderr — if any
+# source file is missing or a copy fails. Silently omitting a sibling is
+# exactly the BL-074 defect, so this fails LOUD rather than leaving a
+# fixture that half-works.
+scaffold_helpers_libs() {
+  local dest="$1"
+  local repo="${2:-$_SCAFFOLD_LIBS_DEFAULT_REPO}"
+  local src="$repo/scripts/lib"
+  local f
+
+  if [ -z "$dest" ]; then
+    echo "scaffold_helpers_libs: missing destination scripts/lib dir" >&2
+    return 2
+  fi
+  mkdir -p "$dest" || return 1
+  for f in $_SCAFFOLD_HELPERS_CHAIN; do
+    if [ ! -f "$src/$f" ]; then
+      echo "scaffold_helpers_libs: missing source $src/$f" >&2
+      return 1
+    fi
+    cp "$src/$f" "$dest/$f" || {
+      echo "scaffold_helpers_libs: failed to copy $f -> $dest" >&2
+      return 1
+    }
+  done
+  return 0
+}

--- a/tests/test-reconfigure-field-handlers.sh
+++ b/tests/test-reconfigure-field-handlers.sh
@@ -34,6 +34,9 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# BL-074: copy the full helpers shim chain (helpers.sh -> helpers-full.sh
+# -> helpers-core.sh) into every fixture, not just the helpers.sh shim.
+source "$REPO_ROOT/tests/test-helpers/scaffold-libs.sh"
 RECONFIG="$REPO_ROOT/scripts/reconfigure-project.sh"
 
 PASSED=0
@@ -56,7 +59,7 @@ mk_fixture() {
 
   # Copy the script under test + its required helpers into the fixture.
   cp "$REPO_ROOT/scripts/reconfigure-project.sh" "$dir/scripts/reconfigure-project.sh"
-  cp "$REPO_ROOT/scripts/lib/helpers.sh" "$dir/scripts/lib/helpers.sh"
+  scaffold_helpers_libs "$dir/scripts/lib" "$REPO_ROOT"
   # enforcement-level.sh is sourced when --enforcement-level is passed;
   # copied defensively so the script doesn't bail on missing files even
   # though the field handlers we're testing never hit that code path.

--- a/tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
+++ b/tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
@@ -28,6 +28,9 @@ set -u
 [[ "${BASH_VERSION:-}" ]] || { echo "bash required"; exit 1; }
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# BL-074: copy the full helpers shim chain (helpers.sh -> helpers-full.sh
+# -> helpers-core.sh) into every fixture, not just the helpers.sh shim.
+source "$REPO_ROOT/tests/test-helpers/scaffold-libs.sh"
 
 # --------------------------------------------------------------------
 # Test scaffolding (mirrors the style of test-tier-crosscheck-6-zdr-gate.sh)
@@ -77,7 +80,7 @@ T1=$(mktemp -d); P1="$T1/p"
 # Build minimal project that reconfigure-project.sh can operate on.
 mkdir -p "$P1/.claude" "$P1/scripts/lib" "$T1/bin"
 cp "$REPO_ROOT/scripts/reconfigure-project.sh" "$P1/scripts/reconfigure-project.sh"
-cp "$REPO_ROOT/scripts/lib/helpers.sh" "$P1/scripts/lib/helpers.sh"
+scaffold_helpers_libs "$P1/scripts/lib" "$REPO_ROOT"
 [ -f "$REPO_ROOT/scripts/lib/enforcement-level.sh" ] && cp "$REPO_ROOT/scripts/lib/enforcement-level.sh" "$P1/scripts/lib/enforcement-level.sh"
 
 cat > "$P1/.claude/phase-state.json" <<'JSON'

--- a/tests/test-tier-crosscheck-6-zdr-gate.sh
+++ b/tests/test-tier-crosscheck-6-zdr-gate.sh
@@ -49,6 +49,9 @@ set -uo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+# BL-074: copy the full helpers shim chain (helpers.sh -> helpers-full.sh
+# -> helpers-core.sh) into every fixture, not just the helpers.sh shim.
+source "$REPO_ROOT/tests/test-helpers/scaffold-libs.sh"
 CHECK_GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
 RECONFIGURE="$REPO_ROOT/scripts/reconfigure-project.sh"
 UPGRADE="$REPO_ROOT/scripts/upgrade-project.sh"
@@ -290,7 +293,7 @@ T=$(mktemp -d); P="$T/p"
 # Build a minimal project that reconfigure-project.sh can operate on.
 mkdir -p "$P/.claude" "$P/scripts/lib"
 cp "$REPO_ROOT/scripts/reconfigure-project.sh" "$P/scripts/reconfigure-project.sh"
-cp "$REPO_ROOT/scripts/lib/helpers.sh" "$P/scripts/lib/helpers.sh"
+scaffold_helpers_libs "$P/scripts/lib" "$REPO_ROOT"
 [ -f "$REPO_ROOT/scripts/lib/enforcement-level.sh" ] && cp "$REPO_ROOT/scripts/lib/enforcement-level.sh" "$P/scripts/lib/enforcement-level.sh"
 
 cat > "$P/.claude/phase-state.json" <<'JSON'
@@ -351,7 +354,7 @@ T=$(mktemp -d); P="$T/p"
 # fixture pattern used by tests/test-upgrade-project-retroactive-section.sh.
 mkdir -p "$P/.claude" "$P/scripts/lib" "$P/scripts/host-drivers" "$P/scripts/hooks"
 cp "$REPO_ROOT/scripts/upgrade-project.sh" "$P/scripts/upgrade-project.sh"
-cp "$REPO_ROOT/scripts/lib/helpers.sh" "$P/scripts/lib/helpers.sh"
+scaffold_helpers_libs "$P/scripts/lib" "$REPO_ROOT"
 [ -f "$REPO_ROOT/scripts/lib/host.sh" ] && cp "$REPO_ROOT/scripts/lib/host.sh" "$P/scripts/lib/host.sh"
 [ -f "$REPO_ROOT/scripts/host-drivers/github.sh" ] && cp "$REPO_ROOT/scripts/host-drivers/github.sh" "$P/scripts/host-drivers/github.sh"
 


### PR DESCRIPTION
## BL-074 — Test scaffolds copy only `helpers.sh`, not the mandatory `helpers-core.sh` / `helpers-full.sh` siblings

### Root cause
The BL-046 helpers split (PR #125) turned `scripts/lib/helpers.sh` into a backwards-compat **shim** that sources `helpers-full.sh`, which in turn sources `helpers-core.sh`. The real product path copies all three into every generated project (`init.sh:1221-1223`), so **shipping projects are unaffected**. But ~10 test files scaffold a fake project by copying **only** `helpers.sh`. Any scaffolded script that sources the shim (`reconfigure-project.sh`, `upgrade-project.sh`, `intake-wizard.sh`, `verify-install.sh`) then dies at `helpers.sh:39` with:

```
scripts/lib/helpers.sh: line 39: .../scripts/lib/helpers-full.sh: No such file or directory
```

These red tests have been sitting on `main` since PR #125 — a test-integrity regression the split introduced that no gate caught.

### Solution — shared helper (prevents drift)
New `tests/test-helpers/scaffold-libs.sh` exposes:

```bash
scaffold_helpers_libs "<dest_scripts_lib_dir>" [repo_root]
```

which copies the **full shim chain** (`helpers.sh` + `helpers-core.sh` + `helpers-full.sh`) in one place. If a future split adds another sibling it is added here, once — the copy set can no longer drift from the shim chain. bash-3.2 safe (verified under `/bin/bash` 3.2.57: no associative arrays, no `mapfile`). Fails loud if a source file is missing rather than leaving a half-scaffolded fixture.

`tests/test-helpers/` is already excluded by `scripts/lint-tests-registered.sh` (and the subdir isn't reached by its non-recursive globs), so no EXEMPT marker was needed.

### The 3 red suites: red → green

| Suite | Before | After |
|---|---|---|
| `test-tier-crosscheck-6-zdr-gate.sh` | T6, T7 FAIL (`helpers-full.sh: No such file`) — 6/8 | **8/8 pass** |
| `test-tier-crosscheck-6-followup-atomicity-and-jq.sh` | F1 FAIL (`shim was not invoked`) — 2/3 | **3/3 pass** |
| `test-reconfigure-field-handlers.sh` | 1/7 (T1,T2,T4-T7 FAIL) | **7/7 pass** |

Before/after evidence (exit codes captured on the base commit vs. this branch):
```
BEFORE:  zdr-gate EXIT=1 (Passed:6 Failed:2)   followup EXIT=1 (Passed:2 Failed:1)   reconfigure EXIT=1 (passed:1 failed:6)
AFTER:   zdr-gate EXIT=0 (Passed:8 Failed:0)   followup EXIT=0 (Passed:3 Failed:0)   reconfigure EXIT=0 (passed:7 failed:0)
```

### Correction to the backlog's T2 note
BL-074 flagged `test-reconfigure-field-handlers.sh` T2 as a **separate, unrelated** "reconfigure→upgrade-project redirect message" issue to track separately. That diagnosis is **incorrect**: T1 **and** T2 fail from the *same* helpers gap. `reconfigure-project.sh` runs under `set -e` and sources `helpers.sh` at line 16 — **before** the `track|deployment` refusal block at line ~429 — so the script exits on the missing sibling before it can print the `upgrade-project.sh` redirect. With the chain present, the redirect fires and both T1 and T2 pass (verified: 4 occurrences of `upgrade-project.sh` in the refusal output). No separate T2 follow-up item is needed.

### Mutation / robustness check (gate is exercised for the right reason)
Confirmed the now-green T6/T7/F1 genuinely exercise the ZDR/data_classification gate — a deliberate break of each gate makes the corresponding test fail, and reverting restores green (product scripts left untouched):

| Mutation (product gate) | Result |
|---|---|
| Neuter reconfigure `data_classification` jq write (`+ {data_classification: $v}` → `+ {}`) | **T6 FAILS** — "process-state.json did not record data_classification=confidential" |
| Remove SIGTERM rollback `trap` in reconfigure atomic envelope | **F1 FAILS** — torn state (pstate committed, APPROVAL_LOG unchanged) |
| Make upgrade precondition always satisfied (`data_classification // ""` → `// "public"`) | **T7 FAILS** — "upgrade-project.sh succeeded without data_classification" |

### Latent-file audit (7 files sharing the copy-only-`helpers.sh` pattern)
Audited each; **none require the fix** — reasons below:

| File | Verdict | Why |
|---|---|---|
| `known-bugs-test-suite.sh:149` | SAFE — no change | `cp -r "$REPO_DIR/scripts/"*` (line 148) recursively copies `scripts/lib/`, so both siblings are already present before the redundant `cp helpers.sh` |
| `edge-cases-upgrade-input.sh:142` | SAFE — no change | Same `cp -r scripts/*` (line 141); executes `upgrade-project.sh` against a fixture that has the whole `lib/` |
| `edge-cases-upgrade-input.sh:594` (`create_input_test_env`) | SAFE — no change | Consumers E33-E40 run **python extracts** (`save_answer`), never sourcing the shell helpers chain; the `helpers.sh` copy is defensive/unused |
| `edge-cases-scripts.sh:160` | SAFE — no change | Same `cp -r scripts/*` (line 159) → siblings present |
| `full-project-test-suite.sh:1247` (TEST4) | SAFE — no change | Fixture carries `intake-wizard.sh` but never runs it; TEST4 only runs `resolve-tools.sh` (no helpers source) and hand-writes `phase-state.json`. `intake-wizard.sh` is exercised via a separate test against the real repo |
| `test-specs-plans-remaining-quartet.sh:292` | SAFE — no change | `verify-install.sh` is only **awk-extracted** (`fix_ci_pipeline` / `fix_release_pipeline`) and sourced as an isolated extract; the whole script (with its top-level `source helpers.sh`) is never run |
| `test-pre-commit-gate-lints.sh:66` | SAFE — no change | Ships `process-checklist.sh`, which sources `helpers-core.sh` **directly** (not the shim) — `helpers-full.sh` is irrelevant here; not a BL-074 risk |
| `test-pre-commit-gate-terminal-mode.sh:36` | SAFE — no change | Same as above — `process-checklist.sh` → `helpers-core.sh`, not the shim |

### Out-of-scope pre-existing failures (flagged, not fixed here)
While auditing, two suites were found **already red on `main`** for reasons unrelated to BL-074 (not helpers errors, files untouched by this PR): `test-pre-commit-gate-lints.sh` (T6a/T6b/T11a/T11b — "`--terminal-mode` did not surface lint") and `test-pre-commit-gate-terminal-mode.sh` (T2 — "docs-only commit blocked"). These are `--terminal-mode` lint-surfacing / commit-classification issues and warrant a separate backlog item.

### Verification
- Full CI lint battery: `lint-counter-antipattern`, `lint-backlog-references`, `lint-fix-functions-stderr`, `lint-raw-read-prompt`, `lint-tests-registered`, `lint-doc-anchors`, `lint-fail-emit-exit-status`, `lint-fixture-envelopes` — **all exit 0**.
- `bash -n` clean on all edited files + the new helper.
- Sibling `test-bl046-helpers-split.sh` still 8/8.
- No product code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
