### PR TITLE
fix(bl183): the emitted hook's npm detection survives a monorepo-sized scripts block

### DIFF
--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -1304,8 +1304,12 @@ soif_tests_not_enforced() {
 # never tested against the opening line, as in sed), and a later
 # `"scripts" :` line may re-open it — so the S1/S4 scoping is byte-for-byte
 # the old semantics, minus the inversion. <pat> is a dynamic ERE, matching
-# the grep -qE it replaces; the placeholder needle contains no ERE
-# metacharacters, so the old grep -q fixed-string read is unchanged too.
+# the grep -qE it replaces; the placeholder needle contains no metacharacters
+# in either grammar, so the old grep -q read (a BRE match, not fixed-string)
+# is unchanged too. Portability: the [[:space:]] class needs a POSIX-class-
+# capable awk — macOS awk, gawk, and mawk >= 1.3.4 (Debian/Ubuntu defaults)
+# all qualify; on an older awk the detection arm degrades to the LOUD
+# not-enforced WARN below, never a silent pass.
 soif_npm_scripts_has() {
   awk -v pat="$1" '
     !r && /"scripts"[[:space:]]*:/ { r = 1; if ($0 ~ pat) f = 1; next }
@@ -1365,9 +1369,14 @@ if [ "$soif_test_src" -gt 0 ]; then
     # && exit 1` — treating it as a real suite would brick every commit on a
     # fresh scaffold (the BL-137 documented-but-impossible class). Verifier
     # S1/S4: BOTH reads are scoped to the "scripts" block (see
-    # # BL-183-NPM-NO-SIGPIPE above), so a dependency literally named "test"
-    # cannot trigger detection and a placeholder string elsewhere in
-    # package.json cannot disable a real suite.
+    # # BL-183-NPM-NO-SIGPIPE above), so while a MULTI-LINE scripts block is
+    # present a dependency literally named "test" cannot trigger detection
+    # and a placeholder string elsewhere in package.json cannot disable a
+    # real suite. One known leak, faithfully preserved from the sed range
+    # this replaced: a ONE-LINE block (`"scripts": {},` or `{ "lint": … },`)
+    # never closes the range on its own line, so a `"test":` key in the NEXT
+    # object can still trigger detection (recorded on BL-183; equivalence
+    # with the old spelling was this fix's contract).
     soif_test_cmd="npm test"
   elif [ -f pytest.ini ] || [ -f conftest.py ] \
        || { [ -f pyproject.toml ] && grep -q '^\[tool\.pytest' pyproject.toml; }; then

--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -1286,6 +1286,32 @@ soif_tests_not_enforced() {
   echo "  This is NOT a green result: nothing was executed. Configure the"
   echo "  command in .claude/test-command (one line, e.g. 'npm test')."
 }
+# BL-183-NPM-NO-SIGPIPE — single-process awk replaces the two
+# `sed -n '/"scripts"…/,/}/p' package.json | grep -q …` pipelines that used
+# to sit in the elif below. Under this hook's `set -euo pipefail`, grep -q
+# exits on first match, sed dies of SIGPIPE writing the rest of the SCRIPTS
+# BLOCK (the range closes at the first `}`, so the trigger is a big block,
+# not a big file), and pipefail promotes rc 141 into "no match" —
+# deterministically on a monorepo-sized block (measured PIPESTATUS=141 0:
+# grep MATCHED and the pipeline still reported false). The detection call
+# then read a real suite as absent — the test gate silently stopped running
+# — and the NEGATED placeholder call read the other way, adopting npm test
+# against a fresh scaffold (the BL-137 documented-but-impossible class).
+# awk is one process on the file: no pipe, nothing to SIGPIPE, no invariant
+# a later edit can quietly re-narrow. It emulates the sed range exactly —
+# a `"scripts" :` line opens the scope (and is itself tested, as sed printed
+# it), the first in-scope line containing `}` closes it (the end pattern is
+# never tested against the opening line, as in sed), and a later
+# `"scripts" :` line may re-open it — so the S1/S4 scoping is byte-for-byte
+# the old semantics, minus the inversion. <pat> is a dynamic ERE, matching
+# the grep -qE it replaces; the placeholder needle contains no ERE
+# metacharacters, so the old grep -q fixed-string read is unchanged too.
+soif_npm_scripts_has() {
+  awk -v pat="$1" '
+    !r && /"scripts"[[:space:]]*:/ { r = 1; if ($0 ~ pat) f = 1; next }
+    r { if ($0 ~ pat) f = 1; if (index($0, "}")) r = 0 }
+    END { exit f ? 0 : 1 }' package.json
+}
 # BL-179-TESTARM-FILTER — Verifier M1: D, R and T are in the filter ON
 # PURPOSE — a commit that DELETES, RENAMES or TYPE-CHANGES the sanitizer
 # is exactly the regression this arm exists to stop, and the old ACM
@@ -1333,14 +1359,15 @@ if [ "$soif_test_src" -gt 0 ]; then
       soif_test_cfg_warned=1
     fi
   elif [ -f package.json ] \
-       && sed -n '/"scripts"[[:space:]]*:/,/}/p' package.json | grep -qE '"test"[[:space:]]*:' \
-       && ! sed -n '/"scripts"[[:space:]]*:/,/}/p' package.json | grep -q 'no test specified'; then
+       && soif_npm_scripts_has '"test"[[:space:]]*:' \
+       && ! soif_npm_scripts_has 'no test specified'; then
     # npm's scaffold placeholder script is `echo "Error: no test specified"
     # && exit 1` — treating it as a real suite would brick every commit on a
     # fresh scaffold (the BL-137 documented-but-impossible class). Verifier
-    # S1/S4: BOTH greps are scoped to the "scripts" block, so a dependency
-    # literally named "test" cannot trigger detection and a placeholder
-    # string elsewhere in package.json cannot disable a real suite.
+    # S1/S4: BOTH reads are scoped to the "scripts" block (see
+    # # BL-183-NPM-NO-SIGPIPE above), so a dependency literally named "test"
+    # cannot trigger detection and a placeholder string elsewhere in
+    # package.json cannot disable a real suite.
     soif_test_cmd="npm test"
   elif [ -f pytest.ini ] || [ -f conftest.py ] \
        || { [ -f pyproject.toml ] && grep -q '^\[tool\.pytest' pyproject.toml; }; then

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -5435,6 +5435,17 @@ BEFORE asserting behavior, so a fixture edit cannot quietly turn it vacuous.
 do not "fix" without a reachability proof, per the triage rule above. (2) The `tests/` census
 this entry has never run (the 80-site table scanned `scripts/` only). (3) The two
 `echo`-of-a-variable candidates in `test-bl104-gate-scoring.sh` / `test-bl073-review-manifest-gate.sh`.
+(4) **The scripts-block scope has a preserved RANGE LEAK on one-line blocks** — found by the
+fix's own adversarial review, present in BOTH spellings (equivalence was the contract, so the
+awk faithfully keeps it): a one-line `"scripts": {},` (or any one-line block) never closes the
+range on its own line — the end pattern is never tested against the opening line, exactly as in
+sed — so the range stays open into the NEXT object and a dependency literally named `test`
+(`"dependencies": { "test": "1.0.0" }` — a real npm package) still triggers detection.
+Reviewer-built fixtures `empty-scripts-leak` / `oneline-block-leak`: both spellings agree,
+rc=0. Consequence when it fires: `npm test` adopted with no test script → `Missing script:
+"test"` → non-127 non-zero → source commits BLOCK (the BL-137 class). The S1/S4 comment at the
+call site now states the leak instead of overclaiming; closing it means deliberately changing
+the range semantics — a semantic change the SIGPIPE fix explicitly refused to smuggle in.
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -5406,6 +5406,36 @@ same configs plus a comment-stripped variant — so narrowing the comment predic
 which would bless a hook whose executable `--config` lines were deleted, also turns it RED.
 Restoring the pipe spelling turns it RED in both files (mutation-proven).
 
+**UPDATE 2026-07-30 — the two emitted-hook npm sites are FIXED (`3a5949f`); the entry stays
+Open for the gitlink site and the un-run `tests/` census.** Sites 2 and 3 of the emitted-hook
+enumeration above (`# BL-125-COMMIT-TESTS` npm detection + placeholder rejection) are replaced
+by `soif_npm_scripts_has` — single-process awk, marker `# BL-183-NPM-NO-SIGPIPE` in
+`scripts/lib/hook-templates.sh` — per this entry's own deviation note: no pipe to break. The
+awk emulates the sed range exactly (opens at a `"scripts" :` line and tests it, closes at the
+first in-scope `}`, may re-open later), so the S1/S4 scripts-block scoping is unchanged.
+
+**A precondition in this entry was WRONG, recorded here rather than silently edited.** The
+"Fix shape" paragraph above prescribes "a multi-KB `package.json` fixture", and the site-2
+enumeration says "on a `package.json` past the pipe buffer". Neither reproduces: `sed`'s range
+closes at the first `}`, after which it READS the rest of the file without WRITING, and SIGPIPE
+needs a write. **The trigger is a large `scripts` BLOCK** — measured 20/20 inversions on a
+~1.2 MB block vs 0/20 on a 1.26 MB file with an ordinary block, independently reproduced by a
+second session from scratch (flaky band ~33–55 KB, deterministic from ~82–110 KB). A fixture
+built to this entry's own prescription would have shown the defect "unreproducible".
+
+Guarded by **T17/T18/T19/T20** in `tests/test-bl125-commit-test-exec.sh`: detection and
+placeholder scope at ~330 KB block scale (both watched RED against the old spelling — T17's
+commit LANDED with the gate silently off; T18 REFUSED where the small-file semantics
+warn-and-land), whole-block-read completeness (a truncating rewrite goes RED), and a standing
+both-directions mutant that re-spells each call back to the old pipeline and requires the
+inversion to return. Each case asserts its fixture's post/pre-match block bytes ≥ 150 KB
+BEFORE asserting behavior, so a fixture edit cannot quietly turn it vacuous.
+
+**Still open:** (1) `# BL-132-GITLINK-SKIP` — single-line producer, condition (a) very weak;
+do not "fix" without a reachability proof, per the triage rule above. (2) The `tests/` census
+this entry has never run (the 80-site table scanned `scripts/` only). (3) The two
+`echo`-of-a-variable candidates in `test-bl104-gate-scoring.sh` / `test-bl073-review-manifest-gate.sh`.
+
 ---
 
 ## BL-184: The full-suite aggregator destroyed its children's failure output — 177 delegates discarded stdout AND stderr, making every CI-only failure unactionable

--- a/tests/test-bl125-commit-test-exec.sh
+++ b/tests/test-bl125-commit-test-exec.sh
@@ -506,6 +506,217 @@ else
 fi
 fi
 
+# ═════════════════════════════════════════════════════════════════════════════
+# BL-183 — the npm-detection predicates must survive a monorepo-sized scripts
+# block. The old spelling (sed -n '/"scripts"…/,/}/p' package.json | grep -q …)
+# inverts under the emitted hook's `set -euo pipefail`: grep -q exits on first
+# match, sed dies of SIGPIPE writing the REST OF THE BLOCK (the range closes at
+# the first `}`, so a big package.json with a small scripts block never fires —
+# the trigger is the block, not the file), and pipefail promotes rc 141 into
+# "no match". Measured deterministic on this fixture class: PIPESTATUS=141 0 —
+# grep MATCHED and the pipeline still reported false. The detection site then
+# reads a real suite as absent (the test gate silently stops running); the
+# NEGATED placeholder site reads the other way (placeholder "absent" -> npm
+# test adopted against a block the small-file semantics say is placeholder-
+# bearing). Fix: single-process awk (soif_npm_scripts_has) — no pipe to break.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# mk_bigpkg <dir> <shape> — package.json whose scripts block carries ~330 KB
+# around the line the predicate matches on (>> the 64 KB pipe buffer and the
+# ~110 KB determinism band measured in BL-183). One entry per line, and no `}`
+# in any value — a `}` would close the sed range early and hide the defect.
+#   test-first        "test": real failing suite FIRST, ~330 KB after it
+#   placeholder-early 'no test specified' inside ANOTHER script's value first,
+#                     real "test" key LAST (so old-spelling detection survives
+#                     while the old placeholder check SIGPIPEs — the site-3
+#                     inversion isolated)
+#   test-last         no placeholder, "test" key LAST after ~330 KB (whole-
+#                     block completeness: a truncating rewrite must not miss it)
+mk_bigpkg() {
+  local d="$1" shape="$2"
+  awk -v shape="$shape" 'BEGIN{
+    print "{"
+    print "  \"name\": \"fixture\","
+    print "  \"version\": \"0.0.1\","
+    print "  \"scripts\": {"
+    if (shape == "test-first")        print "    \"test\": \"exit 1\","
+    if (shape == "placeholder-early") print "    \"lint\": \"echo no test specified here on purpose\","
+    for (i = 0; i < 7000; i++) printf "    \"s%05d\": \"echo filler line number %05d\",\n", i, i
+    if (shape == "test-first")        print "    \"zlast\": \"echo done\""
+    else                              print "    \"test\": \"exit 1\""
+    print "  }"
+    print "}"
+  }' > "$d/package.json"
+}
+
+# bigpkg_tail <dir> <needle> — bytes the sed producer still had to write after
+# the first scripts-block line containing <needle>: the SIGPIPE exposure. Each
+# case asserts this is large enough to force the race BEFORE asserting any
+# behavior, so a future fixture edit cannot quietly turn the case vacuous.
+bigpkg_tail() {
+  awk -v needle="$2" '
+    !f && index($0, needle) { f = 1; next }
+    f && index($0, "}")     { exit }
+    f                       { n += length($0) + 1 }
+    END { print n + 0 }' "$1/package.json"
+}
+
+# bigpkg_lead <dir> <needle> — bytes between the scripts-block open and the
+# first line containing <needle> (the exposure BEFORE a late match — what a
+# truncating rewrite would fail to read).
+bigpkg_lead() {
+  awk -v needle="$2" '
+    !s && index($0, "\"scripts\"") { s = 1; next }
+    s && index($0, needle)          { print n + 0; exit }
+    s                               { n += length($0) + 1 }' "$1/package.json"
+}
+
+if want T17; then
+echo "=== T17-npm-detect-survives-big-scripts-block ==="
+if ! command -v npm >/dev/null 2>&1; then
+  skip_ "T17-npm-detect-survives-big-scripts-block" "npm ABSENT on this host — the npm-detect arm is UNPROVEN here (skip, NOT a pass)"
+else
+  P="$TOPTMP/p17"; mk_proj "$P"
+  mk_bigpkg "$P" test-first
+  TAIL17=$(bigpkg_tail "$P" '"test"')
+  case "$TAIL17" in ''|*[!0-9]*) TAIL17=0 ;; esac
+  if [ "$TAIL17" -lt 150000 ]; then
+    fail_ "T17-npm-detect-survives-big-scripts-block" "fixture too small to force the race (post-match block bytes=$TAIL17 < 150000) — the case is VACUOUS, fix mk_bigpkg"
+  else
+    stage_src "$P"
+    H0=$(head_of "$P")
+    V=$(try_commit "$P" "chore: add widget" "$P/commit.log")
+    H1=$(head_of "$P")
+    if [ "$V" = "REFUSED" ] && [ "$H0" = "$H1" ] \
+       && grep -qF '[BLOCKED] project tests FAILED' "$P/commit.log" \
+       && ! grep -qF 'PROJECT TESTS NOT ENFORCED' "$P/commit.log"; then
+      pass "T17-npm-detect-survives-big-scripts-block (a real suite behind ~330 KB of sibling scripts is still detected — RED suite refuses the commit)"
+    else
+      fail_ "T17-npm-detect-survives-big-scripts-block" "verdict=$V — a real npm suite behind a big scripts block was not enforced (BL-183 SIGPIPE inversion: the test gate silently stopped running): $(tail -3 "$P/commit.log" | tr '\n' ' ')"
+    fi
+  fi
+fi
+fi
+
+if want T18; then
+echo "=== T18-placeholder-scope-survives-big-scripts-block ==="
+# Pins the PRESERVED small-file semantics at scale, not an endorsement of the
+# scope: 'no test specified' ANYWHERE in the scripts block reads as npm's
+# placeholder and detection declines (T6's semantics — see the S1/S4 comment
+# in the emitter). Old spelling on this fixture: detection survives (match is
+# LATE, nothing left to write) while the negated placeholder check SIGPIPEs —
+# `! rc141` reads TRUE, npm test is adopted, and the commit BLOCKS where the
+# small-file predicate would have warned. npm is required so that pre-fix
+# failure mode is the loud [BLOCKED], not a vacuously-landing exit 127.
+if ! command -v npm >/dev/null 2>&1; then
+  skip_ "T18-placeholder-scope-survives-big-scripts-block" "npm ABSENT on this host — the pre-fix failure mode is unreproducible here (skip, NOT a pass)"
+else
+  P="$TOPTMP/p18"; mk_proj "$P"
+  mk_bigpkg "$P" placeholder-early
+  TAIL18=$(bigpkg_tail "$P" 'no test specified')
+  case "$TAIL18" in ''|*[!0-9]*) TAIL18=0 ;; esac
+  if [ "$TAIL18" -lt 150000 ]; then
+    fail_ "T18-placeholder-scope-survives-big-scripts-block" "fixture too small to force the race (post-placeholder block bytes=$TAIL18 < 150000) — the case is VACUOUS, fix mk_bigpkg"
+  else
+    stage_src "$P"
+    V=$(try_commit "$P" "chore: add widget" "$P/commit.log")
+    if [ "$V" = "LANDED" ] && grep -qF 'PROJECT TESTS NOT ENFORCED' "$P/commit.log" \
+       && ! grep -qF '[BLOCKED] project tests FAILED' "$P/commit.log"; then
+      pass "T18-placeholder-scope-survives-big-scripts-block (the placeholder read is size-independent — same verdict as T6 at ~330 KB)"
+    else
+      fail_ "T18-placeholder-scope-survives-big-scripts-block" "verdict=$V — the negated placeholder check inverted at scale (BL-183: '! rc141' read the placeholder as absent and adopted npm test): $(tail -3 "$P/commit.log" | tr '\n' ' ')"
+    fi
+  fi
+fi
+fi
+
+if want T19; then
+echo "=== T19-npm-detect-test-key-late ==="
+# Both spellings pass this today (a LATE match leaves the producer nothing to
+# write, so the old pipe survives too). It stands as the other direction of
+# T17's coin: the fix must read the WHOLE block, so a rewrite that truncates
+# (reads only the first N KB and misses a late "test" key) goes RED here
+# instead of shipping. The vacuity guard is bigpkg_lead, not bigpkg_tail.
+if ! command -v npm >/dev/null 2>&1; then
+  skip_ "T19-npm-detect-test-key-late" "npm ABSENT on this host — the npm-detect arm is UNPROVEN here (skip, NOT a pass)"
+else
+  P="$TOPTMP/p19"; mk_proj "$P"
+  mk_bigpkg "$P" test-last
+  LEAD19=$(bigpkg_lead "$P" '"test"')
+  case "$LEAD19" in ''|*[!0-9]*) LEAD19=0 ;; esac
+  if [ "$LEAD19" -lt 150000 ]; then
+    fail_ "T19-npm-detect-test-key-late" "fixture too small (pre-match block bytes=$LEAD19 < 150000) — the case is VACUOUS, fix mk_bigpkg"
+  else
+    stage_src "$P"
+    V=$(try_commit "$P" "chore: add widget" "$P/commit.log")
+    if [ "$V" = "REFUSED" ] && grep -qF '[BLOCKED] project tests FAILED' "$P/commit.log"; then
+      pass "T19-npm-detect-test-key-late (a \"test\" key ~330 KB into the block is still read — the predicate consumes the whole block)"
+    else
+      fail_ "T19-npm-detect-test-key-late" "verdict=$V — a late \"test\" key was missed (truncating predicate?): $(tail -3 "$P/commit.log" | tr '\n' ' ')"
+    fi
+  fi
+fi
+fi
+
+if want T20; then
+echo "=== T20-mutation-npm-detect-pipe-respell ==="
+# Re-spell each soif_npm_scripts_has call back to the exact pipeline BL-183
+# replaced (the one-character-narrowing lesson of BL-181: a standing mutant,
+# not a one-time proof). RED: the mutant lib re-acquires the inversion on the
+# big-block fixtures. GREEN: the real lib does not. Both directions run HERE
+# so `BL125_ONLY="T20"` is an honest standalone verdict, per T16's precedent.
+if ! command -v npm >/dev/null 2>&1; then
+  skip_ "T20-mutation-npm-detect-pipe-respell" "npm ABSENT on this host — the GREEN directions are unprovable here (skip, NOT a pass)"
+else
+  Q="'"
+  # ── Mutant A: detection call -> old sed|grep -qE pipeline ──────────────────
+  MUTA="$TOPTMP/hook-templates.pipeA.sh"
+  nA=$(grep -cF "&& soif_npm_scripts_has ${Q}\"test\"" "$HOOKLIB") || nA=0
+  case "$nA" in ''|*[!0-9]*) nA=0 ;; esac
+  awk -v q="$Q" '
+    index($0, "&& soif_npm_scripts_has " q "\"test\"") {
+      print "       && sed -n " q "/\"scripts\"[[:space:]]*:/,/}/p" q " package.json | grep -qE " q "\"test\"[[:space:]]*:" q " \\"
+      next
+    }
+    { print }' "$HOOKLIB" > "$MUTA"
+  # ── Mutant B: placeholder call -> old negated sed|grep -q pipeline ─────────
+  MUTB="$TOPTMP/hook-templates.pipeB.sh"
+  nB=$(grep -cF "&& ! soif_npm_scripts_has ${Q}no test specified" "$HOOKLIB") || nB=0
+  case "$nB" in ''|*[!0-9]*) nB=0 ;; esac
+  awk -v q="$Q" '
+    index($0, "&& ! soif_npm_scripts_has " q "no test specified") {
+      print "       && ! sed -n " q "/\"scripts\"[[:space:]]*:/,/}/p" q " package.json | grep -q " q "no test specified" q "; then"
+      next
+    }
+    { print }' "$HOOKLIB" > "$MUTB"
+  if [ "$nA" -ne 1 ] || [ "$nB" -ne 1 ]; then
+    fail_ "T20-mutation-npm-detect-pipe-respell" "MIS-TARGETED — expected each soif_npm_scripts_has call exactly once in $HOOKLIB (detection=$nA placeholder=$nB); retarget this mutation in lockstep"
+  elif ! grep -qF "| grep -qE" "$MUTA" || grep -qF "&& soif_npm_scripts_has ${Q}\"test\"" "$MUTA" \
+       || ! grep -qF "| grep -q ${Q}no test specified" "$MUTB" || grep -qF "&& ! soif_npm_scripts_has" "$MUTB"; then
+    fail_ "T20-mutation-npm-detect-pipe-respell" "mutant construction vacuous — the old spelling did not land or the new call survived (A/B)"
+  elif ! ( source "$MUTA" && soif_write_precommit_hook "$TOPTMP/mut20a-hook" ) >/dev/null 2>&1 \
+       || ! bash -n "$TOPTMP/mut20a-hook" 2>/dev/null \
+       || ! ( source "$MUTB" && soif_write_precommit_hook "$TOPTMP/mut20b-hook" ) >/dev/null 2>&1 \
+       || ! bash -n "$TOPTMP/mut20b-hook" 2>/dev/null; then
+    fail_ "T20-mutation-npm-detect-pipe-respell" "a mutant lib could not emit a syntactically valid hook — a broken mutant proves nothing"
+  else
+    RA=SETUPFAIL; GA=SETUPFAIL; RB=SETUPFAIL; GB=SETUPFAIL
+    PRA="$TOPTMP/p20-redA"; if mk_proj "$PRA" "$MUTA"; then mk_bigpkg "$PRA" test-first; stage_src "$PRA"; RA=$(try_commit "$PRA" "chore: add widget" "$PRA/commit.log"); fi
+    PGA="$TOPTMP/p20-greenA"; if mk_proj "$PGA"; then mk_bigpkg "$PGA" test-first; stage_src "$PGA"; GA=$(try_commit "$PGA" "chore: add widget" "$PGA/commit.log"); fi
+    PRB="$TOPTMP/p20-redB"; if mk_proj "$PRB" "$MUTB"; then mk_bigpkg "$PRB" placeholder-early; stage_src "$PRB"; RB=$(try_commit "$PRB" "chore: add widget" "$PRB/commit.log"); fi
+    PGB="$TOPTMP/p20-greenB"; if mk_proj "$PGB"; then mk_bigpkg "$PGB" placeholder-early; stage_src "$PGB"; GB=$(try_commit "$PGB" "chore: add widget" "$PGB/commit.log"); fi
+    if [ "$RA" = "LANDED" ] && grep -qF 'PROJECT TESTS NOT ENFORCED' "$PRA/commit.log" \
+       && [ "$GA" = "REFUSED" ] && grep -qF '[BLOCKED] project tests FAILED' "$PGA/commit.log" \
+       && [ "$RB" = "REFUSED" ] && grep -qF '[BLOCKED] project tests FAILED' "$PRB/commit.log" \
+       && [ "$GB" = "LANDED" ] && grep -qF 'PROJECT TESTS NOT ENFORCED' "$PGB/commit.log"; then
+      pass "T20-mutation-npm-detect-pipe-respell: each re-piped predicate re-acquires its inversion (detection: real suite unenforced; placeholder: scaffold-shape bricked) and the awk spelling does not — both replacements are load-bearing (BL-183)"
+    else
+      fail_ "T20-mutation-npm-detect-pipe-respell" "expected redA=LANDED+warn/greenA=REFUSED+blocked/redB=REFUSED+blocked/greenB=LANDED+warn; got redA=$RA greenA=$GA redB=$RB greenB=$GB; redA: $(tail -2 "$PRA/commit.log" | tr '\n' ' ') redB: $(tail -2 "$PRB/commit.log" | tr '\n' ' ')"
+    fi
+  fi
+fi
+fi
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$SKIPPED" -gt 0 ] && echo "($SKIPPED skipped — see [SKIP] lines)"


