### PR TITLE
test(suite): repair + retire the 5 known-RED tests so the suite goes green (step 4)

### DIFF
--- a/tests/edge-cases-pre-init.sh
+++ b/tests/edge-cases-pre-init.sh
@@ -125,49 +125,86 @@ build_dryrun_input() {
 
 # ================================================================
 # E1: Project name with apostrophe and spaces
-# Expected: sanitized to lowercase-no-spaces
+#
+# Two distinct, path-dependent contracts — both are current, intended
+# product behavior (verified 2026-07-06):
+#   • Interactive TTY: collect_project_info() sanitizes with
+#     `tr '[:upper:]' '[:lower:]' | tr ' ' '-'` (init.sh:481), so
+#     "Derek's Cool App" -> "derek's-cool-app" (apostrophe preserved)
+#     and is shown verbatim in the DRY RUN SUMMARY "Name:" line.
+#   • Non-interactive --project: the flag value is taken verbatim with
+#     NO sanitizer and is schema-validated against ^[a-z][a-z0-9-]*$
+#     (init.sh:3502). An apostrophe+space name is therefore REJECTED
+#     with a clear error — the flag path must not persist an
+#     unsanitized name to a directory/manifest.
+#
+# BL-040 HARNESS NOTE: earlier revisions PIPED the name on stdin
+# (printf ... | init.sh --dry-run) and grepped for "derek" /
+# "derek's-cool-app". That never exercised name handling at all:
+# scripts/lib/helpers-core.sh:prompt_input() returns its DEFAULT
+# (empty string) whenever stdin is not a TTY, so the piped
+# "Derek's Cool App" was discarded and PROJECT_NAME stayed empty — the
+# greps could never match regardless of product correctness. This is
+# the same TTY-gated defect E2 was migrated off of. The name only
+# reaches PROJECT_NAME through a real TTY or the non-interactive
+# --project flag; the assertions below use the latter, which is the
+# sole deterministic, hermetic, bash-only channel. (Supersedes the
+# stdin-piped assertions and audit finding tests-edge-cases-1.)
 # ================================================================
 section "E1: Project Name with Apostrophe + Spaces"
 
 E1_DIR="$TEST_DIR/e1-project"
-E1_INPUT=$(build_init_input "Derek's Cool App" "A test project" 4 2 1 6 "$E1_DIR" "Y")
-E1_EXTRA_INPUT="${E1_INPUT}
-Y"
 
 echo ""
 echo "  Input project name: Derek's Cool App"
 
-# Use --dry-run to avoid interactive prerequisite prompts consuming stdin
-e1_output=$(printf '%s\n' "$E1_INPUT" | bash "$REPO_DIR/init.sh" --dry-run 2>&1) || true
+# E1a: apostrophe+space name on the non-interactive --project path must
+# be rejected by schema validation (no sanitizer on the flag path).
+e1_reject_exit=0
+e1_reject_output=$(bash "$REPO_DIR/init.sh" \
+  --dry-run \
+  --non-interactive \
+  --project "Derek's Cool App" \
+  --description "A test project" \
+  --platform web \
+  --deployment personal \
+  --language rust \
+  --project-dir "$E1_DIR" 2>&1) || e1_reject_exit=$?
 
-# Check the output for the sanitized project name
-# init.sh does: tr '[:upper:]' '[:lower:]' | tr ' ' '-'
-# So "Derek's Cool App" -> "derek's-cool-app"
-if echo "$e1_output" | grep -qi "derek"; then
-  pass "E1: init.sh accepted name with apostrophe+spaces"
+if [ "$e1_reject_exit" -ne 0 ] \
+   && echo "$e1_reject_output" | grep -qiE "invalid --project name|must start with a lowercase letter"; then
+  pass "E1: non-interactive --project rejects apostrophe+space name with clear error"
 else
-  fail "E1: init.sh did not process name with apostrophe+spaces"
+  fail "E1: non-interactive --project did NOT reject apostrophe+space name (exit=$e1_reject_exit)"
 fi
 
-# Verify dry-run summary shows the sanitized name in its exact documented form.
-# init.sh does: tr '[:upper:]' '[:lower:]' | tr ' ' '-'
-# So "Derek's Cool App" -> "derek's-cool-app". A fixed-string, case-sensitive
-# grep is required so that a regression removing the tr-pipeline (which would
-# leave "Derek's Cool App" or "derek's cool app") would be caught — the raw
-# input "Derek" already contains the substring "derek", so a case-insensitive
-# substring grep is vacuous and inflates the PASS count without coverage.
-# (Closes audit finding tests-edge-cases-1.)
-if echo "$e1_output" | grep -qF "derek's-cool-app"; then
-  pass "E1: dry-run output contains exact sanitized name 'derek's-cool-app'"
+# E1b: dry-run name preservation — a valid (pre-sanitized) name is
+# echoed VERBATIM in the DRY RUN SUMMARY "Name:" line. Anchored,
+# fixed-name grep so a regression that drops the summary line or
+# rewrites/re-cases the name fails RED. This is the core BL-040
+# dry-run-name-preservation invariant.
+E1B_NAME="dereks-cool-app"
+e1b_output=$(bash "$REPO_DIR/init.sh" \
+  --dry-run \
+  --non-interactive \
+  --project "$E1B_NAME" \
+  --description "A test project" \
+  --platform web \
+  --deployment personal \
+  --language rust \
+  --project-dir "$E1_DIR" 2>&1) || true
+
+if echo "$e1b_output" | grep -qE "^[[:space:]]*Name:[[:space:]]+dereks-cool-app[[:space:]]*$"; then
+  pass "E1: dry-run summary preserves the project name verbatim ('$E1B_NAME')"
 else
-  fail "E1: dry-run output missing exact sanitized name 'derek's-cool-app'"
+  fail "E1: dry-run summary did not preserve the project name verbatim ('$E1B_NAME')"
 fi
 
-# Verify dry-run completed
-if echo "$e1_output" | grep -qi "DRY RUN SUMMARY"; then
-  pass "E1: dry-run completed with apostrophe+space name"
+# E1c: dry-run completed for the valid-name run.
+if echo "$e1b_output" | grep -qi "DRY RUN SUMMARY"; then
+  pass "E1: dry-run completed with valid project name"
 else
-  fail "E1: dry-run did not complete with apostrophe+space name"
+  fail "E1: dry-run did not complete with valid project name"
 fi
 
 # ================================================================
@@ -351,11 +388,16 @@ section "E4: Double Init in Same Directory"
 E4_DIR="$TEST_DIR/e4-double-init"
 
 echo ""
-echo "  Testing two sequential dry-runs targeting: $E4_DIR"
+echo "  Testing two sequential --non-interactive dry-runs targeting: $E4_DIR"
+echo "  (stdin-piped names never reach PROJECT_NAME — see E1 HARNESS NOTE —"
+echo "   so the --project flag is the deterministic channel for this check.)"
 
 # First dry-run
-e4_input=$(build_init_input "e4-double" "First run" 4 1 1 6 "$E4_DIR" "Y")
-e4_run1=$(printf '%s\n' "$e4_input" | bash "$REPO_DIR/init.sh" --dry-run 2>&1) || true
+e4_run1=$(bash "$REPO_DIR/init.sh" \
+  --dry-run --non-interactive \
+  --project "e4-double" --description "First run" \
+  --platform web --deployment personal --language rust \
+  --project-dir "$E4_DIR" 2>&1) || true
 
 if echo "$e4_run1" | grep -qi "DRY RUN SUMMARY"; then
   pass "E4: first dry-run completed successfully"
@@ -363,9 +405,12 @@ else
   fail "E4: first dry-run did not complete"
 fi
 
-# Second dry-run — same target directory
-e4_input2=$(build_init_input "e4-double" "Second run" 4 1 1 6 "$E4_DIR" "Y")
-e4_run2=$(printf '%s\n' "$e4_input2" | bash "$REPO_DIR/init.sh" --dry-run 2>&1) || true
+# Second dry-run — same target directory, same project name
+e4_run2=$(bash "$REPO_DIR/init.sh" \
+  --dry-run --non-interactive \
+  --project "e4-double" --description "Second run" \
+  --platform web --deployment personal --language rust \
+  --project-dir "$E4_DIR" 2>&1) || true
 
 if echo "$e4_run2" | grep -qi "DRY RUN SUMMARY"; then
   pass "E4: second dry-run completed (idempotent input handling)"
@@ -373,9 +418,12 @@ else
   fail "E4: second dry-run failed"
 fi
 
-# Both runs should show the same project name
-if echo "$e4_run1" | grep -q "e4-double" && echo "$e4_run2" | grep -q "e4-double"; then
-  pass "E4: both runs accepted the same project name"
+# Both runs must echo the SAME project name in the summary "Name:" line
+# (preservation across repeated runs — the BL-040 invariant). Anchored,
+# fixed-name grep so a dropped/rewritten name fails RED.
+if echo "$e4_run1" | grep -qE "^[[:space:]]*Name:[[:space:]]+e4-double[[:space:]]*$" \
+   && echo "$e4_run2" | grep -qE "^[[:space:]]*Name:[[:space:]]+e4-double[[:space:]]*$"; then
+  pass "E4: both runs preserved the same project name in the summary"
 else
   fail "E4: project name not preserved across runs"
 fi

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -1700,31 +1700,66 @@ fi
 
 # E58: project-local invocation of upgrade-project.sh must exit rc=0.
 # Regression guard for T1-B from 2026-04-26 UAT triage. The BL-009/BL-015
-# helper-refresh block at scripts/upgrade-project.sh:1471 did
-# `cp $SCRIPT_DIR/$helper scripts/$helper` where $SCRIPT_DIR resolved to the
-# project's own scripts/ dir when invoked as `bash scripts/upgrade-project.sh`
-# from the project root. BSD cp returns non-zero on identical source/dest,
-# and `set -euo pipefail` aborted before "Upgrade complete." State changes
-# succeeded but the wrapper signaled failure.
+# helper-refresh block (scripts/upgrade-project.sh, "Refreshing framework
+# helper scripts") did `cp $SCRIPT_DIR/$helper scripts/$helper` where
+# $SCRIPT_DIR resolved to the project's own scripts/ dir when invoked as
+# `bash scripts/upgrade-project.sh` from the project root. BSD cp returns
+# non-zero on identical source/dest, and `set -euo pipefail` aborted before
+# "Upgrade complete." The fix guards the no-op with a `-ef` same-file test;
+# this case keeps that path honest by driving a REAL init scaffold + a
+# project-local upgrade to completion.
+#
+# STALE-TEST repair (BL-039 / baseline §2.5, 2026-07): the prior init baseline
+# was `--deployment organizational --gov-mode private_poc`, which init.sh now
+# correctly REJECTS at Pass-2 validation (init.sh:3648 — "Private POC is always
+# a personal deployment"; the same rule E50b guards). init exited rc=1 so the
+# upgrade never ran and E58 failed on init_rc, not on the T1-B path it exists
+# to guard. The baseline is realigned to a valid personal project that then
+# crosses to organizational/sponsored_poc via --to-sponsored-poc — an
+# org-crossing project-local upgrade that E60 (--to-private-poc stays personal)
+# does not cover. Hermetic: --no-remote-creation (the old form passed a live
+# --remote-url with no --no-remote-creation — a latent network hazard that only
+# never fired because §2.5 rejected it earlier). The personal→organizational
+# ZDR gate (tier-crosscheck-6) is satisfied by seeding phase1_artifacts, mirror-
+# ing E58b.
 _e58_dir="$TEST_DIR/e58"
 mkdir -p "$_e58_dir"
 _e58_proj="$_e58_dir/uat-e58"
 _e58_init_rc=0
 (cd "$_e58_dir" && "$INIT_SH" --non-interactive \
-  --project uat-e58 --platform web --deployment organizational --gov-mode private_poc \
+  --project uat-e58 --platform web --deployment personal \
   --language typescript --project-dir "$_e58_proj" \
-  --git-host other --remote-url https://example.com/fake.git \
-  --branch-protection-attested >/dev/null 2>&1) || _e58_init_rc=$?
+  --git-host github --no-remote-creation >/dev/null 2>&1) || _e58_init_rc=$?
+# Seed phase1_artifacts so the personal→organizational ZDR gate
+# (tier-crosscheck-6 in upgrade-project.sh) does not block the deployment flip.
+_e58_pstate="$_e58_proj/.claude/process-state.json"
+if [ "$_e58_init_rc" = "0" ] && [ -f "$_e58_pstate" ]; then
+  _e58_tmp="$_e58_pstate.tmp"
+  if jq '.phase1_artifacts = ((.phase1_artifacts // {}) + {data_classification:"internal", zdr_attested:true})' \
+       "$_e58_pstate" > "$_e58_tmp" 2>/dev/null; then
+    mv "$_e58_tmp" "$_e58_pstate"
+  else
+    rm -f "$_e58_tmp"
+  fi
+fi
 _e58_upgrade_rc=0
 if [ "$_e58_init_rc" = "0" ] && [ -d "$_e58_proj/scripts" ]; then
   (cd "$_e58_proj" && bash scripts/upgrade-project.sh --to-sponsored-poc >/dev/null 2>&1) || _e58_upgrade_rc=$?
 else
   _e58_upgrade_rc=255
 fi
