### PR TITLE
fix(bl174): backfill the sidecar gitignore lines on upgrade

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -115,6 +115,7 @@ jobs:
             tests/test-bl163-blocked-ledger.sh
             tests/test-bl171-commitmsg-ledger.sh
             tests/test-bl161-ledger-real-events-only.sh
+            tests/test-bl174-gitignore-backfill.sh
             tests/test-bl141-commitmsg-repair.sh
             tests/test-bl143-pastcap-selfapproval.sh
             tests/test-bl155-phase2-init-transition-commit.sh

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -595,13 +595,15 @@ _run_idempotent_backfill() {
   # absent, mirroring the create-if-missing posture of the last-checked-commit.txt
   # / bypass-audit.json siblings above.
   #
-  # GATED on the generated-project marker (.claude/manifest.json) EXACTLY like
-  # every sibling backfill in this function: the enclosing subshell does
+  # GATED on the generated-project marker (.claude/manifest.json), matching the
+  # host-field and BL-030 sibling backfills above: the enclosing subshell does
   # `cd "$PROJECT_ROOT"`, and on a projectless / in-framework invocation
   # PROJECT_ROOT is empty so that `cd` no-ops and cwd stays the invocation dir
-  # (e.g. the framework repo). Without this guard the block would append its two
-  # lines to the framework's OWN .gitignore. The sibling blocks avoid that only
-  # because they are manifest-gated; this one must be too.
+  # (e.g. the framework repo). Without this gate the block would append its two
+  # lines to the framework's OWN .gitignore. NOTE: not every sibling block in
+  # this function carries such a gate — the vendored-skills sync and the BL-088
+  # source-closure copy have NO project gate and do write outside generated
+  # projects today; that structural gap is tracked as BL-177.
   # BL-174-GITIGNORE-BACKFILL START
   if [ -f .claude/manifest.json ]; then
     if [ ! -f .gitignore ]; then

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -582,6 +582,54 @@ _run_idempotent_backfill() {
     print_info "  scripts/reconfigure-project.sh --enforcement-level <light|no> --confirm-pitfalls"
   fi
 
+  # --- BL-174: gitignore sidecar ignore-line backfill ---------------------
+  # init.sh's generate_gitignore() is the ONLY writer of the operational-state
+  # ignore lines, so an UPGRADED project picks up the receipt-WRITING gate
+  # behavior (the install-filesystem-gates.sh re-run above) but never the
+  # matching .gitignore lines. Net: .claude/last-gate-pass.txt (BL-161) and its
+  # sibling .claude/last-checked-commit.txt (BL-030) sit UNTRACKED, and a
+  # downstream `git add -A` would TRACK them — resurrecting the dirty-chase
+  # BL-161 / BL-030 removed. Idempotent append-if-missing: `grep -qxF` guards
+  # each EXACT line so a re-run is a byte-no-op. Best-effort (|| true) — a
+  # gitignore hiccup must never fail the upgrade. Creates .gitignore if wholly
+  # absent, mirroring the create-if-missing posture of the last-checked-commit.txt
+  # / bypass-audit.json siblings above.
+  #
+  # GATED on the generated-project marker (.claude/manifest.json) EXACTLY like
+  # every sibling backfill in this function: the enclosing subshell does
+  # `cd "$PROJECT_ROOT"`, and on a projectless / in-framework invocation
+  # PROJECT_ROOT is empty so that `cd` no-ops and cwd stays the invocation dir
+  # (e.g. the framework repo). Without this guard the block would append its two
+  # lines to the framework's OWN .gitignore. The sibling blocks avoid that only
+  # because they are manifest-gated; this one must be too.
+  # BL-174-GITIGNORE-BACKFILL START
+  if [ -f .claude/manifest.json ]; then
+    if [ ! -f .gitignore ]; then
+      : > .gitignore || true
+    fi
+    _bl174_added=0
+    if ! grep -qxF '.claude/last-checked-commit.txt' .gitignore 2>/dev/null; then
+      {
+        printf '\n# BL-030 operational state — the detection baseline file. Not project\n'
+        printf '# content; ignored so the SessionStart detector and init.sh finish clean.\n'
+        printf '.claude/last-checked-commit.txt\n'
+      } >> .gitignore && _bl174_added=1 || true
+    fi
+    if ! grep -qxF '.claude/last-gate-pass.txt' .gitignore 2>/dev/null; then
+      {
+        printf '\n# BL-161 operational state — the terminal-commit gate-ran receipt written by\n'
+        printf '# .git/hooks/framework-gate.sh on every CLEAN strict-mode commit. Not project\n'
+        printf '# content; ignored (like its sibling above) so it never dirties the tree.\n'
+        printf '.claude/last-gate-pass.txt\n'
+      } >> .gitignore && _bl174_added=1 || true
+    fi
+    if [ "$_bl174_added" -eq 1 ]; then
+      print_ok "gitignore sidecar ignore-lines backfilled (BL-174)"
+    fi
+    unset _bl174_added
+  fi
+  # BL-174-GITIGNORE-BACKFILL END
+
   # --- Vendored-skills sync (audit code-upgrade-project-3, S3 sweep) ---
   # init.sh's skill-install block (init.sh ~line 1239) enumerates each
   # vendored skill explicitly. Skills shipped after a project was created

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4061,4 +4061,36 @@ Neither failure blocks PRs (both suites are full-suite-only, not in the `tests.y
 
 **Secondary (optional hardening, do when BL-174 is built):** `tests/test-filesystem-gate-install.sh` has zero pass-arm coverage — it passed unchanged under both BL-161 receipt mutations, so it cannot catch a regression in the clean-pass receipt path. Add one receipt case (a clean pass writes `.claude/last-gate-pass.txt` and no tracked-ledger row).
 
+**Build note (2026-07-24, branch `fix/bl174-gitignore-backfill`):** implemented the
+append-if-missing backfill inside `_run_idempotent_backfill` (marker
+`# BL-174-GITIGNORE-BACKFILL`), covering BOTH sidecar lines
+(`.claude/last-checked-commit.txt` and `.claude/last-gate-pass.txt`). Idempotent
+(`grep -qxF` guards each exact line → re-run is a byte-no-op), manifest-gated (runs
+for every generated project via the `.claude/manifest.json` marker, exactly like its
+sibling backfills), best-effort (`|| true` so a gitignore hiccup never fails the
+upgrade), and create-if-missing when a project has no `.gitignore` at all — the last
+two mirroring the marker-gated / create-if-missing posture of the sibling
+`.claude/last-checked-commit.txt` / `.claude/bypass-audit.json` backfills in the same
+function. **The manifest gate is load-bearing:** the enclosing subshell runs
+`cd "$PROJECT_ROOT"`, and because the `--backfill-only` path never reaches
+`guard_not_in_framework`, a projectless / in-framework invocation (empty
+`PROJECT_ROOT` → that `cd` no-ops → cwd stays the framework repo) would otherwise
+append the two lines to the framework's OWN `.gitignore`. An earlier UNGUARDED draft
+did exactly that (caught mid-build when an upgrade-family suite polluted the worktree
+`.gitignore`); the `.claude/manifest.json` gate — the same marker every sibling block
+uses — closes it. New hermetic suite `tests/test-bl174-gitignore-backfill.sh` (6
+cases; hand-built fixture, NO init.sh — copies the upgrade script + lib closure and
+drives `--backfill-only`; registered in BOTH the `tests.yml` unit lane and the
+full-project aggregator) pins the two lines BEHAVIORALLY via `git check-ignore` on an
+UPGRADED fixture (the BACKFILL side; the TEMPLATE side stays pinned by
+`tests/test-bl161-ledger-real-events-only.sh` T7) and adds T6 — a no-manifest
+projectless fixture must be a byte-no-op (its watched-RED was observed against the
+unguarded draft). Watched-RED + marker-excision mutation both captured. Secondary hardening also
+landed: `tests/test-filesystem-gate-install.sh` gained T8 — the suite's first
+pass-arm case (a clean commit through the installed gate writes the
+`.claude/last-gate-pass.txt` receipt and appends no row to the tracked
+`.claude/bypass-audit.json`), mutation-proved by deleting the
+`record_gate_pass_receipt` write line (T1–T7 stayed green — the suite was blind to
+the PASS terminal before T8). Status stays **Open** pending PR review/merge.
+
 **Related:** BL-161, BL-107, `templates/generated/gitignore-base.tmpl`.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4066,8 +4066,8 @@ append-if-missing backfill inside `_run_idempotent_backfill` (marker
 `# BL-174-GITIGNORE-BACKFILL`), covering BOTH sidecar lines
 (`.claude/last-checked-commit.txt` and `.claude/last-gate-pass.txt`). Idempotent
 (`grep -qxF` guards each exact line → re-run is a byte-no-op), manifest-gated (runs
-for every generated project via the `.claude/manifest.json` marker, exactly like its
-sibling backfills), best-effort (`|| true` so a gitignore hiccup never fails the
+for every generated project via the `.claude/manifest.json` marker, matching the
+host-field and BL-030 sibling backfills), best-effort (`|| true` so a gitignore hiccup never fails the
 upgrade), and create-if-missing when a project has no `.gitignore` at all — the last
 two mirroring the marker-gated / create-if-missing posture of the sibling
 `.claude/last-checked-commit.txt` / `.claude/bypass-audit.json` backfills in the same
@@ -4077,8 +4077,11 @@ function. **The manifest gate is load-bearing:** the enclosing subshell runs
 `PROJECT_ROOT` → that `cd` no-ops → cwd stays the framework repo) would otherwise
 append the two lines to the framework's OWN `.gitignore`. An earlier UNGUARDED draft
 did exactly that (caught mid-build when an upgrade-family suite polluted the worktree
-`.gitignore`); the `.claude/manifest.json` gate — the same marker every sibling block
-uses — closes it. New hermetic suite `tests/test-bl174-gitignore-backfill.sh` (6
+`.gitignore`); the `.claude/manifest.json` gate — matching the host-field and BL-030
+sibling backfills — closes it. NOTE: not every sibling block carries such a gate — the
+vendored-skills sync and the BL-088 source-closure copy have no project gate and write
+outside generated projects today (the framework repo's month-old untracked
+`.claude/skills/` is standing residue); that structural gap is tracked as **BL-177**. New hermetic suite `tests/test-bl174-gitignore-backfill.sh` (6
 cases; hand-built fixture, NO init.sh — copies the upgrade script + lib closure and
 drives `--backfill-only`; registered in BOTH the `tests.yml` unit lane and the
 full-project aggregator) pins the two lines BEHAVIORALLY via `git check-ignore` on an
@@ -4094,3 +4097,36 @@ pass-arm case (a clean commit through the installed gate writes the
 the PASS terminal before T8). Status stays **Open** pending PR review/merge.
 
 **Related:** BL-161, BL-107, `templates/generated/gitignore-base.tmpl`.
+
+## BL-177: `_run_idempotent_backfill` has no structural projectless/in-framework guard — two sibling blocks write outside generated projects today (`.claude/skills/`, BL-088 script copies)
+
+**Logged:** 2026-07-24 (BL-174 WP-D adversarial verifier)
+**Category:** Upgrade-path safety / framework-repo hygiene
+**Severity:** Medium
+**Status:** Open
+
+`scripts/upgrade-project.sh`'s `_run_idempotent_backfill` runs its whole body inside a subshell that opens with `( cd "$PROJECT_ROOT" …`. `find_project_root` keys on `.claude/phase-state.json`; when that marker is absent — the framework repo itself, or any non-project cwd — `PROJECT_ROOT` is the empty string and **`cd ""` is a SILENT rc-0 no-op under `set -euo pipefail` on bash 3.2** (empty operand → success, cwd unchanged), so the subshell proceeds in the INVOCATION directory rather than a project root. Nothing downstream re-checks that we are in a real project.
+
+The `--backfill-only` path reaches this with **no framework guard**: it fires `_bl015_sentinel_guard`, then `_run_idempotent_backfill`, then hits the `--backfill-only` short-circuit (`exit 0`) BEFORE `guard_not_in_framework` — which lives only on the full-upgrade / `--sync-framework` / `--plan` paths. So an in-framework `upgrade-project.sh --backfill-only` executes the entire backfill body against the framework tree. (`guard_not_in_framework` *does* refuse the identical cwd on the paths that call it, confirming the write is unintended — `--backfill-only` simply never gets there.)
+
+**Six-block gate survey of `_run_idempotent_backfill`** (what protects each writer):
+1. host-aware CI-template migration — **shape-gated only** (`[ -d templates/pipelines/ci ] && [ ! -d …/github ]`), no project marker.
+2. manifest host-field backfill — **manifest-gated** (`[ -f .claude/manifest.json ]`).
+3. BL-030 manifest backfill (incl. the `last-checked-commit.txt` / `bypass-audit.json` writes) — **manifest-gated**.
+4. BL-174 gitignore backfill — **manifest-gated** (added in the BL-174 WP-D fix, after an unguarded draft leaked into the framework repo's own `.gitignore`).
+5. vendored-skills sync — **gated only on the SOURCE dir** (`[ -d "$ORCHESTRATOR_ROOT/templates/generated/skills" ]`); **NO project gate**.
+6. BL-088 source-closure copy — **gated only on cwd shape** (`[ -d scripts ]`); **NO project gate**.
+
+**Two live leaks today.** Blocks 5 and 6 write into the invocation cwd whenever `_run_idempotent_backfill` runs projectless:
+- The skills sync does `mkdir -p .claude/skills` and copies each skill's `SKILL.md` / `NOTICE`. Its self-copy guard `[ "$skill_src" -ef "$skill_dest/" ]` **never matches** here, because the source (`templates/generated/skills/X`) and destination (`.claude/skills/X`) are DIFFERENT paths — the `-ef` guard only skips a true in-place self-copy, not a framework→`.claude/skills` copy. The framework repo's own **untracked `.claude/skills/` (dated ~2026-06-28, a month old at logging) is standing residue of exactly this leak.**
+- The BL-088 block `cp`s `lib/tdd-classify.sh`, `lib/phase2-state.sh`, `lib/cdf-refresh.sh`, `run-phase3-validation.sh` into `scripts/lib/…` of the invocation cwd, its `-ef` guard likewise skipping only a genuine self-copy.
+
+Net: BL-174 closed the *gitignore* instance of this class by manifest-gating block 4, but the **structural** gap — an unguarded subshell that silently runs in whatever cwd it is invoked from — remains, and blocks 5 and 6 still write outside generated projects.
+
+**Fix shape:**
+- Add ONE structural marker check at the TOP of the `_run_idempotent_backfill` subshell — `[ -f .claude/phase-state.json ] || [ -f .claude/manifest.json ] || { print_info "…"; exit 0; }` (the subshell `exit 0` returns from the function without mutating anything). **No current legitimate path regresses:** `find_project_root` already keys on `.claude/phase-state.json`, so any real project reached via a non-empty `PROJECT_ROOT` has that marker present in the cd'd cwd; only the projectless/in-framework case is refused.
+- PLUS call `guard_not_in_framework` on the `--backfill-only` entry (before the backfill) so an in-framework invocation refuses **LOUDLY** rather than silently no-opping — defense in depth matching the full-upgrade / sync paths.
+- Correct the BL-174 block comment so it no longer implies every sibling block is manifest-gated (done as a comment-only change in the BL-174 WP-D follow-up).
+- **Mutation proof:** a projectless fixture (a `scripts/` dir present, a skills source visible via `ORCHESTRATOR_ROOT`, but NO `.claude/manifest.json` and NO `.claude/phase-state.json`) → after the structural guard, `_run_idempotent_backfill` performs ZERO writes (no `.claude/skills/`, no `scripts/lib/` copies, no `.gitignore` append); excise the guard → the skills sync and BL-088 copies reappear (RED).
+
+**Related:** BL-174, BL-080, BL-081.

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1845,6 +1845,11 @@ if bash "$SCRIPT_DIR/tests/test-filesystem-gate-install.sh" >/dev/null 2>&1; the
 else
   fail "tests/test-filesystem-gate-install.sh FAILED (run for details)"
 fi
+if bash "$SCRIPT_DIR/tests/test-bl174-gitignore-backfill.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl174-gitignore-backfill.sh"
+else
+  fail "tests/test-bl174-gitignore-backfill.sh FAILED (run for details)"
+fi
 
 # Enforcement-level family.
 if bash "$SCRIPT_DIR/tests/test-enforcement-level-lib.sh" >/dev/null 2>&1; then

--- a/tests/test-bl174-gitignore-backfill.sh
+++ b/tests/test-bl174-gitignore-backfill.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# tests/test-bl174-gitignore-backfill.sh — BL-174: upgrade-project.sh's
+# _run_idempotent_backfill must append the BL-030 / BL-161 operational-state
+# ignore lines to a project's .gitignore, so an UPGRADED project keeps the two
+# sidecars out of git exactly like an init.sh-scaffolded one:
+#   .claude/last-checked-commit.txt  (BL-030 detection baseline)
+#   .claude/last-gate-pass.txt       (BL-161 terminal-commit gate-ran receipt)
+#
+# Before this backfill an upgraded strict project picked up the receipt-WRITING
+# gate behavior (via the install-filesystem-gates.sh re-run in the same block)
+# but never the matching .gitignore lines — so the receipt sat UNTRACKED and a
+# downstream `git add -A` would TRACK it, resurrecting the BL-161 dirty-chase in
+# tracked form. (Untracked != tracked-dirty, so the pre-fix state is strictly
+# better than what BL-161 removed — this pins the last mile.)
+#
+# ARTIFACT PIN: the two ignore LINES are the artifacts. This suite pins them
+# BEHAVIORALLY (git check-ignore) on the BACKFILL side (an upgraded fixture).
+# The TEMPLATE side is pinned by tests/test-bl161-ledger-real-events-only.sh T7.
+#
+# HERMETIC: hand-built fixture — NO init.sh, NO live remote. A local git repo in
+# mktemp drives the REAL scripts/upgrade-project.sh via --backfill-only (whose
+# path reaches _run_idempotent_backfill and NEVER hits a framework-repo guard —
+# guard_not_in_framework sits only past the --backfill-only exit-0 short-circuit).
+# The script + its lib closure are copied into the fixture; scripts/lib/cdf-refresh.sh
+# is deliberately OMITTED so the --backfill-only CDF-sync short-circuit finds no
+# refresher and skips it (no `git pull`, so the suite stays offline). No init.sh,
+# not an aggregator -> registered in BOTH the tests.yml unit lane and the
+# full-project aggregator. bash-3.2 safe.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "SKIP: git required"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+LINE_LC='.claude/last-checked-commit.txt'
+LINE_GP='.claude/last-gate-pass.txt'
+
+# mk_proj <dir> <gitignore-mode> [project-mode=generated] — a hand-built strict
+# project WITHOUT init.sh. In `generated` mode a MODERN manifest (host +
+# enforcement_level present) makes the host-migration and BL-030 manifest
+# backfills SKIP, so the BL-174 gitignore backfill is the only writer exercised.
+# In `noproject` mode NEITHER .claude/manifest.json NOR .claude/phase-state.json
+# is written, so find_project_root returns empty (PROJECT_ROOT="") and the
+# subshell's `cd "$PROJECT_ROOT"` no-ops — reproducing the framework-repo /
+# projectless invocation the BL-174 backfill MUST NOT write into.
+# <gitignore-mode>:
+#   custom — custom user lines, NEITHER sidecar line (backfill must add both)
+#   both   — custom lines AND both sidecar lines already present (no-op case)
+#   none   — no .gitignore at all (create-if-missing case)
+mk_proj() {
+  local d="$1" mode="$2" pmode="${3:-generated}"
+  rm -rf "$d"; mkdir -p "$d/.claude" "$d/scripts/lib"
+  cp "$REPO_ROOT/scripts/upgrade-project.sh" "$d/scripts/"
+  cp "$REPO_ROOT"/scripts/lib/*.sh "$d/scripts/lib/" 2>/dev/null
+  rm -f "$d/scripts/lib/cdf-refresh.sh"   # keep --backfill-only offline (no git pull)
+  chmod +x "$d/scripts/upgrade-project.sh"
+  if [ "$pmode" = generated ]; then
+    printf '{"current_phase":2,"deployment":"personal","poc_mode":null,"track":"standard"}\n' \
+      > "$d/.claude/phase-state.json"
+    printf '{"frameworkVersion":"test","host":"github","deployment":"personal","poc_mode":null,"enforcement_level":"strict"}\n' \
+      > "$d/.claude/manifest.json"
+  fi
+  case "$mode" in
+    custom) printf 'node_modules/\ndist/\n*.log\n.env\n' > "$d/.gitignore" ;;
+    both)   printf 'node_modules/\ndist/\n%s\n%s\n' "$LINE_LC" "$LINE_GP" > "$d/.gitignore" ;;
+    none)   : ;;  # no .gitignore
+  esac
+  ( cd "$d" && git init -q && git config user.email t@t.invalid && git config user.name t \
+      && git add -A && git commit -q -m "chore: seed" ) >/dev/null 2>&1 || return 1
+}
+
+# run_backfill <dir> — drive the copied upgrade script's --backfill-only path.
+run_backfill() {
+  ( cd "$1" && bash "$1/scripts/upgrade-project.sh" --backfill-only >/dev/null 2>&1 ) || true
+}
+
+# ignored <dir> <path> — 0 iff git ignores <path> in <dir>.
+ignored() { ( cd "$1" && git check-ignore -q "$2" ); }
+
+# count_line <file> <line> — exact whole-line occurrences (fixed string).
+# grep -c prints "0" AND exits 1 on no-match, so capture-then-default (never
+# `grep -c || echo 0`, which would emit "0\n0").
+count_line() {
+  local n
+  [ -f "$1" ] || { echo 0; return 0; }
+  n=$(grep -cxF "$2" "$1" 2>/dev/null) || n=0
+  echo "$n"
+}
+
+# ── T1 (case a): the backfill adds BOTH ignore lines; git check-ignore keeps the
+# two sidecars out of git. THE DISCRIMINATOR — pre-fix neither line exists so
+# check-ignore fails (RED); post-fix both are ignored (GREEN).
+echo "=== T1-backfill-adds-both-ignore-lines ==="
+if mk_proj "$TOPTMP/t1" custom; then
+  run_backfill "$TOPTMP/t1"
+  lc=no; ignored "$TOPTMP/t1" "$LINE_LC" && lc=yes
+  gp=no; ignored "$TOPTMP/t1" "$LINE_GP" && gp=yes
+  if [ "$lc" = yes ] && [ "$gp" = yes ]; then
+    pass "T1-backfill-adds-both-ignore-lines (check-ignore keeps last-checked-commit.txt + last-gate-pass.txt out of git)"
+  else
+    fail_ "T1-backfill-adds-both-ignore-lines" "last-checked-commit ignored=$lc last-gate-pass ignored=$gp (want yes/yes) — .gitignore: $(tr '\n' '|' < "$TOPTMP/t1/.gitignore" 2>/dev/null)"
+  fi
+else
+  fail_ "T1-backfill-adds-both-ignore-lines" "fixture build failed"
+fi
+
+# ── T2 (case b): idempotent — a SECOND backfill is a byte-no-op and each exact
+# line appears EXACTLY once. Pre-fix the lines are absent (count 0) -> RED.
+echo "=== T2-idempotent-second-run-is-byte-noop ==="
+if mk_proj "$TOPTMP/t2" custom; then
+  run_backfill "$TOPTMP/t2"
+  cp "$TOPTMP/t2/.gitignore" "$TOPTMP/t2.after1"
+  run_backfill "$TOPTMP/t2"
+  nlc=$(count_line "$TOPTMP/t2/.gitignore" "$LINE_LC")
+  ngp=$(count_line "$TOPTMP/t2/.gitignore" "$LINE_GP")
+  same=no; cmp -s "$TOPTMP/t2.after1" "$TOPTMP/t2/.gitignore" && same=yes
+  if [ "$nlc" -eq 1 ] && [ "$ngp" -eq 1 ] && [ "$same" = yes ]; then
+    pass "T2-idempotent-second-run-is-byte-noop (each line x1, .gitignore byte-identical across the 2nd run)"
+  else
+    fail_ "T2-idempotent-second-run-is-byte-noop" "count last-checked=$nlc last-gate-pass=$ngp (want 1/1) byte_identical_2nd_run=$same (want yes)"
+  fi
+else
+  fail_ "T2-idempotent-second-run-is-byte-noop" "fixture build failed"
+fi
+
+# ── T3 (case c): pre-existing user content is preserved, nothing overwritten.
+echo "=== T3-user-content-preserved ==="
+if mk_proj "$TOPTMP/t3" custom; then
+  run_backfill "$TOPTMP/t3"
+  missing=""
+  for want in 'node_modules/' 'dist/' '*.log' '.env'; do
+    grep -qxF "$want" "$TOPTMP/t3/.gitignore" 2>/dev/null || missing="$missing $want"
+  done
+  if [ -z "$missing" ]; then
+    pass "T3-user-content-preserved (all 4 custom user lines still present after the backfill append)"
+  else
+    fail_ "T3-user-content-preserved" "missing custom line(s):$missing"
+  fi
+else
+  fail_ "T3-user-content-preserved" "fixture build failed"
+fi
+
+# ── T4 (case d): a .gitignore that ALREADY has both lines is a byte-no-op — the
+# backfill neither duplicates nor rewrites. (Green pre- and post-fix — it pins
+# idempotence against a wrong append-always implementation, and keeps a correct
+# .gitignore undisturbed.)
+echo "=== T4-already-present-is-byte-noop ==="
+if mk_proj "$TOPTMP/t4" both; then
+  cp "$TOPTMP/t4/.gitignore" "$TOPTMP/t4.before"
+  run_backfill "$TOPTMP/t4"
+  same=no; cmp -s "$TOPTMP/t4.before" "$TOPTMP/t4/.gitignore" && same=yes
+  nlc=$(count_line "$TOPTMP/t4/.gitignore" "$LINE_LC")
+  ngp=$(count_line "$TOPTMP/t4/.gitignore" "$LINE_GP")
+  lc=no; ignored "$TOPTMP/t4" "$LINE_LC" && lc=yes
+  gp=no; ignored "$TOPTMP/t4" "$LINE_GP" && gp=yes
+  if [ "$same" = yes ] && [ "$nlc" -eq 1 ] && [ "$ngp" -eq 1 ] && [ "$lc" = yes ] && [ "$gp" = yes ]; then
+    pass "T4-already-present-is-byte-noop (byte-identical, each line x1, both still ignored)"
+  else
+    fail_ "T4-already-present-is-byte-noop" "byte_identical=$same count last-checked=$nlc last-gate-pass=$ngp (want 1/1) ignored lc=$lc gp=$gp"
+  fi
+else
+  fail_ "T4-already-present-is-byte-noop" "fixture build failed"
+fi
+
+# ── T5 (case e): a project with NO .gitignore at all gets one CREATED with both
+# lines (mirroring the create-if-missing posture of the sibling
+# last-checked-commit.txt / bypass-audit.json backfills in the same function).
+# Pre-fix no .gitignore is created -> check-ignore fails -> RED.
+echo "=== T5-missing-gitignore-is-created ==="
+if mk_proj "$TOPTMP/t5" none; then
+  before=absent; [ -f "$TOPTMP/t5/.gitignore" ] && before=present
+  run_backfill "$TOPTMP/t5"
+  after=absent; [ -f "$TOPTMP/t5/.gitignore" ] && after=present
+  lc=no; ignored "$TOPTMP/t5" "$LINE_LC" && lc=yes
+  gp=no; ignored "$TOPTMP/t5" "$LINE_GP" && gp=yes
+  if [ "$before" = absent ] && [ "$after" = present ] && [ "$lc" = yes ] && [ "$gp" = yes ]; then
+    pass "T5-missing-gitignore-is-created (.gitignore created; both sidecars ignored)"
+  else
+    fail_ "T5-missing-gitignore-is-created" ".gitignore before=$before after=$after; ignored lc=$lc gp=$gp (want absent/present/yes/yes)"
+  fi
+else
+  fail_ "T5-missing-gitignore-is-created" "fixture build failed"
+fi
+
+# ── T6 (framework-repo / projectless safety): a fixture with NO
+# .claude/manifest.json (find_project_root returns empty, the subshell's `cd`
+# no-ops, cwd stays the invocation dir) must be a byte-no-op — the backfill is
+# gated on the generated-project marker exactly like its sibling backfills, so it
+# NEVER appends these lines to a non-project (e.g. the framework repo's own)
+# .gitignore. Pre-guard the unguarded block wrote here -> RED.
+echo "=== T6-no-manifest-projectless-is-byte-noop ==="
+if mk_proj "$TOPTMP/t6" custom noproject; then
+  cp "$TOPTMP/t6/.gitignore" "$TOPTMP/t6.before"
+  run_backfill "$TOPTMP/t6"
+  same=no; cmp -s "$TOPTMP/t6.before" "$TOPTMP/t6/.gitignore" && same=yes
+  nlc=$(count_line "$TOPTMP/t6/.gitignore" "$LINE_LC")
+  ngp=$(count_line "$TOPTMP/t6/.gitignore" "$LINE_GP")
+  if [ "$same" = yes ] && [ "$nlc" -eq 0 ] && [ "$ngp" -eq 0 ]; then
+    pass "T6-no-manifest-projectless-is-byte-noop (no generated-project marker → .gitignore byte-unchanged; no framework-repo pollution)"
+  else
+    fail_ "T6-no-manifest-projectless-is-byte-noop" "byte_identical=$same last-checked count=$nlc last-gate-pass count=$ngp (want yes/0/0) — the backfill wrote into a projectless .gitignore"
+  fi
+else
+  fail_ "T6-no-manifest-projectless-is-byte-noop" "fixture build failed"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-filesystem-gate-install.sh
+++ b/tests/test-filesystem-gate-install.sh
@@ -114,6 +114,54 @@ else
 fi
 teardown
 
+# T8: pass-arm coverage — a CLEAN commit through the installed gate writes the
+# .claude/last-gate-pass.txt receipt (BL-161) and appends NO row to the tracked
+# .claude/bypass-audit.json. Before T8 this installer suite was BLIND to the PASS
+# terminal: it stayed green under both BL-161 receipt mutations, so it could not
+# catch a regression in the clean-pass receipt path. Fixture mirrors
+# tests/test-bl161-ledger-real-events-only.sh T1 — the REAL installer + generated
+# framework-gate, with process-checklist / pre-commit-gate STUBS whose exit 0 is
+# the PASS verdict. The generated gate re-invokes the project's OWN
+# scripts/install-filesystem-gates.sh __record_pass, so the fixture copies it in.
+echo "T8: clean commit writes last-gate-pass.txt receipt, no tracked-ledger row"
+if [ ! -f "$INSTALLER" ]; then
+  fail_ "T8" "installer missing"
+elif ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] T8 — jq required for the strict-gate pass path"
+else
+  TMP=$(mktemp -d)
+  mkdir -p "$TMP/.claude" "$TMP/scripts" "$TMP/src"
+  printf '{"frameworkVersion":"test","enforcement_level":"strict"}\n' > "$TMP/.claude/manifest.json"
+  printf '[]\n' > "$TMP/.claude/bypass-audit.json"
+  cp "$INSTALLER" "$TMP/scripts/install-filesystem-gates.sh"
+  chmod +x "$TMP/scripts/install-filesystem-gates.sh"
+  printf '#!/bin/sh\nexit 0\n' > "$TMP/scripts/process-checklist.sh"
+  printf '#!/bin/sh\nexit 0\n' > "$TMP/scripts/pre-commit-gate.sh"
+  chmod +x "$TMP/scripts/process-checklist.sh" "$TMP/scripts/pre-commit-gate.sh"
+  ( cd "$TMP" && git init -q && git config user.email t@t.l && git config user.name t \
+      && git add -A && git commit -q -m "chore: seed" ) >/dev/null 2>&1
+  bash "$INSTALLER" --install "$TMP" >/dev/null 2>&1
+  printf 'export const x = 1;\n' > "$TMP/src/widget.ts"
+  ( cd "$TMP" && git add src/widget.ts ) >/dev/null 2>&1
+  ledger_before=$(cat "$TMP/.claude/bypass-audit.json")
+  if ( cd "$TMP" && git commit -q -m "chore: land widget" ) >/dev/null 2>&1; then
+    receipt=no
+    if [ -s "$TMP/.claude/last-gate-pass.txt" ]; then receipt=yes; fi
+    passrows=$(jq '[.[] | select(.type=="terminal_commit_passed")] | length' "$TMP/.claude/bypass-audit.json" 2>/dev/null || echo ERR)
+    ledger_after=$(cat "$TMP/.claude/bypass-audit.json")
+    lu=no
+    if [ "$ledger_before" = "$ledger_after" ]; then lu=yes; fi
+    if [ "$receipt" = yes ] && [ "$passrows" = 0 ] && [ "$lu" = yes ]; then
+      pass "T8 (receipt written, 0 terminal_commit_passed rows, tracked ledger byte-unchanged)"
+    else
+      fail_ "T8" "receipt=$receipt terminal_commit_passed_rows=$passrows tracked_ledger_unchanged=$lu (want yes/0/yes)"
+    fi
+  else
+    fail_ "T8" "clean commit REFUSED — the gate should PASS with exit-0 stubs"
+  fi
+  rm -rf "$TMP"
+fi
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## BL-174 — upgraded projects get the ignore lines their sidecar files need

\`upgrade-project.sh\` re-runs the gate install (so upgraded projects got BL-161's receipt behavior) but never backfilled the matching \`.gitignore\` lines — the receipt sat untracked, and a downstream \`git add -A\` would re-track it. New \`# BL-174-GITIGNORE-BACKFILL\` block in \`_run_idempotent_backfill\`: idempotent append-if-missing for BOTH sidecar lines (\`.claude/last-gate-pass.txt\` + the same pre-existing gap for \`.claude/last-checked-commit.txt\`), manifest-gated, create-if-missing per the sibling precedent, user content preserved.

### The mid-build catch that matters more than the feature
The implementer's first unguarded draft **wrote into the framework repo's own \`.gitignore\`** — because \`--backfill-only\` exits before \`guard_not_in_framework\` ever runs and \`cd ""\` is a silent no-op under bash-3.2 \`set -euo pipefail\`. It fixed it with the manifest gate + a dedicated test (T6) that reproduces the pollution byte-for-byte when the gate is removed. The verifier then surveyed all six sibling blocks and proved the protection convention is **not even currently true**: the vendored-skills sync and the BL-088 script-copy have NO project gate and demonstrably write outside projects today — including attributing the framework repo's mysterious month-old untracked \`.claude/skills/\` directory to that exact leak (byte-identical fingerprints, June 28 timestamps). Filed as **BL-177 (Medium)** with a structural fix shape; this PR's own comment was corrected to stop claiming "every sibling" carries the gate (verifier's mandatory fix, applied).

### Also in this PR
- \`tests/test-bl174-gitignore-backfill.sh\` (6 cases: behavioral \`git check-ignore\` pins, idempotence via \`cmp\`, content preservation, create-if-missing, the T6 pollution guard) — hermetic WITHOUT init.sh (the CDF-refresh lib is deliberately dropped from the fixture; verifier re-classified that as REQUIRED hermeticization since the real path would \`git pull\` the developer's CDF clone). Registered in BOTH lanes.
- \`tests/test-filesystem-gate-install.sh\` gains T8 — the installer suite's first pass-arm case (receipt written + zero tracked-ledger rows + ledger byte-unchanged), closing the blindness BL-174's entry recorded; mutation-proven (receipt-line deletion → T8 RED alone).

### Independent fable verification — APPROVE-WITH-FIXES (fix applied)
Verifier re-ran all three mutations by hand (fence excise; gate removal reproducing the pollution with T6 RED alone; receipt-line deletion with T8 RED alone), ran an append-edge matrix (trailing-whitespace/CRLF pre-states: cosmetic near-duplicate only, already-ignored either way; foreign-comment pre-state: byte-no-op), and probed the real script against a framework-signature directory — the new gate HELD while two ungated siblings wrote files, which is BL-177's evidence.

### Blast radius (all exit 0)
New suite 6/6 · gate-install suite 8/8 · \`test-bl161\` 7/7 (template-side T7 pin untouched) · \`test-bl169\` · upgrade family (13 suites incl. bl030-backfill, sentinel-block, cdf-refresh, sync-framework, edge-cases) all green + gitignore-clean · \`run-lints.sh\` **11/11**.

### Merge notes
- Backlog end-append: this PR adds BL-177 after BL-174; sibling wave PRs add BL-175 (BL-131/132 PR) and BL-176 (#265) at the same region — **keep all, numeric order**.
- Same-file adjacency with the BL-131/132 PR in \`upgrade-project.sh\` (different functions — \`_run_idempotent_backfill\` here, \`_bl099_sync_precommit_hook\` there); expect clean or trivial merge.
- BL-174 stays **Open** until merge.

**TL;DR (plain English):** When an older project runs the upgrade tool, it now also gets the two "ignore this scratch file" lines that newer projects are born with — so upgraded projects stop showing phantom unsaved files. The real story is what the safety review found along the way: the upgrade tool's protection against writing into the wrong folder turns out to be a per-block honor system that two blocks never joined — they've been quietly dropping files into the framework's own folder for a month. That bigger repair is now a tracked, medium-priority follow-up (BL-177) with the evidence attached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)