### PR TITLE
feat(currency): S1 inventory — the currency block in .claude/manifest.json (BL-109)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,6 +101,7 @@ jobs:
             tests/test-check-phase-gate-retroactive-approval.sh
             tests/test-check-phase-gate-self-approval.sh
             tests/test-check-phase-gate.sh
+            tests/test-currency-manifest.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh
             tests/test-filesystem-gate-install.sh

--- a/init.sh
+++ b/init.sh
@@ -85,6 +85,13 @@ source "$SCRIPT_DIR/scripts/lib/helpers.sh"
 # install_tdd_commit_msg_hook and scripts/upgrade-project.sh --sync-framework
 # emit byte-identical hooks from ONE source of truth.
 source "$SCRIPT_DIR/scripts/lib/hook-templates.sh"
+# BL-109-CURRENCY: currency-inventory (Layer 0) writer/reader helpers. Sourced
+# here so the render sites (generate_claude_md / PROJECT_INTAKE / the A2 template
+# copies) can stash render bases into $SOIF_CURRENCY_RENDERBASE_FILE, and
+# prepare_initial_state_for_commit can stamp the whole `currency` block into
+# .claude/manifest.json at birth. The lib transitively sources
+# scaffold-shipped-set.sh (mechanical shipped-set parsers) if not already loaded.
+source "$SCRIPT_DIR/scripts/lib/currency-manifest.sh"
 
 # ────────────────────────────────────────────────────────────────────
 # BL-064: init-failure tracking (silent-success defect class)
