### PR TITLE
fix(bl201): float the 22 semgrep template pins and log the scanner version

### DIFF
--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -1210,10 +1210,12 @@ if command -v semgrep &>/dev/null; then
       #   PROJECT ACTUALLY HAS — AND NOTE WHICH SEMGREP THAT IS, BECAUSE THERE ARE TWO.
       #   THIS HOOK runs whatever `semgrep` is on the operator's PATH and pins nothing, so
       #   "it passed on my host" is not evidence about the host that will run it. The CI
-      #   SAST job is a DIFFERENT surface and IS pinned — every generated CI template that
-      #   runs semgrep pins `image: semgrep/semgrep:1.170.0`, one release below the 1.171.0
-      #   version on which this instrument goes blind (BL-192), so a routine currency bump
-      #   crosses that line for every generated project at once.
+      #   SAST job is a DIFFERENT surface and — since BL-201 — floats too: every generated
+      #   CI template that runs semgrep uses `image: semgrep/semgrep:latest` and logs
+      #   `semgrep --version` in the job (# BL-201-FLOAT). Both surfaces therefore track
+      #   current semgrep, already past the 1.171.0 blindness line of BL-192 — which is
+      #   safe only because BL-198 removed every clause that reads semgrep's self-report;
+      #   the job log, not a pin, answers which version scanned any given run.
       # BL-187-RULE-COVERAGE (parse) — THE THIRD FACT, AND THE ONE THE FIRST TWO
       # STRUCTURALLY CANNOT SEE. Selection is fixed before a byte is parsed; the parse
       # percentage is fixed once the AST exists. Neither is touched by what happens NEXT:

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -7092,6 +7092,10 @@ pre-existing, and NARROWED by this fix, which now catches the whole-script-comme
 old suite passed 60/0) are filed as BL-206. R-BL201-4 (supply-chain: `:latest` vs the prior
 mutable `1.170.0` tag is the same registry-compromise exposure; only a digest pin differs, and
 digest-pinning is the staleness posture this entry's decision rejects) recorded, no action.
+Confirm round on the delta: **minor_concerns, safe to open** — M8a/M8b confirmed dead against the
+deny-by-default sweep, zero refuted claims, no regression on numeric pins, no false positives on
+the tree's 20 legitimate comment mentions; its one new note-level find (R-BL201-5, the
+quote-blind comment strip) is named in the sweep header and filed on BL-206 item 3.
 
 **Related:** BL-192 (both decision blocks), BL-198 (the gate this waited on), BL-147 (the parity
 suite that moved in the same diff), BL-193 (the version-archaeology cost that motivates the
@@ -7380,7 +7384,7 @@ R-BL201-3 — and filed as named limits rather than silently accepted)
 the shipped templates; the primary enforcement (Cg2/Cg3 github coverage, the Cg4/Cg5 anchors,
 the Cg-no-repin sweep) is unaffected.
 
-Two residuals, one family — the suite's predicates read bytes, not semantics:
+Three residuals, one family — the suite's predicates read bytes, not semantics:
 
 1. **Vacuous version log (R-BL201-2).** Cg4-/Cg5-version-log accept any executable line
    CONTAINING `semgrep --version` — measured: `run: echo semgrep --version` satisfies the pin
@@ -7395,12 +7399,20 @@ Two residuals, one family — the suite's predicates read bytes, not semantics:
    NONGH_SEMGREP census, while Cg5-version-log stays green off the intact version line.
    Pre-existing: at pre-BL-201 main the whole-script-commented variant survived 60/0; BL-201's
    Cg5-version-log narrowed the window to this scan-line-only variant.
+3. **Quote-blind comment strip (R-BL201-5, confirm round).** Cg-no-repin's `sed 's/#.*//'`
+   truncates at a `#` INSIDE a quoted scalar, so a pinned ref later on the same line escapes —
+   measured: `run: echo 'a#b' && docker run semgrep/semgrep:1.170.0` planted outside the
+   per-file lists survives 63/0. Contrived carriers only (`${VAR#prefix}`, URL fragments); the
+   failure direction is safe (truncation can only DROP lines from the deny set, never accuse a
+   clean one), and the per-file anchors remain the primary enforcement. Named in the
+   `# BL-201-FLOAT-SWEEP` header.
 
 **Fix shape:** a Cg2-analogue for non-github templates (an executable `semgrep scan --config`
 line required, `^[^#]*`-guarded) closes item 2 cheaply, and `extract_semgrep_policy` should strip
 comments so a commented DECOY line can never become the compared policy (the Cg-derive fixtures'
-prose-immunity discipline, applied to the template side). Item 1 stays a named limit unless the
-suite gains a render-and-execute stage.
+prose-immunity discipline, applied to the template side). Item 3 wants a quote-aware strip (awk)
+or standing acceptance as a named limit. Item 1 stays a named limit unless the suite gains a
+render-and-execute stage.
 
 **Status:** Open
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -7048,11 +7048,35 @@ clause reads anything semgrep prints, and version drift can only ever ADD findin
 **Adjacent, noted not scoped:** the emitted hook's receipt could print the scanner version for the
 same debuggability (BL-193 cost a day partly to version archaeology). One line; decide at build.
 
