### PR TITLE
fix(bl181,bl135): unit-lane exemption must test INVOCATION not mention — and the mystery test was never a flake

### DIFF
--- a/.claude/skills/grill-with-docs/NOTICE
+++ b/.claude/skills/grill-with-docs/NOTICE
@@ -1,0 +1,78 @@
+This skill is adapted from the `grill-with-docs` skill in the
+mattpocock/skills repository (https://github.com/mattpocock/skills),
+licensed under the MIT License.
+
+Original copyright:
+
+  MIT License
+
+  Copyright (c) Matt Pocock
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+Adaptations made for Solo Orchestrator:
+
+- **Persistence target retargeted.** Upstream uses `CONTEXT.md` as the
+  glossary file (single-context) or `CONTEXT-MAP.md` + per-context
+  `CONTEXT.md` (multi-context). Solo does not ship a separate glossary
+  file — `PROJECT_BIBLE.md` carries the domain vocabulary as part of
+  its architecture section. The skill body retargets all "update
+  CONTEXT.md" guidance to "update PROJECT_BIBLE.md" and explains why.
+- **ADR location.** Upstream uses `docs/adr/`. Solo uses
+  `docs/ADR documentation/` (existing convention, with the space).
+  The skill body cites Solo's `templates/generated/adr.tmpl` as the
+  canonical ADR template.
+- **CLAUDE.md split.** Upstream's CONTEXT.md was glossary-only.
+  Solo splits responsibilities: PROJECT_BIBLE.md for architectural
+  truth; CLAUDE.md for session-readable conventions. The adapted
+  skill documents the distinction.
+- **Cross-reference with tests.** Upstream cross-references code only.
+  Solo's TDD discipline means tests are an additional source of truth;
+  the adapted skill adds tests to the cross-reference list.
+- **Multi-context simplification.** Upstream supports CONTEXT-MAP.md
+  for multi-bounded-context repos. At Solo's typical MVP/POC scale,
+  multi-context is over-engineering; the adapted skill is single-context.
+  If a project grows past that boundary, the right move is an ADR
+  rather than retro-fitting the skill.
+- **Composition with Solo's structured decision points.** New section
+  instructs the skill to escalate user-judgment forks via
+  `scripts/escalate-to-user.sh` (BL-029 / pending-approval.json) rather
+  than assume-and-continue.
+- **Composition with Solo's backlog.** New section instructs the
+  skill to file BL items for deferred questions rather than lose them.
+- **Composition with sibling skills.** Cross-references `zoom-out`,
+  `sweep-triage`, and Superpowers' brainstorming.
+- **Self-check.** New 5-point self-check section at session end,
+  consistent with Solo's other adapted skills.
+
+Preserved from upstream verbatim:
+
+- The interview discipline (one question at a time, recommend an answer,
+  wait for feedback, prefer code exploration over asking).
+- The "challenge against the glossary" / "sharpen fuzzy language" /
+  "probe with concrete scenarios" / "cross-reference with code"
+  during-session moves.
+- The **3-of-3 ADR criteria**: hard to reverse + surprising without
+  context + result of a real trade-off. These criteria are the heart
+  of the skill and are preserved unchanged.
+- The "create files lazily" principle (only when there is something
+  to write).
+- The principle that the truth file (whether CONTEXT.md or
+  PROJECT_BIBLE.md) is NOT a spec, scratch pad, or implementation
+  log — it is the domain record.

--- a/.claude/skills/grill-with-docs/SKILL.md
+++ b/.claude/skills/grill-with-docs/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: grill-with-docs
+description: Stress-test a plan against the project's existing documentation, code, and decisions. Interview-style — one question at a time, recommend an answer, wait for feedback. Update PROJECT_BIBLE.md inline as terms and decisions are resolved. Offer ADRs only when the decision is hard to reverse. Use when a design needs sharpening before implementation.
+---
+
+> **Attribution.** Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, © Matt Pocock). The upstream uses a `CONTEXT.md` glossary as the persistence target. Solo's adaptation retargets to `PROJECT_BIBLE.md` (Solo's canonical architecture/data-model/threat-model document) and `docs/ADR documentation/` (Solo's ADR location, distinct from upstream's `docs/adr/`). The interview pattern, ADR-criteria, and inline-update discipline are preserved. See `NOTICE` for full attribution.
+
+<what-to-do>
+
+Interview the user relentlessly about every aspect of this plan until a shared understanding is reached. Walk down each branch of the design tree, resolving dependencies between decisions one at a time. For each question, provide a recommended answer.
+
+Ask one question at a time. Wait for feedback before continuing.
+
+If a question can be answered by exploring the codebase or reading existing documentation, do that instead of asking.
+
+</what-to-do>
+
+<supporting-info>
+
+## Where Solo's documentation lives
+
+Solo Orchestrator projects keep their truth in a small set of canonical files. Read them before asking the user; cite them in answers.
+
+| File | Role | When to update |
+|---|---|---|
+| `PROJECT_BIBLE.md` | Architecture, data model, threat model, domain vocabulary. The canonical truth. | When terms resolve, when domain boundaries clarify, when the data model changes. **Update inline during grilling.** |
+| `docs/ADR documentation/` | Architectural Decision Records. Per Solo's `templates/generated/adr.tmpl`. | When a decision meets the 3-of-3 ADR criteria (below). Create lazily; never preemptively. |
+| `CLAUDE.md` | Per-session conventions, agent preferences, project-wide reminders. | When a *session-readable* convention emerges (e.g., "always commit in `feat:` form for Cutline work") — distinct from architectural truth. |
+| `solo-orchestrator-backlog.md` (or project equivalent) | Open BL items, parked items, pending decisions. | When a question is *deferred* (not resolved). File a BL entry pointing to the grilling session's open question. |
+| `.claude/phase-state.json` / `.claude/process-state.json` | Where we are in Phase / Build Loop. | Read-only during grilling — informs which decisions are in-scope for this phase. |
+
+Solo intentionally does NOT have a separate `CONTEXT.md` glossary today. `PROJECT_BIBLE.md` carries the domain vocabulary as part of its architecture section. If a project's vocabulary grows large enough to warrant its own glossary file, that decision should itself go through an ADR.
+
+## During the session
+
+### Challenge against the existing record
+
+When the user uses a term that conflicts with `PROJECT_BIBLE.md` or with prior ADRs, call it out immediately:
+
+> "Your Bible defines `Cancellation` as X (§2.3), but you seem to mean Y here. Which is it — and should we update the Bible?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term:
+
+> "You're saying 'account' — do you mean `Customer`, `User`, or `Tenant`? Those are different. The Bible currently distinguishes Customer and User; Tenant isn't defined yet."
+
+### Probe with concrete scenarios
+
+When domain relationships are being discussed, invent scenarios that probe boundaries:
+
+> "If a Customer has two Users and one cancels the subscription, does that cancel for both Users or only one? Walk me through that case."
+
+### Cross-reference with code AND tests
+
+When the user states how something works, check whether the code agrees. Solo's TDD discipline means tests are the second source of truth. If you find a contradiction, surface it:
+
+> "Your `OrderService.cancel()` cancels the whole order, but the test `test_partial_cancellation_skips_shipped_items` implies partial. The code, the tests, and what you just said disagree — which is right?"
+
+### Update PROJECT_BIBLE.md inline
+
+When a term is resolved or a boundary clarifies, update `PROJECT_BIBLE.md` right there. Don't batch. Use the same format the existing sections use.
+
+**`PROJECT_BIBLE.md` is the architecture/domain truth file.** Do not treat it as a spec, a scratch pad, or a repository for in-flight implementation decisions. Implementation decisions belong in plans (`docs/superpowers/plans/`) and ADRs (`docs/ADR documentation/`).
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when **all three** are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful (data migration, public API, contract with another team).
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **A real trade-off** — there were genuine alternatives and one was picked for specific reasons.
+
+If any of the three is missing, skip the ADR. A weak ADR weakens the rest.
+
+Use Solo's existing ADR template at `templates/generated/adr.tmpl`. ADRs live in `docs/ADR documentation/` (note the spaces — that is Solo's existing convention, distinct from upstream's `docs/adr/`).
+
+### When a decision needs the user, not the code
+
+If the grilling reaches a point where the next branch genuinely requires user judgment (e.g., business-policy decision, security/compliance trade-off, scope cut), do NOT continue with assumptions. Use Solo's structured decision-point machinery:
+
+```bash
+scripts/escalate-to-user.sh \
+  --question "<the fork>" \
+  --option "A1: <option 1>" \
+  --option "A2: <option 2>" \
+  --recommendation "A1" \
+  --rationale "<why A1>"
+```
+
+This writes `.claude/pending-approval.json` so the CDF stop-hook and Solo's pre-commit gate both honor the pause until the user resolves it. Bury-the-question-and-proceed-with-an-assumption is the failure mode this skill exists to prevent.
+
+### When a question should be deferred, not resolved
+
+Not every grilling question needs to be answered in this session. If a question is real but out of scope for the current phase / feature / branch, file a BL item:
+
+> "Logging strategy for the Cutline isn't in scope for Phase 1 architecture — filing BL-XXX so it doesn't get lost. Continuing with the Phase 1 boundaries we already have."
+
+Cite the BL in `PROJECT_BIBLE.md` or in the relevant plan so the deferred-question trail is recoverable.
+
+## Composition with other Solo skills
+
+- **`zoom-out`** (companion) — if grilling reveals the user (or you) doesn't have the structural map of the area, pause and zoom-out first. The map informs the grill.
+- **`sweep-triage`** — if grilling produces a cluster of findings that will need batch handling (e.g., post-audit), capture them in a TRIAGE.md under `Reports/<sweep-id>/`.
+- **Brainstorming** (Superpowers, if installed) — grill-with-docs is best for *stress-testing an existing plan against existing docs*. Brainstorming is best for *exploring open questions before a plan exists*. They are complementary, not redundant.
+
+## Self-check before ending the session
+
+1. Did I update `PROJECT_BIBLE.md` for every term or boundary that resolved?
+2. Did I offer ADRs only where the 3-of-3 criteria held?
+3. Did any unresolved questions get filed as BL items rather than lost?
+4. Did I escalate user-judgment forks to `pending-approval.json` rather than assume?
+5. Is the plan actually sharper now than when we started?
+
+If any answer is no, fix it before ending.
+
+</supporting-info>