-if [ "$_e58_upgrade_rc" = "0" ]; then
-  pass "E58: project-local upgrade-project.sh --to-sponsored-poc exits 0 (T1-B regression guard)"
+_e58_deploy=""
+_e58_poc=""
+if [ -f "$_e58_proj/.claude/phase-state.json" ]; then
+  _e58_deploy=$(jq -r '.deployment // empty' "$_e58_proj/.claude/phase-state.json" 2>/dev/null || echo "")
+  _e58_poc=$(jq -r '.poc_mode // empty' "$_e58_proj/.claude/phase-state.json" 2>/dev/null || echo "")
+fi
+if [ "$_e58_upgrade_rc" = "0" ] && \
+   [ "$_e58_deploy" = "organizational" ] && \
+   [ "$_e58_poc" = "sponsored_poc" ]; then
+  pass "E58: project-local upgrade-project.sh --to-sponsored-poc (personal→org) exits 0 + flips to organizational/sponsored_poc (T1-B project-local cp guard)"
 else
-  fail "E58: expected rc=0 from project-local upgrade-project.sh, got rc=$_e58_upgrade_rc (init_rc=$_e58_init_rc)"
+  fail "E58: expected rc=0 deployment=organizational poc_mode=sponsored_poc; got rc=$_e58_upgrade_rc deployment='$_e58_deploy' poc_mode='$_e58_poc' (init_rc=$_e58_init_rc)"
 fi
 
 # E58b: --to-sponsored-poc on a genuinely PERSONAL project succeeds AND flips

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -629,19 +629,10 @@ fi
 # tests/test-prompt-install-noninteractive.sh (verifier-fix 33e351e)
 # is GREEN.
 section "Verify-install + prompt-install fix-functions (PRs #92, 33e351e)"
