### PR TITLE
fix(bl198): transcode undecodable-but-textual staged files — the SAST receipt now covers decode

### DIFF
--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -1030,8 +1030,12 @@ if command -v semgrep &>/dev/null; then
             # there. 0xF5-0xFF never appear in valid UTF-8, so any such byte in
             # the output is a failed transcode. Same lexical-hex trick as the
             # derivation; the iconv check above stays as the stricter belt where
-            # the platform provides it.
-            soif_tc_badbyte=$(od -An -v -tx1 "$soif_tc_tmp" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i >= "f5") { print "bad"; exit } }') || soif_tc_badbyte=""
+            # the platform provides it. The awk is a FULL-INPUT consumer — flag
+            # in the rule, print in END — because an early `exit` SIGPIPEs od on
+            # >pipe-buffer output, pipefail promotes rc 141, and the || guard
+            # ERASES the detection (review R-BL198-6 — the BL-183 class, caught
+            # re-entering this very file; pinned by T-utf8-floor-no-sigpipe).
+            soif_tc_badbyte=$(od -An -v -tx1 "$soif_tc_tmp" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i >= "f5") b = 1 } END { if (b) print "bad" }') || soif_tc_badbyte=""
             if [ -n "$soif_tc_badbyte" ]; then soif_tc_ok=0; fi
           fi
           if [ "$soif_tc_ok" -eq 1 ] && mv "$soif_tc_tmp" "$soif_idx_dest" 2>/dev/null; then

--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -927,11 +927,19 @@ if command -v semgrep &>/dev/null; then
       #   not a ratio. NULs+no-BOM+no-signal → a source extension routes LOUD
       #   (that shape is binary content in source clothing — BL-192's own
       #   `vendor.js` residue, newly CAUGHT); anything else is a real binary and
-      #   passes through untouched, exactly as today. Named residue, deliberately
-      #   NOT closed: a zero-ASCII single-line UTF-16 file has no NUL at all and
-      #   passes through undecoded (bounded — any newline puts a NUL in the file);
-      #   the only tightening that closes it breaks Latin-1. Pinned by
-      #   T-pure-cjk-residue-passthrough.
+      #   passes through untouched, exactly as today. TWO named residues,
+      #   deliberately NOT closed: (a) a zero-ASCII single-line UTF-16 file has
+      #   no NUL at all and passes through undecoded (bounded — any newline puts
+      #   a NUL in the file); the only tightening that closes it breaks Latin-1.
+      #   Pinned by T-pure-cjk-residue-passthrough. (b) one code unit whose LOW
+      #   byte is 0x00 — U+0100 Ā, U+3000 ideographic space, an astral char with
+      #   a zero surrogate byte — puts a zero on the wrong parity and collapses
+      #   the signal: the file goes LOUD named NOTRUN, every commit, until saved
+      #   as UTF-8 (review R-BL198-2). Exactness stays anyway: a dominance RATIO
+      #   would let a crafted no-BOM file steer the derivation to the WRONG
+      #   endianness, whose transcode is NUL-free valid-UTF-8 garbage and a
+      #   receipt over an unscanned sink — the strictly worse failure. Pinned by
+      #   T-u16-wrongparity-residue.
       # Size is SELF-measured rather than borrowed from F2's soif_idx_want, so
       # this fence stays inert (never unbound) under the F2-excision mutant —
       # the two guards are proved independently and must fail independently.
@@ -956,16 +964,26 @@ if command -v semgrep &>/dev/null; then
         # UTF-32's invariant is the always-zero high byte (LE: position 3;
         # BE: position 0). Anything else — zeros on both parities, odd length —
         # is AMBIGUOUS and derives nothing, which fails CLOSED below.
+        # The stride-4 arms carry the U+10FFFF RANGE BOUND (review R-BL198-1): a
+        # UTF-32LE BOM prefixed to a UTF-16LE body shifts a zero onto every
+        # position ≡3 (mod 4), so the zero-position test alone AGREES with the
+        # lie — and libiconv on macOS happily converts the out-of-range code
+        # points a UTF-32 read of UTF-16 bytes produces, minting NUL-free
+        # "valid" output. In GENUINE UTF-32, byte@2 of every LE group (byte@1
+        # for BE) is <= 0x10 — exact for BMP and astral alike — while a shifted
+        # UTF-16 body carries ordinary ASCII there. Lexical compare is sound:
+        # od emits fixed-width lowercase hex, whose string order equals numeric
+        # order. Pinned by T-u32bom-over-u16-body-notrun.
         soif_tc_der=$(od -An -v -tx1 "$soif_idx_dest" 2>/dev/null | awk -v stride="$soif_tc_stride" '
-          { for (i = 1; i <= NF; i++) { if ($i == "00") z[n % stride]++; n++ } }
+          { for (i = 1; i <= NF; i++) { p = n % stride; if ($i == "00") z[p]++; if (p == 1 && $i > m1) m1 = $i; if (p == 2 && $i > m2) m2 = $i; n++ } }
           END {
             if (n == 0 || n % stride != 0) exit 0
             if (stride == 2) {
               if (z[1] > 0 && z[0] == 0) print "UTF-16LE"
               else if (z[0] > 0 && z[1] == 0) print "UTF-16BE"
             } else {
-              if (z[3] == n / 4 && z[0] < n / 4) print "UTF-32LE"
-              else if (z[0] == n / 4 && z[3] < n / 4) print "UTF-32BE"
+              if (z[3] == n / 4 && z[0] < n / 4 && m2 <= "10") print "UTF-32LE"
+              else if (z[0] == n / 4 && z[3] < n / 4 && m1 <= "10") print "UTF-32BE"
             }
           }' 2>/dev/null) || soif_tc_der=""
         soif_tc_enc=""
@@ -981,7 +999,7 @@ if command -v semgrep &>/dev/null; then
           # (drift in this literal fails open, so the pin is the tripwire).
           # BL-198-EXT-SET
           case "$soif_p" in
-            *.ts|*.tsx|*.mts|*.cts|*.js|*.jsx|*.mjs|*.cjs|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.kts|*.swift|*.cs|*.dart|*.c|*.h|*.cc|*.cpp|*.hpp|*.php|*.scala|*.vue|*.svelte|*.html|*.htm|*.sh)
+            *.ts|*.tsx|*.mts|*.cts|*.js|*.jsx|*.mjs|*.cjs|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.kts|*.swift|*.cs|*.dart|*.c|*.h|*.cc|*.cpp|*.hpp|*.cxx|*.hh|*.hxx|*.m|*.mm|*.php|*.scala|*.vue|*.svelte|*.html|*.htm|*.sh)
               soif_tc_bad=1 ;;
           esac
         fi
@@ -1007,6 +1025,14 @@ if command -v semgrep &>/dev/null; then
             soif_tc_ononul=$(LC_ALL=C tr -d '\000' < "$soif_tc_tmp" 2>/dev/null | wc -c | tr -d '[:space:]') || soif_tc_ononul=""
             if [ -z "$soif_tc_osize" ] || [ "$soif_tc_osize" != "$soif_tc_ononul" ]; then soif_tc_ok=0; fi
             if ! iconv -f UTF-8 -t UTF-8 "$soif_tc_tmp" >/dev/null 2>&1; then soif_tc_ok=0; fi
+            # Byte-level UTF-8 floor (review R-BL198-3): macOS libiconv accepts
+            # non-RFC-3629 5-byte sequences, making the revalidation above inert
+            # there. 0xF5-0xFF never appear in valid UTF-8, so any such byte in
+            # the output is a failed transcode. Same lexical-hex trick as the
+            # derivation; the iconv check above stays as the stricter belt where
+            # the platform provides it.
+            soif_tc_badbyte=$(od -An -v -tx1 "$soif_tc_tmp" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i >= "f5") { print "bad"; exit } }') || soif_tc_badbyte=""
+            if [ -n "$soif_tc_badbyte" ]; then soif_tc_ok=0; fi
           fi
           if [ "$soif_tc_ok" -eq 1 ] && mv "$soif_tc_tmp" "$soif_idx_dest" 2>/dev/null; then
             soif_tc_count=$((soif_tc_count + 1))

--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -307,6 +307,24 @@ soif_sast_unread_report() {
     echo "    - $soif_u"
   done
 }
+# BL-198-UNTX-REPORT — the same # BL-182-NAME-THE-ENTRY contract for the OTHER
+# way an entry escapes the scan: its bytes were read fine, but their text
+# encoding could not be VOUCHED (BOM disagrees with the whole-body derivation,
+# no derivable signal on a source extension, or iconv could not convert them),
+# so handing them to semgrep would produce a clean-looking scan of bytes the
+# scanner cannot decode — the BL-192 false attestation. This is a sibling
+# LIST-PRINTER, not new reporting vocabulary: the WARN framing still comes from
+# soif_sast_not_enforced / soif_sast_partial_coverage above, exactly like the
+# unread list. It is a separate printer for the same reason partial_coverage is
+# separate from not_enforced — saying "could not be read" about a file that WAS
+# read is its own small dishonesty.
+soif_sast_untx_report() {
+  echo "  Staged entries NOT scanned (text encoding could not be vouched or converted — BL-198):"
+  for soif_u in ${soif_idx_untx[@]+"${soif_idx_untx[@]}"}; do
+    echo "    - $soif_u"
+  done
+  echo "  Save these files as UTF-8 (or add a correct byte-order mark) to restore SAST coverage."
+}
 # BL-112-SCAN-COVERAGE — THE RECEIPT IS AN ATTESTATION, SO IT MUST BE EARNED END-TO-END.
 # The two guards above cover the entries the materialization loop could not READ. This
 # one covers the step AFTER that: semgrep is handed N materialized targets and may
@@ -786,6 +804,11 @@ if command -v semgrep &>/dev/null; then
     # (that is the whole reason findings get the # BL-178-PER-INDEX-DIR prefix stripped).
     soif_idx_rel=()
     soif_idx_unread=()
+    # BL-198: initialized OUTSIDE the # BL-198-TRANSCODE fence, deliberately —
+    # the reporting arms below read both, and excising the classifier (the
+    # fence is a mutation target) must leave them defined-and-empty, not unset.
+    soif_idx_untx=()
+    soif_tc_count=0
     soif_idx_n=0
     for soif_p in "${soif_staged[@]}"; do
       # BL-178-PER-INDEX-DIR — one subdir PER STAGED ENTRY ($tree/<n>/<relpath>),
@@ -874,6 +897,127 @@ if command -v semgrep &>/dev/null; then
       soif_idx_want=$(git cat-file -s ":0:$soif_p" 2>/dev/null) || soif_idx_want=""
       soif_idx_got=$(wc -c < "$soif_idx_dest" 2>/dev/null | tr -d '[:space:]') || soif_idx_got=""
       if [ -z "$soif_idx_want" ] || [ "$soif_idx_got" != "$soif_idx_want" ]; then soif_idx_unread+=("$soif_p"); continue; fi
