### PR TITLE
test(fixtures): fix stale --language + BL-046 path drift in orphan fixtures (BL-035 Chunk-0)

### DIFF
--- a/tests/test-bl029-integration.sh
+++ b/tests/test-bl029-integration.sh
@@ -15,7 +15,7 @@ fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
 TMP=$(mktemp -d); PROJ="$TMP/p"
 ( cd /tmp && bash "$REPO_ROOT/init.sh" --non-interactive \
     --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track light --deployment personal \
+    --platform web --language typescript --track light --deployment personal \
     >/dev/null 2>&1 )
 
 # T1: project has bypass-detector wired (PostToolUse + Stop).

--- a/tests/test-bl030-calibration-replay.sh
+++ b/tests/test-bl030-calibration-replay.sh
@@ -25,7 +25,7 @@ run_init() {
   if [ "$level" != "strict" ]; then extra="--enforcement-level $level --confirm-pitfalls"; fi
   # shellcheck disable=SC2086
   bash "$INIT" --non-interactive --project x --project-dir "$proj" --no-remote-creation \
-    --platform web --language javascript --track light --deployment personal $extra \
+    --platform web --language typescript --track light --deployment personal $extra \
     >/dev/null 2>&1
 }
 

--- a/tests/test-bypass-audit-schema.sh
+++ b/tests/test-bypass-audit-schema.sh
@@ -15,7 +15,7 @@ cd /tmp
 
 TMP=$(mktemp -d); PROJ="$TMP/p"
 bash "$REPO_ROOT/init.sh" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-  --platform web --language javascript --track light --deployment personal \
+  --platform web --language typescript --track light --deployment personal \
   >/dev/null 2>&1
 
 # T1: init wrote a row whose schema satisfies the minimum contract

--- a/tests/test-enforcement-level-init.sh
+++ b/tests/test-enforcement-level-init.sh
@@ -18,7 +18,7 @@ cd /tmp
 run_init() {
   local proj="$1"; shift
   bash "$INIT" --non-interactive --project x --project-dir "$proj" --no-remote-creation \
-    --platform web --language javascript "$@" >/dev/null 2>&1
+    --platform web --language typescript "$@" >/dev/null 2>&1
 }
 
 # T1: personal + default → enforcement_level=strict.
@@ -59,7 +59,7 @@ rm -rf "$TMP"
 echo "T4: --enforcement-level no without --confirm-pitfalls fails"
 TMP=$(mktemp -d); PROJ="$TMP/p"
 bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track light --deployment personal \
+    --platform web --language typescript --track light --deployment personal \
     --enforcement-level no >/dev/null 2>&1
 rc=$?
 if [ "$rc" != "0" ]; then pass "T4"; else fail_ "T4" "expected non-zero exit, rc=$rc"; fi

--- a/tests/test-enforcement-level-reconfigure.sh
+++ b/tests/test-enforcement-level-reconfigure.sh
@@ -20,14 +20,14 @@ cd /tmp
 setup_personal() {
   TMP=$(mktemp -d); PROJ="$TMP/p"
   bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track light --deployment personal \
+    --platform web --language typescript --track light --deployment personal \
     >/dev/null 2>&1
   RECONFIG="$PROJ/scripts/reconfigure-project.sh"
 }
 setup_org_production() {
   TMP=$(mktemp -d); PROJ="$TMP/p"
   bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track standard --deployment organizational --gov-mode production \
+    --platform web --language typescript --track standard --deployment organizational --gov-mode production \
     >/dev/null 2>&1
   RECONFIG="$PROJ/scripts/reconfigure-project.sh"
 }
@@ -62,7 +62,7 @@ teardown
 echo "T4: light→strict installs filesystem gate"
 TMP=$(mktemp -d); PROJ="$TMP/p"
 bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-  --platform web --language javascript --track light --deployment personal \
+  --platform web --language typescript --track light --deployment personal \
   --enforcement-level light --confirm-pitfalls >/dev/null 2>&1
 RECONFIG="$PROJ/scripts/reconfigure-project.sh"
 if ( cd "$PROJ" && bash "$RECONFIG" --enforcement-level strict >/dev/null 2>&1 ); then
@@ -156,7 +156,7 @@ teardown
 echo "T10: light→strict installer FAILURE rolls back manifest + audit"
 TMP=$(mktemp -d); PROJ="$TMP/p"
 bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-  --platform web --language javascript --track light --deployment personal \
