### PR TITLE
feat(upgrade): wire CDF asset refresh into upgrade-project.sh (BL-001)

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -368,7 +368,8 @@ The init script also generates **two pipelines**: a CI pipeline (`ci.yml`) selec
 
 The manifest is a JSON file maintained jointly by CDF (for framework version pin) and solo-orchestrator (for host/mode/remote). Notable fields:
 
-- `version` — framework version pin (maintained by CDF)
+- `frameworkVersion` — CDF (Development Guardrails) version pin. Written at init and re-bumped by `scripts/upgrade-project.sh` when it refreshes CDF assets (see [Refreshing CDF framework assets](#refreshing-cdf-framework-assets) below).
+- `frameworkCommit` — the CDF clone commit the pinned assets were synced from. Re-bumped alongside `frameworkVersion`.
 - `host` — git host type: `github` | `gitlab` | `bitbucket` | `other`. Written at init time; consumed by host-aware scripts to route calls through the correct driver.
 - `mode` — project mode: `personal` | `org`. Controls protection bar and some governance paths.
 - `remote_url` — HTTPS clone URL of the remote created at init.
@@ -1190,6 +1191,36 @@ After launch, you are the operations team. Schedule these activities.
 Expect 2-4 hours/week for the first 3 months post-launch. It stabilizes to 1-2 hours/week (50-80 hours/year per application). Maintenance is bursty — a security advisory can consume a full day, and then nothing happens for two weeks.
 
 **Scaling warning:** At 10 applications, maintenance alone is a half-time job. If you are managing a portfolio, track hours per application. If total maintenance consistently exceeds your available hours, either graduate applications to engineering teams or stop taking new projects.
+
+### Refreshing CDF framework assets
+
+Your project's `.claude/framework/` subtree holds the Development Guardrails (CDF) hooks, rules, and gates — the machinery behind Claude Code's pre-commit checks (config-guard, branch-safety, plan-tracking, test-strategy, and friends). CDF ships these at project creation and continues to land fixes upstream. **Existing projects do not pick up those fixes automatically** — you refresh them by running an upgrade.
+
+**One-time setup:** keep the CDF clone current so there is something to sync from:
+
+```bash
+cd ~/.claude-dev-framework && git pull --ff-only
+```
+
+(If you do not have the clone: `git clone https://github.com/kraulerson/claude-dev-framework.git ~/.claude-dev-framework`. The default location is `~/.claude-dev-framework`; override with the `CDF_HOME` environment variable if your clone lives elsewhere.)
+
+**Refresh the assets in your project:**
+
+```bash
+cd ~/projects/your-project
+bash scripts/upgrade-project.sh --backfill-only     # lightest upgrade — syncs CDF only, no track/deployment change
+```
+
+`--backfill-only` is the lightest invocation: it refreshes CDF assets (and runs the manifest backfills) without changing your track or deployment. Any full `upgrade-project.sh` run (e.g. `--track`, `--deployment`, `--to-production`) also refreshes CDF assets as part of the upgrade.
+
+What the refresh does:
+
+- Fast-forwards the CDF clone (`git pull --ff-only`), then re-copies its `hooks/`, `rules/`, and `gates/` into your project's `.claude/framework/`, marking hook and gate scripts executable.
+- Bumps `.claude/manifest.json`'s `frameworkVersion` and `frameworkCommit` to the clone's current values, so `scripts/check-updates.sh` and the session-start version check report the version now on disk.
+
+**Graceful degradation:** if the CDF clone is missing (or the upgrade runs non-interactively without a clone), the refresh prints a `[WARN]` to stderr, keeps your project's existing `.claude/framework/` assets untouched, and the upgrade completes normally — a missing clone never blocks an upgrade. If the clone's `git pull --ff-only` fails (dirty tree or local commits), the refresh warns and proceeds using the clone's current working tree; resolve the clone's state and re-run to pick up the latest upstream fixes.
+
+**Frequency:** refresh biannually alongside the framework-document check below, or immediately whenever a CDF fix you need lands upstream.
 
 ### Governance Health Checks
 

--- a/scripts/check-updates.sh
+++ b/scripts/check-updates.sh
@@ -52,12 +52,42 @@ echo -e "${BOLD}║      Solo Orchestrator — Update Check                   �
 echo -e "${BOLD}╚══════════════════════════════════════════════════════════╝${NC}"
 echo ""
 
-# Show pinned Development Guardrails version if available (from CDF's manifest.json)
+# Show pinned Development Guardrails (CDF) version and check it against the
+# local CDF clone.
+#
+# IMPORTANT (BL-001): everything ELSE this script checks — framework
+# documents, utility scripts, CI templates — is compared against the
+# solo-orchestrator repo. CDF's hooks/rules/gates live in a SEPARATE
+# upstream (the CDF clone, default ~/.claude-dev-framework) and are
+# refreshed by scripts/upgrade-project.sh, NOT by copying files from
+# solo-orchestrator. This block is the ONLY CDF-aware part of the checker;
+# without it, a clean "all documents up to date" summary would give a false
+# sense that CDF is covered too.
 if [ -f ".claude/manifest.json" ] && command -v jq &>/dev/null; then
   cdf_commit=$(jq -r '.frameworkCommit // empty' .claude/manifest.json 2>/dev/null)
   cdf_version=$(jq -r '.frameworkVersion // empty' .claude/manifest.json 2>/dev/null)
   if [ -n "$cdf_commit" ] || [ -n "$cdf_version" ]; then
     print_info "Development Guardrails pinned at: ${cdf_version:-unknown}${cdf_commit:+ (${cdf_commit:0:12})}"
+  fi
+
+  # Compare the project's pin against the CDF clone's current FRAMEWORK_VERSION
+  # (default ~/.claude-dev-framework, overridable via CDF_HOME). A newer clone
+  # means the project's .claude/framework/ assets are stale — direct the user
+  # to the upgrade that refreshes them.
+  cdf_home="${CDF_HOME:-$HOME/.claude-dev-framework}"
+  if [ -f "$cdf_home/FRAMEWORK_VERSION" ]; then
+    clone_version=$(tr -d '[:space:]' < "$cdf_home/FRAMEWORK_VERSION" 2>/dev/null)
+    if [ -n "$clone_version" ] && [ "$clone_version" != "$cdf_version" ]; then
+      print_warn "CDF clone is at ${clone_version} — differs from this project's pin (${cdf_version:-none})."
+      echo "         Refresh CDF assets: bash scripts/upgrade-project.sh --backfill-only"
+      echo "         (Run 'cd $cdf_home && git pull --ff-only' first to compare against the latest upstream.)"
+    elif [ -n "$clone_version" ]; then
+      print_ok "CDF framework assets match the local clone (${clone_version})."
+    fi
+  else
+    print_info "CDF clone not found at $cdf_home — cannot check CDF (hooks/rules/gates) freshness."
+    echo "         This checker only covers solo-orchestrator docs/scripts, not CDF."
+    echo "         Clone: git clone https://github.com/kraulerson/claude-dev-framework.git $cdf_home"
   fi
 fi
 

--- a/scripts/lib/cdf-refresh.sh
+++ b/scripts/lib/cdf-refresh.sh
@@ -1,0 +1,90 @@
+# scripts/lib/cdf-refresh.sh — Solo-side thin wrapper around CDF's
+# canonical refresh_cdf_assets (BL-001).
+#
+# THE PROBLEM (BL-001)
+#   Development Guardrails (CDF) ships hooks/rules/gates into a project's
+#   .claude/framework/ subtree at first install (init.sh). Before this
+#   wiring, scripts/upgrade-project.sh performed NO CDF sync — a project
+#   that ran the documented upgrade stayed frozen at its install-time CDF
+#   version, silently missing upstream .claude/framework/ hook/rule/gate
+#   fixes.
+#
+# THE FIX (cross-repo split, Karl 2026)
+#   The refresh LOGIC lives UPSTREAM in the CDF clone at
+#   $CDF_HOME/scripts/cdf-refresh.sh (refresh_cdf_assets), so CDF-only
+#   projects can use it standalone. Solo carries only THIS thin call-site
+#   wrapper, which:
+#     1. Locates the CDF clone (default $HOME/.claude-dev-framework;
+#        overridable via CDF_HOME for hermetic/testable invocation).
+#     2. Sources the clone's scripts/cdf-refresh.sh and delegates to
+#        refresh_cdf_assets "$PROJECT_ROOT" "$CDF_HOME" "$NON_INTERACTIVE".
+#
+# GRACEFUL DEGRADATION (critical — never hard-fail the upgrade)
+#   If the CDF clone or its scripts/cdf-refresh.sh is absent, emit a clear
+#   [WARN] to stderr and return 0. The upgrade keeps the project's existing
+#   .claude/framework/ assets and proceeds. The upstream refresh_cdf_assets
+#   itself extends this contract:
+#     • missing clone + non-interactive → warn + return 0 (no prompt);
+#     • `git pull --ff-only` failure     → warn + proceed with current tree.
+#
+# Usage (sourced):
+#   source "$SCRIPT_DIR/lib/cdf-refresh.sh"
+#   solo_refresh_cdf "$PROJECT_ROOT" "$NON_INTERACTIVE"
+#
+# shellcheck shell=bash
+
+# Print to stderr. Mirrors the upstream cdf-refresh.sh `[WARN]`/`[INFO]`
+# style so the two layers read as one voice, without depending on
+# helpers.sh being sourced (this wrapper may run before/without it).
+_solo_cdf_warn() { echo "  [WARN] $*" >&2; }
+_solo_cdf_info() { echo "  [INFO] $*" >&2; }
+
+# solo_refresh_cdf PROJECT_ROOT [NON_INTERACTIVE]
+#   PROJECT_ROOT     — directory containing .claude/framework/.
+#   NON_INTERACTIVE  — "true" or "false" (default "false"); passed through
+#                      to refresh_cdf_assets so it can skip prompts.
+# Returns 0 on success OR graceful skip. The caller must treat any
+# non-zero return as non-fatal (the CDF sync is an ADDITION to the
+# upgrade, never a gate on it).
+solo_refresh_cdf() {
+  local project_root="$1"
+  local non_interactive="${2:-false}"
+
+  # CDF clone location. CDF_HOME override keeps the refresh hermetic and
+  # testable (point it at a fake clone); default is the canonical clone.
+  local cdf_home="${CDF_HOME:-$HOME/.claude-dev-framework}"
+  local upstream="$cdf_home/scripts/cdf-refresh.sh"
+
+  # Graceful skip: no upstream implementation to source. This covers both
+  # "clone entirely missing" and "clone present but lacks the refresh
+  # script" — in either case there is nothing to sync from, so warn and
+  # return 0 rather than aborting the upgrade.
+  if [ ! -f "$upstream" ]; then
+    _solo_cdf_warn "CDF refresh script not found at $upstream — skipping CDF asset refresh."
+    _solo_cdf_info "Your project keeps its existing .claude/framework/ hooks/rules/gates."
+    _solo_cdf_info "To enable CDF sync: git clone https://github.com/kraulerson/claude-dev-framework.git $cdf_home"
+    return 0
+  fi
+
+  # Source the canonical upstream implementation. `if !` disables the
+  # caller's `set -e` for this command so a source failure degrades
+  # gracefully instead of aborting the upgrade.
+  # shellcheck source=/dev/null
+  if ! . "$upstream"; then
+    _solo_cdf_warn "Failed to source CDF refresh script at $upstream — skipping CDF asset refresh."
+    return 0
+  fi
+
+  # Defensive: the sourced file should define refresh_cdf_assets. If a
+  # future upstream rename breaks the contract, skip loudly rather than
+  # erroring under set -e.
+  if ! command -v refresh_cdf_assets >/dev/null 2>&1; then
+    _solo_cdf_warn "refresh_cdf_assets not defined after sourcing $upstream — skipping CDF asset refresh."
+    return 0
+  fi
+
+  # Delegate to the canonical implementation. It handles the copy of
+  # hooks/rules/gates, chmod +x, manifest frameworkVersion/frameworkCommit
+  # bump, and its own graceful-skip contract (missing .git, pull failure).
+  refresh_cdf_assets "$project_root" "$cdf_home" "$non_interactive"
+}

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -94,6 +94,34 @@ _upgrade_fail() {
   fi
 }
 
+# BL-001: refresh CDF (Development Guardrails) framework assets. Sources the
+# thin Solo-side wrapper (scripts/lib/cdf-refresh.sh), which delegates to the
+# CDF clone's canonical refresh_cdf_assets — it re-copies hooks/rules/gates
+# into .claude/framework/, marks hook/gate scripts +x, and bumps the manifest
+# frameworkVersion/frameworkCommit. Without this, a project that runs the
+# documented upgrade stays frozen at its install-time CDF version and silently
+# misses upstream fixes.
+#
+# Called from TWO sites so exactly one runs per path (see each call site):
+#   • the --backfill-only path, before its short-circuit; and
+#   • the full-upgrade asset-refresh block near the end — deliberately AFTER
+#     the BL-015 pending-approval sentinel guard and the atomic section-2b
+#     mutation, so a sentinel-blocked or rolled-back upgrade never touches
+#     .claude/framework/ or the manifest pin.
+#
+# Graceful: the wrapper warns + returns 0 when the CDF clone is absent; the
+# `|| print_warn` is belt-and-suspenders so a refresh hiccup can NEVER abort
+# the upgrade — the CDF sync is an ADDITION, not a gate.
+_refresh_cdf_assets_solo() {
+  if [ -f "$SCRIPT_DIR/lib/cdf-refresh.sh" ]; then
+    print_step "Refreshing CDF framework assets (BL-001)"
+    # shellcheck source=/dev/null
+    . "$SCRIPT_DIR/lib/cdf-refresh.sh"
+    solo_refresh_cdf "$PROJECT_ROOT" "$NON_INTERACTIVE" \
+      || print_warn "CDF asset refresh skipped (non-fatal — upgrade continues)"
+  fi
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --track)
@@ -378,6 +406,11 @@ fi
 # --backfill-only short-circuits here — no track / deployment / POC
 # transition follows.
 if [ "$BACKFILL_ONLY" = true ]; then
+  # BL-001: --backfill-only refreshes CDF assets too, parallel to the manifest
+  # backfills above. Consistent with --backfill-only's existing semantics (a
+  # deliberate operator-invoked migration that does not consult the BL-015
+  # sentinel guard, which gates the track/deployment/POC transition path).
+  _refresh_cdf_assets_solo
   exit 0
 fi
 
@@ -2305,6 +2338,13 @@ if [ -d scripts ]; then
 else
   print_warn "scripts/ directory not found in project root — skipping helper refresh"
 fi
+
+# BL-001: refresh CDF framework assets on the full-upgrade path. Placed here —
+# after the BL-015 pending-approval sentinel guard and the atomic section-2b
+# mutation — so a blocked or rolled-back upgrade never touches
+# .claude/framework/ or the manifest frameworkVersion pin. (The --backfill-only
+# path refreshes earlier, before its short-circuit.)
+_refresh_cdf_assets_solo
 
 
 # Run full project validation to surface new track requirements

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -602,6 +602,18 @@ if bash "$SCRIPT_DIR/tests/test-upgrade-manifest-refresh.sh" >/dev/null 2>&1; th
 else
   fail "tests/test-upgrade-manifest-refresh.sh FAILED (run for details)"
 fi
+# BL-001: upgrade-project.sh performed no CDF sync, so downstream projects
+# stayed frozen at their install-time .claude/framework/ assets. Regression
+# suite covers the happy-path refresh (--backfill-only), graceful skip on a
+# missing clone (upgrade must still exit 0), pull-failure resilience, and a
+# mutation-proof that neutralizing solo_refresh_cdf's delegating call turns
+# the sync into a no-op. Integration scenarios skip cleanly when the CDF
+# clone is absent (CI without ~/.claude-dev-framework).
+if bash "$SCRIPT_DIR/tests/test-upgrade-cdf-refresh.sh" >/dev/null 2>&1; then
+  pass "tests/test-upgrade-cdf-refresh.sh"
+else
+  fail "tests/test-upgrade-cdf-refresh.sh FAILED (run for details)"
+fi
 
 # ----------------------------------------------------------------
 # TEST 0n: PROCESS-CHECKLIST (commit-ready-subject + reset-phase1)

--- a/tests/test-upgrade-cdf-refresh.sh
+++ b/tests/test-upgrade-cdf-refresh.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# tests/test-upgrade-cdf-refresh.sh — BL-001 regression.
+#
+# BL-001: scripts/upgrade-project.sh performed NO CDF (Development
+# Guardrails) sync. A project that ran the documented upgrade stayed
+# frozen at its install-time CDF version, silently missing upstream
+# .claude/framework/ hook/rule/gate fixes.
+#
+# Fix: upgrade-project.sh's backfill block sources scripts/lib/cdf-refresh.sh
+# (a thin Solo-side wrapper) and calls solo_refresh_cdf, which delegates to
+# the CDF clone's canonical refresh_cdf_assets. It re-copies hooks/rules/gates
+# into .claude/framework/, marks hook/gate scripts +x, and bumps the manifest
+# frameworkVersion/frameworkCommit. Lives in the backfill block so BOTH the
+# full and --backfill-only paths sync CDF.
+#
+# Test scenarios:
+#   T1 — Happy path: `upgrade-project.sh --backfill-only` against a fake CDF
+#        clone (with a working remote so `git pull --ff-only` succeeds)
+#        replaces .claude/framework/hooks|rules|gates with the clone's
+#        versions (content match; hook+gate are +x) and bumps the manifest
+#        frameworkVersion + frameworkCommit to the clone's values.
+#   T2 — Graceful skip: missing CDF clone + non-interactive → the upgrade
+#        still exits 0, emits a stderr skip [WARN], and leaves the project's
+#        existing .claude/framework/ assets untouched. Guards against
+#        re-introducing a silent hard-fail.
+#   T3 — Pull-failure resilience: a fake clone with NO remote makes
+#        `git pull --ff-only` fail → the refresh warns and still syncs from
+#        the clone's current working tree (assets replaced, manifest bumped).
+#   T4 — Mutation proof: neutralizing solo_refresh_cdf's delegating
+#        refresh_cdf_assets call turns the sync into a no-op — the control
+#        (real wrapper) refreshes, the mutant leaves the project STALE.
+#        Proves the delegating call is load-bearing (the T1 assertions go
+#        RED without it).
+#
+# HERMETICITY
+#   T1/T3/T4 need the canonical upstream refresh_cdf_assets implementation.
+#   It is located via CDF_REFRESH_SRC (default
+#   $HOME/.claude-dev-framework/scripts/cdf-refresh.sh). When that file is
+#   absent (e.g. a CI runner without the CDF clone) those scenarios SKIP
+#   with a clear notice and the suite still exits 0. T2 is fully hermetic
+#   (the wrapper short-circuits on a missing clone before it needs upstream).
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+UPGRADE="$REPO_ROOT/scripts/upgrade-project.sh"
+WRAPPER="$REPO_ROOT/scripts/lib/cdf-refresh.sh"
+UPSTREAM_SRC="${CDF_REFRESH_SRC:-$HOME/.claude-dev-framework/scripts/cdf-refresh.sh}"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+skip()  { echo "  [SKIP] $1"; SKIPPED=$((SKIPPED + 1)); }
+
+INTEGRATION_OK=1
+[ -f "$UPSTREAM_SRC" ] || INTEGRATION_OK=0
+
+# Build a fake CDF clone at $1 with FRAMEWORK_VERSION=$2 and a real upstream
+# cdf-refresh.sh, plus a demo hook/rule/gate stamped with the version. When
+# $3 == "with-remote", wire a bare origin so `git pull --ff-only` succeeds
+# (clean happy path); when "no-remote", omit the remote so the pull FAILS.
+make_fake_clone() {
+  local clone="$1" version="$2" remote_mode="$3"
+  mkdir -p "$clone/scripts" "$clone/hooks" "$clone/rules" "$clone/gates"
+  cp "$UPSTREAM_SRC" "$clone/scripts/cdf-refresh.sh"
+  echo "$version" > "$clone/FRAMEWORK_VERSION"
+  printf '#!/usr/bin/env bash\necho FRESH-HOOK-%s\n' "$version" > "$clone/hooks/demo-hook.sh"
+  printf '# fresh rule %s\n' "$version" > "$clone/rules/demo-rule.md"
+  printf '#!/usr/bin/env bash\necho FRESH-GATE-%s\n' "$version" > "$clone/gates/demo-gate.sh"
+  ( cd "$clone" && git init -q && git config user.email t@t.l && git config user.name t \
+      && git add -A && git commit -q -m init ) >/dev/null 2>&1
+  if [ "$remote_mode" = "with-remote" ]; then
+    local origin="$clone.origin.git"
+    git init -q --bare "$origin" >/dev/null 2>&1
+    ( cd "$clone" && git remote add origin "$origin" \
+        && git push -q -u origin HEAD:main ) >/dev/null 2>&1
+  fi
+}
+
+# Scaffold a project with STALE .claude/framework/ assets and an OLD pin.
+# manifest seeds host + enforcement_level so the host/BL-030 backfills are
+# no-ops (keeps the assertion focused on the CDF refresh).
+make_stale_project() {
+  local proj="$1" old_version="$2"
+  mkdir -p "$proj/.claude/framework/hooks" "$proj/.claude/framework/rules" "$proj/.claude/framework/gates"
+  printf '#!/usr/bin/env bash\necho STALE-HOOK\n' > "$proj/.claude/framework/hooks/demo-hook.sh"
+  printf '# stale rule\n' > "$proj/.claude/framework/rules/demo-rule.md"
+  printf '#!/usr/bin/env bash\necho STALE-GATE\n' > "$proj/.claude/framework/gates/demo-gate.sh"
+  cat > "$proj/.claude/manifest.json" <<JSON
+{"host":"github","frameworkVersion":"$old_version","frameworkCommit":"deadbeefdead","enforcement_level":"strict","deployment":"personal","poc_mode":null}
+JSON
+  cat > "$proj/.claude/phase-state.json" <<'JSON'
+{"track":"standard","deployment":"personal","poc_mode":null,"current_phase":1,"phases":{}}
+JSON
+  ( cd "$proj" && git init -q && git config user.email t@t.l && git config user.name t \
+      && git add -A && git commit -q -m init ) >/dev/null 2>&1
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: upgrade --backfill-only syncs CDF assets + bumps manifest ==="
+# ════════════════════════════════════════════════════════════════════
+if [ "$INTEGRATION_OK" = "0" ]; then
+  skip "T1: upstream CDF cdf-refresh.sh not found at $UPSTREAM_SRC (set CDF_REFRESH_SRC to enable)"
+else
+  T=$(mktemp -d); CLONE="$T/cdf"; PROJ="$T/proj"
+  make_fake_clone "$CLONE" "99.9.9" with-remote
+  make_stale_project "$PROJ" "1.0.0"
+
+  ( cd "$PROJ" && CDF_HOME="$CLONE" bash "$UPGRADE" --backfill-only --non-interactive ) > "$T/log" 2>&1
+  rc=$?
+
+  hook=$(tail -1 "$PROJ/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+  gate=$(tail -1 "$PROJ/.claude/framework/gates/demo-gate.sh" 2>/dev/null)
+  rule=$(cat  "$PROJ/.claude/framework/rules/demo-rule.md" 2>/dev/null)
+  hx=$([ -x "$PROJ/.claude/framework/hooks/demo-hook.sh" ] && echo y || echo n)
+  gx=$([ -x "$PROJ/.claude/framework/gates/demo-gate.sh" ] && echo y || echo n)
+  fv=$(jq -r '.frameworkVersion // empty' "$PROJ/.claude/manifest.json" 2>/dev/null)
+  fc=$(jq -r '.frameworkCommit // empty' "$PROJ/.claude/manifest.json" 2>/dev/null)
+  clone_head=$(git -C "$CLONE" rev-parse HEAD 2>/dev/null)
+
+  if [ "$rc" = "0" ] \
+     && [ "$hook" = "echo FRESH-HOOK-99.9.9" ] \
+     && [ "$gate" = "echo FRESH-GATE-99.9.9" ] \
+     && [ "$rule" = "# fresh rule 99.9.9" ] \
+     && [ "$hx" = "y" ] && [ "$gx" = "y" ] \
+     && [ "$fv" = "99.9.9" ] && [ -n "$clone_head" ] && [ "$fc" = "$clone_head" ]; then
+    pass "T1: hooks/rules/gates replaced (hook+gate +x); manifest frameworkVersion+Commit bumped to the clone"
+  else
+    fail_ "T1" "rc=$rc hook='$hook'(x=$hx) gate='$gate'(x=$gx) rule='$rule' fv='$fv' fc='$fc' cloneHEAD='$clone_head'. Log: $(tail -6 "$T/log" 2>/dev/null | tr '\n' '|')"
+  fi
+  rm -rf "$T"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: missing CDF clone + non-interactive → upgrade still exits 0, warns, keeps assets ==="
+# ════════════════════════════════════════════════════════════════════
+T=$(mktemp -d); PROJ="$T/proj"
+make_stale_project "$PROJ" "1.0.0"
+pre_hook=$(tail -1 "$PROJ/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+
+( cd "$PROJ" && CDF_HOME="$T/does-not-exist" bash "$UPGRADE" --backfill-only --non-interactive ) > "$T/log" 2>&1
+rc=$?
+
+post_hook=$(tail -1 "$PROJ/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+warned=$(grep -qiE "skipping CDF asset refresh" "$T/log" && echo y || echo n)
+fv=$(jq -r '.frameworkVersion // empty' "$PROJ/.claude/manifest.json" 2>/dev/null)
+
+if [ "$rc" = "0" ] && [ "$warned" = "y" ] && [ "$post_hook" = "$pre_hook" ] && [ "$fv" = "1.0.0" ]; then
+  pass "T2: missing clone → upgrade exits 0, emits skip [WARN], leaves existing hooks + pin untouched"
+else
+  fail_ "T2" "rc=$rc warned=$warned hook_pre='$pre_hook' hook_post='$post_hook' fv='$fv' (expected rc=0, warned, unchanged). Log: $(tail -6 "$T/log" 2>/dev/null | tr '\n' '|')"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: git pull --ff-only failure → refresh still proceeds from working tree ==="
+# ════════════════════════════════════════════════════════════════════
+if [ "$INTEGRATION_OK" = "0" ]; then
+  skip "T3: upstream CDF cdf-refresh.sh not found at $UPSTREAM_SRC (set CDF_REFRESH_SRC to enable)"
+else
+  T=$(mktemp -d); CLONE="$T/cdf"; PROJ="$T/proj"
+  make_fake_clone "$CLONE" "88.8.8" no-remote    # no origin → git pull --ff-only fails
+  make_stale_project "$PROJ" "1.0.0"
+
+  ( cd "$PROJ" && CDF_HOME="$CLONE" bash "$UPGRADE" --backfill-only --non-interactive ) > "$T/log" 2>&1
+  rc=$?
+
+  hook=$(tail -1 "$PROJ/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+  fv=$(jq -r '.frameworkVersion // empty' "$PROJ/.claude/manifest.json" 2>/dev/null)
+  pullwarn=$(grep -qiE "pull --ff-only failed" "$T/log" && echo y || echo n)
+
+  if [ "$rc" = "0" ] && [ "$pullwarn" = "y" ] \
+     && [ "$hook" = "echo FRESH-HOOK-88.8.8" ] && [ "$fv" = "88.8.8" ]; then
+    pass "T3: pull --ff-only failure warned, but assets refreshed from working tree + manifest bumped"
+  else
+    fail_ "T3" "rc=$rc pullwarn=$pullwarn hook='$hook' fv='$fv' (expected rc=0, warned, refreshed to 88.8.8). Log: $(tail -8 "$T/log" 2>/dev/null | tr '\n' '|')"
+  fi
+  rm -rf "$T"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: mutation proof — neutralizing the delegating call makes the sync a no-op ==="
+# ════════════════════════════════════════════════════════════════════
+if [ "$INTEGRATION_OK" = "0" ]; then
+  skip "T4: upstream CDF cdf-refresh.sh not found at $UPSTREAM_SRC (set CDF_REFRESH_SRC to enable)"
+else
+  T=$(mktemp -d); CLONE="$T/cdf"
+  make_fake_clone "$CLONE" "77.7.7" with-remote
+
+  # -- Control: the real wrapper DOES refresh (the assertion the mutation targets). --
+  PROJ_C="$T/proj_control"; make_stale_project "$PROJ_C" "1.0.0"
+  ( CDF_HOME="$CLONE"; export CDF_HOME
+    . "$WRAPPER"
+    solo_refresh_cdf "$PROJ_C" "true" ) > "$T/log_control" 2>&1
+  hook_c=$(tail -1 "$PROJ_C/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+  fv_c=$(jq -r '.frameworkVersion // empty' "$PROJ_C/.claude/manifest.json" 2>/dev/null)
+  control_ok=$( { [ "$hook_c" = "echo FRESH-HOOK-77.7.7" ] && [ "$fv_c" = "77.7.7" ]; } && echo y || echo n )
+
+  # -- Mutant: neutralize solo_refresh_cdf's delegating call, expect NO refresh. --
+  # Exact whole-line target (grep -Fxq = fixed-string, whole-line). If the
+  # wrapper's call shape changes, this fails LOUDLY rather than silently
+  # passing on a stale mutation.
+  MUT="$T/cdf-refresh.mutant.sh"
+  TARGET='  refresh_cdf_assets "$project_root" "$cdf_home" "$non_interactive"'
+  if ! grep -Fxq "$TARGET" "$WRAPPER"; then
+    fail_ "T4" "mutation target line not found in $WRAPPER — did solo_refresh_cdf's delegating call change? (test needs updating)"
+    rm -rf "$T"
+  else
+    # awk $0==t is an exact string compare — no regex escaping of $ or ".
+    awk -v t="$TARGET" '$0==t{print "  : # MUTATION: delegating call neutralized"; next} {print}' \
+      "$WRAPPER" > "$MUT"
+    if grep -Fxq "$TARGET" "$MUT"; then
+      fail_ "T4" "mutation did not take effect — target line still present in the mutant copy"
+      rm -rf "$T"
+    else
+      PROJ_M="$T/proj_mutant"; make_stale_project "$PROJ_M" "1.0.0"
+      ( CDF_HOME="$CLONE"; export CDF_HOME
+        . "$MUT"
+        solo_refresh_cdf "$PROJ_M" "true" ) > "$T/log_mutant" 2>&1
+      hook_m=$(tail -1 "$PROJ_M/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+      fv_m=$(jq -r '.frameworkVersion // empty' "$PROJ_M/.claude/manifest.json" 2>/dev/null)
+      mutant_noop=$( { [ "$hook_m" = "echo STALE-HOOK" ] && [ "$fv_m" = "1.0.0" ]; } && echo y || echo n )
+
+      if [ "$control_ok" = "y" ] && [ "$mutant_noop" = "y" ]; then
+        pass "T4: control refreshes (hook=FRESH fv=77.7.7); mutant with call removed leaves hook STALE + fv=1.0.0 (call is load-bearing)"
+      else
+        fail_ "T4" "control_ok=$control_ok (hook_c='$hook_c' fv_c='$fv_c'); mutant_noop=$mutant_noop (hook_m='$hook_m' fv_m='$fv_m')"
+      fi
+      rm -rf "$T"
+    fi
+  fi
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: full upgrade (--deployment) also refreshes CDF, AFTER the sentinel/atomic block ==="
+# ════════════════════════════════════════════════════════════════════
+#
+# The full-upgrade path refreshes CDF from a SEPARATE call site — placed
+# after the BL-015 pending-approval sentinel guard and the atomic section-2b
+# manifest mutation (so a blocked/rolled-back upgrade never touches CDF
+# assets). This exercises that call site on a successful personal→org upgrade
+# and asserts the tier change AND the CDF refresh both land.
+if [ "$INTEGRATION_OK" = "0" ]; then
+  skip "T5: upstream CDF cdf-refresh.sh not found at $UPSTREAM_SRC (set CDF_REFRESH_SRC to enable)"
+else
+  T=$(mktemp -d); CLONE="$T/cdf"; PROJ="$T/proj"
+  make_fake_clone "$CLONE" "66.6.6" with-remote
+  make_stale_project "$PROJ" "1.0.0"
+  # tier-crosscheck-6 gate: personal→organizational refuses unless
+  # phase1_artifacts.data_classification is set. Seed it so the upgrade
+  # reaches the post-sentinel CDF refresh.
+  cat > "$PROJ/.claude/process-state.json" <<'JSON'
+{"phase1_artifacts":{"data_classification":"internal","zdr_attested":true,"zdr_attestation_reason":""}}
+JSON
+  ( cd "$PROJ" && git add -A && git commit -q -m "seed process-state" ) >/dev/null 2>&1
+
+  ( cd "$PROJ" && CDF_HOME="$CLONE" bash "$UPGRADE" --deployment organizational --non-interactive ) > "$T/log" 2>&1
+  rc=$?
+
+  ps_dep=$(jq -r '.deployment // empty' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+  mf_dep=$(jq -r '.deployment // empty' "$PROJ/.claude/manifest.json" 2>/dev/null)
+  hook=$(tail -1 "$PROJ/.claude/framework/hooks/demo-hook.sh" 2>/dev/null)
+  fv=$(jq -r '.frameworkVersion // empty' "$PROJ/.claude/manifest.json" 2>/dev/null)
+
+  if [ "$rc" = "0" ] \
+     && [ "$ps_dep" = "organizational" ] && [ "$mf_dep" = "organizational" ] \
+     && [ "$hook" = "echo FRESH-HOOK-66.6.6" ] && [ "$fv" = "66.6.6" ]; then
+    pass "T5: full --deployment upgrade changed tier AND refreshed CDF assets (post-sentinel call site fired)"
+  else
+    fail_ "T5" "rc=$rc ps_dep='$ps_dep' mf_dep='$mf_dep' hook='$hook' fv='$fv' (expected org + FRESH-HOOK-66.6.6 + fv=66.6.6). Log: $(tail -8 "$T/log" 2>/dev/null | tr '\n' '|')"
+  fi
+  rm -rf "$T"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-upgrade-cdf-refresh.sh
+++ b/tests/test-upgrade-cdf-refresh.sh
@@ -6,12 +6,15 @@
 # frozen at its install-time CDF version, silently missing upstream
 # .claude/framework/ hook/rule/gate fixes.
 #
-# Fix: upgrade-project.sh's backfill block sources scripts/lib/cdf-refresh.sh
-# (a thin Solo-side wrapper) and calls solo_refresh_cdf, which delegates to
-# the CDF clone's canonical refresh_cdf_assets. It re-copies hooks/rules/gates
-# into .claude/framework/, marks hook/gate scripts +x, and bumps the manifest
-# frameworkVersion/frameworkCommit. Lives in the backfill block so BOTH the
-# full and --backfill-only paths sync CDF.
+# Fix: scripts/lib/cdf-refresh.sh (a thin Solo-side wrapper) is sourced by
+# upgrade-project.sh's _refresh_cdf_assets_solo helper and calls
+# solo_refresh_cdf, which delegates to the CDF clone's canonical
+# refresh_cdf_assets. It re-copies hooks/rules/gates into .claude/framework/,
+# marks hook/gate scripts +x, and bumps the manifest
+# frameworkVersion/frameworkCommit. The helper is called from TWO distinct
+# call sites so both the --backfill-only path (before its short-circuit) and
+# the full-upgrade path (after the BL-015 sentinel guard + atomic section-2b
+# mutation) sync CDF.
 #
 # Test scenarios:
 #   T1 — Happy path: `upgrade-project.sh --backfill-only` against a fake CDF
@@ -26,19 +29,29 @@
 #   T3 — Pull-failure resilience: a fake clone with NO remote makes
 #        `git pull --ff-only` fail → the refresh warns and still syncs from
 #        the clone's current working tree (assets replaced, manifest bumped).
-#   T4 — Mutation proof: neutralizing solo_refresh_cdf's delegating
-#        refresh_cdf_assets call turns the sync into a no-op — the control
-#        (real wrapper) refreshes, the mutant leaves the project STALE.
-#        Proves the delegating call is load-bearing (the T1 assertions go
-#        RED without it).
+#   T4 — Mutation proof (delegating call): neutralizing solo_refresh_cdf's
+#        delegating refresh_cdf_assets call turns the sync into a no-op — the
+#        control (real wrapper) refreshes, the mutant leaves the project
+#        STALE. Proves the delegating call is load-bearing (T1 goes RED
+#        without it), across both call sites.
+#   T5 — Full-upgrade call site: a successful `--deployment` upgrade also
+#        refreshes CDF from the post-sentinel call site (tier change AND CDF
+#        refresh both land).
+#   T6 — Mutation proof (graceful-skip return): driving the WRAPPER directly
+#        with an absent CDF clone must return 0 and emit the [WARN]. Flipping
+#        the wrapper's missing-clone `return 0` to `return 1` makes that
+#        direct call return non-zero — proving the graceful-skip exit status
+#        is load-bearing (the call-site `|| print_warn` would otherwise mask
+#        a return-1 regression).
 #
 # HERMETICITY
-#   T1/T3/T4 need the canonical upstream refresh_cdf_assets implementation.
+#   T1/T3/T4/T5 need the canonical upstream refresh_cdf_assets implementation.
 #   It is located via CDF_REFRESH_SRC (default
 #   $HOME/.claude-dev-framework/scripts/cdf-refresh.sh). When that file is
 #   absent (e.g. a CI runner without the CDF clone) those scenarios SKIP
-#   with a clear notice and the suite still exits 0. T2 is fully hermetic
-#   (the wrapper short-circuits on a missing clone before it needs upstream).
+#   with a clear notice and the suite still exits 0. T2 and T6 are fully
+#   hermetic (the wrapper short-circuits on a missing clone before it needs
+#   upstream).
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -277,6 +290,64 @@ JSON
     fail_ "T5" "rc=$rc ps_dep='$ps_dep' mf_dep='$mf_dep' hook='$hook' fv='$fv' (expected org + FRESH-HOOK-66.6.6 + fv=66.6.6). Log: $(tail -8 "$T/log" 2>/dev/null | tr '\n' '|')"
   fi
   rm -rf "$T"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: wrapper graceful-skip on missing clone returns 0 + [WARN] (direct, mutation-proof) ==="
+# ════════════════════════════════════════════════════════════════════
+#
+# Fully hermetic — the missing-clone branch short-circuits before the wrapper
+# needs upstream, so no CDF clone is required. Drives solo_refresh_cdf
+# DIRECTLY (not through upgrade-project.sh) so the return status is observed
+# without the call-site's `|| print_warn` masking it.
+#
+#   Control: real wrapper + absent CDF_HOME → return 0 AND the skip [WARN].
+#   Mutant:  flip the missing-clone `return 0` → `return 1`; the SAME direct
+#            call now returns non-zero. Proves the graceful-skip exit status
+#            is load-bearing (a return-1 regression would be invisible through
+#            the call site, but breaks any caller that inspects the status).
+T=$(mktemp -d); ABSENT="$T/no-such-cdf-clone"
+
+# -- Control: real wrapper, absent clone → rc=0 + skip [WARN] on stderr. --
+( CDF_HOME="$ABSENT"; export CDF_HOME; . "$WRAPPER"; solo_refresh_cdf "$T" "true" ) \
+  >"$T/ctl.out" 2>"$T/ctl.err"
+ctl_rc=$?
+ctl_ok=$( { [ "$ctl_rc" = "0" ] && grep -qiE "skipping CDF asset refresh" "$T/ctl.err"; } && echo y || echo n )
+
+# -- Mutant: flip the missing-clone `return 0` → `return 1`. --
+# Exact whole-line anchors (awk $0== compare — no regex escaping of $ [ ] ").
+# The anchor line is unique in the wrapper; the flipped line is the FIRST
+# `    return 0` inside that if-block.
+MUT="$T/cdf-refresh.mutant.sh"
+ANCHOR='  if [ ! -f "$upstream" ]; then'
+RET_LINE='    return 0'
+if ! grep -Fxq "$ANCHOR" "$WRAPPER" || ! grep -Fxq "$RET_LINE" "$WRAPPER"; then
+  fail_ "T6" "mutation anchors not found in $WRAPPER — did the missing-clone graceful-skip block change? (test needs updating)"
+  rm -rf "$T"
+else
+  awk -v a="$ANCHOR" -v r="$RET_LINE" '
+    $0==a { inb=1 }
+    inb && $0==r { print "    return 1  # MUTATION: graceful-skip return flipped"; inb=0; next }
+    { print }
+  ' "$WRAPPER" > "$MUT"
+  if ! grep -Fq "return 1  # MUTATION: graceful-skip return flipped" "$MUT"; then
+    fail_ "T6" "mutation did not take effect — awk did not flip the missing-clone return 0"
+    rm -rf "$T"
+  else
+    ( CDF_HOME="$ABSENT"; export CDF_HOME; . "$MUT"; solo_refresh_cdf "$T" "true" ) \
+      >/dev/null 2>"$T/mut.err"
+    mut_rc=$?
+    # Mutant must (a) return non-zero and (b) still emit the [WARN] (only the
+    # exit status was flipped, so the diagnostic is unchanged).
+    mut_detects=$( { [ "$mut_rc" != "0" ] && grep -qiE "skipping CDF asset refresh" "$T/mut.err"; } && echo y || echo n )
+    if [ "$ctl_ok" = "y" ] && [ "$mut_detects" = "y" ]; then
+      pass "T6: real wrapper returns 0 + [WARN] on missing clone; flipping return 0→1 makes the direct call return $mut_rc (graceful-skip status is load-bearing)"
+    else
+      fail_ "T6" "ctl_ok=$ctl_ok (ctl_rc=$ctl_rc); mut_detects=$mut_detects (mut_rc=$mut_rc)"
+    fi
+    rm -rf "$T"
+  fi
 fi
 
 echo ""


### PR DESCRIPTION
## BL-001 — downstream CDF sync on upgrade

**Problem.** `scripts/upgrade-project.sh` performed **no CDF (Development Guardrails) sync**. A downstream project that ran the documented upgrade stayed frozen at its install-time CDF version, silently missing upstream `.claude/framework/` hook/rule/gate fixes. The refresh logic already existed upstream (`$CDF_HOME/scripts/cdf-refresh.sh: refresh_cdf_assets`); what was never built was the Solo-side wrapper + call site. Per the cross-repo preference, the logic stays upstream in CDF; Solo carries only the thin call site.

## The wiring

- **`scripts/lib/cdf-refresh.sh` (new)** — thin wrapper `solo_refresh_cdf`. Locates the CDF clone (default `$HOME/.claude-dev-framework`, overridable via **`CDF_HOME`** for hermetic tests), sources the clone's `cdf-refresh.sh`, and delegates to `refresh_cdf_assets "$PROJECT_ROOT" "$CDF_HOME" "$NON_INTERACTIVE"`.
- **`scripts/upgrade-project.sh`** — one helper `_refresh_cdf_assets_solo`, called from **two sites** so exactly one runs per path:
  - the **`--backfill-only`** path, before its short-circuit (so backfill-only upgrades sync CDF too);
  - the **full-upgrade** asset-refresh block near the end — **deliberately placed AFTER the BL-015 pending-approval sentinel guard and the atomic section-2b mutation**, so a sentinel-blocked or rolled-back upgrade never touches `.claude/framework/` or the manifest pin. (An earlier draft put it in the backfill block, before the guard — that broke the BL-015 sentinel "no-mutation" contract and the BL-061 atomic-rollback byte-equality. Moving it after the guard fixes both.)
- **`docs/user-guide.md`** — new **"Refreshing CDF framework assets"** section (user-facing invocation: `bash scripts/upgrade-project.sh --backfill-only`, plus the `~/.claude-dev-framework` clone/`git pull` prerequisite). Fixed the manifest field-name nit (`version` → `frameworkVersion`) and documented `frameworkCommit`.

## Graceful-degradation contract (never hard-fail the upgrade)

- Missing CDF clone / missing `cdf-refresh.sh` → wrapper emits a `[WARN]` to stderr and `return 0`; the project keeps its existing `.claude/framework/` assets and the upgrade completes.
- Missing clone + non-interactive → warn + `return 0` (no prompt).
- `git pull --ff-only` failure → upstream warns and refreshes from the clone's current working tree (no abort).
- Belt-and-suspenders `|| print_warn` at the call site guarantees a refresh hiccup can never abort the upgrade — the CDF sync is an ADDITION, not a gate.

## Tests (`tests/test-upgrade-cdf-refresh.sh`, registered in `full-project-test-suite.sh` per BL-034)

- **T1** happy path: `--backfill-only` against a fake clone (working remote) replaces hooks/rules/gates (content match; hook+gate `+x`) and bumps manifest `frameworkVersion`+`frameworkCommit`.
- **T2** missing clone + non-interactive → upgrade **exits 0**, emits the stderr skip `[WARN]`, leaves existing assets + pin untouched.
- **T3** `git pull --ff-only` failure → refresh still syncs from the working tree + bumps the manifest.
- **T4** mutation proof (self-contained A/B): neutralizing the delegating call leaves the project STALE.
- **T5** full `--deployment` upgrade also refreshes CDF via the post-sentinel call site.

Integration scenarios skip cleanly (still exit 0) when the CDF clone is absent (e.g. CI without `~/.claude-dev-framework`); the missing-clone scenario is fully hermetic.

## Mutation evidence

Removing the delegating `refresh_cdf_assets` call from the live wrapper turns the sync into a no-op — **T1, T3, T5 go RED** (assets stay STALE, not `+x`, `frameworkVersion` stuck at `1.0.0`, `frameworkCommit` stuck at the old value) and T4's sanity guard fires; only the hermetic T2 stays green. Restoring the call → **all green**. This proves the call is load-bearing across both call sites.

## check-updates.sh disposition — FIXED (tight fix)

`scripts/check-updates.sh` compared everything against the *solo-orchestrator* repo, giving a false "CDF is covered" impression. The CDF-version line now compares the project's pin against the CDF clone's `FRAMEWORK_VERSION` (`CDF_HOME` override) and:
- warns + points at `upgrade-project.sh --backfill-only` when the clone is newer than the pin;
- confirms a match otherwise;
- when the clone is absent, states plainly that the checker only covers solo-orchestrator docs/scripts, not CDF.

## Verification

- Full lint battery: **8/8 exit 0** (counter-antipattern, fix-functions-stderr, raw-read-prompt, tests-registered, doc-anchors, backlog-references, fail-emit-exit-status, fixture-envelopes).
- `test-upgrade-cdf-refresh.sh`: **5/5 green**; mutation evidence captured.
- Regression sweep green: `test-upgrade-manifest-refresh.sh`, `test-upgrade-sentinel-block.sh`, `test-upgrade-project-atomic.sh`, `test-upgrade-interruption.sh`, `-non-interactive`, `-personal-to-sponsored-poc`, `-to-production-preconditions`, `-to-production-warn`.
- Confirmed a normal full upgrade with the real CDF clone present completes, and a missing/absent clone does NOT break the upgrade (both backfill-only and full paths).

### Pre-existing failures (NOT introduced here)
`tests/upgrade-path-tests.sh` reports 2 failures (init.sh approval-log template markers, lines 433/441). `git diff --stat main -- init.sh tests/upgrade-path-tests.sh` is empty — both files are byte-identical to main, so these are pre-existing. Likewise `test-tier-crosscheck-6-zdr-gate.sh` and `test-upgrade-bl030-backfill.sh` fail identically on pristine main (a `helpers-full.sh` fixture issue). None are related to BL-001; flagged for a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