+      # BL-198-TRANSCODE-BEGIN — decode coverage (BL-192's gap): semgrep ACCEPTS a
+      # UTF-16/UTF-32 staged file, cannot decode it, scans the raw bytes "clean",
+      # and the four-precondition receipt prints over an unseen sink. The receipt
+      # attests bytes-scanned, so the fix operates on bytes the hook already holds:
+      # classify the materialized copy and TRANSCODE it to UTF-8 in place. Runs
+      # AFTER F2, deliberately — UTF-16→UTF-8 roughly halves the byte count, so a
+      # transcode before the size check would fail every converted file and turn
+      # the fix into a permanent cry-wolf. Writes land on the IDENTICAL tree path:
+      # a sibling name is silently unscanned (semgrep picks language by extension)
+      # and breaks # BL-178-PER-INDEX-DIR's operator path mapping — the two
+      # constraints intersect at exactly this shape. Deviation from the BL-198
+      # plan text, recorded: no `git diff --cached --numstat` first pass. numstat's
+      # binary heuristic reads only the FIRST 8000 bytes, so a UTF-16 file whose
+      # first NUL sits later would be exempted as "text" and slip the classifier;
+      # the NUL count below reads the whole file (one streaming `tr` per staged
+      # blob, gated behind F2) and has no such window. Strictly stronger, same
+      # decision tree.
+      #   The classifier, exhaustive (WP0): NUL-free → passthrough (UTF-8, Latin-1,
+      #   Shift-JIS and friends — semgrep handles them; "NUL-free AND valid UTF-8"
+      #   is the WRONG tightening, it breaks Latin-1). NULs+BOM → the BOM is a
+      #   CLAIM, matched LONGEST-FIRST (`FF FE` is a prefix of the UTF-32LE BOM),
+      #   and it must AGREE with the whole-body derivation — a lying BOM otherwise
+      #   transcodes to NUL-free valid-UTF-8 garbage that scans clean and mints
+      #   the receipt over a live sink. NULs+no-BOM → whole-file zero-parity
+      #   derivation (never a head window: a CJK comment block has no NULs in its
+      #   head), stride-aware (2-byte vs 4-byte per BOM family; UTF-32 is
+      #   attempted via BOM only). The rule is ALL-zeros-on-one-parity — exact,
+      #   not a ratio. NULs+no-BOM+no-signal → a source extension routes LOUD
+      #   (that shape is binary content in source clothing — BL-192's own
+      #   `vendor.js` residue, newly CAUGHT); anything else is a real binary and
+      #   passes through untouched, exactly as today. Named residue, deliberately
+      #   NOT closed: a zero-ASCII single-line UTF-16 file has no NUL at all and
+      #   passes through undecoded (bounded — any newline puts a NUL in the file);
+      #   the only tightening that closes it breaks Latin-1. Pinned by
+      #   T-pure-cjk-residue-passthrough.
+      # Size is SELF-measured rather than borrowed from F2's soif_idx_want, so
+      # this fence stays inert (never unbound) under the F2-excision mutant —
+      # the two guards are proved independently and must fail independently.
+      soif_tc_size=$(wc -c < "$soif_idx_dest" 2>/dev/null | tr -d '[:space:]') || soif_tc_size=""
+      soif_tc_nonul=$(LC_ALL=C tr -d '\000' < "$soif_idx_dest" 2>/dev/null | wc -c | tr -d '[:space:]') || soif_tc_nonul=""
+      case "$soif_tc_size" in ''|*[!0-9]*) soif_tc_size="" ;; esac
+      case "$soif_tc_nonul" in ''|*[!0-9]*) soif_tc_nonul="$soif_tc_size" ;; esac
+      if [ -n "$soif_tc_size" ] && [ "$soif_tc_nonul" != "$soif_tc_size" ]; then
+        # NULs present. Read the BOM claim (longest-first), then derive.
+        soif_tc_head=$(od -An -N4 -tx1 "$soif_idx_dest" 2>/dev/null | tr -d ' \t\n') || soif_tc_head=""
+        soif_tc_bom=""
+        case "$soif_tc_head" in
+          fffe0000*) soif_tc_bom="UTF-32LE" ;;
+          0000feff*) soif_tc_bom="UTF-32BE" ;;
+          fffe*)     soif_tc_bom="UTF-16LE" ;;
+          feff*)     soif_tc_bom="UTF-16BE" ;;
+        esac
+        soif_tc_stride=2
+        case "$soif_tc_bom" in UTF-32*) soif_tc_stride=4 ;; esac
+        # Whole-body derivation. Zeros come only from code units with a 0x00 byte,
+        # and in real text those bytes sit on ONE parity (LE: odd; BE: even) —
+        # UTF-32's invariant is the always-zero high byte (LE: position 3;
+        # BE: position 0). Anything else — zeros on both parities, odd length —
+        # is AMBIGUOUS and derives nothing, which fails CLOSED below.
+        soif_tc_der=$(od -An -v -tx1 "$soif_idx_dest" 2>/dev/null | awk -v stride="$soif_tc_stride" '
+          { for (i = 1; i <= NF; i++) { if ($i == "00") z[n % stride]++; n++ } }
+          END {
+            if (n == 0 || n % stride != 0) exit 0
+            if (stride == 2) {
+              if (z[1] > 0 && z[0] == 0) print "UTF-16LE"
+              else if (z[0] > 0 && z[1] == 0) print "UTF-16BE"
+            } else {
+              if (z[3] == n / 4 && z[0] < n / 4) print "UTF-32LE"
+              else if (z[0] == n / 4 && z[3] < n / 4) print "UTF-32BE"
+            }
+          }' 2>/dev/null) || soif_tc_der=""
+        soif_tc_enc=""
+        soif_tc_bad=0
+        if [ -n "$soif_tc_bom" ]; then
+          if [ "$soif_tc_der" = "$soif_tc_bom" ]; then soif_tc_enc="$soif_tc_bom"; else soif_tc_bad=1; fi
+        elif [ -n "$soif_tc_der" ]; then
+          soif_tc_enc="$soif_tc_der"
+        else
+          # No BOM, no signal. A source extension here is unvouchable content the
+          # rulesets are supposed to see — route LOUD. This list is pinned against
+          # the test arm's source-extension list by T-mutation-ext-set-pinned
+          # (drift in this literal fails open, so the pin is the tripwire).
+          # BL-198-EXT-SET
+          case "$soif_p" in
+            *.ts|*.tsx|*.mts|*.cts|*.js|*.jsx|*.mjs|*.cjs|*.py|*.rb|*.go|*.rs|*.java|*.kt|*.kts|*.swift|*.cs|*.dart|*.c|*.h|*.cc|*.cpp|*.hpp|*.php|*.scala|*.vue|*.svelte|*.html|*.htm|*.sh)
+              soif_tc_bad=1 ;;
+          esac
+        fi
+        if [ "$soif_tc_bad" -eq 1 ]; then
+          soif_idx_untx+=("$soif_p")
+          continue
+        fi
+        if [ -n "$soif_tc_enc" ]; then
+          # WP1 — convert to a TEMP file and mv over the dest. NEVER redirect
+          # iconv into the file it reads: `iconv f > f` truncates f first, iconv
+          # converts an EMPTY file, returns 0, and the raw bytes are gone — a
+          # receipt over destroyed evidence. The temp lives INSIDE the tree
+          # (cleaned by the one rm -rf; invisible to the scan — semgrep receives
+          # only the explicit target list). Output is vouched before the mv:
+          # NUL-free AND valid UTF-8, else the transcode FAILED and the raw
+          # bytes stay intact. Brace-grouped redirect for the same reason as the
+          # cat-file above: the open failure must be swallowed, not printed raw.
+          soif_tc_tmp="$soif_idx_dest.soif-bl198-tmp"
+          soif_tc_ok=0
+          if { iconv -f "$soif_tc_enc" -t UTF-8 "$soif_idx_dest" > "$soif_tc_tmp"; } 2>/dev/null; then
+            soif_tc_ok=1
+            soif_tc_osize=$(wc -c < "$soif_tc_tmp" 2>/dev/null | tr -d '[:space:]') || soif_tc_osize=""
+            soif_tc_ononul=$(LC_ALL=C tr -d '\000' < "$soif_tc_tmp" 2>/dev/null | wc -c | tr -d '[:space:]') || soif_tc_ononul=""
+            if [ -z "$soif_tc_osize" ] || [ "$soif_tc_osize" != "$soif_tc_ononul" ]; then soif_tc_ok=0; fi
+            if ! iconv -f UTF-8 -t UTF-8 "$soif_tc_tmp" >/dev/null 2>&1; then soif_tc_ok=0; fi
+          fi
+          if [ "$soif_tc_ok" -eq 1 ] && mv "$soif_tc_tmp" "$soif_idx_dest" 2>/dev/null; then
+            soif_tc_count=$((soif_tc_count + 1))
+          else
+            rm -f "$soif_tc_tmp" 2>/dev/null || :
+            soif_idx_untx+=("$soif_p")
+            continue
+          fi
+        fi
+      fi
+      # BL-198-TRANSCODE-END
       soif_idx_files+=("$soif_idx_dest")
       soif_idx_rel+=("$soif_p")
     done
@@ -887,6 +1031,13 @@ if command -v semgrep &>/dev/null; then
         # to guess which of their staged files went unscanned.
         soif_sast_not_enforced "could not materialize staged content for scanning — SAST skipped."
         soif_sast_unread_report
+        if [ "${#soif_idx_untx[@]}" -gt 0 ]; then soif_sast_untx_report; fi
+      elif [ "${#soif_idx_untx[@]}" -gt 0 ]; then
+        # BL-198: every scannable entry was read fine but none could be VOUCHED —
+        # e.g. a single-file commit whose one file wears a lying BOM. Same honest
+        # NOTRUN contract, encoding-specific wording, entries named.
+        soif_sast_not_enforced "staged content could not be made scannable (unvouchable text encoding) — SAST skipped."
+        soif_sast_untx_report
       else
         # BL-132-EMPTY-TARGETS — nothing scannable was materialized (e.g. a submodule
         # POINTER-BUMP commit stages only a gitlink). The scan did not happen, so the
@@ -1091,6 +1242,7 @@ if command -v semgrep &>/dev/null; then
         # read is strictly safer. The operator is still shown the coverage gap, because
         # a blocked commit is exactly when they are about to re-stage and retry.
         if [ "${#soif_idx_unread[@]}" -gt 0 ]; then soif_sast_unread_report; fi
+        if [ "${#soif_idx_untx[@]}" -gt 0 ]; then soif_sast_untx_report; fi
         # Same reasoning one layer out (# BL-112-SCAN-COVERAGE): a finding in what
         # semgrep DID accept still blocks, and the operator is still told that the scan
         # behind the block was incomplete — otherwise they fix the one reported finding
@@ -1108,8 +1260,9 @@ if command -v semgrep &>/dev/null; then
         # died cannot fix it, and a gate you cannot fix is a gate you route around.
         soif_sast_not_enforced "semgrep could not complete (exit $soif_sg_rc) — the tool itself failed."
         if [ "${#soif_idx_unread[@]}" -gt 0 ]; then soif_sast_unread_report; fi