-if [ "$SKIP_KNOWN_FAILING" = "1" ]; then
-  warn "SKIP_KNOWN_FAILING=1 — skipping tests/test-verify-install-fix-functions.sh (known-RED, BL-037)"
+if bash "$SCRIPT_DIR/tests/test-verify-install-fix-functions.sh" >/dev/null 2>&1; then
+  pass "tests/test-verify-install-fix-functions.sh"
 else
-  # Status: known-RED on main pending BL-037 (T6-T10 tightening) +
-  # underlying fix_tool_install missing-function bug. Aggregator will
-  # exit non-zero until BL-037 lands. Do NOT `|| true` this — that's
-  # the vacuous-pass class BL-034 exists to surface. Karl opts in
-  # via SKIP_KNOWN_FAILING=1 for local iteration.
-  if bash "$SCRIPT_DIR/tests/test-verify-install-fix-functions.sh" >/dev/null 2>&1; then
-    pass "tests/test-verify-install-fix-functions.sh"
-  else
-    fail "tests/test-verify-install-fix-functions.sh FAILED — known-RED on main, tracked by BL-037 (fix_tool_install missing + T6-T10 tightening). SKIP_KNOWN_FAILING=1 to bypass during local iteration."
-  fi
+  fail "tests/test-verify-install-fix-functions.sh FAILED (run for details)"
 fi
 if bash "$SCRIPT_DIR/tests/test-prompt-install-noninteractive.sh" >/dev/null 2>&1; then
   pass "tests/test-prompt-install-noninteractive.sh"