-**Status:** Open — unblocked 2026-07-30 (BL-198 implemented in `02eaa0f`).
+**Status:** Closed — implemented 2026-07-31 on `fix/bl201-float-semgrep-pins` (`cd35254`; markers
+`# BL-201-FLOAT` at all 22 template sites, `# BL-201-FLOAT-ASSERT` / `# BL-201-FLOAT-SWEEP` in
+tests/test-bl147-ci-template-integrity.sh). The floating form decided at build is the explicit
+`image: semgrep/semgrep:latest` — semgrep's own CI docs use both the bare and `:latest` spellings;
+the explicit tag is grep-able and lets the suite demand an EXACT anchored match. Every semgrep job
+logs `semgrep --version` before the scan (github: a dedicated step; gitlab block/flow and
+bitbucket flow scripts: the first command). Deliverable 3 landed in the same diff, as this entry
+required: Cg4-container/Cg5-image now demand the exact anchored `:latest` (a re-pinned
+`semgrep/semgrep:X.Y.Z` fails BY DESIGN), new Cg4-/Cg5-version-log cases pin an EXECUTABLE log
+line (comment-immune `^[^#]*`, the Cg7 house pattern), a new Cg-no-repin sweep refuses a pinned
+semgrep image ANYWHERE under templates/pipelines (the backstop for files outside the per-file
+lists), and the R2-7 failure-message fix shipped — the messages now state that the checks demand
+the floating tag / an executable log line. hook-templates.sh's "the CI surface IS pinned" comment
+was corrected in the same diff (rendered emitted hook verified verbatim — render, not grep).
+Proofs: RED 58/5 on the pinned tree, GREEN 63/0; five mutants (re-pinned github, deleted github
+log step, commented-out gitlab log line, re-pinned bitbucket, a pin planted OUTSIDE the per-file
+lists — the last caught ONLY by the sweep, its unique value) each failed EXACTLY the expected
+case(s) with empty stderr, intact control green; suites bl112 13/0, bl118 7/0, bl125 22/0,
+bl131 18/0, bl132 56/0; lints 11/11. The adjacent hook-receipt version line ("one line; decide at
+build") is DEFERRED, decided: 63 test references pin the `[OK] semgrep` receipt text, so one debug
+line does not justify moving that surface in this diff — it rides with BL-200, which reworks the
+same hook region. Observed while verifying, pre-existing and NOT this change's:
+`templates/pipelines/ci/gitlab/java.yml` fails strict libyaml parse (colons in the maven
+dependencies flow scalar, present at the pre-change HEAD; GitLab's own parser accepts it) — noted
+for housekeeping. gitleaks stays version-pinned (Cg6): the float decision is semgrep-specific.
 
-**Related:** BL-192 (both decision blocks), BL-198 (the gate this waits on), BL-147 (the parity
-suite that must move in the same diff), BL-193 (the version-archaeology cost that motivates the
-logging).
+**Related:** BL-192 (both decision blocks), BL-198 (the gate this waited on), BL-147 (the parity
+suite that moved in the same diff), BL-193 (the version-archaeology cost that motivates the
+logging), BL-200 (carries the deferred hook-receipt version line).
 
 ---
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -7074,9 +7074,29 @@ same hook region. Observed while verifying, pre-existing and NOT this change's:
 dependencies flow scalar, present at the pre-change HEAD; GitLab's own parser accepts it) — noted
 for housekeeping. gitleaks stays version-pinned (Cg6): the float decision is semgrep-specific.
 
+**UPDATE 2026-07-31 (pre-PR adversarial review round):** verdict **minor_concerns**, non-blocking;
+zero refuted claims — the reviewer independently reproduced the RED/GREEN tallies to the digit and
+all five documented mutants (plus its own quoted-scalar and trailing-comment kill attempts, all
+caught). R-BL201-1 — the sweep's first cut matched only `:[0-9]`, so a DIGEST pin (`@sha256:…`,
+the STRONGEST pin form) or a named tag (`:canary`) planted OUTSIDE the per-file lists survived —
+fixed in this same PR: Cg-no-repin is now deny-by-default (after comment-stripping, any executable
+line carrying `semgrep/semgrep` must carry exactly `semgrep/semgrep:latest` at a tag boundary;
+numeric, digest, named-tag, `:latest-nonroot`, and bare spellings all refused). Re-proved with a
+six-probe battery + intact control: digest/canary/bare/nonroot each fail EXACTLY Cg-no-repin with
+empty stderr; a whole-line comment mention leaves the suite green; a trailing-comment mention
+leaves the SWEEP silent while the Cg5-image anchor still fails loudly (primary enforcement, as
+designed); intact 63/0. R-BL201-2 (a vacuous `run: echo semgrep --version` satisfies the
+version-log pin — the `^[^#]*` house pattern's known ceiling) and R-BL201-3 (`extract_semgrep_policy`
+is comment-blind and no case demands non-github templates carry an EXECUTABLE scan line —
+pre-existing, and NARROWED by this fix, which now catches the whole-script-commented variant the
+old suite passed 60/0) are filed as BL-206. R-BL201-4 (supply-chain: `:latest` vs the prior
+mutable `1.170.0` tag is the same registry-compromise exposure; only a digest pin differs, and
+digest-pinning is the staleness posture this entry's decision rejects) recorded, no action.
+
 **Related:** BL-192 (both decision blocks), BL-198 (the gate this waited on), BL-147 (the parity
 suite that moved in the same diff), BL-193 (the version-archaeology cost that motivates the
-logging), BL-200 (carries the deferred hook-receipt version line).
+logging), BL-200 (carries the deferred hook-receipt version line), BL-206 (the review round's two
+grep-level residuals).
 
 ---
 
@@ -7348,3 +7368,41 @@ F-DF2-015, `evaluation-prompts/v2-concepts/post-mvp-feature-development.md` (the
 adjacent, unwired).
 
 **Status:** Open
+
+---
+
+## BL-206: test-bl147's semgrep predicates are grep-level — a vacuous version log satisfies the pin, and a non-github template can lose its scan line to a comment while parity stays green
+
+**Logged:** 2026-07-31 (both surfaced by BL-201's pre-PR adversarial review — R-BL201-2 /
+R-BL201-3 — and filed as named limits rather than silently accepted)
+**Category:** Test-suite hardening / generated-project CI
+**Severity:** Low. Both are decay/tamper windows in the suite's own instruments, not defects in
+the shipped templates; the primary enforcement (Cg2/Cg3 github coverage, the Cg4/Cg5 anchors,
+the Cg-no-repin sweep) is unaffected.
+
+Two residuals, one family — the suite's predicates read bytes, not semantics:
+
+1. **Vacuous version log (R-BL201-2).** Cg4-/Cg5-version-log accept any executable line
+   CONTAINING `semgrep --version` — measured: `run: echo semgrep --version` satisfies the pin
+   (suite 63/0). This is the documented ceiling of the `^[^#]*` house pattern (Cg7, PR #244): a
+   grep cannot cheaply verify execution semantics. A real fix renders/executes the job script —
+   the render-class work, not a one-line widen.
+2. **Comment-blind parity extraction (R-BL201-3).** `extract_semgrep_policy` greps the first
+   `semgrep (scan )?--config` line WITHOUT comment-stripping, and no case requires non-github
+   templates to carry an EXECUTABLE `semgrep scan` line (Cg2 covers github only). Measured at the
+   BL-201 tip: commenting out ONLY the `- semgrep scan …` line of gitlab/python.yml survives
+   63/0 — the commented line still feeds the parity comparison AND keeps the template in the
+   NONGH_SEMGREP census, while Cg5-version-log stays green off the intact version line.
+   Pre-existing: at pre-BL-201 main the whole-script-commented variant survived 60/0; BL-201's
+   Cg5-version-log narrowed the window to this scan-line-only variant.
+
+**Fix shape:** a Cg2-analogue for non-github templates (an executable `semgrep scan --config`
+line required, `^[^#]*`-guarded) closes item 2 cheaply, and `extract_semgrep_policy` should strip
+comments so a commented DECOY line can never become the compared policy (the Cg-derive fixtures'
+prose-immunity discipline, applied to the template side). Item 1 stays a named limit unless the
+suite gains a render-and-execute stage.
+
+**Status:** Open
+
+**Related:** BL-201 (the review that surfaced both), BL-147 (the suite), BL-181 (the
+mention-vs-execution class), BL-197 (failure-message honesty — the R2-7 sibling).

--- a/templates/pipelines/ci/bitbucket/python.yml
+++ b/templates/pipelines/ci/bitbucket/python.yml
@@ -19,8 +19,9 @@ pipelines:
               - pytest
         - step:
             name: SAST
-            image: semgrep/semgrep:1.170.0
-            script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+            # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+            image: semgrep/semgrep:latest
+            script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
         - step:
             name: Secrets
             image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/bitbucket/typescript.yml
+++ b/templates/pipelines/ci/bitbucket/typescript.yml
@@ -17,8 +17,9 @@ pipelines:
               - npm test -- --ci
         - step:
             name: SAST
-            image: semgrep/semgrep:1.170.0
-            script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+            # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+            image: semgrep/semgrep:latest
+            script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
         - step:
             name: Secrets
             image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -129,10 +129,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -128,10 +128,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -131,10 +131,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -136,10 +136,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -136,10 +136,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -149,10 +149,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -150,10 +150,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -134,10 +134,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -151,10 +151,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -151,10 +151,13 @@ jobs:
   sast:
     runs-on: ubuntu-latest
     container:
-      image: semgrep/semgrep:1.170.0
+      # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+      image: semgrep/semgrep:latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
         with:
           fetch-depth: 0
+      - name: Security - SAST scanner version
+        run: semgrep --version
       - name: Security - SAST (Semgrep)
         run: semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error

--- a/templates/pipelines/ci/gitlab/csharp.yml
+++ b/templates/pipelines/ci/gitlab/csharp.yml
@@ -13,8 +13,9 @@ test:
     - dotnet test --no-build
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/dart.yml
+++ b/templates/pipelines/ci/gitlab/dart.yml
@@ -16,8 +16,9 @@ test:
     - dart test
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/go.yml
+++ b/templates/pipelines/ci/gitlab/go.yml
@@ -15,8 +15,9 @@ test:
   script: [go test ./...]
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/java.yml
+++ b/templates/pipelines/ci/gitlab/java.yml
@@ -12,8 +12,9 @@ test:
   script: [mvn -B test --no-transfer-progress]
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/kotlin.yml
+++ b/templates/pipelines/ci/gitlab/kotlin.yml
@@ -12,8 +12,9 @@ test:
     - gradle detekt --no-daemon 2>/dev/null || true
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/other.yml
+++ b/templates/pipelines/ci/gitlab/other.yml
@@ -10,8 +10,9 @@ test:
     - exit 1  # intentional — CI should not pass until builder configures this
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/python.yml
+++ b/templates/pipelines/ci/gitlab/python.yml
@@ -38,8 +38,10 @@ test:
 
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
   script:
+    - semgrep --version
     - semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error
 
 secrets:

--- a/templates/pipelines/ci/gitlab/rust.yml
+++ b/templates/pipelines/ci/gitlab/rust.yml
@@ -16,8 +16,9 @@ test:
     - cargo test --all-features
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/swift.yml
+++ b/templates/pipelines/ci/gitlab/swift.yml
@@ -11,8 +11,9 @@ test:
     - swift test
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
-  script: [semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
+  script: [semgrep --version, semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error]
 secrets:
   stage: security
   image: ghcr.io/gitleaks/gitleaks:v8.30.1

--- a/templates/pipelines/ci/gitlab/typescript.yml
+++ b/templates/pipelines/ci/gitlab/typescript.yml
@@ -37,8 +37,10 @@ test:
 
 sast:
   stage: security
-  image: semgrep/semgrep:1.170.0
+  # BL-201-FLOAT: the tag floats deliberately — a pinned scanner silently stops catching new vulnerabilities (backlog BL-201); the job logs semgrep --version. Do not re-pin without reversing that decision.
+  image: semgrep/semgrep:latest
   script:
+    - semgrep --version
     - semgrep scan --config=p/owasp-top-ten --config=r/javascript.browser.security.insecure-document-method --config=.semgrep/soif-dom-sinks.yml --severity=ERROR --error
 
 secrets:

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -238,8 +238,10 @@ fi
 #        semgrep/semgrep:latest` container AND logs `semgrep --version` (BL-201)
 #   Cg5  every non-github (gitlab+bitbucket) semgrep step uses the floating
 #        image with hook-parity config/severity/--error flags AND a version log
-#   Cg-no-repin  no templates/pipelines file pins `semgrep/semgrep:X.Y.Z`
-#        anywhere (backstop beyond the Cg4/Cg5 per-file lists)
+#   Cg-no-repin  every executable `semgrep/semgrep` reference under
+#        templates/pipelines is EXACTLY `:latest` — numeric/digest/named-tag
+#        pins and the bare spelling all refused (backstop beyond the
+#        Cg4/Cg5 per-file lists)
 #   Cg6  every non-github gitleaks step is modernized: no `detect --source`,
 #        runs `gitleaks dir`/`git`, off zricethezav, version-pinned image
 
@@ -630,18 +632,31 @@ else
   if [ -z "$n_bade" ];   then pass "Cg5-error-parity"; else fail_ "Cg5-error-parity" "--error presence != hook in:$n_bade"; fi
 fi
 
-# ── Cg-no-repin: no pinned semgrep image anywhere under templates/pipelines ──
+# ── Cg-no-repin: every executable semgrep/semgrep ref is EXACTLY :latest ────
 # BL-201-FLOAT-SWEEP: Cg4/Cg5 anchor only the files in TODAY'S lists; this
-# sweep (Cg1's shape) is the backstop that catches a version-pinned semgrep
-# image in a file those lists never see — a new template family, a release
-# pipeline, a copy-paste. gitleaks pins are untouched: the pattern is
-# semgrep-specific by construction.
-echo "Cg-no-repin: no templates/pipelines file pins semgrep/semgrep:X.Y.Z"
-repin="$(grep -rlE 'semgrep/semgrep:[0-9]' "$PIPE_DIR" 2>/dev/null | sed "s|$REPO_ROOT/||" | tr '\n' ' ')"
+# sweep is the backstop that catches a pinned semgrep image in a file those
+# lists never see — a new template family, a release pipeline, a copy-paste.
+# The predicate is deny-by-default (review R-BL201-1: the first cut matched
+# only `:[0-9]` and a DIGEST pin `@sha256:…` — the STRONGEST pin form — plus
+# named tags like `:canary` sailed through): after stripping comments
+# (whole-line and trailing), any line still carrying `semgrep/semgrep` must
+# carry `semgrep/semgrep:latest` at a tag boundary, so numeric tags, digests,
+# named tags, `:latest-nonroot`, and the BARE floating spelling are ALL
+# refused — one canonical form. Named residual, not papered over: the check
+# is line-granular, so a single line carrying both an acceptable and a
+# pinned ref escapes (the per-file Cg4/Cg5 anchors are the primary
+# enforcement; this is the breadth backstop). gitleaks pins are untouched:
+# the pattern is semgrep-specific by construction.
+echo "Cg-no-repin: every executable semgrep/semgrep reference under templates/pipelines is exactly :latest"
+repin="$(grep -rn 'semgrep/semgrep' "$PIPE_DIR" 2>/dev/null \
+  | sed 's/#.*//' \
+  | grep 'semgrep/semgrep' \
+  | grep -Ev 'semgrep/semgrep:latest([^A-Za-z0-9._-]|$)' \
+  | cut -d: -f1 | sort -u | sed "s|$REPO_ROOT/||" | tr '\n' ' ')"
 if [ -z "$repin" ]; then
   pass "Cg-no-repin"
 else
-  fail_ "Cg-no-repin" "version-pinned semgrep image found in: ${repin}(BL-201 floats the scanner deliberately — a pinned scanner silently stops catching new vulnerabilities; re-pinning requires reversing that recorded decision on the backlog, not a template edit)"
+  fail_ "Cg-no-repin" "non-:latest semgrep/semgrep reference on an executable line in: ${repin}(the ONLY accepted form is the exact tag semgrep/semgrep:latest — numeric tags, @sha256 digests, named tags like :canary, and the bare spelling all fail here; BL-201 floats the scanner deliberately, and re-pinning requires reversing that recorded decision on the backlog, not a template edit)"
 fi
 
 # ── Cg6: non-github gitleaks steps modernized (dir/git, pinned, off zricethezav)

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -642,11 +642,15 @@ fi
 # (whole-line and trailing), any line still carrying `semgrep/semgrep` must
 # carry `semgrep/semgrep:latest` at a tag boundary, so numeric tags, digests,
 # named tags, `:latest-nonroot`, and the BARE floating spelling are ALL
-# refused — one canonical form. Named residual, not papered over: the check
-# is line-granular, so a single line carrying both an acceptable and a
-# pinned ref escapes (the per-file Cg4/Cg5 anchors are the primary
-# enforcement; this is the breadth backstop). gitleaks pins are untouched:
-# the pattern is semgrep-specific by construction.
+# refused — one canonical form. Named residuals, not papered over: the
+# check is line-granular, so a single line carrying both an acceptable and
+# a pinned ref escapes; and the comment-strip is QUOTE-BLIND — a `#` inside
+# a quoted scalar truncates the strip mid-string, so a pinned ref AFTER it
+# on the same line escapes (review R-BL201-5; contrived carriers only, and
+# the failure direction is safe — truncation can only DROP lines from the
+# deny set, never accuse a clean one). The per-file Cg4/Cg5 anchors are the
+# primary enforcement; this is the breadth backstop. gitleaks pins are
+# untouched: the pattern is semgrep-specific by construction.
 echo "Cg-no-repin: every executable semgrep/semgrep reference under templates/pipelines is exactly :latest"
 repin="$(grep -rn 'semgrep/semgrep' "$PIPE_DIR" 2>/dev/null \
   | sed 's/#.*//' \

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -215,6 +215,15 @@ fi
 #   • gitlab + bitbucket: rename the semgrep image off returntocorp, bring the
 #     flags to hook parity, and modernize gitleaks (detect --source -> dir;
 #     :latest -> a version-pinned ghcr image).
+#   • BL-201 (2026-07-31): the semgrep image FLOATS (`semgrep/semgrep:latest`).
+#     Karl's recorded decision (backlog BL-201, rationale on BL-192): a pinned
+#     scanner ages out of new detections silently — stale is the invisible
+#     failure. The agreed price is reproducibility, paid consciously by logging
+#     `semgrep --version` in EVERY semgrep job. Cg4/Cg5 pin the floating tag
+#     AND the log line, and REFUSE a re-pinned (`semgrep/semgrep:X.Y.Z`) or
+#     log-less template. gitleaks stays version-pinned (Cg6) — the float
+#     decision is semgrep-specific, made safe by BL-198 (no gate clause reads
+#     anything semgrep prints, so version drift can only ADD findings loudly).
 #
 # PARITY DERIVATION (single source): the expected semgrep flag set is DERIVED
 # from the hook's own `semgrep scan` invocation in scripts/lib/hook-templates.sh
@@ -225,9 +234,12 @@ fi
 #        returntocorp/semgrep (GLOBAL — github, gitlab, bitbucket, release, …)
 #   Cg2  every github CI template carries a `semgrep scan --config` invocation
 #   Cg3  every github semgrep invocation's config/severity/--error EQUAL the hook
-#   Cg4  every github CI template declares the `image: semgrep/semgrep` container
-#   Cg5  every non-github (gitlab+bitbucket) semgrep step uses image:
-#        semgrep/semgrep with hook-parity config/severity/--error flags
+#   Cg4  every github CI template declares the FLOATING `image:
+#        semgrep/semgrep:latest` container AND logs `semgrep --version` (BL-201)
+#   Cg5  every non-github (gitlab+bitbucket) semgrep step uses the floating
+#        image with hook-parity config/severity/--error flags AND a version log
+#   Cg-no-repin  no templates/pipelines file pins `semgrep/semgrep:X.Y.Z`
+#        anywhere (backstop beyond the Cg4/Cg5 per-file lists)
 #   Cg6  every non-github gitleaks step is modernized: no `detect --source`,
 #        runs `gitleaks dir`/`git`, off zricethezav, version-pinned image
 
@@ -560,16 +572,28 @@ else
   if [ -z "$bade" ]; then pass "Cg3-error-parity (all carry --error)"; else fail_ "Cg3-error-parity" "--error presence != hook in:$bade"; fi
 fi
 
-# ── Cg4: github semgrep runs in the semgrep/semgrep container job ────────────
-echo "Cg4: every github CI template declares the semgrep/semgrep container"
-miss_img=""
+# ── Cg4: github semgrep runs in the FLOATING semgrep/semgrep container job ──
+# BL-201-FLOAT-ASSERT: the tag must be EXACTLY `:latest` — anchored to end of
+# line, so a re-pinned `semgrep/semgrep:X.Y.Z` fails BY DESIGN (reversing
+# BL-201 takes a recorded decision, not a quiet edit). The float's agreed
+# price is a `semgrep --version` log line in the job; `^[^#]*` (the Cg7 house
+# pattern, PR #244) rejects comment placements — a commented-out log line
+# must not satisfy the pin.
+echo "Cg4: every github CI template floats semgrep/semgrep:latest + logs the version"
+miss_img=""; miss_ver=""
 for f in "${GH_FILES[@]}"; do
-  grep -Eq '^[[:space:]]*image:[[:space:]]*semgrep/semgrep:[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' "$f" || miss_img="$miss_img ${f##*/}"
+  grep -Eq '^[[:space:]]*image:[[:space:]]*semgrep/semgrep:latest[[:space:]]*$' "$f" || miss_img="$miss_img ${f##*/}"
+  grep -Eq '^[^#]*semgrep --version' "$f" || miss_ver="$miss_ver ${f##*/}"
 done
 if [ -z "$miss_img" ]; then
-  pass "Cg4-container (all $GH_COUNT use image: semgrep/semgrep)"
+  pass "Cg4-container (all $GH_COUNT float image: semgrep/semgrep:latest)"
 else
-  fail_ "Cg4-container" "no 'image: semgrep/semgrep' container in:$miss_img"
+  fail_ "Cg4-container" "no floating 'image: semgrep/semgrep:latest' line — the check demands the EXACT tag ':latest' anchored at end of line, so a version-pinned image (e.g. :1.170.0) fails here on purpose (BL-201 floats the scanner; see the backlog entry before re-pinning) — in:$miss_img"
+fi
+if [ -z "$miss_ver" ]; then
+  pass "Cg4-version-log (all $GH_COUNT log semgrep --version)"
+else
+  fail_ "Cg4-version-log" "no executable 'semgrep --version' line — the image floats (BL-201), so the job log is the ONLY record of which scanner scanned a run; a comment mention does not count — in:$miss_ver"
 fi
 
 # ── Cg5: non-github semgrep steps — image rename + hook flag parity ─────────
@@ -583,15 +607,19 @@ if [ "${#NONGH_SEMGREP[@]}" -ge 12 ]; then
 else
   fail_ "Cg5-floor" "found ${#NONGH_SEMGREP[@]} non-github semgrep templates, expected >=12 — vacuous"
 fi
-n_badimg=""; n_badc=""; n_bads=""; n_bade=""
+# BL-201-FLOAT-ASSERT (non-github half) — same exact-`:latest` anchor and same
+# comment-immune version-log predicate as Cg4; see the note there.
+n_badimg=""; n_badver=""; n_badc=""; n_bads=""; n_bade=""
 for f in "${NONGH_SEMGREP[@]}"; do
-  grep -Eq '^[[:space:]]*image:[[:space:]]*semgrep/semgrep:[0-9]+\.[0-9]+\.[0-9]+[[:space:]]*$' "$f" || n_badimg="$n_badimg ${f#*/ci/}"
+  grep -Eq '^[[:space:]]*image:[[:space:]]*semgrep/semgrep:latest[[:space:]]*$' "$f" || n_badimg="$n_badimg ${f#*/ci/}"
+  grep -Eq '^[^#]*semgrep --version' "$f" || n_badver="$n_badver ${f#*/ci/}"
   extract_semgrep_policy "$f"
   [ "$EX_CONFIGS"  = "$HOOK_CONFIGS" ]  || n_badc="$n_badc ${f#*/ci/}(=$EX_CONFIGS)"
   [ "$EX_SEVERITY" = "$HOOK_SEVERITY" ] || n_bads="$n_bads ${f#*/ci/}"
   [ "$EX_ERROR"    = "$HOOK_ERROR" ]    || n_bade="$n_bade ${f#*/ci/}"
 done
-if [ -z "$n_badimg" ]; then pass "Cg5-image (all use image: semgrep/semgrep)"; else fail_ "Cg5-image" "no 'image: semgrep/semgrep' in:$n_badimg"; fi
+if [ -z "$n_badimg" ]; then pass "Cg5-image (all float image: semgrep/semgrep:latest)"; else fail_ "Cg5-image" "no floating 'image: semgrep/semgrep:latest' line — the check demands the EXACT tag ':latest' anchored at end of line, so a version-pinned image fails here on purpose (BL-201) — in:$n_badimg"; fi
+if [ -z "$n_badver" ]; then pass "Cg5-version-log (all log semgrep --version)"; else fail_ "Cg5-version-log" "no executable 'semgrep --version' line — the float's agreed price is that the job log answers 'what scanned this merge?'; a comment mention does not count — in:$n_badver"; fi
 if [ "$HOOK_POLICY_OK" -eq 0 ]; then   # BL-194-DERIVE-GATE (Cg5-image above is policy-independent, so it still runs)
   skip_ "Cg5-config-parity"   "no hook policy was derived (see Cg-derive)"
   skip_ "Cg5-severity-parity" "no hook policy was derived (see Cg-derive)"
@@ -600,6 +628,20 @@ else
   if [ -z "$n_badc" ];   then pass "Cg5-config-parity (all == '$HOOK_CONFIGS')"; else fail_ "Cg5-config-parity" "config set != hook in:$n_badc"; fi
   if [ -z "$n_bads" ];   then pass "Cg5-severity-parity"; else fail_ "Cg5-severity-parity" "severity != hook in:$n_bads"; fi
   if [ -z "$n_bade" ];   then pass "Cg5-error-parity"; else fail_ "Cg5-error-parity" "--error presence != hook in:$n_bade"; fi
+fi
+
+# ── Cg-no-repin: no pinned semgrep image anywhere under templates/pipelines ──
+# BL-201-FLOAT-SWEEP: Cg4/Cg5 anchor only the files in TODAY'S lists; this
+# sweep (Cg1's shape) is the backstop that catches a version-pinned semgrep
+# image in a file those lists never see — a new template family, a release
+# pipeline, a copy-paste. gitleaks pins are untouched: the pattern is
+# semgrep-specific by construction.
+echo "Cg-no-repin: no templates/pipelines file pins semgrep/semgrep:X.Y.Z"
+repin="$(grep -rlE 'semgrep/semgrep:[0-9]' "$PIPE_DIR" 2>/dev/null | sed "s|$REPO_ROOT/||" | tr '\n' ' ')"
+if [ -z "$repin" ]; then
+  pass "Cg-no-repin"
+else
+  fail_ "Cg-no-repin" "version-pinned semgrep image found in: ${repin}(BL-201 floats the scanner deliberately — a pinned scanner silently stops catching new vulnerabilities; re-pinning requires reversing that recorded decision on the backlog, not a template edit)"
 fi
 
 # ── Cg6: non-github gitleaks steps modernized (dir/git, pinned, off zricethezav)


### PR DESCRIPTION
## What

BL-201 (Karl's recorded decision, 2026-07-29): all 22 `image: semgrep/semgrep:1.170.0` pins under `templates/pipelines/ci/**` (10 github container jobs, 10 gitlab, 2 bitbucket) float to the explicit `image: semgrep/semgrep:latest` under `# BL-201-FLOAT` marker comments, and every semgrep job logs `semgrep --version` before the scan (github: a dedicated step; gitlab block/flow and bitbucket flow scripts: the first command) — the job log answers "what scanned this merge?", the agreed price of floating, paid consciously.

Sequencing rationale (from the entry): floating is safe only since BL-198 — no gate clause reads anything semgrep prints, so version drift can only ADD findings loudly. gitleaks stays version-pinned (Cg6); the float decision is semgrep-specific.

## The entry's named trap, handled in the same diff

`test-bl147`'s `Cg4-container`/`Cg5-image` REQUIRED the version-pinned form. They move here: both now demand the EXACT anchored `semgrep/semgrep:latest` (a re-pinned `X.Y.Z` fails BY DESIGN), joined by new `Cg4-/Cg5-version-log` cases (comment-immune `^[^#]*`, the Cg7 house pattern) and a deny-by-default `Cg-no-repin` sweep: after comment-stripping, any executable `semgrep/semgrep` reference anywhere under `templates/pipelines` must be exactly `:latest` — numeric tags, `@sha256` digests, named tags (`:canary`), `:latest-nonroot`, and the bare spelling all refused. The entry's R2-7 failure-message fix shipped (messages now state what the greps actually demand). `hook-templates.sh`'s now-false "the CI surface IS pinned" comment corrected — comment-only inside the quoted HOOKEOF heredoc, rendered-hook-verified.

## Proof

- **RED first**: 58 passed / 5 failed on the pinned tree — exactly the five new/changed cases, each for the stated reason. **GREEN**: 63/0.
- **Mutation batteries** (all with empty stderr and green intact controls): round 1 — re-pinned github, deleted github log step, commented-out gitlab log line, re-pinned bitbucket, a pin planted OUTSIDE the per-file lists (caught ONLY by the sweep — its unique value). Round 2, post-review — digest/`:canary`/bare/`:latest-nonroot` probes each fail exactly `Cg-no-repin`; whole-line comment mentions immune; a trailing-comment probe leaves the sweep silent while the `Cg5-image` anchor fails loudly (primary enforcement, as designed).
- **Suites**: bl147 63/0, bl112 13/0, bl118 7/0, bl125 22/0, bl131 18/0, bl132 56/0; lints 11/11. All 22 edited templates YAML-parse (`gitlab/java.yml`'s strict-libyaml wart is pre-existing and untouched — confirmed by diff).

## Review (standing gate: adversarial pr-review BEFORE PR creation)

Round 1 verdict **minor_concerns** (non-blocking), zero refuted claims — the reviewer independently reproduced the RED/GREEN tallies and all five mutants, and its own kill attempts (quoted scalars, trailing comments, vacuous-echo probes) were either caught or filed. R-BL201-1 (the sweep's first cut missed digest/named-tag pins outside the per-file lists — the reviewer's surviving M8a/M8b mutants) fixed in-PR (`87680ec`), re-proved. R-BL201-2/-3 filed as **BL-206**. R-BL201-4 recorded, no action (a mutable version tag carries the same registry-compromise exposure as `:latest`; digest pinning is the staleness posture the recorded decision rejects). Confirm round on the delta: **minor_concerns, "safe to open the pull request"** — M8a/M8b confirmed dead, zero refuted claims, no regression on numeric pins, no false positives on the tree's 20 legitimate comment mentions; its one new note-level find (R-BL201-5, the quote-blind comment strip — contrived carriers, fail-safe direction) is named in the sweep header and filed on BL-206 item 3 (`77ffc9e`/`dba92f2`).

Backlog: **BL-201 Closed** (`cd35254`, review rounds `87680ec`/`77ffc9e`); **BL-206 filed** (the suite's three grep-level residuals, each with a measured repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