+        if [ "${#soif_idx_untx[@]}" -gt 0 ]; then soif_sast_untx_report; fi
         sed 's/^/  /' "$soif_sg_err" >&2
-      elif [ "${#soif_idx_unread[@]}" -gt 0 ]; then
+      elif [ "${#soif_idx_unread[@]}" -gt 0 ] || [ "${#soif_idx_untx[@]}" -gt 0 ]; then
         # BL-182-NO-UNEARNED-RECEIPT — the scan RAN and came back clean, but it did not
         # see everything that is being committed. A clean SUBSET is not a clean COMMIT:
         # printing the [OK] receipt here would be precisely the BL-112 lie this whole
@@ -1122,8 +1275,13 @@ if command -v semgrep &>/dev/null; then
         # that implies otherwise is a small lie in a message whose whole job is not to
         # tell them. Report what WAS scanned and what could NOT be read; the list that
         # follows names the second group exactly.
-        soif_sast_partial_coverage "SAST coverage was PARTIAL: ${#soif_idx_files[@]} staged file(s) scanned clean, ${#soif_idx_unread[@]} could NOT be read (listed below)."
-        soif_sast_unread_report
+        # BL-198: both escape routes land here — entries the loop could not READ
+        # and entries whose encoding could not be VOUCHED. Both facts are reported
+        # (same both-facts rule as the coverage report below); the combined count
+        # keeps the headline honest when only one list is populated.
+        soif_sast_partial_coverage "SAST coverage was PARTIAL: ${#soif_idx_files[@]} staged file(s) scanned clean, $(( ${#soif_idx_unread[@]} + ${#soif_idx_untx[@]} )) not scanned (listed below)."
+        if [ "${#soif_idx_unread[@]}" -gt 0 ]; then soif_sast_unread_report; fi
+        if [ "${#soif_idx_untx[@]}" -gt 0 ]; then soif_sast_untx_report; fi
         # Both gaps can hold at once (an unreadable entry AND a target semgrep declined),
         # and they are different facts about different entries. Report both; suppressing
         # the second because the first already forfeited the receipt would leave the
@@ -1204,14 +1362,25 @@ if command -v semgrep &>/dev/null; then
         #      (`Scanning 1 file`, `Targets scanned: 1`, rc=0) and collected this receipt
         #      while the one rule that catches its line-2 innerHTML sink hit semgrep's
         #      5-second per-rule timeout (R-274Rv2-1).
-        # THE GAP THIS RECEIPT DOES NOT COVER, STATED HERE RATHER THAN LEFT TO INFERENCE:
-        # nothing above verifies that semgrep DECODED the bytes it accepted. A file it
-        # takes and cannot read satisfies every one of the four — an ordinary .ts saved as
-        # UTF-16 did exactly that (R-274Rv-1) — and this line still prints. A clause that
-        # read semgrep's `Parsed lines: ~N%` was built for that gap and WITHDRAWN because
-        # on semgrep >= 1.171.0 the number is ~100.0% for a file semgrep never decoded.
-        # The gap is BL-192. Read this receipt as "the four checks above did not fire",
-        # never as "this commit was scanned in full".
+        # THE DECODE GAP IS NOW COVERED — BY BYTES, NOT BY SEMGREP'S SELF-REPORT.
+        # A file semgrep accepts but cannot read used to satisfy all four checks (an
+        # ordinary .ts saved as UTF-16 did exactly that, R-274Rv-1 / BL-192; the
+        # `Parsed lines: ~N%` clause built for it was WITHDRAWN because >= 1.171.0
+        # reports ~100.0% for a file semgrep never decoded). # BL-198-TRANSCODE now
+        # vouches or converts the bytes BEFORE semgrep sees them, and anything it
+        # cannot vouch forfeits this receipt by name — so reaching this line also
+        # means every target was NUL-free-or-transcoded-and-vouched.
+        # THE GAPS THAT REMAIN, NAMED RATHER THAN LEFT TO INFERENCE (both deferred
+        # deliberately, neither closable by any byte-level test):
+        #   • BL-200 — the TOKEN-STREAM BREAK: a pure-ASCII source file with a syntax
+        #     break beside the sink passes every byte test here and semgrep misses the
+        #     sink deterministically. Until BL-200's detector lands, absence of a
+        #     finding is evidence only for files semgrep can actually parse.
+        #   • the zero-ASCII single-line UTF-16 residue (no NUL anywhere, so the
+        #     classifier passes it through undecoded) — bounded: any newline puts a
+        #     NUL in the file; pinned by T-pure-cjk-residue-passthrough.
+        # Read this receipt as "the checks above did not fire", never as "this commit
+        # was scanned in full".
         # The pattern across all four is the same and is the point: N counts the targets
         # this arm INTENDED to scan, and every stage between "staged entry" and "a rule
         # finished matching" needs its own proof that nothing fell out of the set. It is
@@ -1220,6 +1389,11 @@ if command -v semgrep &>/dev/null; then
         # one day; an earlier revision of this line predicted one and was right within a
         # single review round.
         echo "[OK] semgrep: SAST ran on ${#soif_idx_files[@]} staged file(s) — no ERROR-severity findings."
+        # BL-198: the conversion is attested, never silent — an operator whose
+        # UTF-16 file was scanned via a converted copy is told so on the receipt.
+        if [ "${soif_tc_count:-0}" -gt 0 ]; then
+          echo "  ($soif_tc_count staged file(s) transcoded from UTF-16/UTF-32 to UTF-8 for scanning — BL-198)"
+        fi
       fi
     fi
     rm -rf "$soif_idx_tree"

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -6507,9 +6507,37 @@ in the receipt's own documentation. WP3's five withdrawn cases are restored re-a
 iconv failure, `T-parse-threshold-exact` to BOM order, plus both mutation proofs) — the
 condition #278 was held open for. Suite 53/0 with the 8 sink rows watched RED first (every
 one printed the `[OK]` receipt over the unseen sink pre-fix); six sibling emitted-hook
-suites green; 11/11 lints. Residues, still named: BL-200 (token break — no byte-level test
-can see it) and the zero-ASCII single-line UTF-16 passthrough (bounded; pinned by
-`T-pure-cjk-residue-passthrough`).
+suites green; 11/11 lints.
+
+**Adversarial review round (fable), verdict `block` → fixed in `a54df64` — and every finding was real.**
+(1) **R-BL198-1, the blocker:** a UTF-32LE BOM prefixed to a UTF-16LE sink body defeated all
+three vouching surfaces — the 4-byte shift puts a zero on every position ≡3 (mod 4) so the
+stride-4 derivation AGREED with the lie, and macOS libiconv converts the out-of-range code
+points to NUL-free output — reproduced end-to-end by the reviewer with the `[OK]` receipt
+printed and the sink in HEAD: the BL-192 false attestation reborn through the fix itself.
+Closed by the **U+10FFFF range bound** in the derivation (genuine UTF-32 has byte@2 ≤ 0x10
+per LE group, byte@1 for BE — exact for BMP and astral; the reviewer validated the bound
+against genuine/astral/liar shapes in both endiannesses). Watched RED then GREEN
+(`T-u32bom-over-u16-body-notrun`). (2) **R-BL198-2:** the plan's WP0.3 claim *"real UTF-16
+source always has a whole-file signal"* is **REFUTED, recorded here rather than silently
+edited**: one code unit with a 0x00 LOW byte (U+0100, U+3000, an astral char with a zero
+surrogate byte) puts a zero on the wrong parity and collapses the exact rule — a clean CJK
+file with one ideographic space is a permanent loud NOTRUN. Kept exact ANYWAY, as a **third
+named residue** (`T-u16-wrongparity-residue` pins it): a dominance ratio would let a crafted
+no-BOM file steer the derivation to the wrong endianness, whose transcode is NUL-free
+valid-UTF-8 garbage and a receipt over an unscanned sink — the strictly worse failure. The
+residue fails LOUD and names the file; the remedy it prints (save as UTF-8) is real.
+(3) **R-BL198-3:** the output UTF-8 revalidation is inert on macOS (libiconv accepts 5-byte
+sequences) — added the byte-level floor (any 0xF5-0xFF byte in the output ⇒ failed
+transcode; RFC 3629 exact). (4) **R-BL198-4, deviation #2 recorded:** `T-ext-set-pinned`
+pins the extension set against the BL-125 source list — a PROXY for "the shipped rulesets",
+not the rulesets themselves; deriving language→extension from the ruleset YAMLs is the
+honest future tightening. (5) **R-BL198-5:** `.cxx/.hh/.hxx/.m/.mm` added to
+`# BL-198-EXT-SET`. Reviewer note recorded, pre-existing: semgrep's
+`--exclude-binary-files` defaults ON and the hook passes neither spelling — a dropped
+binary target is caught by the selection guard, so not a hole; noted so it is not
+rediscovered. Final: suite 55/0; residues now THREE, all named: BL-200 (token break), the
+zero-ASCII single-line passthrough, and the wrong-parity loud NOTRUN.
 
 **Read first, and do not repeat this work:** BL-192 (the measured diagnosis, the two-version table,
 the two DECISION blocks), the `# BL-112-SCAN-COVERAGE` block in `scripts/lib/hook-templates.sh` —

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -6536,7 +6536,11 @@ honest future tightening. (5) **R-BL198-5:** `.cxx/.hh/.hxx/.m/.mm` added to
 `# BL-198-EXT-SET`. Reviewer note recorded, pre-existing: semgrep's
 `--exclude-binary-files` defaults ON and the hook passes neither spelling — a dropped
 binary target is caught by the selection guard, so not a hole; noted so it is not
-rediscovered. Final: suite 55/0; residues now THREE, all named: BL-200 (token break), the
+rediscovered. A third targeted round found **R-BL198-6**: the R-BL198-3 floor itself was the BL-183 SIGPIPE
+class re-introduced (awk early-exit under pipefail — detection ERASED on outputs past ~8KB;
+no live path reaches it after the range bound, which is exactly why the defense-in-depth
+surface must work). Fixed to a full-input consumer + pinned both-spellings
+(`T-utf8-floor-no-sigpipe`), watched RED→GREEN. Final: suite 56/0; residues THREE, all named: BL-200 (token break), the
 zero-ASCII single-line passthrough, and the wrong-parity loud NOTRUN.
 
 **Read first, and do not repeat this work:** BL-192 (the measured diagnosis, the two-version table,

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -5982,6 +5982,15 @@ protects), BL-187 (the sibling clause with the same fail-open shape — this ent
 looks like once realised), and the `# BL-112-SCAN-COVERAGE` block in `scripts/lib/hook-templates.sh`,
 which carries the same measurement inline so a reader of the code does not need this file.
 