### PR DESCRIPTION
# fix(bl183): the emitted hook's npm detection survives a monorepo-sized scripts block

## The defect — live, shipped enforcement code

The two npm-detection pipelines at `# BL-125-COMMIT-TESTS` in the EMITTED pre-commit hook
(`scripts/lib/hook-templates.sh`) ran `sed -n '/"scripts"…/,/}/p' package.json | grep -q …`
under the hook's `set -euo pipefail`. `grep -q` exits on first match; `sed` dies of SIGPIPE
writing the rest of the **scripts block** (its range closes at the first `}`, after which it
reads without writing — so the trigger is a big *block*, not a big *file*); `pipefail`
promotes rc 141 into "no match".

- **Detection site:** a project with a real jest-shaped suite reads as having none — the hook
  prints `PROJECT TESTS NOT ENFORCED` and the commit-time test gate **silently stops running**.
  Measured deterministic: `PIPESTATUS=141 0` (grep MATCHED; the pipeline still reported false),
  5/5 here and 20/20 in the prior session, independently reproduced end-to-end.
- **Negated placeholder site:** inverts the other way — npm's placeholder reads as absent,
  `npm test` is adopted against a placeholder-bearing block (the BL-137 scaffold-brick class).

## The fix — `# BL-183-NPM-NO-SIGPIPE`

