### PR TITLE
test(wiring): register test-gate/process/poc/docs orphans + fix E60/poc-modes (BL-035 chunk C)

### DIFF
--- a/scripts/lint-tests-registered.sh
+++ b/scripts/lint-tests-registered.sh
@@ -158,7 +158,6 @@ KNOWN_ORPHANS_PENDING_BL035=(
   test-check-gate.sh
   test-check-phase-gate-counter-sanitizer.sh
   test-check-phase-gate.sh
-  test-docs-cluster-six-pack.sh
   test-enforcement-level-init.sh
   test-enforcement-level-lib.sh
   test-enforcement-level-reconfigure.sh
@@ -171,28 +170,13 @@ KNOWN_ORPHANS_PENDING_BL035=(
   test-init-non-interactive.sh
   test-init-other-host-attestation.sh
   test-init-schema-phase-gate.sh
-  test-lint-uat-scenarios.sh
   test-out-of-band-detector.sh
-  test-pending-approval.sh
-  test-phase-finalize.sh
-  test-platform-security-bugs-closer.sh
-  test-poc-modes.sh
-  test-pre-commit-gate-terminal-mode.sh
-  test-process-checklist-auto-advance.sh
-  test-process-checklist-classifier.sh
-  test-record-claude-commit.sh
-  test-session-test-gate-check-merge.sh
-  test-specs-plans-remaining-quartet.sh
-  test-test-gate-counter-sanitizer.sh
-  test-test-gate-null-handling.sh
-  test-unrecord-feature.sh
   test-upgrade-bl030-backfill.sh
   test-upgrade-non-interactive.sh
   test-upgrade-paths.sh
   test-upgrade-personal-to-sponsored-poc.sh
   test-upgrade-to-production-preconditions.sh
   test-upgrade-to-production-warn.sh
-  test-validate-counter-sanitizer.sh
   test-vendored-skills-install.sh
   test-verify-install-bl030-coverage.sh
 )

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1764,10 +1764,18 @@ else
 fi
 
 # E60: upgrade-project.sh --to-private-poc takes a personal project to
-# organizational/private_poc. T1-D regression guard for the missing
+# personal/private_poc. T1-D regression guard for the missing
 # personal -> private_poc CLI path. Before this fix, intake-wizard.sh
 # --upgrade-deployment private_poc was rejected (only personal|organizational
 # accepted) and upgrade-project.sh had no --to-private-poc flag.
+#
+# BL-079 (tier-crosscheck-3, 2026-06): Private POC is ALWAYS a personal
+# deployment per baseline §2.5 (upgrade-project.sh:756-787 sets
+# TARGET_DEPLOYMENT=personal). The prior expectation of deployment=
+# organizational asserted the pre-fix "impossible organizational/private_poc"
+# shape and was stale/RED against current product. Aligned with the correct
+# product contract (and orphan test-poc-modes.sh T5, which asserts the same
+# personal-stays-personal outcome).
 _e60_dir="$TEST_DIR/e60"
 mkdir -p "$_e60_dir"
 _e60_proj="$_e60_dir/uat-e60"
@@ -1791,10 +1799,10 @@ if [ -f "$_e60_proj/.claude/phase-state.json" ]; then
 fi
 if [ "$_e60_upgrade_rc" = "0" ] && \
    [ "$_e60_poc_mode" = "private_poc" ] && \
-   [ "$_e60_deployment" = "organizational" ]; then
-  pass "E60: upgrade-project.sh --to-private-poc takes personal -> organizational/private_poc (T1-D regression guard)"
+   [ "$_e60_deployment" = "personal" ]; then
+  pass "E60: upgrade-project.sh --to-private-poc takes personal -> personal/private_poc (T1-D regression guard)"
 else
-  fail "E60: expected rc=0 poc_mode=private_poc deployment=organizational; got rc=$_e60_upgrade_rc poc_mode='$_e60_poc_mode' deployment='$_e60_deployment'"
+  fail "E60: expected rc=0 poc_mode=private_poc deployment=personal; got rc=$_e60_upgrade_rc poc_mode='$_e60_poc_mode' deployment='$_e60_deployment'"
 fi
 
 # E61: intake-wizard.sh --to-private-poc from a project subdir, invoked via

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -895,6 +895,137 @@ else
   fi
 fi
 
+# --- BL-035 wiring C: test-gate/process/poc/docs ---
+# Registers the pre-Wave-1-4 orphan suites in the test-gate/session,
+# process-checklist/pending/poc, and docs/specs/lint product areas that
+# were parked on scripts/lint-tests-registered.sh::KNOWN_ORPHANS_PENDING_BL035
+# (running ZERO times). Same delegate discipline as the BL-034 block above:
+# no `|| true` wraps, each test invoked exactly once, rc feeds pass()/fail().
+# See Reports/2026-07-06-bl035-orphan-triage.md (chunk C).
+
+# ----------------------------------------------------------------
+# Test-gate / counter-sanitizer / session (BL-035 C)
+# ----------------------------------------------------------------
+# test-gate.sh + validate.sh counter-sanitizer coverage (the counter-
+# antipattern defect class), test-gate null-handling, record/unrecord
+# governance-ledger helpers, and the session-driver test-gate/merge check.
+section "BL-035 C: test-gate / counter-sanitizer / session"
+if bash "$SCRIPT_DIR/tests/test-test-gate-counter-sanitizer.sh" >/dev/null 2>&1; then
+  pass "tests/test-test-gate-counter-sanitizer.sh (5/5)"
+else
+  fail "tests/test-test-gate-counter-sanitizer.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-test-gate-null-handling.sh" >/dev/null 2>&1; then
+  pass "tests/test-test-gate-null-handling.sh (5/5)"
+else
+  fail "tests/test-test-gate-null-handling.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-validate-counter-sanitizer.sh" >/dev/null 2>&1; then
+  pass "tests/test-validate-counter-sanitizer.sh (5/5)"
+else
+  fail "tests/test-validate-counter-sanitizer.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-record-claude-commit.sh" >/dev/null 2>&1; then
+  pass "tests/test-record-claude-commit.sh (9/9)"
+else
+  fail "tests/test-record-claude-commit.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-unrecord-feature.sh" >/dev/null 2>&1; then
+  pass "tests/test-unrecord-feature.sh (7/7)"
+else
+  fail "tests/test-unrecord-feature.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-session-test-gate-check-merge.sh" >/dev/null 2>&1; then
+  pass "tests/test-session-test-gate-check-merge.sh (9/9)"
+else
+  fail "tests/test-session-test-gate-check-merge.sh FAILED (run for details)"
+fi
+
+# ----------------------------------------------------------------
+# Process-checklist / pending-approval / poc-modes (BL-035 C)
+# ----------------------------------------------------------------
+# pending-approval resolve/escalate flow, process-checklist auto-advance +
+# commit classifier, phase-finalize, the platform-security-bugs-closer
+# docstring probe (T4b path fixed in Chunk-0), and poc-modes tier semantics
+# (T5: --to-private-poc from personal stays personal — aligned with E60,
+# see BL-079).
+section "BL-035 C: process-checklist / pending / poc-modes"
+if bash "$SCRIPT_DIR/tests/test-pending-approval.sh" >/dev/null 2>&1; then
+  pass "tests/test-pending-approval.sh (21/21)"
+else
+  fail "tests/test-pending-approval.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-process-checklist-auto-advance.sh" >/dev/null 2>&1; then
+  pass "tests/test-process-checklist-auto-advance.sh (7/7)"
+else
+  fail "tests/test-process-checklist-auto-advance.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-process-checklist-classifier.sh" >/dev/null 2>&1; then
+  pass "tests/test-process-checklist-classifier.sh (12/12)"
+else
+  fail "tests/test-process-checklist-classifier.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-phase-finalize.sh" >/dev/null 2>&1; then
+  pass "tests/test-phase-finalize.sh (6/6)"
+else
+  fail "tests/test-phase-finalize.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-platform-security-bugs-closer.sh" >/dev/null 2>&1; then
+  pass "tests/test-platform-security-bugs-closer.sh (7/7)"
+else
+  fail "tests/test-platform-security-bugs-closer.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-poc-modes.sh" >/dev/null 2>&1; then
+  pass "tests/test-poc-modes.sh (5/5)"
+else
+  fail "tests/test-poc-modes.sh FAILED (run for details)"
+fi
+
+# ----------------------------------------------------------------
+# Pre-commit-gate --terminal-mode (BL-035 C / BL-075)
+# ----------------------------------------------------------------
+# BL-075 caution resolved: the pre-existing T2 / T6a-b / T11a-b reds were NOT
+# a --terminal-mode/classifier product bug but the BL-074 helpers-scaffold gap
+# (setup copied only helpers.sh; process-checklist.sh sources helpers-core.sh
+# directly, so --check-commit-message died and short-circuited the whole
+# terminal-mode flow at the classifier step). Both scaffolds now copy the full
+# helpers-core/helpers-full sibling chain the product ships; both suites GREEN
+# and mutation-provably exercise the real terminal-mode lint path.
+#
+# Only test-pre-commit-gate-terminal-mode.sh is registered here (it was on the
+# KNOWN_ORPHANS_PENDING_BL035 bridge). Its sibling test-pre-commit-gate-lints.sh
+# was already registered at TEST 0o (Wave-3) — the same BL-074 scaffold fix
+# turns it from RED (T6a/b/T11a/b) to GREEN there.
+section "BL-035 C: pre-commit-gate terminal-mode (BL-075)"
+if bash "$SCRIPT_DIR/tests/test-pre-commit-gate-terminal-mode.sh" >/dev/null 2>&1; then
+  pass "tests/test-pre-commit-gate-terminal-mode.sh (3/3)"
+else
+  fail "tests/test-pre-commit-gate-terminal-mode.sh FAILED (run for details)"
+fi
+
+# ----------------------------------------------------------------
+# Docs / specs / lint suites (BL-035 C)
+# ----------------------------------------------------------------
+# Docs-cluster six-pack (doc-consistency guards), specs+plans remaining
+# quartet, and the UAT-scenarios lint behavior suite.
+section "BL-035 C: docs / specs / lint suites"
+if bash "$SCRIPT_DIR/tests/test-docs-cluster-six-pack.sh" >/dev/null 2>&1; then
+  pass "tests/test-docs-cluster-six-pack.sh (28/28)"
+else
+  fail "tests/test-docs-cluster-six-pack.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-specs-plans-remaining-quartet.sh" >/dev/null 2>&1; then
+  pass "tests/test-specs-plans-remaining-quartet.sh (10/10)"
+else
+  fail "tests/test-specs-plans-remaining-quartet.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-lint-uat-scenarios.sh" >/dev/null 2>&1; then
+  pass "tests/test-lint-uat-scenarios.sh (12/12)"
+else
+  fail "tests/test-lint-uat-scenarios.sh FAILED (run for details)"
+fi
+# --- end BL-035 wiring C ---
+
 # ================================================================
 # TEST 1: RESOLVER MATRIX — ALL COMBINATIONS
 # ================================================================

--- a/tests/test-pre-commit-gate-lints.sh
+++ b/tests/test-pre-commit-gate-lints.sh
@@ -63,7 +63,14 @@ setup() {
   chmod +x "$PROJ/scripts/lint-raw-read-prompt.sh"
 
   cp "$REPO_ROOT/scripts/process-checklist.sh" "$PROJ/scripts/"
-  cp "$REPO_ROOT/scripts/lib/helpers.sh" "$PROJ/scripts/lib/"
+  # BL-074: process-checklist.sh sources lib/helpers-core.sh directly, and
+  # helpers.sh is a shim that sources helpers-full.sh -> helpers-core.sh. A
+  # scaffold that copies only helpers.sh makes --check-commit-message die at
+  # source-time, which (via the terminal-mode classifier short-circuit) masks
+  # the lint checks under test. Copy the full sibling chain the product ships.
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-full.sh" "$PROJ/scripts/lib/"
   chmod +x "$PROJ/scripts/process-checklist.sh"
 
   (

--- a/tests/test-pre-commit-gate-terminal-mode.sh
+++ b/tests/test-pre-commit-gate-terminal-mode.sh
@@ -33,7 +33,14 @@ EOF
   # --terminal-mode can delegate to its classifier.
   mkdir -p "$TMP/scripts/lib"
   cp "$REPO_ROOT/scripts/process-checklist.sh" "$TMP/scripts/"
-  cp "$REPO_ROOT/scripts/lib/helpers.sh" "$TMP/scripts/lib/"
+  # BL-074: process-checklist.sh sources lib/helpers-core.sh directly, and
+  # helpers.sh is a shim that sources helpers-full.sh -> helpers-core.sh. A
+  # scaffold that copies only helpers.sh makes --check-commit-message die at
+  # source-time, so --terminal-mode blocks at the classifier step (T2) instead
+  # of reaching the intended behavior. Copy the full sibling chain init.sh ships.
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-full.sh" "$TMP/scripts/lib/"
   chmod +x "$TMP/scripts/process-checklist.sh"
 }
 teardown() { rm -rf "$TMP"; }


### PR DESCRIPTION
## BL-035 Wiring Chunk C — test-gate/session · process/pending/poc · docs/specs/lint

Registers 16 pre-Wave-1-4 orphan suites (parked on `KNOWN_ORPHANS_PENDING_BL035`, running **zero times**) into `tests/full-project-test-suite.sh` under a single `# --- BL-035 wiring C: test-gate/process/poc/docs ---` header (BL-034 delegate pattern). Drains 16 entries from the bridge (50 → 34).

### Registered (all GREEN standalone)
**Test-gate / counter-sanitizer / session:** test-test-gate-counter-sanitizer (5), test-test-gate-null-handling (5), test-validate-counter-sanitizer (5), test-record-claude-commit (9), test-unrecord-feature (7), test-session-test-gate-check-merge (9)
**Process / pending / poc:** test-pending-approval (21), test-process-checklist-auto-advance (7), test-process-checklist-classifier (12), test-phase-finalize (6), test-platform-security-bugs-closer (7, T4b path fixed in Chunk-0), test-poc-modes (5)
**Terminal-mode:** test-pre-commit-gate-terminal-mode (3)
**Docs / specs / lint:** test-docs-cluster-six-pack (28), test-specs-plans-remaining-quartet (10), test-lint-uat-scenarios (12)

### BL-079 — E60 assertion corrected (aligned, but E60 blocked by a separate pre-existing issue)
`edge-cases-scripts.sh` E60 asserted the stale `personal → organizational/private_poc` shape; current product (`upgrade-project.sh:756-787`) keeps `--to-private-poc` **personal**. Fixed E60 to expect `deployment=personal` (poc_mode=private_poc, rc=0), matching the product and orphan `test-poc-modes.sh` T5. **poc-modes is GREEN (5/5)** and independently proves the personal-stays-personal contract (it scaffolds phase-state directly and runs the real `upgrade-project.sh`).

**E60 does NOT yet go green** — but for an unrelated, pre-existing reason: `init.sh --git-host other` exits **2** ("Unsupported SCM host 'other' — no canonical CI destination", `verify-install.sh:221`, landed 2026-06-28 commit 39009aa), so E60's `[ init_rc = 0 ]` guard skips the upgrade (`poc_mode=null`). This is a cohort failure across **E56–E61** (all real-init `--git-host other` cases; E56-E59/E61 untouched by this PR fail identically) — RED on main since ~2026-06-28. Out of scope for BL-035 C; **needs its own backlog item** (init/verify-install exit-2-for-host-other vs. fixture expectation). My assertion fix is a strict improvement and a prerequisite for E60's eventual green.

### BL-075 — decision: FIX + REGISTER (not a product bug)
Investigation found the terminal-mode reds (T2 / T6a-b / T11a-b) are **not** a `--terminal-mode`/classifier product bug — they are the **BL-074 helpers-scaffold gap**: `setup()` copied only `helpers.sh`, but `process-checklist.sh` sources `lib/helpers-core.sh` directly, so `--check-commit-message` died at source-time and short-circuited the whole terminal-mode flow at the classifier step (never reaching the lint checks / docs-only pass). Fixed both scaffolds to copy the full `helpers-core`/`helpers-full` sibling chain the product ships. Both suites now GREEN and mutation-provably exercise the real terminal-mode lint path. `test-pre-commit-gate-lints.sh` was already registered at TEST 0o — the same fix turns it GREEN there (13/13); terminal-mode (was bridged) newly registered.

### Verification
- Every **registered** test GREEN standalone (counts above).
- `scripts/lint-tests-registered.sh` exits **0**; all 16 show `registered`.
- 9 repo-wide lints GREEN (counter-antipattern, fix-functions-stderr, raw-read-prompt, tests-registered, doc-anchors, review-manifest, fail-emit-exit-status, fixture-envelopes, backlog-references).
- Did **not** run the full non-hermetic `full-project-test-suite.sh` against real `gh` (BL-076). `edge-cases-scripts.sh` (hermetic, `--git-host other`) was run to verify E60 — surfacing the E56–E61 init cohort finding above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)