+  --platform web --language typescript --track light --deployment personal \
   --enforcement-level light --confirm-pitfalls >/dev/null 2>&1
 RECONFIG="$PROJ/scripts/reconfigure-project.sh"
 # Replace the project-local installer with a stub that exits 1.

--- a/tests/test-init-atomic-finalize.sh
+++ b/tests/test-init-atomic-finalize.sh
@@ -47,7 +47,7 @@ run_init_no_remote() {
     --project x \
     --project-dir "$proj" \
     --platform web \
-    --language javascript \
+    --language typescript \
     --deployment personal \
     --track light \
     --git-host github \

--- a/tests/test-init-non-interactive.sh
+++ b/tests/test-init-non-interactive.sh
@@ -39,35 +39,35 @@ n1_happy_path() {
 }
 
 n11_invalid_platform() {
-  local out; out=$(run_validate --project p --platform foo --deployment personal --language ts)
+  local out; out=$(run_validate --project p --platform foo --deployment personal --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N11" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--platform"* ]] || { fail_ "N11" "stderr should mention --platform: ${out##*|}"; return; }
   pass "N11: invalid --platform → exit 1 with platform listed"
 }
 
 n12_invalid_project_name() {
-  local out; out=$(run_validate --project "Foo!" --platform web --deployment personal --language ts)
+  local out; out=$(run_validate --project "Foo!" --platform web --deployment personal --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N12" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"project"* ]] || { fail_ "N12" "stderr should mention project: ${out##*|}"; return; }
   pass "N12: invalid --project name → exit 1 with naming-rule message"
 }
 
 n2_missing_project() {
-  local out; out=$(run_validate --platform web --deployment personal --language ts)
+  local out; out=$(run_validate --platform web --deployment personal --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N2" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--project"* ]] || { fail_ "N2" "stderr should mention --project: ${out##*|}"; return; }
   pass "N2: missing --project → exit 1"
 }
 
 n3_missing_platform() {
-  local out; out=$(run_validate --project p --deployment personal --language ts)
+  local out; out=$(run_validate --project p --deployment personal --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N3" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--platform"* ]] || { fail_ "N3" "stderr should mention --platform: ${out##*|}"; return; }
   pass "N3: missing --platform → exit 1"
 }
 
 n4_missing_deployment() {
-  local out; out=$(run_validate --project p --platform web --language ts)
+  local out; out=$(run_validate --project p --platform web --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N4" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--deployment"* ]] || { fail_ "N4" "stderr should mention --deployment: ${out##*|}"; return; }
   pass "N4: missing --deployment → exit 1"
