### PR TITLE
fix(security): make a fresh scaffold scan-clean and stop the offline autorun laundering a real FAIL into a SKIP (BL-113)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint counter-capture antipattern
         run: bash scripts/lint-counter-antipattern.sh
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
         with:
           fetch-depth: 0  # required for `git log BASE..HEAD` resolution
 
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint fix_*() function stderr silencers
         run: bash scripts/lint-fix-functions-stderr.sh
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint raw read -rp / read -p sites
         run: bash scripts/lint-raw-read-prompt.sh
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint tests-registered (BL-038 structural backstop)
         run: bash scripts/lint-tests-registered.sh
@@ -144,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint in-document anchors under docs/ (BL-048)
         run: bash scripts/lint-doc-anchors.sh
@@ -166,7 +166,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint review-manifest schema (BL-073)
         run: bash scripts/lint-review-manifest.sh
@@ -189,7 +189,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint tests for live-remote-reachable init.sh runs (BL-076)
         run: bash scripts/lint-no-live-remote-in-tests.sh
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Lint evaluation-prompts/ for bash-4 constructs (BL-103)
         run: bash scripts/lint-evalprompts-portability.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,7 +47,7 @@ jobs:
     if: github.event_name == 'push' || github.event_name == 'pull_request'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
         with:
           # tests/test-lint-backlog-references.sh runs the linter against the
           # REAL repo with `--base origin/main` (needs the origin/main ref and
@@ -200,7 +200,7 @@ jobs:
         shard: [core, edge-pre-init, edge-scripts, aggregators]
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
         with:
           fetch-depth: 0
 

--- a/init.sh
+++ b/init.sh
@@ -2802,28 +2802,28 @@ SOEOF
 get_release_vars() {
   case "$LANGUAGE" in
     typescript|javascript)
-      RELEASE_SETUP_ACTION="actions/setup-node@v4"
+      RELEASE_SETUP_ACTION="actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)"
       RELEASE_SETUP_VERSION_KEY="node-version"
       RELEASE_SETUP_VERSION_VALUE="'lts/*'"
       RELEASE_INSTALL_COMMAND="npm ci"
       RELEASE_BUILD_COMMAND="npm run build"
       ;;
     python)
-      RELEASE_SETUP_ACTION="actions/setup-python@v5"
+      RELEASE_SETUP_ACTION="actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (v5.6.0)"
       RELEASE_SETUP_VERSION_KEY="python-version"
       RELEASE_SETUP_VERSION_VALUE="'3.x'"
       RELEASE_INSTALL_COMMAND="pip install -r requirements.txt"
       RELEASE_BUILD_COMMAND="python -m build"
       ;;
     rust)
-      RELEASE_SETUP_ACTION="dtolnay/rust-toolchain@stable"
+      RELEASE_SETUP_ACTION="dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch head 2026-06-30"
       RELEASE_SETUP_VERSION_KEY="toolchain"
       RELEASE_SETUP_VERSION_VALUE="stable"
       RELEASE_INSTALL_COMMAND="echo 'No separate install step for Rust'"
       RELEASE_BUILD_COMMAND="cargo build --release"
       ;;
     csharp)
-      RELEASE_SETUP_ACTION="actions/setup-dotnet@v4"
+      RELEASE_SETUP_ACTION="actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4 (v4.3.1)"
       RELEASE_SETUP_VERSION_KEY="dotnet-version"
       # Current LTS — update when next LTS releases
       RELEASE_SETUP_VERSION_VALUE="'8.0.x'"
@@ -2831,7 +2831,7 @@ get_release_vars() {
       RELEASE_BUILD_COMMAND="dotnet build --configuration Release"
       ;;
     kotlin|java)
-      RELEASE_SETUP_ACTION="actions/setup-java@v4"
+      RELEASE_SETUP_ACTION="actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)"
       RELEASE_SETUP_VERSION_KEY="java-version"
       # Current LTS — update when next LTS releases
       RELEASE_SETUP_VERSION_VALUE="'21'"
@@ -2839,14 +2839,14 @@ get_release_vars() {
       RELEASE_BUILD_COMMAND="./gradlew build"
       ;;
     go)
-      RELEASE_SETUP_ACTION="actions/setup-go@v5"
+      RELEASE_SETUP_ACTION="actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 (v5.6.0)"
       RELEASE_SETUP_VERSION_KEY="go-version"
       RELEASE_SETUP_VERSION_VALUE="'stable'"
       RELEASE_INSTALL_COMMAND="echo 'Go modules download automatically'"
       RELEASE_BUILD_COMMAND="go build ./..."
       ;;
     dart)
-      RELEASE_SETUP_ACTION="subosito/flutter-action@v2"
+      RELEASE_SETUP_ACTION="subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2 (v2.23.0)"
       RELEASE_SETUP_VERSION_KEY="channel"
       RELEASE_SETUP_VERSION_VALUE="'stable'"
       RELEASE_INSTALL_COMMAND="flutter pub get"
@@ -2971,7 +2971,14 @@ generate_release() {
   get_release_vars
 
   # Substitute placeholders into the release template
-  sed -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
+  # BL-113: strip the template-only marker comment BEFORE substituting the
+  # placeholder. That comment carries the scanner suppression which keeps the
+  # TEMPLATE itself scan-clean, and it MUST NOT reach a generated project — a
+  # shipped suppression would silence the mutable-action-tag rule on that line in
+  # every downstream repo. Stripping is keyed on the marker token alone so no
+  # suppression directive text exists in any shipped script either.
+  sed -e 's|[[:space:]]*#.*__SOLO_TEMPLATE_ONLY__[[:space:]]*$||' \
+      -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
       -e "s|__SETUP_VERSION_KEY__|$RELEASE_SETUP_VERSION_KEY|g" \
       -e "s|__SETUP_VERSION_VALUE__|$RELEASE_SETUP_VERSION_VALUE|g" \
       -e "s|__INSTALL_COMMAND__|$RELEASE_INSTALL_COMMAND|g" \

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1298,6 +1298,76 @@ fi
 # TRACKED downstream — an UNSCOPED check would mark every summary permanently
 # stale after its first PASS (self-defeating).
 
+# ═══════════════════════════════════════════════════════════════════════
+# BL-113 — the offline autorun must not launder a real FAIL into a SKIP.
+# ═══════════════════════════════════════════════════════════════════════
+# Walk finding F15: whenever the tree is dirty (the NORMAL state while the
+# operator is authoring Phase-3 artifacts) the BL-082 staleness check autoruns
+# the driver with `--offline`, which SKIPs every tool-backed scanner. The
+# operator saw "scanner unavailable", attested the SKIP in good faith, and
+# passed — never learning that a REAL semgrep run FAILs (F14). A FAIL is not
+# attestable; a SKIP is. The autorun was the laundry.
+#
+# TWO defences, both marked `# BL-113-NO-LAUNDER`:
+#
+#   1. IN THE DRIVER (scripts/run-phase3-validation.sh, `_p3_no_launder`): a
+#      SKIP never overwrites a prior REAL FAIL — it is promoted back to FAIL
+#      with a `[STALE - last real result: FAIL]` note and a machine-readable
+#      `CARRIED <scanner> <origin>` line. The gate surfaces that line verbatim
+#      below so the operator reads WHY the FAIL is there.
+#
+#   2. HERE: an offline-autorun SKIP for a scanner whose TOOL IS ON PATH is
+#      REFUSED — attested or not. It is not a result; it is the autorun's own
+#      choice not to look, and the operator cannot honestly sign "scanner
+#      unavailable" for a scanner that is installed. To clear it the operator
+#      must run the driver themselves WITHOUT `--offline`, which yields a real
+#      verdict (PASS/FAIL) or — with the tool present but no network — an
+#      HONEST, attestable SKIP recorded against a non-offline summary.
+#
+# THE AUTORUN STAYS `--offline` (deliberate, verified): `semgrep --config auto`
+# is NOT local-only. It hard-fetches its ruleset from semgrep.dev with no local
+# cache fallback (network blackholed: ~97s of retries, rc=2, no report). Running
+# it from the gate would make the gate non-hermetic, slow, and would brick
+# genuinely-offline operators. The laundering dies; the offline mode does not.
+#
+# GENUINELY OFFLINE STAYS USABLE: tool absent → no refusal → an honest SKIP is
+# still attestable and the gate is still passable. That is the whole point of
+# the attest-on-skip design and BL-113 does not touch it.
+
+# _cpg_phase3_scanner_tool <scanner> — echo the single binary whose presence on
+# PATH makes the scanner LOCALLY RUNNABLE, or "" when there is no unambiguous
+# one. Deliberately narrow (BL-113): only `semgrep-full-tree` is mapped.
+#   * semgrep is the SAST the walk caught being laundered, and its real-run path
+#     now degrades to an honest attestable SKIP when the rule registry is
+#     unreachable (`# BL-113-SEMGREP-OFFLINE`), so forcing a real run can never
+#     brick an offline operator.
+#   * `snyk`'s real-run path FAILs (not SKIPs) on an offline execution error, so
+#     forcing a real snyk run on an offline operator WOULD brick them.
+#   * `license` has no single binary (per-language tool); `threat-model` is
+#     pure-local and already runs under --offline.
+# The DRIVER-side carry-forward (defence 1) protects ALL FIVE scanners, so a
+# real FAIL from any of them is still never laundered.
+_cpg_phase3_scanner_tool() {
+  case "$1" in
+    semgrep-full-tree) echo "semgrep" ;;
+    *)                 echo "" ;;
+  esac
+}
+
+# _cpg_phase3_summary_offline <summary> — echo "yes"/"no": was this summary
+# produced by an --offline run (i.e. by the gate's own autorun)?
+_cpg_phase3_summary_offline() {
+  local v
+  v=$(grep -m1 '^- Offline:' "$1" 2>/dev/null | sed 's/^- Offline:[[:space:]]*//; s/[[:space:]]*$//' || true)
+  case "$v" in yes) echo "yes" ;; *) echo "no" ;; esac
+}
+
+# _cpg_phase3_carried_origin <summary> <scanner> — echo the origin summary of a
+# BL-113 carried-forward FAIL for <scanner>, or "".
+_cpg_phase3_carried_origin() {
+  awk -v s="$2" '$1=="CARRIED" && $2==s {v=$3} END{print v}' "$1" 2>/dev/null || true
+}
+
 # _cpg_phase3_attested <scanner>
 # 0 iff phase-state.json::phase3.attestations.<scanner> carries a non-empty
 # reason AND a non-empty sign-off. jq-absent → not-attested (conservative).
@@ -1433,15 +1503,36 @@ if [ "$current_phase" -ge 4 ]; then
   else
     p3_fail=0
     p3_unattested=0
+    p3_refused=0
     p3_detail=""
+    p3_summary_offline=$(_cpg_phase3_summary_offline "$p3_summary")
     for p3_scanner in semgrep-full-tree license snyk zap-dast threat-model; do
       p3_status=$(awk -v s="$p3_scanner" '$1=="RESULT" && $2==s {v=$3} END{print v}' "$p3_summary" 2>/dev/null || true)
       [ -n "$p3_status" ] || p3_status="MISSING"
       case "$p3_status" in
         PASS) ;;
         SKIP)
-          if _cpg_phase3_attested "$p3_scanner"; then
-            :   # attested-skip-with-signoff → acceptable
+          # BL-113-NO-LAUNDER (defence 2 — see the header block above). An
+          # offline-autorun SKIP for a scanner whose TOOL IS INSTALLED is not a
+          # result and is REFUSED, attested or not. `p3_refuse` is the whole
+          # decision: neutering the marked line below (marker intact) leaves it
+          # 0 forever, restores the laundering, and MUST turn
+          # tests/test-bl113-sast-honesty.sh::T-no-launder-dirty-tree RED.
+          # Both operands are pre-initialised on UNMARKED lines so the mutation
+          # stays syntactically valid and `set -u`-safe.
+          p3_tool=""
+          p3_refuse=0
+          p3_tool=$(_cpg_phase3_scanner_tool "$p3_scanner")
+          if [ -n "$p3_tool" ] && [ "$p3_summary_offline" = "yes" ] && command -v "$p3_tool" >/dev/null 2>&1; then
+            p3_refuse=1   # BL-113-NO-LAUNDER: locally-installed tool + offline autorun => the SKIP is not a result
+            :             # kept non-empty so excising the marked line above stays valid
+          fi
+          if [ "$p3_refuse" -eq 1 ]; then
+            p3_refused=$((p3_refused + 1))
+            p3_detail="${p3_detail}${p3_detail:+, }${p3_scanner}(offline-autorun SKIP REFUSED)"
+            echo -e "${RED}[FAIL]${NC} Phase 3→4: ${p3_scanner} — offline autorun SKIP REFUSED: the gate's own --offline autorun skipped it, but ${p3_tool} IS INSTALLED on this machine. An offline SKIP is not a clean bill of health and will NOT be accepted (attested or not). Run a REAL scan:  bash scripts/run-phase3-validation.sh   (no --offline)"
+          elif _cpg_phase3_attested "$p3_scanner"; then
+            :   # attested-skip-with-signoff → acceptable (honest no-tool/no-network SKIP)
           else
             p3_unattested=$((p3_unattested + 1))
             p3_detail="${p3_detail}${p3_detail:+, }${p3_scanner}(un-attested SKIP)"
@@ -1454,12 +1545,21 @@ if [ "$current_phase" -ge 4 ]; then
           # slip through as clean.
           p3_fail=$((p3_fail + 1))   # BL-070-FAIL-ARM: FAIL/MISSING status is gate-blocking (mutation target)
           p3_detail="${p3_detail}${p3_detail:+, }${p3_scanner}(${p3_status})"
