### PR TITLE
feat(phase3): bind validation summary to tree hash + staleness re-run (BL-082)

### DIFF
--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1280,6 +1280,23 @@ fi
 # per tests/test-phase3-validation-gate.sh::T-mutation). Auto-run marked
 # `# BL-070-GATE-AUTORUN`. Attestation predicate marked
 # `# BL-070-ATTEST-PREDICATE`.
+#
+# BL-082 (2026-07-09): the summary is bound to the tree it validated. A summary
+# is FRESH only if its recorded `tree:` line is present, ≠ `none`, EQUALS the
+# current `git rev-parse HEAD^{tree}`, its recorded `dirty:` is `no`, AND the
+# live SCOPED working tree is clean (HEAD^{tree} alone misses uncommitted edits
+# — a clean-tree summary must not stay trusted while source is edited). Any
+# other state → STALE: print `[STALE]`, regenerate offline via the
+# `# BL-070-GATE-AUTORUN` path, and evaluate the FRESH summary in a single pass;
+# if regeneration is impossible (SOLO_PHASE3_GATE_NOAUTORUN=1 or driver
+# missing/non-executable) STALE = gate FAIL (never silently accept a stale
+# summary). Pre-BL-082 summaries have no `tree:` line → STALE (backward compat).
+# The freshness decision line is marked `# BL-082-STALENESS` (mutation target).
+# The scoped dirty check (# BL-082-STALENESS in _cpg_scoped_dirty) EXCLUDES
+# `.claude/` and the results dir because the gate itself writes the BL-071 gate
+# date into .claude/phase-state.json on PASS (line ~374) and that file is
+# TRACKED downstream — an UNSCOPED check would mark every summary permanently
+# stale after its first PASS (self-defeating).
 
 # _cpg_phase3_attested <scanner>
 # 0 iff phase-state.json::phase3.attestations.<scanner> carries a non-empty
@@ -1297,32 +1314,120 @@ _cpg_phase3_attested() {
   [ -n "$reason" ] && [ "$reason" != "null" ] && [ -n "$signoff" ] && [ "$signoff" != "null" ]
 }
 
+# _cpg_scoped_dirty <results_dir> — echo "yes"/"no". Scoped `git status
+# --porcelain` that EXCLUDES the framework's own write surfaces so a summary is
+# not marked permanently stale by the very writes the gate makes on PASS.
+# BL-082-STALENESS: excludes `.claude/` (the gate writes the BL-071 gate date +
+# the driver writes attestations into phase-state.json, TRACKED downstream) and
+# the results dir. Absolute/parent-relative results dirs are outside the
+# porcelain scope already → exclusion skipped. Not a git repo → conservative
+# "yes". Kept textually identical to _p3_scoped_dirty in
+# scripts/run-phase3-validation.sh.
+_cpg_scoped_dirty() {
+  local rdir out
+  rdir="${1:-}"
+  rdir="${rdir#./}"
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "yes"; return 0
+  fi
+  case "$rdir" in
+    ""|/*|../*|..)
+      out=$(git status --porcelain -- . ':(exclude).claude' 2>/dev/null || true) ;;
+    *)
+      out=$(git status --porcelain -- . ':(exclude).claude' ":(exclude)$rdir" 2>/dev/null || true) ;;
+  esac
+  if [ -n "$out" ]; then echo "yes"; else echo "no"; fi
+  return 0
+}
+
+# _cpg_phase3_freshness <summary> <results_dir> — echo "fresh" or
+# "stale:<reason>". FRESH iff the summary recorded a real tree that EQUALS the
+# current HEAD^{tree} AND recorded dirty=no AND the live scoped tree is clean.
+# HEAD^{tree} alone misses uncommitted edits, so the live scoped check is
+# required (Correction 2): a clean-tree summary must not stay trusted while
+# source is edited uncommitted. Pre-BL-082 summaries (no `tree:` line) → stale.
+# Always returns 0 (the verdict is the echoed string) so the gate's `set -e`
+# is not tripped by a "stale" result.
+_cpg_phase3_freshness() {
+  local summary rdir cur_tree rec_tree rec_dirty live_dirty
+  summary="$1"; rdir="$2"
+  cur_tree=$(git rev-parse "HEAD^{tree}" 2>/dev/null || echo none)
+  rec_tree=$(grep -m1 '^- tree:' "$summary" 2>/dev/null | sed 's/^- tree:[[:space:]]*//; s/[[:space:]]*$//' || true)
+  rec_dirty=$(grep -m1 '^- dirty:' "$summary" 2>/dev/null | sed 's/^- dirty:[[:space:]]*//; s/[[:space:]]*$//' || true)
+  live_dirty=$(_cpg_scoped_dirty "$rdir")
+  if [ -n "$rec_tree" ] && [ "$rec_tree" != "none" ] && [ "$rec_tree" = "$cur_tree" ] && [ "$rec_dirty" = "no" ] && [ "$live_dirty" = "no" ]; then
+    echo "fresh"; return 0
+  fi
+  if [ -z "$rec_tree" ]; then echo "stale:no tree provenance recorded (pre-BL-082 summary)"
+  elif [ "$rec_tree" = "none" ]; then echo "stale:summary was generated outside a git repo (tree: none)"
+  elif [ "$cur_tree" = "none" ]; then echo "stale:current tree unavailable (not a git repo)"
+  elif [ "$rec_tree" != "$cur_tree" ]; then echo "stale:the tree changed since this summary was generated"
+  elif [ "$rec_dirty" != "no" ]; then echo "stale:the summary was generated on a dirty working tree"
+  else echo "stale:there are uncommitted changes since this summary was generated"
+  fi
+  return 0
+}
+
 if [ "$current_phase" -ge 4 ]; then
   P3_RESULTS_DIR="docs/test-results/phase3"
   P3_DRIVER="$SCRIPT_DIR/run-phase3-validation.sh"
 
