### PR TITLE
fix(bl196): the marker-citation validator — the repo's citation primitive gets its lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,8 +17,9 @@
 #
 # Every job here is a PAIR of steps: a GATING step that runs the lint and
 # fails the job, and an INVENTORY step that re-runs the SAME lint with
-# `--list` to print the per-file PASS/FAIL roster. There are NINE such
-# pairs — one per job — and under `if: always()` the inventory step re-ran
+# `--list` to print the per-file PASS/FAIL roster. There are TEN such
+# pairs — one per job; it was NINE until BL-196 added bl-markers-lint —
+# and under `if: always()` the inventory step re-ran
 # the full scan on GREEN runs too, where nobody reads it. That doubled
 # every lint job. Measured on the counter-antipattern job (run 30297887996,
 # job 90083310253, main @ 9d71824): 207s gating + 204s inventory = 419s.
@@ -262,3 +263,33 @@ jobs:
       - name: Show PASS/FAIL inventory (on failure)
         if: failure()
         run: bash scripts/lint-evalprompts-portability.sh --list || true
+
+  # BL-196: citation-integrity backstop for the repo's citation PRIMITIVE.
+  # CLAUDE.md § CITATION RULE makes the grep-able `# BL-NNN-…` marker
+  # comment the only sanctioned way to cite code (never a bare file:line,
+  # because line numbers mis-resolve within 24h) — and nothing validated
+  # it. This job resolves both directions: every marker in the code
+  # surface names a real `## BL-NNN:` entry, and every marker CITED in the
+  # live prose surface resolves to a marker that still exists. A vacuity
+  # floor makes a collapsed scan exit 2 rather than pass silently. See
+  # scripts/lint-bl-markers.sh header for the surface definitions and the
+  # allowlist mechanism, and tests/test-lint-bl-markers.sh for the
+  # behavior suite (incl. the fence-excision mutation).
+  #
+  # NOT a required status check yet — adding this job does not make it
+  # one. Branch protection is Karl's call; deliberately untouched here.
+  # Same job-name-is-required-check convention as the jobs above: if it
+  # IS promoted, keep the name stable.
+  bl-markers-lint:
+    name: bl-markers-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
+
+      - name: Lint BL marker citations (BL-196)
+        run: bash scripts/lint-bl-markers.sh
+
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
+        run: bash scripts/lint-bl-markers.sh --list || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -383,6 +383,7 @@ jobs:
             tests/test-bl202-session-intake-check.sh
             tests/test-intake-wizard-fixes.sh
             tests/test-lint-backlog-references.sh
+            tests/test-lint-bl-markers.sh
             tests/test-lint-counter-antipattern.sh
             tests/test-lint-doc-anchors.sh
             tests/test-lint-fix-functions-stderr.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,10 +144,10 @@ call). Two directions, plus a vacuity floor:
 
 **A citation only counts when prose marks it as code**: backticked
 (`` `# BL-084-TIER-KEY` ``) or hash-prefixed (`# BL-084-TIER-KEY`). A
-**bare** `BL-NNN-suffix` token is invisible to the lint — ~10 real markers
-on the tree are written that way and go unchecked, while ~9 lookalikes are
-ordinary prose hyphenation: BL-140-family, BL-030-edit (left bare here on
-purpose — backtick either one and this very line goes red).
+**bare** `BL-NNN-suffix` token is invisible to the lint — of 21 bare hits,
+**10** are real markers that go unchecked and **11** are ordinary prose
+hyphenation: BL-140-family, BL-030-edit (left bare here on purpose —
+backtick either one and this very line goes red).
 **Backtick your markers** and they become enforced. Cite a fence family
 (`# BL-105-PHASE4-GATE`) or a glob (`# BL-102-MARKET-SIGNAL-*`) and it
 resolves against the `-BEGIN`/`-END` members; a **truncation typo does

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,11 +86,13 @@ here.
 ## LINT GOTCHAS
 
 - `scripts/run-lints.sh` runs **every `scripts/lint-*.sh` EXCEPT
-  `lint-uat-scenarios.sh`** (11 of the 12 lint scripts as of 2026-07-23).
+  `lint-uat-scenarios.sh`** (12 of the 13 lint scripts as of 2026-07-31 — BL-196
+  added `lint-bl-markers.sh`, and run-lints discovers it by glob, no wiring).
 - `scripts/lint-uat-scenarios.sh` is a **parametrized tool, not a repo lint**:
   bare-invoked it exits **2** with a `Usage:` message because it needs a
-  `<populated-html-file>` argument. It is **not** one of the 9 CI-required lint
-  jobs (`.github/workflows/lint.yml`), so run-lints deliberately skips it.
+  `<populated-html-file>` argument. It is **not** one of the CI lint jobs
+  (`.github/workflows/lint.yml`, 10 jobs as of 2026-07-31), so run-lints
+  deliberately skips it.
 - Two lints are **slow full-tree scans**: `lint-counter-antipattern.sh` (~90s)
   and `lint-raw-read-prompt.sh` (~40s). A full `run-lints.sh` is a couple of
   minutes — that is expected, not a hang.
@@ -125,6 +127,32 @@ Cite code by a **grep-able `# BL-NNN-…` marker comment** or a **function name*
 within 24h of being written; the marker comment is the repo's citation
 primitive. When reading an old handoff, **re-grep every line-number citation
 before trusting it**.
+
+**BL-196: the marker half is now lint-enforced** —
+`scripts/lint-bl-markers.sh` (in the run-lints sweep and the
+`bl-markers-lint` CI job; **not** a required check — that is Karl's later
+call). Two directions, plus a vacuity floor:
+- every `# BL-NNN-…` marker in the **code surface** (`init.sh`, `scripts/`,
+  `tests/`, `templates/`, `evaluation-prompts/`, `.github/`) names a real
+  `## BL-NNN:` entry;
+- every marker **cited** in the **live prose surface** (`CLAUDE.md`,
+  `README.md`, `CONTRIBUTING.md`, `solo-orchestrator-backlog.md`,
+  `docs/**` minus `docs/handoffs/archive/**`) resolves to a marker that
+  still exists. Frozen artifacts are deliberately out of scope —
+  `Reports/**`, archived handoffs, `solo-orchestrator-bugs.md` — because
+  they are stamped to the tree they were written against.
+
+**A citation only counts when prose marks it as code**: backticked
+(`` `# BL-084-TIER-KEY` ``) or hash-prefixed (`# BL-084-TIER-KEY`). A
+**bare** `BL-NNN-suffix` token is invisible to the lint — ~10 real markers
+on the tree are written that way and go unchecked, while ~9 lookalikes are
+ordinary prose hyphenation: BL-140-family, BL-030-edit (left bare here on
+purpose — backtick either one and this very line goes red).
+**Backtick your markers** and they become enforced. Cite a fence family
+(`# BL-105-PHASE4-GATE`) or a glob (`# BL-102-MARKET-SIGNAL-*`) and it
+resolves against the `-BEGIN`/`-END` members; a **truncation typo does
+not**. Deliberately-withdrawn markers get an allowlist row with a reason,
+never a deletion.
 
 ## HANDOFFS
 

--- a/scripts/lint-bl-markers.sh
+++ b/scripts/lint-bl-markers.sh
@@ -32,7 +32,7 @@
 #       on all THREE populations — markers, citations, backlog entry ids —
 #       turn a silent no-op into a loud exit 2, and an EMPTY entry set is
 #       refused outright before either join runs (# BL-196-EMPTY-SET-GUARD).
-#       Measured on this branch, 2026-07-31: 284 marker tokens in the code
+#       Measured on this branch, 2026-07-31: 285 marker tokens in the code
 #       surface, 368 citations in the prose surface, 204 entry ids. The
 #       floors sit well below all three so ordinary churn never trips them.
 #
@@ -189,7 +189,7 @@ fi
 ROOT="$(cd "$ROOT" && pwd)" || { echo "lint-bl-markers: cannot enter root: $ROOT" >&2; exit 2; }
 
 # Vacuity floors (pass c). Real-tree defaults sit well below the measured
-# populations (284 markers / 368 citations / 204 entry ids, 2026-07-31); a
+# populations (285 markers / 368 citations / 204 entry ids, 2026-07-31); a
 # fixture tree under --root defaults to 0 and raises them explicitly.
 if [ -z "$MIN_MARKERS" ]; then
   if [ -n "$ROOT_OVERRIDE" ]; then MIN_MARKERS=0; else MIN_MARKERS=50; fi
@@ -281,8 +281,17 @@ done
 #      `cp scripts/lint-bl-markers.sh scripts/zz-copy.sh`: the copy
 #      carries the sentinel because the sentinel is part of the file.
 # Layer 3 subsumes 1 and 2 for honest copies; 1 and 2 stay because they
-# cost nothing and still hold if someone strips the sentinel line.
-# T16 in tests/test-lint-bl-markers.sh is the canary for layer 3.
+# cost nothing and still hold if someone strips the sentinel line — but
+# READ THAT NARROWLY: it holds only for a copy whose PATH still matches
+# layer 1 or 2. A de-sentinelled copy under an arbitrary name defeats all
+# three, and no layer here detects it. That residual is deliberate and is
+# the sabotage class, not the accident class: every layer above is aimed
+# at a copy someone made in good faith (a backup, a rename, an
+# experiment). Nothing in this lint is a defence against an author who is
+# actively editing it to lie.
+# T16 in tests/test-lint-bl-markers.sh is the canary for layer 3, and its
+# control arm is exactly the de-sentinelled copy — so the residual is
+# demonstrated, not merely asserted.
 SELF_SENTINEL="BL-196-SELF-EXCLUDE-SENTINEL"
 if [ -s "$CODE_FILES" ]; then
   grep -vxF "$SELF_REL" "$CODE_FILES" \

