### PR TITLE
fix(bl203): the intake's testing-interval answer reaches the enforced gate

### DIFF
--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1607,6 +1607,9 @@ run_section_11_5() {
     else
       print_warn "Could not update the enforced interval — run: bash scripts/test-gate.sh --set-interval $interval"
     fi
+  else
+    # R-BL203-7: an absent writer must not become the silent no-op again.
+    print_warn "scripts/test-gate.sh not found — the enforced interval is unchanged. Run: bash scripts/test-gate.sh --set-interval $interval"
   fi
   save_answer "human_tester_count" "$tester_count"
   save_answer "sev_critical_sla"   "$sev_critical"
@@ -1783,10 +1786,10 @@ PROMPTEOF
    - **Sponsored POC:** Organization knows. AI deployment path + sponsor + time allocation required. Insurance, liability, ITSM, exit criteria, backup maintainer deferred. Constraints: no production deployment, no real user data, no external users. All technical work is production-grade.
    - **Private POC:** Personal exploration. All pre-conditions deferred. Same constraints as Sponsored POC.
 8. Write completed sections into PROJECT_INTAKE.md progressively as you go.
-9. Section 12 (Tooling Configuration) is auto-populated by `init.sh` from `.claude/tool-preferences.json` — do not prompt the user; confirm the section is recorded and move on.
+9. Section 12 (Tooling Configuration) is auto-populated by \`init.sh\` from \`.claude/tool-preferences.json\` — do not prompt the user; confirm the section is recorded and move on.
 10. Section 13 (Agent Initialization Prompt): auto-generate from the answers. Do not ask the user to write this.
 11. At the end, summarize what was filled in and flag any fields left blank.
-12. After Section 11.5's testing interval is answered, run `bash scripts/test-gate.sh --set-interval N` (N = the answer) — the recorded answer does not reach the enforced gate by itself (BL-203), and this path never runs the wizard's own plumbing.
+12. After Section 11.5's testing interval is answered, run \`bash scripts/test-gate.sh --set-interval N\` (N = the answer) — the recorded answer does not reach the enforced gate by itself (BL-203), and this path never runs the wizard's own plumbing. This heredoc is UNQUOTED (context values substitute), so backticks here MUST stay escaped or they execute at prompt-generation time (review R-BL203-1).
 
 ## Suggestion Data
 

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1597,6 +1597,17 @@ run_section_11_5() {
   bug_tool=$(prompt_input "Bug tracking tool" "GitHub Issues")
 
   save_answer "testing_interval"   "$interval"
+  # BL-203-INTERVAL-PLUMB — the recorded answer must also reach the ENFORCED
+  # field (.claude/build-progress.json::test_interval); saving it into the
+  # intake record alone is the silent no-op BL-203 documents. test-gate.sh
+  # --set-interval is the single writer.
+  if [ -f "scripts/test-gate.sh" ]; then
+    if bash scripts/test-gate.sh --set-interval "$interval" >/dev/null 2>&1; then
+      print_info "Enforced testing interval set to every $interval feature(s)."
+    else
+      print_warn "Could not update the enforced interval — run: bash scripts/test-gate.sh --set-interval $interval"
+    fi
+  fi
   save_answer "human_tester_count" "$tester_count"
   save_answer "sev_critical_sla"   "$sev_critical"
   save_answer "sev_high_sla"       "$sev_high"
@@ -1775,6 +1786,7 @@ PROMPTEOF
 9. Section 12 (Tooling Configuration) is auto-populated by `init.sh` from `.claude/tool-preferences.json` — do not prompt the user; confirm the section is recorded and move on.
 10. Section 13 (Agent Initialization Prompt): auto-generate from the answers. Do not ask the user to write this.
 11. At the end, summarize what was filled in and flag any fields left blank.
+12. After Section 11.5's testing interval is answered, run `bash scripts/test-gate.sh --set-interval N` (N = the answer) — the recorded answer does not reach the enforced gate by itself (BL-203), and this path never runs the wizard's own plumbing.
 
 ## Suggestion Data
 

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -68,6 +68,7 @@ while [ $# -gt 0 ]; do
       echo "       scripts/reconfigure-project.sh --reset-detection-baseline"
       echo ""
       echo "Supported fields:"
+      echo "  test_interval     — enforced testing interval (delegates to test-gate.sh --set-interval; BL-203)"
       echo "  language   — Regenerates CI pipeline, .gitignore language entries, permissions"
       echo "  platform   — Regenerates release pipeline, copies new platform module"
       echo "  name       — Updates phase-state.json, CLAUDE.md, APPROVAL_LOG.md header,"

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -321,6 +321,19 @@ reconfigure() {
   cd "$PROJECT_ROOT"
 
   case "$FIELD" in
+    test_interval)
+      # BL-203-INTERVAL-PLUMB — delegate to the single writer so the enforced
+      # field, testing_required, and the CLAUDE.md prose line move together.
+      case "$NEW_VALUE" in ''|*[!0-9]*)
+        print_fail "test_interval must be a positive integer (got '$NEW_VALUE')"
+        exit 1 ;;
+      esac
+      if ! bash scripts/test-gate.sh --set-interval "$NEW_VALUE"; then
+        print_fail "test-gate.sh --set-interval $NEW_VALUE failed — nothing changed"
+        exit 1
+      fi
+      print_ok "Testing interval reconfigured: every $NEW_VALUE feature(s)"
+      ;;
     language)
       # Update tool-preferences.json
       if [ -f ".claude/tool-preferences.json" ] && command -v jq &>/dev/null; then

--- a/scripts/session-test-gate-check.sh
+++ b/scripts/session-test-gate-check.sh
@@ -197,9 +197,16 @@ fi
 # Read state
 FEATURES_COMPLETED=$(jq -r '.features_completed | length' "$BUILD_PROGRESS" 2>/dev/null || echo "0")
 case "$FEATURES_COMPLETED" in ''|*[!0-9]*) FEATURES_COMPLETED=0 ;; esac
-SINCE_LAST=$(jq -r '.features_since_last_test' "$BUILD_PROGRESS" 2>/dev/null || echo "0")
-INTERVAL=$(jq -r '.test_interval' "$BUILD_PROGRESS" 2>/dev/null || echo "2")
-TESTING_REQUIRED=$(jq -r '.testing_required' "$BUILD_PROGRESS" 2>/dev/null || echo "false")
+# BL-203: `jq -r` on a MISSING key prints the literal string `null` at rc 0,
+# so the `|| echo` fallbacks never fired and the -ge comparison below errored
+# with `integer expression expected` — taking the else branch, i.e. failing
+# OPEN. The `// default` inside jq plus the sanitizer line is the repo's
+# canonical shape (lint-counter-antipattern enforces the sanitizer).
+SINCE_LAST=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS" 2>/dev/null || echo "0")
+case "$SINCE_LAST" in ''|*[!0-9]*) SINCE_LAST=0 ;; esac
+INTERVAL=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS" 2>/dev/null || echo "2")
+case "$INTERVAL" in ''|*[!0-9]*) INTERVAL=2 ;; esac
+TESTING_REQUIRED=$(jq -r '.testing_required // false' "$BUILD_PROGRESS" 2>/dev/null || echo "false")
 
 # Check 1: Testing session is overdue
 if [ "$TESTING_REQUIRED" = "true" ] || [ "$SINCE_LAST" -ge "$INTERVAL" ]; then

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -20,6 +20,7 @@ BUILD_PROGRESS=".claude/build-progress.json"
 # --- Argument parsing ---
 ACTION=""
 FEATURE_NAME=""