@@ -1438,6 +1445,14 @@ create_project() {
   mkdir -p templates/generated
   cp "$SCRIPT_DIR/templates/generated/project-bible.tmpl" templates/generated/
   cp "$SCRIPT_DIR/templates/generated/product-manifesto.tmpl" templates/generated/
+  # BL-109-CURRENCY: record the A2 (agent-authored) render bases by TEMPLATE sha
+  # only — PROJECT_BIBLE.md / PRODUCT_MANIFESTO.md are created by no script and
+  # do not exist at birth (review-r1 B3a), so there is no rendered-output sha and
+  # no files{} entry. Captured here, at the copy site, from the template source.
+  soif_currency_record_render_base A2 PROJECT_BIBLE.md \
+    "$SCRIPT_DIR/templates/generated/project-bible.tmpl" ""
+  soif_currency_record_render_base A2 PRODUCT_MANIFESTO.md \
+    "$SCRIPT_DIR/templates/generated/product-manifesto.tmpl" ""
   cp "$SCRIPT_DIR/templates/generated/frd.tmpl" templates/generated/
   cp "$SCRIPT_DIR/templates/generated/user-journey.tmpl" templates/generated/
   cp "$SCRIPT_DIR/templates/generated/data-contract.tmpl" templates/generated/
@@ -1920,6 +1935,13 @@ PERMEOF
   if [ -n "${RESOLVER_OUTPUT:-}" ]; then
     append_intake_tooling_summary "$RESOLVER_OUTPUT"
   fi
+
+  # BL-109-CURRENCY: capture the A1 render base for PROJECT_INTAKE.md HERE — at
+  # the end of its render (cp template → sed pre-fill → tooling append) — so the
+  # output sha is the render-time truth, never a post-hoc hash of a maybe-touched
+  # file (a MAJOR per the verify focus). {template sha, rendered-output sha}.
+  soif_currency_record_render_base A1 PROJECT_INTAKE.md \
+    "$SCRIPT_DIR/templates/project-intake.md" PROJECT_INTAKE.md
 
   # Generate phase state tracking.
   # BL-073: `review_gate_enforced` is the grandfather cutover for the
@@ -2584,6 +2606,13 @@ generate_claude_md() {
 Branch protection with required reviewers is recommended for organizational deployments and will be required when compliance modules are available. Until then, the Orchestrator creates and merges their own PRs with phase gate review at milestones. When branch protection is enabled, PRs require an independent reviewer before merge — this provides per-change code review that strengthens the governance audit trail.
 COMPEOF
   fi
+
+  # BL-109-CURRENCY: capture the A1 render base for CLAUDE.md HERE — at the end of
+  # its render (sed substitution + the conditional organizational append) — so the
+  # output sha is the render-time truth, never a post-hoc hash (a MAJOR per the
+  # verify focus). {template sha, rendered-output sha}.
+  soif_currency_record_render_base A1 CLAUDE.md \
+    "$SCRIPT_DIR/templates/generated/claude-md.tmpl" CLAUDE.md
 }
 
 generate_approval_log() {
@@ -4128,6 +4157,10 @@ HELPEOF
     resolve_and_install_tools
 
     log_section "Project Creation"
+    # BL-109-CURRENCY: start a fresh render-base scratch file BEFORE create_project
+    # so the render sites inside it (A2 template copies, PROJECT_INTAKE, CLAUDE.md)
+    # can stash {template sha, output sha} for the birth stamp.
+    soif_currency_renderbase_init
     create_project
 
     # BL-030: persist enforcement_level + deployment + poc_mode to manifest,
@@ -4244,6 +4277,21 @@ prepare_initial_state_for_commit() {
         > "$manifest"
     fi
   fi
+
+  # BL-109-CURRENCY: stamp the currency inventory block (design v1.1 §2-L0) into
+  # .claude/manifest.json at birth, immediately AFTER the framework-managed
+  # manifest seed above. Additive — every pre-existing field (soloFrameworkCommit
+  # / frameworkCommit / host / mode / … pins included) is preserved. files{} is
+  # derived MECHANICALLY from the shipped-set parsers and hashed from the
+  # just-scaffolded project tree (all cp/render/hook steps precede this call);
+  # render bases were captured AT the render sites into
+  # $SOIF_CURRENCY_RENDERBASE_FILE. This is the UNIVERSAL birth site —
+  # prepare_initial_state_for_commit runs on EVERY path (incl.
+  # --no-remote-creation), unlike the soloFrameworkCommit stamp, which is
+  # remote-path-only (see the S1 PR body's declared deviation). Skipped as a
+  # no-op when jq is unavailable (same contract as the soloFrameworkCommit stamp).
+  # Re-stamping on sync/apply (soloFrameworkPath refresh) is S3a — out of scope.
+  soif_currency_stamp "$manifest" "$SCRIPT_DIR/init.sh" "$SCRIPT_DIR" "." "$LANGUAGE" "$SCRIPT_DIR"   # BL-109-CURRENCY load-bearing stamping call
 
   # Seed bypass-audit.json with the init enforcement_level_set row.
   [ -f .claude/bypass-audit.json ] || echo "[]" > .claude/bypass-audit.json

--- a/scripts/lib/currency-manifest.sh
+++ b/scripts/lib/currency-manifest.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# scripts/lib/currency-manifest.sh
+#
+# BL-109 SLICE-S1 (Layer 0 — Inventory). Writer/reader helpers for the ONE
+# versioned `currency` block that lives INSIDE the existing
+# `.claude/manifest.json`. There is NEVER a second, separate manifest file — the
+# dual-source ban is the design's review-r1 B2 finding (acceptance: a repo-wide
+# grep for the rejected standalone-manifest filename stays 0 in product code).
+# The pins already in this file (soloFrameworkCommit / frameworkCommit /
+# frameworkVersion) are untouched; this block sits BESIDE them.
+#
+# Schema (design v1.1 §2-L0, exactly):
+#   currency: {
+#     schemaVersion: 1,
+#     soloFrameworkPath,                      # init.sh's own $SCRIPT_DIR
+#     files: { path -> { sha256, mode, class, state } },
+#     renderBases: {                          # captured AT the render site
+#       A1: { artifact -> { templateSha, outputSha } },   # script-rendered
+#       A2: { artifact -> { templateSha } }               # agent-authored
+#     },
+#     hooks: { name -> present | absent-intentional | absent-unavailable },
+#     mcpProbe: { context7: present | absent }
+#   }
+#
+# files{} is derived MECHANICALLY from the same source as
+# scripts/lib/scaffold-shipped-set.sh (extended there to reference docs + skills)
+# — NEVER a hand-maintained list. Class assignment:
+#   M — scripts (incl. hooks-related libs) + vendored skills
+#   T — the docs/reference verbatim set
+#   A1 — CLAUDE.md + PROJECT_INTAKE.md (the two script-rendered artifacts)
+# A2 artifacts (PRODUCT_MANIFESTO.md, PROJECT_BIBLE.md) do NOT exist at birth
+# (created by no script — review-r1 B3a); they appear only under renderBases.A2
+# by template sha.
+#
+# jq-availability / failure handling mirrors init.sh's soloFrameworkCommit
+# birth-stamp: jq is assumed present at the stamp site (the manifest itself is
+# jq-built); the final write is the same `jq ... > tmp && mv tmp manifest`
+# atomic-rename pattern. If jq is somehow absent, the stamp is a no-op (the
+# manifest keeps its pre-block bytes).
+#
+# bash-3.2 safe: no associative arrays, no `[[ -v ]]`, no `((x++))` under set -e,
+# no process-substitution requirement. Pure helpers — the only writes are the
+# render-base scratch file (a $TMPDIR temp) and the final atomic manifest merge.
+
+# ── Dependency wiring ────────────────────────────────────────────────────────
+# scaffold-shipped-set.sh provides the mechanical shipped-set parsers; source it
+# from our own directory if a caller has not already. hook-templates.sh provides
+# soif_lang_test_pattern (the hook-enum predicate); source it likewise.
+_soif_cm_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! command -v soif_parse_shipped_scripts >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  [ -f "$_soif_cm_dir/scaffold-shipped-set.sh" ] && . "$_soif_cm_dir/scaffold-shipped-set.sh"
+fi
+if ! command -v soif_lang_test_pattern >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  [ -f "$_soif_cm_dir/hook-templates.sh" ] && . "$_soif_cm_dir/hook-templates.sh"
+fi
+unset _soif_cm_dir
+
+# ── Primitives: sha256 + mode ────────────────────────────────────────────────
+# soif_currency_sha256 <file> — hex sha256 (shasum -a 256), empty on missing.
+soif_currency_sha256() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  shasum -a 256 "$f" 2>/dev/null | awk '{print $1}'
+}
+
+# soif_currency_mode <file> — octal permission bits, GNU-first then BSD.
+soif_currency_mode() {
+  local f="$1"
+  [ -e "$f" ] || return 1
+  stat -c '%a' "$f" 2>/dev/null || stat -f '%Lp' "$f" 2>/dev/null
+}
+
+# ── Hook three-state enum (review-r1 M9) ─────────────────────────────────────
+# soif_currency_hook_state <hook-name> <language> — reproduces init.sh's own
+# install decision mechanically:
+#   commit-msg: init.sh installs the BL-072 TDD gate iff soif_lang_test_pattern
+#     is non-empty. So a language WITH a pattern -> present; rust (empty pattern
+#     BY DESIGN, inline #[cfg(test)] tests) -> absent-intentional; the `*)`
+#     catch-all (empty pattern, not rust — e.g. `other`) -> absent-unavailable,
+#     which Layer 1 surfaces at the enforcement tier ("TDD gate unavailable for
+#     this language — BL-107"). Expected-absence must never launder a bug into a
+#     fact.
+#   pre-commit: init.sh installs the fallback pre-commit hook UNCONDITIONALLY
+#     (language-agnostic gitleaks + Semgrep), so it is always present at birth.
+soif_currency_hook_state() {
+  local hook="$1" language="$2" pat
+  case "$hook" in
+    pre-commit)
+      printf '%s' "present" ;;
+    commit-msg)
+      pat="$(soif_lang_test_pattern "$language" 2>/dev/null)"
+      if [ -n "$pat" ]; then
+        printf '%s' "present"
+      elif [ "$language" = "rust" ]; then
+        printf '%s' "absent-intentional"
+      else
+        printf '%s' "absent-unavailable"
+      fi ;;
+    *)
+      printf '%s' "absent-unavailable" ;;
+  esac
+}
+
+# ── MCP presence probe ───────────────────────────────────────────────────────
+# soif_currency_mcp_probe — emits {"context7": "present"|"absent"} using the
+# EXISTING is_context7_mcp_registered helper (reuse, never reimplement). Honest
+# best-effort: if the helper is not sourced or jq is missing it reports absent.
+soif_currency_mcp_probe() {
+  local state="absent"
+  if command -v is_context7_mcp_registered >/dev/null 2>&1; then
+    if is_context7_mcp_registered >/dev/null 2>&1; then
+      state="present"
+    fi
+  fi
+  jq -n --arg s "$state" '{context7: $s}'
+}
+
+# ── Render-base capture (called AT the render site) ──────────────────────────
+# The render bases are captured immediately at the init.sh render sites and
+# stashed in a scratch file ($SOIF_CURRENCY_RENDERBASE_FILE) so the stamp can
+# read them WITHOUT re-hashing a possibly-already-touched artifact post-hoc
+# (post-hoc hashing is a MAJOR per the verify focus). Each line is TSV:
+#   <group>\t<artifact>\t<templateSha>\t<outputSha>\t<outputMode>
+# group A1 records template+output; group A2 records template only (output cols
+# empty). For A1, files{} reuses the captured output sha/mode verbatim, so no A1
+# artifact is ever hashed twice.
+
+# soif_currency_renderbase_init — start a fresh render-base scratch file and
+# export its path. Called once by init.sh before the first render.
+soif_currency_renderbase_init() {
+  SOIF_CURRENCY_RENDERBASE_FILE="$(mktemp 2>/dev/null || echo "${TMPDIR:-/tmp}/soif-currency-rb.$$")"
+  : > "$SOIF_CURRENCY_RENDERBASE_FILE"
+  export SOIF_CURRENCY_RENDERBASE_FILE
+}
+
+# soif_currency_record_render_base <group> <artifact> <template-file> <output-file|"">
+soif_currency_record_render_base() {
+  local group="$1" artifact="$2" template="$3" output="$4"
+  local store="${SOIF_CURRENCY_RENDERBASE_FILE:-}"
+  [ -n "$store" ] || return 0
+  local tsha="" osha="" omode=""
+  tsha="$(soif_currency_sha256 "$template" 2>/dev/null)" || tsha=""
+  if [ -n "$output" ]; then
+    osha="$(soif_currency_sha256 "$output" 2>/dev/null)" || osha=""
+    omode="$(soif_currency_mode "$output" 2>/dev/null)" || omode=""
+  fi
+  printf '%s\t%s\t%s\t%s\t%s\n' "$group" "$artifact" "$tsha" "$osha" "$omode" >> "$store"
+}
+
+# ── files{} row emitters (M/T from the shipped-set parsers) ──────────────────
+# _soif_currency_emit_file_row <project_dir> <rel-path> <class> — one TSV row
+# "<rel>\t<sha>\t<mode>\t<class>\tcurrent" hashed from the SCAFFOLDED project
+# tree (what the project actually holds). Silently skips a rel path missing from
+# the tree (a real gap the aggregator fidelity test is designed to catch).
+_soif_currency_emit_file_row() {
+  local proj_dir="$1" rel="$2" class="$3"
+  local abspath sha mode
+  abspath="$proj_dir/$rel"
+  [ -f "$abspath" ] || return 0
+  sha="$(soif_currency_sha256 "$abspath" 2>/dev/null)" || sha=""
+  mode="$(soif_currency_mode "$abspath" 2>/dev/null)" || mode=""
+  [ -n "$sha" ] || return 0
+  printf '%s\t%s\t%s\t%s\tcurrent\n' "$rel" "$sha" "$mode" "$class"
+}
+
+# _soif_currency_mt_files_tsv <init_file> <framework_dir> <project_dir>
+#   Emits M (scripts + skills) and T (reference docs) rows, MECHANICALLY derived.
+#   `local x="$(...)"` captures are set-e-safe (local returns 0).
+_soif_currency_mt_files_tsv() {
+  local init_file="$1" fw_dir="$2" proj_dir="$3"
+  local scripts_list skills_list docs_list rel
+  scripts_list="$(soif_parse_shipped_scripts "$init_file" "$fw_dir/scripts" 2>/dev/null)"
+  skills_list="$(soif_parse_shipped_skills "$init_file" "$fw_dir/templates/generated/skills" 2>/dev/null)"
+  docs_list="$(soif_parse_shipped_reference_docs "$init_file" 2>/dev/null)"
+  printf '%s\n' "$scripts_list" | while IFS= read -r rel; do
+    if [ -n "$rel" ]; then _soif_currency_emit_file_row "$proj_dir" "$rel" M; fi
+  done
+  printf '%s\n' "$skills_list" | while IFS= read -r rel; do
+    if [ -n "$rel" ]; then _soif_currency_emit_file_row "$proj_dir" "$rel" M; fi
+  done
+  printf '%s\n' "$docs_list" | while IFS= read -r rel; do
+    if [ -n "$rel" ]; then _soif_currency_emit_file_row "$proj_dir" "$rel" T; fi
+  done
+}
+
+# ── The stamp (writer) ───────────────────────────────────────────────────────
+# soif_currency_stamp <manifest> <init_file> <framework_dir> <project_dir> \
+#                     <language> <solo_framework_path>
+#   Assembles the whole `currency` block and jq-merges it into <manifest> with
+#   the atomic-rename pattern. Additive: every pre-existing manifest field is
+#   preserved. No-op if jq is unavailable.
+soif_currency_stamp() {
+  local manifest="$1" init_file="$2" fw_dir="$3" proj_dir="$4"
+  local language="$5" solo_fw_path="$6"
+  command -v jq >/dev/null 2>&1 || return 0
+  [ -f "$manifest" ] || return 0
+
+  # M/T rows (scripts + skills + reference docs), hashed from the project tree.
+  local mt_tsv
+  mt_tsv="$(_soif_currency_mt_files_tsv "$init_file" "$fw_dir" "$proj_dir")"
+
+  # Render-base scratch → A1 file rows + A1/A2 renderBases objects.
+  local store store_content=""
+  store="${SOIF_CURRENCY_RENDERBASE_FILE:-}"
+  if [ -n "$store" ] && [ -f "$store" ]; then
+    store_content="$(cat "$store")"
+  fi
+
+  local a1_file_tsv a1_json a2_json
+  a1_file_tsv="$(printf '%s\n' "$store_content" \
+    | awk -F'\t' 'NF>=5 && $1=="A1" { print $2"\t"$4"\t"$5"\tA1\tcurrent" }')"
+  a1_json="$(printf '%s\n' "$store_content" \
+    | awk -F'\t' 'NF>=4 && $1=="A1"' \
+    | jq -Rn '[inputs | select(length>0) | split("\t") | {(.[1]): {templateSha: .[2], outputSha: .[3]}}] | add // {}')"
+  a2_json="$(printf '%s\n' "$store_content" \
+    | awk -F'\t' 'NF>=3 && $1=="A2"' \
+    | jq -Rn '[inputs | select(length>0) | split("\t") | {(.[1]): {templateSha: .[2]}}] | add // {}')"
+
+  # files{} = M/T rows + A1 rows, folded into one object.
+  local all_tsv files_json
+  all_tsv="$(printf '%s\n%s\n' "$mt_tsv" "$a1_file_tsv")"
+  files_json="$(printf '%s\n' "$all_tsv" \
+    | jq -Rn '[inputs | select(length>0) | split("\t") | {(.[0]): {sha256: .[1], mode: .[2], class: .[3], state: .[4]}}] | add // {}')"
+
+  # hooks{} three-state enum + mcpProbe.
+  local cm_state pc_state hooks_json mcp_json
+  cm_state="$(soif_currency_hook_state commit-msg "$language")"
+  pc_state="$(soif_currency_hook_state pre-commit "$language")"
+  hooks_json="$(jq -n --arg cm "$cm_state" --arg pc "$pc_state" \
+    '{"commit-msg": $cm, "pre-commit": $pc}')"
+  mcp_json="$(soif_currency_mcp_probe)"
+
+  # Assemble the block.
+  local currency_json
+  currency_json="$(jq -n \
+    --argjson files "$files_json" \
+    --argjson a1 "$a1_json" \
+    --argjson a2 "$a2_json" \
+    --argjson hooks "$hooks_json" \
+    --argjson mcp "$mcp_json" \
+    --arg path "$solo_fw_path" \
+    '{schemaVersion: 1, soloFrameworkPath: $path, files: $files,
+      renderBases: {A1: $a1, A2: $a2}, hooks: $hooks, mcpProbe: $mcp}')"
+
+  # Merge — atomic rename, mirrors the soloFrameworkCommit stamp.
+  jq --argjson currency "$currency_json" '.currency = $currency' \
+    "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"
+}
+
+# ── Readers ──────────────────────────────────────────────────────────────────
+# soif_currency_read <manifest> <jq-filter> — thin jq -r reader over the block.
+soif_currency_read() {
+  jq -r "$2" "$1" 2>/dev/null
+}
+
+# soif_currency_file_field <manifest> <path> <field> — one files{} entry field
+# (sha256|mode|class|state) for a tracked path; empty if absent.
+soif_currency_file_field() {
+  jq -r --arg p "$2" --arg f "$3" '.currency.files[$p][$f] // empty' "$1" 2>/dev/null
+}

