### PR TITLE
fix(tests): make init tests hermetic — no live remote creation (BL-076)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -174,3 +174,29 @@ jobs:
       - name: Show roster (on failure or on demand)
         if: always()
         run: bash scripts/lint-review-manifest.sh --list || true
+
+  # BL-076: hermeticity backstop for the test suite. A test that runs the
+  # real init.sh with the default (github) host and WITHOUT
+  # --no-remote-creation / --git-host other / a mocked gh creates + pushes a
+  # REAL private repo on an authenticated host (the kraulerson/foo leak,
+  # 2026-07-06) — and blocks the suite from ever running in CI ([[bl077]]).
+  # This lint refuses to merge any test whose init.sh invocation can reach
+  # live remote creation. See scripts/lint-no-live-remote-in-tests.sh header
+  # and tests/test-lint-no-live-remote.sh for the behavior suite. Same
+  # job-name-is-required-check convention as the jobs above — keep it stable.
+  no-live-remote-in-tests-lint:
+    name: no-live-remote-in-tests-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lint tests for live-remote-reachable init.sh runs (BL-076)
+        run: bash scripts/lint-no-live-remote-in-tests.sh
+
+      - name: Run the lint's own behavior suite
+        run: bash tests/test-lint-no-live-remote.sh
+
+      - name: Show PASS/FAIL inventory (on failure or on demand)
+        if: always()
+        run: bash scripts/lint-no-live-remote-in-tests.sh --list || true