@@ -720,19 +711,10 @@ if bash "$SCRIPT_DIR/tests/test-process-checklist-check-commit-ready-subject.sh"
 else
   fail "tests/test-process-checklist-check-commit-ready-subject.sh FAILED (run for details)"
 fi
-if [ "$SKIP_KNOWN_FAILING" = "1" ]; then
-  warn "SKIP_KNOWN_FAILING=1 — skipping tests/test-process-checklist-reset-phase1.sh (known-RED, BL-041)"
+if bash "$SCRIPT_DIR/tests/test-process-checklist-reset-phase1.sh" >/dev/null 2>&1; then
+  pass "tests/test-process-checklist-reset-phase1.sh"
 else
-  # Status: known-RED on main pending BL-041 (framework-repo guard
-  # layering) — T4/T5 invoke process-checklist.sh from inside the
-  # framework checkout, hitting the guard. Aggregator will exit
-  # non-zero until BL-041 lands or the test cd-s to a fixture
-  # project dir first. SKIP_KNOWN_FAILING=1 to bypass locally.
-  if bash "$SCRIPT_DIR/tests/test-process-checklist-reset-phase1.sh" >/dev/null 2>&1; then
-    pass "tests/test-process-checklist-reset-phase1.sh"
-  else
-    fail "tests/test-process-checklist-reset-phase1.sh FAILED — known-RED on main, tracked by BL-041 (framework-repo guard). SKIP_KNOWN_FAILING=1 to bypass during local iteration."
-  fi
+  fail "tests/test-process-checklist-reset-phase1.sh FAILED (run for details)"
 fi
 
 # ----------------------------------------------------------------