--- a/scripts/lib/scaffold-shipped-set.sh
+++ b/scripts/lib/scaffold-shipped-set.sh
@@ -47,3 +47,50 @@ soif_parse_shipped_scripts() {
     fi
   done | sort -u
 }
+
+# soif_parse_shipped_reference_docs <init_file>
+#   Prints one shipped verbatim reference doc per line ("docs/reference/<base>"),
+#   LC-sorted & deduped. Derived MECHANICALLY from init.sh's docs→docs/reference/
+#   cp lines (the seven-doc Class-T verbatim set: builders-guide,
+#   governance-framework, executive-review, cli-setup-addendum, user-guide,
+#   security-scan-guide, uat-authoring-guide). A `cp "$SCRIPT_DIR/docs/foo.md"
+#   docs/reference/` line yields "docs/reference/foo.md" (cp to a directory keeps
+#   the source basename). Extends the shipped-set parser to reference docs for
+#   the BL-109 currency inventory; NO hand-maintained list. bash-3.2 safe.
+soif_parse_shipped_reference_docs() {
+  local init_file="$1"
+  local line src base
+  grep -E 'cp[[:space:]]+"\$SCRIPT_DIR/docs/[^"]*"[[:space:]]+docs/reference/' "$init_file" \
+    | while IFS= read -r line; do
+        src="$(printf '%s\n' "$line" | sed -n 's#.*cp[[:space:]]*"\$SCRIPT_DIR/docs/\([^"]*\)".*#\1#p')"
+        [ -n "$src" ] || continue
+        base="${src##*/}"
+        printf 'docs/reference/%s\n' "$base"
+      done | sort -u
+}
+
+# soif_parse_shipped_skills <init_file> <skills_src_dir>
+#   Prints one shipped vendored-skill file per line (".claude/skills/<name>/SKILL.md"
+#   and, when the source ships one, ".claude/skills/<name>/NOTICE"), LC-sorted &
+#   deduped. Derived MECHANICALLY from init.sh's `for skill in <names>; do` loop
+#   (the vendored-skill installer) — the skill NAMES come from the loop header, and
+#   NOTICE is emitted only when <skills_src_dir>/<name>/NOTICE exists, mirroring
+#   init.sh's own `[ -f .../NOTICE ] && cp` conditional. Extends the shipped-set
+#   parser to skills for the BL-109 currency inventory; NO hand-maintained list.
+#   bash-3.2 safe.
+soif_parse_shipped_skills() {
+  local init_file="$1" skills_src_dir="$2"
+  local line names n
+  line="$(grep -E 'for[[:space:]]+skill[[:space:]]+in[[:space:]].*;[[:space:]]*do' "$init_file" | head -1)"
+  [ -n "$line" ] || return 0
+  # Capture the skill names between `in ` and the FIRST `;` — `[^;]*` (not `.*`)
+  # so a trailing `; do ...; done` on the same line can never over-match.
+  names="$(printf '%s\n' "$line" | sed -n 's#.*for[[:space:]]*skill[[:space:]]*in[[:space:]]*\([^;]*\);.*#\1#p')"
+  [ -n "$names" ] || return 0
+  for n in $names; do
+    printf '.claude/skills/%s/SKILL.md\n' "$n"
+    if [ -f "$skills_src_dir/$n/NOTICE" ]; then
+      printf '.claude/skills/%s/NOTICE\n' "$n"
+    fi
+  done | sort -u
+}

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -541,6 +541,30 @@ else
   fail "tests/test-scaffold-tdd-block-real.sh FAILED (run for details)"
 fi
 
+# BL-109 S1 (Currency System, Layer 0 — Inventory). test-currency-manifest.sh is
+# the lib-level unit test (schema, class assignment, hook enum, sha/mode capture,
+# render-base capture, reader/writer round-trip, dual-source ban) — it never runs
+# init.sh, so it is ALSO in the tests.yml unit fast lane. test-currency-birth-
+# stamp.sh is the BL-088-precedent aggregator: it runs the REAL init.sh three
+# times (typescript/rust/other) to prove the currency block stamps at birth with
+# shas that recompute end-to-end and the three-state hook enum. That aggregator
+# is SUITE_SKIP_AGGREGATORS-gated (three scaffolds is heavy) and is NEVER in the
+# unit list (it executes init.sh).
+if bash "$SCRIPT_DIR/tests/test-currency-manifest.sh" >/dev/null 2>&1; then
+  pass "tests/test-currency-manifest.sh"
+else
+  fail "tests/test-currency-manifest.sh FAILED (run for details)"
+fi
+if [ "${SUITE_SKIP_AGGREGATORS:-0}" = "1" ]; then
+  section "BL-109 currency birth-stamp fidelity — SKIPPED (SUITE_SKIP_AGGREGATORS=1; three real init.sh scaffolds, runs standalone / full-suite)"
+else
+if bash "$SCRIPT_DIR/tests/test-currency-birth-stamp.sh" >/dev/null 2>&1; then
+  pass "tests/test-currency-birth-stamp.sh"
+else
+  fail "tests/test-currency-birth-stamp.sh FAILED (run for details)"
+fi
+fi
+
 # Agent-ergonomics onboarding: tests/test-run-lints.sh — behavior suite for
 # scripts/run-lints.sh, the canonical local lint runner (runs every
 # scripts/lint-*.sh EXCEPT the parametrized lint-uat-scenarios.sh). Its

--- a/tests/test-currency-birth-stamp.sh
+++ b/tests/test-currency-birth-stamp.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# tests/test-currency-birth-stamp.sh — BL-109 S1 AGGREGATOR fidelity test.
+#
+# The BL-088 precedent: fixtures hide scaffold gaps, so this test runs the REAL
+# init.sh into a hermetic scratch project and proves the `currency` block is
+# stamped at birth with shas that recompute end-to-end. It exercises init.sh's
+# OWN copy/render/hook mechanism — the only way to catch a shipped-set or
+# render-site drift that a hand-built fixture would paper over.
+#
+# It runs init.sh THREE times (typescript / rust / other) to cover the hook
+# three-state enum (present / absent-intentional / absent-unavailable) against
+# init.sh's real language→hook install decision. That is why it is an AGGREGATOR:
+# it is registered ONLY in tests/full-project-test-suite.sh (SUITE_SKIP_AGGREGATORS
+# -gated), NEVER in the tests.yml unit list — it executes init.sh.
+#
+# Hermetic: mktemp, GITHUB_BASE_REF unset, init.sh run with --no-remote-creation
+# (the blessed no-live-remote path). bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# Dependency guard — init.sh needs jq + git.
+if ! command -v jq >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: jq/git required for the init.sh-driven currency birth-stamp test"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+# run_init <language> <project-name> <out-scaffold-dir>
+run_init() {
+  local lang="$1" name="$2" out="$3" errf="$TOPTMP/$2.err"
+  ( cd "$TOPTMP" && "$INIT" --non-interactive \
+      --project "$name" \
+      --platform web \
+      --deployment personal \
+      --gov-mode private_poc \
+      --language "$lang" \
+      --project-dir "$out" \
+      --no-remote-creation ) >"$TOPTMP/$name.out" 2>"$errf"
+}
+
+# ════════════════════════════════════════════════════════════════════════════
+# Scaffold 1 — typescript: the FULL fidelity pass (shas, render bases, path,
+# present hook enum).
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== Scaffolding typescript project via real init.sh (hermetic) ==="
+TS="$TOPTMP/ts"
+if ! run_init typescript curbl109ts "$TS"; then
+  fail_ "ts-scaffold-init" "init.sh exited non-zero; stderr tail: $(tail -6 "$TOPTMP/curbl109ts.err" | tr '\n' '|')"
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+MAN="$TS/.claude/manifest.json"
+
+# — currency block present —
+if jq -e '.currency' "$MAN" >/dev/null 2>&1; then
+  pass "currency block present in .claude/manifest.json"
+else
+  fail_ "currency block present" "no .currency key in the birth manifest"
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+
+# — exactly the six schema keys —
+keys="$(jq -r '.currency | keys | join(" ")' "$MAN")"
+if [ "$keys" = "files hooks mcpProbe renderBases schemaVersion soloFrameworkPath" ]; then
+  pass "currency has exactly the six schema keys"
+else
+  fail_ "currency schema keys" "got [$keys]"
+fi
+
+# — schemaVersion == 1 —
+[ "$(jq -r '.currency.schemaVersion' "$MAN")" = "1" ] \
+  && pass "schemaVersion == 1" || fail_ "schemaVersion" "not 1"
+
+# — every files{} sha256 recomputes against the scaffolded tree —
+jq -r '.currency.files | keys[]' "$MAN" > "$TOPTMP/ts.keys"
+sha_bad=0; sha_tot=0
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  sha_tot=$((sha_tot + 1))
+  if [ ! -f "$TS/$rel" ]; then
+    sha_bad=$((sha_bad + 1)); echo "    missing on disk: $rel"; continue
+  fi
+  exp="$(shasum -a 256 "$TS/$rel" | awk '{print $1}')"
+  got="$(jq -r --arg p "$rel" '.currency.files[$p].sha256' "$MAN")"
+  [ "$exp" = "$got" ] || { sha_bad=$((sha_bad + 1)); echo "    sha mismatch: $rel"; }
+done < "$TOPTMP/ts.keys"
+if [ "$sha_bad" -eq 0 ] && [ "$sha_tot" -gt 0 ]; then
+  pass "every files{} sha256 recomputes independently ($sha_tot files)"
+else
+  fail_ "files{} sha recompute" "$sha_bad of $sha_tot mismatched/missing"
+fi
+
+# — every files{} entry has mode + state:"current" —
+non_current="$(jq -r '[.currency.files[] | select(.state != "current")] | length' "$MAN")"
+[ "$non_current" = "0" ] && pass "every files{} entry state == current" \
+  || fail_ "files{} state" "$non_current entries not current"
+no_mode="$(jq -r '[.currency.files[] | select(.mode == null or .mode == "")] | length' "$MAN")"
+[ "$no_mode" = "0" ] && pass "every files{} entry has a mode" \
+  || fail_ "files{} mode" "$no_mode entries lack a mode"
+
+# — class breakdown: T == 7 (docs/reference verbatim set); A1 == 2; M > 0 —
+t_count="$(jq -r '[.currency.files[] | select(.class == "T")] | length' "$MAN")"
+a1_count="$(jq -r '[.currency.files[] | select(.class == "A1")] | length' "$MAN")"
+m_count="$(jq -r '[.currency.files[] | select(.class == "M")] | length' "$MAN")"
+[ "$t_count" = "7" ] && pass "Class T == 7 (docs/reference verbatim set)" \
+  || fail_ "Class T count" "expected 7, got $t_count"
+[ "$a1_count" = "2" ] && pass "Class A1 == 2 (CLAUDE.md + PROJECT_INTAKE.md)" \
+  || fail_ "Class A1 count" "expected 2, got $a1_count"
+[ "$m_count" -gt 0 ] && pass "Class M > 0 (scripts + skills): $m_count" \
+  || fail_ "Class M count" "expected > 0, got $m_count"
+
+# — A2 agent-authored artifacts NOT in files{} (do not exist at birth) —
+if [ "$(jq -r '.currency.files["PRODUCT_MANIFESTO.md"] // "null"' "$MAN")" = "null" ] \
+   && [ "$(jq -r '.currency.files["PROJECT_BIBLE.md"] // "null"' "$MAN")" = "null" ]; then
+  pass "A2 artifacts (manifesto/bible) are NOT in files{}"
+else
+  fail_ "A2 in files{}" "an A2 artifact leaked into files{}"
+fi
+
+# — render bases recompute (A1 template+output; A2 template-only) —
+rb_ok=1
+# A1 CLAUDE.md
+exp="$(shasum -a 256 "$REPO_ROOT/templates/generated/claude-md.tmpl" | awk '{print $1}')"
+[ "$(jq -r '.currency.renderBases.A1["CLAUDE.md"].templateSha' "$MAN")" = "$exp" ] || { rb_ok=0; echo "    A1 CLAUDE tmpl sha diff"; }
+exp="$(shasum -a 256 "$TS/CLAUDE.md" | awk '{print $1}')"
+[ "$(jq -r '.currency.renderBases.A1["CLAUDE.md"].outputSha' "$MAN")" = "$exp" ] || { rb_ok=0; echo "    A1 CLAUDE out sha diff"; }
+# A1 PROJECT_INTAKE.md
+exp="$(shasum -a 256 "$REPO_ROOT/templates/project-intake.md" | awk '{print $1}')"
+[ "$(jq -r '.currency.renderBases.A1["PROJECT_INTAKE.md"].templateSha' "$MAN")" = "$exp" ] || { rb_ok=0; echo "    A1 INTAKE tmpl sha diff"; }
+exp="$(shasum -a 256 "$TS/PROJECT_INTAKE.md" | awk '{print $1}')"
+[ "$(jq -r '.currency.renderBases.A1["PROJECT_INTAKE.md"].outputSha' "$MAN")" = "$exp" ] || { rb_ok=0; echo "    A1 INTAKE out sha diff"; }
+# A2 templates
+exp="$(shasum -a 256 "$REPO_ROOT/templates/generated/project-bible.tmpl" | awk '{print $1}')"
+[ "$(jq -r '.currency.renderBases.A2["PROJECT_BIBLE.md"].templateSha' "$MAN")" = "$exp" ] || { rb_ok=0; echo "    A2 bible tmpl sha diff"; }
+exp="$(shasum -a 256 "$REPO_ROOT/templates/generated/product-manifesto.tmpl" | awk '{print $1}')"
+[ "$(jq -r '.currency.renderBases.A2["PRODUCT_MANIFESTO.md"].templateSha' "$MAN")" = "$exp" ] || { rb_ok=0; echo "    A2 manifesto tmpl sha diff"; }
+# A2 records template ONLY — no outputSha
+[ "$(jq -r '.currency.renderBases.A2["PROJECT_BIBLE.md"].outputSha // "null"' "$MAN")" = "null" ] || { rb_ok=0; echo "    A2 bible has outputSha (should not)"; }
+# A1 files{} sha reuses the captured render-time output sha (single hash, no post-hoc)
+[ "$(jq -r '.currency.files["CLAUDE.md"].sha256' "$MAN")" = "$(jq -r '.currency.renderBases.A1["CLAUDE.md"].outputSha' "$MAN")" ] || { rb_ok=0; echo "    A1 files sha != render outputSha"; }
+if [ "$rb_ok" -eq 1 ]; then pass "render bases recompute (A1 tmpl+out, A2 tmpl-only)"; else fail_ "render bases" "see diffs above"; fi
+
+# — soloFrameworkPath == the framework checkout used —
+got_path="$(jq -r '.currency.soloFrameworkPath' "$MAN")"
+[ "$got_path" = "$REPO_ROOT" ] && pass "soloFrameworkPath == framework checkout ($REPO_ROOT)" \
+  || fail_ "soloFrameworkPath" "expected [$REPO_ROOT], got [$got_path]"
+
+# — mcpProbe is a valid present/absent enum —
+mcp="$(jq -r '.currency.mcpProbe.context7' "$MAN")"
+{ [ "$mcp" = "present" ] || [ "$mcp" = "absent" ]; } \
+  && pass "mcpProbe.context7 is a valid enum ($mcp)" \
+  || fail_ "mcpProbe" "got [$mcp]"
+
+# — pre-existing pins/fields preserved (additive stamp) —
+[ "$(jq -r '.frameworkCommit // "MISSING"' "$MAN")" != "MISSING" ] \
+  && pass "additive: CDF frameworkCommit pin preserved" \
+  || fail_ "additive pin" "frameworkCommit lost"
+
+# — typescript hooks: commit-msg + pre-commit present —
+[ "$(jq -r '.currency.hooks["commit-msg"]' "$MAN")" = "present" ] \
+  && pass "typescript -> commit-msg hook present" \
+  || fail_ "ts commit-msg" "not present"
+[ "$(jq -r '.currency.hooks["pre-commit"]' "$MAN")" = "present" ] \
+  && pass "pre-commit hook present" \
+  || fail_ "pre-commit" "not present"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Scaffold 2 — rust: commit-msg hook is absent-intentional (inline tests).
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== Scaffolding rust project via real init.sh (hermetic) ==="
+RS="$TOPTMP/rs"
+if run_init rust curbl109rs "$RS"; then
+  st="$(jq -r '.currency.hooks["commit-msg"]' "$RS/.claude/manifest.json")"
+  [ "$st" = "absent-intentional" ] \
+    && pass "rust -> commit-msg absent-intentional" \
+    || fail_ "rust commit-msg" "expected absent-intentional, got [$st]"
+else
+  fail_ "rust-scaffold-init" "init.sh exited non-zero; stderr tail: $(tail -6 "$TOPTMP/curbl109rs.err" | tr '\n' '|')"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Scaffold 3 — other: commit-msg hook is absent-unavailable (the *) catch-all,
+# surfaced at the enforcement tier — must NOT launder a bug into a fact.
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== Scaffolding 'other'-language project via real init.sh (hermetic) ==="
+OT="$TOPTMP/ot"
+if run_init other curbl109ot "$OT"; then
+  st="$(jq -r '.currency.hooks["commit-msg"]' "$OT/.claude/manifest.json")"
+  [ "$st" = "absent-unavailable" ] \
+    && pass "other -> commit-msg absent-unavailable" \
+    || fail_ "other commit-msg" "expected absent-unavailable, got [$st]"
+else
+  fail_ "other-scaffold-init" "init.sh exited non-zero; stderr tail: $(tail -6 "$TOPTMP/curbl109ot.err" | tr '\n' '|')"
+fi
+
+# ── Tally ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-currency-manifest.sh
+++ b/tests/test-currency-manifest.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# tests/test-currency-manifest.sh — BL-109 S1 unit lane (LIB-LEVEL ONLY).
+#
+# Exercises scripts/lib/currency-manifest.sh + the scaffold-shipped-set.sh
+# extensions WITHOUT ever invoking init.sh (fast-lane invariant: this test is in
+# the tests.yml unit list, so it must not scaffold a project). It builds a tiny
+# hermetic framework+project fixture, populates a render-base scratch file the
+# way init.sh's render sites would, stamps a `currency` block into a fixture
+# manifest, and asserts the schema, class assignment, hook enum, sha/mode
+# capture, render-base capture, reader/writer round-trip, additive merge, the
+# state:"current" field, and the dual-source ban.
+#
+# The AGGREGATOR fidelity test (tests/test-currency-birth-stamp.sh) runs the REAL
+# init.sh and proves the shas recompute end-to-end — the BL-088 precedent that
+# fixtures hide scaffold gaps. This unit test proves the LIB's behavior.
+#
+# bash-3.2 safe. Hermetic (mktemp, no network, no remotes).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass() { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1" "expected [$2], got [$3]"; fi
+}
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq required for the currency-manifest unit test"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+# ── Load the lib under test (+ its deps) ────────────────────────────────────
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/hook-templates.sh"
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh"
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/currency-manifest.sh"
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# ════════════════════════════════════════════════════════════════════════════
+# T1 — sha/mode capture correctness
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T1: sha256 + mode capture =="
+KNOWN="$TOPTMP/known.txt"
+printf 'currency-fixture-content\n' > "$KNOWN"
+chmod 640 "$KNOWN"
+want_sha="$(shasum -a 256 "$KNOWN" | awk '{print $1}')"
+got_sha="$(soif_currency_sha256 "$KNOWN")"
+assert_eq "T1-sha256 matches independent shasum" "$want_sha" "$got_sha"
+want_mode="$(stat -c '%a' "$KNOWN" 2>/dev/null || stat -f '%Lp' "$KNOWN" 2>/dev/null)"
+got_mode="$(soif_currency_mode "$KNOWN")"
+assert_eq "T1-mode matches independent stat" "$want_mode" "$got_mode"
+assert_eq "T1-mode is the chmod'd 640" "640" "$got_mode"
+if soif_currency_sha256 "$TOPTMP/does-not-exist" >/dev/null 2>&1; then
+  fail "T1-sha256 missing-file returns non-zero" "returned success"
+else
+  pass "T1-sha256 missing-file returns non-zero"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# T2 — hook three-state enum derivation (language matrix)
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T2: hook enum (language matrix) =="
+assert_eq "T2-commit-msg typescript -> present"        "present"            "$(soif_currency_hook_state commit-msg typescript)"
+assert_eq "T2-commit-msg python -> present"            "present"            "$(soif_currency_hook_state commit-msg python)"
+assert_eq "T2-commit-msg go -> present"                "present"            "$(soif_currency_hook_state commit-msg go)"
+assert_eq "T2-commit-msg rust -> absent-intentional"   "absent-intentional" "$(soif_currency_hook_state commit-msg rust)"
+assert_eq "T2-commit-msg other -> absent-unavailable"  "absent-unavailable" "$(soif_currency_hook_state commit-msg other)"
+assert_eq "T2-commit-msg cobol -> absent-unavailable"  "absent-unavailable" "$(soif_currency_hook_state commit-msg cobol)"
+assert_eq "T2-commit-msg empty -> absent-unavailable"  "absent-unavailable" "$(soif_currency_hook_state commit-msg '')"
+assert_eq "T2-pre-commit typescript -> present"        "present"            "$(soif_currency_hook_state pre-commit typescript)"
+assert_eq "T2-pre-commit rust -> present"              "present"            "$(soif_currency_hook_state pre-commit rust)"
+assert_eq "T2-unknown-hook -> absent-unavailable"      "absent-unavailable" "$(soif_currency_hook_state pre-push rust)"
+
+# ════════════════════════════════════════════════════════════════════════════
+# Build a hermetic framework+project fixture for the stamp-based tests (T3–T8).
+# The fixture mirrors init.sh's shape: cp lines for scripts + a reference doc,
+# a `for skill in ... ; do` loop (multi-line, matching init.sh), and A1/A2
+# render sources. The scaffolded project holds byte-copies + rendered artifacts.
+# ════════════════════════════════════════════════════════════════════════════
+echo "== building fixture =="
+FW="$TOPTMP/fw"
+PROJ="$TOPTMP/proj"
+mkdir -p "$FW/scripts/lib" "$FW/scripts/host-drivers" "$FW/docs" \
+         "$FW/templates/generated/skills/alpha-skill" \
+         "$FW/templates/generated/skills/beta-skill" \
+         "$FW/templates/generated"
+mkdir -p "$PROJ/scripts/lib" "$PROJ/scripts/host-drivers" "$PROJ/docs/reference" \
+         "$PROJ/.claude/skills/alpha-skill" "$PROJ/.claude/skills/beta-skill" "$PROJ/.claude"
+
+# Framework sources
+printf 'echo alpha\n'         > "$FW/scripts/alpha.sh"
+printf 'lib=beta\n'           > "$FW/scripts/lib/hook-templates.sh"
+printf 'driver\n'             > "$FW/scripts/host-drivers/github.driver.sh"
+printf '# builders guide\n'   > "$FW/docs/builders-guide.md"
+printf 'ALPHA SKILL\n'        > "$FW/templates/generated/skills/alpha-skill/SKILL.md"
+printf 'ALPHA NOTICE\n'       > "$FW/templates/generated/skills/alpha-skill/NOTICE"
+printf 'BETA SKILL\n'         > "$FW/templates/generated/skills/beta-skill/SKILL.md"   # beta has NO NOTICE
+printf 'CLAUDE TEMPLATE __PROJECT_NAME__\n' > "$FW/templates/generated/claude-md.tmpl"
+printf 'INTAKE TEMPLATE __DATE__\n'         > "$FW/templates/project-intake.md"
+printf 'BIBLE SKELETON [N]\n'               > "$FW/templates/generated/project-bible.tmpl"
+printf 'MANIFESTO SKELETON\n'               > "$FW/templates/generated/product-manifesto.tmpl"
+
+# Fixture init.sh — MECHANICAL source for the parsers (never executed here).
+cat > "$FW/init.sh" <<'FIXTURE_INIT'
+  cp "$SCRIPT_DIR/scripts/alpha.sh" scripts/
+  cp "$SCRIPT_DIR/scripts/lib/hook-templates.sh" scripts/lib/
+  cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
+  cp "$SCRIPT_DIR/docs/builders-guide.md" docs/reference/
+  for skill in alpha-skill beta-skill; do
+    cp "$SCRIPT_DIR/templates/generated/skills/$skill/SKILL.md" ".claude/skills/$skill/"
+  done
+FIXTURE_INIT
+
+# Scaffolded project = byte copies + rendered artifacts.
+cp "$FW/scripts/alpha.sh"                                   "$PROJ/scripts/alpha.sh"
+cp "$FW/scripts/lib/hook-templates.sh"                      "$PROJ/scripts/lib/hook-templates.sh"
+cp "$FW/scripts/host-drivers/github.driver.sh"             "$PROJ/scripts/host-drivers/github.driver.sh"
+cp "$FW/docs/builders-guide.md"                            "$PROJ/docs/reference/builders-guide.md"
+cp "$FW/templates/generated/skills/alpha-skill/SKILL.md"   "$PROJ/.claude/skills/alpha-skill/SKILL.md"
+cp "$FW/templates/generated/skills/alpha-skill/NOTICE"     "$PROJ/.claude/skills/alpha-skill/NOTICE"
+cp "$FW/templates/generated/skills/beta-skill/SKILL.md"    "$PROJ/.claude/skills/beta-skill/SKILL.md"
+printf 'CLAUDE RENDERED fixtureproj\n' > "$PROJ/CLAUDE.md"
+printf 'INTAKE RENDERED 2026-07-12\n'  > "$PROJ/PROJECT_INTAKE.md"
+
+# Pre-existing manifest with pins that MUST survive the additive stamp.
+printf '{"host":"github","mode":"personal","soloFrameworkCommit":"deadbeef","frameworkCommit":"cafef00d"}\n' \
+  > "$PROJ/.claude/manifest.json"
+
+# Populate the render-base scratch the way init.sh's render sites do.
+soif_currency_renderbase_init
+soif_currency_record_render_base A1 CLAUDE.md \
+  "$FW/templates/generated/claude-md.tmpl" "$PROJ/CLAUDE.md"
+soif_currency_record_render_base A1 PROJECT_INTAKE.md \
+  "$FW/templates/project-intake.md" "$PROJ/PROJECT_INTAKE.md"
+soif_currency_record_render_base A2 PROJECT_BIBLE.md \
+  "$FW/templates/generated/project-bible.tmpl" ""
+soif_currency_record_render_base A2 PRODUCT_MANIFESTO.md \
+  "$FW/templates/generated/product-manifesto.tmpl" ""
+
+MAN="$PROJ/.claude/manifest.json"
+soif_currency_stamp "$MAN" "$FW/init.sh" "$FW" "$PROJ" typescript "$FW"
+
+# ════════════════════════════════════════════════════════════════════════════
+# T3 — schema shape (design v1.1 §2-L0)
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T3: schema shape =="
+assert_eq "T3-schemaVersion == 1"     "1"     "$(jq -r '.currency.schemaVersion' "$MAN")"
+assert_eq "T3-soloFrameworkPath set"  "$FW"   "$(jq -r '.currency.soloFrameworkPath' "$MAN")"
+assert_eq "T3-files is an object"     "object" "$(jq -r '.currency.files | type' "$MAN")"
+assert_eq "T3-renderBases.A1 object"  "object" "$(jq -r '.currency.renderBases.A1 | type' "$MAN")"
+assert_eq "T3-renderBases.A2 object"  "object" "$(jq -r '.currency.renderBases.A2 | type' "$MAN")"
+assert_eq "T3-hooks object"           "object" "$(jq -r '.currency.hooks | type' "$MAN")"
+assert_eq "T3-mcpProbe.context7 present-or-absent" "true" \
+  "$(jq -r '(.currency.mcpProbe.context7 == "present") or (.currency.mcpProbe.context7 == "absent")' "$MAN")"
+# Top-level keys are EXACTLY the six from the schema.
+assert_eq "T3-currency has exactly the 6 schema keys" \
+  "files hooks mcpProbe renderBases schemaVersion soloFrameworkPath" \
+  "$(jq -r '.currency | keys | join(" ")' "$MAN")"
+
+# ════════════════════════════════════════════════════════════════════════════
+# T4 — class assignment on the fixture tree
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T4: class assignment =="
+assert_eq "T4-script alpha.sh -> M"                 "M"  "$(soif_currency_file_field "$MAN" "scripts/alpha.sh" class)"
+assert_eq "T4-hook lib -> M"                        "M"  "$(soif_currency_file_field "$MAN" "scripts/lib/hook-templates.sh" class)"
+assert_eq "T4-glob host-driver -> M"                "M"  "$(soif_currency_file_field "$MAN" "scripts/host-drivers/github.driver.sh" class)"
+assert_eq "T4-reference doc -> T"                   "T"  "$(soif_currency_file_field "$MAN" "docs/reference/builders-guide.md" class)"
+assert_eq "T4-skill SKILL.md -> M"                  "M"  "$(soif_currency_file_field "$MAN" ".claude/skills/alpha-skill/SKILL.md" class)"
+assert_eq "T4-skill NOTICE -> M"                    "M"  "$(soif_currency_file_field "$MAN" ".claude/skills/alpha-skill/NOTICE" class)"
+assert_eq "T4-CLAUDE.md -> A1"                      "A1" "$(soif_currency_file_field "$MAN" "CLAUDE.md" class)"
+assert_eq "T4-PROJECT_INTAKE.md -> A1"              "A1" "$(soif_currency_file_field "$MAN" "PROJECT_INTAKE.md" class)"
+# beta-skill has no NOTICE in source: mechanical derivation must NOT invent one.
+assert_eq "T4-beta NOTICE absent (source has none)" "" \
+  "$(jq -r '.currency.files[".claude/skills/beta-skill/NOTICE"] // "" | if . == "" then "" else "PRESENT" end' "$MAN")"
+assert_eq "T4-beta SKILL.md present"                "M"  "$(soif_currency_file_field "$MAN" ".claude/skills/beta-skill/SKILL.md" class)"
+# A2 agent-authored artifacts are NOT in files{} (they do not exist at birth).
+assert_eq "T4-PROJECT_BIBLE.md not in files{}"      "null" "$(jq -r '.currency.files["PROJECT_BIBLE.md"] // "null"' "$MAN")"
+assert_eq "T4-PRODUCT_MANIFESTO.md not in files{}"  "null" "$(jq -r '.currency.files["PRODUCT_MANIFESTO.md"] // "null"' "$MAN")"
+
+# ════════════════════════════════════════════════════════════════════════════
+# T5 — sha/mode in files{} match independent recomputation; state == "current"
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T5: files{} sha/mode fidelity + state =="
+recomputed_ok=1
+for rel in scripts/alpha.sh scripts/lib/hook-templates.sh \
+           scripts/host-drivers/github.driver.sh docs/reference/builders-guide.md \
+           .claude/skills/alpha-skill/SKILL.md .claude/skills/alpha-skill/NOTICE \
+           .claude/skills/beta-skill/SKILL.md CLAUDE.md PROJECT_INTAKE.md; do
+  exp="$(shasum -a 256 "$PROJ/$rel" | awk '{print $1}')"
+  got="$(soif_currency_file_field "$MAN" "$rel" sha256)"
+  [ "$exp" = "$got" ] || { recomputed_ok=0; echo "    mismatch: $rel exp=$exp got=$got"; }
+done
+if [ "$recomputed_ok" -eq 1 ]; then pass "T5-every files{} sha256 recomputes"; else fail "T5-every files{} sha256 recomputes" "see mismatches"; fi
+# state:"current" on every entry.
+non_current="$(jq -r '[.currency.files[] | select(.state != "current")] | length' "$MAN")"
+assert_eq "T5-every files{} entry state == current" "0" "$non_current"
+# mode present on every entry.
+no_mode="$(jq -r '[.currency.files[] | select(.mode == null or .mode == "")] | length' "$MAN")"
+assert_eq "T5-every files{} entry has a mode" "0" "$no_mode"
+
+# ════════════════════════════════════════════════════════════════════════════
+# T6 — render bases captured at render site (A1 template+output, A2 template-only)
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T6: render bases =="
+exp_tmpl="$(shasum -a 256 "$FW/templates/generated/claude-md.tmpl" | awk '{print $1}')"
+exp_out="$(shasum -a 256 "$PROJ/CLAUDE.md" | awk '{print $1}')"
+assert_eq "T6-A1 CLAUDE.md templateSha recomputes" "$exp_tmpl" "$(jq -r '.currency.renderBases.A1["CLAUDE.md"].templateSha' "$MAN")"
+assert_eq "T6-A1 CLAUDE.md outputSha recomputes"   "$exp_out"  "$(jq -r '.currency.renderBases.A1["CLAUDE.md"].outputSha' "$MAN")"
+# The A1 files{} sha256 == the render-base outputSha (captured once, never re-hashed post-hoc).
+assert_eq "T6-A1 files sha == render outputSha" \
+  "$(jq -r '.currency.renderBases.A1["CLAUDE.md"].outputSha' "$MAN")" \
+  "$(soif_currency_file_field "$MAN" "CLAUDE.md" sha256)"
+exp_bible="$(shasum -a 256 "$FW/templates/generated/project-bible.tmpl" | awk '{print $1}')"
+assert_eq "T6-A2 PROJECT_BIBLE templateSha recomputes" "$exp_bible" "$(jq -r '.currency.renderBases.A2["PROJECT_BIBLE.md"].templateSha' "$MAN")"
+# A2 records template ONLY — no outputSha key.
+assert_eq "T6-A2 has no outputSha" "null" "$(jq -r '.currency.renderBases.A2["PROJECT_BIBLE.md"].outputSha // "null"' "$MAN")"
+
+# ════════════════════════════════════════════════════════════════════════════
+# T7 — hooks block value + reader/writer round-trip + additive merge
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T7: hooks value + round-trip + additive =="
+assert_eq "T7-commit-msg present (typescript fixture)" "present" "$(jq -r '.currency.hooks["commit-msg"]' "$MAN")"
+assert_eq "T7-pre-commit present"                      "present" "$(jq -r '.currency.hooks["pre-commit"]' "$MAN")"
+assert_eq "T7-reader round-trip (hook)" "present" "$(soif_currency_read "$MAN" '.currency.hooks["commit-msg"]')"
+assert_eq "T7-reader round-trip (file sha)" \
+  "$(shasum -a 256 "$PROJ/scripts/alpha.sh" | awk '{print $1}')" \
+  "$(soif_currency_file_field "$MAN" "scripts/alpha.sh" sha256)"
+# Additive: pre-existing pins/fields survive untouched.
+assert_eq "T7-additive: host preserved"               "github"   "$(jq -r '.host' "$MAN")"
+assert_eq "T7-additive: soloFrameworkCommit preserved" "deadbeef" "$(jq -r '.soloFrameworkCommit' "$MAN")"
+assert_eq "T7-additive: frameworkCommit preserved"     "cafef00d" "$(jq -r '.frameworkCommit' "$MAN")"
+
+# A rust fixture stamps absent-intentional (fresh manifest, no re-render needed).
+MAN2="$TOPTMP/rust-manifest.json"
+printf '{"host":"gitlab"}\n' > "$MAN2"
+SOIF_CURRENCY_RENDERBASE_FILE="" soif_currency_stamp "$MAN2" "$FW/init.sh" "$FW" "$PROJ" rust "$FW"
+assert_eq "T7-rust fixture -> commit-msg absent-intentional" "absent-intentional" "$(jq -r '.currency.hooks["commit-msg"]' "$MAN2")"
+# An `other`-language fixture stamps absent-unavailable.
+MAN3="$TOPTMP/other-manifest.json"
+printf '{"host":"gitlab"}\n' > "$MAN3"
+SOIF_CURRENCY_RENDERBASE_FILE="" soif_currency_stamp "$MAN3" "$FW/init.sh" "$FW" "$PROJ" other "$FW"
+assert_eq "T7-other fixture -> commit-msg absent-unavailable" "absent-unavailable" "$(jq -r '.currency.hooks["commit-msg"]' "$MAN3")"
+
+# ════════════════════════════════════════════════════════════════════════════
+# T8 — dual-source ban (review-r1 B2): no product-code second-manifest filename
+# ════════════════════════════════════════════════════════════════════════════
+echo "== T8: dual-source ban =="
+# Build the forbidden standalone-manifest filename from parts so THIS test file
+# does not itself contain the literal token it bans (self-reference trap).
+ban_token="framework""-manifest"
+ban_hits="$(grep -rl "$ban_token" "$REPO_ROOT/scripts" "$REPO_ROOT/tests" "$REPO_ROOT/init.sh" 2>/dev/null | wc -l | tr -d ' ')"
+case "$ban_hits" in ''|*[!0-9]*) ban_hits=0 ;; esac
+assert_eq "T8-no standalone-manifest filename in product code" "0" "$ban_hits"
+# The stamp writes exactly one manifest file — never a sibling.
+sibling="$(find "$PROJ/.claude" -maxdepth 1 -name '*manifest*.json' | wc -l | tr -d ' ')"
+case "$sibling" in ''|*[!0-9]*) sibling=0 ;; esac
+assert_eq "T8-exactly one manifest file in .claude/" "1" "$sibling"
+
+# ── Tally ───────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## BL-109 S1 — Inventory (Currency System, Layer 0)