`soif_npm_scripts_has`: single-process awk, per BL-183's own deviation note — no pipe, nothing
to SIGPIPE, no invariant a later edit can quietly re-narrow. The awk replicates the sed range
byte-for-byte (opens at a `"scripts" :` line and tests it; the first in-scope `}` closes it;
may re-open later; single-line package.json runs to EOF), so the **S1/S4 scripts-block scoping
is unchanged**: a dependency named `test` cannot trigger detection (T12), a placeholder string
outside the block cannot disable a real suite (T6).

Deliberately untouched: the `# BL-132-GITLINK-SKIP` `grep -q` site (single-line producer — no
reachability proof, per BL-183's triage rule).

## TDD evidence

- **RED watched:** T17 (detection at ~330 KB block scale) and T18 (placeholder scope at scale)
  written first and run against the old spelling — T17's commit **LANDED with the gate silently
  off**; T18 **REFUSED** where the small-file semantics warn-and-land.
- **GREEN:** full suite 21 cases + T20, all green; T6/T12's single-line fixtures pin the range
  emulation.
- **T19:** whole-block-read completeness — a truncating rewrite goes RED.
- **T20 standing mutant (non-vacuous):** re-spells each call back to the old pipeline;
  construction verified (old spelling present, new call absent, emission + `bash -n`), both
  directions per mutant — each re-piped predicate re-acquires its inversion, the awk does not.
- Every big-block case asserts its fixture's pre/post-match block bytes ≥ 150 KB **before**
  any behavior assertion, so a fixture edit cannot quietly turn it vacuous.

## Verification

- `tests/test-bl125-commit-test-exec.sh`: 22 cases green (T1–T20).
- All six other emitted-hook-consuming suites green (bl118, bl131, bl161, bl132, bl163,
  freshness-check).
- `run-lints.sh` 11/11; `lint-backlog-references.sh` attested green POST-commit.
- Backlog: BL-183 updated — two sites fixed (cited by SHA), the entry's wrong precondition
  ("large package.json") corrected on the record, entry **stays Open** for the gitlink site,
  the un-run `tests/` census, and the two echo-producer candidates.

## Adversarial review (standing gate — ran BEFORE this PR was opened)

Fable-tier reviewer, two rounds. Round 1: 40/40 differential fixtures agree old-vs-new
(the only divergence being the SIGPIPE inversion itself), 20/20 mechanism reproductions,
emitted-bytes fidelity and untouched-site discipline verified, T17/T18 re-run RED against
the parent lib, T20's mutants rebuilt independently byte-identical. Verdict:
`minor_concerns` with two items, both applied on this branch (`e3f5496`, `42f29e5`):

1. **R-BL183-1** — the S1/S4 comment overclaimed ("a dependency named `test` cannot
   trigger detection" fails on a ONE-LINE scripts block, where the range leaks into the
   next object — pre-existing in the sed spelling, faithfully preserved per the
   equivalence contract). The comment now states the leak; the backlog records it as
   BL-183 still-open item (4). Plus the BRE-not-fixed-string nit.
2. **R-BL183-2** — the awk POSIX-class dependency is now stated (macOS awk / gawk /
   mawk ≥ 1.3.4; older awks degrade to the LOUD warn, never a silent pass).

Round 2 (targeted): CONFIRM on all four checks; comments-only delta proven mechanically
(0 non-comment changed lines, heredoc terminator intact, T20 anchors byte-identical);
verdict **approve** with the suite observed `22 passed, 0 failed` at `42f29e5`.

---
**TL;DR (plain English):** Projects generated by this framework get a safety check that runs
their tests before every commit. For projects with a very long scripts section in their
`package.json`, a race condition made that check believe there were no tests at all — so it
quietly stopped running them (or, in another spot, could wrongly block every commit on a brand-new
project). The fix reads the file in one pass with no race window, and new tests prove both the
bug and the fix, including tests that re-introduce the old bug on purpose to make sure the test
suite catches it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
