### PR TITLE
CI: make the test suite real — hermeticity guard (BL-076) + per-push testing (BL-077)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,6 +31,7 @@ name: tests
 
 on:
   push:
+    branches: [main]   # fast lane on main pushes; PRs covered by pull_request
   pull_request:
   schedule:
     # Nightly at 08:00 UTC.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,181 @@
+# .github/workflows/tests.yml — BL-077: run the test suite in CI on Linux.
+#
+# The suite has only ever run on macOS (bash 3.2). GitHub's ubuntu-latest
+# runners ship bash 5; the suite is written to the bash-3.2 subset, which
+# runs unchanged on bash 5. This workflow gives the repo its first
+# automated *test* coverage (the sibling lint.yml only runs lint scripts).
+#
+# Two lanes, because the full suite (tests/full-project-test-suite.sh)
+# scaffolds dozens of real init.sh projects and delegates to the big
+# aggregators — it takes ~1 hour and is far too slow for every push:
+#
+#   * unit (fast lane)  — push + pull_request. Runs only the quick unit
+#                         tests: the individual tests/test-*.sh files that
+#                         do NOT invoke init.sh and are NOT aggregators.
+#                         Derived from `grep -L 'init\.sh' tests/test-*.sh`
+#                         (66 files; ~5 min on macOS, expected faster on
+#                         Linux). The list is explicit and reviewable below
+#                         so a new orphan test cannot silently join CI —
+#                         add new entries deliberately.
+#
+#   * full (slow lane)  — nightly schedule + manual dispatch only. Runs the
+#                         complete tests/full-project-test-suite.sh, which
+#                         honors the SKIP_KNOWN_FAILING env (left at its
+#                         default of 0 so known-RED guards still run).
+#
+# The tests are hermetic (BL-076 lint enforces no live-remote init.sh runs),
+# so CI does NOT authenticate gh and creates no real remotes. Keep it that
+# way. Do not modify lint.yml.
+
+name: tests
+
+on:
+  push:
+  pull_request:
+  schedule:
+    # Nightly at 08:00 UTC.
+    - cron: '0 8 * * *'
+  workflow_dispatch:
+
+jobs:
+  # ── Fast lane ──────────────────────────────────────────────────────────
+  # Quick unit tests only, on every push and PR. Target: a few minutes.
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    # Only the fast lane on push / PR. The full suite runs on schedule /
+    # dispatch (see the `full` job's guard below).
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # tests/test-lint-backlog-references.sh runs the linter against the
+          # REAL repo with `--base origin/main` (needs the origin/main ref and
+          # reachable history). The default shallow clone (fetch-depth: 1)
+          # leaves that ref unresolvable. Mirror lint.yml's backlog job.
+          fetch-depth: 0
+
+      - name: Verify required tools are available
+        # ubuntu-latest ships both, but fail loudly and early if a future
+        # runner image ever drops one rather than mid-suite with a cryptic
+        # error.
+        run: jq --version && git --version
+
+      - name: Run fast unit tests
+        run: |
+          set -uo pipefail
+          # Explicit, reviewable list. A test belongs here iff it does not
+          # invoke init.sh (no project scaffolding) and is not an aggregator
+          # or helper. Regenerate with:
+          #   grep -L 'init\.sh' tests/test-*.sh | sort
+          tests=(
+            tests/test-bl032-gitlab-free-approvals-attestation.sh
+            tests/test-bl046-helpers-split.sh
+            tests/test-bl069-install-cmds-consumers.sh
+            tests/test-bl073-review-manifest-gate.sh
+            tests/test-bypass-audit-integrity.sh
+            tests/test-bypass-audit-lib.sh
+            tests/test-bypass-audit-tmp-hardening.sh
+            tests/test-bypass-audit-trap-isolation.sh
+            tests/test-bypass-detector-session-id.sh
+            tests/test-bypass-detector.sh
+            tests/test-bypass-patterns.sh
+            tests/test-bypass-sentinel.sh
+            tests/test-check-changelog-filter.sh
+            tests/test-check-commit-message.sh
+            tests/test-check-gate.sh
+            tests/test-check-phase-gate-argv-parser.sh
+            tests/test-check-phase-gate-backstop-attestation.sh
+            tests/test-check-phase-gate-blame-walker.sh
+            tests/test-check-phase-gate-counter-sanitizer.sh
+            tests/test-check-phase-gate-date-writeback.sh
+            tests/test-check-phase-gate-noninteractive.sh
+            tests/test-check-phase-gate-retroactive-approval.sh
+            tests/test-check-phase-gate-self-approval.sh
+            tests/test-check-phase-gate.sh
+            tests/test-enforcement-level-lib.sh
+            tests/test-escalate-to-user.sh
+            tests/test-filesystem-gate-install.sh
+            tests/test-gate-principles.sh
+            tests/test-gitlab-ci-status-stderr-approvals.sh
+            tests/test-host-verify-protection-date-parse.sh
+            tests/test-lint-backlog-references.sh
+            tests/test-lint-counter-antipattern.sh
+            tests/test-lint-doc-anchors.sh
+            tests/test-lint-fix-functions-stderr.sh
+            tests/test-lint-raw-read-prompt.sh
+            tests/test-lint-tests-registered.sh
+            tests/test-lint-uat-scenarios.sh
+            tests/test-out-of-band-detector.sh
+            tests/test-pending-approval-resolve-decision.sh
+            tests/test-pending-approval.sh
+            tests/test-phase-finalize.sh
+            tests/test-phase3-validation-gate.sh
+            tests/test-pre-commit-gate-classifier.sh
+            tests/test-pre-commit-gate-lints.sh
+            tests/test-process-checklist-auto-advance.sh
+            tests/test-process-checklist-check-commit-ready-subject.sh
+            tests/test-process-checklist-classifier.sh
+            tests/test-process-checklist-reset-phase1.sh
+            tests/test-record-claude-commit.sh
+            tests/test-session-test-gate-check-merge.sh
+            tests/test-specs-plans-remaining-quartet.sh
+            tests/test-test-gate-counter-sanitizer.sh
+            tests/test-test-gate-null-handling.sh
+            tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
+            tests/test-unrecord-feature.sh
+            tests/test-upgrade-cdf-refresh.sh
+            tests/test-upgrade-interruption.sh
+            tests/test-upgrade-manifest-refresh.sh
+            tests/test-upgrade-non-interactive.sh
+            tests/test-upgrade-project-atomic.sh
+            tests/test-upgrade-sentinel-block.sh
+            tests/test-upgrade-to-production-preconditions.sh
+            tests/test-upgrade-to-production-warn.sh
+            tests/test-validate-counter-sanitizer.sh
+            tests/test-validate-phase-2-3-gate.sh
+            tests/test-validate-phase-state-gates.sh
+          )
+
+          failed=()
+          for t in "${tests[@]}"; do
+            echo "::group::${t}"
+            if bash "${t}"; then
+              echo "PASS ${t}"
+            else
+              rc=$?
+              echo "FAIL ${t} (rc=${rc})"
+              failed+=("${t}")
+            fi
+            echo "::endgroup::"
+          done
+
+          echo ""
+          echo "==================================================================="
+          echo "Ran ${#tests[@]} unit test file(s); ${#failed[@]} failed."
+          if [ "${#failed[@]}" -ne 0 ]; then
+            echo "Failed: ${failed[*]}"
+            exit 1
+          fi
+          echo "All unit tests passed."
+
+  # ── Slow lane ──────────────────────────────────────────────────────────
+  # The complete ~1-hour suite. Nightly + manual only, never on push/PR.
+  full:
+    name: full
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Verify required tools are available
+        run: jq --version && git --version
+
+      - name: Run full project test suite
+        # SKIP_KNOWN_FAILING is intentionally left unset -> defaults to 0
+        # inside the suite, so known-RED guard tests still execute in CI.
+        run: bash tests/full-project-test-suite.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@
 #                         so a new orphan test cannot silently join CI —
 #                         add new entries deliberately.
 #