+NEW_INTERVAL=""
 
 # Source-guard: the argument parser, "no action" check, and dispatch run only
 # when this script is executed directly. When sourced by tests (to call
@@ -31,6 +32,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
       --check-batch)        ACTION="check-batch";        shift ;;
       --check-phase-gate)   ACTION="check-phase-gate";   shift ;;
       --reset-counter)      ACTION="reset-counter";       shift ;;
+      --set-interval)       ACTION="set-interval"; NEW_INTERVAL="${2:-}"; shift 2 ;;
       --reset-health-check) ACTION="reset-health-check"; shift ;;
       --record-feature)     ACTION="record-feature"; FEATURE_NAME="$2"; shift 2 ;;
       --unrecord-feature)   ACTION="unrecord-feature"; FEATURE_NAME="$2"; shift 2 ;;
@@ -41,6 +43,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
         echo "  --check-batch         Check if testing session is due (exit 0=continue, 1=testing required)"
         echo "  --check-phase-gate    Check if Phase 2→3 transition is clear (exit 0=clear, 1=blocked, 2=warnings)"
         echo "  --reset-counter       Reset feature counter after testing session completes"
+        echo "  --set-interval N      Set the enforced testing interval (BL-203: the intake answer's single writer)"
         echo "  --record-feature N    Record a completed feature and increment counter"
         echo "  --unrecord-feature N  Un-record a feature recorded in error (interactive; inverse of --record-feature)"
         exit 0
@@ -74,7 +77,52 @@ ensure_progress_file() {
   "sessions_completed": 0
 }
 EOF
+    # BL-203: this heredoc is the SECOND writer of test_interval (init.sh is
+    # the first), so a recreated file must honor the interval the operator
+    # recorded at intake — otherwise the recorded answer silently reverts to 2
+    # whenever this file is lost (review R-203-1). The intake answer is the
+    # only recoverable source here; absent or non-numeric, the heredoc's 2
+    # stands.
+    local recorded
+    recorded=$(jq -r '.answers.testing_interval // empty' .claude/intake-progress.json 2>/dev/null) || recorded=""
+    case "$recorded" in ''|*[!0-9]*) recorded="" ;; esac
+    if [ -n "$recorded" ] && [ "$recorded" -gt 0 ]; then
+      : # BL-203 guard: the marked line below is excisable without a syntax break
+      _bl203_apply_interval "$recorded" # BL-203-INTERVAL-PLUMB
+    fi
   fi