--- a/.claude/skills/session-handoff/NOTICE
+++ b/.claude/skills/session-handoff/NOTICE
@@ -1,0 +1,44 @@
+This skill is adapted from the `handoff` skill in the mattpocock/skills
+repository (https://github.com/mattpocock/skills), licensed under the
+MIT License.
+
+Original copyright:
+
+  MIT License
+
+  Copyright (c) Matt Pocock
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+Adaptations made for Solo Orchestrator:
+
+- Renamed `handoff` → `session-handoff` to disambiguate from Solo's Phase 4
+  production HANDOFF.md (templates/generated/handoff.tmpl).
+- Save path changed from `mktemp` to `docs/handoffs/YYYY-MM-DD-<topic-slug>.md`
+  so handoff documents live with the project as auditable artifacts
+  (Solo's W7 handoff-readiness principle).
+- Expanded body with required sections (Where we are / Just shipped /
+  Blocked / Next / References / Resume prompt) and composition guidance
+  for Solo's existing artifacts (plans, TRIAGEs, process-state,
+  pending-approval sentinels).
+- Added When / When-not-to-use guidance and a self-check section.
+
+Original content was a 4-paragraph SKILL.md; the adapted version preserves
+the original intent (handoff document, references-not-duplications,
+tailor-to-args) while adding Solo-specific structure.

--- a/.claude/skills/session-handoff/SKILL.md
+++ b/.claude/skills/session-handoff/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: session-handoff
+description: Compact the current conversation into a session-boundary handoff document for another agent to pick up. Use at session end (or before a planned interruption like a machine reboot, hard context-window break, or hand-off to a different operator).
+argument-hint: "What will the next session be used for?"
+---
+
+# Session Handoff
+
+> **Attribution.** This skill is adapted with permission from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, © Matt Pocock). The original skill (`handoff`) was written to be lightweight and tool-agnostic. This Solo Orchestrator-adapted version writes to `docs/handoffs/` so the handoff lives with the project as an auditable artifact (Solo's W7 handoff-readiness principle), and is named `session-handoff` to disambiguate from Solo's Phase 4 production HANDOFF.md (`templates/generated/handoff.tmpl`). See `NOTICE` for full attribution and license.
+
+## When to use
+
+Use **before** any of:
+- Hard context-window break (the next reply might roll context out of memory).
+- Machine reboot or planned shutdown.
+- Switching to a different agent or operator mid-task.
+- End-of-day stop when work is mid-flight and you want to resume cleanly tomorrow.
+
+Do **not** use this skill for:
+- Phase 4 production handoff to operations — that goes in `HANDOFF.md` via the project's existing `templates/generated/handoff.tmpl`. They are different artifacts with different audiences.
+- Single-task summaries inside a session — write those inline.
+
+## What it produces
+
+Write a markdown document summarizing the current conversation so a fresh agent (or future-you) can continue cleanly. Save it to:
+
+```
+docs/handoffs/YYYY-MM-DD-<topic-slug>.md
+```
+
+(Create `docs/handoffs/` if it does not exist.)
+
+The handoff document MUST include:
+
+1. **Where we are** — one-paragraph status of the work in progress: current branch, current PR (if any), current task on the implementation plan, current test-gate state.
+2. **What just shipped this session** — bullet list of commits / PRs / artifacts produced. Link to file paths and PR URLs, do not duplicate content.
+3. **What's blocked / waiting** — anything paused on user review, external state (CI, deploys), or unanswered design questions.
+4. **What's next** — the specific next concrete action. If multiple options exist, list them with the recommendation.
+5. **References** — paths to PRDs, plans, ADRs, specs, TRIAGE docs, calibration reports the next session will need. Use repo-relative paths.
+6. **Resume prompt** — a single paragraph the user can paste into the next session (or have an agent re-enter with) that re-establishes context. Should be self-contained: "Continuing from <date> handoff at <path>. <One-line recap of decision-state>. <Specific next action>."
+
+If the user passed an argument describing the next session's focus, tailor the document to that focus.
+
+## What NOT to do
+
+- **Do not duplicate content** already captured in artifacts. The handoff is a pointer document, not a re-creation. If a decision lives in an ADR, link to it. If a plan lives in `docs/superpowers/plans/`, link to it.
+- **Do not write the handoff as a narrative log.** This is not a journal. Lead with "where we are now" and "what's next" — those are what the resumer needs.
+- **Do not skip the resume prompt.** Without it, the next session has to re-derive context. The prompt is the difference between "useful" and "load-bearing."
+- **Do not invent followup items.** Only record items the conversation actually surfaced.
+
+## Composition with Solo's existing artifacts
+
+- If a feature is mid-implementation, link to its implementation plan (`docs/superpowers/plans/...`) and identify the current task by number.
+- If a calibration / UAT sweep is mid-flight, link to the TRIAGE.md and identify which findings are addressed vs. deferred.
+- If `process-state.json` reflects in-flight Build Loop / Phase work, mention the current step and what step is next.
+- If a `pending-approval.json` sentinel exists (BL-015 / BL-029), call this out prominently — the next session must address it before proceeding.
+
+## Self-check before saving
+
+Read the document you just wrote. Ask:
+1. If I, with no other context, started a session and was given only this document, could I resume cleanly?
+2. Did I link to canonical artifacts rather than re-quoting them?
+3. Is the resume prompt at the bottom usable as a literal first message?
+
+If any answer is no, fix it before saving.

--- a/.claude/skills/sweep-triage/SKILL.md
+++ b/.claude/skills/sweep-triage/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: sweep-triage
+description: Consolidate findings from a sweep (UAT calibration, multi-agent validation, manual audit) into a TRIAGE.md document with severity ranking and ship recommendations. Use when a sweep has produced multiple findings that need to be triaged together to make a single ship/no-ship decision.
+argument-hint: "Path to the sweep directory (e.g., Reports/uat-2026-MM-DD-foo/) OR a description of the sweep being triaged."
+---
+
+# Sweep Triage
+
+> **What this is.** A skill for consolidating findings from a sweep into one decision-grade document. A sweep is any activity that surfaces multiple findings at once: a multi-agent UAT run, a manual audit pass, a security review, a calibration replay. Each finding needs severity, a fix recommendation, and the whole set needs an overall ship recommendation.
+>
+> **What this is NOT.** This skill is not for per-issue triage in an issue tracker (working through GitHub Issues or Linear one at a time, applying state-machine labels). That is a different workflow. If you want issue-tracker triage, see the related work below.
+>
+> **Canonical example.** `Reports/uat-2026-04-29-bl029-validation/TRIAGE.md` (committed to this repo) is the output shape this skill produces. Read it before writing your first TRIAGE — it shows the per-agent verdict table, severity-ranked issue list, and the Resolution section appended after fixes shipped.
+
+## When to use
+
+- A multi-agent UAT sweep just finished and you have N agent reports in `Reports/<sweep-id>/results/agent-*.json`.
+- A manual audit (security review, accessibility pass, code review) produced multiple findings.
+- A calibration replay (cf. BL-029 / BL-030 work) produced verdicts across scenarios and personas.
+- You're about to make a ship / no-ship decision and have more than 2-3 findings to weigh.
+
+## When NOT to use
+
+- Single-finding issues — write the fix or file the BL item directly.
+- Per-issue triage in an issue tracker — that's a different workflow (state machine + labels, not severity tiers + ship decisions). See *Related work* below.
+- Trivial sweeps (everything green, no findings) — no document needed; the green test output is the artifact.
+
+## Output
+
+The skill produces a markdown document at:
+
+```
+Reports/<sweep-id>/TRIAGE.md
+```
+
+Where `<sweep-id>` is the directory the sweep already lives in (e.g., `uat-2026-04-29-bl029-validation`). If there is no sweep directory yet, create one at `Reports/<sweep-id>/` first.
+
+### Required sections
+
+The TRIAGE.md MUST contain, in this order:
+
+1. **Header.** Date, sweep name, target branch/HEAD, wave structure (if multi-wave dispatch), and a one-line per-agent or per-source verdict summary.
+2. **Per-agent verdicts table** (or per-source equivalent). One row per agent / per audit source. Columns: identifier, scope, headline verdict (e.g., `ship | fix-then-ship | block-merge`), headline finding.
+3. **Issues, ranked by severity.** Use severity tiers `S1` (critical / merge-blocker) through `S5` (low / nice-to-have). Each issue gets:
+   - One-line headline
+   - Source(s) — which agent(s) / audit step surfaced it
+   - Description (what's broken, what's the scope, what's at stake)
+   - Recommended action: `fix-in-branch | defer-to-followup | accept-as-is | block-merge`
+   - Fix complexity estimate (small / medium / large)
+4. **"What demonstrably works"** section. Non-findings — list properties of the work that the sweep CONFIRMED rather than just failed to disprove. This is the section that prevents people from reading a TRIAGE as "everything is broken" when actually most things work and N specific things don't.
+5. **Ship decision.** One paragraph: ship | fix-then-ship | block-merge, with reasoning. If fix-then-ship, list the specific subset to fix in this branch and what defers. If block-merge, list the specific blockers and what closes them.
+
+### Optional but recommended
+
+6. **Resolution section** (appended AFTER the recommended fixes ship). Records what was actually done vs. deferred, with commit references. Lets a future reader trace from the original finding to the fix commit without git archaeology.
+
+## Workflow
+
+1. **Locate or create the sweep directory.** If the user passed `Reports/<sweep-id>/`, use it. Otherwise infer from context (current sweep in flight) or ask.
+
+2. **Gather findings.** Inspect everything in the sweep directory that produces signal:
+   - Agent JSON reports (`results/agent-*.json`) — each typically has a `ship_recommendation` field and a list of findings.
+   - Manual notes from the user.
+   - Test output, GitHub issues, ADRs touched during the sweep.
+
+3. **Cluster duplicate findings.** When multiple agents report the same underlying issue with different framings, merge them into one issue with all sources cited. Don't list the same problem 3 times.
+
+4. **Assign severity.** Use the ladder:
+   - **S1 (critical):** merge-blocker; the framework's stated invariant is violated. Examples: silent dropping of `refuse_to_recommend` audit rows (BL-029 calibration S1); secret leakage; data loss path.
+   - **S2 (high):** ship-blocker under strict reading; the calibration scenarios surfaced exactly this phrasing and it's the reason the sweep was run. Examples: regex narrowness on canonical bypass language (BL-029 calibration S2).
+   - **S3 (medium):** real but post-merge OK; bounded blast radius. Examples: documentation false positives (BL-029 calibration S3).
+   - **S4 (medium):** feature gap that prevents a use case from completing, but the use case isn't critical-path for this ship. Examples: missing audit-row closer for W7 utility (BL-029 calibration S4).
+   - **S5 (low):** UX edge or polish. Examples: sentinel priming risk (BL-029 calibration S5).
+
+5. **Recommend per-issue action.** For each issue, pick: `fix-in-branch` (do it now), `defer-to-followup` (file a BL item), `accept-as-is` (document why and move on), `block-merge` (don't ship until this is fixed).
+
+6. **Recommend overall ship decision.** Bias toward shipping with a clear deferred list over blocking everything. Block-merge should be rare — only when an S1 is unresolved or a cluster of S2s collectively crosses the credibility threshold.
+
+7. **Write "What demonstrably works."** This is the section that prevents misreading. Examples: "Confirmation phrase defeats novice acceptance (agent 4 confirmed in-character)" or "Severity elevation routes through correctly when patterns DO match."
+
+8. **Save the TRIAGE.md.** Commit it as part of the sweep evidence, not as a transient artifact.
+
+9. **After fixes ship — append Resolution.** Once the recommended fixes are in, return to the TRIAGE and append a Resolution section recording exactly what was done (commit refs) and what was deferred (BL items). This converts the TRIAGE from a snapshot into a permanent record.
+
+## Self-check before saving
+
+Read the document with fresh eyes. Ask:
+
+1. If someone read only this TRIAGE (not the agent reports), could they decide ship / fix / block?
+2. Did I cluster duplicate findings, or is the issue list inflated with restatements?
+3. Did I include "What demonstrably works"? If not, add it — readers will infer "everything is broken" otherwise.
+4. Is every recommended action concrete (`fix-in-branch this subset`, `defer-to-followup as BL-029.1`) or vague (`investigate`)?
+5. Is the ship decision a clear one-line verdict, or a hedge?
+
+If any answer is no, fix it before saving.
+
+## Composition with Solo's existing artifacts
+
+- **Backlog (`solo-orchestrator-backlog.md`):** `defer-to-followup` items should be filed as BL items. Cite the BL number in the TRIAGE so the reader can trace.
+- **Implementation plans (`docs/superpowers/plans/`):** if a `fix-in-branch` cluster is large enough to warrant a plan, write one. The TRIAGE points to the plan; the plan points back to the TRIAGE.
+- **Calibration / UAT reports (`Reports/<sweep-id>/`):** the TRIAGE lives in the same directory as the agent reports it triages.
+- **Pending-approval sentinel:** if the sweep surfaced an open question for the user, use `scripts/escalate-to-user.sh` (BL-029) to write a structured pending-approval rather than burying the question in the TRIAGE.
+
+## Related work
+
+- **`mattpocock/skills` `triage`** ([upstream](https://github.com/mattpocock/skills/tree/main/skills/engineering/triage), MIT, © Matt Pocock) — a spiritually-related but differently-scoped skill for per-issue triage in an issue tracker (GitHub Issues, Linear). State machine model with `needs-triage` / `needs-info` / `ready-for-agent` labels. Use that if you're working through a backlog of incoming issues one at a time; use this skill if you're consolidating a sweep into a single ship decision.
+- **`session-handoff`** (Solo, adapted from mattpocock) — what to do when the work is mid-flight and the session is ending. Different artifact; different purpose.

--- a/.claude/skills/zoom-out/NOTICE
+++ b/.claude/skills/zoom-out/NOTICE
@@ -1,0 +1,46 @@
+This skill is adapted from the `zoom-out` skill in the mattpocock/skills
+repository (https://github.com/mattpocock/skills), licensed under the
+MIT License.
+
+Original copyright:
+
+  MIT License
+
+  Copyright (c) Matt Pocock
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+
+Adaptations made for Solo Orchestrator:
+
+- The upstream SKILL.md is a one-paragraph prompt ("Go up a layer of abstraction.
+  Give me a map of all the relevant modules and callers, using the project's
+  domain glossary vocabulary.") The Solo adaptation expands it to point at
+  the framework's canonical artifacts as grounding sources, so the map
+  produced is structural rather than improvised.
+- "What to include" section enumerates: phase-state.json, process-state.json,
+  ADR documentation, PROJECT_BIBLE.md, backlog, pending-approval sentinels.
+- "When this is most valuable" section ties zoom-out to specific Solo
+  decision points: between features (Context Health Check), at phase
+  transitions, before hard debugging, on operator handoff, on design forks.
+- Preserves the upstream's `disable-model-invocation: true` frontmatter
+  flag so this only fires when the user explicitly invokes it.
+
+Original content was a 4-line body; the adapted version preserves the
+intent (zoom up, use real vocabulary) while making the map's substrate
+explicit so it produces a Solo-shaped output rather than a generic one.

--- a/.claude/skills/zoom-out/SKILL.md
+++ b/.claude/skills/zoom-out/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: zoom-out
+description: Step back from the current task and produce a higher-level map of where the work fits — modules, callers, decisions, and where this sits in the project's phase. Use when unfamiliar with an area of code, between features, at a phase transition, or whenever the next decision needs context the immediate work doesn't supply.
+disable-model-invocation: true
+---
+
+# Zoom Out
+
+> **Attribution.** Adapted from [mattpocock/skills](https://github.com/mattpocock/skills) (MIT, © Matt Pocock). The upstream is a one-paragraph prompt to "go up a layer of abstraction." Solo's adaptation points the zoom-out at the project's actual artifacts (PROJECT_BIBLE, phase-state, ADRs, backlog) so the map produced is grounded in canonical sources, not improvised. See `NOTICE` for full attribution.
+
+I don't know this area of code (or this decision point) well enough. Go up a layer of abstraction. Produce a map that uses the project's actual vocabulary.
+
+## What to include
+
+1. **Where we are.** Current phase (read `.claude/phase-state.json`), current Build Loop state (read `.claude/process-state.json`), current branch, current PR (if any).
+2. **The relevant code surface.** Modules, files, and callers touching the area in question. Use the names that already exist in the codebase — not invented categories.
+3. **The relevant decisions.** Read `docs/ADR documentation/` for any ADRs in this area. Cite them by number. If a decision is about to be made, ask whether an ADR should be opened.
+4. **The relevant architectural truth.** Cross-reference `PROJECT_BIBLE.md` (architecture, data model, threat model). If `PROJECT_BIBLE.md` and the code disagree on something material, surface the contradiction.
+5. **What's in flight.** Read `solo-orchestrator-backlog.md` (or the project's backlog) for any related open BL items. Note open `pending-approval.json` sentinels.
+6. **What the next decision actually depends on.** Not "what could come next" — what is BLOCKED on what.
+
+## What to skip
+
+- Long prose summaries of the codebase. The map is structural, not literary.
+- Speculation about future features not on the backlog.
+- Repeating content from `PROJECT_BIBLE.md` verbatim — link to it instead.
+
+## When this is most valuable
+
+- **Between features.** After `process-checklist.sh --complete-step build_loop:feature_recorded`, before the next `--start-feature`. The zoom-out is the natural Context Health Check moment (Builder's Guide § "Context Health Checks every 3-4 features").
+- **At a phase transition.** Phase 2→3, Phase 3→4. Step back before crossing the gate.
+- **When debugging.** Before diving into a hard bug, zoom-out tells you which other systems share the failure surface.
+- **When onboarding a successor or returning after a break.** The map is the resumption substrate (pairs with `session-handoff` for that case).
+- **When stuck on a design decision.** If the next step has two defensible paths, zoom-out surfaces the decisions and artifacts that should weigh on the choice.
+
+## Output
+
+A short map. Headings, file paths with line refs, ADR numbers, BL numbers. Not paragraphs.
+
+If `PROJECT_BIBLE.md` does not exist (e.g., very early in Phase 1), say so and produce the map from the code and ADRs alone.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,17 @@
 #   * unit (fast lane)  — push + pull_request. Runs only the quick unit
 #                         tests: the individual tests/test-*.sh files that
 #                         do NOT invoke init.sh and are NOT aggregators.
-#                         Derived from `grep -L 'init\.sh' tests/test-*.sh`
-#                         (66 files; ~5 min on macOS, expected faster on
-#                         Linux). The list is explicit and reviewable below
-#                         so a new orphan test cannot silently join CI —
-#                         add new entries deliberately.
+#                         The list is explicit and reviewable below so a new
+#                         orphan test cannot silently join CI — add new
+#                         entries deliberately.
+#                         BL-181: membership is enforced by
+#                         scripts/lint-tests-registered.sh, whose exemption
+#                         predicate looks at EXECUTED lines only. The older
+#                         `grep -L 'init\.sh' tests/test-*.sh` recipe is
+#                         WRONG as a membership rule — it exempts any file
+#                         that merely MENTIONS init.sh, including a comment
+#                         saying it does not invoke it. Seven such files
+#                         were exempted by a comment until BL-181 landed.
 #
 #   * full (slow lane)  — MANUAL dispatch only (workflow_dispatch); no nightly. Runs the
 #                         complete tests/full-project-test-suite.sh, which
@@ -78,11 +84,18 @@ jobs:
           set -uo pipefail
           # Explicit, reviewable list. A test belongs here iff it does not
           # invoke init.sh (no project scaffolding) and is not an aggregator
-          # or helper. Regenerate with:
-          #   grep -L 'init\.sh' tests/test-*.sh | sort
+          # or helper. Membership is machine-enforced — check it with:
+          #   bash scripts/lint-tests-registered.sh
+          # and see which files the exemption actually fired on with:
+          #   bash scripts/lint-tests-registered.sh --list \
+          #     | grep unit-lane-exempt
+          # Do NOT regenerate from `grep -L 'init\.sh' tests/test-*.sh`: that
+          # matches comments too, so it silently drops any file that merely
+          # mentions init.sh (BL-181).
           tests=(
             tests/test-bl010-commitmsg-bl006.sh
             tests/test-bl032-gitlab-free-approvals-attestation.sh
+            tests/test-bl033-install-cmds-shape.sh
             tests/test-bl046-helpers-split.sh
             tests/test-bl069-install-cmds-consumers.sh
             tests/test-bl070-license-scanner.sh
@@ -162,6 +175,7 @@ jobs:
             tests/test-gate-principles.sh
             tests/test-gitlab-ci-status-stderr-approvals.sh
             tests/test-host-verify-protection-date-parse.sh
+            tests/test-intake-wizard-fixes.sh
             tests/test-lint-backlog-references.sh
             tests/test-lint-counter-antipattern.sh
             tests/test-lint-doc-anchors.sh
@@ -182,6 +196,8 @@ jobs:
             tests/test-process-checklist-check-commit-ready-subject.sh
             tests/test-process-checklist-classifier.sh
             tests/test-process-checklist-reset-phase1.sh
+            tests/test-prompt-install-noninteractive.sh
+            tests/test-reconfigure-field-handlers.sh
             tests/test-record-claude-commit.sh
             tests/test-run-lints.sh
             tests/test-scaffold-source-closure.sh
@@ -190,12 +206,15 @@ jobs:
             tests/test-test-gate-counter-sanitizer.sh
             tests/test-test-gate-null-handling.sh
             tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh
+            tests/test-tier-crosscheck-6-zdr-gate.sh
             tests/test-unrecord-feature.sh
             tests/test-upgrade-cdf-refresh.sh
             tests/test-upgrade-interruption.sh
             tests/test-upgrade-manifest-refresh.sh
             tests/test-upgrade-non-interactive.sh
+            tests/test-upgrade-paths.sh
             tests/test-upgrade-project-atomic.sh
+            tests/test-upgrade-project-retroactive-section.sh
             tests/test-upgrade-sentinel-block.sh
             tests/test-upgrade-sync-framework.sh
             tests/test-upgrade-to-production-preconditions.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -93,8 +93,15 @@ jobs:
           # verdict — the predicate reads executed lines, so a file that only
           # names init.sh inside a string/heredoc (grep/awk target, or a stub
           # it writes) is exempted too. Read the rows, do not just count them:
-          # a 2026-07-26 audit of 33 rows found 5 such files and moved them
-          # here (BL-181 R-B-5).
+          # a 2026-07-26 grep-based audit of 33 rows moved 5 such files here
+          # (BL-181 R-B-5), and a second pass over the remaining 28 — this
+          # time an EXECUTION trace, not a grep — found one MORE
+          # (tests/test-lint-no-live-remote.sh, R-B-11). Audit by execution:
+          # instrument init.sh with an env-gated marker append and run each
+          # exempt row; a marker line is proof of invocation, a grep is not.
+          # As of that 2026-07-26 execution-trace pass, all 27 remaining rows
+          # invoked init.sh; that is a measurement of one tree at one commit,
+          # not a standing guarantee — re-run it, do not cite it.
           # Do NOT regenerate from `grep -L 'init\.sh' tests/test-*.sh`: that
           # matches comments too, so it silently drops any file that merely
           # mentions init.sh (BL-181).
@@ -187,6 +194,7 @@ jobs:
             tests/test-lint-counter-antipattern.sh
             tests/test-lint-doc-anchors.sh
             tests/test-lint-fix-functions-stderr.sh
+            tests/test-lint-no-live-remote.sh
             tests/test-lint-raw-read-prompt.sh
             tests/test-lint-tests-registered.sh
             tests/test-lint-uat-scenarios.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,6 +89,12 @@ jobs:
           # and see which files the exemption actually fired on with:
           #   bash scripts/lint-tests-registered.sh --list \
           #     | grep unit-lane-exempt
+          # Each such row is a CLAIM ("this file invokes init.sh"), not a
+          # verdict — the predicate reads executed lines, so a file that only
+          # names init.sh inside a string/heredoc (grep/awk target, or a stub
+          # it writes) is exempted too. Read the rows, do not just count them:
+          # a 2026-07-26 audit of 33 rows found 5 such files and moved them
+          # here (BL-181 R-B-5).
           # Do NOT regenerate from `grep -L 'init\.sh' tests/test-*.sh`: that
           # matches comments too, so it silently drops any file that merely
           # mentions init.sh (BL-181).
@@ -168,6 +174,7 @@ jobs:
             tests/test-check-phase-gate-self-approval.sh
             tests/test-check-phase-gate.sh
             tests/test-currency-manifest.sh
+            tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh
             tests/test-filesystem-gate-install.sh
@@ -189,6 +196,8 @@ jobs:
             tests/test-phase-finalize.sh
             tests/test-phase3-validation-gate.sh
             tests/test-plan-staging.sh
+            tests/test-platform-mobile-mcp-docs.sh
+            tests/test-platform-security-bugs-closer.sh
             tests/test-pre-commit-gate-classifier.sh
             tests/test-pre-commit-gate-lints.sh
             tests/test-pre-commit-gate-terminal-mode.sh
@@ -199,9 +208,11 @@ jobs:
             tests/test-prompt-install-noninteractive.sh
             tests/test-reconfigure-field-handlers.sh
             tests/test-record-claude-commit.sh
+            tests/test-resolve-tools-memoization.sh
             tests/test-run-lints.sh
             tests/test-scaffold-source-closure.sh
             tests/test-session-test-gate-check-merge.sh
+            tests/test-specs-plans-host-aware-quartet.sh
             tests/test-specs-plans-remaining-quartet.sh
             tests/test-test-gate-counter-sanitizer.sh
             tests/test-test-gate-null-handling.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,8 +84,15 @@ jobs:
           set -uo pipefail
           # Explicit, reviewable list. A test belongs here iff it does not
           # invoke init.sh (no project scaffolding) and is not an aggregator
-          # or helper. Membership is machine-enforced — check it with:
+          # or helper. Membership is machine-checked in the OMISSION direction
+          # — a fast test missing from this array fails the lint — with:
           #   bash scripts/lint-tests-registered.sh
+          # It is NOT tamper-proof in the other direction: `_build_unit_list_set`
+          # scopes with awk between `tests=(` and `)` and does not strip
+          # comments, so an entry COMMENTED OUT inside this array still counts
+          # as membership while bash drops it from the array. A green lint is
+          # therefore not proof that a listed test actually runs here. See the
+          # residual recorded on `## BL-181:`.
           # and see which files the exemption actually fired on with:
           #   bash scripts/lint-tests-registered.sh --list \
           #     | grep unit-lane-exempt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -177,17 +177,23 @@ than no manifest).
   pinned by U6, and the fixture header names both rather than papering over
   them: the sed's `\([^[:space:]]\)` guard (behaviour-neutral once whole-line
   comments are stripped — deleting it leaves the suite at 24/0) and the
-  grep's `^` anchor (not neutral, but it is **U7** that kills it, at 22/2).
+  grep's `^` anchor (not neutral — deleting it fails **U7 and U10**, at 22/2).
   Pin each atom's WIDTH and its SPELLING, not just its presence: a
   one-character narrowing — a quantifier, a character class, or `#` →
   `#[[:space:]]` — re-opened BL-181 three times and passed both PR-blocking
   checks every time. Before BL-181 a comment exempted a test outright and
   seven real files were silently exempt that way.
   **Never derive the unit list from `grep -L 'init\.sh' tests/test-*.sh`**
-  — that recipe matches comments and is what produced the hole. Residual: a
-  mention inside a heredoc/string still exempts (a `grep`/`awk` target, or a
-  stub the test writes), so every *decisive* exemption is rendered for
-  review — audit it with
+  — that recipe matches comments and is what produced the hole. **Two
+  residuals survive, so a green lint is still not proof a fast test runs in
+  the unit lane — check the list by hand.** (1) A mention inside a
+  heredoc/string still exempts (a `grep`/`awk` target, or a stub the test
+  writes). (2) In the OTHER half of the same feature, `_build_unit_list_set`
+  scopes the `tests.yml` array with awk and never strips comments, so an entry
+  **commented out** inside `tests=(` still counts as membership while bash
+  drops it — the lint stays green and the test does not run. Both are recorded
+  on `## BL-181:`, which stays Open for them. Every *decisive* exemption is
+  rendered for review — audit it with
   `bash scripts/lint-tests-registered.sh --list | grep unit-lane-exempt`.
   **An exempt row is a claim, not a verdict: read the rows, do not count
   them — and audit them by EXECUTION, not by grep.** A 2026-07-26 grep-based
@@ -197,8 +203,9 @@ than no manifest).
   this surface twice. The execution recipe: append an env-gated marker line
   to `init.sh`, run each exempt row with that env var set, and treat a marker
   as the only proof of invocation. On the tree of 2026-07-26 that pass
-  classified all 27 remaining rows as real invokers — a measurement at one
-  commit, not a standing property. Re-run it; do not cite it.
+  classified all 27 rows *then present* as real invokers — a measurement at
+  one commit, not a standing property. The tree has since grown (the BL-180
+  suites pushed it to 29). Re-run it; do not cite the number.
 - **Portability:** GNU-first `stat -c … || stat -f …`; never `((x++))` under
   `set -e`; configure a git identity in fixtures; unset `GITHUB_BASE_REF` in
   fixture git ops; no multibyte chars adjacent to variable expansions under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,11 +163,16 @@ than no manifest).
   the `tests.yml` unit list too (per the CANONICAL COMMANDS membership rule).
   `lint-tests-registered.sh` enforces BOTH: the aggregator-registration
   backstop (BL-038) and, via its BL-154 unit-lane arm, the tests.yml
-  `tests=(` membership of tests that do not invoke `init.sh`. **Do not read a
-  green lint as proof of unit-lane registration:** `_check_unit_lane`'s
-  exemption test is a whole-file `grep -q 'init\.sh'`, so any test whose TEXT
-  mentions `init.sh` — *including a comment saying it does NOT invoke
-  init.sh* — is exempted (BL-181). Register by hand and check the list.
+  `tests=(` membership of every test that does not invoke `init.sh`.
+  Since BL-181 the exemption predicate reads **executed lines only**
+  (`# BL-181-UNIT-LANE-PREDICATE`), so a mere *mention* of `init.sh` in a
+  comment no longer exempts a test — before BL-181 it did, and seven real
+  files were silently exempt that way. **Never derive the unit list from
+  `grep -L 'init\.sh' tests/test-*.sh`** — that recipe matches comments and
+  is what produced the hole. Residual: a mention inside a heredoc/string
+  still exempts, so every *decisive* exemption is rendered for review —
+  audit it with
+  `bash scripts/lint-tests-registered.sh --list | grep unit-lane-exempt`.
 - **Portability:** GNU-first `stat -c … || stat -f …`; never `((x++))` under
   `set -e`; configure a git identity in fixtures; unset `GITHUB_BASE_REF` in
   fixture git ops; no multibyte chars adjacent to variable expansions under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,12 +166,15 @@ than no manifest).
   `tests=(` membership of every test that does not invoke `init.sh`.
   Since BL-181 the exemption predicate reads **executed lines only**
   (`# BL-181-UNIT-LANE-PREDICATE`), so a mere *mention* of `init.sh` in a
-  comment no longer exempts a test — before BL-181 it did, and seven real
-  files were silently exempt that way. **Never derive the unit list from
-  `grep -L 'init\.sh' tests/test-*.sh`** — that recipe matches comments and
-  is what produced the hole. Residual: a mention inside a heredoc/string
-  still exempts, so every *decisive* exemption is rendered for review —
-  audit it with
+  comment no longer exempts a test — in **either** spelling, whole-line at
+  any indent **and** trailing (`code   # …`). Both spellings need their own
+  stage in the predicate, and both are pinned by U6's fixture in
+  `tests/test-lint-tests-registered.sh`; before BL-181 a comment exempted a
+  test outright and seven real files were silently exempt that way.
+  **Never derive the unit list from `grep -L 'init\.sh' tests/test-*.sh`**
+  — that recipe matches comments and is what produced the hole. Residual: a
+  mention inside a heredoc/string still exempts, so every *decisive*
+  exemption is rendered for review — audit it with
   `bash scripts/lint-tests-registered.sh --list | grep unit-lane-exempt`.
 - **Portability:** GNU-first `stat -c … || stat -f …`; never `((x++))` under
   `set -e`; configure a git identity in fixtures; unset `GITHUB_BASE_REF` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,15 +170,19 @@ than no manifest).
   (`# BL-181-UNIT-LANE-PREDICATE`), so a mere *mention* of `init.sh` in a
   comment no longer exempts a test — in **either** spelling, whole-line at
   any indent **and** trailing (`code   # …`), and at any whitespace width
-  (tabs and single spaces included). Both spellings need their own stage in
-  the predicate, and U6's fixture in `tests/test-lint-tests-registered.sh`
-  pins every regex atom **except** the sed's `\([^[:space:]]\)` guard, which
-  is behaviour-neutral once whole-line comments are already stripped — that
-  exception is stated in the fixture header rather than papered over. Pin
-  each atom's WIDTH as well as its spelling: a one-character quantifier
-  narrowing re-opened BL-181 twice and passed both PR-blocking checks.
-  Before BL-181 a comment exempted a test outright and seven real files were
-  silently exempt that way.
+  (tabs and single spaces included), and whether or not a space follows the
+  `#`. Both spellings need their own stage in the predicate, and U6's fixture
+  in `tests/test-lint-tests-registered.sh` carries eight init.sh-bearing
+  comment lines to pin them. **Two** atoms of the anchored line are not
+  pinned by U6, and the fixture header names both rather than papering over
+  them: the sed's `\([^[:space:]]\)` guard (behaviour-neutral once whole-line
+  comments are stripped — deleting it leaves the suite at 24/0) and the
+  grep's `^` anchor (not neutral, but it is **U7** that kills it, at 22/2).
+  Pin each atom's WIDTH and its SPELLING, not just its presence: a
+  one-character narrowing — a quantifier, a character class, or `#` →
+  `#[[:space:]]` — re-opened BL-181 three times and passed both PR-blocking
+  checks every time. Before BL-181 a comment exempted a test outright and
+  seven real files were silently exempt that way.
   **Never derive the unit list from `grep -L 'init\.sh' tests/test-*.sh`**
   — that recipe matches comments and is what produced the hole. Residual: a
   mention inside a heredoc/string still exempts (a `grep`/`awk` target, or a
@@ -186,9 +190,15 @@ than no manifest).
   review — audit it with
   `bash scripts/lint-tests-registered.sh --list | grep unit-lane-exempt`.
   **An exempt row is a claim, not a verdict: read the rows, do not count
-  them.** A 2026-07-26 audit of 33 rows found 5 non-invokers hiding behind
-  that residual; they are now in the unit list and the surface is 28 rows,
-  all genuine invokers.
+  them — and audit them by EXECUTION, not by grep.** A 2026-07-26 grep-based
+  audit of 33 rows moved 5 non-invokers into the unit list; a second pass
+  over the remaining 28 — this time tracing execution — found one more
+  (`tests/test-lint-no-live-remote.sh`), so a grep audit has now under-read
+  this surface twice. The execution recipe: append an env-gated marker line
+  to `init.sh`, run each exempt row with that env var set, and treat a marker
+  as the only proof of invocation. On the tree of 2026-07-26 that pass
+  classified all 27 remaining rows as real invokers — a measurement at one
+  commit, not a standing property. Re-run it; do not cite it.
 - **Portability:** GNU-first `stat -c … || stat -f …`; never `((x++))` under
   `set -e`; configure a git identity in fixtures; unset `GITHUB_BASE_REF` in
   fixture git ops; no multibyte chars adjacent to variable expansions under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,19 +163,32 @@ than no manifest).
   the `tests.yml` unit list too (per the CANONICAL COMMANDS membership rule).
   `lint-tests-registered.sh` enforces BOTH: the aggregator-registration
   backstop (BL-038) and, via its BL-154 unit-lane arm, the tests.yml
-  `tests=(` membership of every test that does not invoke `init.sh`.
+  `tests=(` membership of every test whose **executed lines do not name**
+  `init.sh`. Read that predicate literally — it is *names on executed
+  lines*, not *invokes*, and the gap between the two is real (below).
   Since BL-181 the exemption predicate reads **executed lines only**
   (`# BL-181-UNIT-LANE-PREDICATE`), so a mere *mention* of `init.sh` in a
   comment no longer exempts a test — in **either** spelling, whole-line at
-  any indent **and** trailing (`code   # …`). Both spellings need their own
-  stage in the predicate, and both are pinned by U6's fixture in
-  `tests/test-lint-tests-registered.sh`; before BL-181 a comment exempted a
-  test outright and seven real files were silently exempt that way.
+  any indent **and** trailing (`code   # …`), and at any whitespace width
+  (tabs and single spaces included). Both spellings need their own stage in
+  the predicate, and U6's fixture in `tests/test-lint-tests-registered.sh`
+  pins every regex atom **except** the sed's `\([^[:space:]]\)` guard, which
+  is behaviour-neutral once whole-line comments are already stripped — that
+  exception is stated in the fixture header rather than papered over. Pin
+  each atom's WIDTH as well as its spelling: a one-character quantifier
+  narrowing re-opened BL-181 twice and passed both PR-blocking checks.
+  Before BL-181 a comment exempted a test outright and seven real files were
+  silently exempt that way.
   **Never derive the unit list from `grep -L 'init\.sh' tests/test-*.sh`**
   — that recipe matches comments and is what produced the hole. Residual: a
-  mention inside a heredoc/string still exempts, so every *decisive*
-  exemption is rendered for review — audit it with
+  mention inside a heredoc/string still exempts (a `grep`/`awk` target, or a
+  stub the test writes), so every *decisive* exemption is rendered for
+  review — audit it with
   `bash scripts/lint-tests-registered.sh --list | grep unit-lane-exempt`.
+  **An exempt row is a claim, not a verdict: read the rows, do not count
+  them.** A 2026-07-26 audit of 33 rows found 5 non-invokers hiding behind
+  that residual; they are now in the unit list and the surface is 28 rows,
+  all genuine invokers.
 - **Portability:** GNU-first `stat -c … || stat -f …`; never `((x++))` under
   `set -e`; configure a git identity in fixtures; unset `GITHUB_BASE_REF` in
   fixture git ops; no multibyte chars adjacent to variable expansions under

--- a/scripts/lint-tests-registered.sh
+++ b/scripts/lint-tests-registered.sh
@@ -384,15 +384,35 @@ _build_unit_list_set() {
 #   a test exempted by the comment "We bypass init.sh (and its
 #   --non-interactive cost) by hand-rolling the …" — a comment stating the
 #   file does NOT invoke init.sh was what exempted it from the requirement.
-#   The predicate below therefore looks at EXECUTED lines only, reusing
-#   _build_registered_set's whole-line-comment-stripping idiom so both halves
-#   of this lint agree on what "a comment" means.
+#   The predicate below therefore looks at EXECUTED lines only. It needs BOTH
+#   stages, because a shell comment has two spellings and stripping only one
+#   leaves the defect alive in the other:
+#     • `grep -vE '^[[:space:]]*#'` drops WHOLE-LINE comments at any indent —
+#       the `[[:space:]]*` is load-bearing, since an indented comment is the
+#       dominant form inside a function or if-block body;
+#     • the `sed` then drops a TRAILING comment (`code   # note`) — without it
+#       the identical comment TEXT still exempted the file merely by moving to
+#       the end of an executable line, which is verbatim the BL-181 defect.
+#   The sed deliberately requires a NON-SPACE char before the whitespace run,
+#   so it fires only on a real trailing comment and never on a whole-line one
+#   (that stays the grep's job, and keeps the grep's `[[:space:]]*` testable).
+#   NOTE this half of the lint is deliberately STRICTER about what counts as a
+#   comment than _build_registered_set, whose documented contract counts an
+#   inline trailing comment as a real aggregator reference. The two halves
+#   answer different questions and their safe directions differ; do not
+#   "unify" them without re-deriving both contracts.
 #
 # RESIDUAL — KNOWN AND ACCEPTED, NOT A SILENT GAP.
-#   Stripping whole-line comments does NOT catch an `init.sh` mention that
-#   lives inside a quoted string or a heredoc body (e.g. a fixture that WRITES
-#   the token into a generated file). Such a file is still exempted even
-#   though it never executes init.sh. Two things bound that residual:
+#   Stripping comments does NOT catch an `init.sh` mention that lives inside a
+#   quoted string or a heredoc body (e.g. a fixture that WRITES the token into
+#   a generated file); nor a comment introduced with no preceding whitespace
+#   (`foo;#note`), which the sed's non-space-then-space guard skips. Such a
+#   file is still exempted even though it never executes init.sh. Note the
+#   sed's own error direction is the LOUD one: a `#` inside a quoted string can
+#   over-strip the rest of the line, which can only ever REMOVE hits and so
+#   DEMANDS the file into the unit lane — a red lint a human reads, never a
+#   silent exemption. (Measured at the time of the fix: over-stripping
+#   reclassified zero files in tests/.) Two things bound the residual:
 #     • it is conservative in the safe direction only for real invokers — a
 #       wrongly-exempted file is a test that quietly stays out of the fast
 #       lane, the exact BL-181 failure mode, just much rarer;
@@ -414,15 +434,16 @@ _build_unit_list_set() {
 #   size-dependent, so it looks fine on small fixtures and misfires on real
 #   test files: measured on this repo, tests/test-bl112-commit-enforcement.sh
 #   (a genuine init.sh scaffolder) gave rc=141 with `grep -q` and count=4 with
-#   `grep -c`. `grep -c` consumes all of its input, so the upstream grep never
-#   sees a closed pipe and the predicate is deterministic regardless of file
-#   size. Do NOT "simplify" this back to `grep -q`.
+#   `grep -c`. `grep -c` consumes all of its input (as does the `sed` stage
+#   between them), so nothing upstream ever sees a closed pipe and the
+#   predicate is deterministic regardless of file size. Do NOT "simplify" this
+#   back to `grep -q`, and keep every added stage a full-input consumer.
 _check_unit_lane() {
   local file="$1" base="$2" rel="$3"
   local exec_hits
   [ "$UNIT_LANE_ACTIVE" -eq 1 ] || return 0
   case "$base" in test-*.sh) ;; *) return 0 ;; esac
-  exec_hits=$(grep -vE '^[[:space:]]*#' "$file" 2>/dev/null | grep -c 'init\.sh') # BL-181-UNIT-LANE-PREDICATE
+  exec_hits=$(grep -vE '^[[:space:]]*#' "$file" 2>/dev/null | sed 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/' | grep -c 'init\.sh') # BL-181-UNIT-LANE-PREDICATE
   case "$exec_hits" in ''|*[!0-9]*) exec_hits=0 ;; esac
   if [ "$exec_hits" -gt 0 ]; then
     case "$UNIT_LIST_STR" in

--- a/scripts/lint-tests-registered.sh
+++ b/scripts/lint-tests-registered.sh
@@ -372,14 +372,63 @@ _build_unit_list_set() {
 
 # Enforce unit-lane membership for a single candidate file. Applies only to
 # top-level tests/test-*.sh that do NOT invoke init.sh; an init.sh-invoking
-# test is aggregator-only by design (slow lane) and EXEMPT here. The init.sh
-# predicate is the file's own text (grep -L 'init\.sh') — the exact
-# convention the tests.yml comment documents as the unit-list generator.
+# test is aggregator-only by design (slow lane) and EXEMPT here.
+#
+# BL-181 — THE EXEMPTION PREDICATE IS ABOUT INVOCATION, NOT MENTION.
+#   The original predicate was a whole-file `grep -q 'init\.sh' "$file"`, i.e.
+#   the `grep -L 'init\.sh'` generator convention the tests.yml comment
+#   documents. That convention is a human-eyeball heuristic; as an ENFORCEMENT
+#   predicate it is unsound, because it exempts a file that merely MENTIONS
+#   init.sh. A three-state probe (BL-181) showed one added comment line flips
+#   this lint FAIL -> PASS with zero executable change, and the real repo had
+#   a test exempted by the comment "We bypass init.sh (and its
+#   --non-interactive cost) by hand-rolling the …" — a comment stating the
+#   file does NOT invoke init.sh was what exempted it from the requirement.
+#   The predicate below therefore looks at EXECUTED lines only, reusing
+#   _build_registered_set's whole-line-comment-stripping idiom so both halves
+#   of this lint agree on what "a comment" means.
+#
+# RESIDUAL — KNOWN AND ACCEPTED, NOT A SILENT GAP.
+#   Stripping whole-line comments does NOT catch an `init.sh` mention that
+#   lives inside a quoted string or a heredoc body (e.g. a fixture that WRITES
+#   the token into a generated file). Such a file is still exempted even
+#   though it never executes init.sh. Two things bound that residual:
+#     • it is conservative in the safe direction only for real invokers — a
+#       wrongly-exempted file is a test that quietly stays out of the fast
+#       lane, the exact BL-181 failure mode, just much rarer;
+#     • so every DECISIVE exemption (the file is exempted AND is absent from
+#       the unit list, i.e. the exemption actually changed the outcome) is
+#       rendered in --list as `unit-lane-exempt:init-sh-invoker`. The
+#       decision is reviewable instead of silent. An exempted file that is in
+#       the unit list anyway decided nothing and is not rendered.
+#   Closing the residual properly needs a shell-aware parse, which is out of
+#   proportion to the risk; the --list surface is the compensating control.
+#
+# WHY `grep -c` AND NOT `… | grep -q` — SIGPIPE + pipefail, MEASURED HERE.
+#   This script runs under `set -uo pipefail` (top of file). The obvious form
+#       grep -vE '^[[:space:]]*#' "$file" | grep -q 'init\.sh'
+#   is BROKEN under pipefail: `grep -q` exits the instant it matches, the
+#   upstream `grep -vE` is still writing, it dies of SIGPIPE (rc 141), and
+#   pipefail promotes that to the pipeline's status — so a file that DOES
+#   invoke init.sh is reported as "no match" and wrongly DEMANDED. It is
+#   size-dependent, so it looks fine on small fixtures and misfires on real
+#   test files: measured on this repo, tests/test-bl112-commit-enforcement.sh
+#   (a genuine init.sh scaffolder) gave rc=141 with `grep -q` and count=4 with
+#   `grep -c`. `grep -c` consumes all of its input, so the upstream grep never
+#   sees a closed pipe and the predicate is deterministic regardless of file
+#   size. Do NOT "simplify" this back to `grep -q`.
 _check_unit_lane() {
   local file="$1" base="$2" rel="$3"
+  local exec_hits
   [ "$UNIT_LANE_ACTIVE" -eq 1 ] || return 0
   case "$base" in test-*.sh) ;; *) return 0 ;; esac
-  if grep -q 'init\.sh' "$file" 2>/dev/null; then
+  exec_hits=$(grep -vE '^[[:space:]]*#' "$file" 2>/dev/null | grep -c 'init\.sh') # BL-181-UNIT-LANE-PREDICATE
+  case "$exec_hits" in ''|*[!0-9]*) exec_hits=0 ;; esac
+  if [ "$exec_hits" -gt 0 ]; then
+    case "$UNIT_LIST_STR" in
+      *"|${base}|"*) ;;  # already in the unit list — the exemption decided nothing
+      *) LIST_ROWS="${LIST_ROWS}SKIP\t${rel}\tunit-lane-exempt:init-sh-invoker\n" ;;
+    esac
     return 0
   fi
   case "$UNIT_LIST_STR" in

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -3346,6 +3346,21 @@ brew AND npm hidden. Watched-RED before the fix: brew hidden → `Results: 2 pas
 Mutation: delete the `PATH="$_BL135_STUB_DIR:$PATH"` prefix → brew-hidden run returns to
 `2 passed, 6 failed` rc=1 → restore → `8 passed, 0 failed` rc=0.
 
+**Whole-lane sweep — is any OTHER unit-lane test brew-dependent?** Asked and answered by execution,
+not by inspection, because this test is not obviously special and a second instance would redden
+every PR just as effectively. The complete `tests.yml` unit `tests=(` array (135 files) was run
+twice: on the normal PATH → **ran 135; failed 0**; and with brew hidden → **ran 135; failed 0**.
+No other unit-lane test carries this dependency.
+
+**Trap for anyone re-running that sweep.** Hide brew SURGICALLY: farm only the PATH directories that
+actually contain a `brew` executable (symlink everything in them except `brew`) and leave every other
+PATH entry as the real directory. A whole-PATH symlink farm is NOT a valid instrument — it produced
+four spurious failures (test-bl132-sast-index-scan, test-bl125-commit-test-exec,
+test-bl163-blocked-ledger, test-bl161-ledger-real-events-only), all with `git: command not found`,
+because a farmed `git` loses its exec-path. The A/B that identified them as artefacts: the same farm
+WITH brew kept fails all four identically (`normalPATH=0  sandbox+brew=1  sandbox-brew=1`), so the
+failures had nothing to do with brew. Under the surgical sandbox all four pass.
+
 **Residual.** The per-sub-suite `tee` instrumentation this entry demanded is still NOT built, and
 that demand is unaffected by this closure — the aggregate core-shard runner still prints only
 `FAILED (run for details)`, so the NEXT unrelated core-shard failure will be just as opaque. That is

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4534,6 +4534,46 @@ Watched-RED: U6/U8/U9/U10 fail against pre-BL-181 HEAD; U12 fails against the SI
 explicitly documented as WRONG as a membership rule. CLAUDE.md HOUSE RULES restored to the stronger
 claim the fix now earns, with the heredoc residual and the `--list` audit command named.
 
+**REMEDIATION (2026-07-26, WP-B round 2 — adversarial verifier `major_concerns` on the build note
+above; still Open until merge).** Two findings, both reproduced before being fixed:
+
+* **R-B-1 — the defect class was only HALF closed while the note above declared it closed.** The
+  first fix stripped WHOLE-LINE comments only, so the identical comment TEXT still exempted a file
+  merely by moving to the end of an executable line: `echo "hello"   # we bypass init.sh` gave
+  `rc=0` (EXEMPT) where the same words on their own line gave `rc=1` (DEMANDED). One comment
+  repositioned, zero executable change, FAIL → PASS — verbatim this entry's own defect statement.
+  `# BL-181-UNIT-LANE-PREDICATE` now carries a second stage that strips TRAILING comments too. The
+  sed deliberately requires a non-space char before the whitespace run so it fires only on real
+  trailing comments, which keeps the whole-line stage's `[[:space:]]*` independently testable.
+  Measured before shipping: the stricter predicate reclassifies **zero** files in `tests/` (so no
+  new `tests=(` entries), and its own error direction is the loud one — over-stripping can only
+  REMOVE hits, i.e. demand a file into the unit lane where a human sees a red lint, never exempt
+  one silently.
+* **R-B-2 — the `[[:space:]]*` half of the anchored line was pinned by NO test.** Weakening it to
+  `^#` re-opened BL-181 for every INDENTED comment (the dominant form inside a function body) and
+  survived both PR-blocking checks: `lint-tests-registered.sh` rc=0 and the suite at 24 passed /
+  0 failed. Root cause: every BL-181 fixture placed its comments at column 0. `_bl181_fixture_comment_only`
+  now carries all three comment spellings — column-0, indented, and trailing — each alone on its
+  line, so any one surviving the stripper turns U6 red. No new test case was added; the enriched
+  shared fixture kills both mutants through the existing U6.
+
+Mutation proofs, both directions, restore from a byte-exact backup (NOT `git checkout` — the fix is
+uncommitted, so that would silently revert the fix and fake a red): **A** weaken `^[[:space:]]*#` →
+`^#` ⇒ 23 passed / 1 failed rc=1 (U6), restore ⇒ 24 / 0 rc=0. **B** delete the trailing-comment sed
+stage — which reproduces the round-1 predicate byte-for-byte — ⇒ 23 passed / 1 failed rc=1 (U6),
+restore ⇒ 24 / 0 rc=0. Round 1's shipped predicate is therefore now a killed mutant.
+
+**Residual after remediation (narrower, still stated in-script):** a mention inside a quoted string
+or a heredoc body still exempts, as does a comment introduced with no preceding whitespace
+(`foo;#note`). The one real instance on the tree is test-bl096-cold-start.sh's
+`printf '#!/usr/bin/env bash\n' > ".../scripts/init.sh"`, and it is already in the unit list, so
+that exemption is moot and correctly unrendered. `--list` remains the compensating control.
+
+**Non-blocking, recorded so the class is not lost (R-B-3):** the SIGPIPE-under-`pipefail` defect
+class found in round 2 above (`cmd | grep -q` promoting rc=141) is live elsewhere in at least one
+other PR-blocking enforcement script. Pre-existing, not introduced here, deliberately out of scope
+for this change — file it separately rather than widening this one.
+
 ---
 
 ## BL-182: A ~958+ character repo-relative path is UNREPRESENTABLE in the BL-132 index temp tree — PATH_MAX aborts materialization and the whole commit goes NOTRUN (third instance of the same class)

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4800,9 +4800,19 @@ since the fix is what makes the stronger claim true.
 **Fix shape:** restrict to executed lines, reusing `_build_registered_set`'s comment-stripping idiom,
 marked `# BL-181-UNIT-LANE-PREDICATE`:
 `if grep -vE '^[[:space:]]*#' "$file" 2>/dev/null | grep -q 'init\.sh'; then return 0; fi`
-Re-classifies exactly one current file (test-reconfigure-field-handlers.sh) — its tests.yml addition is
-part of the change. Does NOT catch a mention inside a quoted heredoc/string, so also render the
-exemption in `--list` output (`unit-lane-exempt:init-sh-invoker`) so it is visible in review.
+~~Re-classifies exactly one current file (test-reconfigure-field-handlers.sh)~~ — **CORRECTED
+2026-07-27 (retro audit of PR #272, which filed this entry): the "exactly one" prediction was wrong
+by 42x.** Measured with this entry's own prescribed predicate: **42** files re-classify, of which
+**35** were already in the `tests.yml` unit lane (the exemption decided nothing for them) and **7**
+were absent and newly FAIL the lint — `test-bl033-install-cmds-shape.sh`,
+`test-intake-wizard-fixes.sh`, `test-prompt-install-noninteractive.sh`,
+`test-reconfigure-field-handlers.sh`, `test-tier-crosscheck-6-zdr-gate.sh`, `test-upgrade-paths.sh`,
+`test-upgrade-project-retroactive-section.sh`. Their tests.yml additions are part of the change.
+**The undercount also concealed a hard cross-entry dependency:** `test-bl033-install-cmds-shape.sh`
+is BL-135's test and fails on Linux CI, so BL-181 could not land before BL-135 was fixed — the two
+had to ship together, which is why they do. Does NOT catch a mention inside a quoted heredoc/string,
+so also render the exemption in `--list` output (`unit-lane-exempt:init-sh-invoker`) so it is
+visible in review.
 
 **Mutation proof:** fixture pair in tests/test-lint-tests-registered.sh — comment-only mention must FAIL
 rc=1, real invocation must PASS rc=0. Revert the `grep -vE` prefix → comment-only fixture flips FAIL →
@@ -5045,6 +5055,32 @@ predicate is correct against every spelling below, verified before anything was 
 **Standing lesson for this entry (three recurrences of one class, two wrong survivor counts):** a
 regex atom that no fixture line exercises is an atom that can be reverted silently, and a survivor
 row that no execution proves is a claim, not a verdict. Enumerate and execute; do not assert.
+
+**Residual #2 — the SIBLING half of the same feature is still comment-defeatable (found 2026-07-27
+by the pre-merge adversarial review of PR #275; entry stays Open for it).** `_check_unit_lane` now
+reads executed lines, but `_build_unit_list_set` — which parses the `tests.yml` `tests=(` array to
+learn what IS registered — scopes with awk between `tests=(` and `)` and **never strips comments**.
+So an entry **commented out inside the array** is still collected as a member, while bash drops it
+from the array. Net: the test does not run in the fast lane and every PR-blocking check stays green.
+
+Reproduced on the merged tree: commenting out one entry left `lint-tests-registered` rc=0
+("OK: every test file is registered with an aggregator (or EXEMPT)"),
+`tests/test-lint-tests-registered.sh` at `Results: 24 passed, 0 failed`, and `run-lints`
+`11 lints — 11 passed, 0 failed` — while the array evaluated to 134 elements with zero references to
+the victim. Deleting the same line outright DOES go red, so the guard works for omission and not for
+commenting-out.
+
+**Scope note:** this is PRE-EXISTING, not introduced by the BL-181 fix — the awk in
+`_build_unit_list_set` is byte-identical before and after, verified on both revisions. An
+independent refuter confirmed that and downgraded it from the blocking grade it was first filed at.
+It is recorded here because it is the same "a comment defeats the guard" class this entry exists to
+retire, in the other half of the same feature.
+
+**Fix shape:** one awk predicate — `awk '/tests=\(/{f=1; next} f && /^[[:space:]]*\)/{f=0} f &&
+!/^[[:space:]]*#/{print}'` — plus a fixture pair in `tests/test-lint-tests-registered.sh`: a unit
+list carrying the victim COMMENTED OUT must exit 1 and name the file; the same list uncommented must
+exit 0. **Mutation proof:** revert the `!/^[[:space:]]*#/` predicate → the commented-out fixture
+flips from FAIL to PASS → RED → restore → GREEN.
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4688,10 +4688,12 @@ Open until merge).** Two findings, both reproduced before being fixed.
   docs-cluster-six-pack `Results: 28 passed, 0 failed` · `rc=0 0s` platform-mobile-mcp-docs
   `Results: 8 passed, 0 failed` · `rc=0 0s` platform-security-bugs-closer
   `== Total: 7 | Passed: 7 | Failed: 0 ==`); all five already run on Linux via the green full lane.
