### PR TITLE
perf(ci): shard the unit lane and drop the duplicate lint scans — PR feedback ~19 min to ~6 min

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,6 +12,44 @@
 # Subsequent CI jobs (shellcheck, security review, full test suite
 # under CI, etc.) can be added as additional workflows or as
 # additional jobs in this file.
+#
+# ── BL-191: the inventory steps are `if: failure()`, NOT `if: always()` ──
+#
+# Every job here is a PAIR of steps: a GATING step that runs the lint and
+# fails the job, and an INVENTORY step that re-runs the SAME lint with
+# `--list` to print the per-file PASS/FAIL roster. There are NINE such
+# pairs — one per job — and under `if: always()` the inventory step re-ran
+# the full scan on GREEN runs too, where nobody reads it. That doubled
+# every lint job. Measured on the counter-antipattern job (run 30297887996,
+# job 90083310253, main @ 9d71824): 207s gating + 204s inventory = 419s.
+# It is the single slowest PR-blocking job in the repo, so it alone sets
+# the lint floor for the whole PR.
+#
+# `failure()` and `always()` are IDENTICAL on the failure path — which is
+# the only path the inventory was ever for. Evidence, three real runs where
+# a gating step failed: run 29952639143 (backlog-references-lint), run
+# 29633780347 (counter-antipattern-lint), run 29136956152
+# (backlog-references-lint). In every one: gating step `failure`, inventory
+# step `success` (it RAN), job conclusion `failure`. Run 29633780347's
+# no-live-remote job is the clearest read — its middle step with no `if:`
+# shows `skipped` while the `always()` inventory step shows `success`,
+# which is exactly the semantics `failure()` also selects. So a red lint
+# still goes red and still prints its inventory; only the green-path
+# re-scan is gone.
+#
+# The `|| true` stays and is load-bearing: `--list` exits non-zero on a
+# dirty tree, and an inventory step must never be what fails a job. Run
+# 29633780347 proves it end to end — the tree was dirty enough to fail the
+# gate, and the inventory step still concluded `success`.
+#
+# WHY NOT `failure() || github.event_name == 'workflow_dispatch'`: this
+# workflow has no `workflow_dispatch` trigger (see `on:` below — only
+# `push: branches: [main]` and `pull_request`), so that arm is unreachable
+# dead code. A UI re-run is not an on-demand path either: it preserves the
+# ORIGINAL event name, so it would not satisfy it. The step names dropped
+# "or on demand" for the same reason — the real on-demand path is local:
+#     bash scripts/lint-<name>.sh --list
+# If anyone ever adds a `workflow_dispatch` trigger here, revisit this.
 
 name: lint
 
@@ -35,8 +73,8 @@ jobs:
       - name: Lint counter-capture antipattern
         run: bash scripts/lint-counter-antipattern.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-counter-antipattern.sh --list || true
 
   # Cycle-7 Slot-5 sibling backstop: process discipline for backlog
@@ -64,8 +102,8 @@ jobs:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bash scripts/lint-backlog-references.sh --base "origin/${BASE_REF}"
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: bash scripts/lint-backlog-references.sh --base "origin/${BASE_REF}" --list || true
@@ -87,8 +125,8 @@ jobs:
       - name: Lint fix_*() function stderr silencers
         run: bash scripts/lint-fix-functions-stderr.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-fix-functions-stderr.sh --list || true
 
   # Cycle-8 wave-3 Slot-5 sibling: ban raw `read -rp` / `read -p`
@@ -108,8 +146,8 @@ jobs:
       - name: Lint raw read -rp / read -p sites
         run: bash scripts/lint-raw-read-prompt.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-raw-read-prompt.sh --list || true
 
   # BL-038 (cycle-9): structural backstop for the BL-034 orphan-test
@@ -128,8 +166,8 @@ jobs:
       - name: Lint tests-registered (BL-038 structural backstop)
         run: bash scripts/lint-tests-registered.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-tests-registered.sh --list || true
 
   # BL-048: structural backstop for dead in-document anchors under
@@ -149,8 +187,8 @@ jobs:
       - name: Lint in-document anchors under docs/ (BL-048)
         run: bash scripts/lint-doc-anchors.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-doc-anchors.sh --list || true
 
   # BL-073: schema backstop for the Phase 3→4 review manifest
@@ -171,8 +209,8 @@ jobs:
       - name: Lint review-manifest schema (BL-073)
         run: bash scripts/lint-review-manifest.sh
 
-      - name: Show roster (on failure or on demand)
-        if: always()
+      - name: Show roster (on failure)
+        if: failure()
         run: bash scripts/lint-review-manifest.sh --list || true
 
   # BL-076: hermeticity backstop for the test suite. A test that runs the
@@ -197,8 +235,8 @@ jobs:
       - name: Run the lint's own behavior suite
         run: bash tests/test-lint-no-live-remote.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-no-live-remote-in-tests.sh --list || true
 
   # BL-103: portability backstop for evaluation-prompts/. The Phase 3→4 review
@@ -221,6 +259,6 @@ jobs:
       - name: Lint evaluation-prompts/ for bash-4 constructs (BL-103)
         run: bash scripts/lint-evalprompts-portability.sh
 
-      - name: Show PASS/FAIL inventory (on failure or on demand)
-        if: always()
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
         run: bash scripts/lint-evalprompts-portability.sh --list || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,17 @@
 #                         The list is explicit and reviewable below so a new
 #                         orphan test cannot silently join CI — add new
 #                         entries deliberately.
+#                         BL-190: the lane is SHARDED. The list below is
+#                         still one canonical array; a matrix job
+#                         (`unit-shard`) partitions it across five parallel
+#                         runners, and a zero-work `unit` job aggregates
+#                         them so the branch-protection check name survives.
+#                         Nothing was demoted to the full lane: the set of
+#                         tests that gate a PR is byte-identical before and
+#                         after, only the wall clock changed (~19 min serial
+#                         -> ~5.5 min FOR THIS LANE). That is NOT the
+#                         PR-blocking number — see the critical-path note on
+#                         the unit-shard job below.
 #                         BL-181: membership is enforced by
 #                         scripts/lint-tests-registered.sh, whose exemption
 #                         predicate looks at EXECUTED lines only. The older
@@ -31,7 +42,13 @@
 #
 # The tests are hermetic (BL-076 lint enforces no live-remote init.sh runs),
 # so CI does NOT authenticate gh and creates no real remotes. Keep it that
