### PR TITLE
feat(upgrade): --backfill-only honors BL-015 pending-approval sentinel

### DIFF
--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -122,6 +122,49 @@ _refresh_cdf_assets_solo() {
   fi
 }
 
+# --- BL-015 pending-approval sentinel respect (UAT 2026-04-25 fix C5) ---
+# If the agent has offered structured options to the user via
+# scripts/pending-approval.sh, refuse to advance an irreversible mutation.
+# Surfaced by 5/5 upgrade UAT agents (49, 62, 79, 82, 84): upgrade-project.sh
+# was happily writing files and committing while a sentinel existed. Detection
+# matches CDF 4.2.3's "existence alone suffices" semantics: a well-formed
+# sentinel reflects its question/options back; a malformed one is treated as
+# in-flight.
+#
+# Called from TWO sites so the two paths stay in sync (single source of truth
+# for detection — the two must NEVER drift):
+#   • the --backfill-only path, BEFORE its idempotent manifest/host/skills
+#     backfills and its CDF asset refresh (see the guard just before the
+#     backfill block); and
+#   • the full-upgrade path, after guard_not_in_framework and before the
+#     atomic section-2b mutation.
+# Both call sites are at top level (not inside a subshell), so the `exit 1`
+# below aborts the whole script — a sentinel-blocked run mutates nothing.
+_bl015_sentinel_guard() {
+  local PENDING_APPROVAL_FILE="$PROJECT_ROOT/.claude/pending-approval.json"
+  [ -f "$PENDING_APPROVAL_FILE" ] || return 0
+  print_fail "upgrade blocked — pending user decision."
+  if jq -e . "$PENDING_APPROVAL_FILE" >/dev/null 2>&1; then
+    local pa_question pa_offered
+    pa_question=$(jq -r '.question // "(missing)"' "$PENDING_APPROVAL_FILE")
+    pa_offered=$(jq -r '.offered_at // "(unknown)"' "$PENDING_APPROVAL_FILE")
+    echo "" >&2
+    echo "  Pending question: \"$pa_question\" (offered $pa_offered)" >&2
+    echo "  Options:" >&2
+    jq -r '.options[]? // empty | "    " + .' "$PENDING_APPROVAL_FILE" >&2
+  else
+    echo "" >&2
+    echo "  Sentinel file $PENDING_APPROVAL_FILE exists but is malformed." >&2
+    echo "  Treated as in-flight per CDF 4.2.3 contract." >&2
+  fi
+  echo "" >&2
+  echo "  Wait for the user to pick, then:" >&2
+  echo "    scripts/pending-approval.sh --resolve" >&2
+  echo "  Or, if the question is being aborted:" >&2
+  echo "    scripts/pending-approval.sh --clear" >&2
+  exit 1
+}
+
 while [ $# -gt 0 ]; do
   case "$1" in
     --track)
@@ -269,6 +312,21 @@ if [ "$VALIDATE_ONLY" = true ]; then
       validate_only:    true
     }'
   exit 0
+fi
+
+# --- BL-015 (backfill parity): honor the pending-approval sentinel BEFORE any
+# --backfill-only mutation ---
+# The idempotent backfill block below — and the --backfill-only CDF asset
+# refresh that follows its short-circuit — mutate .claude/framework/, the
+# manifest, host config, and .claude/skills/. The full-upgrade path already
+# blocks on the pending-approval sentinel further down (after
+# guard_not_in_framework), but --backfill-only short-circuits before reaching
+# that guard, so it was writing those mutations even while a sentinel existed.
+# Run the SAME guard here — the single _bl015_sentinel_guard the full path
+# calls, so detection never drifts — gated on BACKFILL_ONLY so the
+# full-upgrade path's own guard and its ordering are unchanged.
+if [ "$BACKFILL_ONLY" = true ]; then
+  _bl015_sentinel_guard
 fi
 
 # --- Idempotent manifest backfills (run before target-flag check) ---