--- a/scripts/lint-bl-markers.sh
+++ b/scripts/lint-bl-markers.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+# scripts/lint-bl-markers.sh — BL-196 structural backstop for the repo's
+# citation primitive: the grep-able `# BL-NNN-…` marker comment.
+#
+# THE DEFECT CLASS
+#   CLAUDE.md § CITATION RULE makes the marker comment load-bearing: cite
+#   code by a marker or a function name, NEVER by a bare file:line,
+#   because line numbers mis-resolve within 24h. That makes every marker
+#   an interface — and until this lint nothing validated it. A marker that
+#   is renamed, typo'd, or deleted silently breaks every document that
+#   points at it, and no lint, test or gate noticed. The worked example is
+#   on `## BL-196:`: a marker cited in a closure paragraph was reported to
+#   "exist nowhere", which was true of one commit and false of the commit
+#   14 minutes later — a marker claim is stamped with a TREE, and the only
+#   way to keep the stamp honest is to re-resolve it on every push.
+#
+# THE THREE PASSES (the shape `## BL-196:` prescribes)
+#   (a) MARKER -> ENTRY. Every `# BL-NNN-…` marker comment in the code
+#       surface names a `BL-NNN` that has a `## BL-NNN:` entry in
+#       solo-orchestrator-backlog.md. Catches a marker minted against a
+#       typo'd or nonexistent entry id.
+#   (b) CITE -> MARKER. Every marker CITATION in the live prose surface
+#       resolves to a marker token that actually exists in the code
+#       surface. This is the core defect class: a cite in prose naming a
+#       marker that no longer exists in code.
+#   (c) VACUITY FLOOR. If either grep breaks (a regex edit, a moved
+#       directory, a renamed surface), the scan would find nothing and
+#       "pass". Floors on the two populations turn a silent no-op into a
+#       loud exit 2. Measured on this branch, 2026-07-31: 280 marker
+#       tokens in the code surface, 368 citations in the prose surface.
+#       The floors sit well below both so ordinary churn never trips them.
+#
+# THE CODE SURFACE (where a marker is DEFINED)
+#   init.sh, scripts/, tests/, templates/, evaluation-prompts/, .github/ —
+#   every file, any extension. These are the tree's executable and shipped
+#   artifacts; a marker occurring in one of them is greppable and alive.
+#   `## BL-196:` names only scripts/, tests/ and init.sh; the other three
+#   are added because measurement found real marker families living there
+#   (`# BL-128-*` in evaluation-prompts/Projects/run-reviews.sh,
+#   `# BL-160-AUDIT-SCOPE` in templates/pipelines/ci/**) that a narrower
+#   surface would have reported as broken citations. Widening the surface
+#   makes pass (b) STRICTLY more conservative and leaves pass (a) green.
+#
+#   SELF-EXCLUSION: this script excludes ITSELF from the code surface. Its
+#   allowlist below names withdrawn markers verbatim, and a lint that can
+#   satisfy its own resolution check by mentioning a token in its own
+#   allowlist would be self-certifying. Nothing else is excluded.
+#
+# THE PROSE SURFACE (where a marker is CITED)
+#   CLAUDE.md, README.md, CONTRIBUTING.md, solo-orchestrator-backlog.md,
+#   and docs/**/*.md EXCEPT docs/handoffs/archive/**.
+#
+#   DELIBERATELY OUT OF SCOPE, and why — these are FROZEN artifacts, dated
+#   and stamped to the tree they were written against. Editing one to
+#   satisfy a lint would falsify the record, so a lint that reds on one is
+#   pure cry-wolf:
+#     • Reports/**                 — dogfood / audit run artifacts.
+#     • docs/handoffs/archive/**   — superseded or fully-executed handoffs
+#                                    (docs/handoffs/archive/README.md says
+#                                    so explicitly).
+#     • solo-orchestrator-bugs.md  — every entry is Fixed or Superseded by
+#                                    construction; there is no live half.
+#   CLOSED backlog entries ARE scanned. They are audit trail and must never
+#   be deleted, but they are also where the BL-179 misattribution the entry
+#   documents actually happened, and they sit in a file that is edited every
+#   day — so a break there is both reachable and worth naming. Nothing in
+#   this repo's closed entries is broken today except the two allowlisted
+#   tokens below.
+#
+# WHAT COUNTS AS A CITATION (deliberately narrow — measured, not asserted)
+#   Only a token that prose has explicitly marked as CODE:
+#     1. backticked:      `BL-084-TIER-KEY`  or  `# BL-084-TIER-KEY`
+#     2. hash-prefixed:   # BL-112-SCAN-COVERAGE   (unbackticked, as it
+#                         appears mid-sentence in several entries)
+#   A BARE unbackticked, unhashed token is NOT a citation. Measured over
+#   the whole prose surface (2026-07-31): 389 marker-shaped tokens, of
+#   which 368 carry one of the two explicit shapes and 21 are bare. ELEVEN
+#   of those 21 are ordinary prose hyphenation, not citations at all —
+#   BL-140-family, BL-137-class, BL-122-correct, BL-030-edit, BL-090-style,
+#   BL-101-generator (left unbackticked HERE too, for the same reason).
+#   Treating the bare shape as a citation would make this lint a cry-wolf
+#   machine on day one.
+#   NAMED RESIDUAL, since the trade is not free: the other TEN bare hits
+#   ARE real markers written without backticks (BL-084-TIER-KEY,
+#   BL-073-ESCALATE, BL-107-UNIVERSAL-INSTALL, BL-170-APPEND-DESIGN, …)
+#   and this lint does not check them. Backtick a marker and it becomes
+#   enforced; the fix for the residual is to backtick, not to widen the
+#   regex — widening cannot separate the two halves, the shapes are
+#   identical.
+#
+#   `# BL-NNN-…` (the literal placeholder CLAUDE.md uses to describe the
+#   convention) never matches: `NNN` is not digits.
+#
+# HOW A CITATION RESOLVES
+#   • EXACT: the token appears verbatim somewhere in the code surface.
+#   • FAMILY: `TOKEN-` prefixes some code token. This is what makes a cite
+#     of a FENCE family resolve — prose writes `# BL-105-PHASE4-GATE` while
+#     the code carries `-BEGIN` / `-END` — and what makes the glob form
+#     `# BL-102-MARKET-SIGNAL-*` resolve. A trailing `-` or `*` on the
+#     cited token is stripped before lookup for the same reason. Note the
+#     family rule requires the HYPHEN: a truncation typo (`…-TIER-KE` for
+#     `…-TIER-KEY`) still fails, because `BL-084-TIER-KE-` prefixes nothing.
+#
+# ALLOWLIST — two mechanisms, both requiring a reason
+#   1. INLINE, preferred: put `<!-- lint-bl-markers: allow <reason> -->`
+#      (or `# lint-bl-markers: allow <reason>` in code) on the CITING line.
+#      An empty reason FAILS, matching the allowlist semantics of
+#      lint-counter-antipattern.sh and lint-backlog-references.sh.
+#   2. SCRIPT-LEVEL, for cites in a file this change may not edit: the
+#      ALLOWLIST table below. Every row carries its reason and is rendered
+#      in --list, so it is reviewable.
+#
+# EXIT CODES
+#   0 — every marker resolves to an entry and every citation to a marker.
+#   1 — one or more violations found.
+#   2 — invocation / I/O error, OR the vacuity floor tripped (pass c).
+#
+# USAGE
+#   bash scripts/lint-bl-markers.sh              # quiet pass/fail
+#   bash scripts/lint-bl-markers.sh --list       # PASS/FAIL table
+#   bash scripts/lint-bl-markers.sh --root DIR   # test-mode: scan an
+#       alternate tree (used by tests/test-lint-bl-markers.sh). Under
+#       --root the vacuity floors default to 0 — a fixture is SUPPOSED to
+#       be small — and can be raised explicitly with the two flags below
+#       so the floor itself stays testable.
+#   bash scripts/lint-bl-markers.sh --min-markers N --min-cites N
+#
+# BASH 3.2 COMPATIBILITY
+#   macOS ships bash 3.2.57 as /bin/bash. No associative arrays, no
+#   ${var,,}, no `((x++))` under set -e. Sets are temp files; the two
+#   resolution joins are single awk passes over two files (the NR==FNR
+#   trick), so no shell variable is ever interpolated into an awk
+#   program — awk reads its inputs, never `-v`.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_REL="scripts/lint-bl-markers.sh"
+
+LIST_MODE=0
+ROOT_OVERRIDE=""
+MIN_MARKERS=""
+MIN_CITES=""
+
+USAGE="Usage: $0 [--list] [--root DIR] [--min-markers N] [--min-cites N]"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list) LIST_MODE=1; shift ;;
+    --root)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      ROOT_OVERRIDE="$2"; shift 2 ;;
+    --min-markers)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      MIN_MARKERS="$2"; shift 2 ;;
+    --min-cites)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      MIN_CITES="$2"; shift 2 ;;
+    -h|--help) echo "$USAGE"; exit 0 ;;
+    *) echo "$USAGE" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="${ROOT_OVERRIDE:-$REPO_ROOT}"
+
+if [ ! -d "$ROOT" ]; then
+  echo "lint-bl-markers: root not found: $ROOT" >&2
+  exit 2
+fi
+# Canonicalize: every relative path in this script is produced by stripping
+# "$ROOT/" off a find(1) result, so a trailing slash or a relative --root
+# would leave the prefix un-stripped and every reported path absolute.
+ROOT="$(cd "$ROOT" && pwd)" || { echo "lint-bl-markers: cannot enter root: $ROOT" >&2; exit 2; }
+
+# Vacuity floors (pass c). Real-tree defaults sit well below the measured
+# populations (280 markers / 368 citations, 2026-07-31); a fixture tree
+# under --root defaults to 0 and raises them explicitly.
+if [ -z "$MIN_MARKERS" ]; then
+  if [ -n "$ROOT_OVERRIDE" ]; then MIN_MARKERS=0; else MIN_MARKERS=50; fi
+fi
+if [ -z "$MIN_CITES" ]; then
+  if [ -n "$ROOT_OVERRIDE" ]; then MIN_CITES=0; else MIN_CITES=25; fi
+fi
+case "$MIN_MARKERS" in ''|*[!0-9]*) echo "$USAGE" >&2; exit 2 ;; esac
+case "$MIN_CITES"   in ''|*[!0-9]*) echo "$USAGE" >&2; exit 2 ;; esac
+
+BACKLOG="$ROOT/solo-orchestrator-backlog.md"
+if [ ! -f "$BACKLOG" ]; then
+  echo "lint-bl-markers: backlog not found at $BACKLOG" >&2
+  exit 2
+fi
+
+TMPD=$(mktemp -d) || { echo "lint-bl-markers: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TMPD"' EXIT
+
+# ── BL-196-ALLOWLIST-BEGIN ──────────────────────────────────────────────
+# Script-level allowlist: `TOKEN|reason`. Used only where the citing file
+# is one this change will not rewrite to satisfy a lint. Every row is
+# rendered by --list.
+#
+# The two rows below are the ONLY broken citations on the tree as of
+# 2026-07-31, and both are deliberate: `## BL-192:` records that the
+# BL-186 parse-coverage clause and its five test cases were WITHDRAWN from
+# main and live on the unmerged branch `fix/bl112-sast-scan-coverage`
+# (`e87dbd3`), to be restored only with a decode check that does not
+# depend on semgrep's `Parsed lines`. Entries BL-186, BL-189 and BL-192
+# all cite them as not-on-this-tree on purpose. That is BL-196's own
+# lesson — a marker claim is stamped with a tree — so the citations are
+# correct and it is this lint that must yield. Delete these rows when the
+# branch merges (they then resolve by exact match) or when the entries are
+# rewritten.
+ALLOWLIST="
+BL-186-PARSE-COVERAGE|withdrawn to unmerged branch fix/bl112-sast-scan-coverage (e87dbd3) per BL-192; cited as not-on-this-tree on purpose
+BL-186-EMPTY-TARGETS|withdrawn to unmerged branch fix/bl112-sast-scan-coverage (e87dbd3) per BL-192; cited as not-on-this-tree on purpose
+"
+allow_reason_for() {
+  printf '%s\n' "$ALLOWLIST" | while IFS='|' read -r a_tok a_reason; do
+    [ -n "$a_tok" ] || continue
+    if [ "$a_tok" = "$1" ]; then printf '%s' "$a_reason"; break; fi
+  done
+}
+# ── BL-196-ALLOWLIST-END ────────────────────────────────────────────────
+
+# ── Enumerate the code surface (paths RELATIVE to ROOT) ─────────────────
+CODE_SURFACE="init.sh scripts tests templates evaluation-prompts .github"
+CODE_FILES="$TMPD/code-files"
+: > "$CODE_FILES"
+for surface_entry in $CODE_SURFACE; do
+  target="$ROOT/$surface_entry"
+  if [ -f "$target" ]; then
+    printf '%s\n' "$surface_entry" >> "$CODE_FILES"
+  elif [ -d "$target" ]; then
+    while IFS= read -r found; do
+      [ -n "$found" ] || continue
+      printf '%s\n' "${found#"$ROOT"/}" >> "$CODE_FILES"
+    done < <(find "$target" -type f -print 2>/dev/null)
+  fi
+done
+# Self-exclusion (see header): this script's own allowlist names tokens
+# verbatim; letting it define them would make the lint self-certifying.
+if [ -s "$CODE_FILES" ]; then
+  grep -vxF "$SELF_REL" "$CODE_FILES" > "$CODE_FILES.keep"
+  mv "$CODE_FILES.keep" "$CODE_FILES"
+fi
+# Drop binary and empty files in ONE pass. grep -I skips binaries and the
+# empty pattern matches every line of every text file, so what survives is
+# exactly the set awk can safely read. Without this a stray .DS_Store (or
+# any committed blob) is handed to awk, which has no binary guard of its
+# own and could emit a garbage row. Cost is one extra scan, not one
+# subprocess per file.
+if [ -s "$CODE_FILES" ]; then
+  ( cd "$ROOT" && tr '\n' '\0' < "$CODE_FILES" | xargs -0 grep -lI '' 2>/dev/null ) \
+    | sort -u > "$CODE_FILES.keep"
+  mv "$CODE_FILES.keep" "$CODE_FILES"
+fi
+
+# ── Set 1: every marker TOKEN present anywhere in the code surface ──────
+MARKER_TOKENS="$TMPD/marker-tokens"
+: > "$MARKER_TOKENS"
+if [ -s "$CODE_FILES" ]; then
+  ( cd "$ROOT" && tr '\n' '\0' < "$CODE_FILES" \
+      | xargs -0 grep -hoIE 'BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_-]*' 2>/dev/null ) \
+    | sort -u > "$MARKER_TOKENS"
+fi
+
+MARKER_COUNT=$(grep -c . "$MARKER_TOKENS" 2>/dev/null) || MARKER_COUNT=0
+case "$MARKER_COUNT" in ''|*[!0-9]*) MARKER_COUNT=0 ;; esac
+
+# ── Set 2: every `## BL-NNN:` entry id in the backlog ────────────────────
+ENTRY_IDS="$TMPD/entry-ids"
+grep -oE '^## BL-[0-9]+[a-z]?:' "$BACKLOG" 2>/dev/null \
+  | sed -e 's/^## //' -e 's/:$//' | sort -u > "$ENTRY_IDS"
+
+VIOLATIONS=0
+LIST_ROWS=""
+PROSE_CITES=0
+
+# ── PASS (a): every `# BL-NNN-…` marker names an existing entry ──────────
+# The DEFINITION shape is the hash-comment one only — a bare token inside
+# a string or a grep pattern is a reference, not a minting. Emits
+# `file<TAB>line<TAB>BL-NNN`.
+EXTRACT_DEFS="$TMPD/extract-defs.awk"
+cat > "$EXTRACT_DEFS" <<'AWK'
+{
+  # The HTML comment closer is stripped before the reason is measured, so
+  # `<!-- lint-bl-markers: allow -->` reads as EMPTY and not as the reason
+  # "-->" — an empty reason must fail, per the house allowlist semantics.
+  probe = $0
+  gsub(/-->/, "", probe)
+  if (probe ~ /lint-bl-markers:[ \t]*allow[ \t]+[^ \t]/) next
+  line = $0
+  while (match(line, /#[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_-]*/)) {
+    tok = substr(line, RSTART, RLENGTH)
+    line = substr(line, RSTART + RLENGTH)
+    sub(/^#[[:space:]]*/, "", tok)
+    if (match(tok, /^BL-[0-9]+[a-z]?/)) {
+      print FILENAME "\t" FNR "\t" substr(tok, 1, RLENGTH)
+    }
+  }
+}
+AWK
+
+MARKER_SITES="$TMPD/marker-sites"
+: > "$MARKER_SITES"
+if [ -s "$CODE_FILES" ]; then
+  ( cd "$ROOT" && tr '\n' '\0' < "$CODE_FILES" \
+      | xargs -0 awk -f "$EXTRACT_DEFS" 2>/dev/null ) > "$MARKER_SITES"
+fi
+
+UNKNOWN_ENTRY_SITES="$TMPD/unknown-entry-sites"
+awk -F'\t' 'NR==FNR { ent[$1]=1; next } !($3 in ent)' \
+  "$ENTRY_IDS" "$MARKER_SITES" > "$UNKNOWN_ENTRY_SITES"
+
+while IFS=$'\t' read -r m_file m_line m_id; do
+  [ -n "${m_id:-}" ] || continue
+  echo "lint-bl-markers: ${m_file}:${m_line} marker names ${m_id}, which has no '## ${m_id}:' entry in solo-orchestrator-backlog.md" >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+  LIST_ROWS="${LIST_ROWS}FAIL\tmarker->entry\t${m_file}:${m_line}\t${m_id}\tno backlog entry\n"
+done < "$UNKNOWN_ENTRY_SITES"
+
+# ── BL-196-PROSE-CITE-BEGIN ─────────────────────────────────────────────
+# PASS (b): every marker CITATION in the live prose surface resolves to a
+# marker token in the code surface. THIS IS THE CORE DEFECT CLASS of
+# BL-196 — a cite in prose naming a marker that no longer exists in code.
+# The whole check lives inside this fence; tests/test-lint-bl-markers.sh
+# excises the fence and proves the broken-cite fixture then passes.
+EXTRACT_CITES="$TMPD/extract-cites.awk"
+cat > "$EXTRACT_CITES" <<'AWK'
+{
+  ann = "-"
+  # See EXTRACT_DEFS: strip the HTML comment closer before measuring the
+  # reason, or `<!-- lint-bl-markers: allow -->` self-approves with "-->".
+  probe = $0
+  gsub(/-->/, "", probe)
+  if (probe ~ /lint-bl-markers:[ \t]*allow[ \t]+[^ \t]/) ann = "allow"
+  else if (probe ~ /lint-bl-markers:[ \t]*allow/)        ann = "allow-empty"
+  line = $0
+  while (match(line, /`[[:space:]]*#?[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*`|#[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*/)) {
+    tok = substr(line, RSTART, RLENGTH)
+    line = substr(line, RSTART + RLENGTH)
+    gsub(/`/, "", tok)
+    sub(/^[[:space:]]*#?[[:space:]]*/, "", tok)
+    sub(/[-*]+$/, "", tok)
+    print FILENAME "\t" FNR "\t" tok "\t" ann
+  }
+}
+AWK
+
+PROSE_FILES="$TMPD/prose-files"
+: > "$PROSE_FILES"
+for prose_entry in CLAUDE.md README.md CONTRIBUTING.md solo-orchestrator-backlog.md; do
+  [ -f "$ROOT/$prose_entry" ] && printf '%s\n' "$prose_entry" >> "$PROSE_FILES"
+done
+if [ -d "$ROOT/docs" ]; then
+  while IFS= read -r found; do
+    [ -n "$found" ] || continue
+    rel="${found#"$ROOT"/}"
+    case "$rel" in docs/handoffs/archive/*) continue ;; esac
+    printf '%s\n' "$rel" >> "$PROSE_FILES"
+  done < <(find "$ROOT/docs" -type f -name '*.md' -print 2>/dev/null)
+fi
+sort -u "$PROSE_FILES" -o "$PROSE_FILES"
+
+CITES="$TMPD/cites"
+: > "$CITES"
+if [ -s "$PROSE_FILES" ]; then
+  ( cd "$ROOT" && tr '\n' '\0' < "$PROSE_FILES" \
+      | xargs -0 awk -f "$EXTRACT_CITES" 2>/dev/null ) > "$CITES"
+fi
+
+PROSE_CITES=$(grep -c . "$CITES" 2>/dev/null) || PROSE_CITES=0
+case "$PROSE_CITES" in ''|*[!0-9]*) PROSE_CITES=0 ;; esac
+
+# Resolution join: EXACT match, else FAMILY match (`TOKEN-` prefixes a
+# known code token). Emits `verdict<TAB>file<TAB>line<TAB>token<TAB>ann`.
+RESOLVED="$TMPD/cites-resolved"
+awk -F'\t' '
+  NR==FNR { n++; toks[n] = $1; tok[$1] = 1; next }
+  {
+    verdict = "MISS"
+    if ($3 in tok) verdict = "EXACT"
+    else {
+      pfx = $3 "-"
+      for (i = 1; i <= n; i++) {
+        if (index(toks[i], pfx) == 1) { verdict = "FAMILY"; break }
+      }
+    }
+    print verdict "\t" $1 "\t" $2 "\t" $3 "\t" $4
+  }
+' "$MARKER_TOKENS" "$CITES" > "$RESOLVED"
+
+while IFS=$'\t' read -r c_verdict c_file c_line c_tok c_ann; do
+  [ -n "${c_tok:-}" ] || continue
+  case "$c_verdict" in
+    EXACT|FAMILY)
+      LIST_ROWS="${LIST_ROWS}PASS\tcite->marker\t${c_file}:${c_line}\t${c_tok}\tresolved (${c_verdict})\n"
+      continue
+      ;;
+  esac
+  if [ "$c_ann" = "allow" ]; then
+    LIST_ROWS="${LIST_ROWS}PASS\tcite->marker\t${c_file}:${c_line}\t${c_tok}\tinline-allow\n"
+    continue
+  fi
+  if [ "$c_ann" = "allow-empty" ]; then
+    echo "lint-bl-markers: ${c_file}:${c_line} '${c_tok}' has an EMPTY allowlist reason (use 'lint-bl-markers: allow <reason>')" >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+    LIST_ROWS="${LIST_ROWS}FAIL\tcite->marker\t${c_file}:${c_line}\t${c_tok}\tallowlist-empty-reason\n"
+    continue
+  fi
+  c_reason=$(allow_reason_for "$c_tok")
+  if [ -n "$c_reason" ]; then
+    LIST_ROWS="${LIST_ROWS}PASS\tcite->marker\t${c_file}:${c_line}\t${c_tok}\tallowlist: ${c_reason}\n"
+    continue
+  fi
+  echo "lint-bl-markers: ${c_file}:${c_line} cites marker '# ${c_tok}' but no such marker exists in the code surface (init.sh, scripts/, tests/, templates/, evaluation-prompts/, .github/)" >&2
+  VIOLATIONS=$((VIOLATIONS + 1))
+  LIST_ROWS="${LIST_ROWS}FAIL\tcite->marker\t${c_file}:${c_line}\t${c_tok}\tbroken citation\n"
+done < "$RESOLVED"
+# ── BL-196-PROSE-CITE-END ───────────────────────────────────────────────
+
+if [ "$LIST_MODE" -eq 1 ]; then
+  printf 'STATUS\tPASS\tFILE:LINE\tTOKEN\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+  printf 'INFO\tpopulation\t-\t-\t%s marker token(s) in the code surface, %s citation(s) in the prose surface\n' \
+    "$MARKER_COUNT" "$PROSE_CITES"
+fi
+
+# ── PASS (c): vacuity floor ─────────────────────────────────────────────
+# A broken regex or a moved directory makes both populations collapse to
+# zero, and a lint with nothing to check "passes". Refuse to.
+if [ "$MARKER_COUNT" -lt "$MIN_MARKERS" ] || [ "$PROSE_CITES" -lt "$MIN_CITES" ]; then
+  echo "" >&2
+  echo "lint-bl-markers: VACUOUS SCAN — found $MARKER_COUNT marker token(s) (floor $MIN_MARKERS) and $PROSE_CITES citation(s) (floor $MIN_CITES)." >&2
+  echo "The scan collapsed, so a pass would be meaningless. Check the code/prose surface lists and the extraction regexes in this script." >&2
+  exit 2
+fi
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS marker-citation violation(s). Re-grep each cited marker; if it moved, update the citing prose — if it was deliberately withdrawn, allowlist it with a reason (see scripts/lint-bl-markers.sh header)." >&2
+  exit 1
+fi
+
+echo "OK: $MARKER_COUNT marker token(s) resolve to backlog entries and $PROSE_CITES prose citation(s) resolve to live markers."
+exit 0

--- a/scripts/lint-bl-markers.sh
+++ b/scripts/lint-bl-markers.sh
@@ -18,17 +18,23 @@
 #   (a) MARKER -> ENTRY. Every `# BL-NNN-…` marker comment in the code
 #       surface names a `BL-NNN` that has a `## BL-NNN:` entry in
 #       solo-orchestrator-backlog.md. Catches a marker minted against a
-#       typo'd or nonexistent entry id.
+#       typo'd or nonexistent entry id. Measured on this branch,
+#       2026-07-31: 86 distinct marker prefixes, 0 without an entry.
+#       (86, not 85 — this lint's own test fixtures mint BL-196. Count it
+#       with the recipe, never from memory: that off-by-one is exactly the
+#       stamped-to-a-tree failure `## BL-196:` is about.)
 #   (b) CITE -> MARKER. Every marker CITATION in the live prose surface
 #       resolves to a marker token that actually exists in the code
 #       surface. This is the core defect class: a cite in prose naming a
 #       marker that no longer exists in code.
-#   (c) VACUITY FLOOR. If either grep breaks (a regex edit, a moved
-#       directory, a renamed surface), the scan would find nothing and
-#       "pass". Floors on the two populations turn a silent no-op into a
-#       loud exit 2. Measured on this branch, 2026-07-31: 280 marker
-#       tokens in the code surface, 368 citations in the prose surface.
-#       The floors sit well below both so ordinary churn never trips them.
+#   (c) VACUITY FLOOR. If a grep breaks (a regex edit, a moved directory,
+#       a renamed surface), the scan would find nothing and "pass". Floors
+#       on all THREE populations — markers, citations, backlog entry ids —
+#       turn a silent no-op into a loud exit 2, and an EMPTY entry set is
+#       refused outright before either join runs (# BL-196-EMPTY-SET-GUARD).
+#       Measured on this branch, 2026-07-31: 284 marker tokens in the code
+#       surface, 368 citations in the prose surface, 204 entry ids. The
+#       floors sit well below all three so ordinary churn never trips them.
 #
 # THE CODE SURFACE (where a marker is DEFINED)
 #   init.sh, scripts/, tests/, templates/, evaluation-prompts/, .github/ —
@@ -44,7 +50,10 @@
 #   SELF-EXCLUSION: this script excludes ITSELF from the code surface. Its
 #   allowlist below names withdrawn markers verbatim, and a lint that can
 #   satisfy its own resolution check by mentioning a token in its own
-#   allowlist would be self-certifying. Nothing else is excluded.
+#   allowlist would be self-certifying. Exclusion is by exact path, by the
+#   `scripts/lint-bl-markers*.sh` rename shape, AND by a content sentinel,
+#   so an arbitrarily-named COPY of this file cannot re-mint the allowlisted
+#   tokens (`# BL-196-SELF-EXCLUDE-BEGIN`). Nothing else is excluded.
 #
 # THE PROSE SURFACE (where a marker is CITED)
 #   CLAUDE.md, README.md, CONTRIBUTING.md, solo-orchestrator-backlog.md,
@@ -121,16 +130,19 @@
 #   bash scripts/lint-bl-markers.sh --root DIR   # test-mode: scan an
 #       alternate tree (used by tests/test-lint-bl-markers.sh). Under
 #       --root the vacuity floors default to 0 — a fixture is SUPPOSED to
-#       be small — and can be raised explicitly with the two flags below
-#       so the floor itself stays testable.
-#   bash scripts/lint-bl-markers.sh --min-markers N --min-cites N
+#       be small — and can be raised explicitly with the flags below so the
+#       floor itself stays testable.
+#   bash scripts/lint-bl-markers.sh --min-markers N --min-cites N \
+#        --min-entries N
 #
 # BASH 3.2 COMPATIBILITY
 #   macOS ships bash 3.2.57 as /bin/bash. No associative arrays, no
 #   ${var,,}, no `((x++))` under set -e. Sets are temp files; the two
-#   resolution joins are single awk passes over two files (the NR==FNR
-#   trick), so no shell variable is ever interpolated into an awk
-#   program — awk reads its inputs, never `-v`.
+#   resolution joins are single awk passes over two files, discriminated by
+#   `FILENAME == ARGV[1]` and deliberately NOT by the `NR==FNR` idiom —
+#   `NR==FNR` is TRUE for every record of the second file when the first is
+#   empty, which turned both joins into silent no-ops. No shell variable is
+#   ever interpolated into an awk program — awk reads its inputs, never `-v`.
 
 set -uo pipefail
 
@@ -141,8 +153,9 @@ LIST_MODE=0
 ROOT_OVERRIDE=""
 MIN_MARKERS=""
 MIN_CITES=""
+MIN_ENTRIES=""
 
-USAGE="Usage: $0 [--list] [--root DIR] [--min-markers N] [--min-cites N]"
+USAGE="Usage: $0 [--list] [--root DIR] [--min-markers N] [--min-cites N] [--min-entries N]"
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -156,6 +169,9 @@ while [ $# -gt 0 ]; do
     --min-cites)
       [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
       MIN_CITES="$2"; shift 2 ;;
+    --min-entries)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      MIN_ENTRIES="$2"; shift 2 ;;
     -h|--help) echo "$USAGE"; exit 0 ;;
     *) echo "$USAGE" >&2; exit 2 ;;
   esac
@@ -173,16 +189,20 @@ fi
 ROOT="$(cd "$ROOT" && pwd)" || { echo "lint-bl-markers: cannot enter root: $ROOT" >&2; exit 2; }
 
 # Vacuity floors (pass c). Real-tree defaults sit well below the measured
-# populations (280 markers / 368 citations, 2026-07-31); a fixture tree
-# under --root defaults to 0 and raises them explicitly.
+# populations (284 markers / 368 citations / 204 entry ids, 2026-07-31); a
+# fixture tree under --root defaults to 0 and raises them explicitly.
 if [ -z "$MIN_MARKERS" ]; then
   if [ -n "$ROOT_OVERRIDE" ]; then MIN_MARKERS=0; else MIN_MARKERS=50; fi
 fi
 if [ -z "$MIN_CITES" ]; then
   if [ -n "$ROOT_OVERRIDE" ]; then MIN_CITES=0; else MIN_CITES=25; fi
 fi
+if [ -z "$MIN_ENTRIES" ]; then
+  if [ -n "$ROOT_OVERRIDE" ]; then MIN_ENTRIES=0; else MIN_ENTRIES=50; fi
+fi
 case "$MIN_MARKERS" in ''|*[!0-9]*) echo "$USAGE" >&2; exit 2 ;; esac
 case "$MIN_CITES"   in ''|*[!0-9]*) echo "$USAGE" >&2; exit 2 ;; esac
+case "$MIN_ENTRIES" in ''|*[!0-9]*) echo "$USAGE" >&2; exit 2 ;; esac
 
 BACKLOG="$ROOT/solo-orchestrator-backlog.md"
 if [ ! -f "$BACKLOG" ]; then
@@ -206,9 +226,18 @@ trap 'rm -rf "$TMPD"' EXIT
 # depend on semgrep's `Parsed lines`. Entries BL-186, BL-189 and BL-192
 # all cite them as not-on-this-tree on purpose. That is BL-196's own
 # lesson — a marker claim is stamped with a tree — so the citations are
-# correct and it is this lint that must yield. Delete these rows when the
-# branch merges (they then resolve by exact match) or when the entries are
-# rewritten.
+# correct and it is this lint that must yield.
+#
+# WHEN `fix/bl112-sast-scan-coverage` MERGES, do BOTH of these:
+#   1. delete the two rows below — the tokens then resolve by exact match
+#      and the rows become dead weight; and
+#   2. re-read `T-REPO-LIST` in tests/test-lint-bl-markers.sh. That case
+#      asserts the allowlist MECHANISM is live, and rows only render on a
+#      MISS — so the merge alone changes what it observes. It is written to
+#      accept EITHER a rendered allowlist row OR every allowlisted token
+#      resolving EXACT (and it is vacuously satisfied once the rows are
+#      gone), so the ORDER does not matter and neither step reds the unit
+#      lane on its own. Do not tighten it back to "at least one row".
 ALLOWLIST="
 BL-186-PARSE-COVERAGE|withdrawn to unmerged branch fix/bl112-sast-scan-coverage (e87dbd3) per BL-192; cited as not-on-this-tree on purpose
 BL-186-EMPTY-TARGETS|withdrawn to unmerged branch fix/bl112-sast-scan-coverage (e87dbd3) per BL-192; cited as not-on-this-tree on purpose
@@ -236,12 +265,39 @@ for surface_entry in $CODE_SURFACE; do
     done < <(find "$target" -type f -print 2>/dev/null)
   fi
 done
+# ── BL-196-SELF-EXCLUDE-BEGIN ───────────────────────────────────────────
 # Self-exclusion (see header): this script's own allowlist names tokens
 # verbatim; letting it define them would make the lint self-certifying.
+#
+# THREE LAYERS, because an exact-path exclusion is trivially defeated.
+# A COPY of this script anywhere in the code surface re-mints every
+# allowlisted token, and every allowlisted citation then resolves EXACT —
+# a silent, whole-check bypass that no diagnostic mentions:
+#   1. the exact self path;
+#   2. any `scripts/lint-bl-markers*.sh` — the rename/backup shape
+#      (`lint-bl-markers.sh.bak`, `lint-bl-markers-v2.sh`);
+#   3. ANY file in the surface carrying the sentinel string below,
+#      whatever it is called. This is the layer that catches
+#      `cp scripts/lint-bl-markers.sh scripts/zz-copy.sh`: the copy
+#      carries the sentinel because the sentinel is part of the file.
+# Layer 3 subsumes 1 and 2 for honest copies; 1 and 2 stay because they
+# cost nothing and still hold if someone strips the sentinel line.
+# T16 in tests/test-lint-bl-markers.sh is the canary for layer 3.
+SELF_SENTINEL="BL-196-SELF-EXCLUDE-SENTINEL"
 if [ -s "$CODE_FILES" ]; then
-  grep -vxF "$SELF_REL" "$CODE_FILES" > "$CODE_FILES.keep"
+  grep -vxF "$SELF_REL" "$CODE_FILES" \
+    | grep -vE '^scripts/lint-bl-markers[^/]*\.sh$' > "$CODE_FILES.keep"
   mv "$CODE_FILES.keep" "$CODE_FILES"
 fi
+if [ -s "$CODE_FILES" ]; then
+  ( cd "$ROOT" && tr '\n' '\0' < "$CODE_FILES" \
+      | xargs -0 grep -lF "$SELF_SENTINEL" 2>/dev/null ) | sort -u > "$TMPD/self-copies"
+  if [ -s "$TMPD/self-copies" ]; then
+    grep -vxF -f "$TMPD/self-copies" "$CODE_FILES" > "$CODE_FILES.keep"
+    mv "$CODE_FILES.keep" "$CODE_FILES"
+  fi
+fi
+# ── BL-196-SELF-EXCLUDE-END ─────────────────────────────────────────────
 # Drop binary and empty files in ONE pass. grep -I skips binaries and the
 # empty pattern matches every line of every text file, so what survives is
 # exactly the set awk can safely read. Without this a stray .DS_Store (or
@@ -270,6 +326,21 @@ case "$MARKER_COUNT" in ''|*[!0-9]*) MARKER_COUNT=0 ;; esac
 ENTRY_IDS="$TMPD/entry-ids"
 grep -oE '^## BL-[0-9]+[a-z]?:' "$BACKLOG" 2>/dev/null \
   | sed -e 's/^## //' -e 's/:$//' | sort -u > "$ENTRY_IDS"
