### PR TITLE
fix(bl207): duplicate-header uniqueness arm for the backlog — the citation primitive gets its guard

### DIFF
--- a/scripts/lint-backlog-references.sh
+++ b/scripts/lint-backlog-references.sh
@@ -365,7 +365,9 @@ done <<< "$BLOCK_REPORT"
 #     exempting it here would make this arm disagree with the very
 #     splitter it protects, and the audit-trail block would silently
 #     capture the ID. Quoting a header inside an entry body is still
-#     fine — indent or fence it and the `^` anchor skips it (T15).
+#     fine, but INDENT it (T15) — awk is fence-blind, so a ```-fenced
+#     header still sitting at column 0 is counted, exactly as the
+#     splitter counts it. Only leading whitespace exempts.
 #
 #   • HEADERS ONLY, anchored (T15). Prose cross-references
 #     ("supersedes BL-050") repeat by design and are never violations;
@@ -381,9 +383,20 @@ done <<< "$BLOCK_REPORT"
 #     merge anything and would only distort the ID in the diagnostic,
 #     which reviewers grep for verbatim.
 #
-# BL-093 note: when the archive split lands, this arm must span BOTH
-# files — an ID present in the main backlog AND the archive is the same
-# defect.
+# NOT COVERED (known residuals, so the scope is readable here and not
+# only in the review record):
+#   • `## code-*-N:` headers in this same file (two exist as of
+#     2026-07-31: `## code-upgrade-project-8:` and
+#     `## code-check-gates-1:`) — this arm keys on `BL-` IDs only, which
+#     matches the rest of the lint's scope. A duplicate `code-*` header
+#     is not caught.
+#   • `## BUG-NNN:` headers in solo-orchestrator-bugs.md (7 today) —
+#     that file is never opened by this lint (DELIBERATE SCOPE above
+#     targets only the canonical backlog), so BUG IDs have no
+#     uniqueness guard at all.
+#   • BL-093: when the archive split lands, this arm must span BOTH
+#     files — an ID present in the main backlog AND the archive is the
+#     same defect.
 #
 # ONE awk pass emits both records: a `TOTAL` line (the header count, for
 # the --list row) and a `DUP` line per duplicated ID. Deriving the total
@@ -428,7 +441,7 @@ while IFS=$'\t' read -r rec_kind rec_id rec_count rec_lines; do
       ;;
     DUP)
       # ASCII-only diagnostic: no multibyte char adjacent to an expansion.
-      echo "lint-backlog-references: duplicate entry header '${rec_id}': ${rec_count} headers at lines ${rec_lines}; each BL-NNN must have exactly one '## BL-NNN:' header (indent or fence a header quoted inside an entry body)" >&2
+      echo "lint-backlog-references: duplicate entry header '${rec_id}': ${rec_count} headers at lines ${rec_lines}; each BL-NNN must have exactly one '## BL-NNN:' header (to quote one inside an entry body, indent it -- a code fence at column 0 does not exempt)" >&2
       VIOLATIONS=$((VIOLATIONS + 1))
       HEADER_DUPES=$((HEADER_DUPES + 1))
       LIST_ROWS="${LIST_ROWS}FAIL\theader-uniqueness\t${rec_id}\tduplicate header at lines ${rec_lines}\n"

--- a/scripts/lint-backlog-references.sh
+++ b/scripts/lint-backlog-references.sh
@@ -5,7 +5,7 @@
 # the wave-2 backstop after counter-sanitizer remediation; this is the
 # Slot-5 sibling that backstops backlog-citation hygiene).
 #
-# THE TWO DEFECT CLASSES
+# THE THREE DEFECT CLASSES
 #
 # 1. Unknown BL reference in a commit message.
 #    A commit subject or body cites `BL-NNN` (e.g. `fix(init): host-
@@ -27,6 +27,12 @@
 #      - `**Status:** Closed — shipped DATE (PR #N).` (current convention)
 #    The check is structural — any of these satisfy as long as a PR# or
 #    SHA appears somewhere in the entry block.
+#
+# 3. Duplicate `## BL-NNN:` entry header (BL-207).
+#    The same ID owns two (or more) entry headers, so `BL-NNN` stops
+#    being a unique key — grep, the citation primitive, and this
+#    script's own block splitter all resolve ambiguously. See the
+#    `# BL-207-HEADER-UNIQUENESS` arm below for the decisions.
 #
 # DELIBERATE SCOPE
 #   • Targets ONLY solo-orchestrator-backlog.md (the canonical backlog).
