### PR TITLE
fix(bl197): lint the diagnostic-destruction class — silenced-diagnostic failure reports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,9 @@
 #
 # Every job here is a PAIR of steps: a GATING step that runs the lint and
 # fails the job, and an INVENTORY step that re-runs the SAME lint with
-# `--list` to print the per-file PASS/FAIL roster. There are NINE such
-# pairs — one per job — and under `if: always()` the inventory step re-ran
+# `--list` to print the per-file PASS/FAIL roster. There are TEN such
+# pairs — one per job; BL-197's diagnostic-destruction-lint is the tenth —
+# and under `if: always()` the inventory step re-ran
 # the full scan on GREEN runs too, where nobody reads it. That doubled
 # every lint job. Measured on the counter-antipattern job (run 30297887996,
 # job 90083310253, main @ 9d71824): 207s gating + 204s inventory = 419s.
@@ -238,6 +239,32 @@ jobs:
       - name: Show PASS/FAIL inventory (on failure)
         if: failure()
         run: bash scripts/lint-no-live-remote-in-tests.sh --list || true
+
+  # BL-197: structural backstop for the DIAGNOSTIC-DESTRUCTION class — a
+  # failure report that discards the evidence needed to act on it. The
+  # gating predicate is the narrow one: a silenced command, a `||`, and a
+  # failure reporter in that arm, all on one line. Presence probes and the
+  # `2>&1 >/dev/null` capture idiom are carved out by measurement (see the
+  # linter header), and the truncated-evidence half is advisory-only under
+  # `--census`. See tests/test-lint-diagnostic-destruction.sh for the
+  # behavior suite.
+  #
+  # NOTE: not yet a required status check in branch protection — that is
+  # Karl's call. Adding it here makes it run on every PR; promoting it to
+  # required is a separate branch-protection change.
+  diagnostic-destruction-lint:
+    name: diagnostic-destruction-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
+
+      - name: Lint silenced-diagnostic failure reports (BL-197)
+        run: bash scripts/lint-diagnostic-destruction.sh
+
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
+        run: bash scripts/lint-diagnostic-destruction.sh --list || true
 
   # BL-103: portability backstop for evaluation-prompts/. The Phase 3→4 review
   # gate (BL-073) hands operators `evaluation-prompts/Projects/run-reviews.sh` as

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -384,6 +384,7 @@ jobs:
             tests/test-intake-wizard-fixes.sh
             tests/test-lint-backlog-references.sh
             tests/test-lint-counter-antipattern.sh
+            tests/test-lint-diagnostic-destruction.sh
             tests/test-lint-doc-anchors.sh
             tests/test-lint-fix-functions-stderr.sh
             tests/test-lint-no-live-remote.sh

