### PR TITLE
fix(hooks): run the BL-006 commit-message check at the commit-msg hook (BL-010)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -69,6 +69,7 @@ jobs:
           # or helper. Regenerate with:
           #   grep -L 'init\.sh' tests/test-*.sh | sort
           tests=(
+            tests/test-bl010-commitmsg-bl006.sh
             tests/test-bl032-gitlab-free-approvals-attestation.sh
             tests/test-bl046-helpers-split.sh
             tests/test-bl069-install-cmds-consumers.sh

--- a/docs/handoffs/2026-07-10-gate-wave-close-out.md
+++ b/docs/handoffs/2026-07-10-gate-wave-close-out.md
@@ -98,21 +98,24 @@ is current.
 **Parked:** **BL-017** (intake-wizard.sh non-interactive mode — no operator
 demand in 60+ days; field-specific flags cover known needs).
 
-**Held trio — recon recommendations PRESENTED to Karl 2026-07-10, AWAITING his
-answer. DO NOT FLIP THESE.** They remain `Open — HELD 2026-07-05 pending BL-072
-design`. After the C2 hard block shipped, the one-pass recon recommends:
+**Held trio — DECIDED by Karl 2026-07-10.** Recon recommendations were presented;
+Karl decided BL-010 = "Fix it" (build the residual, then close) and retired
+BL-011 + BL-014 as Won't Fix. Outcomes:
 - **BL-010** (`.git/hooks/commit-msg` for editor-case / human-terminal coverage)
-  — **close-as-absorbed**: PR #166's commit-msg hook infrastructure already
-  delivers editor-case / human-terminal commit enforcement. The residual
-  "extend the BL-006 build-loop check to the same hook" is optional with no
-  demand signal.
-- **BL-011** (Cutline-ID-aware enforcement) — **Won't-Fix recommended**: not
-  absorbed by C2, zero demand in 78 days, and it conflicts doctrinally with
-  BL-007's convention-free rule.
-- **BL-014** (Commit-type hygiene enforcement) — **Won't-Fix recommended**:
-  C1/C2's measured 50% false-positive floor on the EASIER prefix+path signal
-  empirically confirms that diff-intent inference is too brittle to enforce, and
-  the attestation ledger already provides the honest audit trail.
+  — **Fixed + Closed (PR #169)**. PR #166's commit-msg hook infrastructure
+  already reached editor-case / human-terminal commits for the C2 TDD gate; PR
+  #169 wired the residual — the older BL-006 Build-Loop commit-message check —
+  into the same surface (`bl006_terminal_enforce`, delegating to the identical
+  `process-checklist.sh --check-commit-message` the PreToolUse path uses). Full
+  parity, mothership-safe, 11-assertion suite + RED→GREEN mutation.
+- **BL-011** (Cutline-ID-aware enforcement) — **Won't Fix (Karl 2026-07-10)**:
+  zero operator demand since 2026-04-23, and it would re-impose an F-/ID- ID
+  convention BL-007 deliberately avoided. Reopen on a concrete Cutline-drift case.
+- **BL-014** (Commit-type hygiene enforcement) — **Won't Fix (Karl 2026-07-10)**:
+  the BL-072 C1/C2 measurement (`Reports/2026-07-10-bl072-warn-dogfood.md`: 50%
+  false-positive floor on the simpler prefix+path signal) empirically shows
+  diff-intent inference would misfire worse; the C2 attestation ledger provides
+  the audit trail. Reopen on observed abuse of the commit-type escape route.
 
 ---
 
@@ -180,10 +183,9 @@ the known parametrized tool that needs a scenario argument).
 ## 5. What NOT to touch (unchanged from the execution handoff §3)
 
 - **Deferred:** BL-085 (full-suite CI-fast), BL-019/042/043 (next-quarter recon).
-- **Held pending Karl's answer:** BL-010/011/014 — recommendations are recorded
-  in §3 above; do NOT flip until Karl decides.
-- **Parked:** BL-017. **Won't Fix:** BL-012/013/058 (and, if Karl agrees,
-  BL-011/014).
+- **Held trio — DECIDED by Karl 2026-07-10 (see §3):** BL-010 fixed + closed
+  (PR #169); BL-011 + BL-014 Won't Fix.
+- **Parked:** BL-017. **Won't Fix:** BL-011/012/013/014/058.
 - The full-suite CI lane (`workflow_dispatch` `full` job) — leave manual-only.
 - **Branch protection settings** — leave as-is.
 - CDF (`~/.claude-dev-framework`) — no upstream work is in scope; if a fix turns
@@ -240,9 +242,9 @@ git worktree remove scratchpad/wt-pr125
 > close-out doc, then verify state — `main` green (cite the current
 > `gh run list --branch main` run IDs), branch protection active, no open PRs, no
 > pending-approval sentinel — and summarize what you see before dispatching
-> anything. The gate wave is DONE; the open work is: (1) whatever Karl decided on
-> the held trio BL-010/011/014 (recon recommendations are in §3 — close-BL-010,
-> Won't-Fix BL-011, Won't-Fix BL-014 — do NOT flip until he answers); (2) the new
+> anything. The gate wave is DONE; the held trio BL-010/011/014 is RESOLVED
+> (Karl 2026-07-10: BL-010 fixed + closed via PR #169; BL-011 + BL-014 Won't Fix
+> — see §3). The remaining open work is: (1) the new
 > BL-086 license-policy layer (Open, Karl decision on whether/when to build);
 > (3) the deferred set BL-019/042/043/085 (opportunistic only — no demand). Honor
 > every rule in the execution handoff §0 (no merge on red, TDD + mutation proofs,

--- a/init.sh
+++ b/init.sh
@@ -2589,8 +2589,11 @@ EXITEOF
 }
 
 # install_tdd_commit_msg_hook — idempotently add a managed block to
-# .git/hooks/commit-msg that delegates to the framework gate's tier-keyed TDD
-# ordering enforcement (`pre-commit-gate.sh --terminal-mode --tdd-only`). A
+# .git/hooks/commit-msg that delegates to the framework gate's two message-scoped
+# commit-msg enforcers (`pre-commit-gate.sh --terminal-mode --tdd-only`): the
+# tier-keyed TDD-ordering gate (BL-072 C2) AND the BL-006 Build-Loop
+# commit-message check (BL-010) — the latter extends BL-006 to editor-opened /
+# human-terminal commits, which the AI-only PreToolUse hook cannot reach. A
 # non-zero exit aborts the commit. Composes with an existing commit-msg hook via
 # a marked block; graceful no-op if the gate script is absent at commit time.
 install_tdd_commit_msg_hook() {
@@ -2609,11 +2612,16 @@ install_tdd_commit_msg_hook() {
   {
     echo ""
     echo "$mark_open"
-    echo '# Tier-keyed test-first enforcement (BL-072 Phase C2): sponsored-POC /'
-    echo '# production -> HARD BLOCK when a feat/fix/refactor commit ships'
-    echo '# implementation with no accompanying test; personal / private-POC ->'
-    echo '# logged WARNING (bypassable). Escape: SOLO_TDD_ATTESTED=1 (recorded to'
-    echo '# .claude/process-state.json::tdd_attestations[]).'
+    echo '# Two message-scoped commit-msg gates run here (--terminal-mode --tdd-only):'
+    echo '#  1. Tier-keyed test-first enforcement (BL-072 Phase C2): sponsored-POC /'
+    echo '#     production -> HARD BLOCK when a feat/fix/refactor commit ships'
+    echo '#     implementation with no accompanying test; personal / private-POC ->'
+    echo '#     logged WARNING (bypassable). Escape: SOLO_TDD_ATTESTED=1 (recorded to'
+    echo '#     .claude/process-state.json::tdd_attestations[]).'
+    echo '#  2. BL-006 Build-Loop commit-message check (BL-010): a feat: commit in'
+    echo '#     Phase 2+ requires an active, sufficiently-complete Build Loop. This'
+    echo '#     surface reaches editor-opened / human-terminal commits the AI-only'
+    echo '#     PreToolUse hook cannot see.'
     echo 'if [ -x scripts/pre-commit-gate.sh ]; then'
     echo '  scripts/pre-commit-gate.sh --terminal-mode --tdd-only || exit 1'
     echo 'fi'

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -261,16 +261,64 @@ tdd_terminal_enforce() {
 }
 # ── end BL-072 Phase C2 block ────────────────────────────────────────
 
+# ── BL-010: BL-006 Build-Loop commit-message check at the commit-msg surface ──
+# BL-006 (PR #15) enforces "a feat: commit requires an active, sufficiently
+# complete Build Loop". Until now it ran ONLY on the AI-tooling PreToolUse
+# surface (bl006_check, far below). Editor-opened commits (`git commit` with no
+# -m) and human-terminal commits never faced it — the residual BL-010 closes.
+# This function runs the SAME policy subcommand
+# (process-checklist.sh --check-commit-message) at COMMIT-MSG time, where
+# .git/COMMIT_EDITMSG holds the CURRENT message, so it reaches exactly those two
+# populations. It is invoked from the --tdd-only commit-msg surface (the
+# generated commit-msg hook) alongside the C2 TDD gate.
+#
+# SEMANTIC PARITY with the PreToolUse bl006_check: identical delegate, identical
+# message (first line / subject), identical block conditions and remediation.
+# Derivative commits that the PreToolUse path passes through via command-string
+# filters are passed through here via their commit-msg-time git sentinels
+# (MERGE_HEAD / CHERRY_PICK_HEAD / REVERT_HEAD). MOTHERSHIP SAFETY: two layers —
+# (1) no-op when the project has no scripts/process-checklist.sh (a repo that
+# predates BL-006, or the framework repo itself, which is NOT a scaffolded
+# project); (2) check_commit_message phase-gates (current_phase < 2 -> exit 0).
+# Returns 0 to ALLOW, non-zero to BLOCK (caller exits 1 -> git aborts commit).
+bl006_terminal_enforce() {
+  # Derivative commits: git writes these sentinels at commit-msg time. Mirrors
+  # the PreToolUse bl006_check merge/revert/cherry-pick pass-throughs (the
+  # PreToolUse path detects them from the command string; at commit-msg time the
+  # sentinel files are the equivalent, current signal).
+  [ -f .git/MERGE_HEAD ] && return 0
+  [ -f .git/CHERRY_PICK_HEAD ] && return 0
+  [ -f .git/REVERT_HEAD ] && return 0
+  # No project checklist -> nothing to enforce (safe no-op). CWD-relative on
+  # purpose: the commit-msg hook runs from the project root, and this must NOT
+  # resolve to the framework's own copy for a repo that has no scaffolded state.
+  [ -x scripts/process-checklist.sh ] || return 0
+  local subject rc=0
+  subject=$(printf '%s\n' "${COMMIT_MSG:-}" | head -n 1)
+  # Delegate the policy decision to the SAME subcommand the PreToolUse surface
+  # uses (identical block conditions + Case A/B remediation). Fold the delegate's
+  # stdout into stderr so its whole message reaches the terminal (git hooks
+  # ignore stdout). A non-zero exit propagates -> the caller aborts the commit.
+  bash scripts/process-checklist.sh --check-commit-message "$subject" >&2 || rc=$?   # BL-010-COMMITMSG-BL006
+  return "$rc"
+}
+# ── end BL-010 block ─────────────────────────────────────────────────
+
 # BL-030: --terminal-mode invocation from .git/hooks/framework-gate.sh.
 # Reads commit message from .git/COMMIT_EDITMSG instead of stdin JSON;
 # reads staged files from `git diff --cached` instead of tool-input;
 # emits human-readable diagnostics to stderr instead of JSON to stdout.
 TERMINAL_MODE=0
-# --tdd-only (BL-072 C2): scope a --terminal-mode invocation to JUST the
-# tier-keyed TDD gate — skip the process-checklist + operator-side lints. The
-# generated fallback pre-commit hook uses `--terminal-mode --tdd-only` so it
-# runs the real TDD gate WITHOUT newly pulling the full checklist/lint stack
-# into a hook that never carried them.
+# --tdd-only (BL-072 C2 + BL-010): scope a --terminal-mode invocation to the
+# two MESSAGE-SCOPED commit-msg gates — the tier-keyed TDD-ordering gate
+# (BL-072) AND the BL-006 Build-Loop commit-message check (BL-010) — while
+# skipping the full process-checklist + operator-side lints that plain
+# --terminal-mode runs. The generated commit-msg hook uses
+# `--terminal-mode --tdd-only`, so it runs both real gates WITHOUT newly pulling
+# the full checklist/lint stack into a hook that never carried them. The flag
+# name is retained (rather than renamed) for backward-compat with commit-msg
+# hooks already installed by init.sh: those keep working and pick up the added
+# BL-006 enforcement as soon as their scripts/pre-commit-gate.sh is refreshed.
 TDD_ONLY=0
 for arg in "$@"; do
   case "$arg" in
@@ -295,6 +343,13 @@ if [ "$TERMINAL_MODE" -eq 1 ]; then
   # non-zero return means "hard block" without set -e aborting mid-function.
   if [ "$TDD_ONLY" -eq 1 ]; then
     if ! tdd_terminal_enforce; then
+      exit 1
+    fi
+    # BL-010: the commit-msg surface ALSO runs the BL-006 Build-Loop
+    # commit-message check (bl006_terminal_enforce, defined above), extending
+    # BL-006 enforcement to editor-opened and human-terminal commits. Same
+    # policy as the PreToolUse surface; a non-zero return aborts the commit.
+    if ! bl006_terminal_enforce; then
       exit 1
     fi
     exit 0

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -193,7 +193,7 @@ Surfaced during lancache project UAT Session 1 (2026-04-22 → 2026-04-23). The 
 **Logged:** 2026-04-23
 **Category:** Proposal
 **Severity:** Low
-**Status:** Open — Optional; HELD 2026-07-05 pending BL-072 (TDD hard-enforce) design — that item may absorb editor-case/human-terminal commit enforcement.
+**Status:** Closed (2026-07-10, PR #166 shipped the commit-msg hook infrastructure; PR #169 wired the BL-006 check into it per Karl's "Fix it" decision).
 
 Punted from BL-006. Install a local `commit-msg` git hook via `init.sh` that invokes `scripts/process-checklist.sh --check-commit-message "$(head -n1 "$1")"`. Extends enforcement to two populations the PreToolUse hook cannot reach: (a) `git commit` with no `-m` flag (editor opens), and (b) human-Orchestrator commits from the terminal. The BL-006 design was explicitly built so this is a pure addition — no refactor needed.
 
@@ -203,6 +203,8 @@ Punted from BL-006. Install a local `commit-msg` git hook via `init.sh` that inv
 
 **Related:** BL-006 spec § 10 (out-of-scope note); `pre-commit-gate.sh` architecture is Claude-only by design.
 
+**Resolution:** Karl decided 2026-07-10 "Fix it" (build the residual, then close). PR #166 (BL-072 C2) already installed the `commit-msg` git hook (`init.sh::install_tdd_commit_msg_hook`, invoking `pre-commit-gate.sh --terminal-mode --tdd-only`), which reaches editor-written and human-terminal commits. PR #169 wired the older BL-006 Build-Loop commit-message check into that same surface via a new `bl006_terminal_enforce()` — it delegates to the SAME `process-checklist.sh --check-commit-message` subcommand the PreToolUse `bl006_check` uses, enforcing identical block conditions, subject (first message line), and remediation. Derivative commits pass through via their commit-msg-time git sentinels (`MERGE_HEAD` / `CHERRY_PICK_HEAD` / `REVERT_HEAD`), mirroring the PreToolUse command-string filters. Mothership-safe on two layers (no-op when the project lacks `scripts/process-checklist.sh`; `check_commit_message` phase-gates at `current_phase < 2`). Load-bearing wiring marked `# BL-010-COMMITMSG-BL006`. Tests: `tests/test-bl010-commitmsg-bl006.sh` (11 assertions — block / pass / editor-case real `git commit` / mothership no-op / cross-surface parity / RED→GREEN mutation), registered in both aggregators; the BL-072 C1/C2 suite stays green (36/36).
+
 ---
 
 ## BL-011: Cutline-ID-aware enforcement
@@ -210,7 +212,7 @@ Punted from BL-006. Install a local `commit-msg` git hook via `init.sh` that inv
 **Logged:** 2026-04-23
 **Category:** Proposal
 **Severity:** Low
-**Status:** Open — Optional; HELD 2026-07-05 pending BL-072 design — TDD/commit-type enforcement may absorb Cutline-ID-aware enforcement.
+**Status:** Won't Fix (2026-07-10, Karl decision). Zero operator demand since 2026-04-23; would re-impose an F-/ID- ID convention BL-007 deliberately avoided. Reopen on a concrete Cutline-drift case.
 
 Punted from BL-006. Parse `PRODUCT_MANIFESTO.md §5` for F-/ID- Cutline identifiers and require commits that touch Cutline work to explicitly reference the ID (e.g., `feat(ID1): ...`), cross-checking that each Cutline ID gets exactly one Build Loop. Catches drift where Cutline work masquerades as a bugfix (`fix(ID1): ...`) or doesn't mention the ID at all.
 
@@ -261,7 +263,7 @@ Punted from BL-006. `gh pr merge --squash` runs on the remote host, outside the 
 **Logged:** 2026-04-23
 **Category:** Proposal
 **Severity:** Low
-**Status:** Open — Optional; HELD 2026-07-05 pending BL-072 design — commit-type hygiene overlaps the TDD hard-enforce surface.
+**Status:** Won't Fix (2026-07-10, Karl decision). The BL-072 C1/C2 measurement (Reports/2026-07-10-bl072-warn-dogfood.md: 50% false-positive floor on the simpler prefix+path signal) empirically shows diff-intent inference would misfire worse; the C2 attestation ledger provides the audit trail. Reopen on observed abuse of the commit-type escape route.
 
 Punted from BL-006. Prevent mis-typed commit types — e.g., a real feature disguised as `chore:` or `refactor:` to evade the BL-006 gate. Would require intent inference from the staged diff (lines added to `src/`, new public API surface, new test files asserting behavior) combined with the declared commit-type.
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1166,6 +1166,16 @@ if bash "$SCRIPT_DIR/tests/test-check-commit-message.sh" >/dev/null 2>&1; then
 else
   fail "tests/test-check-commit-message.sh FAILED (run for details)"
 fi
+# BL-010: the BL-006 Build-Loop commit-message check now runs at the git
+# commit-msg hook surface (pre-commit-gate.sh --terminal-mode --tdd-only ->
+# bl006_terminal_enforce), reaching editor-opened and human-terminal commits.
+# Mutation-proof: excising the marked `# BL-010-COMMITMSG-BL006` delegation line
+# removes the refusal, flipping T-bl010-commitmsg-bl006-blocks RED.
+if bash "$SCRIPT_DIR/tests/test-bl010-commitmsg-bl006.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl010-commitmsg-bl006.sh"
+else
+  fail "tests/test-bl010-commitmsg-bl006.sh FAILED (run for details)"
+fi
 if bash "$SCRIPT_DIR/tests/test-check-phase-gate.sh" >/dev/null 2>&1; then
   pass "tests/test-check-phase-gate.sh"
 else

--- a/tests/test-bl010-commitmsg-bl006.sh
+++ b/tests/test-bl010-commitmsg-bl006.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# tests/test-bl010-commitmsg-bl006.sh — BL-010 residual.
+#
+# BL-006 (PR #15) enforces "a feat: commit in Phase 2+ requires an active,
+# sufficiently-complete Build Loop" — but it ran ONLY on the AI-tooling
+# PreToolUse surface. BL-010 wires the SAME check into the git COMMIT-MSG hook
+# surface (pre-commit-gate.sh --terminal-mode --tdd-only ->
+# bl006_terminal_enforce), so editor-opened (`git commit` with no -m) and
+# human-terminal commits face it too. The load-bearing wiring line carries the
+# marker `# BL-010-COMMITMSG-BL006`.
+#
+# Cases:
+#   T-bl010-commitmsg-bl006-blocks  feat + Phase 2 + no Build Loop -> commit-msg
+#                                   surface REFUSES with BL-006's message (rc=1)
+#   T-bl010-commitmsg-bl006-passes  feat + a COMPLETE Build Loop -> passes (rc=0)
+#   T-bl010-editor-case             message supplied via the editor (no -m), a
+#                                   REAL git commit through the installed hook ->
+#                                   aborted with BL-006's message, no commit made
+#   T-bl010-mothership-noop         no phase-state.json (phase 0) -> passes; and
+#                                   no scripts/process-checklist.sh -> passes
+#   T-bl010-parity                  the SAME fixture through the PreToolUse and
+#                                   commit-msg surfaces -> the SAME outcome
+#                                   (both refuse the block fixture, both allow a
+#                                   compliant fixture)
+#   T-mutation                      excise # BL-010-COMMITMSG-BL006 from a gate
+#                                   COPY -> the block fixture no longer refuses
+#                                   (rc=0, RED); the real gate refuses (rc=1,
+#                                   GREEN) — proving the marked line is what
+#                                   enforces BL-006 at this surface
+#
+# Hermetic: mktemp fixture repos (git init + local identity + a fake origin
+# pointer only — no real remote is ever contacted); GITHUB_BASE_REF unset so
+# CI's own env cannot leak into fixture git ops; no init.sh execution.
+#
+# bash-3.2 safe: no associative arrays, no mapfile, no ${var,,}, no ((x++)), no
+# multibyte characters adjacent to a $expansion.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GATE="$REPO_ROOT/scripts/pre-commit-gate.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq not available — BL-006 phase / Build-Loop reads require jq."
+  exit 0
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 -- $2"; FAILED=$((FAILED + 1)); }
+
+# ── Fixture scaffolding ──────────────────────────────────────────────
+# Build a hermetic repo that looks like a scaffolded project: it ships
+# scripts/{pre-commit-gate.sh, process-checklist.sh, lib/*} + .claude state so
+# the gate's CWD-relative delegation resolves to the project's own copies (never
+# the framework's). phase="none" omits phase-state.json entirely (mothership).
+# feature="none" leaves the Build Loop inactive; complete="complete" fills the
+# five commit-required Build Loop steps.
+scaffold() {
+  local phase="$1" feature="$2" complete="${3:-}"
+  TMP=$(mktemp -d)
+  PROJ="$TMP/proj"
+  mkdir -p "$PROJ/scripts/lib" "$PROJ/.claude"
+  cp "$REPO_ROOT/scripts/pre-commit-gate.sh" "$PROJ/scripts/"
+  cp "$REPO_ROOT/scripts/process-checklist.sh" "$PROJ/scripts/"
+  cp "$REPO_ROOT"/scripts/lib/*.sh "$PROJ/scripts/lib/"
+  chmod +x "$PROJ/scripts/pre-commit-gate.sh" "$PROJ/scripts/process-checklist.sh"
+
+  if [ "$phase" != "none" ]; then
+    cat > "$PROJ/.claude/phase-state.json" <<EOF
+{"current_phase":$phase,"deployment":"personal","poc_mode":null,"track":"standard"}
+EOF
+  fi
+
+  local steps='[]' feat_json='null'
+  if [ "$feature" != "none" ]; then
+    feat_json="\"$feature\""
+    if [ "$complete" = "complete" ]; then
+      steps='["tests_written","tests_verified_failing","implemented","security_audit","documentation_updated"]'
+    fi
+  fi
+  # phase2_init.verified=true so the PreToolUse full-checklist path (used only in
+  # the parity test) is not blocked by an UNRELATED gate — BL-006 is the only
+  # variable under test. It has no effect on the commit-msg --tdd-only surface,
+  # which reads neither phase2_init nor the UAT session.
+  cat > "$PROJ/.claude/process-state.json" <<EOF
+{"build_loop":{"feature":$feat_json,"step":0,"steps_completed":$steps,"started_at":null},"uat_session":{},"phase1_architecture":{},"phase3_validation":{},"phase4_release":{},"phase2_init":{"steps_completed":["remote_repo_created"],"verified":true}}
+EOF
+
+  ( cd "$PROJ"
+    unset GITHUB_BASE_REF
+    git init -q -b main
+    git config user.email "t@example.invalid"
+    git config user.name "bl010-test"
+    git remote add origin "https://example.invalid/x.git"
+    echo seed > README.md
+    git add README.md
+    git commit -q -m "chore: seed" )
+}
+teardown() { rm -rf "$TMP"; }
+
+# Install a commit-msg hook byte-for-byte equivalent to what init.sh's
+# install_tdd_commit_msg_hook emits (the invocation line is the contract).
+install_commit_msg_hook() {
+  mkdir -p "$PROJ/.git/hooks"
+  cat > "$PROJ/.git/hooks/commit-msg" <<'EOF'
+#!/usr/bin/env bash
+if [ -x scripts/pre-commit-gate.sh ]; then
+  scripts/pre-commit-gate.sh --terminal-mode --tdd-only || exit 1
+fi
+EOF
+  chmod +x "$PROJ/.git/hooks/commit-msg"
+}
+
+# Stage a file (creating parent dirs) without committing.
+stage() {
+  local path="$1" content="${2:-x}"
+  mkdir -p "$PROJ/$(dirname "$path")"
+  printf '%s\n' "$content" > "$PROJ/$path"
+  ( cd "$PROJ" && git add "$path" )
+}
+
+# Set the prospective commit subject (commit-msg surface reads COMMIT_EDITMSG).
+set_subject() { printf '%s\n' "$1" > "$PROJ/.git/COMMIT_EDITMSG"; }
+
+# Stage a feat change that keeps the TDD gate SILENT (an impl file WITH a test
+# riding along), so the ONLY enforcer under test is BL-006.
+stage_feat_with_test() {
+  stage "src/foo.py" "def foo(): return 1"
+  stage "tests/test_foo.py" "def test_foo(): assert True"
+}
+
+# Run the gate at the commit-msg surface. Echoes "rc|<single-line out>".
+run_commitmsg() {
+  local gate="${1:-$GATE}" out rc=0
+  out=$( cd "$PROJ" && unset GITHUB_BASE_REF; bash "$gate" --terminal-mode --tdd-only 2>&1 ) || rc=$?
+  printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+}
+
+# Run the gate at the PreToolUse surface with a bash command. Echoes "rc|out".
+# SKIP_LINT=1 keeps the unrelated operator-side lints out of the comparison.
+run_pretooluse() {
+  local cmd="$1" input out rc=0
+  input=$(jq -n --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  out=$( cd "$PROJ" && unset GITHUB_BASE_REF; export SKIP_LINT=1; \
+         printf '%s' "$input" | bash "$GATE" 2>&1 ) || rc=$?
+  printf '%s|%s' "$rc" "$(printf '%s' "$out" | tr '\n' ' ')"
+}
+
+# BL-006's remediation subjects (require_build_loop_state_for_commit).
+has_bl006_block() {
+  case "$1" in
+    *'no Build Loop active'*|*'Build Loop incomplete'*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+is_deny() { case "$1" in *'"permissionDecision": "deny"'*) return 0 ;; *) return 1 ;; esac; }
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-bl010-commitmsg-bl006-blocks: feat + Phase 2 + no Build Loop -> refuse (rc=1) ==="
+# ════════════════════════════════════════════════════════════════════
+scaffold 2 none
+stage_feat_with_test
+set_subject "feat: add foo without a Build Loop"
+res=$(run_commitmsg); rc="${res%%|*}"; body="${res#*|}"
+if [ "$rc" -eq 1 ] && has_bl006_block "$body"; then
+  pass "T-bl010-commitmsg-bl006-blocks: commit-msg surface REFUSES the feat: commit with BL-006's message (rc=1)"
+else
+  fail_ "T-bl010-commitmsg-bl006-blocks" "expected rc=1 + BL-006 block; got rc=$rc body: $body"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-bl010-commitmsg-bl006-passes: feat + a COMPLETE Build Loop -> allow (rc=0) ==="
+# ════════════════════════════════════════════════════════════════════
+scaffold 2 add-foo complete
+stage_feat_with_test
+set_subject "feat: add foo with a completed Build Loop"
+res=$(run_commitmsg); rc="${res%%|*}"; body="${res#*|}"
+if [ "$rc" -eq 0 ] && ! has_bl006_block "$body"; then
+  pass "T-bl010-commitmsg-bl006-passes: compliant feat: commit passes (rc=0, no BL-006 block)"
+else
+  fail_ "T-bl010-commitmsg-bl006-passes" "expected rc=0 + no block; got rc=$rc body: $body"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-bl010-editor-case: message via the editor (no -m), REAL git commit -> aborted ==="
+# ════════════════════════════════════════════════════════════════════
+# The exact population BL-010 exists for: an editor-opened commit (no -m). git
+# writes the editor's output to .git/COMMIT_EDITMSG, then runs the commit-msg
+# hook — which now runs BL-006. We inject the editor's message via GIT_EDITOR.
+scaffold 2 none
+install_commit_msg_hook
+stage_feat_with_test
+ED="$TMP/editor.sh"
+printf '#!/usr/bin/env bash\nprintf "%%s\\n" "feat: editor-authored feature" > "$1"\n' > "$ED"
+chmod +x "$ED"
+before_count=$( cd "$PROJ" && git rev-list --count HEAD )
+out=$( cd "$PROJ" && unset GITHUB_BASE_REF; GIT_EDITOR="$ED" git commit 2>&1 ); rc=$?
+out=$(printf '%s' "$out" | tr '\n' ' ')
+after_count=$( cd "$PROJ" && git rev-list --count HEAD )
+if [ "$rc" -ne 0 ]; then
+  pass "T-bl010-editor-case: git aborts the editor-authored feat: commit (rc=$rc)"
+else
+  fail_ "T-bl010-editor-case" "expected git commit to fail; got rc=0 out: $out"
+fi
+if has_bl006_block "$out"; then
+  pass "T-bl010-editor-case: the abort carries BL-006's remediation (editor case is now checked)"
+else
+  fail_ "T-bl010-editor-case" "expected BL-006 remediation in the abort output; out: $out"
+fi
+if [ "$after_count" -eq "$before_count" ]; then
+  pass "T-bl010-editor-case: no commit was created (history unchanged: $before_count)"
+else
+  fail_ "T-bl010-editor-case" "a commit landed despite the block ($before_count -> $after_count)"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-bl010-mothership-noop: no framework state -> sails through ==="
+# ════════════════════════════════════════════════════════════════════
+# (a) No phase-state.json -> check_commit_message reads phase 0 -> exits 0. This
+# is exactly the framework repo's own situation (process-checklist.sh present,
+# no phase-state.json): its own feat: commits must NEVER be blocked.
+scaffold none none
+stage_feat_with_test
+set_subject "feat: mothership commit with no phase state"
+res=$(run_commitmsg); rc="${res%%|*}"; body="${res#*|}"
+if [ "$rc" -eq 0 ] && ! has_bl006_block "$body"; then
+  pass "T-bl010-mothership-noop (no phase-state): feat: commit passes (rc=0) — phase gate short-circuits"
+else
+  fail_ "T-bl010-mothership-noop" "expected rc=0 + no block with no phase-state; got rc=$rc body: $body"
+fi
+teardown
+
+# (b) No scripts/process-checklist.sh at all -> bl006_terminal_enforce no-ops.
+# Second mothership-safety layer: a repo that predates BL-006 (or is not a
+# scaffolded project) has no checklist to delegate to.
+scaffold 2 none
+rm -f "$PROJ/scripts/process-checklist.sh"
+stage_feat_with_test
+set_subject "feat: add foo with no checklist present"
+res=$(run_commitmsg); rc="${res%%|*}"; body="${res#*|}"
+if [ "$rc" -eq 0 ] && ! has_bl006_block "$body"; then
+  pass "T-bl010-mothership-noop (no checklist): feat: commit passes (rc=0) — nothing to delegate to"
+else
+  fail_ "T-bl010-mothership-noop" "expected rc=0 + no block with no checklist; got rc=$rc body: $body"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-bl010-parity: the SAME fixture through both surfaces -> the SAME outcome ==="
+# ════════════════════════════════════════════════════════════════════
+# Block fixture: both surfaces must REFUSE.
+scaffold 2 none
+stage_feat_with_test
+set_subject "feat: parity block"
+res_cm=$(run_commitmsg); rc_cm="${res_cm%%|*}"; body_cm="${res_cm#*|}"
+res_pt=$(run_pretooluse 'git commit -m "feat: parity block"'); body_pt="${res_pt#*|}"
+if [ "$rc_cm" -eq 1 ] && has_bl006_block "$body_cm" && is_deny "$body_pt" && has_bl006_block "$body_pt"; then
+  pass "T-bl010-parity (block): commit-msg refuses (rc=1) AND PreToolUse denies — same BL-006 outcome"
+else
+  fail_ "T-bl010-parity" "block divergence: commit-msg rc=$rc_cm body: $body_cm || PreToolUse body: $body_pt"
+fi
+teardown
+
+# Compliant fixture: both surfaces must ALLOW.
+scaffold 2 add-foo complete
+stage_feat_with_test
+set_subject "feat: parity pass"
+res_cm=$(run_commitmsg); rc_cm="${res_cm%%|*}"; body_cm="${res_cm#*|}"
+res_pt=$(run_pretooluse 'git commit -m "feat: parity pass"'); rc_pt="${res_pt%%|*}"; body_pt="${res_pt#*|}"
+if [ "$rc_cm" -eq 0 ] && ! has_bl006_block "$body_cm" && ! is_deny "$body_pt"; then
+  pass "T-bl010-parity (pass): commit-msg allows (rc=0) AND PreToolUse does not deny — same BL-006 outcome"
+else
+  fail_ "T-bl010-parity" "pass divergence: commit-msg rc=$rc_cm body: $body_cm || PreToolUse rc=$rc_pt body: $body_pt"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-mutation: excise # BL-010-COMMITMSG-BL006 -> block disappears (RED->GREEN proof) ==="
+# ════════════════════════════════════════════════════════════════════
+# Removing the marked delegation line must make the commit-msg surface STOP
+# refusing the block fixture (RED), while the real gate still refuses it (GREEN)
+# — proving the marked line is what enforces BL-006 at the commit-msg surface.
+scaffold 2 none
+stage_feat_with_test
+set_subject "feat: mutation target"
+MUT_GATE="$PROJ/scripts/pre-commit-gate.mut.sh"
+grep -v '# BL-010-COMMITMSG-BL006' "$GATE" > "$MUT_GATE"
+chmod +x "$MUT_GATE"
+if ! grep -q '# BL-010-COMMITMSG-BL006' "$GATE"; then
+  fail_ "T-mutation" "BL-010-COMMITMSG-BL006 marker missing from the REAL gate — nothing to mutate"
+elif grep -q '# BL-010-COMMITMSG-BL006' "$MUT_GATE"; then
+  fail_ "T-mutation" "marker still present after excision — mutation did not apply"
+elif ! bash -n "$MUT_GATE" 2>/dev/null; then
+  fail_ "T-mutation" "mutated gate not syntactically valid after excision"
+else
+  res=$(run_commitmsg "$MUT_GATE"); rc="${res%%|*}"; body="${res#*|}"
+  if [ "$rc" -eq 0 ] && ! has_bl006_block "$body"; then
+    pass "T-mutation (RED): excising the marker removes the BL-006 refusal (rc=0) — the line is load-bearing"
+  else
+    fail_ "T-mutation" "mutant STILL refused (rc=$rc) — the marked line is not load-bearing; body: $body"
+  fi
+  res=$(run_commitmsg); rc="${res%%|*}"; body="${res#*|}"
+  if [ "$rc" -eq 1 ] && has_bl006_block "$body"; then
+    pass "T-mutation (GREEN): the real gate refuses the same fixture (rc=1) — contrast holds"
+  else
+    fail_ "T-mutation" "real gate did NOT refuse — contrast broken; rc=$rc body: $body"
+  fi
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl072-tdd-warn-detector.sh
+++ b/tests/test-bl072-tdd-warn-detector.sh
@@ -161,7 +161,7 @@ after=$(ledger_rows)
 if ! has_warn "$body" && [ "$rc" -eq 0 ] && [ "$after" -eq "$before" ]; then
   pass "T-feat-with-tests-silent: no WARN, rc=0, ledger unchanged (test rides along)"
 else
-  fail_ "T-feat-with-tests-silent" "expected silent+unchanged; rc=$rc ledger $before→$after; body: $body"
+  fail_ "T-feat-with-tests-silent" "expected silent+unchanged; rc=$rc ledger $before->$after; body: $body"
 fi
 teardown
 
@@ -193,7 +193,7 @@ after=$(ledger_rows)
 if ! has_warn "$body" && [ "$after" -eq "$before" ]; then
   pass "T-docs-only-silent: docs-only commit is silent, ledger unchanged"
 else
-  fail_ "T-docs-only-silent" "expected silent; rc=$rc ledger $before→$after; body: $body"
+  fail_ "T-docs-only-silent" "expected silent; rc=$rc ledger $before->$after; body: $body"
 fi
 teardown
 
@@ -222,7 +222,7 @@ after=$(ledger_rows)
 if ! has_warn "$body" && [ "$after" -eq "$before" ]; then
   pass "T-branch-diff-tests-count: earlier-branch test satisfies the gate (silent)"
 else
-  fail_ "T-branch-diff-tests-count" "expected silent (branch allowance); rc=$rc ledger $before→$after; body: $body"
+  fail_ "T-branch-diff-tests-count" "expected silent (branch allowance); rc=$rc ledger $before->$after; body: $body"
 fi
 teardown
 
@@ -754,7 +754,7 @@ after=$(ledger_rows)
 if [ "$rc" -eq 0 ] && ! has_fail "$body" && ! has_warn "$body" && [ "$after" -eq "$before" ]; then
   pass "T-lockfile-excluded: lockfile-only change is not implementation (silent, rc=0, no ledger row even on a sponsored tier)"
 else
-  fail_ "T-lockfile-excluded" "expected silent rc=0 + ledger unchanged; got rc=$rc ledger $before→$after body: $body"
+  fail_ "T-lockfile-excluded" "expected silent rc=0 + ledger unchanged; got rc=$rc ledger $before->$after body: $body"
 fi
 teardown
 


### PR DESCRIPTION
## What

BL-010 residual: wire the **BL-006 Build-Loop commit-message check** into the git **commit-msg** hook surface, so it reaches **editor-opened** (`git commit` with no `-m`) and **human-terminal** commits — the two populations the AI-only PreToolUse hook cannot see. Per Karl's 2026-07-10 decision: BL-010 = "Fix it".

Context: PR #166 (BL-072 C2) installed a commit-msg git hook (`init.sh::install_tdd_commit_msg_hook`) that invokes `pre-commit-gate.sh --terminal-mode --tdd-only` for the tier-keyed TDD gate. This PR adds the BL-006 check to that same surface — the older BL-006 check previously ran **only** on the AI-tooling PreToolUse surface.

## The parity contract (hard requirement)

The check at the new commit-msg surface enforces **exactly** what it enforces at the existing PreToolUse surface:

- **Identical delegate**: both call `process-checklist.sh --check-commit-message`.
- **Identical subject**: the first line of the message.
- **Identical block conditions + remediation**: `feat:` in Phase 2+ with no active/complete Build Loop → refuse with BL-006's Case A/B message; everything else passes.
- **Derivative pass-throughs**: the PreToolUse path detects merge/revert/cherry-pick from the command string; at commit-msg time the equivalent, current signals are the git sentinels `MERGE_HEAD` / `CHERRY_PICK_HEAD` / `REVERT_HEAD`, which `bl006_terminal_enforce` passes through.

No new policy, no tier logic, no new env vars. The load-bearing wiring line carries the mutation marker `# BL-010-COMMITMSG-BL006`.

## Mothership safety

The framework repo itself (no scaffolded state) must sail through, and it does — two independent layers:
1. `bl006_terminal_enforce` **no-ops** when the project has no `scripts/process-checklist.sh` (CWD-relative on purpose — it never resolves to the framework's own copy).
2. `check_commit_message` **phase-gates**: `current_phase < 2` → exit 0. This repo has no `.claude/phase-state.json` → phase 0 → pass.

This repo also has **no `.git/hooks/commit-msg`**, so the edited surface never runs on our own commits anyway; the change affects the *template* scaffolded projects receive.

## Editor-case coverage

`tests/test-bl010-commitmsg-bl006.sh::T-bl010-editor-case` drives a **real `git commit` with no `-m`**, injecting the message through `GIT_EDITOR`, through the actually-installed commit-msg hook — the exact population BL-010 exists for. The commit is aborted with BL-006's remediation and no commit lands.

## Upgrade path

`init.sh` installs the extended behavior for new scaffolds (the `--tdd-only` invocation is unchanged; the gate now enforces both gates). `upgrade-project.sh` does **not** backfill `.git/hooks/commit-msg` to existing projects (nor does it re-run `install_tdd_commit_msg_hook`) — this is consistent with how C2 itself shipped (install-time only, no silent upgrade-path invention). Projects that already have the C2 commit-msg hook pick up BL-006 as soon as their `scripts/pre-commit-gate.sh` is refreshed, since the wiring lives in the gate.

## Fold-in (PR #168 close-out verifier minor)

`tests/test-bl072-tdd-warn-detector.sh` used a literal U+2192 arrow adjacent to `$before`/`$after` in four failure diagnostics; under bash 3.2 `set -u` the multibyte-naive identifier scan crashes. Replaced all four `$before<U+2192>$after` with ASCII `$before->$after`. No other arrow-adjacent-to-expansion instances remain.

## Evidence

- **New suite** `tests/test-bl010-commitmsg-bl006.sh`: `Results: 11 passed, 0 failed` (block, pass, editor-case, mothership no-op × 2, cross-surface parity × 2, mutation RED→GREEN).
- **BL-072 C1/C2 suite** unchanged and green: `Results: 36 passed, 0 failed` (`bl006_terminal_enforce` is inert for fixtures with no project-local `process-checklist.sh`).
- **BL-006 suites** green: `test-check-commit-message.sh` 18/18, `test-pre-commit-gate-terminal-mode.sh` 3/3, `test-pre-commit-gate-classifier.sh` 13/13, `test-pre-commit-gate-lints.sh` 13/13.
- **Mutation proof** (verbatim): real gate → `rc=1` + `[FAIL] pre-commit gate: 'feat(...)' commit blocked — no Build Loop active.`; mutant (marker excised) → `rc=0`, zero BL-006 lines.
- **Lints**: all `scripts/lint-*.sh` pass (`lint-uat-scenarios.sh` bare rc=2 is the known parametrized tool); `lint-backlog-references.sh` rc=0; `lint-tests-registered.sh` rc=0; `lint-no-live-remote-in-tests.sh` rc=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)