### PR TITLE
fix(bl180): resolve enforcement_level on init.sh's INTERACTIVE path + repair projects already born without it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -280,6 +280,18 @@ jobs:
         # skipping the only CI execution of the blocking arm.
         run: pip install semgrep
 
+      - name: Install expect (BL-180 real interactive scaffold)
+        # tests/test-bl180-interactive-scaffold-pty.sh drives a REAL interactive
+        # init.sh over a pty. `expect` is its SUPPORTED driver; the script(1)
+        # fallback is a positional stream that its own header calls best-effort
+        # and that desynchronises on any host where a conditional prompt
+        # ("Install Docker via:", CDF's "Install Context7 now?") appears. The
+        # runner image is not guaranteed to carry expect, so without this step
+        # the only end-to-end proof that a strict project is born with a REAL
+        # filesystem gate would silently degrade to the fallback driver.
+        # Install failure fails the shard LOUDLY rather than quietly downgrading.
+        run: sudo apt-get update && sudo apt-get install -y expect
+
       - name: Run shard — ${{ matrix.shard }}
         # SKIP_KNOWN_FAILING left unset -> 0, so known-RED guards still run.
         env:

--- a/init.sh
+++ b/init.sh
@@ -3261,6 +3261,16 @@ dry_run_summary() {
   echo "  Track:     $TRACK"
   echo "  Language:  $LANGUAGE"
   echo "  Directory: $PROJECT_DIR"
+  # BL-180-DRYRUN-ENFORCEMENT: surface the RESOLVED enforcement level on
+  # STDOUT. The sibling log_line "…" calls in main() write to the log FILE
+  # only, so a piped fixture cannot observe them — which is why BL-180 (the
+  # interactive arm never resolving ENFORCEMENT_LEVEL at all) survived every
+  # fed-sequence --dry-run test in the repo. Printing it here makes the
+  # interactive resolution assertable without a pty; the value is echoed
+  # verbatim (NOT defaulted) so an unresolved level shows up as an empty
+  # field rather than being cosmetically repaired at the reporting layer.
+  # Pinned by tests/test-bl180-interactive-enforcement.sh.
+  echo "  Enforcement: $ENFORCEMENT_LEVEL"
   echo ""
 
   echo -e "${BOLD}Tool Resolution:${NC}"
@@ -4195,6 +4205,38 @@ HELPEOF
     check_prerequisites
     collect_project_info
   fi
+
+  # BL-180-ENFORCEMENT-DEFAULT: resolve ENFORCEMENT_LEVEL for EVERY path.
+  # The `# BL-030: resolve enforcement_level` block above lives inside the
+  # NON_INTERACTIVE arm, and the interactive arm (check_prerequisites +
+  # collect_project_info) has no enforcement-level prompt anywhere — so a
+  # hand-run `./init.sh` used to reach prepare_initial_state_for_commit with
+  # ENFORCEMENT_LEVEL still at its top-of-file "". That empty value flowed
+  # verbatim into the manifest, into the bypass-audit enforcement_level_set
+  # row, and made the `[ "$ENFORCEMENT_LEVEL" = "strict" ]` guard around
+  # install-filesystem-gates.sh --install a silent no-op: every interactively
+  # scaffolded project was born with NO commit-time gate while every
+  # lib-mediated diagnostic reported it as strict (read_enforcement_level maps
+  # "" → strict). It was also self-concealing — upgrade-project.sh's BL-030
+  # backfill could not repair it (see # BL-180-BACKFILL-EMPTY there).
+  #
+  # STRICT IS THE RIGHT DEFAULT, not merely a safe one: strict is what the
+  # non-interactive arm already resolves to when no --enforcement-level is
+  # supplied (both its forced arm and its choosable arm's own `-z` default),
+  # so this makes the two entry points agree instead of inventing a tier.
+  #
+  # INERT FOR THE NON-INTERACTIVE ARM: that arm assigns ENFORCEMENT_LEVEL on
+  # every one of its branches before falling through here, so the `-z` guard
+  # never fires there and an explicit `--enforcement-level light` survives
+  # untouched. Proven, not asserted — see T5/T6 of
+  # tests/test-bl180-interactive-enforcement.sh.
+  #
+  # CONFIRM_PITFALLS is deliberately NOT given the same treatment: its
+  # top-of-file default is already 0, it is only ever read as permission to
+  # DOWNGRADE, and the interactive arm offers no downgrade to permit — so 0
+  # is the correct interactive resolution and defaulting it to anything else
+  # would widen the bypass surface rather than close it.
+  [ -z "$ENFORCEMENT_LEVEL" ] && ENFORCEMENT_LEVEL="strict"
 
   log_section "Project Configuration"
   log_line "Project: $PROJECT_NAME"

--- a/scripts/upgrade-project.sh
+++ b/scripts/upgrade-project.sh
@@ -530,7 +530,26 @@ _run_idempotent_backfill() {
   # path), installs the filesystem gate, initializes the detection
   # baseline, and writes an enforcement_level_set audit row sourced
   # 'upgrade-backfill' so the lifecycle is traceable.
-  if [ -f .claude/manifest.json ] && ! jq -e '.enforcement_level' .claude/manifest.json >/dev/null 2>&1; then
+  # BL-180-BACKFILL-EMPTY: an EMPTY enforcement_level counts as ABSENT.
+  # The old gate was `! jq -e '.enforcement_level' …`, and `jq -e` on the empty
+  # string prints "" and EXITS 0 — so a manifest carrying `enforcement_level: ""`
+  # looked already-migrated and this block was skipped. That made an empty value
+  # strictly WORSE than a missing one: it defeated the migration written for
+  # exactly this, and every project born on init.sh's pre-BL-180 INTERACTIVE
+  # path carried it (see # BL-180-ENFORCEMENT-DEFAULT in init.sh). Nothing else
+  # repaired those projects either — read_enforcement_level maps "" → strict, so
+  # every lib-mediated diagnostic reported them as strict while the commit-time
+  # gate was absent, and no operator had a reason to run reconfigure.
+  #
+  # `jq -r '.enforcement_level // ""'` collapses BOTH shapes to the empty string
+  # (`null // ""` → "", `"" // ""` → ""), while a real level passes through
+  # verbatim, so `-z` fires on absent-or-empty and NEVER on a legitimately
+  # chosen tier — an explicit `light` still survives untouched (pinned by T10 of
+  # tests/test-upgrade-bl030-backfill.sh, alongside T8/T9 for the repair itself).
+  # A malformed manifest makes jq fail with empty stdout, which triggers the
+  # backfill exactly as the old `! jq -e` did — the behaviour there is unchanged.
+  if [ -f .claude/manifest.json ] \
+     && [ -z "$(jq -r '.enforcement_level // ""' .claude/manifest.json 2>/dev/null)" ]; then
     print_step "Backfilling manifest.json BL-030 fields (deployment, poc_mode, enforcement_level)"
     mig_deployment=""
     mig_poc=""

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4473,9 +4473,9 @@ TEST 7 fixture broke before BL-136 — and the run is bound to the resolved comb
 derivation fails loudly instead of pinning the wrong project shape. Independently re-derived to
 `web=4 / typescript=7`, matching TEST 7. **T5 is the inertness proof**: non-interactive
 `--enforcement-level light --confirm-pitfalls` must still report `light`. (2)
-`tests/test-bl180-interactive-scaffold-pty.sh` (8 cases, aggregator-ONLY): a REAL interactive
+`tests/test-bl180-interactive-scaffold-pty.sh` (10 cases, aggregator-ONLY): a REAL interactive
 scaffold over a pty via `expect` (fallback `script`; LOUD SKIP with a printed reason when neither
-exists — verified by running it under a PATH containing neither). Hermetic by construction — Git
+exists — verified by running it under a PATH containing neither). Hermetic as to the NETWORK — Git
 host is answered `other` (URL-paste path, never touches gh/glab/curl) and the clone-URL prompt is
 answered EMPTY so `create_and_protect_remote` fails at its `[ -z "$remote_url" ]` guard **before**
 `git remote add`; `init.sh` consequently returns 2 via `record_init_failure` — expected, printed
@@ -4485,7 +4485,68 @@ host-setup outcomes). The real guarantees sit on artifacts written by the earlie
 pass vacuously) and T7 (`git remote -v` is empty). **Both drivers were
 actually exercised**, not just the primary: `SOIF_BL180_FORCE_SCRIPT_FALLBACK=1` forces the
 `script(1)` path (BSD/util-linux invocation auto-detected by probing) and also reports