+
+ENTRY_COUNT=$(grep -c . "$ENTRY_IDS" 2>/dev/null) || ENTRY_COUNT=0
+case "$ENTRY_COUNT" in ''|*[!0-9]*) ENTRY_COUNT=0 ;; esac
+
+# ── BL-196-EMPTY-SET-GUARD ──────────────────────────────────────────────
+# An EMPTY entry-id set is never a legitimate state: the file exists (checked
+# above) and every backlog has `## BL-NNN:` headers. It is the signature of a
+# broken header regex or the wrong file, and it must fail LOUDLY rather than
+# be inherited by the joins below — see the FILENAME note on each join for
+# what an empty first file used to do to an NR==FNR discriminator.
+if [ "$ENTRY_COUNT" -eq 0 ]; then
+  echo "lint-bl-markers: EMPTY ENTRY SET — no '## BL-NNN:' headers matched in $BACKLOG." >&2
+  echo "That is not a clean tree, it is a broken scan: the header regex, the file, or the surface list is wrong. Refusing to report a verdict." >&2
+  exit 2
+fi
 
 VIOLATIONS=0
 LIST_ROWS=""
@@ -307,8 +378,16 @@ if [ -s "$CODE_FILES" ]; then
       | xargs -0 awk -f "$EXTRACT_DEFS" 2>/dev/null ) > "$MARKER_SITES"
 fi
 