+}
+
+# _bl203_apply_interval <N> — the one place test_interval is ever changed after
+# creation: writes the field, re-evaluates testing_required against the new N,
+# and keeps the rendered CLAUDE.md prose line in step (sed-in-place, NOT
+# soif_render_claude_md — that renderer is under a byte-identity contract).
+_bl203_apply_interval() {
+  local n="$1" tmp
+  tmp=$(mktemp)
+  jq --argjson n "$n" '
+    .test_interval = $n |
+    .testing_required = ((.features_since_last_test // 0) >= $n)
+  ' "$BUILD_PROGRESS" > "$tmp" && mv "$tmp" "$BUILD_PROGRESS"
+  if [ -f "CLAUDE.md" ] && grep -q 'Testing interval:' CLAUDE.md; then
+    sed -i.bak "s|\(\*\*Testing interval:\*\* Every \)[0-9][0-9]*\( features\)|\1${n}\2|" CLAUDE.md && rm -f CLAUDE.md.bak
+  fi
+}
+
+set_interval() {
+  local n="$1"
+  case "$n" in ''|*[!0-9]*)
+    print_fail "Usage: scripts/test-gate.sh --set-interval N (positive integer; got '${n:-}')"
+    exit 1 ;;
+  esac
+  if [ "$n" -lt 1 ]; then
+    print_fail "The testing interval must be at least 1 (got $n)"
+    exit 1
+  fi
+  ensure_progress_file
+  : # BL-203 guard: the marked line below is excisable without a syntax break
+  _bl203_apply_interval "$n" # BL-203-INTERVAL-PLUMB
+  print_ok "Enforced testing interval set: every $n feature(s) (.claude/build-progress.json)"
 }
 
 # --- Actions ---
@@ -95,6 +143,17 @@ check_batch() {
   else
     local remaining=$((interval - since_last))
     print_ok "Clear to continue ($remaining features until next testing session)"
+    # BL-203: name the interval and its source, and surface a recorded-answer
+    # mismatch with the exact remedy — the silent-config class this fixes is
+    # only dead if the divergence is self-revealing wherever it can exist.
+    print_info "Testing every $interval features (from .claude/build-progress.json)"
+    local intake_n
+    intake_n=$(jq -r '.answers.testing_interval // empty' .claude/intake-progress.json 2>/dev/null) || intake_n=""
+    case "$intake_n" in ''|*[!0-9]*) intake_n="" ;; esac
+    if [ -n "$intake_n" ] && [ "$intake_n" != "$interval" ]; then
+      print_warn "Your intake asked for testing every $intake_n features, but this project enforces every $interval."
+      print_info "To make them match: bash scripts/test-gate.sh --set-interval $intake_n"
+    fi
     exit 0
   fi
 }
@@ -470,6 +529,7 @@ if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
     check-batch)        check_batch ;;
     check-phase-gate)   check_phase_gate ;;
     reset-counter)      reset_counter ;;
+    set-interval)       set_interval "$NEW_INTERVAL" ;;
     record-feature)     record_feature "$FEATURE_NAME" ;;
     unrecord-feature)   unrecord_feature "$FEATURE_NAME" ;;
     reset-health-check)

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -300,8 +300,10 @@ unrecord_feature() {
   cur_fslt=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
   case "$cur_fslt" in ''|*[!0-9]*) cur_fslt=0 ;; esac
   cur_fslhc=$(jq -r '.features_since_last_health_check // 0' "$BUILD_PROGRESS")
+  case "$cur_fslhc" in ''|*[!0-9]*) cur_fslhc=0 ;; esac
   cur_testing=$(jq -r '.testing_required // false' "$BUILD_PROGRESS")
   interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")
+  case "$interval" in ''|*[!0-9]*) interval=2 ;; esac
 
   new_fslt=$(( cur_fslt - 1 < 0 ? 0 : cur_fslt - 1 ))
   new_fslhc=$(( cur_fslhc - 1 < 0 ? 0 : cur_fslhc - 1 ))

--- a/scripts/test-gate.sh
+++ b/scripts/test-gate.sh
@@ -82,46 +82,73 @@ EOF
     # recorded at intake — otherwise the recorded answer silently reverts to 2
     # whenever this file is lost (review R-203-1). The intake answer is the
     # only recoverable source here; absent or non-numeric, the heredoc's 2
-    # stands.
+    # stands. JSON ONLY — this runs from read-only queries (--check-batch,
+    # session hooks), which must never mutate CLAUDE.md (review R-BL203-6);
+    # the prose edit belongs to the explicit --set-interval action alone.
     local recorded
     recorded=$(jq -r '.answers.testing_interval // empty' .claude/intake-progress.json 2>/dev/null) || recorded=""
-    case "$recorded" in ''|*[!0-9]*) recorded="" ;; esac
-    if [ -n "$recorded" ] && [ "$recorded" -gt 0 ]; then
+    case "$recorded" in ''|*[!0-9]*|0*|??????*) recorded="" ;; esac
+    if [ -n "$recorded" ]; then
       : # BL-203 guard: the marked line below is excisable without a syntax break
-      _bl203_apply_interval "$recorded" # BL-203-INTERVAL-PLUMB
+      _bl203_write_json "$recorded" || true # BL-203-INTERVAL-PLUMB
     fi
   fi
 }
 
