### PR TITLE
fix(bl208): quote the maven flow scalar — strict libyaml parses gitlab/java.yml

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -8100,7 +8100,7 @@ script: [mvn -B dependency:analyze org.owasp:dependency-check-maven:check --no-t
 ```
 
 Old libyaml (Psych / Ruby 2.6, libyaml 0.2.1) rejects colons inside plain scalars in flow
-sequences; modern parsers (PyYAML — every loader — and GitLab's own Go parser) accept it, which
+sequences; modern parsers (PyYAML — every loader — and current GitLab stacks, whose libyaml accepts it) do, which
 is why this survived unnoticed until BL-201's closure review ran a stricter probe. Pre-existing
 since the template was written; not introduced by any recent change.
 
@@ -8113,12 +8113,16 @@ ruby -ryaml -e 'YAML.load_file("templates/pipelines/ci/gitlab/java.yml")'
 A Python probe (`python3 -c 'import yaml; yaml.safe_load(open("templates/pipelines/ci/gitlab/java.yml"))'`)
 **wrongly passes** — PyYAML is lenient about colons in flow-context plain scalars where libyaml
 is not — so a Python check is not evidence this is fine; the ruby/libyaml probe is the one that
-reproduces the failure a stricter YAML consumer (or an older GitLab Runner's own bundled Psych)
+reproduces the failure an older libyaml-based consumer (e.g. Psych on Ruby 2.6)
 would hit.
 
 **Status:** Open — the fix ships on this same branch (`fix/bl208-java-yaml-strict-parse`: the
 single flow-scalar script item is double-quoted as one string so strict libyaml parses it, with
 no semantic change to the executed command). This entry closes at that branch's merge commit.
+Residual, recorded per review R-BL208-1: NO check in either lane strict-parses the 30 CI
+templates (nothing greps or loads them with a strict libyaml), so a recurrence of this exact
+wart merges green — reintroducing the unquoted line passed test-bl147 63/0 and all nine lint
+jobs by identity. Candidate follow-up: a ruby-guarded strict-parse arm in test-bl147.
 
 **Related:** BL-201 (the closure UPDATE where this was first observed and deferred to
 housekeeping).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -8074,3 +8074,51 @@ archive is the same defect).
 **Related:** BL-093 (the split that widens the surface), BL-196 (the marker-citation validator —
 same "the citation primitive has no guard" family), the BL-200 numbering note (cross-branch
 reservation discipline).
+
+---
+
+## BL-208: `templates/pipelines/ci/gitlab/java.yml` fails a STRICT libyaml parse — colons in the maven flow-scalar script item
+
+**Logged:** 2026-07-31 (pre-existing, first observed and noted for housekeeping on Closed
+BL-201's closure UPDATE: "Observed while verifying, pre-existing and NOT this change's:
+`templates/pipelines/ci/gitlab/java.yml` fails strict libyaml parse (colons in the maven
+dependencies flow scalar, present at the pre-change HEAD; GitLab's own parser accepts it) —
+noted for housekeeping")
+**Category:** Generated-project CI / template YAML correctness
+**Severity:** Low
+
+`templates/pipelines/ci/gitlab/java.yml` fails a STRICT libyaml parse:
+
+```
+found unexpected ':' while scanning a plain scalar at line 24 column 12
+```
+
+on the maven flow-scalar line:
+
+```
+script: [mvn -B dependency:analyze org.owasp:dependency-check-maven:check --no-transfer-progress]
+```
+
+Old libyaml (Psych / Ruby 2.6, libyaml 0.2.1) rejects colons inside plain scalars in flow
+sequences; modern parsers (PyYAML — every loader — and GitLab's own Go parser) accept it, which
+is why this survived unnoticed until BL-201's closure review ran a stricter probe. Pre-existing
+since the template was written; not introduced by any recent change.
+
+**REPRO COMMAND (do not substitute a Python probe — see below):**
+
+```
+ruby -ryaml -e 'YAML.load_file("templates/pipelines/ci/gitlab/java.yml")'
+```
+
+A Python probe (`python3 -c 'import yaml; yaml.safe_load(open("templates/pipelines/ci/gitlab/java.yml"))'`)
+**wrongly passes** — PyYAML is lenient about colons in flow-context plain scalars where libyaml
+is not — so a Python check is not evidence this is fine; the ruby/libyaml probe is the one that
+reproduces the failure a stricter YAML consumer (or an older GitLab Runner's own bundled Psych)
+would hit.
+
+**Status:** Open — the fix ships on this same branch (`fix/bl208-java-yaml-strict-parse`: the
+single flow-scalar script item is double-quoted as one string so strict libyaml parses it, with
+no semantic change to the executed command). This entry closes at that branch's merge commit.
+
+**Related:** BL-201 (the closure UPDATE where this was first observed and deferred to
+housekeeping).

--- a/templates/pipelines/ci/gitlab/java.yml
+++ b/templates/pipelines/ci/gitlab/java.yml
@@ -21,7 +21,7 @@ secrets:
   script: [gitleaks dir . --verbose --redact]
 dependencies:
   stage: security
-  script: [mvn -B dependency:analyze org.owasp:dependency-check-maven:check --no-transfer-progress]
+  script: ["mvn -B dependency:analyze org.owasp:dependency-check-maven:check --no-transfer-progress"]
 governance:
   stage: governance
   image: bash:5


### PR DESCRIPTION
First PR of the quick sweep (Karl's 2026-07-31 go). Two quote characters on one template line: the maven flow scalar in `templates/pipelines/ci/gitlab/java.yml` becomes a quoted string so old-libyaml consumers (Psych/Ruby 2.6) parse the file; the parsed VALUE is proven byte-identical across four parser configurations and cross-parser (ruby↔python), so the executed command is unchanged. Entry **BL-208** filed on the same branch (repro command included; a PyYAML probe wrongly passes — the entry says so) and closes at this merge.

Review (standing gate): **minor_concerns, mergeable** — zero refuted claims; the reviewer re-proved the sole-failure-on-main claim hermetically from git objects and verified diff minimality byte-wise. Its two prescribed amendments are applied in the final commit: the **unguarded-everywhere residual** is now recorded on the entry (the reviewer's reintroduction mutant passed test-bl147 63/0 and every lint by identity — nothing in any lane strict-parses the templates; ruby-guarded follow-up candidate named) and the GitLab-parser attribution corrected to the verified fact.

Delegated build (sonnet implementer per the model-selection policy) + fable review; supervisor merge on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)