### PR TITLE
fix(gates): close the --no-remote-creation blind spot — pin + push axes (BL-110, BL-116)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,6 +85,7 @@ jobs:
             tests/test-bl118-sast-dom-xss.sh
             tests/test-bl119-stale-editmsg.sh
             tests/test-bl121-cutline-bsd-sed.sh
+            tests/test-bl116-push-gate-scope.sh
             tests/test-bl123-bp-attestation-recovery.sh
             tests/test-bl124-pending-ratchet.sh
             tests/test-bypass-audit-integrity.sh

--- a/Reports/2026-07-13-dogfood-2/REMEDIATION-PROGRESS.md
+++ b/Reports/2026-07-13-dogfood-2/REMEDIATION-PROGRESS.md
@@ -118,4 +118,17 @@
 - **Affected suites (green):** test-check-gate 5/5 · process-checklist ×4 (classifier/auto-advance/subject/reset-phase1) · run-lints 11/11.
 - **Adversarial verify (Opus-tier, laundering-focused brief):** verdict **SHIP conditional on finding A — condition MET pre-push**. A (precondition guard), B (provenance), C (presence-keyed idempotency) all landed in the amended commit, each with its own watched RED. Verifier also independently re-excised the BL-126 fence (excision-safe + fail-closed confirmed) and noted the recorder/steps-writer root-dir coherence is pre-existing (`_require_manifest` anchors cwd).
 