-# _bl203_apply_interval <N> — the one place test_interval is ever changed after
-# creation: writes the field, re-evaluates testing_required against the new N,
-# and keeps the rendered CLAUDE.md prose line in step (sed-in-place, NOT
-# soif_render_claude_md — that renderer is under a byte-identity contract).
-_bl203_apply_interval() {
+# _bl203_write_json <N> — the one write path for test_interval: sets the field
+# and re-evaluates testing_required against the new N. FAILS LOUDLY: a jq
+# failure (malformed or strange-shaped JSON) must never return 0 — a silent
+# success here recreates the exact doc-vs-gate divergence BL-203 documents
+# (review R-BL203-2). jq runs first and alone so its status is seen; mv only
+# on success.
+_bl203_write_json() {
   local n="$1" tmp
   tmp=$(mktemp)
-  jq --argjson n "$n" '
+  if ! jq --argjson n "$n" '
     .test_interval = $n |
     .testing_required = ((.features_since_last_test // 0) >= $n)
-  ' "$BUILD_PROGRESS" > "$tmp" && mv "$tmp" "$BUILD_PROGRESS"
-  if [ -f "CLAUDE.md" ] && grep -q 'Testing interval:' CLAUDE.md; then
-    sed -i.bak "s|\(\*\*Testing interval:\*\* Every \)[0-9][0-9]*\( features\)|\1${n}\2|" CLAUDE.md && rm -f CLAUDE.md.bak
+  ' "$BUILD_PROGRESS" > "$tmp" 2>/dev/null; then
+    rm -f "$tmp"
+    print_fail "Could not update .claude/build-progress.json (malformed JSON?) — nothing changed."
+    return 1
+  fi
+  if ! mv "$tmp" "$BUILD_PROGRESS"; then
+    rm -f "$tmp"
+    print_fail "Could not replace .claude/build-progress.json — nothing changed."
+    return 1
   fi
 }
 
 set_interval() {
   local n="$1"
-  case "$n" in ''|*[!0-9]*)
-    print_fail "Usage: scripts/test-gate.sh --set-interval N (positive integer; got '${n:-}')"
+  # Bound as well as shape: an all-digit value past ~5 digits breaks bash's
+  # integer tests downstream and would park the gate permanently open
+  # (review R-BL203-4). Leading zeros rejected with it; 1..99999 is ample.
+  case "$n" in ''|*[!0-9]*|0*|??????*)
+    print_fail "Usage: scripts/test-gate.sh --set-interval N (integer 1-99999; got '${n:-}')"
     exit 1 ;;
   esac
-  if [ "$n" -lt 1 ]; then
-    print_fail "The testing interval must be at least 1 (got $n)"
+  ensure_progress_file
+  soif_si_ok=0
+  # The marked line below is the write; excising it must leave valid syntax
+  # (the mutation case pins exactly that), so the failure test reads a flag.
+  _bl203_write_json "$n" && soif_si_ok=1 # BL-203-INTERVAL-PLUMB
+  if [ "$soif_si_ok" -ne 1 ]; then
     exit 1
   fi
-  ensure_progress_file
-  : # BL-203 guard: the marked line below is excisable without a syntax break
-  _bl203_apply_interval "$n" # BL-203-INTERVAL-PLUMB
+  # Prose second, and only after the enforced field moved — the doc must never
+  # advance past the gate (review R-BL203-2). Unique backup suffix so a user's
+  # own CLAUDE.md.bak is never clobbered (R-BL203-10); guard on the NUMERIC
+  # form so an unsubstituted __TEST_INTERVAL__ placeholder warns instead of
+  # silently staying wrong (R-BL203-11).
+  if [ -f "CLAUDE.md" ]; then
+    if grep -qE '\*\*Testing interval:\*\* Every [0-9][0-9]* features' CLAUDE.md; then
+      sed -i.soif-bl203-bak "s|\(\*\*Testing interval:\*\* Every \)[0-9][0-9]*\( features\)|\1${n}\2|" CLAUDE.md \
+        && rm -f CLAUDE.md.soif-bl203-bak
+    elif grep -q 'Testing interval:' CLAUDE.md; then
+      print_warn "CLAUDE.md's Testing interval line is not in the rendered numeric form (unsubstituted template?) — prose not updated."
+    fi
+  fi
   print_ok "Enforced testing interval set: every $n feature(s) (.claude/build-progress.json)"
 }
 
@@ -134,7 +161,9 @@ check_batch() {
   # `[: null: integer expression expected` in the comparison below.
   local since_last interval
   since_last=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
+  case "$since_last" in ''|*[!0-9]*) since_last=0 ;; esac
   interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")
+  case "$interval" in ''|*[!0-9]*) interval=2 ;; esac
 
   if [ "$since_last" -ge "$interval" ]; then
     print_fail "Testing session required ($since_last features since last test, interval is $interval)"
@@ -179,7 +208,9 @@ record_feature() {
   # `[: null: integer expression expected` in the comparison below.
   local since_last interval
   since_last=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
+  case "$since_last" in ''|*[!0-9]*) since_last=0 ;; esac
   interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")
+  case "$interval" in ''|*[!0-9]*) interval=2 ;; esac
 
   print_ok "Feature '$name' recorded ($since_last/$interval until next test session)"
 