--- a/scripts/lint-no-live-remote-in-tests.sh
+++ b/scripts/lint-no-live-remote-in-tests.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# scripts/lint-no-live-remote-in-tests.sh — fail CI when any test under
+# tests/ executes init.sh in a shape that can reach REAL remote-repo
+# creation (a live `gh repo create` / `glab repo create` / Bitbucket
+# `curl` POST against the operator's authenticated host account).
+#
+# THE DEFECT CLASS (BL-076)
+#   A test invokes the real init.sh non-interactively (or via --dry-run
+#   piped stdin) with the DEFAULT --git-host (github) and WITHOUT
+#   --no-remote-creation, no --git-host other, and no mocked CLI on PATH:
+#
+#     bash "$INIT" --non-interactive \
+#       --project foo --platform mobile --language typescript \
+#       --deployment personal --gov-mode private_poc \
+#       --project-dir "$tmp"        # <-- NO --no-remote-creation
+#
+#   Run in an authenticated-`gh` environment (e.g. an agent running
+#   tests/full-project-test-suite.sh), init.sh reaches
+#   create_and_protect_remote → host_create_repo → `gh repo create`, and
+#   a REAL private repo is created + pushed to the operator's account.
+#   This is exactly how `kraulerson/foo` leaked on 2026-07-06. A suite
+#   that sprays real repos also cannot be wired into CI.
+#
+# THE INVARIANT
+#   Every init.sh EXECUTION inside tests/ must be provably hermetic. An
+#   init run is hermetic when its (backslash-joined) invocation carries
+#   at least one of these tokens:
+#     --no-remote-creation      skip the host API entirely (init.sh:2066)
+#     --dry-run                 no scaffold, no remote
+#     --validate-only           argv validation only; exits before scaffold
+#     --git-host other          URL-paste path — no CLI, needs a fake
+#                               --remote-url; never touches gh/glab/curl
+#   ...OR the whole file is mock-driven (defines a write_mock_gh /
+#   write_mock_glab / write_mock_curl stub or prepends a $MOCK_DIR to
+#   PATH, or sources tests/host-drivers/mock-cli.sh) so gh/glab/curl
+#   resolve to a hermetic stub rather than the real CLI.
+#
+# WHY JOIN CONTINUATIONS
+#   Almost every test writes `--no-remote-creation` on the line AFTER the
+#   `bash "$INIT" ... \` line. A naive line-by-line scan would false-flag
+#   the entire suite. This lint reconstructs each backslash-continued
+#   command into one logical line before classifying it.
+#
+# WHAT COUNTS AS AN "init run"
+#   A logical line that references init.sh execution — literal `init.sh`,
+#   or a `$INIT` / `$INIT_SH` (any variable assigned an .../init.sh path
+#   in the same file) — AND carries a `--non-interactive` or `--dry-run`
+#   flag. Static-analysis tests that merely grep/awk/`bash -n` the init.sh
+#   SOURCE never carry those run flags, so they are correctly ignored.
+#
+# ALLOWLIST
+#   Append `# lint-no-live-remote: allow <reason>` to the offending
+#   logical line's FIRST physical line. Reason is REQUIRED (empty reason
+#   fails). Use only if a test genuinely must drive a real host — it
+#   should not; prefer --no-remote-creation or the mock CLI.
+#
+# EXIT CODES
+#   0 — no violations
+#   1 — one or more violations found
+#   2 — invocation / I/O error
+#
+# USAGE
+#   bash scripts/lint-no-live-remote-in-tests.sh        # quiet pass/fail
+#   bash scripts/lint-no-live-remote-in-tests.sh --list # PASS/FAIL table
+#
+# Behavior suite: tests/test-lint-no-live-remote.sh
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_REL="scripts/lint-no-live-remote-in-tests.sh"
+TESTS_DIR="$REPO_ROOT/tests"
+
+# The behavior suite writes synthetic bad/good fixtures to a temp dir and
+# points this lint at them; the suite file itself contains init-run-shaped
+# strings inside heredocs, so exempt it by basename to avoid self-flagging.
+SELFTEST_BASENAME="test-lint-no-live-remote.sh"
+
+LIST_MODE=0
+SCAN_DIR="$TESTS_DIR"
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --list) LIST_MODE=1 ;;
+    --dir)  shift; SCAN_DIR="${1:-}" ;;   # test-only: scan an alternate tree
+    *) echo "Usage: $0 [--list] [--dir DIR]" >&2; exit 2 ;;
+  esac
+  shift
+done
+
+[ -d "$SCAN_DIR" ] || { echo "lint-no-live-remote: scan dir not found: $SCAN_DIR" >&2; exit 2; }
+
+VIOLATIONS=0
+LIST_ROWS=""
+
+# Tokens that make an init run hermetic.
+HERMETIC_RE='(--no-remote-creation|--dry-run|--validate-only|--git-host[[:space:]=]+other)'
+# File-level signal that the whole test mocks the host CLI on PATH.
+MOCK_FILE_RE='(write_mock_gh|write_mock_glab|write_mock_curl|PATH="\$\{?MOCK_DIR\}?|mock-cli\.sh)'
+ALLOW_MARKER='# lint-no-live-remote: allow'
+
+# Collect the set of shell vars a file assigns to an .../init.sh path so
+# `"$INIT"` / `"$INIT_SH"` references resolve back to init.sh. Emits a
+# newline-separated list of bare var names.
+collect_init_vars() {
+  grep -oE '^[[:space:]]*[A-Za-z_][A-Za-z0-9_]*=[^#]*/init\.sh' "$1" 2>/dev/null \
+    | sed -E 's/^[[:space:]]*([A-Za-z_][A-Za-z0-9_]*)=.*/\1/' \
+    | sort -u
+}
+
+# Does the logical line EXECUTE init.sh? We require the init token to sit
+# in genuine command position, not merely appear as substring text inside
+# a reporter string (echo/section/pass/fail_ "...init.sh --non-interactive...")
+# or a static grep/awk/`bash -n` of the init.sh SOURCE. Two shapes:
+#   A) `bash <init-token>`      — bash directly governs an init path/var
+#                                 (flags between → e.g. `bash -n "$INIT"`
+#                                 syntax check → NOT an exec).
+#   B) `<init-var>` as a command word — at line start or after
+#      ( ; & | && / a `cd .. &&` / `env ... ` prefix, then the init var
+#      followed by whitespace (its first flag).
+# $1=buf  $2=pipe-alternation of init var names (never-match sentinel if none)
+line_is_init_exec() {
+  local buf="$1" var_alt="$2"
+  local token="(\\\$\{?(${var_alt})\}?|[^\"'\''[:space:];&|]*/init\.sh)"
+  # A: bash directly followed by an init token (no intervening flags).
+  if printf '%s' "$buf" | grep -Eq "(^|[^A-Za-z0-9_])bash[[:space:]]+\"?${token}"; then
+    return 0
+  fi
+  # B: init var/path used as a command word.
+  if printf '%s' "$buf" | grep -Eq "(^|[(;&|]|&&|env[[:space:]][^;&|]*)[[:space:]]*\"?${token}\"?[[:space:]]"; then
+    return 0
+  fi
+  return 1
+}
+
+scan_file() {
+  local file="$1"
+  [ -f "$file" ] || return 0
+  local rel="${file#"$REPO_ROOT"/}"
+  case "$(basename "$file")" in
+    "$SELFTEST_BASENAME") return 0 ;;
+  esac
+
+  local file_is_mock=0
+  if grep -Eq "$MOCK_FILE_RE" "$file" 2>/dev/null; then
+    file_is_mock=1
+  fi
+
+  local var_alt="" v
+  while IFS= read -r v; do
+    [ -n "$v" ] && var_alt="${var_alt:+$var_alt|}$v"
+  done < <(collect_init_vars "$file")
+  [ -n "$var_alt" ] || var_alt="__NO_INIT_VAR__"
+
+  # Reconstruct backslash-continued commands into single logical lines.
+  local phys=0 start=0 buf="" line
+  local in_cont=0
+  while IFS= read -r line || [ -n "$line" ]; do
+    phys=$((phys + 1))
+    if [ "$in_cont" -eq 0 ]; then
+      start=$phys
+      buf="$line"
+    else
+      buf="$buf $line"
+    fi
+    # Continuation if the physical line ends in a single trailing backslash.
+    case "$line" in
+      *\\)
+        # strip trailing backslash from the accumulated buffer, keep going
+        buf="${buf%\\}"
+        in_cont=1
+        continue
+        ;;
+    esac
+    in_cont=0
+
+    # Pure-comment logical line? skip.
+    local trimmed="${buf#"${buf%%[![:space:]]*}"}"
+    case "$trimmed" in '#'*) continue ;; esac
+
+    # Only classify genuine init.sh EXECUTIONS.
+    line_is_init_exec "$buf" "$var_alt" || continue
+
+    # It is a real init run. Classify.
+    if printf '%s' "$buf" | grep -Eq "$HERMETIC_RE"; then
+      LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${start}\thermetic-token\n"
+      continue
+    fi
+    if [ "$file_is_mock" -eq 1 ]; then
+      LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${start}\tmock-cli-on-path\n"
+      continue
+    fi
+    case "$buf" in
+      *"$ALLOW_MARKER"*)
+        local reason="${buf##*"$ALLOW_MARKER"}"
+        reason="${reason#"${reason%%[![:space:]]*}"}"
+        reason="${reason%"${reason##*[![:space:]]}"}"
+        if [ -n "$reason" ]; then
+          LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${start}\tallow:${reason}\n"
+          continue
+        fi
+        echo "${rel}:${start}: lint-no-live-remote: allow marker present but reason is empty" >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${start}\tallow-empty-reason\n"
+        continue
+        ;;
+    esac
+
+    echo "${rel}:${start}: lint-no-live-remote: init.sh run can reach LIVE remote creation — add --no-remote-creation (or --git-host other + fake --remote-url, or route through a mocked gh/glab/curl). See scripts/lint-no-live-remote-in-tests.sh header (BL-076)." >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+    LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${start}\tlive-remote-reachable\n"
+  done < "$file"
+}
+
+while IFS= read -r f; do
+  scan_file "$f"
+done < <(find "$SCAN_DIR" -type f -name '*.sh' | sort)
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS non-hermetic init run(s) found. See scripts/lint-no-live-remote-in-tests.sh header (BL-076)." >&2
+  exit 1
+fi
+
+echo "OK: no test executes init.sh in a shape that can create a real remote."
+exit 0