--- a/init.sh
+++ b/init.sh
@@ -2470,7 +2470,7 @@ create_and_protect_remote() {
 
     print_info "Pushing initial commit..."
     # Try main first, fall back to master
-    host_push_initial main 2>/dev/null || host_push_initial master || { print_fail "Push failed — $remote_url exists but empty"; return 1; }
+    host_push_initial main 2>/dev/null || host_push_initial master || { print_fail "Push failed — $remote_url exists but empty"; return 1; } # lint-diag-ok: BL-197 — first-attempt noise only; the DECISIVE second attempt (master) is unsilenced, so the failing path still reaches the operator with the host's own words
     _record_phase2_step "pushed_initial"
 
     print_info "Configuring branch protection ($mode mode)..."

--- a/scripts/lint-diagnostic-destruction.sh
+++ b/scripts/lint-diagnostic-destruction.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# scripts/lint-diagnostic-destruction.sh — BL-197 structural backstop.
+#
+# THE DEFECT CLASS (diagnostic destruction)
+#   *A diagnostic that discards, truncates or blurs the evidence needed to
+#   act on the failure it is reporting.* It is the sibling of the
+#   silent-success class (print `[FAIL]`, then `exit 0`): there the VERDICT
+#   lies; here the verdict is correct and the EVIDENCE is destroyed. In all
+#   three measured instances the information was PRESENT and thrown away at
+#   the last step — a `>/dev/null 2>&1`, a `tail -N`, an `echo` naming a
+#   symptom rather than a number. See solo-orchestrator-backlog.md
+#   `## BL-197:` for the three instances and their measured cost (BL-184's
+#   cost BL-135 eight days across two ~3h full-lane runs).
+#
+#   The review question the entry states, which this lint mechanizes for
+#   exactly one shape:
+#     "When this arm fires, does its output contain what the reader needs
+#      to act — and was the underlying evidence available at that point?"
+#
+# ── WHAT GATES (DD1): silenced-diagnostic failure reports ────────────────
+#   A violation is the conjunction of THREE things on ONE line:
+#     (1) a command whose diagnostic stream goes to /dev/null —
+#         `>/dev/null 2>&1`, `1>/dev/null 2>&1`, `>/dev/null 2>/dev/null`
+#         (either order), `&>/dev/null`, `>&/dev/null`, bare `2>/dev/null`,
+#         or `2>&-`;
+#     (2) a `||` short-circuit AFTER that silencer;
+#     (3) a failure reporter invoked in that arm — `fail_`, `fail`,
+#         `print_fail` or `record_init_failure` followed by whitespace and
+#         a quote.
+#   Read together: the command FAILED, its own words were thrown away, and
+#   the sentence that replaces them is all the reader gets. That is the
+#   class, mechanized, with no cross-line inference.
+#
+# ── WHAT DOES NOT GATE, AND WHY (each carve-out was MEASURED) ────────────
+#   Counts below are from the tree of 2026-07-31 over the scanned globs.
+#
+#   • PRESENCE PROBES — `command -v X &>/dev/null && print_ok || fail
+#     "X not found"`. A probe emits no diagnostic; its non-zero status IS
+#     the whole message, so nothing is destroyed. 10 of 19 raw hits were
+#     this shape (all in scripts/validate.sh). Carved out by the head
+#     segment (text before the silencer) naming `command -v|-V`, `type`,
+#     `hash` or `which`. This is the "probing for optional tools" case
+#     BL-197 names as legitimate.
+#   • `2>&1 >/dev/null` — NOT a silencer. Order is load-bearing: this
+#     spelling points stderr at the PRIOR stdout (usually a capture) and
+#     only stdout at /dev/null, so the diagnostic SURVIVES. It is the
+#     repo's own evidence-preserving idiom; flagging it would be the
+#     cry-wolf failure mode BL-197 warns against. Every spelling in (1)
+#     above sends stderr to /dev/null; this one does not, and it is the
+#     only near-miss spelling in the repo.
+#   • A failure reporter reached by `&&` rather than `||` — there the
+#     command SUCCEEDED, so it had no diagnostic to destroy (e.g.
+#     `ls "$D"/*.tmp 2>/dev/null && { fail_ "leftover tmpfile"; }`, where
+#     the offending filenames reach stdout unsilenced).
+#   • Pure-comment lines, and the shape appearing inside a TRAILING
+#     comment (trailing comments are stripped, quote-aware, before the
+#     shape is matched — but the exemption marker is read from the raw
+#     line).
+#
+# ── WHAT IS ADVISORY, NOT GATING (DD2): truncated evidence ───────────────
+#   BL-197's second candidate shape is `tail -N` / `head -N` inside a
+#   failure-reporting expansion (`fail_ "…" "$(… tail -N …)"`) — instance
+#   2's `tail -8` that landed past the SAST section it was meant to show.
+#   The entry says this shape must "render its hits for review … rather
+#   than block outright", and the measurement says the same, louder:
+#     489 sites on today's tree; 216 even after narrowing to "the
+#     truncating expansion is the message's ONLY interpolation".
+#   Those are dominated by the legitimate idiom where the message already
+#   states the expectation and the observed value in words and the tail is
+#   supplementary context. A 216-row roster nobody reads would itself be
+#   diagnostic destruction. So DD2 renders ON DEMAND under `--census`,
+#   never gates, and is deliberately kept OUT of the `--list` roster so
+#   the reviewable roster stays reviewable.
+#
+#   SCOPE DECISION, stated plainly: BL-197's third instance (a message
+#   naming a symptom — "absent or unreadable" — instead of the number the
+#   operator needs) is NOT mechanized here. It is not structurally
+#   decidable: the candidate population is 1120 failure messages with no
+#   interpolation at all, most of which are correct. It stays a review
+#   question, and BL-197 stays open for it.
+#
+# ── SCOPE ────────────────────────────────────────────────────────────────
+#   Walks init.sh, scripts/*.sh, scripts/{lib,hooks,host-drivers}/*.sh,
+#   tests/*.sh, tests/{host-drivers,test-helpers}/*.sh — the operator- AND
+#   verification-facing surfaces. BL-197's accurate gap statement is that
+#   lint-fix-functions-stderr.sh covers `fix_*` functions on the operator
+#   surface while all three instances lived where it does not look: a test
+#   aggregator's delegates, a test case's failure message, and a
+#   heredoc-emitted hook body.
+#
+#   HEREDOC BODIES ARE SCANNED — the deliberate opposite of
+#   lint-fix-functions-stderr.sh, which skips them. Instance 3 lived in a
+#   heredoc-emitted hook body, so skipping them would exclude a third of
+#   the recorded class by construction.
+#
+#   Not scanned: docs/, Reports/, templates/, evaluation-prompts/ (that
+#   tree has its own lint, lint-evalprompts-portability.sh), this script,
+#   and its own behavior suite (whose fixtures are the class by design).
+#
+# ── EXEMPTION ────────────────────────────────────────────────────────────
+#   Append `# lint-diag-ok: <reason>` to the offending line. The reason is
+#   REQUIRED — an empty reason fails the lint, matching the allowlist
+#   semantics of lint-fix-functions-stderr.sh and
+#   lint-fail-emit-exit-status.sh. Use it where the suppression is real
+#   and justified, e.g. a first-attempt retry whose decisive second
+#   attempt is unsilenced.
+#
+# EXIT CODES
+#   0 — no violations (or --census, which never gates)
+#   1 — one or more violations found
+#   2 — invocation / I/O error
+#
+# USAGE
+#   bash scripts/lint-diagnostic-destruction.sh            # quiet pass/fail
+#   bash scripts/lint-diagnostic-destruction.sh --list     # PASS/FAIL roster
+#   bash scripts/lint-diagnostic-destruction.sh --census   # advisory DD2 rows
+#
+# PORTABILITY
+#   bash-3.2 safe: no associative arrays, no ${var,,}, no nullglob. Runs
+#   under `set -uo pipefail` (never `-e`: the scan must reach its summary).
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_PATH="$REPO_ROOT/scripts/lint-diagnostic-destruction.sh"
+OWN_SUITE_BASENAME="test-lint-diagnostic-destruction.sh"
+
+LIST_MODE=0
+CENSUS_MODE=0
+case "${1:-}" in
+  "") : ;;
+  --list)   LIST_MODE=1 ;;
+  --census) CENSUS_MODE=1 ;;
+  *)
+    echo "Usage: $0 [--list|--census]" >&2
+    exit 2
+    ;;
+esac
+
+TARGET_GLOBS=(
+  "$REPO_ROOT/init.sh"
+  "$REPO_ROOT/scripts"/*.sh
+  "$REPO_ROOT/scripts/lib"/*.sh
+  "$REPO_ROOT/scripts/hooks"/*.sh
+  "$REPO_ROOT/scripts/host-drivers"/*.sh
+  "$REPO_ROOT/tests"/*.sh
+  "$REPO_ROOT/tests/host-drivers"/*.sh
+  "$REPO_ROOT/tests/test-helpers"/*.sh
+)
+
+# ── DD1 atoms ────────────────────────────────────────────────────────────
+# (1) The silencer. Every alternative sends the command's DIAGNOSTIC to
+#     /dev/null. `2>&1 >/dev/null` matches NONE of them by construction:
+#     its `2>` is followed by `&1`, its `>/dev/null` is not followed by a
+#     `2>`, and neither `&>` nor `>&` appears — see the header.
+# BL-197-DD1-SILENCER
+SILENCER_RE='(^|[[:space:](;&|])(1?>[[:space:]]*/dev/null[[:space:]]+2>[[:space:]]*(&1|/dev/null)|2>[[:space:]]*/dev/null[[:space:]]+1?>[[:space:]]*/dev/null|&>[[:space:]]*/dev/null|>&[[:space:]]*/dev/null|2>[[:space:]]*/dev/null|2>&-)'
+
+# (2)+(3) A `||` after the silencer, then a failure reporter in that arm.
+#     The `||` requirement is what separates "the command failed and its
+#     words were destroyed" from "the command succeeded" — see header.
+# BL-197-DD1-FAILARM
+FAIL_ARM_RE='\|\|.*[[:space:]{;(](fail_|fail|print_fail|record_init_failure)[[:space:]]+["'"'"']'
+
+# Presence-probe carve-out, matched against the text BEFORE the silencer.
+# BL-197-DD1-PROBE-CARVEOUT
+PROBE_RE='(^|[[:space:](;&|!])(command[[:space:]]+-[vV]|type|hash|which)[[:space:]]'
+
+EXEMPT_MARKER='# lint-diag-ok:'
+
+# ── DD2 atoms (advisory census only) ─────────────────────────────────────
+REPORTER_LINE_RE='(^|[[:space:]{;|&(])(fail_|fail|print_fail|record_init_failure)[[:space:]]+["'"'"']'
+TRUNCATOR_RE='(^|[[:space:]|(])(tail|head)[[:space:]]+(-n[[:space:]]*)?-?[0-9]'
+
+VIOLATIONS=0
+LIST_ROWS=""
+CENSUS_ROWS=""
+CENSUS_COUNT=0
+
+should_skip_file() {
+  local f="$1"
+  [ "$f" = "$SELF_PATH" ] && return 0
+  [ "$(basename "$f")" = "$OWN_SUITE_BASENAME" ] && return 0
+  return 1
+}
+
+# Strip a trailing ` #...` comment unless the `#` lives inside quotes.
+# Same quote-aware scan as lint-fix-functions-stderr.sh — a line whose
+# only occurrence of the shape is in a trailing comment must not fire.
+strip_trailing_comment() {
+  local line="$1"
+  local out="" in_squote=0 in_dquote=0 prev="" i ch
+  local len=${#line}
+  for (( i=0; i<len; i++ )); do
+    ch="${line:i:1}"
+    if [ "$in_squote" = "0" ] && [ "$in_dquote" = "0" ] && [ "$ch" = "#" ]; then
+      if [ -z "$prev" ] || [[ "$prev" =~ [[:space:]] ]]; then
+        break
+      fi
+    fi
+    if [ "$in_dquote" = "0" ] && [ "$ch" = "'" ]; then
+      in_squote=$((1 - in_squote))
+    elif [ "$in_squote" = "0" ] && [ "$ch" = '"' ]; then
+      in_dquote=$((1 - in_dquote))
+    fi
+    out="${out}${ch}"
+    prev="$ch"
+  done
+  printf '%s' "$out"
+}
+
+# Echo the exemption reason (possibly empty) if the marker is present;
+# return 1 when there is no marker at all. Read from the RAW line.
+exempt_reason() {
+  local line="$1" reason
+  case "$line" in
+    *"$EXEMPT_MARKER"*) : ;;
+    *) return 1 ;;
+  esac
+  reason="${line##*"$EXEMPT_MARKER"}"
+  reason="${reason#"${reason%%[![:space:]]*}"}"
+  reason="${reason%"${reason##*[![:space:]]}"}"
+  printf '%s' "$reason"
+  return 0
+}
+
+scan_file_dd1() {
+  local file="$1" rel="$2"
+  local tmp hit lineno raw code head_seg tail_seg reason
+  tmp="$(mktemp)" || return 0
+  # One grep per file, then per-candidate work in-process: the candidate
+  # set is tiny (19 lines across ~200 files on today's tree).
+  # grep's OWN stderr is deliberately left unsilenced — a lint about
+  # destroyed diagnostics must not destroy its own.
+  grep -nE "$SILENCER_RE" "$file" > "$tmp"
+  while IFS= read -r hit || [ -n "$hit" ]; do
+    [ -n "$hit" ] || continue
+    lineno="${hit%%:*}"
+    raw="${hit#*:}"
+
+    # Pure-comment line: nothing executes, nothing is destroyed.
+    case "${raw#"${raw%%[![:space:]]*}"}" in '#'*) continue ;; esac
+
+    code="$(strip_trailing_comment "$raw")"
+    [[ "$code" =~ $SILENCER_RE ]] || continue
+    head_seg="${code%%"${BASH_REMATCH[0]}"*}"
+    tail_seg="${code#*"${BASH_REMATCH[0]}"}"
+
+    [[ "$tail_seg" =~ $FAIL_ARM_RE ]] || continue
+    if [[ "$head_seg" =~ $PROBE_RE ]]; then
+      LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\tpresence-probe (no diagnostic to destroy)\n"
+      continue
+    fi
+
+    if reason="$(exempt_reason "$raw")"; then
+      if [ -z "$reason" ]; then
+        echo "${rel}:${lineno}: lint-diagnostic-destruction: exemption marker present but reason is empty" >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\texemption-empty-reason\n"
+      else
+        LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\texempt: ${reason}\n"
+      fi
+      continue
+    fi
+
+    echo "${rel}:${lineno}: lint-diagnostic-destruction: the failed command's diagnostic is discarded and a failure is reported in its place — capture it (e.g. 'out=\$(cmd 2>&1)') and put it in the message, or append '# lint-diag-ok: <reason>'" >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+    LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\tsilenced-diagnostic-failure-report\n"
+  done < "$tmp"
+  rm -f "$tmp"
+}
+
+scan_file_dd2() {
+  local file="$1" rel="$2"
+  local tmp hit lineno
+  tmp="$(mktemp)" || return 0
+  grep -nE "$REPORTER_LINE_RE" "$file" \
+    | grep -vE '^[0-9]+:[[:space:]]*#' \
+    | grep -F '$(' \
+    | grep -E "$TRUNCATOR_RE" > "$tmp"
+  while IFS= read -r hit || [ -n "$hit" ]; do
+    [ -n "$hit" ] || continue
+    lineno="${hit%%:*}"
+    raw="${hit#*:}"
+    CENSUS_COUNT=$((CENSUS_COUNT + 1))
+    CENSUS_ROWS="${CENSUS_ROWS}REVIEW\t${rel}:${lineno}\n"
+  done < "$tmp"
+  rm -f "$tmp"
+}
+
+for entry in "${TARGET_GLOBS[@]}"; do
+  # bash 3.2 has no nullglob: an unmatched pattern survives literally.
+  [ -f "$entry" ] || continue
+  should_skip_file "$entry" && continue
+  rel="${entry#"$REPO_ROOT"/}"
+  if [ "$CENSUS_MODE" -eq 1 ]; then
+    scan_file_dd2 "$entry" "$rel"
+  else
+    scan_file_dd1 "$entry" "$rel"
+  fi
+done
+
+if [ "$CENSUS_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\n'
+  printf '%b' "$CENSUS_ROWS"
+  echo "census: $CENSUS_COUNT truncated-evidence site(s) — ADVISORY (BL-197 DD2), never gating."
+  echo "Ask of each: when this arm fires, does the message carry what the reader needs to act?"
+  exit 0
+fi
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tFILE:LINE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS violation(s) found. See scripts/lint-diagnostic-destruction.sh header for the fix pattern." >&2
+  exit 1
+fi
+
+echo "OK: no silenced-diagnostic failure reports found."
+echo "    (advisory truncated-evidence census: bash scripts/lint-diagnostic-destruction.sh --census)"
+exit 0

--- a/scripts/lint-diagnostic-destruction.sh
+++ b/scripts/lint-diagnostic-destruction.sh
@@ -56,6 +56,28 @@
 #     comment (trailing comments are stripped, quote-aware, before the
 #     shape is matched — but the exemption marker is read from the raw
 #     line).
+#   • The shape, or the reporter's NAME, appearing inside a STRING —
+#     `echo "never write: cmd >/dev/null 2>&1 || fail_ 'x'"` and
+#     `… || echo "note: call fail_ 'x' first"`. Quoted spans are blanked
+#     before matching (see code_skeleton), and the reporter must be at the
+#     HEAD of a `||` arm, not merely somewhere in it. Both were live false
+#     positives until R-BL197-1's battery fixture caught them.
+#
+# ── DOCUMENTED BLIND SPOTS (pinned as controls in the battery fixture) ───
+#   These ARE the class and this lint does NOT catch them. They are listed
+#   so they stay deliberate rather than drifting into "we thought it was
+#   covered", and each is pinned by a control line in T19 so a future
+#   widening is a visible test change:
+#   • a `||` arm whose reporter is on the NEXT line (`… || {` newline
+#     `fail_ …`) — the predicate is single-line by design, which is what
+#     keeps it free of cross-line false positives;
+#   • `if ! cmd >/dev/null 2>&1; then fail_ …; fi` on one line — same
+#     class, but the reporter is not in a `||` arm. Widening to `if !`
+#     was measured at 58 same-shape sites across the tree, most of them
+#     legitimate, so it stays out;
+#   • a bare `echo "[FAIL] …"` as the reporter — measured to add zero hits
+#     on this tree, so the reporter set stays the four named functions;
+#   • `exec 2>/dev/null` silencing a LATER line — no dataflow analysis.
 #
 # ── WHAT IS ADVISORY, NOT GATING (DD2): truncated evidence ───────────────
 #   BL-197's second candidate shape is `tail -N` / `head -N` inside a
@@ -108,7 +130,10 @@
 # EXIT CODES
 #   0 — no violations (or --census, which never gates)
 #   1 — one or more violations found
-#   2 — invocation / I/O error
+#   2 — invocation error, unusable tempfile, failed grep, or an empty
+#       scannable file set. A scan that could not run must never be
+#       reported as a clean one — that is the silent-success sibling of
+#       the very class this lint polices (# BL-197-IO-HARD-FAIL).
 #
 # USAGE
 #   bash scripts/lint-diagnostic-destruction.sh            # quiet pass/fail
@@ -156,15 +181,23 @@ TARGET_GLOBS=(
 # BL-197-DD1-SILENCER
 SILENCER_RE='(^|[[:space:](;&|])(1?>[[:space:]]*/dev/null[[:space:]]+2>[[:space:]]*(&1|/dev/null)|2>[[:space:]]*/dev/null[[:space:]]+1?>[[:space:]]*/dev/null|&>[[:space:]]*/dev/null|>&[[:space:]]*/dev/null|2>[[:space:]]*/dev/null|2>&-)'
 
-# (2)+(3) A `||` after the silencer, then a failure reporter in that arm.
-#     The `||` requirement is what separates "the command failed and its
-#     words were destroyed" from "the command succeeded" — see header.
+# (2)+(3) A `||` after the silencer, then a failure reporter AT THE HEAD of
+#     that arm. The `||` requirement is what separates "the command failed
+#     and its words were destroyed" from "the command succeeded"; the
+#     HEAD anchoring is what separates a reporter that RUNS from a reporter
+#     merely NAMED in a string (`|| echo "call fail_ 'x' first"` is not a
+#     failure report). Matched against each `||` arm in turn — see
+#     arm_reports_failure().
 # BL-197-DD1-FAILARM
-FAIL_ARM_RE='\|\|.*[[:space:]{;(](fail_|fail|print_fail|record_init_failure)[[:space:]]+["'"'"']'
+REPORTER_HEAD_RE='^[[:space:]]*(\{[[:space:]]*)?(![[:space:]]*)?(fail_|fail|print_fail|record_init_failure)[[:space:]]+["'"'"']'
 
-# Presence-probe carve-out, matched against the text BEFORE the silencer.
+# Presence-probe carve-out. ANCHORED against the LAST simple command of the
+# head segment (the text before the silencer, after its final command
+# separator) — unanchored, `grep -w type config.txt 2>/dev/null || fail_ …`
+# was read as a `type` probe and silently blessed, though `type` there is
+# just an argument.
 # BL-197-DD1-PROBE-CARVEOUT
-PROBE_RE='(^|[[:space:](;&|!])(command[[:space:]]+-[vV]|type|hash|which)[[:space:]]'
+PROBE_RE='^[[:space:]]*(![[:space:]]*)?(command[[:space:]]+-[vV]|type|hash|which)([[:space:]]|$)'
 
 EXEMPT_MARKER='# lint-diag-ok:'
 
@@ -184,29 +217,85 @@ should_skip_file() {
   return 1
 }
 
-# Strip a trailing ` #...` comment unless the `#` lives inside quotes.
-# Same quote-aware scan as lint-fix-functions-stderr.sh — a line whose
-# only occurrence of the shape is in a trailing comment must not fire.
-strip_trailing_comment() {
+# Reduce a raw line to its CODE SKELETON in one quote-aware scan:
+#   • drop a trailing ` #...` comment (the `#` must be outside quotes and
+#     at column 0 or preceded by whitespace), and
+#   • BLANK the contents of every quoted span, keeping the quote characters
+#     themselves.
+# The second half is load-bearing, not cosmetic. Without it a line that
+# merely NAMES the shape inside a string — `echo "never write: cmd
+# >/dev/null 2>&1 || fail_ 'x'"` — matched as if it were code, and so did
+# `|| echo "note: call fail_ 'x' first"`. Keeping the quote characters is
+# what lets the reporter regex still require its `"` argument delimiter:
+# a real `|| fail_ "T2" "msg"` reduces to `|| fail_ "" ""`, which still
+# matches, while the string cases reduce to `echo ""`, which does not.
+# BL-197-CODE-SKELETON
+code_skeleton() {
   local line="$1"
   local out="" in_squote=0 in_dquote=0 prev="" i ch
   local len=${#line}
   for (( i=0; i<len; i++ )); do
     ch="${line:i:1}"
-    if [ "$in_squote" = "0" ] && [ "$in_dquote" = "0" ] && [ "$ch" = "#" ]; then
+    if [ "$in_squote" = "1" ]; then
+      if [ "$ch" = "'" ]; then
+        in_squote=0
+        out="${out}'"
+        prev="$ch"
+      fi
+      continue
+    fi
+    if [ "$in_dquote" = "1" ]; then
+      if [ "$ch" = '"' ]; then
+        in_dquote=0
+        out="${out}\""
+        prev="$ch"
+      fi
+      continue
+    fi
+    if [ "$ch" = "#" ]; then
       if [ -z "$prev" ] || [[ "$prev" =~ [[:space:]] ]]; then
         break
       fi
     fi
-    if [ "$in_dquote" = "0" ] && [ "$ch" = "'" ]; then
-      in_squote=$((1 - in_squote))
-    elif [ "$in_squote" = "0" ] && [ "$ch" = '"' ]; then
-      in_dquote=$((1 - in_dquote))
+    if [ "$ch" = "'" ]; then
+      in_squote=1
+    elif [ "$ch" = '"' ]; then
+      in_dquote=1
     fi
     out="${out}${ch}"
     prev="$ch"
   done
   printf '%s' "$out"
+}
+
+# True iff some `||` arm of "$1" STARTS with a failure-reporter invocation.
+# Walking the arms (rather than searching the whole tail) is what keeps a
+# reporter named inside a string, or a lookalike like `test_fail`, from
+# counting as a failure report.
+arm_reports_failure() {
+  local t="$1"
+  while [ "${t#*||}" != "$t" ]; do
+    t="${t#*||}"
+    if [[ "$t" =~ $REPORTER_HEAD_RE ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# The LAST simple command of a head segment: everything after its final
+# command separator. Successive strips converge on "after the last
+# separator of any kind" because each strip only ever shortens the string.
+last_simple_command() {
+  local t="$1"
+  t="${t##*;}"
+  t="${t##*&}"
+  t="${t##*|}"
+  t="${t##*(}"
+  t="${t##*\{}"
+  t="${t##*\}}"
+  t="${t##*!}"
+  printf '%s' "$t"
 }
 
 # Echo the exemption reason (possibly empty) if the marker is present;
@@ -224,30 +313,89 @@ exempt_reason() {
   return 0
 }
 
-scan_file_dd1() {
-  local file="$1" rel="$2"
-  local tmp hit lineno raw code head_seg tail_seg reason
-  tmp="$(mktemp)" || return 0
-  # One grep per file, then per-candidate work in-process: the candidate
-  # set is tiny (19 lines across ~200 files on today's tree).
-  # grep's OWN stderr is deliberately left unsilenced — a lint about
-  # destroyed diagnostics must not destroy its own.
-  grep -nE "$SILENCER_RE" "$file" > "$tmp"
+# ── SINGLE-PASS SCAN ─────────────────────────────────────────────────────
+# One grep over the WHOLE file list, not one grep + one mktemp per file.
+# The per-file shape cost 12.5s on this tree for ~200 files; this is the
+# same predicate over the same candidate lines in one exec.
+#
+# `/dev/null` is prepended to the file list so grep ALWAYS prefixes its
+# output with a filename — with a single-element list it would otherwise
+# print bare `lineno:content` and every path would parse as a line number.
+# /dev/null is empty, so it contributes nothing else.
+FILES=()
+for entry in "${TARGET_GLOBS[@]}"; do
+  # bash 3.2 has no nullglob: an unmatched pattern survives literally.
+  [ -f "$entry" ] || continue
+  should_skip_file "$entry" && continue
+  FILES+=("$entry")
+done
+
+if [ "${#FILES[@]}" -eq 0 ]; then
+  echo "lint-diagnostic-destruction: no scannable files found under $REPO_ROOT — refusing to report a clean scan of nothing" >&2
+  exit 2
+fi
+
+# BL-197-IO-HARD-FAIL: an unusable tempfile or a failed grep must NOT
+# degrade into "OK: no violations". That silent skip is the exact
+# silent-success sibling of the class this lint polices, and the previous
+# `tmp="$(mktemp)" || return 0` exempted a whole file that way.
+SCAN_TMP="$(mktemp)" || {
+  echo "lint-diagnostic-destruction: mktemp failed — refusing to report a scan it could not run" >&2
+  exit 2
+}
+trap 'rm -f "$SCAN_TMP"' EXIT
+
+if [ "$CENSUS_MODE" -eq 1 ]; then
+  SCAN_RE="$REPORTER_LINE_RE"
+else
+  SCAN_RE="$SILENCER_RE"
+fi
+
+# grep's OWN stderr is deliberately left unsilenced — a lint about
+# destroyed diagnostics must not destroy its own. rc 0 = matches,
+# 1 = none, >=2 = a real I/O error that must not pass for "clean".
+grep -nE "$SCAN_RE" /dev/null "${FILES[@]}" > "$SCAN_TMP"
+scan_rc=$?
+if [ "$scan_rc" -gt 1 ]; then
+  echo "lint-diagnostic-destruction: grep failed (rc=$scan_rc) — refusing to report a scan it could not complete" >&2
+  exit 2
+fi
+
+if [ "$CENSUS_MODE" -eq 1 ]; then
   while IFS= read -r hit || [ -n "$hit" ]; do
     [ -n "$hit" ] || continue
-    lineno="${hit%%:*}"
-    raw="${hit#*:}"
+    stripped="${hit#"$REPO_ROOT"/}"
+    rel="${stripped%%:*}"
+    after="${stripped#*:}"
+    lineno="${after%%:*}"
+    raw="${after#*:}"
+    case "${raw#"${raw%%[![:space:]]*}"}" in '#'*) continue ;; esac
+    case "$raw" in *'$('*) : ;; *) continue ;; esac
+    [[ "$raw" =~ $TRUNCATOR_RE ]] || continue
+    CENSUS_COUNT=$((CENSUS_COUNT + 1))
+    CENSUS_ROWS="${CENSUS_ROWS}REVIEW\t${rel}:${lineno}\n"
+  done < "$SCAN_TMP"
+else
+  while IFS= read -r hit || [ -n "$hit" ]; do
+    [ -n "$hit" ] || continue
+    stripped="${hit#"$REPO_ROOT"/}"
+    rel="${stripped%%:*}"
+    after="${stripped#*:}"
+    lineno="${after%%:*}"
+    raw="${after#*:}"
 
     # Pure-comment line: nothing executes, nothing is destroyed.
     case "${raw#"${raw%%[![:space:]]*}"}" in '#'*) continue ;; esac
 
-    code="$(strip_trailing_comment "$raw")"
+    code="$(code_skeleton "$raw")"
     [[ "$code" =~ $SILENCER_RE ]] || continue
     head_seg="${code%%"${BASH_REMATCH[0]}"*}"
     tail_seg="${code#*"${BASH_REMATCH[0]}"}"
 
-    [[ "$tail_seg" =~ $FAIL_ARM_RE ]] || continue
-    if [[ "$head_seg" =~ $PROBE_RE ]]; then
+    arm_reports_failure "$tail_seg" || continue
+
+    last_cmd="$(last_simple_command "$head_seg")"
+    if [[ "$last_cmd" =~ $PROBE_RE ]]; then
       LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\tpresence-probe (no diagnostic to destroy)\n"
       continue
     fi
@@ -266,39 +414,8 @@ scan_file_dd1() {
     echo "${rel}:${lineno}: lint-diagnostic-destruction: the failed command's diagnostic is discarded and a failure is reported in its place — capture it (e.g. 'out=\$(cmd 2>&1)') and put it in the message, or append '# lint-diag-ok: <reason>'" >&2
     VIOLATIONS=$((VIOLATIONS + 1))
     LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\tsilenced-diagnostic-failure-report\n"
-  done < "$tmp"
-  rm -f "$tmp"
-}
-
-scan_file_dd2() {
-  local file="$1" rel="$2"
-  local tmp hit lineno
-  tmp="$(mktemp)" || return 0
-  grep -nE "$REPORTER_LINE_RE" "$file" \
-    | grep -vE '^[0-9]+:[[:space:]]*#' \
-    | grep -F '$(' \
-    | grep -E "$TRUNCATOR_RE" > "$tmp"
-  while IFS= read -r hit || [ -n "$hit" ]; do
-    [ -n "$hit" ] || continue
-    lineno="${hit%%:*}"
-    raw="${hit#*:}"
-    CENSUS_COUNT=$((CENSUS_COUNT + 1))
-    CENSUS_ROWS="${CENSUS_ROWS}REVIEW\t${rel}:${lineno}\n"
-  done < "$tmp"
-  rm -f "$tmp"
-}
-
-for entry in "${TARGET_GLOBS[@]}"; do
-  # bash 3.2 has no nullglob: an unmatched pattern survives literally.
-  [ -f "$entry" ] || continue
-  should_skip_file "$entry" && continue
-  rel="${entry#"$REPO_ROOT"/}"
-  if [ "$CENSUS_MODE" -eq 1 ]; then
-    scan_file_dd2 "$entry" "$rel"
-  else
-    scan_file_dd1 "$entry" "$rel"
-  fi
-done
+  done < "$SCAN_TMP"
+fi
 
 if [ "$CENSUS_MODE" -eq 1 ]; then
   printf 'STATUS\tFILE:LINE\n'

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -6523,6 +6523,38 @@ asking why it said so little — which does not scale and did not, in fact, happ
 citation-integrity gap filed the same day), `scripts/lint-fail-emit-exit-status.sh`, and the
 silent-success class recorded in the `adversarial-verify-patterns` memory note.
 
+**UPDATE 2026-07-31 — the lint LANDED; entry stays Open for instance 3 only.** Delivered on
+`fix/bl197-diagnostic-destruction-lint` (`0585b90` + review round `ddb3f2f`;
+`scripts/lint-diagnostic-destruction.sh`, markers `# BL-197-DD1-SILENCER` /
+`# BL-197-DD1-FAILARM` / `# BL-197-CODE-SKELETON` / `# BL-197-IO-HARD-FAIL`; suite
+`tests/test-lint-diagnostic-destruction.sh`, 21/0). What ships: DD1 gating (one-line
+silenced-diagnostic failure reports, seven silencer spellings, four reporters, presence-probe
+carve-out anchored to the LAST simple command, `# lint-diag-ok: <reason>` exemption with
+empty-reason-fails), DD2 truncated-evidence census behind `--census` (489 sites, ADVISORY —
+a 216-row gating roster would itself be diagnostic destruction), heredoc bodies scanned
+(instance 3 lived in one), and hard exit-2 on unusable I/O instead of silent skips. EIGHT true
+positives on the merge-day tree were fixed in the same diff (five `bash -n` and one `jq` site in
+the full-suite aggregator, one terminal-mode case) or reason-annotated (the init.sh push
+fallback). Review arc: two adversarial rounds. Round 1 (major_concerns) proved the suite pinned
+only 3 of 7 spellings — three excision mutants survived every PR-blocking check, the thrice-
+recorded BL-181 class; killed by a 12-must-flag/10-control battery (T19), each mutant now failing
+by name. The reviewer's own template then exposed TWO false positives (a reporter merely NAMED in
+a string; the whole shape QUOTED) — fixed by quoted-span blanking and arm-head reporter matching.
+Confirm round: minor_concerns, merge unblocked; its fresh attack found only constructed
+zero-live-exposure corners, accepted as named residuals: backslash-escape blindness in the
+skeleton (FP and FN both constructible, ~4-line fix if it ever goes live), the mid-arm reporter
+after `{ echo ctx; fail_ …; }` (the one regression direction vs the per-line engine — zero tree
+sites), subshell-arm and `$'…'`-quoted reporters, `$(…)` in the probe strip set. MEASURED
+SURVIVING SHAPES beyond scope (round-1 census, recorded so the narrowness is a decision, not a
+blind spot): ~10 multi-line `|| {` reporter arms with silencers (6 in
+`tests/upgrade-path-tests.sh`, 1 in `run-phase3-validation.sh`), ~100 multi-line
+`if ! cmd 2>/dev/null` + reporter sites (~50 of them mutant-parse guards of exactly the shape
+this PR fixed in the aggregator), bare `echo "[FAIL]"`-style reporters. The lint job is in
+lint.yml but NOT a required check (Karl's promotion call, consistent with the
+evalprompts-portability precedent). **Instance 3 (symptom-instead-of-number messages) remains
+unmechanized — 1,120 zero-interpolation candidates, mostly correct — and is what this entry now
+stays Open for.**
+
 ---
 
 ## BL-198: Implementation plan v2 — TRANSCODE undecodable-but-textual staged files and scan the converted bytes; reject only as the fallback

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -450,7 +450,7 @@ run_child_suite "tests/test-lint-raw-read-prompt.sh" \
 # block above: run the linter's OWN behavior suite so a narrowing of its
 # predicate (or of a carve-out) can't quietly start blessing the class.
 run_child_suite "tests/test-lint-diagnostic-destruction.sh" \
-  "scripts/lint-diagnostic-destruction.sh behavior tests (18/18)" \
+  "scripts/lint-diagnostic-destruction.sh behavior tests" \
   "scripts/lint-diagnostic-destruction.sh behavior tests FAILED (run tests/test-lint-diagnostic-destruction.sh for details)"
 
 # BL-076: no test may execute init.sh in a shape that can create a REAL

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -445,6 +445,14 @@ run_child_suite "tests/test-lint-raw-read-prompt.sh" \
   "scripts/lint-raw-read-prompt.sh behavior tests" \
   "scripts/lint-raw-read-prompt.sh behavior tests FAILED (run tests/test-lint-raw-read-prompt.sh for details)"
 
+# BL-197: the diagnostic-destruction backstop — a failure report that
+# discards the evidence the reader needs to act on it. Same shape as the
+# block above: run the linter's OWN behavior suite so a narrowing of its
+# predicate (or of a carve-out) can't quietly start blessing the class.
+run_child_suite "tests/test-lint-diagnostic-destruction.sh" \
+  "scripts/lint-diagnostic-destruction.sh behavior tests (18/18)" \
+  "scripts/lint-diagnostic-destruction.sh behavior tests FAILED (run tests/test-lint-diagnostic-destruction.sh for details)"
+
 # BL-076: no test may execute init.sh in a shape that can create a REAL
 # remote repo against an authenticated host (the kraulerson/foo leak).
 # Run the lint against the live tree AND its own behavior suite so a
@@ -2432,16 +2440,28 @@ section "TEST 8: Script Syntax Validation"
 
 echo ""
 
-bash -n "$SCRIPT_DIR/init.sh" 2>/dev/null && pass "init.sh syntax OK" || fail "init.sh syntax ERROR"
-bash -n "$SCRIPT_DIR/scripts/resolve-tools.sh" 2>/dev/null && pass "resolve-tools.sh syntax OK" || fail "resolve-tools.sh syntax ERROR"
-bash -n "$SCRIPT_DIR/scripts/check-phase-gate.sh" 2>/dev/null && pass "check-phase-gate.sh syntax OK" || fail "check-phase-gate.sh syntax ERROR"
-bash -n "$SCRIPT_DIR/scripts/validate.sh" 2>/dev/null && pass "validate.sh syntax OK" || fail "validate.sh syntax ERROR"
-bash -n "$SCRIPT_DIR/scripts/intake-wizard.sh" 2>/dev/null && pass "intake-wizard.sh syntax OK" || fail "intake-wizard.sh syntax ERROR"
+# BL-197: `bash -n f 2>/dev/null || fail "... syntax ERROR"` discarded the
+# file:line:message that IS the whole actionable payload — the reader was
+# told a file was broken and nothing about where. Capture and quote it.
+for syn_target in \
+  "$SCRIPT_DIR/init.sh" \
+  "$SCRIPT_DIR/scripts/resolve-tools.sh" \
+  "$SCRIPT_DIR/scripts/check-phase-gate.sh" \
+  "$SCRIPT_DIR/scripts/validate.sh" \
+  "$SCRIPT_DIR/scripts/intake-wizard.sh" ; do
+  syn_name=$(basename "$syn_target")
+  syn_err=$(bash -n "$syn_target" 2>&1) \
+    && pass "$syn_name syntax OK" \
+    || fail "$syn_name syntax ERROR: $syn_err"
+done
 
 # Verify all JSON matrix files are valid
 for f in "$MATRIX_DIR"/*.json; do
   fname=$(basename "$f")
-  jq '.' "$f" > /dev/null 2>&1 && pass "JSON valid: $fname" || fail "JSON invalid: $fname"
+  # BL-197: jq's parse error names the offending line/column; the old
+  # `> /dev/null 2>&1` threw it away and reported only "JSON invalid".
+  # `2>&1 >/dev/null` keeps stderr (into the capture) and drops stdout.
+  jq_err=$(jq '.' "$f" 2>&1 >/dev/null) && pass "JSON valid: $fname" || fail "JSON invalid: $fname — $jq_err"
 done
 
 # ================================================================

--- a/tests/test-lint-diagnostic-destruction.sh
+++ b/tests/test-lint-diagnostic-destruction.sh
@@ -1,0 +1,391 @@
+#!/usr/bin/env bash
+# tests/test-lint-diagnostic-destruction.sh
+#
+# Behavior suite for scripts/lint-diagnostic-destruction.sh — the BL-197
+# backstop for the DIAGNOSTIC-DESTRUCTION class: an instrument that
+# discards the evidence needed to act on the failure it is reporting.
+#
+# The gating predicate (DD1) is deliberately narrow. It fires only on the
+# conjunction of THREE things on ONE line:
+#   (1) a command whose diagnostic stream is sent to /dev/null,
+#   (2) a `||` short-circuit after that silencer,
+#   (3) a failure reporter (fail_ / fail / print_fail / record_init_failure)
+#       invoked in that `||` arm.
+# That is "the command failed, its diagnostic was thrown away, and the
+# message that replaces it is all the reader gets."
+#
+# Every case below pins one atom of that predicate or one carve-out. The
+# carve-outs are not cosmetic — each was measured against the real tree
+# before it was written (see the linter header for the counts):
+#   • presence probes (`command -v X &>/dev/null || fail "X not found"`)
+#     are legitimate and account for 10 of 19 raw hits on today's tree.
+#   • `2>&1 >/dev/null` is NOT a silencer — stderr survives to the prior
+#     stdout, which is the repo's own capture idiom.
+#   • a failure reporter reached by `&&` (the command SUCCEEDED) had no
+#     diagnostic to destroy.
+#
+# Harness convention matches tests/test-lint-fix-functions-stderr.sh:
+# per-case fixture repo under a tmpdir, linter copied in, run from the
+# fixture root, assert on exit code and output.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-diagnostic-destruction.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+setup() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/repo"
+  mkdir -p "$PROJ/scripts" "$PROJ/tests"
+  cp "$LINTER" "$PROJ/scripts/lint-diagnostic-destruction.sh"
+  chmod +x "$PROJ/scripts/lint-diagnostic-destruction.sh"
+}
+teardown() { rm -rf "$TMP"; }
+
+run_lint() {
+  ( cd "$PROJ" && bash scripts/lint-diagnostic-destruction.sh "$@" 2>&1 )
+  return $?
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: clean fixture (failure message carries the evidence) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/tests/clean.sh" <<'SH'
+#!/usr/bin/env bash
+out=$(bash -n target.sh 2>&1) && pass "syntax OK" || fail_ "syntax" "syntax ERROR: $out"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T1: a failure message that carries the captured diagnostic exits 0"
+else
+  fail_ "T1" "expected exit 0, got $rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: >/dev/null 2>&1 then || fail_ → exit 1, names file:line ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/tests/bad-total.sh" <<'SH'
+#!/usr/bin/env bash
+run_gate --terminal-mode >/dev/null 2>&1 && pass "T2" || fail_ "T2" "docs-only commit blocked"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "tests/bad-total.sh:2"; then
+  pass "T2: total silence feeding a || failure report is flagged with file:line"
+else
+  fail_ "T2" "expected exit 1 + file:line; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: bare 2>/dev/null then || fail → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# The stderr-only spelling is the one that cost the most on the real
+# tree: `bash -n f 2>/dev/null && pass || fail "syntax ERROR"` throws
+# away the file:line:message that is the WHOLE actionable payload.
+setup
+cat > "$PROJ/tests/bad-stderr-only.sh" <<'SH'
+#!/usr/bin/env bash
+bash -n target.sh 2>/dev/null && pass "syntax OK" || fail "syntax ERROR"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "tests/bad-stderr-only.sh:2"; then
+  pass "T3: stderr-only silencer feeding a || failure report is flagged"
+else
+  fail_ "T3" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: &>/dev/null then || print_fail → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/bad-amp.sh" <<'SH'
+#!/usr/bin/env bash
+push_branch main &>/dev/null || { print_fail "Push failed"; return 1; }
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "scripts/bad-amp.sh:2"; then
+  pass "T4: the &>/dev/null spelling is flagged too"
+else
+  fail_ "T4" "expected exit 1; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: presence probe (command -v) → exit 0 (carve-out) ==="
+# ════════════════════════════════════════════════════════════════════
+# `command -v semgrep &>/dev/null || fail "Semgrep not found"` destroys
+# nothing: a presence probe emits no diagnostic, and its non-zero status
+# IS the whole message. 10 of the 19 raw hits on the real tree are this.
+setup
+cat > "$PROJ/scripts/probe.sh" <<'SH'
+#!/usr/bin/env bash
+command -v semgrep &>/dev/null && print_ok "Semgrep" || fail "Semgrep not found — required for SAST"
+type jq >/dev/null 2>&1 || fail "jq not found"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T5: presence probes are carved out, not flagged"
+else
+  fail_ "T5" "expected exit 0 for presence probes; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: 2>&1 >/dev/null is NOT a silencer → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Order is load-bearing. `2>&1 >/dev/null` points stderr at the PRIOR
+# stdout (the capture) and only stdout at /dev/null — the diagnostic
+# survives. Flagging it would flag the repo's own evidence-preserving
+# idiom, which is the cry-wolf failure mode this lint must avoid.
+setup
+cat > "$PROJ/tests/reversed.sh" <<'SH'
+#!/usr/bin/env bash
+err=$(run_gate --terminal-mode 2>&1 >/dev/null) || fail_ "T1" "classifier fired: $err"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T6: 2>&1 >/dev/null (stderr survives) is correctly NOT flagged"
+else
+  fail_ "T6" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: failure reporter reached by && (not ||) → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# `ls ... 2>/dev/null && { fail_ "leftover tmpfile"; }` reports on the
+# command's SUCCESS. A successful command had no diagnostic to destroy,
+# and here the offending filenames reach stdout unsilenced.
+setup
+cat > "$PROJ/tests/success-arm.sh" <<'SH'
+#!/usr/bin/env bash
+ls "$D/.claude/"*.tmp 2>/dev/null && { fail_ "P1" "tempfile not cleaned up"; return; }
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T7: a failure reporter on the && (success) arm is not the class"
+else
+  fail_ "T7" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: silencer with no failure reporter on the line → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/no-reporter.sh" <<'SH'
+#!/usr/bin/env bash
+git rev-parse --git-dir >/dev/null 2>&1 || return 0
+rm -rf "$T" >/dev/null 2>&1 || true
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T8: a silencer without a same-line failure report is out of scope"
+else
+  fail_ "T8" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9: the whole shape inside a COMMENT → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/tests/commented.sh" <<'SH'
+#!/usr/bin/env bash
+# Never write: cmd >/dev/null 2>&1 || fail_ "T" "it broke" — BL-197.
+echo ok
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T9: the shape quoted in a comment is not flagged"
+else
+  fail_ "T9" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: exemption marker WITH reason → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/exempted.sh" <<'SH'
+#!/usr/bin/env bash
+push_branch main 2>/dev/null || push_branch master || { print_fail "Push failed"; return 1; } # lint-diag-ok: first-attempt noise only; the decisive second attempt is unsilenced
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T10: a same-line '# lint-diag-ok: <reason>' exempts the site"
+else
+  fail_ "T10" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T11: exemption marker WITHOUT reason → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/empty-exempt.sh" <<'SH'
+#!/usr/bin/env bash
+run_thing >/dev/null 2>&1 || fail_ "T" "it broke" # lint-diag-ok:
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -qi "reason"; then
+  pass "T11: an empty-reason exemption fails (justification is required)"
+else
+  fail_ "T11" "expected exit 1 with a reason-required diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T12: the shape inside a HEREDOC body → exit 1 (deliberate) ==="
+# ════════════════════════════════════════════════════════════════════
+# BL-197 instance 3 lived in a heredoc-emitted hook body. This lint
+# therefore does NOT skip heredoc bodies — the opposite of the choice
+# lint-fix-functions-stderr.sh makes, and the reason that lint could
+# never have caught it.
+setup
+cat > "$PROJ/scripts/emitter.sh" <<'SH'
+#!/usr/bin/env bash
+write_hook() {
+  cat > .git/hooks/pre-commit << 'HOOKEOF'
+#!/usr/bin/env bash
+scan_index >/dev/null 2>&1 || print_fail "SAST could not run"
+HOOKEOF
+}
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "scripts/emitter.sh:5"; then
+  pass "T12: heredoc-emitted bodies are scanned (BL-197 instance 3 lived in one)"
+else
+  fail_ "T12" "expected exit 1 naming the heredoc line; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T13: out-of-scope directory → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+mkdir -p "$PROJ/Reports"
+cat > "$PROJ/Reports/sample.sh" <<'SH'
+#!/usr/bin/env bash
+run_thing >/dev/null 2>&1 || fail_ "R" "it broke"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T13: files outside the scanned globs are not walked"
+else
+  fail_ "T13" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T14: --list renders a FAIL row and a PASS row ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/tests/rows.sh" <<'SH'
+#!/usr/bin/env bash
+run_a >/dev/null 2>&1 || fail_ "A" "a broke"
+run_b >/dev/null 2>&1 || fail_ "B" "b broke" # lint-diag-ok: b's diagnostic is captured upstream
+SH
+out=$(run_lint --list); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "^FAIL" \
+   && echo "$out" | grep -q "^PASS" \
+   && echo "$out" | grep -q "STATUS"; then
+  pass "T14: --list renders the PASS/FAIL roster"
+else
+  fail_ "T14" "expected a roster with both a FAIL and a PASS row; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T15: --census renders truncated-evidence sites and exits 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# DD2 (the entry's second candidate shape) is ADVISORY by measurement:
+# 489 raw sites on the real tree, so it renders for review and never
+# gates. Exit 0 even with rows present is the whole contract.
+setup
+cat > "$PROJ/tests/trunc.sh" <<'SH'
+#!/usr/bin/env bash
+fail_ "T1" "gate did not block: $(tail -3 "$P/commit.log" | tr '\n' ' ')"
+SH
+out=$(run_lint --census); rc=$?
+if [ $rc -eq 0 ] && echo "$out" | grep -q "tests/trunc.sh:2"; then
+  pass "T15: --census renders truncated-evidence sites without gating"
+else
+  fail_ "T15" "expected exit 0 + the census row; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T16: a census-only site does NOT gate the default run → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/tests/trunc2.sh" <<'SH'
+#!/usr/bin/env bash
+fail_ "T1" "gate did not block: $(tail -3 "$P/commit.log" | tr '\n' ' ')"
+SH
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T16: the advisory census never affects the gate's exit status"
+else
+  fail_ "T16" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T17: bad argument → exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+out=$(run_lint --bogus); rc=$?
+if [ $rc -eq 2 ] && echo "$out" | grep -qi "usage"; then
+  pass "T17: an unknown flag exits 2 with a usage line"
+else
+  fail_ "T17" "expected exit 2 + usage; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T18: MERGE GATE — the real repo tree is clean → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T18: current repo HEAD carries no unannotated silenced-diagnostic failure reports"
+else
+  fail_ "T18" "current repo HEAD has BL-197 violations; rc=$rc; output:\n$out"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-lint-diagnostic-destruction.sh
+++ b/tests/test-lint-diagnostic-destruction.sh
@@ -296,6 +296,13 @@ cat > "$PROJ/Reports/sample.sh" <<'SH'
 #!/usr/bin/env bash
 run_thing >/dev/null 2>&1 || fail_ "R" "it broke"
 SH
+# An in-scope clean file so the exit 0 proves the scan RAN and skipped
+# Reports/ — not that it found nothing to scan and bailed (that path is
+# its own exit-2 guard, pinned by T21).
+cat > "$PROJ/tests/in-scope-clean.sh" <<'SH'
+#!/usr/bin/env bash
+echo ok
+SH
 out=$(run_lint); rc=$?
 if [ $rc -eq 0 ]; then
   pass "T13: files outside the scanned globs are not walked"
@@ -372,6 +379,121 @@ if [ $rc -eq 2 ] && echo "$out" | grep -qi "usage"; then
   pass "T17: an unknown flag exits 2 with a usage line"
 else
   fail_ "T17" "expected exit 2 + usage; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T19: BATTERY — every silencer spelling, every reporter, every control ==="
+# ════════════════════════════════════════════════════════════════════
+# R-BL197-1. T2/T3/T4 pinned three silencer spellings and one reporter, so
+# three mutants survived a 18/0 suite: excising `|2>&-`, excising the `1?`
+# atom (which kills `1>/dev/null 2>&1`), and excising `|record_init_failure`
+# from the fail-arm regex. ONE fixture now carries EVERY documented spelling
+# and EVERY reporter, plus the controls that pin what must NOT fire.
+#
+# The control lines are as load-bearing as the violations. Lines 12 and 14
+# are the two FALSE POSITIVES the reviewer's template exposed (a reporter
+# named inside a string, and the whole shape quoted inside an echo); line 13
+# is the false NEGATIVE (R-BL197-2 — `grep -w type` read as a presence
+# probe). Lines 7-9, 10, 11, 18-19 are the lint's DOCUMENTED BLIND SPOTS,
+# pinned here so they stay deliberate rather than becoming accidental:
+#   7-9   a `||` arm whose reporter is on the NEXT line (no cross-line
+#         inference, by design — see the linter header)
+#   10    `if ! cmd >/dev/null 2>&1; then fail_ …; fi` — same line, but the
+#         reporter is not in a `||` arm
+#   11    a bare `echo "[FAIL] …"` used as the reporter (not in the reporter
+#         set — measured to add zero hits on this tree)
+#   18-19 `exec 2>/dev/null` silencing a LATER line (no dataflow analysis)
+setup
+cat > "$PROJ/tests/battery.sh" <<'SH'
+#!/usr/bin/env bash
+run_x 1>/dev/null 2>&1 || fail_ "p01" "broke"
+run_x >/dev/null 2>/dev/null || fail_ "p02" "broke"
+run_x 2>/dev/null 1>/dev/null || fail_ "p03" "broke"
+run_x >&/dev/null || fail_ "p04" "broke"
+run_x 2>&- || fail_ "p05" "broke"
+run_x >/dev/null 2>&1 || {
+  fail_ "p06" "broke"
+}
+if ! run_x >/dev/null 2>&1; then fail_ "p07" "broke"; fi
+run_x 2>/dev/null || { echo "[FAIL] p08 broke"; FAILED=$((FAILED+1)); }
+run_x >/dev/null 2>&1 || echo "note: call fail_ 'x' first"
+grep -w type config.txt 2>/dev/null || fail_ "p10" "grep broke"
+echo "never write: cmd >/dev/null 2>&1 || fail_ 'x'"
+run_x 2>/dev/null || test_fail "p12 broke"
+run_x 2> /dev/null || fail_ "p13" "broke"
+err=$(run_x 2>&1 >/dev/null) || fail_ "p15" "broke: $err"
+exec 2>/dev/null
+run_x || fail_ "p16" "broke"
+run_x >/dev/null 2>&1 || fail_ "p17" "broke"
+run_x &>/dev/null || fail_ "p18" "broke"
+run_x >/dev/null 2>&1 || fail "p19 broke"
+run_x >/dev/null 2>&1 || print_fail "p20 broke"
+run_x >/dev/null 2>&1 || record_init_failure "p21" "broke"
+command -v optional_tool >/dev/null 2>&1 || fail_ "p22" "optional_tool not found"
+SH
+BAT_MUST_FLAG="2 3 4 5 6 13 16 20 21 22 23 24"
+BAT_MUST_PASS="7 10 11 12 14 15 17 18 19 25"
+TAB=$'\t'
+out=$(run_lint --list); rc=$?
+bat_missing=""
+bat_extra=""
+for n in $BAT_MUST_FLAG; do
+  echo "$out" | grep -q "^FAIL${TAB}tests/battery.sh:${n}${TAB}" || bat_missing="$bat_missing $n"
+done
+for n in $BAT_MUST_PASS; do
+  if echo "$out" | grep -q "^FAIL${TAB}tests/battery.sh:${n}${TAB}"; then
+    bat_extra="$bat_extra $n"
+  fi
+done
+bat_count=$(echo "$out" | grep -c "^FAIL${TAB}tests/battery.sh:")
+if [ $rc -eq 1 ] && [ -z "$bat_missing" ] && [ -z "$bat_extra" ] && [ "$bat_count" -eq 12 ]; then
+  pass "T19: all 12 battery violations flagged, all 10 controls left alone"
+else
+  fail_ "T19" "rc=$rc (want 1); flagged=$bat_count (want 12); MISSED:${bat_missing:- none}; FALSE-POSITIVES:${bat_extra:- none}; roster:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T20: a failed mktemp hard-fails (exit 2), never a silent clean scan ==="
+# ════════════════════════════════════════════════════════════════════
+# R-BL197-5. `tmp="$(mktemp)" || return 0` skipped a whole file and let the
+# run finish "OK" — the silent-success sibling of the very class this lint
+# polices. A scan that cannot run must say so and exit 2.
+setup
+mkdir -p "$TMP/shim"
+cat > "$TMP/shim/mktemp" <<'SH'
+#!/usr/bin/env bash
+exit 1
+SH
+chmod +x "$TMP/shim/mktemp"
+cat > "$PROJ/tests/plain.sh" <<'SH'
+#!/usr/bin/env bash
+echo ok
+SH
+out=$( cd "$PROJ" && PATH="$TMP/shim:$PATH" bash scripts/lint-diagnostic-destruction.sh 2>&1 ); rc=$?
+if [ $rc -eq 2 ] && echo "$out" | grep -qi "mktemp"; then
+  pass "T20: an unusable tempfile exits 2 and names mktemp"
+else
+  fail_ "T20" "expected exit 2 naming mktemp; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T21: an EMPTY scannable set hard-fails (exit 2) ==="
+# ════════════════════════════════════════════════════════════════════
+# Sibling of T20: if the target globs ever match nothing (a renamed tree, a
+# bad REPO_ROOT), "OK: no violations" would be a scan of zero files
+# reported as a clean bill of health.
+setup
+out=$(run_lint); rc=$?
+if [ $rc -eq 2 ] && echo "$out" | grep -qi "no scannable files"; then
+  pass "T21: a scan with nothing in scope exits 2 instead of reporting clean"
+else
+  fail_ "T21" "expected exit 2 naming an empty scan set; rc=$rc; output:\n$out"
 fi
 teardown
 

--- a/tests/test-pre-commit-gate-terminal-mode.sh
+++ b/tests/test-pre-commit-gate-terminal-mode.sh
@@ -77,7 +77,11 @@ echo "T2: --terminal-mode passes a docs-only commit"
 setup
 ( cd "$TMP" && echo "# README" > README.md && git add README.md )
 echo "docs: add README" > "$TMP/.git/COMMIT_EDITMSG"
-( cd "$TMP" && SKIP_LINT=1 bash "$GATE" --terminal-mode >/dev/null 2>&1 ) && pass "T2" || fail_ "T2" "docs-only commit blocked"
+# BL-197: this used to be `>/dev/null 2>&1 && pass || fail_ "docs-only
+# commit blocked"` — the gate's own explanation of WHY it blocked went to
+# /dev/null, leaving the reader the one fact they already had. T1 above
+# already used the capturing idiom; T2 now matches it.
+t2_out=$( cd "$TMP" && SKIP_LINT=1 bash "$GATE" --terminal-mode 2>&1 ) && pass "T2" || fail_ "T2" "docs-only commit blocked: $t2_out"
 teardown
 
 # T3: --terminal-mode does NOT emit JSON to stdout.


### PR DESCRIPTION
Quick-sweep item. New `scripts/lint-diagnostic-destruction.sh`: a narrow, high-precision gate for the class where an instrument discards the evidence needed to act on the failure it reports — one-line silenced-diagnostic failure reports (seven silencer spellings, four reporters), a presence-probe carve-out anchored to the last simple command, `# lint-diag-ok: <reason>` exemptions (empty reason fails), heredoc bodies scanned (instance 3 lived in one), hard exit-2 on unusable I/O. The truncated-evidence sibling (DD2) ships as an ADVISORY `--census` (489 sites — a gating roster that size would itself be diagnostic destruction). **Eight true positives on today's tree fixed in the same diff** (five `bash -n` + one `jq` site in the full-suite aggregator now print the actual error; one terminal-mode case; the init.sh push fallback reason-annotated).

Review arc (standing gate): round 1 **major_concerns** — the reviewer's excision mutants proved the suite pinned only 3 of 7 promised spellings (the thrice-recorded BL-181 decay class); killed by a 12-must-flag/10-control battery, each mutant now failing by name. The reviewer's template also exposed two false positives nobody had flagged (reporter merely NAMED in a string; whole shape QUOTED) — fixed by quoted-span blanking + arm-head reporter matching. Confirm round: **minor_concerns, merge unblocked** — all fixes re-verified by execution; fresh attack found only constructed zero-live-exposure corners, accepted as named residuals on the entry. Bonus: single-pass restructure, 12.5s → 7.0s, / byte-identical.

The lint joins run-lints by glob (12/12) and lint.yml as a job — **not** a required check (Karl's promotion call, per the evalprompts precedent). Backlog: landing record + measured residual census on `## BL-197:`; stays Open for instance 3 only. Opus implementer + fable reviewer ×2; supervisor merge on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)