@@ -267,6 +298,7 @@ unrecord_feature() {
   # arithmetic and integer-comparison errors below.
   cur_array=$(jq -c '.features_completed // []' "$BUILD_PROGRESS")
   cur_fslt=$(jq -r '.features_since_last_test // 0' "$BUILD_PROGRESS")
+  case "$cur_fslt" in ''|*[!0-9]*) cur_fslt=0 ;; esac
   cur_fslhc=$(jq -r '.features_since_last_health_check // 0' "$BUILD_PROGRESS")
   cur_testing=$(jq -r '.testing_required // false' "$BUILD_PROGRESS")
   interval=$(jq -r '.test_interval // 2' "$BUILD_PROGRESS")

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -762,11 +762,13 @@ fix_claude_md() {
   fi
 
   # Resolve substitution values with safe defaults. PROJECT_NAME and
-  # PROJECT_DESCRIPTION may be empty; init.sh defaults
-  # TEST_INTERVAL to 5 if Section 11.5 is unset.
+  # PROJECT_DESCRIPTION may be empty. TEST_INTERVAL defaults to 2 — the SAME
+  # default init.sh writes and test-gate.sh enforces (`// 2`); an earlier
+  # revision defaulted 5 under a comment claiming init defaults to 5 (false),
+  # so a repair re-render fabricated an interval nobody enforced (BL-203).
   local proj_name="${PROJECT_NAME:-unknown}"
   local proj_desc="${PROJECT_DESCRIPTION:-}"
-  local test_interval="${TEST_INTERVAL:-5}"
+  local test_interval="${TEST_INTERVAL:-2}"
 
   local staged
   staged=$(mktemp "${TMPDIR:-/tmp}/claude-md-stage.XXXXXX") || return 1

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -520,9 +520,12 @@ D=$(mktemp -d)
 _bl203_fixture "$D"
 if ( cd "$D" && bash "$TESTGATE" --set-interval 5 ) >/dev/null 2>&1 \
    && [ "$(jq -r '.test_interval' "$D/.claude/build-progress.json")" = "5" ] \
+   && jq -e '.test_interval | type == "number"' "$D/.claude/build-progress.json" >/dev/null \
    && [ "$(jq -r '.testing_required' "$D/.claude/build-progress.json")" = "false" ] \
-   && grep -qF 'Every 5 features (configured in Intake Section 11.5)' "$D/CLAUDE.md"; then
-  pass "T-bl203-set-interval (writes the field, re-evaluates testing_required at 4<5, updates the CLAUDE.md prose in place)"
+   && grep -qF 'Every 5 features (configured in Intake Section 11.5)' "$D/CLAUDE.md" \
+   && ( cd "$D" && bash "$TESTGATE" --set-interval 4 ) >/dev/null 2>&1 \
+   && [ "$(jq -r '.testing_required' "$D/.claude/build-progress.json")" = "true" ]; then
+  pass "T-bl203-set-interval (numeric-typed field, testing_required false at 4<5 and TRUE at the 4>=4 boundary, CLAUDE.md prose in step)"
 else
   fail_ "T-bl203-set-interval" "test-gate.sh --set-interval 5 did not land in all three places: field=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null) required=$(jq -r '.testing_required' "$D/.claude/build-progress.json" 2>/dev/null) claude_md=$(grep -c 'Every 5 features' "$D/CLAUDE.md" 2>/dev/null)"
 fi
@@ -543,6 +546,23 @@ fi
 rm -rf "$D"
 
 echo ""
+echo "T-bl203-set-interval-hardened: oversized input and corrupt JSON fail LOUDLY, doc never advances past the gate"
+D=$(mktemp -d)
+_bl203_fixture "$D"
+HARD_OK=1
+( cd "$D" && bash "$TESTGATE" --set-interval 99999999999999999999 ) >/dev/null 2>&1 && HARD_OK=0
+[ "$(jq -r '.test_interval' "$D/.claude/build-progress.json")" = "2" ] || HARD_OK=0
+printf 'THIS IS NOT JSON {{{\n' > "$D/.claude/build-progress.json"
+( cd "$D" && bash "$TESTGATE" --set-interval 5 ) >/dev/null 2>&1 && HARD_OK=0
+grep -qF 'Every 2 features' "$D/CLAUDE.md" || HARD_OK=0
+if [ "$HARD_OK" -eq 1 ]; then
+  pass "T-bl203-set-interval-hardened (a 20-digit interval is refused before it can park the gate open; corrupt JSON exits non-zero and CLAUDE.md is NOT advanced — R-BL203-2/-4)"
+else
+  fail_ "T-bl203-set-interval-hardened" "an invalid write path returned success or advanced the doc past the gate (interval=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null) md=$(grep -o 'Every [0-9]* features' "$D/CLAUDE.md" 2>/dev/null))"
+fi
+rm -rf "$D"
+
+echo ""
 echo "T-bl203-wizard-calls-set-interval: the script path plumbs the answer"
 if awk '/^run_section_11_5\(\)/,/^}/' "$WIZARD" | grep -qF -- '--set-interval "$interval"'; then
   pass "T-bl203-wizard-calls-set-interval (run_section_11_5 invokes the single writer)"
@@ -552,22 +572,34 @@ fi
 
 echo ""
 echo "T-bl203-guided-prompt-instructs: the AI path plumbs it too"
-if grep -qF 'test-gate.sh --set-interval' "$WIZARD" && awk '/PROMPTEOF/,0' "$WIZARD" >/dev/null 2>&1 \
-   && sed -n '/cat.*PROMPTEOF/,/^PROMPTEOF/p' "$WIZARD" | grep -qF -- '--set-interval'; then
-  pass "T-bl203-guided-prompt-instructs (the guided prompt tells the agent to run the writer — run_section_11_5 never runs on this path)"
+# RENDERED, not source-grepped: the PROMPTEOF heredoc is UNQUOTED, so an
+# unescaped backtick EXECUTES at prompt-generation time and ships the
+# command's error text instead of the command (review R-BL203-1 — a source
+# grep passed green over exactly that). Render every PROMPTEOF body in an
+# empty fixture dir and assert the literal commands survive.
+D=$(mktemp -d)
+awk '/<< PROMPTEOF/{f=1;next} /^PROMPTEOF$/{f=0} f' "$WIZARD" > "$D/body.txt"
+{ echo 'cat << PROMPTEOF'; cat "$D/body.txt"; echo 'PROMPTEOF'; } > "$D/render.sh"
+RENDERED=$( cd "$D" && bash --noprofile --norc render.sh </dev/null 2>/dev/null )
+if printf '%s' "$RENDERED" | grep -qF -- '`bash scripts/test-gate.sh --set-interval N`' \
+   && printf '%s' "$RENDERED" | grep -qF -- '`init.sh`' \
+   && ! printf '%s' "$RENDERED" | grep -qF '[FAIL]'; then
+  pass "T-bl203-guided-prompt-instructs (the RENDERED prompt carries the literal --set-interval command and instruction 9's init reference — no backtick executed)"
 else
-  fail_ "T-bl203-guided-prompt-instructs" "the AI-assist guided prompt carries no --set-interval instruction — the fix silently no-ops on the path init.sh advertises first"
+  fail_ "T-bl203-guided-prompt-instructs" "the rendered guided prompt lost a backticked command to heredoc expansion (R-BL203-1): $(printf '%s' "$RENDERED" | grep -n 'set-interval\|Tooling Configuration' | head -2 | tr '\n' '|')"
 fi
+rm -rf "$D"
 
 echo ""
 echo "T-bl203-ensure-recreate-consistent: the SECOND writer honors the recorded answer"
 D=$(mktemp -d)
 mkdir -p "$D/.claude"
 printf '{"answers": {"testing_interval": "7"}}\n' > "$D/.claude/intake-progress.json"
+printf -- '- **Testing interval:** Every 2 features (configured in Intake Section 11.5)\n' > "$D/CLAUDE.md"
 ( cd "$D" && bash "$TESTGATE" --check-batch ) >/dev/null 2>&1 || true
 GOT=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null)