+# The join discriminates on FILENAME, NOT on `NR==FNR`. With an EMPTY first
+# file the classic `NR==FNR` idiom stays true for every record of the SECOND
+# file — awk never read a record from the first, so NR and FNR march together
+# — and the whole marker-site set is silently swallowed into `ent[]`, printing
+# nothing and reporting a clean pass over an unchecked tree. FILENAME cannot
+# drift that way: a record either came from ARGV[1] or it did not. The
+# EMPTY-SET-GUARD above already refuses this state; this is the second layer,
+# because the guard protects one call site and the idiom is copied.
 UNKNOWN_ENTRY_SITES="$TMPD/unknown-entry-sites"
-awk -F'\t' 'NR==FNR { ent[$1]=1; next } !($3 in ent)' \
+awk -F'\t' 'FILENAME == ARGV[1] { ent[$1]=1; next } !($3 in ent)' \
   "$ENTRY_IDS" "$MARKER_SITES" > "$UNKNOWN_ENTRY_SITES"
 
 while IFS=$'\t' read -r m_file m_line m_id; do
@@ -373,9 +452,13 @@ case "$PROSE_CITES" in ''|*[!0-9]*) PROSE_CITES=0 ;; esac
 
 # Resolution join: EXACT match, else FAMILY match (`TOKEN-` prefixes a
 # known code token). Emits `verdict<TAB>file<TAB>line<TAB>token<TAB>ann`.
