### PR TITLE
fix(init): ship sourced gate dependencies to scaffolds + source-closure check (BL-088)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,7 @@ jobs:
             tests/test-process-checklist-classifier.sh
             tests/test-process-checklist-reset-phase1.sh
             tests/test-record-claude-commit.sh
+            tests/test-scaffold-source-closure.sh
             tests/test-session-test-gate-check-merge.sh
             tests/test-specs-plans-remaining-quartet.sh
             tests/test-test-gate-counter-sanitizer.sh

--- a/init.sh
+++ b/init.sh
@@ -1307,6 +1307,12 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/helpers-full.sh"  scripts/lib/
   cp "$SCRIPT_DIR/scripts/validate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-phase-gate.sh" scripts/
+  # BL-088: check-phase-gate.sh's Phase-3→4 gate auto-runs (and points the
+  # operator at) scripts/run-phase3-validation.sh via P3_DRIVER="$SCRIPT_DIR/
+  # run-phase3-validation.sh". Omitting it left the pass-path unreachable
+  # downstream — the gate failed closed but told the operator to run a script
+  # that did not exist in the scaffold. Ship the driver beside its caller.
+  cp "$SCRIPT_DIR/scripts/run-phase3-validation.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-updates.sh" scripts/
   cp "$SCRIPT_DIR/scripts/resume.sh" scripts/
