### PR TITLE
chore: agent ergonomics — root CLAUDE.md, canonical lint runner, backlog legend truth-up

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,6 +124,7 @@ jobs:
             tests/test-process-checklist-classifier.sh
             tests/test-process-checklist-reset-phase1.sh
             tests/test-record-claude-commit.sh
+            tests/test-run-lints.sh
             tests/test-scaffold-source-closure.sh
             tests/test-session-test-gate-check-merge.sh
             tests/test-specs-plans-remaining-quartet.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,159 @@
+# CLAUDE.md — agent orientation for the solo-orchestrator repo
+
+Read this first. It is the map for working effectively in THIS repository.
+Counts are date-stamped (they drift); prefer the grep/command recipes — run them
+to get current truth. Verified 2026-07-11.
+
+## WHAT THIS REPO IS
+
+This is the **framework repo that GENERATES downstream projects** — it is not
+itself a scaffolded project. `init.sh` scaffolds a new project elsewhere; the
+files a downstream agent reads at kickoff live in the GENERATED project, not
+here.
+
+- The README "Quick Start" kickoff prompt (README.md § Quick Start) tells the
+  downstream agent to read `CLAUDE.md`, `PROJECT_INTAKE.md`,
+  `docs/reference/builders-guide.md`, `docs/platform-modules/<platform>.md`, and
+  `.claude/phase-state.json`. Those paths exist **in generated projects only** —
+  the README even prefixes the block with "not in this framework repo".
+- `init.sh` ships the guide downstream to `docs/reference/`: see the
+  `cp "$SCRIPT_DIR/docs/builders-guide.md" docs/reference/` line (grep
+  `builders-guide` in init.sh). In THIS repo the guide is **`docs/builders-guide.md`**
+  (top level), and there is **no** `PROJECT_INTAKE.md` and **no**
+  `.claude/phase-state.json`.
+- **`docs/INDEX.md` is the documentation map** — a one-screen index of `docs/**`
+  and `Reports/**`. Start there to find a doc.
+
+## ENVIRONMENT TRAPS
+
+- **No `timeout` / `gtimeout`** on this macOS host. Wrapping a command in them
+  yields a spurious `rc=127` (command-not-found), not a real timeout. Do not use
+  them.
+- **The repo path contains a space** (`Claude Projects/…`). Quote every path in
+  every command, always.
+- **bash is 3.2** (`/bin/bash`, GNU bash 3.2.57). In product code: no `${var,,}`
+  lowercasing, no associative arrays (`declare -A`), no `nullglob`. Use temp
+  files / indexed arrays instead.
+- **Two repos required.** Tests and `init.sh` need the Claude Dev Framework
+  cloned at `~/.claude-dev-framework` (the path is hard-required). Per
+  CONTRIBUTING.md:
+  ```
+  git clone https://github.com/kraulerson/claude-dev-framework.git ~/.claude-dev-framework
+  ```
+- **Install the gate hook yourself.** Contributors working on the framework
+  install the pre-commit gate manually (init.sh does it for user projects, not
+  here). Per CONTRIBUTING.md:
+  ```
+  cp scripts/pre-commit-gate.sh .git/hooks/pre-commit
+  chmod +x .git/hooks/pre-commit
+  ```
+
+## CANONICAL COMMANDS
+
+- **Run one suite:** `bash tests/<file>.sh`. Each suite prints a final tally
+  line — most say `Results: N passed, M failed`, a few `== Total: … | Passed: …
+  | Failed: … ==`. The reliable pass/fail signal is the process **exit code**.
+- **Run every repo lint locally:** `bash scripts/run-lints.sh` (one PASS/FAIL
+  line per lint, summary, non-zero exit iff any failed). This is the dev-tool
+  wrapper — see LINT GOTCHAS.
+- **CI fast lane (unit):** the explicit file list in the `unit` job of
+  `.github/workflows/tests.yml`. A test belongs there iff it does not invoke
+  `init.sh` and is not an aggregator. That list plus `tests/full-project-test-suite.sh`
+  are both lint-enforced (see HOUSE RULES).
+- **FULL suite is ~3h and `workflow_dispatch`-only** (`.github/workflows/tests.yml`
+  `full` job: `if: github.event_name == 'workflow_dispatch'`, `timeout-minutes: 180`).
+  Never run it casually. Locally, `bash tests/full-project-test-suite.sh` and
+  `bash tests/host-drivers/run-all.sh` validate a checkout.
+
+## LINT GOTCHAS
+
+- `scripts/run-lints.sh` runs **every `scripts/lint-*.sh` EXCEPT
+  `lint-uat-scenarios.sh`** (10 of the 11 lint scripts as of 2026-07-11).
+- `scripts/lint-uat-scenarios.sh` is a **parametrized tool, not a repo lint**:
+  bare-invoked it exits **2** with a `Usage:` message because it needs a
+  `<populated-html-file>` argument. It is **not** one of the 8 CI-required lint
+  jobs (`.github/workflows/lint.yml`), so run-lints deliberately skips it.
+- Two lints are **slow full-tree scans**: `lint-counter-antipattern.sh` (~90s)
+  and `lint-raw-read-prompt.sh` (~40s). A full `run-lints.sh` is a couple of
+  minutes — that is expected, not a hang.
+
+## ISSUE TRACKING — two files, two grammars
+
+- **`solo-orchestrator-backlog.md`** — `BL-NNN` entries. Real status vocabulary:
+  **Open**, **Open — DEFERRED** (also "Open — demoted to OPPORTUNISTIC"),
+  **Parked**, **Closed**, **Resolved** (legacy "done"), **Won't Fix**.
+  What's-open recipe:
+  ```
+  grep -n '\*\*Status:\*\* Open' solo-orchestrator-backlog.md
+  ```
+  (returns the whole open family incl. the DEFERRED variants).
+- **`solo-orchestrator-bugs.md`** — `BUG-NNN` entries; statuses are `Fixed` /
+  `Superseded` (no literal `Open`), so "open" = **not Fixed/Superseded, by
+  negation**.
+- **Closed / Resolved entries MUST cite a PR # or a backticked commit SHA**
+  (`scripts/lint-backlog-references.sh` enforces this).
+- **Closed entries are kept deliberately** (audit trail) — never delete them.
+  Two scan traps: some entries preserve an `Original entry (pre-close, kept for
+  audit trail):` block with its OWN `**Status:**` line (a since-Closed entry's
+  preserved `Open`, e.g. BL-055, surfaces in the what's-open grep — eyeball for
+  the marker), and a few entries use `## code-*-N:` headers instead of
+  `## BL-NNN:`. Verify against the entry's current top-of-block status (and git
+  history) before treating any status line as a stray.
+
+## CITATION RULE
+
+Cite code by a **grep-able `# BL-NNN-…` marker comment** or a **function name** —
+**never a bare `file:line`**. Line-number cites in handoffs have mis-resolved
+within 24h of being written; the marker comment is the repo's citation
+primitive. When reading an old handoff, **re-grep every line-number citation
+before trusting it**.
+
+## HANDOFFS
+
+- Live handoffs: `docs/handoffs/` — the **newest date is current** (as of
+  2026-07-11 that is `docs/handoffs/2026-07-10-gate-wave-close-out.md`).
+- Superseded / fully-executed handoffs move to `docs/handoffs/archive/` with a
+  pointer stub left at the old top-level path so citations still resolve. See
+  `docs/handoffs/archive/README.md` (includes the citation convention).
+
+## ENFORCEMENT — SOURCE OF TRUTH
+
+The **gate scripts are authoritative**, prose guides describe them and may lag —
+trust the scripts:
+- `scripts/check-phase-gate.sh` (phase 1→2 / 2→3 / 3→4 gates, approvals)
+- `scripts/pre-commit-gate.sh` (commit-time gates)
+- `scripts/process-checklist.sh` (Build Loop / commit-ready classifier)
+- `scripts/run-phase3-validation.sh` (Phase 3 scanners)
+
+## GOTCHAS
+
+- `pre-commit-gate.sh --tdd-only` runs **TWO** message gates: the BL-072 TDD
+  ordering gate AND the BL-006 Build-Loop commit-message check (BL-010). The
+  `--tdd-only` name is kept for **hook backward-compat**, not because it is
+  TDD-only.
+- The **deployment + poc_mode tier predicate** is implemented in **multiple
+  scripts and must be changed IN SYNC**: `pre-commit-gate.sh`,
+  `check-phase-gate.sh`, `init.sh` (grep the marker `# BL-084-TIER-KEY` — it
+  literally says "SYNC SIBLINGS") plus `scripts/lib/enforcement-level.sh`.
+- **Big files — grep, don't read whole** (`wc -l`, 2026-07-11): `init.sh` 4391,
+  `scripts/upgrade-project.sh` 2498, `scripts/intake-wizard.sh` 2245,
+  `scripts/check-phase-gate.sh` 1921, `tests/full-project-test-suite.sh` 2217.
+
+## HOUSE RULES DIGEST
+
+- **No merge on red, ever.** No `gh pr merge --admin`.
+- **TDD with mutation proofs** for enforcement changes: break the marked line →
+  RED → restore → GREEN. Prove it, don't assert it.
+- **Hermetic tests only** — no real remote creation (`lint-no-live-remote-in-tests.sh`
+  enforces; a live `gh repo create` leaked a real repo on 2026-07-06).
+- **Register every new `tests/test-*.sh`** in BOTH
+  `tests/full-project-test-suite.sh` AND the `tests.yml` unit list
+  (`lint-tests-registered.sh` enforces).
+- **Portability:** GNU-first `stat -c … || stat -f …`; never `((x++))` under
+  `set -e`; configure a git identity in fixtures; unset `GITHUB_BASE_REF` in
+  fixture git ops; no multibyte chars adjacent to variable expansions under
+  `set -u`.
+- **Docs-only commits** (all staged files match `\.(md|json|yml|yaml|toml|tmpl)$`)
+  skip the Build Loop gate; mixed source+docs commits do not — split them
+  (CONTRIBUTING.md § Docs-only bypass).
+- **Never `--no-verify`.**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,9 +135,10 @@ trust the scripts:
   scripts and must be changed IN SYNC**: `pre-commit-gate.sh`,
   `check-phase-gate.sh`, `init.sh` (grep the marker `# BL-084-TIER-KEY` — it
   literally says "SYNC SIBLINGS") plus `scripts/lib/enforcement-level.sh`.