@@ -83,10 +89,11 @@
 #   worse, walk historical commits the operator can't fix from this
 #   commit. Instead, the prospective commit message is supplied via
 #   `--message <text>` or stdin and scanned for `BL-NNN` tokens.
-#   Step 3 (backlog-block scan for Closed/Resolved without citation)
-#   runs unchanged — it's structural on the backlog file, independent
-#   of git history. This is the contract scripts/pre-commit-gate.sh
-#   relies on when invoking the lint at commit time.
+#   Steps 3 and 4 (backlog-block scan for Closed/Resolved without
+#   citation; entry-header uniqueness) run unchanged — both are
+#   structural on the backlog file, independent of git history. This is
+#   the contract scripts/pre-commit-gate.sh relies on when invoking the
+#   lint at commit time.
 
 set -uo pipefail
 
@@ -336,6 +343,96 @@ while IFS=$'\t' read -r id status_found has_pr has_sha has_allow allow_reason; d
     LIST_ROWS="${LIST_ROWS}FAIL\t${id}\t-\tuncited-closure\n"
   fi
 done <<< "$BLOCK_REPORT"
+
+# ── Step 4: entry-header UNIQUENESS ────────────────────────────────
+# BL-207-HEADER-UNIQUENESS
+#
+# Every `BL-NNN` must own exactly ONE `^## BL-NNN:` header. Uniqueness
+# is what makes the ID grep-able as this repo's citation primitive, and
+# Step 3's block splitter assumes it: a second header for the same ID
+# truncates the first block and opens a second one, so the citation
+# check silently evaluates the wrong text. Structural on the file, so
+# it runs in BOTH modes (like Step 3) — an operator adding a duplicate
+# header is blocked at commit time, not only in CI.
+#
+# THREE DECISIONS, each pinned by a test in
+# tests/test-lint-backlog-references.sh:
+#
+#   • NO exemption for preserved `Original entry (pre-close, kept for
+#     audit trail):` blocks (T16). A duplicate is a duplicate wherever
+#     it appears: the splitter above already reads an un-indented
+#     `^## BL-NNN:` line inside such a block as a real entry header, so
+#     exempting it here would make this arm disagree with the very
+#     splitter it protects, and the audit-trail block would silently
+#     capture the ID. Quoting a header inside an entry body is still
+#     fine — indent or fence it and the `^` anchor skips it (T15).
+#
+#   • HEADERS ONLY, anchored (T15). Prose cross-references
+#     ("supersedes BL-050") repeat by design and are never violations;
+#     only the anchored header form is a key.
+#
+#   • The ID grammar is `BL-[0-9]+[a-z]?`, identical to Step 1's
+#     valid-ID builder (T17). The narrower `^## BL-[0-9]+:` from the
+#     BL-207 sketch would go blind to the `BL-003a` / `BL-003b` suffix
+#     splits; the suffix is part of the ID, so those three are distinct
+#     keys and must not be folded together. No case folding is applied
+#     (unlike the commit-token path): the header regex only matches an
+#     upper-case `BL-` with a lower-case suffix, so folding could not
+#     merge anything and would only distort the ID in the diagnostic,
+#     which reviewers grep for verbatim.
+#
+# BL-093 note: when the archive split lands, this arm must span BOTH
+# files — an ID present in the main backlog AND the archive is the same
+# defect.
+#
+# ONE awk pass emits both records: a `TOTAL` line (the header count, for
+# the --list row) and a `DUP` line per duplicated ID. Deriving the total
+# here rather than from a second `grep -c … || true` capture is
+# deliberate — that capture is exactly the counter antipattern
+# scripts/lint-counter-antipattern.sh exists to reject (it caught this
+# during development). Duplicates are emitted in FIRST-HEADER order via
+# the `order[]` index, not `for (k in seen)`, so output is deterministic
+# without a `| sort` (awk's `in` iteration order is unspecified).
+HEADER_SCAN=$(awk '
+  {
+    if (match($0, /^## BL-[0-9]+[a-z]?:/)) {
+      # Drop the leading "## " (3 chars) and the trailing ":" (1 char).
+      id = substr($0, 4, RLENGTH - 4)
+      total = total + 1
+      if (seen[id] == 0) { nids = nids + 1; order[nids] = id }
+      seen[id] = seen[id] + 1
+      if (at[id] == "") { at[id] = NR } else { at[id] = at[id] ", " NR }
+    }
+  }
+  END {
+    printf "TOTAL\t%d\n", total + 0
+    for (i = 1; i <= nids; i++) {
+      k = order[i]
+      if (seen[k] > 1) printf "DUP\t%s\t%d\t%s\n", k, seen[k], at[k]
+    }
+  }
+' "$BACKLOG")
+
+HEADER_TOTAL=0
+HEADER_DUPES=0
+while IFS=$'\t' read -r rec_kind rec_id rec_count rec_lines; do
+  case "$rec_kind" in
+    TOTAL)
+      HEADER_TOTAL="$rec_id"
+      ;;
+    DUP)
+      # ASCII-only diagnostic: no multibyte char adjacent to an expansion.
+      echo "lint-backlog-references: duplicate entry header '${rec_id}': ${rec_count} headers at lines ${rec_lines}; each BL-NNN must have exactly one '## BL-NNN:' header (indent or fence a header quoted inside an entry body)" >&2
+      VIOLATIONS=$((VIOLATIONS + 1))
+      HEADER_DUPES=$((HEADER_DUPES + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\theader-uniqueness\t${rec_id}\tduplicate header at lines ${rec_lines}\n"
+      ;;
+  esac
+done <<< "$HEADER_SCAN"
+
+if [ "$HEADER_DUPES" -eq 0 ]; then
+  LIST_ROWS="${LIST_ROWS}PASS\theader-uniqueness\t-\t${HEADER_TOTAL} BL header(s), all unique\n"
+fi
 
 if [ "$LIST_MODE" -eq 1 ]; then
   printf 'STATUS\tSOURCE\tTOKEN\tDETAIL\n'

--- a/scripts/lint-backlog-references.sh
+++ b/scripts/lint-backlog-references.sh
@@ -397,7 +397,13 @@ HEADER_SCAN=$(awk '
   {
     if (match($0, /^## BL-[0-9]+[a-z]?:/)) {
       # Drop the leading "## " (3 chars) and the trailing ":" (1 char).
-      id = substr($0, 4, RLENGTH - 4)
+      # RSTART-relative, NOT a hardcoded offset 4: under the `^` anchor
+      # RSTART is always 1 so the two are identical, but the hardcoded
+      # form silently mis-extracts (" ## BL" instead of "BL-001") if the
+      # anchor is ever dropped, which MASKED the anchor from mutation
+      # testing — M2 (anchor deleted) passed 21/0 with offset 4 and
+      # fails T15 with this form. Two atoms, each independently pinned.
+      id = substr($0, RSTART + 3, RLENGTH - 4)
       total = total + 1
       if (seen[id] == 0) { nids = nids + 1; order[nids] = id }
       seen[id] = seen[id] + 1

--- a/tests/test-lint-backlog-references.sh
+++ b/tests/test-lint-backlog-references.sh
@@ -359,6 +359,221 @@ fi
 teardown
 
 # ════════════════════════════════════════════════════════════════════
+# BL-207 — entry-header UNIQUENESS (Step 4, `# BL-207-HEADER-UNIQUENESS`)
+#
+# T14..T19 pin the arm that fails when the same `BL-NNN` owns more than
+# one `^## BL-NNN:` header. T14 is the reviewer's own mutant verbatim
+# (a duplicate `## BL-187:` header appended to the backlog, which passed
+# the lint with rc=0 before this arm existed). T15 is the negative
+# control. T16 pins the deliberate NO-exemption decision for preserved
+# `Original entry (pre-close` blocks. T17 pins the `[a-z]?` sub-ID
+# grammar (a narrowing to `^## BL-[0-9]+:` goes blind to `BL-003a`, and
+# a suffix-stripping extraction would conflate BL-003/003a/003b). T18
+# pins mode parity with Step 3. T19 pins the --list row.
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T14: duplicate '## BL-187:' entry header → exit 1 naming BOTH line numbers ==="
+setup
+write_backlog '## BL-186: first entry
+
+**Status:** Open
+
+Body.
+
+## BL-187: original entry
+
+**Status:** Open
+
+Body.
+
+## BL-188: another entry
+
+**Status:** Open
+
+Body.
+
+## BL-187: duplicate header appended in the reviewer mutation lab
+
+**Status:** Open
+
+Body.
+'
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "duplicate entry header 'BL-187'" \
+   && echo "$out" | grep -q "lines 7, 19"; then
+  pass "T14: duplicate BL-187 header is rejected, both line numbers named"
+else
+  fail_ "T14" "expected exit 1 + duplicate-header diagnostic naming lines 7, 19; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T15: unique headers + prose mentions + indented lookalike → exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Negative control for T14, and it pins HEADERS-ONLY scope: repeated
+# prose mentions of an ID are normal (cross-references), and an indented
+# sample header inside an entry body is not an entry header — only the
+# anchored `^## BL-NNN:` form counts.
+setup
+write_backlog '## BL-001: first entry
+
+**Status:** Open
+
+Cross-references BL-001, BL-001 and BL-002 in prose. A sample header,
+indented so it is body text rather than a real entry header:
+
+    ## BL-001: sample header quoted inside the entry body
+
+## BL-002: second entry
+
+**Status:** Open
+
+Body.
+'
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T15: unique headers pass; prose mentions and indented lookalikes are not headers"
+else
+  fail_ "T15" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T16: duplicate header INSIDE a preserved 'Original entry (pre-close' block → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# Deliberate decision (see `# BL-207-HEADER-UNIQUENESS` in the lint):
+# preserved audit-trail blocks get NO exemption. Step 3's block splitter
+# already treats any `^## BL-NNN:` line as an entry header, so an
+# un-indented header inside a preserved block really does truncate the
+# enclosing block and open a second one for the same ID. Exempting it
+# here would make the uniqueness arm disagree with the splitter it is
+# meant to protect. The fix is to indent/fence the quoted header, which
+# T15 shows already passes.
+setup
+write_backlog '## BL-050: closed entry with a preserved original block
+
+**Status:** Closed — shipped 2026-01-02 (PR #42)
+
+Original entry (pre-close, kept for audit trail):
+
+## BL-050: closed entry with a preserved original block
+
+**Status:** Open
+
+Body.
+'
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "duplicate entry header 'BL-050'" \
+   && echo "$out" | grep -q "lines 1, 7"; then
+  pass "T16: preserved audit-trail blocks get no exemption from the uniqueness arm"
+else
+  fail_ "T16" "expected exit 1 + duplicate-header diagnostic naming lines 1, 7; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T17: sub-ID grammar — duplicate '## BL-003a:' flagged, BL-003/003a/003b not conflated ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+write_backlog '## BL-003: parent entry
+
+**Status:** Open
+
+Body.
+
+## BL-003a: gitlab split
+
+**Status:** Open
+
+Body.
+
+## BL-003b: bitbucket split
+
+**Status:** Open
+
+Body.
+
+## BL-003a: duplicated split
+
+**Status:** Open
+
+Body.
+'
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "duplicate entry header 'BL-003a'" \
+   && echo "$out" | grep -q "lines 7, 19" \
+   && ! echo "$out" | grep -q "duplicate entry header 'BL-003'"; then
+  pass "T17: BL-003a duplicate flagged; BL-003 / BL-003a / BL-003b stay distinct IDs"
+else
+  fail_ "T17" "expected exit 1, duplicate 'BL-003a' at lines 7, 19, and no 'BL-003' duplicate; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T18: --pre-commit-mode also runs the uniqueness arm → exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# Mode parity with T13: Step 4 is structural on the backlog file, so an
+# operator committing a duplicate header is blocked at commit time, not
+# only in CI.
+setup
+write_backlog '## BL-042: first
+
+**Status:** Open
+
+Body.
+
+## BL-042: second
+
+**Status:** Open
+
+Body.
+'
+out=$( cd "$PROJ" && bash scripts/lint-backlog-references.sh --pre-commit-mode \
+        --message "chore: unrelated change" 2>&1 ); rc=$?
+if [ $rc -eq 1 ] && echo "$out" | grep -q "duplicate entry header 'BL-042'"; then
+  pass "T18: --pre-commit-mode runs the header-uniqueness arm"
+else
+  fail_ "T18" "expected exit 1 + duplicate-header diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T19: --list renders the header-uniqueness verdict for review ==="
+# ════════════════════════════════════════════════════════════════════
+# House pattern: a decisive judgement must be renderable, not merely
+# silent-on-pass. The PASS row carries the header count so a reviewer
+# can see the arm actually looked at something.
+setup
+write_backlog '## BL-001: first
+
+**Status:** Open
+
+Body.
+
+## BL-002: second
+
+**Status:** Open
+
+Body.
+'
+out=$( cd "$PROJ" && bash scripts/lint-backlog-references.sh --base base --list 2>&1 ); rc=$?
+if [ $rc -eq 0 ] && echo "$out" | grep -q "header-uniqueness" \
+   && echo "$out" | grep -q "2 BL header(s), all unique"; then
+  pass "T19: --list shows the header-uniqueness PASS row with the header count"
+else
+  fail_ "T19" "expected exit 0 + header-uniqueness list row with count 2; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== T9: MERGE GATE — run linter against current repo HEAD vs origin/main → exit 0 ==="
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-lint-backlog-references.sh
+++ b/tests/test-lint-backlog-references.sh
@@ -575,6 +575,73 @@ teardown
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
+echo "=== T20: TWO duplicated IDs are reported in FIRST-HEADER order ==="
+# ════════════════════════════════════════════════════════════════════
+# Pins the `order[]` index against a `for (k in seen)` regression: awk's
+# in-iteration order is UNSPECIFIED, so a for-in implementation emits
+# duplicates in hash order and diagnostics reshuffle between runs/hosts.
+# Every earlier case has at most ONE duplicated ID, where any ordering
+# looks identical — the reviewer's for-in mutant survived 21/0 for
+# exactly that reason.
+#
+# ID choice is empirical, not arbitrary. Under this host's awk
+# (BSD awk, bash 3.2.57) `for (k in seen)` yields BL-050 BEFORE BL-005,
+# i.e. the reverse of first-header order, so the mutant is visible. The
+# pair the review suggested (BL-001/BL-100 with BL-001 first) hashes in
+# the same order as first-header order and would NOT have exposed it —
+# verified with a probe before choosing.
+#
+# The ASSERTION is implementation-independent: first-header order is the
+# specified contract and `order[]` satisfies it on any awk. Only the
+# MUTANT's visibility depends on the host's hash order, which is the
+# normal limit of mutation testing against unspecified behaviour.
+#
+# The fixture also separates "first-header order" from "order of the
+# SECOND occurrence": BL-050's duplicate (line 13) precedes BL-005's
+# duplicate (line 19), so an implementation keyed on the later header
+# would also emit BL-050 first and fail here.
+setup
+write_backlog '## BL-005: first entry, duplicated last
+
+**Status:** Open
+
+Body.
+
+## BL-050: second entry, duplicated first
+
+**Status:** Open
+
+Body.
+
+## BL-050: duplicate of the SECOND id
+
+**Status:** Open
+
+Body.
+
+## BL-005: duplicate of the FIRST id
+
+**Status:** Open
+
+Body.
+'
+out=$(run_lint); rc=$?
+dup_order=$(printf '%s\n' "$out" \
+  | grep -o "duplicate entry header '[^']*'" \
+  | sed "s/.*'\([^']*\)'/\1/" \
+  | tr '\n' ' ')
+if [ $rc -eq 1 ] \
+   && [ "$dup_order" = "BL-005 BL-050 " ] \
+   && echo "$out" | grep -q "'BL-005': 2 headers at lines 1, 19" \
+   && echo "$out" | grep -q "'BL-050': 2 headers at lines 7, 13"; then
+  pass "T20: both duplicated IDs reported, ordered by first header (BL-005 then BL-050)"
+else
+  fail_ "T20" "expected exit 1 and dup order 'BL-005 BL-050 '; got rc=$rc order='$dup_order'; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
 echo "=== T9: MERGE GATE — run linter against current repo HEAD vs origin/main → exit 0 ==="
 # ════════════════════════════════════════════════════════════════════
 # Wave-2 acceptance criterion (mirrors PR #72 T9): proves the lint


### PR DESCRIPTION
Quick-sweep item. `lint-backlog-references.sh` Step 4 (marker `# BL-207-HEADER-UNIQUENESS`): any `BL-NNN` ID owning more than one `^## ` header fails, naming the ID and EVERY line number — in CI and `--pre-commit-mode` both. The grammar is `BL-[0-9]+[a-z]?` (the narrow sketched form would fold the real `BL-003a`/`BL-003b` splits), preserved pre-close blocks get NO exemption (the splitter reads an un-indented inner header as real — demonstrated: it truncates citation checks — so the arm agrees with the splitter it protects), output is deterministic first-header order.

TDD arc: watched RED 16/5 → GREEN, plus the implementer's own M2 mutation exposed a masked-atom pair in its first draft (`substr($0,4,…)` hardcoded the anchor's offset — unanchored lookalikes extracted garbage and never collided) — root-caused and fixed with `RSTART+3`; the repo's counter-antipattern lint also rejected draft 1's unsanitized capture, folded into the single awk pass. Review (standing gate): **minor_concerns** — the reviewer reproduced the M2 story exactly, killed four of its own mutants against the suite, and refuted one guidance sentence ("fence it" does not exempt — only indentation does). All three findings fixed in `7607f2c`: corrected wording, a DUP-order fixture whose ID pair was CHOSEN BY PROBING 14 candidates (the reviewer's suggested pair would have left the for-in mutant invisible on this host — stated in the test comment), and the two uncovered surfaces named in-code (`## code-*-N:` headers ×2; the bugs file's 7 `## BUG-NNN:` headers — both out of BL-207's text, candidates for a follow-up).

Suite 22/0; pre-commit-gate-lints 13/0; run-lints 11/11; ~0.03s cost. Entry closes at merge. Opus implementer + fable review; supervisor merge on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)