-#   * full (slow lane)  — nightly schedule + manual dispatch only. Runs the
+#   * full (slow lane)  — MANUAL dispatch only (workflow_dispatch); no nightly. Runs the
 #                         complete tests/full-project-test-suite.sh, which
 #                         honors the SKIP_KNOWN_FAILING env (left at its
 #                         default of 0 so known-RED guards still run).
@@ -33,10 +33,7 @@ on:
   push:
     branches: [main]   # fast lane on main pushes; PRs covered by pull_request
   pull_request:
-  schedule:
-    # Nightly at 08:00 UTC.
-    - cron: '0 8 * * *'
-  workflow_dispatch:
+  workflow_dispatch:   # the full lane is manual-only (no scheduled nightly)
 
 jobs:
   # ── Fast lane ──────────────────────────────────────────────────────────
@@ -174,12 +171,16 @@ jobs:
   #   • edge-pre-init — tests/edge-cases-pre-init.sh   (68 scaffolds)
   #   • edge-scripts  — tests/edge-cases-scripts.sh    (41 scaffolds)
   #   • aggregators   — the remaining lighter aggregators, run directly.
-  # Union of shards == the un-sharded suite. Nightly + manual only.
+  # Union of shards == the un-sharded suite. Manual dispatch only (no nightly).
   full:
     name: full (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 45
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    # Manual-only comprehensive sweep. The full suite is a ~3h monolith
+    # (200+ init.sh scaffolds); it is NOT scheduled. Sharded for parallelism +
+    # failure isolation, but `core` is still the ~3h long pole. Making it
+    # CI-fast is deferred (backlog). Give core room to finish.
+    timeout-minutes: 180
+    if: github.event_name == 'workflow_dispatch'
     strategy:
       fail-fast: false
       matrix:
@@ -190,8 +191,14 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Verify required tools are available
-        run: jq --version && git --version
+      - name: Verify tools + configure git identity for scaffolds
+        # init.sh / upgrade-project.sh run `git commit` while scaffolding a
+        # project; a fresh CI runner has no git identity, so the commit fails
+        # (rc=128, "empty ident name not allowed"). Configure one.
+        run: |
+          jq --version && git --version
+          git config --global user.name "solo-orchestrator-ci"
+          git config --global user.email "ci@solo-orchestrator.invalid"
 
       - name: Run shard — ${{ matrix.shard }}
         # SKIP_KNOWN_FAILING left unset -> 0, so known-RED guards still run.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -162,21 +162,66 @@ jobs:
           fi
           echo "All unit tests passed."
 
-  # ── Slow lane ──────────────────────────────────────────────────────────
-  # The complete ~1-hour suite. Nightly + manual only, never on push/PR.
+  # ── Slow lane (sharded) ────────────────────────────────────────────────
+  # Serial, the full suite is ~1h — dominated by ~140 sequential init.sh
+  # project scaffolds concentrated in a few heavy aggregators
+  # (edge-cases-pre-init: 68, edge-cases-scripts: 41). BL-077 splits it into
+  # parallel shards so wall-clock is the slowest single shard (~20 min), not
+  # the sum. Coverage is identical to the un-sharded suite:
+  #   • core          — master suite with the heavy aggregators skipped
+  #                     (SUITE_SKIP_AGGREGATORS=1); still runs TEST 0-8, the
+  #                     inline cohorts, and the fast host-drivers aggregator.
+  #   • edge-pre-init — tests/edge-cases-pre-init.sh   (68 scaffolds)
+  #   • edge-scripts  — tests/edge-cases-scripts.sh    (41 scaffolds)
+  #   • aggregators   — the remaining lighter aggregators, run directly.
+  # Union of shards == the un-sharded suite. Nightly + manual only.
   full:
-    name: full
+    name: full (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 45
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [core, edge-pre-init, edge-scripts, aggregators]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Verify required tools are available
         run: jq --version && git --version
 
-      - name: Run full project test suite
-        # SKIP_KNOWN_FAILING is intentionally left unset -> defaults to 0
-        # inside the suite, so known-RED guard tests still execute in CI.
-        run: bash tests/full-project-test-suite.sh
+      - name: Run shard — ${{ matrix.shard }}
+        # SKIP_KNOWN_FAILING left unset -> 0, so known-RED guards still run.
+        env:
+          SHARD: ${{ matrix.shard }}
+        run: |
+          set -uo pipefail
+          case "$SHARD" in
+            core)
+              SUITE_SKIP_AGGREGATORS=1 bash tests/full-project-test-suite.sh
+              ;;
+            edge-pre-init)
+              bash tests/edge-cases-pre-init.sh
+              ;;
+            edge-scripts)
+              bash tests/edge-cases-scripts.sh
+              ;;
+            aggregators)
+              rc=0
+              for t in tests/edge-cases-upgrade-input.sh \
+                       tests/edge-case-test-suite.sh \
+                       tests/known-bugs-test-suite.sh \
+                       tests/upgrade-path-tests.sh; do
+                echo "::group::${t}"
+                if bash "${t}"; then echo "PASS ${t}"; else echo "FAIL ${t}"; rc=1; fi
+                echo "::endgroup::"
+              done
+              exit "$rc"
+              ;;
+            *)
+              echo "unknown shard: $SHARD" >&2; exit 1
+              ;;
+          esac