-`8 passed, 0 failed`, so the fallback is not shipped-but-dead code.
+`10 passed, 0 failed`, so the fallback is not shipped-but-dead code.
+
+**REMEDIATION (2026-07-26, verifier finding R-WPA-1 — CONFIRMED, the original claim was wrong).**
+The pty fixture's "hermetic by construction" and `8 passed, 0 failed` claims held only on a host
+where `CI` is unset. `helpers-core.sh::prompt_input`'s guard is
+`[ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]` — the last two are checked
+**independently of the tty**, so a pty does not defeat them. Re-confirmed here with an isolated
+`expect` probe against the real function: with `CI` unset the call BLOCKS on `read` (interactive
+branch); with `CI=true` it prints `[WARN] Non-interactive context: prompt_input("Project
+directory") returning default …` and returns without reading. Every GitHub Actions runner exports
+`CI=true`, and that is exactly the environment of the `full` lane this test is registered into.
+The consequence is worse than a red test: `PROJECT_NAME` resolves to `""`, so
+`PROJECT_DIR=$(prompt_input "Project directory" "$default_parent/$PROJECT_NAME")` resolves to
+`"$default_parent/"` — the **parent directory of the checkout** — and a complete git-init'd
+project is scaffolded OUTSIDE the fixture's own `mktemp -d`. Reproduced end-to-end from a
+sandboxed COPY of the checkout (so the escape landed in a throwaway dir):
+`CI=true bash tests/test-bl180-interactive-scaffold-pty.sh` → `Results: 0 passed, 1 failed`,
+`EXIT=1`, and `$default_parent` went from `repo` to a full project tree
+(`.claude .claude-backup .git .github … PROJECT_INTAKE.md scripts templates tests`).
+
+Fixed under `# BL-180-PTY-INTERACTIVE-ENV` (three parts, all in the fixture):
+* `unset CI` / `unset SOIF_NONINTERACTIVE` beside the existing `unset GITHUB_BASE_REF` — driving
+  the INTERACTIVE branch is the whole point of this test, and the piped/non-interactive branch is
+  the fast pin's job. This is the actual repair: same sandbox, same `CI=true` invocation, now
+  `Results: 10 passed, 0 failed`, `EXIT=0`, `$default_parent` unchanged (`repo`).
+* **T0a — pre-flight containment**, ordered BEFORE `init.sh` is ever spawned and the only
+  assertion that can PREVENT rather than report an escape. It re-asserts `CI`/`SOIF_NONINTERACTIVE`
+  are unset and that `$PROJ` is under `$TMP`, and on failure prints the directory the run WOULD
+  have escaped to and exits **without spawning**. Watched-RED by deleting the `unset CI` line and
+  re-running under `CI=true`: `[FAIL] T0a — REFUSING to spawn init.sh — CI is set ('true') …`,
+  `Results: 0 passed, 1 failed`, and `$default_parent` **UNCHANGED** — i.e. the failure mode is now
+  "fails loudly, writes nothing" instead of "writes a project outside the fixture".
+* **T0b — post-run escape detector**, deliberately ordered before T1 because T1 `exit 1`s the
+  moment the fixture manifest is missing, which is *precisely* the escape path — so pre-remediation
+  the only message an operator saw named the one directory the project was NOT written to.
+  `.claude/manifest.json` in the checkout's parent is the decisive artifact (no legitimate reason
+  to exist there). Watched-RED by planting that file: `[FAIL] T0b — ESCAPE — a project was
+  scaffolded into '…', OUTSIDE this fixture`, `Results: 9 passed, 1 failed`; removed → `10/10`.
+
+**Also fixed — R-WPA-4 (weak assertion, the `2>/dev/null`-swallows-the-signal class).** T7's
+hermeticity self-check passed both when no remote was attached AND when `$PROJ` was not a git
+repository at all: the failing `git` call's stderr was discarded and its empty stdout was
+indistinguishable from "no remotes". It now requires `$PROJ/.git` to exist and the `git` call to
+succeed before an empty result is allowed to mean anything. Predicate-level watched-RED, OLD vs
+NEW over three inputs: `not-a-repo` OLD=**PASS** / NEW=`FAIL(not a git repo)`;
+`repo-no-remote` PASS/PASS; `repo-with-remote` FAIL/FAIL — the two legitimate cases agree, only
+the vacuous one changes.
+
+**CI driver (second half of R-WPA-1).** The `full` workflow job now installs `expect`
+(`sudo apt-get install -y expect`, alongside the existing semgrep step). `expect` is the fixture's
+SUPPORTED driver; the `script(1)` fallback is a positional stream that the test's own header calls
+best-effort and that desynchronises wherever a conditional prompt appears. Without the install the
+only end-to-end proof that a strict project is born with a REAL filesystem gate would silently
+degrade to the fallback. The alternative the verifier offered — wrapping the delegate in the
+`SUITE_SKIP_AGGREGATORS` gate its five real-scaffold siblings use — was **rejected**: that gate
+would remove the test from the `core` shard, and since the `aggregators` shard runs only four
+explicitly named files, the net effect would be **zero** CI lanes executing the only check that
+catches a hollow strict gate. Installing the driver preserves the catcher; gating it would delete
+it. Re-verified after remediation that the catcher still catches — the verifier's own MUT-3
+(`[ "$ENFORCEMENT_LEVEL" = "strict" ]` → `"strict_REVIEWER_MUT3"`) against the REMEDIATED fixture:
+`[FAIL] T4 — framework-gate.sh ABSENT`, `[FAIL] T5 — pre-commit lacks the 'SOIF framework gate
+(BL-030)' block`, `Results: 8 passed, 2 failed`.
 
 **Two findings the interactive path surfaced that no non-interactive fixture can.** (i) The nested
 CDF installer (`~/.claude-dev-framework/scripts/init.sh`, invoked from `create_project`) has
@@ -4502,9 +4563,12 @@ generated hook. T5 now asserts `install-filesystem-gates.sh`'s MARK_OPEN sentine
 **Mutation proof (both directions, with a non-interactive control identical in both).** Delete the
 `# BL-180-ENFORCEMENT-DEFAULT` line → fast pin `Results: 5 passed, 2 failed` (T1/T3 interactive RED
 showing literally `Enforcement: `; T4/T5/T6 non-interactive controls GREEN) and pty