-- **Big files — grep, don't read whole** (`wc -l`, 2026-07-11): `init.sh` 4391,
-  `scripts/upgrade-project.sh` 2498, `scripts/intake-wizard.sh` 2245,
-  `scripts/check-phase-gate.sh` 1921, `tests/full-project-test-suite.sh` 2217.
+- **Big files — grep, don't read whole** (`wc -l`, 2026-07-11, approximate —
+  they grow): `init.sh` ~4400, `scripts/upgrade-project.sh` ~2500,
+  `scripts/intake-wizard.sh` ~2250, `scripts/check-phase-gate.sh` ~1900,
+  `tests/full-project-test-suite.sh` ~2230.
 
 ## HOUSE RULES DIGEST
 

--- a/docs/handoffs/archive/README.md
+++ b/docs/handoffs/archive/README.md
@@ -37,3 +37,15 @@ plan → PRs → shipped state stays intact and citable.
 - `2026-07-09-gate-wave-execution-handoff.md` — FULLY EXECUTED (gate wave
   shipped as PRs #160–#167); closed out by
   [`../2026-07-10-gate-wave-close-out.md`](../2026-07-10-gate-wave-close-out.md).
+
+## Citation convention for handoffs
+
+Handoffs must cite code by durable handles, not positions:
+
+- Cite a grep-able `# BL-NNN-...` marker comment (the repo's citation
+  primitive) or a function name — both survive edits above them.
+- NEVER cite a bare `file:line`. Line numbers drift as files change and have
+  mis-resolved within ~24h of a handoff being written.
+- If a line number is truly unavoidable, pair it with the marker/function it
+  points at and flag it VERIFY-BEFORE-USE. When reading any older handoff,
+  re-grep every line-number citation before trusting it.

--- a/scripts/run-lints.sh
+++ b/scripts/run-lints.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# scripts/run-lints.sh — canonical LOCAL lint runner for solo-orchestrator.
+#
+# Runs every scripts/lint-*.sh over the repo, one status line each, and exits
+# non-zero iff any lint failed. This is the single command a contributor (or an
+# agent) runs to reproduce the repo's CI lint gate locally without having to
+# remember the individual lint names or their CI job wiring.
+#
+# WHAT IT RUNS
+#   Every scripts/lint-*.sh EXCEPT scripts/lint-uat-scenarios.sh. That one is a
+#   PARAMETRIZED authoring tool, not a repo lint: bare-invoked it exits 2 with a
+#   usage message because it requires a <populated-html-file> argument (it
+#   validates a single rendered UAT scenario file on demand). It is also not one
+#   of the 8 CI-required lint jobs in .github/workflows/lint.yml, so running it
+#   here would spuriously fail the sweep.
+#
+#   NOTE: two of the scanned lints are slow full-tree scans —
+#   lint-counter-antipattern.sh (~90s) and lint-raw-read-prompt.sh (~40s) — so a
+#   full run is a couple of minutes. That is expected.
+#
+# NOT A SHIPPED SCRIPT
+#   This is a DEV tool. It is deliberately NOT in any init.sh copy list and is
+#   not sourced by any scaffold-shipped script, so it has no effect on the
+#   scaffold source-closure check (tests/test-scaffold-source-closure.sh).
+#
+# EXIT STATUS
+#   0  every scanned lint passed
+#   1  at least one lint failed (each failing lint is named in the summary; the
+#      operator re-runs `bash scripts/<name>` to see the detail)
+#
+# TESTABILITY
+#   An optional first argument overrides the lint directory (default: this
+#   script's own directory). tests/test-run-lints.sh points it at a temp dir of
+#   stub lints to prove failure propagation without touching the real lints.
+#
+# PORTABILITY
+#   bash-3.2 safe (no associative arrays, no ${var,,}). Runs under
+#   `set -uo pipefail` — deliberately NOT `-e`: a single failing lint must never
+#   abort the loop before the summary prints, so failures are COLLECTED and
+#   reported at the end.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LINT_DIR="${1:-$SCRIPT_DIR}"
+
+# Parametrized tool, not a repo lint (bare exit 2 on missing HTML arg); skip it.
+EXCLUDE="lint-uat-scenarios.sh"
+
+total=0
+passed=0
+failed=0
+failed_names=""
+
+for lint in "$LINT_DIR"/lint-*.sh; do
+  # bash 3.2 has no nullglob: if nothing matched, the literal pattern survives
+  # and is not a real file — skip it.
+  [ -f "$lint" ] || continue
+  name="$(basename "$lint")"
+  [ "$name" = "$EXCLUDE" ] && continue
+
+  total=$((total + 1))
+  if bash "$lint" >/dev/null 2>&1; then
+    printf 'PASS  %s\n' "$name"
+    passed=$((passed + 1))
+  else
+    printf 'FAIL  %s\n' "$name"
+    failed=$((failed + 1)); failed_names="$failed_names $name"  # RUN-LINTS-FAIL-COLLECT
+  fi
+done
+
+echo "----"
+if [ "$failed" -eq 0 ]; then
+  echo "run-lints: $total lints — $passed passed, 0 failed"
+  exit 0
+fi
+
+echo "run-lints: $total lints — $passed passed, $failed failed —$failed_names"
+echo "re-run a failing lint directly to see detail: bash scripts/<name>"
+exit 1

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -14,9 +14,29 @@ trigger/deadline if any, and status.
 - **Audit** — things to check periodically
 - **Drift-watch** — things that could silently break when upstream/environment changes
 
-**Status values:** `open` / `in-progress` / `promoted-to-spec` / `resolved` / `wontfix`.
+**Status values (as actually used — recount the `**Status:**` lines before trusting any tally):**
+- **Open** — active; not started, or in progress.
+- **Open — DEFERRED `<date>`** (also **Open — demoted to OPPORTUNISTIC**) — still Open, but consciously deprioritized. The revisit trigger is stated inline on the status line.
+- **Parked** — investigated, no current operator demand; an explicit re-evaluation trigger is noted inline.
+- **Closed** — shipped/done. MUST cite a PR # or a backticked commit SHA in the entry block (`scripts/lint-backlog-references.sh` enforces this).
+- **Resolved** — legacy synonym for **Closed** (early-convention "done"); same citation requirement.
+- **Won't Fix** — deliberately declined; the reopen trigger is noted inline.
 
-When an item is promoted to a full spec, leave the entry here with status `promoted-to-spec` and link the spec file — don't delete; the backlog is also an audit trail of what we considered.
+**What's-open recipe (this IS the index — don't add a static open-items list, it drifts):**
+
+```
+grep -n '\*\*Status:\*\* Open' solo-orchestrator-backlog.md
+```
+
+Returns the whole open family, including the `Open — DEFERRED` / `Open — demoted to OPPORTUNISTIC` variants (they are still `Open`).
+
+**Bugs file has a different grammar.** `solo-orchestrator-bugs.md` tracks `BUG-NNN` entries whose statuses are `Fixed` / `Superseded` (with the odd `Still …`); there is no literal `Open` status, so "open" there means *any BUG not marked Fixed/Superseded* — determined by negation, not by the status grep above.
+
+**Audit-trail convention — Closed entries are kept, never deleted.** The backlog is also a record of what we considered (including promoted-to-spec items, which stay with a link to the spec). Two things the naive grep above can misattribute:
+- Some Closed entries preserve an **`Original entry (pre-close, kept for audit trail):`** block that embeds its OWN `**Status:**` line. That preserved `Open` belongs to a since-Closed entry (e.g. BL-055) and will surface in the what's-open grep — eyeball for the `Original entry` marker before counting it as live.
+- A few entries use `## code-*-N:` headers (e.g. `## code-check-gates-1:`) instead of `## BL-NNN:`, so header-only scans miss them.
+
+Verify against the entry's current top-of-block status (and git history if in doubt) before treating any single status line as authoritative.
 
 ---
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -541,6 +541,17 @@ else
   fail "tests/test-scaffold-tdd-block-real.sh FAILED (run for details)"
 fi
 