+**UPDATE 2026-07-30 — the PRIMARY fix this diagnosis called for is IMPLEMENTED: BL-198
+(transcode-first) landed in `02eaa0f` (`# BL-198-TRANSCODE`).** The false-attestation shape this
+entry measured — a UTF-16 staged sink collecting the `[OK]` receipt — now BLOCKS (watched RED
+then GREEN through the real emitted hook, 8 fixture rows). Per this entry's own DECISION
+blocks, no clause of the fix reads anything semgrep reports. The entry STAYS OPEN deliberately
+for its two spawned residues: BL-200 (the token-stream break, the best-effort `--verbose`
+detector + canary) and BL-201 (the 22 template pins float, sequenced after BL-198 — now
+unblocked). Close this entry when both land.
+
 ---
 
 ## BL-193: On CI the emitted hook forfeited the SAST receipt on essentially EVERY clean commit, cascading 13 mutation/coverage proofs into silent SKIPs while the shard reported only 3 named failures — NOT reproducible on any local platform, cause unknown
@@ -6476,7 +6485,31 @@ paid for that lesson.
 **Severity:** High, inherited from BL-192: the outcome it prevents is a **positive false attestation**
 (`[OK] semgrep: SAST ran on N staged file(s) — no ERROR-severity findings.` printed over a file the
 parser never decoded).
-**Status:** Open — planned, not started.
+**Status:** Closed — implemented 2026-07-30 in `02eaa0f` (WP0–WP4 complete; marker `# BL-198-TRANSCODE`
+in `scripts/lib/hook-templates.sh`, reporter `# BL-198-UNTX-REPORT`, extension tripwire `# BL-198-EXT-SET`).
+
+**Closure record.** The decision tree shipped as planned: NUL scan → BOM longest-first →
+whole-body stride-aware zero-parity derivation with the claim/derivation agree-check →
+transcode-to-UTF-8 at the IDENTICAL tree path (temp + `mv`, after F2) → fail-closed named
+NOTRUN for everything unvouchable. The receipt attests the conversion count. **One deviation
+from this plan's text, recorded in the fence comment:** no `numstat` first pass — its binary
+heuristic reads only the first 8000 bytes, so a late-first-NUL UTF-16 file would be exempted
+as "text" and slip the classifier; the whole-file NUL count has no window. Strictly stronger,
+same tree. **No parity ratio exists** (the rule shipped as all-zeros-on-one-parity, exact),
+so the plan's "numeric boundary" proof obligation attaches to the BOM match ORDER instead —
+`T-mutation-parse-threshold` proves shortest-first degrades the UTF-32 row to a SAFE cry-wolf,
+never a receipt. DoD walked: UTF-16LE±BOM/BE±BOM/UTF-32LE+BOM sinks all transcode and BLOCK;
+well-formed, empty, UTF-8-BOM, Latin-1 and binary commits keep their receipts untouched;
+iconv failure (unpaired surrogate) forfeits loudly naming the file; no clause added by this
+work reads anything semgrep printed; the token-break residue is deferred to BL-200 and named
+in the receipt's own documentation. WP3's five withdrawn cases are restored re-aimed
+(`T-utf16-parse-drop-no-receipt` flips to sink-BLOCKED, `T-parse-coverage-fails-closed` to
+iconv failure, `T-parse-threshold-exact` to BOM order, plus both mutation proofs) — the
+condition #278 was held open for. Suite 53/0 with the 8 sink rows watched RED first (every
+one printed the `[OK]` receipt over the unseen sink pre-fix); six sibling emitted-hook
+suites green; 11/11 lints. Residues, still named: BL-200 (token break — no byte-level test
+can see it) and the zero-ASCII single-line UTF-16 passthrough (bounded; pinned by
+`T-pure-cjk-residue-passthrough`).
 
 **Read first, and do not repeat this work:** BL-192 (the measured diagnosis, the two-version table,
 the two DECISION blocks), the `# BL-112-SCAN-COVERAGE` block in `scripts/lib/hook-templates.sh` —
@@ -6935,7 +6968,7 @@ semgrep on the CI host (already true of the `sast` shard). Sequenced AFTER BL-19
 work rewrites the same region, and two hands in that block at once is how BL-179/BL-182 earned their
 "same rewrite by design" note.
 
-**Status:** Open — blocked by BL-198.
+**Status:** Open — unblocked 2026-07-30 (BL-198 implemented in `02eaa0f`).
 
 **Related:** BL-198 (the plan that refuses to claim this), BL-192 (the decision blocks that
 constrain the design), `# BL-112-SCAN-COVERAGE` (the residue note that named it first), BL-193
@@ -6983,7 +7016,7 @@ clause reads anything semgrep prints, and version drift can only ever ADD findin
 **Adjacent, noted not scoped:** the emitted hook's receipt could print the scanner version for the
 same debuggability (BL-193 cost a day partly to version archaeology). One line; decide at build.
 