@@ -81,35 +81,35 @@ n5_missing_language() {
 }
 
 n6_org_without_govmode() {
-  local out; out=$(run_validate --project p --platform web --deployment organizational --language ts)
+  local out; out=$(run_validate --project p --platform web --deployment organizational --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N6" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--gov-mode"* ]] || { fail_ "N6" "stderr should mention --gov-mode: ${out##*|}"; return; }
   pass "N6: --deployment=organizational without --gov-mode → exit 1"
 }
 
 n7_personal_with_govmode() {
-  local out; out=$(run_validate --project p --platform web --deployment personal --gov-mode production --language ts)
+  local out; out=$(run_validate --project p --platform web --deployment personal --gov-mode production --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N7" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--gov-mode"* ]] || { fail_ "N7" "stderr should mention --gov-mode: ${out##*|}"; return; }
   pass "N7: --deployment=personal with --gov-mode → exit 1"
 }
 
 n8_other_without_remoteurl() {
-  local out; out=$(run_validate --project p --platform web --deployment personal --language ts --git-host other)
+  local out; out=$(run_validate --project p --platform web --deployment personal --language typescript --git-host other)
   [ "${out%%|*}" = "1" ] || { fail_ "N8" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--remote-url"* ]] || { fail_ "N8" "stderr should mention --remote-url: ${out##*|}"; return; }
   pass "N8: --git-host=other without --remote-url → exit 1"
 }
 
 n9_other_without_attest() {
-  local out; out=$(run_validate --project p --platform web --deployment personal --language ts --git-host other --remote-url https://example.com/x)
+  local out; out=$(run_validate --project p --platform web --deployment personal --language typescript --git-host other --remote-url https://example.com/x)
   [ "${out%%|*}" = "1" ] || { fail_ "N9" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--branch-protection-attested"* ]] || { fail_ "N9" "stderr should mention --branch-protection-attested: ${out##*|}"; return; }
   pass "N9: --git-host=other without --branch-protection-attested → exit 1"
 }
 
 n10_org_with_public_visibility() {
-  local out; out=$(run_validate --project p --platform web --deployment organizational --gov-mode production --language ts --visibility public)
+  local out; out=$(run_validate --project p --platform web --deployment organizational --gov-mode production --language typescript --visibility public)
   [ "${out%%|*}" = "1" ] || { fail_ "N10" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"--visibility=public"* ]] || { fail_ "N10" "stderr should explain org-forces-private: ${out##*|}"; return; }
   pass "N10: --deployment=organizational + --visibility=public → exit 1"
@@ -180,7 +180,7 @@ n20_validate_only_success() {
 }
 
 n21_validate_only_failure() {
-  local out; out=$(run_validate --platform web --deployment personal --language ts)
+  local out; out=$(run_validate --platform web --deployment personal --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N21" "expected exit 1, got: $out"; return; }
   pass "N21: --validate-only failure → exit 1 with same error as real run"
 }
@@ -225,7 +225,7 @@ JSON
 }
 
 n16_config_not_found() {
-  local out; out=$(run_validate --config /nonexistent/path/init.json --project p --platform web --deployment personal --language ts)
+  local out; out=$(run_validate --config /nonexistent/path/init.json --project p --platform web --deployment personal --language typescript)
   [ "${out%%|*}" = "1" ] || { fail_ "N16" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"not found"* ]] || { fail_ "N16" "stderr should mention 'not found': ${out##*|}"; return; }
   pass "N16: --config file not found → exit 1"
@@ -235,7 +235,7 @@ n17_config_malformed_json() {
   local cfg
   cfg=$(mktemp)
   echo '{"project": "p"' > "$cfg"
-  local out; out=$(run_validate --config "$cfg" --project p --platform web --deployment personal --language ts)
+  local out; out=$(run_validate --config "$cfg" --project p --platform web --deployment personal --language typescript)
   rm -f "$cfg"
   [ "${out%%|*}" = "1" ] || { fail_ "N17" "expected exit 1, got: $out"; return; }
   [[ "${out##*|}" == *"not valid JSON"* ]] || { fail_ "N17" "stderr should mention 'not valid JSON': ${out##*|}"; return; }

--- a/tests/test-platform-security-bugs-closer.sh
+++ b/tests/test-platform-security-bugs-closer.sh
@@ -215,9 +215,12 @@ STUB
   pass "T4a: pending-approval.sh refuses --offer when cwd is the framework"
 }
 
-# --- T4b: docstring/callsite parity — every script named in helpers.sh:201-204 actually invokes the guard ---
+# --- T4b: docstring/callsite parity — every script named in the guard_not_in_framework docstring (helpers-core.sh, moved there in the BL-046 helpers split) actually invokes the guard ---
 t4b_docstring_parity() {
-  local helpers="$REPO_ROOT/scripts/lib/helpers.sh"
+  # BL-046 split: guard_not_in_framework + its docstring moved from
+  # helpers.sh into helpers-core.sh (helpers.sh is now a shim that
+  # sources both -core and -full). Probe the definition site.
+  local helpers="$REPO_ROOT/scripts/lib/helpers-core.sh"
   [ -f "$helpers" ] || { fail_ "T4b" "missing $helpers"; return; }
 
   # Extract the parenthesized list of script basenames in the docstring
@@ -232,7 +235,7 @@ t4b_docstring_parity() {
   ' "$helpers")
 
   if [ -z "$doc_block" ]; then
-    fail_ "T4b" "helpers.sh docstring block for guard_not_in_framework not found"
+    fail_ "T4b" "helpers-core.sh docstring block for guard_not_in_framework not found"
     return
   fi
 
@@ -254,15 +257,15 @@ t4b_docstring_parity() {
     elif [ -f "$REPO_ROOT/scripts/$name" ]; then
       target="$REPO_ROOT/scripts/$name"
     elif [ -f "$REPO_ROOT/scripts/lib/$name" ]; then
-      # helpers.sh DEFINES the guard; skip it (we don't expect a script to guard against itself).
+      # helpers-core.sh DEFINES the guard; skip it (we don't expect a script to guard against itself).
       continue
     fi
     if [ -z "$target" ]; then
       missing="${missing}${name}(not-found) "
       continue
     fi
-    # Skip if this IS helpers.sh (definition site).
-    [ "$(basename "$target")" = "helpers.sh" ] && continue
+    # Skip if this IS the guard definition site (helpers-core.sh).
+    [ "$(basename "$target")" = "helpers-core.sh" ] && continue
     # Count non-comment, non-docstring callsites.
     local hits
     hits=$(grep -v '^[[:space:]]*#' "$target" | grep -c 'guard_not_in_framework')
@@ -272,11 +275,11 @@ t4b_docstring_parity() {
   done
 
   if [ -n "$missing" ]; then
-    fail_ "T4b" "scripts listed in helpers.sh docstring lack guard_not_in_framework callsite: $missing"
+    fail_ "T4b" "scripts listed in helpers-core.sh docstring lack guard_not_in_framework callsite: $missing"
     return
   fi
 
-  pass "T4b: every script in helpers.sh guard docstring actually calls guard_not_in_framework"
+  pass "T4b: every script in helpers-core.sh guard docstring actually calls guard_not_in_framework"
 }
 
 # --- T5: BUG-001 2026-04-22 update wording corrected ---

--- a/tests/test-poc-modes.sh
+++ b/tests/test-poc-modes.sh
@@ -52,7 +52,7 @@ echo "=== Private POC reachability (init.sh non-interactive) ==="
 # "--gov-mode is not valid for --deployment=personal").
 T=$(mktemp -d); P="$T/p"
 run_bounded 90 bash "$INIT" --non-interactive --project x --project-dir "$P" \
-  --no-remote-creation --platform web --language javascript --track light \
+  --no-remote-creation --platform web --language typescript --track light \
   --deployment personal --gov-mode private_poc > "$T/log" 2>&1 < /dev/null
 rc=$RC
 if [ "$rc" = "0" ] && [ -f "$P/.claude/phase-state.json" ]; then
@@ -72,7 +72,7 @@ rm -rf "$T"
 # tier-semantics message.
 T=$(mktemp -d); P="$T/p"
 run_bounded 30 bash "$INIT" --non-interactive --project x --project-dir "$P" \
-  --no-remote-creation --platform web --language javascript --track standard \
+  --no-remote-creation --platform web --language typescript --track standard \
   --deployment personal --gov-mode sponsored_poc > "$T/log" 2>&1 < /dev/null
 rc=$RC
 if [ "$rc" != "0" ] && grep -qE "sponsored_poc is not valid for --deployment=personal" "$T/log"; then
@@ -85,7 +85,7 @@ rm -rf "$T"
 # T3: --deployment=organizational --gov-mode=private_poc rejected.
 T=$(mktemp -d); P="$T/p"
 run_bounded 30 bash "$INIT" --non-interactive --project x --project-dir "$P" \
-  --no-remote-creation --platform web --language javascript --track standard \
+  --no-remote-creation --platform web --language typescript --track standard \
   --deployment organizational --gov-mode private_poc > "$T/log" 2>&1 < /dev/null
 rc=$RC
 if [ "$rc" != "0" ] && grep -qE "private_poc is not valid for --deployment=organizational" "$T/log"; then
@@ -99,7 +99,7 @@ rm -rf "$T"
 # (regression check for the org+sponsored_poc happy path).
 T=$(mktemp -d); P="$T/p"
 run_bounded 90 bash "$INIT" --non-interactive --project x --project-dir "$P" \
-  --no-remote-creation --platform web --language javascript --track standard \
+  --no-remote-creation --platform web --language typescript --track standard \
   --deployment organizational --gov-mode sponsored_poc > "$T/log" 2>&1 < /dev/null
 rc=$RC
 if [ "$rc" = "0" ] && [ -f "$P/.claude/phase-state.json" ]; then

--- a/tests/test-upgrade-bl030-backfill.sh
+++ b/tests/test-upgrade-bl030-backfill.sh
@@ -27,7 +27,7 @@ cd /tmp
 setup_pre_bl030_personal() {
   TMP=$(mktemp -d); PROJ="$TMP/p"
   bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track light --deployment personal \
+    --platform web --language typescript --track light --deployment personal \
     >/dev/null 2>&1
   # Strip the BL-030 fields from manifest.
   tmp=$(mktemp)
@@ -52,7 +52,7 @@ setup_pre_bl030_personal() {
 setup_pre_bl030_organizational_production() {
   TMP=$(mktemp -d); PROJ="$TMP/p"
   bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track standard --deployment organizational --gov-mode production \
+    --platform web --language typescript --track standard --deployment organizational --gov-mode production \
     >/dev/null 2>&1
   tmp=$(mktemp)
   jq 'del(.enforcement_level, .deployment, .poc_mode)' "$PROJ/.claude/manifest.json" > "$tmp" \

--- a/tests/test-verify-install-bl030-coverage.sh
+++ b/tests/test-verify-install-bl030-coverage.sh
@@ -20,7 +20,7 @@ cd /tmp
 setup_clean_project() {
   TMP=$(mktemp -d); PROJ="$TMP/p"
   bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
-    --platform web --language javascript --track light --deployment personal \
+    --platform web --language typescript --track light --deployment personal \
     >/dev/null 2>&1
   VERIFY="$PROJ/scripts/verify-install.sh"
 }


### PR DESCRIPTION
## What

BL-035 **Chunk-0** — mechanical prerequisites for the orphan-test wiring wave. Makes currently-red orphan fixtures runnable so later chunks can register them green. **Test-fixture only**: no product code, no aggregator registration, no changes to `KNOWN_ORPHANS_PENDING_BL035` or `lint-tests-registered.sh`.

### Task 1 (BL-078) — stale `--language javascript`/`ts` drift
`init.sh` tightened language-for-platform validation (audit code-init-sh-5): the accepted `web` set is now `csharp/go/java/kotlin/other/python/rust/typescript`; `javascript` was dropped (no `javascript.yml` CI template). Orphan fixtures still passed `--language javascript` (or the `ts` shorthand), so `init.sh` aborted and the suites cascaded red. Substituted the stale token with `typescript`, **verified per file** — every occurrence is an incidental web-project scaffold, language-neutral to the test's intent (`typescript.yml` is the CI template that historically covered the `typescript|javascript` code paths).

Files: `test-bl029-integration`, `test-bl030-calibration-replay`, `test-bypass-audit-schema`, `test-init-atomic-finalize`, `test-init-non-interactive` (13× `ts`), `test-upgrade-bl030-backfill`, `test-verify-install-bl030-coverage`, `test-poc-modes` (T1/T4), `test-enforcement-level-init`, `test-enforcement-level-reconfigure`.

Out of scope (left untouched): `edge-case-test-suite.sh` also carries stale `--language javascript`, but it is a BL-052 un-invoked **aggregator**, not a bridge orphan — belongs to the later BL-052 chunk.

### Task 2 (BL-079-adjacent) — T4b probe path
`test-platform-security-bugs-closer.sh` T4b probed `scripts/lib/helpers.sh` for the `guard_not_in_framework` docstring, which moved to `scripts/lib/helpers-core.sh` in the BL-046 helpers split. Repointed the probe (and its messages/comments) to `helpers-core.sh`. T3a's `helpers.sh` **source** path is intentionally unchanged — the shim still re-exports the guard.

## Verification (before → after, standalone `bash tests/<file>`)

| Fixture | Before | After |
|---|---|---|
| test-bl029-integration | rc=1 (aborted under `set -e`) | rc=0 · 6/6 |
| test-bl030-calibration-replay | rc=1 · 0/4 | rc=0 · 4/4 |
| test-bypass-audit-schema | rc=1 · 1/3 | rc=0 · 3/3 |
| test-init-atomic-finalize | rc=1 · 0/8 | rc=0 · 8/8 |
| test-upgrade-bl030-backfill | rc=1 · 2/7 | rc=0 · 7/7 |
| test-verify-install-bl030-coverage | rc=1 · 0/8 | rc=0 · 8/8 |
| test-poc-modes | rc=1 · 3/5 | rc=0 · 5/5 |
| test-enforcement-level-init | rc=1 · 1/8 | rc=0 · 8/8 |
| test-enforcement-level-reconfigure | rc=1 · 3/12 | rc=0 · 12/12 |
| test-platform-security-bugs-closer | rc=1 · 6/7 (T4b red) | rc=0 · 7/7 |
| test-init-non-interactive | rc=1 · 28/29 (N7, masked) | rc=1 · 28/29 (N7, **unmasked real finding**) |

- 8-lint battery: all exit 0 (incl. `lint-tests-registered` — no registration drift).
- `bash -n` clean on every edited file.

## ⚠️ Residual real finding — NOT papered over

**`test-init-non-interactive.sh` N7** still fails after the language fix, and it is **not** a language/path issue. N7 asserts `--deployment personal --gov-mode production` → exit 1 with a `--gov-mode` message. Current product (init.sh, audit code-init-sh-4 / tier-crosscheck-2, baseline §2.5: "production valid for both deployments") **accepts** that combo → exit 0 with fully-resolved JSON. The stale `ts` token was previously masking this by making init fail on the language check instead. N7 is a **stale test assertion** (product is correct), to be resolved by the Init-family wiring chunk before registration — e.g. switch N7 to `--gov-mode sponsored_poc` (which *is* rejected for personal), or update the expectation. Per Chunk-0 scope I did **not** touch N7's assertion or product code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)