### PR TITLE
fix(ci-templates): semgrep + gitleaks CI modernization to hook parity (BL-148, BL-153 WP-2)

### DIFF
--- a/Reports/2026-07-21-pr-sweep/PROGRESS.md
+++ b/Reports/2026-07-21-pr-sweep/PROGRESS.md
@@ -96,3 +96,107 @@ list (adjacent to `test-bl143`, each comment kept attached to its own if-block).
   close the parity hole the finding names ("7 of 10 never got the steps"), with
   the plan's "same base-resolution treatment"; the integrity step is the one the
   plan pins byte-identical, and both are byte-identical across all 10.
+
+---
+
+## WP-2 — BL-148 + BL-153: semgrep surface modernization, hook-parity policy
+
+**Branch:** `fix/bl148-bl153-semgrep-modernization` · **Base:** `main` (stacked on
+WP-1 #235, now MERGED to `main` @ `78d944e`; the reset base is an ancestor of
+`main`, so the PR diff vs `main` is exactly the WP-2 delta). **Status:** PR opened
+green, not merged.
+
+### Reproduce (the finding)
+- **BL-148:** all 10 `templates/pipelines/ci/github/*.yml` ran SAST via
+  `semgrep/semgrep-action@713efdd… # v1 (v0.58.0)` — an action **archived
+  upstream 2024-04-09**. Current upstream guidance (context7, semgrep docs): the
+  `semgrep/semgrep` container running `semgrep scan`/`semgrep ci`.
+- **BL-153:** the 2 bitbucket semgrep templates used `image: returntocorp/semgrep`
+  (frozen at the 2023 org rename → `semgrep/semgrep`); all 10 bitbucket gitleaks
+  steps used the pre-8.19 `gitleaks detect --source .` on an unpinned
+  `zricethezav/gitleaks:latest`.
+- **Scope discovery (drove the one deviation):** the same dead
+  `returntocorp/semgrep` image + legacy gitleaks forms were present in **all 10
+  gitlab CI templates** — which the plan's WP-2 "Files" line (github+bitbucket)
+  omitted, but the global RED invariant + blast-radius grep require gone.
+
+### Watched-RED (before any template touched)
+Added WP-2 cases to the shared suite `tests/test-bl147-ci-template-integrity.sh`
+(WP-1 already registered it in both lists). The expected semgrep flag set is
+**DERIVED** from the hook's own `semgrep scan` invocation in
+`scripts/lib/hook-templates.sh` (case `Cg-derive`) — single source, never
+retyped; if the hook's policy changes the suite tracks it. Cases:
+- **Cg1** no `templates/pipelines/**` file references `semgrep/semgrep-action` or
+  `returntocorp/semgrep` (GLOBAL — github, gitlab, bitbucket, release, …)
+- **Cg2** every github CI template carries a `semgrep scan --config` invocation
+- **Cg3** every github semgrep invocation's config/severity/`--error` **EQUAL the
+  hook** (config set = `p/owasp-top-ten` + `r/javascript.browser.security.insecure-document-method`, `--severity=ERROR`, `--error`)
+- **Cg4** every github CI template declares the `image: semgrep/semgrep` container
+- **Cg5** every non-github (gitlab+bitbucket) semgrep step: `image:
+  semgrep/semgrep` + hook-parity flags (floor 12)
+- **Cg6** every non-github gitleaks step modernized: no `detect --source`, runs
+  `gitleaks dir`/`git`, off `zricethezav`, version-pinned image (floor 20)
+
+Pre-fix run: **`Results: 18 passed, 13 failed`** (exit 1) — WP-1's 18 cases stay
+green; every WP-2 failure maps to the finding (Cg1 flags 22 files; github has no
+`semgrep scan`/container/parity; non-github carries `returntocorp` + the legacy
+gitleaks forms). RED evidence saved to `scratchpad/wp2-RED.txt`.
+
+### Fix
+- **GitHub (10):** removed the archived `semgrep/semgrep-action` step; added a
+  sibling `sast` job — `container: image: semgrep/semgrep`, `actions/checkout`
+  (`fetch-depth: 0`, existing pin), then `run: semgrep scan
+  --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method
+  --severity=ERROR --error`. Flags MIRROR the local hook (parity is the contract:
+  CI and the dev gate enforce the identical ruleset). **Dropped `p/security-audit`**
+  — the hook (single source) does not carry it; the backlog fix-shape example did,
+  and it was corrected in the BL-148 Status update.
+- **Verified the container form is correct** (context7 + web): `semgrep/semgrep`
+  is Alpine-based (`docker.base_image=alpine:3.23`), but GitHub's runner detects
+  Alpine and runs JS actions (checkout) with its musl `node20_alpine` build — this
+  is Semgrep's own documented CI pattern. No deviation on the form.
+- **GitLab + Bitbucket (20):** `returntocorp/semgrep` → `semgrep/semgrep`; the
+  semgrep invocation → the same hook-parity form (`semgrep scan …`); gitleaks
+  `detect --source .` → `dir .`; `zricethezav/gitleaks:latest` →
+  `ghcr.io/gitleaks/gitleaks:v8.30.1` (official image; latest release confirmed via
+  `gh api repos/gitleaks/gitleaks/releases/latest` = `v8.30.1`, manifest verified
+  pullable HTTP 200).
+
+Post-fix run: **`Results: 31 passed, 0 failed`** (exit 0). All 30 changed CI
+templates re-validated as parseable YAML (PyYAML `safe_load`, 30/0). Evidence:
+`scratchpad/wp2-GREEN.txt`.
+
+### Mutation proof (run against the working tree; restored to GREEN)
+- Strip the DOM-XSS config (`r/javascript.browser.security.insecure-document-method`)
+  from `github/go.yml`'s semgrep line → **Cg3-config-parity RED**
+  (`go.yml(=--config=p/owasp-top-ten )` ≠ hook; `Results: 30 passed, 1 failed`).
+  Restore → GREEN (`31 passed, 0 failed`).
+
+### Blast radius
+- `grep -rln 'semgrep-action|returntocorp' templates/ scripts/ tests/ docs/` → the
+  ONLY surviving hit is `tests/test-bl147-ci-template-integrity.sh` itself (the Cg1
+  assertion pattern + its comments must contain the literals to grep for them).
+  No template, script, or product doc references the dead namespaces.
+- Two present-tense code comments corrected ("semgrep-action container" →
+  "semgrep container") in `scripts/check-phase-gate.sh` + `tests/test-bl137-ci-tools-scope.sh`.
+- Docs modernized (BL-153 theme): `docs/builders-guide.md`, `docs/user-guide.md`
+  (`gitleaks detect --source .` → `gitleaks dir .`), `docs/cli-setup-addendum.md`
+  (stale "CI runs gitleaks-action" → "the gitleaks CLI").
+- Left untouched (historical/out-of-scope): all `Reports/**`, archived plans, the
+  `evaluation-prompts/**` eval fixtures, and the BL-148/BL-153 problem statements.
+- `bash scripts/run-lints.sh` → PASS (tally in the PR body).
+  `scripts/lint-backlog-references.sh` → OK after the Status updates.
+
+### Deviations from the plan
+- **Expanded to gitlab CI (the one deviation).** The plan's WP-2 "Files" line lists
+  github + bitbucket, but the dispatcher's RED case (i) is global ("no template
+  ANYWHERE references … returntocorp/semgrep") and the blast-radius grep expects
+  zero `returntocorp` under `templates/`. All 10 gitlab CI templates carried it, so
+  eliminating the dead namespace forced editing every gitlab file. Being already in
+  each file, the gitleaks + semgrep-flag modernization (identical debt to bitbucket)
+  rode along for one consistent three-host surface. No other WP owns gitlab CI
+  templates; stacked cleanly on WP-1.
+- **gitleaks image registry:** the plan said only "pin the image tag." Chose the
+  official current image `ghcr.io/gitleaks/gitleaks:v8.30.1` (DockerHub `gitleaks/gitleaks`
+  does not exist; `zricethezav/*` is the retired personal namespace) — consistent
+  with WP-3's `ghcr.io/zaproxy/*` convention.