+# Agent-ergonomics onboarding: tests/test-run-lints.sh — behavior suite for
+# scripts/run-lints.sh, the canonical local lint runner (runs every
+# scripts/lint-*.sh EXCEPT the parametrized lint-uat-scenarios.sh). Its
+# T-all-pass case executes the real lints end-to-end, so this block takes a
+# couple of minutes (the two slow full-tree scans dominate).
+if bash "$SCRIPT_DIR/tests/test-run-lints.sh" >/dev/null 2>&1; then
+  pass "tests/test-run-lints.sh"
+else
+  fail "tests/test-run-lints.sh FAILED (run for details)"
+fi
+
 # BL-070 increment (WP-B1): scripts/run-phase3-validation.sh's `license` scanner
 # promoted from stub to REAL. Reads the project language from
 # .claude/tool-preferences.json (.context.language — the canonical source, NOT

--- a/tests/test-run-lints.sh
+++ b/tests/test-run-lints.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# tests/test-run-lints.sh — behavior suite for scripts/run-lints.sh, the
+# canonical local lint runner.
+#
+#   T-all-pass        Runner over the REAL repo → rc=0, one status line per
+#                     real scripts/lint-*.sh, and lint-uat-scenarios.sh ABSENT
+#                     from the output (it is a parametrized tool, not a lint).
+#                     Note: this actually executes every real lint, including
+#                     the two slow full-tree scans, so it takes a couple of
+#                     minutes — that is the honest end-to-end signal.
+#   T-fail-propagates A temp lint dir containing one deliberately-failing stub
+#                     lint → rc≠0 and the failing lint is NAMED in the output.
+#                     Also proves a uat-scenarios stub is skipped in an override
+#                     dir.
+#   T-mutation        Neuter the failure-collection line (marker
+#                     RUN-LINTS-FAIL-COLLECT) in a COPY of the runner → the
+#                     failing-stub case goes RED (rc becomes 0). The intact
+#                     runner is GREEN (rc≠0). Proves the collection line is
+#                     load-bearing for both the summary and the exit status.
+#
+# Hermetic, bash-3.2 safe (no associative arrays), set -uo pipefail (not -e so a
+# single failed assertion does not abort the suite before the tally prints).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNNER="$REPO_ROOT/scripts/run-lints.sh"
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# Build a temp lint dir: one passing stub, one failing stub, and a
+# uat-scenarios stub (to prove it is skipped even when present in an override
+# dir). Prints the dir path on stdout.
+make_stub_lint_dir() {
+  local d; d="$(mktemp -d)"
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$d/lint-aaa-ok.sh"
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$d/lint-zzz-fail.sh"
+  printf '#!/usr/bin/env bash\nexit 2\n' > "$d/lint-uat-scenarios.sh"
+  chmod +x "$d"/lint-*.sh
+  echo "$d"
+}
+
+# ── T-all-pass: the real repo ────────────────────────────────────────────────
+out="$(bash "$RUNNER" 2>&1)"; rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "T-all-pass: runner over real repo exits 0"
+else
+  fail "T-all-pass: runner over real repo exits 0" "rc=$rc; out=$out"
+fi
+
+missing=""
+for lint in "$REPO_ROOT"/scripts/lint-*.sh; do
+  n="$(basename "$lint")"
+  [ "$n" = "lint-uat-scenarios.sh" ] && continue
+  echo "$out" | grep -q "$n" || missing="$missing $n"
+done
+if [ -z "$missing" ]; then
+  pass "T-all-pass: every real lint named in output"
+else
+  fail "T-all-pass: every real lint named in output" "missing:$missing"
+fi
+
+if echo "$out" | grep -q "lint-uat-scenarios.sh"; then
+  fail "T-all-pass: lint-uat-scenarios.sh excluded" "it appeared in output"
+else
+  pass "T-all-pass: lint-uat-scenarios.sh excluded"
+fi
+
+# ── T-fail-propagates: override dir with a failing stub lint ─────────────────
+stub_dir="$(make_stub_lint_dir)"
+out="$(bash "$RUNNER" "$stub_dir" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  pass "T-fail-propagates: failing stub lint → rc≠0"
+else
+  fail "T-fail-propagates: failing stub lint → rc≠0" "rc=$rc; out=$out"
+fi
+if echo "$out" | grep -q "lint-zzz-fail.sh"; then
+  pass "T-fail-propagates: failing lint named in summary"
+else
+  fail "T-fail-propagates: failing lint named in summary" "out=$out"
+fi
+if echo "$out" | grep -q "lint-uat-scenarios.sh"; then
+  fail "T-fail-propagates: uat-scenarios skipped in override dir" "it appeared"
+else
+  pass "T-fail-propagates: uat-scenarios skipped in override dir"
+fi
+
+# ── T-mutation: neuter the failure-collection line in a COPY ─────────────────
+copy="$(mktemp)"
+sed 's/.*# RUN-LINTS-FAIL-COLLECT.*/    : # neutered for mutation test/' "$RUNNER" > "$copy"
+if diff -q "$RUNNER" "$copy" >/dev/null 2>&1; then
+  fail "T-mutation: marker line present and mutated" \
+       "sed changed nothing — marker RUN-LINTS-FAIL-COLLECT missing from runner?"
+else
+  out="$(bash "$copy" "$stub_dir" 2>&1)"; rc=$?
+  if [ "$rc" -eq 0 ]; then
+    pass "T-mutation: neutered collection line → failure no longer propagates (RED)"
+  else
+    fail "T-mutation: neutered collection line → failure no longer propagates (RED)" \
+         "rc=$rc still non-zero; mutation was ineffective; out=$out"
+  fi
+fi
+
+# GREEN: the intact runner still propagates the same failure.
+out="$(bash "$RUNNER" "$stub_dir" 2>&1)"; rc=$?
+if [ "$rc" -ne 0 ]; then
+  pass "T-mutation: intact runner propagates failure (GREEN)"
+else
+  fail "T-mutation: intact runner propagates failure (GREEN)" "rc=$rc"
+fi
+
+rm -rf "$stub_dir" "$copy"
+
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Ships the three cheapest, highest-leverage agent-ergonomics fixes identified by the fresh-eyes audit + the 40-agent orchestration arc. **No product-behavior changes** — scaffold-shipped scripts, gates, and templates are untouched. Four deliverables across four logical commits.

