### PR TITLE
docs(handoffs): 2026-07-29 state-of-record; archive the seven-WP handoff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ before trusting it**.
 ## HANDOFFS
 
 - Live handoffs: `docs/handoffs/` — the **newest date is current** (as of
-  2026-07-25 that is `docs/handoffs/2026-07-24-seven-wp-wave-handoff.md`).
+  2026-07-29 that is `docs/handoffs/2026-07-29-sast-coverage-and-ci-lane.md`).
   Everything else at the top level is a pointer stub, so "newest date" and
   "the one non-stub file" agree — if they ever disagree, trust the non-stub.
 - Superseded / fully-executed handoffs move to `docs/handoffs/archive/` with a

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,8 +29,8 @@ Session handoff documents. **One live state-of-record at the top level; finished
 handoffs move to `archive/` and leave a pointer stub at the old path** so every
 citation still resolves. Convention: [handoffs/archive/README.md](handoffs/archive/README.md).
 
-- **Live:** [handoffs/2026-07-24-seven-wp-wave-handoff.md](handoffs/2026-07-24-seven-wp-wave-handoff.md) — the current state-of-record (the seven-WP wave shipped as PRs #265–#271; read its ⚠ SUPERSEDING UPDATE header first, then `git fetch` and re-derive merge state).
-- **Archived:** [handoffs/archive/](handoffs/archive/) — seven finished handoffs, 2026-07-08 through 2026-07-24, each with a pointer stub left at its old top-level path. See [handoffs/archive/README.md](handoffs/archive/README.md) for the per-file status (superseded vs fully executed). Everything at the top level of `docs/handoffs/` other than the live doc above is a stub.
+- **Live:** [handoffs/2026-07-29-sast-coverage-and-ci-lane.md](handoffs/2026-07-29-sast-coverage-and-ci-lane.md) — the current state-of-record (eleven PRs merged; CI feedback ~19 min → ~6 min; #280 and #278 still open). Read its § 3 ⚠ CORRECTION before acting on the blocker, then `git fetch` and re-derive merge state.
+- **Archived:** [handoffs/archive/](handoffs/archive/) — eight finished handoffs, 2026-07-08 through 2026-07-24, each with a pointer stub left at its old top-level path. See [handoffs/archive/README.md](handoffs/archive/README.md) for the per-file status (superseded vs fully executed). Everything at the top level of `docs/handoffs/` other than the live doc above is a stub.
 
 ## Superpowers (`docs/superpowers/`)
 

--- a/docs/handoffs/2026-07-08-ci-arc-close-and-gate-wave.md
+++ b/docs/handoffs/2026-07-08-ci-arc-close-and-gate-wave.md
@@ -9,6 +9,6 @@
 > - **Full archived copy:** [`archive/2026-07-08-ci-arc-close-and-gate-wave.md`](archive/2026-07-08-ci-arc-close-and-gate-wave.md)
 > - **Superseded by (execution plan):** [`2026-07-09-gate-wave-execution-handoff.md`](2026-07-09-gate-wave-execution-handoff.md)
 > - **Closed out by (now archived):** [`archive/2026-07-10-gate-wave-close-out.md`](archive/2026-07-10-gate-wave-close-out.md)
-> - **Live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-09-gate-wave-execution-handoff.md
+++ b/docs/handoffs/2026-07-09-gate-wave-execution-handoff.md
@@ -10,6 +10,6 @@
 >
 > - **Full archived copy:** [`archive/2026-07-09-gate-wave-execution-handoff.md`](archive/2026-07-09-gate-wave-execution-handoff.md)
 > - **Closed out by (now archived):** [`archive/2026-07-10-gate-wave-close-out.md`](archive/2026-07-10-gate-wave-close-out.md)
-> - **Live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-10-gate-wave-close-out.md
+++ b/docs/handoffs/2026-07-10-gate-wave-close-out.md
@@ -13,6 +13,6 @@
 >   copy, not against this stub.
 > - **Superseded by (next in the chain):** [`archive/2026-07-18-dogfood-remediation-handoff.md`](archive/2026-07-18-dogfood-remediation-handoff.md)
 >   → [`archive/2026-07-20-arc-close-phase-g.md`](archive/2026-07-20-arc-close-phase-g.md)
-> - **Live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-18-dogfood-remediation-handoff.md
+++ b/docs/handoffs/2026-07-18-dogfood-remediation-handoff.md
@@ -8,6 +8,6 @@
 >
 > - **Full archived copy:** [`archive/2026-07-18-dogfood-remediation-handoff.md`](archive/2026-07-18-dogfood-remediation-handoff.md)
 > - **Superseded by:** [`archive/2026-07-20-arc-close-phase-g.md`](archive/2026-07-20-arc-close-phase-g.md)
-> - **Live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-20-arc-close-phase-g.md
+++ b/docs/handoffs/2026-07-20-arc-close-phase-g.md
@@ -10,6 +10,6 @@
 >
 > - **Full archived copy:** [`archive/2026-07-20-arc-close-phase-g.md`](archive/2026-07-20-arc-close-phase-g.md)
 > - **Supersedes:** [`2026-07-18-dogfood-remediation-handoff.md`](2026-07-18-dogfood-remediation-handoff.md)
-> - **Live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-24-next-session-prompt.md
+++ b/docs/handoffs/2026-07-24-next-session-prompt.md
@@ -9,6 +9,6 @@
 >
 > - **Full archived copy:** [`archive/2026-07-24-next-session-prompt.md`](archive/2026-07-24-next-session-prompt.md)
 > - **Companion handoff (also archived):** [`2026-07-24-residuals-wave-and-next-builds.md`](2026-07-24-residuals-wave-and-next-builds.md)
-> - **Live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md
+++ b/docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md
@@ -12,6 +12,6 @@
 > - **Full archived copy:** [`archive/2026-07-24-residuals-wave-and-next-builds.md`](archive/2026-07-24-residuals-wave-and-next-builds.md)
 >   (§ 3 = the two pre-existing full-suite failures, later filed as BL-173)
 > - **Companion launch prompt (also archived):** [`2026-07-24-next-session-prompt.md`](2026-07-24-next-session-prompt.md)
-> - **Superseded by / live state-of-record:** [`2026-07-24-seven-wp-wave-handoff.md`](2026-07-24-seven-wp-wave-handoff.md)
+> - **Superseded by / live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
 > See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-24-seven-wp-wave-handoff.md
+++ b/docs/handoffs/2026-07-24-seven-wp-wave-handoff.md
@@ -1,65 +1,15 @@
-# Handoff — seven-WP wave delivered as PRs #265–#270; next = merge + closures, then Big-strategy & housekeeping
+# Handoff — seven-WP wave delivered as PRs #265–#270; next = merge + closures, then Big-strategy & housekeeping (2026-07-24)
 
-**Date:** 2026-07-24 EOD · **Author session:** supervisor (Fable 5) · **Focus for next session:** land the wave, then start the phase Karl already queued ("Once this is complete, we'll work on the Big strategy and housekeeping items").
-
-> ### ⚠ SUPERSEDING UPDATE — 2026-07-25, read this before acting on anything below
+> **Archived 2026-07-29:** FULLY EXECUTED and SUPERSEDED. Its wave landed — #265 (`7866022`),
+> #266 (`d857294`), #271 (`064d578`), #269 (`8afb9ba`), #268 (`ed406c8`), #270 (`b0b60aa`) — and
+> the closures it queued shipped as #272 (`d970b27`). Its § 3 blocker (the staged-gitlink abort
+> in the BL-132 index scan) was fixed and merged before #270 landed. Kept as a pointer stub so
+> every existing citation of this path still resolves.
 >
-> Karl authorized supervisor merges, and the wave has moved. **Everything in §1–§3 below is the 2026-07-24 EOD snapshot, kept as the historical record — it is NOT current state.** As of 2026-07-25:
+> Its own ⚠ SUPERSEDING UPDATE header already warned that its § 1–§ 3 inventory was a
+> 2026-07-24 snapshot and would move. It moved. Read the successor for current state, not this.
 >
-> - **Merged:** #265 (BL-172, merge `7866022`) and #266 (BL-173, merge `d857294`). `main` is at **`d857294`**, not `6fc1c11`. BL-176 is therefore already in `main`, not on a branch.
-> - **Remaining queue as this was written:** #271 (this PR) merges first, then #267 → #269 → #268, with #270 last. **This list moves — `git fetch` and re-derive it; do not trust any inventory in this document.**
-> - **#270 is BLOCKED on a confirmed security regression** found by a second adversarial pass (a staged submodule gitlink aborts the whole BL-132 index scan, so a staged vuln that `main` blocks would land). Fix in progress; no lane catches it, so do not treat its green suites as coverage.
-> - **BL-173 closes AT MERGE** (its own entry's condition), not after a full-lane run. Only **BL-136** carries the full-lane condition; **BL-135** awaits a second data point.
-> - **Do NOT flip BUG-001** — see § 2.
-> - Every PR in this wave was re-reviewed on 2026-07-25 by the standing adversarial pr-reviewer (Opus; the Fable quota was exhausted), plus independent refuters on blocking-class findings and a cross-PR completeness critic.
+> - **Full archived copy:** [`archive/2026-07-24-seven-wp-wave-handoff.md`](archive/2026-07-24-seven-wp-wave-handoff.md)
+> - **Superseded by / live state-of-record:** [`2026-07-29-sast-coverage-and-ci-lane.md`](2026-07-29-sast-coverage-and-ci-lane.md)
 >
-> The § 6 resume prompt already opens by telling you to `git fetch` and re-derive real merge state — do that first and trust it over any inventory in this document.
-
-## 1. Where we are
-
-`main` is at `6fc1c11` (the BL-161/BL-165 wave + closures #264, all merged earlier today). On top of it, the **seven-WP wave is complete and open as SIX green PRs — NOT merged** (supervisor never self-merges; all await Karl). Every WP ran implementer (opus, isolated worktree, fable-authored plan) → independent fable verifier; every single one surfaced a real finding — the fifth consecutive wave where the two-layer discipline caught something the implementer missed.
-
-| PR | Item(s) | Verifier arc |
-|---|---|---|
-| [#265](https://github.com/kraulerson/solo-orchestrator/pull/265) | BL-172 (cherry-pick/revert resume sentinels, both TDD-gate surfaces) | APPROVE-WITH-FIXES (word fix; filed BL-176) |
-| [#266](https://github.com/kraulerson/solo-orchestrator/pull/266) | BL-173 (two stale full-suite tests repaired; test-only) | clean APPROVE (7-row mutation matrix; root-caused the "flake" as deterministic) |
-| [#267](https://github.com/kraulerson/solo-orchestrator/pull/267) | BL-136 (TEST 5/7 fixture-era repairs) + BL-135 evidence pass | APPROVE-WITH-FIXES (3 vacuous assertions de-vacuated with bite proofs) |
-| [#268](https://github.com/kraulerson/solo-orchestrator/pull/268) | BL-174 (upgrade-path gitignore backfill + installer pass-arm case) | APPROVE-WITH-FIXES (comment truth; filed BL-177 **Medium**) |
-| [#269](https://github.com/kraulerson/solo-orchestrator/pull/269) | BL-097/098/100 **operating-model design doc** (the trio's gated deliverable) | 3 adversarial rounds: BLOCK → narrow BLOCK → **APPROVE** |
-| [#270](https://github.com/kraulerson/solo-orchestrator/pull/270) | BL-131 + BL-132 (SAST: staged-bytes index scan + shipped DOM-sink ruleset) | **REJECT** (default-`.semgrepignore` silent-skip regression) → FIX B → **APPROVE** |
-
-All six are CI-green (lints + unit lane; `full` shard is `workflow_dispatch`-only by design). WP-G (the CDF bug write-up) needed no PR — see § 2.
-
-## 2. What shipped this session
-
-- The six PRs above (branches: `fix/bl172-sentinel-parity`, `fix/bl173-test-cleanups`, `fix/bl135-bl136-fullsuite-debt`, `fix/bl174-gitignore-backfill`, `docs/bl097-100-operating-model-design`, `fix/bl131-bl132-sast-hardening`). Each: watched-RED TDD, marker fences (`# BL-172-RESUME-SENTINELS`, `# BL-136`, `# BL-174-GITIGNORE-BACKFILL`, `# BL-132-INDEX-SCAN`, `# BL-131-DOM-SINKS`), mutation proofs, both-lane registration where applicable, fable verification.
-- **The operating-model design of record:** `docs/designs/2026-07-24-operating-model-v1.md` (v1.2.1, 645 lines, §0 carries the full three-round traceability). Headline decisions: `operatingModel` block in `.claude/manifest.json`; tier tokens + `modelsBound`; three presets; **hard per-dispatch enforcement IS achievable** (PreToolUse `Agent`-matcher deny gate + manifest-rendered `.claude/agents/` role files — BL-146's `pr-reviewer.md` is the in-repo precedent) with STRICT composition; single-model degradation; 9-WP build skeleton in §10. Build is un-gated on review but **stays sequenced per the recorded 2026-07-20 trio decision**; entries stay Open.
-- **WP-G / BUG-001 (CDF context7 detection):** VERIFIED **already fixed upstream** (CDF commit `16c7f20`; clone clean+even with origin; live `check_context7` → DETECTED on this host). Write-up placed at `~/Documents/Claude Projects/claude-dev-framework/BUG-context7-detection-status.md` (outside this repo — Karl works it separately). **No bugs-file edit is needed:** Solo's BUG-001 is already terminal — its last block is `### 2026-04-22 Update — Superseded by CDF upstream`, recording this same upstream landing (CDF FRAMEWORK_VERSION 4.2.2, of which `16c7f20` — dated 2026-04-22 — is the commit). The "still says Still needed" reading came from a superseded 2026-04-21 block **mid-entry**; the WP-G pass re-confirms the recorded resolution rather than correcting it. *(Correction applied 2026-07-25 after the adversarial pr-review of this PR proved the original wording would have driven a flip that overwrote a correct `Superseded` with a weaker `Fixed`.)*
-- **Four follow-ups filed** (all Open): **BL-175** (shipped semgrep ruleset outside the shipped-set/currency registries, Low), **BL-176** (sentinel `.git/<S>` checks blind in linked worktrees, Low), **BL-177** (`_run_idempotent_backfill` has NO structural projectless guard — two sibling blocks write outside projects TODAY; explains the framework repo's month-old untracked `.claude/skills/`; **Medium**), **BL-178** (case-insensitive-FS materialization collision in the index temp tree, Low).
-- Prior to the wave, earlier today (already merged by Karl): BL-161 (#262), BL-165 (#263), BL-173-filing (#261), closures #264.
-
-## 3. What's blocked / waiting
-
-- **The six PRs await Karl's review + merge.** Recommended order: **#265 → #266 → #267 → #269 → #268 → #270** (small/docs first; the two `upgrade-project.sh` touchers last — #268 edits `_run_idempotent_backfill`, #270 edits `_bl099_sync_precommit_hook`, different functions). Expected trivial conflicts as merges proceed: the two registration anchors (`tests.yml` `tests=(`, `tests/full-project-test-suite.sh`) → keep both lines; backlog end-appends (BL-175/176/177/178) → keep all, numeric order.
-- **After merge — closure flips** (usual closures-PR pattern): BL-131, BL-132, BL-172, BL-173, BL-174 → Closed with PR + merge SHAs. **BL-136 stays Open until a green full-lane run** (its entry's stated closure condition); **BL-135** stays Open awaiting its second full-lane data point; **BL-097/098/100** stay Open (design delivered; build pending).
-- **A post-merge full-lane `workflow_dispatch` run** (~3h) is the natural next validation: it confirms the TEST 5/7 repairs and the two repaired suites, and gives BL-135 its second data point in one shot. Needs Karl to trigger (or approve triggering).
-- **Live-ZAP smoke** at the next dogfood walk (carried recommendation from the BL-165 reviewers). *(A BUG-001 entry flip was listed here and has been REMOVED — the entry is already `Superseded`; see § 2.)*
-
-## 4. What's next (Karl's stated sequence: "Big strategy and housekeeping items")
-
-1. **Land the wave** (merge + closures PR + optional full-lane dispatch), per § 3.
-2. **Big strategy:** (a) the **operating-model build** — plan directly from the design's §10 nine-WP skeleton (WP1 schema → WP4a/4b enforcement surfaces → …), same wave discipline; (b) **BL-109 Currency System** remaining slices (design of record `docs/designs/2026-07-12-currency-system-v1.md` v1.1).
-3. **Housekeeping batch:** BL-085 (CI-fast full suite, deferred), BL-090 (doc-reference checker), BL-092 (generated CLAUDE.md diet), BL-093 (backlog archive split), BL-094 (grep indexes for big scripts).
-4. **New-follow-up queue** when convenient: **BL-177 first (Medium — live leak)**, then BL-175/176/178 (Low).
-
-## 5. References
-
-- Backlog (source of truth): `solo-orchestrator-backlog.md` — `## BL-131:` `## BL-132:` `## BL-172:` `## BL-173:` `## BL-174:` `## BL-135:` `## BL-136:` `## BL-097:` `## BL-098:` `## BL-100:` + new `## BL-175:` … `## BL-178:` (the 175–178 entries live on the un-merged wave branches until merge).
-- Design doc: `docs/designs/2026-07-24-operating-model-v1.md` (on the #269 branch until merge). Currency design: `docs/designs/2026-07-12-currency-system-v1.md`.
-- CDF write-up: `~/Documents/Claude Projects/claude-dev-framework/BUG-context7-detection-status.md` (outside this repo).
-- Repo discipline: `CLAUDE.md` (bash-3.2 subset, [WARN]-trap, marker citations, both-lane registration, quote paths).
-- Prior handoff (superseded by this one): `docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md`.
-
-## 6. Resume prompt
-
-> Continuing from the 2026-07-24 EOD handoff at `docs/handoffs/2026-07-24-seven-wp-wave-handoff.md` in /Users/karl/Documents/Claude Projects/solo-orchestrator. Read that handoff and CLAUDE.md first. State when I stopped: the seven-WP wave (BL-131+132 SAST, BL-172, BL-173, BL-174, BL-135/136 investigation, the BL-097/098/100 operating-model design doc, and the CDF BUG-001 verification) is open as six green, fable-verified PRs #265–#270 — none merged; never self-merge. FIRST: `git fetch` and check the actual merge state of #265–#270 — Karl may have merged some or all since. If merges happened: resolve any keep-both-lines conflicts on the remaining PRs (registration anchors + backlog end-appends, numeric order), then open the closures PR (flip BL-131/132/172/173/174 → Closed with PR + merge SHAs; BL-135/136 stay Open pending a green full-lane run — propose triggering the ~3h `workflow_dispatch` full lane to Karl, never run it unasked; BL-097/098/100 stay Open, design delivered). Do NOT touch BUG-001 — it is already `Superseded` (2026-04-22, the same upstream landing WP-G re-verified); an earlier draft of this prompt said to flip it, which would have regressed a correct entry. If PRs are still open: surface the review queue and wait. THEN proceed to Karl's queued phase — Big strategy (the operating-model build planned from `docs/designs/2026-07-24-operating-model-v1.md` §10's nine-WP skeleton, and BL-109 currency slices) and housekeeping (BL-085/090/092/093/094), plus the follow-up queue led by BL-177 (Medium). Use the standing discipline: fable-authored junior-followable plans, opus implementers in isolated worktrees, fable verifiers ≥ implementer on anything behavioral, watched-RED TDD with mutation proofs, both-lane registration, commit-not-push until verified, and nudge any subagent that ends its turn "waiting" on a background job — completion notifications only reach the supervisor.
+> See [`archive/README.md`](archive/README.md) for the handoff-archive convention.

--- a/docs/handoffs/2026-07-29-sast-coverage-and-ci-lane.md
+++ b/docs/handoffs/2026-07-29-sast-coverage-and-ci-lane.md
@@ -1,0 +1,185 @@
+# Handoff — SAST coverage split + CI lane rebalance; #280 down to one CI-only blocker (BL-193)
+
+**Date:** 2026-07-29 · **Author session:** supervisor (Opus 5) · **Prior handoff:** `docs/handoffs/archive/2026-07-24-seven-wp-wave-handoff.md` (archived by this one)
+
+> **Backlog ids filed on unmerged branches — grep `main` for them and you will find nothing.**
+> `BL-192`, `BL-193`, `BL-194` exist only on **#280**; `BL-185`–`BL-189` only on **#278**. They
+> land with their PRs. Everything else this document cites is on `main` today.
+
+## 1. Where we are
+
+`main` is at **`08d5eec`**. Backlog on `main`: **183 `BL-`numbered entries** (186 counting the three legacy `## code-*:` headers), **27 open** — count with the trap-aware recipe, not a raw grep, because BL-055's preserved pre-close block carries its own `**Status:** Open` line:
+
+```
+awk '/^## /{p=0} /Original entry \(pre-close/{p=1} /\*\*Status:\*\* Open/{if(!p) n++} END{print n}' solo-orchestrator-backlog.md
+```
+
+Two PRs open, **neither mergeable as-is**:
+
+- **[#280](https://github.com/kraulerson/solo-orchestrator/pull/280)** `fix/bl112-sast-coverage-portable` @ **`4cbe83c`** — the portable half of the SAST coverage work. **This SHA moves; `git fetch` and re-derive rather than trusting it.** Four adversarial rounds: `minor_concerns` pre-open (six findings fixed), then `major_concerns` on the delta (the BL-194 anchor was itself forgeable — see § 3), then `minor_concerns` twice more. **One blocker left: `unit-shard (sast)`, and it is CI-ONLY — it does NOT reproduce locally on any platform tried, including on CI's own semgrep** (BL-193). Every other check is green, and as of `4cbe83c` those three cases finally PRINT the SAST section they were capturing and discarding, so the next run should name the cause. See § 3 and § 6.1.
+- **[#278](https://github.com/kraulerson/solo-orchestrator/pull/278)** `fix/bl112-sast-scan-coverage` @ `e87dbd3` — the original full stack, **superseded by #280**. Do not merge. It still owns BL-185/186/188/189 and the withdrawn parse clause; it needs a disposition decision once #280 lands (§ 4).
+
+Everything else this session is merged and green.
+
+## 2. What shipped this session
+
+Merged, in order: **#271** (`064d578`), **#269** (`8afb9ba`), **#268** (`ed406c8`), **#270** (`b0b60aa`), **#272** closures (`d970b27`), **#273** BL-180 (`3ad2bf7`), **#274** BL-179/182 (`24ac0bd`), **#276** BL-184 aggregator (`ffc43a8`), **#275** BL-181/135 (`58c7332`), **#277** skills untrack (`9d71824`), **#279** CI lane rebalance (`08d5eec`).
+
+Headline outcomes:
+- **CI feedback ~19 min → ~6 min** (#279). Unit lane sharded into 5 parallel legs, **zero demotions** (partition proven exact at 136 tests); all 9 `lint.yml` inventory steps `if: always()` → `if: failure()`, ending a double-scan of every lint. `timeout-minutes` **lowered** 20 → 12. First real run: longest leg 365s, aggregator 4s.
+- **BL-135 root-caused** — never a flake. `scripts/resolve-tools.sh` probes the host for Homebrew, so a `--dev-os darwin` test passed on macOS and failed on Linux CI.
+- **BL-180** — interactive `init.sh` left `enforcement_level: ""` and installed no filesystem gate, while every diagnostic reported the project as strict.
+- **BL-184** — the full-suite aggregator discarded child stdout **and stderr** at 177 sites; a CI failure said only "run for details", which was impossible for CI-only failures.
+- A full-lane `workflow_dispatch` run (`30204845017`) confirmed BL-136's TEST 5/7 repairs — **but that run's overall conclusion is `failure`, so do NOT cite it as "the full lane went green".** TEST 5 and TEST 7 each passed every case; `full (core)` failed on one unrelated child, `tests/test-bl033-install-cmds-shape.sh`, which passes locally 8/0. Close BL-136 on those `[PASS]` lines, not on the run's colour. That `test-bl033` failure is itself an untracked CI-only red on `main`'s full lane — and the run predates BL-184's evidence fix (`ffc43a8`, one day later) by just over a day, so `run for details` was the entire diagnostic. A re-run now would print the child's output.
+
+## 3. #280's two test-instrument blockers — root-caused and FIXED (`0467d56`); one CI-only blocker remains
+
+> **⚠ CORRECTION (2026-07-29, later the same day).** The original § 3 said the `test-bl147`
+> failure was caused by `--max-target-bytes=0` being present in the hook and absent from the
+> 22 CI templates, and recommended adding the flag to all 22. **That was wrong**, and it was
+> wrong in the way the failure message invited — the message accused config parity, so the
+> diagnosis went looking at templates. The templates were correct and untouched throughout.
+> The real causes are below. Nothing in `templates/pipelines/**` needed to change.
+
+Two independent defects, neither in the code the PR set out to change, both in **test
+instruments that reported the opposite of what they measured**. Filed as BL-194 and BL-183.
+
+**(a) BL-194 — a documentation comment became the enforced policy.** `test-bl147` derives the
+expected flag set from the hook itself (deliberately — never retyped) using an awk scoper
+matching a bare `/semgrep scan/`, with no comment stripping. This PR added a `FALSIFIER:` block
+above the invocation which, as a falsifier must, *names the command*. That comment is the first
+match in the file and carries no trailing `\`, so the collector emitted one prose line and
+exited → `configs='' severity='' error=no` → all 22 templates graded against the empty policy.
+Same shape as `_build_unit_list_set`'s unanchored `tests=(` scoper (CLAUDE.md CANONICAL
+COMMANDS). Fixed by anchoring on `# BL-194-HOOK-SEMGREP-POLICY`, plus an assertion that the
+collected text is really the invocation — so a drifted anchor now fails naming *itself* and
+says the CI templates are not implicated.
+
+**(b) BL-183 — the SIGPIPE predicate inversion, already diagnosed on 2026-07-28 and unfixed.**
+`has_live`/`has_cfg` in `test-bl118` and `test-bl131` were `grep -v … | grep -q …` under
+`set -o pipefail`. BL-183 had already named these exact two files and measured **1–7 failures
+per 300 runs on Linux, 0 on macOS** — and called it a flake. It fired on the **first** CI run
+here, in both files at once, because this stack **doubled the emitted hook (645 → 1231 lines,
+41,211 → 88,824 bytes)**. The rate is a function of that size, not of luck; read BL-183's
+table as a property of a file size. The CI messages claimed `p/owasp-top-ten dropped` and
+`BL-131 wiring absent` — two security regressions that never happened. Fixed with
+single-process awk (no pipe to break). BL-183 stays **Open** for its three emitted-hook sites
+and the `tests/` census it never ran.
+
+**Why both were missed locally:** `test-bl147` was never in anyone's local tally set (everyone
+ran bl132/bl125/bl131/bl118/bl112-commit-enforcement + run-lints), and BL-183 is invisible on
+macOS/BSD grep at ordinary file sizes. Run the shard's actual file list, not a habitual subset.
+
+**Both fixes are CONFIRMED ON CI** (run `30465215103`, head `e021d34`) — not merely green
+locally:
+
+| check | before (`a8dbef7`) | after (`e021d34`) |
+|---|---|---|
+| `unit-shard (rest)` — test-bl147 | 47/7 **fail** | **pass** (56/0) |
+| `test-bl131` | 14/1 | **15/0** |
+| `test-bl118` | 3/1 | **5/0**, incl. the new `T-predicate-no-sigpipe` |
+| all other shards + all 9 lint jobs | pass | pass |
+
+No `grep: write error: Broken pipe` anywhere in the new log.
+
+**Still open on #280 — the `sast` shard's 3 failures (BL-193).** `T-coverage-no-cry-wolf`,
+`T-empty-target-receipt` and `T-mutation-typechange-filter` (the third only because its RED
+direction needs an `[OK]` the other two show is being withheld). **The semgrep-version story is
+REFUTED, not merely unconfirmed** — measured 2026-07-29, and this closes § 4.1's leading
+candidate:
+> - CI installs unpinned and pulled **1.172.0** (it was 1.171.0 a day earlier — the drift is
+>   continuous). This host has 1.157.0.
+> - On the exact five-file fixture `T-coverage-no-cry-wolf` uses, both versions emit a
+>   **byte-identical** Scan Status banner — `Scanning 5 files with 174 Code rules:`, header
+>   count 1, rc=0. The banner the guard parses did not change.
+> - `bl132` run end-to-end against **1.172.0 itself**: **38 passed, 0 failed, 0 skipped** —
+>   identical to 1.157.0. All three CI failures and all ten CI skips pass here.
+>
+> (Trap worth keeping: a venv semgrep reports the *Homebrew* version unless you clear `PATH` —
+> `env -i PATH="$VENV/bin:/usr/bin:/bin" semgrep --version`. Measuring without that reads
+> 1.157.0 and quietly compares a version against itself.)
+
+So whatever CI is doing, it is not the binary. BL-193's own recommendation stands and is now the
+next concrete step: **re-run the shard with the hook's `$soif_sg_err` preserved as a CI
+artifact** — the hook writes and then deletes it, and those bytes are the only thing that
+separates the remaining candidate causes.
+
+## 4. What's blocked / waiting
+
+- **#280** — on § 3.
+- **#278** — needs a disposition once #280 lands. Its BL-187 copy **must be deleted during rebase, not merged**; #280 moved its own copy so the merge now conflicts *visibly* (proven with `git merge-tree`; the prior arrangement auto-merged to two divergent `## BL-187:` entries with no lint catching it).
+- **Two open decisions for Karl**, both explained in-session, neither answered:
+  1. **The semgrep pin.** CI installs unpinned (`pip install semgrep`, two sites); it pulled **1.171.0 on 2026-07-26 and 1.172.0 on 2026-07-29** — the drift is continuous. This host has 1.157.0. Two things are now settled and narrow the decision: § 5 shows pinning does **not** protect against the BL-192 soundness defect and that version ordering is **not monotone**; and § 3 shows the drift is **not** what fails the `sast` shard (all three failures pass locally on 1.172.0 itself). So this is a question of build determinism, not of correctness or of unblocking #280. Recommendation: pin, to the **newer**, so a version-dependent defect surfaces as a failing test on a known version rather than as an unreproducible CI flake — but it buys reproducibility, not safety, and it will not turn #280 green.
+  2. **Whether to write the BL-192 fix plan** (offered, not started).
+- **The 5 `unit-shard (…)` checks are not individually required** on `main`; `unit` is, and is transitively gated. Karl's call whether to require them.
+- Pre-existing: `lint.yml` defines **nine** lint jobs but only **eight** are required — `evalprompts-portability-lint` runs and cannot block.
+
+## 5. The BL-192 root cause (settled — do not re-derive)
+
+`Parsed lines` is, byte-identically in 1.157.0 and 1.171.0 (read from shipped `semgrep/output.py`):
+
+```
+(sum of 0x0A bytes over all targets − summed line-extent of REPORTED error spans) / same total
+```
+
+It is **the arithmetic complement of reported errors, not a coverage measure**. A file the parser never opened and one parsed perfectly both subtract zero. The UTF-16 file is excluded by a raw-byte **literal prefilter** (the rule needs `innerHTML`; UTF-16LE spells it `i\0n\0n\0e\0r\0…`), so no error is emitted and its unread lines count as parsed.
+
+Four measured consequences, all in `## BL-192:`:
+- **`--error` — which the gate passes — forces the metric to 100%** on every version (parse accounting populates only in the third arm of an if/elif any finding short-circuits). Measured `~50.0%` → `~100.0%`.
+- **Pinning does not protect**: on 1.157.0 the same sink in UTF-16LE *without* a BOM already reports `~100.0%`, `errors: []`, rc=0.
+- **Not monotone**: one fixture is missed by 1.157.0 and caught by 1.171.0.
+- **Run-level, not per-file** — one clean file dilutes a broken one toward 100%.
+
+**A canary does NOT work for this class — tested and refuted.** Generic-regex fires 186 matches on the undetected file; an appended ASCII marker is found on all six UTF-16 fixtures while the body vulnerability is missed.
+
+**What survives:** a **finding is a fact** (rc=1 + a result at a path proves a real match). Presence is trustworthy; **absence is not**. `Targets scanned`, `paths.scanned`, `paths.skipped`, `errors[]`, exit code and `parse_times` are all measured unsafe.
+
+**The fix shape:** a **NUL-byte/BOM precheck the gate performs itself** — explicitly *not* a UTF-8 decode test, since the no-BOM case decodes as valid UTF-8. Route failures to the existing `soif_sast_not_enforced` vocabulary.
+
+## 6. What's next
+
+1. **Unblock #280 — the ONLY red check is `unit-shard (sast)`, and it is BL-193.** The
+   test-bl147 parity failure is already fixed (§ 3); do not go looking for it. The next
+   concrete action is to make the three failing cases print what they measured: they capture
+   the hook's full output to `$TOPTMP/<log>` and then show only a `tail -8` (and, in
+   `T-mutation-typechange-filter`, a `tail -3` twice), which on these fixtures lands on
+   the unrelated `[WARN] no test command configured` block — so the SAST
+   section is captured and thrown away. Replace those tails with a dump of the SAST reporter
+   lines. Failure-path only, no product change, and it discriminates every surviving candidate
+   in BL-193 in one CI run. Then merge #280.
+2. **Dispose of #278** (§ 4) — delete its BL-187 copy on rebase.
+3. **The bookkeeping PR** — close BL-179/180/182 (`24ac0bd`/`3ad2bf7`) and BL-184 (`ffc43a8`)
+   with merge SHAs; close BL-136 on run `30204845017`'s TEST 5/7 `[PASS]` lines, **not** on the
+   run's colour (§ 2); correct BL-182's false "regression versus main" claim (the defect had
+   shipped via #270 19 minutes before that sentence was written); fold the #273/#274 retro
+   re-grades; file the "no lint catches a broken `# BL-NNN` marker" gap; file `test-bl033` as
+   an untracked CI-only full-lane red (§ 2).
+4. **Answer the two open decisions** (§ 4).
+5. **Fix the confirmed BL-183 emitted-hook site — it is a live defect in shipped enforcement
+   code, and it is NOT the one BL-183 predicts.** In `# BL-125-COMMIT-TESTS`, the npm detector
+   `sed -n '/"scripts"…/,/}/p' package.json | grep -qE '"test"…'` inverts under the emitted
+   hook's `set -euo pipefail`, so a project with a real `jest` suite is told
+   `PROJECT TESTS NOT ENFORCED` and the commit-time test gate stops running. Measured
+   **20/20 deterministic on macOS** — the platform BL-183's table records as immune.
+   **BL-183's stated precondition for this site is wrong and hides the bug:** it blames a large
+   `package.json`, but `sed`'s range closes at the first `}` and it then reads without
+   *writing*, and SIGPIPE needs a write. A 1.25 MB `package.json` with an ordinary scripts
+   block does **not** invert; a monorepo-sized *scripts block* inverts every time. Fix with the
+   same single-process awk used in #280 (preserving the S1/S4 scripts-block scoping), in its
+   own PR — not folded into a SAST PR.
+6. **Then the queued phase**: the operating-model build (design v1.2.3, five adversarial rounds,
+   WP2–WP3 plans drafted — see § 7), BL-085, BL-109, housekeeping, and BL-177 leading the
+   follow-ups.
+
+## 7. References
+
+- Backlog: `solo-orchestrator-backlog.md`. **On `main` today:** `## BL-190:`/`## BL-191:` (lane rebalance; the per-line fork in `lint-counter-antipattern.sh`), `## BL-177:` (projectless backfill guard — has a live trigger in the PR-blocking unit lane).
+- **`## BL-183:` — entry exists on `main`, but the REVISION this handoff quotes does not.** Its platform table (`1–7 failures per 300 runs` on Linux, `0 per 300` on macOS) and its three-emitted-hook-site enumeration (including `# BL-125-COMMIT-TESTS`) were added in the 2026-07-28 update and live **only on #280**. § 3(b) and § 6.5 cite that revision. Grepping `main`'s BL-183 for `per 300 runs` or `BL-125-COMMIT-TESTS` returns nothing — read #280's copy, or wait for it to land. **Filed on #280, NOT yet on `main`:** `## BL-192:` (semgrep parse-coverage unsound), `## BL-193:` (CI-only receipt forfeiture + 13-proof skip cascade), `## BL-194:` (prose captured the parity derivation). **Filed on #278:** `BL-185`/`186`/`187`/`188`/`189`.
+- Operating-model design of record: `docs/designs/2026-07-24-operating-model-v1.md` (v1.2.3).
+- WP plans (scratchpad, **session-local — copy them out before this session's scratchpad is lost**): `wp2-plan-setup-selection.md` and `wp3-plan-reconfigure-audit.md`. **WP1 was never written** — the design's WP1 (operating-model schema + stamp) still needs a plan; do not go looking for a `wp1-plan-*.md` file. Open escalation recorded in WP2: §3's `singleModel` iff makes the `always-best` preset compute `true`; a reviewer judged it coherent as a config-shape predicate, but WP2's tests must encode one semantic.
+- Repo discipline: `CLAUDE.md` — note its HOUSE RULES now record BL-181's two residuals and the `unit-shard` job rename.
+- Standing gates (memory): **review before opening any PR**, docs-only and supervisor-authored commits included; plus **periodic adversarial sweeps of merged `main`**, which is what found the severe >1MB defect.
+
+## 8. Resume prompt
+
+> Continuing from the 2026-07-29 handoff at `docs/handoffs/2026-07-29-sast-coverage-and-ci-lane.md` in /Users/karl/Documents/Claude Projects/solo-orchestrator. Read that handoff and CLAUDE.md first, and read § 3 before touching #280. State: `main` is at `08d5eec`; eleven PRs merged; CI feedback is down from ~19 min to ~6 min; #280 is at `e021d34` with **every check green except `unit-shard (sast)`**. **The test-bl147 parity failure is ALREADY FIXED** (BL-194 anchor + BL-183 SIGPIPE, commit `0467d56`, confirmed on CI run `30465215103`) — an earlier draft of this handoff blamed it on `--max-target-bytes=0` missing from the 22 CI templates and told you to add the flag there; that was **wrong**, the templates were correct throughout, and § 3 carries the correction. Do not edit `templates/pipelines/**` for this. FIRST: `git fetch`, confirm #280 and #278 are still open, then unblock #280's ONE remaining red — `unit-shard (sast)`, which is BL-193: three cases (`T-coverage-no-cry-wolf`, `T-empty-target-receipt`, `T-mutation-typechange-filter`) that fail **only on the GitHub runner** and pass locally on every platform tried, including on CI's own semgrep 1.172.0 (`bl132` is 38/0/0 there — the version story is refuted, § 3). Per § 6.1 the next action is to make those cases print the SAST section they already capture instead of the `tail -8`/`tail -3` that lands on an unrelated WARN block; that is failure-path only and discriminates every surviving candidate in one run. Then merge #280. THEN dispose of #278 (superseded by #280 — its `## BL-187:` copy must be DELETED during rebase, not merged). THEN the bookkeeping PR per § 6.3 — note BL-136 closes on run `30204845017`'s TEST 5/7 `[PASS]` lines, **not** on that run's colour, which is red for an unrelated child. THEN § 6.5, a confirmed live defect in shipped enforcement code: the emitted hook's npm-test detector inverts under `pipefail` on a monorepo-sized `scripts` block (20/20 on macOS), so a project with a real suite is told `PROJECT TESTS NOT ENFORCED` — and BL-183's own stated precondition for that site is wrong in a way that makes the bug look unreachable. Two decisions are open for Karl and must not be decided unilaterally: the semgrep pin (§ 4.1 — now a build-determinism question only; it will **not** turn #280 green) and whether to write the BL-192 fix plan. Do NOT re-derive BL-192's root cause — it is settled in § 5, including that a canary was tested and refuted for this class. `BL-192`/`193`/`194` live on #280 and `BL-185`–`189` on #278, so grepping `main` for them finds nothing. Standing discipline: adversarial review runs on the branch tip BEFORE `gh pr create` (docs-only and supervisor-authored commits included, wired into the dispatch so a plain Agent call cannot skip it); claims in shipped comments are scoped to this invocation and this version and carry a falsifier runnable as written; never a bare tally; never an upstream quote standing in for a measurement.

--- a/docs/handoffs/archive/2026-07-24-seven-wp-wave-handoff.md
+++ b/docs/handoffs/archive/2026-07-24-seven-wp-wave-handoff.md
@@ -1,0 +1,65 @@
+# Handoff — seven-WP wave delivered as PRs #265–#270; next = merge + closures, then Big-strategy & housekeeping
+
+**Date:** 2026-07-24 EOD · **Author session:** supervisor (Fable 5) · **Focus for next session:** land the wave, then start the phase Karl already queued ("Once this is complete, we'll work on the Big strategy and housekeeping items").
+
+> ### ⚠ SUPERSEDING UPDATE — 2026-07-25, read this before acting on anything below
+>
+> Karl authorized supervisor merges, and the wave has moved. **Everything in §1–§3 below is the 2026-07-24 EOD snapshot, kept as the historical record — it is NOT current state.** As of 2026-07-25:
+>
+> - **Merged:** #265 (BL-172, merge `7866022`) and #266 (BL-173, merge `d857294`). `main` is at **`d857294`**, not `6fc1c11`. BL-176 is therefore already in `main`, not on a branch.
+> - **Remaining queue as this was written:** #271 (this PR) merges first, then #267 → #269 → #268, with #270 last. **This list moves — `git fetch` and re-derive it; do not trust any inventory in this document.**
+> - **#270 is BLOCKED on a confirmed security regression** found by a second adversarial pass (a staged submodule gitlink aborts the whole BL-132 index scan, so a staged vuln that `main` blocks would land). Fix in progress; no lane catches it, so do not treat its green suites as coverage.
+> - **BL-173 closes AT MERGE** (its own entry's condition), not after a full-lane run. Only **BL-136** carries the full-lane condition; **BL-135** awaits a second data point.
+> - **Do NOT flip BUG-001** — see § 2.
+> - Every PR in this wave was re-reviewed on 2026-07-25 by the standing adversarial pr-reviewer (Opus; the Fable quota was exhausted), plus independent refuters on blocking-class findings and a cross-PR completeness critic.
+>
+> The § 6 resume prompt already opens by telling you to `git fetch` and re-derive real merge state — do that first and trust it over any inventory in this document.
+
+## 1. Where we are
+
+`main` is at `6fc1c11` (the BL-161/BL-165 wave + closures #264, all merged earlier today). On top of it, the **seven-WP wave is complete and open as SIX green PRs — NOT merged** (supervisor never self-merges; all await Karl). Every WP ran implementer (opus, isolated worktree, fable-authored plan) → independent fable verifier; every single one surfaced a real finding — the fifth consecutive wave where the two-layer discipline caught something the implementer missed.
+
+| PR | Item(s) | Verifier arc |
+|---|---|---|
+| [#265](https://github.com/kraulerson/solo-orchestrator/pull/265) | BL-172 (cherry-pick/revert resume sentinels, both TDD-gate surfaces) | APPROVE-WITH-FIXES (word fix; filed BL-176) |
+| [#266](https://github.com/kraulerson/solo-orchestrator/pull/266) | BL-173 (two stale full-suite tests repaired; test-only) | clean APPROVE (7-row mutation matrix; root-caused the "flake" as deterministic) |
+| [#267](https://github.com/kraulerson/solo-orchestrator/pull/267) | BL-136 (TEST 5/7 fixture-era repairs) + BL-135 evidence pass | APPROVE-WITH-FIXES (3 vacuous assertions de-vacuated with bite proofs) |
+| [#268](https://github.com/kraulerson/solo-orchestrator/pull/268) | BL-174 (upgrade-path gitignore backfill + installer pass-arm case) | APPROVE-WITH-FIXES (comment truth; filed BL-177 **Medium**) |
+| [#269](https://github.com/kraulerson/solo-orchestrator/pull/269) | BL-097/098/100 **operating-model design doc** (the trio's gated deliverable) | 3 adversarial rounds: BLOCK → narrow BLOCK → **APPROVE** |
+| [#270](https://github.com/kraulerson/solo-orchestrator/pull/270) | BL-131 + BL-132 (SAST: staged-bytes index scan + shipped DOM-sink ruleset) | **REJECT** (default-`.semgrepignore` silent-skip regression) → FIX B → **APPROVE** |
+
+All six are CI-green (lints + unit lane; `full` shard is `workflow_dispatch`-only by design). WP-G (the CDF bug write-up) needed no PR — see § 2.
+
+## 2. What shipped this session
+
+- The six PRs above (branches: `fix/bl172-sentinel-parity`, `fix/bl173-test-cleanups`, `fix/bl135-bl136-fullsuite-debt`, `fix/bl174-gitignore-backfill`, `docs/bl097-100-operating-model-design`, `fix/bl131-bl132-sast-hardening`). Each: watched-RED TDD, marker fences (`# BL-172-RESUME-SENTINELS`, `# BL-136`, `# BL-174-GITIGNORE-BACKFILL`, `# BL-132-INDEX-SCAN`, `# BL-131-DOM-SINKS`), mutation proofs, both-lane registration where applicable, fable verification.
+- **The operating-model design of record:** `docs/designs/2026-07-24-operating-model-v1.md` (v1.2.1, 645 lines, §0 carries the full three-round traceability). Headline decisions: `operatingModel` block in `.claude/manifest.json`; tier tokens + `modelsBound`; three presets; **hard per-dispatch enforcement IS achievable** (PreToolUse `Agent`-matcher deny gate + manifest-rendered `.claude/agents/` role files — BL-146's `pr-reviewer.md` is the in-repo precedent) with STRICT composition; single-model degradation; 9-WP build skeleton in §10. Build is un-gated on review but **stays sequenced per the recorded 2026-07-20 trio decision**; entries stay Open.
+- **WP-G / BUG-001 (CDF context7 detection):** VERIFIED **already fixed upstream** (CDF commit `16c7f20`; clone clean+even with origin; live `check_context7` → DETECTED on this host). Write-up placed at `~/Documents/Claude Projects/claude-dev-framework/BUG-context7-detection-status.md` (outside this repo — Karl works it separately). **No bugs-file edit is needed:** Solo's BUG-001 is already terminal — its last block is `### 2026-04-22 Update — Superseded by CDF upstream`, recording this same upstream landing (CDF FRAMEWORK_VERSION 4.2.2, of which `16c7f20` — dated 2026-04-22 — is the commit). The "still says Still needed" reading came from a superseded 2026-04-21 block **mid-entry**; the WP-G pass re-confirms the recorded resolution rather than correcting it. *(Correction applied 2026-07-25 after the adversarial pr-review of this PR proved the original wording would have driven a flip that overwrote a correct `Superseded` with a weaker `Fixed`.)*
+- **Four follow-ups filed** (all Open): **BL-175** (shipped semgrep ruleset outside the shipped-set/currency registries, Low), **BL-176** (sentinel `.git/<S>` checks blind in linked worktrees, Low), **BL-177** (`_run_idempotent_backfill` has NO structural projectless guard — two sibling blocks write outside projects TODAY; explains the framework repo's month-old untracked `.claude/skills/`; **Medium**), **BL-178** (case-insensitive-FS materialization collision in the index temp tree, Low).
+- Prior to the wave, earlier today (already merged by Karl): BL-161 (#262), BL-165 (#263), BL-173-filing (#261), closures #264.
+
+## 3. What's blocked / waiting
+
+- **The six PRs await Karl's review + merge.** Recommended order: **#265 → #266 → #267 → #269 → #268 → #270** (small/docs first; the two `upgrade-project.sh` touchers last — #268 edits `_run_idempotent_backfill`, #270 edits `_bl099_sync_precommit_hook`, different functions). Expected trivial conflicts as merges proceed: the two registration anchors (`tests.yml` `tests=(`, `tests/full-project-test-suite.sh`) → keep both lines; backlog end-appends (BL-175/176/177/178) → keep all, numeric order.
+- **After merge — closure flips** (usual closures-PR pattern): BL-131, BL-132, BL-172, BL-173, BL-174 → Closed with PR + merge SHAs. **BL-136 stays Open until a green full-lane run** (its entry's stated closure condition); **BL-135** stays Open awaiting its second full-lane data point; **BL-097/098/100** stay Open (design delivered; build pending).
+- **A post-merge full-lane `workflow_dispatch` run** (~3h) is the natural next validation: it confirms the TEST 5/7 repairs and the two repaired suites, and gives BL-135 its second data point in one shot. Needs Karl to trigger (or approve triggering).
+- **Live-ZAP smoke** at the next dogfood walk (carried recommendation from the BL-165 reviewers). *(A BUG-001 entry flip was listed here and has been REMOVED — the entry is already `Superseded`; see § 2.)*
+
+## 4. What's next (Karl's stated sequence: "Big strategy and housekeeping items")
+
+1. **Land the wave** (merge + closures PR + optional full-lane dispatch), per § 3.
+2. **Big strategy:** (a) the **operating-model build** — plan directly from the design's §10 nine-WP skeleton (WP1 schema → WP4a/4b enforcement surfaces → …), same wave discipline; (b) **BL-109 Currency System** remaining slices (design of record `docs/designs/2026-07-12-currency-system-v1.md` v1.1).
+3. **Housekeeping batch:** BL-085 (CI-fast full suite, deferred), BL-090 (doc-reference checker), BL-092 (generated CLAUDE.md diet), BL-093 (backlog archive split), BL-094 (grep indexes for big scripts).
+4. **New-follow-up queue** when convenient: **BL-177 first (Medium — live leak)**, then BL-175/176/178 (Low).
+
+## 5. References
+
+- Backlog (source of truth): `solo-orchestrator-backlog.md` — `## BL-131:` `## BL-132:` `## BL-172:` `## BL-173:` `## BL-174:` `## BL-135:` `## BL-136:` `## BL-097:` `## BL-098:` `## BL-100:` + new `## BL-175:` … `## BL-178:` (the 175–178 entries live on the un-merged wave branches until merge).
+- Design doc: `docs/designs/2026-07-24-operating-model-v1.md` (on the #269 branch until merge). Currency design: `docs/designs/2026-07-12-currency-system-v1.md`.
+- CDF write-up: `~/Documents/Claude Projects/claude-dev-framework/BUG-context7-detection-status.md` (outside this repo).
+- Repo discipline: `CLAUDE.md` (bash-3.2 subset, [WARN]-trap, marker citations, both-lane registration, quote paths).
+- Prior handoff (superseded by this one): `docs/handoffs/2026-07-24-residuals-wave-and-next-builds.md`.
+
+## 6. Resume prompt
+
+> Continuing from the 2026-07-24 EOD handoff at `docs/handoffs/2026-07-24-seven-wp-wave-handoff.md` in /Users/karl/Documents/Claude Projects/solo-orchestrator. Read that handoff and CLAUDE.md first. State when I stopped: the seven-WP wave (BL-131+132 SAST, BL-172, BL-173, BL-174, BL-135/136 investigation, the BL-097/098/100 operating-model design doc, and the CDF BUG-001 verification) is open as six green, fable-verified PRs #265–#270 — none merged; never self-merge. FIRST: `git fetch` and check the actual merge state of #265–#270 — Karl may have merged some or all since. If merges happened: resolve any keep-both-lines conflicts on the remaining PRs (registration anchors + backlog end-appends, numeric order), then open the closures PR (flip BL-131/132/172/173/174 → Closed with PR + merge SHAs; BL-135/136 stay Open pending a green full-lane run — propose triggering the ~3h `workflow_dispatch` full lane to Karl, never run it unasked; BL-097/098/100 stay Open, design delivered). Do NOT touch BUG-001 — it is already `Superseded` (2026-04-22, the same upstream landing WP-G re-verified); an earlier draft of this prompt said to flip it, which would have regressed a correct entry. If PRs are still open: surface the review queue and wait. THEN proceed to Karl's queued phase — Big strategy (the operating-model build planned from `docs/designs/2026-07-24-operating-model-v1.md` §10's nine-WP skeleton, and BL-109 currency slices) and housekeeping (BL-085/090/092/093/094), plus the follow-up queue led by BL-177 (Medium). Use the standing discipline: fable-authored junior-followable plans, opus implementers in isolated worktrees, fable verifiers ≥ implementer on anything behavioral, watched-RED TDD with mutation proofs, both-lane registration, commit-not-push until verified, and nudge any subagent that ends its turn "waiting" on a background job — completion notifications only reach the supervisor.

--- a/docs/handoffs/archive/README.md
+++ b/docs/handoffs/archive/README.md
@@ -9,7 +9,7 @@ plan → PRs → shipped state stays intact and citable.
 
 - **Live handoff:** the single most recent state-of-record for the current
   arc lives at the top level of `docs/handoffs/`. Right now that is
-  [`../2026-07-24-seven-wp-wave-handoff.md`](../2026-07-24-seven-wp-wave-handoff.md).
+  [`../2026-07-29-sast-coverage-and-ci-lane.md`](../2026-07-29-sast-coverage-and-ci-lane.md).
   Everything else at the top level is a pointer stub.
 - **Archived handoff:** once a handoff is executed or superseded, its full
   text moves here and a short **pointer stub** is left at the original
@@ -55,6 +55,14 @@ In chain order (oldest first). Each has a pointer stub at its old top-level path
   first surfacing of the two stale full-suite tests later filed as BL-173.
 - `2026-07-24-next-session-prompt.md` — FULLY EXECUTED (archived 2026-07-25);
   the launch prompt for that BL-161 + BL-165 session.
+- `2026-07-24-seven-wp-wave-handoff.md` — FULLY EXECUTED + SUPERSEDED (archived
+  2026-07-29). Its wave landed as #265 (`7866022`), #266 (`d857294`), #271
+  (`064d578`), #269 (`8afb9ba`), #268 (`ed406c8`) and #270 (`b0b60aa`); the
+  closures it queued shipped as #272 (`d970b27`). Its § 3 blocker — a staged
+  submodule gitlink aborting the BL-132 index scan — was fixed before #270
+  merged. Note this file carries its OWN ⚠ SUPERSEDING UPDATE header from
+  2026-07-25 warning that its § 1–§ 3 inventory was already stale when written;
+  treat both layers as historical.
 
 ## Citation convention for handoffs
 


### PR DESCRIPTION
Adds the 2026-07-29 state-of-record and archives its predecessor, restoring the
**one live non-stub handoff** invariant at the top level of `docs/handoffs/`.

## What it does

- Adds `docs/handoffs/2026-07-29-sast-coverage-and-ci-lane.md`.
- `git mv`s the 2026-07-24 seven-WP handoff into `archive/` (history preserved,
  copy byte-identical — same blob OID both sides) and leaves a pointer stub at the
  old top-level path so every existing citation still resolves.
- Repoints seven older stubs whose `Live state-of-record:` link named the archived
  handoff — that claim was no longer true.
- Refreshes `docs/INDEX.md` (live pointer, archive count 7 → 8) and `CLAUDE.md`
  § HANDOFFS.

## The § 3 correction is the point of the document

Its first draft blamed #280's `test-bl147` failure on `--max-target-bytes=0` being
missing from the 22 CI templates, and told the next session to add it there. **That
was wrong** — the templates were correct throughout. The real causes were BL-194 (a
`FALSIFIER:` comment captured the parity derivation, because the collector matched
on the command name and prose is entitled to use it) and BL-183 (a SIGPIPE predicate
inversion that had been diagnosed a day earlier and left unfixed).

The correction is kept **visible** rather than rewritten, because the transferable
lesson is that the failure message accused the wrong subsystem — and a loud failure
that names an innocent component is how the wrong diagnosis got written down as
settled fact in the first place.

## Pre-open review

Ran the standing adversarial `pr-reviewer` before opening, per the standing gate.
It returned **`block`** on seven findings, all fixed here, then **`minor_concerns`**
on re-verification. The two that mattered:

1. **A required check was failing while the commit message claimed it passed.**
   `lint-backlog-references.sh` rejects the bare `BL-194` token in the body — that
   entry exists only on the unmerged #280 branch. Fixed with the documented
   `lint-backlog-references-ignore:` footer. The bad attestation came from running
   the lint *before* committing, when the token was only in the working tree.
2. **§ 8's resume prompt still carried the refuted story** and still told the next
   session to edit the 22 templates § 3 says not to touch. That block is designed to
   be pasted and acted on, so it was the costliest finding — the same failure mode,
   one document later.

Also fixed: `28 open` → **27** (the 28th raw-grep hit sits inside BL-055's preserved
pre-close block — the trap `CLAUDE.md` documents by name; the trap-aware recipe now
ships inside § 1 and is load-bearing, returning 28 if the guard is removed); a stale
#280 head; entry ids that live only on unmerged branches now labelled as such; one
referenced WP plan that was never written; and the full-lane run cited for BL-136,
which is overall **red** on an unrelated child (`test-bl033`, which passes locally
8/0) — § 6.3 now says close BL-136 on the per-test `[PASS]` lines, not the run's
colour.

## Verification

- Exactly **one** file over 25 lines remains at the top level of `docs/handoffs/`.
- All **85** relative links resolve from each file's own directory; **0** broken.
- All **13** cited SHAs verified: each exists, is a merge of the PR named, and is an
  ancestor of `main`.
- `lint-doc-anchors.sh` OK (92 files) · `lint-backlog-references.sh` OK bare **and**
  with `--base origin/main` — re-run after committing, which is when it counts.
- Docs-only file set (13 paths, all markdown), so the Build Loop bypass legitimately
  applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