@@ -504,32 +562,12 @@ fi
 guard_not_in_framework || exit 1
 
 # --- BL-015 pending-approval sentinel respect (UAT 2026-04-25 fix C5) ---
-# If the agent has offered structured options to the user via
-# scripts/pending-approval.sh, refuse to advance an irreversible upgrade.
-# Surfaced by 5/5 upgrade UAT agents (49, 62, 79, 82, 84): upgrade-project.sh
-# was happily writing files and committing while a sentinel existed.
-PENDING_APPROVAL_FILE="$PROJECT_ROOT/.claude/pending-approval.json"
-if [ -f "$PENDING_APPROVAL_FILE" ]; then
-  print_fail "upgrade blocked — pending user decision."
-  if jq -e . "$PENDING_APPROVAL_FILE" >/dev/null 2>&1; then
-    pa_question=$(jq -r '.question // "(missing)"' "$PENDING_APPROVAL_FILE")
-    pa_offered=$(jq -r '.offered_at // "(unknown)"' "$PENDING_APPROVAL_FILE")
-    echo "" >&2
-    echo "  Pending question: \"$pa_question\" (offered $pa_offered)" >&2
-    echo "  Options:" >&2
-    jq -r '.options[]? // empty | "    " + .' "$PENDING_APPROVAL_FILE" >&2
-  else
-    echo "" >&2
-    echo "  Sentinel file $PENDING_APPROVAL_FILE exists but is malformed." >&2
-    echo "  Treated as in-flight per CDF 4.2.3 contract." >&2
-  fi
-  echo "" >&2
-  echo "  Wait for the user to pick, then:" >&2
-  echo "    scripts/pending-approval.sh --resolve" >&2
-  echo "  Or, if the question is being aborted:" >&2
-  echo "    scripts/pending-approval.sh --clear" >&2
-  exit 1
-fi
+# Full-upgrade call site. Detection + deny message live in
+# _bl015_sentinel_guard (defined near the top), which the --backfill-only path
+# also calls so the two paths can never drift. Placed here — after
+# guard_not_in_framework and before the atomic section-2b mutation — so a
+# blocked or rolled-back upgrade never touches project state.
+_bl015_sentinel_guard
 
 # --- File paths ---
 PHASE_STATE="$PROJECT_ROOT/.claude/phase-state.json"

--- a/tests/test-upgrade-sentinel-block.sh
+++ b/tests/test-upgrade-sentinel-block.sh
@@ -2,17 +2,17 @@
 # tests/test-upgrade-sentinel-block.sh — tests-upgrade-paths-5 regression.
 #
 # Audit finding: no test asserted the BL-015 pending-approval sentinel
-# guard (scripts/upgrade-project.sh:473-498) actually blocks an
-# upgrade and leaves project state unmutated. The guard was added
-# after 5/5 upgrade UAT agents (49, 62, 79, 82, 84) observed
+# guard (scripts/upgrade-project.sh's _bl015_sentinel_guard) actually
+# blocks an upgrade and leaves project state unmutated. The guard was
+# added after 5/5 upgrade UAT agents (49, 62, 79, 82, 84) observed
 # upgrade-project.sh writing files and committing while a sentinel
 # existed. A regression that loosens the guard (e.g., wrong path,
 # weaker check, missing exit) would currently slip through CI.
 #
-# This test stages a minimal upgradeable project fixture, pre-writes
-# a well-formed `.claude/pending-approval.json`, invokes
-# `scripts/upgrade-project.sh --to-private-poc --non-interactive`
-# (the same shape a UAT agent would use), and asserts:
+# Full-upgrade coverage (T1–T3): stage a minimal upgradeable project
+# fixture, pre-write a well-formed `.claude/pending-approval.json`,
+# invoke `scripts/upgrade-project.sh --to-private-poc --non-interactive`
+# (the same shape a UAT agent would use), and assert:
 #
 #   (1) exit code is non-zero
 #   (2) stderr contains "upgrade blocked — pending user decision" and