-`Results: 4 passed, 4 failed` (T3 `enforcement_level=''`, T4 gate ABSENT, T5 sentinel absent, T6
+`Results: 6 passed, 4 failed` (T3 `enforcement_level=''`, T4 gate ABSENT, T5 sentinel absent, T6
 audit row `''` — the filing's signature reproduced exactly). Restore → `7 passed, 0 failed` and
-`8 passed, 0 failed`.
+`10 passed, 0 failed`. (Re-run against the REMEDIATED fixture on 2026-07-26; the pty RED tally is
+`6 passed, 4 failed` rather than the pre-remediation `4 passed, 4 failed` because T0a/T0b are two
+additional PASSING cases under this mutation — the four caught consequences are unchanged, which
+is the point: the R-WPA-1 repair did not blunt the catcher.)
 
 **Registration:** both are registered in `tests/full-project-test-suite.sh` (enforcement-level
 cohort), and neither is in the `.github/workflows/tests.yml` unit lane — both invoke `init.sh`,
@@ -4513,11 +4577,32 @@ and the documented membership rule is "does not invoke init.sh". Per BL-181 a gr
 merely mentions `init.sh`), so both were verified BY HAND: grep of the aggregator for the two
 delegate invocations, and a grep of the `tests=(` array confirming absence. The pty test's aggregator entry deliberately
 CAPTURES output instead of `>/dev/null 2>&1` so its rc=0 LOUD SKIP cannot masquerade as a genuine
-8/8 pass. **See the escalation:** the fast pin is genuinely unit-lane-CAPABLE (seconds, hermetic,
-no scaffold) and would catch this on every PR instead of only in the manual ~3h lane, but listing
-it contradicts a rule stated in three places and would be silently deleted by the documented
-regeneration recipe (`grep -L 'init\.sh'`) — that rule change was left for a decision rather than
-made unilaterally.
+10/10 pass.
+
+**LANE DECISION (2026-07-26, verifier findings R-WPA-2 + R-WPA-3) — RECORDED, not deferred.
+The BL-180 surface is accepted as FULL-LANE-ONLY.** The original escalation rested on a measured
+claim that was wrong: it described the fast pin as "seconds, hermetic, no scaffold". Hermetic and
+no-scaffold hold; **"seconds" does not.** Measured on this host,
+`bash tests/test-bl180-interactive-enforcement.sh` → `Results: 7 passed, 0 failed`, `EXIT=0`,
+**wall clock 116 s** — an order of magnitude off the claim, and roughly a 40 % increase on a unit
+lane documented at ~5 min. That measurement inverts the escalation's own premise, so the decision
+is to leave the membership rule ("does not invoke `init.sh`") ALONE and keep all three BL-180 test
+surfaces in the aggregator only. Three reasons, in order of weight: (1) the fast pin is not fast
+enough to be free on every PR; (2) changing the rule to "does not SCAFFOLD a project" is a
+governance edit touching `CLAUDE.md`, the `tests.yml` comments and the `grep -L 'init\.sh'`
+regeneration recipe — strictly larger than this remediation and the kind of change the WP said to
+escalate rather than make unilaterally; (3) the honest residual is narrower than it first looks,
+because the chain that made R-WPA-2 material has been broken — R-WPA-1 is fixed, so the pty test
+now PASSES under `CI=true` and genuinely executes in the `full` lane's `core` shard with `expect`
+installed. **The residual, stated plainly:** a mutation of the
+`[ "$ENFORCEMENT_LEVEL" = "strict" ]` gate-install guard in
+`init.sh::prepare_initial_state_for_commit` is still invisible to every PR-BLOCKING check
+(`lint-tests-registered` rc=0, `lint-no-live-remote` rc=0,
+`tests/test-filesystem-gate-install.sh` 8/8, `tests/test-enforcement-level-lib.sh` 10/10, and the
+fast pin 7/7 — which cannot observe it because `--dry-run` returns from `main()` before
+`create_project`). It is caught only by the manual `workflow_dispatch` lane. Closing that gap
+properly means a unit-lane-cheap pin on the gate-install guard specifically, which is its own
+work item — see the follow-on escalation below.
 
 **Repair path for already-scaffolded projects — `# BL-180-BACKFILL-EMPTY` in
 `scripts/upgrade-project.sh`.** The BL-030 backfill's gate was `! jq -e '.enforcement_level' …`,
@@ -4547,6 +4632,31 @@ hand-edited or partially-migrated manifest would silently self-disable the gate.
 "strict"` arm). Hardening those three readers is a separate change.
 
 Status stays **Open** pending PR + merge.
+
+**ESCALATED, not fixed here (2026-07-26, from the R-WPA-2 lane decision):** the gate-install guard
+`[ "$ENFORCEMENT_LEVEL" = "strict" ]` has no PR-blocking pin. The cheap shape would be a
+unit-lane test that drives `prepare_initial_state_for_commit`'s gate-install decision WITHOUT a
+full scaffold — but that function is not independently invocable today, so it needs either an
+extraction or a `--validate-only`-style seam in `init.sh`. That is a source change to the birth
+path with its own blast radius; it is deliberately NOT bundled into a remediation whose remit was
+the pty fixture's containment.
+
+**ESCALATED, not fixed here (2026-07-26, verifier finding R-WPA-5 — CONFIRMED):** both pty drivers
+answer `init.sh::resolve_and_install_tools`' consent gate with yes — the `expect` script has
+`-re {Proceed with this plan\?} { send -- "Y\r"; … }` and the `script(1)` answers file feeds bare
+`y` lines — so on a host missing an `auto_install`/`manual_install` tool the fixture authorises a
+REAL tool installation. The mock-`gh`/`glab` PATH shim does not cover this (it stubs the host CLIs,
+not package managers). Answering `N` instead is NOT a safe one-line change: the plan gate is a
+control-flow branch, and refusing it alters what `create_project` receives, so the whole 10-case
+contract would need re-deriving and re-watching. Left as-is with the behaviour recorded rather
+than half-changed. Note it did not fire on this host (all tools present) — which is exactly why it
+survived the first build.
+
+**Report-hygiene note (verifier finding R-WPA-6):** the implementer's tally block labelled an
+`edge-cases-pre-init` blast-radius run "105 dry-run assertions" while the quoted tally beneath it
+read 37. The label was wrong; the quoted tally is the evidence. No repo artifact carried the bad
+number (it lived only in the hand-off text), so there is nothing to correct in-tree — recorded
+here so the discrepancy is not re-derived as a real disagreement.
 
 **Adjacent item — NOT fixed here, deliberately escalated (2026-07-26):** `--no-remote-creation`
 being silently inert interactively is a genuine SAFETY defect (an operator who asks for no remote

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4436,6 +4436,127 @@ GREEN (`strict` + gate present), non-interactive control identical both ways.
 `ARG_PROJECT$ARG_PLATFORM$ARG_DEPLOYMENT$ARG_LANGUAGE` — not that flag, nor `ARG_CONFIRM_PITFALLS`
 (which IS part of the BL-030 surface).
 
+**Build note (2026-07-26, worktree branch `worktree-wf_79ea23a3-eb4-1`):** Fixed exactly as the
+entry prescribed, under `# BL-180-ENFORCEMENT-DEFAULT` in `init.sh::main` —
+`[ -z "$ENFORCEMENT_LEVEL" ] && ENFORCEMENT_LEVEL="strict"`, hoisted out of the
+`if [ "$NON_INTERACTIVE" = true ] … else … fi` dispatch and placed immediately after it, before
+`log_section "Project Configuration"`. The `&&`-list form was **verified safe under
+`set -euo pipefail` on this host's bash 3.2.57 before being written** (`X="light";
+[ -z "$X" ] && X="strict"; echo` survives, rc=0 — a failing mid-script AND-list does not trip
+`set -e`), which is also why the pre-existing sibling inside the BL-030 choosable arm has always
+been safe. `docs/builders-guide.md`'s "`strict` (default)" claim is now TRUE on every entry path
+rather than only the non-interactive one, so no doc edit was needed.
+
+**Observability companion** `# BL-180-DRYRUN-ENFORCEMENT` in `dry_run_summary` emits
+`  Enforcement: $ENFORCEMENT_LEVEL` on **stdout**. This is load-bearing, not cosmetic: the sibling
+`log_line` calls write to the log FILE only, and that invisibility is exactly why every
+fed-sequence `--dry-run` fixture in the repo was blind to a defect sitting in plain sight. The
+value is echoed **verbatim** — never `// "strict"`-defaulted — so an unresolved level surfaces as
+an empty field instead of being cosmetically repaired at the reporting layer.
+
+**CONFIRM_PITFALLS — considered and deliberately NOT given the same treatment** (reasoning
+recorded in the marker comment). It is not the same defect: (a) `ENFORCEMENT_LEVEL`'s top-of-file
+`""` is not a legal value, whereas `CONFIRM_PITFALLS=0` already **is** its correct interactive
+value; (b) its only semantic is permission to DOWNGRADE below strict, and the interactive arm
+offers no downgrade to authorize — 0 is correct, not merely safe; (c) its other consumer is the
+bypass-audit birth row's `confirmed_pitfalls: ($confirmed=="1")`, so defaulting it to 1 would
+write a FALSE attestation ("operator accepted the pitfalls") into the audit trail of an operator
+who was never asked. Any non-zero default widens the bypass surface instead of closing it.
+
+**Tests — both watched-RED first.** (1) `tests/test-bl180-interactive-enforcement.sh` (7 cases,
+fast, pty-free): feeds the wizard's `prompt_choice` sequence to `init.sh --dry-run` and asserts the
+resolved level, with three NON-INTERACTIVE controls. Menu ordinals are **re-derived at run time**
+from the same globs/markers `collect_project_info` uses (`platform-modules/*.md` →
+`release/github/*.yml` → `other`; `ci/github/*.yml` filtered by the
+`# solo-orchestrator: platforms=` marker), not hardcoded — a stale ordinal is how the aggregator's
+TEST 7 fixture broke before BL-136 — and the run is bound to the resolved combo so a drifted
+derivation fails loudly instead of pinning the wrong project shape. Independently re-derived to
+`web=4 / typescript=7`, matching TEST 7. **T5 is the inertness proof**: non-interactive
+`--enforcement-level light --confirm-pitfalls` must still report `light`. (2)
+`tests/test-bl180-interactive-scaffold-pty.sh` (8 cases, aggregator-ONLY): a REAL interactive
+scaffold over a pty via `expect` (fallback `script`; LOUD SKIP with a printed reason when neither
+exists — verified by running it under a PATH containing neither). Hermetic by construction — Git
+host is answered `other` (URL-paste path, never touches gh/glab/curl) and the clone-URL prompt is
+answered EMPTY so `create_and_protect_remote` fails at its `[ -z "$remote_url" ]` guard **before**
+`git remote add`; `init.sh` consequently returns 2 via `record_init_failure` — expected, printed
+for diagnosis, and deliberately NOT asserted (pinning it would couple the test to unrelated
+host-setup outcomes). The real guarantees sit on artifacts written by the earlier
+`prepare_initial_state_for_commit`, plus T1 (the scaffold happened at all, so nothing below can
+pass vacuously) and T7 (`git remote -v` is empty). **Both drivers were
+actually exercised**, not just the primary: `SOIF_BL180_FORCE_SCRIPT_FALLBACK=1` forces the
+`script(1)` path (BSD/util-linux invocation auto-detected by probing) and also reports
+`8 passed, 0 failed`, so the fallback is not shipped-but-dead code.
+
+**Two findings the interactive path surfaced that no non-interactive fixture can.** (i) The nested
+CDF installer (`~/.claude-dev-framework/scripts/init.sh`, invoked from `create_project`) has
+`[ -t 0 ]`-guarded prompts — `Proceed with framework installation? (y/n)` and
+`Install Context7 now?` — that exist ONLY on a pty; the first cut of the driver hung on them for
+15 minutes, and the T1 "did the scaffold happen at all" guard reported it loudly with a transcript
+tail rather than passing vacuously. Note `[ "$proceed" != "y" ]` there is case-SENSITIVE, so "Y"
+aborts. (ii) The mutation proof caught a weak assertion **in my own test**: T5 originally grepped
+`.git/hooks/pre-commit` for `framework-gate.sh` and PASSED with the gate provably absent, because
+`scripts/lib/hook-templates.sh` names that file in explanatory COMMENTS emitted into every
+generated hook. T5 now asserts `install-filesystem-gates.sh`'s MARK_OPEN sentinel
+(`SOIF framework gate (BL-030)`), the string the filing's own A/B counted.
+
+**Mutation proof (both directions, with a non-interactive control identical in both).** Delete the
+`# BL-180-ENFORCEMENT-DEFAULT` line → fast pin `Results: 5 passed, 2 failed` (T1/T3 interactive RED
+showing literally `Enforcement: `; T4/T5/T6 non-interactive controls GREEN) and pty
+`Results: 4 passed, 4 failed` (T3 `enforcement_level=''`, T4 gate ABSENT, T5 sentinel absent, T6
+audit row `''` — the filing's signature reproduced exactly). Restore → `7 passed, 0 failed` and
+`8 passed, 0 failed`.
+
+**Registration:** both are registered in `tests/full-project-test-suite.sh` (enforcement-level
+cohort), and neither is in the `.github/workflows/tests.yml` unit lane — both invoke `init.sh`,
+and the documented membership rule is "does not invoke init.sh". Per BL-181 a green
+`lint-tests-registered.sh` proves NEITHER fact here (its unit-lane arm exempts any file whose text
+merely mentions `init.sh`), so both were verified BY HAND: grep of the aggregator for the two
+delegate invocations, and a grep of the `tests=(` array confirming absence. The pty test's aggregator entry deliberately
+CAPTURES output instead of `>/dev/null 2>&1` so its rc=0 LOUD SKIP cannot masquerade as a genuine
+8/8 pass. **See the escalation:** the fast pin is genuinely unit-lane-CAPABLE (seconds, hermetic,
+no scaffold) and would catch this on every PR instead of only in the manual ~3h lane, but listing
+it contradicts a rule stated in three places and would be silently deleted by the documented
+regeneration recipe (`grep -L 'init\.sh'`) — that rule change was left for a decision rather than
+made unilaterally.
+
+**Repair path for already-scaffolded projects — `# BL-180-BACKFILL-EMPTY` in
+`scripts/upgrade-project.sh`.** The BL-030 backfill's gate was `! jq -e '.enforcement_level' …`,
+and `jq -e` on `""` prints `""` and EXITS 0 (re-confirmed on this host across all four shapes:
+`""`→0, missing→1, `null`→1, `"strict"`→0), so the block skipped the very projects it exists to
+repair. Replaced with `[ -z "$(jq -r '.enforcement_level // ""' … )" ]`, which collapses BOTH
+absent and empty to `""` while a real level passes through verbatim. Deliberately scoped: it
+widens the trigger to the empty string ONLY — never to a legitimately chosen tier — and a
+malformed manifest still triggers the backfill exactly as the old `! jq -e` did, so that
+behaviour is unchanged. Watched-RED first with the gate untouched: `T8 [FAIL] enforcement_level=''
+— the empty value defeated its own migration`, `T9 [FAIL] gate still absent after backfill`,
+`Results: 8 passed, 2 failed` — with the T10 control (`explicit light survives the backfill`) and
+the T2 idempotency case PASSING in that same RED run, so the fix is proven to move only the two
+intended cases. New fixture `setup_bl180_empty_level_personal` reproduces the pre-fix interactive
+birth shape exactly: it BLANKS `enforcement_level` rather than deleting the key (that distinction
+IS the bug), uninstalls the gate, and strips the birth audit row. After the fix:
+`Results: 10 passed, 0 failed`.
+
+**Residual, reported not fixed (defense in depth):** `jq -r '.enforcement_level // "strict"'`
+does NOT fire on the empty string (`//` only substitutes on `null`/`false`), so
+`scripts/install-filesystem-gates.sh` (including the EMITTED `.git/hooks/framework-gate.sh`,
+which re-reads it on every commit and `exit 0`s when the value is not exactly `strict`),
+`scripts/escalate-to-user.sh` and `scripts/hooks/bypass-detector.sh` would still stamp/act on
+`""`. With the birth site and the repair path both fixed, `""` should no longer arise — but a
+hand-edited or partially-migrated manifest would silently self-disable the gate. Only
+`scripts/lib/enforcement-level.sh::read_enforcement_level` is immune (its `case … *) echo
+"strict"` arm). Hardening those three readers is a separate change.
+
+Status stays **Open** pending PR + merge.
+
+**Adjacent item — NOT fixed here, deliberately escalated (2026-07-26):** `--no-remote-creation`
+being silently inert interactively is a genuine SAFETY defect (an operator who asks for no remote
+still reaches `create_and_protect_remote` against their authenticated host), and it is a strictly
+larger change than a warning tweak: making the flag WORK interactively changes documented
+interactive-path semantics, while merely warning about it needs its own accurate message because
+`main`'s existing "interactive flow will prompt" text is FALSE for both `--no-remote-creation` and
+`--confirm-pitfalls` (nothing prompts for either). It wants its own watched-RED + test + review
+rather than being tacked onto this diff.
+
 **Related:** BL-030, BL-084, BL-112, BL-110 (same "written only on one path" class), BL-161/163/171.
 
 ---

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1911,9 +1911,20 @@ else
 fi
 # Output is CAPTURED, not discarded, for this one: its LOUD SKIP (no expect and
 # no script on PATH) is an rc=0 outcome, and the standard `>/dev/null 2>&1`
-# delegate shape would render it indistinguishable from a genuine 8/8 pass —
+# delegate shape would render it indistinguishable from a genuine 10/10 pass —
 # turning a documented skip back into the silent-success class this test exists
 # to close. Surface the skip in the suite line instead.
+#
+# NOT SUITE_SKIP_AGGREGATORS-gated, unlike the five real-scaffold siblings above
+# — a deliberate exception (verifier finding R-WPA-1, 2026-07-26). The `core`
+# shard is the ONLY CI shard that reaches this delegate (`aggregators` runs four
+# explicitly named files), so gating it here would leave the sole check that
+# catches a HOLLOW strict gate executing in zero CI lanes. The .github/workflows
+# `full` job installs `expect` so the supported driver is present rather than
+# the best-effort script(1) fallback. The fixture's own
+# # BL-180-PTY-INTERACTIVE-ENV unsets CI/SOIF_NONINTERACTIVE (a pty does NOT
+# defeat those two guards in helpers-core.sh::prompt_input) and its T0a refuses
+# to spawn init.sh at all if that ever stops taking.
 bl180_pty_out=""
 bl180_pty_rc=0
 bl180_pty_out="$(bash "$SCRIPT_DIR/tests/test-bl180-interactive-scaffold-pty.sh" 2>&1)" || bl180_pty_rc=$?

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1894,6 +1894,39 @@ if bash "$SCRIPT_DIR/tests/test-enforcement-level-reconfigure.sh" >/dev/null 2>&
 else
   fail "tests/test-enforcement-level-reconfigure.sh FAILED (run for details)"
 fi
+# BL-180: the INTERACTIVE birth site. Everything above this pair covers the
+# --non-interactive arm only, which is why an interactively scaffolded project
+# shipped with enforcement_level="" and no filesystem gate.
+#   * -interactive-enforcement.sh — fast, pty-free pin of the RESOLVED level,
+#     read off dry_run_summary's `# BL-180-DRYRUN-ENFORCEMENT` stdout line.
+#   * -interactive-scaffold-pty.sh — the real end-to-end scaffold over a pty
+#     (manifest + .git/hooks/framework-gate.sh on disk). Aggregator-ONLY: it
+#     invokes init.sh for a full create_project, so it must NOT be added to
+#     the .github/workflows/tests.yml unit lane. LOUD-SKIPS (rc=0, printed
+#     reason) when neither expect nor script is installed.
+if bash "$SCRIPT_DIR/tests/test-bl180-interactive-enforcement.sh" >/dev/null 2>&1; then
+  pass "tests/test-bl180-interactive-enforcement.sh"
+else
+  fail "tests/test-bl180-interactive-enforcement.sh FAILED (run for details)"
+fi
+# Output is CAPTURED, not discarded, for this one: its LOUD SKIP (no expect and
+# no script on PATH) is an rc=0 outcome, and the standard `>/dev/null 2>&1`
+# delegate shape would render it indistinguishable from a genuine 8/8 pass —
+# turning a documented skip back into the silent-success class this test exists
+# to close. Surface the skip in the suite line instead.
+bl180_pty_out=""
+bl180_pty_rc=0
+bl180_pty_out="$(bash "$SCRIPT_DIR/tests/test-bl180-interactive-scaffold-pty.sh" 2>&1)" || bl180_pty_rc=$?
+if [ "$bl180_pty_rc" -eq 0 ]; then
+  case "$bl180_pty_out" in
+    *"SKIPPED: no pty driver"*)
+      pass "tests/test-bl180-interactive-scaffold-pty.sh — SKIPPED (no expect/script on PATH; install expect to exercise the real interactive scaffold)" ;;
+    *)
+      pass "tests/test-bl180-interactive-scaffold-pty.sh" ;;
+  esac
+else
+  fail "tests/test-bl180-interactive-scaffold-pty.sh FAILED (run for details)"
+fi
 # --- BL-035 wiring B: init/upgrade ---
 # ================================================================
 # Registers the init-family and upgrade-family orphan tests that were