+          # BL-113-NO-LAUNDER: if this FAIL is the driver's carry-forward of a
+          # prior REAL FAIL (defence 1), say so in words — the operator must
+          # know the scan they were about to attest away really ran and really
+          # failed, and that a FAIL is not attestable.
+          p3_carried_from=""
+          p3_carried_from=$(_cpg_phase3_carried_origin "$p3_summary" "$p3_scanner")   # BL-113-NO-LAUNDER
+          if [ -n "$p3_carried_from" ]; then
+            echo -e "${RED}[FAIL]${NC} Phase 3→4: ${p3_scanner} — [STALE — last real result: FAIL] (origin: ${p3_carried_from}). This scanner SKIPped in the latest run, but the last time it REALLY ran it FAILED, so the SKIP was refused rather than laundered. A FAIL is not attestable — fix the findings and re-run:  bash scripts/run-phase3-validation.sh   (no --offline)"
+          fi
           ;;
       esac
     done
-    if [ "$p3_fail" -gt 0 ] || [ "$p3_unattested" -gt 0 ]; then
+    if [ "$p3_fail" -gt 0 ] || [ "$p3_unattested" -gt 0 ] || [ "$p3_refused" -gt 0 ]; then
       p3_block=1
-      p3_msg="validation scans not clean: ${p3_fail} FAIL, ${p3_unattested} un-attested SKIP [${p3_detail}] — attest: bash scripts/run-phase3-validation.sh --attest <scanner> --reason \"...\", or install the tool and re-run"
+      p3_msg="validation scans not clean: ${p3_fail} FAIL, ${p3_unattested} un-attested SKIP, ${p3_refused} offline-autorun SKIP REFUSED (tool installed) [${p3_detail}] — attest: bash scripts/run-phase3-validation.sh --attest <scanner> --reason \"...\", or install the tool and re-run"
     else
       p3_ok_detail="all PASS or attested-skip; summary: $(basename "$p3_summary")"
     fi

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -60,8 +60,18 @@ version_gte() {
 
   if [ "$a" = "$b" ]; then return 0; fi
 
-  local IFS='.'
-  local -a av=($a) bv=($b)
+  # BL-113: split on '.' WITHOUT setting IFS for the whole function body.
+  # `local IFS='.'` is flagged by semgrep `bash.lang.security.ifs-tampering`
+  # (a function-scoped IFS still changes word-splitting for every unquoted
+  # expansion below it, including any command this function later calls), and
+  # a fresh scaffold must pass the framework's own Phase-3 SAST. The
+  # command-prefix form scopes IFS to the single `read` builtin — exactly the
+  # remediation the rule recommends (`IFS="," read -a my_array`). `read`
+  # returns 1 at EOF-without-delimiter, so `|| :` keeps `set -e` happy when a
+  # version string is empty.
+  local -a av=() bv=()
+  IFS='.' read -r -a av <<< "$a" || :
+  IFS='.' read -r -a bv <<< "$b" || :
   local max=${#av[@]}
   [ ${#bv[@]} -gt $max ] && max=${#bv[@]}
 

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -249,49 +249,49 @@ get_release_vars() {
   local lang="$1"
   case "$lang" in
     typescript|javascript)
-      RELEASE_SETUP_ACTION="actions/setup-node@v4"
+      RELEASE_SETUP_ACTION="actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)"
       RELEASE_SETUP_VERSION_KEY="node-version"
       RELEASE_SETUP_VERSION_VALUE="'lts/*'"
       RELEASE_INSTALL_COMMAND="npm ci"
       RELEASE_BUILD_COMMAND="npm run build"
       ;;
     python)
-      RELEASE_SETUP_ACTION="actions/setup-python@v5"
+      RELEASE_SETUP_ACTION="actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (v5.6.0)"
       RELEASE_SETUP_VERSION_KEY="python-version"
       RELEASE_SETUP_VERSION_VALUE="'3.x'"
       RELEASE_INSTALL_COMMAND="pip install -r requirements.txt"
       RELEASE_BUILD_COMMAND="python -m build"
       ;;
     rust)
-      RELEASE_SETUP_ACTION="dtolnay/rust-toolchain@stable"
+      RELEASE_SETUP_ACTION="dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch head 2026-06-30"
       RELEASE_SETUP_VERSION_KEY="toolchain"
       RELEASE_SETUP_VERSION_VALUE="stable"
       RELEASE_INSTALL_COMMAND="echo 'No separate install step for Rust'"
       RELEASE_BUILD_COMMAND="cargo build --release"
       ;;
     csharp)
-      RELEASE_SETUP_ACTION="actions/setup-dotnet@v4"
+      RELEASE_SETUP_ACTION="actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4 (v4.3.1)"
       RELEASE_SETUP_VERSION_KEY="dotnet-version"
       RELEASE_SETUP_VERSION_VALUE="'8.0.x'"
       RELEASE_INSTALL_COMMAND="dotnet restore"
       RELEASE_BUILD_COMMAND="dotnet build --configuration Release"
       ;;
     kotlin|java)
-      RELEASE_SETUP_ACTION="actions/setup-java@v4"
+      RELEASE_SETUP_ACTION="actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)"
       RELEASE_SETUP_VERSION_KEY="java-version"
       RELEASE_SETUP_VERSION_VALUE="'21'"
       RELEASE_INSTALL_COMMAND="echo 'Gradle handles dependencies automatically'"
       RELEASE_BUILD_COMMAND="./gradlew build"
       ;;
     go)
-      RELEASE_SETUP_ACTION="actions/setup-go@v5"
+      RELEASE_SETUP_ACTION="actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 (v5.6.0)"
       RELEASE_SETUP_VERSION_KEY="go-version"
       RELEASE_SETUP_VERSION_VALUE="'stable'"
       RELEASE_INSTALL_COMMAND="echo 'Go modules download automatically'"
       RELEASE_BUILD_COMMAND="go build ./..."
       ;;
     dart)
-      RELEASE_SETUP_ACTION="subosito/flutter-action@v2"
+      RELEASE_SETUP_ACTION="subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2 (v2.23.0)"
       RELEASE_SETUP_VERSION_KEY="channel"
       RELEASE_SETUP_VERSION_VALUE="'stable'"
       RELEASE_INSTALL_COMMAND="flutter pub get"