Stamps ONE versioned `currency` block **inside** the existing
`.claude/manifest.json` at project birth — the machine-derived fact base every
later slice (detection, staging, apply) reads. **Never a second manifest file**
(dual-source ban, review-r1 **B2**): a repo-wide grep for the rejected
standalone-manifest filename stays 0 in product code (asserted in the unit test).

Design of record: `docs/designs/2026-07-12-currency-system-v1.md` (v1.1), §2-L0.
Honors review-r1 **B2** (one block, `soloFrameworkPath`) and **M9** (three-state
hook enum). Backlog **UNTOUCHED** — BL-109 stays **Open** (S1 only).

### Schema (v1.1 §2-L0, as stamped)

| Field | Type | Value at birth |
|---|---|---|
| `schemaVersion` | int | `1` |
| `soloFrameworkPath` | string | init.sh's own `$SCRIPT_DIR` (absolute) |
| `files{}` | `path → {sha256, mode, class, state}` | M scripts+skills, T docs/reference, A1 CLAUDE.md + PROJECT_INTAKE.md |
| `renderBases.A1` | `artifact → {templateSha, outputSha}` | CLAUDE.md, PROJECT_INTAKE.md |
| `renderBases.A2` | `artifact → {templateSha}` | PRODUCT_MANIFESTO.md, PROJECT_BIBLE.md |
| `hooks{}` | `name → enum` | commit-msg, pre-commit |
| `mcpProbe` | `{context7: present\|absent}` | via the existing `is_context7_mcp_registered` |