-# way. Do not modify lint.yml.
+# way.
+#
+# (The "do not modify lint.yml" line that used to sit here was a scope guard
+# for the sharding change, not a standing rule. Karl lifted it so the BL-191
+# `if: always()` -> `if: failure()` fix to lint.yml's nine inventory steps
+# could land alongside this — that fix is what actually moves the PR-blocking
+# floor, and it is documented in lint.yml's own header.)
 
 name: tests
 
@@ -42,15 +59,118 @@ on:
   workflow_dispatch:   # the full lane is manual-only (no scheduled nightly)
 
 jobs:
-  # ── Fast lane ──────────────────────────────────────────────────────────
-  # Quick unit tests only, on every push and PR. Target: a few minutes.
-  unit:
-    name: unit
+  # ── Fast lane (sharded) ────────────────────────────────────────────────
+  # BL-190: the fast lane was SERIAL and had reached its own 20-minute cap —
+  # 18m51s on main (run 30297887329) and CANCELLED at 20m15s on PR #278,
+  # "The operation was canceled", not an assertion failure. A lane that
+  # blocks any PR merely for ADDING a test has stopped being a fast lane, so
+  # this splits the SAME test list across parallel shards instead of raising
+  # the cap (raising it would only hide the next doubling).
+  #
+  # Where the 18m51s went (measured, run 30297887329, ::group:: spans):
+  #     318s tests/test-run-lints.sh
+  #     243s tests/test-lint-counter-antipattern.sh
+  #     122s tests/test-pre-commit-gate-lints.sh
+  #      77s tests/test-bl132-sast-index-scan.sh   (213s on PR #278)
+  #      54s tests/test-bl131-domsink-rules.sh
+  #      41s tests/test-lint-raw-read-prompt.sh
+  #      37s tests/test-upgrade-sync-framework.sh
+  #      34s tests/test-plan-staging.sh
+  #      16s tests/test-lint-doc-anchors.sh
+  #     170s the other 127 files, TOGETHER (avg 1.34s)
+  # i.e. 85% of the lane is nine files, and the other 127 are noise. Sharding
+  # is therefore the whole fix; nothing needs to be deleted, skipped or
+  # demoted, and every test below still runs on every PR.
+  #
+  # WHY THOSE NINE ARE SLOW (verified, not assumed). The two biggest are
+  # lint work the PR ALREADY does elsewhere:
+  #   • tests/test-run-lints.sh — its T-all-pass arm runs `scripts/run-lints.sh`
+  #     over the REAL repo, i.e. all 11 lints end-to-end.
+  #   • tests/test-lint-counter-antipattern.sh — 12 tiny fixture cases, plus
+  #     "T9: MERGE GATE" which runs the linter over the REAL repo. Same for
+  #     test-lint-raw-read-prompt.sh and test-lint-doc-anchors.sh.
+  # lint.yml already runs each of those lints over the repo in its own
+  # PARALLEL job (counter-antipattern-lint, raw-read-prompt-lint,
+  # doc-anchors-lint — all three are required checks), so on a PR the
+  # full-tree counter-antipattern scan executed FOUR times per PR, not the
+  # three originally claimed:
+  #   1. lint.yml counter-antipattern-lint, step "Lint counter-capture
+  #      antipattern"                                       207s on main
+  #   2. lint.yml counter-antipattern-lint, step "Show PASS/FAIL
+  #      inventory" — the `--list` re-scan, then gated `if: always()`,
+  #      so it re-ran on SUCCESS too                        204s on main
+  #   3. tests/test-lint-counter-antipattern.sh `T9: MERGE GATE`
+  #   4. tests/test-run-lints.sh `T-all-pass`, via scripts/run-lints.sh
+  # (1) and (2) are measured from run 30297887996 job 90083310253 (main
+  # @ 9d71824); (3) and (4) are the 243s attributed above.
+  #
+  # (2) IS NOW GONE ON GREEN RUNS. This change also flips lint.yml's nine
+  # inventory steps from `if: always()` to `if: failure()` (BL-191), so on a
+  # passing PR the scan runs THREE times and on a failing one it still runs
+  # four — the inventory prints exactly when someone needs it. The remaining
+  # duplication is genuine merge gates the suites own, so nothing is
+  # removed; (3) and (4) are merely moved off each other's critical path.
+  # The root cost is still scripts/lint-counter-antipattern.sh's
+  # `scan_file`, which forks `echo "$line" | grep -Eq` PER LINE of every
+  # file it walks; making that a single-pass scan is an enforcement-script
+  # change (TDD + mutation proof) and stays out of scope for a CI rebalance.
+  # BL-191 stays Open for it.
+  #
+  # SHARDS. Only the measured long poles are pinned; `rest` is the
+  # COMPLEMENT of the pins, so a newly added test needs no edit here — it
+  # lands in `rest` automatically and the partition assertion still holds.
+  # Expected wall clock per shard. The per-file seconds are MEASURED; the
+  # per-shard totals are DERIVED from them (measured seconds + ~20s job
+  # overhead, itself measured from the old serial job's non-test steps).
+  # No run has yet executed the five-leg topology, so nothing in this table
+  # is an observation:
+  #     lint-sweep  318s ->  ~5.5 min   (  1 file)
+  #     lint-scan   299s ->  ~5.2 min   (  3 files)
+  #     sast        281s ->  ~4.9 min   (  3 files; PR #278 worst case for bl132)
+  #     slow-misc   193s ->  ~3.5 min   (  3 files)
+  #     rest        157s ->  ~2.9 min   (126 files; the shard that grows)
+  #                 ----                ----
+  #                1248s                 136 files — same 136 as the serial lane
+  # THIS LANE's long pole is ~5.5 min against a 12-minute cap. The cap is
+  # LOWERED from 20 on purpose: it has to stay a tripwire, not a ceiling to
+  # grow into.
+  #
+  # THE PR-BLOCKING CRITICAL PATH IS NOT THIS LANE'S NUMBER — check both.
+  # Sharding alone would have left the PR floored at ~7-9 min by lint.yml's
+  # REQUIRED `counter-antipattern-lint` job: MEASURED 6m59s on main (run
+  # 30297887996, job 90083310253, @ 9d71824) and 9m03s on PR #278 (run
+  # 30380689795, job 90347515417, @ 8ea8c6c). Sharding takes THIS lane off
+  # the critical path; it cannot lower that floor.
+  #
+  # So this change also lowers the floor, in lint.yml (BL-191): its nine
+  # `--list` inventory steps go `if: always()` -> `if: failure()`, dropping
+  # a full duplicate scan from every green lint job. DERIVED, not observed —
+  # no run has executed either topology yet:
+  #     counter-antipattern-lint  419s -> ~215s  (~3.6 min)  main
+  #                               543s -> ~277s  (~4.6 min)  PR #278
+  #     unit lane long pole       lint-sweep ~5.5 min, plus the `unit`
+  #                               aggregator that gates on it     ~6 min
+  # The lint floor drops below the unit lane, so the expected new
+  # PR-blocking critical path is ~6 min, SET BY THIS LANE's lint-sweep
+  # shard — the first time it has been the unit lane's number to own.
+  # Lowering it further means making the scan itself cheap: BL-191's
+  # per-line-fork rewrite, still Open.
+  unit-shard:
+    name: unit-shard (${{ matrix.shard }})
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    # Deliberately LOWER than the old 20. Slowest measured shard is ~5.5 min,
+    # so this is ~2x headroom; if a shard ever approaches it, that is the
+    # signal to re-pin, exactly as it was here.
+    timeout-minutes: 12
     # Only the fast lane on push / PR. The full suite runs on schedule /
     # dispatch (see the `full` job's guard below).
     if: github.event_name == 'push' || github.event_name == 'pull_request'