-  # AUTO-RUN (Karl: "evals should be automatic"). If no summary exists yet,
-  # generate a baseline offline summary so the attestation gate always has
-  # teeth (offline => hermetic/fast: NO network/Docker/semgrep run from the
-  # gate). Operators run `scripts/run-phase3-validation.sh` (no --offline)
-  # for REAL scans; a later increment can auto-run real scans in interactive
-  # sessions. Set SOLO_PHASE3_GATE_NOAUTORUN=1 to disable auto-generation
-  # (e.g. CI that pre-runs the driver, or a pure read-only inspection).
+  # Discover the newest existing summary.
   p3_summary=""
   if compgen -G "$P3_RESULTS_DIR/summary-*.md" >/dev/null 2>&1; then
     p3_summary=$(ls -1 "$P3_RESULTS_DIR"/summary-*.md 2>/dev/null | sort | tail -1)
   fi
-  if [ -z "$p3_summary" ] && [ -z "${SOLO_PHASE3_GATE_NOAUTORUN:-}" ] && [ -x "$P3_DRIVER" ]; then
-    bash "$P3_DRIVER" --offline >/dev/null 2>&1 || true   # BL-070-GATE-AUTORUN
-    if compgen -G "$P3_RESULTS_DIR/summary-*.md" >/dev/null 2>&1; then
-      p3_summary=$(ls -1 "$P3_RESULTS_DIR"/summary-*.md 2>/dev/null | sort | tail -1)
+
+  # BL-082 freshness: trust an existing summary only if it was generated
+  # against the CURRENT tree with a clean (scoped) working tree. The decision
+  # line below is the mutation target — excising every `# BL-082-STALENESS`
+  # line defaults p3_fresh to "fresh" and MUST make
+  # tests/test-phase3-validation-gate.sh::T-stale-norerun-fails go RED.
+  p3_stale=0
+  p3_stale_reason=""
+  p3_fresh="fresh"
+  if [ -n "$p3_summary" ]; then
+    p3_fresh=$(_cpg_phase3_freshness "$p3_summary" "$P3_RESULTS_DIR")   # BL-082-STALENESS
+    : # keep this then-branch non-empty so excising the marked line above stays valid
+  fi
+  case "$p3_fresh" in
+    fresh) p3_stale=0 ;;
+    *)     p3_stale=1; p3_stale_reason="${p3_fresh#stale:}" ;;
+  esac
+
+  # AUTO-RUN (Karl: "evals should be automatic"). Regenerate an offline
+  # baseline summary when NONE exists OR the existing one is STALE (offline =>
+  # hermetic/fast: NO network/Docker/semgrep run from the gate). Operators run
+  # `scripts/run-phase3-validation.sh` (no --offline) for REAL scans. A STALE
+  # summary prints an explicit [STALE] line, then we regenerate and evaluate
+  # the FRESH file in a SINGLE pass (no second staleness check — it was just
+  # written against the current tree). Set SOLO_PHASE3_GATE_NOAUTORUN=1 to
+  # disable auto-generation; then STALE = gate FAIL (never silently accept a
+  # stale summary).
+  if [ "$p3_stale" -eq 1 ]; then
+    echo -e "${BLUE}[STALE]${NC} Phase 3→4: ${p3_stale_reason} — the recorded validation summary no longer matches the working tree; regenerating."
+  fi
+  if [ -z "$p3_summary" ] || [ "$p3_stale" -eq 1 ]; then
+    if [ -z "${SOLO_PHASE3_GATE_NOAUTORUN:-}" ] && [ -x "$P3_DRIVER" ]; then
+      bash "$P3_DRIVER" --offline >/dev/null 2>&1 || true   # BL-070-GATE-AUTORUN
+      p3_summary=""
+      if compgen -G "$P3_RESULTS_DIR/summary-*.md" >/dev/null 2>&1; then
+        p3_summary=$(ls -1 "$P3_RESULTS_DIR"/summary-*.md 2>/dev/null | sort | tail -1)
+      fi
+      p3_stale=0   # freshly regenerated against the current tree → evaluate directly
     fi
   fi
 
   p3_block=0
   p3_msg=""
   p3_ok_detail=""
-  if [ -z "$p3_summary" ]; then
+  if [ "$p3_stale" -eq 1 ]; then
+    # STALE and regeneration was impossible (SOLO_PHASE3_GATE_NOAUTORUN=1 or
+    # the driver is missing/non-executable) — never silently accept a stale
+    # summary. Tell the operator to re-run the driver.
+    p3_block=1
+    p3_msg="Phase 3 validation summary is STALE (${p3_stale_reason}) and auto-regeneration is off/unavailable — re-run: bash scripts/run-phase3-validation.sh"
+  elif [ -z "$p3_summary" ]; then
     p3_block=1
     p3_msg="no Phase 3 validation summary (docs/test-results/phase3/summary-*.md) — run: bash scripts/run-phase3-validation.sh"
   else

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -33,6 +33,25 @@ set -uo pipefail
 #   every scanner is PASS or attested-skip-with-signoff (zero un-attested
 #   SKIPs, zero FAILs). See the `# BL-070-GATE-CHECK` block in that script.
 #
