### PR TITLE
refactor(install): migrate consumers to honor install_cmds array (BL-069)

### DIFF
--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -341,6 +341,76 @@ prompt_choice() {
   return 1
 }
 
+# ── Multi-stage install runner (BL-069) ─────────────────────────────
+# Split a ` && `-joined install string back into its ordered stages.
+# The resolver (scripts/resolve-tools.sh, BL-033) joins an install_cmds
+# array with EXACTLY ` && ` to produce the legacy singular install_cmd,
+# so splitting on that delimiter recovers the original stage list. A
+# legacy single-command string (no ` && `) yields exactly one stage —
+# identical to the pre-BL-069 single-eval path. Result is returned in
+# the global array SOIF_INSTALL_STAGES (bash-3.2 has no namerefs).
+_soif_split_on_and() {
+  local s="$1"
+  SOIF_INSTALL_STAGES=()
+  while :; do
+    case "$s" in
+      *" && "*)
+        SOIF_INSTALL_STAGES+=( "${s%%" && "*}" )
+        s="${s#*" && "}"
+        ;;
+      *)
+        SOIF_INSTALL_STAGES+=( "$s" )
+        break
+        ;;
+    esac
+  done
+}
+
+# Execute an ordered list of install stages with per-stage fail-fast and
+# per-stage diagnosis. This is the shared eval-path consumer of the
+# resolver's `install_cmds` array (BL-033/BL-069): each argument after
+# the tool name is one stage.
+#
+# Semantics (the BL-069 contract):
+#   • Stages run IN ORDER, each eval'd IN THIS FUNCTION'S SHELL SCOPE,
+#     so a variable assigned in stage N is visible to stage N+1 —
+#     behaviorally identical to `eval "stage1 && stage2 && …"`, but with
+#     a per-stage audit line and a per-stage exit-code check.
+#   • FAIL-FAST: the first stage to exit non-zero STOPS the sequence.
+#     Later stages do NOT run (matching `&&` short-circuit).
+#   • RESUMABLE: side effects of already-completed stages are left in
+#     place, so a repair re-run can pick up from the failing stage.
+#   • Returns 0 iff every stage succeeded; otherwise returns the failing
+#     stage's non-zero exit code.
+#
+# Usage: run_install_stages "<tool-name>" "<stage1>" ["<stage2>" …]
+# A single stage (the legacy-string case) runs exactly as the old
+# `eval "$install_cmd"` did — no per-stage banner, identical behavior.
+run_install_stages() {
+  local tool_name="$1"; shift
+  local total=$#
+  if [ "$total" -eq 0 ]; then
+    return 0
+  fi
+  local idx=0 stage rc
+  for stage in "$@"; do
+    idx=$((idx + 1))
+    if [ "$total" -gt 1 ]; then
+      print_info "[$tool_name] install stage $idx/$total: $stage"
+    fi
+    eval "$stage"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      if [ "$total" -gt 1 ]; then
+        print_warn "[$tool_name] install stage $idx/$total FAILED (exit $rc): $stage"
+        print_warn "[$tool_name] earlier stages left their effects in place — re-run to resume from stage $idx."
+      fi
+      return "$rc"
+    fi
+  done
+  return 0
+}
+
 # Prompt user to install a missing tool. Returns 0 if installed, 1 if skipped.
 # Usage: prompt_install "tool_name" "install_command" [needs_sudo]
 #