@@ -363,7 +363,9 @@ reconfigure() {
             local project_name
             project_name=$(jq -r '.project // "project"' .claude/phase-state.json 2>/dev/null)
             get_release_vars "$NEW_VALUE"
-            sed -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
+            # BL-113: strip the template-only marker comment before substitution
+            sed -e 's|[[:space:]]*#.*__SOLO_TEMPLATE_ONLY__[[:space:]]*$||' \
+                -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
                 -e "s|__SETUP_VERSION_KEY__|$RELEASE_SETUP_VERSION_KEY|g" \
                 -e "s|__SETUP_VERSION_VALUE__|$RELEASE_SETUP_VERSION_VALUE|g" \
                 -e "s|__INSTALL_COMMAND__|$RELEASE_INSTALL_COMMAND|g" \
@@ -411,7 +413,9 @@ reconfigure() {
         else
           get_release_vars "other"
         fi
-        sed -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
+        # BL-113: strip the template-only marker comment before substitution
+        sed -e 's|[[:space:]]*#.*__SOLO_TEMPLATE_ONLY__[[:space:]]*$||' \
+            -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
             -e "s|__SETUP_VERSION_KEY__|$RELEASE_SETUP_VERSION_KEY|g" \
             -e "s|__SETUP_VERSION_VALUE__|$RELEASE_SETUP_VERSION_VALUE|g" \
             -e "s|__INSTALL_COMMAND__|$RELEASE_INSTALL_COMMAND|g" \

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -301,6 +301,88 @@ _p3_actor() {
   fi
 }
 
+# ═══════════════════════════════════════════════════════════════════════
+# BL-113 — NO LAUNDERING: a real FAIL is never downgraded to a fresh SKIP.
+# ═══════════════════════════════════════════════════════════════════════
+# THE DEFECT (walk finding F15). The 3→4 gate autoruns THIS driver with
+# `--offline` whenever the working tree is dirty — the NORMAL state while the
+# operator is authoring Phase-3 artifacts. `--offline` SKIPs every tool-backed
+# scanner. So a scanner whose last REAL result was a FAIL (walk finding F14:
+# semgrep FAILed on a fresh scaffold) was silently rewritten to SKIP, the
+# operator attested the SKIP in good faith ("scanner unavailable"), and the
+# gate passed. A FAIL is NOT attestable; a SKIP is. The offline autorun was
+# the laundry.
+#
+# THE INVARIANT (marker `# BL-113-NO-LAUNDER`): a SKIP must never overwrite a
+# prior REAL verdict of FAIL. When a scanner SKIPs, this driver looks back at
+# the most recent summary that recorded a REAL (non-SKIP) verdict for that
+# scanner. If that verdict was FAIL, the SKIP is REFUSED: the status is
+# recorded as FAIL with a `[STALE - last real result: FAIL]` note plus a
+# machine-readable `CARRIED <scanner> <origin>` line, so the gate blocks and
+# the operator is told, in words, that the scan they are about to attest away
+# was really run and really failed.
+#
+# WHY NOT "just run semgrep under the offline autorun" (option (i))? VERIFIED
+# FALSE PREMISE: `semgrep --config auto` is NOT local-only. It hard-fetches its
+# ruleset from https://semgrep.dev/c/auto and has NO local cache fallback — with
+# the network blackholed it spends ~97s retrying, exits rc=2, and writes no
+# report. Running it from the gate's autorun would therefore (a) make the gate
+# non-hermetic and network-dependent, (b) add minutes to every dirty-tree gate
+# run, and (c) brick genuinely-offline operators. The autorun stays `--offline`;
+# the LAUNDERING is what dies, not the offline mode.
+#
+# OFFLINE MUST STAY USABLE. An honest "no tool / no network" SKIP remains
+# attestable (that is what makes the framework work on a plane). Two supports:
+#   * `_p3_scan_semgrep` now reports a registry-unreachable run as an honest
+#     SKIP rather than a FAIL (see `# BL-113-SEMGREP-OFFLINE`), so an operator
+#     with semgrep installed but no network can still produce a real, honest,
+#     attestable non-result by running the driver WITHOUT --offline.
+#   * The carry-forward below only fires when a REAL FAIL was actually observed.
+#
+# _p3_last_real_verdict <scanner> — echo "<PASS|FAIL> <origin-summary>" for the
+# most recent summary in RESULTS_DIR that recorded a REAL (non-SKIP) verdict for
+# <scanner>; echo "" when none exists. `CARRIED` provenance is preserved so the
+# origin of a carried FAIL does not drift forward each run. Never returns
+# non-zero (the verdict is the echoed string).
+_p3_last_real_verdict() {
+  local name="$1" f st origin
+  [ -d "$RESULTS_DIR" ] || { echo ""; return 0; }
+  for f in $(ls -1 "$RESULTS_DIR"/summary-*.md 2>/dev/null | sort -r); do
+    [ -f "$f" ] || continue
+    st=$(awk -v s="$name" '$1=="RESULT" && $2==s {v=$3} END{print v}' "$f" 2>/dev/null || true)
+    case "$st" in
+      PASS|FAIL)
+        origin=$(awk -v s="$name" '$1=="CARRIED" && $2==s {v=$3} END{print v}' "$f" 2>/dev/null || true)
+        [ -n "$origin" ] || origin=$(basename "$f")
+        echo "${st} ${origin}"
+        return 0
+        ;;
+    esac
+  done
+  echo ""
+  return 0
+}
+
+# _p3_no_launder <scanner> — THE load-bearing BL-113 decision. Reads the just-
+# computed P3_STATUS/P3_NOTE; if this run produced a SKIP but the scanner's most
+# recent REAL verdict was a FAIL, promotes the SKIP back to FAIL and records the
+# carry-forward origin in P3_CARRIED. Idempotent, and a no-op for PASS/FAIL.
+P3_CARRIED=""
+_p3_no_launder() {
+  local name="$1" lrv lrv_status lrv_origin
+  P3_CARRIED=""
+  [ "$P3_STATUS" = "SKIP" ] || return 0
+  lrv=$(_p3_last_real_verdict "$name")
+  [ -n "$lrv" ] || return 0
+  lrv_status="${lrv%% *}"
+  lrv_origin="${lrv#* }"
+  [ "$lrv_status" = "FAIL" ] || return 0
+  P3_CARRIED="$lrv_origin"
+  P3_STATUS="FAIL"
+  P3_NOTE="[STALE - last real result: FAIL] SKIP REFUSED (was: ${P3_NOTE}) - the last REAL run of this scanner (${lrv_origin}) FAILED; an offline/unavailable SKIP does not clear it. Re-run for a real verdict: bash scripts/run-phase3-validation.sh (no --offline)"
+  return 0
+}
+
 # _p3_is_attested <scanner>
 # Returns 0 iff phase-state.json::phase3.attestations.<scanner> carries a
 # non-empty reason AND a non-empty sign-off (the two-part attestation the
@@ -386,7 +468,17 @@ P3_STATUS=""; P3_NOTE=""; P3_ARCHIVE="-"
 _p3_scan_semgrep() {
   local archive="$1"
   if [ -n "$OFFLINE" ]; then
-    P3_STATUS="SKIP"; P3_NOTE="offline mode (--offline / SOLO_PHASE3_OFFLINE) — semgrep not run"
+    # BL-113: an offline SKIP must DISCLOSE whether the tool is sitting right
+    # there on PATH. "semgrep not run because the gate chose --offline, and
+    # semgrep IS installed" is a very different thing to attest than "semgrep
+    # is not available" — the gate refuses the former (# BL-113-NO-LAUNDER in
+    # check-phase-gate.sh) precisely because the operator cannot honestly sign
+    # "scanner unavailable" for a scanner that is installed.
+    if command -v semgrep >/dev/null 2>&1; then
+      P3_STATUS="SKIP"; P3_NOTE="offline mode (--offline / SOLO_PHASE3_OFFLINE) — semgrep not run, but semgrep IS INSTALLED locally: this SKIP is an artifact of the offline autorun, NOT a clean bill of health"
+    else
+      P3_STATUS="SKIP"; P3_NOTE="offline mode (--offline / SOLO_PHASE3_OFFLINE) — semgrep not run (semgrep is also not on PATH)"
+    fi
     return
   fi
   if ! command -v semgrep >/dev/null 2>&1; then
@@ -394,14 +486,31 @@ _p3_scan_semgrep() {
     return
   fi
   # REAL full-tree scan (distinct from pre-commit-gate.sh's staged-only scan).
-  local rc=0
-  semgrep --config auto --json --output "$archive" . >/dev/null 2>&1 || rc=$?
+  local rc=0 errlog
+  errlog=$(mktemp "${TMPDIR:-/tmp}/p3-semgrep-err-XXXXXX") || errlog="/dev/null"
+  semgrep --config auto --json --output "$archive" . >/dev/null 2>"$errlog" || rc=$?
   P3_ARCHIVE="$archive"
   # semgrep exit: 0 = clean, 1 = findings, >=2 = execution error.
   if [ "$rc" -ge 2 ] || [ ! -f "$archive" ]; then
+    # BL-113-SEMGREP-OFFLINE. `semgrep --config auto` is NOT local-only: it
+    # fetches its ruleset from semgrep.dev and has no local-cache fallback, so
+    # with no network it exits rc=2 having written NO report. Reporting that as
+    # a FAIL would BRICK a genuinely-offline operator (a FAIL is not
+    # attestable). A registry/network failure is an honest "could not look" —
+    # i.e. a SKIP, attestable with a reason + sign-off, exactly like an absent
+    # tool. A non-network execution error is still a real FAIL.
+    if grep -qiE 'semgrep\.dev|max retries|proxyerror|connectionerror|nameresolution|failed to establish a new connection|temporary failure in name resolution|network is unreachable|failed to resolve' "$errlog" 2>/dev/null; then
+      P3_STATUS="SKIP"
+      P3_NOTE="semgrep could not reach its rule registry (semgrep.dev) — rc=$rc, no report produced. \`--config auto\` requires network; this is a no-network SKIP, not a clean result"
+      P3_ARCHIVE="-"
+      rm -f "$errlog" 2>/dev/null || true
+      return
+    fi
     P3_STATUS="FAIL"; P3_NOTE="semgrep execution error (rc=$rc)"
+    rm -f "$errlog" 2>/dev/null || true
     return
   fi
+  rm -f "$errlog" 2>/dev/null || true
   local findings=0
   if command -v jq >/dev/null 2>&1; then
     findings=$(jq '(.results | length) // 0' "$archive" 2>/dev/null || echo 0)
@@ -1250,13 +1359,32 @@ echo -e "${BOLD}Phase 3 validation scans${NC}"
 
 # Accumulators.
 n_pass=0; n_skip_attested=0; n_skip_unattested=0; n_fail=0
+n_carried=0
 result_lines=""   # machine-readable "RESULT <name> <STATUS>" block
+carried_lines=""  # machine-readable "CARRIED <name> <origin-summary>" block
 table_rows=""     # human Markdown table body
 
 for s in $P3_SCANNERS; do
   _p3_run_scanner "$s" "$TS"
+
+  # BL-113-NO-LAUNDER — THE decision. A SKIP produced by this run must never
+  # overwrite a prior REAL FAIL for the same scanner (see the header block).
+  # Neutering the two marked lines below (marker intact) makes the promotion a
+  # no-op — a fresh attestable SKIP survives — and MUST turn
+  # tests/test-bl113-sast-honesty.sh::T-no-launder-dirty-tree RED.
+  # (`carried_origin` is pre-initialised on the UNMARKED line above so the
+  # mutation stays `set -u`-safe.)
+  carried_origin=""
+  _p3_no_launder "$s"                                     # BL-113-NO-LAUNDER
+  carried_origin="$P3_CARRIED"                            # BL-113-NO-LAUNDER
+
   status="$P3_STATUS"; note="$P3_NOTE"; archive="$P3_ARCHIVE"
   attested_col="-"
+  if [ -n "$carried_origin" ]; then
+    n_carried=$((n_carried + 1))
+    carried_lines="${carried_lines}CARRIED ${s} ${carried_origin}
+"
+  fi
 
   case "$status" in
     PASS)
@@ -1306,6 +1434,7 @@ fi
   echo "- Offline: $([ -n "$OFFLINE" ] && echo yes || echo no)"
   echo "- Scanners: $(echo $P3_SCANNERS | wc -w | tr -d ' ')"
   echo "- PASS: ${n_pass}  SKIP(attested): ${n_skip_attested}  SKIP(un-attested): ${n_skip_unattested}  FAIL: ${n_fail}"
+  echo "- SKIP-refused (BL-113 carry-forward of a prior REAL FAIL): ${n_carried}"
   echo "- Overall: ${overall}"
   echo ""
   echo "## Results"
@@ -1318,6 +1447,7 @@ fi
   echo ""
   echo '```'
   printf '%s' "$result_lines"
+  printf '%s' "$carried_lines"
   echo '```'
   echo ""
   echo "## Attest a skipped scanner"
@@ -1340,4 +1470,11 @@ fi
 echo -e "${YELLOW}[ACTION]${NC} $n_skip_unattested un-attested SKIP(s) / $n_fail FAIL(s) block Phase 3→4."
 echo "  Attest a skip:  bash scripts/run-phase3-validation.sh --attest <scanner> --reason \"...\""
 echo "  Or install the tool and re-run (drop --offline) to get a real result."
+if [ "$n_carried" -gt 0 ]; then
+  echo ""
+  echo -e "${RED}[BL-113]${NC} $n_carried scanner(s) SKIPped in this run but FAILED the last time they REALLY ran."
+  echo "  A real FAIL is NOT laundered into an attestable SKIP: those are recorded FAIL."
+  echo "  A FAIL is not attestable. Fix the findings, then re-run a REAL scan:"
+  echo "      bash scripts/run-phase3-validation.sh          (no --offline)"
+fi
 exit 1

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -2808,7 +2808,7 @@ For Rust the skip is *deliberate* (inline `#[cfg(test)]` tests cannot be detecte
 **Logged:** 2026-07-12 (E2E validation walk, findings F14 + F15)
 **Category:** Bug / security-gate credibility
 **Severity:** **High**
-**Status:** Open
+**Status:** Closed — fixed in PR #196 (2026-07-12)
 
 **F14 — a fresh scaffold cannot pass its own security scan.** A freshly-scaffolded organizational project fails `semgrep --config auto` with **6 WARNING findings, ALL in framework-shipped files** — 5 mutable action-tags in the generated `.github/workflows/ci.yml` + `release.yml`, and 1 IFS-tamper in `scripts/check-versions.sh` — and **ZERO in the app's own `src/`**. An honest operator cannot clear Phase 3 without editing framework-generated files, and a scanner **FAIL is not attestable — only a SKIP is**. The framework hands you a project that fails the framework's own gate.
 
@@ -2816,7 +2816,27 @@ For Rust the skip is *deliberate* (inline `#[cfg(test)]` tests cannot be detecte
 
 **Fix shape:** (1) fix the framework-shipped findings at source (pin action SHAs in the generated workflows; fix the `check-versions.sh` IFS pattern) so a fresh scaffold is scan-clean — the acceptance test is *"scaffold → semgrep → zero findings"*; (2) the offline autorun must **not** silently downgrade a scanner that was previously FAILing or that is locally available — either run it online-capable, or surface `[STALE — last real result: FAIL]` rather than a fresh attestable SKIP; (3) make a scanner FAIL **attestable-but-loud** rather than unattestable-and-therefore-laundered. TDD + mutation proofs; scaffold-fidelity test.
 
-**Related:** BL-070 (the five real scanners); BL-082 (the staleness binding whose autorun is the laundering vector); BL-112 (commit-time SAST is hollow too); `Reports/2026-07-12-e2e-walk/RESULTS.md` (F14, F15).
+### Resolution (PR #196, 2026-07-12)
+
+**F14 — a fresh scaffold is now scan-clean.** Measured on a REAL `init.sh` organizational scaffold with a REAL `semgrep --config auto`: **6 findings BEFORE → 0 findings AFTER.**
+- Every GitHub Action in the shipped pipeline templates — and in the framework's own workflows — is pinned to an **immutable 40-hex commit SHA** with a `# vN (vX.Y.Z)` provenance comment. SHAs were resolved through the GitHub API (tag ref → annotated-tag deref → commit) and each was verified to be a real commit; none was invented. The `__SETUP_ACTION__` substitution values in `init.sh` **and** `scripts/reconfigure-project.sh` (sync siblings) are pinned too, so the sed-rendered `release.yml` is pinned as well.
+- Two latent bugs fell out of the pin work: `realm/SwiftLint@v0.57.0` was a **phantom ref** (no such tag — the real tag is `0.57.0`, unprefixed), and `dtolnay/rust-toolchain` now passes `toolchain: stable` explicitly because a SHA pin no longer carries the toolchain in the ref name.
+- `check-versions.sh::version_gte` no longer sets a function-scoped `IFS`; it uses the command-prefix form (`IFS='.' read -r -a`) — the remediation semgrep's own rule recommends. **No suppression** was used for it.
+- The one genuine false positive (`uses: __SETUP_ACTION__` — a build-time placeholder, not an action ref) carries a `# nosemgrep` **with a why-comment in the template only**; it is **stripped at render time** (keyed on a `__SOLO_TEMPLATE_ONLY__` marker) so no suppression ever ships into a generated project. The framework repo itself now scans to **0 findings**.
+
+**F15 — the laundering is dead.** Marker `# BL-113-NO-LAUNDER`, two defences:
+1. **Driver carry-forward** (`run-phase3-validation.sh::_p3_no_launder`) — a SKIP never overwrites a prior **REAL FAIL**. The driver reads back the most recent summary carrying a real (non-SKIP) verdict for that scanner; if it was FAIL, the SKIP is **refused** and recorded as FAIL with a `[STALE - last real result: FAIL]` note plus a machine-readable `CARRIED <scanner> <origin>` line. Covers all five scanners.
+2. **Gate refusal** (`check-phase-gate.sh`) — an offline-autorun SKIP for a scanner whose **tool is on PATH** is refused outright, attested or not. Scoped to semgrep, deliberately: its real-run path now degrades to an honest attestable SKIP when the rule registry is unreachable, so forcing a real run can never brick an offline operator (snyk's path FAILs instead, so it is not in scope).
+
+**Option (i) — "just run semgrep under the offline autorun" — was tested and REJECTED on evidence.** `semgrep --config auto` is **not** local-only: it hard-fetches its ruleset from `semgrep.dev` with **no local-cache fallback**. With the network blackholed it spends ~97 s retrying, exits rc=2, and writes no report. Running it from the gate would make the gate non-hermetic, slow, and would brick genuinely-offline operators. The autorun therefore **stays `--offline`** — the laundering dies, not the offline mode.
+
+**The framework remains usable genuinely offline.** `_p3_scan_semgrep` now reports a registry-unreachable run as an honest **attestable SKIP** rather than a FAIL (`# BL-113-SEMGREP-OFFLINE`); a FAIL there would have bricked an offline operator, since a FAIL is not attestable. No tool + no prior real FAIL still yields an honest attestable SKIP and a passable gate — asserted by `T-offline-still-usable`.
+
+**Tests:** `tests/test-bl113-sast-honesty.sh` (AGGREGATOR — real `init.sh`; registered in `tests/full-project-test-suite.sh`, never in the `tests.yml` unit list) — 17/17. Both anti-laundering guards are additionally pinned as rows in `tests/test-bl099-guard-coverage.sh` (27/27 PINNED; that harness was generalised to a per-section mutation target + killing suite, leaving every existing row unchanged). Mutation proofs: neutering `# BL-113-NO-LAUNDER` (marker intact) reintroduces the laundering → RED; restore → GREEN. Un-pinning one action in a scratch scaffold → the scan goes RED.
+
+**Note (deferred, not in scope):** F14's remediation message is still a no-op for a scanner FAIL — a FAIL remains **non-attestable by design**, which is the correct security posture now that a fresh scaffold no longer produces one. Option (iii) (make a FAIL "attestable-but-loud") was deliberately **not** taken: an attestable FAIL is a laundering vector by another name.
+
+**Related:** BL-070 (the five real scanners); BL-082 (the staleness binding whose autorun is the laundering vector); BL-112 (commit-time SAST is hollow too — the `[BLOCKED]` branch is still dead, unrelated to this fix); `Reports/2026-07-12-e2e-walk/RESULTS.md` (F14, F15).
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -2808,7 +2808,7 @@ For Rust the skip is *deliberate* (inline `#[cfg(test)]` tests cannot be detecte
 **Logged:** 2026-07-12 (E2E validation walk, findings F14 + F15)
 **Category:** Bug / security-gate credibility
 **Severity:** **High**
-**Status:** Closed — fixed in PR #196 (2026-07-12)
+**Status:** Closed — fixed in PR #197 (2026-07-12)
 
 **F14 — a fresh scaffold cannot pass its own security scan.** A freshly-scaffolded organizational project fails `semgrep --config auto` with **6 WARNING findings, ALL in framework-shipped files** — 5 mutable action-tags in the generated `.github/workflows/ci.yml` + `release.yml`, and 1 IFS-tamper in `scripts/check-versions.sh` — and **ZERO in the app's own `src/`**. An honest operator cannot clear Phase 3 without editing framework-generated files, and a scanner **FAIL is not attestable — only a SKIP is**. The framework hands you a project that fails the framework's own gate.
 
@@ -2816,7 +2816,7 @@ For Rust the skip is *deliberate* (inline `#[cfg(test)]` tests cannot be detecte
 
 **Fix shape:** (1) fix the framework-shipped findings at source (pin action SHAs in the generated workflows; fix the `check-versions.sh` IFS pattern) so a fresh scaffold is scan-clean — the acceptance test is *"scaffold → semgrep → zero findings"*; (2) the offline autorun must **not** silently downgrade a scanner that was previously FAILing or that is locally available — either run it online-capable, or surface `[STALE — last real result: FAIL]` rather than a fresh attestable SKIP; (3) make a scanner FAIL **attestable-but-loud** rather than unattestable-and-therefore-laundered. TDD + mutation proofs; scaffold-fidelity test.
 
-### Resolution (PR #196, 2026-07-12)
+### Resolution (PR #197, 2026-07-12)
 
 **F14 — a fresh scaffold is now scan-clean.** Measured on a REAL `init.sh` organizational scaffold with a REAL `semgrep --config auto`: **6 findings BEFORE → 0 findings AFTER.**
 - Every GitHub Action in the shipped pipeline templates — and in the framework's own workflows — is pinned to an **immutable 40-hex commit SHA** with a `# vN (vX.Y.Z)` provenance comment. SHAs were resolved through the GitHub API (tag ref → annotated-tag deref → commit) and each was verified to be a real commit; none was invented. The `__SETUP_ACTION__` substitution values in `init.sh` **and** `scripts/reconfigure-project.sh` (sync siblings) are pinned too, so the sed-rendered `release.yml` is pinned as well.

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-dotnet@v4
+      - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4 (v4.3.1)
         with:
           # Current LTS — update when next LTS releases
           dotnet-version: '8.0.x'

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: subosito/flutter-action@v2
+      - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2 (v2.23.0)
         with:
           channel: 'stable'
 

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 (v5.6.0)
         with:
           go-version: 'stable'
 
@@ -25,7 +25,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@55c2c1448f86e01eaae002a5a3a9624417608d84 # v6 (v6.5.2)
         with:
           version: latest
 

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
         with:
           distribution: 'temurin'
           # Current LTS — update when next LTS releases

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
         with:
           distribution: 'temurin'
           # Current LTS — update when next LTS releases

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       # TODO: Add language/runtime setup step
-      # Example: actions/setup-node@v4, actions/setup-python@v5,
-      #   actions/setup-dotnet@v4, actions/setup-java@v4, actions/setup-go@v5
+      # Example: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0), actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (v5.6.0),
+      #   actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4 (v4.3.1), actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0), actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 (v5.6.0)
 
       # TODO: Install dependencies
       # - name: Install dependencies

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (v5.6.0)
         with:
           python-version: '3.x'
 

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -12,9 +12,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: dtolnay/rust-toolchain@stable
+      # SHA-pinned (BL-113): the ref name no longer selects the toolchain, so
+      # the toolchain is now passed explicitly.
+      - uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable branch head 2026-06-30
+        with:
+          toolchain: stable
 
       - name: Build
         run: cargo build --release

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
@@ -33,7 +33,7 @@ jobs:
         run: swift test
 
       - name: Lint (SwiftLint)
-        uses: realm/SwiftLint@v0.57.0
+        uses: realm/SwiftLint@168fb98ed1f3e343d703ecceaf518b6cf565207b # 0.57.0
         with:
           strict: true
 

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)
         with:
           node-version: 'lts/*'
           cache: 'npm'

--- a/templates/pipelines/release/github/desktop.yml
+++ b/templates/pipelines/release/github/desktop.yml
@@ -27,9 +27,9 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: __SETUP_ACTION__
+      - uses: __SETUP_ACTION__ # nosemgrep -- the value here is a build-time PLACEHOLDER token, not an action ref: init.sh substitutes a SHA-pinned action (BL-113). This entire trailing comment is STRIPPED when the template is rendered, so NO suppression ever ships into a generated project. __SOLO_TEMPLATE_ONLY__
         with:
           __SETUP_VERSION_KEY__: __SETUP_VERSION_VALUE__
 
@@ -61,7 +61,7 @@ jobs:
         #     Import key and sign artifacts with gpg --detach-sign.
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
         with:
           name: release-${{ matrix.os }}
           path: dist/*
@@ -75,7 +75,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 (v4.3.0)
 
       - name: Generate checksums
         run: sha256sum release-*/* > checksums.sha256
@@ -102,7 +102,7 @@ jobs:
       #       -J zap-report.json
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
         with:
           files: |
             release-*/*

--- a/templates/pipelines/release/github/mcp_server.yml
+++ b/templates/pipelines/release/github/mcp_server.yml
@@ -22,9 +22,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)
         with:
           node-version: 'lts/*'
           cache: 'npm'
@@ -69,7 +69,7 @@ jobs:
         #   docker push ghcr.io/${{ github.repository }}:latest
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
         with:
           generate_release_notes: true
           files: sbom.json

--- a/templates/pipelines/release/github/mobile.yml
+++ b/templates/pipelines/release/github/mobile.yml
@@ -46,9 +46,9 @@ permissions:
 #     runs-on: ubuntu-latest
 #
 #     steps:
-#       - uses: actions/checkout@v4
+#       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 #
-#       - uses: actions/setup-node@v4
+#       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)
 #         with:
 #           node-version: '20'
 #
@@ -56,7 +56,7 @@ permissions:
 #         run: npm ci
 #
 #       - name: Setup Expo
-#         uses: expo/expo-github-action@v8
+#         uses: expo/expo-github-action@c7b66a9c327a43a8fa7c0158e7f30d6040d2481e # v8 (8.2.1)
 #         with:
 #           eas-version: latest
 #           token: ${{ secrets.EXPO_TOKEN }}
@@ -72,7 +72,7 @@ permissions:
 #         #            Upload google-service-account.json as a repo secret or EAS secret.
 #
 #       - name: Create GitHub Release
-#         uses: softprops/action-gh-release@v2
+#         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
 #         with:
 #           generate_release_notes: true
 
@@ -86,14 +86,14 @@ permissions:
 #     runs-on: ubuntu-latest
 #
 #     steps:
-#       - uses: actions/checkout@v4
+#       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 #
-#       - uses: actions/setup-java@v4
+#       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
 #         with:
 #           distribution: temurin
 #           java-version: '17'
 #
-#       - uses: subosito/flutter-action@v2
+#       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2 (v2.23.0)
 #         with:
 #           channel: stable
 #
@@ -114,7 +114,7 @@ permissions:
 #         # prior step). Flutter does not consume keystore env vars automatically.
 #
 #       - name: Upload Android artifact
-#         uses: actions/upload-artifact@v4
+#         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
 #         with:
 #           name: __PROJECT_NAME__-android
 #           path: build/app/outputs/bundle/release/*.aab
@@ -123,9 +123,9 @@ permissions:
 #     runs-on: macos-latest
 #
 #     steps:
-#       - uses: actions/checkout@v4
+#       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 #
-#       - uses: subosito/flutter-action@v2
+#       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2 (v2.23.0)
 #         with:
 #           channel: stable
 #
@@ -141,7 +141,7 @@ permissions:
 #         #   3. Install the provisioning profile on the runner.
 #
 #       - name: Upload iOS artifact
-#         uses: actions/upload-artifact@v4
+#         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
 #         with:
 #           name: __PROJECT_NAME__-ios
 #           path: build/ios/ipa/*.ipa
@@ -151,10 +151,10 @@ permissions:
 #     runs-on: ubuntu-latest
 #
 #     steps:
-#       - uses: actions/download-artifact@v4
+#       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4 (v4.3.0)
 #
 #       - name: Create GitHub Release
-#         uses: softprops/action-gh-release@v2
+#         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
 #         with:
 #           files: |
 #             __PROJECT_NAME__-android/*
@@ -176,9 +176,9 @@ permissions:
 #     runs-on: ubuntu-latest
 #
 #     steps:
-#       - uses: actions/checkout@v4
+#       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 #
-#       - uses: actions/setup-java@v4
+#       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
 #         with:
 #           distribution: temurin
 #           java-version: '17'
@@ -194,13 +194,13 @@ permissions:
 #           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
 #
 #       - name: Upload artifact
-#         uses: actions/upload-artifact@v4
+#         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
 #         with:
 #           name: __PROJECT_NAME__-android
 #           path: app/build/outputs/bundle/release/*.aab
 #
 #       - name: Create GitHub Release
-#         uses: softprops/action-gh-release@v2
+#         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
 #         with:
 #           files: app/build/outputs/bundle/release/*.aab
 #           generate_release_notes: true
@@ -220,7 +220,7 @@ permissions:
 #     runs-on: macos-latest
 #
 #     steps:
-#       - uses: actions/checkout@v4
+#       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 #
 #       - name: Select Xcode version
 #         run: sudo xcode-select -s /Applications/Xcode_16.0.app/Contents/Developer
@@ -300,13 +300,13 @@ permissions:
 #         #   </plist>
 #
 #       - name: Upload IPA artifact
-#         uses: actions/upload-artifact@v4
+#         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4 (v4.6.2)
 #         with:
 #           name: __PROJECT_NAME__-ios
 #           path: ${{ runner.temp }}/output/*.ipa
 #
 #       - name: Create GitHub Release
-#         uses: softprops/action-gh-release@v2
+#         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
 #         with:
 #           files: ${{ runner.temp }}/output/*.ipa
 #           generate_release_notes: true

--- a/templates/pipelines/release/github/web.yml
+++ b/templates/pipelines/release/github/web.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
 
-      - uses: __SETUP_ACTION__
+      - uses: __SETUP_ACTION__ # nosemgrep -- the value here is a build-time PLACEHOLDER token, not an action ref: init.sh substitutes a SHA-pinned action (BL-113). This entire trailing comment is STRIPPED when the template is rendered, so NO suppression ever ships into a generated project. __SOLO_TEMPLATE_ONLY__
         with:
           __SETUP_VERSION_KEY__: __SETUP_VERSION_VALUE__
 
@@ -56,7 +56,7 @@ jobs:
           zap-baseline.py -t ${{ vars.PREVIEW_URL }}
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2 (v2.6.2)
         with:
           generate_release_notes: true
           files: sbom.json

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -589,6 +589,23 @@ else
 fi
 fi
 
+# BL-113 (SAST honesty — walk findings F14 + F15). test-bl113-sast-honesty.sh is a
+# BL-088-precedent AGGREGATOR: it runs the REAL init.sh and proves (F14) a fresh
+# scaffold scans CLEAN under the framework's own `semgrep --config auto`, and (F15)
+# the 3→4 gate's dirty-tree offline autorun no longer launders a REAL scanner FAIL
+# into an attestable SKIP — while a genuinely-offline project stays passable. It is
+# SUITE_SKIP_AGGREGATORS-gated (a real scaffold + a real semgrep run is heavy) and is
+# NEVER in the tests.yml unit list (it executes init.sh).
+if [ "${SUITE_SKIP_AGGREGATORS:-0}" = "1" ]; then
+  section "BL-113 SAST honesty — SKIPPED (SUITE_SKIP_AGGREGATORS=1; a real init.sh scaffold + semgrep, runs standalone / full-suite)"
+else
+if bash "$SCRIPT_DIR/tests/test-bl113-sast-honesty.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl113-sast-honesty.sh"
+else
+  fail "tests/test-bl113-sast-honesty.sh FAILED (run for details)"
+fi
+fi
+
 # Agent-ergonomics onboarding: tests/test-run-lints.sh — behavior suite for
 # scripts/run-lints.sh, the canonical local lint runner (runs every
 # scripts/lint-*.sh EXCEPT the parametrized lint-uat-scenarios.sh). Its

--- a/tests/test-bl099-guard-coverage.sh
+++ b/tests/test-bl099-guard-coverage.sh
@@ -78,8 +78,22 @@ MUT="$MUTANT_TREE/scripts/upgrade-project.sh"
 cleanup() { rm -rf "$ROOT_TMP" 2>/dev/null || true; }
 trap cleanup EXIT
 
+# ── THE PER-SECTION TARGET (BL-113, 2026-07-12) ────────────────────────────────
+# The registry originally pinned exactly one script (upgrade-project.sh) with one
+# killing suite. The BL-113 anti-laundering guards live in DIFFERENT scripts and
+# are killed by a DIFFERENT suite, so three knobs are now section-scoped:
+#   PRISTINE      the real script a row mutates (the neuter primitives all edit $MUT)
+#   MUT           its copy inside $MUTANT_TREE
+#   GUARD_RUNNER  the function that runs the named killing test against $MUTANT_TREE
+# Every existing row keeps the BL-099 defaults below — nothing about them changes.
+GUARD_RUNNER=_run_killing
+
 # Reset the mutant script to pristine (cp preserves the +x mode).
 _reset_mutant() { cp "$PRISTINE" "$MUT"; chmod +x "$MUT"; }
+
+# Point the registry at a different script + killing suite for the rows that follow.
+# use_target <pristine-path> <mutant-path> <runner-fn>
+use_target() { PRISTINE="$1"; MUT="$2"; GUARD_RUNNER="$3"; }
 
 # ── NEUTER PRIMITIVES ───────────────────────────────────────────────────────────
 # Each rewrites $MUT in place, chmods +x (mv from mktemp drops the exec bit — the
@@ -161,6 +175,31 @@ _neu_modepreserve() {
   mv "$tmp" "$MUT"; chmod +x "$MUT"
 }
 
+# Neuter EVERY CODE line carrying literal <marker> to `: # <marker> (NEUTERED)` —
+# the marker survives (rule 4) and the decision body is gone. Comment-only lines
+# are left intact. Non-zero unless it hit at least once. This is the primitive for
+# guards whose decision is spread over more than one marked statement (BL-113).
+_neu_markerline() {
+  local marker="$1" tmp; tmp="$(mktemp)"
+  awk -v marker="$marker" '
+    {
+      line=$0
+      # leading-whitespace-only-then-# => a comment line; never neuter it.
+      s=line; sub(/^[ \t]+/, "", s)
+      if (substr(s,1,1)=="#") { print line; next }
+      if (index(line, marker)>0) {
+        n=match(line, /^[ \t]*/); ind=substr(line, 1, RLENGTH)
+        print ind ": # " marker " (NEUTERED)"
+        c++
+        next
+      }
+      print line
+    }
+    END { if(c<1) exit 3 }
+  ' "$MUT" > "$tmp" || { rm -f "$tmp"; return 1; }
+  mv "$tmp" "$MUT"; chmod +x "$MUT"
+}
+
 _apply_neuter() {
   local kind="$1" a1="$2" a2="$3"
   case "$kind" in
@@ -168,6 +207,7 @@ _apply_neuter() {
     fnbody)       _neu_fnbody "$a1" "$a2" ;;
     subline)      _neu_subline "$a1" "$a2" ;;
     delline)      _neu_delline "$a1" ;;
+    markerline)   _neu_markerline "$a1" ;;
     modepreserve) _neu_modepreserve ;;
     *) return 2 ;;
   esac