--- a/tests/edge-case-test-suite.sh
+++ b/tests/edge-case-test-suite.sh
@@ -80,11 +80,18 @@ hook_teardown() { rm -rf "$TMP"; }
 # init.sh wrapper. CD's to /tmp first (init refuses to run inside the
 # framework repo). Caller passes flags. Bounded at 90s; the suite would
 # otherwise hang if a regression reintroduces the resolve-tools bug.
+#
+# BL-076: --no-remote-creation is baked in so this wrapper is hermetic by
+# construction — no caller (present or future) can drive init.sh into a
+# real `gh repo create` against an authenticated host. Every current call
+# site already passes --no-remote-creation directly; keeping it here means
+# the invariant holds even if someone routes a new run through this helper.
 run_init() {
   local proj_dir="$1"; shift
   (
     cd /tmp
-    run_bounded 90 bash "$INIT" --non-interactive --project x --project-dir "$proj_dir" "$@"
+    run_bounded 90 bash "$INIT" --non-interactive --no-remote-creation \
+      --project x --project-dir "$proj_dir" "$@"
     return $RC
   )
 }

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -337,6 +337,23 @@ else
   fail "scripts/lint-raw-read-prompt.sh behavior tests FAILED (run tests/test-lint-raw-read-prompt.sh for details)"
 fi
 
