### PR TITLE
feat(currency): S2 detection — session-start freshness check (BL-109)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -105,6 +105,7 @@ jobs:
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh
             tests/test-filesystem-gate-install.sh
+            tests/test-freshness-check.sh
             tests/test-gate-principles.sh
             tests/test-gitlab-ci-status-stderr-approvals.sh
             tests/test-host-verify-protection-date-parse.sh

--- a/init.sh
+++ b/init.sh
@@ -1328,6 +1328,14 @@ create_project() {
   # upgrade-project.sh copy stays source-closed after a sync replaces it.
   cp "$SCRIPT_DIR/scripts/lib/hook-templates.sh"       scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/scaffold-shipped-set.sh" scripts/lib/
+  # BL-109 Currency System: the manifest currency-block reader/writer (S1) and
+  # the session-start freshness detector lib (S2). session-freshness-check.sh
+  # sources freshness-detect.sh, which sources currency-manifest.sh (which in
+  # turn sources scaffold-shipped-set.sh + hook-templates.sh, both above) — the
+  # whole chain must ship or the SessionStart hook is not source-closed
+  # downstream. (S1 carried obligation 5: currency-manifest.sh ships downstream.)
+  cp "$SCRIPT_DIR/scripts/lib/currency-manifest.sh"    scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/freshness-detect.sh"     scripts/lib/
   cp "$SCRIPT_DIR/scripts/validate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-phase-gate.sh" scripts/
   # BL-088: check-phase-gate.sh's Phase-3→4 gate auto-runs (and points the
@@ -1347,6 +1355,7 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/test-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-versions.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-version-check.sh" scripts/
+  cp "$SCRIPT_DIR/scripts/session-freshness-check.sh" scripts/   # BL-109 S2 (Currency System, Layer 1)
   cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-end-qdrant-reminder.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-mcp-gate.sh" scripts/
@@ -1399,7 +1408,7 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/host.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
   chmod +x scripts/host-drivers/*.sh
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-test-gate-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions
@@ -1791,6 +1800,14 @@ PERMEOF
         # Add test gate check hook
         if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("session-test-gate-check.sh"))' .claude/settings.json >/dev/null 2>&1; then
           jq '.hooks.SessionStart[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-test-gate-check.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
+            && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
+        fi
+        # BL-109 S2: freshness check hook (Currency System, Layer 1 — detection).
+        # Silent-when-current, zero-network, fail-open (exit 0 always), writes only
+        # .claude/cache/. Injected exactly like session-version-check.sh above.
+        if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("session-freshness-check.sh"))' .claude/settings.json >/dev/null 2>&1; then
+          jq '.hooks.SessionStart[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-freshness-check.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
             && mv .claude/settings.json.tmp .claude/settings.json
           hooks_added=true
         fi
@@ -2632,6 +2649,17 @@ generate_approval_log() {
 
 generate_gitignore() {
   cp "$SCRIPT_DIR/templates/generated/gitignore-base.tmpl" .gitignore
+
+  # BL-109 S2 (Currency System, Layer 1): the session-start freshness detector's
+  # atomic cache (snooze store + warm-cache marker). Operational state, never
+  # project content — invariant I7 confines detection's only project-tree write
+  # to `.claude/cache/`, which must therefore be gitignored so it never dirties
+  # the tree or shows up as a diff.
+  cat >> .gitignore << 'CACHEEOF'
+
+# BL-109 freshness detector cache (session-start Currency System state)
+.claude/cache/
+CACHEEOF
 
   # Add platform-specific ignores
   case "$PLATFORM" in

--- a/scripts/lib/freshness-detect.sh
+++ b/scripts/lib/freshness-detect.sh
@@ -1,0 +1,646 @@
+#!/usr/bin/env bash
+# scripts/lib/freshness-detect.sh
+#
+# BL-109 SLICE-S2 (Layer 1 — Detection). The read-only session-start freshness
+# detector for the Currency System (design v1.1 §2-L1; invariant I7). Consumed
+# by scripts/session-freshness-check.sh (the SessionStart hook wrapper). Pure
+# detection + an atomic snooze cache — NO staging, NO plan, NO apply.
+#
+# CONTRACT (design v1.1 §2-L1 + I7 + review-r1 M5/M6/M9):
+#   • SILENT when current — zero bytes on stdout/stderr (Appendix P rung 1).
+#   • ZERO network — ever. Reads the LOCAL framework/CDF clones' files + refs
+#     only; never git fetch / ls-remote / curl.
+#   • Writes NOTHING in the project tree except `.claude/cache/freshness.json`
+#     (temp-write in the SAME dir + atomic rename; torn/invalid = cold start,
+#     never fatal; embedded FUTURE timestamps are clamped to expired).
+#   • Fail-open: the caller wraps the dispatch so any internal fault yields
+#     exit 0 (I7 — a broken checker must not brick a session). This lib returns
+#     0 on the normal path and only nonzero on a genuine internal fault.
+#   • Tiered output: ENFORCEMENT drift first ("recommended now"), then
+#     INFORMATIONAL. Snooze: informational holds until the upstream delta
+#     changes; ENFORCEMENT auto-expires after 7 days AND is recorded through
+#     scripts/lib/bypass-audit.sh (review-r1 M5). Standing line
+#     "N enforcement items snoozed" prints while any enforcement snooze is held,
+#     even if otherwise current.
+#
+# CHECKS (all local; §2-L1 a–f):
+#   (a) LOCAL-EDIT     — project's framework-owned files (class M/T) vs files{}
+#                        → informational ('local edits … sync would archive-and-replace').
+#   (b) FRAMEWORK-DRIFT— via soloFrameworkPath: pin vs framework HEAD
+#                        (informational 'N commits behind') + per-file shas of
+#                        the framework's CURRENT shipped set vs files{}
+#                        (gate scripts/hooks → ENFORCEMENT; other → informational).
+#                        Skips SILENTLY when the path is missing / not a git
+#                        checkout OR soloFrameworkCommit is absent (BL-110 interim).
+#   (c) ORPHANS        — files{} entries whose upstream source no longer exists
+#                        → ENFORCEMENT (design B4).
+#   (d) HOOK CURRENCY  — installed hook managed-blocks vs the framework's current
+#                        templates. hooks{} expectation enum honored (review-r1 M9):
+#                        absent-intentional → silent; absent-unavailable →
+#                        ENFORCEMENT ('TDD gate unavailable for this language —
+#                        BL-107'); present-but-missing / drift → ENFORCEMENT.
+#   (e) RENDER-BASE    — A1/A2 template shas vs the framework's current templates
+#                        → informational ('your CLAUDE.md was rendered from an
+#                        older template').
+#   (f) CDF STALENESS  — read-only via the existing cdf-refresh surfaces
+#                        (frameworkCommit pin vs the local CDF clone HEAD) →
+#                        informational. Skips silently if the clone is absent.
+#   TOOLS — NOT covered here. The existing data-driven check
+#           (scripts/check-versions.sh + its session-version-check.sh wiring)
+#           owns tools; S2 does not duplicate it (see the machine-block schema:
+#           "toolsCovered": false).
+#
+# bash-3.2 safe: no associative arrays, no `[[ -v ]]`, no `((x++))` under set -e,
+# no `nullglob`. This lib assumes the CALLER does NOT run under `set -e`
+# (fail-open). Depends on: jq, git (local reads), shasum, and the sibling libs
+# currency-manifest.sh + hook-templates.sh (sourced by the caller/script).
+
+# ── Wiring: source sibling libs if a caller has not already ──────────────────
+_soif_fd_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! command -v soif_currency_sha256 >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  [ -f "$_soif_fd_dir/currency-manifest.sh" ] && . "$_soif_fd_dir/currency-manifest.sh"
+fi
+if ! command -v soif_tdd_region_body >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  [ -f "$_soif_fd_dir/hook-templates.sh" ] && . "$_soif_fd_dir/hook-templates.sh"
+fi
+unset _soif_fd_dir
+
+# Enforcement-tier auto-expiry window for snoozes (review-r1 M5): 7 days.
+SOIF_FRESH_ENFORCE_SNOOZE_SECS=604800   # 7 * 24 * 60 * 60
+
+# ── Primitives ───────────────────────────────────────────────────────────────
+# soif_freshness_now — current epoch seconds. SOIF_FRESHNESS_NOW overrides it
+# (deterministic snooze-boundary tests). Never touches the network.
+soif_freshness_now() {
+  if [ -n "${SOIF_FRESHNESS_NOW:-}" ]; then
+    printf '%s' "$SOIF_FRESHNESS_NOW"
+  else
+    date +%s
+  fi
+}
+
+# _soif_fresh_sha <file> — hex sha256, empty on missing. Reuses the currency lib
+# primitive when available, else a local shasum fallback.
+_soif_fresh_sha() {
+  if command -v soif_currency_sha256 >/dev/null 2>&1; then
+    soif_currency_sha256 "$1" 2>/dev/null
+  else
+    [ -f "$1" ] || return 1
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  fi
+}
+
+# _soif_fresh_is_enforcement_path <rel> — 0 if this tracked path is a gate
+# script / hook (its drift is ENFORCEMENT tier), else 1. Mirrors CLAUDE.md's
+# ENFORCEMENT source-of-truth list + everything under scripts/hooks/.
+_soif_fresh_is_enforcement_path() {
+  case "$1" in
+    scripts/pre-commit-gate.sh|scripts/check-phase-gate.sh|scripts/check-gate.sh|\
+    scripts/process-checklist.sh|scripts/run-phase3-validation.sh|\
+    scripts/lib/tdd-classify.sh|scripts/lib/enforcement-level.sh|\
+    scripts/lib/gate-principles.sh|scripts/lib/hook-templates.sh|\
+    scripts/hooks/*)
+      return 0 ;;
+    *)
+      return 1 ;;
+  esac
+}
+
+# _soif_fresh_fw_source <fw_dir> <init_file> <rel> — echo the framework SOURCE
+# abspath a downstream tracked rel-path was shipped FROM, or empty if it is not
+# a mechanically-mappable class (A1 renders are handled by the render-base
+# check, never here). Relocations are mechanical (init.sh is the source of
+# truth): scripts keep their path; skills come from templates/generated/skills;
+# reference docs come from docs/<base> (resolved off init.sh's own cp line).
+_soif_fresh_fw_source() {
+  local fw="$1" init="$2" rel="$3" name base src
+  case "$rel" in
+    scripts/*)
+      printf '%s/%s' "$fw" "$rel" ;;
+    .claude/skills/*)
+      name="${rel#.claude/skills/}"
+      printf '%s/templates/generated/skills/%s' "$fw" "$name" ;;
+    docs/reference/*)
+      base="${rel#docs/reference/}"
+      src="$(grep -E 'cp[[:space:]]+"\$SCRIPT_DIR/docs/[^"]*'"$base"'"[[:space:]]+docs/reference/' "$init" 2>/dev/null \
+        | head -1 \
+        | sed -n 's#.*cp[[:space:]]*"\$SCRIPT_DIR/\(docs/[^"]*\)".*#\1#p')"
+      if [ -n "$src" ]; then
+        printf '%s/%s' "$fw" "$src"
+      else
+        printf '%s/docs/%s' "$fw" "$base"
+      fi ;;
+    *)
+      printf '' ;;
+  esac
+}
+
+# _soif_fresh_is_git_checkout <dir> — 0 if <dir> is a git work-tree (LOCAL read
+# only; never network).
+_soif_fresh_is_git_checkout() {
+  [ -n "$1" ] || return 1
+  [ -d "$1" ] || return 1
+  git -C "$1" rev-parse --is-inside-work-tree >/dev/null 2>&1
+}
+
+# ── Item emitter ─────────────────────────────────────────────────────────────
+# Every drift item is one TSV line, all fields present (empty allowed):
+#   id \t check \t tier \t path \t verb \t sig \t message
+# `sig` is the per-item delta signature used only for snooze delta-change
+# detection; it is cache-internal and is NOT emitted in the machine block.
+_soif_fresh_emit() {
+  # <id> <check> <tier> <path> <verb> <sig> <message...>
+  local id="$1" check="$2" tier="$3" path="$4" verb="$5" sig="$6"
+  shift 6
+  printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$check" "$tier" "$path" "$verb" "$sig" "$*"
+}
+
+# ── (a) LOCAL-EDIT ───────────────────────────────────────────────────────────
+_soif_fresh_check_local_edits() {
+  local proj="$1" mani="$2" line rel msha cls disk_sha
+  jq -r '.currency.files // {} | to_entries[]
+         | select(.value.class=="M" or .value.class=="T")
+         | "\(.key)\t\(.value.sha256)\t\(.value.class)"' "$mani" 2>/dev/null \
+  | while IFS="$(printf '\t')" read -r rel msha cls; do
+      [ -n "$rel" ] || continue
+      [ -f "$proj/$rel" ] || continue          # absent locally is an orphan/hook concern, not a local edit
+      disk_sha="$(_soif_fresh_sha "$proj/$rel")"
+      [ -n "$disk_sha" ] || continue
+      if [ "$disk_sha" != "$msha" ]; then
+        _soif_fresh_emit "local-edit:$rel" local-edit informational "$rel" update "$disk_sha" \
+          "local edit to framework-managed file $rel (a sync would archive-and-replace it)"
+      fi
+    done
+}
+
+# ── (b) FRAMEWORK-DRIFT + (c) ORPHANS ────────────────────────────────────────
+_soif_fresh_check_framework() {
+  local proj="$1" mani="$2" fw="$3" init="$4"
+  local pin head sig rel msha cls src src_sha tier verb
+
+  pin="$(jq -r '.soloFrameworkCommit // empty' "$mani" 2>/dev/null)"
+
+  # Skip contract (design §2-L0 + BL-110 interim): no path, not a git checkout,
+  # or pin absent → skip SILENTLY (never a crash, never false drift).
+  _soif_fresh_is_git_checkout "$fw" || return 0
+  [ -n "$pin" ] || return 0
+
+  head="$(git -C "$fw" rev-parse HEAD 2>/dev/null)"
+  sig="${pin}..${head}"
+
+  # pin vs HEAD — informational "N commits behind" (only when the pin is a known
+  # ancestor of HEAD; a shallow/absent pin object → no history line, per M1's
+  # never-fetch rule; per-file drift below still runs).
+  if [ -n "$head" ] && [ "$pin" != "$head" ]; then
+    if git -C "$fw" merge-base --is-ancestor "$pin" HEAD >/dev/null 2>&1; then
+      local n
+      n="$(git -C "$fw" rev-list --count "$pin"..HEAD 2>/dev/null)"
+      if [ -n "$n" ] && [ "$n" != "0" ]; then
+        _soif_fresh_emit "pin-behind" framework informational "-" update "$sig" \
+          "framework clone is $n commit(s) ahead of your pin (${pin} → ${head})"
+      fi
+    fi
+  fi
+
+  # per-file drift + orphans over class M/T (A1 handled by render-base).
+  jq -r '.currency.files // {} | to_entries[]
+         | select(.value.class=="M" or .value.class=="T")
+         | "\(.key)\t\(.value.sha256)\t\(.value.class)"' "$mani" 2>/dev/null \
+  | while IFS="$(printf '\t')" read -r rel msha cls; do
+      [ -n "$rel" ] || continue
+      src="$(_soif_fresh_fw_source "$fw" "$init" "$rel")"
+      [ -n "$src" ] || continue                # unmappable class — leave to other checks
+      if [ ! -f "$src" ]; then
+        # (c) ORPHAN — the manifest ships it but upstream deleted the source.
+        _soif_fresh_emit "orphan:$rel" orphan enforcement "$rel" retire "gone@$head" \
+          "orphaned: $rel is tracked but no longer exists upstream (a sync would retire it)"
+        continue
+      fi
+      src_sha="$(_soif_fresh_sha "$src")"
+      [ -n "$src_sha" ] || continue
+      if [ "$src_sha" != "$msha" ]; then
+        if _soif_fresh_is_enforcement_path "$rel"; then
+          tier=enforcement
+        else
+          tier=informational
+        fi
+        _soif_fresh_emit "fw-drift:$rel" framework-drift "$tier" "$rel" update "$src_sha" \
+          "framework updated $rel since you installed it (a sync would refresh it)"
+      fi
+    done
+}
+
+# ── (d) HOOK CURRENCY ────────────────────────────────────────────────────────
+# Installed hook managed-blocks vs the framework's current templates. The
+# expectation enum comes from the MANIFEST (no framework needed for the
+# missing / absent-unavailable arms); the DRIFT arm needs the framework's
+# current template and is skipped silently when the framework is unavailable.
+_soif_fresh_check_hooks() {
+  local proj="$1" mani="$2" fw="$3"
+  local hooks want hookfile block current
+  hooks="$(jq -r '.currency.hooks // {} | to_entries[] | "\(.key)\t\(.value)"' "$mani" 2>/dev/null)"
+  [ -n "$hooks" ] || return 0
+
+  # Prefer the framework's CURRENT hook templates for the drift comparison
+  # (a downstream copy may itself be stale). Source them from the framework
+  # clone if present; else fall back to whatever is already sourced.
+  local fw_hooktpl=""
+  if [ -n "$fw" ] && [ -f "$fw/scripts/lib/hook-templates.sh" ]; then
+    fw_hooktpl="$fw/scripts/lib/hook-templates.sh"
+  fi
+
+  printf '%s\n' "$hooks" | while IFS="$(printf '\t')" read -r want_name want_state; do
+    [ -n "$want_name" ] || continue
+    case "$want_state" in
+      absent-intentional)
+        : ;;                                    # silent — a real, expected absence
+      absent-unavailable)
+        # review-r1 M9 + BL-107 — never launder a bug into a fact.
+        _soif_fresh_emit "hook-unavailable:$want_name" hook enforcement "-" add "unavailable" \
+          "TDD gate unavailable for this language ($want_name hook not installed) — BL-107" ;;
+      present)
+        hookfile="$proj/.git/hooks/$want_name"
+        # Which managed-region emitter + markers govern this hook?
+        local open close bodyfn
+        case "$want_name" in
+          pre-commit)  open="$SOIF_PRECOMMIT_OPEN"; close="$SOIF_PRECOMMIT_CLOSE"; bodyfn=soif_precommit_region_body ;;
+          commit-msg)  open="$SOIF_TDD_OPEN";       close="$SOIF_TDD_CLOSE";       bodyfn=soif_tdd_region_body ;;
+          *)           open=""; close=""; bodyfn="" ;;
+        esac
+        if [ ! -f "$hookfile" ] || [ -z "$open" ] || ! grep -qF "$open" "$hookfile" 2>/dev/null; then
+          _soif_fresh_emit "hook-missing:$want_name" hook enforcement "-" add "missing" \
+            "$want_name hook is expected but its managed block is missing (a sync would reinstall it)"
+          continue
+        fi
+        # DRIFT — compare the installed managed region to the current template.
+        # Needs the emitter; if we cannot resolve a current template, skip the
+        # drift arm silently (missing was already handled above).
+        [ -n "$bodyfn" ] || continue
+        block="$(awk -v o="$open" -v c="$close" '
+          index($0,o){f=1} f{print} index($0,c){f=0}' "$hookfile" 2>/dev/null)"
+        current="$(
+          if [ -n "$fw_hooktpl" ]; then
+            ( . "$fw_hooktpl" >/dev/null 2>&1; "$bodyfn" 2>/dev/null )
+          else
+            "$bodyfn" 2>/dev/null
+          fi
+        )"
+        [ -n "$current" ] || continue
+        if [ "$(printf '%s' "$block" | _soif_fresh_stdin_sha)" != "$(printf '%s' "$current" | _soif_fresh_stdin_sha)" ]; then
+          _soif_fresh_emit "hook-drift:$want_name" hook enforcement "-" update \
+            "$(printf '%s' "$current" | _soif_fresh_stdin_sha)" \
+            "$want_name hook managed block is stale vs the framework template (a sync would refresh it)"
+        fi ;;
+      *)
+        : ;;                                    # unknown enum value — stay silent
+    esac
+  done
+}
+
+# _soif_fresh_stdin_sha — sha256 of stdin, hex only (portable helper for block
+# comparison without temp files).
+_soif_fresh_stdin_sha() {
+  shasum -a 256 2>/dev/null | awk '{print $1}'
+}
+
+# ── (e) RENDER-BASE drift ────────────────────────────────────────────────────
+_soif_fresh_check_render_base() {
+  local mani="$1" fw="$2"
+  [ -n "$fw" ] || return 0
+  local rows group artifact tpl mtpl_sha ftpl_sha
+  # (group, artifact, framework-template-relpath) — the stable A1/A2 mapping.
+  rows='A1	CLAUDE.md	templates/generated/claude-md.tmpl
+A1	PROJECT_INTAKE.md	templates/project-intake.md
+A2	PROJECT_BIBLE.md	templates/generated/project-bible.tmpl
+A2	PRODUCT_MANIFESTO.md	templates/generated/product-manifesto.tmpl'
+  printf '%s\n' "$rows" | while IFS="$(printf '\t')" read -r group artifact tpl; do
+    [ -n "$artifact" ] || continue
+    mtpl_sha="$(jq -r --arg g "$group" --arg a "$artifact" \
+      '.currency.renderBases[$g][$a].templateSha // empty' "$mani" 2>/dev/null)"
+    [ -n "$mtpl_sha" ] || continue
+    [ -f "$fw/$tpl" ] || continue
+    ftpl_sha="$(_soif_fresh_sha "$fw/$tpl")"
+    [ -n "$ftpl_sha" ] || continue
+    if [ "$ftpl_sha" != "$mtpl_sha" ]; then
+      _soif_fresh_emit "render-base:$artifact" render-base informational "$artifact" update "$ftpl_sha" \
+        "your $artifact was rendered from an older template (the framework template changed)"
+    fi
+  done
+}
+
+# ── (f) CDF STALENESS (read-only) ────────────────────────────────────────────
+_soif_fresh_check_cdf() {
+  local mani="$1" cdf_home="$2"
+  local pin head n
+  pin="$(jq -r '.frameworkCommit // empty' "$mani" 2>/dev/null)"
+  [ -n "$pin" ] || return 0
+  _soif_fresh_is_git_checkout "$cdf_home" || return 0     # clone absent → silent
+  head="$(git -C "$cdf_home" rev-parse HEAD 2>/dev/null)"
+  [ -n "$head" ] || return 0
+  [ "$pin" != "$head" ] || return 0
+  git -C "$cdf_home" merge-base --is-ancestor "$pin" HEAD >/dev/null 2>&1 || return 0
+  n="$(git -C "$cdf_home" rev-list --count "$pin"..HEAD 2>/dev/null)"
+  [ -n "$n" ] && [ "$n" != "0" ] || return 0
+  _soif_fresh_emit "cdf-behind" cdf informational "-" update "${pin}..${head}" \
+    "Development Guardrails (CDF) clone is $n commit(s) ahead of your pin"
+}
+
+# ── The dispatch (load-bearing) ──────────────────────────────────────────────
+# soif_freshness_detect <proj> <mani> <fw_dir> <init_file> <cdf_home>
+#   Runs EVERY check and prints the union of drift items (TSV) to stdout.
+#   Prints nothing when everything is current.
+soif_freshness_detect() {
+  local proj="$1" mani="$2" fw="$3" init="$4" cdf="$5"
+  # BL-109-FRESHNESS — neutering this body (checks not run) makes ALL drift
+  # detection go dark. The fail-open wrapper and cache/snooze logic are separate
+  # so this marker isolates the detection surface for the mutation proof.
+  _soif_fresh_check_local_edits   "$proj" "$mani"
+  _soif_fresh_check_framework     "$proj" "$mani" "$fw" "$init"
+  _soif_fresh_check_hooks         "$proj" "$mani" "$fw"
+  _soif_fresh_check_render_base   "$mani" "$fw"
+  _soif_fresh_check_cdf           "$mani" "$cdf"
+}
+
+# ── Cache (I7) ───────────────────────────────────────────────────────────────
+# _soif_fresh_cache_read <cache_file> — echo valid cache JSON, or `{}` for a
+# missing/torn/invalid cache (cold start, never fatal).
+_soif_fresh_cache_read() {
+  local f="$1"
+  [ -f "$f" ] || { printf '{}'; return 0; }
+  if jq -e 'type=="object"' "$f" >/dev/null 2>&1; then
+    cat "$f"
+  else
+    printf '{}'
+  fi
+}
+
+# _soif_fresh_cache_write <cache_file> <json> — temp-write in the SAME directory
+# + atomic rename. Never fatal (a write failure is swallowed — detection must
+# not brick a session).
+_soif_fresh_cache_write() {
+  local f="$1" json="$2" dir tmp
+  dir="$(dirname "$f")"
+  mkdir -p "$dir" 2>/dev/null || return 0
+  tmp="$(mktemp "$dir/.freshness.XXXXXX" 2>/dev/null)" || return 0
+  if printf '%s\n' "$json" | jq . > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$f" 2>/dev/null || rm -f "$tmp" 2>/dev/null
+  else
+    rm -f "$tmp" 2>/dev/null
+  fi
+  return 0
+}
+
+# _soif_fresh_snooze_held <cache_json> <id> <tier> <sig> <now> — 0 if a live
+# snooze suppresses this item, else 1. Informational snoozes hold while the
+# stored deltaSig still matches the item's current sig; ENFORCEMENT snoozes hold
+# only while ALSO within the 7-day window (review-r1 M5). A stored snoozedAt in
+# the FUTURE is clamped to "expired" (safe direction — re-surface).
+_soif_fresh_snooze_held() {
+  local cache="$1" id="$2" tier="$3" sig="$4" now="$5"
+  local stored_sig stored_at age
+  stored_sig="$(printf '%s' "$cache" | jq -r --arg id "$id" '.snoozes[$id].deltaSig // empty' 2>/dev/null)"
+  [ -n "$stored_sig" ] || return 1              # not snoozed
+  [ "$stored_sig" = "$sig" ] || return 1        # upstream delta moved → void
+  if [ "$tier" = "enforcement" ]; then
+    stored_at="$(printf '%s' "$cache" | jq -r --arg id "$id" '.snoozes[$id].snoozedAt // empty' 2>/dev/null)"
+    case "$stored_at" in ''|*[!0-9]*) return 1 ;; esac
+    # FUTURE-timestamp clamp: snoozedAt > now → treat as expired.
+    [ "$stored_at" -le "$now" ] || return 1     # BL-109-FRESHNESS-EXPIRY (clamp)
+    age=$(( now - stored_at ))
+    [ "$age" -lt "$SOIF_FRESH_ENFORCE_SNOOZE_SECS" ] || return 1   # BL-109-FRESHNESS-EXPIRY (7-day)
+  fi
+  return 0
+}
+
+# ── Rendering ────────────────────────────────────────────────────────────────
+# _soif_fresh_machine_json <items_tsv> <now> <enf_snoozed> — the fenced machine
+# block payload (stable-key JSON; schema "soif-freshness/1").
+_soif_fresh_machine_json() {
+  local items="$1" now="$2" enf_snoozed="$3" gen items_json current
+  gen="$(_soif_fresh_iso "$now")"
+  items_json="$(printf '%s\n' "$items" | jq -Rn '
+    [ inputs | select(length>0) | split("\t")
+      | { id:.[0], check:.[1], tier:.[2],
+          path:(if (.[3]=="" or .[3]=="-") then null else .[3] end),
+          verb:(if (.[4]=="" or .[4]=="-") then null else .[4] end),
+          message:.[6] } ]')"
+  if [ -z "$(printf '%s' "$items" | tr -d '[:space:]')" ]; then
+    items_json='[]'
+  fi
+  if [ "$items_json" = "[]" ]; then current=true; else current=false; fi
+  jq -n \
+    --arg gen "$gen" \
+    --argjson items "$items_json" \
+    --argjson current "$current" \
+    --argjson snoozed "$enf_snoozed" \
+    '{ schema: "soif-freshness/1",
+       generatedAt: $gen,
+       current: $current,
+       enforcementSnoozed: $snoozed,
+       toolsCovered: false,
+       network: "none",
+       items: $items }'
+}
+
+# _soif_fresh_iso <epoch> — ISO-8601 UTC. GNU-first then BSD.
+_soif_fresh_iso() {
+  date -u -d "@$1" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u -r "$1" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+    || date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# _soif_fresh_render_human <items_tsv> <enf_snoozed> — the compact tiered human
+# block: ENFORCEMENT first ("recommended now"), then informational.
+_soif_fresh_render_human() {
+  local items="$1" enf_snoozed="$2"
+  local enf inf id check tier path verb sig msg
+  enf="$(printf '%s\n' "$items" | awk -F'\t' '$3=="enforcement"')"
+  inf="$(printf '%s\n' "$items" | awk -F'\t' '$3=="informational"')"
+  printf 'FRAMEWORK CURRENCY — updates available. Report to the operator; do NOT auto-apply.\n'
+  if [ -n "$(printf '%s' "$enf" | tr -d '[:space:]')" ]; then
+    printf '\nRecommended now (enforcement):\n'
+    printf '%s\n' "$enf" | while IFS="$(printf '\t')" read -r id check tier path verb sig msg; do
+      [ -n "$id" ] || continue
+      printf '  - %s\n' "$msg"
+    done
+  fi
+  if [ -n "$(printf '%s' "$inf" | tr -d '[:space:]')" ]; then
+    printf '\nInformational:\n'
+    printf '%s\n' "$inf" | while IFS="$(printf '\t')" read -r id check tier path verb sig msg; do
+      [ -n "$id" ] || continue
+      printf '  - %s\n' "$msg"
+    done
+  fi
+  if [ "$enf_snoozed" -gt 0 ]; then
+    printf '\n(%s enforcement items snoozed.)\n' "$enf_snoozed"
+  fi
+}
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+# soif_freshness_run <proj_dir> — the normal-path orchestrator the fail-open
+# wrapper calls. Resolves paths, detects, filters/prunes snoozes, atomically
+# updates the cache, and renders output. Returns 0 on the normal path; nonzero
+# ONLY on a genuine internal fault (which the wrapper converts to exit 0).
+soif_freshness_run() {
+  local proj="$1"
+
+  # Selftest fault hook — exercises the fail-open wrapper (I7). Product-inert
+  # unless SOIF_FRESHNESS_SELFTEST_CRASH=1 is explicitly set (never in a session).
+  if [ "${SOIF_FRESHNESS_SELFTEST_CRASH:-}" = "1" ]; then
+    echo "injected fault (freshness selftest)" >&2
+    return 1
+  fi
+
+  command -v jq >/dev/null 2>&1 || return 0            # no jq → cannot read manifest → silent
+  local mani="$proj/.claude/manifest.json"
+  [ -f "$mani" ] || return 0                           # not a scaffolded project → silent
+  jq -e '.currency' "$mani" >/dev/null 2>&1 || return 0 # pre-S1 project (no currency block) → silent
+
+  local fw cdf init now cache items
+  fw="$(jq -r '.currency.soloFrameworkPath // empty' "$mani" 2>/dev/null)"
+  cdf="${CDF_HOME:-$HOME/.claude-dev-framework}"
+  init="$fw/init.sh"
+  now="$(soif_freshness_now)"
+  cache="$proj/.claude/cache/freshness.json"
+
+  items="$(soif_freshness_detect "$proj" "$mani" "$fw" "$init" "$cdf")"
+
+  # Snooze filter + prune (I7 cache). Held snoozes suppress their item; an
+  # enforcement snooze also increments the standing count. Only snoozes whose
+  # item is still drifting AND still held survive the prune.
+  local cache_json enf_snoozed=0 kept_ids_file displayed_file
+  cache_json="$(_soif_fresh_cache_read "$cache")"
+  kept_ids_file="$(mktemp 2>/dev/null)" || kept_ids_file="${TMPDIR:-/tmp}/soif-fresh-keep.$$"
+  displayed_file="$(mktemp 2>/dev/null)" || displayed_file="${TMPDIR:-/tmp}/soif-fresh-disp.$$"
+  : > "$kept_ids_file"; : > "$displayed_file"
+
+  local id check tier path verb sig msg
+  while IFS="$(printf '\t')" read -r id check tier path verb sig msg; do
+    [ -n "$id" ] || continue
+    if _soif_fresh_snooze_held "$cache_json" "$id" "$tier" "$sig" "$now"; then
+      printf '%s\n' "$id" >> "$kept_ids_file"
+      [ "$tier" = "enforcement" ] && enf_snoozed=$(( enf_snoozed + 1 ))
+    else
+      printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' "$id" "$check" "$tier" "$path" "$verb" "$sig" "$msg" >> "$displayed_file"
+    fi
+  done <<< "$items"
+
+  # Rebuild the cache: keep only still-held snoozes for currently-drifting items.
+  local keep_json new_cache
+  keep_json="$(jq -Rn '[inputs | select(length>0)]' < "$kept_ids_file" 2>/dev/null)"
+  [ -n "$keep_json" ] || keep_json='[]'
+  new_cache="$(printf '%s' "$cache_json" | jq --argjson keep "$keep_json" --arg now "$now" '
+      { schemaVersion: 1,
+        updatedAt: ($now|tonumber),
+        snoozes: ( (.snoozes // {}) | with_entries(select(.key as $k | $keep | index($k))) ) }' 2>/dev/null)"
+  [ -n "$new_cache" ] || new_cache="$(jq -n --arg now "$now" '{schemaVersion:1, updatedAt:($now|tonumber), snoozes:{}}')"
+  _soif_fresh_cache_write "$cache" "$new_cache"
+
+  local displayed
+  displayed="$(cat "$displayed_file")"
+  rm -f "$kept_ids_file" "$displayed_file" 2>/dev/null
+
+  # SILENT when current. Exception (review-r1 M5): the standing snoozed line
+  # prints while any enforcement snooze is held, even if otherwise current.
+  if [ -z "$(printf '%s' "$displayed" | tr -d '[:space:]')" ]; then
+    if [ "$enf_snoozed" -gt 0 ]; then
+      printf '%s enforcement items snoozed\n' "$enf_snoozed"
+    fi
+    return 0
+  fi
+
+  # Drift present: one compact human block + one fenced machine block.
+  _soif_fresh_render_human "$displayed" "$enf_snoozed"
+  printf '\n```soif-freshness\n'
+  _soif_fresh_machine_json "$displayed" "$now" "$enf_snoozed"
+  printf '\n```\n'
+  return 0
+}
+
+# ── Snooze setting (out-of-band; NEVER during silent detection) ──────────────
+# soif_freshness_snooze <proj_dir> <item-id> — record a snooze for a currently-
+# drifting item. Informational snoozes hold until the upstream delta changes;
+# enforcement snoozes auto-expire after 7 days AND are recorded through
+# scripts/lib/bypass-audit.sh (review-r1 M5). Trivially safe: writes only the
+# cache + (for enforcement) an audit row. Returns 1 if the id is not an active
+# drift item.
+soif_freshness_snooze() {
+  local proj="$1" target="$2"
+  command -v jq >/dev/null 2>&1 || return 1
+  local mani="$proj/.claude/manifest.json"
+  [ -f "$mani" ] || return 1
+
+  local fw cdf init now cache items
+  fw="$(jq -r '.currency.soloFrameworkPath // empty' "$mani" 2>/dev/null)"
+  cdf="${CDF_HOME:-$HOME/.claude-dev-framework}"
+  init="$fw/init.sh"
+  now="$(soif_freshness_now)"
+  cache="$proj/.claude/cache/freshness.json"
+  items="$(soif_freshness_detect "$proj" "$mani" "$fw" "$init" "$cdf")"
+
+  local id check tier path verb sig msg _snz_tier="" _snz_sig=""
+  while IFS="$(printf '\t')" read -r id check tier path verb sig msg; do
+    if [ "$id" = "$target" ]; then _snz_tier="$tier"; _snz_sig="$sig"; break; fi
+  done <<< "$items"
+  if [ -z "$_snz_tier" ]; then
+    printf 'freshness: no active drift item with id "%s" to snooze\n' "$target" >&2
+    return 1
+  fi
+
+  local cache_json new_cache
+  cache_json="$(_soif_fresh_cache_read "$cache")"
+  new_cache="$(printf '%s' "$cache_json" | jq \
+      --arg id "$target" --arg tier "$_snz_tier" --arg sig "$_snz_sig" --arg now "$now" '
+      .schemaVersion = 1
+      | .updatedAt = ($now|tonumber)
+      | .snoozes = ((.snoozes // {}) + { ($id): { tier:$tier, snoozedAt:($now|tonumber), deltaSig:$sig } })' 2>/dev/null)"
+  _soif_fresh_cache_write "$cache" "$new_cache"
+
+  if [ "$_snz_tier" = "enforcement" ]; then
+    _soif_fresh_audit_snooze "$proj" "$target" "$now"
+  fi
+  printf 'freshness: snoozed "%s" (%s tier)\n' "$target" "$_snz_tier"
+  return 0
+}
+
+# soif_freshness_unsnooze <proj_dir> <item-id> — drop a snooze entry.
+soif_freshness_unsnooze() {
+  local proj="$1" target="$2"
+  command -v jq >/dev/null 2>&1 || return 1
+  local cache="$proj/.claude/cache/freshness.json"
+  local cache_json new_cache now
+  now="$(soif_freshness_now)"
+  cache_json="$(_soif_fresh_cache_read "$cache")"
+  new_cache="$(printf '%s' "$cache_json" | jq --arg id "$target" --arg now "$now" '
+      .schemaVersion = 1 | .updatedAt = ($now|tonumber)
+      | .snoozes = ((.snoozes // {}) | del(.[$id]))' 2>/dev/null)"
+  _soif_fresh_cache_write "$cache" "$new_cache"
+  printf 'freshness: unsnoozed "%s"\n' "$target"
+  return 0
+}
+
+# _soif_fresh_audit_snooze <proj> <id> <now> — record an enforcement snooze
+# through scripts/lib/bypass-audit.sh (review-r1 M5). Mirrors the canonical row
+# shape; the `type` value "freshness_enforcement_snooze" EXTENDS the documented
+# enum (declared deviation — the append API validates object-shape only, so no
+# parallel audit file is invented). Best-effort: never fatal.
+_soif_fresh_audit_snooze() {
+  local proj="$1" id="$2" now="$3"
+  if ! command -v bypass_audit_append >/dev/null 2>&1; then
+    local d
+    d="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    # shellcheck source=/dev/null
+    [ -f "$d/bypass-audit.sh" ] && . "$d/bypass-audit.sh"
+  fi
+  command -v bypass_audit_append >/dev/null 2>&1 || return 0
+  local ts row
+  ts="$(_soif_fresh_iso "$now")"
+  row="$(jq -nc --arg ts "$ts" --arg id "$id" '
+      { timestamp:$ts, session_id:null, type:"freshness_enforcement_snooze", actor:"framework",
+        enforcement_level_at_event:"n/a",
+        details:{ item_id:$id, ttl_days:7, source:"session-freshness-check --snooze" },
+        user_response:"n/a", final_outcome:"recorded_only" }')"
+  bypass_audit_append "$proj" "$row" >/dev/null 2>&1 || true
+}

--- a/scripts/session-freshness-check.sh
+++ b/scripts/session-freshness-check.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# scripts/session-freshness-check.sh
+#
+# Solo Orchestrator — SessionStart hook wrapper for the Currency System's
+# read-only freshness detector (BL-109 SLICE-S2, Layer 1 — Detection; design
+# v1.1 §2-L1; invariant I7). Injected by init.sh into SessionStart exactly the
+# way session-version-check.sh is. Silent when everything is current — no noise
+# for the agent to bury.
+#
+# BEHAVIOUR (design v1.1 §2-L1 + I7):
+#   • SILENT when current — ZERO bytes on stdout/stderr (Appendix P rung 1:
+#     a noisy day zero is a live-test abort).
+#   • ZERO network — ever. Reads the LOCAL framework/CDF clones only.
+#   • Writes NOTHING in the project tree except `.claude/cache/freshness.json`.
+#   • FAIL-OPEN: this wrapper guarantees exit 0 under EVERY failure mode. An
+#     internal crash prints at most one short `[freshness check unavailable]`
+#     line and still exits 0 — a broken checker must never brick a session.
+#   • On drift: ONE compact tiered human block (enforcement first) + ONE fenced
+#     machine block (schema below). The agent RELAYS it and offers the update
+#     flow; detection never applies anything.
+#
+# MACHINE-BLOCK CONTRACT (fenced as ```soif-freshness; S5 will lint it):
+#   {
+#     "schema":            "soif-freshness/1",   // stable identifier
+#     "generatedAt":       "<ISO-8601 UTC>",
+#     "current":           true|false,           // true iff items == []
+#     "enforcementSnoozed":<int>,                // held enforcement snoozes
+#     "toolsCovered":      false,                // S2 does NOT cover tools —
+#                                                //   check-versions.sh + its
+#                                                //   session-version-check.sh
+#                                                //   wiring own the tool surface
+#     "network":           "none",               // zero-network guarantee
+#     "items": [
+#       { "id":     "<stable-item-id>",          // e.g. "orphan:scripts/foo.sh"
+#         "check":  "local-edit|framework|framework-drift|orphan|hook|render-base|cdf",
+#         "tier":   "enforcement|informational",
+#         "path":   "<rel-path>|null",
+#         "verb":   "add|update|retire|null",    // the §2-L2 lifecycle verb
+#         "message":"<human string>" }
+#     ]
+#   }
+#
+# USAGE:
+#   session-freshness-check.sh                 # detect (the SessionStart path)
+#   session-freshness-check.sh --snooze <id>   # snooze a drift item (out of band)
+#   session-freshness-check.sh --unsnooze <id> # drop a snooze
+#   session-freshness-check.sh --help
+#
+# SNOOZE: informational snoozes hold until the upstream delta changes;
+# ENFORCEMENT snoozes auto-expire after 7 days AND are recorded through
+# scripts/lib/bypass-audit.sh (review-r1 M5). Snooze SETTING is out of band —
+# it is exposed here only as the explicit --snooze flag (never prompted, never
+# invoked during silent detection).
+#
+# NOT under `set -e` — fail-open is the whole point; a mid-detection error must
+# degrade to exit 0, not abort the shell.
+
+set -uo pipefail   # deliberately NO -e (I7 fail-open)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Load the detection lib (transitively loads currency-manifest.sh +
+# hook-templates.sh). Shipped downstream beside this script by init.sh.
+# shellcheck source=/dev/null
+if [ -f "$SCRIPT_DIR/lib/freshness-detect.sh" ]; then
+  . "$SCRIPT_DIR/lib/freshness-detect.sh"
+else
+  # Lib absent (a broken scaffold) — fail open, silently.
+  exit 0
+fi
+
+# Project root: the harness passes CLAUDE_PROJECT_DIR; fall back to this
+# script's parent (scripts/..) for direct invocation.
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+
+# ── Flag dispatch (out-of-band; never the SessionStart path) ─────────────────
+case "${1:-}" in
+  --help|-h)
+    sed -n '2,60p' "$SCRIPT_DIR/session-freshness-check.sh" 2>/dev/null | sed 's/^# \{0,1\}//'
+    exit 0
+    ;;
+  --snooze)
+    if command -v soif_freshness_snooze >/dev/null 2>&1; then
+      soif_freshness_snooze "$PROJECT_DIR" "${2:-}" || true
+    fi
+    exit 0
+    ;;
+  --unsnooze)
+    if command -v soif_freshness_unsnooze >/dev/null 2>&1; then
+      soif_freshness_unsnooze "$PROJECT_DIR" "${2:-}" || true
+    fi
+    exit 0
+    ;;
+esac
+
+# ── The fail-open wrapper (I7) ───────────────────────────────────────────────
+# Run the detection dispatch, capturing stdout. ANY nonzero return (a genuine
+# internal fault) is converted to exit 0 + one short line. stderr is discarded
+# so a stray sub-tool message can never leak into the agent's context.
+# BL-109-FRESHNESS-FAILOPEN — this arm is what makes a broken checker inert.
+_soif_fresh_out=""
+_soif_fresh_rc=0
+_soif_fresh_out="$(soif_freshness_run "$PROJECT_DIR" 2>/dev/null)" || _soif_fresh_rc=$?
+
+if [ "$_soif_fresh_rc" -ne 0 ]; then
+  printf '%s\n' "[freshness check unavailable]"
+elif [ -n "$_soif_fresh_out" ]; then
+  printf '%s\n' "$_soif_fresh_out"
+fi
+
+exit 0

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -565,6 +565,30 @@ else
 fi
 fi
 
+# BL-109 S2 (Currency System, Layer 1 — Detection). test-freshness-check.sh is
+# the lib-level unit test (every drift class → tier, pin/path skip contracts,
+# torn cache, snooze hold/expiry + future clamp, machine-block JSON, fail-open
+# exit-0) — it never runs init.sh, so it is ALSO in the tests.yml unit fast lane.
+# test-freshness-birth.sh is the BL-088-precedent aggregator: it runs the REAL
+# init.sh to prove day-zero silence, hook injection, downstream ship-set, seeded
+# drift in the right tier, and the whole-tree I7 fingerprint. That aggregator is
+# SUITE_SKIP_AGGREGATORS-gated (a real init.sh scaffold is heavy) and is NEVER in
+# the unit list (it executes init.sh).
+if bash "$SCRIPT_DIR/tests/test-freshness-check.sh" >/dev/null 2>&1; then
+  pass "tests/test-freshness-check.sh"
+else
+  fail "tests/test-freshness-check.sh FAILED (run for details)"
+fi
+if [ "${SUITE_SKIP_AGGREGATORS:-0}" = "1" ]; then
+  section "BL-109 freshness birth fidelity — SKIPPED (SUITE_SKIP_AGGREGATORS=1; a real init.sh scaffold, runs standalone / full-suite)"
+else
+if bash "$SCRIPT_DIR/tests/test-freshness-birth.sh" >/dev/null 2>&1; then
+  pass "tests/test-freshness-birth.sh"
+else
+  fail "tests/test-freshness-birth.sh FAILED (run for details)"
+fi
+fi
+
 # Agent-ergonomics onboarding: tests/test-run-lints.sh — behavior suite for
 # scripts/run-lints.sh, the canonical local lint runner (runs every
 # scripts/lint-*.sh EXCEPT the parametrized lint-uat-scenarios.sh). Its

--- a/tests/test-currency-birth-stamp.sh
+++ b/tests/test-currency-birth-stamp.sh
@@ -121,8 +121,30 @@ m_count="$(jq -r '[.currency.files[] | select(.class == "M")] | length' "$MAN")"
   || fail_ "Class T count" "expected 7, got $t_count"
 [ "$a1_count" = "2" ] && pass "Class A1 == 2 (CLAUDE.md + PROJECT_INTAKE.md)" \
   || fail_ "Class A1 count" "expected 2, got $a1_count"
-[ "$m_count" -gt 0 ] && pass "Class M > 0 (scripts + skills): $m_count" \
-  || fail_ "Class M count" "expected > 0, got $m_count"
+
+# — Class M count: INDEPENDENTLY re-derived, not a hardcoded number (BL-109 S2
+#   carried-obligation-7 tightening of the S1 '>0' placeholder). Recompute the
+#   shipped M set (scripts + vendored skills) via the SAME lib the product uses
+#   (scripts/lib/scaffold-shipped-set.sh) against the PRISTINE framework checkout,
+#   count those present in the scaffolded tree exactly as the product's row
+#   emitter does (skip-if-missing), and assert the manifest's M count matches
+#   EXACTLY. If init.sh grows/loses a shipped script or skill, both sides move
+#   together — the test can never drift the way a literal would.
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh"
+exp_m=0
+while IFS= read -r _rel; do
+  [ -n "$_rel" ] || continue
+  [ -f "$TS/$_rel" ] && exp_m=$((exp_m + 1))
+done <<EOF
+$(soif_parse_shipped_scripts "$INIT" "$REPO_ROOT/scripts")
+$(soif_parse_shipped_skills  "$INIT" "$REPO_ROOT/templates/generated/skills")
+EOF
+if [ "$m_count" = "$exp_m" ] && [ "$exp_m" -gt 0 ]; then
+  pass "Class M == independently lib-derived shipped-M count ($exp_m: scripts + skills)"
+else
+  fail_ "Class M count" "manifest M=$m_count but independent lib-derived M=$exp_m"
+fi
 
 # — A2 agent-authored artifacts NOT in files{} (do not exist at birth) —
 if [ "$(jq -r '.currency.files["PRODUCT_MANIFESTO.md"] // "null"' "$MAN")" = "null" ] \

--- a/tests/test-freshness-birth.sh
+++ b/tests/test-freshness-birth.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# tests/test-freshness-birth.sh — BL-109 S2 AGGREGATOR fidelity test.
+#
+# The BL-088 precedent (mirrors tests/test-currency-birth-stamp.sh): fixtures
+# hide scaffold gaps, so this test runs the REAL init.sh into a hermetic scratch
+# project and proves the session-start freshness detector (BL-109 S2, Layer 1)
+# behaves correctly against a genuine birth manifest + genuine injected hook:
+#
+#   • DAY-ZERO SILENCE — on a freshly scaffolded project the detector prints
+#     ZERO bytes (stdout AND stderr) and exits 0 (Appendix P rung 1: a noisy day
+#     zero is an instant live-test abort).
+#   • The freshness hook is INJECTED into SessionStart and actually RUNS (exit 0).
+#   • The whole S2 lib chain is present downstream: session-freshness-check.sh,
+#     lib/freshness-detect.sh, lib/currency-manifest.sh (S1 obligation 5).
+#   • SEEDED POST-BIRTH DRIFT is detected in the right tier: editing a vendored
+#     script → informational local-edit; deleting a line from an installed hook's
+#     managed block → enforcement hook drift.
+#   • WHOLE-TREE FINGERPRINT — running the detector changes NOTHING outside
+#     `.claude/cache/` (invariant I7), and leaves the git tree clean.
+#
+# It is an AGGREGATOR: registered ONLY in tests/full-project-test-suite.sh
+# (SUITE_SKIP_AGGREGATORS-gated — it executes init.sh), NEVER in the tests.yml
+# unit list.
+#
+# Hermetic: mktemp, GITHUB_BASE_REF unset, init.sh run with --no-remote-creation
+# (the blessed no-live-remote path). CDF_HOME pinned to a nonexistent path for
+# the silence + seeded-drift assertions so the CDF-staleness axis (a real,
+# separate signal) cannot make day zero flaky. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: jq/git required for the init.sh-driven freshness birth test"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+NOCDF="$TOPTMP/no-cdf"   # deliberately nonexistent → CDF check skips silently
+
+# ── Scaffold a real project via init.sh (hermetic) ───────────────────────────
+echo "=== Scaffolding typescript project via real init.sh (hermetic) ==="
+PROJ="$TOPTMP/proj"
+if ! ( cd "$TOPTMP" && "$INIT" --non-interactive \
+        --project frbl109 \
+        --platform web \
+        --deployment personal \
+        --gov-mode private_poc \
+        --language typescript \
+        --project-dir "$PROJ" \
+        --no-remote-creation ) >"$TOPTMP/init.out" 2>"$TOPTMP/init.err"; then
+  fail_ "scaffold-init" "init.sh exited non-zero; stderr tail: $(tail -6 "$TOPTMP/init.err" | tr '\n' '|')"
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+
+SUT="$PROJ/scripts/session-freshness-check.sh"
+
+# ── The S2 lib chain ships downstream (S1 obligation 5 + S2) ─────────────────
+missing=""
+for f in scripts/session-freshness-check.sh scripts/lib/freshness-detect.sh scripts/lib/currency-manifest.sh; do
+  [ -f "$PROJ/$f" ] || missing="$missing $f"
+done
+if [ -z "$missing" ]; then
+  pass "S2 lib chain shipped downstream (session-freshness-check.sh + freshness-detect.sh + currency-manifest.sh)"
+else
+  fail_ "ship-set" "missing downstream:$missing"
+fi
+
+# ── The freshness hook is injected into SessionStart ─────────────────────────
+if [ -f "$PROJ/.claude/settings.json" ] \
+   && jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("session-freshness-check.sh"))' \
+        "$PROJ/.claude/settings.json" >/dev/null 2>&1; then
+  pass "session-freshness-check.sh injected into SessionStart"
+else
+  fail_ "hook-injected" "no SessionStart entry for session-freshness-check.sh (settings.json present? $( [ -f "$PROJ/.claude/settings.json" ] && echo yes || echo no ))"
+fi
+
+# ── DAY-ZERO SILENCE — zero bytes stdout+stderr, exit 0 ──────────────────────
+echo "=== day-zero silence ==="
+d0_out="$(CDF_HOME="$NOCDF" CLAUDE_PROJECT_DIR="$PROJ" bash "$SUT" 2>"$TOPTMP/d0.err")"; d0_rc=$?
+d0_err="$(cat "$TOPTMP/d0.err")"
+if [ "$d0_rc" -eq 0 ] && [ -z "$d0_out" ] && [ -z "$d0_err" ]; then
+  pass "day-zero: byte-empty stdout+stderr, exit 0 (the hook actually ran)"
+else
+  fail_ "day-zero-silence" "rc=$d0_rc stdout=[$d0_out] stderr=[$d0_err]"
+fi
+
+# ── WHOLE-TREE FINGERPRINT — only .claude/cache/ changed ─────────────────────
+# Fingerprint every file EXCEPT .git/** and .claude/cache/**; running detection
+# again must not perturb it (I7: detection writes nothing but the cache).
+echo "=== whole-tree fingerprint (only .claude/cache/ may change) ==="
+fingerprint() {
+  ( cd "$PROJ" && find . -type f \
+      -not -path './.git/*' \
+      -not -path './.claude/cache/*' \
+      | LC_ALL=C sort \
+      | while IFS= read -r p; do shasum -a 256 "$p"; done \
+      | shasum -a 256 | awk '{print $1}' )
+}
+fp_before="$(fingerprint)"
+CDF_HOME="$NOCDF" CLAUDE_PROJECT_DIR="$PROJ" bash "$SUT" >/dev/null 2>&1
+fp_after="$(fingerprint)"
+git_dirty="$(git -C "$PROJ" status --porcelain 2>/dev/null)"
+cache_present="no"; [ -f "$PROJ/.claude/cache/freshness.json" ] && cache_present="yes"
+if [ "$fp_before" = "$fp_after" ] && [ -z "$git_dirty" ] && [ "$cache_present" = "yes" ]; then
+  pass "detection changed nothing outside .claude/cache/ and the git tree stays clean (I7)"
+else
+  fail_ "fingerprint" "changed=$( [ "$fp_before" = "$fp_after" ] && echo no || echo YES) git_dirty=[$git_dirty] cache=$cache_present"
+fi
+
+# ── SEEDED DRIFT 1: edit a vendored script → informational local-edit ────────
+echo "=== seeded drift: edit a vendored script → informational ==="
+printf '\n# locally hand-edited line (seeded drift)\n' >> "$PROJ/scripts/validate.sh"
+se_out="$(CDF_HOME="$NOCDF" CLAUDE_PROJECT_DIR="$PROJ" bash "$SUT" 2>/dev/null)"
+se_mach="$(printf '%s' "$se_out" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+se_tier="$(printf '%s' "$se_mach" | jq -r '.items[] | select(.id=="local-edit:scripts/validate.sh") | .tier' 2>/dev/null)"
+if [ "$se_tier" = "informational" ] && printf '%s' "$se_out" | grep -qi 'archive-and-replace'; then
+  pass "editing a vendored script surfaces as informational local-edit drift"
+else
+  fail_ "seeded-local-edit" "tier=[$se_tier] out=[$se_out]"
+fi
+# restore the vendored script so the next seed is isolated
+git -C "$PROJ" checkout -- scripts/validate.sh >/dev/null 2>&1 || \
+  printf 'true\n' > "$PROJ/scripts/validate.sh"
+
+# ── SEEDED DRIFT 2: delete a hook managed-block line → enforcement hook drift ─
+echo "=== seeded drift: delete an installed hook line → enforcement ==="
+CM="$PROJ/.git/hooks/commit-msg"
+if [ -f "$CM" ]; then
+  # Delete the load-bearing gate invocation line from the managed block.
+  grep -v 'pre-commit-gate.sh --terminal-mode --tdd-only' "$CM" > "$CM.tmp" && mv "$CM.tmp" "$CM"
+  sh_out="$(CDF_HOME="$NOCDF" CLAUDE_PROJECT_DIR="$PROJ" bash "$SUT" 2>/dev/null)"
+  sh_mach="$(printf '%s' "$sh_out" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+  sh_tier="$(printf '%s' "$sh_mach" | jq -r '.items[] | select(.id=="hook-drift:commit-msg") | .tier' 2>/dev/null)"
+  if [ "$sh_tier" = "enforcement" ] && printf '%s' "$sh_out" | grep -q 'Recommended now (enforcement):'; then
+    pass "deleting a hook managed-block line surfaces as enforcement hook drift"
+  else
+    fail_ "seeded-hook-drift" "tier=[$sh_tier] out=[$sh_out]"
+  fi
+else
+  fail_ "seeded-hook-drift" "no installed commit-msg hook to perturb (unexpected for typescript)"
+fi
+
+# ── Tally ────────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-freshness-check.sh
+++ b/tests/test-freshness-check.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# tests/test-freshness-check.sh
+#
+# BL-109 SLICE-S2 (Currency System, Layer 1 — Detection) UNIT LANE.
+#
+# Exercises scripts/session-freshness-check.sh + scripts/lib/freshness-detect.sh
+# entirely through hand-built fixture manifests + fixture framework/CDF trees —
+# NEVER init.sh (that fidelity proof is the aggregator, tests/test-freshness-
+# birth.sh). Because it does not execute init.sh it is ALSO in the tests.yml
+# unit fast lane.
+#
+# Coverage (design v1.1 §2-L1 + I7 + review-r1 M5/M6/M9):
+#   • silence-when-current — ZERO bytes on stdout AND stderr, exit 0
+#   • every drift class → the right tier (local-edit/fw-drift-gate/fw-drift-non-
+#     gate/orphan/hook-drift/hook-missing/hook-unavailable/render-base/cdf)
+#   • hooks expectation enum: absent-intentional silent; absent-unavailable
+#     enforcement (BL-107)
+#   • pin-absent + path-missing → framework checks skip SILENTLY (BL-110 interim)
+#   • torn cache → cold start, never fatal
+#   • future-timestamp snooze clamp → treated expired (item re-surfaces)
+#   • snooze hold/expiry boundaries (6-day held, 8-day expired) + informational
+#     delta-change void + standing "N enforcement items snoozed" line (M5)
+#   • machine-block JSON validity + key stability
+#   • exit 0 under an injected crash (fail-open, I7)
+#   • --snooze records an enforcement snooze through bypass-audit.sh (M5)
+#
+# Hermetic: mktemp, git identity set in fixtures, GITHUB_BASE_REF unset,
+# CDF_HOME pointed at a nonexistent path (no live remotes). bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SUT="$REPO_ROOT/scripts/session-freshness-check.sh"
+HOOKTPL="$REPO_ROOT/scripts/lib/hook-templates.sh"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: jq/git required"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOP="$(mktemp -d)"
+trap 'rm -rf "$TOP"' EXIT
+NCASE=0
+
+# sha <file>
+sha() { shasum -a 256 "$1" | awk '{print $1}'; }
+
+# build_fw <dir> — a fresh framework git checkout with a known shipped surface:
+#   scripts/validate.sh          (non-gate M)
+#   scripts/pre-commit-gate.sh   (gate M → enforcement tier)
+#   scripts/lib/hook-templates.sh (copied from the repo; drives hook currency)
+#   templates/generated/claude-md.tmpl (render-base A1)
+#   docs/builders-guide.md       (reference-doc T source)
+#   init.sh stub (reference-doc source mapping)
+# Sets globals FW + PIN (never echoes — a stray git message must not corrupt the
+# capture; git output is silenced for the same reason).
+FW=""; PIN=""
+build_fw() {
+  local fw="$1"
+  mkdir -p "$fw/scripts/lib" "$fw/templates/generated" "$fw/docs"
+  printf 'echo validate v1\n'            > "$fw/scripts/validate.sh"
+  printf 'echo gate v1\n'                > "$fw/scripts/pre-commit-gate.sh"
+  cp "$HOOKTPL"                            "$fw/scripts/lib/hook-templates.sh"
+  printf 'CLAUDE template v1\n'          > "$fw/templates/generated/claude-md.tmpl"
+  printf 'builders guide v1\n'          > "$fw/docs/builders-guide.md"
+  printf 'cp "$SCRIPT_DIR/docs/builders-guide.md" docs/reference/\n' > "$fw/init.sh"
+  git -C "$fw" init -q >/dev/null 2>&1
+  git -C "$fw" config user.email t@t.t
+  git -C "$fw" config user.name  tester
+  git -C "$fw" add -A >/dev/null 2>&1
+  git -C "$fw" commit -qm "fw v1" >/dev/null 2>&1
+  FW="$fw"
+  PIN="$(git -C "$fw" rev-parse HEAD 2>/dev/null)"
+}
+
+# build_proj_current <projdir> <fwdir> <pin> — a project whose manifest currency
+# block is fully CURRENT against <fwdir>@<pin>: tracked files match, hooks
+# installed + current, render base matches, pin present.
+build_proj_current() {
+  local proj="$1" fw="$2" pin="$3"
+  mkdir -p "$proj/.claude" "$proj/scripts/lib" "$proj/docs/reference" "$proj/.git/hooks"
+  cp "$fw/scripts/validate.sh"          "$proj/scripts/validate.sh"
+  cp "$fw/scripts/pre-commit-gate.sh"   "$proj/scripts/pre-commit-gate.sh"
+  cp "$fw/docs/builders-guide.md"       "$proj/docs/reference/builders-guide.md"
+  # install current hooks from the framework templates
+  ( . "$HOOKTPL"; soif_write_precommit_hook "$proj/.git/hooks/pre-commit" )
+  { printf '#!/usr/bin/env bash\n'; ( . "$HOOKTPL"; soif_emit_tdd_commitmsg_block ); } > "$proj/.git/hooks/commit-msg"
+  local v_sha g_sha d_sha tpl_sha cm_block
+  v_sha="$(sha "$fw/scripts/validate.sh")"
+  g_sha="$(sha "$fw/scripts/pre-commit-gate.sh")"
+  d_sha="$(sha "$fw/docs/builders-guide.md")"
+  tpl_sha="$(sha "$fw/templates/generated/claude-md.tmpl")"
+  jq -n --arg pin "$pin" --arg fw "$fw" \
+        --arg v "$v_sha" --arg g "$g_sha" --arg d "$d_sha" --arg tpl "$tpl_sha" '{
+    soloFrameworkCommit:$pin,
+    frameworkCommit:"cdfpinabc",
+    currency:{
+      schemaVersion:1, soloFrameworkPath:$fw,
+      files:{
+        "scripts/validate.sh":{sha256:$v, mode:"755", class:"M", state:"current"},
+        "scripts/pre-commit-gate.sh":{sha256:$g, mode:"755", class:"M", state:"current"},
+        "docs/reference/builders-guide.md":{sha256:$d, mode:"644", class:"T", state:"current"}
+      },
+      renderBases:{ A1:{ "CLAUDE.md":{templateSha:$tpl, outputSha:"deadbeef"} }, A2:{} },
+      hooks:{ "pre-commit":"present", "commit-msg":"present" },
+      mcpProbe:{context7:"absent"}
+    }
+  }' > "$proj/.claude/manifest.json"
+}
+
+# run <projdir> — invoke the SUT; captures stdout to $OUT, stderr to $ERR,
+# exit to $RC. CDF defaults to a nonexistent clone (silent). Extra env is
+# inherited from the caller (SOIF_FRESHNESS_NOW etc.).
+OUT=""; ERR=""; RC=0
+run() {
+  local proj="$1"
+  OUT="$(CDF_HOME="${CDF_HOME:-$TOP/no-cdf}" CLAUDE_PROJECT_DIR="$proj" bash "$SUT" 2>"$TOP/err.$$")"
+  RC=$?
+  ERR="$(cat "$TOP/err.$$")"
+  rm -f "$TOP/err.$$"
+}
+
+newdir() { NCASE=$((NCASE + 1)); echo "$TOP/c$NCASE"; }
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== silence-when-current: zero bytes stdout+stderr, exit 0 ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+run "$D/proj"
+if [ "$RC" -eq 0 ] && [ -z "$OUT" ] && [ -z "$ERR" ]; then
+  pass "current scaffold is byte-silent on stdout+stderr, exit 0"
+else
+  fail_ "silence-when-current" "rc=$RC stdout=[$OUT] stderr=[$ERR]"
+fi
+# warm cache written under .claude/cache/ only
+if [ -f "$D/proj/.claude/cache/freshness.json" ] && jq -e . "$D/proj/.claude/cache/freshness.json" >/dev/null 2>&1; then
+  pass "warm cache written + valid JSON at .claude/cache/freshness.json"
+else
+  fail_ "warm cache" "cache missing or invalid"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== local-edit → informational ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+printf 'echo locally edited\n' > "$D/proj/scripts/validate.sh"
+run "$D/proj"
+if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -qi 'archive-and-replace' \
+   && printf '%s' "$OUT" | grep -q 'Informational:'; then
+  pass "local edit surfaces as an informational archive-and-replace warning"
+else
+  fail_ "local-edit" "rc=$RC out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== framework drift on a GATE script → enforcement ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+printf 'echo gate v2 upstream\n' > "$FW/scripts/pre-commit-gate.sh"
+git -C "$FW" add -A >/dev/null 2>&1; git -C "$FW" commit -qm "gate bump" >/dev/null 2>&1
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+tier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="fw-drift:scripts/pre-commit-gate.sh") | .tier' 2>/dev/null)"
+if [ "$tier" = "enforcement" ] && printf '%s' "$OUT" | grep -q 'Recommended now (enforcement):'; then
+  pass "gate-script framework drift is ENFORCEMENT tier"
+else
+  fail_ "fw-drift-gate" "tier=[$tier] out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== framework drift on a NON-gate script → informational ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+printf 'echo validate v2 upstream\n' > "$FW/scripts/validate.sh"
+git -C "$FW" add -A >/dev/null 2>&1; git -C "$FW" commit -qm "validate bump" >/dev/null 2>&1
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+tier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="fw-drift:scripts/validate.sh") | .tier' 2>/dev/null)"
+[ "$tier" = "informational" ] && pass "non-gate framework drift is informational" \
+  || fail_ "fw-drift-nongate" "tier=[$tier] out=[$OUT]"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== orphan (upstream source deleted) → enforcement ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+git -C "$FW" rm -q "scripts/validate.sh" >/dev/null 2>&1; rm -f "$FW/scripts/validate.sh"
+git -C "$FW" commit -qm "delete validate" >/dev/null 2>&1
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+otier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="orphan:scripts/validate.sh") | .tier' 2>/dev/null)"
+overb="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="orphan:scripts/validate.sh") | .verb' 2>/dev/null)"
+if [ "$otier" = "enforcement" ] && [ "$overb" = "retire" ]; then
+  pass "orphaned tracked file is ENFORCEMENT tier with verb=retire"
+else
+  fail_ "orphan" "tier=[$otier] verb=[$overb] out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== hook drift (stale managed block) → enforcement ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+# Corrupt the installed commit-msg managed block so it differs from the template.
+sed -i.bak 's/scripts\/pre-commit-gate.sh --terminal-mode --tdd-only/echo STALE/' "$D/proj/.git/hooks/commit-msg" && rm -f "$D/proj/.git/hooks/commit-msg.bak"
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+htier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="hook-drift:commit-msg") | .tier' 2>/dev/null)"
+[ "$htier" = "enforcement" ] && pass "stale hook managed block is ENFORCEMENT tier" \
+  || fail_ "hook-drift" "tier=[$htier] out=[$OUT]"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== hook missing when expected present → enforcement ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+rm -f "$D/proj/.git/hooks/commit-msg"
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+htier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="hook-missing:commit-msg") | .tier' 2>/dev/null)"
+[ "$htier" = "enforcement" ] && pass "missing expected hook is ENFORCEMENT tier" \
+  || fail_ "hook-missing" "tier=[$htier] out=[$OUT]"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== hook absent-unavailable → enforcement (BL-107) ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+jq '.currency.hooks["commit-msg"]="absent-unavailable"' "$D/proj/.claude/manifest.json" > "$D/proj/.claude/m.tmp" && mv "$D/proj/.claude/m.tmp" "$D/proj/.claude/manifest.json"
+rm -f "$D/proj/.git/hooks/commit-msg"
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+utier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="hook-unavailable:commit-msg") | .tier' 2>/dev/null)"
+if [ "$utier" = "enforcement" ] && printf '%s' "$OUT" | grep -q 'BL-107'; then
+  pass "absent-unavailable hook is ENFORCEMENT tier and cites BL-107"
+else
+  fail_ "hook-unavailable" "tier=[$utier] out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== hook absent-intentional → silent ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+jq '.currency.hooks["commit-msg"]="absent-intentional"' "$D/proj/.claude/manifest.json" > "$D/proj/.claude/m.tmp" && mv "$D/proj/.claude/m.tmp" "$D/proj/.claude/manifest.json"
+rm -f "$D/proj/.git/hooks/commit-msg"
+run "$D/proj"
+if [ "$RC" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "absent-intentional hook is silent (a real expected absence)"
+else
+  fail_ "hook-absent-intentional" "rc=$RC out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== render-base drift → informational ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+printf 'CLAUDE template v2 (changed)\n' > "$FW/templates/generated/claude-md.tmpl"
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+rtier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="render-base:CLAUDE.md") | .tier' 2>/dev/null)"
+if [ "$rtier" = "informational" ] && printf '%s' "$OUT" | grep -qi 'older template'; then
+  pass "render-base drift is informational ('older template')"
+else
+  fail_ "render-base" "tier=[$rtier] out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== pin-absent → framework checks skip SILENTLY (BL-110 interim) ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+# Real upstream drift exists, but with no pin the framework check must stay silent.
+printf 'echo gate v2 upstream\n' > "$FW/scripts/pre-commit-gate.sh"; git -C "$FW" add -A >/dev/null 2>&1; git -C "$FW" commit -qm bump >/dev/null 2>&1
+jq 'del(.soloFrameworkCommit)' "$D/proj/.claude/manifest.json" > "$D/proj/.claude/m.tmp" && mv "$D/proj/.claude/m.tmp" "$D/proj/.claude/manifest.json"
+run "$D/proj"
+if [ "$RC" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "pin-absent manifest → framework-drift check skips silently"
+else
+  fail_ "pin-absent-skip" "rc=$RC out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== path-missing → framework checks skip SILENTLY ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+jq --arg p "$TOP/does-not-exist" '.currency.soloFrameworkPath=$p' "$D/proj/.claude/manifest.json" > "$D/proj/.claude/m.tmp" && mv "$D/proj/.claude/m.tmp" "$D/proj/.claude/manifest.json"
+run "$D/proj"
+if [ "$RC" -eq 0 ] && [ -z "$OUT" ]; then
+  pass "missing soloFrameworkPath → framework check skips silently"
+else
+  fail_ "path-missing-skip" "rc=$RC out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== CDF staleness → informational; CDF absent → silent ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+CDFD="$D/cdf"; mkdir -p "$CDFD"; git -C "$CDFD" init -q; git -C "$CDFD" config user.email t@t.t; git -C "$CDFD" config user.name t
+printf 'a\n' > "$CDFD/f"; git -C "$CDFD" add -A; git -C "$CDFD" commit -qm c1
+CDFPIN="$(git -C "$CDFD" rev-parse HEAD)"
+printf 'b\n' > "$CDFD/f"; git -C "$CDFD" add -A; git -C "$CDFD" commit -qm c2
+jq --arg p "$CDFPIN" '.frameworkCommit=$p' "$D/proj/.claude/manifest.json" > "$D/proj/.claude/m.tmp" && mv "$D/proj/.claude/m.tmp" "$D/proj/.claude/manifest.json"
+CDF_HOME="$CDFD" run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+ctier="$(printf '%s' "$mach" | jq -r '.items[] | select(.id=="cdf-behind") | .tier' 2>/dev/null)"
+[ "$ctier" = "informational" ] && pass "CDF staleness is informational" \
+  || fail_ "cdf-stale" "tier=[$ctier] out=[$OUT]"
+# CDF absent → the cdf check is silent (this project is otherwise current)
+run "$D/proj"   # default CDF_HOME = nonexistent
+if [ -z "$OUT" ]; then pass "absent CDF clone → cdf check silent"; else fail_ "cdf-absent" "out=[$OUT]"; fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== torn cache → cold start, never fatal ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+mkdir -p "$D/proj/.claude/cache"; printf '{ this is not valid json ::: ' > "$D/proj/.claude/cache/freshness.json"
+run "$D/proj"
+if [ "$RC" -eq 0 ] && [ -z "$OUT" ] && jq -e . "$D/proj/.claude/cache/freshness.json" >/dev/null 2>&1; then
+  pass "torn cache is treated as cold (exit 0, silent, cache rewritten valid)"
+else
+  fail_ "torn-cache" "rc=$RC out=[$OUT]"
+fi
+
+# ── Snooze fixtures use the enforcement 'hook-unavailable' item (stable sig) ──
+# seed_snooze <proj> <id> <tier> <snoozedAt> <sig>
+seed_snooze() {
+  local proj="$1" id="$2" tier="$3" at="$4" sig="$5"
+  mkdir -p "$proj/.claude/cache"
+  jq -n --arg id "$id" --arg tier "$tier" --argjson at "$at" --arg sig "$sig" \
+    '{schemaVersion:1, updatedAt:$at, snoozes:{ ($id): {tier:$tier, snoozedAt:$at, deltaSig:$sig} }}' \
+    > "$proj/.claude/cache/freshness.json"
+}
+# an enforcement-only project (absent-unavailable commit-msg, otherwise current)
+mk_enf_proj() {
+  local proj="$1" fw="$2" pin="$3"
+  build_proj_current "$proj" "$fw" "$pin"
+  jq '.currency.hooks["commit-msg"]="absent-unavailable"' "$proj/.claude/manifest.json" > "$proj/.claude/m.tmp" && mv "$proj/.claude/m.tmp" "$proj/.claude/manifest.json"
+  rm -f "$proj/.git/hooks/commit-msg"
+}
+NOW=1800000000
+DAY=86400
+
+echo "=== snooze 6-day (enforcement) → held: item suppressed, standing line ==="
+D="$(newdir)"; build_fw "$D/fw"; mk_enf_proj "$D/proj" "$FW" "$PIN"
+seed_snooze "$D/proj" "hook-unavailable:commit-msg" enforcement "$((NOW - 6*DAY))" "unavailable"
+SOIF_FRESHNESS_NOW="$NOW" run "$D/proj"
+if [ "$RC" -eq 0 ] && printf '%s' "$OUT" | grep -q 'enforcement items snoozed' \
+   && ! printf '%s' "$OUT" | grep -q 'BL-107'; then
+  pass "6-day enforcement snooze is HELD (item suppressed, standing line printed)"
+else
+  fail_ "snooze-6day-held" "out=[$OUT]"
+fi
+
+echo "=== snooze 8-day (enforcement) → EXPIRED: item re-surfaces ==="
+D="$(newdir)"; build_fw "$D/fw"; mk_enf_proj "$D/proj" "$FW" "$PIN"
+seed_snooze "$D/proj" "hook-unavailable:commit-msg" enforcement "$((NOW - 8*DAY))" "unavailable"
+SOIF_FRESHNESS_NOW="$NOW" run "$D/proj"
+if printf '%s' "$OUT" | grep -q 'BL-107' && printf '%s' "$OUT" | grep -q 'Recommended now'; then
+  pass "8-day enforcement snooze is EXPIRED (item re-surfaces at enforcement tier)"
+else
+  fail_ "snooze-8day-expired" "out=[$OUT]"
+fi
+
+echo "=== snooze FUTURE snoozedAt → clamped to expired: item re-surfaces ==="
+D="$(newdir)"; build_fw "$D/fw"; mk_enf_proj "$D/proj" "$FW" "$PIN"
+seed_snooze "$D/proj" "hook-unavailable:commit-msg" enforcement "$((NOW + 5*DAY))" "unavailable"
+SOIF_FRESHNESS_NOW="$NOW" run "$D/proj"
+if printf '%s' "$OUT" | grep -q 'BL-107'; then
+  pass "future snoozedAt is clamped to expired (item re-surfaces)"
+else
+  fail_ "snooze-future-clamp" "out=[$OUT]"
+fi
+
+echo "=== informational snooze holds while delta unchanged; voids on delta change ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+printf 'echo edited once\n' > "$D/proj/scripts/validate.sh"
+EDIT_SHA="$(sha "$D/proj/scripts/validate.sh")"
+seed_snooze "$D/proj" "local-edit:scripts/validate.sh" informational "$((NOW - 30*DAY))" "$EDIT_SHA"
+SOIF_FRESHNESS_NOW="$NOW" run "$D/proj"
+held_ok=0
+[ -z "$OUT" ] && held_ok=1     # only item is snoozed + informational → fully silent
+# now change the file again → delta moves → snooze voids → item re-surfaces
+printf 'echo edited twice (delta moved)\n' > "$D/proj/scripts/validate.sh"
+SOIF_FRESHNESS_NOW="$NOW" run "$D/proj"
+if [ "$held_ok" -eq 1 ] && printf '%s' "$OUT" | grep -qi 'archive-and-replace'; then
+  pass "informational snooze holds on stable delta, voids when the upstream/local delta changes"
+else
+  fail_ "info-snooze-delta" "held_ok=$held_ok out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== machine-block: valid JSON + stable key set ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+printf 'echo drift\n' > "$D/proj/scripts/validate.sh"
+run "$D/proj"
+mach="$(printf '%s' "$OUT" | sed -n '/```soif-freshness/,/```/p' | sed '1d;$d')"
+if printf '%s' "$mach" | jq -e . >/dev/null 2>&1; then
+  keys="$(printf '%s' "$mach" | jq -r 'keys | join(",")')"
+  want="current,enforcementSnoozed,generatedAt,items,network,schema,toolsCovered"
+  schema="$(printf '%s' "$mach" | jq -r '.schema')"
+  tools="$(printf '%s' "$mach" | jq -r '.toolsCovered')"
+  net="$(printf '%s' "$mach" | jq -r '.network')"
+  ikeys="$(printf '%s' "$mach" | jq -r '.items[0] | keys | join(",")')"
+  if [ "$keys" = "$want" ] && [ "$schema" = "soif-freshness/1" ] && [ "$tools" = "false" ] && [ "$net" = "none" ] \
+     && [ "$ikeys" = "check,id,message,path,tier,verb" ]; then
+    pass "machine block is valid JSON with the stable documented key set (tools not covered; network none)"
+  else
+    fail_ "machine-keys" "keys=[$keys] schema=[$schema] tools=[$tools] net=[$net] ikeys=[$ikeys]"
+  fi
+else
+  fail_ "machine-json" "not valid JSON: [$mach]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== fail-open: injected crash → exit 0 + single unavailable line ==="
+D="$(newdir)"; build_fw "$D/fw"; build_proj_current "$D/proj" "$FW" "$PIN"
+OUT="$(SOIF_FRESHNESS_SELFTEST_CRASH=1 CDF_HOME="$TOP/no-cdf" CLAUDE_PROJECT_DIR="$D/proj" bash "$SUT" 2>/dev/null)"; RC=$?
+if [ "$RC" -eq 0 ] && [ "$OUT" = "[freshness check unavailable]" ]; then
+  pass "injected crash → exit 0 + exactly '[freshness check unavailable]'"
+else
+  fail_ "fail-open-crash" "rc=$RC out=[$OUT]"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== --snooze records an ENFORCEMENT snooze through bypass-audit.sh (M5) ==="
+D="$(newdir)"; build_fw "$D/fw"; mk_enf_proj "$D/proj" "$FW" "$PIN"
+SOIF_FRESHNESS_NOW="$NOW" CDF_HOME="$TOP/no-cdf" CLAUDE_PROJECT_DIR="$D/proj" bash "$SUT" --snooze "hook-unavailable:commit-msg" >/dev/null 2>&1
+snz="$(jq -r '.snoozes["hook-unavailable:commit-msg"].tier // empty' "$D/proj/.claude/cache/freshness.json" 2>/dev/null)"
+audit_rows="$(jq '[.[] | select(.type=="freshness_enforcement_snooze")] | length' "$D/proj/.claude/bypass-audit.json" 2>/dev/null || echo 0)"
+if [ "$snz" = "enforcement" ] && [ "${audit_rows:-0}" -ge 1 ]; then
+  pass "--snooze writes the cache snooze AND records a bypass-audit row (M5)"
+else
+  fail_ "snooze-audit" "cache-tier=[$snz] audit_rows=[$audit_rows]"
+fi
+# and the freshly-snoozed enforcement item is now suppressed + standing line
+SOIF_FRESHNESS_NOW="$NOW" run "$D/proj"
+if printf '%s' "$OUT" | grep -q 'enforcement items snoozed' && ! printf '%s' "$OUT" | grep -q 'BL-107'; then
+  pass "after --snooze the enforcement item is suppressed (standing line only)"
+else
+  fail_ "post-snooze-suppressed" "out=[$OUT]"
+fi
+
+# ── Tally ────────────────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## BL-109 Slice S2 — Currency System, Layer 1 (Detection)

Read-only, zero-network, fail-open **session-start freshness detector**, injected into `SessionStart` exactly the way `session-version-check.sh` is. Detection **only** — NO staging, NO plan, NO apply. Design of record: `docs/designs/2026-07-12-currency-system-v1.md` v1.1 §2-L1; honors invariant **I7** and review-r1 findings **M5/M6/M9**. Acceptance = Appendix P rung 1 (day-zero silence).

New:
- `scripts/lib/freshness-detect.sh` — detection dispatch (marker `# BL-109-FRESHNESS`), cache, snooze, machine block.
- `scripts/session-freshness-check.sh` — the SessionStart wrapper (fail-open) + `--snooze`/`--unsnooze`.
- `tests/test-freshness-check.sh` (unit) + `tests/test-freshness-birth.sh` (aggregator, real `init.sh`).

Wired: `init.sh` ships the lib chain downstream (incl. `currency-manifest.sh` — S1 obligation 5), injects the hook, adds `.claude/cache/` to `generate_gitignore`. Tightened `tests/test-currency-birth-stamp.sh` Class-M to an independently lib-derived exact count (S1 obligation 1).

---

### Check inventory (check → tier → evidence)

| Check (§2-L1) | Item id | Tier | Skip / silence contract | Unit evidence |
|---|---|---|---|---|
| (a) local edit to framework-managed file (M/T) | `local-edit:<path>` | informational (archive-and-replace) | absent-locally is not a local edit | `local edit … informational` |
| (b) framework pin vs HEAD | `pin-behind` | informational (N commits ahead) | pin absent / not-ancestor → no line (never fetch) | seen in gate-drift case |
| (b) per-file framework drift, **gate script/hook** | `fw-drift:<path>` | **enforcement** | skip all of (b/c) if path missing/not-a-checkout OR pin absent (BL-110 interim) | `gate-script framework drift is ENFORCEMENT` |
| (b) per-file framework drift, other script/doc/skill | `fw-drift:<path>` | informational | " | `non-gate framework drift is informational` |
| (c) orphan (upstream source deleted) | `orphan:<path>` | **enforcement** (verb `retire`) | " | `orphaned … ENFORCEMENT … verb=retire` |
| (d) hook managed-block drift | `hook-drift:<hook>` | **enforcement** | drift arm needs framework template; else silent | `stale hook managed block is ENFORCEMENT` |
| (d) hook missing when expected `present` | `hook-missing:<hook>` | **enforcement** | — | `missing expected hook is ENFORCEMENT` |
| (d) `absent-unavailable` (BL-107) | `hook-unavailable:<hook>` | **enforcement** | `absent-intentional` → **silent** | `absent-unavailable … cites BL-107` / `absent-intentional … silent` |
| (e) render-base A1/A2 template drift | `render-base:<artifact>` | informational (older template) | template missing → skip | `render-base drift is informational` |
| (f) CDF staleness (read-only) | `cdf-behind` | informational | clone absent/not-ancestor → silent | `CDF staleness is informational` / `absent CDF … silent` |
| **tools** | — | — | **NOT covered** — `check-versions.sh` + `session-version-check.sh` own tools; machine block advertises `"toolsCovered": false` | machine-key test |

Tiered output: enforcement first ("Recommended now"), then informational. **Silent when current** (zero bytes). Standing line `N enforcement items snoozed` prints while any enforcement snooze is held even if otherwise current (M5).

---

### I7 conformance proofs

**1. Fingerprint — detection writes nothing but `.claude/cache/`.** `tests/test-freshness-birth.sh` snapshots a whole-tree sha of the real scaffold (excluding `.git/**` and `.claude/cache/**`), runs the detector, re-snapshots: byte-identical, `git status --porcelain` empty, `.claude/cache/freshness.json` present. Cache write is temp-file-in-same-dir + atomic `mv`; torn/invalid cache → cold start (unit `torn cache …`); future `snoozedAt` → clamped to expired (unit `future snoozedAt is clamped`).

**2. Network tripwire — zero network, ever (M6).** No `git fetch` / `ls-remote` / `pull` / `clone` / `push` / `curl` / `wget` anywhere in the S2 surface (the only string matches are in comments). Every git call is a **local read**: `rev-parse`, `merge-base --is-ancestor`, `rev-list --count` against the local framework/CDF clones. Tests run hermetic with `CDF_HOME` pinned to a nonexistent path.

**3. Exit-0 matrix — fail-open under every failure mode.**

| Condition | Result |
|---|---|
| current project | exit 0, **zero bytes** |
| any drift | exit 0, human + machine block |
| no jq / no manifest / no `currency` block | exit 0, silent |
| pin absent / framework path missing | exit 0, framework checks skip silently |
| torn/invalid cache | exit 0, treated as cold |
| **injected internal crash** (`SOIF_FRESHNESS_SELFTEST_CRASH=1`) | exit 0 + exactly one `[freshness check unavailable]` line |
| lib absent downstream | exit 0, silent |

Day-zero silence proven end-to-end on a **real `--no-remote-creation` scaffold** (aggregator): the hook is injected, actually runs, and prints nothing.

---

### Machine-block schema (fenced ```` ```soif-freshness ````; S5 will lint it)

```json
{
  "schema": "soif-freshness/1",
  "generatedAt": "<ISO-8601 UTC>",
  "current": true,
  "enforcementSnoozed": 0,
  "toolsCovered": false,
  "network": "none",
  "items": [
    { "id": "orphan:scripts/foo.sh", "check": "orphan",
      "tier": "enforcement", "path": "scripts/foo.sh",
      "verb": "retire", "message": "…" }
  ]
}
```

`check` ∈ `local-edit | framework | framework-drift | orphan | hook | render-base | cdf`; `tier` ∈ `enforcement | informational`; `verb` ∈ `add | update | retire | null`. Key set pinned by the unit test.

---

### Mutation evidence (behavioral, RED→GREEN verbatim)

| # | Mutation (marker preserved) | RED | GREEN |
|---|---|---|---|
| 1 | neuter `# BL-109-FRESHNESS` dispatch body (`return 0` after marker) | `Results: 8 passed, 16 failed` — every drift case emits empty | `Results: 24 passed, 0 failed` |
| 2 | invert orphan tier `enforcement`→`informational` | `Results: 23 passed, 1 failed` — `orphan — tier=[informational]` | `24 passed, 0 failed` |
| 3 | remove the 7-day enforcement snooze expiry (keep future-clamp) | `Results: 23 passed, 1 failed` — 8-day snooze stays held (`[1 enforcement items snoozed]`) | `24 passed, 0 failed` |
| 4 | fail-open wrapper propagates crash (`exit 0`→`exit $rc`) | `Results: 23 passed, 1 failed` — injected crash `rc=1` | `24 passed, 0 failed` |

---

### Suites & lints

- `tests/test-freshness-check.sh` (unit) — **24 passed, 0 failed**
- `tests/test-freshness-birth.sh` (aggregator, real init.sh) — **6 passed, 0 failed**
- `tests/test-currency-birth-stamp.sh` (tightened Class-M pin) — **18 passed, 0 failed** (M==54, independently lib-derived)
- `tests/test-currency-manifest.sh` — 53/0 · `tests/test-scaffold-source-closure.sh` — 6/0 · `tests/test-upgrade-sync-framework.sh` — 35/0 · `tests/test-bl099-guard-coverage.sh` — 25/0 (pinned) · `tests/test-upgrade-cdf-refresh.sh` — 6/0
- `scripts/run-lints.sh` — **11 lints, 11 passed, 0 failed**

Registered: `test-freshness-check.sh` in **both** `tests/full-project-test-suite.sh` and the `tests.yml` unit list; `test-freshness-birth.sh` aggregator-only, `SUITE_SKIP_AGGREGATORS`-gated (a real init.sh scaffold is heavy).

---

### DECLARED DEVIATIONS

1. **Snooze-setting mechanism = shipped `--snooze`/`--unsnooze` flags (trivially safe).** Detection itself never prompts and never snoozes. Setting is out of band via explicit flags that write only the cache and (for enforcement) one audit row. Chosen over "expiry/display only, defer to S4" because it is bounded and testable; the expiry/hold/clamp logic that detection depends on is fully exercised regardless.

2. **Enforcement-snooze audit `type` extends the bypass-audit enum.** Recorded through `scripts/lib/bypass-audit.sh` with the canonical row shape (`timestamp/session_id/type/actor/enforcement_level_at_event/details/user_response/final_outcome`), using a **new** `type` value `freshness_enforcement_snooze`. `bypass_audit_append` validates object-shape only, so no parallel audit file is invented (honoring review-r1 M5's "recorded through bypass-audit.sh"). Flagged because the enum comment in `bypass-audit.sh` documents a fixed set that this value is not (yet) part of.

3. **Existing-projects hook-injection is NOT covered by S2.** `init.sh` injects the `SessionStart` hook and gitignores `.claude/cache/` at **birth**; a project scaffolded before this PR will not gain the freshness hook (or the `.claude/cache/` ignore, or the downstream `freshness-detect.sh`/`currency-manifest.sh`) until it runs the upgrade/backfill path. Wiring the freshness hook + lib ship into `scripts/upgrade-project.sh` (the BL-088-class backfill for existing projects) is **out of S2 scope** — it belongs with the sync/apply work (S3a/S4), where `soloFrameworkPath` re-stamping already lives (S1 obligation 4). Detection degrades to a clean no-op (exit 0, silent) in any project lacking the hook or a `currency` block, so this is a coverage gap, not a hazard.

4. **Framework per-file drift + orphans are pin-gated (BL-110 interim contract).** On the hermetic `--no-remote-creation` path `soloFrameworkCommit` is absent (BL-110), so checks (b)/(c) skip silently there; local-edit, hook-currency, and render-base still run. This is the interim contract BL-110 mandates and is what keeps day-zero silent. When BL-110 stamps the pin universally, (b)/(c) light up with no change here.

5. **Reference-doc source mapping reads `init.sh`'s own `cp` lines.** `_soif_fresh_fw_source` resolves a `docs/reference/<base>` tracked path back to its framework source by grepping the framework clone's `init.sh` (mechanical, drift-proof), falling back to `docs/<base>`. Scripts map 1:1; skills map `.claude/skills/X` → `templates/generated/skills/X`. A1 renders are excluded from per-file drift (handled by the render-base check).

DO NOT MERGE — awaiting checks + adversarial acceptance (BL-100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
