### PR TITLE
fix(bl202): a fresh session tells you what to do — intake SessionStart hook + state-aware resume.sh

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -378,6 +378,7 @@ jobs:
             tests/test-gate-principles.sh
             tests/test-gitlab-ci-status-stderr-approvals.sh
             tests/test-host-verify-protection-date-parse.sh
+            tests/test-bl202-session-intake-check.sh
             tests/test-intake-wizard-fixes.sh
             tests/test-lint-backlog-references.sh
             tests/test-lint-counter-antipattern.sh

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ your-project/
 │   ├── session-test-gate-check.sh         # SessionStart hook: test gate + MCP gate init
 │   ├── session-mcp-gate.sh                # PreToolUse hook: block Write/Edit until MCP called
 │   ├── session-end-qdrant-reminder.sh     # Stop hook: Qdrant storage reminder
-│   ├── resume.sh                          # Session resume prompt generator
+│   ├── resume.sh                          # Prints the exact first message to paste (state-aware: intake / Phase 0 / resume)
 │   └── lib/helpers.sh                     # Shared shell helpers (colors, logging, MCP detection)
 ├── templates/
 │   ├── generated/                         # 24 .tmpl files (CLAUDE.md, Manifesto, Bible, ADR, ...)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -369,7 +369,7 @@ Either way, the **Phase 1→2 gate enforces a verified remote**, keyed on the sa
 | `docs/platform-modules/` | init.sh (copied) | Nothing | Platform-specific guidance |
 | `docs/reference/security-scan-guide.md` | init.sh (copied) | Nothing | Plain-language guide for common scan findings |
 | `scripts/intake-wizard.sh` | init.sh (copied) | Run to fill out the Intake | Guided script or AI-assisted conversation |