-  The audit surface drops **33 → 28 rows**, and all 28 survivors are genuine invokers (the two the
-  naive command-position grep misses are `test-poc-modes.sh`, `run_bounded 90 bash "$INIT" …`, and
-  `test-bl099-guard-coverage.sh`, which copies init.sh into a mutant tree and drives scaffolding
-  sub-suites through `BL099_REPO_OVERRIDE`).
+  The audit surface drops **33 → 28 rows**. ~~All 28 survivors are genuine invokers~~ — **that
+  absolute was WRONG, see R-B-11 below**: it was a grep classification, and re-running the same
+  question as an EXECUTION trace found a 29th row misfiled. The two rows the naive
+  command-position grep misses are `test-poc-modes.sh` (`run_bounded 90 bash "$INIT" …`) and
+  `test-bl099-guard-coverage.sh` (copies init.sh into a mutant tree and drives scaffolding
+  sub-suites through `BL099_REPO_OVERRIDE`); both are confirmed invokers by execution in R-B-11.
 
 Round-3 mutation proofs, all restored from a byte-exact backup (NOT `git checkout` — the fix is
 uncommitted, so that would silently revert it and fake a red). The round-3 fix is fixture-only, so
@@ -4712,6 +4714,84 @@ class (`cmd | grep -q` promoting rc=141 through `set -o pipefail`) is pre-existi
 here. Round 2 said it was live "in at least one other PR-blocking enforcement script" without
 naming one, which left the class unowned. Filed as **BL-183** with the measurement recipe; do not
 widen this entry to cover it.