+---
+
+## WP-D2 — BL-110 (Med) pin absent on hermetic path + BL-116 (Med) push gate host-scoped — DONE-PR-open
+
+- **Branch:** `fix/bl110-bl116-noremote-blindspot` (stacked on PR #206). **PR #207**, commit `6e7ecaf`.
+- **Reproduce:** BL-116 hermetic RED — a github/org fixture with no init-push records and no remote produced **0 push-gate lines** (the MANDATORY gate did not exist for first-class hosts on the hermetic flow). BL-110 mutation-direction RED — a HEAD-reverted init.sh scaffolded a real `--no-remote-creation` project with `soloFrameworkCommit` **ABSENT**.
+- **Fix (markers):** `# BL-110-PIN-UNIVERSAL` — stamp moved to `prepare_initial_state_for_commit` (runs on every path, before the currency stamp; idempotent; remote-path duplicate removed with a pointer comment). `# BL-116-PUSH-GATE-SCOPE` (excision-safe fence) — the first-class exemption is EARNED: gate skipped only when `remote_repo_created`+`pushed_initial` are both recorded; host=other unconditional as before.
+- **Tests:** `test-bl116-push-gate-scope.sh` 4/4 (gated/exempt/other-regression/fence-excision mutant) — both lists. Scaffold suite gains `T-scaffold-pin-stamped` (pin == framework HEAD on the real hermetic scaffold) — 8/8.
+- **Fixture updates (honest modeling, not weakening):** bl104 / bl102 / backstop-attestation fixtures now record the two init-push steps they always represented — the scope fix correctly began gating fixtures that "never pushed", which is the fix WORKING. bl124's fixture left as-is (its assertions are diagnostic-scoped; the push-gate FAIL rides harmlessly in its output — noted for hygiene).
+- **Mutation proofs:** BL-116 in-test fence-excision (github no-remote case regresses to silence). BL-110: reverted-init probe scaffold → `MUTANT-PIN=ABSENT` → restore → scaffold suite pin case green.
+- **Affected suites (green):** bl104 · bl102 · backstop-attestation · bl124 · check-phase-gate · scaffold-tdd 8/8 · run-lints 11/11.
+- **Adversarial verify:** Opus-tier dispatched post-commit (both items Medium, mechanical scope/stamp changes with two-sided mutations on record) — outcome in the PR thread; any findings land as follow-up commits on the branch.
+
 - **Notes / residuals:** (1) `eval()` sinks remain invisible to the commit-time gate (neither pack carries an ERROR-severity eval rule); Phase-3 `--config auto` catches them. (2) gitlab templates run `p/security-audit` only vs github's two packs — pre-existing asymmetry, untouched. (3) The pinned `semgrep/semgrep-action@713efdd… (v1/v0.58.0)` is 2021-era; verifier traced it as pass-through-correct for `r/` configs, but modernizing the pin is worth a look. (4) `--config auto` at commit time NOT adopted (network + metrics on every commit; deterministic registry pack keeps the BL-112-SAST-NOTRUN discipline meaningful).

--- a/init.sh
+++ b/init.sh
@@ -2458,25 +2458,13 @@ create_and_protect_remote() {
 MANIFESTEOF
   fi
 
-  # BL-099: birth-stamp .claude/manifest.json.soloFrameworkCommit — the
-  # solo-orchestrator framework commit this project was scaffolded from. This
-  # is the pin scripts/upgrade-project.sh --sync-framework advances and reports
-  # drift against. camelCase and deliberately named to sit BESIDE — never be
-  # confused with — CDF's `frameworkCommit`, which pins the SEPARATE Development
-  # Guardrails clone. Stamped UNCONDITIONALLY after the manifest if/else (not
-  # inside either branch — the jq-merge branch is the common CDF-created path).
-  # Skipped with a note when the framework dir isn't a git checkout (e.g. a
-  # tarball install), leaving the field absent (sync treats absent as unpinned).
-  if git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
-    _solo_fw_commit="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || echo "")"
-    if [ -n "$_solo_fw_commit" ]; then
-      jq --arg c "$_solo_fw_commit" '.soloFrameworkCommit = $c' .claude/manifest.json > .claude/manifest.json.tmp \
-        && mv .claude/manifest.json.tmp .claude/manifest.json
-    fi
-    unset _solo_fw_commit
-  else
-    print_info "solo-orchestrator framework dir is not a git checkout — skipping soloFrameworkCommit birth-stamp"
-  fi
+  # BL-099 / BL-110: the soloFrameworkCommit birth-stamp used to live HERE
+  # (remote path only) — which left every --no-remote-creation scaffold born
+  # with NO pin (BL-110: the anchor of the Currency System absent on the
+  # blessed hermetic flow). The stamp now lives at the UNIVERSAL manifest-seed
+  # site in prepare_initial_state_for_commit (# BL-110-PIN-UNIVERSAL), which
+  # runs on EVERY path before this function — by the time this branch
+  # executes, the pin is already present. Nothing to do here.
 
   # Trailing dedup pass. The named steps (remote_repo_created, pushed_initial,
   # branch_protection_configured, branch_protection_verified) are now written
@@ -4275,6 +4263,28 @@ prepare_initial_state_for_commit() {
   # remote-path-only (see the S1 PR body's declared deviation). Skipped as a
   # no-op when jq is unavailable (same contract as the soloFrameworkCommit stamp).
   # Re-stamping on sync/apply (soloFrameworkPath refresh) is S3a — out of scope.
+  # BL-110-PIN-UNIVERSAL — birth-stamp .claude/manifest.json.soloFrameworkCommit
+  # at the UNIVERSAL seed site (this function runs on EVERY path, including
+  # --no-remote-creation), fixing BL-110: the stamp's old home inside
+  # create_and_protect_remote() sat AFTER that function's --no-remote-creation
+  # early return, so every hermetic scaffold was born with NO pin — degrading
+  # the entire Currency System (BL-109) and --sync-framework drift reporting.
+  # Same contract as before: camelCase, sits BESIDE CDF's frameworkCommit;
+  # skipped with a note when the framework dir isn't a git checkout (sync
+  # treats absent as unpinned); idempotent (skip when already present).
+  if [ "$(jq -r '.soloFrameworkCommit // ""' "$manifest" 2>/dev/null)" = "" ]; then
+    if git -C "$SCRIPT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
+      _solo_fw_commit="$(git -C "$SCRIPT_DIR" rev-parse HEAD 2>/dev/null || echo "")"
+      if [ -n "$_solo_fw_commit" ]; then
+        jq --arg c "$_solo_fw_commit" '.soloFrameworkCommit = $c' "$manifest" > "$manifest.tmp" \
+          && mv "$manifest.tmp" "$manifest"
+      fi
+      unset _solo_fw_commit
+    else
+      print_info "solo-orchestrator framework dir is not a git checkout — skipping soloFrameworkCommit birth-stamp"
+    fi
+  fi
+
   soif_currency_stamp "$manifest" "$SCRIPT_DIR/init.sh" "$SCRIPT_DIR" "." "$LANGUAGE" "$SCRIPT_DIR"   # BL-109-CURRENCY load-bearing stamping call
 
   # Seed bypass-audit.json with the init enforcement_level_set row.

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -982,7 +982,30 @@ if [ "$current_phase" -ge 2 ]; then
   if [ -f .claude/manifest.json ] && command -v jq >/dev/null 2>&1; then
     bl084_host=$(jq -r '.host // ""' .claude/manifest.json 2>/dev/null || echo "")
   fi
-  if [ "$bl084_host" = "other" ]; then
+  bl084_gate_applies=false
+  [ "$bl084_host" = "other" ] && bl084_gate_applies=true
+  # BL-116-PUSH-GATE-SCOPE-BEGIN
+  # BL-116: the gate used to be scoped `host == "other"` on the premise that
+  # "first-class hosts are provably pushed at init" — FALSE for
+  # --no-remote-creation, which is the blessed hermetic flow: a github/gitlab
+  # project scaffolded that way never received the MANDATORY push gate at all
+  # (E2E walk F7). The first-class exemption is now EARNED, not assumed: it
+  # holds only when phase2_init.steps_completed records BOTH
+  # remote_repo_created and pushed_initial — the on-disk meaning of "provably
+  # pushed at init". Fence is excision-safe: removing it restores the
+  # host=other-only scope.
+  if [ "$bl084_gate_applies" != true ]; then
+    bl084_init_pushed=false
+    if [ -f .claude/process-state.json ] && command -v jq >/dev/null 2>&1; then
+      if jq -e '.phase2_init.steps_completed | (index("remote_repo_created") != null) and (index("pushed_initial") != null)' \
+           .claude/process-state.json >/dev/null 2>&1; then
+        bl084_init_pushed=true
+      fi
+    fi
+    [ "$bl084_init_pushed" != true ] && bl084_gate_applies=true
+  fi
+  # BL-116-PUSH-GATE-SCOPE-END
+  if [ "$bl084_gate_applies" = true ]; then
     bl084_local_only_ack=false
     bl084_push_deferred_ack=false
     if [ -f .claude/process-state.json ] && command -v jq >/dev/null 2>&1; then

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -2763,6 +2763,8 @@ For Rust the skip is *deliberate* (inline `#[cfg(test)]` tests cannot be detecte
 **Severity:** Medium
 **Status:** Open
 
+**Status update 2026-07-17:** fix implemented on PR #207 (branch `fix/bl110-bl116-noremote-blindspot`), awaiting merge. `# BL-110-PIN-UNIVERSAL`: the stamp moved to the universal manifest-seed site in `prepare_initial_state_for_commit` (idempotent; remote-path duplicate removed with a pointer comment). Fidelity: `T-scaffold-pin-stamped` in the scaffold suite asserts pin == framework HEAD on a REAL `--no-remote-creation` init (8/8). Mutation observed both directions: HEAD-reverted init scaffolds with the pin ABSENT; fixed init stamps it. Evidence: `Reports/2026-07-13-dogfood-2/REMEDIATION-PROGRESS.md` § WP-D2.
+
 **Verified evidence:** the BL-099 birth-stamp (`# BL-099: birth-stamp .claude/manifest.json.soloFrameworkCommit`, init.sh ~:2498) lives INSIDE `create_and_protect_remote()` (opens ~:2182) — and that function's `--no-remote-creation` branch (~:2211) exits with `return 0` BEFORE the stamp is reached. Net: **every hermetic scaffold — all UAT/CI/agent runs and any operator passing `--no-remote-creation` — is born with NO `soloFrameworkCommit` pin.** Empirically reproduced during S1 (a real `--no-remote-creation` scaffold's manifest has no such key). The pin is the anchor of the entire Currency System (BL-109) and of `--sync-framework`'s drift reporting; a pin-absent manifest degrades both (sync stamps it on first run — self-healing there — but session-start detection reads it at birth).
 
 **Why tests missed it:** the BL-099 suites drive sync/stamp paths directly; no fidelity test scaffolds via `--no-remote-creation` and asserts the pin — the [[bl088-scaffold-source-closure]] fixture-hides-gap class, on a FLAG axis this time (BL-107 was the same class on the LANGUAGE axis).
@@ -2898,6 +2900,8 @@ Three defects in the same gate, all walk-reproduced:
 **Category:** Bug / gate scope
 **Severity:** Medium
 **Status:** Open
+
+**Status update 2026-07-17:** fix implemented on PR #207 alongside BL-110, awaiting merge. `# BL-116-PUSH-GATE-SCOPE` (excision-safe fence) in check-phase-gate.sh: the first-class exemption is EARNED — skipped only when `remote_repo_created`+`pushed_initial` are on record (the on-disk meaning of "provably pushed at init"); host=other keeps unconditional gating. `tests/test-bl116-push-gate-scope.sh` 4/4 incl. the fence-excision mutant; the github no-remote RED was observed (0 push-gate lines pre-fix). Evidence: § WP-D2.
 
 The BL-084 push-verification gate — documented as **MANDATORY and non-bypassable** — is implemented only for `host == "other"`. A `github` / `gitlab` / `bitbucket` project scaffolded with `--no-remote-creation` **never receives the mandatory push verification**: `grep -c 'push gate'` in the gate's output is **0**, both with and without a pushed remote. The scope comment's stated premise — *"first-class hosts are provably pushed at init"* — is **false for `--no-remote-creation`**, which is precisely the flow every hermetic/UAT/CI run and many operators use.
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -659,6 +659,17 @@ else
   fail "tests/test-bl121-cutline-bsd-sed.sh FAILED (run for details)"
 fi
 
+# BL-116 (Med): the MANDATORY push gate keys on recorded facts, not host brand
+# — first-class hosts are exempt only when remote_repo_created+pushed_initial
+# are on record ("provably pushed at init", on disk); --no-remote-creation
+# scaffolds now gate. Fence-excision mutant proves the scope change
+# load-bearing. No init.sh -> both lanes.
+if bash "$SCRIPT_DIR/tests/test-bl116-push-gate-scope.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl116-push-gate-scope.sh"
+else
+  fail "tests/test-bl116-push-gate-scope.sh FAILED (run for details)"
+fi
+
 # BL-123/BL-111/BL-126 (High/High/Med): the branch-protection attestation is
 # recordable post-hoc (check-gate.sh --repair --branch-protection-attested /
 # SOLO_BP_ATTESTED=1, host-keyed reason, explicit-only) and honored by ALL

--- a/tests/test-bl073-review-manifest-gate.sh
+++ b/tests/test-bl073-review-manifest-gate.sh
@@ -98,6 +98,11 @@ build_project() {
   TMP=$(mktemp -d)
   PROJ="$TMP/p"
   mkdir -p "$PROJ/.claude" "$PROJ/docs/test-results" "$PROJ/docs/eval-results"
+  # BL-114 (PR #208): the 0->1 gate demands real Step-0 intermediates.
+  mkdir -p "$PROJ/docs/phase-0"
+  printf 'frd\n' > "$PROJ/docs/phase-0/frd.md"
+  printf 'journey\n' > "$PROJ/docs/phase-0/user-journey.md"
+  printf 'contract\n' > "$PROJ/docs/phase-0/data-contract.md"
 
   local flag_json=""
   [ "$flag" = "yes" ] && flag_json='"review_gate_enforced": true,'
@@ -133,7 +138,7 @@ JSON
   cat > "$PROJ/.claude/process-state.json" <<JSON
 {
   "phase1_artifacts": { "data_classification": "public" },
-  "phase2_init": { "attestations": { "branch_protection": { "reason": "github_free_tier" } } },
+  "phase2_init": { "steps_completed": ["remote_repo_created","pushed_initial"], "attestations": { "branch_protection": { "reason": "github_free_tier" } } },
   "phase3_validation": { "steps_completed": ["integration_testing","security_hardening","chaos_testing","accessibility_audit","performance_audit","contract_testing","results_archived","pre_launch_preparation","legal_review"] }
 }
 JSON

--- a/tests/test-bl102-market-signal-warn.sh
+++ b/tests/test-bl102-market-signal-warn.sh
@@ -95,7 +95,7 @@ JSON
   cat > "$PROJ/.claude/process-state.json" <<'JSON'
 {
   "phase1_artifacts": { "data_classification": "public" },
-  "phase2_init": { "attestations": { "branch_protection": { "reason": "github_free_tier" } } }
+  "phase2_init": { "steps_completed": ["remote_repo_created","pushed_initial"], "attestations": { "branch_protection": { "reason": "github_free_tier" } } }
 }
 JSON
   cat > "$PROJ/.claude/manifest.json" <<'JSON'

--- a/tests/test-bl104-gate-scoring.sh
+++ b/tests/test-bl104-gate-scoring.sh
@@ -152,7 +152,7 @@ JSON
   cat > "$PROJ/.claude/process-state.json" <<JSON
 {
   "phase1_artifacts": { "data_classification": "public" },
-  "phase2_init": { "attestations": { "branch_protection": { "reason": "github_free_tier" } } },
+  "phase2_init": { "steps_completed": ["remote_repo_created","pushed_initial"], "attestations": { "branch_protection": { "reason": "github_free_tier" } } },
   "phase3_validation": { "steps_completed": [ $steps_json ] }
 }
 JSON

--- a/tests/test-bl116-push-gate-scope.sh
+++ b/tests/test-bl116-push-gate-scope.sh
@@ -1,0 +1,146 @@
+#!/usr/bin/env bash
+# tests/test-bl116-push-gate-scope.sh — BL-116: the MANDATORY push gate must
+# key on recorded facts, not host brand.
+#
+# WHY THIS EXISTS (E2E walk F7 / BL-116, Medium)
+#   The BL-084 push-verification gate — documented MANDATORY and
+#   non-bypassable — was implemented only for `host == "other"`. Its scope
+#   comment's premise ("first-class hosts are provably pushed at init") is
+#   FALSE for `--no-remote-creation`: a github/gitlab project scaffolded
+#   hermetically never received the gate at all. The fix
+#   (# BL-116-PUSH-GATE-SCOPE in check-phase-gate.sh) makes the first-class
+#   exemption CONDITIONAL on the recorded facts — the gate is skipped only
+#   when phase2_init.steps_completed carries BOTH remote_repo_created and
+#   pushed_initial (what "provably pushed at init" actually means on disk);
+#   host=other keeps its unconditional gating.
+#
+# CASES
+#   T-github-noremote-gated   github host, org tier, NO init-push records, no
+#                             remote branch → the push-gate FAIL fires.
+#   T-github-initpushed-exempt github host WITH both records → no push-gate
+#                             FAIL (the premise holds, exemption earned).
+#   T-other-still-gated       host=other unchanged (regression pin).
+#   T-mutation-bl116          excise the fence from a COPY → the github
+#                             no-remote case regresses to silence.
+#
+# REGISTRATION: no init.sh → BOTH lists. Fixture adapted from
+# test-bl104-gate-scoring.sh. Hermetic. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# build <dir> <host> <init_pushed:yes|no>
+build() {
+  local d="$1" host="$2" pushed="$3"
+  rm -rf "$d"
+  mkdir -p "$d/.claude"
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.invalid && git config user.name t \
+      && echo x > README.md && git add README.md && git commit -q -m "chore: init" ) || return 1
+  printf '{"host":"%s","mode":"personal"}\n' "$host" > "$d/.claude/manifest.json"
+  cat > "$d/.claude/phase-state.json" <<'JSON'
+{
+  "project": "bl116",
+  "current_phase": 2,
+  "track": "full",
+  "deployment": "organizational",
+  "poc_mode": "sponsored_poc",
+  "gates": { "phase_0_to_1": "2026-02-01", "phase_1_to_2": "2026-03-01", "phase_2_to_3": null, "phase_3_to_4": null }
+}
+JSON
+  local steps='[]'
+  [ "$pushed" = "yes" ] && steps='["remote_repo_created","pushed_initial"]'
+  jq -n --argjson s "$steps" '{phase1_artifacts:{data_classification:"public"},phase2_init:{steps_completed:$s,attestations:{branch_protection:{reason:"github_free_tier"}}}}' > "$d/.claude/process-state.json"
+  cat > "$d/APPROVAL_LOG.md" <<'MD'
+# Approval Log
+
+## Phase Gate: Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| Approver | Alice Signer |
+| Date | 2026-02-01 |
+
+## Phase Gate: Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| Approver | Alice Signer |
+| Date | 2026-03-01 |
+MD
+  { local n; for n in 1 2 3 4 5 6 7 8; do echo "## ${n}. S${n}"; echo "Content."; echo ""; done; } > "$d/PRODUCT_MANIFESTO.md"
+  { echo "# Project Bible"; local b; for b in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16; do echo "## ${b}. S${b}"; echo "C."; echo ""; done; } > "$d/PROJECT_BIBLE.md"
+}
+
+run_gate() { ( cd "$1" && bash "${2:-$SCRIPT}" --gate phase_1_to_2 2>&1 ); }
+
+# ── T-github-noremote-gated ──────────────────────────────────────────────────
+echo "=== T-github-noremote-gated ==="
+P="$TOPTMP/gh-norem"
+build "$P" github no
+out=$(run_gate "$P")
+if printf '%s' "$out" | grep -q "push gate" && printf '%s' "$out" | grep -qE "\[FAIL\].*push gate"; then
+  pass "T-github-noremote-gated"
+else
+  fail_ "T-github-noremote-gated" "a github project with NO init-push records and no remote produced no push-gate FAIL — the MANDATORY gate does not exist for first-class hosts scaffolded --no-remote-creation (BL-116): $(printf '%s' "$out" | grep -ci 'push gate') push-gate lines"
+fi
+
+# ── T-github-initpushed-exempt ───────────────────────────────────────────────
+echo "=== T-github-initpushed-exempt ==="
+P="$TOPTMP/gh-pushed"
+build "$P" github yes
+out=$(run_gate "$P")
+if printf '%s' "$out" | grep -qE "\[FAIL\].*push gate"; then
+  fail_ "T-github-initpushed-exempt" "a github project WITH remote_repo_created+pushed_initial recorded still drew the push-gate FAIL — the earned exemption (provably pushed at init) must hold"
+else
+  pass "T-github-initpushed-exempt"
+fi
+
+# ── T-other-still-gated ──────────────────────────────────────────────────────
+echo "=== T-other-still-gated ==="
+P="$TOPTMP/other-norem"
+build "$P" other no
+out=$(run_gate "$P")
+if printf '%s' "$out" | grep -qE "\[FAIL\].*push gate"; then
+  pass "T-other-still-gated"
+else
+  fail_ "T-other-still-gated" "host=other regression: the push gate no longer fires for an unpushed other-host project"
+fi
+
+# ── T-mutation-bl116 ─────────────────────────────────────────────────────────
+echo "=== T-mutation-bl116 ==="
+MUT="$TOPTMP/mut"
+mkdir -p "$MUT/scripts/lib"
+cp "$REPO_ROOT"/scripts/lib/*.sh "$MUT/scripts/lib/" 2>/dev/null || true
+if ! grep -q "BL-116-PUSH-GATE-SCOPE-BEGIN" "$SCRIPT"; then
+  fail_ "T-mutation-bl116" "no BL-116-PUSH-GATE-SCOPE fence in check-phase-gate.sh — fix not in place"
+else
+  sed '/# BL-116-PUSH-GATE-SCOPE-BEGIN/,/# BL-116-PUSH-GATE-SCOPE-END/d' "$SCRIPT" > "$MUT/scripts/check-phase-gate.sh"
+  chmod +x "$MUT/scripts/check-phase-gate.sh"
+  if ! bash -n "$MUT/scripts/check-phase-gate.sh" 2>/dev/null; then
+    fail_ "T-mutation-bl116" "excised mutant is syntactically broken — keep the scope change excision-safe"
+  else
+    P="$TOPTMP/gh-mut"
+    build "$P" github no
+    out=$(run_gate "$P" "$MUT/scripts/check-phase-gate.sh")
+    if printf '%s' "$out" | grep -qE "\[FAIL\].*push gate"; then
+      fail_ "T-mutation-bl116" "fence excised but the github no-remote case still gates — the fence does not contain the scope change"
+    else
+      pass "T-mutation-bl116"
+    fi
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-check-phase-gate-backstop-attestation.sh
+++ b/tests/test-check-phase-gate-backstop-attestation.sh
@@ -138,7 +138,7 @@ echo ""
 echo "T1: attestation present → backstop honors it, exits 0"
 setup_phase2_project
 cat > "$PROJ/.claude/process-state.json" <<'JSON'
-{"phase2_init":{"steps_completed":[],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-04-27T00:00:00Z","reason":"github_free_tier"}}},
+{"phase2_init":{"steps_completed":["remote_repo_created","pushed_initial"],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-04-27T00:00:00Z","reason":"github_free_tier"}}},
  "phase1_artifacts":{"data_classification":"public","zdr_attested":false}}
 JSON
 out=$(run_gate)
@@ -205,7 +205,7 @@ fi
 echo "T4: gitlab_free_tier_approvals attestation → backstop honors it, exits 0"
 setup_phase2_project
 cat > "$PROJ/.claude/process-state.json" <<'JSON'
-{"phase2_init":{"steps_completed":[],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-06-30T12:00:00Z","reason":"gitlab_free_tier_approvals"}}},
+{"phase2_init":{"steps_completed":["remote_repo_created","pushed_initial"],"attestations":{"branch_protection":{"attested_by":"orchestrator","at":"2026-06-30T12:00:00Z","reason":"gitlab_free_tier_approvals"}}},
  "phase1_artifacts":{"data_classification":"public","zdr_attested":false}}
 JSON
 out=$(run_gate)

--- a/tests/test-check-phase-gate-poc-block-contract.sh
+++ b/tests/test-check-phase-gate-poc-block-contract.sh
@@ -89,20 +89,27 @@ build_poc_fixture() {
   local mode="$1"
   PROJ=$(mktemp -d)
   mkdir -p "$PROJ/.claude" "$PROJ/docs/test-results"
+  mkdir -p "$PROJ/docs/phase-0"
+  printf 'frd\n' > "$PROJ/docs/phase-0/frd.md"
+  printf 'journey\n' > "$PROJ/docs/phase-0/user-journey.md"
+  printf 'contract\n' > "$PROJ/docs/phase-0/data-contract.md"
 
   cat > "$PROJ/.claude/phase-state.json" <<JSON
 {"current_phase":3,"deployment":"personal","track":"light","poc_mode":"$mode","gates":{"phase_0_to_1":"2026-02-01","phase_1_to_2":"2026-03-01","phase_2_to_3":"2026-04-01"}}
 JSON
 
   cat > "$PROJ/.claude/process-state.json" <<'JSON'
-{"phase1_artifacts":{"data_classification":"public"}}
+{"phase1_artifacts":{"data_classification":"public"},"phase2_init":{"steps_completed":["remote_repo_created","pushed_initial"]}}
 JSON
 
   cat > "$PROJ/APPROVAL_LOG.md" <<'MD'
 # APPROVAL_LOG
 
 ## Phase Gate: Phase 0 → Phase 1
-Approved 2026-02-01 by Alice Approver
+| Field | Value |
+|---|---|
+| Approver | Alice Approver |
+| Date | 2026-02-01 |
 
 ## Phase Gate: Phase 1 → Phase 2
 Approved 2026-03-01 by Alice Approver

--- a/tests/test-scaffold-tdd-block-real.sh
+++ b/tests/test-scaffold-tdd-block-real.sh
@@ -99,6 +99,23 @@ else
   fail_ "T-scaffold-ships-deps" "init.sh omitted one or more sourced deps (the BL-088 gap)"
 fi
 
+# ── T-scaffold-pin-stamped (BL-110) ─────────────────────────────────────────
+# The soloFrameworkCommit pin — the anchor of the Currency System and of
+# --sync-framework drift reporting — must be born on the HERMETIC path too.
+# Its old home inside create_and_protect_remote() sat after the
+# --no-remote-creation early return, so this exact scaffold (a real
+# --no-remote-creation init) was born pin-less.
+echo "=== T-scaffold-pin-stamped (BL-110): soloFrameworkCommit present on the hermetic path ==="
+pin="$(jq -r '.soloFrameworkCommit // ""' "$SCAFFOLD/.claude/manifest.json" 2>/dev/null)"
+fw_head="$(git -C "$REPO_ROOT" rev-parse HEAD 2>/dev/null)"
+if [ -z "$pin" ]; then
+  fail_ "T-scaffold-pin-stamped" "--no-remote-creation scaffold born with NO soloFrameworkCommit pin (BL-110: the Currency System's anchor is absent on the blessed hermetic flow)"
+elif [ "$pin" != "$fw_head" ]; then
+  fail_ "T-scaffold-pin-stamped" "pin '$pin' != framework HEAD '$fw_head' — stamped from the wrong checkout"
+else
+  pass "T-scaffold-pin-stamped: soloFrameworkCommit = framework HEAD on the hermetic path"
+fi
+
 # ── T-scaffold-phase3-driver-present ────────────────────────────────────────
 echo "=== T-scaffold-phase3-driver-present: driver present + executable ==="
 if [ -x "$SCAFFOLD/scripts/run-phase3-validation.sh" ]; then


### PR DESCRIPTION
## Findings (the third and fourth corners of the one uncovered flow)

**BL-110:** the `soloFrameworkCommit` birth-stamp lived inside `create_and_protect_remote()` **after** its `--no-remote-creation` early return — every hermetic scaffold (all UAT/CI/agent runs) was born **pin-less**, degrading the Currency System's anchor and `--sync-framework` drift reporting. **BL-116:** the MANDATORY BL-084 push gate was implemented only for `host == "other"` on the premise that first-class hosts are "provably pushed at init" — false for exactly this flow.

## Fix

- **`# BL-110-PIN-UNIVERSAL`**: stamp moved to the universal manifest-seed site in `prepare_initial_state_for_commit` (every path, before the currency stamp; idempotent; remote-path duplicate removed with a pointer comment).
- **`# BL-116-PUSH-GATE-SCOPE`** (excision-safe fence): the first-class exemption is now **earned, not assumed** — the gate is skipped only when `remote_repo_created`+`pushed_initial` are both on record (the on-disk meaning of the premise); `host=other` keeps unconditional gating.

## Proof

- BL-116 RED observed: github/org fixture, no records, no remote → **0 push-gate lines**. Post-fix: FAIL fires; recorded-steps fixture exempt; host=other regression pinned; **fence-excision mutant** restores the old scope and the case regresses (4/4).
- BL-110 RED observed via mutation: HEAD-reverted init scaffolds a real `--no-remote-creation` project with `MUTANT-PIN=ABSENT`; fixed init stamps pin == framework HEAD (`T-scaffold-pin-stamped`, scaffold suite 8/8 with a real init).
- Fixture updates are **honest modeling, not weakening**: bl104/bl102/backstop fixtures now record the init-push steps they always represented — the scope fix correctly began gating "never-pushed" fixtures, which is the fix working.

## Verification

- `test-bl116-push-gate-scope.sh` 4/4 · scaffold suite 8/8 (3 real inits) · bl104 · bl102 · backstop-attestation · bl124 · check-phase-gate · run-lints 11/11

**Stacked on #206** → #205 → #204 → #203. Merge ascending; auto-delete retargets each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)