+    strategy:
+      # Report every shard. A red shard must not cancel the others, or the
+      # PR author sees one failure and cannot tell what else is broken.
+      fail-fast: false
+      matrix:
+        shard: [lint-sweep, lint-scan, sast, slow-misc, rest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
@@ -74,14 +194,70 @@ jobs:
         # registry-token drift without semgrep, but only a real run proves
         # the emitted hook still BLOCKS — a renamed/retired registry rule
         # would otherwise re-blind every generated hook while CI stayed
-        # green between manual full-lane dispatches. Accepted cost: one
-        # registry fetch per PR. An install failure fails the lane LOUDLY
-        # rather than silently skipping the blocking arm.
+        # green between manual full-lane dispatches. An install failure fails
+        # the lane LOUDLY rather than silently skipping the blocking arm.
+        #
+        # BL-190: installed in EVERY shard, not only `sast`. The semgrep
+        # suites are pinned to `sast` today, but `rest` is the complement —
+        # a future semgrep-requiring test lands there with no edit here, and
+        # those suites SKIP LOUDLY (not fail) without semgrep, which is
+        # precisely the silent-blinding this step exists to prevent. Uniform
+        # install keeps the pin map free to move. Cost: the "one registry
+        # fetch per PR" of the old serial lane becomes one per shard, ~12s
+        # each and fully parallel, so it is not on the critical path.
         run: pip install semgrep
 
-      - name: Run fast unit tests
+      - name: Run fast unit tests — shard ${{ matrix.shard }}
+        env:
+          SHARD: ${{ matrix.shard }}
+          # strategy.job-total is the number of legs in the matrix above.
+          # See the roster-drift guard at the top of the script.
+          SHARD_TOTAL: ${{ strategy.job-total }}
         run: |
           set -uo pipefail
+
+          # ── Shard roster: the SINGLE SOURCE for the shard set ──────────
+          # THE HAZARD. `rest` is the complement of the PINNED paths, not of
+          # the paths some shard actually ran. So if a shard stops existing
+          # but its pins keep contributing to `pinned`, its tests are
+          # excluded from `rest` and then run NOWHERE — while the partition
+          # arithmetic still balances and every remaining shard still goes
+          # green. A hand-maintained leg COUNT does not close that: you
+          # delete the leg, you update the count because the error message
+          # told you to, and the tests vanish anyway.
+          #
+          # THE CLOSURE. This roster is the only place a shard is named in
+          # this script. The leg-count guard counts it; `pins_for` cases on
+          # exactly these names; the pinned set is built by walking this
+          # roster THROUGH `pins_for`; and the dispatch validates against
+          # it. Delete a name here and its `pin_*` array is ORPHANED — it
+          # no longer enters `pinned`, so those paths fall back into `rest`
+          # and STILL RUN. Fail-safe, not silently dropped.
+          shard_names="lint-sweep lint-scan sast slow-misc rest"
+
+          roster="|"
+          shard_arms=0
+          for s in $shard_names; do
+            roster="${roster}${s}|"
+            shard_arms=$((shard_arms + 1))
+          done
+
+          # The matrix leg count is the one thing this script cannot read —
+          # it lives in the YAML above. `strategy.job-total` carries it down
+          # so a matrix edited apart from the roster fails loudly. This is
+          # now the ONLY hand-kept correspondence, and getting it wrong is
+          # non-silent in both directions: too few legs fails here, and an
+          # extra leg fails the roster-membership check below.
+          if [ "${SHARD_TOTAL}" != "${shard_arms}" ]; then
+            echo "shard roster drift: the matrix declares ${SHARD_TOTAL} leg(s) but the roster names ${shard_arms} (${shard_names}). Edit the matrix list and the roster TOGETHER." >&2
+            exit 1
+          fi
+
+          case "$roster" in
+            *"|${SHARD}|"*) ;;
+            *) echo "unknown shard: '${SHARD}' is not in the roster (${shard_names})" >&2
+               exit 1 ;;
+          esac
           # Explicit, reviewable list. A test belongs here iff it does not
           # invoke init.sh (no project scaffolding) and is not an aggregator
           # or helper. Membership is machine-checked in the OMISSION direction
@@ -252,8 +428,147 @@ jobs:
             tests/test-validate-phase-state-gates.sh
           )
 