--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -1504,7 +1504,7 @@ Consolidate all findings into a single remediation list. Fix critical findings f
    ```
 3. Full repository secret scan:
    ```bash
-   gitleaks detect --source . --verbose
+   gitleaks dir . --verbose
    ```
 4. License compliance (using your ecosystem's tool)
 5. Direct the agent to: fix all critical/high findings, verify data isolation on every interface, verify input validation at every entry point, write regression tests for every fix.

--- a/docs/cli-setup-addendum.md
+++ b/docs/cli-setup-addendum.md
@@ -233,7 +233,7 @@ The Builder's Guide defines quality controls at each phase. The Development Guar
 | Builder's Guide Requirement | Development Guardrails Enforcement |
 |---|---|
 | TDD — tests before implementation (Phase 2, Step 2.2) | Pre-commit hook validates test file exists for changed source files |
-| Secret detection (Phase 2, Step 2.4) | Pre-commit hook runs gitleaks on staged files; CI pipeline runs gitleaks-action as backstop |
+| Secret detection (Phase 2, Step 2.4) | Pre-commit hook runs gitleaks on staged files; CI pipeline runs the gitleaks CLI as backstop |
 | SAST quick scan (Phase 2, Step 2.4) | Pre-commit hook runs Semgrep on staged files; CI pipeline runs full Semgrep scan |
 | License compliance (Phase 2, CI/CD) | Pre-push hook runs license-checker |
 | Documentation updates (Phase 2, Step 2.5) | Hook validates CHANGELOG.md updated when source files change |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -990,7 +990,7 @@ If any check fails, return to the Build Loop. Do not proceed to Phase 3.
 | Run E2E/integration tests on all target platforms | Fix failures — these are integration gaps | Same |
 | Run full SAST: `semgrep scan --config=p/owasp-top-ten --config=p/security-audit --severity ERROR --severity WARNING .` | Fix all critical/high findings | Same |
 | Run dependency scan: `snyk test` | Fix vulnerable dependencies | Same |
-| Run secret scan: `gitleaks detect --source . --verbose` | Remove any detected secrets | Same |
+| Run secret scan: `gitleaks dir . --verbose` | Remove any detected secrets | Same |
 | Generate SBOM (CycloneDX or equivalent) | Archive in docs/test-results/ | Same |
 | Validate threat model — every vector from Phase 1 has a verified mitigation or documented acceptance | Fix gaps | Same |
 | Run chaos/edge-case tests | Verify error recovery and input abuse defenses | Same |

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -2154,7 +2154,7 @@ if [ -f "$TOOL_PREFS" ] && [ -x "$RESOLVER" ] && command -v jq &>/dev/null; then
         # project's CI governance job STRUCTURALLY unpassable — the
         # required-tools contract names DEV-WORKSTATION tools (Semgrep CLI,
         # Snyk CLI, Claude Code) no CI runner carries (CI runs SAST via the
-        # semgrep-action container and never holds Snyk auth or an
+        # semgrep container and never holds Snyk auth or an
         # interactive CLI), so every push failed governance while the same
         # command exited 0 locally. The sibling install prompts already
         # hard-N under $CI; the BLOCK now scopes the same way: on a CI

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -3526,6 +3526,8 @@ All 10 `templates/pipelines/ci/github/*.yml` pin `semgrep/semgrep-action@713efdd
 
 **Related:** BL-118 (the hook policy to mirror); BL-153 (the bitbucket image twin).
 
+**Status update 2026-07-21 (WP-2, branch `fix/bl148-bl153-semgrep-modernization`, stacked on merged WP-1 #235):** Implemented. All 10 `templates/pipelines/ci/github/*.yml` now run SAST in a sibling `container: semgrep/semgrep` job (`actions/checkout` with `fetch-depth: 0` → `semgrep scan …`), replacing the archived action. The scan's flag set is DERIVED from the local pre-commit hook (`scripts/lib/hook-templates.sh`) by the test suite — single source, never retyped. **Correction to the fix-shape above:** the hook policy is `--config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error` — it does **not** carry `p/security-audit`. Parity with the hook is the contract (CI now enforces the IDENTICAL ruleset the dev gate does), so the CI templates dropped `p/security-audit` to match. Verified (context7 + web) that `actions/checkout` runs cleanly in the Alpine-based `semgrep/semgrep` container: GitHub's runner detects Alpine and uses its musl node build for JS actions — this is Semgrep's own documented CI pattern. Watched-RED + mutation proof (strip the DOM-XSS config → parity RED → restore → GREEN) recorded; pinned by cases Cg1–Cg5 in `tests/test-bl147-ci-template-integrity.sh`. Status stays Open pending merge.
+
 ---
 
 ## BL-149: Emitted release-pipeline DAST is the un-fixed BL-122 twin — unpassable for essentially every web app
@@ -3600,6 +3602,8 @@ gitleaks-action requires `GITLEAKS_LICENSE` for ORGANIZATION accounts and `fetch
 **Fix shape:** `image: semgrep/semgrep` + the BL-148 flag policy; `gitleaks dir .` with a version-tagged image.
 
 **Related:** BL-148 (the github twin).
+
+**Status update 2026-07-21 (WP-2, branch `fix/bl148-bl153-semgrep-modernization`):** Implemented. Both bitbucket semgrep templates now use `image: semgrep/semgrep` with the hook-parity flags (`semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error`). All 10 bitbucket gitleaks steps modernized: `gitleaks detect --source .` → `gitleaks dir .`; image `zricethezav/gitleaks:latest` → `ghcr.io/gitleaks/gitleaks:v8.30.1` (official image, version-pinned — latest release confirmed via `gh api repos/gitleaks/gitleaks/releases/latest` = v8.30.1, `ghcr.io/gitleaks/gitleaks:v8.30.1` manifest verified pullable). The SAME modernization was applied to the 10 gitlab CI templates for a consistent three-host surface: the global "no `returntocorp/semgrep` anywhere" invariant (WP-2's RED case Cg1 + the blast-radius grep) forced the gitlab semgrep image rename, and the gitleaks + flag-parity modernization rode along in the same edit. Pinned by cases Cg5/Cg6 in `tests/test-bl147-ci-template-integrity.sh`. Docs modernized: `docs/builders-guide.md`, `docs/user-guide.md` (`gitleaks detect --source .` → `gitleaks dir .`) and `docs/cli-setup-addendum.md` (stale "CI runs gitleaks-action" → "the gitleaks CLI"). Status stays Open pending merge.
 
 ---
 

--- a/templates/pipelines/ci/bitbucket/csharp.yml
+++ b/templates/pipelines/ci/bitbucket/csharp.yml
@@ -11,8 +11,8 @@ pipelines:
           - dotnet list package --vulnerable --include-transitive 2>&1 | tee /tmp/v.out; ! grep -qi "vulnerable" /tmp/v.out
     - step:
         name: Secrets
-        image: zricethezav/gitleaks:latest
-        script: [gitleaks detect --source . --verbose --redact]
+        image: ghcr.io/gitleaks/gitleaks:v8.30.1
+        script: [gitleaks dir . --verbose --redact]
     - step:
         name: Governance
         image: bash:5

--- a/templates/pipelines/ci/bitbucket/dart.yml
+++ b/templates/pipelines/ci/bitbucket/dart.yml
@@ -7,8 +7,8 @@ pipelines:
         script: [dart pub get, dart analyze, dart test]
     - step:
         name: Secrets
-        image: zricethezav/gitleaks:latest
-        script: [gitleaks detect --source . --verbose --redact]
+        image: ghcr.io/gitleaks/gitleaks:v8.30.1
+        script: [gitleaks dir . --verbose --redact]
     - step:
         name: Governance
         image: bash:5

--- a/templates/pipelines/ci/bitbucket/go.yml
+++ b/templates/pipelines/ci/bitbucket/go.yml
@@ -11,8 +11,8 @@ pipelines:
     - parallel:
         - step:
             name: Secrets
-            image: zricethezav/gitleaks:latest
-            script: [gitleaks detect --source . --verbose --redact]
+            image: ghcr.io/gitleaks/gitleaks:v8.30.1
+            script: [gitleaks dir . --verbose --redact]
         - step:
             name: Dependencies
             script:

--- a/templates/pipelines/ci/bitbucket/java.yml
+++ b/templates/pipelines/ci/bitbucket/java.yml
@@ -9,8 +9,8 @@ pipelines:
           - mvn -B dependency:analyze --no-transfer-progress
     - step:
         name: Secrets
-        image: zricethezav/gitleaks:latest
-        script: [gitleaks detect --source . --verbose --redact]
+        image: ghcr.io/gitleaks/gitleaks:v8.30.1
+        script: [gitleaks dir . --verbose --redact]
     - step:
         name: Governance
         image: bash:5

--- a/templates/pipelines/ci/bitbucket/kotlin.yml
+++ b/templates/pipelines/ci/bitbucket/kotlin.yml
@@ -7,8 +7,8 @@ pipelines:
         script: [gradle test --no-daemon]
     - step:
         name: Secrets
-        image: zricethezav/gitleaks:latest
-        script: [gitleaks detect --source . --verbose --redact]
+        image: ghcr.io/gitleaks/gitleaks:v8.30.1
+        script: [gitleaks dir . --verbose --redact]
     - step:
         name: Governance
         image: bash:5

--- a/templates/pipelines/ci/bitbucket/other.yml
+++ b/templates/pipelines/ci/bitbucket/other.yml
@@ -10,8 +10,8 @@ pipelines:
           - exit 1
     - step:
         name: Secrets
-        image: zricethezav/gitleaks:latest
-        script: [gitleaks detect --source . --verbose --redact]
+        image: ghcr.io/gitleaks/gitleaks:v8.30.1
+        script: [gitleaks dir . --verbose --redact]
     - step:
         name: Governance
         script:

--- a/templates/pipelines/ci/bitbucket/python.yml
+++ b/templates/pipelines/ci/bitbucket/python.yml
@@ -19,12 +19,12 @@ pipelines:
               - pytest
         - step:
             name: SAST
-            image: returntocorp/semgrep
-            script: [semgrep --config=p/owasp-top-ten --config=p/security-audit --error]
+            image: semgrep/semgrep
+            script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
         - step:
             name: Secrets
-            image: zricethezav/gitleaks:latest
-            script: [gitleaks detect --source . --verbose --redact]
+            image: ghcr.io/gitleaks/gitleaks:v8.30.1
+            script: [gitleaks dir . --verbose --redact]
         - step:
             name: Dependencies
             caches: [pip]

--- a/templates/pipelines/ci/bitbucket/rust.yml
+++ b/templates/pipelines/ci/bitbucket/rust.yml
@@ -12,8 +12,8 @@ pipelines:
     - parallel:
         - step:
             name: Secrets
-            image: zricethezav/gitleaks:latest
-            script: [gitleaks detect --source . --verbose --redact]
+            image: ghcr.io/gitleaks/gitleaks:v8.30.1
+            script: [gitleaks dir . --verbose --redact]
         - step:
             name: Dependencies
             caches: [cargo]

--- a/templates/pipelines/ci/bitbucket/swift.yml
+++ b/templates/pipelines/ci/bitbucket/swift.yml
@@ -9,8 +9,8 @@ pipelines:
         script: [swift build, swift test]
     - step:
         name: Secrets
-        image: zricethezav/gitleaks:latest
-        script: [gitleaks detect --source . --verbose --redact]
+        image: ghcr.io/gitleaks/gitleaks:v8.30.1
+        script: [gitleaks dir . --verbose --redact]
     - step:
         name: Governance
         image: bash:5

--- a/templates/pipelines/ci/bitbucket/typescript.yml
+++ b/templates/pipelines/ci/bitbucket/typescript.yml
@@ -17,12 +17,12 @@ pipelines:
               - npm test -- --ci
         - step:
             name: SAST
-            image: returntocorp/semgrep
-            script: [semgrep --config=p/security-audit --error]
+            image: semgrep/semgrep
+            script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
         - step:
             name: Secrets
-            image: zricethezav/gitleaks:latest
-            script: [gitleaks detect --source . --verbose --redact]
+            image: ghcr.io/gitleaks/gitleaks:v8.30.1
+            script: [gitleaks dir . --verbose --redact]
         - step:
             name: Dependencies
             caches: [node]

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -30,14 +30,6 @@ jobs:
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -105,3 +97,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -29,14 +29,6 @@ jobs:
       - name: Test
         run: flutter test
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -104,3 +96,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -31,14 +31,6 @@ jobs:
         with:
           version: latest
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -107,3 +99,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -35,14 +35,6 @@ jobs:
         # Requires detekt Gradle plugin. Add to build.gradle.kts:
         #   plugins { id("io.gitlab.arturbosch.detekt") version "1.23.+" }
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -112,3 +104,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -35,14 +35,6 @@ jobs:
         # Requires detekt Gradle plugin. Add to build.gradle.kts:
         #   plugins { id("io.gitlab.arturbosch.detekt") version "1.23.+" }
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -112,3 +104,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -35,14 +35,6 @@ jobs:
       # - name: Test
       #   run: <your test command>
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -125,3 +117,19 @@ jobs:
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
         # Tier 1.5: warning only. Set SOIF_STRICT_SESSION=true to block.
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -32,14 +32,6 @@ jobs:
       - name: Test
         run: pytest
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -126,3 +118,19 @@ jobs:
         # Tier 1.5: warning only. Set SOIF_STRICT_SESSION=true to block.
         # env:
         #   SOIF_STRICT_SESSION: "true"
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -34,14 +34,6 @@ jobs:
       - name: Lint
         run: cargo clippy -- -D warnings
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -110,3 +102,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -39,14 +39,6 @@ jobs:
         with:
           strict: true
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -127,3 +119,19 @@ jobs:
 
       - name: Governance - Session state check
         run: bash scripts/check-session-state.sh 2>/dev/null || true
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -33,14 +33,6 @@ jobs:
       - name: Test
         run: npm test
 
-      - name: Security - SAST (Semgrep)
-        uses: semgrep/semgrep-action@713efdd345f3035192eaa63f56867b88e63e4e5d # v1 (v0.58.0)
-        with:
-          config: >-
-            p/owasp-top-ten
-            p/security-audit
-            r/javascript.browser.security.insecure-document-method
-
       - name: Security - Secret detection (gitleaks)
         run: |
           # BL-151: run the gitleaks CLI directly — gitleaks-action needs GITLEAKS_LICENSE
@@ -118,3 +110,19 @@ jobs:
         # Tier 1.5: warning only. Set SOIF_STRICT_SESSION=true to block.
         # env:
         #   SOIF_STRICT_SESSION: "true"
+
+  # BL-148: SAST runs in the semgrep/semgrep container (replaces the archived
+  # Semgrep GitHub Action). The scan's config + severity flags MIRROR the local
+  # pre-commit hook (scripts/lib/hook-templates.sh) so CI and the dev gate enforce
+  # the IDENTICAL ruleset. semgrep/semgrep is Alpine-based; GitHub's runner detects
+  # that and runs JS actions (checkout) with its musl node build, so checkout works.
+  sast:
+    runs-on: ubuntu-latest
+    container:
+      image: semgrep/semgrep
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4 (v4.3.1)
+        with:
+          fetch-depth: 0
+      - name: Security - SAST (Semgrep)
+        run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error

--- a/templates/pipelines/ci/gitlab/csharp.yml
+++ b/templates/pipelines/ci/gitlab/csharp.yml
@@ -13,12 +13,12 @@ test:
     - dotnet test --no-build
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
   script: [dotnet list package --vulnerable --include-transitive 2>&1 | tee /tmp/vuln.out; ! grep -qi "has the following vulnerable" /tmp/vuln.out]

--- a/templates/pipelines/ci/gitlab/dart.yml
+++ b/templates/pipelines/ci/gitlab/dart.yml
@@ -16,12 +16,12 @@ test:
     - dart test
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
   extends: .setup

--- a/templates/pipelines/ci/gitlab/go.yml
+++ b/templates/pipelines/ci/gitlab/go.yml
@@ -15,12 +15,12 @@ test:
   script: [go test ./...]
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
   script:

--- a/templates/pipelines/ci/gitlab/java.yml
+++ b/templates/pipelines/ci/gitlab/java.yml
@@ -12,12 +12,12 @@ test:
   script: [mvn -B test --no-transfer-progress]
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
   script: [mvn -B dependency:analyze org.owasp:dependency-check-maven:check --no-transfer-progress]

--- a/templates/pipelines/ci/gitlab/kotlin.yml
+++ b/templates/pipelines/ci/gitlab/kotlin.yml
@@ -12,12 +12,12 @@ test:
     - gradle detekt --no-daemon 2>/dev/null || true
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
   script: [gradle dependencyCheckAnalyze --no-daemon 2>/dev/null || echo "OWASP Dependency-Check not configured"]

--- a/templates/pipelines/ci/gitlab/other.yml
+++ b/templates/pipelines/ci/gitlab/other.yml
@@ -10,12 +10,12 @@ test:
     - exit 1  # intentional — CI should not pass until builder configures this
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 governance:
   stage: governance
   script:

--- a/templates/pipelines/ci/gitlab/python.yml
+++ b/templates/pipelines/ci/gitlab/python.yml
@@ -38,15 +38,15 @@ test:
 
 sast:
   stage: security
-  image: returntocorp/semgrep
+  image: semgrep/semgrep
   script:
-    - semgrep --config=p/owasp-top-ten --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error
+    - semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error
 
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
   script:
-    - gitleaks detect --source . --verbose --redact
+    - gitleaks dir . --verbose --redact
 
 dependencies:
   stage: security

--- a/templates/pipelines/ci/gitlab/rust.yml
+++ b/templates/pipelines/ci/gitlab/rust.yml
@@ -16,12 +16,12 @@ test:
     - cargo test --all-features
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
   script:

--- a/templates/pipelines/ci/gitlab/swift.yml
+++ b/templates/pipelines/ci/gitlab/swift.yml
@@ -11,12 +11,12 @@ test:
     - swift test
 sast:
   stage: security
-  image: returntocorp/semgrep
-  script: [semgrep --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error]
+  image: semgrep/semgrep
+  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error]
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
-  script: [gitleaks detect --source . --verbose --redact]
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
+  script: [gitleaks dir . --verbose --redact]
 governance:
   stage: governance
   image: bash:5

--- a/templates/pipelines/ci/gitlab/typescript.yml
+++ b/templates/pipelines/ci/gitlab/typescript.yml
@@ -37,15 +37,15 @@ test:
 
 sast:
   stage: security
-  image: returntocorp/semgrep
+  image: semgrep/semgrep
   script:
-    - semgrep --config=p/owasp-top-ten --config=p/security-audit --config=r/javascript.browser.security.insecure-document-method --error
+    - semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error
 
 secrets:
   stage: security
-  image: zricethezav/gitleaks:latest
+  image: ghcr.io/gitleaks/gitleaks:v8.30.1
   script:
-    - gitleaks detect --source . --verbose --redact
+    - gitleaks dir . --verbose --redact
 
 dependencies:
   stage: security

--- a/tests/test-bl137-ci-tools-scope.sh
+++ b/tests/test-bl137-ci-tools-scope.sh
@@ -6,7 +6,7 @@
 #   The generated project's CI runs check-phase-gate.sh as its governance
 #   job. The required-tools contract names DEV-WORKSTATION tools (Semgrep
 #   CLI, Snyk CLI, Claude Code) that no CI runner carries — CI does SAST via
-#   the semgrep-action container and never holds Snyk auth or an interactive
+#   the semgrep container and never holds Snyk auth or an interactive
 #   CLI. The arm's install PROMPTS already hard-N under $CI, but the
 #   `issues+1` BLOCK had no CI awareness: every generated project shipped
 #   with a permanently red governance check (the documented-but-impossible

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -193,6 +193,170 @@ else
   fail_ "Cf-loud-fail" "no loud-fail 'git rev-parse --verify \"\$BASE\"' in gitlab:$gnoloud"
 fi
 
+# ═══════════════════════════════════════════════════════════════════════════
+# WP-2 (BL-148 + BL-153): semgrep surface modernization + hook-parity policy
+# ═══════════════════════════════════════════════════════════════════════════
+# The emitted CI SAST rode on the ARCHIVED semgrep/semgrep-action (github) and
+# the RENAMED returntocorp/semgrep image (gitlab + bitbucket) — both dead
+# namespaces. And the gitleaks step used the OLD `detect --source` command +
+# the personal `zricethezav/gitleaks:latest` image (unpinned). WP-2:
+#   • github: semgrep moves to a `semgrep/semgrep` CONTAINER JOB whose flags
+#     EQUAL the local pre-commit hook's policy — CI and the dev hook enforce
+#     the IDENTICAL ruleset (parity is the contract).
+#   • gitlab + bitbucket: rename the semgrep image off returntocorp, bring the
+#     flags to hook parity, and modernize gitleaks (detect --source -> dir;
+#     :latest -> a version-pinned ghcr image).
+#
+# PARITY DERIVATION (single source): the expected semgrep flag set is DERIVED
+# from the hook's own `semgrep scan` invocation in scripts/lib/hook-templates.sh
+# — never retyped here. If the hook's policy changes, this suite tracks it.
+#
+# WP-2 CASES:
+#   Cg1  no templates/pipelines file references semgrep/semgrep-action or
+#        returntocorp/semgrep (GLOBAL — github, gitlab, bitbucket, release, …)
+#   Cg2  every github CI template carries a `semgrep scan --config` invocation
+#   Cg3  every github semgrep invocation's config/severity/--error EQUAL the hook
+#   Cg4  every github CI template declares the `image: semgrep/semgrep` container
+#   Cg5  every non-github (gitlab+bitbucket) semgrep step uses image:
+#        semgrep/semgrep with hook-parity config/severity/--error flags
+#   Cg6  every non-github gitleaks step is modernized: no `detect --source`,
+#        runs `gitleaks dir`/`git`, off zricethezav, version-pinned image
+
+BB_DIR="$REPO_ROOT/templates/pipelines/ci/bitbucket"
+HOOK="$REPO_ROOT/scripts/lib/hook-templates.sh"
+PIPE_DIR="$REPO_ROOT/templates/pipelines"
+
+BB_FILES=()
+while IFS= read -r f; do
+  [ -n "$f" ] && BB_FILES+=("$f")
+done < <(find "$BB_DIR" -name '*.yml' | sort)
+BB_COUNT=${#BB_FILES[@]}
+
+# ── Derive the hook's semgrep policy (SINGLE SOURCE — never retyped) ─────────
+# Join the hook's `semgrep scan …` invocation across its line-continuations,
+# then read the --config / --severity / --error tokens off it. The staged-files
+# array + stderr redirect carry no config/severity token, so they drop out.
+HOOK_INVOC="$(awk '
+  /semgrep scan/ { collecting=1 }
+  collecting {
+    line=$0
+    sub(/[[:space:]]*\\[[:space:]]*$/, "", line)
+    printf "%s ", line
+    if ($0 !~ /\\[[:space:]]*$/) exit
+  }' "$HOOK")"
+HOOK_CONFIGS="$(printf '%s\n' "$HOOK_INVOC" | grep -oE '\-\-config=[^[:space:]]+' | sort -u | tr '\n' ' ')"
+HOOK_SEVERITY="$(printf '%s\n' "$HOOK_INVOC" | grep -oE '\-\-severity=[A-Za-z]+' | head -1)"
+if printf '%s\n' "$HOOK_INVOC" | grep -qE '(^|[[:space:]])--error([[:space:]]|$)'; then HOOK_ERROR=yes; else HOOK_ERROR=no; fi
+
+echo "Cg-derive: hook semgrep policy derived from hook-templates.sh (single source)"
+if [ -n "$HOOK_CONFIGS" ] && [ -n "$HOOK_SEVERITY" ] && [ "$HOOK_ERROR" = yes ]; then
+  pass "Cg-derive (configs='$HOOK_CONFIGS' severity='$HOOK_SEVERITY' --error=$HOOK_ERROR)"
+else
+  fail_ "Cg-derive" "could not derive the semgrep policy (configs='$HOOK_CONFIGS' severity='$HOOK_SEVERITY' error=$HOOK_ERROR)"
+fi
+
+# extract a template's semgrep policy -> sets EX_CONFIGS EX_SEVERITY EX_ERROR
+extract_semgrep_policy() {
+  local file="$1" line
+  line="$(grep -E 'semgrep (scan )?--config' "$file" | head -1)"
+  EX_CONFIGS="$(printf '%s\n' "$line" | grep -oE '\-\-config=[^][:space:],]+' | sort -u | tr '\n' ' ')"
+  EX_SEVERITY="$(printf '%s\n' "$line" | grep -oE '\-\-severity=[A-Za-z]+' | head -1)"
+  if printf '%s\n' "$line" | grep -qE '(^|[[:space:]])--error([[:space:]]|\]|$)'; then EX_ERROR=yes; else EX_ERROR=no; fi
+}
+
+# ── Cg1: no dead semgrep namespace anywhere under templates/pipelines ────────
+echo "Cg1: no templates/pipelines file references semgrep/semgrep-action or returntocorp/semgrep"
+dead="$(grep -rlE 'semgrep/semgrep-action|returntocorp/semgrep' "$PIPE_DIR" 2>/dev/null | sed "s|$REPO_ROOT/||" | tr '\n' ' ')"
+if [ -z "$dead" ]; then
+  pass "Cg1-no-dead-namespace"
+else
+  fail_ "Cg1-no-dead-namespace" "dead semgrep namespace still referenced in:$dead"
+fi
+
+# ── Cg2: every github CI template runs `semgrep scan --config` ──────────────
+echo "Cg2: every github CI template carries a semgrep scan invocation"
+miss_sg=""
+for f in "${GH_FILES[@]}"; do
+  grep -Eq 'semgrep scan --config' "$f" || miss_sg="$miss_sg ${f##*/}"
+done
+if [ -z "$miss_sg" ]; then
+  pass "Cg2-semgrep-scan (all $GH_COUNT)"
+else
+  fail_ "Cg2-semgrep-scan" "no 'semgrep scan --config' invocation in:$miss_sg"
+fi
+
+# ── Cg3: github semgrep flags EQUAL the hook's policy (parity) ──────────────
+echo "Cg3: every github semgrep invocation's flags EQUAL the hook policy"
+badc=""; bads=""; bade=""
+for f in "${GH_FILES[@]}"; do
+  extract_semgrep_policy "$f"
+  [ "$EX_CONFIGS"  = "$HOOK_CONFIGS" ]  || badc="$badc ${f##*/}(=$EX_CONFIGS)"
+  [ "$EX_SEVERITY" = "$HOOK_SEVERITY" ] || bads="$bads ${f##*/}"
+  [ "$EX_ERROR"    = "$HOOK_ERROR" ]    || bade="$bade ${f##*/}"
+done
+if [ -z "$badc" ]; then pass "Cg3-config-parity (all $GH_COUNT == '$HOOK_CONFIGS')"; else fail_ "Cg3-config-parity" "config set != hook '$HOOK_CONFIGS' in:$badc"; fi
+if [ -z "$bads" ]; then pass "Cg3-severity-parity (all == '$HOOK_SEVERITY')"; else fail_ "Cg3-severity-parity" "severity != hook in:$bads"; fi
+if [ -z "$bade" ]; then pass "Cg3-error-parity (all carry --error)"; else fail_ "Cg3-error-parity" "--error presence != hook in:$bade"; fi
+
+# ── Cg4: github semgrep runs in the semgrep/semgrep container job ────────────
+echo "Cg4: every github CI template declares the semgrep/semgrep container"
+miss_img=""
+for f in "${GH_FILES[@]}"; do
+  grep -Eq '^[[:space:]]*image:[[:space:]]*semgrep/semgrep[[:space:]]*$' "$f" || miss_img="$miss_img ${f##*/}"
+done
+if [ -z "$miss_img" ]; then
+  pass "Cg4-container (all $GH_COUNT use image: semgrep/semgrep)"
+else
+  fail_ "Cg4-container" "no 'image: semgrep/semgrep' container in:$miss_img"
+fi
+
+# ── Cg5: non-github semgrep steps — image rename + hook flag parity ─────────
+echo "Cg5: gitlab+bitbucket semgrep steps use image: semgrep/semgrep + hook-parity flags"
+NONGH_SEMGREP=()
+for f in "${GL_FILES[@]}" "${BB_FILES[@]}"; do
+  grep -Eq 'semgrep (scan )?--config' "$f" && NONGH_SEMGREP+=("$f")
+done
+if [ "${#NONGH_SEMGREP[@]}" -ge 12 ]; then
+  pass "Cg5-floor (${#NONGH_SEMGREP[@]} non-github semgrep templates, floor 12)"
+else
+  fail_ "Cg5-floor" "found ${#NONGH_SEMGREP[@]} non-github semgrep templates, expected >=12 — vacuous"
+fi
+n_badimg=""; n_badc=""; n_bads=""; n_bade=""
+for f in "${NONGH_SEMGREP[@]}"; do
+  grep -Eq '^[[:space:]]*image:[[:space:]]*semgrep/semgrep[[:space:]]*$' "$f" || n_badimg="$n_badimg ${f#*/ci/}"
+  extract_semgrep_policy "$f"
+  [ "$EX_CONFIGS"  = "$HOOK_CONFIGS" ]  || n_badc="$n_badc ${f#*/ci/}(=$EX_CONFIGS)"
+  [ "$EX_SEVERITY" = "$HOOK_SEVERITY" ] || n_bads="$n_bads ${f#*/ci/}"
+  [ "$EX_ERROR"    = "$HOOK_ERROR" ]    || n_bade="$n_bade ${f#*/ci/}"
+done
+if [ -z "$n_badimg" ]; then pass "Cg5-image (all use image: semgrep/semgrep)"; else fail_ "Cg5-image" "no 'image: semgrep/semgrep' in:$n_badimg"; fi
+if [ -z "$n_badc" ];   then pass "Cg5-config-parity (all == '$HOOK_CONFIGS')"; else fail_ "Cg5-config-parity" "config set != hook in:$n_badc"; fi
+if [ -z "$n_bads" ];   then pass "Cg5-severity-parity"; else fail_ "Cg5-severity-parity" "severity != hook in:$n_bads"; fi
+if [ -z "$n_bade" ];   then pass "Cg5-error-parity"; else fail_ "Cg5-error-parity" "--error presence != hook in:$n_bade"; fi
+
+# ── Cg6: non-github gitleaks steps modernized (dir/git, pinned, off zricethezav)
+echo "Cg6: gitlab+bitbucket gitleaks steps modernized (dir/git, version-pinned)"
+NONGH_GITLEAKS=()
+for f in "${GL_FILES[@]}" "${BB_FILES[@]}"; do
+  grep -q 'gitleaks' "$f" && NONGH_GITLEAKS+=("$f")
+done
+if [ "${#NONGH_GITLEAKS[@]}" -ge 20 ]; then
+  pass "Cg6-floor (${#NONGH_GITLEAKS[@]} non-github gitleaks templates, floor 20)"
+else
+  fail_ "Cg6-floor" "found ${#NONGH_GITLEAKS[@]} non-github gitleaks templates, expected >=20 — vacuous"
+fi
+g_detect=""; g_nocmd=""; g_legacy=""; g_unpinned=""
+for f in "${NONGH_GITLEAKS[@]}"; do
+  grep -Eq 'gitleaks detect --source' "$f" && g_detect="$g_detect ${f#*/ci/}"
+  grep -Eq 'gitleaks (dir|git) ' "$f"      || g_nocmd="$g_nocmd ${f#*/ci/}"
+  grep -q 'zricethezav/gitleaks' "$f"       && g_legacy="$g_legacy ${f#*/ci/}"
+  grep -Eq 'gitleaks:v[0-9]+\.[0-9]+\.[0-9]+' "$f" || g_unpinned="$g_unpinned ${f#*/ci/}"
+done
+if [ -z "$g_detect" ];   then pass "Cg6-no-detect (no 'gitleaks detect --source')"; else fail_ "Cg6-no-detect" "'gitleaks detect --source' still present in:$g_detect"; fi
+if [ -z "$g_nocmd" ];    then pass "Cg6-dir-or-git (all run 'gitleaks dir' or 'gitleaks git')"; else fail_ "Cg6-dir-or-git" "no 'gitleaks dir|git' invocation in:$g_nocmd"; fi
+if [ -z "$g_legacy" ];   then pass "Cg6-off-zricethezav"; else fail_ "Cg6-off-zricethezav" "zricethezav/gitleaks still referenced in:$g_legacy"; fi
+if [ -z "$g_unpinned" ]; then pass "Cg6-version-pinned (all gitleaks images carry a vX.Y.Z tag)"; else fail_ "Cg6-version-pinned" "gitleaks image not version-pinned in:$g_unpinned"; fi
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ] || exit 1