+
+---
+
+**REMEDIATION ROUND 4 (2026-07-26, WP-B — adversarial verifier `major_concerns` on round 3; still
+Open until merge).** Two findings. Both are the SAME two failure modes this entry has now produced
+three and two times respectively: an unpinned atom in the predicate regex (R-B-2, R-B-4, R-B-10) and
+a wrong absolute about the survivor set (R-B-5, R-B-11). Neither is a product defect — the shipped
+predicate is correct against every spelling below, verified before anything was touched.
+
+* **R-B-10 — three more single-atom mutations SURVIVED both PR-blocking checks.** Round 3 pinned
+  each comment's WIDTH but not the `#` itself, and pinned the whole-line stage's whitespace as a
+  class while leaving the TRAILING stage's whitespace pinned only by spaces. So three
+  one-character narrowings each re-opened BL-181 for a spelling the fixture did not carry, while
+  `lint-tests-registered.sh` stayed rc=0 and the suite stayed 24 passed / 0 failed:
+  narrowing the trailing whitespace run to a literal space (re-exempts every TAB-separated trailing
+  comment), narrowing the whole-line `#` to `#[[:space:]]`, and narrowing the trailing `#` to
+  `#[[:space:]]` (both re-exempt every `#like this` comment — a very common shell spelling).
+  **Fix is fixture-only — no production change.** `_bl181_fixture_comment_only` grows from five
+  init.sh-bearing comment lines to **eight**: adds a column-0 whole-line comment with no space
+  after the hash, a trailing comment with no space after the hash, and a TAB-separated trailing
+  comment.
+  Mutation proofs (mutant applied to the PRODUCTION predicate, killed through the existing U6,
+  restored from a byte-exact backup — NOT `git checkout`, which would silently revert uncommitted
+  work and fake a red): **E** trailing `[[:space:]][[:space:]]*` → `  *` ⇒ 23 passed / 1 failed rc=1
+  (U6) → restore ⇒ 24 / 0 rc=0. **F** `^[[:space:]]*#` → `^[[:space:]]*#[[:space:]]` ⇒ 23 / 1 rc=1
+  → 24 / 0 rc=0. **G** trailing `#` → `#[[:space:]]` ⇒ 23 / 1 rc=1 → 24 / 0 rc=0. Rounds 2–3's
+  mutants were re-run rather than assumed still dead: **A** `^#`, **B** delete the sed stage,
+  **C** quantifier 1+ → 2+, **D** `^ *#` — all 23 / 1 rc=1 → 24 / 0 rc=0. `lint-tests-registered.sh`
+  restored byte-identical each time (md5 `1a1cd956faf17ff6d7dbb4a0f242b133`).
+  The fixture header's "pins every regex atom except the sed's guard" claim is replaced. It now
+  names **two** unpinned atoms and states each one's MEASURED behaviour instead of asserting it:
+  deleting the sed's `\([^[:space:]]\)` guard leaves the suite at 24 / 0 (mutant **H**) — genuinely
+  behaviour-neutral on this fixture, kept because it stops the sed masking the grep; dropping the
+  grep's `^` anchor is NOT neutral but is killed by **U7 and U10**, not U6 (mutant **I**, 22 passed
+  / 2 failed rc=1), because the real-invoker fixture's invocation carries a trailing comment an
+  unanchored pattern would delete wholesale.
+* **R-B-11 — round 3's "all 28 survivors are genuine invokers" was a GREP verdict, and it was
+  wrong.** `tests/test-lint-no-live-remote.sh` sits on the exempt surface and never executes
+  init.sh: every mention is argument text inside single-quoted `body` strings that `assert_lint`
+  writes to a temp fixture for the lint to SCAN. It ran in ~5-6s, so it was silently absent from
+  every PR fast-lane run — exactly the BL-181 harm. Added to the tests.yml `tests=(` array
+  (confirmed: aggregator-registered in full-project-test-suite.sh, no `git commit`, no
+  `git config user`, no `~/.claude-dev-framework` dependency, `== Total: 14 | Passed: 14 |
+  Failed: 0 ==` rc=0 in 6s). **Linux evidence, not an assumption:** it already runs green on
+  ubuntu through the aggregator — full-lane run 30204845017 (2026-07-26), core shard,
+  `[PASS] scripts/lint-no-live-remote-in-tests.sh behavior tests (14/14)`. Unit list
+  **134 → 135** entries, hand-verified: exactly one occurrence
+  of the new path inside the array, zero duplicates, all 135 paths exist, YAML still parses.
+  Exempt surface **28 → 27** rows (its exemption is now moot, so U11's contract stops rendering it).
+
+  **The whole surface was then RE-AUDITED BY EXECUTION, not by grep** — because a grep verdict has
+  now under-read this surface twice. Method: append an env-gated marker line
+  (`printf … >> "${SOLO_INITSH_TRACE:-/dev/null}"`) to `init.sh` as line 2, then run each of the 28
+  rows under `bash -x` with `SOLO_INITSH_TRACE` set and a watchdog that kills the run the moment the
+  marker appears. A marker line is proof the init.sh CODE executed — including through a copy the
+  test makes, which no command-position grep can see. `init.sh` was restored byte-exact afterwards
+  (md5 `0be49cdda069dc4680e0172bd7b30e16`). Result: **27 of 28 rows fired the marker** (26 within
+  1s); the 1 that did not is `test-lint-no-live-remote.sh`, which ran to completion at rc=0 in 6s
+  with an empty marker file. No further non-invokers exist on this surface, so nothing else was
+  registered.
+
+  The verifier's second flag is **REFUTED by that trace**: `tests/test-bl099-guard-coverage.sh` was
+  called a milder mislabel ("exempted by a `cp "$REPO_ROOT/init.sh" …` line, never executing it").
+  It DOES execute init.sh. The xtrace shows the `cp` into `$TMPDIR/framework/init.sh`, and 74s later
+  the marker fires — the last traced command being
+  `BL112_REPO_OVERRIDE=$TMPDIR/framework bash tests/test-bl112-commit-enforcement.sh`, i.e. it
+  drives a scaffolding sub-suite against the mutant framework tree whose init.sh is that copy. It is
+  also ≥74s to reach that point, so it is not fast-lane material on either ground. Row kept exempt.
+
+  **The absolute is not re-stated in a stronger form anywhere.** All three sites that carried it —
+  CLAUDE.md HOUSE RULES, this entry's round-3 note, and the tests.yml unit-lane comment — now say
+  the same measured, dated thing: on the 2026-07-26 tree an execution trace classified all 27
+  remaining rows as invokers; that is a measurement at one commit, not a standing property, and the
+  instruction is to re-run the trace rather than cite the number.
+
+**Standing lesson for this entry (three recurrences of one class, two wrong survivor counts):** a
+regex atom that no fixture line exercises is an atom that can be reverted silently, and a survivor
+row that no execution proves is a claim, not a verdict. Enumerate and execute; do not assert.
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4488,6 +4488,52 @@ PASS → RED → restore → GREEN.
 
 **Related:** BL-154, BL-038/034/035, BL-067, CLAUDE.md CANONICAL COMMANDS + HOUSE RULES DIGEST.
 
+**BUILD NOTE (2026-07-26, WP-B — implemented, Open until merge).** Fixed at
+`# BL-181-UNIT-LANE-PREDICATE` in `_check_unit_lane` (scripts/lint-tests-registered.sh). Two
+corrections to this entry's own analysis, both verified empirically rather than assumed:
+
+1. **Scope was 7 files, not 1.** The entry predicted "exactly one current file
+   (test-reconfigure-field-handlers.sh)". A full sweep of `tests/` found **42** files whose
+   classification flips comment-mention → executed-lines, of which **35 were already in the
+   tests.yml unit list** (present by human diligence, exactly as the entry's Evidence paragraph
+   said of test-currency-manifest.sh / test-plan-staging.sh) and **7 were newly DEMANDED**:
+   test-bl033-install-cmds-shape, test-intake-wizard-fixes, test-prompt-install-noninteractive,
+   test-reconfigure-field-handlers, test-tier-crosscheck-6-zdr-gate, test-upgrade-paths,
+   test-upgrade-project-retroactive-section. All 7 were confirmed to genuinely not invoke
+   init.sh, to already be aggregator-registered in full-project-test-suite.sh, to set their own
+   git identity where they commit, and to be fast (1s/1s/3s/1s/2s/10s/1s, all rc=0). All 7 added
+   to the `tests=(` unit list in the same change.
+
+2. **The prescribed one-liner is UNSOUND on this host — it was not adopted verbatim.** The entry's
+   `grep -vE '^[[:space:]]*#' "$file" | grep -q 'init\.sh'` breaks under this script's
+   `set -uo pipefail`: `grep -q` exits on first match, the upstream `grep -vE` dies of SIGPIPE,
+   and pipefail promotes rc=141 to the pipeline — so a file that DOES invoke init.sh reads as a
+   NON-invoker and is wrongly demanded. Measured: tests/test-bl112-commit-enforcement.sh gives
+   `rc=141` with `grep -q` vs `count=4` with `grep -c`. It is size-dependent, hence invisible on
+   small fixtures and **nondeterministic across runs on the real tree** (one run flagged
+   test-bl099-guard-coverage.sh, the next test-bl112-commit-enforcement.sh). Shipped predicate
+   keeps the entry's exact semantics but uses a downstream that consumes all input:
+   `exec_hits=$(grep -vE '^[[:space:]]*#' "$file" 2>/dev/null | grep -c 'init\.sh')`.
+   Guarded by a dedicated regression test (U12) with a multi-KB fixture; `grep -q` fails it.
+
+**Visibility (implemented).** `--list` now renders every *decisive* exemption (exempted AND absent
+from the unit list — i.e. the exemption actually changed the outcome) as
+`unit-lane-exempt:init-sh-invoker`; 33 rows on the current tree. A moot exemption (file exempt but
+in the unit list anyway) is deliberately NOT rendered — U11 pins that.
+Audit: `bash scripts/lint-tests-registered.sh --list | grep unit-lane-exempt`.
+
+**Residual, stated in-script and unchanged:** a mention inside a quoted string or heredoc body
+still exempts. Accepted; the `--list` surface is the compensating control.
+
+**Tests (tests/test-lint-tests-registered.sh, 24 passed / 0 failed):** U6 comment-only mention →
+DEMANDED · U7 real invocation → EXEMPT · U8 mutation restoring the whole-file predicate → U6 stops
+flagging · U9 mutation disabling the exemption → U7 starts flagging · U10 `--list` renders the
+decisive exemption · U11 moot exemption not rendered · U12 SIGPIPE/pipefail regression.
+Watched-RED: U6/U8/U9/U10 fail against pre-BL-181 HEAD; U12 fails against the SIGPIPE-broken form.
+`.github/workflows/tests.yml` generator comments amended — the `grep -L 'init\.sh'` recipe is now
+explicitly documented as WRONG as a membership rule. CLAUDE.md HOUSE RULES restored to the stronger
+claim the fix now earns, with the heredoc residual and the `--list` audit command named.
+
 ---
 
 ## BL-182: A ~958+ character repo-relative path is UNREPRESENTABLE in the BL-132 index temp tree — PATH_MAX aborts materialization and the whole commit goes NOTRUN (third instance of the same class)

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -4565,14 +4565,84 @@ restore ⇒ 24 / 0 rc=0. Round 1's shipped predicate is therefore now a killed m
 
 **Residual after remediation (narrower, still stated in-script):** a mention inside a quoted string
 or a heredoc body still exempts, as does a comment introduced with no preceding whitespace
-(`foo;#note`). The one real instance on the tree is test-bl096-cold-start.sh's
-`printf '#!/usr/bin/env bash\n' > ".../scripts/init.sh"`, and it is already in the unit list, so
-that exemption is moot and correctly unrendered. `--list` remains the compensating control.
+(`foo;#note`). `--list` remains the compensating control.
 
-**Non-blocking, recorded so the class is not lost (R-B-3):** the SIGPIPE-under-`pipefail` defect
-class found in round 2 above (`cmd | grep -q` promoting rc=141) is live elsewhere in at least one
-other PR-blocking enforcement script. Pre-existing, not introduced here, deliberately out of scope
-for this change — file it separately rather than widening this one.
+---
+
+**REMEDIATION ROUND 3 (2026-07-26, WP-B — adversarial verifier `major_concerns` on round 2; still
+Open until merge).** Two findings, both reproduced before being fixed.
+
+* **R-B-4 — the fixture pinned each comment SPELLING but not its WIDTH, so round 2's own root cause
+  recurred.** Round 2 enriched `_bl181_fixture_comment_only` to three spellings and claimed all
+  atoms were pinned. They were not: every trailing comment in the fixture used THREE spaces, so
+  narrowing the trailing stage's quantifier `[[:space:]][[:space:]]*` (1+) to
+  `[[:space:]][[:space:]][[:space:]]*` (2+) — one character — left the fixture's behaviour
+  unchanged and survived **both** PR-blocking checks (`lint-tests-registered.sh` rc=0, suite
+  24 passed / 0 failed). Under that mutant a **single-space** trailing comment, the commonest
+  spelling in shell, re-exempts a file: A/B probe (two files identical but for the space count,
+  both aggregator-registered, unit list naming neither) gave
+  `SKIP … test-probe-single-space.sh unit-lane-exempt:init-sh-invoker` + `FAIL …
+  test-probe-three-space.sh not-in-unit-lane`, rc=1 with 1 violation, against a pristine control of
+  `FAIL`/`FAIL`, rc=1 with 2 violations. The same class held for the whole-line stage: the fixture's
+  indented comment used spaces only, so narrowing `^[[:space:]]*#` to `^ *#` also survived both
+  checks (rc=0, 24/0) while re-exempting every TAB-indented file.
+  **Fix is fixture-only — no production change.** `_bl181_fixture_comment_only` now carries FIVE
+  init.sh-bearing comment lines, each shape alone on its line: column-0 whole-line, SPACE-indented
+  whole-line, TAB-indented whole-line, trailing at ONE space, trailing at THREE spaces. The one atom U6 cannot
+  pin — the sed's leading `\([^[:space:]]\)` guard — is now stated as unpinnable-and-why rather
+  than counted as covered.
+* **R-B-5 — the round-2 residual paragraph undercounted by 5, and CLAUDE.md's restored absolute was
+  false by those same 5.** Round 2 asserted "the one real instance on the tree is
+  test-bl096-cold-start.sh … already in the unit list, so that exemption is moot". Running the
+  audit the `--list` surface exists for (`bash scripts/lint-tests-registered.sh --list | grep -c
+  unit-lane-exempt` → **33**) and classifying every row shows **5 of the 33 decisive exemptions
+  belong to files that never execute init.sh** — they name it inside a string as a `grep`/`awk`
+  target, or write a stub they never run:
+  `test-resolve-tools-memoization.sh` (`INIT_SH="$REPO_ROOT/init.sh"`, then `awk … "$INIT_SH"`),
+  `test-specs-plans-host-aware-quartet.sh` (`grep -q … "$INIT_SH"`),
+  `test-docs-cluster-six-pack.sh` (`grep -qE 'cp …' "$INIT_SH"`),
+  `test-platform-mobile-mcp-docs.sh` (`awk … "$INIT_SH"`),
+  `test-platform-security-bugs-closer.sh` (`cat > "$fake_fw/init.sh" <<'STUB'`, never executed).
+  A further **9 mention-only exemptions** are moot because the file is already in the unit list —
+  test-bl096-cold-start, test-bl108-bl117-ship-closure, test-bl119-stale-editmsg,
+  test-bl123-bp-attestation-recovery, test-bl141-commitmsg-repair, test-bl147-ci-template-integrity,
+  test-currency-manifest, test-freshness-check, test-upgrade-sync-framework — so "one instance" was
+  wrong by an order of magnitude in both directions.
+  **Fixed three ways.** (1) This paragraph replaces the undercount with the measured audit.
+  (2) CLAUDE.md HOUSE RULES now says the arm enforces membership of every test whose **executed
+  lines do not name** `init.sh` — the predicate stated literally — and adds "an exempt row is a
+  claim, not a verdict: read the rows, do not count them". (3) The 5 non-invokers were added to the
+  `tests=(` unit list: each is aggregator-registered in full-project-test-suite.sh, uses no
+  `git commit`/`git config user` and needs no `~/.claude-dev-framework`, and runs in 0-2s
+  (`rc=0 0s` resolve-tools-memoization `Results: 2 passed, 0 failed` · `rc=0 2s`
+  specs-plans-host-aware-quartet `== Total: 8 | Passed: 8 | Failed: 0 ==` · `rc=0 0s`
+  docs-cluster-six-pack `Results: 28 passed, 0 failed` · `rc=0 0s` platform-mobile-mcp-docs
+  `Results: 8 passed, 0 failed` · `rc=0 0s` platform-security-bugs-closer
+  `== Total: 7 | Passed: 7 | Failed: 0 ==`); all five already run on Linux via the green full lane.
+  The audit surface drops **33 → 28 rows**, and all 28 survivors are genuine invokers (the two the
+  naive command-position grep misses are `test-poc-modes.sh`, `run_bounded 90 bash "$INIT" …`, and
+  `test-bl099-guard-coverage.sh`, which copies init.sh into a mutant tree and drives scaffolding
+  sub-suites through `BL099_REPO_OVERRIDE`).
+
+Round-3 mutation proofs, all restored from a byte-exact backup (NOT `git checkout` — the fix is
+uncommitted, so that would silently revert it and fake a red). The round-3 fix is fixture-only, so
+each mutant is applied to the PRODUCTION predicate and killed by the enriched fixture through the
+existing U6: **C** trailing quantifier 1+ → 2+ ⇒ 23 passed / 1 failed rc=1 (U6), restore ⇒ 24 / 0
+rc=0. **D** `^[[:space:]]*#` → `^ *#` ⇒ 23 / 1 rc=1 (U6), restore ⇒ 24 / 0 rc=0. Round 2's mutants
+stay killed under the enriched fixture: **A** `^[[:space:]]*#` → `^#` ⇒ 23 / 1 rc=1; **B** delete
+the trailing-comment sed stage ⇒ 23 / 1 rc=1.
+
+**Note on this entry's own "Fix shape" paragraph (R-B-6):** the one-liner quoted there
+(`grep -vE '^[[:space:]]*#' … | grep -q 'init\.sh'`) is the SUPERSEDED round-1 proposal, kept for
+history. It is unsound twice over — SIGPIPE under `pipefail` (see build note item 2) and no
+trailing-comment stage — and U6 now kills it as mutant B. The shipped predicate is the two-stage
+form at `# BL-181-UNIT-LANE-PREDICATE`; read the script, not this paragraph.
+
+**Non-blocking, now owned rather than gestured at (R-B-3 / R-B-7):** the SIGPIPE-under-`pipefail`
+class (`cmd | grep -q` promoting rc=141 through `set -o pipefail`) is pre-existing and out of scope
+here. Round 2 said it was live "in at least one other PR-blocking enforcement script" without
+naming one, which left the class unowned. Filed as **BL-183** with the measurement recipe; do not
+widen this entry to cover it.
 
 ---
 
@@ -4634,3 +4704,70 @@ transcript.
 still-open hole in the same arm — rename-and-edit commits skip SAST entirely and silently), BL-178
 (the per-index subdir that adds the `/<n>/` segment), BL-112 (the honest-NOTRUN contract that holds
 here).