--- a/scripts/lint-no-live-remote-in-tests.sh
+++ b/scripts/lint-no-live-remote-in-tests.sh
@@ -145,9 +145,11 @@ scan_file() {
     file_is_mock=1
   fi
 
-  local var_alt="" v
+  local var_alt="" init_var_names="" v
   while IFS= read -r v; do
-    [ -n "$v" ] && var_alt="${var_alt:+$var_alt|}$v"
+    [ -n "$v" ] || continue
+    var_alt="${var_alt:+$var_alt|}$v"
+    init_var_names="${init_var_names:+$init_var_names }$v"
   done < <(collect_init_vars "$file")
   [ -n "$var_alt" ] || var_alt="__NO_INIT_VAR__"
 
@@ -176,6 +178,25 @@ scan_file() {
     # Pure-comment logical line? skip.
     local trimmed="${buf#"${buf%%[![:space:]]*}"}"
     case "$trimmed" in '#'*) continue ;; esac
+
+    # Pure-bash pre-filter (PERF, zero subprocess): a logical line can be an
+    # init EXECUTION only if it names init.sh literally or references one of
+    # this file's init-path vars ($INIT / $INIT_SH / ...). Both patterns in
+    # line_is_init_exec require one of those tokens, so skipping lines that
+    # contain neither is behavior-preserving — it only avoids spawning the
+    # per-line printf|grep pair for the ~99% of lines that can never match.
+    # Without this gate the full-tree scan spawns thousands of subprocesses
+    # (~100s wall — too slow for the pre-commit gate); with it, a few seconds.
+    local _maybe=0 _iv
+    case "$buf" in *init.sh*) _maybe=1 ;; esac
+    if [ "$_maybe" -eq 0 ] && [ -n "$init_var_names" ]; then
+      for _iv in $init_var_names; do
+        case "$buf" in
+          *"\$$_iv"*|*"\${$_iv}"*) _maybe=1; break ;;
+        esac
+      done
+    fi
+    [ "$_maybe" -eq 1 ] || continue
 
     # Only classify genuine init.sh EXECUTIONS.
     line_is_init_exec "$buf" "$var_alt" || continue

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -69,7 +69,7 @@ if [ "$TERMINAL_MODE" -eq 1 ]; then
   #   - raw-read-prompt            (cycle-8 wave-3 slot-5, this PR)
   # SKIP_LINT=1 escape mirrors the PreToolUse path.
   if [ "${SKIP_LINT:-0}" = "1" ]; then