-**Status:** Open — blocked by BL-198.
+**Status:** Open — unblocked 2026-07-30 (BL-198 implemented in `02eaa0f`).
 
 **Related:** BL-192 (both decision blocks), BL-198 (the gate this waits on), BL-147 (the parity
 suite that must move in the same diff), BL-193 (the version-archaeology cost that motivates the

--- a/tests/test-bl132-sast-index-scan.sh
+++ b/tests/test-bl132-sast-index-scan.sh
@@ -2814,6 +2814,67 @@ else
   fi
 fi
 
+# ── T-u32bom-over-u16-body-notrun (review R-BL198-1 — the stride-shift liar) ──────
+# A UTF-32LE BOM (FF FE 00 00) prefixed to a UTF-16LE body: the 4-byte shift puts a
+# zero on every position ≡3 (mod 4), so the naive stride-4 derivation AGREES with
+# the lie (z[3]==n/4 exactly), macOS libiconv then accepts the out-of-range code
+# points a real UTF-32 read of UTF-16 bytes produces, and the output is NUL-free —
+# all three vouching surfaces defeated, [OK] receipt over a live sink (reproduced
+# end-to-end in review). The U+10FFFF range bound closes it: in genuine UTF-32LE
+# byte@2 of every group is <= 0x10 (and byte@1 for BE) — exact for BMP AND astral —
+# while the shifted UTF-16 body carries ordinary ASCII there. Expect: loud named
+# NOTRUN, no receipt, no block, commit lands.
+echo "=== T-u32bom-over-u16-body-notrun ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-u32bom-over-u16-body-notrun" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xff\xfe\x00\x00'; printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16LE; } > "$BL198FIX/u32lie.bin"
+  if [ "$(_bl198_head4 "$BL198FIX/u32lie.bin")" != "fffe0000" ]; then
+    fail_ "T-u32bom-over-u16-body-notrun" "fixture head is not the UTF-32LE BOM — the case proves nothing"
+  else
+    U32L_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-u32lie" widget.ts "$BL198FIX/u32lie.bin")"
+    if [ "$U32L_V" = "COMMITTED" ] && grep -qF 'SAST NOT ENFORCED' "$TOPTMP/bl198-u32lie" \
+       && grep -qF 'widget.ts' "$TOPTMP/bl198-u32lie" \
+       && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-u32lie" \
+       && ! grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-u32lie"; then
+      pass "T-u32bom-over-u16-body-notrun: a stride-4 BOM over a stride-2 body is caught by the U+10FFFF range bound — loud named NOTRUN, never a receipt over garbage (R-BL198-1)"
+    else
+      fail_ "T-u32bom-over-u16-body-notrun" "verdict=$U32L_V — the stride-shift liar must be a loud named NOTRUN (a receipt here is the BL-192 false attestation reborn through the fix itself): $(sast_evidence "$TOPTMP/bl198-u32lie")"
+    fi
+  fi
+fi
+
+# ── T-u16-wrongparity-residue (review R-BL198-2 — the THIRD residue, pinned) ──────
+# One code unit whose LOW byte is 0x00 — U+3000 ideographic space, U+0100 Ā, any
+# astral char with a zero surrogate byte (U+1F600) — puts a single zero on the
+# wrong parity and collapses the all-zeros-on-one-parity signal: the file goes
+# LOUD named NOTRUN, forever. This is deliberate and pinned AS the boundary:
+# relaxing to a dominance ratio would let a CRAFTED no-BOM file steer the
+# derivation to the wrong endianness, whose transcode is NUL-free valid-UTF-8
+# garbage — a receipt over an unscanned sink, the strictly worse failure. Exact
+# stays; the cost is this loud residue (named in the plan and the fence comment).
+echo "=== T-u16-wrongparity-residue ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-u16-wrongparity-residue" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  printf 'const pad = "\343\200\200";\nexport const n = 1;\n' | iconv -f UTF-8 -t UTF-16LE > "$BL198FIX/wrongparity.bin"
+  WP_EVEN_ZEROS=$(od -An -v -tx1 "$BL198FIX/wrongparity.bin" | awk '{ for (i = 1; i <= NF; i++) { if ($i == "00" && n % 2 == 0) e++; n++ } } END { print e + 0 }')
+  if [ "${WP_EVEN_ZEROS:-0}" -eq 0 ]; then
+    fail_ "T-u16-wrongparity-residue" "fixture has no wrong-parity zero (U+3000 low byte) — it is not the residue shape"
+  else
+    WPR_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-wrongparity" widget.ts "$BL198FIX/wrongparity.bin")"
+    if [ "$WPR_V" = "COMMITTED" ] && grep -qF 'SAST NOT ENFORCED' "$TOPTMP/bl198-wrongparity" \
+       && grep -qF 'widget.ts' "$TOPTMP/bl198-wrongparity" \
+       && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-wrongparity"; then
+      pass "T-u16-wrongparity-residue: a clean UTF-16LE file with one U+3000 is a LOUD named NOTRUN — the exactness residue is real, bounded, and pinned (R-BL198-2; dominance was rejected because it reopens crafted mis-derivation)"
+    else
+      fail_ "T-u16-wrongparity-residue" "verdict=$WPR_V — the wrong-parity residue boundary moved (this case exists to make that loud): $(sast_evidence "$TOPTMP/bl198-wrongparity")"
+    fi
+  fi
+fi
+
 # ── T-mutation-parse-coverage (restored from e87dbd3, RE-AIMED at the fence) ──────
 # Excise the whole # BL-198-TRANSCODE fence from the emitted hook -> the BL-192
 # false attestation RETURNS (UTF-16LE+BOM sink lands with the [OK] receipt) — RED.

--- a/tests/test-bl132-sast-index-scan.sh
+++ b/tests/test-bl132-sast-index-scan.sh
@@ -1862,7 +1862,7 @@ else
   # it must be RED. Restored, the same commit gets the loud partial NOTRUN (GREEN).
   echo "=== T-mutation-partial-receipt ==="
   MPR="$TOPTMP/mut-receipt"
-  if ! _mut_n "$EMITTED" "$MPR" 'elif [ "${#soif_idx_unread[@]}" -gt 0 ]; then' 'elif false; then' 1; then
+  if ! _mut_n "$EMITTED" "$MPR" 'elif [ "${#soif_idx_unread[@]}" -gt 0 ] || [ "${#soif_idx_untx[@]}" -gt 0 ]; then' 'elif false; then' 1; then
     fail_ "T-mutation-partial-receipt" "MIS-TARGETED — the clean-but-partial receipt guard is not present exactly once in the emitted hook"
   elif ! bash -n "$MPR" 2>/dev/null; then
     fail_ "T-mutation-partial-receipt" "mutated hook has a syntax error — a broken mutant proves nothing"
@@ -2480,6 +2480,454 @@ elif ! grep -qF 'CANNOT BE VERIFIED' "$TOPTMP/sr-red"; then
   fail_ "T-scan-status-singular-rule" "the plural-only mutant neither receipted nor reported an unverifiable header: $(tail -6 "$TOPTMP/sr-red" | tr '\n' '|')"
 else
   pass "T-scan-status-singular-rule: 'Scanning 1 file with 1 Code rule:' EARNS the receipt; narrowing the grep back to the plural turns it into a permanent NOTRUN (RED) — the singular spelling is real and is now accepted (R-274Rv2-8)"
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════════
+# BL-198 — TRANSCODE-FIRST DECODE COVERAGE (# BL-198-TRANSCODE in the emitted hook).
+# BL-192's gap: semgrep ACCEPTS a UTF-16 staged file, cannot decode it, scans it
+# "clean", and the four-precondition receipt prints over an unseen sink — a positive
+# false attestation. The fix classifies each materialized blob AFTER F2 (NUL scan →
+# BOM longest-first → whole-file stride-aware zero-parity derivation, BOM and
+# derivation required to AGREE), transcodes vouched UTF-16/UTF-32 to UTF-8 at the
+# IDENTICAL tree path (temp + mv, never a redirect into the source), and fails
+# CLOSED to a loud named NOTRUN on anything it cannot vouch. These cases are the
+# fixture matrix from the BL-198 plan; five restore the shape of the cases withdrawn
+# with the BL-186 parse clause (held on PR #278 @ e87dbd3), re-aimed off semgrep's
+# self-report onto the transcode — the UTF-16 sink cases flip from "receipt
+# forfeited" to the stronger "sink CAUGHT, commit BLOCKED".
+#   Every fixture asserts its own byte shape (NUL count, BOM bytes, length parity)
+#   before any behavior assertion, so a fixture edit cannot quietly turn a case
+#   vacuous. A plain-UTF-8 control probe gates the sink cases: on a host where the
+#   baseline sink does not block (no registry, rules unresolved), they SKIP as
+#   UNPROVEN rather than mis-reporting the transcode.
+# ═════════════════════════════════════════════════════════════════════════════════
+
+HAVE_ICONV=0
+command -v iconv >/dev/null 2>&1 && HAVE_ICONV=1
+
+_bl198_nuls() {  # <file> -> count of NUL bytes
+  local tot non
+  tot=$(wc -c < "$1" 2>/dev/null | tr -d '[:space:]') || tot=0
+  non=$(LC_ALL=C tr -d '\000' < "$1" 2>/dev/null | wc -c | tr -d '[:space:]') || non=0
+  echo $(( tot - non ))
+}
+
+_bl198_head4() {  # <file> -> first 4 bytes as bare hex
+  od -An -N4 -tx1 "$1" 2>/dev/null | tr -d ' \t\n'
+}
+
+_bl198_run() {  # <hookfile> <log> <relpath> <bytesfile> -> COMMITTED|REFUSED|SETUPFAIL
+  local d v
+  d="$(mktemp -d)"
+  mk_repo "$d" "$1" >/dev/null 2>&1 || { rm -rf "$d"; echo SETUPFAIL; return; }
+  cp "$4" "$d/$3" 2>/dev/null || { rm -rf "$d"; echo SETUPFAIL; return; }
+  ( cd "$d" && git add -- "$3" ) >/dev/null 2>&1 || { rm -rf "$d"; echo SETUPFAIL; return; }
+  if ( cd "$d" && git commit -m "feat: add module" ) >"$2" 2>&1; then v=COMMITTED; else v=REFUSED; fi
+  rm -rf "$d"
+  echo "$v"
+}
+
+BL198FIX="$TOPTMP/bl198fix"
+mkdir -p "$BL198FIX"
+
+# Control probe: the SAME sink in plain UTF-8 must block on this host, or the
+# UTF-16 cases cannot distinguish "transcode failed" from "rules never resolved".
+BL198_CONTROL=0
+if [ "$HAVE_SEMGREP" -eq 1 ]; then
+  printf '%s\n' "$REN_VULN" > "$BL198FIX/control.bin"
+  BL198_CTL_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-control" widget.ts "$BL198FIX/control.bin")"
+  if [ "$BL198_CTL_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-control"; then
+    BL198_CONTROL=1
+  fi
+fi
+
+_bl198_skip_reason() {  # -> the reason the matrix cases cannot run, or empty
+  if [ "$HAVE_SEMGREP" -eq 0 ]; then echo "semgrep ABSENT"; return; fi
+  if [ "$HAVE_ICONV" -eq 0 ]; then echo "iconv ABSENT — cannot build UTF-16 fixtures"; return; fi
+  if [ "$BL198_CONTROL" -eq 0 ]; then echo "plain-UTF-8 sink control did not BLOCK (registry unreachable?)"; fi
+}
+
+# ── T-utf16-parse-drop-no-receipt (restored from e87dbd3, RE-AIMED) ───────────────
+# The original case pinned "receipt forfeited" via the withdrawn parse clause. The
+# transcode buys the stronger DoD: the SAME fixture — an ordinary .ts saved as
+# UTF-16LE WITH BOM, carrying the innerHTML sink — is now DECODED and its sink
+# BLOCKS the commit outright.
+echo "=== T-utf16-parse-drop-no-receipt ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-utf16-parse-drop-no-receipt" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xff\xfe'; printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16LE; } > "$BL198FIX/le-bom.bin"
+  if [ "$(_bl198_nuls "$BL198FIX/le-bom.bin")" -eq 0 ] || [ "$(_bl198_head4 "$BL198FIX/le-bom.bin" | cut -c1-4)" != "fffe" ]; then
+    fail_ "T-utf16-parse-drop-no-receipt" "fixture is not BOM'd UTF-16LE (nuls=$(_bl198_nuls "$BL198FIX/le-bom.bin") head=$(_bl198_head4 "$BL198FIX/le-bom.bin")) — the case proves nothing"
+  else
+    U16A_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-lebom" widget.ts "$BL198FIX/le-bom.bin")"
+    if [ "$U16A_V" = "SETUPFAIL" ]; then
+      fail_ "T-utf16-parse-drop-no-receipt" "fixture setup failed"
+    elif [ "$U16A_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-lebom" \
+         && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-lebom"; then
+      pass "T-utf16-parse-drop-no-receipt: a UTF-16LE+BOM staged sink is transcoded and BLOCKS — the BL-192 false attestation is gone and the DoD is the strong form"
+    else
+      fail_ "T-utf16-parse-drop-no-receipt" "verdict=$U16A_V — the sink in a UTF-16LE+BOM .ts did not block (BL-192: semgrep scans the undecoded bytes 'clean' and the receipt lies): $(sast_evidence "$TOPTMP/bl198-lebom")"
+    fi
+  fi
+fi
+
+# ── T-utf16le-nobom-sink-blocked (the decoy row: NO BOM, decodes as valid UTF-8) ──
+# UTF-16LE without a BOM is the trap variant: the raw bytes happen to be valid
+# UTF-8 (every other byte NUL), so any "is it valid UTF-8?" tightening waves it
+# through. Whole-file zero-parity derivation is what catches it.
+echo "=== T-utf16le-nobom-sink-blocked ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-utf16le-nobom-sink-blocked" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16LE > "$BL198FIX/le-nobom.bin"
+  U16B_H="$(_bl198_head4 "$BL198FIX/le-nobom.bin" | cut -c1-4)"
+  if [ "$(_bl198_nuls "$BL198FIX/le-nobom.bin")" -eq 0 ] || [ "$U16B_H" = "fffe" ]; then
+    fail_ "T-utf16le-nobom-sink-blocked" "fixture is not BOM-less UTF-16LE (head=$U16B_H) — the case proves nothing"
+  else
+    U16B_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-lenobom" widget.ts "$BL198FIX/le-nobom.bin")"
+    if [ "$U16B_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-lenobom"; then
+      pass "T-utf16le-nobom-sink-blocked: BOM-less UTF-16LE (raw bytes are VALID UTF-8 — the decoy) is parity-derived, transcoded, and its sink BLOCKS"
+    else
+      fail_ "T-utf16le-nobom-sink-blocked" "verdict=$U16B_V — the BOM-less UTF-16LE sink did not block: $(sast_evidence "$TOPTMP/bl198-lenobom")"
+    fi
+  fi
+fi
+
+# ── T-utf16be-sink-blocked (both BE variants: with and without BOM) ───────────────
+echo "=== T-utf16be-sink-blocked ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-utf16be-sink-blocked" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xfe\xff'; printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16BE; } > "$BL198FIX/be-bom.bin"
+  printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16BE > "$BL198FIX/be-nobom.bin"
+  if [ "$(_bl198_head4 "$BL198FIX/be-bom.bin" | cut -c1-4)" != "feff" ] || [ "$(_bl198_nuls "$BL198FIX/be-nobom.bin")" -eq 0 ]; then
+    fail_ "T-utf16be-sink-blocked" "BE fixtures malformed — the case proves nothing"
+  else
+    BE1_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-bebom" widget.ts "$BL198FIX/be-bom.bin")"
+    BE2_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-benobom" widget.ts "$BL198FIX/be-nobom.bin")"
+    if [ "$BE1_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-bebom" \
+       && [ "$BE2_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-benobom"; then
+      pass "T-utf16be-sink-blocked: UTF-16BE sinks block with a BOM (claim+derivation agree) and without one (derivation alone)"
+    else
+      fail_ "T-utf16be-sink-blocked" "BE+BOM=$BE1_V BE-noBOM=$BE2_V (both must REFUSE): $(sast_evidence "$TOPTMP/bl198-benobom")"
+    fi
+  fi
+fi
+
+# ── T-utf16-cjk-head-sink-blocked (the head-window refuter) ───────────────────────
+# The file OPENS with a CJK comment block — UTF-16 code units with BOTH bytes
+# non-zero, so a head-window sniff sees no NULs and reads "no signal" — and the
+# ASCII sink sits after it. Whole-file parity must still catch it. (No BOM.)
+echo "=== T-utf16-cjk-head-sink-blocked ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-utf16-cjk-head-sink-blocked" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '// %s\n' "中文注释中文注释中文注释中文注释中文注释中文注释中文注释中文注释"; printf '%s\n' "$REN_VULN"; } | iconv -f UTF-8 -t UTF-16LE > "$BL198FIX/cjk-head.bin"
+  if [ "$(_bl198_nuls "$BL198FIX/cjk-head.bin")" -eq 0 ]; then
+    fail_ "T-utf16-cjk-head-sink-blocked" "fixture carries no NULs at all — it is not the shape this case names"
+  else
+    CJK_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-cjk" widget.ts "$BL198FIX/cjk-head.bin")"
+    if [ "$CJK_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-cjk"; then
+      pass "T-utf16-cjk-head-sink-blocked: a CJK-opening UTF-16 file is parity-read over the WHOLE file and its sink blocks — no head window to fool"
+    else
+      fail_ "T-utf16-cjk-head-sink-blocked" "verdict=$CJK_V — the CJK-head UTF-16 sink did not block: $(sast_evidence "$TOPTMP/bl198-cjk")"
+    fi
+  fi
+fi
+
+# ── T-parse-threshold-exact (restored from e87dbd3, RE-AIMED at BOM order) ────────
+# The original pinned an exact `-ge 100` threshold. The transcode design has no
+# ratio (the parity rule is all-zeros-on-one-parity, exact by construction); the
+# boundary that CAN silently re-narrow is the BOM match ORDER — `FF FE` is a
+# PREFIX of the UTF-32LE BOM, so longest-first is load-bearing. A UTF-32LE+BOM
+# sink must be read as UTF-32LE and block; shortest-first would misread it as
+# UTF-16LE, fail the output vouch, and cry wolf on a legitimate file.
+echo "=== T-parse-threshold-exact ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-parse-threshold-exact" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xff\xfe\x00\x00'; printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-32LE; } > "$BL198FIX/u32le-bom.bin"
+  if [ "$(_bl198_head4 "$BL198FIX/u32le-bom.bin")" != "fffe0000" ]; then
+    fail_ "T-parse-threshold-exact" "fixture head is not the UTF-32LE BOM — the case proves nothing"
+  else
+    U32_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-u32" widget.ts "$BL198FIX/u32le-bom.bin")"
+    if [ "$U32_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-u32"; then
+      pass "T-parse-threshold-exact: a UTF-32LE+BOM sink is matched longest-first, transcoded as UTF-32LE, and BLOCKS"
+    else
+      fail_ "T-parse-threshold-exact" "verdict=$U32_V — the UTF-32LE+BOM sink did not block (BOM order or stride derivation broken): $(sast_evidence "$TOPTMP/bl198-u32")"
+    fi
+  fi
+fi
+
+# ── T-utf16-lying-bom-notrun (the agree-check, BOTH directions) ───────────────────
+# A BOM is a CLAIM. `FF FE` (claims LE) over a UTF-16BE body transcodes to
+# NUL-free valid-UTF-8 GARBAGE that passes every output check — so without the
+# claim/derivation agree-check the fix itself mints a fresh false receipt. Both
+# lying directions must land as a LOUD named NOTRUN: never scanned-clean, never
+# blocked, never receipted.
+echo "=== T-utf16-lying-bom-notrun ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-utf16-lying-bom-notrun" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xff\xfe'; printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16BE; } > "$BL198FIX/lie-le-over-be.bin"
+  { printf '\xfe\xff'; printf '%s\n' "$REN_VULN" | iconv -f UTF-8 -t UTF-16LE; } > "$BL198FIX/lie-be-over-le.bin"
+  LIE1_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-lie1" widget.ts "$BL198FIX/lie-le-over-be.bin")"
+  LIE2_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-lie2" widget.ts "$BL198FIX/lie-be-over-le.bin")"
+  LIE_OK=1
+  for LIE_LOG in "$TOPTMP/bl198-lie1" "$TOPTMP/bl198-lie2"; do
+    if ! grep -qF 'SAST NOT ENFORCED' "$LIE_LOG" || ! grep -qF 'widget.ts' "$LIE_LOG" \
+       || grep -qF '[OK] semgrep: SAST ran' "$LIE_LOG"; then LIE_OK=0; fi
+  done
+  if [ "$LIE1_V" = "COMMITTED" ] && [ "$LIE2_V" = "COMMITTED" ] && [ "$LIE_OK" -eq 1 ]; then
+    pass "T-utf16-lying-bom-notrun: both lying-BOM directions land as a LOUD NOTRUN that NAMES widget.ts — no receipt over garbage, no block on an unvouchable read"
+  else
+    fail_ "T-utf16-lying-bom-notrun" "lie1=$LIE1_V lie2=$LIE2_V named-and-unreceipted=$LIE_OK — a lying BOM must forfeit the receipt and name the file, in both directions: $(sast_evidence "$TOPTMP/bl198-lie1")"
+  fi
+fi
+
+# ── T-parse-coverage-fails-closed (restored from e87dbd3, RE-AIMED at iconv) ──────
+# The original pinned the withdrawn clause's unreadable-banner arm. Re-aimed: a
+# vouched-looking file iconv still cannot convert — BOM'd UTF-16LE with an
+# UNPAIRED HIGH SURROGATE (U+D834 with no low half) — must fail CLOSED: iconv
+# exits non-zero, the raw bytes stay intact, the receipt is forfeited, the file
+# is NAMED, and the commit lands as a WARN (an unconvertible file is not
+# evidence of a defect).
+echo "=== T-parse-coverage-fails-closed ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-parse-coverage-fails-closed" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xff\xfe'; printf 'const a = "x";\n' | iconv -f UTF-8 -t UTF-16LE; printf '\x34\xd8'; printf 'const b = "y";\n' | iconv -f UTF-8 -t UTF-16LE; } > "$BL198FIX/surrogate.bin"
+  if iconv -f UTF-16LE -t UTF-8 "$BL198FIX/surrogate.bin" >/dev/null 2>&1; then
+    skip_ "T-parse-coverage-fails-closed" "this host's iconv ACCEPTS an unpaired surrogate — the iconv-failure path is unreachable with this fixture here (skip, NOT a pass)"
+  else
+    SUR_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-sur" widget.ts "$BL198FIX/surrogate.bin")"
+    if [ "$SUR_V" = "COMMITTED" ] && grep -qF 'SAST NOT ENFORCED' "$TOPTMP/bl198-sur" \
+       && grep -qF 'widget.ts' "$TOPTMP/bl198-sur" \
+       && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-sur"; then
+      pass "T-parse-coverage-fails-closed: an unconvertible (unpaired-surrogate) UTF-16 file forfeits the receipt LOUDLY, names the file, and never mints [OK]"
+    else
+      fail_ "T-parse-coverage-fails-closed" "verdict=$SUR_V — iconv failure must be a loud named NOTRUN, never a receipt: $(sast_evidence "$TOPTMP/bl198-sur")"
+    fi
+  fi
+fi
+
+# ── T-utf16-clean-transcode-receipt (the receipt names the transcode) ─────────────
+echo "=== T-utf16-clean-transcode-receipt ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-utf16-clean-transcode-receipt" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xff\xfe'; printf '%s\n' "$SAFE_TS" | iconv -f UTF-8 -t UTF-16LE; } > "$BL198FIX/le-clean.bin"
+  CLN_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-clean" widget.ts "$BL198FIX/le-clean.bin")"
+  if [ "$CLN_V" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran on 1 staged file(s)' "$TOPTMP/bl198-clean" \
+     && grep -qE 'transcoded' "$TOPTMP/bl198-clean"; then
+    pass "T-utf16-clean-transcode-receipt: a CLEAN UTF-16 file earns the receipt AND the receipt says it was transcoded — the conversion is attested, not silent"
+  else
+    fail_ "T-utf16-clean-transcode-receipt" "verdict=$CLN_V — a clean UTF-16 commit must earn a receipt that NAMES the transcode: $(sast_evidence "$TOPTMP/bl198-clean")"
+  fi
+fi
+
+# ── T-utf8-bom-passthrough + T-latin1-passthrough (must NOT be touched) ───────────
+# UTF-8+BOM is legal and common from Windows editors; Latin-1 is NUL-free and
+# invalid UTF-8 and semgrep handles it (measured in the plan's review) — the
+# classifier must pass BOTH through untouched with the receipt intact. Latin-1 is
+# also why "NUL-free AND valid UTF-8" is the WRONG tightening.
+echo "=== T-utf8-bom-and-latin1-passthrough ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-utf8-bom-and-latin1-passthrough" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  { printf '\xef\xbb\xbf'; printf '%s\n' "$SAFE_TS"; } > "$BL198FIX/u8bom.bin"
+  printf 'const cafe = "caf\xe9";\nexport const n = 1;\n' > "$BL198FIX/latin1.bin"
+  if [ "$(_bl198_nuls "$BL198FIX/u8bom.bin")" -ne 0 ] || [ "$(_bl198_nuls "$BL198FIX/latin1.bin")" -ne 0 ]; then
+    fail_ "T-utf8-bom-and-latin1-passthrough" "passthrough fixtures unexpectedly carry NULs — wrong shape"
+  else
+    U8_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-u8bom" widget.ts "$BL198FIX/u8bom.bin")"
+    L1_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-latin1" widget.ts "$BL198FIX/latin1.bin")"
+    if [ "$U8_V" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-u8bom" \
+       && ! grep -qE 'transcoded' "$TOPTMP/bl198-u8bom" \
+       && [ "$L1_V" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-latin1" \
+       && ! grep -qE 'transcoded' "$TOPTMP/bl198-latin1"; then
+      pass "T-utf8-bom-and-latin1-passthrough: UTF-8+BOM and Latin-1 sources pass through untouched and still earn the receipt — no transcode, no cry-wolf"
+    else
+      fail_ "T-utf8-bom-and-latin1-passthrough" "u8bom=$U8_V latin1=$L1_V — NUL-free files must be untouched with receipts intact: $(sast_evidence "$TOPTMP/bl198-latin1")"
+    fi
+  fi
+fi
+
+# ── T-binary-passthrough-receipt (WP4's binary-commit case) ───────────────────────
+# A real binary (PNG magic + NULs, non-source extension) staged beside a clean .ts:
+# no transcode attempt, no block, and the commit LANDS exactly as it does today.
+echo "=== T-binary-passthrough-receipt ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-binary-passthrough-receipt" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  _bl198_bin_commit() {  # <hookfile> <log> -> COMMITTED|REFUSED|SETUPFAIL
+    local d; d="$(mktemp -d)"
+    mk_repo "$d" "$1" >/dev/null 2>&1 || { rm -rf "$d"; echo SETUPFAIL; return; }
+    printf '\x89PNG\r\n\x1a\n\x00\x00\x00\x0dIHDR\x00\x00\x00\x01\x00\x00\x00\x01\x08\x02\x00\x00\x00\x90wS\xde' > "$d/logo.png"
+    printf '%s\n' "$SAFE_TS" > "$d/app.ts"
+    ( cd "$d" && git add -- logo.png app.ts ) >/dev/null 2>&1
+    if ( cd "$d" && git commit -m "feat: add renderer and logo" ) >"$2" 2>&1; then echo COMMITTED; else echo REFUSED; fi
+    rm -rf "$d"
+  }
+  BIN_V="$(_bl198_bin_commit "$EMITTED" "$TOPTMP/bl198-bin")"
+  if [ "$BIN_V" = "COMMITTED" ] && ! grep -qE 'transcoded' "$TOPTMP/bl198-bin" \
+     && ! grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-bin"; then
+    pass "T-binary-passthrough-receipt: a PNG (NULs, no BOM, no parity signal, non-source extension) rides along untouched — no transcode attempt, no block, commit lands"
+  else
+    fail_ "T-binary-passthrough-receipt" "verdict=$BIN_V — a binary sibling must neither transcode nor block: $(sast_evidence "$TOPTMP/bl198-bin")"
+  fi
+fi
+
+# ── T-pure-cjk-residue-passthrough (the NAMED residue, pinned as documentation) ───
+# A single-line zero-ASCII pure-CJK UTF-16 file has NO NUL anywhere (every code
+# unit is two non-zero bytes), so WP0.1 passes it through and semgrep scans it
+# undecoded — receipt granted. This is the plan's DOCUMENTED residue (review
+# R3-2), bounded to zero-ASCII single-line files, and deliberately NOT closed:
+# the only tightening that would catch it also breaks Latin-1 passthrough. The
+# case pins the boundary so a future "fix" that silently widens or narrows it
+# shows up here.
+echo "=== T-pure-cjk-residue-passthrough ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-pure-cjk-residue-passthrough" "$BL198_WHY — UNPROVEN here (skip, NOT a pass)"
+else
+  printf '%s' "中文注释中文注释中文注释中文注释" | iconv -f UTF-8 -t UTF-16LE > "$BL198FIX/purecjk.bin"
+  if [ "$(_bl198_nuls "$BL198FIX/purecjk.bin")" -ne 0 ]; then
+    fail_ "T-pure-cjk-residue-passthrough" "fixture carries a NUL — it is not the zero-ASCII shape the residue names"
+  else
+    CJ2_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-purecjk" widget.ts "$BL198FIX/purecjk.bin")"
+    if [ "$CJ2_V" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-purecjk" \
+       && ! grep -qE 'transcoded' "$TOPTMP/bl198-purecjk"; then
+      pass "T-pure-cjk-residue-passthrough: the zero-ASCII single-line UTF-16 residue passes through with a receipt — NAMED and BOUNDED in the plan, pinned here so the boundary cannot move silently"
+    else
+      fail_ "T-pure-cjk-residue-passthrough" "verdict=$CJ2_V — the documented residue boundary moved (this case exists to make that loud): $(sast_evidence "$TOPTMP/bl198-purecjk")"
+    fi
+  fi
+fi
+
+# ── T-mutation-parse-coverage (restored from e87dbd3, RE-AIMED at the fence) ──────
+# Excise the whole # BL-198-TRANSCODE fence from the emitted hook -> the BL-192
+# false attestation RETURNS (UTF-16LE+BOM sink lands with the [OK] receipt) — RED.
+# The unmutated hook REFUSES the same fixture — GREEN. Both directions run here so
+# the case is an honest standalone verdict.
+echo "=== T-mutation-parse-coverage ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-mutation-parse-coverage" "$BL198_WHY — mutation UNPROVEN here (skip, NOT a pass)"
+else
+  MTC="$TOPTMP/mut-transcode"
+  MTC_B=$(grep -c '# BL-198-TRANSCODE-BEGIN' "$EMITTED") || MTC_B=0
+  MTC_E=$(grep -c '# BL-198-TRANSCODE-END' "$EMITTED") || MTC_E=0
+  sed '/# BL-198-TRANSCODE-BEGIN/,/# BL-198-TRANSCODE-END/d' "$EMITTED" > "$MTC"
+  # Count only the fence MARKERS left — the init comment outside the fence
+  # legitimately names BL-198-TRANSCODE and must survive the excision.
+  MTC_LEFT=$(grep -cE 'BL-198-TRANSCODE-(BEGIN|END)' "$MTC") || MTC_LEFT=0
+  if [ "$MTC_B" -ne 1 ] || [ "$MTC_E" -ne 1 ] || [ "$MTC_LEFT" -ne 0 ]; then
+    fail_ "T-mutation-parse-coverage" "MIS-TARGETED — fence not present exactly once (begin=$MTC_B end=$MTC_E left=$MTC_LEFT); retarget this mutation in lockstep"
+  elif ! bash -n "$MTC" 2>/dev/null; then
+    fail_ "T-mutation-parse-coverage" "mutated hook has a syntax error — a broken mutant proves nothing"
+  else
+    chmod +x "$MTC"
+    MTC_RED="$(_bl198_run "$MTC" "$TOPTMP/bl198-mut-red" widget.ts "$BL198FIX/le-bom.bin")"
+    MTC_GRN="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-mut-grn" widget.ts "$BL198FIX/le-bom.bin")"
+    if [ "$MTC_RED" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-mut-red" \
+       && [ "$MTC_GRN" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-mut-grn"; then
+      pass "T-mutation-parse-coverage: excising the # BL-198-TRANSCODE fence brings the BL-192 false attestation back (RED: receipt over an unseen sink) and the shipped hook blocks it (GREEN) — the fence is load-bearing"
+    else
+      fail_ "T-mutation-parse-coverage" "expected RED=COMMITTED+receipt / GREEN=REFUSED+blocked; got RED=$MTC_RED GREEN=$MTC_GRN: $(sast_evidence "$TOPTMP/bl198-mut-red")"
+    fi
+  fi
+fi
+
+# ── T-mutation-parse-threshold (restored from e87dbd3, RE-AIMED at BOM order) ─────
+# Swap the BOM match so the UTF-16LE prefix is tested BEFORE the UTF-32LE BOM —
+# the one-character-narrowing analogue for this classifier. The UTF-32LE+BOM sink
+# then derives stride-2 (a UTF-32 file carries zeros on BOTH 2-byte parities), the
+# claim/derivation agree-check fails, and the file degrades to a LOUD cry-wolf
+# NOTRUN instead of a caught sink (RED). The shipped order transcodes and BLOCKS
+# (GREEN). Degrading SAFELY is exactly why this is a mutation case and not a hole:
+# the failure direction is a false WARN, never a false receipt.
+echo "=== T-mutation-parse-threshold ==="
+BL198_WHY="$(_bl198_skip_reason)"
+if [ -n "$BL198_WHY" ]; then
+  skip_ "T-mutation-parse-threshold" "$BL198_WHY — mutation UNPROVEN here (skip, NOT a pass)"
+else
+  MBO="$TOPTMP/mut-bomorder"
+  MBO_N=$(grep -c 'fffe0000\*) soif_tc_bom="UTF-32LE" ;;' "$EMITTED") || MBO_N=0
+  awk '
+    /fffe0000\*\) soif_tc_bom="UTF-32LE" ;;/ { print "          fffe*)     soif_tc_bom=\"UTF-16LE\" ;;"; print; next }
+    /fffe\*\)     soif_tc_bom="UTF-16LE" ;;/ { next }
+    { print }' "$EMITTED" > "$MBO"
+  if [ "$MBO_N" -ne 1 ] || ! grep -qF 'fffe*)' "$MBO" || cmp -s "$EMITTED" "$MBO"; then
+    fail_ "T-mutation-parse-threshold" "MIS-TARGETED — could not reorder the BOM arms (n=$MBO_N, identical=$(cmp -s "$EMITTED" "$MBO" && echo yes || echo no)); retarget this mutation in lockstep"
+  elif ! bash -n "$MBO" 2>/dev/null; then
+    fail_ "T-mutation-parse-threshold" "mutated hook has a syntax error — a broken mutant proves nothing"
+  else
+    chmod +x "$MBO"
+    MBO_RED="$(_bl198_run "$MBO" "$TOPTMP/bl198-bom-red" widget.ts "$BL198FIX/u32le-bom.bin")"
+    MBO_GRN="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-bom-grn" widget.ts "$BL198FIX/u32le-bom.bin")"
+    if [ "$MBO_RED" = "COMMITTED" ] && grep -qF 'SAST NOT ENFORCED' "$TOPTMP/bl198-bom-red" \
+       && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-bom-red" \
+       && [ "$MBO_GRN" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bl198-bom-grn"; then
+      pass "T-mutation-parse-threshold: shortest-first BOM order degrades the UTF-32LE sink to a cry-wolf NOTRUN (RED, safe direction) and longest-first catches it (GREEN) — the order is load-bearing (was: the -ge 100 exact-threshold proof)"
+    else
+      fail_ "T-mutation-parse-threshold" "expected RED=COMMITTED+NOTRUN-no-receipt / GREEN=REFUSED+blocked; got RED=$MBO_RED GREEN=$MBO_GRN: $(sast_evidence "$TOPTMP/bl198-bom-red")"
+    fi
+  fi
+fi
+
+# ── T-ext-set-pinned (the WP0.4 drift tripwire — its failure mode is fail-OPEN) ───
+# The NULs+no-BOM+no-signal branch routes LOUD only for extensions in the
+# # BL-198-EXT-SET literal; an extension missing from it passes through instead —
+# fail-open by design (real binaries must pass), so drift is silent. Two pins:
+# (1) STATIC — every extension in the BL-125 test arm's source list (the house
+# definition of "source") must appear in the hook's BL-198-EXT-SET literal;
+# (2) BEHAVIORAL — a both-parities NUL file (no BOM, no derivable signal) with a
+# source extension lands as a LOUD named NOTRUN, never a receipt.
+echo "=== T-ext-set-pinned ==="
+EXT_LINE=$(grep -A2 '# BL-198-EXT-SET' "$EMITTED" | grep '\*\.' | head -1)
+TESTARM_EXTS=$(grep -oE '\\.\(([a-z|]+)\)\$' "$EMITTED" | head -1 | sed 's/^\\\.(//; s/)\$//')
+if [ -z "$EXT_LINE" ] || [ -z "$TESTARM_EXTS" ]; then
+  fail_ "T-ext-set-pinned" "could not extract the BL-198-EXT-SET case line or the BL-125 test-arm extension list from the emitted hook — retarget this pin in lockstep"
+else
+  EXT_MISSING=""
+  for EXT in $(printf '%s' "$TESTARM_EXTS" | tr '|' ' '); do
+    case "$EXT_LINE" in *"*.$EXT"*) : ;; *) EXT_MISSING="$EXT_MISSING $EXT" ;; esac
+  done
+  if [ -n "$EXT_MISSING" ]; then
+    fail_ "T-ext-set-pinned" "BL-198-EXT-SET is missing source extensions the BL-125 arm treats as source:$EXT_MISSING — the no-signal branch fails OPEN for them"
+  else
+    BL198_WHY="$(_bl198_skip_reason)"
+    if [ -n "$BL198_WHY" ]; then
+      skip_ "T-ext-set-pinned" "static pin PASSED; behavioral half unprovable: $BL198_WHY"
+    else
+      # Both-parities NULs: 'A\0\0B' repeated — zeros at even AND odd offsets.
+      awk 'BEGIN { for (i = 0; i < 64; i++) printf "A%c%cB", 0, 0 }' > "$BL198FIX/nosignal.bin"
+      NS_NULS="$(_bl198_nuls "$BL198FIX/nosignal.bin")"
+      NS_HEAD="$(_bl198_head4 "$BL198FIX/nosignal.bin" | cut -c1-4)"
+      if [ "$NS_NULS" -eq 0 ] || [ "$NS_HEAD" = "fffe" ] || [ "$NS_HEAD" = "feff" ]; then
+        fail_ "T-ext-set-pinned" "no-signal fixture malformed (nuls=$NS_NULS head=$NS_HEAD)"
+      else
+        NS_V="$(_bl198_run "$EMITTED" "$TOPTMP/bl198-nosignal" widget.ts "$BL198FIX/nosignal.bin")"
+        if [ "$NS_V" = "COMMITTED" ] && grep -qF 'SAST NOT ENFORCED' "$TOPTMP/bl198-nosignal" \
+           && grep -qF 'widget.ts' "$TOPTMP/bl198-nosignal" \
+           && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/bl198-nosignal"; then
+          pass "T-ext-set-pinned: the test-arm source set is a subset of BL-198-EXT-SET (static), and an undecodable no-signal .ts routes LOUD and named, never receipted (behavioral) — binary-in-source-clothing is CAUGHT"
+        else
+          fail_ "T-ext-set-pinned" "verdict=$NS_V — a NUL-bearing no-signal .ts must be a loud named NOTRUN: $(sast_evidence "$TOPTMP/bl198-nosignal")"
+        fi
+      fi
+    fi
+  fi
 fi
 
 echo ""

--- a/tests/test-bl132-sast-index-scan.sh
+++ b/tests/test-bl132-sast-index-scan.sh
@@ -2875,6 +2875,53 @@ else
   fi
 fi
 
+# ── T-utf8-floor-no-sigpipe (review R-BL198-6 — the BL-183 class, same file) ──────
+# The transcode-output byte floor is a `od | awk` pipeline under the hook's
+# `set -euo pipefail`. An `exit` in awk's MAIN rule SIGPIPEs od on input past the
+# pipe buffer: rc 141, and the `|| soif_tc_badbyte=""` guard ERASES the detection
+# awk just printed — the floor fails OPEN as a pure function of file size
+# (threshold ~1-8 KB; measured in review with awk printing 'bad' every time).
+# No live path reaches the floor today (R-BL198-1's bound caps code points at
+# U+10FFFF), which is exactly why it must work: it is the surface that catches a
+# future weakening of surface 1. Both spellings run here against a >100 KB
+# bad-byte-FIRST fixture (the T-predicate-no-sigpipe pattern from bl118/bl131),
+# plus a spelling pin on the emitted hook so the shipped floor cannot quietly
+# revert to the early-exit form. LOCKSTEP: the two awk programs below must match
+# the emitted hook's floor line (# BL-198 comment block, soif_tc_badbyte).
+echo "=== T-utf8-floor-no-sigpipe ==="
+FLOOR_FIX="$TOPTMP/floor-fixture.bin"
+{ printf '\xf5'; awk 'BEGIN { for (i = 0; i < 8000; i++) print "abcdefghijklm" }'; } > "$FLOOR_FIX"
+FLOOR_SZ=$(wc -c < "$FLOOR_FIX" | tr -d '[:space:]')
+if [ "${FLOOR_SZ:-0}" -lt 100000 ]; then
+  fail_ "T-utf8-floor-no-sigpipe" "fixture too small to force the race ($FLOOR_SZ < 100000) — the case is VACUOUS"
+elif [ "$(grep -c 'soif_tc_badbyte=' "$EMITTED")" -ne 1 ]; then
+  fail_ "T-utf8-floor-no-sigpipe" "the floor assignment line is not present exactly once in the emitted hook (assignment + its || reset share the line) — retarget this pin in lockstep"
+else
+  _floor_old() {  # the early-exit spelling (MUST miss on the big fixture under pipefail)
+    ( set -euo pipefail
+      v=$(od -An -v -tx1 "$FLOOR_FIX" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i >= "f5") { print "bad"; exit } }') || v=""
+      [ -n "$v" ] && echo DETECTED || echo MISSED ) 2>/dev/null
+  }
+  _floor_new() {  # the full-input-consumer spelling (MUST detect at every size)
+    ( set -euo pipefail
+      v=$(od -An -v -tx1 "$FLOOR_FIX" 2>/dev/null | awk '{ for (i = 1; i <= NF; i++) if ($i >= "f5") b = 1 } END { if (b) print "bad" }') || v=""
+      [ -n "$v" ] && echo DETECTED || echo MISSED ) 2>/dev/null
+  }
+  FLOOR_OLD_V="$(_floor_old)"
+  FLOOR_NEW_V="$(_floor_new)"
+  if [ "$FLOOR_OLD_V" != "MISSED" ]; then
+    fail_ "T-utf8-floor-no-sigpipe" "the early-exit spelling did NOT miss on a $FLOOR_SZ-byte bad-first fixture (got $FLOOR_OLD_V) — the fixture no longer forces the race, so the case proves nothing"
+  elif [ "$FLOOR_NEW_V" != "DETECTED" ]; then
+    fail_ "T-utf8-floor-no-sigpipe" "the END-form spelling MISSED the bad byte — the fixed floor does not detect"
+  elif grep -qF 'if ($i >= "f5") { print "bad"; exit }' "$EMITTED"; then
+    fail_ "T-utf8-floor-no-sigpipe" "the emitted hook still carries the early-exit floor spelling — the SIGPIPE class is live in the shipped bytes (R-BL198-6)"
+  elif ! grep -qF 'if ($i >= "f5") b = 1 } END { if (b) print "bad" }' "$EMITTED"; then
+    fail_ "T-utf8-floor-no-sigpipe" "the emitted hook does not carry the END-form floor spelling — the lockstep pin lost its target; retarget in lockstep"
+  else
+    pass "T-utf8-floor-no-sigpipe: the early-exit floor misses a $FLOOR_SZ-byte bad-first output under pipefail while the shipped END-form detects it — the defense-in-depth surface actually defends (R-BL198-6, the BL-183 class)"
+  fi
+fi
+
 # ── T-mutation-parse-coverage (restored from e87dbd3, RE-AIMED at the fence) ──────
 # Excise the whole # BL-198-TRANSCODE fence from the emitted hook -> the BL-192
 # false attestation RETURNS (UTF-16LE+BOM sink lands with the [OK] receipt) — RED.


### PR DESCRIPTION
# fix(bl198): transcode undecodable-but-textual staged files — the SAST receipt now covers decode

## The gap (BL-192, measured)

semgrep ACCEPTS a UTF-16/UTF-32 staged file, cannot decode it, scans the raw bytes "clean",
and the emitted hook's four-precondition `[OK]` receipt printed over an unseen sink — a
positive false attestation. Every byte-shape in the new fixture matrix reproduced it RED:
eight cases, each showing `[OK] semgrep: SAST ran on 1 staged file(s)` over a live
`innerHTML` sink before the fix.

## The fix — `# BL-198-TRANSCODE`, per the four-round BL-198 v2 plan

Classify each materialized blob AFTER the F2 size check: NUL scan → BOM longest-first
(`FF FE` is a prefix of the UTF-32LE BOM — order is load-bearing) → whole-body stride-aware
zero-parity derivation, with the BOM's CLAIM required to AGREE with the derivation (a lying
BOM otherwise transcodes to NUL-free valid-UTF-8 garbage that scans clean). Vouched
UTF-16/UTF-32 is converted to UTF-8 at the IDENTICAL tree path via temp + `mv` — never a
sibling name (silently unscanned; breaks BL-178's operator path mapping), never `iconv` into
its own input (truncate-then-convert mints a receipt over destroyed bytes). Anything
unvouchable — lying BOM, no derivable signal on a source extension, iconv failure — fails
CLOSED to a loud NOTRUN naming the file (`# BL-198-UNTX-REPORT`). The receipt attests the
conversion count. No clause added by this work reads anything semgrep printed (BL-192's
decision blocks).

**Recorded deviation from the plan text:** no `numstat` first pass — its binary heuristic
reads only the first 8000 bytes, so a late-first-NUL UTF-16 file would be exempted as "text";
the whole-file NUL count has no window. Strictly stronger, same decision tree.

## Evidence

- **TDD red-first:** 8 sink/transcode cases watched fail against the unfixed hook; 3
  passthrough pins (UTF-8+BOM, Latin-1, PNG-sibling) green in both states; the zero-ASCII
  single-line residue pinned AS a residue (`T-pure-cjk-residue-passthrough`).
- **WP3:** the five cases withdrawn with the BL-186 parse clause (held on draft #278 @
  `e87dbd3`) are restored re-aimed off semgrep's self-report — the UTF-16 rows flip from
  "receipt forfeited" to the stronger "sink CAUGHT, commit BLOCKED". This satisfies the
  condition #278 was held open for.
- **Mutations, vacuity-guarded:** fence excision resurrects the false attestation (RED both
  directions); BOM-order swap degrades the UTF-32 row SAFELY to cry-wolf, never a receipt;
  the fail-open extension set is pinned statically against the BL-125 source list and
  behaviorally (binary-in-source-clothing → loud named NOTRUN — BL-192's own `vendor.js`
  residue, newly caught). No parity ratio exists by design (all-zeros-on-one-parity, exact).
- **Suite:** `test-bl132` 56/0 (0 skipped); all six sibling emitted-hook suites green;
  lints 11/11; backlog lint attested post-commit.
- **Adversarial review (standing gate):** fable-tier, three rounds pre-PR. Round 1 verdict
  `block` — a real hole: a UTF-32LE BOM over a UTF-16LE body defeated all three vouching
  surfaces on macOS libiconv (reproduced end-to-end, sink in HEAD). Closed by the exact
  U+10FFFF range bound the reviewer validated (genuine + astral UTF-32 keep transcoding;
  the liar goes LOUD) — `T-u32bom-over-u16-body-notrun`, watched RED→GREEN. The review also
  refuted the plan's "real UTF-16 source always has a whole-file signal" claim (one U+xx00
  code unit collapses the parity signal): kept exact ANYWAY — the reviewer built the
  dominance counterexample itself and confirmed a ratio would trade a loud residue for a
  silent false receipt — and pinned as the third named residue. Round 2 confirmed every
  disposition and found one more: the new byte floor was the BL-183 SIGPIPE class
  re-introduced (awk early-exit erasing its own detection past ~8KB) — fixed to a
  full-input consumer with a both-spellings pin (`T-utf8-floor-no-sigpipe`), RED→GREEN.
  Final suite: 56/0.

Closes BL-198 (backlog cites `02eaa0f`); records the primary-fix landing on BL-192 (stays
Open for BL-200/BL-201, both now unblocked).

---
**TL;DR (plain English):** The pre-commit security scanner used to stamp "all clear" on
files saved in unusual text encodings that it never actually read — the worst kind of wrong,
a confident receipt over an unchecked file. Now the hook detects those files, converts a copy
into normal text, scans the real content, and blocks genuinely dangerous code it previously
waved through. Anything it can't confidently convert gets a loud "NOT SCANNED — here's the
file" warning instead of a fake pass. Every case was proven broken first, then proven fixed,
with booby-trap tests that catch anyone who quietly re-breaks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