@@ -22,6 +22,29 @@
 #       `chore(upgrade)` commit appended; git HEAD intact)
 #   (4) the sentinel file itself is still present (the guard never
 #       deletes the sentinel — only --resolve/--clear may do that)
+#
+# --backfill-only coverage (T4–T6, BL-001 × BL-015 parity): the
+# --backfill-only path short-circuits BEFORE the full-upgrade path's
+# sentinel guard, yet it mutates .claude/framework/ (CDF assets), the
+# manifest, host config and .claude/skills/. It must honor the SAME
+# sentinel. These scenarios assert:
+#
+#   T4 (T-backfill-blocks-on-sentinel): sentinel present →
+#       `--backfill-only` exits non-zero with the BL-015 deny message
+#       and leaves .claude/framework/ + manifest byte-identical (md5).
+#   T5 (T-backfill-proceeds-no-sentinel): no sentinel → the backfill
+#       runs (BL-030 fields get backfilled) — existing behavior intact.
+#   T6 (mutation proof): neutralize the backfill call to
+#       _bl015_sentinel_guard in a copy of the script → the SAME
+#       sentinel run now MUTATES the manifest (backfill fires despite
+#       the sentinel), while the real script leaves it byte-identical.
+#       Proves the backfill guard is load-bearing.
+#
+# HERMETICITY: every --backfill-only run pins CDF_HOME to a nonexistent
+# path so the BL-001 CDF asset refresh gracefully skips — no CDF clone,
+# no network, no real remotes. The discriminating mutation signal is the
+# fully-hermetic BL-030 manifest backfill (manifest lacks
+# enforcement_level → the backfill would add it).
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -32,6 +55,23 @@ PASSED=0
 FAILED=0
 pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
 fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Portable md5 of a single file (macOS `md5 -q`, Linux `md5sum`).
+_md5file() {
+  if command -v md5 >/dev/null 2>&1; then md5 -q "$1"
+  else md5sum "$1" | awk '{print $1}'; fi
+}
+
+# Deterministic fingerprint of every file under a directory (relative
+# path + content md5, LC_ALL=C-sorted). Detects content changes,
+# additions AND deletions. "(absent)" when the dir does not exist.
+_tree_fingerprint() {
+  local d="$1"
+  [ -d "$d" ] || { echo "(absent)"; return; }
+  ( cd "$d" && find . -type f 2>/dev/null | LC_ALL=C sort | while IFS= read -r f; do
+      printf '%s:%s\n' "$f" "$(_md5file "$f")"
+    done )
+}
 
 # Minimal personal/private_poc fixture — any track flag would trip
 # the sentinel guard the same way; we pick --to-private-poc because
@@ -194,10 +234,187 @@ t3_no_sentinel_no_guard_message() {
   teardown_project
 }
 