--- a/tests/test-bl180-interactive-enforcement.sh
+++ b/tests/test-bl180-interactive-enforcement.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# tests/test-bl180-interactive-enforcement.sh — BL-180 regression pin.
+#
+# THE DEFECT
+#   init.sh assigned ENFORCEMENT_LEVEL only inside the
+#   `if [ "$NON_INTERACTIVE" = true ]` arm of main() (the
+#   `# BL-030: resolve enforcement_level` block). The `else` arm ran only
+#   check_prerequisites + collect_project_info, and there is NO interactive
+#   enforcement-level prompt anywhere in init.sh — so an interactive scaffold
+#   was born with `enforcement_level: ""` in the manifest, and the
+#   `if [ "$ENFORCEMENT_LEVEL" = "strict" ]` guard around
+#   install-filesystem-gates.sh --install was a silent no-op. The fix is the
+#   `# BL-180-ENFORCEMENT-DEFAULT` line hoisted OUT of that dispatch.
+#
+# WHY THIS TEST SHAPE
+#   The defect survived because no test exercised the interactive path far
+#   enough to observe a resolved enforcement level: every fed-sequence init.sh
+#   test in the repo uses --dry-run, and pre-BL-180 dry_run_summary never
+#   printed the level. The companion `# BL-180-DRYRUN-ENFORCEMENT` line in
+#   dry_run_summary makes the resolved value observable on STDOUT (log_line
+#   writes to the log FILE only and is invisible to a piped test), so the
+#   INTERACTIVE resolution can be pinned without a pty. The end-to-end pty
+#   scaffold (manifest + filesystem gate on disk) lives in the aggregator-only
+#   sibling tests/test-bl180-interactive-scaffold-pty.sh.
+#
+# HERMETIC: every invocation here carries --dry-run, so init.sh returns from
+# main() before create_project — no scaffold, no git, no host CLI, no remote.
+#
+# MENU POSITIONS ARE DERIVED, NOT HARDCODED. init.sh builds the Platform and
+# Primary-language menus from globs (docs/platform-modules/*.md,
+# templates/pipelines/release/github/*.yml, templates/pipelines/ci/github/*.yml
+# + their `# solo-orchestrator: platforms=` markers). A hardcoded ordinal goes
+# stale the moment a template is added or removed — that is exactly how the
+# aggregator's TEST 7 fixture broke before BL-136. This test re-derives the
+# ordinals from the same globs at run time AND pins the resolved combo in the
+# output, so a derivation that drifts fails loudly instead of asserting on the
+# wrong project shape.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# init.sh refuses to scaffold from inside the framework repo (the --dry-run
+# path skips that guard, but keep the cwd honest anyway).
+cd /tmp || exit 1
+
+# ── Menu-ordinal derivation (mirrors collect_project_info) ──────────────
+# Platform menu: platform-modules/*.md basenames, then release/github/*.yml
+# basenames not already seen, then a literal "other" appended last.
+derive_platform_index() {
+  local want="$1" idx=0 seen="" f p
+  for f in "$REPO_ROOT/docs/platform-modules/"*.md; do
+    [ -f "$f" ] || continue
+    p="$(basename "$f" .md)"
+    case " $seen " in *" $p "*) continue ;; esac
+    seen="$seen $p"
+    idx=$((idx + 1))
+    [ "$p" = "$want" ] && { echo "$idx"; return 0; }
+  done
+  for f in "$REPO_ROOT/templates/pipelines/release/github/"*.yml; do
+    [ -f "$f" ] || continue
+    p="$(basename "$f" .yml)"
+    case " $seen " in *" $p "*) continue ;; esac
+    seen="$seen $p"
+    idx=$((idx + 1))
+    [ "$p" = "$want" ] && { echo "$idx"; return 0; }
+  done
+  idx=$((idx + 1))
+  [ "$want" = "other" ] && { echo "$idx"; return 0; }
+  return 1
+}
+
+# Language menu: ci/github/*.yml basenames whose first-line
+# `# solo-orchestrator: platforms=` marker lists the chosen platform (a file
+# with no marker is included unconditionally, matching init.sh), then "other".
+derive_language_index() {
+  local want="$1" platform="$2" idx=0 f l marker csv
+  for f in "$REPO_ROOT/templates/pipelines/ci/github/"*.yml; do
+    [ -f "$f" ] || continue
+    l="$(basename "$f" .yml)"
+    [ "$l" = "other" ] && continue
+    marker="$(head -1 "$f")"
+    csv=""
+    case "$marker" in *"# solo-orchestrator: platforms="*) csv="${marker#*platforms=}" ;; esac
+    if [ -z "$csv" ]; then
+      idx=$((idx + 1))
+    else
+      case ",$csv," in
+        *",$platform,"*) idx=$((idx + 1)) ;;
+        *) continue ;;
+      esac
+    fi
+    [ "$l" = "$want" ] && { echo "$idx"; return 0; }
+  done
+  idx=$((idx + 1))
+  [ "$want" = "other" ] && { echo "$idx"; return 0; }
+  return 1
+}
+
+PLATFORM_IDX="$(derive_platform_index web)" || PLATFORM_IDX=""
+LANGUAGE_IDX="$(derive_language_index typescript web)" || LANGUAGE_IDX=""
+
+echo "T0: menu ordinals derived from the current globs/markers"
+if [ -n "$PLATFORM_IDX" ] && [ -n "$LANGUAGE_IDX" ]; then
+  pass "T0: Platform 'web'=$PLATFORM_IDX, Language 'typescript'=$LANGUAGE_IDX"
+else
+  fail_ "T0" "could not derive ordinals (platform='$PLATFORM_IDX' language='$LANGUAGE_IDX')"
+fi
+
+# Ordered prompt_choice answers for the interactive wizard. prompt_input
+# (project name / description / directory) auto-returns its default in a piped
+# context WITHOUT consuming a line (helpers-core.sh::prompt_input's `[ ! -t 0 ]`
+# guard), so ONLY the prompt_choice selections plus the raw "Continue? [Y/n]"
+# read may appear here.
+#   Platform=web · Track=standard(2) · Deployment=personal(1) ·
+#   Governance=Production Build(2) · Language=typescript · Continue?=Y
+feed_interactive() {
+  local gov="$1"
+  printf '%s\n%s\n%s\n%s\n%s\n%s\n' \
+    "$PLATFORM_IDX" 2 1 "$gov" "$LANGUAGE_IDX" Y
+}
+
+run_interactive_dry_run() {
+  local gov="$1"
+  feed_interactive "$gov" | bash "$INIT" --dry-run 2>&1
+}
+
+run_noninteractive_dry_run() {
+  bash "$INIT" --dry-run --non-interactive \
+    --project bl180 --project-dir /tmp/bl180-dryrun --no-remote-creation \
+    --platform web --language typescript --track standard "$@" 2>&1
+}
+
+# ── T1: the interactive path resolves an enforcement level at all ───────
+# Pre-fix this printed "Enforcement: " (empty) — the exact value that flows
+# into the manifest and makes the strict-gate guard a no-op.
+echo "T1: interactive (piped) dry-run resolves enforcement_level=strict"
+out_i="$(run_interactive_dry_run 2)"
+if echo "$out_i" | grep -q "^  Enforcement: strict$"; then
+  pass "T1: interactive dry-run reports 'Enforcement: strict'"
+else
+  fail_ "T1" "got: $(echo "$out_i" | grep -c '^  Enforcement:') Enforcement line(s): $(echo "$out_i" | grep '^  Enforcement:' | tr '\n' '|')"
+fi
+
+# ── T2: bind T1 to the combo the fed sequence was MEANT to select ───────
+# Without this, a drifted ordinal would still satisfy T1 while pinning the
+# enforcement level of an entirely different project shape.
+echo "T2: fed sequence still selects web / standard / typescript"
+if echo "$out_i" | grep -q "Platform: web | Track: standard | Language: typescript"; then
+  pass "T2: interactive combo pinned (web / standard / typescript)"
+else
+  fail_ "T2" "combo drifted — derived ordinals no longer map to web/standard/typescript"
+fi
+
+# ── T3: the interactive POC governance answer resolves too ──────────────
+# personal + Private POC is the choosable tier (BL-030), i.e. the one where a
+# downgrade would be legal if init.sh ever prompted for one. It does not, so
+# strict is the only correct resolution — and pre-fix it was "" here as well.
+echo "T3: interactive personal + Private POC also resolves to strict"
+out_poc="$(run_interactive_dry_run 1)"
+if echo "$out_poc" | grep -q "^  Enforcement: strict$"; then
+  pass "T3: interactive private-POC dry-run reports 'Enforcement: strict'"
+else
+  fail_ "T3" "got: $(echo "$out_poc" | grep '^  Enforcement:' | tr '\n' '|')"
+fi
+
+# ── T4: NON-INTERACTIVE CONTROL — default is unchanged ──────────────────
+echo "T4: non-interactive control (personal, no flag) still strict"
+out_n1="$(run_noninteractive_dry_run --deployment personal --gov-mode production)"
+if echo "$out_n1" | grep -q "^  Enforcement: strict$"; then
+  pass "T4: non-interactive default reports 'Enforcement: strict'"
+else
+  fail_ "T4" "got: $(echo "$out_n1" | grep '^  Enforcement:' | tr '\n' '|')"
+fi
+
+# ── T5: INERTNESS PROOF — the BL-180 default must not clobber a real ────
+# non-interactive downgrade. personal + --enforcement-level light
+# --confirm-pitfalls is the one shape where a hoisted default placed wrongly
+# (or written without the -z guard) would silently re-strictify the operator's
+# explicit choice. This is the assertion that proves the new line is inert for
+# the non-interactive arm rather than merely asserting it.
+echo "T5: non-interactive --enforcement-level light survives (inertness proof)"
+out_n2="$(run_noninteractive_dry_run --deployment personal --gov-mode production \
+  --enforcement-level light --confirm-pitfalls)"
+if echo "$out_n2" | grep -q "^  Enforcement: light$"; then
+  pass "T5: non-interactive light is NOT clobbered to strict"
+else
+  fail_ "T5" "got: $(echo "$out_n2" | grep '^  Enforcement:' | tr '\n' '|')"
+fi
+
+# ── T6: forced-strict arm unchanged ─────────────────────────────────────
+echo "T6: non-interactive organizational forces strict (flag ignored)"
+out_n3="$(run_noninteractive_dry_run --deployment organizational --gov-mode production \
+  --enforcement-level light --confirm-pitfalls)"
+if echo "$out_n3" | grep -q "^  Enforcement: strict$"; then
+  pass "T6: organizational still forced to strict"
+else
+  fail_ "T6" "got: $(echo "$out_n3" | grep '^  Enforcement:' | tr '\n' '|')"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl180-interactive-scaffold-pty.sh
+++ b/tests/test-bl180-interactive-scaffold-pty.sh
@@ -26,6 +26,13 @@
 #   ONLY and must NOT be added to the .github/workflows/tests.yml unit lane.
 #   The fast pin for the same defect is tests/test-bl180-interactive-enforcement.sh.
 #
