### PR TITLE
fix(process-checklist,tdd-classify): BL-120 double-print dedup + BL-072 .claude/ exclusion (BL-162/BL-167)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -108,6 +108,8 @@ jobs:
             tests/test-bl095-state-readers.sh
             tests/test-bl106-golive-checklist.sh
             tests/test-bl120-audit-verdict.sh
+            tests/test-bl162-audit-dedup.sh
+            tests/test-bl167-claude-classifier.sh
             tests/test-bl125-commit-test-exec.sh
             tests/test-bl163-blocked-ledger.sh
             tests/test-bl141-commitmsg-repair.sh

--- a/scripts/lib/tdd-classify.sh
+++ b/scripts/lib/tdd-classify.sh
@@ -56,7 +56,7 @@ _bl072_is_test_file() {
 # _bl072_is_impl_file <path>
 # Returns 0 (true) if <path> is an implementation file: a modified/added file
 # that is NOT a test file and NOT under one of the exempt trees
-# (docs/, .github/, Reports/, templates/) and is NOT one of the exempt
+# (docs/, .github/, .claude/, Reports/, templates/) and is NOT one of the exempt
 # script shapes (scripts/lint-*.sh). Everything else counts as
 # implementation — the classifier is deliberately broad; the dogfood measures
 # how broad is too broad.
@@ -75,12 +75,13 @@ _bl072_is_impl_file() {
   base="${p##*/}"
   _bl072_is_test_file "$p" && return 1
   case "$p" in
-    docs/*|*/docs/*)     return 1 ;;
-    .github/*)           return 1 ;;
-    Reports/*)           return 1 ;;
-    templates/*)         return 1 ;;
-    scripts/lint-*.sh)   return 1 ;;
-    *.md)                return 1 ;;   # BL-072 C2: all markdown, anywhere
+    docs/*|*/docs/*)       return 1 ;;
+    .github/*)             return 1 ;;
+    .claude/*|*/.claude/*) return 1 ;;   # BL-167-CLAUDE-EXCLUDE: framework state files (phase-state.json, process-state.json, …) are never implementation
+    Reports/*)             return 1 ;;
+    templates/*)           return 1 ;;
+    scripts/lint-*.sh)     return 1 ;;
+    *.md)                  return 1 ;;   # BL-072 C2: all markdown, anywhere
   esac
   case "$base" in
     package-lock.json)   return 1 ;;   # BL-072 C2: npm lockfile (generated)

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -393,10 +393,25 @@ complete_step() {
       # gate closes the dishonest-by-OMISSION path, the same honesty
       # boundary as BL-112/117.
       if [ "$artifact_check_failed" = false ]; then
-        local bl120_f bl120_files="" bl120_mt bl120_max=0
+        local bl120_f bl120_files="" bl120_mt bl120_max=0 bl120_seen=""
+        # BL-162-AUDIT-DEDUP: the two globs (*slug* and *name*) match the SAME
+        # file twice when feature_slug == feature_name (an already-slug-shaped
+        # feature like "find-in-document"), which made the verdict loop print
+        # its finding twice. Deduplicate by path so each distinct audit file is
+        # processed — and its verdict printed — exactly once. Print-count only:
+        # bl120_max is a max over identical mtimes (a duplicate cannot change
+        # it) and the verdict loop's any-open-blocks / newest-mtime semantics
+        # are unchanged (the BLOCK is idempotent — it sets
+        # artifact_check_failed=true regardless of how many times it fires).
+        local bl120_nl='
+'
         for bl120_f in docs/security-audits/*"${feature_slug}"* \
                        docs/security-audits/*"${feature_name}"*; do
           [ -f "$bl120_f" ] || continue
+          case "${bl120_nl}${bl120_seen}" in
+            *"${bl120_nl}${bl120_f}${bl120_nl}"*) continue ;;
+          esac
+          bl120_seen="${bl120_seen}${bl120_f}${bl120_nl}"
           bl120_mt=$(stat -c %Y "$bl120_f" 2>/dev/null || stat -f %m "$bl120_f" 2>/dev/null) || bl120_mt=0
           case "$bl120_mt" in ''|*[!0-9]*) bl120_mt=0 ;; esac
           if [ "$bl120_mt" -gt "$bl120_max" ]; then bl120_max="$bl120_mt"; fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -3781,6 +3781,8 @@ The `# BL-120-AUDIT-VERDICT` arm in `process-checklist.sh` globs audit files by 
 
 **Related:** BL-120 (the arm; its BLOCK behavior verified HELD by Dogfood-4 S2 Probe B).
 
+**Status update 2026-07-23 (residuals wave WP-B, branch `fix/bl162-bl167-precision`; Karl-approved 2026-07-23; stays Open until merge):** Fixed (source+tests `424bdd4`). `# BL-162-AUDIT-DEDUP` in `process-checklist.sh`: the glob loop now deduplicates by path (a newline-bounded `bl120_seen` accumulator + a `case … continue` skip) BEFORE the verdict loop, so a file matched by both the `*slug*` and `*name*` globs is processed — and its verdict printed — exactly once. PRINT-COUNT ONLY, confirmed: `bl120_max` is a max over identical mtimes (the two duplicate entries carry the byte-identical `stat` value, so a duplicate cannot move it) and the verdict loop's newest-mtime selection + any-open-blocks tie-break are untouched — the BLOCK is idempotent (it sets `artifact_check_failed=true` regardless of how many times the arm fires), so WHICH verdict is reached is unchanged; only the duplicate PRINT is removed. TDD (`tests/test-bl162-audit-dedup.sh`, unit lane): watched-RED against pre-fix code = T1 FAIL (`warn_count=2` on the slug==name `find-in-document` fixture) with T2 (slug!=name) already single; GREEN post-fix 4/4 (T1 one warning + still BLOCKS, T2 unaffected, T3 mutation RED reverting the dedup restores the double-print / GREEN real prints once). Registered in BOTH lists. Blast radius all green: bl120 17/17, bl118 6/6, bl125 16/16, bl108-bl117 5/5, platform-security-bugs-closer 7/7, bl112 13/13. `run-lints.sh` 11/11.
+
 ---
 
 ## BL-163: Blocked commit attempts leave NO row in bypass-audit.json — the SAST and test-execution blocks are invisible to the enforcement ledger
@@ -3865,6 +3867,8 @@ A `fix:` commit staging only source + `.claude/phase-state.json` produced a BL-0
 **Fix shape:** exclude `.claude/` paths from the BL-072 impl-file classifier.
 
 **Related:** BL-072 (the gate), BL-139 (same-family classifier precision).
+
+**Status update 2026-07-23 (residuals wave WP-B, branch `fix/bl162-bl167-precision`; Karl-approved 2026-07-23; stays Open until merge):** Fixed (source+tests `424bdd4`). `# BL-167-CLAUDE-EXCLUDE` in `scripts/lib/tdd-classify.sh`: `_bl072_is_impl_file` gains a `.claude/*|*/.claude/*) return 1` arm so framework state files (`phase-state.json`, `process-state.json`, …) never classify as implementation. Scoped to `.claude/` ONLY — the exclusion did NOT over-reach: real source under `src/`/`lib/`/`app/` still classifies as impl (pinned by T2 + T3). TDD (`tests/test-bl167-claude-classifier.sh`, unit lane): watched-RED against pre-fix code = T1 FAIL (`.claude/phase-state.json` listed in the BL-072 WARN impl listing) + T3 FAIL (`_bl072_impl_files` emitted the `.claude/*` paths) + T4 FAIL (marker absent, nothing to mutate), with T2 (lone `src/app.ts`) already impl; GREEN post-fix 5/5 (T1 `.claude` excluded from the listing / `src/app.ts` still listed, T2 no over-reach, T3 direct-classifier assertions incl. nested `*/.claude/*`, T4 mutation RED excising the arm relists `.claude` / GREEN real omits it). Registered in BOTH lists. Blast radius all green: bl072 36/36, bl096 8/8, bl107 7/7, bl119 4/4, bl139 5/5, bl141 6/6, bl112 13/13, upgrade-sync-framework 35/35, scaffold-source-closure 6/6, scaffold-tdd-block-real 10/10. `run-lints.sh` 11/11.
 
 ---
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -929,6 +929,29 @@ else
   fail "tests/test-bl120-audit-verdict.sh FAILED (run for details)"
 fi
 
+# BL-162 (Dogfood-4 S2 F-DF4-008): the BL-120 verdict arm globbed audit files
+# by both *slug* and *name*; when slug==name (an already-slug-shaped feature)
+# the same artifact matched twice and its OPEN-finding warning printed twice.
+# Dedupe by path (# BL-162-AUDIT-DEDUP) — print-count only, the BLOCK is
+# unchanged. In-suite mutation reverts the dedup → double-print returns.
+# No init.sh -> both lanes.
+if bash "$SCRIPT_DIR/tests/test-bl162-audit-dedup.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl162-audit-dedup.sh"
+else
+  fail "tests/test-bl162-audit-dedup.sh FAILED (run for details)"
+fi
+
+# BL-167 (Dogfood-4 S3 F-DF4-014): the BL-072 TDD-ordering classifier counted
+# .claude/* framework state files (phase-state.json, …) as impl files lacking
+# a test. _bl072_is_impl_file now excludes .claude/ (# BL-167-CLAUDE-EXCLUDE),
+# scoped to .claude/ only (real src/lib/app stays impl). In-suite mutation
+# excises the arm → .claude state relists as impl. No init.sh -> both lanes.
+if bash "$SCRIPT_DIR/tests/test-bl167-claude-classifier.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl167-claude-classifier.sh"
+else
+  fail "tests/test-bl167-claude-classifier.sh FAILED (run for details)"
+fi
+
 # BL-138 (Dogfood-3 F-DF3-001): validate_approval_fields no longer
 # self-collides with the template — H2-anchored section-bounded window
 # (table rows can neither anchor nor extend the scan) + template-literal

--- a/tests/test-bl162-audit-dedup.sh
+++ b/tests/test-bl162-audit-dedup.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# tests/test-bl162-audit-dedup.sh — BL-162 (Dogfood-4 S2, F-DF4-008):
+# the BL-120 security-audit verdict arm globs candidate files by BOTH
+# `*<feature_slug>*` and `*<feature_name>*`. When slug == name (an already-
+# slug-shaped feature like "find-in-document") the SAME artifact matches both
+# globs, so — before the fix — the same file was processed twice and its
+# `records N OPEN finding(s)` warning printed TWICE. The BLOCK itself was
+# always correct (exactly one step-refusal); only the duplicate PRINT was the
+# bug.
+#
+# THE FIX (# BL-162-AUDIT-DEDUP): deduplicate the matched-file list by path
+# before the verdict loop, so each distinct audit file is processed — and its
+# verdict printed — exactly once. It is print-count only: the newest-mtime
+# selection and any-open-blocks semantics are unchanged.
+#
+# Cases:
+#   T1-slug-eq-name-single-warn  slug==name + one OPEN-finding audit →
+#                                the OPEN-finding warning appears EXACTLY ONCE
+#                                and the step still BLOCKS (rc!=0, not recorded).
+#   T2-slug-neq-name-single-warn slug!=name ("Comment Widget") + OPEN finding →
+#                                still exactly one warning, still BLOCKS (the fix
+#                                did not perturb the normal one-glob path).
+#   T3-mutation                  revert the dedup (strip the # BL-162 case guard)
+#                                from a fixture copy → the slug==name fixture
+#                                prints the warning TWICE again (RED); the real
+#                                script prints it once (GREEN).
+#
+# REGISTRATION: no init.sh, not an aggregator → BOTH lists (tests.yml unit
+# list + full-project-test-suite.sh). Hermetic (mktemp fixtures, no remote).
+# bash-3.2 safe: no associative arrays, no mapfile, no ${var,,}, no ((x++)).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq required"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# mk_loop <dir> <feature-name> — phase-2 project with an ACTIVE Build Loop for
+# <feature-name>, the three prior steps completed, so
+# --complete-step build_loop:security_audit reaches the artifact/verdict check.
+mk_loop() {
+  local d="$1" feat="$2"
+  rm -rf "$d"
+  mkdir -p "$d/.claude" "$d/scripts/lib" "$d/docs/security-audits"
+  ( cd "$d" && git init -q && git config user.email t@t.invalid && git config user.name t \
+      && echo x > seed && git add seed && git commit -q -m "chore: init" ) || return 1
+  cat > "$d/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"gates":{}}
+JSON
+  cat > "$d/.claude/process-state.json" <<JSON
+{"phase2_init":{"steps_completed":["remote_repo_created","pushed_initial"],"verified":true},"build_loop":{"feature":"$feat","step":3,"steps_completed":["tests_written","tests_verified_failing","implemented"]},"uat_session":{},"phase3_validation":{},"phase4_release":{}}
+JSON
+  cp "$REPO_ROOT/scripts/process-checklist.sh" "$d/scripts/"
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-full.sh" "$d/scripts/lib/"
+  chmod +x "$d/scripts/process-checklist.sh"
+}
+
+# An audit body that records OPEN findings → the verdict arm must WARN + BLOCK.
+open_audit() {  # open_audit <path>
+  cat > "$1" <<'EOF'
+# Security Audit Findings
+
+## Summary
+
+| Status | Count |
+|--------|-------|
+| Fixed | 1 |
+| Open | 2 |
+
+**All findings resolved:** No
+EOF
+}
+
+run_audit_step() {  # run_audit_step <dir> [script-rel-path]
+  local d="$1" rel="${2:-scripts/process-checklist.sh}"
+  ( cd "$d" && bash "$rel" --complete-step build_loop:security_audit </dev/null 2>&1 )
+}
+
+step_recorded() {  # step_recorded <dir> → 0 iff security_audit landed in state
+  jq -e '.build_loop.steps_completed | index("security_audit")' \
+    "$1/.claude/process-state.json" >/dev/null 2>&1
+}
+
+# Count how many times the OPEN-finding verdict warning appears in output.
+open_warn_count() { printf '%s\n' "$1" | grep -c 'OPEN finding(s)' || true; }
+
+# ── T1: slug == name ("find-in-document") — the warning prints EXACTLY once ───
+echo "=== T1-slug-eq-name-single-warn ==="
+P="$TOPTMP/p1"; mk_loop "$P" "find-in-document"
+open_audit "$P/docs/security-audits/find-in-document-security-audit.md"
+out=$(run_audit_step "$P"); rc=$?
+n=$(open_warn_count "$out")
+if [ "$rc" -ne 0 ] && ! step_recorded "$P" && [ "$n" -eq 1 ]; then
+  pass "T1-slug-eq-name-single-warn (slug==name: one OPEN warning, step still BLOCKS)"
+else
+  fail_ "T1-slug-eq-name-single-warn" "rc=$rc warn_count=$n (want rc!=0, not-recorded, count=1) — $(printf '%s' "$out" | tr '\n' ' ')"
+fi
+
+# ── T2: slug != name ("Comment Widget") — normal one-glob path unaffected ─────
+echo "=== T2-slug-neq-name-single-warn ==="
+P="$TOPTMP/p2"; mk_loop "$P" "Comment Widget"
+open_audit "$P/docs/security-audits/comment-widget-security-audit.md"
+out=$(run_audit_step "$P"); rc=$?
+n=$(open_warn_count "$out")
+if [ "$rc" -ne 0 ] && ! step_recorded "$P" && [ "$n" -eq 1 ]; then
+  pass "T2-slug-neq-name-single-warn (slug!=name still prints once and BLOCKS — dedup did not perturb it)"
+else
+  fail_ "T2-slug-neq-name-single-warn" "rc=$rc warn_count=$n (want rc!=0, not-recorded, count=1) — $(printf '%s' "$out" | tr '\n' ' ')"
+fi
+
+# ── T3: mutation — revert the dedup → the slug==name double-print returns ─────
+# Strip the # BL-162-AUDIT-DEDUP case guard (the load-bearing skip) from a
+# fixture copy so both globs are processed again. RED: the warning prints
+# twice. GREEN: the real (deduped) script prints it once. Both still BLOCK.
+echo "=== T3-mutation-dedup-load-bearing ==="
+P="$TOPTMP/p3"; mk_loop "$P" "find-in-document"
+open_audit "$P/docs/security-audits/find-in-document-security-audit.md"
+MUT="$P/scripts/process-checklist.mut.sh"
+# Delete the dedup guard: from the `case "${bl120_nl}${bl120_seen}"` line
+# through its terminating `esac` (single-quoted so the shell does not expand
+# the $bl120_* tokens — they are literal text in the target script).
+sed '/case "${bl120_nl}${bl120_seen}"/,/esac/d' \
+  "$P/scripts/process-checklist.sh" > "$MUT" && chmod +x "$MUT"
+mut_ok=1
+grep -q 'bl120_seen' "$P/scripts/process-checklist.sh" || mut_ok=0   # guard present in REAL
+if grep -q '${bl120_nl}${bl120_seen}' "$MUT"; then mut_ok=0; fi       # guard gone in MUTANT
+if ! bash -n "$MUT" 2>/dev/null; then mut_ok=0; fi                    # mutant still valid
+if [ "$mut_ok" -ne 1 ]; then
+  fail_ "T3-mutation-dedup-load-bearing" "mutation vacuous/invalid (real has guard? mutant stripped? syntax ok?)"
+else
+  mout=$(run_audit_step "$P" "scripts/process-checklist.mut.sh"); mrc=$?
+  mn=$(open_warn_count "$mout")
+  # RED: reverting the dedup restores the double-print (still blocks).
+  if [ "$mrc" -ne 0 ] && [ "$mn" -eq 2 ]; then
+    pass "T3-mutation (RED): reverting the dedup prints the OPEN warning TWICE again (still BLOCKS)"
+  else
+    fail_ "T3-mutation (RED)" "mrc=$mrc mut_warn_count=$mn (want rc!=0, count=2) — dedup guard not load-bearing"
+  fi
+  # GREEN: the real deduped script prints it once on the same fixture.
+  rout=$(run_audit_step "$P"); rrc=$?
+  rn=$(open_warn_count "$rout")
+  if [ "$rrc" -ne 0 ] && [ "$rn" -eq 1 ]; then
+    pass "T3-mutation (GREEN): the real (deduped) script prints the OPEN warning once (contrast holds)"
+  else
+    fail_ "T3-mutation (GREEN)" "rrc=$rrc real_warn_count=$rn (want rc!=0, count=1) — contrast broken"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-bl167-claude-classifier.sh
+++ b/tests/test-bl167-claude-classifier.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# tests/test-bl167-claude-classifier.sh — BL-167 (Dogfood-4 S3, F-DF4-014):
+# the BL-072 TDD-ordering classifier counted `.claude/*` framework STATE files
+# (phase-state.json, process-state.json, …) as "implementation files with no
+# accompanying test". A `fix:`/`refactor:` commit staging real source PLUS
+# `.claude/phase-state.json` warned that `.claude/phase-state.json` was an impl
+# file lacking a test. Framework state files are never implementation.
+#
+# THE FIX (# BL-167-CLAUDE-EXCLUDE in scripts/lib/tdd-classify.sh):
+# `_bl072_is_impl_file` excludes `.claude/` paths (both `.claude/*` and any
+# `*/.claude/*`). The exclusion is scoped to `.claude/` ONLY — real source
+# under src/lib/app must still classify as implementation.
+#
+# Cases:
+#   T1-claude-not-listed  fix: staging src/app.ts + .claude/phase-state.json →
+#                         the BL-072 WARN impl listing contains `- src/app.ts`
+#                         but NOT `.claude/phase-state.json`.
+#   T2-src-still-impl     fix: staging ONLY src/app.ts → still listed as impl
+#                         (the exclusion did not over-reach onto real source).
+#   T3-classifier-direct  source tdd-classify.sh: _bl072_impl_files over a
+#                         name-status stream emits src/app.ts (and src/lib/x.ts)
+#                         but NOT .claude/phase-state.json; _bl072_is_impl_file
+#                         returns impl for src/*, non-impl for .claude/*.
+#   T4-mutation           excise # BL-167-CLAUDE-EXCLUDE from a gate copy →
+#                         `.claude/phase-state.json` reappears in the WARN
+#                         listing (RED); the real classifier omits it (GREEN).
+#
+# REGISTRATION: no init.sh, not an aggregator → BOTH lists (tests.yml unit
+# list + full-project-test-suite.sh). Hermetic (mktemp fixtures, no remote;
+# GITHUB_BASE_REF unset; SKIP_LINT=1 as in the BL-072 detector suite — the
+# detector runs before lints_check regardless).
+# bash-3.2 safe: no associative arrays, no mapfile, no ${var,,}, no ((x++)).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GATE="$REPO_ROOT/scripts/pre-commit-gate.sh"
+TDD_LIB="$REPO_ROOT/scripts/lib/tdd-classify.sh"
+PC="$REPO_ROOT/scripts/process-checklist.sh"
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq not available — the BL-072 detector ledger requires jq."
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TAB=$(printf '\t')
+
+# ── Fixture scaffolding (mirrors the BL-072 detector suite) ──────────────
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/proj"
+  mkdir -p "$PROJ"
+  (
+    cd "$PROJ"
+    unset GITHUB_BASE_REF
+    git init -q -b main
+    git config user.email "t@example.invalid"
+    git config user.name "bl167-test"
+    git remote add origin "https://example.invalid/x.git"
+    mkdir -p src
+    echo "seed" > README.md
+    git add README.md
+    git commit -q -m "chore: seed"
+  )
+}
+teardown() { rm -rf "$TMP"; }
+
+stage() {
+  local path="$1" content="${2:-x}"
+  mkdir -p "$PROJ/$(dirname "$path")"
+  printf '%s\n' "$content" > "$PROJ/$path"
+  ( cd "$PROJ" && git add "$path" )
+}
+
+# Pipe a JSON tool_input.command into the gate; echo "rc|<single-line output>".
+run_hook_gate() {
+  local gate="$1" cmd="$2" input out rc=0
+  input=$(jq -n --arg c "$cmd" '{tool_name:"Bash", tool_input:{command:$c}}')
+  out=$( cd "$PROJ" && unset GITHUB_BASE_REF; export SKIP_LINT=1; \
+         printf '%s' "$input" | bash "$gate" 2>&1 ) || rc=$?
+  echo "$rc|$(printf '%s' "$out" | tr '\n' ' ')"
+}
+run_hook() { run_hook_gate "$GATE" "$1"; }
+
+# Build a mutation tree so a single classifier excision is the ONLY difference.
+build_mut_tree() {
+  local mut="$1"
+  mkdir -p "$mut/scripts/lib"
+  cp "$GATE" "$mut/scripts/pre-commit-gate.sh"
+  cp "$TDD_LIB" "$mut/scripts/lib/tdd-classify.sh"
+  cp "$PC" "$mut/scripts/process-checklist.sh" 2>/dev/null || true
+  cp "$REPO_ROOT"/scripts/lib/*.sh "$mut/scripts/lib/" 2>/dev/null || true
+  chmod +x "$mut/scripts/pre-commit-gate.sh"
+}
+
+has_warn()  { case "$1" in *'[WARN] BL-072 TDD ordering'*) return 0 ;; *) return 1 ;; esac; }
+# Is <path> present as a `- <path>` line in the WARN impl listing?
+listed()    { case "$2" in *"- $1"*) return 0 ;; *) return 1 ;; esac; }
+
+# ── T1: .claude/phase-state.json must NOT be listed as an impl file ───────────
+echo "=== T1-claude-not-listed ==="
+setup
+stage "src/app.ts" "export const app = () => 1"
+stage ".claude/phase-state.json" '{"current_phase":2}'
+res=$(run_hook 'git commit -m "fix: patch app and bump phase state"')
+body="${res#*|}"
+ok=1
+has_warn "$body" || ok=0                          # the WARN must fire (src/app.ts is impl, no test)
+listed "src/app.ts" "$body" || ok=0               # real source IS listed
+listed ".claude/phase-state.json" "$body" && ok=0 # framework state is NOT listed
+if [ "$ok" -eq 1 ]; then
+  pass "T1-claude-not-listed: src/app.ts listed, .claude/phase-state.json excluded from the impl listing"
+else
+  fail_ "T1-claude-not-listed" "body: $body"
+fi
+teardown
+
+# ── T2: real source alone still classifies as impl (no over-reach) ───────────
+echo "=== T2-src-still-impl ==="
+setup
+stage "src/app.ts" "export const app = () => 2"
+res=$(run_hook 'git commit -m "fix: patch app"')
+body="${res#*|}"
+if has_warn "$body" && listed "src/app.ts" "$body"; then
+  pass "T2-src-still-impl: a lone src/*.ts still warns + is listed (the .claude exclusion did not over-reach)"
+else
+  fail_ "T2-src-still-impl" "expected WARN listing src/app.ts; body: $body"
+fi
+teardown
+
+# ── T3: direct classifier assertions (deterministic, sourced) ────────────────
+echo "=== T3-classifier-direct ==="
+# shellcheck source=/dev/null
+. "$TDD_LIB"
+name_status="A${TAB}src/app.ts
+A${TAB}src/lib/util.ts
+A${TAB}.claude/phase-state.json
+M${TAB}.claude/process-state.json"
+impl_out=$(printf '%s\n' "$name_status" | _bl072_impl_files)
+ok=1
+case "
+$impl_out" in *"
+src/app.ts"*) : ;; *) ok=0 ;; esac
+case "
+$impl_out" in *"
+src/lib/util.ts"*) : ;; *) ok=0 ;; esac
+case "$impl_out" in *'.claude/'*) ok=0 ;; esac
+_bl072_is_impl_file "src/app.ts"            || ok=0   # 0 = impl
+_bl072_is_impl_file "src/lib/util.ts"       || ok=0   # 0 = impl
+_bl072_is_impl_file ".claude/phase-state.json"   && ok=0   # 1 = NOT impl (expected)
+_bl072_is_impl_file "pkg/.claude/state.json"     && ok=0   # nested .claude also excluded
+if [ "$ok" -eq 1 ]; then
+  pass "T3-classifier-direct: _bl072_impl_files emits src/* only; .claude/* classifies non-impl (both top-level and nested)"
+else
+  fail_ "T3-classifier-direct" "impl_out=[$(printf '%s' "$impl_out" | tr '\n' ',')]"
+fi
+
+# ── T4: mutation — excise the exclusion → .claude reappears in the listing ───
+echo "=== T4-mutation-exclusion-load-bearing ==="
+setup
+stage "src/app.ts" "export const app = () => 4"
+stage ".claude/phase-state.json" '{"current_phase":2}'
+MUT="$TMP/mut"
+build_mut_tree "$MUT"
+grep -v 'BL-167-CLAUDE-EXCLUDE' "$MUT/scripts/lib/tdd-classify.sh" > "$MUT/scripts/lib/tdd-classify.sh.tmp"
+mv "$MUT/scripts/lib/tdd-classify.sh.tmp" "$MUT/scripts/lib/tdd-classify.sh"
+if ! grep -q 'BL-167-CLAUDE-EXCLUDE' "$TDD_LIB"; then
+  fail_ "T4-mutation-exclusion-load-bearing" "BL-167-CLAUDE-EXCLUDE marker missing from the REAL classifier — nothing to mutate"
+elif grep -q 'BL-167-CLAUDE-EXCLUDE' "$MUT/scripts/lib/tdd-classify.sh"; then
+  fail_ "T4-mutation-exclusion-load-bearing" "marker still present after excision — mutation did not apply"
+elif ! bash -n "$MUT/scripts/lib/tdd-classify.sh" 2>/dev/null; then
+  fail_ "T4-mutation-exclusion-load-bearing" "mutant tdd-classify.sh not syntactically valid after excision"
+else
+  # RED: without the exclusion, .claude/phase-state.json is listed as impl.
+  mres=$(run_hook_gate "$MUT/scripts/pre-commit-gate.sh" 'git commit -m "fix: patch app and bump phase state"')
+  mbody="${mres#*|}"
+  if has_warn "$mbody" && listed ".claude/phase-state.json" "$mbody"; then
+    pass "T4-mutation (RED): excising BL-167-CLAUDE-EXCLUDE relists .claude/phase-state.json as impl"
+  else
+    fail_ "T4-mutation (RED)" "mutant did NOT relist .claude state — exclusion not load-bearing; mbody: $mbody"
+  fi
+  # GREEN: the real classifier omits it on the same fixture.
+  rres=$(run_hook 'git commit -m "fix: patch app and bump phase state"')
+  rbody="${rres#*|}"
+  if has_warn "$rbody" && ! listed ".claude/phase-state.json" "$rbody"; then
+    pass "T4-mutation (GREEN): the real classifier keeps .claude/phase-state.json out of the impl listing (contrast holds)"
+  else
+    fail_ "T4-mutation (GREEN)" "real classifier listed .claude state — contrast broken; rbody: $rbody"
+  fi
+fi
+teardown
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

Two Dogfood-4 cosmetic/precision residuals (Karl-approved residuals wave, 2026-07-23).

- **BL-162** (`# BL-162-AUDIT-DEDUP` in `process-checklist.sh`): the BL-120 security-audit gate globbed audit files by both `*<slug>*` and `*<name>*`, so when slug==name (e.g. `find-in-document`) the same file matched twice and its `records N OPEN finding(s)` warning printed twice. Now deduped by path (newline-anchored, bash-3.2-safe) before the verdict loop. Print-count only — the newest-mtime / any-open-blocks verdict and the BLOCK are unchanged.
- **BL-167** (`# BL-167-CLAUDE-EXCLUDE` in `scripts/lib/tdd-classify.sh`): the BL-072 TDD-ordering warn counted `.claude/*.json` state files as impl-files-lacking-a-test. `.claude/` (top-level and nested) now exempt; `src/lib/app` still classify as impl.

## Proof discipline
- `tests/test-bl162-audit-dedup.sh` 4/4 and `tests/test-bl167-claude-classifier.sh` 5/5 — each watched-RED (double-print / `.claude` listed pre-fix) → GREEN, with an in-suite mutation-proof case (revert the dedup → double-print RED; excise the exclusion → `.claude` relisted RED)
- Blast radius green: `test-bl120-audit-verdict` 17/0, `test-bl072-tdd-warn-detector` 36/0 (plus the implementer's wider battery)
- Registered both lanes; `lint-tests-registered.sh` + `run-lints.sh` 11/11
- Direct-reviewed by the supervisor (small cosmetic scope; no subagent verifier)

Part of the post-Dogfood-4 residuals wave — supervisor will not self-merge. Shares registration-file anchors with the sibling wave PRs; trivial keep-both-lines conflicts possible at later merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)