`files{}` is derived **mechanically** from the same source as
`scripts/lib/scaffold-shipped-set.sh` — extended there to the 7 docs/reference
verbatim docs (Class **T**) and the vendored skills (Class **M**), same parsing
approach as the existing scripts parser. **No hand-maintained list anywhere.**
Each entry's sha256/mode is hashed from the just-scaffolded project tree;
`state` is `"current"`. Real birth run: **60 files** (M=51, T=7, A1=2), every
sha independently recomputes.

Class rubric: **M** = scripts + hooks-related libs + vendored skills · **T** =
docs/reference verbatim set · **A1** = CLAUDE.md + PROJECT_INTAKE.md
(script-rendered). **A2** artifacts (PRODUCT_MANIFESTO.md, PROJECT_BIBLE.md) are
created by no script and do **not** exist at birth (review-r1 **B3a**) — they
appear only under `renderBases.A2` by template sha, never in `files{}`.

### Render-base timing guarantee

The render bases are captured **at the render site**, into a scratch file, the
moment each artifact is produced — **never post-hoc** (post-hoc hashing of a
maybe-already-touched file is a MAJOR per the verify focus):

- **CLAUDE.md** — captured at the end of `generate_claude_md`, *after* the sed
  substitution **and** the conditional organizational append (its final bytes).