-    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing all four pre-commit lints (counter-antipattern, backlog-references, fix-functions-stderr, raw-read-prompt)" >&2
+    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing all pre-commit lints (counter-antipattern, backlog-references, fix-functions-stderr, raw-read-prompt, tests-registered, no-live-remote-in-tests)" >&2
   else
     # Counter-antipattern: prefer project-local copy (framework installs
     # the script alongside pre-commit-gate.sh in scripts/), fall back to
@@ -148,6 +148,27 @@ if [ "$TERMINAL_MODE" -eq 1 ]; then
       if ! tr_out=$(bash "$TR_LINT" 2>&1); then
         echo "[FRAMEWORK GATE — strict mode] tests-registered lint failed:" >&2
         echo "$tr_out" >&2
+        echo "" >&2
+        echo "To bypass anyway:  SKIP_LINT=1 git commit ..." >&2
+        exit 1
+      fi
+    fi
+
+    # no-live-remote-in-tests (BL-076): every init.sh run under tests/ must be
+    # provably hermetic (--no-remote-creation / --dry-run / --validate-only /
+    # --git-host other, or a mocked host CLI) so the suite can never create a
+    # REAL repo on an authenticated host (the kraulerson/foo leak, 2026-07-06).
+    # Full-tree scan, no message dependency. See
+    # scripts/lint-no-live-remote-in-tests.sh header.
+    NR_LINT=""
+    for cand in "$PROJECT_ROOT/scripts/lint-no-live-remote-in-tests.sh" \
+                "$SCRIPT_DIR/lint-no-live-remote-in-tests.sh"; do
+      [ -f "$cand" ] && { NR_LINT="$cand"; break; }
+    done
+    if [ -n "$NR_LINT" ]; then
+      if ! nr_out=$(bash "$NR_LINT" 2>&1); then
+        echo "[FRAMEWORK GATE — strict mode] no-live-remote-in-tests lint failed:" >&2
+        echo "$nr_out" >&2
         echo "" >&2
         echo "To bypass anyway:  SKIP_LINT=1 git commit ..." >&2
         exit 1