-if [ "$GOT" = "7" ]; then
-  pass "T-bl203-ensure-recreate-consistent (a recreated build-progress.json carries the recorded 7, not the heredoc 2)"
+if [ "$GOT" = "7" ] && grep -qF 'Every 2 features' "$D/CLAUDE.md"; then
+  pass "T-bl203-ensure-recreate-consistent (a recreated file carries the recorded 7 — and the read-only query did NOT touch CLAUDE.md, R-BL203-6)"
 else
   fail_ "T-bl203-ensure-recreate-consistent" "ensure_progress_file recreated with test_interval=$GOT — the second writer silently reverts the answer (review R-203-1)"
 fi

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -581,8 +581,12 @@ D=$(mktemp -d)
 awk '/<< PROMPTEOF/{f=1;next} /^PROMPTEOF$/{f=0} f' "$WIZARD" > "$D/body.txt"
 { echo 'cat << PROMPTEOF'; cat "$D/body.txt"; echo 'PROMPTEOF'; } > "$D/render.sh"
 RENDERED=$( cd "$D" && bash --noprofile --norc render.sh </dev/null 2>/dev/null )
+# NEEDLE split keeps the literal init-script token off executed lines — the
+# BL-181 unit-lane predicate reads names-on-executed-lines, and the token
+# here would silently exempt this file from the tests.yml membership lint.
+NEEDLE='init'; NEEDLE="${NEEDLE}.sh"
 if printf '%s' "$RENDERED" | grep -qF -- '`bash scripts/test-gate.sh --set-interval N`' \
-   && printf '%s' "$RENDERED" | grep -qF -- '`init.sh`' \
+   && printf '%s' "$RENDERED" | grep -qF -- "\`$NEEDLE\`" \
    && ! printf '%s' "$RENDERED" | grep -qF '[FAIL]'; then
   pass "T-bl203-guided-prompt-instructs (the RENDERED prompt carries the literal --set-interval command and instruction 9's init reference — no backtick executed)"
 else
@@ -633,6 +637,11 @@ echo "T-bl203-mutation: excising the marked write line makes the answer a no-op 
 D=$(mktemp -d)
 _bl203_fixture "$D"
 MUT="$D/test-gate.mut.sh"
+# R-BL203-13: the mutant must be RUNNABLE or the case is vacuous — it sources
+# lib/helpers-core.sh relative to its own location, so give it the real libs
+# and require an empty stderr as proof it reached the BL-203 code at all (an
+# unloadable copy dies at source-time and looks identical by field value).
+mkdir -p "$D/lib" && cp "$REPO_ROOT/scripts/lib/"*.sh "$D/lib/"
 MARKS=$(grep -c 'BL-203-INTERVAL-PLUMB' "$TESTGATE" 2>/dev/null) || MARKS=0
 sed '/# BL-203-INTERVAL-PLUMB$/d' "$TESTGATE" > "$MUT"
 LEFT=$(grep -c 'BL-203-INTERVAL-PLUMB' "$MUT" 2>/dev/null) || LEFT=0
@@ -643,9 +652,11 @@ elif [ "${LEFT:-0}" -ne 0 ]; then
 elif ! bash -n "$MUT" 2>/dev/null; then
   fail_ "T-bl203-mutation" "mutant has a syntax error — a broken mutant proves nothing (the marked line needs its : guard)"
 else
-  ( cd "$D" && bash "$MUT" --set-interval 5 ) >/dev/null 2>&1 || true
+  ( cd "$D" && bash "$MUT" --set-interval 5 ) >/dev/null 2>"$D/mut.stderr" || true
   MUT_GOT=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null)
-  if [ "$MUT_GOT" = "2" ]; then
+  if [ -s "$D/mut.stderr" ]; then
+    fail_ "T-bl203-mutation" "the mutant errored before reaching the BL-203 code ($(head -1 "$D/mut.stderr")) — a mutant that cannot run proves nothing (R-BL203-13)"
+  elif [ "$MUT_GOT" = "2" ]; then
     pass "T-bl203-mutation (excised writer -> the answer no-ops again, field stays 2 — the marked line is load-bearing and the mutant is non-vacuous)"
   else
     fail_ "T-bl203-mutation" "mutant still wrote test_interval=$MUT_GOT — the mutation is not cutting the write path"

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -496,6 +496,131 @@ fi
 # ----------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------