+# SUMMARY PROVENANCE — tree binding (BL-082, 2026-07-09)
+#   The summary header records the tree it validated so a stale summary cannot
+#   satisfy the gate forever:
+#       - tree: <git rev-parse HEAD^{tree}>   (or `none` outside a git repo)
+#       - dirty: yes|no                        (scoped working-tree state)
+#   `dirty` comes from a SCOPED `git status --porcelain` that EXCLUDES the
+#   framework's OWN write surfaces — `.claude/` (this driver writes
+#   attestations, and check-phase-gate.sh writes the BL-071 gate date, into
+#   .claude/phase-state.json, which is TRACKED in downstream projects — the
+#   generated .gitignore covers `test-results/` but not `.claude/`) and the
+#   --results-dir (where this summary + scan archives land). WHY the scoping
+#   (Karl-approved correction, 2026-07-09): an UNSCOPED dirty check would read
+#   the tree as dirty the instant the gate writes phase-state.json on its first
+#   PASS, marking every summary permanently stale (self-defeating; with
+#   SOLO_PHASE3_GATE_NOAUTORUN=1 it bricks the gate). check-phase-gate.sh
+#   re-checks freshness against the CURRENT tree AND live scoped porcelain and
+#   regenerates when stale. Pre-BL-082 summaries have no `tree:` line and are
+#   treated as STALE (backward compat).
+#
 # USAGE
 #   bash scripts/run-phase3-validation.sh [--offline] [--results-dir DIR]
 #                                         [--state FILE]
@@ -166,6 +185,34 @@ done
 
 _p3_is_registered() {
   case " $P3_SCANNERS " in *" $1 "*) return 0 ;; *) return 1 ;; esac
