### PR TITLE
docs(handoffs): residuals-wave handoff + BL-161/BL-165 next-session launch prompt

### DIFF
--- a/docs/handoffs/2026-07-24-next-session-prompt.md
+++ b/docs/handoffs/2026-07-24-next-session-prompt.md
@@ -1,0 +1,129 @@
+# Next-session launch prompt — BL-161 + BL-165 (paste into a fresh session)
+
+You are the SUPERVISOR of a two-item build wave in the solo-orchestrator framework repo
+(`/Users/karl/Documents/Claude Projects/solo-orchestrator`). Both items are Karl-approved
+(2026-07-23/24) design-fork decisions; the recommended option was chosen for each. Read
+`CLAUDE.md` (repo discipline) and the handoff
+`docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md` first.
+
+## Preconditions (verify, do not assume)
+1. `cd "/Users/karl/Documents/Claude Projects/solo-orchestrator"`; `git fetch origin`;
+   `git checkout main && git pull --ff-only origin main`.
+2. The four residuals-wave PRs (#255–#258) may or may not be merged yet. If **unmerged**,
+   branch each new WP off `origin/main` and expect trivial keep-both-lines conflicts at
+   later merge on `tests.yml` / `full-project-test-suite.sh`. If **merged**, `main` already
+   carries them — just branch off the updated `main`. Do NOT depend on their content; both
+   BL-161 and BL-165 touch different files.
+3. `bash scripts/run-lints.sh` should be 11/11 on a clean checkout before you start.
+
+## Discipline (both WPs)
+- Watched-RED TDD, `# BL-NNN-` marker fences, mutation proofs, register new `tests/test-*.sh`
+  in BOTH `tests/full-project-test-suite.sh` AND the `.github/workflows/tests.yml` unit
+  `tests=(` list (unless it invokes `init.sh`). `lint-tests-registered.sh` + full
+  `run-lints.sh` green before committing.
+- bash-3.2 subset (no `${var,,}`, no `declare -A`, no `nullglob`; never `((x++))` under
+  `set -e`; GNU-first `stat -c … || stat -f …`); quote every path (space in repo path);
+  `unset GITHUB_BASE_REF` + git identity in fixtures; hermetic tests only (local bare repos,
+  never a live remote — `lint-no-live-remote-in-tests.sh` enforces).
+- Each WP: opus implementer in an isolated worktree, commit-not-push (source+tests commit,
+  then docs-only backlog commit inside the entry, Status stays Open until merge). Then a
+  **fable verifier** (≥ implementer tier) on each — both are behavioral. Apply verifier
+  findings, then open a green PR and surface to Karl. NEVER self-merge, NEVER `--no-verify`.
+- After both PRs are up and CI-green, write a short close-out to Karl and (if he merges)
+  the closure flips.
+
+---
+
+## WP-1 — BL-161: `.claude/bypass-audit.json` records only real events
+
+**Decision (Karl, 2026-07-23):** *record only real events* — stop tracking routine
+`terminal_commit_passed` receipts. The tracked ledger should change only when something
+noteworthy happens (a bypass, an out-of-band commit, or a `terminal_commit_blocked`
+refusal from BL-163/BL-171), so the working tree is no longer left perpetually one row
+dirty after every session. Keep the file **tracked** (audit trail); do NOT gitignore it.
+
+Read FIRST: `## BL-161:` in `solo-orchestrator-backlog.md`; `scripts/lib/bypass-audit.sh`
+(the append primitive + row schema); `scripts/install-filesystem-gates.sh` (writes
+`terminal_commit_passed` via `record_audit_row`); `scripts/detect-out-of-band-commits.sh`
+(reads the ledger); the BL-163/BL-171 emitted-hook ledger calls (they write
+`terminal_commit_blocked` — those MUST keep working).
+
+**Load-bearing precondition (do this before changing anything):** enumerate mechanically
+every consumer that READS `terminal_commit_passed` rows — `grep -rn 'terminal_commit_passed'
+scripts/ tests/ init.sh` and classify each. If any consumer genuinely depends on the pass
+receipts (a heartbeat / "last terminal commit seen" cursor, or the out-of-band detector's
+baseline), that is a scope change to SURFACE to Karl, not to silently break. The likely
+finding: the pass row is a convenience receipt with no load-bearing reader, but PROVE it.
+
+**Fix shape:** stop emitting the routine `terminal_commit_passed` row at the terminal-commit
+success path (mark `# BL-161-NO-ROUTINE-PASS`), while preserving: (a) all
+`terminal_commit_blocked` writes (BL-163/BL-171), (b) genuine bypass / out-of-band /
+`enforcement_level_set` event rows, (c) whatever the out-of-band detector needs to establish
+its baseline — if it relied on the last pass row, give it a non-tracked cursor (mirror
+`.claude/last-checked-commit.txt`, already gitignored) rather than the tracked ledger.
+
+**Tests (hermetic, watched-RED):** new `tests/test-bl161-ledger-real-events-only.sh`:
+(a) a CLEAN terminal commit writes NO new ledger row (RED pre-fix: a `terminal_commit_passed`
+row appears) and leaves the tracked ledger byte-unchanged; (b) a BLOCKED commit STILL writes
+its `terminal_commit_blocked` row (regression guard — the BL-163/BL-171 behavior is intact);
+(c) a genuine bypass/out-of-band event STILL records; (d) the out-of-band detector still
+functions with the new baseline mechanism. Mutation proof: reverting the fix re-introduces
+the routine pass row → (a) RED. Blast radius: all four `test-bypass-audit-*` suites,
+`test-bl163-blocked-ledger.sh`, `test-bl171-commitmsg-ledger.sh`, `test-bypass-detector*.sh`,
+`test-bl112-commit-enforcement.sh` (its `T-clean-commit-still-works` asserts a passed row
+today — expect to update it WITH justification: the contract is changing by design).
+
+Branch `fix/bl161-ledger-real-events`. Watch for: `test-bl112`'s clean-commit assertion and
+any bypass-audit-integrity test that counts rows — those encode the old contract and must be
+updated deliberately, not worked around.
+
+---
+
+## WP-2 — BL-165: Phase-3 DAST hardened-serve harness for static apps
+
+**Decision (Karl, 2026-07-23):** *build the harness* (harness + guidance), the most complete
+option — so a genuinely clean static app that declares its production headers can PASS
+Phase-3 DAST honestly, instead of structurally FAILing on deploy-time host-header alerts
+(missing CSP / anti-clickjacking) that no bundle change can fix.
+
+Read FIRST: `## BL-165:` in `solo-orchestrator-backlog.md`; the zap-dast arm in
+`scripts/run-phase3-validation.sh` (markers `# BL-122-ZAP-RISK-FILTER` riskcode≥2 judge and
+`# BL-140-ZAP-WORKDIR`, and the just-fixed `# BL-168-TM-SIGPIPE` nearby — do NOT regress any);
+`docs/platform-modules/web.md` § 4.4 (the CSP non-inheriting-directives note landed on #245)
+and the Bible §11 production-header convention; `tests/test-bl070-snyk-zap-scanners.sh` and
+`tests/test-phase3-validation-gate.sh` for the DAST test patterns (hermetic — they stub the
+scanner, they do not run real ZAP).
+
+**Fix shape (mark `# BL-165-HARDENED-SERVE`):** when the project declares a production header
+set — decide the declaration surface (a Bible §11 parse, or a small config file the harness
+reads; pick the simplest robust one and document it) — the zap-dast arm serves the built
+artifact WITH those headers applied and records the applied header config as part of the
+evidence summary. When the project declares NO header dependence, keep the current
+raw-preview FAIL semantics (an app that SHOULD set headers must still fail — do not blunt the
+check globally; that was the rejected "downgrade alerts" option). The riskcode≥2 judge and
+the BL-140 workdir handling stay intact. Add builders-guide / web.md guidance on the declared
+header set and how the harness uses it.
+
+**Tests (hermetic, watched-RED — never run real ZAP/docker in the suite):** new
+`tests/test-bl165-dast-hardened-serve.sh`: (a) a project that DECLARES headers → the harness
+records the header config in evidence and the arm judges the (stubbed) hardened-serve result,
+not the bare-preview result (RED pre-fix: only bare-preview is judged, so the clean app
+FAILs); (b) a project with NO declared headers → raw-preview FAIL semantics UNCHANGED (the
+regression guard — a genuinely header-dependent app still fails); (c) the riskcode≥2 judge
+and BL-140 workdir are unaffected. Mutation proof: revert the harness → (a) RED. Blast
+radius: `test-bl070-snyk-zap-scanners.sh`, `test-phase3-validation-gate.sh`,
+`test-bl122*`/DAST-family suites, and confirm `# BL-168-TM-SIGPIPE` (same file) is untouched.
+
+Branch `fix/bl165-dast-hardened-serve`. This is the more substantial of the two — the
+declaration-surface choice is an implementation decision (pick and document it, don't ask
+Karl unless it forces a genuine product fork); if the header-declaration parse turns out to
+need a Bible-schema change, surface that as a scope note.
+
+---
+
+## Start
+Confirm preconditions, announce the plan, dispatch WP-1 and WP-2 in parallel (isolated
+worktrees, background), then verify each with a fable subagent before opening its PR.
+Surface both PRs to Karl; do not self-merge. Also worth a cleanup entry if time allows: the
+two pre-existing non-blocking test failures noted in the handoff (`test-currency-birth-stamp.sh`
+stale vs BL-107; `test-bl113-sast-honesty.sh` env-sensitive).

--- a/docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md
+++ b/docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md
@@ -1,0 +1,50 @@
+# Handoff — Dogfood-4 residuals wave complete; next builds = BL-161 + BL-165
+
+**Date:** 2026-07-24 · **Author session:** supervisor (Fable 5) · **Focus for next session:** build the two Karl-approved design-fork items, BL-161 and BL-165.
+
+## 1. Where we are
+
+`main` is at the post-`#254` state (Dogfood-4 fully closed). On top of it, the **post-Dogfood-4 residuals wave** is **complete and open as four green PRs** — NOT yet merged (supervisor never self-merges; awaiting Karl):
+
+| PR | Item(s) | Verifier catch (all fixed on the PR) |
+|---|---|---|
+| [#255](https://github.com/kraulerson/solo-orchestrator/pull/255) | BL-162 (BL-120 double-print dedup) + BL-167 (`.claude/` excluded from BL-072 classifier) | direct-reviewed (cosmetic scope) |
+| [#256](https://github.com/kraulerson/solo-orchestrator/pull/256) | BL-157 (auto-record remote markers for hand-wired origins) | **HIGH** — attestation could be laundered onto an *unpushed* project via a same-named remote branch; fixed with a `cat-file` shared-commit check + 3 security fixtures |
+| [#257](https://github.com/kraulerson/solo-orchestrator/pull/257) | BL-171 (commit-msg hook refusals now write ledger rows) + filed BL-172 | **MAJOR** — under a `set -e` composed preamble the row silently vanished; fixed with `\|\| soif_cm_rc=$?` + T6 |
+| [#258](https://github.com/kraulerson/solo-orchestrator/pull/258) | BL-158 + BL-166 (`--gate` exit-scope + honest header) | **MAJOR** (test gap) — the `-lt 4`→`-le 4` threshold slip survived every PR-blocking test; closed by cases (f)/(g) |
+
+Every enforcement WP again had a real defect caught by the independent fable verifier — the two-layer discipline held. Merge order to minimize the trivial registration-file conflicts: **#255 → #256 → #257 → #258** (they share `tests.yml` + `full-project-test-suite.sh` anchors; keep-both-lines).
+
+## 2. What shipped this session
+
+- The four PRs above (branches: `fix/bl162-bl167-precision`, `fix/bl157-remote-marker`, `fix/bl171-commitmsg-ledger`, `fix/bl158-bl166-gate-scope`). Each: watched-RED TDD, marker fences, mutation proofs, both-lane registration, fable verifier (except the cosmetic WP-B, direct-reviewed).
+- New backlog entry **BL-172** (Low, Open) — the TDD commit-msg gate honors `MERGE_HEAD` only vs BL-006's fuller sentinel set (cherry-pick/revert resumes refused). Filed, not fixed.
+- Earlier this session (already merged by Karl): CLAUDE.md count true-up (#249), and the Dogfood-4 closures (#254 `c739d38`).
+
+## 3. What's blocked / waiting
+
+- The four residual PRs await Karl's review + merge. After merge: flip BL-157/158/162/166/167/171 → Closed with SHAs (BL-172 stays Open), same closure-PR pattern as #248/#254.
+- **Two pre-existing test failures** surfaced by verifiers, NOT caused by this wave, NOT in the PR-blocking unit lane (both full-suite only) — worth a small cleanup entry when convenient:
+  - `tests/test-currency-birth-stamp.sh` — 2 failures, stale vs the BL-107 universal-hook-install contract (rust/other now emit a commit-msg hook; the test still expects absent).
+  - `tests/test-bl113-sast-honesty.sh` — 1 failure (`T-mutation-no-launder RED(a)`), identical on origin/main; environment-sensitive.
+
+## 4. What's next — the two builds for the next session
+
+Both are **Karl-approved (2026-07-23/24)** design-fork decisions; the recommended options were chosen. Full briefs are in the launch prompt (§ References). In short:
+
+- **BL-161 (record only real events).** Stop recording routine `terminal_commit_passed` receipts in `.claude/bypass-audit.json`; the tracked ledger records only real events (bypasses, out-of-band commits, and the BL-163/BL-171 `terminal_commit_blocked` rows). Kills the perpetual one-row-dirty tail. **Load-bearing precondition:** first enumerate every consumer that reads `terminal_commit_passed` rows (`detect-out-of-band-commits.sh`, `install-filesystem-gates.sh`, the bypass-audit suites, any dashboard/heartbeat) — if any depends on the pass receipts, that's a scope change to surface, not silently break. Keep the file tracked (audit trail).
+- **BL-165 (Phase-3 DAST hardened-serve harness).** Add a serve harness to `run-phase3-validation.sh`'s zap-dast arm: when the project declares production headers (Bible §11 / a config-declared header set), serve the built artifact WITH those headers applied and record the header config as evidence; apps that declare no header dependence keep the raw-preview FAIL semantics. Plus builders-guide guidance. Interacts with the BL-122 riskcode≥2 judge and BL-140 workdir — do not regress those.
+
+Recommendation: run them as **two parallel WPs** (opus implementers in isolated worktrees, commit-not-push) with **fable verifiers** on each (both are behavioral: BL-161 changes ledger-write semantics, BL-165 changes a security scanner's pass/fail surface). Same discipline as this wave.
+
+## 5. References
+
+- Backlog entries (source of truth, all Open): `solo-orchestrator-backlog.md` — `## BL-161:`, `## BL-165:`, plus `## BL-172:` (filed this session).
+- Enforcement source of truth: `scripts/lib/bypass-audit.sh` + `scripts/install-filesystem-gates.sh` (BL-161 target); `scripts/run-phase3-validation.sh` (BL-165 target — see the `# BL-122-ZAP-RISK-FILTER` / `# BL-140-ZAP-WORKDIR` / `# BL-168-TM-SIGPIPE` markers).
+- Repo discipline: `CLAUDE.md` (bash-3.2 subset, `[WARN]`-trap, marker-citation rule, both-lane registration, quote paths).
+- Prior wave patterns (how these WPs were run): `Reports/2026-07-22-dogfood-4/LEDGER.md`.
+- Launch prompt for the next session: `docs/handoffs/2026-07-24-next-session-prompt.md`.
+
+## 6. Resume prompt
+
+> Continuing from the 2026-07-24 handoff at `docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md`. The Dogfood-4 residuals wave shipped as four green PRs (#255–#258) awaiting Karl's merge; do not merge them. This session builds the two Karl-approved design-fork items: **BL-161** (make `.claude/bypass-audit.json` record only real events — stop tracking routine `terminal_commit_passed` receipts, after enumerating every consumer of those rows) and **BL-165** (add a hardened-serve DAST harness to `run-phase3-validation.sh` so a static app that declares production headers passes Phase-3 DAST honestly, keeping raw-preview FAIL for apps with no declared headers). Run them as two parallel WPs in isolated worktrees with watched-RED TDD + marker fences + mutation proofs + a fable verifier each; commit but never push; open green PRs and surface to Karl. Read the full briefs in `docs/handoffs/2026-07-24-next-session-prompt.md` and repo discipline in `CLAUDE.md` first.


### PR DESCRIPTION
Session-boundary handoff (via the session-handoff skill) for the post-Dogfood-4 residuals wave.

- `docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md` — state, the four green residual PRs (#255–#258) and their verifier catches, merge order, blocked/waiting items, and what's next.
- `docs/handoffs/2026-07-24-next-session-prompt.md` — self-contained launch prompt with full WP briefs for the two Karl-approved next builds: **BL-161** (ledger records only real events) and **BL-165** (Phase-3 DAST hardened-serve harness).

Docs-only. Merge alongside or after the four residual PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)