@@ -178,6 +218,15 @@ _apply_neuter() {
 # FAILED, because BL099_ONLY runs only those tests).
 _run_killing() {
   BL099_REPO_OVERRIDE="$MUTANT_TREE" BL099_ONLY="$1" bash "$SUITE" 2>&1
+}
+
+# BL-113 runner: drive tests/test-bl113-sast-honesty.sh against the mutant tree's
+# scripts/. The suite scaffolds a real project with the REAL init.sh and then swaps
+# in the (possibly neutered) scripts via BL113_SCRIPTS_OVERRIDE; BL113_ONLY narrows
+# it to the anti-laundering arms so each row costs two scaffolds, not six.
+_run_killing_bl113() {
+  BL113_SCRIPTS_OVERRIDE="$MUTANT_TREE/scripts" BL113_ONLY="$1" \
+    bash "$REPO_ROOT/tests/test-bl113-sast-honesty.sh" 2>&1
 }
 
 # ── THE REGISTRY PIPELINE ────────────────────────────────────────────────────────
@@ -202,7 +251,7 @@ check_guard() {
     fail_ "$name" "the mutant has a bash syntax error — a syntax-broken mutant proves nothing (kind=$kind)"
     GUARD_ROWS="${GUARD_ROWS}SYNTAX\t${name}\t${tests}\n"; _reset_mutant; return
   fi
-  local mout mrc=0; mout=$(_run_killing "$tests") || mrc=$?
+  local mout mrc=0; mout=$("$GUARD_RUNNER" "$tests") || mrc=$?
   if echo "$mout" | grep -qF "running as root"; then
     _reset_mutant
     skip_ "$name" "killing test [$tests] short-circuits under root (mode bits do not restrict root) — cannot pin here on this host"
@@ -215,7 +264,7 @@ check_guard() {
   fi
   # RED confirmed. Restore and prove GREEN so the RED is attributable to the neuter.
   _reset_mutant
-  local gout grc=0; gout=$(_run_killing "$tests") || grc=$?
+  local gout grc=0; gout=$("$GUARD_RUNNER" "$tests") || grc=$?
   if [ "$grc" != "0" ]; then
     fail_ "$name" "killing test [$tests] FAILS even against the RESTORED pristine script — the RED was not caused by the neuter (environment/flake?).\nrestored PASS/FAIL lines:\n$(echo "$gout" | grep -E '\[PASS\]|\[FAIL\]' | head -4)"
     GUARD_ROWS="${GUARD_ROWS}FLAKY\t${name}\t${tests}\n"; return
@@ -279,6 +328,30 @@ check_guard "mode/hook-refresh-preservation" "-" t_hook_mode_preserved modeprese
 
 # ── (J) THE INTERACTIVE APPLY-PROMPT FALLBACK (# BL-099-PROMPT-FALLBACK, BLOCK-2) ──
 check_guard "prompt/apply-fallback-is-skip" "# BL-099-PROMPT-FALLBACK" t_doc_prompt_default_is_skip subline '|| action="skip"  # BL-099-PROMPT-FALLBACK' '|| action="overwrite"  # BL-099-PROMPT-FALLBACK'
+
+# ══════════════════════════════════════════════════════════════════════════════════
+# (K) BL-113 — THE ANTI-LAUNDERING GUARDS (a different pair of scripts, a different
+#     killing suite; same anti-cheat contract). Walk findings F14 + F15: the 3→4
+#     gate's dirty-tree autorun ran the validation driver with `--offline`, which
+#     rewrote a REAL semgrep FAIL into an attestable SKIP. Two defences, both
+#     marked `# BL-113-NO-LAUNDER`, both pinned here:
+#       driver — a SKIP never overwrites a prior REAL FAIL (carry-forward)
+#       gate   — an offline-autorun SKIP for an INSTALLED tool is refused outright
+#     The killing test is tests/test-bl113-sast-honesty.sh::T-no-launder-dirty-tree
+#     (driven with BL113_ONLY=no-launder). Neutering EITHER marked decision must
+#     turn it RED; restoring must turn it GREEN.
+# ══════════════════════════════════════════════════════════════════════════════════
+use_target "$REPO_ROOT/scripts/run-phase3-validation.sh" \
+           "$MUTANT_TREE/scripts/run-phase3-validation.sh" _run_killing_bl113
+check_guard "bl113/driver-carry-forward" "# BL-113-NO-LAUNDER" no-launder markerline '# BL-113-NO-LAUNDER'
+
+use_target "$REPO_ROOT/scripts/check-phase-gate.sh" \
+           "$MUTANT_TREE/scripts/check-phase-gate.sh" _run_killing_bl113
+check_guard "bl113/gate-refuses-offline-skip" "# BL-113-NO-LAUNDER" no-launder markerline '# BL-113-NO-LAUNDER'
+
+# Restore the BL-099 target for anything appended after this point.
+use_target "$REPO_ROOT/scripts/upgrade-project.sh" \
+           "$MUTANT_TREE/scripts/upgrade-project.sh" _run_killing
 
 echo ""
 echo "── Guard-coverage registry (STATUS  guard  killing-test) ──"

--- a/tests/test-bl113-sast-honesty.sh
+++ b/tests/test-bl113-sast-honesty.sh
@@ -1,0 +1,524 @@
+#!/usr/bin/env bash
+# tests/test-bl113-sast-honesty.sh — BL-113 AGGREGATOR (walk findings F14 + F15).
+#
+# TWO defects, one credibility story:
+#
+#   F14 — a freshly-scaffolded project FAILED the framework's OWN Phase-3 SAST.
+#         `semgrep --config auto` flagged 6 WARNINGs, ALL in framework-shipped
+#         files (5 mutable GitHub-Action tags in the generated
+#         .github/workflows/{ci,release}.yml + 1 IFS-tamper in
+#         scripts/check-versions.sh) and ZERO in the app's own src/. A scanner
+#         FAIL is NOT attestable (only a SKIP is) — so an honest operator could
+#         not clear Phase 3 without editing framework-generated files.
+#
+#   F15 — and the gate then LAUNDERED that FAIL. Whenever the tree is dirty (the
+#         NORMAL state while authoring Phase-3 artifacts) the 3→4 gate's BL-082
+#         staleness check autoruns the driver with `--offline`, which downgraded
+#         semgrep/license/snyk/zap to SKIP. The operator saw "scanner
+#         unavailable", attested the SKIP in good faith, and passed — never
+#         learning that a REAL scan FAILs.
+#
+# WHAT THIS PROVES
+#   T-scaffold-scan-clean   REAL init.sh scaffold → REAL `semgrep --config auto`
+#                           → ZERO framework-origin findings. (SKIPs loudly if
+#                           semgrep is not installed.)
+#   T-no-launder-dirty-tree A dirty tree + a prior REAL semgrep FAIL → the 3→4
+#                           gate does NOT present a fresh attestable SKIP. Both
+#                           BL-113 defences are asserted on the operator-visible
+#                           wording. Hermetic: needs no semgrep binary (the
+#                           carry-forward arm) and uses a PATH stub (the
+#                           tool-installed refusal arm).
+#   T-offline-still-usable  Genuinely no tool + no prior real FAIL → an honest
+#                           attestable SKIP, and the gate's Phase-3 validation
+#                           arm still passes. The framework MUST work offline.
+#   T-mutation-no-launder   Neuter the `# BL-113-NO-LAUNDER` decision bodies
+#                           (marker intact) → T-no-launder goes RED; restore →
+#                           GREEN.
+#   T-mutation-action-pin   Revert ONE action pin to a mutable tag in a scratch
+#                           scaffold → T-scaffold-scan-clean goes RED.
+#
+# AGGREGATOR: runs the REAL init.sh, so it is registered ONLY in
+# tests/full-project-test-suite.sh (SUITE_SKIP_AGGREGATORS-gated) and NEVER in
+# the tests.yml unit fast lane.
+#
+# Hermetic: mktemp scratch, --no-remote-creation, GITHUB_BASE_REF unset, local
+# git identity in every fixture repo. bash-3.2 safe (no ${var,,}, no declare -A,
+# no ((x++)) under set -e).
+
+# HARNESS HOOKS (used ONLY by tests/test-bl099-guard-coverage.sh; a bare run of
+# this file ignores both):
+#   BL113_SCRIPTS_OVERRIDE=<dir>  after scaffolding, replace the scaffold's copies
+#                                 of run-phase3-validation.sh + check-phase-gate.sh
+#                                 with the ones in <dir>, so the guard harness can
+#                                 drive this suite against a NEUTERED script.
+#   BL113_ONLY=no-launder         run only the F15 anti-laundering arms (skip the
+#                                 semgrep scaffold scan and the in-file mutation
+#                                 arms) — keeps the harness's 2-runs-per-row cost
+#                                 down and pins the assertion to the guard.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+DRIVER_SRC="$REPO_ROOT/scripts/run-phase3-validation.sh"
+GATE_SRC="$REPO_ROOT/scripts/check-phase-gate.sh"
+BL113_ONLY="${BL113_ONLY:-}"
+BL113_SCRIPTS_OVERRIDE="${BL113_SCRIPTS_OVERRIDE:-}"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+note()  { echo "  [NOTE] $1"; }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+if ! command -v jq >/dev/null 2>&1 || ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: jq/git required for the BL-113 SAST-honesty aggregator"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Shared fixture: ONE real organizational scaffold via the REAL init.sh.
+# ════════════════════════════════════════════════════════════════════════════
+SCAFFOLD="$TOPTMP/proj"
+echo "=== Scaffolding an organizational project via the REAL init.sh (hermetic) ==="
+if ! ( cd "$TOPTMP" && "$INIT" --non-interactive \
+        --project bl113sast \
+        --platform web \
+        --deployment organizational \
+        --gov-mode production \
+        --language typescript \
+        --project-dir "$SCAFFOLD" \
+        --no-remote-creation ) >"$TOPTMP/init.out" 2>"$TOPTMP/init.err"; then
+  fail_ "scaffold-init" "init.sh exited non-zero; stderr tail: $(tail -6 "$TOPTMP/init.err" | tr '\n' '|')"
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+pass "real init.sh scaffolded an organizational project"
+
+# Guard-harness override: swap the scaffold's copies of the two BL-113 scripts for
+# the (possibly NEUTERED) ones the harness points at. Applied to the shared
+# scaffold so every derived fixture below inherits it.
+if [ -n "$BL113_SCRIPTS_OVERRIDE" ]; then
+  for _ovr in run-phase3-validation.sh check-phase-gate.sh; do
+    if [ -f "$BL113_SCRIPTS_OVERRIDE/$_ovr" ]; then
+      cp "$BL113_SCRIPTS_OVERRIDE/$_ovr" "$SCAFFOLD/scripts/$_ovr"
+      chmod +x "$SCAFFOLD/scripts/$_ovr"
+    fi
+  done
+  echo "  [HOOK] scaffold scripts overridden from $BL113_SCRIPTS_OVERRIDE"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# T-scaffold-scan-clean (F14) — a fresh scaffold must PASS the framework's own
+# SAST. Zero findings of framework origin. This is the acceptance criterion.
+# ════════════════════════════════════════════════════════════════════════════
+if [ "$BL113_ONLY" = "no-launder" ]; then
+  echo "=== T-scaffold-scan-clean / T-mutation-action-pin — SKIPPED (BL113_ONLY=no-launder) ==="
+else
+echo "=== T-scaffold-scan-clean: REAL semgrep --config auto on the fresh scaffold ==="
+SEMGREP_AVAILABLE=0
+if command -v semgrep >/dev/null 2>&1; then
+  SEMGREP_AVAILABLE=1
+fi
+
+# scan_scaffold <dir> <out.json> — echo the finding count (or "ERR").
+scan_scaffold() {
+  local dir="$1" out="$2" rc=0
+  ( cd "$dir" && semgrep --config auto --json --output "$out" . ) >/dev/null 2>&1 || rc=$?
+  if [ "$rc" -ge 2 ] || [ ! -f "$out" ]; then echo "ERR"; return 0; fi
+  jq -r '(.results | length) // 0' "$out" 2>/dev/null || echo "ERR"
+}
+
+if [ "$SEMGREP_AVAILABLE" -eq 0 ]; then
+  # SKIP CLEANLY AND LOUDLY — never silently green. The acceptance criterion is
+  # unverifiable without the tool, and pretending otherwise is the exact class of
+  # dishonesty BL-113 exists to kill.
+  echo ""
+  echo "  ############################################################"
+  echo "  # [SKIP-LOUD] T-scaffold-scan-clean + T-mutation-action-pin"
+  echo "  # semgrep is NOT installed on this host."
+  echo "  # The BL-113 F14 acceptance criterion (fresh scaffold →"
+  echo "  # semgrep --config auto → ZERO framework-origin findings)"
+  echo "  # CANNOT be verified here. This is NOT a pass."
+  echo "  # Install semgrep (brew install semgrep) and re-run."
+  echo "  ############################################################"
+  echo ""
+  note "T-scaffold-scan-clean SKIPPED (semgrep absent) — not counted as a pass"
+  note "T-mutation-action-pin SKIPPED (semgrep absent) — not counted as a pass"
+else
+  count="$(scan_scaffold "$SCAFFOLD" "$TOPTMP/scan-clean.json")"
+  if [ "$count" = "0" ]; then
+    pass "T-scaffold-scan-clean: fresh scaffold has ZERO semgrep findings (real --config auto)"
+  elif [ "$count" = "ERR" ]; then
+    # A registry/network failure is not a test failure — but it is not a pass.
+    note "T-scaffold-scan-clean INCONCLUSIVE: semgrep could not complete (rule registry unreachable?) — not counted"
+  else
+    fail_ "T-scaffold-scan-clean" "fresh scaffold has $count semgrep finding(s): $(jq -r '[.results[] | "\(.check_id)@\(.path):\(.start.line)"] | join(", ")' "$TOPTMP/scan-clean.json" 2>/dev/null)"
+  fi
+
+  # — the two F14 classes, asserted structurally as well (cheap, tool-free) —
+  mutable=0
+  for wf in "$SCAFFOLD/.github/workflows/ci.yml" "$SCAFFOLD/.github/workflows/release.yml"; do
+    [ -f "$wf" ] || continue
+    while IFS= read -r line; do
+      case "$line" in
+        *"uses:"*"@"*) ;;
+        *) continue ;;
+      esac
+      # Anything after the `@` that is not a 40-hex commit SHA is a mutable ref.
+      ref="${line#*@}"
+      ref="${ref%% *}"
+      if ! printf '%s' "$ref" | grep -qE '^[0-9a-f]{40}$'; then
+        mutable=$((mutable + 1))
+        echo "    mutable action ref in $(basename "$wf"): $line"
+      fi
+    done < "$wf"
+  done
+  if [ "$mutable" -eq 0 ]; then
+    pass "T-scaffold-scan-clean: every generated-workflow action ref is a 40-hex commit SHA"
+  else
+    fail_ "T-scaffold-scan-clean action pins" "$mutable mutable action ref(s) in the generated workflows"
+  fi
+
+  # — NO SUPPRESSION MAY SHIP. The two release TEMPLATES carry a `# nosemgrep` on
+  #   the `uses: __SETUP_ACTION__` placeholder line (the token is a build-time
+  #   placeholder, not an action ref — a genuine false positive). That comment is
+  #   STRIPPED at render time, keyed on the `__SOLO_TEMPLATE_ONLY__` marker. If it
+  #   ever leaked, every generated project would silently suppress the
+  #   mutable-action-tag rule on its own setup step — laundering-by-suppression,
+  #   the very thing this PR exists to prevent. Assert it never reaches a scaffold.
+  leak=0
+  for wf in "$SCAFFOLD/.github/workflows/"*.yml; do
+    [ -f "$wf" ] || continue
+    if grep -qE 'nosemgrep|__SOLO_TEMPLATE_ONLY__|__SETUP_ACTION__' "$wf"; then
+      leak=$((leak + 1))
+      echo "    suppression/placeholder leaked into $(basename "$wf")"
+    fi
+  done
+  if [ "$leak" -eq 0 ]; then
+    pass "T-scaffold-scan-clean: no scanner suppression and no unsubstituted placeholder reaches the generated workflows"
+  else
+    fail_ "T-scaffold-scan-clean suppression leak" "$leak generated workflow(s) carry a nosemgrep suppression or an unsubstituted placeholder token"
+  fi
+
+  # ══════════════════════════════════════════════════════════════════════════
+  # T-mutation-action-pin — revert ONE action pin to a mutable tag in a SCRATCH
+  # copy of the real scaffold. T-scaffold-scan-clean must go RED.
+  # ══════════════════════════════════════════════════════════════════════════
+  echo "=== T-mutation-action-pin: un-pin actions/checkout in a scratch scaffold ==="
+  MUT="$TOPTMP/mut-pin"
+  cp -R "$SCAFFOLD" "$MUT"
+  sed -e 's|actions/checkout@[0-9a-f]\{40\}.*$|actions/checkout@v4|' \
+      "$MUT/.github/workflows/ci.yml" > "$MUT/.github/workflows/ci.yml.tmp" \
+      && mv "$MUT/.github/workflows/ci.yml.tmp" "$MUT/.github/workflows/ci.yml"
+  if grep -q 'actions/checkout@v4$' "$MUT/.github/workflows/ci.yml"; then
+    mcount="$(scan_scaffold "$MUT" "$TOPTMP/scan-mut.json")"
+    if [ "$mcount" = "ERR" ]; then
+      note "T-mutation-action-pin INCONCLUSIVE: semgrep could not complete — not counted"
+    elif [ "$mcount" -gt 0 ] 2>/dev/null; then
+      pass "T-mutation-action-pin: RED as required — un-pinning actions/checkout re-introduces $mcount finding(s)"
+    else
+      fail_ "T-mutation-action-pin" "un-pinning actions/checkout did NOT make the scan RED (still 0 findings) — the acceptance test cannot detect a regression"
+    fi
+  else
+    fail_ "T-mutation-action-pin" "could not apply the un-pin mutation to the scratch scaffold"
+  fi
+fi
+fi
+
+# — the IFS-tamper class (F14's 6th finding), asserted tool-free —
+# semgrep's `bash.lang.security.ifs-tampering` flags an IFS *assignment* (`IFS=x`
+# on its own, `local/export/declare IFS=x`) — it does NOT flag the COMMAND-PREFIX
+# form (`IFS=',' read -a arr`), which is the remediation the rule itself
+# recommends. Assert exactly that distinction so the check is tool-free but not
+# a false alarm on the legitimate `IFS=',' read` lines the script also contains.
+if [ "$BL113_ONLY" = "no-launder" ]; then
+  :
+elif [ ! -f "$SCAFFOLD/scripts/check-versions.sh" ]; then
+  fail_ "T-scaffold-scan-clean IFS" "scripts/check-versions.sh was not shipped into the scaffold"
+else
+  ifs_bad=0
+  # (i) scoped/exported assignment — always flagged.
+  if grep -qE '^[[:space:]]*(local|export|declare|readonly)[[:space:]]+IFS=' "$SCAFFOLD/scripts/check-versions.sh"; then
+    ifs_bad=$((ifs_bad + 1))
+  fi
+  # (ii) bare assignment with NO command following it on the line.
+  if grep -qE '^[[:space:]]*IFS=[^[:space:]]*[[:space:]]*(#.*)?$' "$SCAFFOLD/scripts/check-versions.sh"; then
+    ifs_bad=$((ifs_bad + 1))
+  fi
+  if [ "$ifs_bad" -eq 0 ]; then
+    pass "T-scaffold-scan-clean: shipped check-versions.sh no longer tampers with IFS (command-prefix form only)"
+  else
+    fail_ "T-scaffold-scan-clean IFS" "the shipped scripts/check-versions.sh still ASSIGNS IFS ($ifs_bad form(s)) — semgrep bash.lang.security.ifs-tampering: $(grep -nE '^[[:space:]]*((local|export|declare|readonly)[[:space:]]+)?IFS=' "$SCAFFOLD/scripts/check-versions.sh" | tr '\n' '|')"
+  fi
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# Phase-3 fixture helpers — put the scaffold at the 3→4 gate.
+# ════════════════════════════════════════════════════════════════════════════
+
+# seed_phase3 <project-dir>
+# Commit the scaffold, then move phase-state to phase 4 so the BL-070 Phase-3
+# validation block (guarded `current_phase >= 4`) evaluates. Leaves the tree
+# CLEAN; the caller dirties it.
+seed_phase3() {
+  local p="$1"
+  ( cd "$p" \
+      && git config user.email "bl113@example.test" \
+      && git config user.name "BL-113 Fixture" \
+      && git add -A \
+      && git -c core.hooksPath=/dev/null commit -q -m "chore: bl113 fixture baseline" ) >/dev/null 2>&1
+  local st="$p/.claude/phase-state.json"
+  jq '.current_phase = 4' "$st" > "$st.tmp" && mv "$st.tmp" "$st"
+}
+
+# attest_all <project-dir> — attest every scanner that a genuinely-offline run
+# would SKIP, exactly as an honest operator would.
+attest_all() {
+  local p="$1" s
+  for s in semgrep-full-tree license snyk zap-dast threat-model; do
+    ( cd "$p" && bash scripts/run-phase3-validation.sh --attest "$s" \
+        --reason "tool unavailable in this environment; recorded honestly" \
+        --signoff "BL-113 Fixture" ) >/dev/null 2>&1 || true
+  done
+}
+
+# A PATH-prefix dir containing a fake `semgrep` binary, so the gate's
+# "tool is installed" probe is TRUE regardless of the host. Hermetic — it is
+# never executed by the gate (only `command -v`-probed).
+STUBBIN="$TOPTMP/stubbin"
+mkdir -p "$STUBBIN"
+printf '#!/bin/sh\nexit 2\n' > "$STUBBIN/semgrep"
+chmod +x "$STUBBIN/semgrep"
+
+# A PATH with NO semgrep at all (genuinely-no-tool arm). Built from the real
+# PATH minus every dir that contains a semgrep binary.
+nosemgrep_path() {
+  local d out=""
+  local oldifs="$IFS"
+  IFS=':'
+  for d in $PATH; do
+    [ -n "$d" ] || continue
+    [ -x "$d/semgrep" ] && continue
+    out="${out}${out:+:}${d}"
+  done
+  IFS="$oldifs"
+  printf '%s' "$out"
+}
+NOSEMGREP_PATH="$(nosemgrep_path)"
+
+# seed_prior_real_fail <project-dir>
+# Write a PRIOR summary that records a REAL (non-offline) semgrep FAIL — exactly
+# what a real `semgrep --config auto` produced on a pre-BL-113 scaffold (F14).
+# This is the ground truth the offline autorun used to launder away.
+seed_prior_real_fail() {
+  local p="$1" rd="$1/docs/test-results/phase3"
+  mkdir -p "$rd"
+  cat > "$rd/summary-2000-01-01T00-00-00Z.md" <<'EOF'
+# Phase 3 Validation Summary
+
+- Generated: 2000-01-01T00:00:00Z
+- tree: 0000000000000000000000000000000000000000
+- dirty: no
+- Offline: no
+- Scanners: 5
+- PASS: 0  SKIP(attested): 4  SKIP(un-attested): 0  FAIL: 1
+- Overall: FAIL
+
+## Machine-readable results (parsed by scripts/check-phase-gate.sh)
+
+```
+RESULT semgrep-full-tree FAIL
+RESULT license SKIP
+RESULT snyk SKIP
+RESULT zap-dast SKIP
+RESULT threat-model SKIP
+```
+EOF
+}
+
+# ════════════════════════════════════════════════════════════════════════════
+# T-no-launder-dirty-tree (F15) — a dirty tree + a REAL prior semgrep FAIL must
+# NOT yield a fresh attestable SKIP at the 3→4 gate.
+#
+# TWO independent defences, asserted separately:
+#   (a) DRIVER carry-forward — the offline autorun's SKIP is promoted back to
+#       FAIL with `[STALE — last real result: FAIL]`. Needs NO semgrep binary.
+#   (b) GATE refusal — an offline-autorun SKIP for a scanner whose TOOL IS ON
+#       PATH is refused outright, attested or not.
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== T-no-launder-dirty-tree: dirty tree + a REAL prior semgrep FAIL ==="
+
+# dirty_tree <project-dir> — make the SCOPED working tree dirty exactly the way
+# an operator authoring Phase-3 artifacts does: an uncommitted edit to a TRACKED
+# source path outside `.claude/` and the results dir (the two paths the BL-082
+# scoped-dirty check excludes). This is what triggers the [STALE] autorun.
+dirty_tree() {
+  local p="$1"
+  printf '\n<!-- BL-113 fixture: Phase-3 work in progress (uncommitted) -->\n' >> "$p/README.md"
+}
+
+# In every arm below the tree is DIRTIED after seeding — the NORMAL state while
+# authoring Phase-3 artifacts, and precisely what makes the BL-082 staleness
+# check autorun the driver with `--offline` (the laundering vector).
+#
+# (a) DRIVER carry-forward — semgrep NOT on PATH, so the gate's tool-presence
+#     refusal cannot fire. The ONLY thing that can save us is the driver
+#     promoting the offline SKIP back to FAIL. Fully hermetic.
+NL_A="$TOPTMP/nl-carry"
+rm -rf "$NL_A"; cp -R "$SCAFFOLD" "$NL_A"
+seed_phase3 "$NL_A"
+seed_prior_real_fail "$NL_A"
+attest_all "$NL_A"
+dirty_tree "$NL_A"
+OUT_A="$( cd "$NL_A" && PATH="$NOSEMGREP_PATH" bash scripts/check-phase-gate.sh --gate phase_3_to_4 2>&1 )" || true
+if printf '%s' "$OUT_A" | grep -q 'STALE'  && printf '%s' "$OUT_A" | grep -q 'last real result: FAIL'; then
+  pass "T-no-launder-dirty-tree (a) driver carry-forward: gate shows '[STALE — last real result: FAIL]' instead of a fresh SKIP"
+else
+  fail_ "T-no-launder-dirty-tree (a)" "gate did NOT surface the carried-forward FAIL. Phase-3 lines: $(printf '%s' "$OUT_A" | grep -i 'phase 3' | tr '\n' '|')"
+fi
+if printf '%s' "$OUT_A" | grep -qi 'validation scans clean'; then
+  fail_ "T-no-launder-dirty-tree (a)" "the gate reported 'validation scans clean' despite a prior REAL semgrep FAIL — THE LAUNDERING IS BACK"
+else
+  pass "T-no-launder-dirty-tree (a): the gate refuses to call the scans clean"
+fi
+# The attested SKIP must NOT be what carries the day: the summary must record FAIL.
+NEW_SUM="$(ls -1 "$NL_A"/docs/test-results/phase3/summary-*.md 2>/dev/null | sort | tail -1)"
+if [ -n "$NEW_SUM" ] && grep -q '^RESULT semgrep-full-tree FAIL' "$NEW_SUM"; then
+  pass "T-no-launder-dirty-tree (a): the regenerated offline summary records semgrep FAIL, not SKIP"
+else
+  fail_ "T-no-launder-dirty-tree (a)" "the regenerated summary ($NEW_SUM) does not record semgrep FAIL: $(grep '^RESULT semgrep' "$NEW_SUM" 2>/dev/null | tr '\n' '|')"
+fi
+
+# (b) GATE refusal — semgrep IS on PATH (stub) and there is NO prior real FAIL,
+#     so the carry-forward cannot fire. The ONLY thing that can save us is the
+#     gate refusing an offline-autorun SKIP for an installed tool.
+NL_B="$TOPTMP/nl-refuse"
+rm -rf "$NL_B"; cp -R "$SCAFFOLD" "$NL_B"
+seed_phase3 "$NL_B"
+attest_all "$NL_B"
+dirty_tree "$NL_B"
+OUT_B="$( cd "$NL_B" && PATH="$STUBBIN:$NOSEMGREP_PATH" bash scripts/check-phase-gate.sh --gate phase_3_to_4 2>&1 )" || true
+if printf '%s' "$OUT_B" | grep -q 'offline autorun SKIP REFUSED'; then
+  pass "T-no-launder-dirty-tree (b) gate refusal: an offline-autorun SKIP for an INSTALLED semgrep is refused (attested or not)"
+else
+  fail_ "T-no-launder-dirty-tree (b)" "the gate accepted an attested offline-autorun SKIP while semgrep was installed. Phase-3 lines: $(printf '%s' "$OUT_B" | grep -i 'phase 3' | tr '\n' '|')"
+fi
+if printf '%s' "$OUT_B" | grep -qi 'validation scans clean'; then
+  fail_ "T-no-launder-dirty-tree (b)" "the gate reported 'validation scans clean' for an offline SKIP of an INSTALLED scanner"
+else
+  pass "T-no-launder-dirty-tree (b): the gate refuses to call the scans clean"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# T-offline-still-usable — the framework MUST work genuinely offline. No tool,
+# no prior real FAIL → an honest attestable SKIP, and the Phase-3 validation arm
+# of the gate PASSES.
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== T-offline-still-usable: genuinely no tool → honest attestable SKIP → gate passable ==="
+OFF="$TOPTMP/offline"
+rm -rf "$OFF"; cp -R "$SCAFFOLD" "$OFF"
+seed_phase3 "$OFF"
+attest_all "$OFF"
+dirty_tree "$OFF"
+OUT_OFF="$( cd "$OFF" && PATH="$NOSEMGREP_PATH" bash scripts/check-phase-gate.sh --gate phase_3_to_4 2>&1 )" || true
+if printf '%s' "$OUT_OFF" | grep -qi 'Phase 3→4: validation scans clean'; then
+  pass "T-offline-still-usable: no tool + honest attestations → '[OK] validation scans clean' (the gate stays passable offline)"
+else
+  fail_ "T-offline-still-usable" "the Phase-3 validation arm BLOCKED a genuinely-offline, honestly-attested project — BL-113 must not break offline use. Phase-3 lines: $(printf '%s' "$OUT_OFF" | grep -i 'phase 3' | tr '\n' '|')"
+fi
+if printf '%s' "$OUT_OFF" | grep -q 'SKIP REFUSED'; then
+  fail_ "T-offline-still-usable" "the gate REFUSED a SKIP even though no tool is installed — the refusal must be scoped to locally-installed tools"
+else
+  pass "T-offline-still-usable: no spurious refusal when the tool is genuinely absent"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# T-mutation-no-launder — neuter the `# BL-113-NO-LAUNDER` decision bodies
+# (marker intact) in BOTH the driver and the gate → T-no-launder must go RED.
+# Restore → GREEN. This proves the marked lines are load-bearing, not decorative.
+# ════════════════════════════════════════════════════════════════════════════
+# (Under BL113_ONLY the guard harness is ALREADY driving this file against a
+# neutered script — re-neutering here would be redundant and would double the
+# harness's runtime, so the in-file mutation arms stand down.)
+if [ "$BL113_ONLY" = "no-launder" ]; then
+  echo "=== T-mutation-no-launder — SKIPPED (BL113_ONLY=no-launder; the guard harness owns the mutation) ==="
+else
+echo "=== T-mutation-no-launder: neuter the BL-113-NO-LAUNDER decision bodies ==="
+
+# neuter <file> — replace every CODE line carrying the marker with `: # marker`
+# (marker intact, body gone). Comment-only lines are left alone. The exec bit is
+# RESTORED afterwards: the gate's autorun is guarded by `[ -x "$P3_DRIVER" ]`, so
+# a mutant that merely lost its +x would block for the WRONG reason and give a
+# false RED (the mutation must fail the gate *by laundering*, not by absence).
+neuter() {
+  local f="$1"
+  sed -e '/^[[:space:]]*#/!s|^\([[:space:]]*\).*# BL-113-NO-LAUNDER.*$|\1: # BL-113-NO-LAUNDER (NEUTERED BY MUTATION TEST)|' \
+      "$f" > "$f.mut" && mv "$f.mut" "$f"
+  chmod +x "$f"
+}
+
+MUTP="$TOPTMP/mut-launder"
+rm -rf "$MUTP"; cp -R "$SCAFFOLD" "$MUTP"
+neuter "$MUTP/scripts/run-phase3-validation.sh"
+neuter "$MUTP/scripts/check-phase-gate.sh"
+
+mut_driver_hits="$(grep -c 'NEUTERED BY MUTATION TEST' "$MUTP/scripts/run-phase3-validation.sh" 2>/dev/null || echo 0)"
+mut_gate_hits="$(grep -c 'NEUTERED BY MUTATION TEST' "$MUTP/scripts/check-phase-gate.sh" 2>/dev/null || echo 0)"
+if [ "$mut_driver_hits" -ge 1 ] && [ "$mut_gate_hits" -ge 1 ] \
+   && bash -n "$MUTP/scripts/run-phase3-validation.sh" 2>/dev/null \
+   && bash -n "$MUTP/scripts/check-phase-gate.sh" 2>/dev/null; then
+  pass "T-mutation-no-launder: neutered $mut_driver_hits driver + $mut_gate_hits gate decision line(s); both still parse (marker intact)"
+else
+  fail_ "T-mutation-no-launder setup" "neuter did not apply cleanly (driver=$mut_driver_hits gate=$mut_gate_hits) or broke syntax"
+fi
+
+# — RED arm (a): carry-forward, no semgrep on PATH —
+seed_phase3 "$MUTP"
+seed_prior_real_fail "$MUTP"
+attest_all "$MUTP"
+dirty_tree "$MUTP"
+MOUT_A="$( cd "$MUTP" && PATH="$NOSEMGREP_PATH" bash scripts/check-phase-gate.sh --gate phase_3_to_4 2>&1 )" || true
+if printf '%s' "$MOUT_A" | grep -qi 'validation scans clean'; then
+  pass "T-mutation-no-launder RED(a): with the decision neutered the gate LAUNDERS again ('validation scans clean' despite a prior REAL FAIL) — the marked driver lines are load-bearing"
+else
+  fail_ "T-mutation-no-launder RED(a)" "neutering the driver decision did NOT reintroduce the laundering — the test is not actually pinned to the marked lines. Phase-3 lines: $(printf '%s' "$MOUT_A" | grep -i 'phase 3' | tr '\n' '|')"
+fi
+
+# — RED arm (b): gate refusal, semgrep stub on PATH, no prior FAIL —
+MUTB="$TOPTMP/mut-launder-b"
+rm -rf "$MUTB"; cp -R "$SCAFFOLD" "$MUTB"
+neuter "$MUTB/scripts/run-phase3-validation.sh"
+neuter "$MUTB/scripts/check-phase-gate.sh"
+seed_phase3 "$MUTB"
+attest_all "$MUTB"
+dirty_tree "$MUTB"
+MOUT_B="$( cd "$MUTB" && PATH="$STUBBIN:$NOSEMGREP_PATH" bash scripts/check-phase-gate.sh --gate phase_3_to_4 2>&1 )" || true
+if printf '%s' "$MOUT_B" | grep -q 'offline autorun SKIP REFUSED'; then
+  fail_ "T-mutation-no-launder RED(b)" "the refusal still fired with the marked gate line neutered — the assertion is not pinned to the decision"
+else
+  pass "T-mutation-no-launder RED(b): with the decision neutered the gate accepts the offline SKIP of an INSTALLED semgrep again — the marked gate line is load-bearing"
+fi
+
+# — GREEN restore: the pristine shipped scripts still hold the line. (NL_A/NL_B
+#   above already exercised the un-mutated scripts and went GREEN; re-assert the
+#   markers survive in the SOURCE so the mutation was to a copy, not the repo.)
+if grep -q '# BL-113-NO-LAUNDER' "$DRIVER_SRC" && grep -q '# BL-113-NO-LAUNDER' "$GATE_SRC" \
+   && ! grep -q 'NEUTERED BY MUTATION TEST' "$DRIVER_SRC" \
+   && ! grep -q 'NEUTERED BY MUTATION TEST' "$GATE_SRC"; then
+  pass "T-mutation-no-launder GREEN: the repo's own scripts are unmutated and still carry the BL-113-NO-LAUNDER markers"
+else
+  fail_ "T-mutation-no-launder GREEN" "the mutation leaked into the repo source — scripts/ must never be modified by this test"
+fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
Closes **BL-113** (E2E validation walk findings **F14 + F15** — `Reports/2026-07-12-e2e-walk/RESULTS.md`).

This is a **security-credibility** fix. The framework shipped you a project that **failed the framework's own SAST**, and then the 3→4 gate **quietly stopped showing you the failure**.

---

## BUG A (F14) — a fresh scaffold failed its own SAST

### Before / after: real `init.sh` scaffold → real `semgrep --config auto`

Both runs are a REAL organizational scaffold (`--platform web --deployment organizational --gov-mode production --language typescript --no-remote-creation`), scanned with the exact command the Phase-3 driver uses.

**BEFORE** (scaffolded from pristine `origin/main`) — **6 findings, all framework-origin, ZERO in the app's `src/`:**

```
TOTAL FINDINGS: 6
  yaml.github-actions.security.github-actions-mutable-action-tag  .github/workflows/ci.yml:15       [WARNING]
  yaml.github-actions.security.github-actions-mutable-action-tag  .github/workflows/ci.yml:17       [WARNING]
  yaml.github-actions.security.github-actions-mutable-action-tag  .github/workflows/release.yml:23  [WARNING]
  yaml.github-actions.security.github-actions-mutable-action-tag  .github/workflows/release.yml:25  [WARNING]
  yaml.github-actions.security.github-actions-mutable-action-tag  .github/workflows/release.yml:59  [WARNING]
  bash.lang.security.ifs-tampering                                scripts/check-versions.sh:63      [WARNING]
```

**AFTER** (this branch):

```
semgrep rc=0
TOTAL FINDINGS: 0
```

The whole **framework repo** — templates included — also now scans to **0 findings**.

### The resolved action SHAs

Resolution method (**no SHA was invented**): for each `owner/repo@ref` I called the GitHub API `repos/<repo>/git/ref/tags/<ref>`, dereferenced the annotated tag object via `repos/<repo>/git/tags/<sha>` to get the **commit**, cross-checked which release tags point at that commit via `repos/<repo>/tags`, and finally **verified every SHA is a real commit** with `repos/<repo>/commits/<sha>`. Branch-backed refs were resolved via `repos/<repo>/branches/<name>`.

| Action | Ref requested | Pinned commit SHA | Concrete release |
|---|---|---|---|
| `actions/checkout` | `v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/setup-node` | `v4` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4.4.0 |
| `actions/setup-python` | `v5` | `a26af69be951a213d495a4c3e4e4022e16d87065` | v5.6.0 |
| `actions/setup-java` | `v4` | `c1e323688fd81a25caa38c78aa6df2d33d3e20d9` | v4.8.0 |
| `actions/setup-go` | `v5` | `40f1582b2485089dde7abd97c1529aa768e1baff` | v5.6.0 |
| `actions/setup-dotnet` | `v4` | `67a3573c9a986a3f9c594539f4ab511d57bb3ce9` | v4.3.1 |
| `actions/upload-artifact` | `v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | v4.6.2 |
| `actions/download-artifact` | `v4` | `d3f86a106a0bac45b974a628896c90dbdf5c8093` | v4.3.0 |
| `subosito/flutter-action` | `v2` | `1a449444c387b1966244ae4d4f8c696479add0b2` | v2.23.0 |
| `golangci/golangci-lint-action` | `v6` | `55c2c1448f86e01eaae002a5a3a9624417608d84` | v6.5.2 |
| `softprops/action-gh-release` | `v2` | `3bb12739c298aeb8a4eeaf626c5b8d85266b0e65` | v2.6.2 |
| `expo/expo-github-action` | `v8` | `c7b66a9c327a43a8fa7c0158e7f30d6040d2481e` | v8 / 8.2.1 |
| `realm/SwiftLint` | `v0.57.0` → **`0.57.0`** | `168fb98ed1f3e343d703ecceaf518b6cf565207b` | 0.57.0 |
| `dtolnay/rust-toolchain` | `stable` *(branch)* | `4be7066ada62dd38de10e7b70166bc74ed198c30` | stable branch head, 2026-06-30 |

**Two latent bugs fell out of the pin work:**
- **`realm/SwiftLint@v0.57.0` was a phantom ref.** `gh api repos/realm/SwiftLint/git/ref/tags/v0.57.0` → **404**. The real tag is `0.57.0` (no `v`). The Swift CI template has been referencing a **non-existent ref**; pinning fixes it.
- **`dtolnay/rust-toolchain` selects the toolchain by *ref name*.** A SHA pin destroys that, so the CI template now passes `with: toolchain: stable` explicitly. (The release template already passed it.)

### The IFS finding — fixed properly, not suppressed

`scripts/check-versions.sh::version_gte` used `local IFS='.'` + `local -a av=($a)`. semgrep's `bash.lang.security.ifs-tampering` says: *"Don't set it globally… set IFS locally using e.g. `IFS="," read -a my_array`."* That is exactly what it now does:

```bash
local -a av=() bv=()
IFS='.' read -r -a av <<< "$a" || :
IFS='.' read -r -a bv <<< "$b" || :
```

**No suppression.** Behaviour verified **identical** on **bash 3.2** across 10 comparison cases including the empty-string edges (`version_gte "" "1.0"`, `version_gte "1.0" ""`), and the shipped script is exercised end-to-end by `edge-cases-scripts.sh::E22` (stubbed-offline network) — 4/4 PASS.

### The one suppression used (declared)

`uses: __SETUP_ACTION__` in `templates/pipelines/release/github/{web,desktop}.yml` is a **build-time placeholder token, not an action ref** — a genuine false positive that semgrep cannot know about. It carries a **same-line `# nosemgrep` with a why-comment**, **in the template only**, and that comment is **stripped at render time** (keyed on a `__SOLO_TEMPLATE_ONLY__` marker, in all three render sites: `init.sh` + the two in `scripts/reconfigure-project.sh`).

**No suppression ever ships into a generated project** — that is asserted by the test (`grep -E 'nosemgrep|__SOLO_TEMPLATE_ONLY__|__SETUP_ACTION__'` over the scaffold's `.github/workflows/` → 0 hits), and the strip is keyed on the marker token alone so **no scanner-directive text exists in any shipped script either**. A leaked `# nosemgrep` would silence the mutable-action-tag rule on every downstream project's own setup step — laundering-by-suppression, the very thing this PR exists to kill.

---

## BUG B (F15) — the offline autorun laundered the FAIL into a SKIP

When the tree is dirty (**the normal state while authoring Phase-3 artifacts**), the 3→4 gate's BL-082 staleness check autoruns the driver with `--offline`, which downgraded semgrep/license/snyk/zap to **SKIP**. A **FAIL is not attestable; a SKIP is.** The operator saw *"scanner unavailable"*, attested in good faith, and passed — never learning a real scan **FAILs**. The autorun was the laundry.

### Mechanism chosen — and why (marker `# BL-113-NO-LAUNDER`)

**Option (i) — "run locally-capable scanners even under the offline autorun" — was TESTED and REJECTED on evidence.**

The task's premise was *"semgrep is local-only — it does not need network for `--config` rules that are already cached; verify"*. **I verified it. It is false.** With the network blackholed (proxy → closed port):

```
requests.exceptions.ProxyError: HTTPSConnectionPool(host='semgrep.dev', port=443):
  Max retries exceeded with url: /c/auto
rc=2   •   elapsed 1:36.76   •   NO report file written
```

`semgrep --config auto` **hard-fetches its ruleset from `semgrep.dev` and has no local-cache fallback.** Running it from the gate's autorun would therefore (a) make the gate **non-hermetic and network-dependent**, (b) add **minutes** to every dirty-tree gate run, and (c) **brick genuinely-offline operators** (rc=2 → FAIL → non-attestable). So **the autorun stays `--offline`. The laundering dies, not the offline mode.**

**Adopted: option (ii), hardened — two independent defences.**

**1. Driver carry-forward** — `run-phase3-validation.sh::_p3_no_launder`. A SKIP **never overwrites a prior REAL FAIL**. Before recording a SKIP, the driver reads back the most recent summary carrying a real (non-SKIP) verdict for that scanner; if it was **FAIL**, the SKIP is **refused** and recorded as FAIL, with a `[STALE - last real result: FAIL]` note and a machine-readable `CARRIED <scanner> <origin>` provenance line. **Applies to all five scanners.** Operator-visible at the gate:

```
[FAIL] Phase 3→4: semgrep-full-tree — [STALE — last real result: FAIL] (origin: summary-….md).
       This scanner SKIPped in the latest run, but the last time it REALLY ran it FAILED, so the
       SKIP was refused rather than laundered. A FAIL is not attestable — fix the findings and
       re-run:  bash scripts/run-phase3-validation.sh   (no --offline)
```

**2. Gate refusal** — `check-phase-gate.sh`. An offline-autorun SKIP for a scanner whose **tool is on PATH** is **refused outright, attested or not**. It is not a result; it is the autorun's own choice not to look, and nobody can honestly sign *"scanner unavailable"* for a scanner that is installed. This closes the hole the carry-forward alone leaves open (a scanner that was **never really run**):

```
[FAIL] Phase 3→4: semgrep-full-tree — offline autorun SKIP REFUSED: the gate's own --offline autorun
       skipped it, but semgrep IS INSTALLED on this machine. An offline SKIP is not a clean bill of
       health and will NOT be accepted (attested or not). Run a REAL scan:
       bash scripts/run-phase3-validation.sh   (no --offline)
```

**Defence 2 is scoped to semgrep — declared, on purpose.** Its real-run path now degrades to an **honest attestable SKIP** when the rule registry is unreachable, so forcing a real run can *never* brick an offline operator. `snyk`'s real-run path **FAILs** (not SKIPs) on an offline execution error, so forcing a real snyk run on an offline operator **would** brick them; `license` has no single binary; `threat-model` is pure-local and already runs under `--offline`. **Defence 1 protects all five scanners regardless.**

**Option (iii) — make a scanner FAIL "attestable-but-loud" — was deliberately NOT taken.** An attestable FAIL is a laundering vector by another name. A FAIL stays non-attestable, which is the correct posture now that a fresh scaffold no longer produces one.

### The framework is still usable genuinely offline (proof)

`_p3_scan_semgrep` now reports a **registry-unreachable** run as an honest **attestable SKIP** rather than a FAIL (`# BL-113-SEMGREP-OFFLINE`) — a FAIL there would have bricked an offline operator, because a FAIL is not attestable. It distinguishes a network failure from a real execution error by inspecting semgrep's stderr; a genuine crash is still a FAIL.

`T-offline-still-usable` asserts it end-to-end on a real scaffold: **no tool on PATH + honest attestations + dirty tree** →

```
[OK] Phase 3→4: validation scans clean (all PASS or attested-skip; summary: summary-….md)
```

…and **no spurious refusal fires** when the tool is genuinely absent.

---

## Mutation evidence (both, RED → GREEN, from REAL scaffolds)

**`tests/test-bl113-sast-honesty.sh` — 17 passed, 0 failed.**

**T-mutation-no-launder** — neuter the `# BL-113-NO-LAUNDER` decision bodies in a real scaffold's copies of the driver + gate (**marker intact**, `bash -n` still parses, exec bit preserved):

```
[PASS] T-mutation-no-launder: neutered 2 driver + 2 gate decision line(s); both still parse (marker intact)
[PASS] T-mutation-no-launder RED(a): with the decision neutered the gate LAUNDERS again
       ('validation scans clean' despite a prior REAL FAIL) — the marked driver lines are load-bearing
[PASS] T-mutation-no-launder RED(b): with the decision neutered the gate accepts the offline SKIP of an
       INSTALLED semgrep again — the marked gate line is load-bearing
[PASS] T-mutation-no-launder GREEN: the repo's own scripts are unmutated and still carry the markers
```

**T-mutation-action-pin** — revert ONE action pin to a mutable tag in a scratch copy of the real scaffold:

```
[PASS] T-mutation-action-pin: RED as required — un-pinning actions/checkout re-introduces 1 finding(s)
```

**Guard registry** — both guards are also rows in `tests/test-bl099-guard-coverage.sh`, which independently neuters the **real** scripts and proves the killing test goes RED then GREEN:

```
PINNED  bl113/driver-carry-forward         no-launder
PINNED  bl113/gate-refuses-offline-skip    no-launder
== Total: 27 | Pinned: 27 | Failed: 0 | Skipped: 0 ==
```

---

## Suites + lints

| Suite | Result |
|---|---|
| `tests/test-bl113-sast-honesty.sh` **(new)** | **17 passed, 0 failed** |
| `tests/test-bl099-guard-coverage.sh` | **27 PINNED, 0 failed** (25 pre-existing + 2 new) |
| `tests/test-phase3-validation-gate.sh` | 51 passed, 0 failed |
| `tests/test-bl073-review-manifest-gate.sh` | 29 passed, 0 failed |
| `tests/test-check-phase-gate*.sh` (10 suites) | all green (8/4/4/7/12/3/5/3/5/8) |
| `tests/test-scaffold-source-closure.sh` | 6 passed, 0 failed |
| `tests/test-currency-birth-stamp.sh` | 18 passed, 0 failed — **derived hashes recompute** despite the workflow byte changes |
| `tests/test-currency-manifest.sh` | 53 passed, 0 failed |
| `tests/test-freshness-check.sh` / `-birth.sh` | 24 / 6 passed, 0 failed |
| `tests/edge-cases-scripts.sh` (incl. **E22 check-versions**) | green — E22 4/4 |
| `tests/test-enforcement-level-reconfigure.sh` | 12 passed, 0 failed |
| `scripts/run-lints.sh` | **11 lints — 11 passed, 0 failed** |

`tests/test-bl113-sast-honesty.sh` is an **AGGREGATOR** (real `init.sh`): registered in `tests/full-project-test-suite.sh` under the `SUITE_SKIP_AGGREGATORS` gate, and **not** in the `tests.yml` unit list.

---

## DECLARED DEVIATIONS

1. **Option (i) was rejected on measured evidence, not preference.** The task's stated premise (*"semgrep is local-only… verify"*) is **false** for `--config auto`: it hard-fetches `semgrep.dev` with no cache fallback (rc=2, no report, ~97 s of retries with the network blackholed). The autorun stays `--offline` and the invariant is enforced by refusing the SKIP instead. This is the biggest deviation and it is deliberate.
2. **The gate-side "tool installed ⇒ refuse the SKIP" defence is scoped to semgrep**, not all five scanners. Reason above (snyk would brick an offline operator). The driver-side carry-forward is unscoped.
3. **One suppression used**, as permitted: a same-line `# nosemgrep` + why-comment on the `uses: __SETUP_ACTION__` placeholder line in the two release templates. It is a genuine false positive (placeholder token, not an action ref), it is **stripped at render time**, and the test asserts it **never reaches a generated project**.
4. **Semgrep-registry-unreachable is now a SKIP, not a FAIL** — a *widening* of the attestable surface. It is safe because it is paired with the carry-forward: a previously-observed real FAIL can no longer be cleared by breaking the tool or pulling the plug. Without this, the offline-usability requirement and a semgrep-installed operator are irreconcilable.
5. **The framework's own `.github/workflows/*` were pinned too** (`actions/checkout` ×9). Behaviourally identical (same action, exact v4.3.1 commit) — CI is not disturbed. Verify on this PR's checks.
6. **`tests/test-bl099-guard-coverage.sh` was generalised** to a per-section mutation target + killing suite (`use_target`, `GUARD_RUNNER`, a new `markerline` neuter primitive). Every pre-existing row is byte-for-byte unchanged in behaviour — all 25 still PINNED.
7. **Docs not updated.** `docs/extending-platforms.md` / `docs/platform-modules/*.md` show `actions/checkout@v4` in illustrative code fences. Markdown is not scanned by semgrep's YAML rules and these are not shipped as workflows, so they are out of scope for the SAST fix. Flagging for a follow-up doc pass.
8. **BL-112 (hollow commit-time SAST) is untouched and still real.** The pre-commit hook printed these very findings as `❰❰ Blocking ❱❱` and then **allowed the commit** (no `--error`). Out of scope here; the backlog note records it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