+# FILENAME-discriminated for the same reason as the pass-(a) join above: an
+# empty MARKER_TOKENS under `NR==FNR` swallowed the entire citation list and
+# reported nothing. On the real tree the marker floor masks that; under
+# --root, where the floors default to 0, it was a live false pass.
 RESOLVED="$TMPD/cites-resolved"
 awk -F'\t' '
-  NR==FNR { n++; toks[n] = $1; tok[$1] = 1; next }
+  FILENAME == ARGV[1] { n++; toks[n] = $1; tok[$1] = 1; next }
   {
     verdict = "MISS"
     if ($3 in tok) verdict = "EXACT"
@@ -421,16 +504,19 @@ done < "$RESOLVED"
 if [ "$LIST_MODE" -eq 1 ]; then
   printf 'STATUS\tPASS\tFILE:LINE\tTOKEN\tDETAIL\n'
   printf '%b' "$LIST_ROWS"
-  printf 'INFO\tpopulation\t-\t-\t%s marker token(s) in the code surface, %s citation(s) in the prose surface\n' \
-    "$MARKER_COUNT" "$PROSE_CITES"
+  printf 'INFO\tpopulation\t-\t-\t%s marker token(s) in the code surface, %s citation(s) in the prose surface, %s backlog entry id(s)\n' \
+    "$MARKER_COUNT" "$PROSE_CITES" "$ENTRY_COUNT"
 fi
 
 # ── PASS (c): vacuity floor ─────────────────────────────────────────────
-# A broken regex or a moved directory makes both populations collapse to
-# zero, and a lint with nothing to check "passes". Refuse to.
-if [ "$MARKER_COUNT" -lt "$MIN_MARKERS" ] || [ "$PROSE_CITES" -lt "$MIN_CITES" ]; then
+# A broken regex or a moved directory makes a population collapse, and a lint
+# with nothing to check "passes". Refuse to. All THREE populations are floored:
+# the entry-id set is the input to pass (a)'s join, so a collapsed entry set is
+# every bit as blinding as a collapsed marker set.
+if [ "$MARKER_COUNT" -lt "$MIN_MARKERS" ] || [ "$PROSE_CITES" -lt "$MIN_CITES" ] \
+   || [ "$ENTRY_COUNT" -lt "$MIN_ENTRIES" ]; then
   echo "" >&2
-  echo "lint-bl-markers: VACUOUS SCAN — found $MARKER_COUNT marker token(s) (floor $MIN_MARKERS) and $PROSE_CITES citation(s) (floor $MIN_CITES)." >&2
+  echo "lint-bl-markers: VACUOUS SCAN — found $MARKER_COUNT marker token(s) (floor $MIN_MARKERS), $PROSE_CITES citation(s) (floor $MIN_CITES) and $ENTRY_COUNT backlog entry id(s) (floor $MIN_ENTRIES)." >&2
   echo "The scan collapsed, so a pass would be meaningless. Check the code/prose surface lists and the extraction regexes in this script." >&2
   exit 2
 fi

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -519,6 +519,26 @@ run_child_suite "scripts/lint-doc-anchors.sh" \
   "Every in-document anchor reference under docs/ resolves" \
   "Doc-anchors lint found broken anchor reference(s) (see scripts/lint-doc-anchors.sh --list)"
 
+# BL-196: tests/test-lint-bl-markers.sh — behavior suite for the
+# marker-citation backstop. Validates both directions (marker -> backlog
+# entry, prose citation -> live marker), the family/glob resolution rules,
+# the false-positive guards that keep bare prose hyphenation out of scope,
+# the frozen-surface exclusions, the allowlist semantics, and the vacuity
+# floor — plus the fence-excision mutation that proves the cite -> marker
+# check is where the comment says it is.
+section "Marker-citation lint (BL-196 structural backstop)"
+run_child_suite "tests/test-lint-bl-markers.sh" \
+  "scripts/lint-bl-markers.sh behavior tests" \
+  "scripts/lint-bl-markers.sh behavior tests FAILED (run tests/test-lint-bl-markers.sh for details)"
+
+# BL-196: repo-wide lint invocation. Fails when prose in the live surface
+# cites a `# BL-NNN-…` marker that no longer exists in the code surface,
+# or when a marker in code names a backlog entry that was never filed.
+# See scripts/lint-bl-markers.sh header for the surface definitions.
+run_child_suite "scripts/lint-bl-markers.sh" \
+  "Every live marker citation resolves to a marker in code" \
+  "Marker-citation lint found broken citation(s) (see scripts/lint-bl-markers.sh --list)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-lint-bl-markers.sh
+++ b/tests/test-lint-bl-markers.sh
@@ -101,9 +101,35 @@ run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
 # the real backlog's broken citations would then resolve EXACT off this
 # suite — masking the very thing the allowlist documents.
 allowlisted_tokens() {
-  sed -n '/BL-196-ALLOWLIST-BEGIN/,/BL-196-ALLOWLIST-END/p' "$LINTER" \
+  sed -n '/BL-196-ALLOWLIST-BEGIN/,/BL-196-ALLOWLIST-END/p' "${1:-$LINTER}" \
     | grep -E '^BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_-]*\|' \
     | sed -e 's/|.*//'
+}
+
+# ── unaccounted_allowlist_tokens: the T-REPO-LIST predicate, factored out so
+# T17 can run it against a deliberately-corrupted allowlist. Scans the REAL
+# tree with the given lint and echoes one line per allowlisted token that has
+# NEITHER its own `allowlist:` row NOR its own `resolved (EXACT)` row.
+#
+# PER-TOKEN, not a global disjunction. An earlier draft short-circuited on
+# "at least one row rendered anywhere", which let a bogus or stale allowlist
+# entry ride along green behind the real rows — the accounting has to be owed
+# by each token individually or it accounts for nothing.
+unaccounted_allowlist_tokens() {
+  local lint="${1:-$LINTER}" root="${2:-}" out t
+  if [ -n "$root" ]; then
+    out=$(bash "$lint" --root "$root" --list 2>&1)
+  else
+    out=$(bash "$lint" --list 2>&1)
+  fi
+  while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    printf '%s\n' "$out" | grep -qF "$(printf '\t%s\tresolved (EXACT)' "$t")" && continue
+    printf '%s\n' "$out" | grep -qF "$(printf '\t%s\tallowlist: ' "$t")" && continue
+    printf '%s\n' "$t"
+  done <<EOF
+$(allowlisted_tokens "$lint")
+EOF
 }
 
 # ════════════════════════════════════════════════════════════════════
@@ -420,37 +446,78 @@ echo "=== T-REPO-LIST: the script-level allowlist mechanism is accounted for ===
 # on a MISS, so the moment fix/bl112-sast-scan-coverage merges and the BL-186
 # markers come back, a row-count assertion reds the required unit lane with
 # zero edits to BL-196 — and deleting the allowlist rows does not rescue it
-# either. The predicate is therefore a DISJUNCTION over the allowlist read
-# out of the lint at runtime:
-#   • at least one reasoned row renders (today: the markers are still gone), OR
-#   • every allowlisted token renders as `resolved (EXACT)` (post-merge: the
-#     markers are back and the rows are merely stale), which is VACUOUSLY
-#     true once the rows are deleted.
-# Every ordering of {merge, delete the rows} is green; a token that renders
-# NEITHER way is a genuine finding and still fails.
+# either.
+#
+# The predicate is PER-TOKEN, not a global disjunction. Each allowlisted token,
+# read out of the lint at runtime, must own EITHER its own reasoned
+# `allowlist:` row (today: the markers are still gone) OR its own
+# `resolved (EXACT)` row (post-merge: the markers are back and the row is
+# merely stale). Every ordering of {merge, delete the rows} is green, and an
+# empty allowlist is vacuously satisfied — which is what makes "delete the
+# rows" a valid move.
+#
+# WHY PER-TOKEN AND NOT `rows >= 1 OR all-EXACT`: that disjunction
+# SHORT-CIRCUITS. With the real rows rendering, `rows >= 1` was true and no
+# token was ever checked individually, so a bogus or stale allowlist entry
+# rode along green — the accounting has to be owed by each token or it
+# accounts for nothing. T17 pins exactly that.
 out=$(bash "$LINTER" --list 2>&1); rc=$?
 rows=$(printf '%s\n' "$out" | grep -c 'allowlist: ') || rows=0
 case "$rows" in ''|*[!0-9]*) rows=0 ;; esac