+# BL-076: no test may execute init.sh in a shape that can create a REAL
+# remote repo against an authenticated host (the kraulerson/foo leak).
+# Run the lint against the live tree AND its own behavior suite so a
+# regression in the guard (false negative letting a live run through, or
+# false positive on a reporter string / mocked run) is caught here.
+section "No-live-remote-in-tests lint (BL-076)"
+if bash "$SCRIPT_DIR/scripts/lint-no-live-remote-in-tests.sh" >/dev/null 2>&1; then
+  pass "No test executes init.sh in a live-remote-reachable shape"
+else
+  fail "Non-hermetic init run found (see scripts/lint-no-live-remote-in-tests.sh --list)"
+fi
+if bash "$SCRIPT_DIR/tests/test-lint-no-live-remote.sh" >/dev/null 2>&1; then
+  pass "scripts/lint-no-live-remote-in-tests.sh behavior tests (14/14)"
+else
+  fail "scripts/lint-no-live-remote-in-tests.sh behavior tests FAILED (run tests/test-lint-no-live-remote.sh for details)"
+fi
+
 # BL-051: tests/test-resolve-tools-memoization.sh — proves init.sh's
 # get_available_platforms() memoizes its filesystem scan (guard-var +
 # cached string, bash-3.2-safe) so 10 invocations trigger exactly one

--- a/tests/test-init-non-interactive-mobile-auto-install.sh
+++ b/tests/test-init-non-interactive-mobile-auto-install.sh
@@ -43,6 +43,15 @@ fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
 # mobile so the resolver auto-installs Android Studio (the row that hit the
 # bug). stdin is closed (</dev/null) to mirror the dogfood walker.
 #