-          failed=()
+          # ── BL-190 shard pins ──────────────────────────────────────────
+          # These arrays PARTITION the canonical list above; they do not add
+          # to it and they must never contain a path that is not in it (the
+          # assertion below enforces exactly that). Only the measured long
+          # poles are named — `rest` is the complement, so appending to the
+          # canonical array above is still the ONLY edit a new test needs.
+          #
+          # NOTHING BELOW THIS LINE MAY CONTAIN THE LITERAL ARRAY-OPENING
+          # TOKEN (the word `tests`, `=`, open-paren). Not in an array name,
+          # not in a comment, not inside an echo string.
+          # scripts/lint-tests-registered.sh scopes the unit list with
+          # `awk '/tests=\(/{f=1;next} f && /^[ ]*\)/{f=0}'` — an UNANCHORED
+          # substring match with no comment stripping — so any reappearance
+          # of that token re-opens the scope, and every `tests/test-*.sh`
+          # path between it and the next lone `)` line gets folded into the
+          # lint's membership set. That is a silent widening of an
+          # enforcement predicate: a new test file merely NAMED in a comment
+          # down here would satisfy the lint while never running in CI —
+          # verbatim the BL-181 defect class. `pin_*` names cannot match,
+          # and the prose/echo text below is worded to avoid the token.
+          # Comment-out is likewise not a move mechanism anywhere in the
+          # canonical array: the same awk does not strip comments, so a
+          # commented entry still counts as membership while bash drops it
+          # (BL-181 residual #2). Move a path BETWEEN pin arrays instead.
+          #
+          # Seconds are measured CI time from run 30297887329 (main @ 9d71824).
+          pin_lint_sweep=(
+            tests/test-run-lints.sh                    # 318s — runs the WHOLE lint sweep over the real repo
+          )
+          pin_lint_scan=(
+            tests/test-lint-counter-antipattern.sh     # 243s — T9 re-scans the real repo
+            tests/test-lint-raw-read-prompt.sh         #  41s — real-repo arm
+            tests/test-lint-doc-anchors.sh             #  16s — real-repo arm
+          )
+          pin_sast=(
+            tests/test-bl132-sast-index-scan.sh        #  77s on main, 213s on PR #278 — pinned at the worst case
+            tests/test-bl131-domsink-rules.sh          #  54s
+            tests/test-bl118-sast-dom-xss.sh           #  13s
+          )
+          pin_slow_misc=(
+            tests/test-pre-commit-gate-lints.sh        # 122s — runs 4 lint copies inside fixture projects
+            tests/test-upgrade-sync-framework.sh       #  37s
+            tests/test-plan-staging.sh                 #  34s
+          )
+
+          # The ONLY thing that maps a roster name to a pin array. Both the
+          # pinned-set build and the dispatch go through this function, so
+          # they cannot disagree, and an array with no arm here is simply
+          # never claimed — its paths stay in `rest`. `rest` itself pins
+          # nothing: it is the computed complement. A roster name with no
+          # arm is a hard error, never a silently empty shard.
+          pins_for() {
+            case "$1" in
+              lint-sweep) printf '%s\n' "${pin_lint_sweep[@]}" ;;
+              lint-scan)  printf '%s\n' "${pin_lint_scan[@]}" ;;
+              sast)       printf '%s\n' "${pin_sast[@]}" ;;
+              slow-misc)  printf '%s\n' "${pin_slow_misc[@]}" ;;
+              rest)       : ;;
+              *) echo "shard roster: '$1' is in the roster but has no arm in pins_for" >&2
+                 return 1 ;;
+            esac
+          }
+
+          # Canonical set, with a duplicate guard (a path listed twice would
+          # make the partition arithmetic below lie).
+          canon="|"
           for t in "${tests[@]}"; do