@@ -1340,6 +1346,23 @@ create_project() {
   # the strict-mode framework-gate.sh.
   cp "$SCRIPT_DIR/scripts/lib/enforcement-level.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/gate-principles.sh"   scripts/lib/
+  # BL-088: sourced gate dependencies that shipped gate scripts load via
+  # "$SCRIPT_DIR/lib/<name>" but that this copy list never enumerated. Each
+  # absence is a silent downstream failure of the sourcing gate:
+  #   • tdd-classify.sh — pre-commit-gate.sh sources it for the tier-keyed TDD
+  #     hard block (BL-072 C2). Its silent-skip loop meant a test-less feat:
+  #     commit in a Sponsored-POC scaffold was ALLOWED (rc=0) — the flagship
+  #     gate no-op'd. (Empirically proven, PR #173 adversarial review.)
+  #   • phase2-state.sh — check-gate.sh sources it (no [-f] guard) for Phase-2
+  #     step write-back; absent, that path dies "No such file or directory".
+  #   • cdf-refresh.sh — upgrade-project.sh sources it to refresh CDF assets;
+  #     absent, every scaffolded project silently skipped the CDF sync on
+  #     upgrade. The source-closure check (tests/test-scaffold-source-closure.sh)
+  #     is the class fix: it fails if any shipped script sources an unshipped
+  #     sibling.
+  cp "$SCRIPT_DIR/scripts/lib/tdd-classify.sh"      scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/phase2-state.sh"      scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/cdf-refresh.sh"       scripts/lib/
   cp "$SCRIPT_DIR/scripts/install-filesystem-gates.sh" scripts/
   cp "$SCRIPT_DIR/scripts/detect-out-of-band-commits.sh" scripts/
   cp "$SCRIPT_DIR/scripts/hooks/record-claude-commit.sh" scripts/hooks/
@@ -1353,7 +1376,7 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/host.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
   chmod +x scripts/host-drivers/*.sh
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-test-gate-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-test-gate-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -478,6 +478,42 @@ if [ "$BACKFILL_ONLY" != true ]; then _bl015_sentinel_guard; fi
     done
     print_ok "Vendored skills synced into .claude/skills/ (code-upgrade-project-3)"
   fi
+
+  # --- BL-088: scaffold source-closure backfill ---------------------------
+  # init.sh's copy list omitted several sourced gate dependencies, so projects
+  # scaffolded before the fix lack them and the sourcing gate breaks silently:
+  #   • scripts/lib/tdd-classify.sh — pre-commit-gate.sh's silent-skip source
+  #     loop no-op'd the tier-keyed TDD hard block (a test-less feat: commit in
+  #     a Sponsored-POC project was ALLOWED). This block restores enforcement.
+  #   • scripts/lib/phase2-state.sh — check-gate.sh sources it unguarded.
+  #   • scripts/lib/cdf-refresh.sh  — upgrade sources it to sync CDF assets.
+  #   • scripts/run-phase3-validation.sh — check-phase-gate.sh's Phase-3→4 gate
+  #     auto-runs / points the operator at it.
+  # Lives inside the backfill subshell (after the BL-015 sentinel guard, per
+  # BL-081 ordering) so BOTH --backfill-only and the full upgrade heal it.
+  # Idempotent: cp overwrites identically; the -ef self-copy guard skips the
+  # in-framework-repo invocation (source and dest resolve to the same file).
+  if [ -d scripts ]; then
+    mkdir -p scripts/lib
+    for _bl088_rel in \
+      "lib/tdd-classify.sh" \
+      "lib/phase2-state.sh" \
+      "lib/cdf-refresh.sh" \
+      "run-phase3-validation.sh"; do
+      _bl088_src="$SCRIPT_DIR/$_bl088_rel"
+      _bl088_dst="scripts/$_bl088_rel"
+      [ -f "$_bl088_src" ] || continue
+      if [ -e "$_bl088_dst" ] && [ "$_bl088_src" -ef "$_bl088_dst" ]; then
+        continue
+      fi
+      cp "$_bl088_src" "$_bl088_dst"
+      case "$_bl088_rel" in
+        run-phase3-validation.sh) chmod +x "$_bl088_dst" ;;  # exec'd by the gate
+      esac
+      print_ok "scripts/$_bl088_rel backfilled (BL-088 source-closure)"
+    done
+    unset _bl088_rel _bl088_src _bl088_dst
+  fi
 )
 
 # --backfill-only short-circuits here — no track / deployment / POC

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -318,6 +318,10 @@ check_scripts() {
   local scripts=(
     "scripts/validate.sh"
     "scripts/check-phase-gate.sh"
+    # BL-088: the Phase-3→4 gate in check-phase-gate.sh auto-runs / points at
+    # this driver via P3_DRIVER="$SCRIPT_DIR/run-phase3-validation.sh". Verify +
+    # backfill it so pre-BL-088 projects heal on `verify-install --auto-fix`.
+    "scripts/run-phase3-validation.sh"
     "scripts/check-gate.sh"
     "scripts/check-updates.sh"
     "scripts/resume.sh"
@@ -353,6 +357,14 @@ check_scripts() {
   local libs=(
     "scripts/lib/enforcement-level.sh"
     "scripts/lib/gate-principles.sh"
+    # BL-088: sourced gate deps that shipped scripts load via
+    # "$SCRIPT_DIR/lib/<name>" — each absence silently breaks the sourcing
+    # gate (tdd-classify.sh no-ops the TDD hard block; phase2-state.sh crashes
+    # check-gate.sh's Phase-2 write-back; cdf-refresh.sh silently skips the CDF
+    # upgrade sync). Verify + backfill so pre-BL-088 projects heal on fixup.
+    "scripts/lib/tdd-classify.sh"
+    "scripts/lib/phase2-state.sh"
+    "scripts/lib/cdf-refresh.sh"
   )
   local lib_name
   for lib in "${libs[@]}"; do
@@ -1075,7 +1087,7 @@ fix_script() {
 }
 
 # Generate fix functions for each script
-for _s in validate check-phase-gate check-gate check-updates resume intake-wizard resolve-tools upgrade-project reconfigure-project verify-install test-gate check-versions session-version-check session-test-gate-check session-end-qdrant-reminder session-mcp-gate process-checklist pre-commit-gate track-tool-usage pending-approval lint-uat-scenarios escalate-to-user detect-out-of-band-commits install-filesystem-gates lint-fixture-envelopes; do
+for _s in validate check-phase-gate run-phase3-validation check-gate check-updates resume intake-wizard resolve-tools upgrade-project reconfigure-project verify-install test-gate check-versions session-version-check session-test-gate-check session-end-qdrant-reminder session-mcp-gate process-checklist pre-commit-gate track-tool-usage pending-approval lint-uat-scenarios escalate-to-user detect-out-of-band-commits install-filesystem-gates lint-fixture-envelopes; do
   eval "fix_script_chmod_${_s}() { chmod +x 'scripts/${_s}.sh'; }"
   eval "fix_script_copy_${_s}() { fix_script '${_s}.sh'; }"
 done
@@ -1085,6 +1097,11 @@ eval "fix_script_copy_record-claude-commit()  { fix_script 'hooks/record-claude-
 # BL-030: sourced libs — no chmod, copy only.
 fix_lib_copy_enforcement-level() { if has_source && [ -f "$SOURCE_DIR/scripts/lib/enforcement-level.sh" ]; then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/enforcement-level.sh" scripts/lib/; else return 1; fi; }
 fix_lib_copy_gate-principles()   { if has_source && [ -f "$SOURCE_DIR/scripts/lib/gate-principles.sh" ];   then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/gate-principles.sh"   scripts/lib/; else return 1; fi; }
+# BL-088: sourced gate deps (tdd-classify, phase2-state, cdf-refresh). No chmod
+# — they are sourced, not executed (mirrors enforcement-level/gate-principles).
+fix_lib_copy_tdd-classify()      { if has_source && [ -f "$SOURCE_DIR/scripts/lib/tdd-classify.sh" ];      then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/tdd-classify.sh"      scripts/lib/; else return 1; fi; }
+fix_lib_copy_phase2-state()      { if has_source && [ -f "$SOURCE_DIR/scripts/lib/phase2-state.sh" ];      then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/phase2-state.sh"      scripts/lib/; else return 1; fi; }
+fix_lib_copy_cdf-refresh()       { if has_source && [ -f "$SOURCE_DIR/scripts/lib/cdf-refresh.sh" ];       then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/cdf-refresh.sh"       scripts/lib/; else return 1; fi; }
 # Hooks live in a subdirectory; chmod + copy paths reflect that. The
 # basename of scripts/hooks/bypass-detector.sh is `bypass-detector`, so
 # the helper names must match (with hyphens, via eval).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -2222,3 +2222,28 @@ Two follow-ups from the PR #169 verifier (BL-010 residual fix), both zero-impact
 **Trigger:** (1) fires if/when anyone installs a commit-msg hook in the framework repo itself; (2) doc-only unless strict amend parity is ever demanded.
 
 **Related:** BL-010 (PR #169 + its correction comment); BL-006; `scripts/pre-commit-gate.sh::bl006_terminal_enforce`; `scripts/lib/helpers-core.sh::guard_not_in_framework`; the C2 mothership-safety pattern (PR #166).
+
+---
+
+## BL-088: init.sh scaffold omits sourced dependencies (tdd-classify.sh, run-phase3-validation.sh) — TDD hard block silently no-ops downstream
+
+**Logged:** 2026-07-11 (PR #173 adversarial review, empirical repro)
+**Category:** Bug / deployment-gap + defect-class (fixture-hides-scaffold-gap)
+**Severity:** High
+**Status:** Closed — shipped 2026-07-11 (PR #175). Fix-first-flip-second: the fix commit + this flip are both in PR #175.
+
+**What:** `init.sh` ships a CURATED `scripts/` copy list to every scaffolded project (`init.sh:~1305-1360`). It was never updated when BL-072 C2 (PR #166) added `scripts/lib/tdd-classify.sh`, which `scripts/pre-commit-gate.sh` sources via a silently-skipping loop (`:21-27` — absent ⇒ no-op). RESULT (empirically reproduced with a full hermetic `--deployment organizational --gov-mode sponsored_poc --language typescript --no-remote-creation` init): in a real scaffolded Sponsored-POC project a test-less `feat:` commit was ALLOWED (`rc=0`) — the flagship TDD hard block silently no-op'd downstream.
+
+**The two instances (same class):**
+1. `scripts/lib/tdd-classify.sh` — sourced by `pre-commit-gate.sh` (silent-skip loop) ⇒ the tier-keyed TDD hard block no-ops in the scaffold.
+2. `scripts/run-phase3-validation.sh` — `check-phase-gate.sh`'s Phase-3→4 gate auto-runs / points the operator at it (`P3_DRIVER="$SCRIPT_DIR/run-phase3-validation.sh"`). Unshipped, the gate failed CLOSED but instructed the operator to run a script that did not exist — the pass-path was unreachable.
+
+**Two further instances the closure check surfaced (also fixed):** `check-gate.sh` sources `scripts/lib/phase2-state.sh` (unguarded ⇒ "No such file or directory" crash) and `upgrade-project.sh` sources `scripts/lib/cdf-refresh.sh` (⇒ every scaffolded project silently skipped the CDF asset sync on upgrade). Neither was shipped.
+
+**Why the wave's tests missed it:** every BL-072 test copies `tdd-classify.sh` into its OWN fixture (`tests/test-bl072-tdd-warn-detector.sh:311/:391` `cp "$REPO_ROOT"/scripts/lib/*.sh …`) — the fixture supplied the dependency the real scaffold lacked. Fixture-hides-scaffold-gap: the test scaffold is not byte-derived from `init.sh`'s copy mechanism, so it cannot see what `init.sh` fails to ship (precedent: BL-074, the same class in test scaffolds).
+
+**The class fix (source-closure check):** `tests/test-scaffold-source-closure.sh` derives `init.sh`'s shipped set mechanically from its `cp` lines (not a hardcoded copy — that would drift; expands the `host-drivers/*.sh` glob) and asserts every `"$SCRIPT_DIR/<sibling>.sh"` a shipped script sources/execs is ALSO shipped (marker `# BL-088-CLOSURE`), excluding author-wired degrade-safe optionals (the `$PROJECT_ROOT`-preferred pre-commit-lint idiom). RED on pre-fix `init.sh` (4 gaps) → GREEN after (0 gaps, 42 shipped); mutation self-tests prove it load-bearing. This catches any FUTURE sourced-but-unshipped sibling, not just today's four.
+
+**Fix:** `init.sh` ships the driver (+chmod) and the three libs; `verify-install.sh` adds them to its verify arrays + fix functions (`--auto-fix` heals existing projects, BL-074 precedent); `upgrade-project.sh` gains an idempotent source-closure backfill inside the backfill subshell — after the BL-015 sentinel guard (BL-081 ordering) — so `--backfill-only` and the full upgrade both heal existing projects. Also added the init.sh-driven fidelity test `tests/test-scaffold-tdd-block-real.sh` (real Sponsored-POC scaffold blocks the test-less `feat:` commit; upgrade/verify backfill regressions).
+
+**Related:** BL-072 C2 (PR #166, added `tdd-classify.sh`); BL-070 (`run-phase3-validation.sh`); BL-074 (fixture-hides-scaffold-gap precedent); BL-015/BL-081 (sentinel-before-backfill ordering); PR #173 (surfacing adversarial review); PR #175 (this fix). `init.sh:~1305-1360`; `scripts/pre-commit-gate.sh:21-27`; `scripts/check-phase-gate.sh` BL-070-GATE-AUTORUN; `scripts/verify-install.sh`; `scripts/upgrade-project.sh`.

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -522,6 +522,25 @@ else
   fail "tests/test-phase3-validation-gate.sh FAILED (run for details)"
 fi
 
+# BL-088: scaffold source-closure. init.sh must ship every sibling script that a
+# shipped gate sources/execs via "$SCRIPT_DIR/..." (tdd-classify.sh silently
+# no-op'd the TDD hard block; run-phase3-validation.sh's pass-path was
+# unreachable). test-scaffold-source-closure.sh is the static class killer (RED
+# if any shipped script sources an unshipped sibling); test-scaffold-tdd-block-
+# real.sh is the init.sh-driven fidelity proof (a real Sponsored-POC scaffold
+# blocks a test-less feat: commit) + the upgrade/verify backfill for existing
+# projects.
+if bash "$SCRIPT_DIR/tests/test-scaffold-source-closure.sh" >/dev/null 2>&1; then
+  pass "tests/test-scaffold-source-closure.sh"
+else
+  fail "tests/test-scaffold-source-closure.sh FAILED (run for details)"
+fi
+if bash "$SCRIPT_DIR/tests/test-scaffold-tdd-block-real.sh" >/dev/null 2>&1; then
+  pass "tests/test-scaffold-tdd-block-real.sh"
+else
+  fail "tests/test-scaffold-tdd-block-real.sh FAILED (run for details)"
+fi
+
 # BL-070 increment (WP-B1): scripts/run-phase3-validation.sh's `license` scanner
 # promoted from stub to REAL. Reads the project language from
 # .claude/tool-preferences.json (.context.language — the canonical source, NOT

--- a/tests/test-scaffold-source-closure.sh
+++ b/tests/test-scaffold-source-closure.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# tests/test-scaffold-source-closure.sh
+#
+# BL-088 CLASS KILLER — scaffold source-closure check.
+#
+# THE DEFECT CLASS
+#   init.sh ships a CURATED list of scripts/ files to every scaffolded
+#   project (the `cp "$SCRIPT_DIR/scripts/..."` block). When a shipped gate
+#   script grows a new `source`/`.`/`bash "$SCRIPT_DIR/<sibling>"` dependency
+#   but the copy list is NOT updated, the sibling is absent downstream and the
+#   feature breaks silently: a silently-skipping source loop no-ops the gate
+#   (BL-072 tdd-classify.sh — a test-less feat: commit was ALLOWED in a real
+#   Sponsored-POC scaffold), an unguarded source crashes the path
+#   (check-gate.sh → phase2-state.sh), or an exec pass-path points the operator
+#   at a script that does not exist (check-phase-gate.sh → run-phase3-validation.sh).
+#   Every BL-072 test masked this by copying tdd-classify.sh into its own
+#   fixture — the fixture supplied the dependency the real scaffold lacked.
+#
+# THE CHECK (this file)
+#   1. Derive the SHIPPED SET mechanically from init.sh's cp lines (never a
+#      hardcoded copy of the list — that would drift). Expands the
+#      host-drivers/*.sh glob against the real scripts/ tree.
+#   2. For every shipped scripts/**.sh, extract each reference to a sibling
+#      script under scripts/ expressed via "$SCRIPT_DIR/<subpath>.sh" (the
+#      script's own install directory). Full-line comments are stripped so a
+#      usage-example comment is not mistaken for a dependency edge.
+#   3. Assert every such sibling is ALSO in the shipped set — UNLESS it is
+#      explicitly degrade-safe: a target the corpus ALSO references via a
+#      project-root-preferred prefix ($PROJECT_ROOT/$PROJECT_DIR/$REPO_ROOT/
+#      $proj_root) is an author-wired optional (the pre-commit lint idiom:
+#      prefer-project-local, clean-skip-if-absent) and is excluded.
+#
+#   This catches (a) the two shipped gaps this PR fixes AND (b) any future
+#   sourced-but-unshipped sibling. The load-bearing comparison carries the
+#   marker # BL-088-CLOSURE.
+#
+# Hermetic + fast: pure static analysis, no init.sh execution, bash-3.2 safe
+# (no `case ... )` inside $(...); temp files instead of associative arrays).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# closure_check <init_file> <scripts_dir>
+#   Prints one "GAP: ..." line per shipped script that sources/execs an
+#   unshipped, non-optional sibling. Returns 0 iff closed (no gaps).
+#   Also prints a "SHIPPED_COUNT n" line so callers can assert the parser
+#   actually derived a set (tamper-evidence against a silent-empty parse).
+closure_check() {
+  local init_file="$1" scripts_dir="$2"
+  local work ship opt rel base f sdir refs sub target
+  work="$(mktemp -d)"
+  ship="$work/ship"; opt="$work/opt"; : > "$ship"; : > "$opt"
+
+  # 1) Shipped set from init.sh cp lines.
+  grep -E 'cp[[:space:]]+"\$SCRIPT_DIR/scripts/' "$init_file" | while IFS= read -r line; do
+    rel="$(printf '%s\n' "$line" | sed -n 's#.*cp[[:space:]]*"\$SCRIPT_DIR/\(scripts/[^"]*\)".*#\1#p')"
+    [ -n "$rel" ] || continue
+    if [ "${rel%/}" != "$rel" ]; then
+      # captured path ends in '/': a glob copy of *.sh under that dir
+      base="${rel#scripts/}"
+      for f in "$scripts_dir/$base"*.sh; do
+        [ -f "$f" ] && printf 'scripts/%s%s\n' "$base" "$(basename "$f")" >> "$ship"
+      done
+    else
+      printf '%s\n' "$rel" >> "$ship"
+    fi
+  done
+  sort -u "$ship" -o "$ship"
+
+  # 2) Optional set: any sibling the corpus references via a project-root
+  #    prefix (degrade-safe, author-wired optional). Comments stripped.
+  while IFS= read -r rel; do
+    case "$rel" in *.sh) : ;; *) continue ;; esac
+    f="$scripts_dir/${rel#scripts/}"
+    [ -f "$f" ] || continue
+    grep -vE '^[[:space:]]*#' "$f" \
+      | grep -oE '\$(PROJECT_ROOT|PROJECT_DIR|REPO_ROOT|proj_root)/scripts/(lib/|hooks/|host-drivers/)?[A-Za-z0-9_.-]+\.sh' 2>/dev/null \
+      | sed -E 's#^\$[A-Za-z_]+/##' >> "$opt"
+  done < "$ship"
+  sort -u "$opt" -o "$opt"
+
+  # 3) Closure: every $SCRIPT_DIR sibling reference must be shipped-or-optional.
+  echo "SHIPPED_COUNT $(grep -c . "$ship")"
+  while IFS= read -r rel; do
+    case "$rel" in *.sh) : ;; *) continue ;; esac
+    f="$scripts_dir/${rel#scripts/}"
+    [ -f "$f" ] || continue
+    sdir="scripts/$(dirname "${rel#scripts/}")"
+    sdir="${sdir%/.}"
+    refs="$(grep -vE '^[[:space:]]*#' "$f" \
+              | grep -oE '\$SCRIPT_DIR/(lib/|hooks/|host-drivers/)?[A-Za-z0-9_.-]+\.sh' 2>/dev/null \
+              | sed -E 's#^\$SCRIPT_DIR/##' | sort -u)"
+    [ -n "$refs" ] || continue
+    printf '%s\n' "$refs" | while IFS= read -r sub; do
+      [ -n "$sub" ] || continue
+      target="$sdir/$sub"
+      grep -qxF "$target" "$opt" && continue
+      # BL-088-CLOSURE: a "$SCRIPT_DIR" sibling reference in a shipped script
+      # must itself be shipped by init.sh, or the dependency breaks downstream.
+      grep -qxF "$target" "$ship" && continue
+      printf 'GAP: %s sources/execs %s but init.sh does not ship it\n' "$rel" "$target"
+    done
+  done < "$ship" | sort -u
+
+  local rc=0
+  rm -rf "$work"
+  return "$rc"
+}
+
+INIT="$REPO_ROOT/init.sh"
+SCRIPTS="$REPO_ROOT/scripts"
+
+# ── T-parser-nonempty: the ship-set parser must actually derive a set ──────
+# Guards the silent-success failure mode: a broken regex that yields an empty
+# shipped set would scan nothing and vacuously report zero gaps.
+echo "=== T-parser-nonempty: init.sh cp-list parse yields a real shipped set ==="
+out="$(closure_check "$INIT" "$SCRIPTS")"
+shipped_n="$(printf '%s\n' "$out" | sed -n 's/^SHIPPED_COUNT //p')"
+if [ -n "$shipped_n" ] && [ "$shipped_n" -ge 30 ]; then
+  pass "T-parser-nonempty: derived $shipped_n shipped scripts from init.sh"
+else
+  fail_ "T-parser-nonempty" "parser derived only '${shipped_n:-0}' shipped scripts (expected >=30) — cp-line regex likely drifted"
+fi
+
+# Sentinel: known-shipped load-bearing files must be present in the set.
+echo "=== T-parser-sentinels: known-shipped gate files are in the derived set ==="
+sentinels_ok=1
+# Re-derive the ship list directly for the sentinel assertion.
+ship_probe="$(grep -E 'cp[[:space:]]+"\$SCRIPT_DIR/scripts/' "$INIT" \
+  | sed -n 's#.*cp[[:space:]]*"\$SCRIPT_DIR/\(scripts/[^"]*\)".*#\1#p')"
+for want in scripts/pre-commit-gate.sh scripts/check-phase-gate.sh scripts/lib/helpers-core.sh; do
+  printf '%s\n' "$ship_probe" | grep -qxF "$want" || sentinels_ok=0
+done
+if [ "$sentinels_ok" -eq 1 ]; then
+  pass "T-parser-sentinels: pre-commit-gate.sh, check-phase-gate.sh, helpers-core.sh all in the shipped set"
+else
+  fail_ "T-parser-sentinels" "a known-shipped sentinel file was missing from the derived set — parser broken"
+fi
+
+# ── T-closure-green: the REAL tree is closed (post-BL-088 fix) ─────────────
+echo "=== T-closure-green: every shipped script's \$SCRIPT_DIR deps are shipped ==="
+gaps="$(closure_check "$INIT" "$SCRIPTS" | grep '^GAP:' || true)"
+if [ -z "$gaps" ]; then
+  pass "T-closure-green: source-closure holds — no shipped script sources an unshipped sibling"
+else
+  fail_ "T-closure-green" "open source-closure gap(s):
+$gaps"
+fi
+
+# ── T-closure-catches-tdd-classify (mutation): re-open the ORIGINAL bug ─────
+# Remove init.sh's tdd-classify.sh cp line from a COPY. pre-commit-gate.sh
+# still sources "$SCRIPT_DIR/lib/tdd-classify.sh" -> the check MUST go RED.
+echo "=== T-closure-catches-tdd-classify: drop the tdd-classify cp line → RED ==="
+mut_init="$(mktemp)"
+grep -v 'cp "\$SCRIPT_DIR/scripts/lib/tdd-classify.sh"' "$INIT" > "$mut_init"
+mut_gaps="$(closure_check "$mut_init" "$SCRIPTS" | grep '^GAP:' || true)"
+if printf '%s\n' "$mut_gaps" | grep -q 'scripts/lib/tdd-classify.sh'; then
+  pass "T-closure-catches-tdd-classify: removing the cp line makes the check flag tdd-classify.sh"
+else
+  fail_ "T-closure-catches-tdd-classify" "mutant init.sh (no tdd-classify cp) did NOT flag the gap — check not load-bearing; got:
+$mut_gaps"
+fi
+rm -f "$mut_init"
+
+# ── T-closure-catches-generic (mutation): a DIFFERENT unshipped sibling ─────
+# Remove the check-versions.sh cp line; session-version-check.sh execs
+# "$SCRIPT_DIR/check-versions.sh" -> the check MUST flag it. Proves the check
+# is general (not special-cased to the two known gaps).
+echo "=== T-closure-catches-generic: drop the check-versions cp line → RED ==="
+mut_init2="$(mktemp)"
+grep -v 'cp "\$SCRIPT_DIR/scripts/check-versions.sh"' "$INIT" > "$mut_init2"
+mut_gaps2="$(closure_check "$mut_init2" "$SCRIPTS" | grep '^GAP:' || true)"
+if printf '%s\n' "$mut_gaps2" | grep -q 'scripts/check-versions.sh'; then
+  pass "T-closure-catches-generic: removing the cp line makes the check flag check-versions.sh"
+else
+  fail_ "T-closure-catches-generic" "mutant init.sh (no check-versions cp) did NOT flag the gap; got:
+$mut_gaps2"
+fi
+rm -f "$mut_init2"
+
+# ── T-closure-excludes-optional: the lint idiom is NOT flagged ──────────────
+# The pre-commit lints (lint-tests-registered.sh, ...) are exec'd via a
+# prefer-project-local candidate loop with a clean skip. They are intentionally
+# NOT shipped by init.sh; the check must NOT flag them.
+echo "=== T-closure-excludes-optional: degrade-safe lint deps are not flagged ==="
+opt_leak="$(closure_check "$INIT" "$SCRIPTS" | grep '^GAP:' | grep -E 'lint-(tests-registered|counter-antipattern|backlog-references|fix-functions-stderr|raw-read-prompt|no-live-remote-in-tests)\.sh' || true)"
+if [ -z "$opt_leak" ]; then
+  pass "T-closure-excludes-optional: project-local-preferred lint deps correctly excluded"
+else
+  fail_ "T-closure-excludes-optional" "check wrongly flagged a degrade-safe optional:
+$opt_leak"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-scaffold-tdd-block-real.sh
+++ b/tests/test-scaffold-tdd-block-real.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# tests/test-scaffold-tdd-block-real.sh
+#
+# BL-088 scaffold-fidelity + backfill regression (init.sh-driven, hermetic).
+#
+# THE BUG (empirically proven, PR #173 adversarial review)
+#   init.sh shipped a CURATED scripts/ copy list that was never updated when
+#   BL-072 C2 added scripts/lib/tdd-classify.sh (sourced by pre-commit-gate.sh
+#   via a silently-skipping loop). In a REAL scaffolded Sponsored-POC project,
+#   a test-less feat: commit was therefore ALLOWED (rc=0) — the flagship TDD
+#   hard block silently no-op'd. Same class: scripts/run-phase3-validation.sh
+#   (the Phase-3→4 driver) was likewise unshipped.
+#
+# WHY THE BL-072 SUITE MISSED IT
+#   Every BL-072 test copies tdd-classify.sh into its OWN fixture
+#   (test-bl072-tdd-warn-detector.sh :311/:391 `cp "$REPO_ROOT"/scripts/lib/*.sh
+#   ...`) — the fixture supplied the dependency the real scaffold lacked. This
+#   test refuses to hand-copy: the fixture's scripts/ tree is byte-derived from
+#   INIT.SH'S OWN copy mechanism (a full hermetic `--no-remote-creation` init),
+#   so it fails if — and only if — the real product ships the gap.
+#
+# Cases:
+#   T-scaffold-ships-deps        the scaffold contains the four previously-
+#                                omitted sourced deps (run-phase3 executable).
+#   T-scaffold-tdd-block-real    deployment=organizational + poc_mode=
+#                                sponsored_poc + init's commit-msg hook; a
+#                                test-less feat: commit is BLOCKED (rc=1 +
+#                                [FAIL]). RED on pre-BL-088 main (rc=0).
+#   T-scaffold-phase3-driver-present  run-phase3-validation.sh present + exec.
+#   T-backfill-upgrade           OLD-list project (4 files deleted) → repo
+#                                upgrade-project.sh --backfill-only → files
+#                                restored AND the TDD block now enforces (rc=1).
+#   T-backfill-verify            OLD-list project → verify-install --auto-fix →
+#                                files restored.
+#
+# Hermetic: mktemp, git identity set locally, GITHUB_BASE_REF unset, init.sh
+# run with --no-remote-creation (the blessed no-live-remote path). bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+UPGRADE="$REPO_ROOT/scripts/upgrade-project.sh"
+VERIFY="$REPO_ROOT/scripts/verify-install.sh"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# Dependency guard — init.sh needs jq + git.
+if ! command -v jq >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: jq/git required for the init.sh-driven scaffold test"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+# ── One hermetic init: build the canonical scaffold ONCE (byte-derived) ─────
+SCAFFOLD="$TOPTMP/scaffold"
+echo "=== Scaffolding a Sponsored-POC project via real init.sh (hermetic) ==="
+init_err="$TOPTMP/init.err"
+( cd "$TOPTMP" && "$INIT" --non-interactive \
+    --project bl088-scaffold \
+    --platform web \
+    --deployment organizational \
+    --gov-mode sponsored_poc \
+    --language typescript \
+    --git-host github \
+    --visibility private \
+    --project-dir "$SCAFFOLD" \
+    --no-remote-creation ) >"$TOPTMP/init.out" 2>"$init_err"
+init_rc=$?
+if [ "$init_rc" -ne 0 ]; then
+  fail_ "scaffold-init" "init.sh exited $init_rc; stderr tail: $(tail -8 "$init_err" | tr '\n' '|')"
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+
+# ── T-scaffold-ships-deps ───────────────────────────────────────────────────
+echo "=== T-scaffold-ships-deps: the four sourced gate deps are present ==="
+deps_ok=1
+for rel in scripts/lib/tdd-classify.sh scripts/lib/phase2-state.sh \
+           scripts/lib/cdf-refresh.sh scripts/run-phase3-validation.sh; do
+  [ -f "$SCAFFOLD/$rel" ] || { deps_ok=0; echo "    missing: $rel"; }
+done
+if [ "$deps_ok" -eq 1 ]; then
+  pass "T-scaffold-ships-deps: tdd-classify, phase2-state, cdf-refresh, run-phase3-validation all shipped"
+else
+  fail_ "T-scaffold-ships-deps" "init.sh omitted one or more sourced deps (the BL-088 gap)"
+fi
+
+# ── T-scaffold-phase3-driver-present ────────────────────────────────────────
+echo "=== T-scaffold-phase3-driver-present: driver present + executable ==="
+if [ -x "$SCAFFOLD/scripts/run-phase3-validation.sh" ]; then
+  pass "T-scaffold-phase3-driver-present: scripts/run-phase3-validation.sh is executable"
+else
+  fail_ "T-scaffold-phase3-driver-present" "run-phase3-validation.sh missing or not executable (Phase-3→4 pass-path unreachable)"
+fi
+
+# feat_commit_blocks <project_dir> <label> — stage a test-less feat: impl and
+# attempt a commit; echoes "BLOCKED" (rc=1) or "ALLOWED" (rc=0).
+feat_commit_blocks() {
+  local proj="$1" tag="$2" rc=0
+  ( cd "$proj"
+    git config user.email bl088@test.invalid
+    git config user.name  bl088-test
+    mkdir -p "src_$tag"
+    printf 'export const add_%s = (a: number, b: number): number => a + b;\n' "$tag" > "src_$tag/widget.ts"
+    git add "src_$tag/widget.ts"
+    git commit -m "feat: add widget $tag without a test" >"$proj/commit.$tag.log" 2>&1 )
+  rc=$?
+  [ "$rc" -eq 0 ] && echo "ALLOWED" || echo "BLOCKED"
+}
+
+# ── T-scaffold-tdd-block-real ───────────────────────────────────────────────
+echo "=== T-scaffold-tdd-block-real: test-less feat: commit is BLOCKED (rc=1) ==="
+BLK="$TOPTMP/blk"
+cp -r "$SCAFFOLD" "$BLK"
+# Confirm init installed the commit-msg hook the way it ships it.
+if ! grep -q 'tdd-only' "$BLK/.git/hooks/commit-msg" 2>/dev/null; then
+  fail_ "T-scaffold-tdd-block-real" "init.sh did not install the --tdd-only commit-msg hook"
+else
+  verdict="$(feat_commit_blocks "$BLK" main)"
+  if [ "$verdict" = "BLOCKED" ] && grep -q 'BL-072 TDD ordering' "$BLK/commit.main.log"; then
+    pass "T-scaffold-tdd-block-real: sponsored-POC scaffold blocks the test-less feat: commit"
+  else
+    fail_ "T-scaffold-tdd-block-real" "expected BLOCKED+[FAIL]; got $verdict; log: $(tail -3 "$BLK/commit.main.log" | tr '\n' '|')"
+  fi
+fi
+
+# ── T-backfill-upgrade ──────────────────────────────────────────────────────
+# Simulate a pre-BL-088 project: delete the four files, then heal via the repo
+# upgrade-project.sh --backfill-only (source-closure backfill, after the BL-015
+# sentinel guard). Assert restore AND that the TDD block then enforces.
+echo "=== T-backfill-upgrade: OLD-list project → upgrade --backfill-only heals ==="
+BFU="$TOPTMP/bf-upgrade"
+cp -r "$SCAFFOLD" "$BFU"
+rm -f "$BFU/scripts/lib/tdd-classify.sh" "$BFU/scripts/lib/phase2-state.sh" \
+      "$BFU/scripts/lib/cdf-refresh.sh"  "$BFU/scripts/run-phase3-validation.sh"
+( cd "$BFU" && bash "$UPGRADE" --backfill-only ) >"$TOPTMP/bf-upgrade.log" 2>&1
+bfu_rc=$?
+bfu_ok=1
+for rel in scripts/lib/tdd-classify.sh scripts/lib/phase2-state.sh \
+           scripts/lib/cdf-refresh.sh scripts/run-phase3-validation.sh; do
+  [ -f "$BFU/$rel" ] || { bfu_ok=0; echo "    not restored: $rel"; }
+done
+if [ "$bfu_ok" -eq 1 ] && [ -x "$BFU/scripts/run-phase3-validation.sh" ] && [ "$bfu_rc" -eq 0 ]; then
+  verdict="$(feat_commit_blocks "$BFU" bf)"
+  if [ "$verdict" = "BLOCKED" ]; then
+    pass "T-backfill-upgrade: --backfill-only restored all four deps; TDD block now enforces"
+  else
+    fail_ "T-backfill-upgrade" "files restored but the TDD block did NOT engage (got $verdict)"
+  fi
+else
+  fail_ "T-backfill-upgrade" "backfill rc=$bfu_rc; restore incomplete or driver not executable"
+fi
+
+# ── T-backfill-verify ───────────────────────────────────────────────────────
+echo "=== T-backfill-verify: OLD-list project → verify-install --auto-fix heals ==="
+BFV="$TOPTMP/bf-verify"
+cp -r "$SCAFFOLD" "$BFV"
+rm -f "$BFV/scripts/lib/tdd-classify.sh" "$BFV/scripts/lib/phase2-state.sh" \
+      "$BFV/scripts/lib/cdf-refresh.sh"  "$BFV/scripts/run-phase3-validation.sh"
+# Ensure the fixup source resolves to the framework under test.
+mkdir -p "$BFV/.claude"
+printf '{"source_dir":"%s"}\n' "$REPO_ROOT" > "$BFV/.claude/orchestrator-source.json"
+( cd "$BFV" && bash "$VERIFY" --auto-fix ) >"$TOPTMP/bf-verify.log" 2>&1
+bfv_ok=1
+for rel in scripts/lib/tdd-classify.sh scripts/lib/phase2-state.sh \
+           scripts/lib/cdf-refresh.sh scripts/run-phase3-validation.sh; do
+  [ -f "$BFV/$rel" ] || { bfv_ok=0; echo "    not restored: $rel"; }
+done
+if [ "$bfv_ok" -eq 1 ] && [ -x "$BFV/scripts/run-phase3-validation.sh" ]; then
+  pass "T-backfill-verify: verify-install --auto-fix restored all four deps"
+else
+  fail_ "T-backfill-verify" "verify --auto-fix did not restore all four deps (see bf-verify.log)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-scaffold-tdd-block-real.sh
+++ b/tests/test-scaffold-tdd-block-real.sh
@@ -17,7 +17,11 @@
 #   ...`) — the fixture supplied the dependency the real scaffold lacked. This
 #   test refuses to hand-copy: the fixture's scripts/ tree is byte-derived from
 #   INIT.SH'S OWN copy mechanism (a full hermetic `--no-remote-creation` init),
-#   so it fails if — and only if — the real product ships the gap.
+#   so it fails whenever the SHIPPED SCAFFOLD carries the gap. Note the scope
+#   (PR #175 verifier): init.sh's terminal `verify-install.sh --auto-fix` also
+#   backfills these files, so a copy-list-only regression self-heals and does
+#   NOT fail this test — tests/test-scaffold-source-closure.sh (PR-CI lane)
+#   is the check that pins the copy list itself.
 #
 # Cases:
 #   T-scaffold-ships-deps        the scaffold contains the four previously-


### PR DESCRIPTION
## BL-088 — init.sh scaffold omits sourced dependencies; the TDD hard block silently no-ops downstream

### The bug (empirically reproduced against `main`)

`init.sh` ships a **curated** `scripts/` copy list to every scaffolded project. It was never updated when BL-072 C2 (PR #166) added `scripts/lib/tdd-classify.sh`, which `scripts/pre-commit-gate.sh` sources through a **silently-skipping loop** (`:21-27` — absent ⇒ no-op). So in a real scaffolded Sponsored-POC project the flagship TDD hard block silently no-op'd.

Reproduced with a full hermetic init (`--deployment organizational --gov-mode sponsored_poc --language typescript --no-remote-creation`):

| | `main` (pre-fix) | this PR |
|---|---|---|
| `scripts/lib/tdd-classify.sh` in scaffold | **absent** | present |
| `scripts/run-phase3-validation.sh` in scaffold | **absent** | present (+x) |
| commit-msg hook installed (`--tdd-only`) | yes | yes |
| **test-less `feat:` commit** | **`rc=0` — ALLOWED (BUG)** | **`rc=1` — BLOCKED `[FAIL] BL-072 TDD ordering`** |

Second instance, same class: `init.sh` did not ship `scripts/run-phase3-validation.sh`, so `check-phase-gate.sh`'s Phase-3→4 gate (`P3_DRIVER="$SCRIPT_DIR/run-phase3-validation.sh"`) failed **closed** but pointed the operator at a script that does not exist — the pass-path was unreachable.

**Why the BL-072 suite missed it:** every BL-072 test copies `tdd-classify.sh` into its own fixture (`test-bl072-tdd-warn-detector.sh:311/:391` `cp "$REPO_ROOT"/scripts/lib/*.sh …`). The fixture supplied the dependency the real scaffold lacked — a fixture-hides-scaffold-gap defect class.

### The class killer — `tests/test-scaffold-source-closure.sh`

Static, fast, runs in the CI fast-unit lane. It:
1. **Derives** `init.sh`'s shipped set mechanically from its `cp` lines (never a hardcoded copy — that would drift; expands the `host-drivers/*.sh` glob against the real tree).
2. For every shipped `scripts/**.sh`, extracts each `"$SCRIPT_DIR/<sibling>.sh"` reference (source/`.`/exec; full-line comments stripped so a usage-example isn't mistaken for an edge).
3. Asserts every sibling is **shipped** — marker `# BL-088-CLOSURE` — *unless* it's explicitly degrade-safe (a target the corpus also references via a `$PROJECT_ROOT/$PROJECT_DIR/$REPO_ROOT/$proj_root` project-local-preferred prefix, i.e. the pre-commit-lint "prefer-project-local, clean-skip" idiom).

Mutation self-tests prove it's load-bearing: drop the `tdd-classify.sh` cp line → RED; drop the `check-versions.sh` cp line → RED (general, not special-cased); the degrade-safe lints are correctly **not** flagged.

### Every gap it found (all fixed)

| Shipped script | sources/execs | was shipped? |
|---|---|---|
| `pre-commit-gate.sh` | `lib/tdd-classify.sh` | **no** → now shipped |
| `check-phase-gate.sh` | `run-phase3-validation.sh` | **no** → now shipped (+x) |
| `check-gate.sh` | `lib/phase2-state.sh` (unguarded source ⇒ crash) | **no** → now shipped |
| `upgrade-project.sh` | `lib/cdf-refresh.sh` (CDF sync silently skipped) | **no** → now shipped |

Closure check: **RED on pre-fix `init.sh` (4 gaps) → GREEN after the fix (0 gaps, 42 shipped)**.

### Fix

- **`init.sh`** — ship `run-phase3-validation.sh` (+ chmod) beside `check-phase-gate.sh`; ship the three sourced libs `tdd-classify.sh` / `phase2-state.sh` / `cdf-refresh.sh`.
- **`verify-install.sh`** — add the driver + three libs to the verify arrays with fix functions ⇒ `verify-install --auto-fix` heals pre-BL-088 projects (BL-074 helpers-siblings precedent).
- **`upgrade-project.sh`** — idempotent source-closure backfill inside the backfill subshell, **after** the BL-015 sentinel guard (BL-081 ordering), so **both** `--backfill-only` and the full upgrade heal existing projects. A `-ef` self-copy guard skips the in-framework-repo invocation. `test-upgrade-sentinel-block.sh` stays 7/7 (a sentinel-blocked upgrade still mutates nothing).

### Backfill behavior (verified)

Old-list project (4 files deleted) → `upgrade-project.sh --backfill-only` → all four restored (`run-phase3` +x) → the test-less `feat:` commit is then **BLOCKED (rc=1)**. Same via `verify-install --auto-fix`.

### Evidence

- `tests/test-scaffold-source-closure.sh` — **6 passed, 0 failed**
- `tests/test-scaffold-tdd-block-real.sh` — **5 passed, 0 failed** (init-driven, hermetic `--no-remote-creation`)
- Neighbors, no regression: `test-bl072-tdd-warn-detector` 36/0 · `test-bl010-commitmsg-bl006` 11/0 · `test-phase3-validation-gate` 51/0 · `test-upgrade-sentinel-block` 7/0
- Lints green: counter-antipattern, fix-functions-stderr, raw-read-prompt, fail-emit-exit-status, fixture-envelopes, doc-anchors, no-live-remote-in-tests, tests-registered, review-manifest.

README is intentionally untouched (owned by PR #173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