+# ─────────────────────────────────────────────────────────────────────
+# --backfill-only × BL-015 parity (T4–T6)
+# ─────────────────────────────────────────────────────────────────────
+
+# Scaffold a backfillable project at $1: a manifest that HAS a host but
+# LACKS enforcement_level (so the fully-hermetic BL-030 backfill would
+# rewrite it), plus a stale .claude/framework/ tree the CDF refresh
+# would replace on the full happy path. Git-inited so the BL-030
+# backfill's `git rev-parse HEAD` succeeds.
+setup_backfill_project() {
+  local proj="$1"
+  mkdir -p "$proj/.claude/framework/hooks" "$proj/.claude/framework/rules" "$proj/.claude/framework/gates"
+  printf '#!/usr/bin/env bash\necho STALE-HOOK\n' > "$proj/.claude/framework/hooks/demo-hook.sh"
+  printf '# stale rule\n'                          > "$proj/.claude/framework/rules/demo-rule.md"
+  printf '#!/usr/bin/env bash\necho STALE-GATE\n'  > "$proj/.claude/framework/gates/demo-gate.sh"
+  # host present, enforcement_level ABSENT → BL-030 backfill is the mutation signal.
+  cat > "$proj/.claude/manifest.json" <<'JSON'
+{"frameworkVersion":"1.0.0","host":"github","mode":"personal"}
+JSON
+  cat > "$proj/.claude/phase-state.json" <<'JSON'
+{"track":"light","deployment":"personal","poc_mode":null,"current_phase":1,"phases":{}}
+JSON
+  ( cd "$proj" && git init -q && git config user.email t@t.local && git config user.name "Test User" \
+      && git add -A && git commit -q -m init ) >/dev/null 2>&1
+}
+
+write_sentinel() {
+  cat > "$1/.claude/pending-approval.json" <<'JSON'
+{
+  "question": "Adopt sponsored POC governance?",
+  "offered_at": "2026-06-28T12:00:00Z",
+  "options": ["yes", "no", "defer"],
+  "owner": "uat-agent"
+}
+JSON
+}
+
+# T4 — T-backfill-blocks-on-sentinel: sentinel present → --backfill-only
+# blocks (non-zero + deny message) and mutates NOTHING
+# (.claude/framework/ + manifest byte-identical md5; no .claude/skills
+# created; sentinel preserved; enforcement_level still absent).
+t4_backfill_blocks_on_sentinel() {
+  local T; T=$(mktemp -d)
+  local PROJ="$T/proj"
+  setup_backfill_project "$PROJ"
+  write_sentinel "$PROJ"
+
+  local pre_manifest_md5;  pre_manifest_md5=$(_md5file "$PROJ/.claude/manifest.json")
+  local pre_framework_fp;  pre_framework_fp=$(_tree_fingerprint "$PROJ/.claude/framework")
+  local pre_sentinel;      pre_sentinel=$(cat "$PROJ/.claude/pending-approval.json")
+
+  local out rc=0
+  out=$(cd "$PROJ" && CDF_HOME="$T/no-such-cdf-clone" "$SCRIPT" --backfill-only --non-interactive </dev/null 2>&1) || rc=$?
+
+  local post_manifest_md5;  post_manifest_md5=$(_md5file "$PROJ/.claude/manifest.json")
+  local post_framework_fp;  post_framework_fp=$(_tree_fingerprint "$PROJ/.claude/framework")
+
+  if [ "$rc" = "0" ]; then
+    fail_ "T4" "expected non-zero exit for --backfill-only with sentinel; rc=$rc tail:\n$(echo "$out" | tail -10)"; rm -rf "$T"; return
+  fi
+  if ! echo "$out" | grep -qF "upgrade blocked — pending user decision"; then
+    fail_ "T4" "stderr missing canonical BL-015 deny message; out:\n$(echo "$out" | tail -15)"; rm -rf "$T"; return
+  fi
+  if ! echo "$out" | grep -qF "pending-approval.sh --resolve" || ! echo "$out" | grep -qF "pending-approval.sh --clear"; then
+    fail_ "T4" "stderr missing --resolve/--clear recovery hints; out:\n$(echo "$out" | tail -15)"; rm -rf "$T"; return
+  fi
+  # Deny message reflects the sentinel's question (same style the full path uses).
+  if ! echo "$out" | grep -qF "Adopt sponsored POC governance?"; then
+    fail_ "T4" "deny message did not reflect the sentinel question; out:\n$(echo "$out" | tail -15)"; rm -rf "$T"; return
+  fi
+  # No mutation: manifest byte-identical.
+  if [ "$pre_manifest_md5" != "$post_manifest_md5" ]; then
+    fail_ "T4" "manifest.json mutated despite sentinel (md5 $pre_manifest_md5 -> $post_manifest_md5)"; rm -rf "$T"; return
+  fi
+  # No mutation: .claude/framework/ byte-identical.
+  if [ "$pre_framework_fp" != "$post_framework_fp" ]; then
+    fail_ "T4" ".claude/framework/ mutated despite sentinel (fingerprint changed)"; rm -rf "$T"; return
+  fi
+  # BL-030 backfill must NOT have fired (positive proof it was short-circuited).
+  if jq -e '.enforcement_level' "$PROJ/.claude/manifest.json" >/dev/null 2>&1; then
+    fail_ "T4" "enforcement_level was backfilled despite sentinel — backfill mutated the manifest"; rm -rf "$T"; return
+  fi
+  # Skills sync must NOT have created .claude/skills/.
+  if [ -d "$PROJ/.claude/skills" ]; then
+    fail_ "T4" ".claude/skills/ was created despite sentinel — skills backfill fired"; rm -rf "$T"; return
+  fi
+  # Sentinel preserved unchanged (guard never deletes it).
+  if [ "$pre_sentinel" != "$(cat "$PROJ/.claude/pending-approval.json" 2>/dev/null)" ]; then
+    fail_ "T4" "sentinel file changed/removed despite block"; rm -rf "$T"; return
+  fi
+
+  pass "T4 (T-backfill-blocks-on-sentinel): --backfill-only blocks; rc!=0, deny+question+hints, .claude/framework/ + manifest byte-identical, no skills, sentinel preserved"
+  rm -rf "$T"
+}
+
+# T5 — T-backfill-proceeds-no-sentinel: no sentinel → --backfill-only
+# runs normally (BL-030 backfill fires: enforcement_level appears; no
+# deny message). Proves the guard is silent when no sentinel exists.
+t5_backfill_proceeds_no_sentinel() {
+  local T; T=$(mktemp -d)
+  local PROJ="$T/proj"
+  setup_backfill_project "$PROJ"   # no sentinel written
+
+  local out rc=0
+  out=$(cd "$PROJ" && CDF_HOME="$T/no-such-cdf-clone" "$SCRIPT" --backfill-only --non-interactive </dev/null 2>&1) || rc=$?
+
+  if [ "$rc" != "0" ]; then
+    fail_ "T5" "expected rc=0 for --backfill-only without sentinel; rc=$rc tail:\n$(echo "$out" | tail -10)"; rm -rf "$T"; return
+  fi
+  if echo "$out" | grep -qF "upgrade blocked — pending user decision"; then
+    fail_ "T5" "guard deny message fired without a sentinel present (false positive); out:\n$(echo "$out" | tail -10)"; rm -rf "$T"; return
+  fi
+  # Existing behavior: the BL-030 backfill ran and added enforcement_level.
+  if ! jq -e '.enforcement_level == "strict"' "$PROJ/.claude/manifest.json" >/dev/null 2>&1; then
+    fail_ "T5" "BL-030 backfill did not run without a sentinel — existing --backfill-only behavior regressed; manifest:\n$(cat "$PROJ/.claude/manifest.json")"; rm -rf "$T"; return
+  fi
+
+  pass "T5 (T-backfill-proceeds-no-sentinel): no sentinel → backfill runs (enforcement_level backfilled), guard silent"
+  rm -rf "$T"
+}
+
+# T6 — mutation proof: neutralize the --backfill-only path's call to
+# _bl015_sentinel_guard in a COPY of the script tree. The SAME
+# sentinel-present run must then MUTATE the manifest (backfill fires
+# despite the sentinel), while the real script leaves it byte-identical.
+# Exact whole-line awk target (grep -Fxq guards against drift); the
+# indented backfill call is distinct from the full-path (0-indent) call,
+# which is left intact.
+t6_backfill_guard_mutation_proof() {
+  local T; T=$(mktemp -d)
+  local TARGET='  _bl015_sentinel_guard'
+
+  if ! grep -Fxq "$TARGET" "$SCRIPT"; then
+    fail_ "T6" "mutation target line '  _bl015_sentinel_guard' not found in $SCRIPT — did the backfill guard call change? (test needs updating)"; rm -rf "$T"; return
+  fi
+
+  # Control: real script + sentinel → manifest byte-identical (blocked).
+  local PROJ_C="$T/proj_control"
+  setup_backfill_project "$PROJ_C"; write_sentinel "$PROJ_C"
+  local pre_c;  pre_c=$(_md5file "$PROJ_C/.claude/manifest.json")
+  ( cd "$PROJ_C" && CDF_HOME="$T/no-such-cdf-clone" "$SCRIPT" --backfill-only --non-interactive </dev/null ) >/dev/null 2>&1
+  local post_c; post_c=$(_md5file "$PROJ_C/.claude/manifest.json")
+  local control_clean; control_clean=$( [ "$pre_c" = "$post_c" ] && echo y || echo n )
+
+  # Mutant: copy scripts/ (so lib/ resolves), neutralize the backfill call.
+  cp -R "$REPO_ROOT/scripts" "$T/scripts"
+  local MUT="$T/scripts/upgrade-project.sh"
+  awk -v t="$TARGET" '$0==t{print "  : # MUTATION: backfill sentinel guard neutralized"; next}{print}' \
+    "$SCRIPT" > "$MUT"
+  chmod +x "$MUT"
+  # The indented backfill call must be gone; the full-path (0-indent) call must remain.
+  if grep -Fxq "$TARGET" "$MUT"; then
+    fail_ "T6" "mutation did not take effect — indented backfill call still present in the mutant"; rm -rf "$T"; return
+  fi
+  if [ "$(grep -Fxc '_bl015_sentinel_guard' "$MUT")" != "1" ]; then
+    fail_ "T6" "mutation removed the wrong call — expected exactly 1 remaining full-path (0-indent) call"; rm -rf "$T"; return
+  fi
+
+  # Mutant run + SAME sentinel → manifest MUST mutate (guard neutralized).
+  local PROJ_M="$T/proj_mutant"
+  setup_backfill_project "$PROJ_M"; write_sentinel "$PROJ_M"
+  local pre_m;  pre_m=$(_md5file "$PROJ_M/.claude/manifest.json")
+  ( cd "$PROJ_M" && CDF_HOME="$T/no-such-cdf-clone" bash "$MUT" --backfill-only --non-interactive </dev/null ) >/dev/null 2>&1
+  local post_m; post_m=$(_md5file "$PROJ_M/.claude/manifest.json")
+  local mutant_mutates; mutant_mutates=$( { [ "$pre_m" != "$post_m" ] && jq -e '.enforcement_level' "$PROJ_M/.claude/manifest.json" >/dev/null 2>&1; } && echo y || echo n )
+
+  if [ "$control_clean" = "y" ] && [ "$mutant_mutates" = "y" ]; then
+    pass "T6 (mutation proof): real script leaves manifest byte-identical under sentinel; neutralizing the backfill guard makes --backfill-only mutate the manifest despite the sentinel (guard is load-bearing)"
+  else
+    fail_ "T6" "control_clean=$control_clean (pre=$pre_c post=$post_c); mutant_mutates=$mutant_mutates (pre=$pre_m post=$post_m)"
+  fi
+  rm -rf "$T"
+}
+
 echo "== tests/test-upgrade-sentinel-block.sh =="
 t1_sentinel_blocks_to_private_poc
 t2_malformed_sentinel_still_blocks
 t3_no_sentinel_no_guard_message