@@ -378,7 +448,14 @@ prompt_install() {
     return 1
   fi
 
-  if eval "$install_cmd"; then
+  # BL-069: honor the resolver's multi-stage install_cmds shape. The
+  # command may be a ` && `-joined sequence of stages (the legacy
+  # singular form of an install_cmds array). Split it back into stages
+  # and run each with per-stage fail-fast + diagnosis via the shared
+  # runner. A single-command string is one stage — behaviorally
+  # identical to the previous `eval "$install_cmd"`.
+  _soif_split_on_and "$install_cmd"
+  if run_install_stages "$tool_name" "${SOIF_INSTALL_STAGES[@]}"; then
     print_ok "$tool_name installed"
     return 0
   else

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -1988,6 +1988,47 @@ fi
 RESOLVER="$ORCHESTRATOR_ROOT/scripts/resolve-tools.sh"
 MATRIX_DIR="$ORCHESTRATOR_ROOT/templates/tool-matrix"
 
+# BL-069: install every auto_install tool from the resolver output,
+# iterating each tool's structured install_cmds stages (fail-fast per
+# stage) via run_install_stages. Falls back to the legacy singular
+# install_cmd only when the array is absent (legacy-string matrix
+# entries behave unchanged). No 2>/dev/null: per-stage install failures
+# must surface so the operator can act on the exact failing stage.
+#
+# Factored out of the interactive track-upgrade path (verifier
+# follow-up) so the stage iteration is directly unit-testable — the
+# `[ -t 0 ]` + prompt_yes_no gates around the call site made this loop
+# unreachable from the non-interactive test suite.
+#   $1 = resolver JSON output   $2 = count of .auto_install entries
+upgrade_auto_install_from_resolver() {
+  local resolver_output="$1"
+  local auto_count="$2"
+  local _ui=0
+  while [ "$_ui" -lt "$auto_count" ]; do
+    local _tool_name _stages_json _st
+    _tool_name=$(echo "$resolver_output" | jq -r --argjson i "$_ui" '.auto_install[$i].name // "tool"')
+    _stages_json=$(echo "$resolver_output" | jq -c --argjson i "$_ui" '
+      .auto_install[$i] as $t
+      | (if ($t.install_cmds | type) == "array" and ($t.install_cmds | length) > 0
+         then $t.install_cmds else [$t.install_cmd] end)
+      | map(select(. != null and . != ""))
+    ')
+    local _stages=()
+    while IFS= read -r _st; do
+      [ -n "$_st" ] && _stages+=("$_st")
+    done < <(echo "$_stages_json" | jq -r '.[]')
+    if [ "${#_stages[@]}" -gt 0 ]; then
+      print_info "Installing: $_tool_name"
+      if run_install_stages "$_tool_name" "${_stages[@]}"; then
+        print_ok "Installed successfully"
+      else
+        print_warn "Install failed — you may need to install manually"
+      fi
+    fi
+    _ui=$((_ui + 1))
+  done
+}
+
 if [ "$TRACK_CHANGES" = true ] && [ -f "$RESOLVER" ] && [ -d "$MATRIX_DIR" ] && \
    [ -n "$CURRENT_PLATFORM" ] && [ -n "$CURRENT_LANGUAGE" ]; then
   print_step "Resolving tools for upgraded track"
@@ -2030,35 +2071,12 @@ if [ "$TRACK_CHANGES" = true ] && [ -f "$RESOLVER" ] && [ -d "$MATRIX_DIR" ] && 
         # already gates this branch — prompt_yes_no's defense-in-
         # depth N return here is harmless (we don't enter the block).
         if prompt_yes_no "$(echo -e "  ${BOLD}Auto-install $AUTO_COUNT tool(s) now? [Y/n]${NC}")" "Y"; then
-          # BL-069: iterate each tool's structured install_cmds array so
-          # per-stage failures are diagnosed and fail-fast per stage. Fall
-          # back to the legacy singular install_cmd only when the array is
-          # absent (legacy-string matrix entries behave unchanged). No
-          # 2>/dev/null: per-stage install failures must surface so the
-          # operator can act on the exact failing stage.
-          _ui=0
-          while [ "$_ui" -lt "$AUTO_COUNT" ]; do
-            _tool_name=$(echo "$RESOLVER_OUTPUT" | jq -r --argjson i "$_ui" '.auto_install[$i].name // "tool"')
-            _stages_json=$(echo "$RESOLVER_OUTPUT" | jq -c --argjson i "$_ui" '
-              .auto_install[$i] as $t
-              | (if ($t.install_cmds | type) == "array" and ($t.install_cmds | length) > 0
-                 then $t.install_cmds else [$t.install_cmd] end)
-              | map(select(. != null and . != ""))
-            ')
-            _stages=()
-            while IFS= read -r _st; do
-              [ -n "$_st" ] && _stages+=("$_st")
-            done < <(echo "$_stages_json" | jq -r '.[]')
-            if [ "${#_stages[@]}" -gt 0 ]; then
-              print_info "Installing: $_tool_name"
-              if run_install_stages "$_tool_name" "${_stages[@]}"; then
-                print_ok "Installed successfully"
-              else
-                print_warn "Install failed — you may need to install manually"
-              fi
-            fi
-            _ui=$((_ui + 1))
-          done
+          # BL-069: delegate to the factored stage-iterating installer.
+          # Factored out (verifier follow-up) so the per-stage iteration
+          # is DIRECTLY testable — the interactive prompt_yes_no + `-t 0`
+          # gates above made this loop unreachable from the test suite,
+          # which hid a stage-drop regression.
+          upgrade_auto_install_from_resolver "$RESOLVER_OUTPUT" "$AUTO_COUNT"
         else
           print_info "Skipped auto-install. You can install tools later."
         fi

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -2030,15 +2030,34 @@ if [ "$TRACK_CHANGES" = true ] && [ -f "$RESOLVER" ] && [ -d "$MATRIX_DIR" ] && 
         # already gates this branch — prompt_yes_no's defense-in-
         # depth N return here is harmless (we don't enter the block).
         if prompt_yes_no "$(echo -e "  ${BOLD}Auto-install $AUTO_COUNT tool(s) now? [Y/n]${NC}")" "Y"; then
-          echo "$RESOLVER_OUTPUT" | jq -r '.auto_install[] | .install_cmd' | while IFS= read -r cmd; do
-            if [ -n "$cmd" ]; then
-              print_info "Installing: $cmd"
-              if eval "$cmd" 2>/dev/null; then
+          # BL-069: iterate each tool's structured install_cmds array so
+          # per-stage failures are diagnosed and fail-fast per stage. Fall
+          # back to the legacy singular install_cmd only when the array is
+          # absent (legacy-string matrix entries behave unchanged). No
+          # 2>/dev/null: per-stage install failures must surface so the
+          # operator can act on the exact failing stage.
+          _ui=0
+          while [ "$_ui" -lt "$AUTO_COUNT" ]; do
+            _tool_name=$(echo "$RESOLVER_OUTPUT" | jq -r --argjson i "$_ui" '.auto_install[$i].name // "tool"')
+            _stages_json=$(echo "$RESOLVER_OUTPUT" | jq -c --argjson i "$_ui" '
+              .auto_install[$i] as $t
+              | (if ($t.install_cmds | type) == "array" and ($t.install_cmds | length) > 0
+                 then $t.install_cmds else [$t.install_cmd] end)
+              | map(select(. != null and . != ""))
+            ')
+            _stages=()
+            while IFS= read -r _st; do
+              [ -n "$_st" ] && _stages+=("$_st")
+            done < <(echo "$_stages_json" | jq -r '.[]')
+            if [ "${#_stages[@]}" -gt 0 ]; then
+              print_info "Installing: $_tool_name"
+              if run_install_stages "$_tool_name" "${_stages[@]}"; then
                 print_ok "Installed successfully"
               else
                 print_warn "Install failed — you may need to install manually"
               fi
             fi
+            _ui=$((_ui + 1))
           done
         else
           print_info "Skipped auto-install. You can install tools later."

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -1317,14 +1317,14 @@ _tool_install_legacy_metachar_safe() {
   return 0
 }
 
-fix_tool_install() {
-  local index="$1"
-  if [ -z "$RESOLVER_OUTPUT" ]; then return 1; fi
-  local install_cmd
-  install_cmd=$(echo "$RESOLVER_OUTPUT" | jq -r ".auto_install[$index].install_cmd")
-  if [ -z "$install_cmd" ] || [ "$install_cmd" = "null" ]; then
-    return 1
-  fi
+# Dispatch a SINGLE install stage through the two-layer pipeline.
+# Returns 0 on success, non-zero on failure/refusal. Extracted from
+# fix_tool_install (BL-069) so the per-stage loop can invoke it once per
+# element of the resolver's install_cmds array. A stage that fails the
+# structured shape AND the legacy metachar gate is REFUSED (non-zero) —
+# the loop then halts fail-fast without running later stages.
+_tool_install_dispatch_one() {
+  local install_cmd="$1"
 
   # -------- Layer 1: structured dispatch --------
   _tool_install_dispatch_structured "$install_cmd"
@@ -1396,6 +1396,49 @@ fix_tool_install() {
   # — but the metachar gate above has already rejected the dangerous
   # chaining forms.
   bash -c -- "$install_cmd"
+}
+
+fix_tool_install() {
+  local index="$1"
+  if [ -z "$RESOLVER_OUTPUT" ]; then return 1; fi
+
+  # BL-069: honor the resolver's structured `install_cmds` array so each
+  # stage is dispatched (and diagnosed) independently with fail-fast.
+  # Fall back to the legacy singular `install_cmd` ONLY when the array is
+  # absent/empty — legacy-string matrix entries behave exactly as before.
+  local stages_json
+  stages_json=$(echo "$RESOLVER_OUTPUT" | jq -c --argjson i "$index" '
+    .auto_install[$i] as $t
+    | (if ($t.install_cmds | type) == "array" and ($t.install_cmds | length) > 0
+       then $t.install_cmds else [$t.install_cmd] end)
+    | map(select(. != null and . != ""))
+  ')
+  if [ -z "$stages_json" ] || [ "$stages_json" = "null" ] || [ "$stages_json" = "[]" ]; then
+    return 1
+  fi
+
+  local total
+  total=$(echo "$stages_json" | jq 'length')
+
+  # Iterate stages: dispatch each through the two-layer pipeline. A
+  # non-zero stage HALTS the sequence (fail-fast); later stages do NOT
+  # run, and earlier stages' side effects remain for a repair re-run.
+  local idx=0 stage rc
+  while IFS= read -r stage; do
+    idx=$((idx + 1))
+    if [ "$total" -gt 1 ]; then
+      print_info "fix_tool_install: stage $idx/$total: $stage" >&2
+    fi
+    _tool_install_dispatch_one "$stage"
+    rc=$?
+    if [ "$rc" -ne 0 ]; then
+      if [ "$total" -gt 1 ]; then
+        print_warn "fix_tool_install: stage $idx/$total failed (exit $rc) — halting; earlier stages' effects remain for a repair re-run." >&2
+      fi
+      return "$rc"
+    fi
+  done < <(echo "$stages_json" | jq -r '.[]')
+  return 0
 }
 
 # BL-050 (Step 4 ROI #6): synthesize the 20 fix_tool_install_N wrappers only

--- a/templates/tool-matrix/common.json
+++ b/templates/tool-matrix/common.json
@@ -201,9 +201,18 @@
       "latest_check": {"method": "github_release", "package": "gitleaks/gitleaks"},
       "install": {
         "darwin_brew": "brew install gitleaks",
-        "linux_apt": "GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name) && curl -sSfL \"https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz\" | sudo tar -xz -C /usr/local/bin gitleaks",
-        "linux_dnf": "GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name) && curl -sSfL \"https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz\" | sudo tar -xz -C /usr/local/bin gitleaks",
-        "linux_pacman": "GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name) && curl -sSfL \"https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz\" | sudo tar -xz -C /usr/local/bin gitleaks",
+        "linux_apt": [
+          "GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)",
+          "curl -sSfL \"https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz\" | sudo tar -xz -C /usr/local/bin gitleaks"
+        ],
+        "linux_dnf": [
+          "GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)",
+          "curl -sSfL \"https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz\" | sudo tar -xz -C /usr/local/bin gitleaks"
+        ],
+        "linux_pacman": [
+          "GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)",
+          "curl -sSfL \"https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz\" | sudo tar -xz -C /usr/local/bin gitleaks"
+        ],
         "manual": "https://github.com/gitleaks/gitleaks/releases"
       },
       "auto_installable": true,
@@ -387,8 +396,14 @@
       "min_version": "1.70.0",
       "latest_check": null,
       "install": {
-        "darwin_brew": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source \"$HOME/.cargo/env\"",
-        "linux_apt": "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source \"$HOME/.cargo/env\"",
+        "darwin_brew": [
+          "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
+          "source \"$HOME/.cargo/env\""
+        ],
+        "linux_apt": [
+          "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y",
+          "source \"$HOME/.cargo/env\""
+        ],
         "linux_pacman": "sudo pacman -S --noconfirm rust",
         "manual": "https://rustup.rs/"
       },

--- a/templates/tool-matrix/web.json
+++ b/templates/tool-matrix/web.json
@@ -129,7 +129,13 @@
       "latest_check": {"method": "brew", "package": "k6"},
       "install": {
         "darwin_brew": "brew install k6",
-        "linux_apt": "sudo gpg -k && sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69 && echo 'deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main' | sudo tee /etc/apt/sources.list.d/k6.list && sudo apt update && sudo apt install k6",
+        "linux_apt": [
+          "sudo gpg -k",
+          "sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69",
+          "echo 'deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main' | sudo tee /etc/apt/sources.list.d/k6.list",
+          "sudo apt update",
+          "sudo apt install k6"
+        ],
         "linux_pacman": "sudo pacman -S --noconfirm k6",
         "manual": "https://k6.io/docs/get-started/installation/"
       },

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -784,6 +784,27 @@ else
 fi
 
 # ----------------------------------------------------------------
+# TEST 0r-bl069: install_cmds ARRAY CONSUMERS (BL-069)
+# ----------------------------------------------------------------
+# BL-033 (above) shipped the resolver SCHEMA — install_cmd (legacy
+# joined) + install_cmds (structured array) — but no consumer READ the
+# array. tests/test-bl069-install-cmds-consumers.sh proves the three
+# migrated readers (helpers-core.sh run_install_stages/prompt_install,
+# verify-install.sh fix_tool_install, upgrade-project.sh install loop)
+# iterate install_cmds with per-stage fail-fast + resumability, fall
+# back to the legacy singular install_cmd when the array is absent, and
+# that gitleaks/rust/k6 are migrated to the array shape (join-preserving).
+# Mutation-proven: a reader that used only install_cmds[0] flips
+# T-runner-happy-multi / T-extract-prefers-array / T-vi-multi-both RED.
+# Registered here per BL-038 discipline.
+section "BL-069 install_cmds array consumers"
+if bash "$SCRIPT_DIR/tests/test-bl069-install-cmds-consumers.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl069-install-cmds-consumers.sh (Groups A-E: split, run_install_stages, extraction, fix_tool_install dispatch, wrapper JSON regression)"
+else
+  fail "tests/test-bl069-install-cmds-consumers.sh FAILED (run for details)"
+fi
+
+# ----------------------------------------------------------------
 # TEST 0s: HOST-DRIVER AGGREGATOR
 # ----------------------------------------------------------------
 # tests/host-drivers/run-all.sh wraps the per-host unit tests

--- a/tests/test-bl069-install-cmds-consumers.sh
+++ b/tests/test-bl069-install-cmds-consumers.sh
@@ -354,6 +354,80 @@ K6_JOIN="sudo gpg -k && sudo gpg --no-default-keyring --keyring /usr/share/keyri
 _assert_array_joins "T-wrap-k6-linux_apt" "$WEB_JSON" \
   '.tools[] | select(.name=="k6") | .install.linux_apt' 5 "$K6_JOIN"
 
+# ============================================================
+# GROUP F — upgrade-project.sh reader (DIRECT coverage). The interactive
+# track-upgrade auto-install loop is gated behind prompt_yes_no +
+# `[ -t 0 ]`, so it is unreachable from this non-interactive suite (the
+# verifier proved a `"${_stages[@]}"`->`"${_stages[0]}"` stage-drop went
+# undetected). It was factored into upgrade_auto_install_from_resolver()
+# specifically so the stage iteration can be exercised here. This is the
+# MUTATION ANCHOR for reader #3.
+# ============================================================
+echo ""
+echo "GROUP F: upgrade-project.sh auto-install stage loop (direct)"
+
+UPGRADE_SH="$REPO_ROOT/scripts/upgrade-project.sh"
+
+# Extract just upgrade_auto_install_from_resolver() and run it in a
+# subshell that also sources helpers-core (for run_install_stages +
+# print_*). Drives the REAL function with a fake resolver payload whose
+# tool has a multi-stage install_cmds; each stage touches a file so the
+# stages that actually ran are observable on disk afterward.
+_run_upgrade_installer() {
+  local payload="$1" count="$2"
+  local fn; fn=$(mktemp)
+  awk '
+    /^upgrade_auto_install_from_resolver\(\) \{/ {flag=1}
+    flag {print}
+    flag && /^\}$/ {exit}
+  ' "$UPGRADE_SH" > "$fn"
+  env _PAYLOAD="$payload" _COUNT="$count" _FN="$fn" _HC="$HELPERS_CORE" bash -c '
+    set +e
+    # shellcheck source=/dev/null
+    source "$_HC"
+    # shellcheck source=/dev/null
+    source "$_FN"
+    upgrade_auto_install_from_resolver "$_PAYLOAD" "$_COUNT"
+  ' >/dev/null 2>&1
+  rm -f "$fn"
+}
+
+echo "T-upg-multi-both: 2-stage tool runs BOTH stages [MUTATION ANCHOR]"
+T=$(mktemp -d)
+PAYLOAD=$(jq -n --arg s1 "touch $T/u1" --arg s2 "touch $T/u2" \
+  '{auto_install:[{name:"multi",category:"x",install_cmd:($s1+" && "+$s2),install_cmds:[$s1,$s2],required:false,description:"x"}],already_installed:[],manual_install:[],deferred:[]}')
+_run_upgrade_installer "$PAYLOAD" 1
+if [ -e "$T/u1" ] && [ -e "$T/u2" ]; then
+  pass "T-upg-multi-both: upgrade loop ran stage1 AND stage2"
+else
+  fail_ "T-upg-multi-both" "u1=$([ -e "$T/u1" ] && echo y || echo n) u2=$([ -e "$T/u2" ] && echo y || echo n) — a '\${_stages[0]}' mutation fails HERE"
+fi
+rm -rf "$T"
+
+echo "T-upg-failfast: stage-1 fails -> stage-2 MUST NOT run"
+T=$(mktemp -d)
+PAYLOAD=$(jq -n --arg s2 "touch $T/u2_no" \
+  '{auto_install:[{name:"ff",category:"x",install_cmd:("false && "+$s2),install_cmds:["false",$s2],required:false,description:"x"}],already_installed:[],manual_install:[],deferred:[]}')
+_run_upgrade_installer "$PAYLOAD" 1
+if [ ! -e "$T/u2_no" ]; then
+  pass "T-upg-failfast: stage-1 failure halted the upgrade loop"
+else
+  fail_ "T-upg-failfast" "stage-2 ran despite stage-1 failure"
+fi
+rm -rf "$T"
+
+echo "T-upg-legacy-fallback: tool with ONLY install_cmd still installs (back-compat)"
+T=$(mktemp -d)
+PAYLOAD=$(jq -n --arg s1 "touch $T/leg" \
+  '{auto_install:[{name:"leg",category:"x",install_cmd:$s1,required:false,description:"x"}],already_installed:[],manual_install:[],deferred:[]}')
+_run_upgrade_installer "$PAYLOAD" 1
+if [ -e "$T/leg" ]; then
+  pass "T-upg-legacy-fallback: legacy singular install_cmd ran"
+else
+  fail_ "T-upg-legacy-fallback" "legacy install_cmd did not run"
+fi
+rm -rf "$T"
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]

--- a/tests/test-bl069-install-cmds-consumers.sh
+++ b/tests/test-bl069-install-cmds-consumers.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# tests/test-bl069-install-cmds-consumers.sh
+#
+# BL-069: prove the install-command CONSUMERS honor the resolver's
+# structured `install_cmds` array (BL-033/PR #136 shipped the schema;
+# the array was emitted but read by no consumer). Three readers were
+# migrated to iterate stages with per-stage fail-fast + diagnosis,
+# falling back to the legacy singular `install_cmd` only when the array
+# is absent:
+#
+#   1. scripts/lib/helpers-core.sh  — run_install_stages + prompt_install
+#   2. scripts/verify-install.sh    — fix_tool_install (two-layer dispatch)
+#   3. scripts/upgrade-project.sh   — track-upgrade tool-install loop
+#
+# The upgrade-project reader DELEGATES to run_install_stages (Group B)
+# and uses the IDENTICAL jq stages-extraction as fix_tool_install
+# (Group C + Group D), so its behavior is covered transitively — the
+# same-filter extraction is asserted directly, and the shared runner's
+# iteration is mutation-proven.
+#
+# PER-STAGE CONTRACT (the point of the array shape):
+#   • stage-1 fails  -> stage-2 MUST NOT run (fail-fast).
+#   • stage-2 fails  -> stage-1's side effects MUST remain observable
+#                       (a repair re-run resumes mid-sequence).
+#
+# MUTATION EVIDENCE (required by BL-069): a reader that used only
+#   install_cmds[0] (ignoring later stages) MUST flip a test RED.
+#   • Group B  T-runner-happy-multi : asserts BOTH stage side effects —
+#     a runner that ran only stage[0] leaves stage-2's file missing -> RED.
+#   • Group C  T-extract-prefers-array : the shared extraction yields the
+#     FULL array, not [0]; a `.install_cmds[0]` mutation -> length 1 -> RED.
+#   • Group D  T-vi-multi-both : fix_tool_install dispatches BOTH stages;
+#     a `.install_cmds[0]`/`.[]`->`.[0]` mutation logs only stage 1 -> RED.
+#
+# Test harness conventions mirror tests/test-bl033-install-cmds-shape.sh
+# and tests/test-verify-install-fix-functions.sh: self-contained, each
+# scenario isolated in its own tmpdir, PASS/FAIL counters + exit status.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HELPERS_CORE="$REPO_ROOT/scripts/lib/helpers-core.sh"
+VERIFY_INSTALL="$REPO_ROOT/scripts/verify-install.sh"
+COMMON_JSON="$REPO_ROOT/templates/tool-matrix/common.json"
+WEB_JSON="$REPO_ROOT/templates/tool-matrix/web.json"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Source helpers-core in THIS shell so run_install_stages / prompt_install
+# / _soif_split_on_and are callable directly. Silence LOG_FILE side
+# effects by leaving it empty (helpers-core makes log_line a no-op then).
+# shellcheck source=/dev/null
+source "$HELPERS_CORE"
+
+# ============================================================
+# GROUP A — _soif_split_on_and: recover stages from a ` && `-joined
+# string (the resolver's legacy singular form of an install_cmds array).
+# ============================================================
+echo "GROUP A: _soif_split_on_and"
+
+echo "T-split-single: a single command (no ' && ') is one stage"
+_soif_split_on_and "brew install jq"
+if [ "${#SOIF_INSTALL_STAGES[@]}" -eq 1 ] && [ "${SOIF_INSTALL_STAGES[0]}" = "brew install jq" ]; then
+  pass "T-split-single: single-command string -> 1 stage, unchanged"
+else
+  fail_ "T-split-single" "got ${#SOIF_INSTALL_STAGES[@]} stage(s): ${SOIF_INSTALL_STAGES[*]}"
+fi
+
+echo "T-split-multi: 'a && b && c' splits into exactly 3 ordered stages"
+_soif_split_on_and "cmd one && cmd two && cmd three"
+if [ "${#SOIF_INSTALL_STAGES[@]}" -eq 3 ] \
+   && [ "${SOIF_INSTALL_STAGES[0]}" = "cmd one" ] \
+   && [ "${SOIF_INSTALL_STAGES[1]}" = "cmd two" ] \
+   && [ "${SOIF_INSTALL_STAGES[2]}" = "cmd three" ]; then
+  pass "T-split-multi: 3 stages recovered in order"
+else
+  fail_ "T-split-multi" "got ${#SOIF_INSTALL_STAGES[@]} stage(s): ${SOIF_INSTALL_STAGES[*]}"
+fi
+
+echo "T-split-preserves-internal: pipes/quotes inside a stage are preserved"
+_soif_split_on_and 'GITLEAKS_VERSION=$(curl x | jq -r .tag) && curl "y" | sudo tar -xz'
+if [ "${#SOIF_INSTALL_STAGES[@]}" -eq 2 ] \
+   && [ "${SOIF_INSTALL_STAGES[0]}" = 'GITLEAKS_VERSION=$(curl x | jq -r .tag)' ] \
+   && [ "${SOIF_INSTALL_STAGES[1]}" = 'curl "y" | sudo tar -xz' ]; then
+  pass "T-split-preserves-internal: pipes/quotes kept within their stage"
+else
+  fail_ "T-split-preserves-internal" "got ${#SOIF_INSTALL_STAGES[@]}: ${SOIF_INSTALL_STAGES[*]}"
+fi
+
+# ============================================================
+# GROUP B — run_install_stages: the shared eval-path runner used by
+# prompt_install (and, transitively, upgrade-project). This is the
+# MUTATION ANCHOR for "iterate all stages".
+# ============================================================
+echo ""
+echo "GROUP B: run_install_stages (per-stage fail-fast + resumability)"
+
+echo "T-runner-happy-multi: BOTH stages run -> both side effects observable [MUTATION ANCHOR]"
+T=$(mktemp -d)
+run_install_stages "demo" "touch $T/s1" "touch $T/s2" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ -e "$T/s1" ] && [ -e "$T/s2" ]; then
+  pass "T-runner-happy-multi: stage1 AND stage2 executed (rc=0)"
+else
+  fail_ "T-runner-happy-multi" "rc=$rc s1=$([ -e "$T/s1" ] && echo y || echo n) s2=$([ -e "$T/s2" ] && echo y || echo n) — a runner that ran only stage[0] fails HERE"
+fi
+rm -rf "$T"
+
+echo "T-runner-failfast: stage-1 fails -> stage-2 MUST NOT run"
+T=$(mktemp -d)
+run_install_stages "demo" "false" "touch $T/should_not_exist" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ] && [ ! -e "$T/should_not_exist" ]; then
+  pass "T-runner-failfast: stage-1 failure halted the sequence (rc=$rc, stage-2 skipped)"
+else
+  fail_ "T-runner-failfast" "rc=$rc stage2_ran=$([ -e "$T/should_not_exist" ] && echo YES || echo no)"
+fi
+rm -rf "$T"
+
+echo "T-runner-stage2-fail-resumable: stage-2 fails -> stage-1 side effect remains"
+T=$(mktemp -d)
+run_install_stages "demo" "touch $T/s1_kept" "false" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -ne 0 ] && [ -e "$T/s1_kept" ]; then
+  pass "T-runner-stage2-fail-resumable: stage-1 effect persists for a repair re-run (rc=$rc)"
+else
+  fail_ "T-runner-stage2-fail-resumable" "rc=$rc s1_kept=$([ -e "$T/s1_kept" ] && echo y || echo MISSING)"
+fi
+rm -rf "$T"
+
+echo "T-runner-single-backcompat: a single stage runs as before (identical behavior)"
+T=$(mktemp -d)
+run_install_stages "demo" "touch $T/only" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ -e "$T/only" ]; then
+  pass "T-runner-single-backcompat: 1-stage path unchanged (rc=0)"
+else
+  fail_ "T-runner-single-backcompat" "rc=$rc only=$([ -e "$T/only" ] && echo y || echo n)"
+fi
+rm -rf "$T"
+
+echo "T-runner-crossstage-var: a var set in stage-1 is visible in stage-2 (gitleaks pattern)"
+T=$(mktemp -d)
+run_install_stages "demo" "MYVER=8.28.0" "echo \"\$MYVER\" > \"$T/ver\"" >/dev/null 2>&1
+rc=$?
+if [ "$rc" -eq 0 ] && [ -f "$T/ver" ] && [ "$(cat "$T/ver")" = "8.28.0" ]; then
+  pass "T-runner-crossstage-var: shared-scope eval carries VAR across stages"
+else
+  fail_ "T-runner-crossstage-var" "rc=$rc content='$([ -f "$T/ver" ] && cat "$T/ver")'"
+fi
+rm -rf "$T"
+
+# ============================================================
+# GROUP C — shared stages-extraction contract. Both readers
+# (fix_tool_install + upgrade-project) extract stages from resolver
+# output with this exact jq: prefer install_cmds when it's a non-empty
+# array; else fall back to [install_cmd]. This is where a
+# `.install_cmds[0]` mutation would collapse the array to one stage.
+# ============================================================
+echo ""
+echo "GROUP C: shared stages-extraction (prefer install_cmds, fall back to [install_cmd])"
+
+_extract_stages() {
+  # Mirrors the reader extraction in verify-install.sh:fix_tool_install
+  # and upgrade-project.sh (BL-069). $1 = resolver-shaped JSON, index 0.
+  echo "$1" | jq -c --argjson i 0 '
+    .auto_install[$i] as $t
+    | (if ($t.install_cmds | type) == "array" and ($t.install_cmds | length) > 0
+       then $t.install_cmds else [$t.install_cmd] end)
+    | map(select(. != null and . != ""))
+  '
+}
+
+echo "T-extract-prefers-array: a 2-stage install_cmds yields 2 stages, NOT [install_cmd] [MUTATION ANCHOR]"
+PAYLOAD='{"auto_install":[{"name":"x","install_cmd":"a && b","install_cmds":["a","b"]}]}'
+got=$(_extract_stages "$PAYLOAD")
+len=$(echo "$got" | jq 'length')
+if [ "$len" = "2" ] && [ "$(echo "$got" | jq -r '.[0]')" = "a" ] && [ "$(echo "$got" | jq -r '.[1]')" = "b" ]; then
+  pass "T-extract-prefers-array: extraction returns the full 2-element array"
+else
+  fail_ "T-extract-prefers-array" "len=$len got=$got — a '.install_cmds[0]' mutation fails HERE"
+fi
+
+echo "T-extract-legacy-fallback: absent install_cmds falls back to [install_cmd]"
+PAYLOAD='{"auto_install":[{"name":"x","install_cmd":"brew install legacy"}]}'
+got=$(_extract_stages "$PAYLOAD")
+if [ "$(echo "$got" | jq 'length')" = "1" ] && [ "$(echo "$got" | jq -r '.[0]')" = "brew install legacy" ]; then
+  pass "T-extract-legacy-fallback: legacy singular string preserved as 1 stage"
+else
+  fail_ "T-extract-legacy-fallback" "got=$got"
+fi
+
+echo "T-extract-empty-array-fallback: empty install_cmds falls back to [install_cmd]"
+PAYLOAD='{"auto_install":[{"name":"x","install_cmd":"brew install legacy2","install_cmds":[]}]}'
+got=$(_extract_stages "$PAYLOAD")
+if [ "$(echo "$got" | jq 'length')" = "1" ] && [ "$(echo "$got" | jq -r '.[0]')" = "brew install legacy2" ]; then
+  pass "T-extract-empty-array-fallback: empty array -> legacy fallback"
+else
+  fail_ "T-extract-empty-array-fallback" "got=$got"
+fi
+
+# ============================================================
+# GROUP D — verify-install.sh fix_tool_install: the REAL reader, driven
+# through its two-layer structured-dispatch pipeline with a PATH-isolated
+# `brew` shim that LOGS every invocation (so we can observe which stages
+# actually dispatched). Extractor mirrors
+# tests/test-verify-install-fix-functions.sh (Pass-1 anchor).
+# ============================================================
+echo ""
+echo "GROUP D: verify-install fix_tool_install (structured multi-stage dispatch)"
+
+# Extract the allowlist + dispatch helpers + _tool_install_dispatch_one
+# + fix_tool_install body and run fix_tool_install 0 against a payload.
+# env vars PATH + BREW_LOG are inherited into the bash -c subshell (and
+# thence the brew shim) from the caller's environment.
+_run_fix_tool_install() {
+  local payload="$1"
+  local extract; extract=$(mktemp)
+  awk '
+    /^_TOOL_INSTALL_ALLOWED_HEADS=\(/ {flag=1}
+    flag {print}
+    flag && /^fix_tool_install\(\) \{/ {f=1}
+    f && /^\}$/ {print "# end-of-block"; flag=0; f=0; exit}
+  ' "$VERIFY_INSTALL" > "$extract"
+  env _PAYLOAD="$payload" _EXTRACT="$extract" bash -c '
+    set +e
+    print_info() { echo "[INFO] $*" >&2; }
+    print_warn() { echo "[WARN] $*" >&2; }
+    print_fail() { echo "[FAIL] $*" >&2; }
+    print_ok()   { echo "[OK] $*" >&2; }
+    print_step() { echo "[STEP] $*" >&2; }
+    source "$_EXTRACT"
+    RESOLVER_OUTPUT="$_PAYLOAD"
+    fix_tool_install 0
+    echo "RC=$?" >&2
+  ' 2>&1
+  rm -f "$extract"
+}
+
+# Build a brew shim that records each call and fails on a sentinel pkg.
+_make_brew_shim() {
+  local dir; dir=$(mktemp -d)
+  cat > "$dir/brew" <<'SHIM'
+#!/usr/bin/env bash
+echo "$*" >> "$BREW_LOG"
+case "$*" in
+  *FAILNOW*) exit 7 ;;
+esac
+exit 0
+SHIM
+  chmod +x "$dir/brew"
+  echo "$dir"
+}
+
+echo "T-vi-multi-both: install_cmds=[stage1,stage2] dispatches BOTH stages [MUTATION ANCHOR]"
+SHIM=$(_make_brew_shim); LOG=$(mktemp)
+PAYLOAD=$(jq -n '{auto_install:[{name:"multi",category:"x",
+  install_cmd:"brew install pkgone && brew install pkgtwo",
+  install_cmds:["brew install pkgone","brew install pkgtwo"],
+  required:false, description:"x"}], already_installed:[], manual_install:[], deferred:[]}')
+out=$(PATH="$SHIM:$PATH" BREW_LOG="$LOG" _run_fix_tool_install "$PAYLOAD")
+if grep -q "install -- pkgone" "$LOG" && grep -q "install -- pkgtwo" "$LOG"; then
+  pass "T-vi-multi-both: both stages reached the brew dispatch (log: $(tr '\n' ';' < "$LOG"))"
+else
+  fail_ "T-vi-multi-both" "log did not contain both stages: $(tr '\n' ';' < "$LOG") | out=$out — a reader using only install_cmds[0] fails HERE"
+fi
+rm -rf "$SHIM"; rm -f "$LOG"
+
+echo "T-vi-failfast: stage-1 fails -> stage-2 MUST NOT dispatch"
+SHIM=$(_make_brew_shim); LOG=$(mktemp)
+PAYLOAD=$(jq -n '{auto_install:[{name:"ff",category:"x",
+  install_cmd:"brew install FAILNOW && brew install pkgtwo",
+  install_cmds:["brew install FAILNOW","brew install pkgtwo"],
+  required:false, description:"x"}], already_installed:[], manual_install:[], deferred:[]}')
+out=$(PATH="$SHIM:$PATH" BREW_LOG="$LOG" _run_fix_tool_install "$PAYLOAD")
+if grep -q "install -- FAILNOW" "$LOG" && ! grep -q "install -- pkgtwo" "$LOG" && echo "$out" | grep -q "RC=7"; then
+  pass "T-vi-failfast: stage-1 failure halted dispatch (rc=7, stage-2 never ran)"
+else
+  fail_ "T-vi-failfast" "log=$(tr '\n' ';' < "$LOG") out=$out (expected FAILNOW logged, pkgtwo NOT logged, RC=7)"
+fi
+rm -rf "$SHIM"; rm -f "$LOG"
+
+echo "T-vi-stage2-fail-resumable: stage-2 fails -> stage-1 dispatch already happened"
+SHIM=$(_make_brew_shim); LOG=$(mktemp)
+PAYLOAD=$(jq -n '{auto_install:[{name:"r",category:"x",
+  install_cmd:"brew install pkgone && brew install FAILNOW",
+  install_cmds:["brew install pkgone","brew install FAILNOW"],
+  required:false, description:"x"}], already_installed:[], manual_install:[], deferred:[]}')
+out=$(PATH="$SHIM:$PATH" BREW_LOG="$LOG" _run_fix_tool_install "$PAYLOAD")
+if grep -q "install -- pkgone" "$LOG" && grep -q "install -- FAILNOW" "$LOG" && echo "$out" | grep -q "RC=7"; then
+  pass "T-vi-stage2-fail-resumable: stage-1 completed before stage-2 failed (rc=7)"
+else
+  fail_ "T-vi-stage2-fail-resumable" "log=$(tr '\n' ';' < "$LOG") out=$out"
+fi
+rm -rf "$SHIM"; rm -f "$LOG"
+
+echo "T-vi-legacy-fallback: payload with ONLY install_cmd (no install_cmds) still dispatches"
+SHIM=$(_make_brew_shim); LOG=$(mktemp)
+PAYLOAD=$(jq -n '{auto_install:[{name:"legacy",category:"x",
+  install_cmd:"brew install legacypkg",
+  required:false, description:"x"}], already_installed:[], manual_install:[], deferred:[]}')
+out=$(PATH="$SHIM:$PATH" BREW_LOG="$LOG" _run_fix_tool_install "$PAYLOAD")
+if grep -q "install -- legacypkg" "$LOG"; then
+  pass "T-vi-legacy-fallback: legacy singular install_cmd dispatched (back-compat)"
+else
+  fail_ "T-vi-legacy-fallback" "legacypkg not dispatched: log=$(tr '\n' ';' < "$LOG") out=$out"
+fi
+rm -rf "$SHIM"; rm -f "$LOG"
+
+# ============================================================
+# GROUP E — wrapper JSON regression: gitleaks / rust / k6 are now the
+# structured array shape and JOIN back to their pre-migration strings
+# (catches accidental stage drop/reorder). Mirrors BL-033
+# T-migrated-semantics for docker/colima.
+# ============================================================
+echo ""
+echo "GROUP E: gitleaks / rust / k6 migrated to array shape (join-preserves-semantics)"
+
+_assert_array_joins() {
+  local label="$1" json="$2" filter="$3" expect_len="$4" expect_join="$5"
+  local arr len joined
+  arr=$(jq -c "$filter" "$json")
+  local t; t=$(echo "$arr" | jq -r 'type')
+  if [ "$t" != "array" ]; then
+    fail_ "$label" "expected array, got type=$t ($arr)"
+    return
+  fi
+  len=$(echo "$arr" | jq 'length')
+  joined=$(echo "$arr" | jq -r 'join(" && ")')
+  if [ "$len" = "$expect_len" ] && [ "$joined" = "$expect_join" ]; then
+    pass "$label: $expect_len-stage array joins to the pre-migration string"
+  else
+    fail_ "$label" "len=$len (want $expect_len); joined='$joined'"
+  fi
+}
+
+GITLEAKS_JOIN='GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name) && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION#v}_linux_x64.tar.gz" | sudo tar -xz -C /usr/local/bin gitleaks'
+for k in linux_apt linux_dnf linux_pacman; do
+  _assert_array_joins "T-wrap-gitleaks-$k" "$COMMON_JSON" \
+    ".tools[] | select(.name==\"gitleaks\") | .install.$k" 2 "$GITLEAKS_JOIN"
+done
+
+RUST_JOIN="curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y && source \"\$HOME/.cargo/env\""
+for k in darwin_brew linux_apt; do
+  _assert_array_joins "T-wrap-rust-$k" "$COMMON_JSON" \
+    ".tools[] | select(.name==\"Rust\") | .install.$k" 2 "$RUST_JOIN"
+done
+
+K6_JOIN="sudo gpg -k && sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69 && echo 'deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main' | sudo tee /etc/apt/sources.list.d/k6.list && sudo apt update && sudo apt install k6"
+_assert_array_joins "T-wrap-k6-linux_apt" "$WEB_JSON" \
+  '.tools[] | select(.name=="k6") | .install.linux_apt' 5 "$K6_JOIN"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## BL-069 — finish the install_cmds migration (approved Option A)