+}
+
+# ── BL-082 summary provenance ────────────────────────────────────────
+# _p3_scoped_dirty <results_dir> — echo "yes" when the working tree has
+# changes OUTSIDE the framework's own write surfaces, else "no".
+# BL-082-STALENESS: the scoped porcelain EXCLUDES `.claude/` (this driver + the
+# gate write phase-state.json there, and it is TRACKED downstream) and the
+# results dir (this summary + scan archives), so a summary is not marked
+# permanently stale by the very writes the gate makes on PASS. An absolute or
+# parent-relative results dir is outside the porcelain scope already, so its
+# exclusion is skipped (a repo-external path never appears in porcelain). Not a
+# git repo / git error → conservative "yes". Kept textually identical to
+# _cpg_scoped_dirty in scripts/check-phase-gate.sh.
+_p3_scoped_dirty() {
+  local rdir out
+  rdir="${1:-}"
+  rdir="${rdir#./}"
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "yes"; return 0
+  fi
+  case "$rdir" in
+    ""|/*|../*|..)
+      out=$(git status --porcelain -- . ':(exclude).claude' 2>/dev/null || true) ;;
+    *)
+      out=$(git status --porcelain -- . ':(exclude).claude' ":(exclude)$rdir" 2>/dev/null || true) ;;
+  esac
+  if [ -n "$out" ]; then echo "yes"; else echo "no"; fi
+  return 0
 }
 
 # ── Identity / attestation helpers ───────────────────────────────────
@@ -415,6 +462,13 @@ TS=$(date -u +"%Y-%m-%dT%H-%M-%SZ")
 GEN=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 SUMMARY="$RESULTS_DIR/summary-${TS}.md"
 
+# BL-082: bind the summary to the tree it validated (see header). `dirty` is
+# computed BEFORE the summary/archives are written into RESULTS_DIR, and the
+# scoped check excludes RESULTS_DIR + .claude anyway, so recording it here does
+# not race with this run's own writes.
+P3_TREE=$(git rev-parse "HEAD^{tree}" 2>/dev/null || echo none)
+P3_DIRTY=$(_p3_scoped_dirty "$RESULTS_DIR")
+
 echo -e "${BOLD}Phase 3 validation scans${NC}"
 [ -n "$OFFLINE" ] && echo -e "${BLUE}[INFO]${NC} offline mode — real-execution scanners will SKIP (no network/Docker/semgrep run)."
 
@@ -471,6 +525,8 @@ fi
   echo "# Phase 3 Validation Summary"
   echo ""
   echo "- Generated: ${GEN}"
+  echo "- tree: ${P3_TREE}"
+  echo "- dirty: ${P3_DIRTY}"
   echo "- Offline: $([ -n "$OFFLINE" ] && echo yes || echo no)"
   echo "- Scanners: $(echo $P3_SCANNERS | wc -w | tr -d ' ')"
   echo "- PASS: ${n_pass}  SKIP(attested): ${n_skip_attested}  SKIP(un-attested): ${n_skip_unattested}  FAIL: ${n_fail}"

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -2124,11 +2124,13 @@ Sibling of [[bl080-backfill-honors-sentinel]]. On the FULL `upgrade-project.sh` 
 **Logged:** 2026-07-06 (BL-070 verifier follow-up)
 **Category:** Debt / gate hardening
 **Severity:** Low
-**Status:** Open
+**Status:** Closed — shipped 2026-07-09 (PR #160). The Phase-3 summary is bound to the tree it validated; the gate re-runs (or FAILs) when stale.
 
 Sibling of [[bl070-phase-3-validation-scans]] (PR #145). The BL-070 skeleton's Phase 3→4 gate trusts an existing `docs/test-results/phase3/summary-*.md` as-is: the auto-run only fires when NO summary exists, so a stale summary (e.g. an old `semgrep-full-tree PASS`) is reused indefinitely, and a hand-forged all-PASS summary is trusted. The verifier noted forgery is outside a self-audit gate's threat model (a determined operator has easier documented escapes), but staleness is a real limitation — a summary from before the latest code changes should not satisfy the gate.
 
 **Scope:** bind the summary to the tree/commit it validated — record the `git rev-parse HEAD` (or a tree hash) in the summary and have the gate re-run (or FAIL-with-stale) when the current tree differs from the recorded one. Optionally add an authenticity marker. Ships as a later increment on top of the BL-070 skeleton, alongside promoting the stubbed scanners (license/snyk/zap/threat-model) to real.
+
+**Resolution (PR #160, 2026-07-09):** the driver (`scripts/run-phase3-validation.sh`) records `- tree: <git rev-parse HEAD^{tree}>` (or `none`) and `- dirty: yes|no` in the summary header; the gate (`scripts/check-phase-gate.sh`) treats a summary as FRESH only if the recorded tree matches the current `HEAD^{tree}`, recorded `dirty:no`, AND the live scoped working tree is clean — else it prints `[STALE]`, regenerates offline, and evaluates the fresh summary in one pass (or FAILs when `SOLO_PHASE3_GATE_NOAUTORUN=1`/driver unavailable). Two Karl-approved corrections (2026-07-09) supersede the handoff's WP-A design: **(1)** the dirty check is SCOPED — `git status --porcelain -- . ':(exclude).claude' ':(exclude)<RESULTS_DIR>'` — because the gate writes `.claude/phase-state.json` on PASS (BL-071) and the driver writes attestations there, and that file is TRACKED downstream, so an unscoped check would mark every summary permanently stale after its first PASS; **(2)** the gate ALSO checks live worktree dirtiness (not just the recorded flag), since `HEAD^{tree}` misses uncommitted edits. Freshness decision marked `# BL-082-STALENESS` (mutation target). Suite `tests/test-phase3-validation-gate.sh` extended to 42 tests (git-repo fixtures + 8 new BL-082 cases incl. the two-correction pins) with an excise-and-restore mutation proof (RED 31/10 -> GREEN 42/0).
 
 **Related:** [[bl070-phase-3-validation-scans]] (PR #145 skeleton); `scripts/run-phase3-validation.sh`; `scripts/check-phase-gate.sh` Phase 3→4 block.
 

--- a/tests/test-phase3-validation-gate.sh
+++ b/tests/test-phase3-validation-gate.sh
@@ -35,6 +35,28 @@
 #                                enforcement is load-bearing: remove it → the
 #                                blocking test goes RED).
 #
+# BL-082 staleness binding (2026-07-09) — the gate trusts a summary only if it
+# was generated against the CURRENT tree with a clean (scoped) working tree.
+# Fixtures are REAL git repos (setup() git-inits + commits); write_summary_*
+# stamp a matching `tree:` + `dirty: no` so the pre-existing cases keep testing
+# trusted-summary paths. Added:
+#   T-fresh-trusted          matching tree + clean → gate does NOT re-run the
+#                            driver (asserted via a counting mock driver).
+#   T-stale-rerun            2nd commit advances HEAD^{tree} → old summary
+#                            superseded; the gate regenerates + evaluates fresh.
+#   T-stale-norerun-fails    SOLO_PHASE3_GATE_NOAUTORUN=1 + stale → gate FAIL,
+#                            rc=1, actionable re-run message. (Flipped RED by
+#                            the BL-082-STALENESS mutation.)
+#   T-dirty-tree-stale       summary recorded `dirty: yes` → stale path.
+#   T-pre-bl082-summary-stale  summary with NO `tree:` line → stale path.
+#   T-stateflip-not-dirty    (Correction 1) modify ONLY .claude/phase-state.json
+#                            uncommitted → still FRESH, no re-run.
+#   T-live-dirty-stale       (Correction 2) uncommitted SOURCE edit → stale even
+#                            though HEAD^{tree} still matches.
+#   T-bl082-mutation         excise `# BL-082-STALENESS` → T-stale-norerun-fails
+#                            goes RED (staleness defeated → stale all-PASS
+#                            summary trusted); restore → GREEN.
+#
 # HERMETIC: scanners are never run for real — the driver is always invoked
 # with --offline, so no network / Docker / semgrep / gh. bash-3.2 safe.
 
@@ -86,55 +108,161 @@ setup() {
 |---|---|
 | **Date** | 2026-04-01 |
 MD
+  # BL-082: fixtures must be REAL git repos — the gate now binds the summary to
+  # HEAD^{tree}. Make PROJ a git repo with an initial commit so a matching
+  # `tree:` line renders a seeded summary FRESH (mirrors that
+  # .claude/phase-state.json is tracked in downstream projects). Without this
+  # every seeded summary would resolve to `tree: none` / mismatched → always
+  # stale, and these cases could no longer exercise the trusted-summary paths.
+  (
+    cd "$PROJ" || exit 1
+    unset GITHUB_BASE_REF
+    git init -q
+    git config user.name "Test"
+    git config user.email "test@example.com"
+    git config commit.gpgsign false
+    git add -A
+    git commit -q -m "init fixture" >/dev/null 2>&1
+  )
 }
 teardown() { rm -rf "$TMP"; }
 
-# Pre-create a summary whose five scanners are all SKIP (the driver's
-# machine-readable RESULT contract). Only the RESULT lines are load-bearing
-# for the gate parser.
-write_summary_all_skip() {
-  mkdir -p "$PROJ/docs/test-results/phase3"
-  cat > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md" <<'MD'
-# Phase 3 Validation Summary
-- Overall: FAIL
+# Current tree of the PROJ fixture repo (empty if not a git repo).
+proj_tree() { ( cd "$PROJ" && git rev-parse "HEAD^{tree}" 2>/dev/null ); }
 
-## Machine-readable results
-```
-RESULT semgrep-full-tree SKIP
-RESULT license SKIP
-RESULT snyk SKIP
-RESULT zap-dast SKIP
-RESULT threat-model SKIP
-```
-MD
+# Add a second commit so HEAD^{tree} advances → any summary bound to the
+# earlier tree becomes STALE (tree-mismatch path).
+proj_advance_tree() {
+  ( cd "$PROJ" && echo "change-$RANDOM" > src-change.txt && git add -A && git commit -q -m "advance" >/dev/null 2>&1 )
 }
 
-# semgrep reports a FAIL finding; the other four SKIP. Used to exercise the
-# gate's FAIL arm in isolation (attest the four skips so the ONLY blocker is
-# the FAIL status).
-write_summary_semgrep_fail() {
+# _write_summary <tree> <dirty> <newline-separated RESULT lines> — write a
+# summary in the BL-082 format. Pass tree="" / omit the `- tree:` line via
+# _write_summary_legacy for the pre-BL-082 backward-compat case.
+_write_summary() {
+  local tree="$1" dirty="$2" body="$3"
   mkdir -p "$PROJ/docs/test-results/phase3"
-  cat > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md" <<'MD'
-# Phase 3 Validation Summary
-RESULT semgrep-full-tree FAIL
+  {
+    echo "# Phase 3 Validation Summary"
+    echo "- tree: ${tree}"
+    echo "- dirty: ${dirty}"
+    echo "- Overall: FAIL"
+    echo ""
+    echo "## Machine-readable results"
+    echo '```'
+    printf '%s\n' "$body"
+    echo '```'
+  } > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md"
+}
+
+# Pre-BL-082 summary: NO `tree:`/`dirty:` header lines at all (backward-compat
+# → the gate must treat it as STALE).
+_write_summary_legacy() {
+  local body="$1"
+  mkdir -p "$PROJ/docs/test-results/phase3"
+  {
+    echo "# Phase 3 Validation Summary"
+    echo "- Overall: FAIL"
+    echo ""
+    echo "## Machine-readable results"
+    echo '```'
+    printf '%s\n' "$body"
+    echo '```'
+  } > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md"
+}
+
+ALL_SKIP_ROWS='RESULT semgrep-full-tree SKIP
 RESULT license SKIP
 RESULT snyk SKIP
 RESULT zap-dast SKIP
-RESULT threat-model SKIP
-MD
+RESULT threat-model SKIP'
+
+ALL_PASS_ROWS='RESULT semgrep-full-tree PASS
+RESULT license PASS
+RESULT snyk PASS
+RESULT zap-dast PASS
+RESULT threat-model PASS'
+
+# Build a sandbox scripts/ dir holding the REAL gate + lib but a COUNTING MOCK
+# driver, so tests can assert whether the gate re-ran the driver (fresh →
+# no call; stale → call). The mock appends a line to $DRIVER_CALLS_FILE each
+# invocation and emits a minimal FRESH summary (tree = current HEAD^{tree}).
+make_sandbox_with_mock_driver() {
+  SANDBOX="$TMP/sandbox"
+  mkdir -p "$SANDBOX/scripts/lib"
+  cp "$GATE" "$SANDBOX/scripts/check-phase-gate.sh"
+  cp "$REPO_ROOT"/scripts/lib/*.sh "$SANDBOX/scripts/lib/" 2>/dev/null || true
+  MOCK_GATE="$SANDBOX/scripts/check-phase-gate.sh"
+  DRIVER_CALLS="$TMP/driver-calls"
+  : > "$DRIVER_CALLS"
+  cat > "$SANDBOX/scripts/run-phase3-validation.sh" <<'MOCK'
+#!/usr/bin/env bash
+set -uo pipefail
+[ -n "${DRIVER_CALLS_FILE:-}" ] && echo call >> "$DRIVER_CALLS_FILE"
+rdir="docs/test-results/phase3"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --results-dir) rdir="$2"; shift 2 ;;
+    --results-dir=*) rdir="${1#--results-dir=}"; shift ;;
+    *) shift ;;
+  esac
+done
+mkdir -p "$rdir"
+tree=$(git rev-parse "HEAD^{tree}" 2>/dev/null || echo none)
+f="$rdir/summary-$(date -u +%Y-%m-%dT%H-%M-%SZ).md"
+{
+  echo "# Phase 3 Validation Summary"
+  echo "- tree: $tree"
+  echo "- dirty: no"
+  echo ""
+  echo "## Machine-readable results"
+  echo '```'
+  echo "RESULT semgrep-full-tree SKIP"
+  echo "RESULT license SKIP"
+  echo "RESULT snyk SKIP"
+  echo "RESULT zap-dast SKIP"
+  echo "RESULT threat-model SKIP"
+  echo '```'
+} > "$f"
+exit 1
+MOCK
+  chmod +x "$SANDBOX/scripts/run-phase3-validation.sh"
+}
+
+# Run the MOCK-driver gate. $1 = SOLO_PHASE3_GATE_NOAUTORUN value (default empty
+# → auto-run enabled).
+run_mock_gate() {
+  ( cd "$PROJ" && DRIVER_CALLS_FILE="$DRIVER_CALLS" SOLO_PHASE3_GATE_NOAUTORUN="${1:-}" bash "$MOCK_GATE" 2>&1 ) || true
+}
+
+# Count how many times the mock driver was invoked (line count; 0 when empty).
+driver_call_count() { wc -l < "$DRIVER_CALLS" 2>/dev/null | tr -d ' '; }
+
+# Pre-create a FRESH summary (BL-082: matching tree + dirty:no) whose five
+# scanners are all SKIP. Only the RESULT lines + the tree/dirty provenance are
+# load-bearing for the gate.
+write_summary_all_skip() {
+  _write_summary "$(proj_tree)" "no" "$ALL_SKIP_ROWS"
+}
+
+# semgrep reports a FAIL finding; the other four SKIP. FRESH. Used to exercise
+# the gate's FAIL arm in isolation (attest the four skips so the ONLY blocker
+# is the FAIL status).
+write_summary_semgrep_fail() {
+  _write_summary "$(proj_tree)" "no" 'RESULT semgrep-full-tree FAIL
+RESULT license SKIP
+RESULT snyk SKIP
+RESULT zap-dast SKIP
+RESULT threat-model SKIP'
 }
 
 # Summary that OMITS semgrep's RESULT line (→ gate reads it as MISSING) and
-# has a garbled status for license. Both must count as blocking.
+# has a garbled status for license. Both must count as blocking. FRESH.
 write_summary_missing_and_garbled() {
-  mkdir -p "$PROJ/docs/test-results/phase3"
-  cat > "$PROJ/docs/test-results/phase3/summary-2026-07-06T00-00-00Z.md" <<'MD'
-# Phase 3 Validation Summary
-RESULT license BOGUS
+  _write_summary "$(proj_tree)" "no" 'RESULT license BOGUS
 RESULT snyk SKIP
 RESULT zap-dast SKIP
-RESULT threat-model SKIP
-MD
+RESULT threat-model SKIP'
 }
 
 attest_all() {
@@ -481,6 +609,244 @@ else
     fail_ "T-mutation" "mutant STILL emitted the phase-3 FAIL — enforcement not load-bearing (mutation is not proof)"
   else
     pass "T-mutation: mutant (enforcement stripped) does NOT emit the phase-3 FAIL (RED proof)"
+  fi
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-fresh-trusted: matching tree + clean → gate does NOT re-run driver ==="
+# ════════════════════════════════════════════════════════════════════
+# BL-082: a summary bound to the CURRENT tree with dirty:no is FRESH and must be
+# trusted as-is — the gate must NOT auto-run the driver. Proven with a counting
+# mock driver: the call count stays 0 while the gate reports the fresh
+# (all-attested-skip) summary CLEAN.
+setup
+make_sandbox_with_mock_driver
+write_summary_all_skip
+attest_all
+out=$(run_mock_gate)          # auto-run ENABLED — fresh summary must pre-empt it
+calls=$(driver_call_count)
+if [ "$calls" -eq 0 ]; then
+  pass "T-fresh-trusted: driver NOT re-run for a fresh summary (calls=0)"
+else
+  fail_ "T-fresh-trusted" "gate re-ran the driver for a FRESH summary (calls=$calls)"
+fi
+if echo "$out" | grep -qE "validation scans clean"; then
+  pass "T-fresh-trusted: gate trusts + reports the fresh summary CLEAN"
+else
+  fail_ "T-fresh-trusted" "gate did not report the fresh summary clean; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-stale-rerun: 2nd commit advances tree → old summary superseded, fresh generated ==="
+# ════════════════════════════════════════════════════════════════════
+# A summary bound to commit-1's tree is superseded once HEAD^{tree} advances.
+# With auto-run enabled the gate prints [STALE], regenerates (mock driver
+# called ≥1), and evaluates the FRESH summary — proven by the newest summary
+# on disk being bound to the NEW tree, and the gate blocking on the
+# regenerated file's un-attested skips (nothing attested).
+setup
+make_sandbox_with_mock_driver
+write_summary_all_skip         # bound to commit-1
+proj_advance_tree              # HEAD^{tree} now differs from the recorded tree
+out=$(run_mock_gate)           # auto-run ENABLED
+calls=$(driver_call_count)
+if [ "$calls" -ge 1 ]; then
+  pass "T-stale-rerun: gate re-ran the driver on stale (calls=$calls)"
+else
+  fail_ "T-stale-rerun" "gate did NOT re-run the driver for a stale summary (calls=$calls)"
+fi
+if echo "$out" | grep -q "\[STALE\]"; then
+  pass "T-stale-rerun: gate printed an explicit [STALE] line"
+else
+  fail_ "T-stale-rerun" "no [STALE] line; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+newest=$(ls -1 "$PROJ"/docs/test-results/phase3/summary-*.md 2>/dev/null | sort | tail -1)
+newest_tree=$(grep -m1 '^- tree:' "$newest" 2>/dev/null | sed 's/^- tree:[[:space:]]*//; s/[[:space:]]*$//')
+cur_tree=$(proj_tree)
+if [ -n "$newest_tree" ] && [ "$newest_tree" = "$cur_tree" ]; then
+  pass "T-stale-rerun: a FRESH summary bound to the NEW tree was generated + is what gets evaluated"
+else
+  fail_ "T-stale-rerun" "newest summary not bound to the current tree (newest='$newest_tree' cur='$cur_tree')"
+fi
+if echo "$out" | grep -qE "validation scans not clean|un-attested SKIP"; then
+  pass "T-stale-rerun: gate evaluated the REGENERATED summary (un-attested skips block)"
+else
+  fail_ "T-stale-rerun" "gate did not evaluate the regenerated summary; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-stale-norerun-fails: NOAUTORUN=1 + stale → gate FAIL, rc=1, actionable ==="
+# ════════════════════════════════════════════════════════════════════
+# With regeneration disabled, a stale summary must NOT be silently accepted:
+# gate FAILs (rc=1) with a message telling the operator to re-run the driver.
+# The summary is all-PASS so that WITHOUT the staleness check it would be
+# trusted CLEAN — isolating staleness as the sole blocker (see T-bl082-mutation).
+setup
+_write_summary "$(proj_tree)" "no" "$ALL_PASS_ROWS"
+proj_advance_tree              # → stale (tree mismatch)
+rc=0
+out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$GATE" 2>&1 ) || rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "T-stale-norerun-fails: gate blocks (rc=1)"
+else
+  fail_ "T-stale-norerun-fails" "expected rc=1, got $rc"
+fi
+if echo "$out" | grep -q "STALE"; then
+  pass "T-stale-norerun-fails: gate emits a STALE FAIL"
+else
+  fail_ "T-stale-norerun-fails" "no STALE message; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+if echo "$out" | grep -q "run-phase3-validation.sh"; then
+  pass "T-stale-norerun-fails: message is actionable (re-run the driver)"
+else
+  fail_ "T-stale-norerun-fails" "message not actionable; out:
+$(echo "$out" | grep -iE 'stale' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-dirty-tree-stale: summary recorded dirty:yes → stale path ==="
+# ════════════════════════════════════════════════════════════════════
+# Tree MATCHES the current HEAD^{tree}, but the summary recorded dirty:yes
+# (generated on a dirty tree) → must be stale.
+setup
+_write_summary "$(proj_tree)" "yes" "$ALL_PASS_ROWS"
+out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$GATE" 2>&1 ) || true
+if echo "$out" | grep -q "STALE"; then
+  pass "T-dirty-tree-stale: dirty:yes summary is stale despite a matching tree"
+else
+  fail_ "T-dirty-tree-stale" "expected a STALE result; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+if echo "$out" | grep -qE "validation scans clean"; then
+  fail_ "T-dirty-tree-stale" "gate wrongly reported CLEAN for a dirty:yes summary"
+else
+  pass "T-dirty-tree-stale: gate did NOT report clean"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-pre-bl082-summary-stale: summary with NO tree: line → stale (backward compat) ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+_write_summary_legacy "$ALL_PASS_ROWS"
+out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$GATE" 2>&1 ) || true
+if echo "$out" | grep -q "STALE"; then
+  pass "T-pre-bl082-summary-stale: a pre-BL-082 summary (no tree line) is stale"
+else
+  fail_ "T-pre-bl082-summary-stale" "expected a STALE result; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-stateflip-not-dirty (Correction 1): modifying ONLY .claude/ → still FRESH ==="
+# ════════════════════════════════════════════════════════════════════
+# The gate writes phase-state.json (BL-071 gate date) on PASS and the driver
+# writes attestations there; that file is TRACKED downstream. Modifying ONLY
+# .claude/ (tracked-modified via attest + an untracked file) must NOT mark the
+# tree dirty → the summary stays FRESH → no re-run.
+setup
+make_sandbox_with_mock_driver
+write_summary_all_skip
+attest_all                                  # rewrites .claude/phase-state.json (tracked)
+echo '{}' > "$PROJ/.claude/scratch-untracked.json"   # untracked file under .claude/
+# sanity: an UNSCOPED porcelain WOULD see .claude changes
+unscoped=$( cd "$PROJ" && git status --porcelain 2>/dev/null )
+if [ -n "$unscoped" ]; then
+  pass "T-stateflip-not-dirty: unscoped tree is dirty (.claude changes present) — the interesting case"
+else
+  fail_ "T-stateflip-not-dirty" "fixture did not dirty .claude as intended"
+fi
+out=$(run_mock_gate)
+calls=$(driver_call_count)
+if [ "$calls" -eq 0 ]; then
+  pass "T-stateflip-not-dirty: .claude-only changes do NOT trigger a re-run (calls=0)"
+else
+  fail_ "T-stateflip-not-dirty" "gate re-ran despite only .claude changing (calls=$calls)"
+fi
+if echo "$out" | grep -qE "validation scans clean"; then
+  pass "T-stateflip-not-dirty: summary stays FRESH → gate reports clean"
+else
+  fail_ "T-stateflip-not-dirty" "gate did not stay fresh/clean; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-live-dirty-stale (Correction 2): uncommitted SOURCE edit → stale ==="
+# ════════════════════════════════════════════════════════════════════
+# The summary's recorded tree still equals HEAD^{tree} and it recorded
+# dirty:no, but the operator edits a SOURCE file uncommitted. HEAD^{tree} does
+# not reflect that — only the live scoped porcelain does. Must be stale.
+setup
+write_summary_all_skip                       # fresh: tree matches, dirty:no
+echo "print('changed')" > "$PROJ/app.py"     # uncommitted SOURCE change (outside .claude + results)
+out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$GATE" 2>&1 ) || true
+if echo "$out" | grep -q "STALE"; then
+  pass "T-live-dirty-stale: uncommitted source edit makes a tree-matched summary stale"
+else
+  fail_ "T-live-dirty-stale" "expected STALE on live-dirty tree; out:
+$(echo "$out" | grep -iE 'phase 3.4|stale' | head)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-bl082-mutation: strip # BL-082-STALENESS → T-stale-norerun-fails goes RED ==="
+# ════════════════════════════════════════════════════════════════════
+# MUTATION-PROOF for the staleness binding. Copy the gate, delete every line
+# carrying `# BL-082-STALENESS` (the freshness decision defaults to "fresh"),
+# and re-run the stale all-PASS + NOAUTORUN fixture. Real gate: STALE FAIL.
+# Mutant: staleness defeated → the stale all-PASS summary is trusted CLEAN and
+# NO [STALE] line appears — proving the marked line is load-bearing.
+setup
+_write_summary "$(proj_tree)" "no" "$ALL_PASS_ROWS"
+proj_advance_tree              # stale by tree mismatch
+MUT2="$TMP/mut82"
+mkdir -p "$MUT2/scripts/lib"
+cp "$GATE" "$MUT2/scripts/check-phase-gate.sh"
+cp "$DRIVER" "$MUT2/scripts/run-phase3-validation.sh"
+cp "$REPO_ROOT"/scripts/lib/*.sh "$MUT2/scripts/lib/" 2>/dev/null || true
+grep -v 'BL-082-STALENESS' "$MUT2/scripts/check-phase-gate.sh" > "$MUT2/scripts/check-phase-gate.sh.tmp"
+mv "$MUT2/scripts/check-phase-gate.sh.tmp" "$MUT2/scripts/check-phase-gate.sh"
+chmod +x "$MUT2/scripts/check-phase-gate.sh"
+if ! grep -q 'BL-082-STALENESS' "$GATE"; then
+  fail_ "T-bl082-mutation" "BL-082-STALENESS marker missing from the REAL gate — nothing to mutate"
+elif grep -q 'BL-082-STALENESS' "$MUT2/scripts/check-phase-gate.sh"; then
+  fail_ "T-bl082-mutation" "BL-082-STALENESS still present after excision — mutation did not apply"
+elif ! bash -n "$MUT2/scripts/check-phase-gate.sh" 2>/dev/null; then
+  fail_ "T-bl082-mutation" "mutant gate is not syntactically valid after excision"
+else
+  real_out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$GATE" 2>&1 ) || true
+  mut_out=$( cd "$PROJ" && SOLO_PHASE3_GATE_NOAUTORUN=1 bash "$MUT2/scripts/check-phase-gate.sh" 2>&1 ) || true
+  if echo "$real_out" | grep -q "STALE"; then
+    pass "T-bl082-mutation: real gate emits the STALE FAIL"
+  else
+    fail_ "T-bl082-mutation" "real gate did NOT emit STALE (fixture wrong?); out:
+$(echo "$real_out" | grep -iE 'stale|clean' | head)"
+  fi
+  if echo "$mut_out" | grep -q "STALE"; then
+    fail_ "T-bl082-mutation" "mutant STILL flagged STALE — staleness not load-bearing (mutation not proof)"
+  elif echo "$mut_out" | grep -qE "validation scans clean"; then
+    pass "T-bl082-mutation: mutant trusts the stale all-PASS summary CLEAN (RED proof)"
+  else
+    fail_ "T-bl082-mutation" "mutant neither STALE nor CLEAN — unexpected; out:
+$(echo "$mut_out" | grep -iE 'stale|clean|not clean' | head)"
   fi
 fi
 teardown


### PR DESCRIPTION
## What & why

The BL-070 Phase 3->4 gate trusted an existing `docs/test-results/phase3/summary-*.md` **as-is forever** — the auto-run fired only when NO summary existed, so a summary generated 50 commits ago still satisfied the gate. BL-082 binds the summary to the tree it validated and re-runs (or FAILs) when stale.

## Design

**Driver (`scripts/run-phase3-validation.sh`)** records provenance in the summary header:
```
- tree: <git rev-parse HEAD^{tree}>   (or `none` outside a git repo)
- dirty: yes|no                        (scoped working-tree state)
```

**Gate (`scripts/check-phase-gate.sh`)** — a summary is **FRESH** iff its `tree:` line is present, `!= none`, `==` the current `HEAD^{tree}`, recorded `dirty: no`, **and** the live scoped working tree is clean. Anything else -> **STALE**: print an explicit `[STALE]` line, regenerate offline via the existing `# BL-070-GATE-AUTORUN` path, and evaluate the FRESH summary in a **single pass**. If regeneration is impossible (`SOLO_PHASE3_GATE_NOAUTORUN=1`, or the driver is missing/non-executable) STALE = gate **FAIL** with a re-run message — never silently accept a stale summary. Pre-BL-082 summaries (no `tree:` line) are STALE (backward compat, documented in both script headers). The freshness decision is marked `# BL-082-STALENESS` (mutation target).

## Two Karl-approved corrections (2026-07-09) that supersede the handoff's WP-A text

Both stem from one fact: the gate itself writes `.claude/phase-state.json` on PASS (BL-071 gate-date write, `check-phase-gate.sh:374`) and the driver writes attestations into the same file (`run-phase3-validation.sh:216`), and **`.claude/phase-state.json` is TRACKED downstream** (the generated `.gitignore` covers `test-results/` but not `.claude/`).

**Correction 1 - scoped dirty computation.** `dirty` (driver) and the gate's live check both use `git status --porcelain -- . ':(exclude).claude' ':(exclude)<RESULTS_DIR>'`. An **unscoped** check would mark every summary permanently stale the instant the gate writes `phase-state.json` on its first PASS (self-defeating; with `SOLO_PHASE3_GATE_NOAUTORUN=1` it would brick the gate). Absolute/parent-relative results dirs are outside the porcelain scope already, so their exclusion is skipped. The driver-side (`_p3_scoped_dirty`) and gate-side (`_cpg_scoped_dirty`) predicates are textually identical.

**Correction 2 - the gate ALSO checks CURRENT worktree dirtiness**, not only the recorded flag. `HEAD^{tree}` does not reflect uncommitted edits: a summary generated on a clean tree would stay tree-matched while the operator edits source uncommitted (recorded `dirty: no` + matching tree would wrongly trust it). Freshness therefore also requires the live scoped porcelain to be empty.

## Verification

**Suite** (`bash tests/test-phase3-validation-gate.sh`, hermetic, mktemp; fixtures are now real git repos so seeded summaries can be FRESH):
```
Results: 42 passed, 0 failed
```
New cases: `T-fresh-trusted`, `T-stale-rerun`, `T-stale-norerun-fails`, `T-dirty-tree-stale`, `T-pre-bl082-summary-stale`, `T-stateflip-not-dirty` (pins Correction 1), `T-live-dirty-stale` (pins Correction 2), `T-bl082-mutation`.

**Mutation proof** — excise every `# BL-082-STALENESS` line from the real gate, run the suite:
```
RED (marker excised):
  === T-stale-norerun-fails ... ===
    [PASS] T-stale-norerun-fails: gate blocks (rc=1)
    [FAIL] T-stale-norerun-fails — no STALE message
    [FAIL] T-stale-norerun-fails — message not actionable
  Results: 31 passed, 10 failed

GREEN (restored):
  Results: 42 passed, 0 failed
```
(The self-contained `T-bl082-mutation` case also excises the marker in a gate copy and asserts the stale all-PASS summary is then trusted CLEAN with no `[STALE]` line.)

**Lint** — all 8 CI lint jobs pass: `counter-antipattern`, `backlog-references`, `fix-functions-stderr`, `raw-read-prompt`, `tests-registered`, `doc-anchors`, `review-manifest`, `no-live-remote-in-tests`. (Also `lint-fail-emit-exit-status`, `lint-fix-functions-stderr`, `lint-fixture-envelopes` pass. `lint-uat-scenarios.sh` is a parametrized tool requiring a file argument — not a repo-wide lint — and is exercised in CI via `tests/test-lint-uat-scenarios.sh`.)

The extended suite is already in the CI fast lane (`.github/workflows/tests.yml`) and the `full-project-test-suite.sh` aggregator (existing file, extended in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)