-not_exact=""
-tok_total=0
+tok_total=$(allowlisted_tokens | grep -c .) || tok_total=0
+case "$tok_total" in ''|*[!0-9]*) tok_total=0 ;; esac
+unaccounted=""
 while IFS= read -r t; do
   [ -n "$t" ] || continue
-  tok_total=$((tok_total + 1))
-  printf '%s\n' "$out" | grep -qF "$(printf '\t%s\tresolved (EXACT)' "$t")" \
-    || not_exact="$not_exact $t"
+  unaccounted="$unaccounted $t"
 done <<EOF
-$(allowlisted_tokens)
+$(unaccounted_allowlist_tokens)
 EOF
-# Disjunction, evaluated exactly as written above. The second arm is vacuous
-# for an empty allowlist, which is what makes "delete the rows" a valid move.
-mech_ok=0
-[ "$rows" -ge 1 ] && mech_ok=1
-[ -z "$not_exact" ] && mech_ok=1
-if [ "$rc" -eq 0 ] && [ "$mech_ok" -eq 1 ]; then
-  pass "T-REPO-LIST: allowlist mechanism accounted for ($tok_total token(s), $rows row(s) rendered)"
+if [ "$rc" -eq 0 ] && [ -z "$unaccounted" ]; then
+  pass "T-REPO-LIST: all $tok_total allowlisted token(s) individually accounted for ($rows row(s) rendered)"
 else
-  fail_ "T-REPO-LIST" "rc=$rc; rendered rows=$rows; allowlisted tokens not resolving EXACT:$not_exact"
+  fail_ "T-REPO-LIST" "rc=$rc; rendered rows=$rows; allowlisted token(s) owning neither an allowlist row nor an EXACT row:$unaccounted"
 fi
+
+echo ""
+echo "=== T17 (RF-3): a BOGUS allowlist token is caught even while real rows render ==="
+# The regression this pins is the SHORT-CIRCUIT, so the mutant must be built in
+# the regime where the old predicate was satisfied: the real rows ARE
+# rendering. A `rows >= 1` test passes here; the per-token test must not.
+#
+# The mutant lives OUTSIDE the repo and is pointed at the real tree with
+# --root, so it never joins the code surface and cannot mint its own bogus
+# token. (The literal below is minted in tests/, which is harmless: accounting
+# is about --list ROWS, and rows exist only for prose CITATIONS. Nothing cites
+# it, so it can own no row by either route — which is the point.)
+BOGUS_TOK="BL-196-BOGUS-ALLOWLIST-PROBE"
+T17DIR=$(mktemp -d)
+T17L="$T17DIR/lint.bogus.sh"
+# Splice one bogus row in immediately after the fence opener. Built with sed,
+# not `awk -v`: the repo's portability rule is ENVIRON-or-nothing for passing
+# shell values into awk, and here neither is needed.
+{
+  sed -n '1,/BL-196-ALLOWLIST-BEGIN/p' "$LINTER"
+  printf '%s|deliberately bogus row, T17 probe\n' "$BOGUS_TOK"
+  sed -n '/BL-196-ALLOWLIST-BEGIN/,$p' "$LINTER" | sed '1d'
+} > "$T17L"
+# The mutant lives outside the repo, so it must be pointed at the real tree
+# explicitly — otherwise its REPO_ROOT resolves to the temp dir, it exits 2
+# with no backlog, and every token reads "unaccounted" for the wrong reason.
+# The mut_rows>=1 arm below is what refuses that false positive.
+ctl_unacc=$(unaccounted_allowlist_tokens "$LINTER" "$REPO_ROOT" | grep -c .) || ctl_unacc=0
+case "$ctl_unacc" in ''|*[!0-9]*) ctl_unacc=0 ;; esac
+mut_unacc=$(unaccounted_allowlist_tokens "$T17L" "$REPO_ROOT") || mut_unacc=""
+mut_rows=$(bash "$T17L" --root "$REPO_ROOT" --list 2>&1 | grep -c 'allowlist: ') || mut_rows=0
+case "$mut_rows" in ''|*[!0-9]*) mut_rows=0 ;; esac
+if [ "$ctl_unacc" -eq 0 ] \
+   && [ "$mut_rows" -ge 1 ] \
+   && printf '%s\n' "$mut_unacc" | grep -qxF "$BOGUS_TOK"; then
+  pass "T17: bogus allowlist token reported unaccounted while $mut_rows real row(s) still render (short-circuit is gone)"
+else
+  fail_ "T17" "expected control 0 unaccounted, mutant rows>=1 AND the bogus token unaccounted; ctl=$ctl_unacc mut_rows=$mut_rows mut_unaccounted:[$mut_unacc]"
+fi
+rm -rf "$T17DIR"
 
 echo ""
 echo "=== T14 (R-BL196-2): an EMPTY entry-id set exits 2, never a false OK ==="

--- a/tests/test-lint-bl-markers.sh
+++ b/tests/test-lint-bl-markers.sh
@@ -95,6 +95,17 @@ teardown_fixture() { rm -rf "$TMP"; }
 
 run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
 
+# ── allowlisted_tokens: the lint's SCRIPT-LEVEL allowlist, read out of the
+# lint at runtime. Deliberately not hard-coded: writing an allowlisted token
+# into this file would mint it in tests/, the real tree's code surface, and
+# the real backlog's broken citations would then resolve EXACT off this
+# suite — masking the very thing the allowlist documents.
+allowlisted_tokens() {
+  sed -n '/BL-196-ALLOWLIST-BEGIN/,/BL-196-ALLOWLIST-END/p' "$LINTER" \
+    | grep -E '^BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_-]*\|' \
+    | sed -e 's/|.*//'
+}
+
 # ════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== T1: prose cite that resolves exactly -> exit 0 ==="
@@ -404,13 +415,134 @@ else
 fi
 
 echo ""
-echo "=== T-REPO-LIST: the script-level allowlist is live and rendered ==="
+echo "=== T-REPO-LIST: the script-level allowlist mechanism is accounted for ==="
+# DO NOT tighten this back to "at least one allowlist row". Rows render only
+# on a MISS, so the moment fix/bl112-sast-scan-coverage merges and the BL-186
+# markers come back, a row-count assertion reds the required unit lane with
+# zero edits to BL-196 — and deleting the allowlist rows does not rescue it
+# either. The predicate is therefore a DISJUNCTION over the allowlist read
+# out of the lint at runtime:
+#   • at least one reasoned row renders (today: the markers are still gone), OR
+#   • every allowlisted token renders as `resolved (EXACT)` (post-merge: the
+#     markers are back and the rows are merely stale), which is VACUOUSLY
+#     true once the rows are deleted.
+# Every ordering of {merge, delete the rows} is green; a token that renders
+# NEITHER way is a genuine finding and still fails.
 out=$(bash "$LINTER" --list 2>&1); rc=$?