+# ----------------------------------------------------------------
+# BL-203 — the intake's testing-interval answer must reach the ENFORCED
+# field. Single writer: `test-gate.sh --set-interval N` (marker
+# # BL-203-INTERVAL-PLUMB), called from the wizard's script path and
+# instructed on the AI path; ensure_progress_file() (the SECOND writer)
+# must honor the recorded answer when recreating; the session hook's
+# reads must not fail open on missing keys. Fixtures are hand-rolled —
+# NO scaffolding — so these stay unit-lane eligible.
+# ----------------------------------------------------------------
+TESTGATE="$REPO_ROOT/scripts/test-gate.sh"
+SESSCHECK="$REPO_ROOT/scripts/session-test-gate-check.sh"
+
+_bl203_fixture() {  # <dir> — minimal project state for test-gate.sh
+  mkdir -p "$1/.claude"
+  printf '{\n  "features_completed": ["a","b","c","d"],\n  "features_since_last_test": 4,\n  "test_interval": 2,\n  "last_test_session": null,\n  "testing_required": true,\n  "tester_count": 1,\n  "bug_tracker": "github_issues",\n  "sessions_completed": 0\n}\n' > "$1/.claude/build-progress.json"
+  printf -- '- **Testing interval:** Every 2 features (configured in Intake Section 11.5)\n' > "$1/CLAUDE.md"
+}
+
+echo ""
+echo "T-bl203-set-interval: the single-writer action exists and is atomic+complete"
+D=$(mktemp -d)
+_bl203_fixture "$D"
+if ( cd "$D" && bash "$TESTGATE" --set-interval 5 ) >/dev/null 2>&1 \
+   && [ "$(jq -r '.test_interval' "$D/.claude/build-progress.json")" = "5" ] \
+   && [ "$(jq -r '.testing_required' "$D/.claude/build-progress.json")" = "false" ] \
+   && grep -qF 'Every 5 features (configured in Intake Section 11.5)' "$D/CLAUDE.md"; then
+  pass "T-bl203-set-interval (writes the field, re-evaluates testing_required at 4<5, updates the CLAUDE.md prose in place)"
+else
+  fail_ "T-bl203-set-interval" "test-gate.sh --set-interval 5 did not land in all three places: field=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null) required=$(jq -r '.testing_required' "$D/.claude/build-progress.json" 2>/dev/null) claude_md=$(grep -c 'Every 5 features' "$D/CLAUDE.md" 2>/dev/null)"
+fi
+rm -rf "$D"
+
+echo ""
+echo "T-bl203-set-interval-rejects: non-numeric and zero are refused, file untouched"
+D=$(mktemp -d)
+_bl203_fixture "$D"
+BAD=0
+( cd "$D" && bash "$TESTGATE" --set-interval abc ) >/dev/null 2>&1 && BAD=1
+( cd "$D" && bash "$TESTGATE" --set-interval 0 ) >/dev/null 2>&1 && BAD=1
+if [ "$BAD" -eq 0 ] && [ "$(jq -r '.test_interval' "$D/.claude/build-progress.json")" = "2" ]; then
+  pass "T-bl203-set-interval-rejects (abc and 0 exit non-zero and change nothing)"
+else
+  fail_ "T-bl203-set-interval-rejects" "invalid input accepted or file mutated (bad=$BAD interval=$(jq -r '.test_interval' "$D/.claude/build-progress.json"))"
+fi
+rm -rf "$D"
+
+echo ""
+echo "T-bl203-wizard-calls-set-interval: the script path plumbs the answer"
+if awk '/^run_section_11_5\(\)/,/^}/' "$WIZARD" | grep -qF -- '--set-interval "$interval"'; then
+  pass "T-bl203-wizard-calls-set-interval (run_section_11_5 invokes the single writer)"
+else
+  fail_ "T-bl203-wizard-calls-set-interval" "run_section_11_5 saves testing_interval but never calls test-gate.sh --set-interval — the answer is a silent no-op (BL-203)"
+fi
+
+echo ""
+echo "T-bl203-guided-prompt-instructs: the AI path plumbs it too"
+if grep -qF 'test-gate.sh --set-interval' "$WIZARD" && awk '/PROMPTEOF/,0' "$WIZARD" >/dev/null 2>&1 \
+   && sed -n '/cat.*PROMPTEOF/,/^PROMPTEOF/p' "$WIZARD" | grep -qF -- '--set-interval'; then
+  pass "T-bl203-guided-prompt-instructs (the guided prompt tells the agent to run the writer — run_section_11_5 never runs on this path)"
+else
+  fail_ "T-bl203-guided-prompt-instructs" "the AI-assist guided prompt carries no --set-interval instruction — the fix silently no-ops on the path init.sh advertises first"
+fi
+
+echo ""
+echo "T-bl203-ensure-recreate-consistent: the SECOND writer honors the recorded answer"
+D=$(mktemp -d)
+mkdir -p "$D/.claude"
+printf '{"answers": {"testing_interval": "7"}}\n' > "$D/.claude/intake-progress.json"
+( cd "$D" && bash "$TESTGATE" --check-batch ) >/dev/null 2>&1 || true
+GOT=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null)
+if [ "$GOT" = "7" ]; then
+  pass "T-bl203-ensure-recreate-consistent (a recreated build-progress.json carries the recorded 7, not the heredoc 2)"
+else
+  fail_ "T-bl203-ensure-recreate-consistent" "ensure_progress_file recreated with test_interval=$GOT — the second writer silently reverts the answer (review R-203-1)"
+fi
+rm -rf "$D"
+
+echo ""
+echo "T-bl203-session-check-null-safe: missing keys must not error or fail open"
+D=$(mktemp -d)
+mkdir -p "$D/.claude"
+printf '{"current_phase": "2"}\n' > "$D/.claude/phase-state.json"
+printf '{"features_since_last_test": 4}\n' > "$D/.claude/build-progress.json"
+OUT=$( cd "$D" && bash "$SESSCHECK" 2>&1 ); RC=$?
+if [ "$RC" -eq 0 ] && ! printf '%s' "$OUT" | grep -q 'integer expression' \
+   && printf '%s' "$OUT" | grep -q 'TEST GATE BLOCKED'; then
+  pass "T-bl203-session-check-null-safe (missing test_interval defaults to 2; 4>=2 correctly reports the gate, no bash error)"
+else
+  fail_ "T-bl203-session-check-null-safe" "rc=$RC — a missing test_interval key must default to 2 and still report (got: $(printf '%s' "$OUT" | head -2 | tr '\n' '|'))"
+fi
+rm -rf "$D"
+
+echo ""
+echo "T-bl203-verify-install-default: the repair renderer must not fabricate a 5"
+if grep -qF ':-5}' "$REPO_ROOT/scripts/verify-install.sh"; then
+  fail_ "T-bl203-verify-install-default" "verify-install.sh still defaults TEST_INTERVAL to 5 under a false comment — a repair re-render writes an interval nobody enforces"
+else
+  pass "T-bl203-verify-install-default (the repair default matches the enforced default)"
+fi
+
+echo ""
+echo "T-bl203-mutation: excising the marked write line makes the answer a no-op again"
+D=$(mktemp -d)
+_bl203_fixture "$D"
+MUT="$D/test-gate.mut.sh"
+MARKS=$(grep -c 'BL-203-INTERVAL-PLUMB' "$TESTGATE" 2>/dev/null) || MARKS=0
+sed '/# BL-203-INTERVAL-PLUMB$/d' "$TESTGATE" > "$MUT"
+LEFT=$(grep -c 'BL-203-INTERVAL-PLUMB' "$MUT" 2>/dev/null) || LEFT=0
+if [ "${MARKS:-0}" -lt 1 ]; then
+  fail_ "T-bl203-mutation" "no # BL-203-INTERVAL-PLUMB marker in test-gate.sh — nothing to excise (mis-targeted)"
+elif [ "${LEFT:-0}" -ne 0 ]; then
+  fail_ "T-bl203-mutation" "excision left $LEFT marker(s) — vacuous mutant"
+elif ! bash -n "$MUT" 2>/dev/null; then
+  fail_ "T-bl203-mutation" "mutant has a syntax error — a broken mutant proves nothing (the marked line needs its : guard)"
+else
+  ( cd "$D" && bash "$MUT" --set-interval 5 ) >/dev/null 2>&1 || true
+  MUT_GOT=$(jq -r '.test_interval' "$D/.claude/build-progress.json" 2>/dev/null)
+  if [ "$MUT_GOT" = "2" ]; then
+    pass "T-bl203-mutation (excised writer -> the answer no-ops again, field stays 2 — the marked line is load-bearing and the mutant is non-vacuous)"
+  else
+    fail_ "T-bl203-mutation" "mutant still wrote test_interval=$MUT_GOT — the mutation is not cutting the write path"
+  fi
+fi
+rm -rf "$D"
+
 echo ""
 echo "==============================="
 echo "Passed: $PASSED   Failed: $FAILED"