+
+---
+
+## BL-183: `producer | grep -q` under `set -o pipefail` inverts a predicate via SIGPIPE — size-dependent, so it passes every small fixture
+
+**Logged:** 2026-07-26 (split out of BL-181 remediation round 3, finding R-B-7 — the class was
+described there but never given an owner)
+**Category:** Enforcement correctness / portability — silent predicate inversion in gate scripts
+**Severity:** Medium — a predicate that reads FALSE when it should read TRUE, in scripts that decide
+whether a commit is allowed; but each site needs its own reachability proof, so this is an audit,
+not a known live break.
+
+**The mechanism, measured during BL-181.** Under `set -o pipefail`, `grep -q` exits the instant it
+matches. The upstream producer is still writing, dies of `SIGPIPE` (rc 141), and `pipefail` promotes
+that to the pipeline's status — so a pipeline whose *content* matched reports **failure**. Whether it
+fires depends on how much the producer still had to write when the downstream exited, i.e. on FILE
+SIZE, so it is invisible on small fixtures and appears only on real inputs. Measured instance:
+`_check_unit_lane` in `scripts/lint-tests-registered.sh` gave `rc=141` on
+`tests/test-bl112-commit-enforcement.sh` with `grep -q` versus `count=4` with `grep -c`, and picked a
+*different* victim file on consecutive runs of the same tree. Fixed there by making every stage a
+full-input consumer (`# BL-181-UNIT-LANE-PREDICATE`, and the long "WHY `grep -c` AND NOT `… | grep -q`"
+comment above it).
+
+**Scope of the audit — candidate sites, not confirmed breaks.** Non-comment `… | grep -[a-z]*q`
+pipelines in files that set `pipefail`, measured 2026-07-26 on this tree — **80 sites across 13
+files**, three of them authoritative gate scripts:
+
+| sites | file |
+|---|---|
+| 34 | `scripts/pre-commit-gate.sh` |
+| 9 | `scripts/process-checklist.sh` |
+| 8 | `scripts/check-phase-gate.sh` |
+| 5 | `scripts/upgrade-project.sh` |
+| 5 | `scripts/lint-counter-antipattern.sh` |
+| 4 | `scripts/validate.sh` |
+| 4 | `scripts/lint-fail-emit-exit-status.sh` |
+| 3 | `scripts/lint-no-live-remote-in-tests.sh` |
+| 3 | `scripts/lib/hook-templates.sh` |
+| 2 | `scripts/detect-out-of-band-commits.sh` |
+| 1 each | `scripts/lint-raw-read-prompt.sh`, `scripts/lint-fix-functions-stderr.sh`, `scripts/check-changelog.sh` |
+
+Reproduce with:
+```
+for f in scripts/*.sh scripts/lib/*.sh; do
+  grep -qE 'set -[a-zA-Z]*o[[:space:]]+pipefail' "$f" || continue
+  n=$(grep -vE '^[[:space:]]*#' "$f" | grep -cE '\|[[:space:]]*grep[[:space:]]+-[a-zA-Z]*q')
+  [ "$n" -gt 0 ] && printf '%3s  %s\n' "$n" "$f"
+done | sort -rn
+```
+
+**A site is only a real defect if all three hold** — a mechanical count is an upper bound, not a
+finding: (a) the producer can outlive the `grep -q` (large or streaming input — a `printf` of one
+line cannot SIGPIPE); (b) the pipeline's status is actually *consumed* (an `if`, `&&`, or captured
+`$?`), not discarded; (c) `pipefail` is in effect at that point. Triage the 80 against those three
+before changing anything.
+
+**Fix shape (per confirmed site):** make the downstream consume all input — `grep -c` plus a numeric
+test, or `grep -q` behind a variable that already holds the full producer output. Do NOT drop
+`pipefail`; it is load-bearing elsewhere. Each fix needs the same evidence BL-181 produced: a
+multi-KB fixture that fails with `grep -q` and passes with the consuming form (see U12 in
+`tests/test-lint-tests-registered.sh` for the pattern).
+
+**Status:** Open
+
+**Related:** BL-181 (where the class was found, measured, and fixed at one site), BL-168
+(`test-bl168-tm-table-sigpipe.sh` — a prior SIGPIPE instance, evidence that this is a recurring class
+in this repo), CLAUDE.md ENFORCEMENT — SOURCE OF TRUTH.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -3266,12 +3266,12 @@ The full lane's aggregators shard failed on `tests/edge-case-test-suite.sh` T2.1
 
 ---
 