### PR DESCRIPTION
## WP-2 — BL-148 + BL-153: semgrep surface modernization, hook-parity policy

Second WP of the PR-sweep remediation wave (`Reports/2026-07-21-pr-sweep/REMEDIATION-PLAN.md`). Cut from WP-1's tip (now merged as #235); the reset base `330870a` is an ancestor of `main`, so **this PR's diff vs `main` is exactly the WP-2 delta**. Base is `main` (WP-1's branch was deleted post-merge).

### The findings
- **BL-148 (High):** all 10 `templates/pipelines/ci/github/*.yml` ran SAST via `semgrep/semgrep-action` — **archived upstream 2024-04-09**.
- **BL-153 (Medium):** the 2 bitbucket semgrep templates used `image: returntocorp/semgrep` (frozen at the 2023 org rename); all 10 bitbucket gitleaks steps used the pre-8.19 `gitleaks detect --source .` on an unpinned `zricethezav/gitleaks:latest`.
- **Scope discovery:** the same dead `returntocorp/semgrep` image + legacy gitleaks forms were also in **all 10 gitlab CI templates** — which the plan's WP-2 file list omitted but the global RED invariant requires gone.

### Watched-RED (before any template touched)
Added cases Cg1–Cg6 to the shared suite `tests/test-bl147-ci-template-integrity.sh` (WP-1 registered it in both lists). The expected semgrep flag set is **DERIVED** from the hook's own `semgrep scan` invocation in `scripts/lib/hook-templates.sh` (`Cg-derive`) — single source, never retyped.

```
Cg1 no templates/pipelines file references semgrep/semgrep-action or returntocorp/semgrep (GLOBAL)
Cg2 every github CI template carries a `semgrep scan --config` invocation
Cg3 github semgrep config/severity/--error EQUAL the hook (owasp-top-ten + DOM-XSS rule, --severity=ERROR, --error)
Cg4 every github CI template declares the `image: semgrep/semgrep` container
Cg5 non-github (gitlab+bitbucket) semgrep: image: semgrep/semgrep + hook-parity flags (floor 12)
Cg6 non-github gitleaks: no `detect --source`, runs `dir`/`git`, off zricethezav, version-pinned (floor 20)
```

**Pre-fix:** `Results: 18 passed, 13 failed` (exit 1) — WP-1's 18 cases stay green; every WP-2 failure maps to the finding (Cg1 flags 22 files; github has no `semgrep scan`/container/parity; non-github carries `returntocorp` + the legacy gitleaks forms).

### The fix
- **GitHub (10):** removed the archived action step; added a sibling `sast` job — `container: image: semgrep/semgrep`, `actions/checkout` (`fetch-depth: 0`), then `semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --severity=ERROR --error`. **Dropped `p/security-audit`** — the hook (single source) does not carry it; parity with the hook is the contract. Verified the checkout-in-Alpine-container form is correct (GitHub's runner uses its musl `node20_alpine` build for JS actions — Semgrep's own documented CI pattern).
- **GitLab + Bitbucket (20):** `returntocorp/semgrep` → `semgrep/semgrep`; invocation → the same hook-parity form; gitleaks `detect --source .` → `dir .`; `zricethezav/gitleaks:latest` → `ghcr.io/gitleaks/gitleaks:v8.30.1` (official image; latest release confirmed via `gh api repos/gitleaks/gitleaks/releases/latest` = `v8.30.1`, manifest verified pullable).

**Post-fix:** `Results: 31 passed, 0 failed` (exit 0). All 30 changed templates re-validated as parseable YAML (PyYAML `safe_load`, 30/0).

### Mutation proof
Strip the DOM-XSS config (`r/javascript.browser.security.insecure-document-method`) from `github/go.yml` → **Cg3-config-parity RED** (`go.yml(=--config=p/owasp-top-ten )` ≠ hook; `30 passed, 1 failed`). Restore → GREEN (`31/0`).

### Blast radius
- `grep -rln 'semgrep-action|returntocorp' templates/ scripts/ tests/ docs/` → only surviving hit is the Cg1 assertion pattern inside the suite itself. No template, script, or product doc references the dead namespaces.
- Docs modernized (BL-153 theme): `docs/builders-guide.md` + `docs/user-guide.md` (`gitleaks detect --source .` → `gitleaks dir .`), `docs/cli-setup-addendum.md` (stale "CI runs gitleaks-action" → "the gitleaks CLI"). Two stale `semgrep-action container` code comments corrected.
- Left untouched (historical/out-of-scope): all `Reports/**`, archived plans, `evaluation-prompts/**` fixtures, the BL-148/BL-153 problem statements.
- `bash scripts/run-lints.sh` → **11 lints — 11 passed, 0 failed**. `scripts/lint-backlog-references.sh` → OK.

### Deviation from the plan (one)
The plan's WP-2 "Files" line lists github + bitbucket, but the dispatcher's RED case (i) is global ("no template ANYWHERE references … returntocorp/semgrep") and the blast-radius grep expects zero `returntocorp` under `templates/`. All 10 gitlab CI templates carried it, so eliminating the dead namespace forced editing every gitlab file; being already in each file, the gitleaks + semgrep-flag modernization (identical debt to bitbucket) rode along for one consistent three-host surface. No other WP owns gitlab CI templates. Also chose the official `ghcr.io/gitleaks/gitleaks` image (DockerHub `gitleaks/gitleaks` does not exist; `zricethezav/*` is retired) over merely re-tagging the legacy one.

Backlog Status updates appended to BL-148 + BL-153 (status stays **Open**; Closed flips at merge). Do not merge — awaiting Fable verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016rA7CKSQ3HcAQjcAGP9hxY