+t4_backfill_blocks_on_sentinel
+t5_backfill_proceeds_no_sentinel
+t6_backfill_guard_mutation_proof
 
 echo ""
 echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="


### PR DESCRIPTION
## The hole

`scripts/upgrade-project.sh --backfill-only` short-circuits (around the old `upgrade-project.sh:408-414`) **before** the BL-015 pending-approval sentinel guard that the full-upgrade path runs (the inline `exit 1` around `upgrade-project.sh:512`). As a result, `--backfill-only` mutated `.claude/framework/` (CDF assets via `_refresh_cdf_assets_solo`), the manifest (host + BL-030 fields), host config, and `.claude/skills/` **even when a `.claude/pending-approval.json` sentinel was present** — the same class of "wrote files while a decision was pending" defect the full-upgrade path already blocks (surfaced by 5/5 upgrade UAT agents in the BL-015 history).

The idempotent backfill block runs unconditionally before the short-circuit, so the mutations landed before any sentinel check on the backfill path.

## The fix

Additive guard, reusing the exact same detection the full path uses — no reimplementation:

- Extracted the inline full-path sentinel check into a shared `_bl015_sentinel_guard()` function. It is the single source of truth for both detection (existence of `$PROJECT_ROOT/.claude/pending-approval.json`, matching CDF 4.2.3 "existence alone suffices" semantics, malformed = in-flight) and the deny message (reflects the sentinel's question/options, prints the `--resolve` / `--clear` recovery hints, `exit 1`).
- The full-upgrade path now calls `_bl015_sentinel_guard` at its original location (after `guard_not_in_framework`, before the atomic section-2b mutation) — behavior-preserving refactor.
- The `--backfill-only` path calls the **same** `_bl015_sentinel_guard` **before** the idempotent manifest/host/skills backfill block and the CDF asset refresh, gated on `BACKFILL_ONLY=true` so the full-upgrade path's guard and its ordering are untouched.

When a sentinel is present, `--backfill-only` now blocks with a non-zero exit and the BL-015 deny message, mutating nothing. When absent, backfill behaves exactly as before. The two paths call one function, so their detection can never drift.

## Byte-identical no-mutation proof

New `T4 (T-backfill-blocks-on-sentinel)` in `tests/test-upgrade-sentinel-block.sh`: scaffolds a project (manifest with `host` but no `enforcement_level`, plus a stale `.claude/framework/` tree), writes a valid sentinel, runs `upgrade-project.sh --backfill-only --non-interactive`, and asserts:

- non-zero exit,
- deny message present and reflecting the sentinel question + `--resolve`/`--clear` hints,
- **manifest md5 unchanged**,
- **`.claude/framework/` fingerprint (per-file path + content md5, sorted) unchanged**,
- BL-030 backfill did NOT fire (`enforcement_level` still absent),
- `.claude/skills/` not created,
- sentinel preserved unchanged.

## Mutation evidence (RED → GREEN)

`T6` embeds a mutation proof: it copies the script tree, neutralizes the `--backfill-only` call to `_bl015_sentinel_guard` (exact whole-line awk; `grep -Fxq` guards against drift; the full-path 0-indent call is left intact), then runs the same sentinel-present scenario. The mutant **mutates the manifest** (BL-030 backfill fires despite the sentinel) while the real script leaves it byte-identical.

Captured explicitly by neutralizing the guard in the real script and re-running:

```
RED  (guard neutralized): T4 FAIL — expected non-zero exit; rc=0
       log shows [STEP] Backfilling manifest.json BL-030 fields ...
                 [OK] BL-030 fields backfilled ...
                 [OK] Vendored skills synced into .claude/skills/
GREEN (guard restored):   6 | Passed: 6 | Failed: 0
```

## Hermeticity

Every backfill run pins `CDF_HOME` to a nonexistent path, so the BL-001 CDF refresh gracefully skips — no CDF clone, no network, no real remotes. The discriminating mutation signal is the fully-hermetic BL-030 manifest backfill.

## Test registration (BL-034)

Extends `tests/test-upgrade-sentinel-block.sh`, already registered in `tests/full-project-test-suite.sh` (not the KNOWN_ORPHANS bridge).

## Verification

- `tests/test-upgrade-sentinel-block.sh`: 6/6 (incl. new T4/T5/T6)
- `tests/test-upgrade-project-atomic.sh`: 4/4
- `tests/test-upgrade-interruption.sh`: 2/2
- `tests/test-upgrade-cdf-refresh.sh`: 6/6, 0 skipped
- 8-lint battery: 7 green. `test-pre-commit-gate-lints` fails **pre-existing/environmental** (identical `9 passed, 4 failed` on baseline without this change — its `--terminal-mode` scenarios hit the BL-006 commit-classifier block before the asserted lint surfaces). Not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