+# HERMETICITY (BL-076): --no-remote-creation is MANDATORY here. This suite
+# asserts only on the tool-installation-plan flow (resolve_and_install_tools),
+# which runs BEFORE create_and_protect_remote. Without --no-remote-creation the
+# default --git-host github drives the real gh CLI and, on an authenticated
+# host, creates + pushes a REAL private repo (this is exactly how kraulerson/foo
+# was leaked on 2026-07-06). --no-remote-creation skips the host API entirely
+# (init.sh:2066) and does not touch the tool-install path, so every assertion
+# below is preserved while the test can never reach live gh.
+#
 # Echoes "EXIT|STDOUT|STDERR" with newlines flattened to spaces.
 run_init_mobile() {
   local extra_env="${1:-}"
@@ -59,6 +68,7 @@ run_init_mobile() {
       --track full \
       --deployment personal \
       --gov-mode private_poc \
+      --no-remote-creation \
       --project foo \
       --project-dir "$tmpprojdir" </dev/null 2>&1) || rc=$?
   else
@@ -69,6 +79,7 @@ run_init_mobile() {
       --track full \
       --deployment personal \
       --gov-mode private_poc \
+      --no-remote-creation \
       --project foo \
       --project-dir "$tmpprojdir" </dev/null 2>&1) || rc=$?
   fi

--- a/tests/test-lint-no-live-remote.sh
+++ b/tests/test-lint-no-live-remote.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# tests/test-lint-no-live-remote.sh — behavior suite for
+# scripts/lint-no-live-remote-in-tests.sh (BL-076).
+#
+# The lint is the merge-time backstop that stops a test from executing
+# init.sh in a shape that can create a REAL remote repo against an
+# authenticated host (the `kraulerson/foo` leak, 2026-07-06). These
+# cases pin its detection contract so a regression in the LINT itself
+# (a false negative that lets a live-remote run through, or a false
+# positive on a reporter string / static grep / mocked run) is caught.
+#
+# Each case writes a synthetic fixture into an isolated temp dir and
+# points the lint at it with --dir, so the assertions never depend on
+# the live tests/ tree.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINT="$REPO_ROOT/scripts/lint-no-live-remote-in-tests.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# run_case NAME EXPECT_RC <<'FIXTURE'  ... fixture body ...
+# Writes the heredoc to $dir/fixture.sh and asserts the lint's exit code.
+assert_lint() {
+  local name="$1" expect="$2" body="$3"
+  local dir rc=0
+  dir=$(mktemp -d)
+  printf '%s\n' "$body" > "$dir/fixture.sh"
+  bash "$LINT" --dir "$dir" >/dev/null 2>&1 || rc=$?
+  if [ "$rc" = "$expect" ]; then
+    pass "$name (rc=$rc)"
+  else
+    fail_ "$name" "expected rc=$expect, got rc=$rc"
+  fi
+  rm -rf "$dir"
+}
+
+echo "== tests/test-lint-no-live-remote.sh =="
+
+# N1: bare github/default-host init run, no hermetic token → VIOLATION.
+assert_lint "N1: default-host init run without guard is flagged" 1 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive --project x --project-dir "$P" --platform web'
+
+# N2: same run + --no-remote-creation → hermetic.
+assert_lint "N2: --no-remote-creation clears the violation" 0 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive --project x --project-dir "$P" --no-remote-creation --platform web'
+
+# N3: --git-host other (URL-paste path, no CLI) → hermetic.
+assert_lint "N3: --git-host other is hermetic" 0 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive --project x --git-host other --remote-url https://example.com/x.git'
+
+# N4: --dry-run → hermetic.
+assert_lint "N4: --dry-run is hermetic" 0 \
+'#!/usr/bin/env bash
+printf "%s\n" "$IN" | bash "$REPO/init.sh" --dry-run'
+
+# N5: --validate-only → hermetic (exits before scaffold).
+assert_lint "N5: --validate-only is hermetic" 0 \
+'#!/usr/bin/env bash
+INIT_SH="$REPO_ROOT/init.sh"
+"$INIT_SH" --non-interactive --validate-only --project p --platform web'
+
+# N6: CRITICAL — multi-line continuation with the guard on the NEXT
+# physical line (the real corpus shape). Must be treated as hermetic.
+assert_lint "N6: guard on backslash-continuation line is honored" 0 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive \
+  --project x --platform web \
+  --no-remote-creation \
+  --project-dir "$P"'
+
+# N7: CRITICAL — multi-line continuation WITHOUT the guard anywhere in
+# the joined command → VIOLATION (the unfixed mobile-test shape).
+assert_lint "N7: multi-line run with no guard is flagged" 1 \
+'#!/usr/bin/env bash
+INIT_SH="$REPO_ROOT/init.sh"
+out=$(cd "$cwd" && env "$e" "$INIT_SH" \
+  --non-interactive \
+  --platform mobile \
+  --project foo \
+  --project-dir "$P" </dev/null 2>&1)'
+
+# N8: mock-driven file (write_mock_gh + $MOCK_DIR on PATH) → hermetic
+# even though the run uses --git-host github with no --no-remote-creation.
+assert_lint "N8: mocked-CLI file is exempt" 0 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+write_mock_gh() { :; }
+write_mock_gh "$MOCK_DIR"
+export PATH="$MOCK_DIR:$PATH"
+bash "$INIT" --non-interactive --project x --git-host github --visibility private'
+
+# N9: reporter strings that MENTION init.sh --non-interactive must NOT be
+# flagged — they are not executions.
+assert_lint "N9: reporter strings are not flagged" 0 \
+'#!/usr/bin/env bash
+section "init.sh --non-interactive honors AUTO_INSTALL_TOOLS"
+echo "  Testing init.sh --non-interactive with read-only dir"
+pass "init.sh --non-interactive tests (3/3)"'
+
+# N10: static source analysis (grep / bash -n of init.sh) must NOT be
+# flagged — no execution, no remote.
+assert_lint "N10: static grep / bash -n of init.sh is not flagged" 0 \
+'#!/usr/bin/env bash
+INIT_SH="$REPO_ROOT/init.sh"
+grep -q "get_available_platforms" "$INIT_SH" || exit 1
+bash -n "$INIT_SH"
+for f in "$INIT_SH"; do echo "$f"; done'
+
+# N11: allowlist marker with a non-empty reason → hermetic.
+assert_lint "N11: allow marker with reason passes" 0 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive --project x --platform web # lint-no-live-remote: allow drives a throwaway sandbox host'
+
+# N12: allowlist marker with an EMPTY reason → still a VIOLATION.
+assert_lint "N12: allow marker with empty reason fails" 1 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive --project x --platform web # lint-no-live-remote: allow'
+
+# N13: gitlab / bitbucket first-class hosts with no guard are ALSO
+# flagged (not just github) — any first-class host reaches a live CLI.
+assert_lint "N13: gitlab host without guard is flagged" 1 \
+'#!/usr/bin/env bash
+INIT="$REPO_ROOT/init.sh"
+bash "$INIT" --non-interactive --project x --git-host gitlab --platform web'
+
+# N14: end-to-end — the REAL repo tree must currently pass clean.
+real_rc=0
+bash "$LINT" >/dev/null 2>&1 || real_rc=$?
+if [ "$real_rc" = "0" ]; then
+  pass "N14: live tests/ tree passes the lint (rc=0)"
+else
+  fail_ "N14" "live tests/ tree is non-hermetic (rc=$real_rc); run: bash scripts/lint-no-live-remote-in-tests.sh --list"
+fi
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## BL-076: Non-hermetic init tests create real remote repos

Some tests executed the real `init.sh` with the default (github) host and **no** `--no-remote-creation` / `--git-host other` / mocked `gh`, so running the suite on an authenticated host created + pushed **REAL private repos**. This is how `kraulerson/foo` leaked on 2026-07-06 during Wave-1 verification, and it blocks the suite from ever running in CI ([[bl077]]).

### Audit — every test that runs `init.sh` / `create_and_protect_remote`

| Test | Status | Fix |
|------|--------|-----|
| `tests/test-init-non-interactive-mobile-auto-install.sh` | **NON-HERMETIC** | Ran `init.sh --project foo`, default github host, no guard → real repo. Added `--no-remote-creation` to both invocations. |
| `tests/edge-case-test-suite.sh` | latent hazard | Dead `run_init()` wrapper forwarded `"$@"` with no guard. Baked `--no-remote-creation` into the wrapper (hermetic by construction). |
| all others (`test-init-*`, `edge-cases-*`, `test-poc-modes`, `test-enforcement-level-*`, `test-verify-install-*`, `test-bl029/030`, `test-vendored-skills`, host-driver `e2e-init*`) | already hermetic | `--no-remote-creation` on the continuation line, `--dry-run`, `--validate-only`, `--git-host other` + fake `--remote-url`, or PATH-mocked `gh`/`glab`/`curl`. No change. |

No test calls `create_and_protect_remote` directly; the only gitlab/bitbucket host runs (edge-case-test-suite) already carry `--no-remote-creation`. **`test-init-non-interactive-mobile-auto-install.sh` was the sole live-remote leak.**

The mobile fix preserves assertion intent: the suite only asserts on the tool-installation-plan flow (`resolve_and_install_tools`), which runs **before** `create_and_protect_remote`, so `--no-remote-creation` changes nothing the test checks — it just stops the host API from being reached.

### Regression guard

`scripts/lint-no-live-remote-in-tests.sh` (bash-3.2) reconstructs each backslash-continued `init.sh` invocation and **FAILs** any that can reach live remote creation (default/first-class host, no guard, non-mock file). Detection keys on genuine **command-position execution**, so reporter strings (`section "init.sh --non-interactive ..."`) and static `grep`/`awk`/`bash -n` of the source are correctly ignored.

- Wired into `.github/workflows/lint.yml` as the `no-live-remote-in-tests-lint` CI job.
- Wired into `tests/full-project-test-suite.sh` (also satisfies the tests-registered lint).
- 14-case behavior suite: `tests/test-lint-no-live-remote.sh` (multi-line guard on continuation line, unfixed-mobile shape, mocked-file exemption, reporter-string / static-grep non-flagging, allowlist reason enforcement, gitlab host, live-tree end-to-end).

### Verification

- Fixed mobile test: **3/3 PASS**, `gh repo list kraulerson` before/after shows **no `foo` repo created**.
- New lint: **green** on the live tree — 94 init runs detected, all hermetic (`--list` shows `hermetic-token` / `mock-cli-on-path`), 0 violations.
- New lint behavior suite: **14/14 PASS**.
- 8-lint battery green: counter-antipattern, backlog-references, fix-functions-stderr, raw-read-prompt, tests-registered, doc-anchors, review-manifest, fail-emit-exit-status — all rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)