- **PROJECT_INTAKE.md** — captured *after* the full render (cp template → sed
  pre-fill → `append_intake_tooling_summary`), i.e. its final bytes.
- **A2 templates** — captured at the template-copy site (template sha only; no
  render output exists).

The A1 `files{}` sha256 **reuses** the captured render-time `outputSha`, so an A1
artifact is hashed exactly once — asserted (`files.sha256 == renderBases.outputSha`)
in both tests.

### Hook three-state enum (review-r1 M9)

Reproduces init.sh's own install decision mechanically (`soif_lang_test_pattern`):

| Language | `commit-msg` | Why |
|---|---|---|
| has a test-file pattern (typescript, javascript, python, go, java, kotlin, csharp, dart, swift) | `present` | init.sh installs the BL-072 TDD gate |
| `rust` | `absent-intentional` | inline `#[cfg(test)]` tests — no test-file convention, deliberately no hook |
| `*)` catch-all (e.g. `other`) | `absent-unavailable` | BL-107 gap — surfaces at the enforcement tier; must never launder a bug into a fact |
| any language | `pre-commit` = `present` | fallback hook (gitleaks + Semgrep) installed unconditionally |

Proven end-to-end against **real init.sh** (typescript → present, rust →
absent-intentional, other → absent-unavailable) in the aggregator test.