+# FIXTURE-SCOPED — and this is NOT free (see # BL-180-PTY-INTERACTIVE-ENV):
+#   prompt_input's non-interactive guard fires on CI / SOIF_NONINTERACTIVE
+#   INDEPENDENTLY of the tty, and when it does this run scaffolds into the
+#   checkout's PARENT rather than into its own mktemp -d. Those two vars are
+#   therefore unset for the run, T0a refuses to spawn init.sh if that unset
+#   ever stops taking, and T0b fails loudly if anything lands outside anyway.
+#
 # HERMETIC — no remote is ever contacted:
 #   * Git host is answered "other", the URL-paste path. It never invokes gh /
 #     glab / curl, so no authenticated host account can be touched.
@@ -157,6 +164,26 @@ export GIT_ASKPASS=/usr/bin/true
 # House rule: unset GITHUB_BASE_REF in fixture git ops.
 unset GITHUB_BASE_REF 2>/dev/null || true
 
+# ── BL-180-PTY-INTERACTIVE-ENV: neutralise the non-interactive overrides ─
+# helpers-core.sh::prompt_input / prompt_yes_no / prompt_choice all guard on
+#   [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]
+# A pty satisfies `-t 0`, but CI and SOIF_NONINTERACTIVE are checked
+# INDEPENDENTLY of the tty — so on any host that exports them (every GitHub
+# Actions runner exports CI=true, which is precisely the environment of the
+# `full` lane this test is registered into) prompt_input auto-returns its
+# DEFAULT without consuming the fed answer. That is not merely a failing test:
+# PROJECT_NAME resolves to "" and
+#   PROJECT_DIR=$(prompt_input "Project directory" "$default_parent/$PROJECT_NAME")
+# resolves to "$default_parent/" — the PARENT DIRECTORY OF THE CHECKOUT — so a
+# complete git-init'd project is scaffolded OUTSIDE this fixture's own
+# `mktemp -d`. Driving the INTERACTIVE branch is the entire point of this test,
+# so these two are unset for the run. The piped/non-interactive branch is the
+# fast pin's job (tests/test-bl180-interactive-enforcement.sh), not this one.
+# T0a below re-asserts the unset actually took, and refuses to spawn init.sh
+# if it did not.
+unset CI 2>/dev/null || true
+unset SOIF_NONINTERACTIVE 2>/dev/null || true
+
 # Defence in depth: even though the "other" host path never shells out to a
 # host CLI, make gh/glab resolve to refusing stubs for the whole run.
 MOCK_DIR="$TMP/mockbin"
@@ -183,6 +210,42 @@ export PATH="$MOCK_DIR:$PATH"
 
 # init.sh refuses to scaffold from inside the framework repo.
 cd /tmp || exit 1