PR #136 (BL-033) shipped the resolver **schema** — `scripts/resolve-tools.sh` emits BOTH `install_cmd` (legacy singular, joined with ` && `) AND `install_cmds` (structured stage array). The verifier confirmed the array was **emitted but read by no consumer**. This PR migrates the consumers so per-stage failure diagnosis works.

### 3 readers migrated (iterate `install_cmds`; fall back to singular only when the array is absent)
- **`scripts/lib/helpers-core.sh`** — new shared `run_install_stages` runner (in-scope `eval` per stage, fail-fast, resumable) + `_soif_split_on_and`; `prompt_install` now runs its command through the runner.
- **`scripts/verify-install.sh`** — `fix_tool_install` iterates `install_cmds`, dispatching each stage through the existing two-layer structured/legacy security pipeline (extracted as `_tool_install_dispatch_one`); halts fail-fast on the first failing stage.
- **`scripts/upgrade-project.sh`** — the track-upgrade install loop iterates each tool's stages via `run_install_stages` (also drops the `2>/dev/null` that was hiding install failures).

### 3 wrappers migrated to the array shape (`templates/tool-matrix/*.json`)
Pure ` && ` decomposition — the resolver re-joins each array to the **byte-identical** pre-migration string, so the legacy `install_cmd` field is unchanged:
- **gitleaks** `linux_apt`/`linux_dnf`/`linux_pacman` → 2 stages (version-fetch, download+extract)
- **Rust** `darwin_brew`/`linux_apt` → 2 stages (`curl … | sh`, `source …/.cargo/env`)
- **k6** `linux_apt` → 5 stages (gpg keyring, recv-keys, sources.list, apt update, apt install)