-| `scripts/resume.sh` | init.sh (copied) | Run at session start | Generates resume prompt from project state |
+| `scripts/resume.sh` | init.sh (copied) | Run at session start | Prints the exact first message to paste — state-aware: intake prompt, Phase-0 initialization prompt (Intake §13), or the classic resume prompt |
 | `templates/intake-suggestions/` | init.sh (copied) | Nothing | Context-aware suggestions for the wizard |
 | **Superpowers** | You (optional) | Install plugin, configure in CLAUDE.md | See [CLI Setup Addendum](cli-setup-addendum.md#1-superpowers) |
 | **Context7 MCP** | You (optional) | One command to add MCP server | See [CLI Setup Addendum](cli-setup-addendum.md#4-context7) |

--- a/init.sh
+++ b/init.sh
@@ -1365,7 +1365,6 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/session-freshness-check.sh" scripts/   # BL-109 S2 (Currency System, Layer 1)
   cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-intake-check.sh" scripts/   # BL-202 (intake/Phase-0 dead-air)
-  cp "$SCRIPT_DIR/scripts/start-here.sh" scripts/             # BL-202 first-timer alias for resume.sh
   cp "$SCRIPT_DIR/scripts/session-end-qdrant-reminder.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-mcp-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/process-checklist.sh" scripts/
@@ -1427,7 +1426,7 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/host.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
   chmod +x scripts/host-drivers/*.sh
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-intake-check.sh scripts/start-here.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-intake-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions
@@ -3131,7 +3130,7 @@ print_next_steps() {
   echo "     bash scripts/intake-wizard.sh          — guided wizard (interactive or AI-assisted)"
   echo "     Or edit directly: $PROJECT_DIR/PROJECT_INTAKE.md"
   echo "     When the intake is done, 'bash scripts/resume.sh' prints the exact"
-  echo "     first message to paste into Claude Code (BL-202)."
+  echo "     first message to paste into Claude Code."
   echo ""
   echo "     IMPORTANT: Run the wizard and edit the intake from your PROJECT directory,"
   echo "     not from the solo-orchestrator source directory."
@@ -3179,23 +3178,10 @@ print_next_steps() {
   echo "     cd $PROJECT_DIR"
   echo "     claude"
   echo ""
-  echo "     Then give the agent the full project context. A blank Claude Code"
-  echo "     screen means it is ready and waiting, not stuck."
-  echo ""
-  echo "     --- copy from here ---------------------------------------------"
-  echo "     Read the following files in order, then confirm what you"
-  echo "     understand about this project before taking any action:"
-  echo ""
-  echo "     1. CLAUDE.md (your instructions and constraints)"
-  echo "     2. PROJECT_INTAKE.md (the product definition)"
-  echo "     3. docs/reference/builders-guide.md (the phase-gate method)"
-  echo "     4. docs/platform-modules/ (platform-specific guidance)"
-  echo "     5. .claude/phase-state.json (current phase)"
-  echo ""
-  echo "     After reading, summarize: the project goal, your constraints,"
-  echo "     the current phase, and what tools/MCP servers are available to"
-  echo "     you. Then begin Phase 0. Ask me only for clarifying questions."
-  echo "     --- to here ----------------------------------------------------"
+  echo "     Then paste the first message printed by:  bash scripts/resume.sh"
+  echo "     (state-aware: it prints the intake prompt, the Phase-0 initialization"
+  echo "     prompt from PROJECT_INTAKE.md Section 13, or the resume prompt — and a"
+  echo "     blank Claude Code screen means it is ready and waiting, not stuck)"
   echo ""
 
   if [ -f "$PROJECT_DIR/.github/workflows/release.yml" ]; then

--- a/init.sh
+++ b/init.sh
@@ -1364,6 +1364,8 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/session-version-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-freshness-check.sh" scripts/   # BL-109 S2 (Currency System, Layer 1)
   cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/
+  cp "$SCRIPT_DIR/scripts/session-intake-check.sh" scripts/   # BL-202 (intake/Phase-0 dead-air)
+  cp "$SCRIPT_DIR/scripts/start-here.sh" scripts/             # BL-202 first-timer alias for resume.sh
   cp "$SCRIPT_DIR/scripts/session-end-qdrant-reminder.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-mcp-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/process-checklist.sh" scripts/
@@ -1425,7 +1427,7 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/host.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
   chmod +x scripts/host-drivers/*.sh
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-intake-check.sh scripts/start-here.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions
@@ -1891,6 +1893,17 @@ PERMEOF
             && mv .claude/settings.json.tmp .claude/settings.json
           hooks_added=true
         fi
+        # BL-202-INTAKE-HOOK-BEGIN — intake/Phase-0 onboarding state on every
+        # launch surface (desktop/IDE included, where terminal prints cannot
+        # reach). Silent when healthy; the agent relays. Injected exactly like
+        # the three hooks above; fenced so the registration is excisable for
+        # mutation proofs without touching its siblings.
+        if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("session-intake-check.sh"))' .claude/settings.json >/dev/null 2>&1; then
+          jq '.hooks.SessionStart[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-intake-check.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
+            && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
+        fi
+        # BL-202-INTAKE-HOOK-END
         # Add Qdrant reminder to Stop hook
         if jq -e '.hooks.Stop' .claude/settings.json >/dev/null 2>&1; then
           if ! jq -e '.hooks.Stop[0].hooks[] | select(.command | contains("session-end-qdrant-reminder.sh"))' .claude/settings.json >/dev/null 2>&1; then
@@ -3117,6 +3130,8 @@ print_next_steps() {
   echo "     cd $PROJECT_DIR"
   echo "     bash scripts/intake-wizard.sh          — guided wizard (interactive or AI-assisted)"
   echo "     Or edit directly: $PROJECT_DIR/PROJECT_INTAKE.md"
+  echo "     When the intake is done, 'bash scripts/resume.sh' prints the exact"
+  echo "     first message to paste into Claude Code (BL-202)."
   echo ""
   echo "     IMPORTANT: Run the wizard and edit the intake from your PROJECT directory,"
   echo "     not from the solo-orchestrator source directory."
@@ -3164,21 +3179,23 @@ print_next_steps() {
   echo "     cd $PROJECT_DIR"
   echo "     claude"
   echo ""
-  echo "     Then give the agent the full project context:"
-  echo "     ┌─────────────────────────────────────────────────────────────────┐"
-  echo "     │ Read the following files in order, then confirm what you        │"
-  echo "     │ understand about this project before taking any action:         │"
-  echo "     │                                                                 │"
-  echo "     │ 1. CLAUDE.md (your instructions and constraints)                │"
-  echo "     │ 2. PROJECT_INTAKE.md (the product definition)                   │"
-  echo "     │ 3. docs/reference/builders-guide.md (the phase-gate method)     │"
-  echo "     │ 4. docs/platform-modules/ (platform-specific guidance)          │"
-  echo "     │ 5. .claude/phase-state.json (current phase)                     │"
-  echo "     │                                                                 │"
-  echo "     │ After reading, summarize: the project goal, your constraints,   │"
-  echo "     │ the current phase, and what tools/MCP servers are available to   │"
-  echo "     │ you. Then begin Phase 0. Ask me only for clarifying questions.  │"
-  echo "     └─────────────────────────────────────────────────────────────────┘"
+  echo "     Then give the agent the full project context. A blank Claude Code"
+  echo "     screen means it is ready and waiting, not stuck."
+  echo ""
+  echo "     --- copy from here ---------------------------------------------"
+  echo "     Read the following files in order, then confirm what you"
+  echo "     understand about this project before taking any action:"
+  echo ""
+  echo "     1. CLAUDE.md (your instructions and constraints)"
+  echo "     2. PROJECT_INTAKE.md (the product definition)"
+  echo "     3. docs/reference/builders-guide.md (the phase-gate method)"
+  echo "     4. docs/platform-modules/ (platform-specific guidance)"
+  echo "     5. .claude/phase-state.json (current phase)"
+  echo ""
+  echo "     After reading, summarize: the project goal, your constraints,"
+  echo "     the current phase, and what tools/MCP servers are available to"
+  echo "     you. Then begin Phase 0. Ask me only for clarifying questions."
+  echo "     --- to here ----------------------------------------------------"
   echo ""
 
   if [ -f "$PROJECT_DIR/.github/workflows/release.yml" ]; then

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1739,7 +1739,13 @@ run_script_mode() {
   echo ""
   print_ok "Answers saved to $PROGRESS_FILE"
   print_ok "PROJECT_INTAKE.md updated with 'Intake Answers (Auto-Populated)' appendix"
-  print_info "Review PROJECT_INTAKE.md, then start Claude Code and begin Phase 0."
+  print_ok "Your intake is filled in. Nothing more is needed here."
+  echo ""
+  echo "  Next: open Claude Code and give it the project."
+  echo "    1. Type:  claude"
+  echo "    2. It will sit there quietly until you send a message — that's normal."
+  echo "    3. Paste the first message printed by:  bash scripts/resume.sh"
+  echo "       (it prints your project's own Section 13 initialization prompt)"
   echo ""
 }
 
@@ -1829,6 +1835,7 @@ PROMPTEOF
   echo "    2. Generate prompt file only"
   echo "       INTAKE_GUIDED_PROMPT.md is ready for you to review first."
   echo "       When ready: claude \"Read INTAKE_GUIDED_PROMPT.md and begin\""
+  echo "       (a blank Claude Code screen means it is ready and waiting, not stuck)"
   echo ""
   local launch_choice
   read -rp "$(echo -e "  ${BOLD}Select [1-2]${NC}: ")" launch_choice # lint-raw-read-prompt: allow intake-wizard.sh interactive-only launch-mode choice (1 = launch Claude, 2 = generate prompt file); wizard is interactive-only by design
@@ -1839,7 +1846,8 @@ PROMPTEOF
       cd "$PROJECT_ROOT"
       exec claude "Read INTAKE_GUIDED_PROMPT.md and follow its instructions to help me fill out PROJECT_INTAKE.md."
     else
-      print_warn "Claude Code not found. Install it first, then run:"
+      print_warn "Claude Code isn't installed on this computer."
+      print_info "Install it from https://claude.com/claude-code, then run:"
       echo "  claude \"Read INTAKE_GUIDED_PROMPT.md and begin\""
     fi
   else
@@ -2247,6 +2255,8 @@ main() {
       ;;
     3)
       print_info "No problem. Open PROJECT_INTAKE.md in your editor when ready."
+      print_info "When you've filled it in, run: bash scripts/resume.sh"
+      print_info "That prints the exact message to paste into Claude Code to begin."
       print_info "See docs/reference/user-guide.md Section 3 for field-by-field guidance."
       ;;
     *)

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -1739,7 +1739,7 @@ run_script_mode() {
   echo ""
   print_ok "Answers saved to $PROGRESS_FILE"
   print_ok "PROJECT_INTAKE.md updated with 'Intake Answers (Auto-Populated)' appendix"
-  print_ok "Your intake is filled in. Nothing more is needed here."
+  print_ok "Done — your answers are recorded in the appendix at the end of PROJECT_INTAKE.md."
   echo ""
   echo "  Next: open Claude Code and give it the project."
   echo "    1. Type:  claude"

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -23,6 +23,47 @@ if [ -f ".claude/phase-state.json" ]; then
   [ -z "$PHASE" ] && PHASE="unknown"
 fi
 
+# --- BL-202: state-aware first-message branches ---------------------------
+# This script is the SINGLE generator of "what do I paste into Claude Code";
+# every wizard/init print points here. Three states, checked in order:
+#   1. intake unfinished  -> the intake first-message
+#   2. intake done, Phase 0 never started -> the project's own Section 13
+#      (Agent Initialization Prompt) verbatim
+#   3. anything else -> the classic resume prompt below
+# Detection matches scripts/session-intake-check.sh (blank-cell predicate).
+if [ -f "PROJECT_INTAKE.md" ] && [ "$PHASE" != "unknown" ] && [ "${PHASE:-1}" -eq 0 ] 2>/dev/null; then
+  bl202_blanks=$(grep -cE '\| *\|$|\| *$' PROJECT_INTAKE.md 2>/dev/null || true)
+  case "$bl202_blanks" in ''|*[!0-9]*) bl202_blanks=0 ;; esac
+  if [ "$bl202_blanks" -gt 20 ]; then
+    echo -e "${CYAN}--- Copy everything below this line into Claude Code ---${NC}"
+    echo ""
+    if [ -f "INTAKE_GUIDED_PROMPT.md" ]; then
+      echo "Read INTAKE_GUIDED_PROMPT.md and follow it."
+    else
+      echo "Help me finish this project's intake: read PROJECT_INTAKE.md and walk me"
+      echo "through the unfilled sections, writing my answers into the file as we go."
+    fi
+    echo ""
+    echo -e "${CYAN}--- End (a blank Claude Code screen means it is ready and waiting, not stuck) ---${NC}"
+    exit 0
+  fi
+  if [ ! -f "PRODUCT_MANIFESTO.md" ]; then
+    # Extract §13's fenced prompt from the PROJECT's intake (not the template).
+    bl202_s13=$(awk '/^## 13\./{f=1; next} f && /^## /{exit} f && /^```/{c = !c; next} f && c' PROJECT_INTAKE.md 2>/dev/null)
+    echo -e "${CYAN}--- Copy everything below this line into Claude Code ---${NC}"
+    echo ""
+    if [ -n "$bl202_s13" ]; then
+      printf '%s\n' "$bl202_s13"
+    else
+      echo "Read PROJECT_INTAKE.md — Section 13 is your initialization prompt — and"
+      echo "begin Phase 0 from it."
+    fi
+    echo ""
+    echo -e "${CYAN}--- End (a blank Claude Code screen means it is ready and waiting, not stuck) ---${NC}"
+    exit 0
+  fi
+fi
+
 # Last 3 git log entries
 RECENT_COMMITS="(no commits)"
 if command -v git &>/dev/null && [ -d ".git" ]; then

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -32,7 +32,8 @@ fi
 #   3. anything else -> the classic resume prompt below
 # Detection matches scripts/session-intake-check.sh (blank-cell predicate).
 if [ -f "PROJECT_INTAKE.md" ] && [ "$PHASE" != "unknown" ] && [ "${PHASE:-1}" -eq 0 ] 2>/dev/null; then
-  bl202_blanks=$(grep -cE '\| *\|$|\| *$' PROJECT_INTAKE.md 2>/dev/null || true)
+  # BL-202-INTAKE-PREDICATE (SYNC SIBLINGS: scripts/validate.sh, scripts/session-intake-check.sh, scripts/resume.sh) — count only truly-blank cells: '\| *\|$'. The old '|\| *$' alternative matched EVERY table row (constant 258 on real intakes — review R-BL202-1).
+  bl202_blanks=$(grep -cE '\| *\|$' PROJECT_INTAKE.md 2>/dev/null || true)
   case "$bl202_blanks" in ''|*[!0-9]*) bl202_blanks=0 ;; esac
   if [ "$bl202_blanks" -gt 20 ]; then
     echo -e "${CYAN}--- Copy everything below this line into Claude Code ---${NC}"

--- a/scripts/session-intake-check.sh
+++ b/scripts/session-intake-check.sh
@@ -3,8 +3,14 @@
 # BL-202: Claude Code loads project context only when the FIRST message is
 # sent, so a fresh session in a generated project dead-airs — the user does
 # not know what to type, and Claude does not know the intake is unfinished.
-# This hook puts that fact INTO context on every launch surface (CLI, desktop,
-# IDE), where terminal prints can never reach. Contract mirrors
+# This hook puts that fact INTO CLAUDE'S CONTEXT on every launch surface (CLI,
+# desktop, IDE). Honest contract (review R-BL202-3): SessionStart stdout is
+# context for Claude, NOT text shown to the operator — the blank screen stays
+# blank until they type SOMETHING, but whatever they type, Claude's first
+# reply now knows the intake state and relays it. The documented
+# initialUserMessage JSON field could start the conversation outright; that
+# upgrade is deliberately out of scope here and noted on BL-202. Contract
+# otherwise mirrors
 # session-test-gate-check.sh / session-freshness-check.sh: silent when
 # healthy, fail-open (exit 0 always), the agent RELAYS the output.
 #
@@ -22,6 +28,10 @@ set -uo pipefail
 [ -f ".claude/phase-state.json" ] || exit 0
 [ -f "PROJECT_INTAKE.md" ] || exit 0
 
+# Without jq the ack below is unreadable AND the printed remedy is unrunnable —
+# an unsilenceable nag loop (review R-BL202-6). Every sibling hook guards this.
+command -v jq >/dev/null 2>&1 || exit 0
+
 # The operator already chose to proceed without the intake — never nag twice.
 ACK=$(jq -r '.intake.proceed_without_intake_acknowledged // false' .claude/process-state.json 2>/dev/null) || ACK="false"
 [ "$ACK" = "true" ] && exit 0
@@ -32,7 +42,8 @@ case "$CURRENT_PHASE" in ''|*[!0-9]*) CURRENT_PHASE=0 ;; esac
 [ "$CURRENT_PHASE" -eq 0 ] || exit 0
 
 # BL-202-INTAKE-DETECT-BEGIN
-blank_cells=$(grep -cE '\| *\|$|\| *$' PROJECT_INTAKE.md 2>/dev/null || true)
+# BL-202-INTAKE-PREDICATE (SYNC SIBLINGS: scripts/validate.sh, scripts/session-intake-check.sh, scripts/resume.sh) — count only truly-blank cells: '\| *\|$'. The old '|\| *$' alternative matched EVERY table row (constant 258 on real intakes — review R-BL202-1).
+blank_cells=$(grep -cE '\| *\|$' PROJECT_INTAKE.md 2>/dev/null || true)
 case "$blank_cells" in ''|*[!0-9]*) blank_cells=0 ;; esac
 
 if [ "$blank_cells" -gt 20 ]; then
@@ -43,8 +54,8 @@ This project's intake (PROJECT_INTAKE.md) has ~${blank_cells} unfilled fields an
 not started. Offer the operator these two choices ONCE, then respect the answer:
   1. Continue the intake now — run: bash scripts/intake-wizard.sh
      (or work through PROJECT_INTAKE.md's unfilled sections together).
-  2. Proceed without it — record the choice so this notice never repeats:
-     [ -f .claude/process-state.json ] || echo '{}' > .claude/process-state.json
+  2. Proceed without it — record the choice so this notice never repeats (if
+     .claude/process-state.json is missing, run bash scripts/process-checklist.sh --verify-init first):
      jq '.intake.proceed_without_intake_acknowledged = true' .claude/process-state.json > .claude/process-state.json.tmp && mv .claude/process-state.json.tmp .claude/process-state.json
 If the operator's first message is a real task, answer it AFTER offering this choice once —
 never block their work over paperwork.

--- a/scripts/session-intake-check.sh
+++ b/scripts/session-intake-check.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Solo Orchestrator — SessionStart hook for intake/Phase-0 onboarding state
+# BL-202: Claude Code loads project context only when the FIRST message is
+# sent, so a fresh session in a generated project dead-airs — the user does
+# not know what to type, and Claude does not know the intake is unfinished.
+# This hook puts that fact INTO context on every launch surface (CLI, desktop,
+# IDE), where terminal prints can never reach. Contract mirrors
+# session-test-gate-check.sh / session-freshness-check.sh: silent when
+# healthy, fail-open (exit 0 always), the agent RELAYS the output.
+#
+# Detection is MODE-AGNOSTIC — the blank-table-cell count over
+# PROJECT_INTAKE.md (scripts/validate.sh's predicate, >20 = incomplete).
+# .claude/intake-progress.json is written by the wizard's main-menu mode 1
+# ONLY, so it must never be the deciding signal (AI-assist and manual users
+# would read "incomplete" forever).
+#
+# Standalone by design: sources nothing, so tests can run a copy from any
+# directory (the R-BL203-13 lesson — an unloadable mutant proves nothing).
+set -uo pipefail
+
+# Not a generated project (or init mid-flight): not ours, stay silent.
+[ -f ".claude/phase-state.json" ] || exit 0
+[ -f "PROJECT_INTAKE.md" ] || exit 0
+
+# The operator already chose to proceed without the intake — never nag twice.
+ACK=$(jq -r '.intake.proceed_without_intake_acknowledged // false' .claude/process-state.json 2>/dev/null) || ACK="false"
+[ "$ACK" = "true" ] && exit 0
+
+CURRENT_PHASE=$(grep -o '"current_phase"[[:space:]]*:[[:space:]]*"*[0-9][0-9]*"*' .claude/phase-state.json 2>/dev/null | grep -o '[0-9][0-9]*' | head -1) || CURRENT_PHASE=""
+case "$CURRENT_PHASE" in ''|*[!0-9]*) CURRENT_PHASE=0 ;; esac
+# Past Phase 0: onboarding is over; this hook has nothing to say.
+[ "$CURRENT_PHASE" -eq 0 ] || exit 0
+
+# BL-202-INTAKE-DETECT-BEGIN
+blank_cells=$(grep -cE '\| *\|$|\| *$' PROJECT_INTAKE.md 2>/dev/null || true)
+case "$blank_cells" in ''|*[!0-9]*) blank_cells=0 ;; esac
+
+if [ "$blank_cells" -gt 20 ]; then
+  cat <<EOF
+INTAKE INCOMPLETE — relay this to the operator as your FIRST response, then follow it.
+
+This project's intake (PROJECT_INTAKE.md) has ~${blank_cells} unfilled fields and Phase 0 has
+not started. Offer the operator these two choices ONCE, then respect the answer:
+  1. Continue the intake now — run: bash scripts/intake-wizard.sh
+     (or work through PROJECT_INTAKE.md's unfilled sections together).
+  2. Proceed without it — record the choice so this notice never repeats:
+     [ -f .claude/process-state.json ] || echo '{}' > .claude/process-state.json
+     jq '.intake.proceed_without_intake_acknowledged = true' .claude/process-state.json > .claude/process-state.json.tmp && mv .claude/process-state.json.tmp .claude/process-state.json
+If the operator's first message is a real task, answer it AFTER offering this choice once —
+never block their work over paperwork.
+EOF
+  exit 0
+fi
+# BL-202-INTAKE-DETECT-END
+
+# Intake looks filled; has Phase 0 produced anything yet?
+if [ ! -f "PRODUCT_MANIFESTO.md" ]; then
+  cat <<EOF
+READY FOR PHASE 0 — relay this to the operator as your FIRST response.
+
+The intake looks complete and Phase 0 has not started yet (no PRODUCT_MANIFESTO.md).
+The exact first message to paste is printed by: bash scripts/resume.sh
+(It is the Agent Initialization Prompt from PROJECT_INTAKE.md Section 13.)
+If the operator asks you directly, offer to begin Phase 0 from that prompt now.
+EOF
+fi
+exit 0

--- a/scripts/start-here.sh
+++ b/scripts/start-here.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Solo Orchestrator — first-timer alias for scripts/resume.sh (BL-202).
-# "Resume" reads wrong before anything has started; this name does not.
-exec bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/resume.sh" "$@"

--- a/scripts/start-here.sh
+++ b/scripts/start-here.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Solo Orchestrator — first-timer alias for scripts/resume.sh (BL-202).
+# "Resume" reads wrong before anything has started; this name does not.
+exec bash "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/resume.sh" "$@"

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -383,7 +383,8 @@ print_section "Intake Completeness"
 
 if [ -f "PROJECT_INTAKE.md" ]; then
   # Count blank table cells (likely unfilled fields)
-  blank_cells=$(grep -cE '\| *\|$|\| *$' PROJECT_INTAKE.md 2>/dev/null || true)
+  # BL-202-INTAKE-PREDICATE (SYNC SIBLINGS: scripts/validate.sh, scripts/session-intake-check.sh, scripts/resume.sh) — count only truly-blank cells: '\| *\|$'. The old '|\| *$' alternative matched EVERY table row (constant 258 on real intakes — review R-BL202-1).
+  blank_cells=$(grep -cE '\| *\|$' PROJECT_INTAKE.md 2>/dev/null || true)
   case "$blank_cells" in ''|*[!0-9]*) blank_cells=0 ;; esac
   # Count N/A entries (explicitly marked as not applicable — this is fine)
   na_cells=$(grep -ciE '\| *N/?A' PROJECT_INTAKE.md 2>/dev/null || true)

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -7113,6 +7113,18 @@ CONSOLIDATE, not add a fourth magic phrase.
 class this repairs for onboarding), `docs/user-guide.md`'s §12→§13 pointer fix (shipped with
 this entry's filing PR — the guide told users to paste from the section that says "do not edit").
 
+**UPDATE 2026-07-31 — fix landed; two recorded residuals.** The fix shipped (SessionStart hook
+`scripts/session-intake-check.sh`, state-aware `resume.sh`, converged prints) with its honest
+contract: SessionStart stdout is CLAUDE'S context, not operator-visible text — the blank screen
+stays until the user types something, but the first reply then knows the intake state and relays
+it. (1) Claude Code's documented `initialUserMessage` SessionStart JSON field could start the
+conversation outright — the full fix for the user-facing half; deliberately out of scope here,
+recorded as this entry's follow-up. (2) `README.md`'s Quick Start still carries the last verbatim
+copy of the kickoff paste block; consolidating it onto the generator needs its own pass against
+the BL-199 quick-start pins, so it is left in place and named here rather than touched blind.
+Also unaddressed by choice: `resume.sh`'s §13 extractor accepts only the shipped `## 13.` heading
+spelling (hardening-only, reviewer-rated), and an unreadable PROJECT_INTAKE.md reads as complete.
+
 **Status:** Open
 
 ---

--- a/tests/edge-cases-scripts.sh
+++ b/tests/edge-cases-scripts.sh
@@ -200,6 +200,12 @@ section "E12: resume.sh with empty/missing CLAUDE.md"
 E12_DIR="$TEST_DIR/e12-no-claude"
 create_test_project "$E12_DIR"
 rm -f "$E12_DIR/CLAUDE.md"
+# BL-202: resume.sh is now state-aware — at phase 0 with no PRODUCT_MANIFESTO.md
+# it prints the Section-13 first-message instead of the classic prompt. E12's
+# contract is the CLASSIC path's robustness to a missing/empty CLAUDE.md, so
+# the fixture gets a manifesto to be genuinely mid-flight; the assertions below
+# are unchanged.
+printf '# manifesto\n' > "$E12_DIR/PRODUCT_MANIFESTO.md"
 
 result=0
 output=$( cd "$E12_DIR" && bash "$E12_DIR/scripts/resume.sh" 2>&1 </dev/null ) || result=$?
@@ -236,6 +242,7 @@ fi
 # Test with empty CLAUDE.md
 E12B_DIR="$TEST_DIR/e12-empty-claude"
 create_test_project "$E12B_DIR"
+printf '# manifesto\n' > "$E12B_DIR/PRODUCT_MANIFESTO.md"   # BL-202: keep E12b on the classic path (see E12a note)
 : > "$E12B_DIR/CLAUDE.md"
 
 result=0

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -528,6 +528,7 @@ run_child_suite "scripts/lint-doc-anchors.sh" \
 # snapshot pattern for reconfigure-project.sh --field handlers.
 section "Intake wizard + reconfigure field handlers (PRs #83, #84)"
 run_child_suite "tests/test-intake-wizard-fixes.sh" "tests/test-intake-wizard-fixes.sh"
+run_child_suite "tests/test-bl202-session-intake-check.sh" "tests/test-bl202-session-intake-check.sh"
 run_child_suite "tests/test-reconfigure-field-handlers.sh" \
   "tests/test-reconfigure-field-handlers.sh"
 

--- a/tests/test-bl202-session-intake-check.sh
+++ b/tests/test-bl202-session-intake-check.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# tests/test-bl202-session-intake-check.sh — BL-202: a fresh Claude Code
+# session in a generated project dead-airs — nothing tells the user what to
+# type, and nothing tells Claude the intake is unfinished.
+#
+# THE FIX UNDER TEST: scripts/session-intake-check.sh (a SessionStart hook,
+# modeled on session-test-gate-check.sh: silent when healthy, output the agent
+# RELAYS) plus scripts/resume.sh becoming the single state-aware first-message
+# generator. Detection is MODE-AGNOSTIC (blank-table-cell count — the
+# validate.sh predicate; .claude/intake-progress.json is written by main-menu
+# mode 1 only, so it can corroborate but never decide).
+#
+# HERMETIC: hand-rolled fixtures, direct hook/script invocation, stdin closed
+# everywhere. No scaffolding. bash-3.2 safe. Registered in BOTH lanes.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+HOOK="$REPO_ROOT/scripts/session-intake-check.sh"
+RESUME="$REPO_ROOT/scripts/resume.sh"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# mk_proj <dir> <blank-cells> <phase> — minimal generated-project state.
+# <blank-cells> unfilled table rows go into PROJECT_INTAKE.md alongside a few
+# filled ones; <phase> lands in phase-state.json.
+mk_proj() {
+  local d="$1" blanks="$2" phase="$3" i
+  mkdir -p "$d/.claude" "$d/scripts"
+  printf '{"current_phase": "%s"}\n' "$phase" > "$d/.claude/phase-state.json"
+  {
+    printf '# Project Intake\n\n## 1. Basics\n\n'
+    printf '| **Project name** | demo |\n'
+    printf '| **Description** | a demo |\n'
+    i=0
+    while [ "$i" -lt "$blanks" ]; do
+      printf '| **Field %s** | |\n' "$i"
+      i=$((i + 1))
+    done
+    printf '\n## 13. Agent Initialization Prompt\n\n```\nBL202-S13-SENTINEL: read the intake, then begin Phase 0.\n```\n'
+  } > "$d/PROJECT_INTAKE.md"
+}
+
+run_hook() {  # <dir> <log>
+  ( cd "$1" && bash "$HOOK" </dev/null ) > "$2" 2>"$2.err"
+}
+
+# ── H1: incomplete intake -> loud relay naming the wizard and the ack ────────
+echo "=== H1-incomplete-intake-loud ==="
+D="$TOPTMP/h1"; mk_proj "$D" 25 0
+if run_hook "$D" "$TOPTMP/h1.log" && grep -q 'INTAKE INCOMPLETE' "$TOPTMP/h1.log" \
+   && grep -q 'intake-wizard.sh' "$TOPTMP/h1.log" \
+   && grep -q 'proceed_without_intake_acknowledged' "$TOPTMP/h1.log" \
+   && ! [ -s "$TOPTMP/h1.log.err" ]; then
+  pass "H1-incomplete-intake-loud (25 blank cells at phase 0 -> the agent is told, offered continue-vs-proceed, clean stderr)"
+else
+  fail_ "H1-incomplete-intake-loud" "rc/content wrong: $(head -2 "$TOPTMP/h1.log" 2>/dev/null | tr '\n' '|') err=$(head -1 "$TOPTMP/h1.log.err" 2>/dev/null)"
+fi
+
+# ── H2: intake filled, Phase 0 never started -> stranded relay ───────────────
+echo "=== H2-stranded-before-phase0 ==="
+D="$TOPTMP/h2"; mk_proj "$D" 3 0
+if run_hook "$D" "$TOPTMP/h2.log" && grep -q 'READY FOR PHASE 0' "$TOPTMP/h2.log" \
+   && grep -q 'resume.sh' "$TOPTMP/h2.log"; then
+  pass "H2-stranded-before-phase0 (filled intake + no PRODUCT_MANIFESTO.md -> points at resume.sh — the state modes 1 and 2 land in by construction)"
+else
+  fail_ "H2-stranded-before-phase0" "$(head -2 "$TOPTMP/h2.log" 2>/dev/null | tr '\n' '|')"
+fi
+
+# ── H3: acknowledged proceed-without-intake -> permanently silent ────────────
+echo "=== H3-acked-silent ==="
+D="$TOPTMP/h3"; mk_proj "$D" 25 0
+printf '{"intake": {"proceed_without_intake_acknowledged": true}}\n' > "$D/.claude/process-state.json"
+if run_hook "$D" "$TOPTMP/h3.log" && ! [ -s "$TOPTMP/h3.log" ]; then
+  pass "H3-acked-silent (the operator chose to proceed once — the hook never nags again)"
+else
+  fail_ "H3-acked-silent" "hook spoke over an acknowledged choice: $(head -1 "$TOPTMP/h3.log" 2>/dev/null)"
+fi
+
+# ── H4: healthy states are silent (manifesto present; later phase) ───────────
+echo "=== H4-healthy-silent ==="
+D="$TOPTMP/h4a"; mk_proj "$D" 3 0
+printf '# manifesto\n' > "$D/PRODUCT_MANIFESTO.md"
+D2="$TOPTMP/h4b"; mk_proj "$D2" 25 2
+H4_OK=1
+run_hook "$D" "$TOPTMP/h4a.log" && [ ! -s "$TOPTMP/h4a.log" ] || H4_OK=0
+run_hook "$D2" "$TOPTMP/h4b.log" && [ ! -s "$TOPTMP/h4b.log" ] || H4_OK=0
+if [ "$H4_OK" -eq 1 ]; then
+  pass "H4-healthy-silent (Phase 0 underway, and past-Phase-0 projects, are both left alone — even with blank cells)"
+else
+  fail_ "H4-healthy-silent" "a healthy state produced output: a=$(head -1 "$TOPTMP/h4a.log" 2>/dev/null) b=$(head -1 "$TOPTMP/h4b.log" 2>/dev/null)"
+fi
+
+# ── H5: not a generated project -> silent ────────────────────────────────────
+echo "=== H5-not-a-project-silent ==="
+D="$TOPTMP/h5"; mkdir -p "$D"
+if run_hook "$D" "$TOPTMP/h5.log" && [ ! -s "$TOPTMP/h5.log" ]; then
+  pass "H5-not-a-project-silent (no phase-state, no intake -> not ours, stay quiet)"
+else
+  fail_ "H5-not-a-project-silent" "$(head -1 "$TOPTMP/h5.log" 2>/dev/null)"
+fi
+
+# ── H6: excision mutation — the detection fence is load-bearing ──────────────
+# Negative control included (R-BL203-13's lesson): the mutant must be RUNNABLE
+# (empty stderr is the proof it reached the code), and an INTACT copy must
+# fail this case's excised-expectation.
+echo "=== H6-mutation-detect-fence ==="
+MUT="$TOPTMP/hook.mut.sh"
+MB=$(grep -c '# BL-202-INTAKE-DETECT-BEGIN' "$HOOK" 2>/dev/null) || MB=0
+ME=$(grep -c '# BL-202-INTAKE-DETECT-END' "$HOOK" 2>/dev/null) || ME=0
+sed '/# BL-202-INTAKE-DETECT-BEGIN/,/# BL-202-INTAKE-DETECT-END/d' "$HOOK" > "$MUT" 2>/dev/null || true
+if [ "$MB" -ne 1 ] || [ "$ME" -ne 1 ]; then
+  fail_ "H6-mutation-detect-fence" "fence not present exactly once (begin=$MB end=$ME) — retarget this mutation in lockstep"
+elif ! bash -n "$MUT" 2>/dev/null; then
+  fail_ "H6-mutation-detect-fence" "mutant has a syntax error — a broken mutant proves nothing"
+else
+  D="$TOPTMP/h6"; mk_proj "$D" 25 0
+  ( cd "$D" && bash "$MUT" </dev/null ) > "$TOPTMP/h6.log" 2>"$TOPTMP/h6.err" || true
+  if [ -s "$TOPTMP/h6.err" ]; then
+    fail_ "H6-mutation-detect-fence" "the mutant errored before reaching the code ($(head -1 "$TOPTMP/h6.err")) — an unrunnable mutant proves nothing"
+  elif grep -q 'INTAKE INCOMPLETE' "$TOPTMP/h6.log"; then
+    fail_ "H6-mutation-detect-fence" "excising the detection fence did NOT silence the incomplete arm — the fence is not cutting what it claims"
+  else
+    pass "H6-mutation-detect-fence (excised detection -> the incomplete arm goes dark while the mutant runs clean — the fence is load-bearing and the mutant is runnable)"
+  fi
+fi
+
+# ── R1: resume.sh, incomplete intake -> the intake first-message ─────────────
+echo "=== R1-resume-intake-branch ==="
+D="$TOPTMP/r1"; mk_proj "$D" 25 0
+cp "$RESUME" "$D/scripts/resume.sh" 2>/dev/null || true
+R1_OUT=$( cd "$D" && bash "$RESUME" </dev/null 2>/dev/null )
+if printf '%s' "$R1_OUT" | grep -q 'intake' && printf '%s' "$R1_OUT" | grep -qi 'copy everything below'; then
+  pass "R1-resume-intake-branch (an unfinished intake gets the intake first-message with the copy-delimiter convention)"
+else
+  fail_ "R1-resume-intake-branch" "resume.sh did not branch on an unfinished intake: $(printf '%s' "$R1_OUT" | head -2 | tr '\n' '|')"
+fi
+
+# ── R2: resume.sh, stranded -> §13's block verbatim ──────────────────────────
+echo "=== R2-resume-stranded-branch ==="
+D="$TOPTMP/r2"; mk_proj "$D" 3 0
+R2_OUT=$( cd "$D" && bash "$RESUME" </dev/null 2>/dev/null )
+if printf '%s' "$R2_OUT" | grep -q 'BL202-S13-SENTINEL'; then
+  pass "R2-resume-stranded-branch (intake done + Phase 0 unstarted -> the project's own Section 13 prompt, verbatim)"
+else
+  fail_ "R2-resume-stranded-branch" "resume.sh did not surface the Section 13 block: $(printf '%s' "$R2_OUT" | head -2 | tr '\n' '|')"
+fi
+
+# ── R3: resume.sh, normal project -> today's behavior unchanged ──────────────
+echo "=== R3-resume-normal-unchanged ==="
+D="$TOPTMP/r3"; mk_proj "$D" 3 2
+printf '# manifesto\n' > "$D/PRODUCT_MANIFESTO.md"
+printf '# claude\n' > "$D/CLAUDE.md"
+R3_OUT=$( cd "$D" && bash "$RESUME" </dev/null 2>/dev/null )
+if printf '%s' "$R3_OUT" | grep -q 'We are resuming work'; then
+  pass "R3-resume-normal-unchanged (a mid-flight project still gets the classic resume prompt)"
+else
+  fail_ "R3-resume-normal-unchanged" "the classic resume prompt is gone: $(printf '%s' "$R3_OUT" | head -2 | tr '\n' '|')"
+fi
+
+echo ""
+if [ "$SKIPPED" -gt 0 ]; then echo "($SKIPPED skipped)"; fi
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-bl202-session-intake-check.sh
+++ b/tests/test-bl202-session-intake-check.sh
@@ -21,7 +21,6 @@ RESUME="$REPO_ROOT/scripts/resume.sh"
 
 PASSED=0
 FAILED=0
-SKIPPED=0
 pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
 fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
 
@@ -128,7 +127,42 @@ else
   elif grep -q 'INTAKE INCOMPLETE' "$TOPTMP/h6.log"; then
     fail_ "H6-mutation-detect-fence" "excising the detection fence did NOT silence the incomplete arm — the fence is not cutting what it claims"
   else
-    pass "H6-mutation-detect-fence (excised detection -> the incomplete arm goes dark while the mutant runs clean — the fence is load-bearing and the mutant is runnable)"
+    # Negative control (the R-BL203-13 lesson, run rather than claimed): the
+    # INTACT hook on the same fixture must still speak, or this case cannot
+    # tell an excision from a hook that never fires.
+    ( cd "$D" && bash "$HOOK" </dev/null ) > "$TOPTMP/h6-intact.log" 2>/dev/null || true
+    if grep -q 'INTAKE INCOMPLETE' "$TOPTMP/h6-intact.log"; then
+      pass "H6-mutation-detect-fence (excised -> dark, intact -> speaks, mutant runnable — the fence is load-bearing and the case discriminates)"
+    else
+      fail_ "H6-mutation-detect-fence" "NEGATIVE CONTROL FAILED — the intact hook did not fire on the incomplete fixture, so this case cannot discriminate"
+    fi
+  fi
+fi
+
+# ── H7: the predicate against the REAL template (review R-BL202-1) ───────────
+# The suite's hand-rolled fixtures could not see the shipped predicate counting
+# EVERY table row (constant 258, filled or not). Pin discrimination against the
+# artifact that matters: the shipped template must read INCOMPLETE, and the same
+# file with every blank cell filled must read complete.
+echo "=== H7-template-predicate-discriminates ==="
+TPL="$REPO_ROOT/templates/project-intake.md"
+if [ ! -f "$TPL" ]; then
+  fail_ "H7-template-predicate-discriminates" "template missing at $TPL"
+else
+  D="$TOPTMP/h7"; mkdir -p "$D/.claude"
+  printf '{"current_phase": "0"}\n' > "$D/.claude/phase-state.json"
+  cp "$TPL" "$D/PROJECT_INTAKE.md"
+  run_hook "$D" "$TOPTMP/h7a.log"
+  sed 's/|[[:space:]]*|$/| filled |/' "$TPL" > "$D/PROJECT_INTAKE.md"
+  H7_BLANKS=$(grep -cE '\| *\|$' "$D/PROJECT_INTAKE.md" || true)  # lint-counter-antipattern: allow — sanitized on the next line to 1, not 0: zero is this assertion's PASS value, so the fail-safe default must be nonzero
+  case "$H7_BLANKS" in ''|*[!0-9]*) H7_BLANKS=1 ;; esac
+  run_hook "$D" "$TOPTMP/h7b.log"
+  if grep -q 'INTAKE INCOMPLETE' "$TOPTMP/h7a.log" \
+     && [ "${H7_BLANKS:-1}" = "0" ] \
+     && ! grep -q 'INTAKE INCOMPLETE' "$TOPTMP/h7b.log"; then
+    pass "H7-template-predicate-discriminates (the SHIPPED template reads incomplete; the same file fully filled reads complete — the predicate discriminates on the real artifact)"
+  else
+    fail_ "H7-template-predicate-discriminates" "unfilled-fires=$(grep -c 'INTAKE INCOMPLETE' "$TOPTMP/h7a.log") filled-blanks=$H7_BLANKS filled-fires=$(grep -c 'INTAKE INCOMPLETE' "$TOPTMP/h7b.log") — the predicate does not discriminate on the shipped template (R-BL202-1)"
   fi
 fi
 
@@ -166,7 +200,6 @@ else
 fi
 
 echo ""
-if [ "$SKIPPED" -gt 0 ]; then echo "($SKIPPED skipped)"; fi
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ] || exit 1
 exit 0

--- a/tests/test-freshness-birth.sh
+++ b/tests/test-freshness-birth.sh
@@ -89,6 +89,19 @@ else
   fail_ "hook-injected" "no SessionStart entry for session-freshness-check.sh (settings.json present? $( [ -f "$PROJ/.claude/settings.json" ] && echo yes || echo no ))"
 fi
 
+# ── BL-202 (review R-BL202-2): the intake hook must be SHIPPED and INJECTED ──
+# A registered-but-unshipped hook is a failing SessionStart in every generated
+# project — the reviewer excised only the cp line and every PR-blocking check
+# stayed green. This is the birth-level pin that closes that hole.
+echo "=== BL-202 intake hook shipped + injected ==="
+if [ -f "$PROJ/scripts/session-intake-check.sh" ] && [ -x "$PROJ/scripts/session-intake-check.sh" ] \
+   && jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("session-intake-check.sh"))' \
+        "$PROJ/.claude/settings.json" >/dev/null 2>&1; then
+  pass "session-intake-check.sh shipped (executable) and injected into SessionStart"
+else
+  fail_ "bl202-hook-birth" "shipped=$( [ -f "$PROJ/scripts/session-intake-check.sh" ] && echo yes || echo no ) exec=$( [ -x "$PROJ/scripts/session-intake-check.sh" ] && echo yes || echo no ) injected=$( jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("session-intake-check.sh"))' "$PROJ/.claude/settings.json" >/dev/null 2>&1 && echo yes || echo no )"
+fi
+
 # ── DAY-ZERO SILENCE — zero bytes stdout+stderr, exit 0 ──────────────────────
 echo "=== day-zero silence ==="
 d0_out="$(CDF_HOME="$NOCDF" CLAUDE_PROJECT_DIR="$PROJ" bash "$SUT" 2>"$TOPTMP/d0.err")"; d0_rc=$?

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -633,6 +633,24 @@ else
 fi
 
 echo ""
+echo "T-bl202-prints-and-registration: every dead-air surface names the same next step"
+INITF="$REPO_ROOT/init"; INITF="${INITF}.sh"
+BL202_OK=1
+grep -qF "Paste the first message printed by:  bash scripts/resume.sh" "$WIZARD" || BL202_OK=0
+grep -qF "a blank Claude Code screen means it is ready and waiting, not stuck" "$WIZARD" || BL202_OK=0
+grep -qF "https://claude.com/claude-code" "$WIZARD" || BL202_OK=0
+grep -qF "When you've filled it in, run: bash scripts/resume.sh" "$WIZARD" || BL202_OK=0
+grep -qF "# BL-202-INTAKE-HOOK-BEGIN" "$INITF" || BL202_OK=0
+grep -qF 'session-intake-check.sh"))' "$INITF" || BL202_OK=0
+grep -qF -- "--- copy from here ---" "$INITF" || BL202_OK=0
+grep -qF "│ Read the following files in order" "$INITF" && BL202_OK=0   # only the PASTE block must be unboxed — other init boxes are out of BL-202 scope
+if [ "$BL202_OK" -eq 1 ]; then
+  pass "T-bl202-prints-and-registration (mode-1/2/3 prints converge on resume.sh, the hook is registered under its fence, and the box art is gone)"
+else
+  fail_ "T-bl202-prints-and-registration" "a BL-202 surface regressed: wizard prints, the SessionStart registration fence, or the copy-delimiter block"
+fi
+
+echo ""
 echo "T-bl203-mutation: excising the marked write line makes the answer a no-op again"
 D=$(mktemp -d)
 _bl203_fixture "$D"

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -634,15 +634,19 @@ fi
 
 echo ""
 echo "T-bl202-prints-and-registration: every dead-air surface names the same next step"
+# The split keeps the init-script token off executed lines — the BL-181/BL-154
+# unit-lane predicate reads names-on-executed-lines and would silently exempt
+# this file from the tests.yml membership lint. Do not "simplify" this back.
 INITF="$REPO_ROOT/init"; INITF="${INITF}.sh"
 BL202_OK=1
 grep -qF "Paste the first message printed by:  bash scripts/resume.sh" "$WIZARD" || BL202_OK=0
+grep -rqF "start-here" "$REPO_ROOT/scripts" && BL202_OK=0   # R-BL202-9: the undiscoverable alias stays dropped
 grep -qF "a blank Claude Code screen means it is ready and waiting, not stuck" "$WIZARD" || BL202_OK=0
 grep -qF "https://claude.com/claude-code" "$WIZARD" || BL202_OK=0
 grep -qF "When you've filled it in, run: bash scripts/resume.sh" "$WIZARD" || BL202_OK=0
 grep -qF "# BL-202-INTAKE-HOOK-BEGIN" "$INITF" || BL202_OK=0
 grep -qF 'session-intake-check.sh"))' "$INITF" || BL202_OK=0
-grep -qF -- "--- copy from here ---" "$INITF" || BL202_OK=0
+grep -qF "Then paste the first message printed by:  bash scripts/resume.sh" "$INITF" || BL202_OK=0
 grep -qF "│ Read the following files in order" "$INITF" && BL202_OK=0   # only the PASTE block must be unboxed — other init boxes are out of BL-202 scope
 if [ "$BL202_OK" -eq 1 ]; then
   pass "T-bl202-prints-and-registration (mode-1/2/3 prints converge on resume.sh, the hook is registered under its fence, and the box art is gone)"


### PR DESCRIPTION
Implements BL-202 per its corrected entry: a new SessionStart hook (`scripts/session-intake-check.sh`) puts the intake/Phase-0 state into Claude's context on every launch surface (silent when healthy, nag-once ack contract, fail-open on all 11 hostile-input shapes the review threw at it); `scripts/resume.sh` becomes the single state-aware first-message generator (intake prompt → the project's own Intake §13 verbatim → classic resume); every wizard/init print converges on that one generator, and the drag-unfriendly box art is gone.

**Adversarial review (standing gate): three rounds, twenty findings, final verdict `approve`.** Round 1 `block`: the blank-cell predicate — inherited verbatim from validate.sh — counted EVERY table row (constant 258 on real intakes: the nag fired forever and two of the three user-facing states were dead code; the reviewer proved it live with the real renderer). Fixed in all three files under a SYNC SIBLINGS marker — validate.sh's pre-existing bug included — and pinned by a case that fixtures the SHIPPED template (87/86/0 discrimination; the reviewer verified H7 is the ONLY case that catches the old regex). Also from review: a birth pin (shipped+executable+injected after a real scaffold — the reviewer's clean-unship mutation survived every PR-blocking check until it existed), the honest SessionStart contract (stdout is Claude's context, not operator-visible text; `initialUserMessage` recorded on BL-202 as the follow-up), print consolidation, a jq-absent guard on the ack read, and a scope catch (four stray scratch files swept in by `git add -A` — removed). E12a/E12b re-aimed with recorded rationale (their old fixture state IS the state whose contract this changes).

Suites: bl202 10/0 (8 watched RED first + 2 pins); wizard-fixes 19/0; edge 74/0 (E12/E56); freshness-birth 7/0 with both reviewer mutations red; lints 11/11; backlog lint attested post-commit.

---
**TL;DR (plain English):** New projects no longer greet you with a dead blank screen and no clue. Claude now knows on session start whether your intake questionnaire is finished and says so in its first reply, one command prints exactly what to paste at every stage, and all the setup instructions point at that one command. The reviewer found the fix's own worst bug — a counter that said '258 unfilled fields' even on a finished questionnaire — plus a way the new file could silently go missing from new projects; both are fixed with permanent tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)