## Deliverable 1 — root `CLAUDE.md` (agent orientation)

159 lines. Every claim was verified by running the command before writing it down (recipes preferred over counts; counts date-stamped 2026-07-11).

| Claim in CLAUDE.md | Verification |
|---|---|
| Framework repo GENERATES downstream projects; kickoff paths are downstream-only | README.md § Quick Start (line 64) prefixes the read-list with "not in this framework repo"; items are `CLAUDE.md` / `PROJECT_INTAKE.md` / `docs/reference/builders-guide.md` / `.claude/phase-state.json` |
| `init.sh` ships guide to `docs/reference/` downstream | `cp "$SCRIPT_DIR/docs/builders-guide.md" docs/reference/` in init.sh (grep `builders-guide`) |
| This repo has the guide at `docs/builders-guide.md`, no `PROJECT_INTAKE.md` / `.claude/phase-state.json` | `ls` confirmed both absent; `docs/builders-guide.md` present |
| `docs/INDEX.md` is the doc map | head of file: "Documentation Estate Index" |
| No `timeout`/`gtimeout` on host | given in task context (host fact) |
| bash is 3.2 | `bash --version` → GNU bash 3.2.57 |
| Two-repo clone line | CONTRIBUTING.md § Local development setup, verbatim |
| Manual gate-hook install line | CONTRIBUTING.md step 4, verbatim (`cp scripts/pre-commit-gate.sh .git/hooks/pre-commit` + `chmod +x`) |
| 8 CI-required lint jobs | counted job names in `.github/workflows/lint.yml` (counter-antipattern, backlog-references, fix-functions-stderr, raw-read-prompt, tests-registered, doc-anchors, review-manifest, no-live-remote) |
| `lint-uat-scenarios.sh` bare → exit 2 usage, not a repo lint | ran it: `Usage: … <populated-html-file>` rc=2 |
| Full suite ~3h, `workflow_dispatch`-only | tests.yml `full` job: `if: github.event_name == 'workflow_dispatch'`, `timeout-minutes: 180`, comment "~3h monolith" |
| Suite tally format | sampled: 4/5 print `Results: N passed, M failed`, minority `== Total: … ==`; CLAUDE.md says exit code is the reliable signal |
| `--tdd-only` runs TWO gates (BL-072 TDD + BL-006 Build-Loop/BL-010), name kept for hook back-compat | pre-commit-gate.sh lines 264-321 |
| Tier predicate in multiple scripts, change in SYNC | marker `# BL-084-TIER-KEY` ("SYNC SIBLINGS") in pre-commit-gate.sh, check-phase-gate.sh, init.sh + `scripts/lib/enforcement-level.sh` |
| Big-file `wc -l` (2026-07-11) | init.sh 4391, upgrade-project.sh 2498, intake-wizard.sh 2245, check-phase-gate.sh 1921, full-project-test-suite.sh 2217 |
| Newest handoff | `docs/handoffs/2026-07-10-gate-wave-close-out.md` |
| Citation primitive `# BL-NNN` markers | `grep -rEn '# BL-[0-9]+…'` hits in pre-commit-gate.sh |