### Tests

- **`tests/test-currency-manifest.sh`** — UNIT LANE, lib-level, **never runs
  init.sh** (registered in the suite **and** the tests.yml unit list). Covers
  schema shape, class assignment, hook enum matrix, sha/mode capture,
  render-base capture, reader/writer round-trip, additive merge, `state:"current"`,
  and the dual-source ban. **53 passed, 0 failed.**
- **`tests/test-currency-birth-stamp.sh`** — the BL-088-precedent AGGREGATOR
  (fixtures hide scaffold gaps): runs the **real init.sh three times** and proves
  the block stamps with shas that recompute, render bases match, and the three
  hook enums land. **18 passed, 0 failed.** Registered in the suite,
  **SUITE_SKIP_AGGREGATORS-gated** (three real scaffolds is heavy, per the exact
  pattern of `test-bl099-guard-coverage.sh`); **not** in the unit list (it
  executes init.sh).

### Mutation evidence (behavioral RED → GREEN)

1. **Excise the `# BL-109-CURRENCY` stamping call** (scratch init) → birth-stamp
   test RED: `[FAIL] currency block present — no .currency key in the birth
   manifest` → `Results: 0 passed, 1 failed`. Restore → byte-identical init.sh →
   `Results: 18 passed, 0 failed`.