-if [ "$rc" -eq 0 ] && echo "$out" | grep -q 'allowlist: '; then
-  pass "T-REPO-LIST: --list renders at least one reasoned allowlist row"
+rows=$(printf '%s\n' "$out" | grep -c 'allowlist: ') || rows=0
+case "$rows" in ''|*[!0-9]*) rows=0 ;; esac
+not_exact=""
+tok_total=0
+while IFS= read -r t; do
+  [ -n "$t" ] || continue
+  tok_total=$((tok_total + 1))
+  printf '%s\n' "$out" | grep -qF "$(printf '\t%s\tresolved (EXACT)' "$t")" \
+    || not_exact="$not_exact $t"
+done <<EOF
+$(allowlisted_tokens)
+EOF
+# Disjunction, evaluated exactly as written above. The second arm is vacuous
+# for an empty allowlist, which is what makes "delete the rows" a valid move.
+mech_ok=0
+[ "$rows" -ge 1 ] && mech_ok=1
+[ -z "$not_exact" ] && mech_ok=1
+if [ "$rc" -eq 0 ] && [ "$mech_ok" -eq 1 ]; then
+  pass "T-REPO-LIST: allowlist mechanism accounted for ($tok_total token(s), $rows row(s) rendered)"
 else
-  fail_ "T-REPO-LIST" "expected rc=0 and a rendered allowlist row; rc=$rc"
+  fail_ "T-REPO-LIST" "rc=$rc; rendered rows=$rows; allowlisted tokens not resolving EXACT:$not_exact"
 fi