+
+# ── T0a: PRE-FLIGHT CONTAINMENT — checked BEFORE init.sh is ever spawned ─
+# This is the only assertion that can PREVENT rather than merely report an
+# escape, so it is deliberately ordered ahead of the run and exits without
+# spawning when it trips.
+#
+# ESCAPE_DIR is init.sh::collect_project_info's own expression
+#   default_parent="$(cd "$SCRIPT_DIR/.." && pwd)"
+# evaluated here with SCRIPT_DIR=$REPO_ROOT. When prompt_input takes its
+# non-interactive branch, PROJECT_NAME="" and the run scaffolds a whole
+# project into exactly this directory. Naming it up front is what makes a
+# future escape legible instead of surfacing as a confusing "no manifest at
+# <fixture path>" from T1.
+ESCAPE_DIR="$(cd "$REPO_ROOT/.." 2>/dev/null && pwd)"
+
+echo "T0a: pre-flight containment (interactive branch reachable, fixture-scoped)"
+preflight_err=""
+[ -n "${CI:-}" ] && preflight_err="CI is set ('$CI')"
+[ -z "$preflight_err" ] && [ -n "${SOIF_NONINTERACTIVE:-}" ] \
+  && preflight_err="SOIF_NONINTERACTIVE is set ('$SOIF_NONINTERACTIVE')"
+if [ -z "$preflight_err" ]; then
+  case "$PROJ/" in
+    "$TMP"/*) : ;;
+    *) preflight_err="PROJ ('$PROJ') is not under the fixture TMP ('$TMP')" ;;
+  esac
+fi
+if [ -n "$preflight_err" ]; then
+  fail_ "T0a" "REFUSING to spawn init.sh — $preflight_err.
+            helpers-core.sh::prompt_input would take its NON-interactive branch and
+            auto-return defaults, resolving PROJECT_DIR to '$ESCAPE_DIR/' and
+            scaffolding a complete project OUTSIDE this fixture. Nothing was run."
+  echo ""
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+pass "T0a: interactive branch reachable (CI/SOIF_NONINTERACTIVE unset) and PROJ is inside \$TMP"
 
 # ── Driver: expect ─────────────────────────────────────────────────────
 # Pattern-driven rather than a fixed stream, because two prompts are
@@ -307,6 +370,27 @@ else
 fi
 echo "      init.sh rc=$INIT_RC, project dir=$PROJ"
 
+# ── T0b: POST-RUN ESCAPE DETECTOR — ordered BEFORE T1 on purpose ────────
+# T1 exits 1 the moment the fixture manifest is missing, so anything after it
+# never runs on the failing path. An escape is EXACTLY that failing path, which
+# is why the escape has to be diagnosed here rather than below: otherwise the
+# only message an operator sees is "no manifest at <fixture path>", which names
+# the one directory the project was NOT written to.
+#
+# .claude/manifest.json is the decisive scaffold artifact (create_project +
+# bl030_finalize_init write it). It has no legitimate reason to exist in the
+# checkout's parent, so this is a precise detector, not a heuristic.
+echo "T0b: the run stayed inside the fixture (no scaffold in the checkout's parent)"
+if [ -e "$ESCAPE_DIR/.claude/manifest.json" ]; then
+  fail_ "T0b" "ESCAPE — a project was scaffolded into '$ESCAPE_DIR', OUTSIDE this
+            fixture's mktemp -d ('$TMP'). This is the R-WPA-1 failure mode:
+            helpers-core.sh::prompt_input took its non-interactive branch, so
+            PROJECT_NAME resolved to \"\" and PROJECT_DIR to '$ESCAPE_DIR/'.
+            Remove that directory by hand — it was written by this test run."
+else
+  pass "T0b: no .claude/manifest.json in '$ESCAPE_DIR' — nothing escaped the fixture"
+fi
+
 # ── T1: the scaffold actually happened ─────────────────────────────────
 # Guards every assertion below from passing vacuously on a run that never got
 # past the wizard.
@@ -413,10 +497,23 @@ fi
 # ── T7: hermeticity self-check ─────────────────────────────────────────
 # Prove the run really did not attach a remote. If this ever fails, the test
 # has started touching a real host and must be fixed before anything else.
+#
+# THE EMPTY STRING MUST NOT BE THE PASS CONDITION ON ITS OWN. `git -C "$PROJ"
+# remote -v 2>/dev/null` prints NOTHING and exits non-zero when $PROJ is not a
+# git repository at all — indistinguishable from a healthy "no remotes" — so
+# discarding stderr and testing only `-z` made this case pass for the wrong
+# reason. Require the repo to exist AND the command to succeed before an empty
+# result is allowed to mean anything.
 echo "T7: no git remote was attached (hermeticity self-check)"
-remotes="$(git -C "$PROJ" remote -v 2>/dev/null)"
-if [ -z "$remotes" ]; then
-  pass "T7: git remote -v is empty"
+remotes=""
+remotes_rc=0
+remotes="$(git -C "$PROJ" remote -v 2>&1)" || remotes_rc=$?
+if [ ! -d "$PROJ/.git" ]; then
+  fail_ "T7" "'$PROJ' is not a git repository — 'no remotes' here would be vacuous, not hermetic"
+elif [ "$remotes_rc" -ne 0 ]; then
+  fail_ "T7" "git remote -v failed (rc=$remotes_rc): $(echo "$remotes" | tr '\n' '|')"
+elif [ -z "$remotes" ]; then
+  pass "T7: \$PROJ is a git repo and git remote -v is empty"
 else
   fail_ "T7" "a remote was attached: $(echo "$remotes" | tr '\n' '|')"
 fi

--- a/tests/test-bl180-interactive-scaffold-pty.sh
+++ b/tests/test-bl180-interactive-scaffold-pty.sh
@@ -1,0 +1,426 @@
+#!/usr/bin/env bash
+# tests/test-bl180-interactive-scaffold-pty.sh — BL-180 end-to-end proof.
+#
+# WHAT THIS PROVES THAT NOTHING ELSE DOES
+#   A REAL interactive scaffold — init.sh with NO flags, driven over a pty so
+#   helpers-core.sh::prompt_input takes its interactive branch — produces a
+#   project whose manifest carries enforcement_level="strict" AND whose
+#   .git/hooks/ actually contains the strict-mode filesystem gate. Pre-BL-180
+#   that combination was impossible: main()'s `# BL-030: resolve
+#   enforcement_level` block sits inside the NON_INTERACTIVE arm, so the
+#   interactive arm reached prepare_initial_state_for_commit with
+#   ENFORCEMENT_LEVEL="" — the manifest recorded "" and the
+#   `[ "$ENFORCEMENT_LEVEL" = "strict" ]` guard around
+#   install-filesystem-gates.sh --install silently did nothing. The fix is the
+#   `# BL-180-ENFORCEMENT-DEFAULT` line in init.sh::main.
+#
+#   Every OTHER init.sh fixture in tests/ is either --non-interactive (which
+#   resolves the level on a different code path) or --dry-run (which returns
+#   from main() before create_project and never writes a manifest). That is
+#   precisely why this defect shipped, so the pin has to be a real scaffold.
+#
+# WHY AGGREGATOR-ONLY
+#   This performs a full create_project (framework clone, template render, git
+#   init + commit, verify-install) over a pty. It is minutes, not seconds, and
+#   it invokes init.sh — so it is registered in tests/full-project-test-suite.sh
+#   ONLY and must NOT be added to the .github/workflows/tests.yml unit lane.
+#   The fast pin for the same defect is tests/test-bl180-interactive-enforcement.sh.
+#
+# HERMETIC — no remote is ever contacted:
+#   * Git host is answered "other", the URL-paste path. It never invokes gh /
+#     glab / curl, so no authenticated host account can be touched.
+#   * The clone-URL prompt is answered with an EMPTY line, so
+#     create_and_protect_remote fails at its `[ -z "$remote_url" ]` guard
+#     BEFORE `git remote add origin` — nothing is even resolved, let alone
+#     pushed. init.sh consequently returns 2 via record_init_failure. That
+#     non-zero rc is EXPECTED and is deliberately NOT asserted: pinning it
+#     would couple this test to unrelated host-setup outcomes. It is printed
+#     in the T0 line for diagnosis, and the real guarantees are carried by
+#     T1 (the scaffold happened) and T7 (no remote was ever attached).
+#   * A mock gh/glab is prepended to PATH as defence in depth (write_mock_gh).
+#   * The assertions target artifacts written by prepare_initial_state_for_commit,
+#     which runs BEFORE create_and_protect_remote — so the remote failure
+#     cannot mask the thing under test.
+#
+# LOUD SKIP: when neither `expect` nor `script` is available this prints an
+# explicit SKIPPED line with the reason and exits 0. It never silently passes
+# assertions it did not run.
+#
+# DEV KNOB: SOIF_BL180_FORCE_SCRIPT_FALLBACK=1 forces the script(1) driver even
+# when expect is present, so the fallback path stays exercised and honest.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INIT="$REPO_ROOT/init.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ── Menu-ordinal derivation (mirrors init.sh::collect_project_info) ─────
+# Hardcoded ordinals go stale whenever a platform module or CI template is
+# added/removed — the failure mode that broke the aggregator's TEST 7 fixture
+# before BL-136. Derive them, then bind the run to the combo they resolved to.
+derive_platform_index() {
+  local want="$1" idx=0 seen="" f p
+  for f in "$REPO_ROOT/docs/platform-modules/"*.md; do
+    [ -f "$f" ] || continue
+    p="$(basename "$f" .md)"
+    case " $seen " in *" $p "*) continue ;; esac
+    seen="$seen $p"; idx=$((idx + 1))
+    [ "$p" = "$want" ] && { echo "$idx"; return 0; }
+  done
+  for f in "$REPO_ROOT/templates/pipelines/release/github/"*.yml; do
+    [ -f "$f" ] || continue
+    p="$(basename "$f" .yml)"
+    case " $seen " in *" $p "*) continue ;; esac
+    seen="$seen $p"; idx=$((idx + 1))
+    [ "$p" = "$want" ] && { echo "$idx"; return 0; }
+  done
+  idx=$((idx + 1))
+  [ "$want" = "other" ] && { echo "$idx"; return 0; }
+  return 1
+}
+derive_language_index() {
+  local want="$1" platform="$2" idx=0 f l marker csv
+  for f in "$REPO_ROOT/templates/pipelines/ci/github/"*.yml; do
+    [ -f "$f" ] || continue
+    l="$(basename "$f" .yml)"
+    [ "$l" = "other" ] && continue
+    marker="$(head -1 "$f")"
+    csv=""
+    case "$marker" in *"# solo-orchestrator: platforms="*) csv="${marker#*platforms=}" ;; esac
+    if [ -z "$csv" ]; then
+      idx=$((idx + 1))
+    else
+      case ",$csv," in
+        *",$platform,"*) idx=$((idx + 1)) ;;
+        *) continue ;;
+      esac
+    fi
+    [ "$l" = "$want" ] && { echo "$idx"; return 0; }
+  done
+  idx=$((idx + 1))
+  [ "$want" = "other" ] && { echo "$idx"; return 0; }
+  return 1
+}
+
+# ── pty driver selection (LOUD SKIP when neither tool exists) ───────────
+DRIVER=""
+if [ "${SOIF_BL180_FORCE_SCRIPT_FALLBACK:-0}" = "1" ] && command -v script >/dev/null 2>&1; then
+  DRIVER="script"
+elif command -v expect >/dev/null 2>&1; then
+  DRIVER="expect"
+elif command -v script >/dev/null 2>&1; then
+  DRIVER="script"
+fi
+
+if [ -z "$DRIVER" ]; then
+  echo "  [SKIPPED] tests/test-bl180-interactive-scaffold-pty.sh — no pty driver available."
+  echo "            Neither 'expect' nor 'script' is on PATH, so a REAL interactive"
+  echo "            init.sh run (which requires a tty for helpers-core.sh::prompt_input)"
+  echo "            cannot be driven. Install expect (brew install expect / apt-get"
+  echo "            install -y expect) to run this test. The fast, pty-free pin for the"
+  echo "            same defect is tests/test-bl180-interactive-enforcement.sh."
+  echo ""
+  echo "Results: 0 passed, 0 failed (SKIPPED: no pty driver)"
+  exit 0
+fi
+
+PLATFORM_IDX="$(derive_platform_index web)" || PLATFORM_IDX=""
+LANGUAGE_IDX="$(derive_language_index typescript web)" || LANGUAGE_IDX=""
+if [ -z "$PLATFORM_IDX" ] || [ -z "$LANGUAGE_IDX" ]; then
+  echo "  [FAIL] menu-ordinal derivation — platform='$PLATFORM_IDX' language='$LANGUAGE_IDX'"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+PROJ="$TMP/bl180pty"
+TRANSCRIPT="$TMP/transcript.log"
+
+# Hermetic git identity — a fixture must never depend on the host's global
+# git config, and env vars beat config on every git version we support.
+export GIT_AUTHOR_NAME="BL180 Fixture"
+export GIT_AUTHOR_EMAIL="bl180@example.invalid"
+export GIT_COMMITTER_NAME="BL180 Fixture"
+export GIT_COMMITTER_EMAIL="bl180@example.invalid"
+# Never let git open a credential prompt on the pty (would hang the driver).
+export GIT_TERMINAL_PROMPT=0
+export GIT_ASKPASS=/usr/bin/true
+# House rule: unset GITHUB_BASE_REF in fixture git ops.
+unset GITHUB_BASE_REF 2>/dev/null || true
+
+# Defence in depth: even though the "other" host path never shells out to a
+# host CLI, make gh/glab resolve to refusing stubs for the whole run.
+MOCK_DIR="$TMP/mockbin"
+mkdir -p "$MOCK_DIR"
+write_mock_gh() {
+  cat > "$MOCK_DIR/gh" <<'MOCKEOF'
+#!/usr/bin/env bash
+echo "mock gh: refusing (hermetic fixture — no live remote)" >&2
+exit 1
+MOCKEOF
+  chmod +x "$MOCK_DIR/gh"
+}
+write_mock_glab() {
+  cat > "$MOCK_DIR/glab" <<'MOCKEOF'
+#!/usr/bin/env bash
+echo "mock glab: refusing (hermetic fixture — no live remote)" >&2
+exit 1
+MOCKEOF
+  chmod +x "$MOCK_DIR/glab"
+}
+write_mock_gh
+write_mock_glab
+export PATH="$MOCK_DIR:$PATH"
+
+# init.sh refuses to scaffold from inside the framework repo.
+cd /tmp || exit 1
+
+# ── Driver: expect ─────────────────────────────────────────────────────
+# Pattern-driven rather than a fixed stream, because two prompts are
+# CONDITIONAL on the host: "Install Docker via:" (only when docker is absent)
+# and "Proceed with this plan?" (only when the resolver produced an
+# auto_install/manual_install row). A positional stream silently desynchronises
+# on such a host; a pattern loop does not. Titles set the pending answer and
+# the generic "Select [1-N]" prompt sends it, so ordering changes inside
+# collect_project_info cannot mis-target an answer either.
+run_expect() {
+  cat > "$TMP/drive.exp" <<'EXPEOF'
+set timeout 900
+set projname [lindex $argv 0]
+set projdir  [lindex $argv 1]
+set pidx     [lindex $argv 2]
+set lidx     [lindex $argv 3]
+set initsh   [lindex $argv 4]
+set ans ""
+
+spawn bash $initsh
+expect {
+    -re {Project name}                  { send -- "$projname\r";  exp_continue }
+    -re {One-sentence description}      { send -- "bl180 pty fixture\r"; exp_continue }
+    -re {Project directory}             { send -- "$projdir\r";   exp_continue }
+    -re {Platform type:}                { set ans $pidx;          exp_continue }
+    -re {Project track:}                { set ans 2;              exp_continue }
+    -re {Personal or organizational\?}  { set ans 1;              exp_continue }
+    -re {Governance mode:}              { set ans 2;              exp_continue }
+    -re {Primary language:}             { set ans $lidx;          exp_continue }
+    -re {Install Docker via:}           { set ans 3;              exp_continue }
+    -re {Git host:}                     { set ans 4;              exp_continue }
+    -re {Repository visibility:}        { set ans 1;              exp_continue }
+    -re {Select \[1-[0-9]+\]}           { send -- "$ans\r";       exp_continue }
+    -re {Proceed with this plan\?}      { send -- "Y\r";          exp_continue }
+    -re {Continue\? \[Y/n\]}            { send -- "Y\r";          exp_continue }
+    -re {Paste the HTTPS clone URL}     { send -- "\r";           exp_continue }
+    -re {type 'yes' to attest}          { send -- "no\r";         exp_continue }
+    -re {Proceed anyway\? \[l/d/N\]}    { send -- "l\r";          exp_continue }
+
+    # ---- Nested Development Guardrails (CDF) installer ----
+    # create_project shells out to ~/.claude-dev-framework/scripts/init.sh.
+    # Several of ITS prompts are `[ -t 0 ]`-guarded, so they exist ONLY on a
+    # pty — they are invisible to every non-interactive fixture in this repo
+    # and they will hang an under-fed driver. Answering them is part of what
+    # "a real interactive scaffold" means.
+    -re {Proceed with framework installation\?} { send -- "y\r"; exp_continue }
+    -re {Install Context7 now\?}                { send -- "n\r"; exp_continue }
+    -re {Push these to the global framework\?}  { send -- "n\r"; exp_continue }
+    # Defensive: the discovery interview is normally skipped because Solo
+    # passes --prepopulate, but CDF falls back to it when that file is
+    # missing/invalid. Accept every default rather than stalling.
+    -re {Are there other branches}              { send -- "n\r"; exp_continue }
+    -re {What does the '}                       { send -- "\r";  exp_continue }
+    -re {What OS are you developing ON}         { send -- "\r";  exp_continue }
+    -re {What platform does this branch TARGET} { send -- "\r";  exp_continue }
+    -re {Build tools or constraints}            { send -- "\r";  exp_continue }
+    -re {Will this project expand}              { send -- "\r";  exp_continue }
+
+    timeout {
+        puts "\nBL180-DRIVER: TIMEOUT — no known prompt matched. Last 400 bytes seen:"
+        puts $expect_out(buffer)
+        catch { exec kill -9 [exp_pid] }
+        exit 3
+    }
+    eof { }
+}
+catch wait result
+exit [lindex $result 3]
+EXPEOF
+  expect -f "$TMP/drive.exp" \
+    "bl180pty" "$PROJ" "$PLATFORM_IDX" "$LANGUAGE_IDX" "$INIT" > "$TRANSCRIPT" 2>&1
+  echo "$?"
+}
+
+# ── Driver: script(1) fallback ─────────────────────────────────────────
+# BEST-EFFORT, and deliberately so: script(1) allocates a pty but offers no
+# pattern matching, so this is a positional stream and a positional stream
+# cannot be correct in the presence of CONDITIONAL prompts. Two are benign —
+# the tool-plan "Proceed with this plan?" and the extra "y" below are
+# self-correcting, because if the plan prompt is absent the surplus answer
+# lands on a prompt_choice, which rejects it ("Invalid choice") and re-reads.
+# Two are NOT: "Install Docker via:" (docker-less host) and CDF's
+# "Install Context7 now?" (context7 not configured) both shift every later
+# answer by one. On such a host this driver fails LOUDLY at T1 with the
+# transcript tail rather than passing vacuously — install `expect`, which is
+# the supported driver, to run the test there.
+#
+# Answers are lowercase "y" on purpose: the nested CDF installer tests
+# `[ "$proceed" != "y" ]` and ABORTS on "Y".
+run_script_fallback() {
+  cat > "$TMP/answers.txt" <<ANSEOF
+bl180pty
+bl180 pty fixture
+$PLATFORM_IDX
+2
+1
+2
+$LANGUAGE_IDX
+$PROJ
+y
+y
+y
+4
+1
+
+ANSEOF
+  if script -q /dev/null true </dev/null >/dev/null 2>&1; then
+    # BSD/macOS: script [-q] file command [args...]
+    script -q /dev/null bash "$INIT" < "$TMP/answers.txt" > "$TRANSCRIPT" 2>&1
+  else
+    # util-linux: script -q -c "command" file
+    script -q -c "bash '$INIT'" /dev/null < "$TMP/answers.txt" > "$TRANSCRIPT" 2>&1
+  fi
+  echo "$?"
+}
+
+echo "T0: driving a REAL interactive init.sh over a pty (driver: $DRIVER)"
+if [ "$DRIVER" = "expect" ]; then
+  INIT_RC="$(run_expect)"
+else
+  INIT_RC="$(run_script_fallback)"
+fi
+echo "      init.sh rc=$INIT_RC, project dir=$PROJ"
+
+# ── T1: the scaffold actually happened ─────────────────────────────────
+# Guards every assertion below from passing vacuously on a run that never got
+# past the wizard.
+echo "T1: the interactive run reached project creation"
+if [ -f "$PROJ/.claude/manifest.json" ]; then
+  pass "T1: manifest.json exists — create_project ran"
+else
+  fail_ "T1" "no manifest at $PROJ/.claude/manifest.json (driver=$DRIVER rc=$INIT_RC); transcript tail: $(tail -20 "$TRANSCRIPT" 2>/dev/null | tr '\n' '|')"
+  echo ""
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 1
+fi
+
+# ── T2: the combo the fed answers were meant to select ─────────────────
+# Neither manifest.json nor phase-state.json stores platform/language, so pin
+# against init.sh's OWN resolved-combo line (collect_project_info's summary —
+# the same string the aggregator's BL-136 F1 assertion uses) and corroborate
+# it with a filesystem artifact that only the 'web' answer produces. Without
+# this, a drifted ordinal would scaffold some OTHER project shape and every
+# assertion below would still pass, pinning the wrong thing.
+echo "T2: fed answers selected the intended project shape"
+combo_ok=0
+grep -q "Platform: web | Track: standard | Language: typescript" "$TRANSCRIPT" 2>/dev/null && combo_ok=1
+if [ "$combo_ok" = "1" ] && [ -f "$PROJ/docs/platform-modules/web.md" ]; then
+  pass "T2: resolved combo is web / standard / typescript (+ web platform module on disk)"
+else
+  fail_ "T2" "derived ordinals drifted — combo line found=$combo_ok, web platform module present=$([ -f "$PROJ/docs/platform-modules/web.md" ] && echo yes || echo no)"
+fi
+
+# ── T2b: the run really was INTERACTIVE ────────────────────────────────
+# The whole point is that this exercises the arm --non-interactive never
+# takes. helpers-core.sh::prompt_input emits a "Non-interactive context:"
+# warning whenever it auto-returns a default instead of reading — its absence
+# is positive proof the pty was honoured and the wizard truly prompted.
+echo "T2b: the wizard ran on the interactive arm (no prompt_input fallbacks)"
+if grep -q "Non-interactive context: prompt_input" "$TRANSCRIPT" 2>/dev/null; then
+  fail_ "T2b" "prompt_input took its NON-interactive branch — the pty was not honoured, so this run does not exercise the BL-180 arm"
+else
+  pass "T2b: prompt_input read from the pty (no non-interactive fallback warning)"
+fi
+
+# ── T3: THE DEFECT — manifest enforcement_level ────────────────────────
+# Pre-BL-180 this was the empty string, which is strictly WORSE than absent:
+# `jq -e '.enforcement_level'` exits 0 on "", so upgrade-project.sh's BL-030
+# backfill skipped the very project it was written to repair (see
+# # BL-180-BACKFILL-EMPTY in scripts/upgrade-project.sh).
+echo "T3: manifest enforcement_level is resolved (not the empty string)"
+level="$(jq -r '.enforcement_level' "$PROJ/.claude/manifest.json" 2>/dev/null)"
+if [ "$level" = "strict" ]; then
+  pass "T3: enforcement_level=strict"
+else
+  fail_ "T3" "enforcement_level='$level' (pre-BL-180 this was \"\")"
+fi
+
+# ── T4: the strict-mode filesystem gate is actually ON DISK ────────────
+# The manifest value is only a claim; this is the enforcement it is supposed
+# to imply. verify-install.sh --auto-fix passes 83/83 either way because it
+# checks the INSTALLER was copied, never that the HOOK was installed — so this
+# assertion is the only thing standing between "reported strict" and
+# "actually gated".
+echo "T4: .git/hooks/framework-gate.sh installed"
+if [ -f "$PROJ/.git/hooks/framework-gate.sh" ]; then
+  pass "T4: framework-gate.sh present"
+else
+  fail_ "T4" "framework-gate.sh ABSENT — strict enforcement is hollow"
+fi
+
+# ── T5: the gate is actually WIRED into pre-commit ─────────────────────
+# A gate script nobody calls is the BL-112 hollow-gate class.
+#
+# ASSERT THE SENTINEL, NOT THE FILENAME. The first cut of this case grepped
+# for "framework-gate.sh" and PASSED under the mutation proof with the gate
+# provably absent — scripts/lib/hook-templates.sh names framework-gate.sh in
+# explanatory COMMENTS that are emitted into every generated pre-commit hook,
+# strict or not. Only install-filesystem-gates.sh's MARK_OPEN sentinel is
+# written exclusively by an actual --install, so that is the load-bearing
+# string (the same one the BL-180 filing's A/B counted: 0 interactive vs 1
+# non-interactive).
+echo "T5: pre-commit invokes the gate"
+if [ -f "$PROJ/.git/hooks/pre-commit" ] \
+   && grep -qF "SOIF framework gate (BL-030)" "$PROJ/.git/hooks/pre-commit"; then
+  pass "T5: .git/hooks/pre-commit carries the installed-gate sentinel"
+else
+  fail_ "T5" "pre-commit lacks the 'SOIF framework gate (BL-030)' block — the gate was never installed"
+fi
+
+# ── T6: the bypass-audit birth row records the real level ──────────────
+# prepare_initial_state_for_commit stamps enforcement_level_at_event from the
+# same variable; pre-BL-180 it recorded "" and the audit trail lied from the
+# project's first row onward.
+echo "T6: bypass-audit init row records the resolved level"
+if [ -f "$PROJ/.claude/bypass-audit.json" ]; then
+  row_level="$(jq -r '[.[] | select(.type == "enforcement_level_set")][0].enforcement_level_at_event // "MISSING"' \
+    "$PROJ/.claude/bypass-audit.json" 2>/dev/null)"
+  if [ "$row_level" = "strict" ]; then
+    pass "T6: enforcement_level_set row records 'strict'"
+  else
+    fail_ "T6" "audit row enforcement_level_at_event='$row_level'"
+  fi
+else
+  fail_ "T6" "no .claude/bypass-audit.json"
+fi
+
+# ── T7: hermeticity self-check ─────────────────────────────────────────
+# Prove the run really did not attach a remote. If this ever fails, the test
+# has started touching a real host and must be fixed before anything else.
+echo "T7: no git remote was attached (hermeticity self-check)"
+remotes="$(git -C "$PROJ" remote -v 2>/dev/null)"
+if [ -z "$remotes" ]; then
+  pass "T7: git remote -v is empty"
+else
+  fail_ "T7" "a remote was attached: $(echo "$remotes" | tr '\n' '|')"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-upgrade-bl030-backfill.sh
+++ b/tests/test-upgrade-bl030-backfill.sh
@@ -65,6 +65,35 @@ setup_pre_bl030_organizational_production() {
     && mv "$tmp" "$PROJ/.claude/bypass-audit.json"
   UPGRADE="$PROJ/scripts/upgrade-project.sh"
 }
+# BL-180: a project scaffolded by the pre-fix INTERACTIVE init.sh path — the
+# manifest carries the BL-030 keys but enforcement_level is the EMPTY STRING,
+# and the strict-mode filesystem gate was never installed because the
+# `[ "$ENFORCEMENT_LEVEL" = "strict" ]` guard saw "". This shape is strictly
+# WORSE than the pre-BL-030 shape above: `jq -e '.enforcement_level'` on ""
+# prints "" and EXITS 0, so the backfill's own `! jq -e …` gate treated the
+# broken project as already-migrated and skipped it. Mimic it exactly.
+setup_bl180_empty_level_personal() {
+  TMP=$(mktemp -d); PROJ="$TMP/p"
+  bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
+    --platform web --language typescript --track light --deployment personal \
+    >/dev/null 2>&1
+  # Blank the level — do NOT delete the key. That distinction IS the bug.
+  tmp=$(mktemp)
+  jq '.enforcement_level = ""' "$PROJ/.claude/manifest.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/manifest.json"
+  # The gate the pre-fix interactive path never installed.
+  rm -f "$PROJ/.claude/last-checked-commit.txt"
+  rm -f "$PROJ/.git/hooks/framework-gate.sh"
+  bash "$PROJ/scripts/install-filesystem-gates.sh" --uninstall "$PROJ" >/dev/null 2>&1
+  # The birth audit row recorded "" as well.
+  tmp=$(mktemp)
+  jq '[.[] | select(.type != "enforcement_level_set")]' "$PROJ/.claude/bypass-audit.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/bypass-audit.json"
+  tmp=$(mktemp)
+  jq '. + {deployment: "personal", poc_mode: null}' "$PROJ/.claude/phase-state.json" > "$tmp" \
+    && mv "$tmp" "$PROJ/.claude/phase-state.json"
+  UPGRADE="$PROJ/scripts/upgrade-project.sh"
+}
 teardown() { rm -rf "$TMP"; }
 
 # T1: pre-BL-030 personal project: upgrade backfills manifest fields.
@@ -157,6 +186,55 @@ if [ -s "$PROJ/.claude/last-checked-commit.txt" ]; then
   pass "T7: last-checked-commit.txt initialized"
 else
   fail_ "T7" "last-checked-commit.txt missing or empty"
+fi
+teardown
+
+# ── BL-180: EMPTY enforcement_level must be treated as ABSENT ──────────
+# The repair path for every project born on the pre-fix INTERACTIVE init.sh
+# path. See # BL-180-BACKFILL-EMPTY in scripts/upgrade-project.sh.
+
+# T8: the migration actually fires on an empty value.
+echo "T8: BL-180 — manifest with enforcement_level=\"\" is backfilled to strict"
+setup_bl180_empty_level_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+level=$(jq -r '.enforcement_level // empty' "$PROJ/.claude/manifest.json")
+if [ "$level" = "strict" ]; then
+  pass "T8: empty enforcement_level repaired to strict"
+else
+  fail_ "T8" "enforcement_level='$level' — the empty value defeated its own migration"
+fi
+teardown
+
+# T9: the repair is not cosmetic — the gate the interactive path never
+# installed must actually land on disk. Without this, T8 could pass on a
+# manifest edit that leaves the project just as hollow as before.
+echo "T9: BL-180 — backfill installs the filesystem gate the interactive path skipped"
+setup_bl180_empty_level_personal
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+if [ -x "$PROJ/.git/hooks/framework-gate.sh" ] \
+   && grep -q "SOIF framework gate" "$PROJ/.git/hooks/pre-commit" 2>/dev/null; then
+  pass "T9: framework-gate.sh installed + wired into pre-commit"
+else
+  fail_ "T9" "gate still absent after backfill"
+fi
+teardown
+
+# T10: CONTROL — a manifest that already carries a real non-strict level must
+# NOT be re-strictified. The empty-vs-absent fix must widen the trigger only
+# to the empty string, never to a legitimately chosen tier. (personal + light
+# is the one combo where that distinction is observable.)
+echo "T10: BL-180 control — an explicit 'light' level is NOT clobbered by the backfill"
+TMP=$(mktemp -d); PROJ="$TMP/p"
+bash "$INIT" --non-interactive --project x --project-dir "$PROJ" --no-remote-creation \
+  --platform web --language typescript --track light --deployment personal \
+  --enforcement-level light --confirm-pitfalls >/dev/null 2>&1
+UPGRADE="$PROJ/scripts/upgrade-project.sh"
+( cd "$PROJ" && bash "$UPGRADE" --backfill-only >/dev/null 2>&1 ) || true
+level=$(jq -r '.enforcement_level // empty' "$PROJ/.claude/manifest.json")
+if [ "$level" = "light" ]; then
+  pass "T10: explicit light survives the backfill"
+else
+  fail_ "T10" "enforcement_level='$level' — backfill clobbered an explicit choice"
 fi
 teardown
 


### PR DESCRIPTION
Closes the HIGH-severity BL-180: `./init.sh` with no flags — the default operator UX — produced a project with `enforcement_level: ""` and **no filesystem gate installed**, while every diagnostic reported it as strict.

## Root cause
`ENFORCEMENT_LEVEL` was assigned only inside the `if [ "$NON_INTERACTIVE" = true ]` arm of `main`. The interactive `else` arm never resolved it, so the empty value flowed into the manifest seed and made the `[ "$ENFORCEMENT_LEVEL" = "strict" ]` gate-install guard a no-op.

## What landed
- **`# BL-180-ENFORCEMENT-DEFAULT`** — the resolution hoisted out of the dispatch so it runs on **every** path exactly once.
- **`# BL-180-DRYRUN-ENFORCEMENT`** — `dry_run_summary` now emits `Enforcement:` on **stdout**, so the interactive path is pinnable without a pty.
- **Repair for projects already born broken** — `upgrade-project.sh`'s BL-030 backfill was gated on `! jq -e '.enforcement_level'`, and `jq -e` on `""` exits 0, so an empty value defeated its own migration. Now treated as absent.
- **Two new tests**: a fast interactive pin, and an aggregator-only pty-driven real-scaffold test asserting both the manifest value and the gate file. The reason this bug survived is that **no test had ever performed a real interactive scaffold**.

## Review
Opus implementer → adversarial reviewer at max effort, 2 rounds. Final verdict `minor_concerns`. Round 1 caught a fixture that scaffolded **outside its own temp dir** when `CI=true`; fixed in `416988d`.

Three items were escalated rather than silently decided, and are recorded in-tree: unit-lane registration of the fast pin, `--no-remote-creation` being silently inert interactively, and three readers that still act on `""` because `jq`'s `//` does not fire on an empty string.

**TL;DR (plain English):** Setting up a project by answering questions on screen left its main safety system switched off, while everything reported it as on. This turns it on, repairs projects already created that way, and adds the test that should have caught it.