@@ -814,31 +796,15 @@ fi
 # Known-RED siblings are gated on SKIP_KNOWN_FAILING so a local
 # iteration loop can mask them; default = surface the failure.
 section "Edge-cases aggregators (pre-init, scripts, upgrade-input)"
-if [ "$SKIP_KNOWN_FAILING" = "1" ]; then
-  warn "SKIP_KNOWN_FAILING=1 — skipping tests/edge-cases-pre-init.sh (known-RED, BL-040)"
+if bash "$SCRIPT_DIR/tests/edge-cases-pre-init.sh" >/dev/null 2>&1; then
+  pass "tests/edge-cases-pre-init.sh"
 else
-  # Status: known-RED on main pending BL-040 (init.sh:2781 dry_run
-  # summary). Do NOT `|| true` — apostrophe-handling regressions in
-  # init.sh must surface. SKIP_KNOWN_FAILING=1 to bypass locally.
-  if bash "$SCRIPT_DIR/tests/edge-cases-pre-init.sh" >/dev/null 2>&1; then
-    pass "tests/edge-cases-pre-init.sh"
-  else
-    fail "tests/edge-cases-pre-init.sh FAILED — known-RED on main, tracked by BL-040 (E1, E4 apostrophe/dry-run name preservation). SKIP_KNOWN_FAILING=1 to bypass during local iteration."
-  fi
+  fail "tests/edge-cases-pre-init.sh FAILED (run for details)"
 fi