-## BL-135: test-bl033-install-cmds-shape failed in the full-lane CI run but is GREEN locally — unreproduced divergence, needs a second data point
+## BL-135: test-bl033-install-cmds-shape fails on ubuntu CI and is GREEN on macOS — the harness depends on the host having Homebrew
 
 **Logged:** 2026-07-18 (full-lane run 29649055577, core shard)
-**Category:** Bug / test flake (unreproduced)
+**Category:** Bug / host-dependent test (NOT a flake — deterministic on both hosts)
 **Severity:** Low
-**Status:** Open
+**Status:** Closed — root-caused, reproduced locally, and fixed 2026-07-26 (commit `c98775c`, branch `fix/bl181-bl135-unit-lane`). Test-side fix at `# BL-135-RESOLVER-PROBE-STUB`; `scripts/resolve-tools.sh` deliberately unchanged. See the closure block at the end of this entry.
 
 The core shard reported `[FAIL] tests/test-bl033-install-cmds-shape.sh` at 16:12Z; the aggregate runner suppresses sub-suite output (`run for details`), so NO case-level detail is recoverable from the log. The suite passes locally on the same content (post-#213 main). Candidates: ubuntu/GNU divergence, runner load (the same run surfaced BL-134's timing-margin class), or a real intermittent. Disposition: watch the next full-lane dispatch — a second failure warrants instrumenting the runner to tee sub-suite output; a second pass declassifies to noise.
 
@@ -3282,6 +3282,75 @@ The core shard reported `[FAIL] tests/test-bl033-install-cmds-shape.sh` at 16:12
 **Investigation 2026-07-24 (WP-F, branch `fix/bl135-bl136-fullsuite-debt`):** local-stability datum + full candidate scan; NOT reproduced. (1) LOCAL 10× — `bash tests/test-bl033-install-cmds-shape.sh` ran ten consecutive times, ALL GREEN (rc=0, `Results: 8 passed, 0 failed` each; sub-second per run). Deterministic locally on `6fc1c11`. (2) CI LOG STILL AVAILABLE — `gh run view 29649055577 --log` retrieves (ubuntu-24.04 runner); it confirms the aggregate core shard prints ONLY `[FAIL] tests/test-bl033-install-cmds-shape.sh FAILED (run for details)` — NO case-level detail is recoverable, so WHICH of the 8 cases failed is unknowable from the log (this BOUNDS the diagnosis and re-justifies the per-sub-suite `tee` demand). That shard reported 5 failures total: this test, `tier-crosscheck-6` zdr-gate, `test-init-schema-phase-gate`, plus the two BL-136 cases (TEST 5 + TEST 7). (3) CANDIDATE SCAN (anchors = case/function names in `test-bl033-install-cmds-shape.sh`): the suite is exceptionally portable — `set -uo pipefail` (NOT `-e`), byte-comparison `[ "$x" = … ]` tests, and NO `sed -i`/`stat`/`date -d`/`grep -P`/`sort`/locale use. Host-shaped constructs, exhaustively: (a) `mktemp -d` in `_mk_matrix` (GNU+BSD both support the no-template form — benign); (b) the ONLY timing/race-shaped surface — the `$$`-keyed shared `/tmp/bl033-fail-fast-stage{1,2}-$$` markers in `T-array-fail-fast`, guarded by `rm -f` before use (low collision risk even under parallel-shard load); (c) COMMIT-STATE (not host) sensitivity — `T-migrated-entries` + `T-migrated-semantics` read the SHIPPED `templates/tool-matrix/common.json` and assert docker/colima carry the array shape, so a 2026-07-18 main with that matrix mid-migration would fail LEGITIMATELY and is NOT reproducible at `6fc1c11`. No candidate reproduces the failure locally, so the runner-`tee` instrumentation was deliberately NOT built this WP (per plan — build only if a candidate makes it locally reproducible). (4) DISPOSITION unchanged (Status stays Open, awaiting a second full-lane data point): per this entry's own rule, a second full-lane FAIL → `tee` each sub-suite's output (inspect candidate (c) first); a second full-lane PASS → declassify to noise.
 
 **Merged 2026-07-25 (PR #267 `73c6083`) — Status stays OPEN.** The WP-F evidence pass above landed on `main` alongside the BL-136 fixture repairs. It changed no product code and no test code for this entry — it is an investigation record, not a fix — so the disposition is untouched: **still awaiting a second full-lane data point.** `tests/test-bl033-install-cmds-shape.sh` DOES run in the `core` shard (it is not `SUITE_SKIP_AGGREGATORS`-gated), so the next full-lane `workflow_dispatch` genuinely supplies that data point: a second FAIL → build the per-sub-suite `tee` instrumentation (inspect the commit-state candidate (c) first); a second PASS → declassify to noise and Close.
+
+**CLOSURE 2026-07-26 — ROOT-CAUSED AND FIXED (commit `c98775c`). It was never a flake.** The
+second full-lane data point arrived and it was a FAIL, but the `tee` instrumentation this entry
+demanded was not needed: the divergence is deterministic and reproduces on demand.
+
+**Second CI data point.** Full-lane `workflow_dispatch` run **30204845017**, 2026-07-26, ubuntu
+runner. `full (core)` shard: `[FAIL] tests/test-bl033-install-cmds-shape.sh FAILED (run for
+details)` — the shard's **SOLE** failure (`FAIL: 1`), the other three shards green. Two FAILs on
+ubuntu (29649055577 on 2026-07-18, 30204845017 on 2026-07-26) against a suite that is
+deterministically GREEN on macOS is a host split, not noise — and the 10× local stability run
+recorded in the WP-F investigation above is now explained rather than contradicted.
+
+**Root cause.** `scripts/resolve-tools.sh` builds its install-key priority list by probing the
+**REAL HOST**:
+
+```
+HAS_BREW=false
+command -v brew &>/dev/null && HAS_BREW=true
+...
+[ "$HAS_BREW" = true ] && _keys="${_keys}darwin_brew,"
+```
+
+`tests/test-bl033-install-cmds-shape.sh` drives the resolver through its `_run_resolver` helper
+with `--dev-os darwin` and every scenario asserts on a `darwin_brew` install key. The helper's own
+comment claimed it "pins linux_apt keys via env so the harness never depends on the host's package
+managers" — **that comment was false**: the test set no env at all (zero exports) and the resolver
+has no env override. On macOS brew is present, `darwin_brew` is in the key list, 8/8 pass. On
+ubuntu brew is absent, `darwin_brew` is dropped, the fixture tool falls through to
+`.manual` / `manual_install`, and every scenario that reads `auto_install[0]` or expects a
+malformed-shape refusal collapses. Candidate (c) of the WP-F scan (commit-state sensitivity of the
+two `T-migrated-*` cases) was the wrong suspect — those two are precisely the survivors.
+
+**Local reproduction (the method, so it is repeatable).** Build a temp dir of symlinks to every
+executable in `/bin`, `/usr/bin`, `/sbin`, `/usr/sbin` while deliberately EXCLUDING `brew` (and
+omitting `/opt/homebrew/bin` and `/usr/local/bin` entirely), then run the suite with `PATH` set to
+that dir. Measured on the macOS host, byte-identical test content:
+
+| host state | result | rc |
+|---|---|---|
+| brew present (normal macOS) | `Results: 8 passed, 0 failed` | 0 |
+| brew hidden (emulated ubuntu) | `Results: 2 passed, 6 failed` | 1 |
+
+The 2 survivors are `T-migrated-entries` and `T-migrated-semantics` — the only cases that read
+`templates/tool-matrix/*.json` directly with `jq` and never call the resolver.
+
+**Fix — TEST-SIDE; the product is correct and was not touched.** Making `--dev-os` authoritative in
+`resolve-tools.sh` was considered and **rejected**: the host probe is correct behaviour, since a Mac
+user without Homebrew must be handed `darwin_manual`, not brew commands they cannot run. Regressing
+real behaviour to satisfy a test would be the wrong trade. Instead `# BL-135-RESOLVER-PROBE-STUB`
+in the test creates empty executable `brew` and `npm` stubs in a temp dir and prepends it to `PATH`
+as a **command-scoped assignment on the resolver invocation inside `_run_resolver` only** — never
+exported, so it cannot leak into sibling scenarios or sibling test files — with an `EXIT` trap
+removing the dir. The resolver only ever runs `command -v` against those names, so an empty file
+suffices; nothing is executed. That pins the key list to exactly
+`darwin_brew,darwin_manual,npm,manual` on every host. `apt`/`dnf`/`pacman` need no stub because they
+gate `linux_*` keys the harness never reaches under `--dev-os darwin` — stated in the comment, with
+the standing requirement that any future `--dev-os linux` scenario MUST extend the stub set. The
+false "pins ... via env" comment is replaced with one describing what the test actually does.
+
+**Proof.** `Results: 8 passed, 0 failed` rc=0 in three environments — brew present, brew hidden, and
+brew AND npm hidden. Watched-RED before the fix: brew hidden → `Results: 2 passed, 6 failed` rc=1.
+Mutation: delete the `PATH="$_BL135_STUB_DIR:$PATH"` prefix → brew-hidden run returns to
+`2 passed, 6 failed` rc=1 → restore → `8 passed, 0 failed` rc=0.
+
+**Residual.** The per-sub-suite `tee` instrumentation this entry demanded is still NOT built, and
+that demand is unaffected by this closure — the aggregate core-shard runner still prints only
+`FAILED (run for details)`, so the NEXT unrelated core-shard failure will be just as opaque. That is
+a separate ask, not part of BL-135. The 2026-07-18 Dogfood-3 gitleaks observation (F-DF3-003)
+recorded above is an unrelated surface and is NOT closed by this.
 
 ---
 

--- a/tests/test-bl033-install-cmds-shape.sh
+++ b/tests/test-bl033-install-cmds-shape.sh
@@ -86,13 +86,44 @@ EOF
   echo "$tmp"
 }
 
-# Run the resolver against the fixture matrix. Uses --dev-os darwin
-# and pins linux_apt keys via env so the harness never depends on the
-# host's package managers. Returns resolver JSON on stdout, exit code
-# from the resolver.
+# BL-135-RESOLVER-PROBE-STUB — pin the resolver's package-manager probe
+# so this harness is host-independent.
+#
+# scripts/resolve-tools.sh builds its install-key priority list by
+# probing the REAL HOST (`command -v brew`, `command -v npm`, … — the
+# HAS_BREW/HAS_NPM block). That is CORRECT product behaviour: a Mac with
+# no Homebrew must be handed `darwin_manual`, not brew commands it cannot
+# run. So the product is left alone and the HARNESS is pinned instead.
+# Every `_run_resolver` scenario below asserts on a `darwin_brew` install
+# key; on a host without Homebrew (every ubuntu-latest CI runner) that
+# key is silently dropped from the priority list and 6 of the 8 scenarios
+# collapse — measured 8/8 with brew present, 2/8 with brew hidden. That
+# is the CI-vs-local divergence BL-135 tracked; it was never a flake.
+#
+# Only brew and npm are stubbed. apt/dnf/pacman gate the `linux_*` keys,
+# which this harness never reaches because `_run_resolver` always passes
+# `--dev-os darwin`; stubbing brew+npm makes the resolver's key list
+# exactly `darwin_brew,darwin_manual,npm,manual` on EVERY host. If a
+# scenario is ever added that passes `--dev-os linux`, it MUST extend
+# this stub set or the harness becomes host-dependent again.
+#
+# The resolver only ever runs `command -v` against these names — nothing
+# is executed — so an empty executable file is sufficient.
+_BL135_STUB_DIR=$(mktemp -d)
+for _bl135_stub in brew npm; do
+  : > "$_BL135_STUB_DIR/$_bl135_stub"
+  chmod +x "$_BL135_STUB_DIR/$_bl135_stub"
+done
+trap 'rm -rf "$_BL135_STUB_DIR"' EXIT
+
+# Run the resolver against the fixture matrix with --dev-os darwin. The
+# stub dir is prepended to PATH as a command-scoped assignment on the
+# resolver invocation ONLY — never exported, so it cannot leak into
+# sibling scenarios or sibling test files. Returns resolver JSON on
+# stdout, exit code from the resolver.
 _run_resolver() {
   local matrix_dir="$1"
-  bash "$RESOLVER" \
+  PATH="$_BL135_STUB_DIR:$PATH" bash "$RESOLVER" \
     --dev-os darwin \
     --platform web \
     --language typescript \

--- a/tests/test-lint-tests-registered.sh
+++ b/tests/test-lint-tests-registered.sh
@@ -537,33 +537,55 @@ rm -f "$MUTYML"
 # (that was R-B-4: `[[:space:]][[:space:]]*` → `[[:space:]][[:space:]][[:space:]]*`
 # survived `lint-tests-registered.sh` rc=0 AND this suite at 24/0, while
 # re-exempting every single-space trailing comment — the commonest spelling
-# there is). So the fixture carries FIVE init.sh-bearing comment lines, each
-# shape ALONE on its line, so any one of them surviving the stripper is enough
-# to turn U6 red:
-#   • column-0 whole-line     — the original BL-181 shape; pins the `#` anchor
-#   • SPACE-indented whole-line — the dominant form inside a function/if body;
-#     pins the `*` in the whole-line stripper's `^[[:space:]]*#`
-#   • TAB-indented whole-line — pins `[[:space:]]` as a CHARACTER CLASS rather
-#     than a literal space; narrowing it to `^ *#` re-exempts tab-indented files
-#   • TRAILING at ONE space   — pins the LOWER bound of the trailing stage's
-#     whitespace run (a 2+ quantifier must not compile)
+# there is). The `#` in each stage needs the same treatment: narrowing either
+# one to `#[[:space:]]` re-exempts every file that spells a comment `#like
+# this` — that was R-B-10, and both mutants survived both PR-blocking checks
+# until this fixture grew the lines that kill them.
+#
+# So the fixture carries EIGHT init.sh-bearing comment lines, each shape ALONE
+# on its line, so any one of them surviving the stripper is enough to turn U6
+# red. Whole-line stage (`grep -vE '^[[:space:]]*#'`):
+#   • column-0, SPACE after the hash — the original BL-181 shape
+#   • column-0, NO space after the hash — pins this stage's `#` as a bare
+#     literal (a `#[[:space:]]` narrowing must not compile)
+#   • SPACE-indented — the dominant form inside a function/if body; pins the
+#     `*` in `^[[:space:]]*#`
+#   • TAB-indented — pins `[[:space:]]` as a CHARACTER CLASS rather than a
+#     literal space; narrowing it to `^ *#` re-exempts tab-indented files
+# Trailing stage (`sed 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/'`):
+#   • TRAILING at ONE space   — pins the LOWER bound of the whitespace run
+#     (a 2+ quantifier must not compile)
 #   • TRAILING at THREE spaces — pins the UPPER side, i.e. the `*` itself (an
 #     exactly-one-space quantifier must not compile)
-# The one atom U6 canNOT pin is the sed's leading `\([^[:space:]]\)` guard:
-# every whole-line comment is already gone by the time the sed runs, so
-# deleting the guard is behaviour-neutral ON THIS FIXTURE. It is kept because
-# it stops the sed from masking the grep — with the guard removed, mutant A
-# (weakening `^[[:space:]]*#` to `^#`) would survive. Stated, not overclaimed.
+#   • TRAILING with NO space after the hash — pins THIS stage's `#` as a bare
+#     literal, independently of the whole-line stage's
+#   • TRAILING separated by a TAB — pins this stage's whitespace run as a
+#     CHARACTER CLASS; narrowing it to a literal space re-exempts every
+#     tab-separated trailing comment
+# Two atoms of the anchored line are NOT pinned by this fixture — stated, not
+# counted as covered:
+#   • the sed's leading `\([^[:space:]]\)` guard: every whole-line comment is
+#     already gone by the time the sed runs, so deleting the guard is
+#     behaviour-neutral ON THIS FIXTURE. It is kept because it stops the sed
+#     from masking the grep — with the guard removed, mutant A (weakening
+#     `^[[:space:]]*#` to `^#`) would survive.
+#   • the grep's `^` anchor: dropping it is NOT behaviour-neutral, but it is
+#     U7 — not U6 — that kills it. The real-invoker fixture's invocation
+#     carries a trailing comment, so an unanchored `[[:space:]]*#` would drop
+#     that whole line and demand a genuine invoker into the fast lane.
 _bl181_fixture_comment_only() {
   cat > "$TMP/tests/test-bl181-comment-only.sh" <<'SH'
 #!/usr/bin/env bash
 # We bypass init.sh (and its --non-interactive cost) by hand-rolling the
 # fixture below - this test scaffolds nothing and runs in about a second.
+#no space after the hash, and we never run init.sh here either.
 _hand_roll() {
   # Space-indented mention of init.sh - still a comment, still not an invocation.
 	# Tab-indented mention of init.sh - pins [[:space:]] as a class, not a space.
   echo "fast unit test - one space before the hash" # and we never call init.sh
   echo "fast unit test - three spaces before the hash"   # nor here: no init.sh
+  echo "fast unit test - no space after the trailing hash"  #nor here: no init.sh
+  echo "fast unit test - a tab before the trailing hash"	# and no init.sh here
 }
 _hand_roll
 SH

--- a/tests/test-lint-tests-registered.sh
+++ b/tests/test-lint-tests-registered.sh
@@ -529,24 +529,41 @@ rm -f "$MUTYML"
 # except WHERE the init.sh token sits: inside a comment vs. on an executed
 # line. That is the whole A/B.
 #
-# The comment-only fixture carries all THREE comment shapes a shell file can
-# spell, because the predicate needs a distinct regex atom for each and an
-# untested atom is an atom that can be silently reverted:
-#   • column-0 whole-line   — the original BL-181 shape
-#   • INDENTED whole-line   — the dominant form inside a function/if body;
-#     pins the `[[:space:]]*` in the predicate's whole-line stripper
-#   • TRAILING, at the end of an executed line — pins the trailing-comment
-#     stage; without it one repositioned comment still flipped FAIL → PASS
-# Each shape appears ALONE on its line, so any one of them surviving the
-# stripper is enough to re-exempt the file and turn U6 red.
+# The comment-only fixture carries every comment shape a shell file can spell,
+# because the predicate needs a distinct regex atom for each and an untested
+# atom is an atom that can be silently reverted. Pinning the SPELLING is not
+# enough — each atom's WIDTH has to be pinned too, or a one-character narrowing
+# of a quantifier re-opens BL-181 and still passes both PR-blocking checks
+# (that was R-B-4: `[[:space:]][[:space:]]*` → `[[:space:]][[:space:]][[:space:]]*`
+# survived `lint-tests-registered.sh` rc=0 AND this suite at 24/0, while
+# re-exempting every single-space trailing comment — the commonest spelling
+# there is). So the fixture carries FIVE init.sh-bearing comment lines, each
+# shape ALONE on its line, so any one of them surviving the stripper is enough
+# to turn U6 red:
+#   • column-0 whole-line     — the original BL-181 shape; pins the `#` anchor
+#   • SPACE-indented whole-line — the dominant form inside a function/if body;
+#     pins the `*` in the whole-line stripper's `^[[:space:]]*#`
+#   • TAB-indented whole-line — pins `[[:space:]]` as a CHARACTER CLASS rather
+#     than a literal space; narrowing it to `^ *#` re-exempts tab-indented files
+#   • TRAILING at ONE space   — pins the LOWER bound of the trailing stage's
+#     whitespace run (a 2+ quantifier must not compile)
+#   • TRAILING at THREE spaces — pins the UPPER side, i.e. the `*` itself (an
+#     exactly-one-space quantifier must not compile)
+# The one atom U6 canNOT pin is the sed's leading `\([^[:space:]]\)` guard:
+# every whole-line comment is already gone by the time the sed runs, so
+# deleting the guard is behaviour-neutral ON THIS FIXTURE. It is kept because
+# it stops the sed from masking the grep — with the guard removed, mutant A
+# (weakening `^[[:space:]]*#` to `^#`) would survive. Stated, not overclaimed.
 _bl181_fixture_comment_only() {
   cat > "$TMP/tests/test-bl181-comment-only.sh" <<'SH'
 #!/usr/bin/env bash
 # We bypass init.sh (and its --non-interactive cost) by hand-rolling the
 # fixture below - this test scaffolds nothing and runs in about a second.
 _hand_roll() {
-  # Indented mention of init.sh - still only a comment, still not an invocation.
-  echo "fast unit test - no project scaffolding here"   # and we never call init.sh
+  # Space-indented mention of init.sh - still a comment, still not an invocation.
+	# Tab-indented mention of init.sh - pins [[:space:]] as a class, not a space.
+  echo "fast unit test - one space before the hash" # and we never call init.sh
+  echo "fast unit test - three spaces before the hash"   # nor here: no init.sh
 }
 _hand_roll
 SH

--- a/tests/test-lint-tests-registered.sh
+++ b/tests/test-lint-tests-registered.sh
@@ -528,19 +528,36 @@ rm -f "$MUTYML"
 # Shared fixture builders for the U6/U7 pair. Identical in every respect
 # except WHERE the init.sh token sits: inside a comment vs. on an executed
 # line. That is the whole A/B.
+#
+# The comment-only fixture carries all THREE comment shapes a shell file can
+# spell, because the predicate needs a distinct regex atom for each and an
+# untested atom is an atom that can be silently reverted:
+#   • column-0 whole-line   — the original BL-181 shape
+#   • INDENTED whole-line   — the dominant form inside a function/if body;
+#     pins the `[[:space:]]*` in the predicate's whole-line stripper
+#   • TRAILING, at the end of an executed line — pins the trailing-comment
+#     stage; without it one repositioned comment still flipped FAIL → PASS
+# Each shape appears ALONE on its line, so any one of them surviving the
+# stripper is enough to re-exempt the file and turn U6 red.
 _bl181_fixture_comment_only() {
   cat > "$TMP/tests/test-bl181-comment-only.sh" <<'SH'
 #!/usr/bin/env bash
 # We bypass init.sh (and its --non-interactive cost) by hand-rolling the
-# fixture below — this test scaffolds nothing and runs in about a second.
-echo "fast unit test — no project scaffolding here"
+# fixture below - this test scaffolds nothing and runs in about a second.
+_hand_roll() {
+  # Indented mention of init.sh - still only a comment, still not an invocation.
+  echo "fast unit test - no project scaffolding here"   # and we never call init.sh
+}
+_hand_roll
 SH
 }
 _bl181_fixture_real_invoker() {
+  # The invocation carries a TRAILING comment of its own: stripping trailing
+  # comments must not truncate away an init.sh that sits BEFORE the `#`.
   cat > "$TMP/tests/test-bl181-real-invoker.sh" <<'SH'
 #!/usr/bin/env bash
 # This test scaffolds a real project (hermetic: --no-remote-creation, BL-076):
-bash "$REPO/init.sh" --no-remote-creation --platform web
+bash "$REPO/init.sh" --no-remote-creation --platform web  # hermetic scaffold
 SH
 }
 # Aggregator that registers both fixture names, and a unit list that lists

--- a/tests/test-lint-tests-registered.sh
+++ b/tests/test-lint-tests-registered.sh
@@ -505,6 +505,264 @@ else
 fi
 rm -f "$MUTYML"
 
+# ════════════════════════════════════════════════════════════════════
+# BL-181: the unit-lane exemption predicate must test INVOCATION, not MENTION.
+#
+# The BL-154 arm shipped with `grep -q 'init\.sh' "$file"` over the WHOLE file
+# including comments, so any test that merely mentioned init.sh was exempted
+# from the tests.yml unit-lane requirement — including a test whose comment
+# said it does NOT invoke init.sh. One comment line flipped the lint FAIL →
+# PASS with zero executable change. The fix (# BL-181-UNIT-LANE-PREDICATE)
+# strips whole-line comments first.
+#   • U6 (comment-only mention)  → must be DEMANDED (exit 1)
+#   • U7 (real invocation)       → must stay EXEMPT (exit 0)   [pair control]
+#   • U8 (mutation, BL-181 dir)  → restore the whole-file predicate in a COPY
+#                                  → U6 stops flagging (the fix is load-bearing)
+#   • U9 (mutation, over-correct)→ hardwire the predicate false in a COPY
+#                                  → U7 starts flagging (the exemption is real,
+#                                    the fix is not a blanket "demand all")
+#   • U10 (visibility)           → --list renders the DECISIVE exemption as
+#                                  `unit-lane-exempt:init-sh-invoker`
+# ════════════════════════════════════════════════════════════════════
+
+# Shared fixture builders for the U6/U7 pair. Identical in every respect
+# except WHERE the init.sh token sits: inside a comment vs. on an executed
+# line. That is the whole A/B.
+_bl181_fixture_comment_only() {
+  cat > "$TMP/tests/test-bl181-comment-only.sh" <<'SH'
+#!/usr/bin/env bash
+# We bypass init.sh (and its --non-interactive cost) by hand-rolling the
+# fixture below — this test scaffolds nothing and runs in about a second.
+echo "fast unit test — no project scaffolding here"
+SH
+}
+_bl181_fixture_real_invoker() {
+  cat > "$TMP/tests/test-bl181-real-invoker.sh" <<'SH'
+#!/usr/bin/env bash
+# This test scaffolds a real project (hermetic: --no-remote-creation, BL-076):
+bash "$REPO/init.sh" --no-remote-creation --platform web
+SH
+}
+# Aggregator that registers both fixture names, and a unit list that lists
+# NEITHER — so the aggregator arm is satisfied and the unit-lane arm is the
+# only thing under test.
+_bl181_fixture_scaffolding() {
+  cat > "$TMP/tests/myagg.sh" <<SH
+#!/usr/bin/env bash
+bash "$TMP/tests/test-bl181-comment-only.sh"
+bash "$TMP/tests/test-bl181-real-invoker.sh"
+SH
+  cat > "$TMP/tests.yml" <<'SH'
+          tests=(
+            tests/test-some-other-unit.sh
+          )
+SH
+}
+_bl181_run() {
+  bash "$LINTER" --tests-dir "$TMP/tests" --aggregators "$TMP/tests/myagg.sh" \
+       --tests-yml "$TMP/tests.yml" "$@" 2>&1
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U6: comment-only init.sh MENTION is NOT an exemption → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+_bl181_fixture_comment_only
+_bl181_fixture_scaffolding
+out=$(_bl181_run); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q "test-bl181-comment-only.sh" \
+   && echo "$out" | grep -q "unit lane"; then
+  pass "U6: a test whose only init.sh reference is a comment is DEMANDED in the unit lane"
+else
+  fail_ "U6" "expected exit 1 + 'unit lane' naming test-bl181-comment-only.sh (a comment must not exempt); rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U7: real init.sh INVOCATION is still exempt → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Pair control for U6. Same fixture shape, token on an EXECUTED line. If this
+# regressed, the BL-181 fix would have become a blanket "every test must be in
+# the unit lane" — which would drag ~40 scaffolding tests into the fast lane.
+setup_fixture
+_bl181_fixture_real_invoker
+_bl181_fixture_scaffolding
+out=$(_bl181_run); rc=$?
+if [ "$rc" -eq 0 ] && ! echo "$out" | grep -q "unit lane"; then
+  pass "U7: a test that really invokes init.sh stays exempt from the unit lane"
+else
+  fail_ "U7" "expected exit 0 with no unit-lane flag; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U8: mutation — restore the pre-BL-181 whole-file predicate → U6 stops flagging ==="
+# ════════════════════════════════════════════════════════════════════
+# Rewrite the single # BL-181-UNIT-LANE-PREDICATE line in a COPY back to the
+# original whole-file grep. The U6 fixture must flip FAIL → PASS, proving the
+# comment-stripping prefix is what does the work (and that U6 is not passing
+# for some unrelated reason).
+setup_fixture
+_bl181_fixture_comment_only
+_bl181_fixture_scaffolding
+MUT="$TMP/mut"
+mkdir -p "$MUT/scripts"
+pred_n=$(grep -c '# BL-181-UNIT-LANE-PREDICATE$' "$LINTER" 2>/dev/null || echo "0")
+case "$pred_n" in ''|*[!0-9]*) pred_n=0 ;; esac
+# Single-quoted so $file stays literal. Whole-file grep = the pre-BL-181
+# predicate (comments included); the -c form keeps the mutant's shape
+# compatible with the surrounding `[ "$exec_hits" -gt 0 ]` test.
+PRE181='  exec_hits=$(grep -c "init\.sh" "$file" 2>/dev/null)'
+awk -v repl="$PRE181" '/# BL-181-UNIT-LANE-PREDICATE$/ { print repl; next } { print }' \
+    "$LINTER" > "$MUT/scripts/lint-tests-registered.sh"
+chmod +x "$MUT/scripts/lint-tests-registered.sh"
+if [ "$pred_n" -ne 1 ]; then
+  fail_ "U8" "expected exactly one '# BL-181-UNIT-LANE-PREDICATE' anchor line in the linter, found $pred_n — the mutation has no unambiguous target"
+elif cmp -s "$LINTER" "$MUT/scripts/lint-tests-registered.sh"; then
+  fail_ "U8" "the mutation changed nothing — the anchored line is already the pre-BL-181 predicate"
+elif ! bash -n "$MUT/scripts/lint-tests-registered.sh" 2>/dev/null; then
+  fail_ "U8" "mutant is syntactically broken — keep the predicate on one self-contained line"
+else
+  out=$(bash "$MUT/scripts/lint-tests-registered.sh" --tests-dir "$TMP/tests" \
+        --aggregators "$TMP/tests/myagg.sh" --tests-yml "$TMP/tests.yml" 2>&1); rc=$?
+  if [ "$rc" -eq 0 ] && ! echo "$out" | grep -q "unit lane"; then
+    pass "U8: pre-BL-181 predicate restored → the comment-only test is exempted again (fix is load-bearing)"
+  else
+    fail_ "U8" "expected the mutant to exempt the comment-only test (rc=0, no flag); rc=$rc; output:\n$out"
+  fi
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U9: mutation — hardwire the predicate false → U7 starts flagging ==="
+# ════════════════════════════════════════════════════════════════════
+# The other direction. If the exemption arm is removed entirely, a genuine
+# init.sh invoker must become a violation — which proves U7 passes because the
+# exemption fires, not because the unit-lane arm is inert in this fixture.
+setup_fixture
+_bl181_fixture_real_invoker
+_bl181_fixture_scaffolding
+MUT="$TMP/mut"
+mkdir -p "$MUT/scripts"
+NOEXEMPT='  exec_hits=0'
+awk -v repl="$NOEXEMPT" '/# BL-181-UNIT-LANE-PREDICATE$/ { print repl; next } { print }' \
+    "$LINTER" > "$MUT/scripts/lint-tests-registered.sh"
+chmod +x "$MUT/scripts/lint-tests-registered.sh"
+if cmp -s "$LINTER" "$MUT/scripts/lint-tests-registered.sh"; then
+  fail_ "U9" "the over-correction mutation changed nothing — no anchored predicate line to disable"
+elif ! bash -n "$MUT/scripts/lint-tests-registered.sh" 2>/dev/null; then
+  fail_ "U9" "over-correction mutant is syntactically broken"
+else
+  out=$(bash "$MUT/scripts/lint-tests-registered.sh" --tests-dir "$TMP/tests" \
+        --aggregators "$TMP/tests/myagg.sh" --tests-yml "$TMP/tests.yml" 2>&1); rc=$?
+  if [ "$rc" -eq 1 ] \
+     && echo "$out" | grep -q "test-bl181-real-invoker.sh" \
+     && echo "$out" | grep -q "unit lane"; then
+    pass "U9: exemption disabled → the real invoker is flagged (U7 passes because the exemption fires)"
+  else
+    fail_ "U9" "expected the no-exemption mutant to flag test-bl181-real-invoker.sh; rc=$rc; output:\n$out"
+  fi
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U10: --list renders the DECISIVE exemption as unit-lane-exempt:init-sh-invoker ==="
+# ════════════════════════════════════════════════════════════════════
+# BL-181 residual: comment-stripping does not catch an init.sh token inside a
+# quoted string / heredoc body, so a wrongly-exempted file is still possible.
+# The compensating control is that a decisive exemption (exempted AND absent
+# from the unit list) shows up in --list instead of being silent.
+setup_fixture
+_bl181_fixture_real_invoker
+_bl181_fixture_scaffolding
+out=$(_bl181_run --list); rc=$?
+if [ "$rc" -eq 0 ] \
+   && echo "$out" | grep -q "unit-lane-exempt:init-sh-invoker" \
+   && echo "$out" | grep "unit-lane-exempt:init-sh-invoker" | grep -q "test-bl181-real-invoker.sh"; then
+  pass "U10: --list surfaces the decisive unit-lane exemption on the exempted file's row"
+else
+  fail_ "U10" "expected a 'unit-lane-exempt:init-sh-invoker' row for test-bl181-real-invoker.sh; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U11: an exempted file that IS in the unit list is NOT rendered as exempt ==="
+# ════════════════════════════════════════════════════════════════════
+# The exemption only "decided" something when the file is absent from the unit
+# list. Listing it there anyway makes the exemption moot, and a moot exemption
+# must not add noise to the review surface.
+setup_fixture
+_bl181_fixture_real_invoker
+cat > "$TMP/tests/myagg.sh" <<SH
+#!/usr/bin/env bash
+bash "$TMP/tests/test-bl181-real-invoker.sh"
+SH
+cat > "$TMP/tests.yml" <<'SH'
+          tests=(
+            tests/test-bl181-real-invoker.sh
+          )
+SH
+out=$(_bl181_run --list); rc=$?
+if [ "$rc" -eq 0 ] && ! echo "$out" | grep -q "unit-lane-exempt:init-sh-invoker"; then
+  pass "U11: a moot exemption (file already in the unit list) is not rendered"
+else
+  fail_ "U11" "expected no unit-lane-exempt row when the file is in the unit list; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U12: SIGPIPE/pipefail regression — a LARGE real invoker stays exempt ==="
+# ════════════════════════════════════════════════════════════════════
+# The BL-181 predicate was first written as
+#     grep -vE '^[[:space:]]*#' "$file" | grep -q 'init\.sh'
+# which is broken under the linter's `set -o pipefail`: grep -q exits on the
+# first match, the upstream grep dies of SIGPIPE (rc 141), and pipefail
+# promotes that to the pipeline's status — so a real init.sh invoker is
+# reported as a NON-invoker and wrongly demanded into the unit lane. The
+# misfire is SIZE-dependent: every small fixture above passes with the broken
+# form, and only real (multi-KB) test files trip it — this repo's
+# tests/test-bl112-commit-enforcement.sh did, at rc=141.
+#
+# This fixture reproduces that shape deterministically: the init.sh invocation
+# is on line 3, followed by thousands of non-comment lines so the upstream grep
+# still has plenty to write when a `grep -q` downstream would exit. It must be
+# EXEMPT. With the `grep -q` form this test FAILS; with `grep -c` it passes.
+setup_fixture
+{
+  echo '#!/usr/bin/env bash'
+  echo '# Hermetic scaffolder (BL-076): --no-remote-creation, no live remote.'
+  echo 'bash "$REPO/init.sh" --no-remote-creation --platform web'
+  i=0
+  while [ "$i" -lt 4000 ]; do
+    echo "echo \"padding line $i — non-comment, keeps the upstream grep writing\""
+    i=$((i + 1))
+  done
+} > "$TMP/tests/test-bl181-big-invoker.sh"
+cat > "$TMP/tests/myagg.sh" <<SH
+#!/usr/bin/env bash
+bash "$TMP/tests/test-bl181-big-invoker.sh"
+SH
+cat > "$TMP/tests.yml" <<'SH'
+          tests=(
+            tests/test-some-other-unit.sh
+          )
+SH
+out=$(_bl181_run); rc=$?
+if [ "$rc" -eq 0 ] && ! echo "$out" | grep -q "unit lane"; then
+  pass "U12: a large real init.sh invoker stays exempt (no SIGPIPE/pipefail misfire)"
+else
+  fail_ "U12" "large real invoker was flagged — the predicate is SIGPIPE-sensitive (rc=141 under pipefail); use a downstream that consumes all input; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Closes **BL-181** and **BL-135**, and files **BL-183**. These ship together because they are causally linked: fixing the lint predicate *demands* `tests/test-bl033-install-cmds-shape.sh` join the unit lane, and that test fails on Linux CI until BL-135 is fixed. Landing BL-181 alone would have turned every PR red.

## BL-181 — a comment could defeat the unit-lane guard
`_check_unit_lane` decided "does this test invoke init.sh?" with a whole-file `grep -q 'init\.sh'`, **comments included** — so a test whose comment said it does *not* invoke init.sh was exempted from the requirement that applies to tests not invoking init.sh. One comment line flipped the lint FAIL → PASS with zero executable change.

Now reads executed lines only (`# BL-181-UNIT-LANE-PREDICATE`). **Scope was not what the entry predicted:** it said "exactly one file"; a full sweep found 42 classification flips, 35 already registered by human diligence, and **7 genuinely missing from the fast lane**. All 7 verified individually — no init.sh invocation, aggregator-registered, own git identity, 1–10s.

## BL-135 — reproduced, root-caused, fixed. It was never a flake.
`scripts/resolve-tools.sh` probes the **real host** (`command -v brew`) when building its install-key list. The test passed `--dev-os darwin` and asserted on `darwin_brew` while its own comment claimed it "never depends on the host's package managers" — **that comment was false**; the test set no env at all. macOS has brew → 8/8. Ubuntu CI does not → 6 failures. Two CI runs eight days apart failed identically.

Fixed test-side; the product is **correct** and unchanged — a Mac without Homebrew *should* get `darwin_manual`. Verified both ways with the full `PATH` minus only Homebrew's directory:

| | result |
|---|---|
| pre-fix, brew hidden | `2 passed, 6 failed` |
| post-fix, brew hidden | `8 passed, 0 failed` |
| post-fix, brew present | `8 passed, 0 failed` |

Then the whole **135-test unit lane** was run with brew hidden, to prove no *other* test carries the same dependency. It passes.

## BL-183 (filed, not fixed) — SIGPIPE inverts a predicate under `pipefail`
Found while fixing the above: `producer | grep -q` under `set -o pipefail` can report **failure on a match**, because `grep -q` exits on first match and the dying producer's rc 141 becomes the pipeline status. It is **size-dependent**, so it is invisible on small fixtures and appears only on real inputs. Measured live in this very lint. **80 candidate sites across 13 files**, including `pre-commit-gate.sh`, `check-phase-gate.sh` and `process-checklist.sh` — filed as an audit with three reachability conditions, not 80 confirmed breaks.

## Review
Opus implementer → adversarial reviewer at max effort, 3 rounds. Two blockers from round 3 are fixed here: a fixture that failed to pin three comment spellings (so single-atom mutations of the predicate survived both PR-blocking checks), and an audit that asserted "all 28 survivors are genuine invokers" and had **missed one**.

**TL;DR (plain English):** A safety check meant to ensure new tests join the fast test set could be switched off by writing a comment — even a comment saying "this doesn't need the exemption." Fixed, which revealed 7 tests that had been silently skipping the fast lane. One of them was the long-standing mystery failure, now solved: it checks Mac-specific instructions and quietly asks whether Homebrew is installed, so it passed here and failed on the build server. Also logs a newly discovered subtle bug affecting up to 80 places, including three of the most important safety scripts.