### Back-compat proof
- Legacy-string matrix entries resolve to a 1-element `install_cmds` and run as one stage — identical to the pre-BL-069 single `eval`. Covered by `T-runner-single-backcompat`, `T-extract-legacy-fallback`, `T-vi-legacy-fallback`.
- Every wrapper array re-joins to its original string (`GROUP E` — `T-wrap-gitleaks-*`, `T-wrap-rust-*`, `T-wrap-k6-*`), so the resolver's legacy `install_cmd` output is unchanged.
- Resolver still emits BOTH fields for every `auto_install` entry (verified).
- Existing suites green: `test-bl033-install-cmds-shape.sh` 8/8, `test-verify-install-fix-functions.sh` 15/15 (security tests T11/T11b/T12/T13/T14 intact).

### Per-stage contract + mutation evidence
New file `tests/test-bl069-install-cmds-consumers.sh` (21 tests, registered in `tests/full-project-test-suite.sh` per BL-038 — **not** the `KNOWN_ORPHANS_PENDING_BL035` bridge):
- stage-1 fails → stage-2 **not** run (`T-runner-failfast`, `T-vi-failfast`).
- stage-2 fails → stage-1 side effects remain observable (`T-runner-stage2-fail-resumable`, `T-vi-stage2-fail-resumable`).
- **Mutation-proven** (a reader using only `install_cmds[0]` flips RED):
  - `run_install_stages` `for stage in "$@"` → `"$1"`  ⇒  **T-runner-happy-multi RED** (`s2` file missing).
  - `fix_tool_install` `jq -r '.[]'` → `.[0]`  ⇒  **T-vi-multi-both RED** (only `install -- pkgone` reached the dispatch).

### Verification
- All 8 CI lints exit 0 (counter-antipattern, backlog-references, fix-functions-stderr, raw-read-prompt, tests-registered, doc-anchors, fail-emit-exit-status, fixture-envelopes).
- `bash -n` clean on all edited scripts.
- bash-3.2 safe (macOS target): no namerefs, guarded empty-array expansions, process-substitution already used in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)