### PR TITLE
fix(ci-templates): make emitted CI approval-log integrity real + drop gitleaks org-license trap (BL-147, BL-151 WP-1)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -111,6 +111,7 @@ jobs:
             tests/test-bl125-commit-test-exec.sh
             tests/test-bl141-commitmsg-repair.sh
             tests/test-bl143-pastcap-selfapproval.sh
+            tests/test-bl147-ci-template-integrity.sh
             tests/test-bl089-doc-foundations.sh
             tests/test-bl137-ci-tools-scope.sh
             tests/test-bl138-approval-window.sh

--- a/Reports/2026-07-21-pr-sweep/PROGRESS.md
+++ b/Reports/2026-07-21-pr-sweep/PROGRESS.md
@@ -1,0 +1,98 @@
+# PR-Sweep Remediation — PROGRESS ledger
+
+One entry per work package, appended as each WP opens its PR. Executor: Opus 4.8.
+Plan: `REMEDIATION-PLAN.md` (this directory).
+
+---
+
+## WP-1 — BL-147 + BL-151: make the approval-integrity step real; gitleaks without the org-license trap
+
+**Branch:** `fix/bl147-bl151-ci-approval-integrity` · **Base:** `main` @ `e7bc567`
+(fast-forwarded to the plan commit `e724d6a` to carry the BL-147/BL-151 backlog
+entries — see the note under "Deviations"). **Status:** PR opened green, not merged.
+
+### Reproduce (the finding)
+- `templates/pipelines/ci/github/{python,typescript,other}.yml` ran
+  `git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'`.
+  `actions/checkout` defaults to a depth-1 clone with **no `origin/main` ref** →
+  the diff dies `fatal: bad revision`, the `2>/dev/null` swallows it, and the
+  step **PASSES on a tampered append-only log**. On push-to-main the `A...B`
+  expression is self-comparing (vacuous there too).
+- Parity hole: **7 of 10** GitHub language templates never got the approval
+  steps at all (`csharp, dart, go, java, kotlin, rust, swift`).
+- `gitleaks/gitleaks-action` needs `GITLEAKS_LICENSE` for ORG accounts +
+  `fetch-depth: 0`; the templates set neither → org-track projects get a
+  failing/license-less secret scan (BL-151).
+
+### Watched-RED (before any template touched)
+New shared content-pin suite `tests/test-bl147-ci-template-integrity.sh` —
+the wave's ONE shared asset. Template lists derived mechanically
+(`find … -name '*.yml'`) with a **>=10 count floor** (vacuity guard); cases:
+- **Ca** checkout carries `fetch-depth: 0` (all 10 github)
+- **Cb** both approval steps present in ALL 10 github (integrity + author)
+- **Cc** no APPROVAL_LOG-touching line carries `2>/dev/null` (github + gitlab)
+- **Cd** base resolved explicitly (`github.base_ref`, loud-fail
+  `git rev-parse --verify "$BASE"`), never bare `origin/main...HEAD`
+- **Ce** no `gitleaks/gitleaks-action`; every github template runs `./gitleaks git`
+- **Cf** gitlab twin of Cc/Cd on the approval-bearing gitlab templates
+
+Pre-fix run: **`Results: 3 passed, 11 failed`** (exit 1). Every failure mapped
+to the finding — all 10 lack fetch-depth; 7 lack the steps; other/python/ts
+(github) + python/ts (gitlab) silence stderr / use the bare base; all 10 use
+gitleaks-action. RED evidence saved to `scratchpad/wp1-RED.txt`.
+
+### Fix
+- **Checkout** — `with: fetch-depth: 0` added to all 10 github CI templates
+  (pin unchanged; WP-4 owns the pin refresh).
+- **Approval steps** — both governance steps (integrity + author verification)
+  stamped **BYTE-IDENTICAL** into all 10 (single sha `83ccd86…` across all 10):
+  `BASE="origin/${{ github.base_ref || 'main' }}"`, `${{ github.event.before }}`
+  on push, `git fetch origin … --quiet || true`, then a LOUD `exit 1` if
+  `git rev-parse --verify "$BASE"` fails (a check that cannot run must not pass),
+  then the append-only diff. No `2>/dev/null`.
+- **gitleaks** — action → license-free CLI: `GITLEAKS_VERSION=8.30.1`
+  (`gh api repos/gitleaks/gitleaks/releases/latest` → `v8.30.1`), `curl … |
+  tar -xz gitleaks && ./gitleaks git --redact --exit-code 1`. `gitleaks git`
+  scans full history — rides the fetch-depth fix.
+- **GitLab twins** (`python.yml`, `typescript.yml`) — same explicit-base +
+  loud-fail + no-silencer, using `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` /
+  `CI_DEFAULT_BRANCH`.
+
+Post-fix run: **`Results: 14 passed, 0 failed`** (exit 0). All 20 CI templates
+re-validated as parseable YAML (PyYAML `safe_load`).
+
+### Tests
+Registered in BOTH `tests/full-project-test-suite.sh` and the `tests.yml` unit
+list (adjacent to `test-bl143`, each comment kept attached to its own if-block).
+`scripts/lint-tests-registered.sh` → OK.
+
+### Mutation proofs (run against the committed baseline; both restored to GREEN)
+- Re-add `2>/dev/null` to one template's APPROVAL_LOG diff line → **Cc RED**
+  (`Results: 13 passed, 1 failed`). `git checkout` restore → GREEN.
+- Remove `fetch-depth: 0` from one template → **Ca RED**
+  (`Results: 13 passed, 1 failed`). Restore → GREEN. (The gitleaks CLI comment's
+  incidental "fetch-depth: 0 on checkout." mention is correctly ignored by the
+  case's `…0$` anchor.)
+
+### Blast radius
+- `grep -rl 'origin/main...HEAD' tests/` → **none** (the old text was pinned by
+  no test fixture — only the templates carried it). No fixture updates needed.
+- `grep -rln 'gitleaks|Approval log|Secret detection' tests/` → the hits are
+  hook/PATH/install-command surfaces, NONE pin the changed CI-template content.
+- `bash scripts/run-lints.sh` → PASS (see the PR body for the tally).
+- `scripts/lint-backlog-references.sh` → OK after the backlog Status updates.
+
+### Deviations from the plan
+- **Base reconciliation (not a spec deviation):** the worktree was cut from
+  `origin/main`, but the BL-147/BL-151 backlog entries + the plan live only on
+  `origin/docs/pr-sweep-remediation-plan` (one docs commit `e724d6a` = main + the
+  entries/plan). To append the required in-entry Status updates, the WP-1 branch
+  was **fast-forwarded** to that commit (zero file overlap with the WP-1 code
+  changes — clean FF). Consequence: this PR also carries the sweep findings +
+  plan doc. No change to the WP-1 work itself.
+- **gitleaks version:** the plan's `8.28.0` was flagged indicative; used the real
+  current `8.30.1` per `gh api … releases/latest`, exactly as instructed.
+- Author-verification step stamped into all 10 (not just the 3 that had it) to
+  close the parity hole the finding names ("7 of 10 never got the steps"), with
+  the plan's "same base-resolution treatment"; the integrity step is the one the
+  plan pins byte-identical, and both are byte-identical across all 10.

--- a/Reports/2026-07-21-pr-sweep/REMEDIATION-PLAN.md
+++ b/Reports/2026-07-21-pr-sweep/REMEDIATION-PLAN.md
@@ -1,0 +1,193 @@
+# PR-Sweep Remediation Plan — BL-147…BL-154
+
+**Provenance:** BL-146 cumulative-history review of all 229 merged PRs (2026-07-21,
+Fable reviewer, every finding demonstrated by an executed probe on main
+`e7bc567`), findings independently re-validated by the orchestrating session.
+**Executor: Opus 4.8** (Karl's directive). **Plan author + final verifier:
+Fable** (verifier tier ≥ implementer, the BL-097 rule). This plan is written to
+the BL-098 junior-followable standard: follow it literally; where reality
+disagrees with the plan, STOP and report — do not improvise.
+
+**Ground rules (non-negotiable, all work):** watched-RED TDD (write/extend the
+test, RUN it, see it fail for the stated reason, then build); every new test
+registered in BOTH `tests/full-project-test-suite.sh` and the `tests.yml` unit
+list; hermetic tests only (no network, no live remotes — CI-template checks are
+CONTENT pins, never live runs); bash-3.2 subset; quote every path (the repo
+path contains a space); no `--no-verify`; no gate route-arounds; one WP = one
+branch = one PR, opened green, never self-merged; ledger entry per WP appended
+to THIS file's directory as `PROGRESS.md`; backlog status updates staged
+in-entry (Closed flips happen at merge, citing PR# + SHA).
+
+---
+
+## The one shared test asset (build FIRST, in WP-1)
+
+`tests/test-bl147-ci-template-integrity.sh` — content-pin suite over
+`templates/pipelines/**`. Grammar: derive the template list mechanically
+(`find templates/pipelines/ci/github -name '*.yml'` etc. — never a hand
+enumeration; a count floor guards vacuity, ≥10 github CI files). Each WP below
+adds its cases here. Register in BOTH lists in WP-1; later WPs just add cases.
+
+---
+
+## WP-1 — BL-147 + BL-151: make the approval-integrity step real; gitleaks without the org-license trap
+
+**Files:** all 10 `templates/pipelines/ci/github/*.yml`, both
+`templates/pipelines/ci/gitlab/*.yml`, the new test suite.
+
+1. RED first: cases asserting (a) every github CI template's checkout step
+   carries `fetch-depth: 0`; (b) every github CI template contains the
+   approval-integrity step (all 10 — today only python/typescript/other do);
+   (c) no approval step contains `2>/dev/null`; (d) the diff base is the
+   explicit expression below, not bare `origin/main...HEAD`; (e) no template
+   uses `gitleaks/gitleaks-action` (the CLI form replaces it). Run → RED.
+2. Checkout step in every github CI template becomes:
+   `- uses: actions/checkout@<current-pin>` with `with: fetch-depth: 0`.
+3. The approval step (stamp into ALL 10, byte-identical apart from nothing):
+   ```yaml
+   - name: Governance - Approval log integrity
+     if: hashFiles('APPROVAL_LOG.md') != ''
+     run: |
+       BASE="origin/${{ github.base_ref || 'main' }}"
+       if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+       git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+       if ! git rev-parse --verify "$BASE" >/dev/null; then
+         echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+       fi
+       if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+         echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+       fi
+   ```
+   (Author-verification step: same base-resolution treatment.) NOTE the
+   removed `2>/dev/null` and the fail-loud arm — that is the finding.
+4. gitleaks: replace the action step in every github CI template with the CLI:
+   ```yaml
+   - name: Security - Secret detection (gitleaks)
+     run: |
+       GITLEAKS_VERSION=8.28.0
+       curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+       ./gitleaks git --redact --exit-code 1
+   ```
+   (Version: check `gh api repos/gitleaks/gitleaks/releases/latest` at build
+   time and use that; the value above is indicative. `gitleaks git` scans full
+   history — that is why fetch-depth 0 matters here too.)
+5. GitLab twins: same base-resolution + loud-fail fix in the gitlab CI
+   templates' approval steps (gitlab clones are full by default, but the
+   explicit-base + no-silencer discipline applies; verify what the templates
+   actually contain and mirror the github semantics).
+6. Mutation proofs: re-add `2>/dev/null` to one template → the suite case
+   goes RED; remove `fetch-depth` from one → RED. Record both.
+7. Blast radius: `bash scripts/run-lints.sh`; grep tests/ for any suite
+   pinning the old approval-step text (`grep -rl 'origin/main...HEAD' tests/`)
+   and update those fixtures deliberately (documented-bug exception applies —
+   they pinned a vacuous step).
+
+## WP-2 — BL-148 + BL-153: semgrep surface modernization, hook-parity policy
+
+**Files:** all 10 github CI templates, all bitbucket CI templates, suite cases.
+
+1. RED: cases asserting no template references `semgrep/semgrep-action` or
+   `returntocorp/semgrep`; every github CI template carries a semgrep job/step
+   whose flags EQUAL the local hook's policy string (derive the expected flag
+   set by grepping `scripts/lib/hook-templates.sh` for the `semgrep scan`
+   invocation — single source, never retype the rule list).
+2. GitHub: replace the action step with:
+   ```yaml
+   sast:
+     runs-on: ubuntu-latest
+     container: { image: semgrep/semgrep }
+     steps:
+       - uses: actions/checkout@<current-pin>
+         with: { fetch-depth: 0 }
+       - run: semgrep scan --config p/owasp-top-ten --config p/security-audit --config r/javascript.browser.security.insecure-document-method --severity=ERROR --error
+   ```
+   (Exact flags: whatever the hook emits — read it, don't copy this.)
+3. Bitbucket: `image: returntocorp/semgrep` → `image: semgrep/semgrep`; same
+   flag parity; `gitleaks detect --source .` → `gitleaks dir .` and pin the
+   image tag to a real version (check upstream latest).
+4. Mutation: strip the DOM-XSS config from one template → parity case RED.
+
+## WP-3 — BL-149: port BL-122 into the release DAST + tool-matrix image fix
+
+**Files:** `templates/pipelines/release/github/web.yml`,
+`templates/tool-matrix/web.json`, suite cases.
+
+1. RED: cases asserting the release template (a) pins
+   `ghcr.io/zaproxy/zaproxy:stable` (the scanner's image — not zap-stable);
+   (b) judges `riskcode >= 2` via jq on a `-J` JSON report, never the raw exit
+   code; (c) guards on `vars.PREVIEW_URL != ''`; and tool-matrix checks the
+   SAME image the scanner runs.
+2. Port the `# BL-122-ZAP-RISK-FILTER` logic (read it in
+   `scripts/run-phase3-validation.sh`): run with mounted workdir + `-J`,
+   drop rc 1/2 from the verdict, jq-count riskcode≥2, fail iff count>0 or the
+   report is unreadable (unreadable = fail LOUDLY, the BL-140 posture).
+3. tool-matrix/web.json: `zaproxy/zap-stable` → `ghcr.io/zaproxy/zaproxy:stable`
+   in both check_command and the manual hint.
+4. Mutation: revert the verdict line to raw exit → RED.
+
+## WP-4 — BL-150: the pin refresh
+
+**Files:** `.github/workflows/{lint,tests}.yml`, all emitted CI + release
+templates, init.sh `RELEASE_SETUP_ACTION` table.
+
+1. For each action: `gh api repos/<owner>/<repo>/releases/latest` → tag; then
+   `gh api repos/<owner>/<repo>/git/ref/tags/<tag>` (deref annotated tags) →
+   commit SHA. Update every pin to `<sha> # vN (vN.N.N)` comment form.
+   Actions list: checkout, setup-node, setup-python, setup-java, setup-go?,
+   upload-artifact, softprops/action-gh-release, golangci-lint-action,
+   gitleaks-action IF any usage survives WP-1 (it should not), flutter-action
+   (verify current), everything else `grep -rhoE 'uses: [^@]+@' templates/ .github/` finds.
+2. gitleaks-action v3 note is moot if WP-1 removed it — verify.
+3. RED-able pin case: suite asserts every `uses:` line carries a 40-hex SHA
+   pin + a version comment (shape check, not version check — the version
+   WATCHER is BL-109/BL-150's deferred half, out of scope here).
+4. THE FRAMEWORK'S OWN workflows changed → CI must stay green on the PR; that
+   run IS the live test of the new pins.
+
+## WP-5 — BL-152: GitLab approval_rules migration
+
+**Files:** `scripts/host-drivers/gitlab.sh`, `tests/test-gitlab-*` suites.
+
+1. Read the driver's exit-code contract header FIRST (rc 3 generic / rc 4
+   Premium-only — BL-032). RED: extend the driver suite (it stubs `glab`) with
+   a case asserting the invocation is `POST projects/:id/approval_rules` with
+   `approvals_required` — watch it fail against the PUT form.
+2. Swap the call; preserve the BL-032 Premium-only detection (the error-body
+   sniff — verify what string the approval_rules endpoint returns on free
+   tier by reading the suite's existing fixtures; if unknowable offline, keep
+   BOTH sniffs).
+3. All gitlab suites green; mutation: revert to PUT → new case RED.
+
+## WP-6 — BL-154: unit-list enforcement arm + CLAUDE.md true-up
+
+**Files:** `scripts/lint-tests-registered.sh`, its test suite, CLAUDE.md.
+
+1. RED: suite case with a fixture test file that is aggregator-registered but
+   absent from a fixture tests.yml unit list → the new arm must flag it; and
+   an init.sh-invoking fixture file must be EXEMPT (aggregator-only is correct
+   for those — derive the predicate from the file's own text, the
+   `grep -L 'init\.sh'` convention documented in tests.yml).
+2. Implement behind a marker fence; the real repo must pass (delta is zero
+   today — verified).
+3. CLAUDE.md: the "lint-tests-registered.sh enforces" sentence becomes true —
+   no edit needed beyond confirming; if the arm lands with a different name,
+   update the sentence.
+
+---
+
+## Sequencing & discipline
+
+Order: WP-1 → WP-2 → WP-3 (template wave, same suite file, stacked or
+sequential-after-merge to avoid same-anchor conflicts — SEQUENTIAL preferred;
+note the tests.yml/full-suite registration anchors collide across parallel
+branches: the merge-choreography lesson) → WP-4 → WP-5 → WP-6.
+Each WP: watched-RED evidence in the PR body; mutation proofs recorded; a
+`PROGRESS.md` entry in this directory written before the PR opens. After the
+last WP merges: consolidated Fable adversarial verification of the whole wave
+(the #225–#227 pattern), then the Dogfood-4 milestone
+(Solo-Orchestrator-work-example) proceeds.
+
+**Out of scope (recorded, not built):** the action-pin version WATCHER
+(BL-150's durable half — BL-109 territory); gitlab/bitbucket release-DAST
+parity (recorded in BL-149); host-parity of approval steps beyond
+github+gitlab (bitbucket has no approval step today — record, don't invent).

--- a/Reports/2026-07-21-pr-sweep/SWEEP-FINDINGS.md
+++ b/Reports/2026-07-21-pr-sweep/SWEEP-FINDINGS.md
@@ -1,0 +1,36 @@
+# BL-146 Cumulative PR Sweep — Findings Record (2026-07-21)
+
+Reviewer: the BL-146 standing adversarial PR reviewer (second live run,
+Fable tier), Karl-directed: all 229 merged PRs (#1–#231), issue-threading
+required — only defects DEMONSTRATED on main `e7bc567` by an executed probe
+count. Findings independently re-validated by the orchestrating session
+before planning (every probe reproduced).
+
+## Unresolved findings → filed as backlog entries
+
+| Sweep ID | Backlog | Tier | One line |
+|----------|---------|------|----------|
+| CR-1 | BL-147 | MUST | Emitted CI approval-log integrity steps vacuous under depth-1 checkout — tampering passes silently; 7/10 languages lack the step entirely |
+| CR-2 | BL-148 | MUST | Emitted CI SAST rides semgrep-action — archived upstream 2024-04 |
+| CR-3 | BL-149 | MUST | Emitted release DAST is the un-fixed BL-122 twin — unpassable for any real web app |
+| CR-4 | BL-150 | SHOULD | Every action pin lags 1–3 majors; pins invisible to the currency system |
+| CR-5 | BL-151 | SHOULD | Org-track gitleaks CI step unlicensed + depth-starved |
+| CR-6 | BL-152 | SHOULD | GitLab approvals call on an API deprecated since 14.0 |
+| CR-7 | BL-153 | SHOULD | Bitbucket semgrep image rename-frozen; gitleaks command form deprecated |
+| CR-8 | BL-154 | NICE | tests.yml unit-list membership unenforced; CLAUDE.md overclaims |
+
+## The headline pattern
+
+All eight live in the EMITTED-TEMPLATE / EXTERNAL-TOOL surfaces — the one
+region the (excellent) internal test estate structurally cannot execute: no
+test runs a generated workflow on a real runner, and nothing watches upstream
+tool lifecycles. The internal history is clean: every issue the sweep spotted
+in gate scripts, hooks, scanners, and test infra was already corrected by a
+later PR (nine threaded non-findings, each verified fixed on main).
+
+## Disposition
+
+Remediation plan: `REMEDIATION-PLAN.md` (this directory) — six WPs, executor
+Opus 4.8 per Karl's directive, Fable consolidated verification at the end,
+then the Dogfood-4 milestone. Full sweep transcript (probes, coverage
+accounting, currency report) preserved in the session record 2026-07-21.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -3509,6 +3509,8 @@ The "Approval log integrity" + "Approval author verification" steps in `template
 
 **Related:** BL-112/BL-113 (the class); PR #8 (origin); BL-151 (shares the fetch-depth fix).
 
+**Status update 2026-07-21:** WP-1 shipped on branch `fix/bl147-bl151-ci-approval-integrity` (status stays Open — Closed flip happens at merge, citing PR# + SHA). All 10 `templates/pipelines/ci/github/*.yml` gained `fetch-depth: 0` on checkout; both governance approval steps (integrity + author verification) are now stamped BYTE-IDENTICAL into all 10 (7 previously had none — verified single sha across all 10), resolving the base explicitly (`origin/${{ github.base_ref || 'main' }}`, `${{ github.event.before }}` on push) and failing LOUDLY via `git rev-parse --verify "$BASE"` when the base cannot resolve; every `2>/dev/null` on an APPROVAL_LOG line is gone. The two gitlab approval twins (`python.yml`, `typescript.yml`) got the same explicit-base + loud-fail + no-silencer treatment via `CI_MERGE_REQUEST_TARGET_BRANCH_NAME`/`CI_DEFAULT_BRANCH`. Watched-RED via the wave's one shared content-pin suite `tests/test-bl147-ci-template-integrity.sh` (mechanically derived template lists + >=10 count floor): pre-fix **3 passed / 11 failed**, post-fix **14 passed / 0 failed**. Mutation proofs (both restored to GREEN): re-adding `2>/dev/null` to one template → case Cc RED (13/1); removing `fetch-depth: 0` from one → case Ca RED (13/1). Registered in BOTH `tests/full-project-test-suite.sh` and the `tests.yml` unit list. All 20 CI templates re-validated as parseable YAML.
+
 ---
 
 ## BL-148: Every generated GitHub CI workflow runs SAST via semgrep-action — archived upstream April 2024
@@ -3566,6 +3568,8 @@ gitleaks-action requires `GITLEAKS_LICENSE` for ORGANIZATION accounts and `fetch
 **Fix shape:** drop the action; run the gitleaks CLI directly (`gitleaks git` — no license, mirrors the local hook), riding BL-147's fetch-depth fix. Alternative (rejected for friction): wire the license secret.
 
 **Related:** BL-147 (shared checkout fix); BL-137 (the class).
+
+**Status update 2026-07-21:** WP-1 shipped on branch `fix/bl147-bl151-ci-approval-integrity` (status stays Open — Closed flip happens at merge, citing PR# + SHA). The `gitleaks/gitleaks-action` step was dropped from all 10 `templates/pipelines/ci/github/*.yml` and replaced by the license-free CLI (`GITLEAKS_VERSION=8.30.1` — the current release per `gh api repos/gitleaks/gitleaks/releases/latest` → `v8.30.1`; `curl … | tar -xz gitleaks && ./gitleaks git --redact --exit-code 1`), so no `GITLEAKS_LICENSE` is required for org accounts. `gitleaks git` scans full history, so it rides BL-147's `fetch-depth: 0` fix. Content-pinned by the shared suite `tests/test-bl147-ci-template-integrity.sh` case Ce (no `gitleaks/gitleaks-action`; every github CI template runs `./gitleaks git`). Suite tally post-fix **14 passed / 0 failed** (pre-fix 3/11). Registered in BOTH lists.
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -3493,3 +3493,119 @@ Karl's directive: an agent that reviews PRs ADVERSARIALLY with the intent of mak
 **Related:** BL-100 (the acceptance doctrine this makes standing); BL-097/BL-098 (operating model / reviewer role); BL-128 (headless review dispatch machinery precedent); `evaluation-prompts/` (the phase-review library); the context7 global rule.
 
 **Live test 2026-07-21 (Karl-directed):** one Fable subagent reviewed PRs #229+#231 under this entry's five-dimension brief. IT WORKS — verdicts #229 approve (every SHA/path/marker claim verified) and #231 major_concerns whose MAJOR was a genuine miss two prior adversarial verifiers left standing (comment-blind wiring greps: a disabled-instantiation mutant passed every PR-blocking check; only the manual-dispatch full lane would catch it). All findings landed same-day. Design inputs from the run (META): (1) the reviewer needs a WORKTREE pinned to the PR tip — this run got lucky that the checkout was the branch; (2) pre-cleared scratch/mutation-lab semantics (first lab setup was permission-denied); (3) verdict posting + numbered finding IDs in the ledger grammar; (4) a standing LANE-REACHABILITY probe — evaluate mutation survivorship against the PR-BLOCKING check set, not the whole estate (else every full-lane-only gap becomes an automatic major on unrelated PRs); (5) trigger = slash-command/dispatch-on-demand, NOT auto-on-open (~40 tool calls + a mutation lab per run); (6) context7 was reachable via ToolSearch and produced a real oracle (GFM cell-count grammar over the new tables) — headless dispatch must verify reachability before claiming currency coverage; (7) the Agent tool exposes a model knob but no EFFORT knob — "max effort" rode in the prompt; the operating-model design (BL-097) should carry effort as a first-class reviewer parameter.
+
+---
+
+## BL-147: Emitted CI approval-log integrity steps are vacuous under every standard Actions checkout — tampering sails through silently
+
+**Logged:** 2026-07-21 (BL-146 cumulative PR sweep, CR-1; validated in-session)
+**Category:** Bug / silent-success (emitted CI, security lane)
+**Severity:** High
+**Status:** Open
+
+The "Approval log integrity" + "Approval author verification" steps in `templates/pipelines/ci/github/{python,typescript,other}.yml` (+ gitlab twins) run `git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'` — but the templates set NO `fetch-depth`, and `actions/checkout`'s default depth-1 clone has no `origin/main` ref: the diff dies `fatal: bad revision`, the `2>/dev/null` eats it, and the step PASSES on a tampered approval log (executed proof: sweep fixture). On push-to-main the expression is self-comparing (vacuous there too). Parity hole: 7 of 10 GitHub language templates never got the steps at all. Introduced PR #8 (`db2c14e`), never revisited — the BL-112/113 silent-success class, in the governance lane, shipped to every generated project.
+
+**Fix shape:** `fetch-depth: 0` on checkout; resolve the base explicitly (`origin/${{ github.base_ref || 'main' }}`; `${{ github.event.before }}` on push); drop the `2>/dev/null` (a bad revision must fail LOUDLY); stamp the corrected step into all 10 languages × both hosts; content-pin suite.
+
+**Related:** BL-112/BL-113 (the class); PR #8 (origin); BL-151 (shares the fetch-depth fix).
+
+---
+
+## BL-148: Every generated GitHub CI workflow runs SAST via semgrep-action — archived upstream April 2024
+
+**Logged:** 2026-07-21 (sweep CR-2; validated: `gh api repos/semgrep/semgrep-action` → archived:true, pushed 2024-04-09)
+**Category:** Bug / currency (emitted CI, security lane)
+**Severity:** High
+**Status:** Open
+
+All 10 `templates/pipelines/ci/github/*.yml` pin `semgrep/semgrep-action@713efdd… # v1 (v0.58.0)` — the 2021 semgrep-agent era of an action dead upstream for 2+ years. Current upstream guidance (context7): the `semgrep/semgrep` container running `semgrep scan`/`semgrep ci`.
+
+**Fix shape:** replace with a `container: semgrep/semgrep` job (or `pip install semgrep` run step) executing the LOCAL HOOK'S exact policy — `semgrep scan --config p/owasp-top-ten --config p/security-audit --config r/javascript.browser.security.insecure-document-method --severity=ERROR --error` — so CI and the pre-commit hook enforce identical rules (`# BL-118-DOMXSS-CONFIG` parity).
+
+**Related:** BL-118 (the hook policy to mirror); BL-153 (the bitbucket image twin).
+
+---
+
+## BL-149: Emitted release-pipeline DAST is the un-fixed BL-122 twin — unpassable for essentially every web app
+
+**Logged:** 2026-07-21 (sweep CR-3; validated: raw exit-code judgment on `zap-baseline.py`)
+**Category:** Bug / gate correctness (emitted release pipeline)
+**Severity:** High
+**Status:** Open
+
+`templates/pipelines/release/github/web.yml` runs `docker run -t zaproxy/zap-stable zap-baseline.py -t ${{ vars.PREVIEW_URL }}` and judges the RAW exit code — baseline reports ALL alerts as WARN (exit 2), and rule 10049 fires under every possible Cache-Control value (the proven BL-122 mechanism), so any real site fails the release. PR #203 fixed exactly this in `run-phase3-validation.sh` and never touched the template. Aggravators: image unpinned (every other action in the file is SHA-pinned); no guard when `PREVIEW_URL` is unset; gitlab/bitbucket release templates have no DAST at all (recorded, not fixed here).
+
+**Fix shape:** port BL-122 — `-J zap-report.json` + mounted workdir + jq `riskcode>=2` verdict; pin the image (`ghcr.io/zaproxy/zaproxy:stable` to match the phase-3 scanner); `if: vars.PREVIEW_URL != ''`. Also fix `templates/tool-matrix/web.json`'s check of `zaproxy/zap-stable` — an image the scanner never uses (sweep CR-8 nit).
+
+**Related:** BL-122 (`# BL-122-ZAP-RISK-FILTER`, the port source); BL-070 (the scanner).
+
+---
+
+## BL-150: Every SHA-pinned GitHub Action in the estate lags 1–3 majors; pins are invisible to the currency system
+
+**Logged:** 2026-07-21 (sweep CR-4; validated: checkout v4.3.1 vs v7.0.1 latest)
+**Category:** Debt / currency (framework workflows + emitted templates + init.sh pin table)
+**Severity:** Medium
+**Status:** Open
+
+checkout v4.3.1→v7.0.1, setup-node v4→v7, setup-python v5→v7, upload-artifact v4→v7, setup-java v4→v5, action-gh-release v2→v3, golangci-lint-action v6→v9, gitleaks-action v2→v3 (flutter-action current). Surfaces: `.github/workflows/{lint,tests}.yml`, all emitted CI/release templates, init.sh's `RELEASE_SETUP_ACTION` table. BL-109's currency block tracks file SHAs/hooks/MCP — action pins structurally invisible.
+
+**Fix shape:** one refresh PR re-pinning to current majors (new SHAs + version comments); then a durable watcher: pin inventory in the currency block or a lint diffing pin comments vs `releases/latest` (design-light, can defer the watcher to BL-109).
+
+---
+
+## BL-151: Org-track generated projects get a failing (or license-less) gitleaks CI step
+
+**Logged:** 2026-07-21 (sweep CR-5; validated: no GITLEAKS_LICENSE anywhere in templates; depth-1 checkout)
+**Category:** Bug / documented-but-impossible (emitted CI, org tier)
+**Severity:** Medium
+**Status:** Open
+
+gitleaks-action requires `GITLEAKS_LICENSE` for ORGANIZATION accounts and `fetch-depth: 0`; the emitted templates set neither. Organizational deployment is a first-class tier — the BL-137 class in the security lane.
+
+**Fix shape:** drop the action; run the gitleaks CLI directly (`gitleaks git` — no license, mirrors the local hook), riding BL-147's fetch-depth fix. Alternative (rejected for friction): wire the license secret.
+
+**Related:** BL-147 (shared checkout fix); BL-137 (the class).
+
+---
+
+## BL-152: GitLab driver's org-mode approvals call uses an API deprecated since GitLab 14.0
+
+**Logged:** 2026-07-21 (sweep CR-6; validated: `glab api -X PUT projects/:id/approvals` + `approvals_before_merge` in gitlab.sh)
+**Category:** Debt / currency (host driver)
+**Severity:** Medium
+**Status:** Open
+
+`scripts/host-drivers/gitlab.sh` PUTs `/approvals` with `approvals_before_merge` — deprecated since 14.0, removal flagged (approval_rules is current; the field is slated out in API v5). Works today; on removal the failure lands in the generic exit-3 arm, not the handled BL-032 free-tier arm.
+
+**Fix shape:** `POST /projects/:id/approval_rules` with `approvals_required: 1`, preserving the BL-032 Premium-only detection wording; the driver suite pins both arms.
+
+**Related:** BL-032 (the free-tier arm to preserve); PR #91 (the prior "modern API" pass).
+
+---
+
+## BL-153: Bitbucket CI templates scan with a rename-frozen semgrep image and the deprecated gitleaks command form
+
+**Logged:** 2026-07-21 (sweep CR-7; validated: `returntocorp/semgrep` + `zricethezav/gitleaks:latest` + `gitleaks detect` in the templates)
+**Category:** Bug / currency (emitted CI, bitbucket host)
+**Severity:** Medium
+**Status:** Open
+
+`returntocorp/semgrep` stopped receiving updates at the 2023 org rename (current: `semgrep/semgrep`) — generated bitbucket projects scan with a frozen engine/ruleset. `gitleaks detect` is the pre-8.19 deprecated form (`gitleaks git`/`dir` current); `:latest` tag unpinned.
+
+**Fix shape:** `image: semgrep/semgrep` + the BL-148 flag policy; `gitleaks dir .` with a version-tagged image.
+
+**Related:** BL-148 (the github twin).
+
+---
+
+## BL-154: tests.yml unit-list membership is convention, not enforcement — and CLAUDE.md claims otherwise
+
+**Logged:** 2026-07-21 (sweep CR-8; validated: no lint greps tests.yml; current delta = 0)
+**Category:** Debt / latent enforcement gap + doc drift
+**Severity:** Low
+**Status:** Open
+
+`lint-tests-registered.sh` checks aggregator registration only; nothing structural enforces the tests.yml unit list, while CLAUDE.md says the lint enforces BOTH. Today's delta is zero (verified) — latent, not live.
+
+**Fix shape:** fast-lane arm in lint-tests-registered.sh (every non-init-invoking `tests/test-*.sh` must appear in the tests.yml unit list) + true-up the CLAUDE.md sentence.

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-dotnet@67a3573c9a986a3f9c594539f4ab511d57bb3ce9 # v4 (v4.3.1)
         with:
@@ -37,9 +39,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: |
@@ -51,6 +57,44 @@ jobs:
           dotnet tool install --global dotnet-project-licenses
           dotnet-project-licenses --input . --fail-on "GPL-2.0-only;GPL-3.0-only;AGPL-3.0-only;LGPL-2.0-only;LGPL-2.1-only;LGPL-3.0-only;SSPL-1.0;EUPL-1.1;EUPL-1.2"
           # MPL-2.0 has file-level copyleft — review on a case-by-case basis if detected
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
+          fi
 
       - name: Governance - Phase gate check
         if: hashFiles('.claude/phase-state.json') != ''

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2 # v2 (v2.23.0)
         with:
@@ -36,9 +38,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         uses: google/osv-scanner-action/osv-scanner-action@c51854704019a247608d928f370c98740469d4b5 # v2.3.5
@@ -50,6 +56,44 @@ jobs:
           dart pub global activate dart_license_checker
           dart pub global run dart_license_checker --fail-on "GPL-2.0,GPL-3.0,AGPL-3.0,LGPL-2.0,LGPL-2.1,LGPL-3.0,SSPL-1.0,EUPL-1.1,EUPL-1.2"
           # MPL-2.0 has file-level copyleft — review on a case-by-case basis if detected
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
+          fi
 
       - name: Governance - Phase gate check
         if: hashFiles('.claude/phase-state.json') != ''

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5 (v5.6.0)
         with:
@@ -38,9 +40,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: |
@@ -53,6 +59,44 @@ jobs:
           go-licenses check ./... --disallowed_types=restricted
           # "restricted" covers GPL, AGPL, LGPL, SSPL, EUPL, and other copyleft licenses
           # MPL-2.0 has file-level copyleft — review on a case-by-case basis if detected
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
+          fi
 
       - name: Governance - Phase gate check
         if: hashFiles('.claude/phase-state.json') != ''

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
         with:
@@ -42,9 +44,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: ./gradlew dependencyCheckAnalyze
@@ -58,6 +64,44 @@ jobs:
         # Configure the plugin to block: GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.0, LGPL-2.1,
         # LGPL-3.0, SSPL-1.0, EUPL-1.1, EUPL-1.2. See plugin docs for allowedLicenses config.
         # MPL-2.0 has file-level copyleft — review on a case-by-case basis if detected
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
+          fi
 
       - name: Governance - Phase gate check
         if: hashFiles('.claude/phase-state.json') != ''

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4 (v4.8.0)
         with:
@@ -42,9 +44,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: ./gradlew dependencyCheckAnalyze
@@ -58,6 +64,44 @@ jobs:
         # Configure the plugin to block: GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-2.0, LGPL-2.1,
         # LGPL-3.0, SSPL-1.0, EUPL-1.1, EUPL-1.2. See plugin docs for allowedLicenses config.
         # MPL-2.0 has file-level copyleft — review on a case-by-case basis if detected
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
+          fi
 
       - name: Governance - Phase gate check
         if: hashFiles('.claude/phase-state.json') != ''

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       # TODO: Add language/runtime setup step
       # Example: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0), actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (v5.6.0),
@@ -42,9 +44,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: |
@@ -68,21 +74,37 @@ jobs:
       - name: Governance - Approval log integrity
         if: hashFiles('APPROVAL_LOG.md') != ''
         run: |
-          if git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'; then
-            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."
-            exit 1
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
           fi
 
       - name: Governance - Approval author verification
         if: hashFiles('APPROVAL_LOG.md') != ''
         run: |
-          if git diff --name-only origin/main...HEAD 2>/dev/null | grep -q 'APPROVAL_LOG.md'; then
-            COMMIT_AUTHOR=$(git log --format='%an' origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | head -1)
-            ADDED_LINES=$(git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep '^+' | grep -i 'Approver' | head -1 || true)
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
             if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
               APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
               if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
                 echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
               fi
             fi
           fi

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5 (v5.6.0)
         with:
@@ -39,9 +41,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: pip-audit
@@ -65,20 +71,32 @@ jobs:
       - name: Governance - Approval log integrity
         if: hashFiles('APPROVAL_LOG.md') != ''
         run: |
-          # Verify no prior APPROVAL_LOG.md entries were modified or deleted (append-only enforcement)
-          if git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'; then
-            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."
-            echo "Prior entries must not be changed. If a correction is needed, add a new entry with a correction note."
-            exit 1
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
           fi
 
       - name: Governance - Approval author verification
         if: hashFiles('APPROVAL_LOG.md') != ''
         run: |
-          # When APPROVAL_LOG.md is modified, check commit author against listed approver
-          if git diff --name-only origin/main...HEAD 2>/dev/null | grep -q 'APPROVAL_LOG.md'; then
-            COMMIT_AUTHOR=$(git log --format='%an' origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | head -1)
-            ADDED_LINES=$(git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep '^+' | grep -i 'Approver' | head -1 || true)
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
             if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
               APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
               if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       # SHA-pinned (BL-113): the ref name no longer selects the toolchain, so
       # the toolchain is now passed explicitly.
@@ -41,9 +43,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Install security tools
         run: |
@@ -56,6 +62,44 @@ jobs:
       - name: Security - License check
         run: cargo license --avoid-build-deps --avoid-dev-deps | tee /dev/stderr | (! grep -qi "GPL-2.0\|GPL-3.0\|AGPL-3.0\|LGPL-2.0\|LGPL-2.1\|LGPL-3.0\|SSPL\|EUPL")
         # MPL-2.0 has file-level copyleft — review on a case-by-case basis if detected
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
+          fi
 
       - name: Governance - Phase gate check
         if: hashFiles('.claude/phase-state.json') != ''

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - name: Select Xcode version
         run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
@@ -46,9 +48,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: |
@@ -72,6 +78,44 @@ jobs:
             echo "[WARN] swift-license not found — license check skipped."
             echo "  Install: brew install nicklama/tap/swift-license"
             echo "  Alternative: review Package.swift dependencies manually."
+          fi
+
+      - name: Governance - Approval log integrity
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
+          fi
+
+      - name: Governance - Approval author verification
+        if: hashFiles('APPROVAL_LOG.md') != ''
+        run: |
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
+            if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
+              APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
+              if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
+                echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
+              fi
+            fi
           fi
 
       - name: Governance - Phase gate check

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4 (v4.4.0)
         with:
@@ -40,9 +42,13 @@ jobs:
             r/javascript.browser.security.insecure-document-method
 
       - name: Security - Secret detection (gitleaks)
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2 (v2.3.9)
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
+          # for org accounts and a full clone; the CLI needs neither and mirrors the local hook.
+          # `gitleaks git` scans full history — hence fetch-depth: 0 on checkout.
+          GITLEAKS_VERSION=8.30.1
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" | tar -xz gitleaks
+          ./gitleaks git --redact --exit-code 1
 
       - name: Security - Dependency audit
         run: npm audit --audit-level=high
@@ -57,21 +63,37 @@ jobs:
       - name: Governance - Approval log integrity
         if: hashFiles('APPROVAL_LOG.md') != ''
         run: |
-          if git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'; then
-            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."
-            exit 1
+          # BL-147: resolve the diff base explicitly and fail LOUDLY if it cannot be resolved.
+          # A default-depth checkout has no origin/main ref; a check that cannot run must not pass.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+            echo "::error::APPROVAL_LOG.md has deleted or modified lines. This file is append-only."; exit 1
           fi
 
       - name: Governance - Approval author verification
         if: hashFiles('APPROVAL_LOG.md') != ''
         run: |
-          if git diff --name-only origin/main...HEAD 2>/dev/null | grep -q 'APPROVAL_LOG.md'; then
-            COMMIT_AUTHOR=$(git log --format='%an' origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | head -1)
-            ADDED_LINES=$(git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep '^+' | grep -i 'Approver' | head -1 || true)
+          # BL-147: same explicit-base + loud-fail resolution as the integrity step.
+          BASE="origin/${{ github.base_ref || 'main' }}"
+          if [ "${{ github.event_name }}" = "push" ]; then BASE="${{ github.event.before }}"; fi
+          git fetch origin "${{ github.base_ref || 'main' }}" --quiet || true
+          if ! git rev-parse --verify "$BASE" >/dev/null; then
+            echo "::error::approval-author check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"; exit 1
+          fi
+          # When APPROVAL_LOG.md is modified, check the commit author against the listed approver.
+          if git diff --name-only "$BASE...HEAD" | grep -q 'APPROVAL_LOG.md'; then
+            COMMIT_AUTHOR=$(git log --format='%an' "$BASE...HEAD" -- APPROVAL_LOG.md | head -1)
+            ADDED_LINES=$(git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep '^+' | grep -i 'Approver' | head -1 || true)
             if [ -n "$ADDED_LINES" ] && [ -n "$COMMIT_AUTHOR" ]; then
               APPROVER_NAME=$(echo "$ADDED_LINES" | awk -F'|' '{ gsub(/^[[:space:]]+|[[:space:]]+$/, "", $3); gsub(/\*/, "", $3); gsub(/\+/, "", $3); print $3 }' | xargs)
               if [ -n "$APPROVER_NAME" ] && [ "$APPROVER_NAME" != "$COMMIT_AUTHOR" ]; then
                 echo "::warning::Commit author ($COMMIT_AUTHOR) differs from listed approver ($APPROVER_NAME). Verify this is intentional."
+                # Organizations wanting hard enforcement: change ::warning:: to ::error:: and uncomment: exit 1
               fi
             fi
           fi

--- a/templates/pipelines/ci/gitlab/python.yml
+++ b/templates/pipelines/ci/gitlab/python.yml
@@ -69,7 +69,16 @@ governance:
     - bash scripts/check-changelog.sh 2>/dev/null || true
     # APPROVAL_LOG.md append-only enforcement
     - |
-      if [ -f APPROVAL_LOG.md ] && git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'; then
-        echo "ERROR: APPROVAL_LOG.md has deleted or modified lines (append-only)"
-        exit 1
+      # BL-147: resolve the base explicitly, fail LOUDLY if unresolvable, no stderr silencer.
+      if [ -f APPROVAL_LOG.md ]; then
+        BASE="origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${CI_DEFAULT_BRANCH:-main}}"
+        git fetch origin "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${CI_DEFAULT_BRANCH:-main}}" --quiet || true
+        if ! git rev-parse --verify "$BASE" >/dev/null; then
+          echo "ERROR: approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"
+          exit 1
+        fi
+        if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+          echo "ERROR: APPROVAL_LOG.md has deleted or modified lines (append-only)"
+          exit 1
+        fi
       fi

--- a/templates/pipelines/ci/gitlab/typescript.yml
+++ b/templates/pipelines/ci/gitlab/typescript.yml
@@ -67,7 +67,16 @@ governance:
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true
     - |
-      if [ -f APPROVAL_LOG.md ] && git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'; then
-        echo "ERROR: APPROVAL_LOG.md has deleted or modified lines (append-only)"
-        exit 1
+      # BL-147: resolve the base explicitly, fail LOUDLY if unresolvable, no stderr silencer.
+      if [ -f APPROVAL_LOG.md ]; then
+        BASE="origin/${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${CI_DEFAULT_BRANCH:-main}}"
+        git fetch origin "${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-${CI_DEFAULT_BRANCH:-main}}" --quiet || true
+        if ! git rev-parse --verify "$BASE" >/dev/null; then
+          echo "ERROR: approval-log check cannot resolve base '$BASE' — failing LOUDLY (a check that cannot run must not pass)"
+          exit 1
+        fi
+        if git diff "$BASE...HEAD" -- APPROVAL_LOG.md | grep -qE '^\-[^-]'; then
+          echo "ERROR: APPROVAL_LOG.md has deleted or modified lines (append-only)"
+          exit 1
+        fi
       fi

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -835,6 +835,19 @@ else
   fail "tests/test-bl143-pastcap-selfapproval.sh FAILED (run for details)"
 fi
 
+# BL-147 + BL-151 (PR-sweep WP-1): the ONE shared content-pin suite over
+# templates/pipelines/**. The emitted CI approval-log integrity steps are now
+# real — fetch-depth 0 + explicit base (github.base_ref) + loud-fail, no
+# 2>/dev/null silencer, stamped byte-identical into all 10 github langs (7 had
+# no steps at all) + the gitlab twins — and gitleaks runs via the license-free
+# CLI, not the org-license-trapped action. Template lists derived mechanically
+# with a count floor. Content-pin, hermetic. No init.sh -> both lanes.
+if bash "$SCRIPT_DIR/tests/test-bl147-ci-template-integrity.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl147-ci-template-integrity.sh"
+else
+  fail "tests/test-bl147-ci-template-integrity.sh FAILED (run for details)"
+fi
+
 # BL-139 (Dogfood-3 F-DF3-004): a subject-less --check-commit-ready no
 # longer presumes feat — framework-gate's pre-commit call cannot know the
 # subject (BL-119 doctrine), and the commit-msg surface owns the feat rule

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# tests/test-bl147-ci-template-integrity.sh — the ONE shared content-pin
+# suite over templates/pipelines/** (the PR-sweep remediation wave's shared
+# asset). Each WP of the wave adds its cases here; WP-1 opens the file.
+#
+# WP-1 (BL-147 + BL-151): the emitted CI approval-log integrity steps were
+# VACUOUS under every standard Actions checkout — `git diff origin/main...HEAD
+# -- APPROVAL_LOG.md 2>/dev/null` dies `fatal: bad revision` on the default
+# depth-1 clone (no origin/main ref), the `2>/dev/null` eats it, and the step
+# PASSES on a tampered log. Parity hole: 7 of 10 GitHub language templates
+# never got the steps at all. And gitleaks-action needs GITLEAKS_LICENSE for
+# org accounts + fetch-depth 0 — neither was set (BL-151), so org-track
+# generated projects got a failing/license-less secret-scan step.
+#
+# WP-1 CASES (all github CI templates unless noted):
+#   (a) checkout step carries `fetch-depth: 0`
+#   (b) every github CI template contains BOTH governance approval steps
+#       (integrity + author verification) — all 10, not just python/ts/other
+#   (c) no APPROVAL_LOG-touching line carries `2>/dev/null` (github + gitlab)
+#   (d) the diff base is resolved explicitly (github.base_ref, loud-fail via
+#       `git rev-parse --verify`) — never bare `origin/main...HEAD`
+#   (e) no template uses `gitleaks/gitleaks-action`; every github CI template
+#       runs the gitleaks CLI (`./gitleaks git`)
+#   (f) gitlab twin of (c)/(d): the gitlab approval steps use the explicit
+#       base + loud-fail and drop the silencer
+#
+# GRAMMAR: the template lists are derived MECHANICALLY (find), never
+# hand-enumerated, guarded by a count floor (>=10 github CI files) so the
+# suite cannot pass vacuously.
+#
+# REGISTRATION: content-pin only — no init.sh, not an aggregator -> BOTH the
+# aggregator (tests/full-project-test-suite.sh) and the tests.yml unit list.
+# Hermetic (reads tracked files only; no network, no git ops).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+GH_DIR="$REPO_ROOT/templates/pipelines/ci/github"
+GL_DIR="$REPO_ROOT/templates/pipelines/ci/gitlab"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ── Mechanically derived template lists (never hand-enumerated) ──────────────
+GH_FILES=()
+while IFS= read -r f; do
+  [ -n "$f" ] && GH_FILES+=("$f")
+done < <(find "$GH_DIR" -name '*.yml' | sort)
+
+GL_FILES=()
+while IFS= read -r f; do
+  [ -n "$f" ] && GL_FILES+=("$f")
+done < <(find "$GL_DIR" -name '*.yml' | sort)
+
+GH_COUNT=${#GH_FILES[@]}
+GL_COUNT=${#GL_FILES[@]}
+
+# ── Vacuity guard: the count floors ─────────────────────────────────────────
+echo "C0: mechanically derived template counts meet the vacuity floors"
+if [ "$GH_COUNT" -ge 10 ]; then
+  pass "C0-github-floor ($GH_COUNT github CI templates, floor 10)"
+else
+  fail_ "C0-github-floor" "found $GH_COUNT github CI templates, expected >=10 — list derivation is vacuous"
+fi
+if [ "$GL_COUNT" -ge 10 ]; then
+  pass "C0-gitlab-floor ($GL_COUNT gitlab CI templates, floor 10)"
+else
+  fail_ "C0-gitlab-floor" "found $GL_COUNT gitlab CI templates, expected >=10 — list derivation is vacuous"
+fi
+
+# ── (a) checkout carries fetch-depth: 0 ─────────────────────────────────────
+echo "Ca: every github CI template's checkout sets fetch-depth: 0"
+miss=""
+for f in "${GH_FILES[@]}"; do
+  # the checkout step must have a `with:` carrying `fetch-depth: 0`
+  if ! grep -Eq '^[[:space:]]+fetch-depth: 0$' "$f"; then
+    miss="$miss ${f##*/}"
+  fi
+done
+if [ -z "$miss" ]; then
+  pass "Ca-fetch-depth (all $GH_COUNT github CI templates)"
+else
+  fail_ "Ca-fetch-depth" "missing 'fetch-depth: 0':$miss"
+fi
+
+# ── (b) both governance approval steps present in ALL github templates ──────
+echo "Cb: every github CI template carries BOTH approval steps (integrity + author)"
+miss_int=""
+miss_auth=""
+for f in "${GH_FILES[@]}"; do
+  grep -Fq -e '- name: Governance - Approval log integrity'       "$f" || miss_int="$miss_int ${f##*/}"
+  grep -Fq -e '- name: Governance - Approval author verification' "$f" || miss_auth="$miss_auth ${f##*/}"
+done
+if [ -z "$miss_int" ]; then
+  pass "Cb-integrity-step (all $GH_COUNT)"
+else
+  fail_ "Cb-integrity-step" "missing 'Approval log integrity':$miss_int"
+fi
+if [ -z "$miss_auth" ]; then
+  pass "Cb-author-step (all $GH_COUNT)"
+else
+  fail_ "Cb-author-step" "missing 'Approval author verification':$miss_auth"
+fi
+
+# ── (c) no APPROVAL_LOG-touching line carries the 2>/dev/null silencer ──────
+echo "Cc: no APPROVAL_LOG line silences stderr (github + gitlab)"
+hits=""
+for f in "${GH_FILES[@]}" "${GL_FILES[@]}"; do
+  if grep 'APPROVAL_LOG' "$f" | grep -Fq '2>/dev/null'; then
+    hits="$hits ${f##*/}"
+  fi
+done
+if [ -z "$hits" ]; then
+  pass "Cc-no-silencer"
+else
+  fail_ "Cc-no-silencer" "APPROVAL_LOG line still silences stderr in:$hits"
+fi
+
+# ── (d) explicit base resolution, never bare origin/main...HEAD (github) ────
+echo "Cd: github approval steps resolve the base explicitly + loud-fail"
+bare=""
+noexpr=""
+noloud=""
+for f in "${GH_FILES[@]}"; do
+  grep -Fq 'origin/main...HEAD' "$f" && bare="$bare ${f##*/}"
+  grep -Fq 'github.base_ref'    "$f" || noexpr="$noexpr ${f##*/}"
+  grep -Fq 'git rev-parse --verify "$BASE"' "$f" || noloud="$noloud ${f##*/}"
+done
+if [ -z "$bare" ]; then
+  pass "Cd-no-bare-base"
+else
+  fail_ "Cd-no-bare-base" "bare 'origin/main...HEAD' still present in:$bare"
+fi
+if [ -z "$noexpr" ]; then
+  pass "Cd-explicit-base (all $GH_COUNT carry github.base_ref)"
+else
+  fail_ "Cd-explicit-base" "no explicit github.base_ref base in:$noexpr"
+fi
+if [ -z "$noloud" ]; then
+  pass "Cd-loud-fail (all $GH_COUNT rev-parse --verify the base)"
+else
+  fail_ "Cd-loud-fail" "no loud-fail 'git rev-parse --verify \"\$BASE\"' in:$noloud"
+fi
+
+# ── (e) gitleaks CLI, never the org-license-trapped action ──────────────────
+echo "Ce: gitleaks runs via the CLI, never gitleaks/gitleaks-action (github)"
+action=""
+nocli=""
+for f in "${GH_FILES[@]}"; do
+  grep -Fq 'gitleaks/gitleaks-action' "$f" && action="$action ${f##*/}"
+  grep -Fq './gitleaks git'           "$f" || nocli="$nocli ${f##*/}"
+done
+if [ -z "$action" ]; then
+  pass "Ce-no-action"
+else
+  fail_ "Ce-no-action" "gitleaks/gitleaks-action still present in:$action"
+fi
+if [ -z "$nocli" ]; then
+  pass "Ce-cli (all $GH_COUNT run ./gitleaks git)"
+else
+  fail_ "Ce-cli" "no './gitleaks git' CLI invocation in:$nocli"
+fi
+
+# ── (f) gitlab twin: the approval-bearing gitlab templates get the same fix ─
+echo "Cf: gitlab approval steps use explicit base + loud-fail, no silencer"
+gl_approval=()
+for f in "${GL_FILES[@]}"; do
+  grep -Fq 'APPROVAL_LOG' "$f" && gl_approval+=("$f")
+done
+if [ "${#gl_approval[@]}" -ge 2 ]; then
+  pass "Cf-floor (${#gl_approval[@]} gitlab templates carry an approval step, floor 2)"
+else
+  fail_ "Cf-floor" "found ${#gl_approval[@]} gitlab approval-bearing templates, expected >=2 — case is vacuous"
+fi
+gbare=""
+gnoloud=""
+for f in "${gl_approval[@]}"; do
+  grep -Fq 'origin/main...HEAD' "$f" && gbare="$gbare ${f##*/}"
+  grep -Fq 'git rev-parse --verify "$BASE"' "$f" || gnoloud="$gnoloud ${f##*/}"
+done
+if [ -z "$gbare" ]; then
+  pass "Cf-no-bare-base (gitlab)"
+else
+  fail_ "Cf-no-bare-base" "bare 'origin/main...HEAD' still present in gitlab:$gbare"
+fi
+if [ -z "$gnoloud" ]; then
+  pass "Cf-loud-fail (gitlab)"
+else
+  fail_ "Cf-loud-fail" "no loud-fail 'git rev-parse --verify \"\$BASE\"' in gitlab:$gnoloud"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## WP-1 — BL-147 + BL-151: make the emitted CI approval-log integrity real; gitleaks without the org-license trap

First work package of the BL-146 PR-sweep remediation wave (`Reports/2026-07-21-pr-sweep/REMEDIATION-PLAN.md`). Executor: Opus 4.8. **Do not merge** — Fable verifies the wave.

### The finding
- The emitted GitHub Actions "Approval log integrity" + "Approval author verification" steps ran `git diff origin/main...HEAD -- APPROVAL_LOG.md 2>/dev/null | grep -qE '^\-[^-]'`. `actions/checkout` defaults to a **depth-1 clone with no `origin/main` ref** → the diff dies `fatal: bad revision`, the `2>/dev/null` swallows it, and the step **PASSES on a tampered append-only log**. On push-to-main the `A...B` range self-compares (vacuous there too).
- Parity hole: **7 of 10** GitHub language templates never got the steps at all.
- `gitleaks/gitleaks-action` needs `GITLEAKS_LICENSE` for ORG accounts + `fetch-depth: 0` — the templates set neither, so org-track projects got a failing/license-less secret scan (BL-151).

### Watched-RED (test written & run BEFORE any template changed)
New shared content-pin suite `tests/test-bl147-ci-template-integrity.sh` — the wave's ONE shared asset. Template lists derived **mechanically** (`find … -name '*.yml'`) with a **>=10 count floor** so it cannot pass vacuously. Cases Ca (fetch-depth), Cb (both approval steps in all 10), Cc (no `2>/dev/null` on APPROVAL_LOG lines), Cd (explicit base + loud-fail, no bare `origin/main...HEAD`), Ce (no gitleaks-action; `./gitleaks git` present), Cf (gitlab twin).

```
Pre-fix:  Results: 3 passed, 11 failed   (exit 1)
Post-fix: Results: 14 passed, 0 failed   (exit 0)
```
Every pre-fix failure mapped to the finding (all 10 lack fetch-depth; 7 lack the steps; other/python/ts github + python/ts gitlab silence stderr / use the bare base; all 10 use gitleaks-action).

### The fix
- `fetch-depth: 0` on checkout in all 10 github CI templates (pin unchanged — WP-4 owns the refresh).
- Both governance approval steps stamped **BYTE-IDENTICAL** into all 10 (single sha `83ccd86…` across all 10): explicit `BASE="origin/${{ github.base_ref || 'main' }}"` / `${{ github.event.before }}` on push, and a **LOUD `exit 1`** when `git rev-parse --verify "$BASE"` fails — a check that cannot run must not pass. No `2>/dev/null`.
- gitleaks-action → license-free CLI: `GITLEAKS_VERSION=8.30.1` (`gh api repos/gitleaks/gitleaks/releases/latest` → `v8.30.1`), `curl … | tar -xz gitleaks && ./gitleaks git --redact --exit-code 1`. `gitleaks git` scans full history → rides the fetch-depth fix.
- GitLab twins (`python.yml`, `typescript.yml`): same explicit-base + loud-fail + no-silencer via `CI_MERGE_REQUEST_TARGET_BRANCH_NAME` / `CI_DEFAULT_BRANCH`.

All 20 CI templates re-validated as parseable YAML.

### Mutation proofs (against the committed baseline; both restored to GREEN)
| Mutation | Result |
|---|---|
| Re-add `2>/dev/null` to one template's APPROVAL_LOG diff line | **Cc RED** (`13 passed, 1 failed`) → restore → GREEN |
| Remove `fetch-depth: 0` from one template | **Ca RED** (`13 passed, 1 failed`) → restore → GREEN |

### Registration & blast radius
- Registered in BOTH `tests/full-project-test-suite.sh` and the `tests.yml` unit list (adjacent to `test-bl143`). `lint-tests-registered.sh` → OK.
- `grep -rl 'origin/main...HEAD' tests/` → none pinned the old text (only the templates carried it) — no fixture updates needed.
- `bash scripts/run-lints.sh` → all PASS. `lint-backlog-references.sh` → OK after the backlog Status updates.

### Note on base
The worktree was cut from `main`, but the BL-147/BL-151 backlog entries + the plan live only on `origin/docs/pr-sweep-remediation-plan` (one docs commit = main + entries/plan). To append the required in-entry Status updates, this branch was **fast-forwarded** to that commit (zero overlap with the WP-1 code — clean FF), so the PR also carries the sweep findings + plan doc. No change to the WP-1 work itself.

Backlog BL-147/BL-151 stay **Open** (Closed flip happens at merge, citing PR# + SHA), each with a `**Status update 2026-07-21:**` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rA7CKSQ3HcAQjcAGP9hxY