-if [ "$SKIP_KNOWN_FAILING" = "1" ]; then
-  warn "SKIP_KNOWN_FAILING=1 — skipping tests/edge-cases-scripts.sh (known-RED, BL-065 / BL-009 follow-up: E30 --platform other)"
+if bash "$SCRIPT_DIR/tests/edge-cases-scripts.sh" >/dev/null 2>&1; then
+  pass "tests/edge-cases-scripts.sh"
 else
-  # Status: known-RED on main pending BL-065 (E30 --platform other
-  # refs/template handling — BL-009 follow-up). BL-039 (E50) was
-  # closed in the PR that landed this gate-narrowing — E50 + new
-  # E50b now reflect the actual baseline §2.5 tier contract.
-  # Do NOT `|| true`. SKIP_KNOWN_FAILING=1 to bypass locally.
-  if bash "$SCRIPT_DIR/tests/edge-cases-scripts.sh" >/dev/null 2>&1; then
-    pass "tests/edge-cases-scripts.sh"
-  else
-    fail "tests/edge-cases-scripts.sh FAILED — known-RED on main, tracked by BL-065 (E30 --platform other / BL-009 follow-up). SKIP_KNOWN_FAILING=1 to bypass during local iteration."
-  fi
+  fail "tests/edge-cases-scripts.sh FAILED (run for details)"
 fi
 if bash "$SCRIPT_DIR/tests/edge-cases-upgrade-input.sh" >/dev/null 2>&1; then
   pass "tests/edge-cases-upgrade-input.sh"
@@ -916,18 +882,10 @@ fi
 # and surface the failure so the e2e-init regressions can't ship
 # silent.
 section "Host-driver aggregator (tests/host-drivers/run-all.sh)"
-if [ "$SKIP_KNOWN_FAILING" = "1" ]; then
-  warn "SKIP_KNOWN_FAILING=1 — skipping tests/host-drivers/run-all.sh (e2e-init-* trio known-RED)"
+if bash "$SCRIPT_DIR/tests/host-drivers/run-all.sh" >/dev/null 2>&1; then
+  pass "tests/host-drivers/run-all.sh (all children)"
 else
-  # Status: 6 of 9 children GREEN; 3 e2e-init.*.test.sh children
-  # RED on main (existing defect, not introduced by BL-034). Do
-  # NOT `|| true` — the per-host unit tests inside the aggregator
-  # MUST be allowed to fail loudly when they regress.
-  if bash "$SCRIPT_DIR/tests/host-drivers/run-all.sh" >/dev/null 2>&1; then
-    pass "tests/host-drivers/run-all.sh (9/9 children)"
-  else
-    fail "tests/host-drivers/run-all.sh FAILED — known-RED: e2e-init / e2e-init-gitlab / e2e-init-bitbucket. Unit-test children (github/gitlab/regressions/mock-cli) should still PASS. SKIP_KNOWN_FAILING=1 to bypass."
-  fi
+  fail "tests/host-drivers/run-all.sh FAILED (run for details)"
 fi
 
 # --- BL-035 wiring C: test-gate/process/poc/docs ---