+            case "$canon" in
+              *"|${t}|"*)
+                echo "unit list: '${t}' appears twice in the canonical unit array" >&2
+                exit 1 ;;
+            esac
+            canon="${canon}${t}|"
+          done
+
+          # Pinned set — built by walking the ROSTER through `pins_for`,
+          # never by naming the pin arrays directly. That indirection is
+          # what makes an orphaned array fall into `rest` instead of
+          # vanishing from CI. Every pin must exist in the canonical list,
+          # exactly once, and be claimed by exactly one shard.
+          pinned="|"
+          n_pinned=0
+          for s in $shard_names; do
+            shard_pins=$(pins_for "$s") || exit 1
+            for t in $shard_pins; do
+              case "$canon" in
+                *"|${t}|"*) ;;
+                *) echo "shard pins: '${t}' is pinned to shard '${s}' but is absent from the canonical unit array" >&2
+                   exit 1 ;;
+              esac
+              case "$pinned" in
+                *"|${t}|"*) echo "shard pins: '${t}' is pinned to more than one shard" >&2
+                            exit 1 ;;
+              esac
+              pinned="${pinned}${t}|"
+              n_pinned=$((n_pinned + 1))
+            done
+          done
+
+          # `rest` = canonical minus pinned.
+          rest_list=()
+          for t in "${tests[@]}"; do
+            case "$pinned" in
+              *"|${t}|"*) ;;
+              *) rest_list+=("${t}") ;;
+            esac
+          done
+
+          # COVERAGE ASSERTION — the five shards are a partition of the
+          # canonical list: disjoint (guarded above) and complete (here).
+          # Every shard job re-runs this, so a mis-pin fails the PR loudly
+          # instead of silently dropping a test out of CI.
+          n_union=$((n_pinned + ${#rest_list[@]}))
+          if [ "$n_union" -ne "${#tests[@]}" ]; then
+            echo "shard partition is not a cover: shards total ${n_union}, canonical unit array has ${#tests[@]}" >&2
+            exit 1
+          fi
+
+          # Dispatch through the SAME source the pinned set was built from,
+          # so a leg can never run one set while `rest` excludes another.
+          # `rest` is the computed complement; membership of $SHARD in the
+          # roster was already validated at the top.
+          run_list=()
+          if [ "${SHARD}" = "rest" ]; then
+            run_list=( "${rest_list[@]}" )
+          else
+            for t in $(pins_for "${SHARD}"); do
+              run_list+=("${t}")
+            done
+          fi
+
+          if [ "${#run_list[@]}" -eq 0 ]; then
+            echo "shard '${SHARD}' selected 0 tests — the pin map or the shard name is wrong" >&2
+            exit 1
+          fi
+
+          echo "shard '${SHARD}': ${#run_list[@]} of ${#tests[@]} unit tests"
+          echo "partition verified: ${n_pinned} pinned + ${#rest_list[@]} rest == ${#tests[@]} canonical"
+
+          failed=()
+          for t in "${run_list[@]}"; do
             echo "::group::${t}"
             if bash "${t}"; then
               echo "PASS ${t}"
@@ -267,12 +582,49 @@ jobs:
 
           echo ""
           echo "==================================================================="
-          echo "Ran ${#tests[@]} unit test file(s); ${#failed[@]} failed."
+          echo "Shard ${SHARD}: ran ${#run_list[@]} unit test file(s); ${#failed[@]} failed."
           if [ "${#failed[@]}" -ne 0 ]; then
             echo "Failed: ${failed[*]}"
             exit 1
           fi
-          echo "All unit tests passed."
+          echo "All unit tests in shard ${SHARD} passed."
+
+  # ── Required-check anchor ──────────────────────────────────────────────
+  # `unit` is a REQUIRED STATUS CHECK on main (branch protection lists it
+  # alongside the eight lint jobs). A matrix cannot keep that name — its
+  # check runs are `unit-shard (<shard>)` — and deleting the `unit` context
+  # would leave every PR waiting forever on a check that never reports. So
+  # the name survives here as a zero-work aggregator that is red unless
+  # EVERY shard is green. Same convention as lint.yml: the job name is the
+  # branch-protection label — keep it stable.
+  #
+  # `needs.unit-shard.result` is the matrix's ROLLED-UP result: `success`
+  # only when all five legs succeeded. `always()` is required so this job
+  # still runs (and still fails) when a shard fails, times out, or is
+  # cancelled — a cancelled shard yields `cancelled` here and turns `unit`
+  # RED. Note what PR #278's 20m15s cancellation was and was not: it was
+  # NOT silent, and it DID block — the check reported and the PR could not
+  # merge. The defect was that the lane blocked any PR that ADDED a test,
+  # regardless of content. Sharding fixes that; the aggregator exists to
+  # keep the required check name reporting at all.
+  unit:
+    name: unit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs: [unit-shard]
+    if: always() && (github.event_name == 'push' || github.event_name == 'pull_request')
+    steps:
+      - name: Assert every unit shard succeeded
+        env:
+          SHARD_RESULT: ${{ needs.unit-shard.result }}
+        run: |
+          set -uo pipefail
+          echo "unit-shard (matrix) aggregate result: ${SHARD_RESULT}"
+          if [ "${SHARD_RESULT}" != "success" ]; then
+            echo "unit: the sharded fast lane did not fully succeed (aggregate result: ${SHARD_RESULT}). Open the unit-shard (…) jobs for the failing shard." >&2
+            exit 1
+          fi
+          echo "unit: all unit-shard legs passed."
 
   # ── Slow lane (sharded) ────────────────────────────────────────────────
   # Serial, the full suite is ~1h — dominated by ~140 sequential init.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,10 +56,28 @@ here.
 - **Run every repo lint locally:** `bash scripts/run-lints.sh` (one PASS/FAIL
   line per lint, summary, non-zero exit iff any failed). This is the dev-tool
   wrapper — see LINT GOTCHAS.
-- **CI fast lane (unit):** the explicit file list in the `unit` job of
-  `.github/workflows/tests.yml`. A test belongs there iff it does not invoke
-  `init.sh` and is not an aggregator. That list plus `tests/full-project-test-suite.sh`
-  are both lint-enforced (see HOUSE RULES).
+- **CI fast lane (unit):** the explicit file list in the **`unit-shard`** job of
+  `.github/workflows/tests.yml` (BL-190 renamed the job; it was `unit`). A test
+  belongs there iff it does not invoke `init.sh` and is not an aggregator. That
+  list plus `tests/full-project-test-suite.sh` are both lint-enforced (see
+  HOUSE RULES).
+  - **Adding a test is still a ONE-LINE edit** — append it to the canonical
+    array. The lane is sharded (matrix `shard: [lint-sweep, lint-scan, sast,
+    slow-misc, rest]`), but only the measured long poles are pinned to a
+    shard by the `pin_*` arrays; `rest` is the COMPLEMENT, so a new entry
+    lands there automatically.
+  - **Never write the literal array-opening token (`tests`+`=`+`(`) anywhere
+    else in that file below the array.** `_build_unit_list_set` scopes with an
+    UNANCHORED `awk '/tests=\(/'` and does not strip comments, so a second
+    occurrence re-opens the scope and folds every `tests/test-*.sh` path
+    after it into the lint's membership set — a test merely NAMED in a
+    comment would then satisfy the lint while never running. The pin arrays
+    are named `pin_*` for exactly this reason.
+  - The job name **`unit` is a required status check** on `main` (confirmed
+    via `gh api repos/kraulerson/solo-orchestrator/branches/main/protection`).
+    It survives as a zero-work aggregator job that is red unless every
+    `unit-shard` leg is green. Renaming or deleting it leaves every PR waiting
+    forever on a check that never reports.
 - **FULL suite is ~3h and `workflow_dispatch`-only** (`.github/workflows/tests.yml`
   `full` job: `if: github.event_name == 'workflow_dispatch'`, `timeout-minutes: 180`).
   Never run it casually. Locally, `bash tests/full-project-test-suite.sh` and

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -5308,3 +5308,260 @@ delegates in, with the discard shape), BL-038 / BL-154 / BL-181 (registration li
 delegate that already captured, and why it stays exempt), BL-064 (silent-success-after-FAIL — same
 defect class, different surface).
 
+---
+
+## BL-190: The `unit` fast lane reached its own 20-minute cap and began blocking PRs for ADDING a test rather than for failing one
+
+> **Numbering note.** This entry and BL-191 were first filed as BL-185/BL-186. PR #278 was already
+> open with its own BL-185…BL-189, so it has precedence and these two were renumbered to BL-190/191
+> before either branch merged. Any pre-merge reference to "BL-185 (the lane rebalance)" or
+> "BL-186 (the per-line fork)" means these entries.
+
+**Logged:** 2026-07-28
+**Status:** Open — remediation shipped on branch `perf/unit-lane-shard-rebalance`; flip to Closed with
+the PR # once merged (a Closed entry must cite a PR # or a backticked SHA, and neither exists yet).
+**Category:** CI capacity / merge-blocking
+**Severity:** High — a required status check that fails on capacity, not on correctness, blocks every
+PR indiscriminately and teaches everyone to ignore it.
+
+**The measurement.** `.github/workflows/tests.yml` `unit` had `timeout-minutes: 20` and was running a
+serial list of 136 test files. Job 90083307522 (run 30297887329, main @ `9d71824`) took **18m51s**;
+the preceding two main runs were 19m21s and 20m00s. PR #278 added SAST cases and its `unit` job was
+**CANCELLED at 20m15s** — "The operation was canceled", not an assertion failure. The lane was at its
+cap, so any PR that added a test case failed on wall clock regardless of content.
+
+**Where the time went** (per-test `::group::` spans extracted from the two job logs; only >=15s shown):
+
+| seconds | file |
+|---|---|
+| 318 | `tests/test-run-lints.sh` |
+| 243 | `tests/test-lint-counter-antipattern.sh` |
+| 122 | `tests/test-pre-commit-gate-lints.sh` |
+| 77 (213 on PR #278) | `tests/test-bl132-sast-index-scan.sh` |
+| 54 | `tests/test-bl131-domsink-rules.sh` |
+| 41 | `tests/test-lint-raw-read-prompt.sh` |
+| 37 | `tests/test-upgrade-sync-framework.sh` |
+| 34 | `tests/test-plan-staging.sh` |
+| 16 | `tests/test-lint-doc-anchors.sh` |
+| 170 | **the other 127 files, together** (avg 1.34s) |
+
+85% of the lane is nine files; the remaining 127 are noise. That shape is why sharding is a complete
+fix and no test needed deleting, skipping or demoting.
+
+**The duplication is real, and was verified rather than assumed.** `tests/test-run-lints.sh`'s
+`T-all-pass` arm runs `scripts/run-lints.sh` over the **real repo** — all 11 lints end to end.
+`tests/test-lint-counter-antipattern.sh` is 12 cheap fixture cases plus `T9: MERGE GATE`, which runs
+the linter over the **real repo**; `tests/test-lint-raw-read-prompt.sh` and
+`tests/test-lint-doc-anchors.sh` have the same real-repo arm. `.github/workflows/lint.yml` already
+runs each of those lints over the repo in its own parallel job, and `counter-antipattern-lint`,
+`raw-read-prompt-lint` and `doc-anchors-lint` are all **required** checks.
+
+**The count was wrong: it is FOUR, not three.** The original filing said the counter-antipattern
+scan runs three times per PR. Re-counted against the workflows and the run logs, the full-tree scan
+executed **four** times:
+
+| # | site | measured |
+|---|---|---|
+| 1 | `lint.yml` `counter-antipattern-lint`, step "Lint counter-capture antipattern" | 207s |
+| 2 | `lint.yml` `counter-antipattern-lint`, step "Show PASS/FAIL inventory" — the `--list` re-scan, then gated `if: always()`, so it re-ran on SUCCESS too | 204s |
+| 3 | `tests/test-lint-counter-antipattern.sh` `T9: MERGE GATE` | (of the 243s) |
+| 4 | `tests/test-run-lints.sh` `T-all-pass`, via `scripts/run-lints.sh` | (of the 243s) |
+
+(1) and (2) from run 30297887996 job 90083310253, main @ `9d71824`. The missed one was (2) — a
+second execution hiding inside the *same job* as (1), which is why a per-job reading found three.
+**Site (2) is now gone on green runs**: this change also flips lint.yml's inventory steps to
+`if: failure()` (BL-191), so a passing PR pays the scan three times and a failing one still pays
+four. The rest are genuine merge gates the suites own, so nothing was removed — (3) and (4) were
+moved off each other's critical path.
+
+**The fix — rebalance, not a bigger cap.** Raising `timeout-minutes` was explicitly rejected: it only
+hides the next doubling. `unit` became a matrix job `unit-shard` over
+`[lint-sweep, lint-scan, sast, slow-misc, rest]`, cap **lowered** 20 → 12 so it stays a tripwire.
+Nothing is demoted: the set of tests gating a PR is identical before and after.
+
+**The headline number was overstated, and is corrected here.** The original commit subject and this
+entry both claimed "~5.5 min critical path". That is the **unit lane's** new long pole, not the
+PR-blocking critical path. Sharding alone would have left the PR floored at **~7-9 min** by
+lint.yml's required `counter-antipattern-lint` job — **measured 6m59s** on main (run 30297887996,
+job 90083310253, @ `9d71824`) and **9m03s** on PR #278 (run 30380689795, job 90347515417,
+@ `8ea8c6c`) — which sharding does not touch. So the honest framing is: **~5.5 min for the unit
+lane; the PR-blocking critical path becomes ~7-9 min, floored by lint.yml's required
+counter-antipattern-lint.** That refutation is what motivated folding the BL-191 lint.yml fix into
+the same change; with it, the lint floor drops to ~3.6-4.6 min and the expected critical path
+becomes **~6 min, set by this lane's `lint-sweep` shard**. All post-change timings are **DERIVED**,
+not observed — no run has yet executed the five-leg topology or the `if: failure()` lint jobs.
+
+**The cost side, on the record.** Sharding buys wall clock with billable minutes and job count.
+DERIVED (GitHub bills each job rounded UP to the whole minute; ~22s per-job overhead measured from
+the old serial job's non-test steps):
+
+- **Unit lane:** ~19 → ~26 job-minutes (6+6+6+4+3 for the five legs at PR #278's worst case, plus 1
+  for the `unit` aggregator; ~23 on a main-like tree where `sast` is 144s not 281s).
+- **Lint jobs**, thanks to the BL-191 `if: failure()` change: ~16 → ~12 job-minutes
+  (counter-antipattern 7→4, raw-read-prompt 2→1, the other seven unchanged at 1 each).
+- **Whole PR:** ~35 → ~38 job-minutes across **10 → 15 jobs**, for ~18m53s → ~6 min of wall clock.
+
+The trade is a real one and should be re-judged if the runner bill matters more than PR latency.
+
+**Two structural hazards the design had to dodge, both load-bearing.**
+1. `_build_unit_list_set` in `scripts/lint-tests-registered.sh` scopes the unit list with an
+   **unanchored** `awk '/tests=\(/…'` that does **not** strip comments. A second array whose name ends
+   in that token — or the token merely appearing in a comment or an `echo` string below the array —
+   re-opens the scope and folds every following `tests/test-*.sh` path into the lint's membership set.
+   A new test named only in a comment would then satisfy the lint while never running: verbatim the
+   BL-181 defect class. Hence the pin arrays are `pin_*`, and the prose below the array is worded to
+   avoid the token. Proof: the parser's output is byte-identical before and after (136 entries), and
+   `scripts/lint-tests-registered.sh --list` is byte-identical (209 rows, 29 `unit-lane-exempt`).
+2. `rest` is the complement of the **pinned** paths, not of the paths some shard actually ran, so
+   deleting a leg from the matrix would silently stop running that leg's pinned tests with the
+   partition arithmetic still balancing.
+
+**Hazard 2's first guard did not close it, and was rebuilt.** The original guard pinned
+`strategy.job-total` to a hand-written `shard_arms=5`. That is a second hand-kept copy of the same
+fact, and its own error message told you to update it (*"Change the matrix list, the case arms and
+the pin arrays TOGETHER, then update shard_arms"*) — so a maintainer who follows the instructions
+deletes the leg, bumps the count, and the pinned tests vanish anyway. **Proved reachable**: on a
+scratch copy, deleting the `sast` leg + its `case` arm + `shard_arms` 5→4 left all four remaining
+shards **green** while `tests/test-bl118-sast-dom-xss.sh`,
+`tests/test-bl131-domsink-rules.sh` and `tests/test-bl132-sast-index-scan.sh` ran in **no** shard —
+133 of 136, with the in-workflow partition assertion still balancing because `pinned` still counted
+them and `rest` still excluded them.
+
+Rebuilt so the **case dispatch is the single source** of the pinned set: a `shard_names` roster
+declared once, a `pins_for()` that cases on exactly those names, `pinned` built by walking the
+roster *through* `pins_for`, and the dispatch reading the same function. An orphaned `pin_*` array
+is then never claimed, so its paths fall back into `rest` and **still run**. Mutation proof, all
+four executing the real `run:` script extracted from the committed YAML:
+
+| mutation | result |
+|---|---|
+| N1 — delete `sast` from BOTH matrix and roster (the real maintainer action) | **fail-safe**: `rest` 126 → **129**, partition still 136, all tests still run |
+| N2 — delete the leg from the matrix only | every leg exits 1: `shard roster drift: the matrix declares 4 leg(s) but the roster names 5` |
+| N3 — delete the name from the roster only | every leg exits 1, same guard, inverted |
+| N4 — roster name with no `pins_for` arm (typo class) | every leg exits 1: `'sasts' is in the roster but has no arm in pins_for` |
+
+The matrix leg count remains the one hand-kept correspondence — it lives in YAML the script cannot
+read — but it is now non-silent in both directions (N2 and N3).
+
+**Also:** `unit` is a **required status check** on `main` (confirmed via
+`gh api repos/kraulerson/solo-orchestrator/branches/main/protection`). A matrix cannot keep that name,
+so `unit` survives as a zero-work aggregator job that is red unless every `unit-shard` leg is green.
+Renaming or deleting it would leave every PR waiting forever on a check that never reports.
+
+**FOR KARL — branch protection decision, not yet made.** The required contexts on `main` are
+`unit` plus eight lint jobs. The five new `unit-shard (<shard>)` checks are **not** individually
+required, by design — the `unit` aggregator is red unless every leg is green, so they are covered
+transitively. If you would rather each leg be independently required, that is a branch-protection
+edit nobody can make from a PR, and it must be done in the same window as the merge or the `unit`
+context alone will gate.
+
+**Pre-existing finding, unrelated to this change but recorded here because it surfaced during it:**
+`lint.yml` defines **nine** lint jobs but only **eight** are required on `main` —
+`evalprompts-portability-lint` runs on every PR and **does not block**. Confirmed against the
+protection API contexts list. Not fixed here; it is a policy call.
+
+**Related:** BL-191 (the per-line fork that makes the counter-antipattern scan cost 4 minutes in the
+first place — the deeper fix; its `if: failure()` half shipped with this change), BL-154 / BL-181
+(the unit-lane membership lint this had to leave behaviourally untouched), BL-077 (which created
+these lanes).
+
+---
+
+## BL-191: `lint-counter-antipattern.sh` forks a subshell per LINE, and every PR paid that ~4-minute scan four times — two of them in the same job
+
+> **Numbering note.** Filed first as BL-186; renumbered to BL-191 because PR #278 already held
+> BL-185…BL-189. See the note on BL-190.
+
+**Logged:** 2026-07-28
+**Status:** Open — the **duplicate-execution half is FIXED** on branch
+`perf/unit-lane-shard-rebalance` (below); the **per-line fork itself is not**, and that is what this
+entry stays open for. Flip to Closed only when `scan_file` is single-pass.
+**Category:** CI capacity / lint performance
+**Severity:** Medium — no correctness impact; it is the single largest cost in PR CI, and it is the
+root cause under BL-190's symptom.
+
+**The mechanism.** `scan_file` in `scripts/lint-counter-antipattern.sh` reads each file into an array
+and then, for every line, runs `echo "$line" | grep -Eq "$ANTIPATTERN_RE"` — a fork plus a pipe **per
+line** across `scripts/**`, `tests/**` and `init.sh`. Measured cost of one full-tree scan: **243s** on
+`ubuntu-latest` (run 30297887329), ~90s on the macOS host.
+
+**It was paid FOUR times per PR, not three.** The original filing (and BL-190's) said three. The
+missed execution was a second one inside the *same* `counter-antipattern-lint` job, which is why a
+per-job reading undercounted:
+
+| # | site | measured |
+|---|---|---|
+| 1 | `lint.yml` `counter-antipattern-lint` — the gating step | 207s main / 269s PR #278 |
+| 2 | `lint.yml` `counter-antipattern-lint` — the `--list` inventory step, gated `if: always()` | 204s main / 269s PR #278 |
+| 3 | `tests/test-lint-counter-antipattern.sh` `T9: MERGE GATE` | (of the 243s) |
+| 4 | `tests/test-run-lints.sh` `T-all-pass` → `scripts/run-lints.sh` | (of the 243s) |
+
+Sources: run 30297887996 job 90083310253 (main @ `9d71824`, job total **419s**) and run 30380689795
+job 90347515417 (PR #278 @ `8ea8c6c`, job total **543s**). In both, the inventory step costs
+**almost exactly half the job**.
+
+### SHIPPED with BL-190: `if: always()` → `if: failure()` on the inventory steps
+
+**The count here is NINE, not three and not eight.** Every job in `lint.yml` is a PAIR — a gating
+step that runs the lint, and an inventory step that re-runs the *same* lint with `--list`. There are
+nine jobs and therefore **nine** such pairs, and all nine inventory steps were `if: always()`.
+Two greps undercount and both were used at some point in review:
+
+- `grep -c 'sh --list'` returns **8**. It misses
+  `bash scripts/lint-backlog-references.sh --base "origin/${BASE_REF}" --list || true`, where
+  `--base …` sits between `sh` and `--list`.
+- Counting by step name misses `review-manifest-lint`, whose step is named "Show roster", not
+  "Show PASS/FAIL inventory".
+
+Structural count (parse the YAML, don't grep): 9 jobs, 9 `if: always()` steps, 9 `--list` steps, and
+the sets coincide exactly — **there is no `always()` step that is not a `--list` re-scan.**
+
+**Nothing stops being checked.** The gating steps are untouched: nine of them, no `if:`, no
+`continue-on-error`. Only the inventory re-scan became conditional, and `failure()` and `always()`
+are *identical on the failure path* — the only path the inventory was ever for. Evidence from three
+real runs where a gating step failed:
+
+| run | job | gating step | inventory step | job conclusion |
+|---|---|---|---|---|
+| 29952639143 | backlog-references-lint | **failure** | success (ran) | **failure** |
+| 29633780347 | counter-antipattern-lint | **failure** | success (ran) | **failure** |
+| 29136956152 | backlog-references-lint | **failure** | success (ran) | **failure** |
+
+Run 29633780347's `no-live-remote-in-tests-lint` is the clearest read of the semantics: its middle
+step, which has no `if:`, shows **skipped** after the failure while the `always()` inventory step
+shows **success**. That is exactly the situation `failure()` also selects. So a red lint still goes
+red, still blocks, and still prints its inventory; the `|| true` still prevents the inventory from
+ever being what fails a job — proven by the same run, where the tree was dirty enough to fail the
+gate and the inventory step still concluded `success`.
+
+**"or on demand" was never real.** `lint.yml` has no `workflow_dispatch` trigger — only
+`push: branches: [main]` and `pull_request` — so `github.event_name == 'workflow_dispatch'` would be
+unreachable dead code, and a UI re-run preserves the ORIGINAL event name rather than becoming a
+dispatch. Plain `if: failure()` therefore loses nothing that existed. The step names dropped "or on
+demand" to match; the genuine on-demand path is local: `bash scripts/lint-<name>.sh --list`.
+
+**Saving (DERIVED — no run has executed the `if: failure()` topology):** counter-antipattern-lint
+419s → ~215s on main and 543s → ~277s on PR #278; raw-read-prompt-lint 89s → ~47s; doc-anchors-lint
+38s → ~22s. Because the lint jobs run in PARALLEL, the PR-blocking lint floor is the *slowest* one,
+so it moves from **~7-9 min to ~3.6-4.6 min** — below the sharded unit lane's ~5.5 min, making that
+lane the new long pole for the first time.
+
+### STILL OPEN: the per-line fork
+
+**The fix.** Replace the per-line fork with a single-pass `grep -nE` over each file (or over the whole
+target set), then post-process only the matching lines for the sanitizer/allowlist checks. The
+neighbour-line lookahead (`LINES[i+1]`) and the BL-121 sed-alternation rule both still need the file
+body, so the rewrite has to preserve line numbering — this is why it is not a trivial edit.
+
+**Why it is still not bundled.** This is an **enforcement script**, so it needs the house TDD
+treatment: break the marked line → RED → restore → GREEN, against
+`tests/test-lint-counter-antipattern.sh` (13 cases incl. the BL-121 arms). The `if: failure()` change
+above is a workflow-only edit with no behaviour change to any lint, which is why it could ride along;
+rewriting `scan_file` cannot. Expected remaining payoff: roughly **-240s from the `lint-sweep`
+shard, -240s from `lint-scan`, and a further -190s from lint.yml's required job** — i.e. it is now
+the only thing left that lowers the ~6 min critical path.
+
+**Related:** BL-190 (the lane rebalance this sits under, and where the `if: failure()` half shipped),
+BL-121 (the sed-alternation rule the rewrite must preserve), BL-067..BL-071 (the wave-1 remediation
+this lint backstops).
+


### PR DESCRIPTION
**Merge this before #278.** #278's checks cannot go green until this lands — its `unit` job was cancelled at 20m15s, and this is the fix for that. Once this merges, re-run #278's checks.

## Why
`main`'s `unit` job already ran **18m51s–20m00s against a 20-minute cap**. PR #278 added test cases and the job was **cancelled**, not failed — `"The operation was canceled"`, no assertion failure. The lane was one test away from blocking *any* PR, whatever it contained.

85% of the lane was nine files. Per-test CI durations from the cancelled run:

| test | time |
|---|---|
| `test-run-lints.sh` | 318s |
| `test-lint-counter-antipattern.sh` | 243s |
| `test-pre-commit-gate-lints.sh` | 122s |
| `test-bl132-sast-index-scan.sh` | 77s (213s on #278) |
| the other 127 files **together** | 170s |

## What changed

**1. The unit lane is sharded, not thinned.** `unit` becomes a 5-leg matrix (`lint-sweep`, `lint-scan`, `sast`, `slow-misc`, `rest`) plus a zero-work aggregator that preserves the `unit` required-check name. **Zero demotions** — the set of tests gating a PR is byte-identical before and after. `timeout-minutes` **lowered 20 → 12**, so the cap stays a tripwire rather than a ceiling to grow into. `rest` is the complement, so adding a test is still a one-line append.

**2. Every lint stopped running twice.** Each `lint.yml` job ran its lint as the gating step, then ran it **again** under `--list` for an inventory nobody reads on a green run. All 9 inventory steps become `if: failure()`. The gating `run:` lines are **byte-identical** — verified — so nothing stops being checked; the inventory still prints when a lint actually fails, proven against three real red runs.

## Result
PR-blocking critical path **~18m53s → ~6 min** (derived from real CI per-test numbers; no run has yet executed the 5-leg topology, so this is **derived, not observed** — the first run on this PR is the proof).

## Two counts were wrong and both got corrected
The review that proposed the `lint.yml` change said "three" inventory steps; **I** then verified "eight" and briefed that. Both wrong — it is **nine**. `grep -c 'sh --list'` misses `lint-backlog-references.sh --base "…" --list` (the `--base` sits between), and `review-manifest-lint`'s step is named "Show roster", not "Show PASS/FAIL inventory". Counted structurally: 9 jobs, 9 `always()`, 9 `--list`, sets coincide. Also corrected: the counter-antipattern scan runs **four** times per PR, not three.

## A guard that did not guard
The first draft's roster-drift comment claimed deleting a matrix leg could not silently drop its tests. **Proven false**: deleting the `sast` leg left all four remaining shards **green** while 3 tests ran in no shard at all (133/136). Rebuilt so the case dispatch is the single source of the roster — an orphaned leg now falls into `rest` (fail-safe, tests still run) and every drift shape exits 1. All four shapes proven under bash 3.2.57 against the real `run:` script extracted from the committed YAML.

## Verification
Partition proof on the git blob at HEAD: **136 tests, 1/3/3/3/126, zero duplicates, zero omissions**. `yaml.safe_load` parses both workflows. `timeout-minutes` main `{unit:20, full:180}` → HEAD `{unit-shard:12, unit:5, full:180}` — nothing rose. `run-lints` **11/11 rc=0**; `lint-tests-registered` rc=0 with its parser membership set byte-identical to main.

## For you
- **BL-190** (this rebalance) and **BL-191** (the per-line fork in `lint-counter-antipattern.sh` — `scan_file` forks `echo | grep -Eq` *per line*, the real 243s cause) both stay **Open**; a Closed entry needs a PR # to cite.
- The five `unit-shard (…)` checks are **not** individually required on main. `unit` still is and is transitively gated on all five. Your call whether to require them individually.
- Pre-existing, unrelated: `lint.yml` defines **nine** lint jobs but only **eight** are required — `evalprompts-portability-lint` runs and does not block.
- Renumbered from BL-185/186 to avoid colliding with #278, which is already open and holds BL-185–189.

**TL;DR (plain English):** Checks on every change were taking about nineteen minutes and had hit their time limit, so the next change to add any test would fail regardless of what it did. This runs them five at a time instead of one after another, and stops every quality check from needlessly running twice. Feedback should drop to about six minutes. Nothing stopped being checked — I proved the before and after lists are identical. I also found a safety net that didn't actually catch what it claimed, and rebuilt it.