2. **Add a fake ship line** to a scratch shipped-set source → derived scripts
   grow `44 → 45`, the new path present in the derived set (proves mechanical
   derivation — no hand list).
3. **Mutate the rust arm** (`absent-intentional` → `present`) → unit test RED:
   `[FAIL] T2-commit-msg rust -> absent-intentional … got [present]` +
   `[FAIL] T7-rust fixture …` → `Results: 51 passed, 2 failed`. Restore →
   `Results: 53 passed, 0 failed`.

### Verification

- `bash scripts/run-lints.sh` → **11 lints — 11 passed, 0 failed**.
- Neighbors all green: `test-scaffold-source-closure` (6/0),
  `test-upgrade-sync-framework` (**35/35**), `test-bl099-guard-coverage`
  (**25 pinned/0**), `test-scaffold-tdd-block-real` (5/0),
  `test-upgrade-cdf-refresh` (6/0).
- Existing manifest content + pins preserved byte-for-byte aside from the added
  block (asserted: CDF `frameworkCommit` survives).

### Declared deviations

1. **Stamp site — universal manifest-seed, not "after the soloFrameworkCommit
   stamp."** The task specified stamping *after the existing manifest creation +
   soloFrameworkCommit stamp*. Ground truth: the `soloFrameworkCommit` stamp
   (init.sh, `# BL-099` birth-stamp) is **remote-path-only** — the
   `--no-remote-creation` branch of `create_and_protect_remote` returns **before**
   it (verified: a real `--no-remote-creation` scaffold has **no**
   `soloFrameworkCommit`). Since the aggregator acceptance requires the currency
   block on the `--no-remote-creation` path (and every UAT/CI/agent scaffold uses
   it), anchoring to `soloFrameworkCommit` would leave the block **absent** on the
   common birth path. The currency stamp is therefore placed at the **universal**
   manifest-creation site — `prepare_initial_state_for_commit` — which runs on
   **every** path, immediately after the framework-managed manifest seed and
   before the chore-init commit. This is the only placement consistent with the
   task's own acceptance criteria. Flagged rather than silently improvised
   (the manifest-reality defect class is exactly what blocked the design at B2).
2. **`renderBases`/`files{}` template scope.** The task's class enum (M/T/A1) is
   closed and assigns no class to bulk `.tmpl` skeletons; A2 templates are
   explicitly render-base-only. Accordingly, `files{}` tracks scripts+skills (M),
   the 7 docs/reference (T), and the two A1 artifacts; **all** templates the
   currency system needs in S1 are render sources and are captured in
   `renderBases` (A1 with output sha, A2 template-sha-only). "Extend the parser to
   templates" is satisfied via that render-base capture. Broader `.tmpl` drift
   tracking, if wanted, needs a class decision and is deferred (not improvised).
3. **`soloFrameworkPath` re-stamping on sync/apply is S3a** — out of scope here
   (init.sh stamps its own `$SCRIPT_DIR` at birth; re-validation/refresh is a
   later slice, as the task notes).
4. **`scripts/lib/currency-manifest.sh` is not shipped downstream in S1.** It is
   used framework-side at init time only. S2 (detection) will add the cp line
   when in-project consumption needs it. No source-closure violation: only
   init.sh (which is not itself shipped) sources it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
