### PR TITLE
feat(phase3): run-phase3-validation.sh driver + attest-on-skip gate skeleton (BL-070)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1097,6 +1097,104 @@ if [ "$current_phase" -ge 4 ]; then
   fi
 fi
 
+# ═══════════════════════════════════════════════════════════════════════
+# BL-070: Phase 3 validation scans (Snyk / license / full-tree Semgrep /
+# OWASP ZAP DAST / threat-model) + attest-on-skip gate.
+#
+# The Builder's/User guides imply Phase 3 auto-runs these five scans; a grep
+# of scripts/ found ZERO invocations. This distinct, self-contained step
+# (Karl-approved Option C) refuses Phase 3→4 unless the aggregate summary
+# from scripts/run-phase3-validation.sh exists AND every scanner is PASS or
+# an attested-skip-with-signoff (zero un-attested SKIPs, zero FAILs).
+#
+# Positioned deliberately APART from the review-manifest reviewer check
+# (BL-073, further below) to keep the two Phase-3→4 gate edits from
+# colliding on rebase.
+#
+# `# BL-070-GATE-CHECK` marks the load-bearing enforcement (mutation target,
+# per tests/test-phase3-validation-gate.sh::T-mutation). Auto-run marked
+# `# BL-070-GATE-AUTORUN`. Attestation predicate marked
+# `# BL-070-ATTEST-PREDICATE`.
+
+# _cpg_phase3_attested <scanner>
+# 0 iff phase-state.json::phase3.attestations.<scanner> carries a non-empty
+# reason AND a non-empty sign-off. jq-absent → not-attested (conservative).
+_cpg_phase3_attested() {
+  local name="$1" reason signoff
+  command -v jq >/dev/null 2>&1 || return 1   # BL-070-ATTEST-PREDICATE
+  reason=$(jq -r --arg n "$name" '.phase3.attestations[$n].reason // ""' "$PHASE_STATE" 2>/dev/null || echo "")
+  signoff=$(jq -r --arg n "$name" '.phase3.attestations[$n].signoff // ""' "$PHASE_STATE" 2>/dev/null || echo "")
+  [ -n "$reason" ] && [ "$reason" != "null" ] && [ -n "$signoff" ] && [ "$signoff" != "null" ]
+}
+
+if [ "$current_phase" -ge 4 ]; then
+  P3_RESULTS_DIR="docs/test-results/phase3"
+  P3_DRIVER="$SCRIPT_DIR/run-phase3-validation.sh"
+
+  # AUTO-RUN (Karl: "evals should be automatic"). If no summary exists yet,
+  # generate a baseline offline summary so the attestation gate always has
+  # teeth (offline => hermetic/fast: NO network/Docker/semgrep run from the
+  # gate). Operators run `scripts/run-phase3-validation.sh` (no --offline)
+  # for REAL scans; a later increment can auto-run real scans in interactive
+  # sessions. Set SOLO_PHASE3_GATE_NOAUTORUN=1 to disable auto-generation
+  # (e.g. CI that pre-runs the driver, or a pure read-only inspection).
+  p3_summary=""
+  if compgen -G "$P3_RESULTS_DIR/summary-*.md" >/dev/null 2>&1; then
+    p3_summary=$(ls -1 "$P3_RESULTS_DIR"/summary-*.md 2>/dev/null | sort | tail -1)
+  fi
+  if [ -z "$p3_summary" ] && [ -z "${SOLO_PHASE3_GATE_NOAUTORUN:-}" ] && [ -x "$P3_DRIVER" ]; then
+    bash "$P3_DRIVER" --offline >/dev/null 2>&1 || true   # BL-070-GATE-AUTORUN
+    if compgen -G "$P3_RESULTS_DIR/summary-*.md" >/dev/null 2>&1; then
+      p3_summary=$(ls -1 "$P3_RESULTS_DIR"/summary-*.md 2>/dev/null | sort | tail -1)
+    fi
+  fi
+
+  p3_block=0
+  p3_msg=""
+  p3_ok_detail=""
+  if [ -z "$p3_summary" ]; then
+    p3_block=1
+    p3_msg="no Phase 3 validation summary (docs/test-results/phase3/summary-*.md) — run: bash scripts/run-phase3-validation.sh"
+  else
+    p3_fail=0
+    p3_unattested=0
+    p3_detail=""
+    for p3_scanner in semgrep-full-tree license snyk zap-dast threat-model; do
+      p3_status=$(awk -v s="$p3_scanner" '$1=="RESULT" && $2==s {v=$3} END{print v}' "$p3_summary" 2>/dev/null || true)
+      [ -n "$p3_status" ] || p3_status="MISSING"
+      case "$p3_status" in
+        PASS) ;;
+        SKIP)
+          if _cpg_phase3_attested "$p3_scanner"; then
+            :   # attested-skip-with-signoff → acceptable
+          else
+            p3_unattested=$((p3_unattested + 1))
+            p3_detail="${p3_detail}${p3_detail:+, }${p3_scanner}(un-attested SKIP)"
+          fi
+          ;;
+        *)
+          p3_fail=$((p3_fail + 1))
+          p3_detail="${p3_detail}${p3_detail:+, }${p3_scanner}(${p3_status})"
+          ;;
+      esac
+    done
+    if [ "$p3_fail" -gt 0 ] || [ "$p3_unattested" -gt 0 ]; then
+      p3_block=1
+      p3_msg="validation scans not clean: ${p3_fail} FAIL, ${p3_unattested} un-attested SKIP [${p3_detail}] — attest: bash scripts/run-phase3-validation.sh --attest <scanner> --reason \"...\", or install the tool and re-run"
+    else
+      p3_ok_detail="all PASS or attested-skip; summary: $(basename "$p3_summary")"
+    fi
+  fi
+
+  if [ "$p3_block" -eq 1 ]; then
+    echo -e "${RED}[FAIL]${NC} Phase 3→4: $p3_msg"   # BL-070-GATE-CHECK
+    issues=$((issues + 1))                            # BL-070-GATE-CHECK
+    : # phase-3 validation enforcement block — kept non-empty so a mutation excising the two marked lines above stays syntactically valid
+  else
+    echo -e "${GREEN}  [OK]${NC} Phase 3→4: validation scans clean (${p3_ok_detail})"
+  fi
+fi
+
 # POC mode check (Phase 3→4) — block production release if in POC mode
 if [ "$current_phase" -ge 3 ]; then
   poc_mode=""

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1124,6 +1124,11 @@ _cpg_phase3_attested() {
   command -v jq >/dev/null 2>&1 || return 1   # BL-070-ATTEST-PREDICATE
   reason=$(jq -r --arg n "$name" '.phase3.attestations[$n].reason // ""' "$PHASE_STATE" 2>/dev/null || echo "")
   signoff=$(jq -r --arg n "$name" '.phase3.attestations[$n].signoff // ""' "$PHASE_STATE" 2>/dev/null || echo "")
+  # Trim leading/trailing whitespace (bash-3.2 param-expansion) BEFORE the
+  # non-empty check so a whitespace-only reason/signoff is un-attested → gate
+  # FAIL (verifier follow-up — `[ -n " " ]` is true, which would pass " ").
+  reason="${reason#"${reason%%[![:space:]]*}"}"; reason="${reason%"${reason##*[![:space:]]}"}"
+  signoff="${signoff#"${signoff%%[![:space:]]*}"}"; signoff="${signoff%"${signoff##*[![:space:]]}"}"
   [ -n "$reason" ] && [ "$reason" != "null" ] && [ -n "$signoff" ] && [ "$signoff" != "null" ]
 }
 
@@ -1173,7 +1178,11 @@ if [ "$current_phase" -ge 4 ]; then
           fi
           ;;
         *)
-          p3_fail=$((p3_fail + 1))
+          # FAIL, MISSING, or any garbled/unknown status counts toward the
+          # block — a real scanner (e.g. semgrep) reporting findings, or a
+          # summary missing/corrupting a scanner's RESULT line, must NOT
+          # slip through as clean.
+          p3_fail=$((p3_fail + 1))   # BL-070-FAIL-ARM: FAIL/MISSING status is gate-blocking (mutation target)
           p3_detail="${p3_detail}${p3_detail:+, }${p3_scanner}(${p3_status})"
           ;;
       esac

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -169,6 +169,18 @@ _p3_is_registered() {
 }
 
 # ── Identity / attestation helpers ───────────────────────────────────
+# _p3_trim <string> — strip leading + trailing whitespace (bash-3.2 safe
+# parameter-expansion idiom; same form as scripts/lint-counter-antipattern.sh
+# parse_line). Load-bearing for the attestation checks: a whitespace-only
+# reason/signoff must be treated as empty so the gate rejects it (verifier
+# follow-up — `[ -n " " ]` is true, which would let " " pass as attested).
+_p3_trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
 # Best-effort "who signed off" — prefers git identity, falls back to
 # whoami@hostname (mirrors check-phase-gate.sh::_cpg_gate_actor).
 _p3_actor() {
@@ -194,8 +206,8 @@ _p3_is_attested() {
   local name="$1" reason signoff
   command -v jq >/dev/null 2>&1 || return 1
   [ -f "$STATE_FILE" ] || return 1
-  reason=$(jq -r --arg n "$name" '.phase3.attestations[$n].reason // ""' "$STATE_FILE" 2>/dev/null || echo "")
-  signoff=$(jq -r --arg n "$name" '.phase3.attestations[$n].signoff // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  reason=$(_p3_trim "$(jq -r --arg n "$name" '.phase3.attestations[$n].reason // ""' "$STATE_FILE" 2>/dev/null || echo "")")
+  signoff=$(_p3_trim "$(jq -r --arg n "$name" '.phase3.attestations[$n].signoff // ""' "$STATE_FILE" 2>/dev/null || echo "")")
   [ -n "$reason" ] && [ "$reason" != "null" ] && [ -n "$signoff" ] && [ "$signoff" != "null" ]
 }
 
@@ -368,8 +380,13 @@ if [ "$MODE" = "attest" ]; then
     echo -e "${RED}[FAIL]${NC} --attest: '$ATTEST_SCANNER' is not a registered scanner. Valid: $P3_SCANNERS" >&2
     exit 2
   fi
+  # Trim BEFORE the non-empty check so a whitespace-only reason/signoff is
+  # rejected (or falls back to the actor), not silently recorded as a
+  # "valid" attestation. Verifier follow-up.
+  ATTEST_REASON="$(_p3_trim "$ATTEST_REASON")"
+  ATTEST_SIGNOFF="$(_p3_trim "$ATTEST_SIGNOFF")"
   if [ -z "$ATTEST_REASON" ]; then
-    echo -e "${RED}[FAIL]${NC} --attest requires --reason \"<why the scan was skipped>\"." >&2
+    echo -e "${RED}[FAIL]${NC} --attest requires a non-empty --reason \"<why the scan was skipped>\" (whitespace-only is rejected)." >&2
     exit 2
   fi
   [ -n "$ATTEST_SIGNOFF" ] || ATTEST_SIGNOFF="$(_p3_actor)"

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -1,0 +1,494 @@
+#!/usr/bin/env bash
+# NOTE: deliberately NOT `set -e`. A single scanner returning non-zero
+# (findings, missing tool, auth prompt) must NOT abort the whole driver —
+# the driver's job is to run EVERY registered scanner and aggregate.
+set -uo pipefail
+
+# ═══════════════════════════════════════════════════════════════════════
+# scripts/run-phase3-validation.sh — BL-070 Phase 3 validation-scan driver
+# (SKELETON: harness + gate integration + attest-on-skip; NOT all 5 real
+# scanners — see the SCANNER REGISTRY notes below for what is real vs
+# stubbed).
+#
+# WHY THIS EXISTS
+#   The Builder's/User guides + workflow.html imply Phase 3 automatically
+#   runs Snyk (deps), license compliance, full-tree Semgrep SAST, OWASP ZAP
+#   DAST, and threat-model verification. A grep of scripts/ found ZERO
+#   invocations of any of these tools — a documented gate mechanic that was
+#   not real. BL-070 (Karl-approved Option C) builds the DRIVER + GATE first,
+#   every scanner SKIP-able, and adds real scanners incrementally.
+#
+# ATTEST-ON-SKIP (Karl's refinement)
+#   When a scanner is unavailable/SKIP, the operator decides whether to
+#   download + run it manually. ANY skipped scanner requires an attestation
+#   (a reason AND a sign-off) recorded in
+#   `.claude/phase-state.json::phase3.attestations.<scanner>`. A non-attested
+#   SKIP counts as a gate FAIL. Mirrors the BL-032 escape-hatch pattern and
+#   reuses BL-071's atomic-finalize write pattern (mkdir-lock + adjacent
+#   mktemp + rename) so the state write is race-safe on macOS bash-3.2.
+#
+# GATE INTEGRATION
+#   scripts/check-phase-gate.sh auto-invokes this driver on the Phase 3→4
+#   check and refuses the transition unless the aggregate summary exists AND
+#   every scanner is PASS or attested-skip-with-signoff (zero un-attested
+#   SKIPs, zero FAILs). See the `# BL-070-GATE-CHECK` block in that script.
+#
+# USAGE
+#   bash scripts/run-phase3-validation.sh [--offline] [--results-dir DIR]
+#                                         [--state FILE]
+#   bash scripts/run-phase3-validation.sh --attest <scanner> \
+#                                         --reason "<why skipped>" \
+#                                         [--signoff "<who>"]
+#   bash scripts/run-phase3-validation.sh --list
+#   bash scripts/run-phase3-validation.sh --help
+#
+# EXIT CODES
+#   0 — every scanner PASS or attested-skip (gate-ready), or --attest/--list
+#       succeeded.
+#   1 — at least one un-attested SKIP or a scanner FAIL (the gate would
+#       block Phase 3→4).
+#   2 — usage / precondition error (bad flag, jq missing for --attest).
+#
+# bash-3.2 safe: no associative arrays, no mapfile, no `${var^^}`.
+# ═══════════════════════════════════════════════════════════════════════
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Colors (mirror helpers-core.sh; kept inline so the driver has no hard
+# dependency on the helper lib when invoked from odd contexts).
+if [ -t 1 ]; then
+  RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'; BOLD='\033[1m'; NC='\033[0m'
+else
+  RED=''; GREEN=''; YELLOW=''; BLUE=''; BOLD=''; NC=''
+fi
+
+# ── SCANNER REGISTRY ─────────────────────────────────────────────────
+# The five documented Phase 3 checks. Order is stable (used by --list, the
+# summary, and the gate's per-scanner loop). Each name maps (via case
+# dispatch in _p3_run_scanner / _p3_scan_*) to a detect+run implementation.
+#
+#   semgrep-full-tree  REAL   — full-tree SAST (`semgrep --config auto`),
+#                               distinct from pre-commit-gate.sh's staged-
+#                               only scan. Runs when semgrep is on PATH and
+#                               we are not --offline; SKIP otherwise.
+#   license            STUB   — dependency-license compliance. The per-
+#                               language matrix (license-checker / pip-
+#                               licenses / cargo-license / dotnet-project-
+#                               licenses) is a LATER INCREMENT; always SKIP.
+#   snyk               STUB   — `snyk test --json` needs `snyk auth` +
+#                               network. Registered but SKIP in the skeleton
+#                               (do NOT auto-run an auth prompt).
+#   zap-dast           STUB   — OWASP ZAP baseline needs Docker + a live
+#                               URL. Registered but SKIP in the skeleton.
+#   threat-model       STUB   — parse docs/threat-model.md mitigation IDs vs
+#                               the test suite. Registered but SKIP in the
+#                               skeleton.
+P3_SCANNERS="semgrep-full-tree license snyk zap-dast threat-model"
+
+_p3_label() {
+  case "$1" in
+    semgrep-full-tree) echo "Full-tree Semgrep SAST" ;;
+    license)           echo "License compliance" ;;
+    snyk)              echo "Snyk dependency scan" ;;
+    zap-dast)          echo "OWASP ZAP DAST" ;;
+    threat-model)      echo "Threat-model verification" ;;
+    *)                 echo "$1" ;;
+  esac
+}
+
+_p3_kind() {   # "real" or "stub" — surfaced in --list and the summary.
+  case "$1" in
+    semgrep-full-tree) echo "real" ;;
+    *)                 echo "stub" ;;
+  esac
+}
+
+# ── Defaults / arg parsing ───────────────────────────────────────────
+OFFLINE="${SOLO_PHASE3_OFFLINE:-}"
+RESULTS_DIR="docs/test-results/phase3"
+STATE_FILE=".claude/phase-state.json"
+MODE="run"           # run | attest | list
+ATTEST_SCANNER=""
+ATTEST_REASON=""
+ATTEST_SIGNOFF=""
+
+_p3_usage() {
+  cat <<'EOF'
+run-phase3-validation.sh — Phase 3 validation-scan driver (BL-070 skeleton)
+
+Run all registered scanners and write an aggregate summary:
+  bash scripts/run-phase3-validation.sh [--offline] [--results-dir DIR] [--state FILE]
+
+Attest a skipped scanner (reason + sign-off, recorded in phase-state.json):
+  bash scripts/run-phase3-validation.sh --attest <scanner> --reason "<why>" [--signoff "<who>"]
+
+List the scanner registry:
+  bash scripts/run-phase3-validation.sh --list
+
+Flags:
+  --offline            Force every real-execution scanner to SKIP (no
+                       network / Docker / semgrep run). Also SOLO_PHASE3_OFFLINE=1.
+  --results-dir DIR    Where to archive scan JSON + summary (default docs/test-results/phase3).
+  --state FILE         phase-state.json path (default .claude/phase-state.json).
+  --attest <scanner>   Record a skip-attestation for <scanner>.
+  --reason "<why>"     Attestation reason (required with --attest).
+  --signoff "<who>"    Attestation sign-off (defaults to git/host identity).
+  --list               Print the scanner registry (name / kind / label).
+  --help, -h           This help.
+
+Scanners: semgrep-full-tree license snyk zap-dast threat-model
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --offline)      OFFLINE=1; shift ;;
+    --results-dir)  RESULTS_DIR="${2:?--results-dir requires a value}"; shift 2 ;;
+    --results-dir=*) RESULTS_DIR="${1#--results-dir=}"; shift ;;
+    --state)        STATE_FILE="${2:?--state requires a value}"; shift 2 ;;
+    --state=*)      STATE_FILE="${1#--state=}"; shift ;;
+    --attest)       MODE="attest"; ATTEST_SCANNER="${2:?--attest requires a scanner name}"; shift 2 ;;
+    --attest=*)     MODE="attest"; ATTEST_SCANNER="${1#--attest=}"; shift ;;
+    --reason)       ATTEST_REASON="${2:?--reason requires a value}"; shift 2 ;;
+    --reason=*)     ATTEST_REASON="${1#--reason=}"; shift ;;
+    --signoff)      ATTEST_SIGNOFF="${2:?--signoff requires a value}"; shift 2 ;;
+    --signoff=*)    ATTEST_SIGNOFF="${1#--signoff=}"; shift ;;
+    --list)         MODE="list"; shift ;;
+    --help|-h)      _p3_usage; exit 0 ;;
+    *)
+      echo -e "${RED}[FAIL]${NC} Unknown argument: '$1'" >&2
+      echo "Run 'bash scripts/run-phase3-validation.sh --help' for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+_p3_is_registered() {
+  case " $P3_SCANNERS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# ── Identity / attestation helpers ───────────────────────────────────
+# Best-effort "who signed off" — prefers git identity, falls back to
+# whoami@hostname (mirrors check-phase-gate.sh::_cpg_gate_actor).
+_p3_actor() {
+  local name email host
+  name=$(git config user.name 2>/dev/null || echo "")
+  email=$(git config user.email 2>/dev/null || echo "")
+  if [ -n "$name" ] && [ -n "$email" ]; then
+    printf '%s <%s>' "$name" "$email"
+  elif [ -n "$name" ]; then
+    printf '%s' "$name"
+  else
+    host=$(hostname -s 2>/dev/null || hostname 2>/dev/null || echo "localhost")
+    printf '%s@%s' "$(whoami 2>/dev/null || echo unknown)" "$host"
+  fi
+}
+
+# _p3_is_attested <scanner>
+# Returns 0 iff phase-state.json::phase3.attestations.<scanner> carries a
+# non-empty reason AND a non-empty sign-off (the two-part attestation the
+# gate requires). Returns 1 if jq is absent (conservative — an un-verifiable
+# attestation is treated as un-attested → gate FAIL).
+_p3_is_attested() {
+  local name="$1" reason signoff
+  command -v jq >/dev/null 2>&1 || return 1
+  [ -f "$STATE_FILE" ] || return 1
+  reason=$(jq -r --arg n "$name" '.phase3.attestations[$n].reason // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  signoff=$(jq -r --arg n "$name" '.phase3.attestations[$n].signoff // ""' "$STATE_FILE" 2>/dev/null || echo "")
+  [ -n "$reason" ] && [ "$reason" != "null" ] && [ -n "$signoff" ] && [ "$signoff" != "null" ]
+}
+
+# _p3_write_attestation <scanner> <reason> <signoff>
+# Atomically records phase3.attestations.<scanner> = {reason, signoff, at}
+# into phase-state.json. Reuses BL-071's atomic-finalize lineage: a portable
+# mkdir advisory lock (flock is unavailable on macOS bash-3.2), a temp file
+# written ADJACENT to the state file so `mv` is a same-filesystem atomic
+# rename, and an EXIT/INT/TERM trap contained in a subshell.
+# Returns 0 on success, 2 on failure (jq missing, lock timeout, jq error).
+_p3_write_attestation() {
+  local name="$1" reason="$2" signoff="$3"
+  local file="$STATE_FILE"
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo -e "${RED}[FAIL]${NC} --attest needs jq to edit $file structurally (jq not found)." >&2
+    return 2
+  fi
+
+  mkdir -p "$(dirname "$file")" 2>/dev/null || true
+  if [ ! -f "$file" ]; then
+    echo '{"phase3":{"attestations":{}}}' > "$file"
+  fi
+
+  local at lock_dir attempts rc
+  at=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+  lock_dir="$file.lockdir"
+
+  attempts=0
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 100 ]; then
+      echo -e "${YELLOW}[WARN]${NC} attestation write lock timeout (>10s; possible stale $lock_dir from a killed run — remove it and retry)." >&2
+      return 2
+    fi
+    sleep 0.1
+  done
+
+  rc=0
+  (
+    tmp=$(mktemp "${file}.XXXXXX") || exit 1
+    trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
+    if jq --arg n "$name" --arg r "$reason" --arg s "$signoff" --arg at "$at" \
+         '.phase3 = (.phase3 // {}) | .phase3.attestations = ((.phase3.attestations // {}) + {($n): {"reason":$r,"signoff":$s,"at":$at}})' \
+         "$file" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$file" || exit 1   # BL-070-ATTEST-WRITE: atomic attestation finalize (mutation target)
+      trap - EXIT INT TERM
+      exit 0
+    else
+      rm -f "$tmp"
+      trap - EXIT INT TERM
+      exit 1
+    fi
+  ) || rc=1
+  rmdir "$lock_dir" 2>/dev/null || true
+
+  if [ "$rc" -eq 0 ]; then
+    return 0
+  fi
+  echo -e "${YELLOW}[WARN]${NC} attestation auto-write failed (jq error) — record it in $file manually." >&2
+  return 2
+}
+
+# ── Scanner implementations ──────────────────────────────────────────
+# Each _p3_scan_* sets three globals consumed by _p3_run_scanner:
+#   P3_STATUS  — PASS | SKIP | FAIL
+#   P3_NOTE    — human note for the summary
+#   P3_ARCHIVE — path to the archived JSON, or "-"
+P3_STATUS=""; P3_NOTE=""; P3_ARCHIVE="-"
+
+# REAL — full-tree Semgrep SAST.
+_p3_scan_semgrep() {
+  local archive="$1"
+  if [ -n "$OFFLINE" ]; then
+    P3_STATUS="SKIP"; P3_NOTE="offline mode (--offline / SOLO_PHASE3_OFFLINE) — semgrep not run"
+    return
+  fi
+  if ! command -v semgrep >/dev/null 2>&1; then
+    P3_STATUS="SKIP"; P3_NOTE="semgrep not on PATH — install to enable full-tree SAST"
+    return
+  fi
+  # REAL full-tree scan (distinct from pre-commit-gate.sh's staged-only scan).
+  local rc=0
+  semgrep --config auto --json --output "$archive" . >/dev/null 2>&1 || rc=$?
+  P3_ARCHIVE="$archive"
+  # semgrep exit: 0 = clean, 1 = findings, >=2 = execution error.
+  if [ "$rc" -ge 2 ] || [ ! -f "$archive" ]; then
+    P3_STATUS="FAIL"; P3_NOTE="semgrep execution error (rc=$rc)"
+    return
+  fi
+  local findings=0
+  if command -v jq >/dev/null 2>&1; then
+    findings=$(jq '(.results | length) // 0' "$archive" 2>/dev/null || echo 0)
+    case "$findings" in ''|*[!0-9]*) findings=0 ;; esac
+  fi
+  if [ "$findings" -gt 0 ]; then
+    P3_STATUS="FAIL"; P3_NOTE="$findings semgrep finding(s) — review $archive"
+  else
+    P3_STATUS="PASS"; P3_NOTE="0 findings (full-tree --config auto)"
+  fi
+}
+
+# STUB — license compliance. Always SKIP in the skeleton.
+_p3_scan_license() {
+  # BL-070 SKELETON STUB: the per-language dependency-license matrix
+  # (license-checker / pip-licenses / cargo-license / dotnet-project-
+  # licenses) is a later increment. Until then this scanner always SKIPs
+  # and therefore requires an attestation — the gate never silently green-
+  # lights an unscanned dependency tree.
+  P3_STATUS="SKIP"
+  P3_NOTE="license-compliance scanner stubbed (BL-070 skeleton) — wire the per-language license matrix in a later increment"
+}
+
+# STUB — Snyk dependency scan. Always SKIP in the skeleton.
+_p3_scan_snyk() {
+  # BL-070 SKELETON STUB: `snyk test --json` needs `snyk auth` + network.
+  # We deliberately do NOT auto-run it (an auth prompt would hang unattended
+  # runs). Real invocation is a later increment.
+  P3_STATUS="SKIP"
+  P3_NOTE="snyk dependency scan stubbed (BL-070 skeleton) — needs 'snyk auth'; wire 'snyk test --json' in a later increment"
+}
+
+# STUB — OWASP ZAP DAST. Always SKIP in the skeleton.
+_p3_scan_zap() {
+  # BL-070 SKELETON STUB: OWASP ZAP baseline needs Docker + a live target
+  # URL (web/api platforms only). Real invocation is a later increment.
+  P3_STATUS="SKIP"
+  P3_NOTE="OWASP ZAP DAST stubbed (BL-070 skeleton) — needs Docker + a live URL; wire zap-baseline.py in a later increment"
+}
+
+# STUB — threat-model verification. Always SKIP in the skeleton.
+_p3_scan_threat_model() {
+  # BL-070 SKELETON STUB: parse docs/threat-model.md mitigation IDs and grep
+  # the test suite for each mitigation's test-id anchor. Later increment.
+  P3_STATUS="SKIP"
+  P3_NOTE="threat-model verification stubbed (BL-070 skeleton) — parse docs/threat-model.md mitigations vs tests in a later increment"
+}
+
+# _p3_run_scanner <name> <timestamp> — dispatch to the right implementation.
+_p3_run_scanner() {
+  local name="$1" ts="$2"
+  local archive="$RESULTS_DIR/${name}-${ts}.json"
+  P3_STATUS="SKIP"; P3_NOTE=""; P3_ARCHIVE="-"
+  case "$name" in
+    semgrep-full-tree) _p3_scan_semgrep "$archive" ;;
+    license)           _p3_scan_license "$archive" ;;
+    snyk)              _p3_scan_snyk "$archive" ;;
+    zap-dast)          _p3_scan_zap "$archive" ;;
+    threat-model)      _p3_scan_threat_model "$archive" ;;
+    *)                 P3_STATUS="FAIL"; P3_NOTE="unknown scanner" ;;
+  esac
+}
+
+# ═══════════════════════════════════════════════════════════════════════
+# MODE: list
+# ═══════════════════════════════════════════════════════════════════════
+if [ "$MODE" = "list" ]; then
+  echo -e "${BOLD}Phase 3 scanner registry${NC}"
+  for s in $P3_SCANNERS; do
+    printf '  %-20s %-5s %s\n' "$s" "[$(_p3_kind "$s")]" "$(_p3_label "$s")"
+  done
+  exit 0
+fi
+
+# ═══════════════════════════════════════════════════════════════════════
+# MODE: attest
+# ═══════════════════════════════════════════════════════════════════════
+if [ "$MODE" = "attest" ]; then
+  if ! _p3_is_registered "$ATTEST_SCANNER"; then
+    echo -e "${RED}[FAIL]${NC} --attest: '$ATTEST_SCANNER' is not a registered scanner. Valid: $P3_SCANNERS" >&2
+    exit 2
+  fi
+  if [ -z "$ATTEST_REASON" ]; then
+    echo -e "${RED}[FAIL]${NC} --attest requires --reason \"<why the scan was skipped>\"." >&2
+    exit 2
+  fi
+  [ -n "$ATTEST_SIGNOFF" ] || ATTEST_SIGNOFF="$(_p3_actor)"
+  if _p3_write_attestation "$ATTEST_SCANNER" "$ATTEST_REASON" "$ATTEST_SIGNOFF"; then
+    echo -e "${GREEN}[OK]${NC} Attested skip for '$ATTEST_SCANNER' recorded in $STATE_FILE::phase3.attestations"
+    echo "     reason:  $ATTEST_REASON"
+    echo "     signoff: $ATTEST_SIGNOFF"
+    exit 0
+  fi
+  echo -e "${RED}[FAIL]${NC} Could not record the attestation for '$ATTEST_SCANNER'." >&2
+  exit 2
+fi
+
+# ═══════════════════════════════════════════════════════════════════════
+# MODE: run — execute every registered scanner + write the aggregate summary
+# ═══════════════════════════════════════════════════════════════════════
+mkdir -p "$RESULTS_DIR" 2>/dev/null || {
+  echo -e "${RED}[FAIL]${NC} Cannot create results dir: $RESULTS_DIR" >&2
+  exit 2
+}
+
+# File-safe timestamp (dashes, no colons — sortable, matches the repo's
+# `date -u +"%Y-%m-%dT%H-%M-%SZ"` file-stamp idiom). The `at`/Generated
+# fields below use the colon form to match the repo's ISO-8601 body idiom.
+TS=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
+GEN=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+SUMMARY="$RESULTS_DIR/summary-${TS}.md"
+
+echo -e "${BOLD}Phase 3 validation scans${NC}"
+[ -n "$OFFLINE" ] && echo -e "${BLUE}[INFO]${NC} offline mode — real-execution scanners will SKIP (no network/Docker/semgrep run)."
+
+# Accumulators.
+n_pass=0; n_skip_attested=0; n_skip_unattested=0; n_fail=0
+result_lines=""   # machine-readable "RESULT <name> <STATUS>" block
+table_rows=""     # human Markdown table body
+
+for s in $P3_SCANNERS; do
+  _p3_run_scanner "$s" "$TS"
+  status="$P3_STATUS"; note="$P3_NOTE"; archive="$P3_ARCHIVE"
+  attested_col="-"
+
+  case "$status" in
+    PASS)
+      n_pass=$((n_pass + 1))
+      echo -e "  ${GREEN}[PASS]${NC} $s — $note"
+      ;;
+    SKIP)
+      if _p3_is_attested "$s"; then
+        attested_col="yes"
+        n_skip_attested=$((n_skip_attested + 1))
+        echo -e "  ${BLUE}[SKIP]${NC} $s — $note ${GREEN}(attested)${NC}"
+      else
+        attested_col="NO"
+        n_skip_unattested=$((n_skip_unattested + 1))
+        echo -e "  ${YELLOW}[SKIP]${NC} $s — $note ${RED}(UN-ATTESTED — attest or run manually)${NC}"
+      fi
+      ;;
+    *)
+      status="FAIL"
+      n_fail=$((n_fail + 1))
+      echo -e "  ${RED}[FAIL]${NC} $s — $note"
+      ;;
+  esac
+
+  result_lines="${result_lines}RESULT ${s} ${status}
+"
+  table_rows="${table_rows}| ${s} | $(_p3_kind "$s") | ${status} | ${attested_col} | ${archive} | ${note} |
+"
+done
+
+# Overall verdict: gate-ready iff no FAIL and no un-attested SKIP.
+overall="PASS"
+if [ "$n_fail" -gt 0 ] || [ "$n_skip_unattested" -gt 0 ]; then
+  overall="FAIL"
+fi
+
+# Write the aggregate summary. The `RESULT <name> <STATUS>` lines are the
+# machine-readable contract the gate parses (decoupled from the Markdown
+# table formatting); live attestations are re-checked by the gate at read
+# time, so attesting AFTER this summary is written still flips the gate.
+{
+  echo "# Phase 3 Validation Summary"
+  echo ""
+  echo "- Generated: ${GEN}"
+  echo "- Offline: $([ -n "$OFFLINE" ] && echo yes || echo no)"
+  echo "- Scanners: $(echo $P3_SCANNERS | wc -w | tr -d ' ')"
+  echo "- PASS: ${n_pass}  SKIP(attested): ${n_skip_attested}  SKIP(un-attested): ${n_skip_unattested}  FAIL: ${n_fail}"
+  echo "- Overall: ${overall}"
+  echo ""
+  echo "## Results"
+  echo ""
+  echo "| Scanner | Kind | Status | Attested | Archive | Note |"
+  echo "|---|---|---|---|---|---|"
+  printf '%s' "$table_rows"
+  echo ""
+  echo "## Machine-readable results (parsed by scripts/check-phase-gate.sh)"
+  echo ""
+  echo '```'
+  printf '%s' "$result_lines"
+  echo '```'
+  echo ""
+  echo "## Attest a skipped scanner"
+  echo ""
+  echo "A SKIP without an attestation blocks the Phase 3→4 gate. To attest:"
+  echo ""
+  echo '```'
+  echo 'bash scripts/run-phase3-validation.sh --attest <scanner> --reason "<why skipped>"'
+  echo '```'
+} > "$SUMMARY"
+
+echo ""
+echo -e "${BOLD}Summary:${NC} $SUMMARY"
+echo -e "  PASS=${n_pass}  SKIP(attested)=${n_skip_attested}  SKIP(un-attested)=${n_skip_unattested}  FAIL=${n_fail}  →  ${overall}"
+
+if [ "$overall" = "PASS" ]; then
+  echo -e "${GREEN}[OK]${NC} Phase 3 validation gate-ready (all PASS or attested-skip)."
+  exit 0
+fi
+echo -e "${YELLOW}[ACTION]${NC} $n_skip_unattested un-attested SKIP(s) / $n_fail FAIL(s) block Phase 3→4."
+echo "  Attest a skip:  bash scripts/run-phase3-validation.sh --attest <scanner> --reason \"...\""
+echo "  Or install the tool and re-run (drop --offline) to get a real result."
+exit 1

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -2116,3 +2116,18 @@ Sibling of [[bl080-backfill-honors-sentinel]]. On the FULL `upgrade-project.sh` 
 **Scope:** decide whether the full-path BL-015 guard should move earlier (before the idempotent backfill block), so NO mutation occurs on any path while a decision is pending — OR whether the pre-guard idempotent backfill is intentionally exempt (it is non-destructive/idempotent). If moved, add a regression asserting a sentinel-blocked full upgrade leaves `.claude/skills/` + manifest byte-identical. Also tighten the `_bl015_sentinel_guard()` docstring, which currently claims "mutates nothing" for both call sites (only strictly true for `--backfill-only`).
 
 **Related:** [[bl080-backfill-honors-sentinel]] (PR #144); BL-015; `scripts/upgrade-project.sh` full-upgrade path.
+
+---
+
+## BL-082: Bind the Phase-3 validation summary to a commit/tree hash + re-run when stale
+
+**Logged:** 2026-07-06 (BL-070 verifier follow-up)
+**Category:** Debt / gate hardening
+**Severity:** Low
+**Status:** Open
+
+Sibling of [[bl070-phase-3-validation-scans]] (PR #145). The BL-070 skeleton's Phase 3→4 gate trusts an existing `docs/test-results/phase3/summary-*.md` as-is: the auto-run only fires when NO summary exists, so a stale summary (e.g. an old `semgrep-full-tree PASS`) is reused indefinitely, and a hand-forged all-PASS summary is trusted. The verifier noted forgery is outside a self-audit gate's threat model (a determined operator has easier documented escapes), but staleness is a real limitation — a summary from before the latest code changes should not satisfy the gate.
+
+**Scope:** bind the summary to the tree/commit it validated — record the `git rev-parse HEAD` (or a tree hash) in the summary and have the gate re-run (or FAIL-with-stale) when the current tree differs from the recorded one. Optionally add an authenticity marker. Ships as a later increment on top of the BL-070 skeleton, alongside promoting the stubbed scanners (license/snyk/zap/threat-model) to real.
+
+**Related:** [[bl070-phase-3-validation-scans]] (PR #145 skeleton); `scripts/run-phase3-validation.sh`; `scripts/check-phase-gate.sh` Phase 3→4 block.

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -489,6 +489,21 @@ if bash "$SCRIPT_DIR/tests/test-init-seeds-four-gate-keys.sh" >/dev/null 2>&1; t
 else
   fail "tests/test-init-seeds-four-gate-keys.sh FAILED (run for details)"
 fi
+# BL-070: scripts/run-phase3-validation.sh (Phase 3 validation-scan driver) +
+# the attest-on-skip Phase 3→4 gate in scripts/check-phase-gate.sh. The docs
+# imply Phase 3 auto-runs Snyk/license/full-tree-Semgrep/ZAP/threat-model; a
+# grep of scripts/ found ZERO invocations. This SKELETON builds the driver +
+# gate first (Karl-approved Option C): every scanner SKIP-able, any SKIP needs
+# an attestation (reason + sign-off) in phase-state.json::phase3.attestations,
+# and the gate refuses Phase 3→4 on any un-attested SKIP or FAIL. The
+# enforcement is mutation-proof: the suite strips the marked
+# `# BL-070-GATE-CHECK` lines from a copy of the gate and asserts the phase-3
+# FAIL disappears (proving the lines are load-bearing).
+if bash "$SCRIPT_DIR/tests/test-phase3-validation-gate.sh" >/dev/null 2>&1; then
+  pass "tests/test-phase3-validation-gate.sh"
+else
+  fail "tests/test-phase3-validation-gate.sh FAILED (run for details)"
+fi
 
 # ----------------------------------------------------------------
 # TEST 0i: PENDING-APPROVAL RESOLVE-DECISION

--- a/tests/test-phase3-validation-gate.sh
+++ b/tests/test-phase3-validation-gate.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# tests/test-phase3-validation-gate.sh
+#
+# BL-070 regression: scripts/run-phase3-validation.sh (Phase 3 validation-scan
+# driver) + the attest-on-skip Phase 3→4 gate in scripts/check-phase-gate.sh.
+#
+# The Builder's/User guides imply Phase 3 auto-runs Snyk / license / full-tree
+# Semgrep / OWASP ZAP / threat-model; a grep of scripts/ found ZERO invocations
+# — a documented gate mechanic that was not real. This suite pins the SKELETON
+# (harness + gate + attest-on-skip), NOT all five real scanners.
+#
+# Contract pinned here:
+#   T-driver-attest-recorded     driver --attest writes
+#                                phase-state.json::phase3.attestations.<name>
+#                                with a non-empty reason AND sign-off; exit 0.
+#   T-driver-attest-needs-reason --attest without --reason → exit 2, nothing
+#                                written.
+#   T-driver-offline-cycle       --offline (all SKIP, un-attested) → exit 1;
+#                                after attesting all 5 → exit 0.
+#   T-gate-blocks-without-summary  current_phase=4 + NO summary (auto-run
+#                                disabled) → gate emits the phase-3 FAIL and
+#                                blocks (exit != 0).
+#   T-gate-autoruns-driver       current_phase=4 + NO summary + auto-run
+#                                enabled → gate auto-generates an offline
+#                                summary and blocks on un-attested SKIPs.
+#   T-gate-blocks-unattested-skip  summary with SKIPs but NO attestations →
+#                                gate emits the "un-attested SKIP" FAIL.
+#   T-gate-passes-attested-skip  summary with SKIPs + every skip attested
+#                                (reason + signoff) → gate emits the phase-3
+#                                [OK] line, NOT the FAIL.
+#   T-mutation                   MUTATION-PROOF: strip the `# BL-070-GATE-CHECK`
+#                                enforcement lines from a copy of the gate and
+#                                re-run the unattested-skip fixture → the
+#                                phase-3 FAIL message is gone (proving the
+#                                enforcement is load-bearing: remove it → the
+#                                blocking test goes RED).
+#
+# HERMETIC: scanners are never run for real — the driver is always invoked
+# with --offline, so no network / Docker / semgrep / gh. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+DRIVER="$REPO_ROOT/scripts/run-phase3-validation.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq not available — BL-070 attest-on-skip requires jq."
+  exit 0
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/p"
+  mkdir -p "$PROJ/.claude"
+  printf '%s\n' '{"project":"p3","current_phase":4,"deployment":"personal","track":"light","gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01","phase_2_to_3":"2026-03-01","phase_3_to_4":"2026-04-01"}}' \
+    > "$PROJ/.claude/phase-state.json"
+  # APPROVAL_LOG.md is required — the gate exits early without it. Provide
+  # dated entries for every gate so the run reaches the Phase 3→4 checks.
+  cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| **Date** | 2026-01-01 |
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| **Date** | 2026-02-01 |
+
+## Phase Gate: Phase 2 → Phase 3
+| Field | Value |
+|---|---|
+| **Date** | 2026-03-01 |
+
+## Phase Gate: Phase 3 → Phase 4
+| Field | Value |
+|---|---|
+| **Date** | 2026-04-01 |
+MD
+}
+teardown() { rm -rf "$TMP"; }
+
+# Pre-create a summary whose five scanners are all SKIP (the driver's
+# machine-readable RESULT contract). Only the RESULT lines are load-bearing
+# for the gate parser.
+write_summary_all_skip() {
+  mkdir -p "$PROJ/docs/test-results/phase3"
+  cat > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md" <<'MD'
+# Phase 3 Validation Summary
+- Overall: FAIL
+
+## Machine-readable results
+```
+RESULT semgrep-full-tree SKIP
+RESULT license SKIP
+RESULT snyk SKIP
+RESULT zap-dast SKIP
+RESULT threat-model SKIP
+```
+MD
+}
+
+attest_all() {
+  local s
+  for s in semgrep-full-tree license snyk zap-dast threat-model; do
+    ( cd "$PROJ" && bash "$DRIVER" --attest "$s" --reason "test: tool not provisioned" --signoff "Tester" ) >/dev/null 2>&1
+  done
+}
+
+# Run the gate in $PROJ. $1 (optional) = value for SOLO_PHASE3_GATE_NOAUTORUN
+# ("1" disables the gate's driver auto-run; empty leaves it enabled).
+run_gate() {
+  ( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN="${1:-}" bash "$GATE" 2>&1 ) || true
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-driver-attest-recorded: --attest writes phase3.attestations ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+rc=0
+( cd "$PROJ" && bash "$DRIVER" --attest snyk --reason "no snyk auth in this env" --signoff "Alice" ) >/dev/null 2>&1 || rc=$?
+reason=$(jq -r '.phase3.attestations.snyk.reason // ""' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+signoff=$(jq -r '.phase3.attestations.snyk.signoff // ""' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+at=$(jq -r '.phase3.attestations.snyk.at // ""' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+if [ "$rc" -eq 0 ] && [ "$reason" = "no snyk auth in this env" ] && [ "$signoff" = "Alice" ] && [ -n "$at" ]; then
+  pass "T-driver-attest-recorded: reason+signoff+at recorded (reason='$reason', signoff='$signoff')"
+else
+  fail_ "T-driver-attest-recorded" "rc=$rc reason='$reason' signoff='$signoff' at='$at'"
+fi
+# preserves pre-existing top-level keys
+cp_phase=$(jq -r '.current_phase // ""' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+if [ "$cp_phase" = "4" ]; then
+  pass "T-driver-attest-recorded: pre-existing phase-state keys preserved (current_phase=4)"
+else
+  fail_ "T-driver-attest-recorded" "attest clobbered current_phase (got '$cp_phase')"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-driver-attest-needs-reason: --attest without --reason → exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+rc=0
+( cd "$PROJ" && bash "$DRIVER" --attest snyk ) >/dev/null 2>&1 || rc=$?
+recorded=$(jq -r '.phase3.attestations.snyk // "none"' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+if [ "$rc" -eq 2 ] && [ "$recorded" = "none" ]; then
+  pass "T-driver-attest-needs-reason: exit 2, nothing recorded"
+else
+  fail_ "T-driver-attest-needs-reason" "expected exit 2 + no record; rc=$rc recorded='$recorded'"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-driver-offline-cycle: all-SKIP exit 1 → attest all → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+rc=0
+( cd "$PROJ" && bash "$DRIVER" --offline ) >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "T-driver-offline-cycle: un-attested all-SKIP → exit 1 (gate would block)"
+else
+  fail_ "T-driver-offline-cycle" "expected exit 1 on un-attested skips, got $rc"
+fi
+if compgen -G "$PROJ/docs/test-results/phase3/summary-*.md" >/dev/null 2>&1; then
+  pass "T-driver-offline-cycle: aggregate summary written"
+else
+  fail_ "T-driver-offline-cycle" "no summary-*.md produced"
+fi
+attest_all
+rc=0
+( cd "$PROJ" && bash "$DRIVER" --offline ) >/dev/null 2>&1 || rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "T-driver-offline-cycle: after attesting all 5 skips → exit 0 (gate-ready)"
+else
+  fail_ "T-driver-offline-cycle" "expected exit 0 after attesting all skips, got $rc"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-blocks-without-summary: no summary (auto-run off) → FAIL ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+rc=0
+out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$GATE" 2>&1 ) || rc=$?
+if echo "$out" | grep -qE "no Phase 3 validation summary"; then
+  pass "T-gate-blocks-without-summary: gate emits the missing-summary FAIL"
+else
+  fail_ "T-gate-blocks-without-summary" "expected 'no Phase 3 validation summary' FAIL; out:
+$(echo "$out" | grep -iE 'phase 3|validation' | head)"
+fi
+if [ "$rc" -ne 0 ]; then
+  pass "T-gate-blocks-without-summary: gate blocks (exit $rc)"
+else
+  fail_ "T-gate-blocks-without-summary" "expected non-zero exit, got 0"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-autoruns-driver: no summary + auto-run → offline summary + block ==="
+# ════════════════════════════════════════════════════════════════════
+# Karl: evals should be automatic. With NO pre-existing summary and auto-run
+# enabled (default), the gate invokes the driver (offline) to generate a
+# baseline summary, then blocks on the un-attested SKIPs.
+setup
+rc=0
+out=$( cd "$PROJ" && bash "$GATE" 2>&1 ) || rc=$?
+if compgen -G "$PROJ/docs/test-results/phase3/summary-*.md" >/dev/null 2>&1; then
+  pass "T-gate-autoruns-driver: gate auto-generated a phase-3 summary"
+else
+  fail_ "T-gate-autoruns-driver" "gate did not auto-generate a summary"
+fi
+if echo "$out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+  pass "T-gate-autoruns-driver: gate blocks on the auto-generated un-attested SKIPs"
+else
+  fail_ "T-gate-autoruns-driver" "expected an un-attested SKIP FAIL; out:
+$(echo "$out" | grep -iE 'phase 3.4|validation' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-blocks-unattested-skip: summary SKIPs, no attestation → FAIL ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+write_summary_all_skip
+out=$(run_gate 1)
+if echo "$out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+  pass "T-gate-blocks-unattested-skip: gate emits the un-attested SKIP FAIL"
+else
+  fail_ "T-gate-blocks-unattested-skip" "expected un-attested SKIP FAIL; out:
+$(echo "$out" | grep -iE 'phase 3.4|validation' | head)"
+fi
+if echo "$out" | grep -qE "validation scans clean"; then
+  fail_ "T-gate-blocks-unattested-skip" "gate wrongly reported scans CLEAN with un-attested skips"
+else
+  pass "T-gate-blocks-unattested-skip: gate did NOT report clean"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-passes-attested-skip: summary SKIPs + all attested → [OK] ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+write_summary_all_skip
+attest_all
+out=$(run_gate 1)
+if echo "$out" | grep -qE "validation scans clean"; then
+  pass "T-gate-passes-attested-skip: gate reports phase-3 scans CLEAN (all attested-skip)"
+else
+  fail_ "T-gate-passes-attested-skip" "expected phase-3 [OK] clean line; out:
+$(echo "$out" | grep -iE 'phase 3.4|validation' | head)"
+fi
+if echo "$out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+  fail_ "T-gate-passes-attested-skip" "gate still emitted an un-attested FAIL despite full attestation"
+else
+  pass "T-gate-passes-attested-skip: no un-attested FAIL emitted"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-mutation: strip # BL-070-GATE-CHECK → phase-3 FAIL disappears (RED) ==="
+# ════════════════════════════════════════════════════════════════════
+# Copy the gate (+ lib + driver) into a temp scripts/ tree, delete the two
+# lines carrying `# BL-070-GATE-CHECK` (the FAIL emit + the issues++), and
+# re-run the SAME unattested-skip fixture. With the enforcement removed the
+# phase-3 FAIL must vanish. Together with T-gate-blocks-unattested-skip
+# (enforcement present → FAIL emitted) this proves the marked lines are
+# load-bearing: remove them and the blocking test goes RED.
+setup
+write_summary_all_skip
+MUT="$TMP/mut"
+mkdir -p "$MUT/scripts/lib"
+cp "$GATE" "$MUT/scripts/check-phase-gate.sh"
+cp "$DRIVER" "$MUT/scripts/run-phase3-validation.sh"
+cp "$REPO_ROOT"/scripts/lib/*.sh "$MUT/scripts/lib/" 2>/dev/null || true
+grep -v 'BL-070-GATE-CHECK' "$MUT/scripts/check-phase-gate.sh" > "$MUT/scripts/check-phase-gate.sh.tmp"
+mv "$MUT/scripts/check-phase-gate.sh.tmp" "$MUT/scripts/check-phase-gate.sh"
+chmod +x "$MUT/scripts/check-phase-gate.sh"
+
+if ! grep -q 'BL-070-GATE-CHECK' "$GATE"; then
+  fail_ "T-mutation" "BL-070-GATE-CHECK marker missing from the REAL gate — nothing to mutate"
+elif grep -q 'BL-070-GATE-CHECK' "$MUT/scripts/check-phase-gate.sh"; then
+  fail_ "T-mutation" "BL-070-GATE-CHECK still present after excision — mutation did not apply"
+else
+  # Real gate: FAIL present.
+  real_out=$(run_gate 1)
+  # Mutant gate: FAIL absent.
+  mut_out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$MUT/scripts/check-phase-gate.sh" 2>&1 ) || true
+  if echo "$real_out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+    pass "T-mutation: real gate emits the phase-3 FAIL"
+  else
+    fail_ "T-mutation" "real gate did NOT emit the phase-3 FAIL (fixture wrong?)"
+  fi
+  if echo "$mut_out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+    fail_ "T-mutation" "mutant STILL emitted the phase-3 FAIL — enforcement not load-bearing (mutation is not proof)"
+  else
+    pass "T-mutation: mutant (enforcement stripped) does NOT emit the phase-3 FAIL (RED proof)"
+  fi
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-phase3-validation-gate.sh
+++ b/tests/test-phase3-validation-gate.sh
@@ -109,10 +109,58 @@ RESULT threat-model SKIP
 MD
 }
 
+# semgrep reports a FAIL finding; the other four SKIP. Used to exercise the
+# gate's FAIL arm in isolation (attest the four skips so the ONLY blocker is
+# the FAIL status).
+write_summary_semgrep_fail() {
+  mkdir -p "$PROJ/docs/test-results/phase3"
+  cat > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md" <<'MD'
+# Phase 3 Validation Summary
+RESULT semgrep-full-tree FAIL
+RESULT license SKIP
+RESULT snyk SKIP
+RESULT zap-dast SKIP
+RESULT threat-model SKIP
+MD
+}
+
+# Summary that OMITS semgrep's RESULT line (→ gate reads it as MISSING) and
+# has a garbled status for license. Both must count as blocking.
+write_summary_missing_and_garbled() {
+  mkdir -p "$PROJ/docs/test-results/phase3"
+  cat > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md" <<'MD'
+# Phase 3 Validation Summary
+RESULT license BOGUS
+RESULT snyk SKIP
+RESULT zap-dast SKIP
+RESULT threat-model SKIP
+MD
+}
+
 attest_all() {
   local s
   for s in semgrep-full-tree license snyk zap-dast threat-model; do
     ( cd "$PROJ" && bash "$DRIVER" --attest "$s" --reason "test: tool not provisioned" --signoff "Tester" ) >/dev/null 2>&1
+  done
+}
+
+# Attest only the four stub scanners (leave semgrep-full-tree un-attested).
+attest_four_stubs() {
+  local s
+  for s in license snyk zap-dast threat-model; do
+    ( cd "$PROJ" && bash "$DRIVER" --attest "$s" --reason "test: tool not provisioned" --signoff "Tester" ) >/dev/null 2>&1
+  done
+}
+
+# Write whitespace-only attestations DIRECTLY (bypassing the driver's own
+# reject-on-whitespace guard) so we test the gate predicate's trim in
+# isolation. reason=" " signoff=" " for all five scanners.
+attest_all_whitespace_direct() {
+  local s tmp
+  for s in semgrep-full-tree license snyk zap-dast threat-model; do
+    tmp="$PROJ/.claude/phase-state.json.tmp"
+    jq --arg n "$s" '.phase3 = (.phase3 // {}) | .phase3.attestations = ((.phase3.attestations // {}) + {($n): {"reason":" ","signoff":" ","at":"2026-07-06T00:00:00Z"}})' \
+      "$PROJ/.claude/phase-state.json" > "$tmp" && mv "$tmp" "$PROJ/.claude/phase-state.json"
   done
 }
 
@@ -269,6 +317,128 @@ if echo "$out" | grep -qE "validation scans not clean|un-attested SKIP"; then
   fail_ "T-gate-passes-attested-skip" "gate still emitted an un-attested FAIL despite full attestation"
 else
   pass "T-gate-passes-attested-skip: no un-attested FAIL emitted"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-blocks-fail-status: a RESULT <scanner> FAIL → gate FAILs ==="
+# ════════════════════════════════════════════════════════════════════
+# The four stub SKIPs are attested, so the ONLY blocker is semgrep's FAIL
+# status — isolating the gate's FAIL arm.
+setup
+write_summary_semgrep_fail
+attest_four_stubs
+out=$(run_gate 1)
+if echo "$out" | grep -qE "validation scans not clean.*FAIL"; then
+  pass "T-gate-blocks-fail-status: gate blocks on the semgrep FAIL status"
+else
+  fail_ "T-gate-blocks-fail-status" "expected a FAIL-arm block; out:
+$(echo "$out" | grep -iE 'phase 3.4|validation' | head)"
+fi
+if echo "$out" | grep -qE "validation scans clean"; then
+  fail_ "T-gate-blocks-fail-status" "gate wrongly reported CLEAN with a FAIL status present"
+else
+  pass "T-gate-blocks-fail-status: gate did NOT report clean"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-blocks-missing-status: MISSING/garbled RESULT → gate FAILs ==="
+# ════════════════════════════════════════════════════════════════════
+# semgrep has NO RESULT line (→ MISSING) and license has a garbled status
+# (BOGUS). The three real SKIPs are attested; the ONLY blockers are the
+# MISSING + garbled statuses, which must count as gate-blocking.
+setup
+write_summary_missing_and_garbled
+( cd "$PROJ" && bash "$DRIVER" --attest snyk --reason "t" --signoff "T" ) >/dev/null 2>&1
+( cd "$PROJ" && bash "$DRIVER" --attest zap-dast --reason "t" --signoff "T" ) >/dev/null 2>&1
+( cd "$PROJ" && bash "$DRIVER" --attest threat-model --reason "t" --signoff "T" ) >/dev/null 2>&1
+out=$(run_gate 1)
+if echo "$out" | grep -qE "validation scans not clean"; then
+  pass "T-gate-blocks-missing-status: gate blocks on MISSING/garbled status"
+else
+  fail_ "T-gate-blocks-missing-status" "expected a block on MISSING/garbled status; out:
+$(echo "$out" | grep -iE 'phase 3.4|validation' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-fail-arm-mutation: drop the FAIL check → FAIL-status no longer blocks (RED) ==="
+# ════════════════════════════════════════════════════════════════════
+# MUTATION-PROOF for the FAIL arm. Copy the gate, strip the line marked
+# `# BL-070-FAIL-ARM` (the p3_fail increment), and re-run the semgrep-FAIL
+# fixture (four stubs attested). With the FAIL count defeated, p3_fail stays 0
+# and the gate reports the phase-3 scans CLEAN — proving that increment is
+# what makes T-gate-blocks-fail-status pass (remove it → that test goes RED).
+setup
+write_summary_semgrep_fail
+attest_four_stubs
+MUT="$TMP/mutfail"
+mkdir -p "$MUT/scripts/lib"
+cp "$GATE" "$MUT/scripts/check-phase-gate.sh"
+cp "$DRIVER" "$MUT/scripts/run-phase3-validation.sh"
+cp "$REPO_ROOT"/scripts/lib/*.sh "$MUT/scripts/lib/" 2>/dev/null || true
+grep -v 'BL-070-FAIL-ARM' "$MUT/scripts/check-phase-gate.sh" > "$MUT/scripts/cpg.tmp"
+mv "$MUT/scripts/cpg.tmp" "$MUT/scripts/check-phase-gate.sh"
+chmod +x "$MUT/scripts/check-phase-gate.sh"
+if ! grep -q 'BL-070-FAIL-ARM' "$GATE"; then
+  fail_ "T-fail-arm-mutation" "BL-070-FAIL-ARM marker missing from the REAL gate — nothing to mutate"
+elif grep -q 'BL-070-FAIL-ARM' "$MUT/scripts/check-phase-gate.sh"; then
+  fail_ "T-fail-arm-mutation" "BL-070-FAIL-ARM still present after excision — mutation did not apply"
+else
+  real_out=$(run_gate 1)
+  mut_out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$MUT/scripts/check-phase-gate.sh" 2>&1 ) || true
+  if echo "$real_out" | grep -qE "validation scans not clean.*FAIL"; then
+    pass "T-fail-arm-mutation: real gate blocks on the FAIL status"
+  else
+    fail_ "T-fail-arm-mutation" "real gate did NOT block on the FAIL status (fixture wrong?)"
+  fi
+  if echo "$mut_out" | grep -qE "validation scans not clean"; then
+    fail_ "T-fail-arm-mutation" "mutant STILL blocked — the FAIL arm is not load-bearing (mutation is not proof)"
+  else
+    pass "T-fail-arm-mutation: mutant (FAIL check stripped) reports CLEAN — FAIL status slips through (RED proof)"
+  fi
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-driver-rejects-whitespace-reason: --reason ' ' → exit 2, nothing written ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+rc=0
+( cd "$PROJ" && bash "$DRIVER" --attest snyk --reason " " --signoff " " ) >/dev/null 2>&1 || rc=$?
+recorded=$(jq -r '.phase3.attestations.snyk // "none"' "$PROJ/.claude/phase-state.json" 2>/dev/null)
+if [ "$rc" -eq 2 ] && [ "$recorded" = "none" ]; then
+  pass "T-driver-rejects-whitespace-reason: whitespace-only --reason → exit 2, nothing recorded"
+else
+  fail_ "T-driver-rejects-whitespace-reason" "expected exit 2 + no record; rc=$rc recorded='$recorded'"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-gate-rejects-whitespace-attestation: ' '/' ' in state → un-attested → FAIL ==="
+# ════════════════════════════════════════════════════════════════════
+# Whitespace-only attestations written DIRECTLY into phase-state.json (past
+# the driver's own guard) must still be rejected by the gate predicate's trim.
+setup
+write_summary_all_skip
+attest_all_whitespace_direct
+out=$(run_gate 1)
+if echo "$out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+  pass "T-gate-rejects-whitespace-attestation: gate treats ' '/' ' as un-attested → FAIL"
+else
+  fail_ "T-gate-rejects-whitespace-attestation" "gate accepted a whitespace-only attestation as valid; out:
+$(echo "$out" | grep -iE 'phase 3.4|validation' | head)"
+fi
+if echo "$out" | grep -qE "validation scans clean"; then
+  fail_ "T-gate-rejects-whitespace-attestation" "gate reported CLEAN on whitespace-only attestations"
+else
+  pass "T-gate-rejects-whitespace-attestation: gate did NOT report clean"
 fi
 teardown
 


### PR DESCRIPTION
## BL-070 — Phase 3 validation scans (SKELETON, Karl-approved Option C)

Docs (Builder's/User guides + workflow.html) imply Phase 3 auto-runs Snyk / license / full-tree Semgrep / OWASP ZAP / threat-model. A `grep scripts/` found **zero invocations** — a documented gate mechanic that was not real. This ships the **driver + gate + attest-on-skip** first; real scanners land incrementally.

### What's real vs stubbed
| Scanner | Skeleton status |
|---|---|
| `semgrep-full-tree` | **REAL** — `semgrep --config auto --json .` when present and not `--offline`; SKIP otherwise |
| `license` | STUB — always SKIP (per-language license matrix = later increment) |
| `snyk` | STUB — SKIP (needs `snyk auth` + network) |
| `zap-dast` | STUB — SKIP (needs Docker + live URL) |
| `threat-model` | STUB — SKIP (parse `docs/threat-model.md` = later increment) |

All stubs are clearly commented `# BL-070 SKELETON STUB`.

### Attest-on-skip (Karl's refinement)
`bash scripts/run-phase3-validation.sh --attest <scanner> --reason "..." [--signoff "..."]` records `{reason, signoff, at}` into `phase-state.json::phase3.attestations` via the **BL-071 atomic-finalize pattern** (mkdir-lock + adjacent mktemp + rename). A non-attested SKIP counts as a gate FAIL.

### Gate integration (`check-phase-gate.sh`, `# BL-070-GATE-CHECK`)
A distinct, self-contained Phase 3→4 step that **auto-invokes** the driver (offline baseline) when no summary exists, then refuses the transition unless every scanner is **PASS or attested-skip-with-signoff** (zero un-attested SKIPs, zero FAILs). Placed apart from the review-manifest check (BL-073) to minimize rebase collisions. `SOLO_PHASE3_GATE_NOAUTORUN=1` disables auto-generation.

### Tests — `tests/test-phase3-validation-gate.sh` (16/16, registered per BL-034)
attestation-recorded, blocks-without-summary, blocks-unattested-skip, passes-attested-skip, auto-runs-driver, driver offline→attest→pass cycle, and a **mutation** stripping `# BL-070-GATE-CHECK` → the phase-3 FAIL disappears (RED→GREEN captured). Hermetic: driver always `--offline` in tests.

### Verification
- 8-lint battery: all exit 0 (counter-antipattern, fix-functions-stderr, raw-read-prompt, tests-registered, doc-anchors, fail-emit-exit-status, fixture-envelopes, backlog-references)
- check-phase-gate cohort: 8/8 green
- new suite: 16/16 green
- driver end-to-end: all-skip (exit 1) → attest all 5 → pass (exit 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)