@@ -512,7 +533,7 @@ lints_check() {
 
   # Escape hatch.
   if [ "${SKIP_LINT:-0}" = "1" ]; then
-    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing counter-antipattern + backlog-references + fix-functions-stderr + raw-read-prompt + tests-registered lints" >&2
+    echo "[pre-commit-gate] SKIP_LINT=1 set — bypassing counter-antipattern + backlog-references + fix-functions-stderr + raw-read-prompt + tests-registered + no-live-remote-in-tests lints" >&2
     return 0
   fi
 
@@ -522,7 +543,7 @@ lints_check() {
   # still self-checks when run from the framework repo's own working
   # tree. Project root = `git rev-parse --show-toplevel` from the
   # current cwd, since Claude Code invokes the hook from the project.
-  local proj_root ca_lint="" br_lint="" ff_lint="" rr_lint="" tr_lint=""
+  local proj_root ca_lint="" br_lint="" ff_lint="" rr_lint="" tr_lint="" nr_lint=""
   proj_root=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
   for cand in "$proj_root/scripts/lint-counter-antipattern.sh" \
               "$SCRIPT_DIR/lint-counter-antipattern.sh"; do
@@ -543,6 +564,10 @@ lints_check() {
   for cand in "$proj_root/scripts/lint-tests-registered.sh" \
               "$SCRIPT_DIR/lint-tests-registered.sh"; do
     [ -n "$cand" ] && [ -f "$cand" ] && { tr_lint="$cand"; break; }
+  done
+  for cand in "$proj_root/scripts/lint-no-live-remote-in-tests.sh" \
+              "$SCRIPT_DIR/lint-no-live-remote-in-tests.sh"; do
+    [ -n "$cand" ] && [ -f "$cand" ] && { nr_lint="$cand"; break; }
   done
 
   # Counter-antipattern: full repo-relative scan, fast.
@@ -594,6 +619,17 @@ lints_check() {
     tr_out=$(bash "$tr_lint" 2>&1) || tr_exit=$?
     if [ "$tr_exit" -ne 0 ]; then
       emit_lint_block "pre-commit gate: scripts/lint-tests-registered.sh failed. ${tr_out} Register the test in tests/full-project-test-suite.sh (or another aggregator) following the BL-034 cohort pattern, or add '# LINT_TEST_REGISTRATION_EXEMPT: <reason>' to the file header. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
+    fi
+  fi
+
+  # no-live-remote-in-tests (BL-076): every init.sh run under tests/ must be
+  # provably hermetic so the suite can never create a REAL repo on an
+  # authenticated host. Full repo-relative scan.
+  if [ -n "$nr_lint" ]; then
+    local nr_out nr_exit=0
+    nr_out=$(bash "$nr_lint" 2>&1) || nr_exit=$?
+    if [ "$nr_exit" -ne 0 ]; then
+      emit_lint_block "pre-commit gate: scripts/lint-no-live-remote-in-tests.sh failed. ${nr_out} Make the init.sh run hermetic — add --no-remote-creation (or --git-host other + a fake --remote-url, or route gh/glab/curl through a mocked CLI). Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency (logged to .claude/bypass-audit.json)."
     fi
   fi
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -795,6 +795,12 @@ fi
 # All three are gated together because they share BL-034 status.
 # Known-RED siblings are gated on SKIP_KNOWN_FAILING so a local
 # iteration loop can mask them; default = surface the failure.
+# SUITE_SKIP_AGGREGATORS: CI shards these heavy aggregators into separate
+# parallel jobs (BL-077 full-lane sharding). When set, skip them here so the
+# "core" shard doesn't re-run them; a standalone run (env unset) runs everything.
+if [ "${SUITE_SKIP_AGGREGATORS:-0}" = "1" ]; then
+  section "Edge-cases aggregators — SKIPPED (SUITE_SKIP_AGGREGATORS=1; run as separate CI shards)"
+else
 section "Edge-cases aggregators (pre-init, scripts, upgrade-input)"
 if bash "$SCRIPT_DIR/tests/edge-cases-pre-init.sh" >/dev/null 2>&1; then
   pass "tests/edge-cases-pre-init.sh"
@@ -810,6 +816,7 @@ if bash "$SCRIPT_DIR/tests/edge-cases-upgrade-input.sh" >/dev/null 2>&1; then
   pass "tests/edge-cases-upgrade-input.sh"
 else
   fail "tests/edge-cases-upgrade-input.sh FAILED (run for details)"
+fi
 fi
 
 # ----------------------------------------------------------------
@@ -2051,6 +2058,9 @@ done
 # correctness and tracked with the master suite's own runtime under
 # BL-045 (TEST 1 matrix parallelization) / BL-077 (CI-runnability). It
 # stays wired here regardless.
+if [ "${SUITE_SKIP_AGGREGATORS:-0}" = "1" ]; then
+  section "BL-052 aggregators — SKIPPED (SUITE_SKIP_AGGREGATORS=1; run as separate CI shards)"
+else
 section "BL-052: previously-un-invoked aggregators (edge-case / known-bugs / upgrade-path)"
 
 if bash "$SCRIPT_DIR/tests/edge-case-test-suite.sh" >/dev/null 2>&1; then
@@ -2069,6 +2079,7 @@ if bash "$SCRIPT_DIR/tests/upgrade-path-tests.sh" >/dev/null 2>&1; then
   pass "tests/upgrade-path-tests.sh (track/deployment/POC upgrade + strict-superset no-regression)"
 else
   fail "tests/upgrade-path-tests.sh FAILED (run tests/upgrade-path-tests.sh for details)"
+fi
 fi
 # --- end BL-052 aggregator wiring ---
 

--- a/tests/test-bypass-audit-tmp-hardening.sh
+++ b/tests/test-bypass-audit-tmp-hardening.sh
@@ -50,8 +50,8 @@ echo "T1: 0640 audit file keeps 0640 after append"
 setup
 chmod 640 "$PROJ/.claude/bypass-audit.json"
 ( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
-mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
-     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+mode=$(stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
 if [ "$mode" = "640" ]; then
   pass "T1: post-append mode preserved (was 640, is $mode)"
 else
@@ -65,8 +65,8 @@ setup
 ( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
 chmod 640 "$PROJ/.claude/bypass-audit.json"
 ( source "$LIB" && bypass_audit_close_pending "$PROJ" "accept" >/dev/null 2>&1 )
-mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
-     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+mode=$(stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
 if [ "$mode" = "640" ]; then
   pass "T2: post-close_pending mode preserved"
 else
@@ -85,8 +85,8 @@ chmod 644 "$PROJ/.claude/bypass-audit.json"  # simulate a permissive prior
 # Touch fresh, simulating no operator override:
 rm -f "$PROJ/.claude/bypass-audit.json"
 ( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
-mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
-     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+mode=$(stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
 # When bypass_audit_init creates the file via `echo > file` it inherits
 # umask; the subsequent append's chmod-from-reference will then copy
 # that mode. So this test asserts the file is at most the mode the
@@ -100,11 +100,11 @@ mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
 teardown
 setup
 # Pre-state: file exists with init's umask-derived mode.
-pre_mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
-        || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+pre_mode=$(stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+        || stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
 ( source "$LIB" && bypass_audit_append "$PROJ" "$ROW" >/dev/null 2>&1 )
-post_mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
-         || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+post_mode=$(stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+         || stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
 if [ "$pre_mode" = "$post_mode" ]; then
   pass "T3: append preserves the pre-existing mode ($pre_mode unchanged)"
 else

--- a/tests/test-bypass-audit-trap-isolation.sh
+++ b/tests/test-bypass-audit-trap-isolation.sh
@@ -223,8 +223,8 @@ setup
 rm -f "$PROJ/.claude/bypass-audit.json"
 # Force a permissive umask so the bug (if any) is visible.
 ( umask 022; source "$LIB" && bypass_audit_init "$PROJ" )
-mode=$(stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
-     || stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+mode=$(stat -c "%a" "$PROJ/.claude/bypass-audit.json" 2>/dev/null \
+     || stat -f "%Lp" "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
 if [ "$mode" = "600" ]; then
   pass "T5: bypass_audit_init created file with mode 600 (was $mode)"
 else

--- a/tests/test-check-changelog-filter.sh
+++ b/tests/test-check-changelog-filter.sh
@@ -55,7 +55,10 @@ run_with_file() {
   # Run in strict mode so the script EXITs 1 on missing changelog (rather
   # than the GH-Actions warning-only default).
   local rc=0
-  ( cd "$TMP" && SOIF_STRICT_CHANGELOG=true bash "$REPO_ROOT/scripts/check-changelog.sh" >/dev/null 2>&1 ) || rc=$?
+  # GITHUB_BASE_REF= isolates this temp repo from CI/PR env: on a pull_request
+  # event check-changelog.sh would diff against origin/$GITHUB_BASE_REF (absent
+  # in this throwaway repo → empty diff → false pass). Force the HEAD~1..HEAD path.
+  ( cd "$TMP" && GITHUB_BASE_REF= SOIF_STRICT_CHANGELOG=true bash "$REPO_ROOT/scripts/check-changelog.sh" >/dev/null 2>&1 ) || rc=$?
   rm -rf "$TMP"
   echo "$rc"
 }

--- a/tests/test-specs-plans-remaining-quartet.sh
+++ b/tests/test-specs-plans-remaining-quartet.sh
@@ -209,7 +209,7 @@ setup_cv_fixture() {
       "languages": ["all"],
       "platforms": ["all"],
       "dev_os": ["darwin", "linux"],
-      "install": { "darwin_brew": "brew install claude-fake" }
+      "install": { "darwin_brew": "brew install claude-fake", "manual": "brew install claude-fake" }
     }
   ]
 }

--- a/tests/upgrade-path-tests.sh
+++ b/tests/upgrade-path-tests.sh
@@ -786,7 +786,7 @@ new_in_standard=0
 while IFS= read -r tool; do
   [ -z "$tool" ] && continue
   if ! echo "$names_light" | grep -qxF "$tool"; then
-    ((new_in_standard++))
+    new_in_standard=$((new_in_standard + 1))   # not ((x++)): returns 1 when x=0, tripping set -e on bash 5
   fi
 done <<< "$names_standard"
 
@@ -801,7 +801,7 @@ new_in_full=0
 while IFS= read -r tool; do
   [ -z "$tool" ] && continue
   if ! echo "$names_standard" | grep -qxF "$tool"; then
-    ((new_in_full++))
+    new_in_full=$((new_in_full + 1))   # not ((x++)): returns 1 when x=0, tripping set -e on bash 5
   fi
 done <<< "$names_full"
 


### PR DESCRIPTION
Ships the "make the test suite real in CI" work (Tier-1).

## BL-076 — hermeticity guard
- Pre-commit + CI lint (`lint-no-live-remote-in-tests.sh`) that fails if any test can run `init.sh` in a shape that creates a REAL remote repo (the `kraulerson/foo` leak class). Wired into the pre-commit gate + made gate-fast (102s→3s). Double-mutation verified.

## BL-077 — automated testing in CI (was: lint-only)
- **Fast lane (`unit`)** — 66 unit test files (no init scaffolds), on every push to `main` + every PR. **~4 min, green on Linux.** This is the real per-push gate.
- **Full lane (`full`)** — the comprehensive suite is a ~3h monolith (200+ init.sh scaffolds), so it is **manual-dispatch only** (no scheduled nightly). Sharded into 4 parallel jobs for isolation. Making it CI-fast is deferred (needs core-splitting / init.sh speedup / de-flaking) — filed as a follow-up.

## Linux-portability fixes surfaced by validation
- `stat -f`→GNU-first in bypass-audit tests
- git identity configured on the runner (init.sh commits during scaffolds; rc=128 otherwise)
- `((x++))` → `x=$((x+1))` set -e footgun (returns 1 at x=0 on bash 5) in upgrade-path-tests.sh
- T-CV-MULTIWORD host-OS-hermetic (brew fixture)

Fast lane validated green on GitHub Linux across multiple runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)