--- a/tests/test-process-checklist-reset-phase1.sh
+++ b/tests/test-process-checklist-reset-phase1.sh
@@ -86,7 +86,15 @@ teardown_project
 # arm AND is seeded in both ensure_state_file and reset_all templates.
 # Fails (rc=1) if any gap.
 echo "T4: --invariant-check passes on healthy script"
-out=$("$SCRIPT" --invariant-check 2>&1) ; rc=$?
+# process-checklist.sh calls guard_not_in_framework at load (before dispatch),
+# which refuses when cwd IS the framework repo. --invariant-check is a pure
+# self-test that reads only the script text ($BASH_SOURCE) and writes no state,
+# but the guard is unconditional — so run it from a non-framework sandbox cwd,
+# exactly as T3 does for --status. Without this the test trips the framework-
+# repo guard whenever the suite runs from inside the framework checkout.
+SANDBOX_T4=$(mktemp -d)
+out=$(cd "$SANDBOX_T4" && "$SCRIPT" --invariant-check 2>&1) ; rc=$?
+rm -rf "$SANDBOX_T4"
 if [ "$rc" -eq 0 ] && echo "$out" | grep -q "invariant-check: all processes wired"; then
   pass "T4: invariant-check passes (every process has reset arm + template entry)"
 else
@@ -133,7 +141,11 @@ assert new_body != body, "phase1_architecture arm not found / not removed"
 open(path, 'w').write(s.replace(body, new_body))
 PY
 chmod +x "$TMPSCRIPT"
-out=$("$TMPSCRIPT" --invariant-check 2>&1) ; rc=$?
+# Same framework-repo guard as T4: run the copied script from a non-framework
+# sandbox cwd so the guard passes and we exercise the invariant-check gap path.
+SANDBOX_T5=$(mktemp -d)
+out=$(cd "$SANDBOX_T5" && "$TMPSCRIPT" --invariant-check 2>&1) ; rc=$?
+rm -rf "$SANDBOX_T5"
 if [ "$rc" -ne 0 ] && echo "$out" | grep -q "phase1_architecture"; then
   pass "T5: invariant-check fails (rc=$rc) and names the missing arm"
 else


### PR DESCRIPTION
Repairs/retires the ~5 pre-existing known-RED tests so the master suite is genuinely green — the prerequisite for turning on auto-testing in CI (BL-077).

## Headline: ZERO product bugs. Every failure was test-side.

| Test | Finding | Action |
|---|---|---|
| **BL-037** `test-verify-install-fix-functions` | Already GREEN — fixed weeks ago (PR #115), only the "known-RED" label was left behind. Proven non-vacuous via mutation. | Retire stale guard |
| **e2e-init trio** `host-drivers/run-all.sh` | Already GREEN — fixed June (BL-066); the label was written ~18h *before* the fix and never removed. | Retire stale guard |
| **BL-041** `test-process-checklist-reset-phase1` | Test-harness: T4/T5 ran from the framework repo cwd → hit the (correct) framework-repo guard. | Fix test (sandbox cwd) |
| **BL-040** `edge-cases-pre-init` | Test-harness: fed the name via piped stdin, which the TTY-gated prompt intentionally discards. Product handles names correctly (proven on both channels). Mutation-proven. | Rewrite E1/E4 via `--project` |
| **edge-cases-scripts** (BL-065 E30 / BL-079 E60) | E30 + E60 already green; the real red was **E58** (stale §2.5 baseline: init now correctly rejects organizational+private_poc). Also closed a **latent live-remote hazard** in old E58. | Fix E58 + hermeticity |

All 5 `SKIP_KNOWN_FAILING` "known-RED" guard blocks are converted to normal required-test invocations, so a future regression fails loudly instead of hiding behind a stale label.

## Verification
- Each test green standalone; mutation-proven where product-adjacent (BL-040, BL-037).
- All 8 repo lints green; hermetic (no real `gh`; a latent live-remote case in old E58 was closed).
- Full hermetic master `full-project-test-suite.sh` run in progress as the final green check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