### PR DESCRIPTION
Implements BL-203 per its (adversarially corrected) entry: the recorded answer now reaches the ENFORCED field through a single writer — `test-gate.sh --set-interval N` (`# BL-203-INTERVAL-PLUMB`) — called from the wizard's script path, instructed on the AI-guided path, and exposed as a `reconfigure-project.sh` field. BOTH hardcoding writers are repaired (init.sh stays by design; `ensure_progress_file()` now honors the recorded answer instead of silently reverting to 2 on file loss). The session hook's fails-open reads get `// ` defaults + sanitizers; `verify-install.sh` stops fabricating a 5; divergence is self-revealing (the gate names its interval, its source, and the exact remedy when the recorded answer differs).

**Adversarial review (standing gate): four rounds, thirteen findings, final verdict `approve`.** Round 1 `block`: the unquoted PROMPTEOF heredoc EXECUTED my instruction's backticks at prompt-generation (the shipped AI prompt carried the command's error text; instruction 9 had the same pre-existing break — both fixed, and the test now RENDERS the prompt instead of grepping source); the write path silently succeeded on corrupt JSON while advancing CLAUDE.md (now fails loudly, JSON-before-prose); two reviewer mutations survived the suite (boundary + type now pinned); an oversized interval parked the gate permanently open (input bounded). Round 2 confirmed all four by re-running the reviewer's own reproductions and caught three more — including my mutation case being VACUOUS (the mutant died at lib-load and an INTACT copy also 'passed'; it now carries a negative control via an empty-stderr proof). Round 3: `approve`, with the reviewer's own drop-control and intact-copy control inverted as required.

Suite 18/0 (all watched RED first); test-gate null-handling 5/0; reconfigure field-handlers 7/0; full edge suite green including E56 (the no-intake default stays 2 — full-lane only, run locally, twice); lints 11/11 at every commit.

---
**TL;DR (plain English):** When you tell the setup wizard 'run a testing session every 5 features', the project now actually does that — before, the answer was recorded and silently ignored (always 2). The fix survived four rounds with a hostile reviewer that personally re-ran every attack it invented, including two ways it secretly broke the code to prove the tests would notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)