## Deliverable 2 — `scripts/run-lints.sh` + `tests/test-run-lints.sh`

**Design:** runs every `scripts/lint-*.sh` EXCEPT `lint-uat-scenarios.sh` (parametrized tool, commented in-file). One `PASS/FAIL <name>` line per lint, a summary line, non-zero exit iff any lint failed. `set -uo pipefail` (deliberately **not** `-e`) so a failing lint never aborts the loop before the summary — failures are collected then reported (load-bearing line marked `# RUN-LINTS-FAIL-COLLECT`). bash-3.2 safe (no assoc arrays, nullglob-guarded). Optional first arg overrides the lint dir for testability. **Dev tool only** — not in any init.sh copy list, not sourced by a shipped script.

**Final lint pass** (`bash scripts/run-lints.sh`):
```
PASS  lint-backlog-references.sh
PASS  lint-counter-antipattern.sh
PASS  lint-doc-anchors.sh
PASS  lint-fail-emit-exit-status.sh
PASS  lint-fix-functions-stderr.sh
PASS  lint-fixture-envelopes.sh
PASS  lint-no-live-remote-in-tests.sh
PASS  lint-raw-read-prompt.sh
PASS  lint-review-manifest.sh
PASS  lint-tests-registered.sh
----
run-lints: 10 lints — 10 passed, 0 failed
```