+
+echo ""
+echo "=== T14 (R-BL196-2): an EMPTY entry-id set exits 2, never a false OK ==="
+# The NR==FNR trap. With an empty first file the idiom stays true for every
+# record of the SECOND file, so pass (a) swallowed every marker site into the
+# entry set and printed `OK: ...` over a completely unchecked tree. Two
+# independent fixes are pinned here and by T15: this guard, and the switch to
+# FILENAME discrimination.
+setup_fixture
+printf '# fixture backlog with no entry headers\n\nnothing here\n' \
+  > "$TMP/solo-orchestrator-backlog.md"
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The live arm is marked `# BL-196-FIXTURE-LIVE`.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 2 ] \
+   && echo "$out" | grep -q 'EMPTY ENTRY SET' \
+   && ! echo "$out" | grep -q '^OK:'; then
+  pass "T14: empty entry set exits 2 naming the cause, and prints no OK verdict"
+else
+  fail_ "T14" "expected exit 2 + EMPTY ENTRY SET and NO OK line; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+echo ""
+echo "=== T15 (R-BL196-2): an EMPTY marker set still REPORTS the broken cite ==="
+# The same trap on the other join. With zero marker tokens the citation list
+# was consumed as if it were the token set, so every broken cite vanished and
+# the lint passed. On the real tree the marker floor hides this; under --root,
+# where the floors default to 0, it was a live false pass.
+setup_fixture
+printf '#!/usr/bin/env bash\necho no markers here at all\n' > "$TMP/scripts/thing.sh"
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The renamed arm is `# BL-196-FIXTURE-GHOST`, which no longer exists.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'BL-196-FIXTURE-GHOST'; then
+  pass "T15: zero-marker code surface still reports the broken citation"
+else
+  fail_ "T15" "expected exit 1 naming the ghost (the join must not swallow the cites); rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+echo ""
+echo "=== T16 (R-BL196-6): an arbitrarily-named COPY of the lint cannot mint tokens ==="
+# Exact-path self-exclusion is defeated by `cp lint.sh scripts/zz-copy.sh`:
+# the copy re-mints every token the lint names — including its own allowlist —
+# so allowlisted citations resolve EXACT and the allowlist silently stops
+# meaning anything. Layer 3 of the exclusion is a CONTENT sentinel, which
+# travels with the bytes and so survives any rename.
+#
+# The sentinel is assembled at runtime. Written as a literal, this file would
+# carry it and exclude ITSELF from the real tree's code surface — an
+# unintended coverage hole in the fix's own test.
+SENTINEL="BL-196-SELF-EXCLUDE""-SENTINEL"
+# A structural marker that lives ONLY inside the lint, so the fixture's own
+# files cannot supply it.
+COPY_ONLY_TOKEN="BL-196-EMPTY-SET-GUARD"
+setup_fixture
+cp "$LINTER" "$TMP/scripts/zz-copy.sh"
+{
+  printf '# Fixture orientation\n\n'
+  printf 'Cite: `# %s`\n' "$COPY_ONLY_TOKEN"
+} > "$TMP/CLAUDE.md"
+out=$(run_fixture); rc_excl=$?
+
+# CONTROL: the same copy with the sentinel lines stripped IS a valid definer.
+# Without this arm T16 would also pass if the fixture simply never carried the
+# token — the classic vacuous-canary failure.
+#
+# The control is asserted on the CITATION verdict, not on the exit code. A
+# de-sentinelled copy is a full copy of the lint, so its own header mints
+# markers for a dozen unrelated entries that the small fixture backlog does
+# not carry, and pass (a) reports those — a true finding about the fixture,
+# and noise with respect to what this case measures. What must flip is
+# exactly one thing: the copy-only token stops being reported as a broken
+# citation, because the copy now supplies it.
+sed "/${SENTINEL}/d" "$LINTER" > "$TMP/scripts/zz-copy.sh"
+out_ctl=$(run_fixture); rc_ctl=$?
+cite_broken_re="cites marker '# ${COPY_ONLY_TOKEN}'"
+
+if [ "$rc_excl" -eq 1 ] && echo "$out" | grep -qF "$cite_broken_re" \
+   && ! echo "$out_ctl" | grep -qF "$cite_broken_re"; then
+  pass "T16: sentinel-bearing copy mints nothing; de-sentinelled control resolves the same token (rc_ctl=$rc_ctl on unrelated pass-(a) noise)"
+else
+  fail_ "T16" "expected the copy-only token reported broken WITH the sentinel and NOT reported without it; rc_excl=$rc_excl rc_ctl=$rc_ctl; output:\n$out\n--- control ---\n$out_ctl"
+fi
+teardown_fixture
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/tests/test-lint-bl-markers.sh
+++ b/tests/test-lint-bl-markers.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+# tests/test-lint-bl-markers.sh
+#
+# Behavior tests for scripts/lint-bl-markers.sh — the BL-196 marker-citation
+# backstop. Each case stages a hermetic tmpdir tree (a fake code surface, a
+# fake backlog, fake prose), points the lint at it with --root, and asserts
+# on exit code + diagnostics.
+#
+# CORE COVERAGE (the defect class BL-196 files)
+#   • T2 (negative): prose cites a marker that exists nowhere in the code
+#       surface -> exit 1, and the diagnostic NAMES the cite and where.
+#   • T13 (mutation): excise the BL-196-PROSE-CITE fence from a copy of the
+#       lint and T2's fixture PASSES -> the fence carries the whole check.
+#
+# SURROUNDING COVERAGE
+#   • T1  clean tree -> exit 0
+#   • T3  marker in code whose BL-NNN has no `## BL-NNN:` entry -> exit 1
+#   • T4  FAMILY resolution: prose cites the fence family, code carries
+#         -BEGIN/-END -> exit 0
+#   • T5  glob form `# BL-...-*` resolves the same way -> exit 0
+#   • T6  a TRUNCATION typo does NOT get rescued by the family rule
+#   • T7  false-positive guards: bare prose hyphenation and the literal
+#         `# BL-NNN-…` placeholder are not citations
+#   • T8  frozen surfaces (Reports/, docs/handoffs/archive/) are out of scope
+#   • T9  inline allow with a reason suppresses; an EMPTY reason fails
+#   • T10 --list emits the STATUS table including the FAIL row
+#   • T11 unknown flag -> exit 2
+#   • T12 vacuity floor -> exit 2 (pass c)
+#   • T-REPO / T-REPO-LIST: the real tree passes, and the script-level
+#         allowlist is live (>=1 rendered allowlist row)
+#
+# A NOTE ON THIS SUITE'S OWN TEXT, because it is a real hazard here.
+# This file lives under tests/, which IS the lint's code surface — every
+# marker-shaped token written below becomes a marker DEFINITION on the real
+# tree. Two consequences are designed around:
+#   1. Fixture markers use the `BL-196-FIXTURE-*` family, so pass (a) on the
+#      real tree resolves them to the existing `## BL-196:` entry.
+#   2. The no-entry id for T3 is BUILT BY CONCATENATION and never appears
+#      here as a literal. Writing it out would mint a marker on the real
+#      tree naming an entry that does not exist, and this suite would red
+#      the repo it is meant to guard.
+# For the same reason no fixture cites a token that the real backlog also
+# cites: a fixture literal would silently satisfy a real broken citation.
+#
+# Style mirrors tests/test-lint-doc-anchors.sh: set -uo pipefail, mktemp
+# fixtures, pass/fail counters, teardown after each case.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-bl-markers.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# ── Fixture builder ─────────────────────────────────────────────────────
+# A minimal tree with the shapes the lint cares about: one code dir, a
+# backlog carrying two entry headers, and an empty docs/ ready for prose.
+setup_fixture() {
+  TMP=$(mktemp -d)
+  mkdir -p "$TMP/scripts" "$TMP/docs"
+  cat > "$TMP/solo-orchestrator-backlog.md" <<'MD'
+# fixture backlog
+
+## BL-196: fixture entry the fixture markers hang off
+
+**Status:** Open
+
+---
+
+## BL-042: second fixture entry
+
+**Status:** Closed — PR #1
+
+---
+MD
+  cat > "$TMP/scripts/thing.sh" <<'SH'
+#!/usr/bin/env bash
+# BL-196-FIXTURE-LIVE: a marker that really is in the code surface.
+echo live
+# BL-196-FIXTURE-FENCE-BEGIN
+echo fenced
+# BL-196-FIXTURE-FENCE-END
+SH
+}
+teardown_fixture() { rm -rf "$TMP"; }
+
+run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T1: prose cite that resolves exactly -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The live arm is marked `# BL-196-FIXTURE-LIVE` — grep for it.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T1: resolving citation exits 0"
+else
+  fail_ "T1" "expected exit 0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T2: prose cites a marker that exists nowhere -> exit 1, named ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The live arm is marked `# BL-196-FIXTURE-LIVE` — grep for it.
+The renamed arm is marked `# BL-196-FIXTURE-GHOST`, which no longer exists.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'CLAUDE\.md:4' \
+   && echo "$out" | grep -q 'BL-196-FIXTURE-GHOST'; then
+  pass "T2: broken citation exits 1 naming the token AND file:line"
+else
+  fail_ "T2" "expected exit 1 + 'CLAUDE.md:4' + the ghost token; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T3: code marker whose BL-NNN has no backlog entry -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# The id is assembled at runtime so this suite's own text never mints a
+# marker naming a nonexistent entry on the real tree (see header note).
+setup_fixture
+NOENT_ID="BL-9""97"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# %s-NO-SUCH-ENTRY: minted against an id nobody filed.\n' "$NOENT_ID"
+  printf 'echo orphan\n'
+} > "$TMP/scripts/orphan.sh"
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The live arm is marked `# BL-196-FIXTURE-LIVE`.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/orphan\.sh:2' \
+   && echo "$out" | grep -q "no '## ${NOENT_ID}:' entry"; then
+  pass "T3: marker naming a nonexistent entry exits 1 naming the site"
+else
+  fail_ "T3" "expected exit 1 + orphan.sh:2 + missing-entry text; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T4: FAMILY resolution — prose cites the fence family -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The fenced arm is `# BL-196-FIXTURE-FENCE` (BEGIN/END in the code).
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T4: family cite resolves against the -BEGIN/-END pair"
+else
+  fail_ "T4" "expected exit 0 for the family cite; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T5: glob form '# BL-...-*' resolves the same way -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+Per the fenced-arm template (`# BL-196-FIXTURE-FENCE-*`, no issues++).
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T5: glob-suffixed family cite resolves"
+else
+  fail_ "T5" "expected exit 0 for the glob cite; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T6: a TRUNCATION typo is NOT rescued by the family rule ==="
+# ════════════════════════════════════════════════════════════════════
+# The family rule appends a HYPHEN before the prefix test, so a token that
+# is merely a character-prefix of a live marker still fails. Without that
+# hyphen this whole lint would accept any truncation.
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The fenced arm is `# BL-196-FIXTURE-FENC` — one character short.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'BL-196-FIXTURE-FENC'; then
+  pass "T6: truncation typo still fails (family rule requires the hyphen)"
+else
+  fail_ "T6" "expected exit 1 for the truncated cite; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T7: bare prose hyphenation and the NNN placeholder are not cites ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+Cite code by a grep-able `# BL-NNN-…` marker comment, never a file:line.
+This is the BL-042-family of entries, and the BL-042-class of defects;
+the BL-042-correct reading is the one below. None of those is a citation.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T7: bare hyphenation + '# BL-NNN-…' placeholder produce zero hits"
+else
+  fail_ "T7" "a non-citation shape was flagged; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T8: frozen surfaces (Reports/, docs/handoffs/archive/) out of scope ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+mkdir -p "$TMP/Reports/2026-01-01-run" "$TMP/docs/handoffs/archive"
+cat > "$TMP/Reports/2026-01-01-run/LEDGER.md" <<'MD'
+# Frozen run artifact
+
+Stamped at its own tree: `# BL-196-FIXTURE-GONE-FROM-MAIN`.
+MD
+cat > "$TMP/docs/handoffs/archive/2026-01-01-old.md" <<'MD'
+# Superseded handoff
+
+Also stamped: `# BL-196-FIXTURE-ALSO-GONE`.
+MD
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The live arm is marked `# BL-196-FIXTURE-LIVE`.
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T8: frozen dated artifacts are not scanned"
+else
+  fail_ "T8" "a frozen surface was scanned; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T9a: inline allow WITH a reason suppresses the violation ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The withdrawn arm was `# BL-196-FIXTURE-GHOST`. <!-- lint-bl-markers: allow lives on an unmerged branch -->
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q "OK:"; then
+  pass "T9a: inline allow with a reason suppresses the broken cite"
+else
+  fail_ "T9a" "expected exit 0 under the inline allow; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+echo ""
+echo "=== T9b: inline allow with an EMPTY reason still fails ==="
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The withdrawn arm was `# BL-196-FIXTURE-GHOST`. <!-- lint-bl-markers: allow -->
+MD
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'EMPTY allowlist reason'; then
+  pass "T9b: empty allowlist reason is itself a violation"
+else
+  fail_ "T9b" "expected exit 1 + empty-reason diagnostic; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T10: --list emits a STATUS table carrying the FAIL row ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The renamed arm is `# BL-196-FIXTURE-GHOST`.
+MD
+out=$(bash "$LINTER" --root "$TMP" --list 2>&1); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'STATUS' \
+   && echo "$out" | grep -q 'FAIL.*BL-196-FIXTURE-GHOST.*broken citation' \
+   && echo "$out" | grep -q 'INFO.*population'; then
+  pass "T10: --list prints the STATUS table, the FAIL row and the population line"
+else
+  fail_ "T10" "expected --list header + FAIL row + INFO row; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T11: unknown flag -> exit 2 + usage ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" --bogus-flag 2>&1); rc=$?
+if [ "$rc" -eq 2 ] && echo "$out" | grep -q "Usage:"; then
+  pass "T11: unknown flag rejected with exit 2 + usage"
+else
+  fail_ "T11" "expected exit 2 + usage; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T12: vacuity floor (pass c) -> exit 2, not a silent pass ==="
+# ════════════════════════════════════════════════════════════════════
+# The fixture is clean, so without the floor this run would exit 0. With a
+# floor above the fixture's population it must exit 2 instead — that is the
+# whole point: a collapsed scan must never read as a pass.
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The live arm is marked `# BL-196-FIXTURE-LIVE`.
+MD
+out=$(bash "$LINTER" --root "$TMP" 2>&1); rc_clean=$?
+out2=$(bash "$LINTER" --root "$TMP" --min-cites 999 2>&1); rc=$?
+if [ "$rc_clean" -eq 0 ] && [ "$rc" -eq 2 ] && echo "$out2" | grep -q 'VACUOUS SCAN'; then
+  pass "T12: population below the floor exits 2 where the same tree otherwise exits 0"
+else
+  fail_ "T12" "expected clean rc=0 then floored rc=2 + VACUOUS SCAN; rc_clean=$rc_clean rc=$rc; output:\n$out2"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T13 (MUTATION): excise the BL-196-PROSE-CITE fence -> T2 passes ==="
+# ════════════════════════════════════════════════════════════════════
+# The decisive check for BL-196's core defect class lives entirely inside
+# the fence. Delete the fence and the broken-citation fixture must sail
+# through — if it still fails, the check is not (only) where the comment
+# says it is, and the mutation proves nothing.
+m=$(grep -c 'BL-196-PROSE-CITE' "$LINTER") || m=0
+case "$m" in ''|*[!0-9]*) m=0 ;; esac
+MUTDIR=$(mktemp -d)
+MUTL="$MUTDIR/lint.mut.sh"
+sed '/BL-196-PROSE-CITE-BEGIN/,/BL-196-PROSE-CITE-END/d' "$LINTER" > "$MUTL"
+l=$(grep -c 'BL-196-PROSE-CITE' "$MUTL") || l=0
+case "$l" in ''|*[!0-9]*) l=0 ;; esac
+setup_fixture
+cat > "$TMP/CLAUDE.md" <<'MD'
+# Fixture orientation
+
+The renamed arm is `# BL-196-FIXTURE-GHOST`, which no longer exists.
+MD
+if [ "$m" -lt 2 ] || [ "$l" -ne 0 ]; then
+  fail_ "T13" "excision vacuous (fence markers before=$m after=$l) — the fence is absent"
+else
+  out=$(bash "$MUTL" --root "$TMP" 2>&1); rc=$?
+  if [ "$rc" -eq 0 ] && ! echo "$out" | grep -q 'BL-196-FIXTURE-GHOST'; then
+    pass "T13: fence-excised mutant misses the broken cite — the fence carries the check"
+  else
+    fail_ "T13" "mutant still caught it (or broke, rc=$rc) — check does not live only in the fence:\n$out"
+  fi
+fi
+teardown_fixture
+rm -rf "$MUTDIR"
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T-REPO: the real tree passes -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# The merge gate. If this fails, either a new broken citation landed or a
+# marker was renamed without updating the prose that points at it.
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "T-REPO: every live citation on the real tree resolves"
+else
+  fail_ "T-REPO" "the real tree has broken marker citations; rc=$rc; output:\n$out"
+fi
+
+echo ""
+echo "=== T-REPO-LIST: the script-level allowlist is live and rendered ==="
+out=$(bash "$LINTER" --list 2>&1); rc=$?
+if [ "$rc" -eq 0 ] && echo "$out" | grep -q 'allowlist: '; then
+  pass "T-REPO-LIST: --list renders at least one reasoned allowlist row"
+else
+  fail_ "T-REPO-LIST" "expected rc=0 and a rendered allowlist row; rc=$rc"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Quick-sweep item. New `scripts/lint-bl-markers.sh` (the entry's own name): two-pass validation — every `# BL-NNN-…` marker in the code surface resolves to a backlog entry, and every prose citation resolves to a live marker (EXACT else FAMILY-at-a-hyphen). Measured scoping: surfaces widened to templates/ and evaluation-prompts/ because real marker families live there; frozen artifacts (Reports/, archived handoffs, the bugs file) excluded — history is never edited to satisfy a tool; the ~10 unchecked bare tokens are a named residual (the fix is backticking them, not widening the regex). Found exactly two broken cites on today's tree — both the deliberately-withdrawn BL-186 tokens (parked on the retained branch), carried as REASONED allowlist rows. The lint caught the implementer's own CLAUDE.md edit mid-build and runs in 0.9s.

Review arc (standing gate), three passes: round 1 **minor_concerns** with two real stability defects — T-REPO-LIST was wired to today's transient tree state (would have redded the required lane when the parked branch merges) and the classic awk `NR==FNR` empty-first-file trap could print a FALSE 'OK' over a broken scan. Fixed: predicate decoupled (and later made PER-TOKEN when the confirm round proved the disjunction could hide a stale allowlist row — the reviewer's C7 bogus-token probe now fails by name), `FILENAME==ARGV[1]` joins + a refuse-to-verdict empty-set guard + population floors, and a THREE-LAYER self-exclusion (path, name-glob, content sentinel surviving renames) after the reviewer defeated the exact-path version with `cp`. Confirm round: **minor_concerns, fine to merge**; every fix verified by the reviewer's own replays. Honest scope line shipped in-file: the layers defend good-faith copies, not deliberate tampering — with the sabotage-class residual demonstrated by the canary's own control arm.

Suite 20/0; lint 285/368 rc=0; run-lints 12/12. NOT a required check (Karl's promotion call). Entry closes at merge with the residuals recorded. Opus implementer + fable review ×3; supervisor merge on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)