**Test suite** (`tests/test-run-lints.sh`, 8 assertions, all green): T-all-pass (runner over real repo → rc=0, every lint named, uat-scenarios absent), T-fail-propagates (temp lint-dir override with a failing stub → rc≠0 + named; uat stub skipped), T-mutation.

**Mutation evidence** (neuter `# RUN-LINTS-FAIL-COLLECT` in a copy):
- intact runner over a stub dir with one failing lint → **rc=1** (GREEN, "1 failed")
- neutered copy over the same dir → **rc=0** (RED, "0 failed")

Registered in `tests/full-project-test-suite.sh` AND the `tests.yml` unit list. `tests/test-scaffold-source-closure.sh` re-run: 6 passed, 0 failed (dev-only runner does not affect the closure check).

## Deliverable 3 — backlog legend truth-up

Replaced the stale `open / in-progress / promoted-to-spec / resolved / wontfix` legend with the vocabulary actually used, recounted from `**Status:**` lines on 2026-07-11: **Closed** 66, **Resolved** 9, **Open**-family 8 (3 bare + 5 `Open — DEFERRED`/demoted), **Won't Fix** 5, **Parked** 1. Added the what's-open grep recipe (the recipe is the index — no static list, it drifts), the bugs-file grammar note (Fixed/Superseded; open by negation), and the audit-trail convention (Closed entries kept; preserved `Original entry` blocks embed their own Status line — e.g. BL-055's preserved `Open` inside what is now a Closed entry; `## code-*-N:` non-BL headers exist). `lint-backlog-references.sh` passes; what's-open recipe still returns the same 8 real open items.

## Deliverable 4 — citation convention

Added a 12-line "Citation convention for handoffs" section to `docs/handoffs/archive/README.md`: cite `# BL-NNN` markers or function names, never bare `file:line`; any unavoidable line number carries a VERIFY-BEFORE-USE flag.

## Notes
- Local pre-commit semgrep hook flagged pre-existing `actions/checkout@v4` mutable-tag findings on tests.yml lines 50/198 — **not introduced here** (my edit only inserts one test into the unit-list array); out of scope, and not a CI-required check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
