### PR TITLE
fix(bl185,bl187): the last unrecorded escape gets its logbook; the rule budget is 30s by policy

### DIFF
--- a/scripts/lib/bypass-audit.sh
+++ b/scripts/lib/bypass-audit.sh
@@ -10,7 +10,12 @@
 #     "session_id":                string-or-null,
 #     "type":                      "claude_bypass_proposal" | "terminal_commit_blocked" |
 #                                  "terminal_commit_passed" | "out_of_band_commit" |
-#                                  "enforcement_level_set" | "detector_error" | "escalation",
+#                                  "enforcement_level_set" | "detector_error" | "escalation" |
+#                                  "sast_suppression",
+#                                  (BL-185: "sast_suppression" records a staged
+#                                  nosemgrep/nosem directive observed by the SAST arm;
+#                                  final_outcome is always "recorded_only" — the arm
+#                                  cannot know whether a later gate refuses the commit.)
 #                                  (BL-161: "terminal_commit_passed" is a schema-valid
 #                                  LEGACY type — routine CLEAN terminal commits no
 #                                  longer emit it. The tracked ledger records only

--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -189,6 +189,52 @@ soif_ledger_blocked() {
   fi
   return 0
 }
+# BL-185-SUPPRESSION-LEDGER helper — soif_ledger_blocked's sibling, same
+# BEST-EFFORT contract: a failed append prints ONE [note] and never changes
+# the hook's outcome — the receipt already NAMED the suppression loudly, and
+# unlike a refusal there is nothing here to weaken. Row type sast_suppression,
+# final_outcome "landed" (the commit DID land — that is the event; BL-161's
+# doctrine: the ledger records only real events). Called `|| true` and only
+# on landing paths (rc != 1).
+soif_ledger_suppression() {
+  soif_ls_n="${1:-0}"
+  soif_ls_files="${2:-}"
+  soif_ls_root=$(git rev-parse --show-toplevel 2>/dev/null) || soif_ls_root=""
+  if [ -z "$soif_ls_root" ]; then
+    echo "[note] BL-185: project root not found — suppression printed above, not ledgered." >&2
+    return 0
+  fi
+  soif_ls_lib="$soif_ls_root/scripts/lib/bypass-audit.sh"
+  if [ ! -r "$soif_ls_lib" ]; then
+    echo "[note] BL-185: bypass-audit.sh unavailable — suppression printed above, not ledgered." >&2
+    return 0
+  fi
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "[note] BL-185: jq unavailable — suppression printed above, not ledgered." >&2
+    return 0
+  fi
+  soif_ls_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || soif_ls_ts=""
+  soif_ls_level=$(jq -r '.enforcement_level // "n/a"' "$soif_ls_root/.claude/manifest.json" 2>/dev/null) || soif_ls_level="n/a"
+  [ -n "$soif_ls_level" ] || soif_ls_level="n/a"
+  soif_ls_row=$(jq -nc \
+    --arg ts "$soif_ls_ts" \
+    --arg n "$soif_ls_n" \
+    --arg f "$soif_ls_files" \
+    --arg lvl "$soif_ls_level" \
+    '{timestamp:$ts, session_id:null, type:"sast_suppression", actor:"user_terminal", enforcement_level_at_event:$lvl, details:{directive_count:(($n|tonumber?) // 0), files:$f}, user_response:"n/a", final_outcome:"landed"}' 2>/dev/null) || soif_ls_row=""
+  if [ -z "$soif_ls_row" ]; then
+    echo "[note] BL-185: could not build the ledger row — suppression printed above, not ledgered." >&2
+    return 0
+  fi
+  # Same SUBSHELL confinement as soif_ledger_blocked (the trojan-exit lesson):
+  # a sourced lib that `exit`s must terminate only the append attempt.
+  # shellcheck disable=SC1090
+  if ! ( . "$soif_ls_lib" && bypass_audit_append "$soif_ls_root" "$soif_ls_row" ) >/dev/null 2>&1; then
+    echo "[note] BL-185: ledger append failed — suppression printed above, not ledgered." >&2
+    return 0
+  fi
+  return 0
+}
 # BL-163-BLOCKED-LEDGER-END
 LEDGEREOF
 }
@@ -1130,13 +1176,37 @@ if command -v semgrep &>/dev/null; then
       #   What made it safe is not the flag, it is # BL-187-RULE-COVERAGE landing beside
       #   it. Do not restate (a) or (b); they are refuted, and they are recorded here so
       #   the next reader does not re-derive them.
-      #   THE PER-RULE TIMEOUT IS LEFT AT ITS 5s DEFAULT, DELIBERATELY AND AS A DEFERRAL.
-      #   `--timeout=0` removes the limit and DOES catch the dense fixture ([BLOCKED],
-      #   ~11s wall on this host) — but "no limit" in a pre-commit hook means a rule with
-      #   catastrophic backtracking hangs the operator's terminal with no message, which is
-      #   worse than a forfeited receipt on every axis this arm cares about: not loud, not
-      #   honest, and indistinguishable from a crash. Picking a finite larger value is a
-      #   latency-budget POLICY call, not an implementation detail. Filed as BL-187.
+      #   THE PER-RULE TIMEOUT IS 30 SECONDS BY DECISION (Karl 2026-07-31, recorded on
+      #   BL-187), set explicitly below (--timeout=30) — no longer semgrep's 5s default
+      #   and no longer a deferral. 30s catches the measured dense-fixture class
+      #   (blocked in ~11s WALL at timeout=0) with headroom while keeping the hard
+      #   ceiling: `--timeout=0` would let a catastrophic-backtracking rule hang the
+      #   operator's terminal with no message — worse than a forfeited receipt on every
+      #   axis this arm cares about. The # BL-187-RULE-COVERAGE detector below STAYS:
+      #   30s shrinks the timeout class, it does not close it, and
+      #   T-bl187-budget-mutant-proof exercises the detector on every host via a
+      #   budget-shrunk mutant instead of waiting for a host slow enough to blow 30s.
+      # BL-185-SUPPRESSION-DETECT-BEGIN — "allow it, but log it" (Karl 2026-07-31,
+      # recorded on BL-185). Count `nosemgrep` directives in the MATERIALIZED staged
+      # blobs — the bytes being committed (the BL-132 doctrine), no extra scanner
+      # invocation. Word-boundary grep, deliberately imprecise in the SAFE direction:
+      # over-detection (the bare word in prose or a string) only ever QUALIFIES a
+      # receipt and adds an audit row, never blocks and never grants; under-detection
+      # of the word itself is not possible for the directive semgrep honors. Every
+      # failure mode lands on zero — exactly today's behavior — via the house
+      # `|| …=0` + case-glob plumbing.
+      soif_sg_supp_n=0
+      soif_sg_supp_files=""
+      for soif_sp_f in ${soif_idx_files[@]+"${soif_idx_files[@]}"}; do
+        soif_sp_c=$(grep -cw 'nosemgrep' "$soif_sp_f" 2>/dev/null) || soif_sp_c=0
+        soif_sp_c=$(printf '%s' "$soif_sp_c" | tr -d '[:space:]') || soif_sp_c=0
+        case "$soif_sp_c" in ''|*[!0-9]*) soif_sp_c=0 ;; esac
+        if [ "$soif_sp_c" -gt 0 ]; then
+          soif_sg_supp_n=$((soif_sg_supp_n + soif_sp_c))
+          soif_sg_supp_files="$soif_sg_supp_files $(printf '%s' "$soif_sp_f" | sed "s#${soif_idx_tree}/[0-9][0-9]*/##")"
+        fi
+      done
+      # BL-185-SUPPRESSION-DETECT-END
       # BL-200-SYNTAX-BREAK (flag) — `--verbose` exists here for ONE line of output:
       # `[WARN] Syntax error at line <target>:N`, the only known tell for a token-stream
       # break (an ordinary ASCII file whose syntax error hides its sink from every rule —
@@ -1155,6 +1225,7 @@ if command -v semgrep &>/dev/null; then
         --max-target-bytes=0 \
         --no-git-ignore \
         --verbose \
+        --timeout=30 \
         --severity=ERROR --error ${soif_idx_files[@]+"${soif_idx_files[@]}"} >"$soif_sg_out" 2>"$soif_sg_err"
       soif_sg_rc=$?
       set -e
@@ -1503,13 +1574,34 @@ if command -v semgrep &>/dev/null; then
         # # BL-112-SCAN-COVERAGE, plus BL-192 and BL-187. An earlier revision of this
         # block predicted "a FIFTH precondition will exist one day" and was right — item 5
         # is it (BL-200). The prediction stands re-armed: a SIXTH will exist one day.
-        echo "[OK] semgrep: SAST ran on ${#soif_idx_files[@]} staged file(s) — no ERROR-severity findings."
+        # BL-185-SUPPRESSION-RECEIPT (verdict) — the UNQUALIFIED receipt is forfeited
+        # when a staged blob carries a `nosemgrep` directive: semgrep reported nothing
+        # for those lines BY INSTRUCTION, so the plain "no findings" sentence would be
+        # the false-attestation shape this arm exists to prevent, sanctioned edition.
+        # Allow-but-log (Karl 2026-07-31): the commit LANDS either way; the naming and
+        # the ledger row happen once, below the verdict chain, on every landing path.
+        if [ "${soif_sg_supp_n:-0}" -gt 0 ]; then
+          echo "[OK] semgrep: SAST ran on ${#soif_idx_files[@]} staged file(s) — no ERROR-severity findings outside suppressed lines."
+        else
+          echo "[OK] semgrep: SAST ran on ${#soif_idx_files[@]} staged file(s) — no ERROR-severity findings."
+        fi
         echo "  scanner: semgrep ${soif_sg_version:-(version unknown)}"
         # BL-198: the conversion is attested, never silent — an operator whose
         # UTF-16 file was scanned via a converted copy is told so on the receipt.
         if [ "${soif_tc_count:-0}" -gt 0 ]; then
           echo "  ($soif_tc_count staged file(s) transcoded from UTF-16/UTF-32 to UTF-8 for scanning — BL-198)"
         fi
+      fi
+    fi
+    # BL-185-SUPPRESSION-RECEIPT (record) — printed on EVERY path (a blocked
+    # operator about to fix findings should know suppressions ride the same
+    # commit), ledgered only when the commit LANDS (rc!=1): on the [BLOCKED]
+    # path no suppression event occurs, and the block itself is already
+    # ledgered (BL-163). Best-effort append — `|| true`, the BL-163 contract.
+    if [ "${soif_sg_supp_n:-0}" -gt 0 ]; then
+      echo "  BL-185: ${soif_sg_supp_n} 'nosemgrep' suppression directive(s) in:${soif_sg_supp_files} — those lines were skipped BY INSTRUCTION; this commit's SAST verdict does not vouch for them (recorded to .claude/bypass-audit.json when the commit lands)."
+      if [ "$soif_sg_rc" -ne 1 ]; then
+        soif_ledger_suppression "$soif_sg_supp_n" "$soif_sg_supp_files" || true   # BL-185-SUPPRESSION-LEDGER
       fi
     fi
     rm -rf "$soif_idx_tree"

--- a/scripts/lib/hook-templates.sh
+++ b/scripts/lib/hook-templates.sh
@@ -193,9 +193,10 @@ soif_ledger_blocked() {
 # BEST-EFFORT contract: a failed append prints ONE [note] and never changes
 # the hook's outcome — the receipt already NAMED the suppression loudly, and
 # unlike a refusal there is nothing here to weaken. Row type sast_suppression,
-# final_outcome "landed" (the commit DID land — that is the event; BL-161's
-# doctrine: the ledger records only real events). Called `|| true` and only
-# on landing paths (rc != 1).
+# final_outcome "recorded_only": the SAST arm observes the suppression but a
+# LATER gate can still refuse the commit (review R-HP-2's measured repro), so
+# claiming "landed" here would be a false governance record. Called `|| true`
+# on every SAST verdict except the arm's own [BLOCKED].
 soif_ledger_suppression() {
   soif_ls_n="${1:-0}"
   soif_ls_files="${2:-}"
@@ -221,7 +222,7 @@ soif_ledger_suppression() {
     --arg n "$soif_ls_n" \
     --arg f "$soif_ls_files" \
     --arg lvl "$soif_ls_level" \
-    '{timestamp:$ts, session_id:null, type:"sast_suppression", actor:"user_terminal", enforcement_level_at_event:$lvl, details:{directive_count:(($n|tonumber?) // 0), files:$f}, user_response:"n/a", final_outcome:"landed"}' 2>/dev/null) || soif_ls_row=""
+    '{timestamp:$ts, session_id:null, type:"sast_suppression", actor:"user_terminal", enforcement_level_at_event:$lvl, details:{directive_count:(($n|tonumber?) // 0), files:$f}, user_response:"n/a", final_outcome:"recorded_only"}' 2>/dev/null) || soif_ls_row=""
   if [ -z "$soif_ls_row" ]; then
     echo "[note] BL-185: could not build the ledger row — suppression printed above, not ledgered." >&2
     return 0
@@ -1189,16 +1190,20 @@ if command -v semgrep &>/dev/null; then
       # BL-185-SUPPRESSION-DETECT-BEGIN — "allow it, but log it" (Karl 2026-07-31,
       # recorded on BL-185). Count `nosemgrep` directives in the MATERIALIZED staged
       # blobs — the bytes being committed (the BL-132 doctrine), no extra scanner
-      # invocation. Word-boundary grep, deliberately imprecise in the SAFE direction:
-      # over-detection (the bare word in prose or a string) only ever QUALIFIES a
-      # receipt and adds an audit row, never blocks and never grants; under-detection
-      # of the word itself is not possible for the directive semgrep honors. Every
-      # failure mode lands on zero — exactly today's behavior — via the house
-      # `|| …=0` + case-glob plumbing.
+      # invocation. TWO SPELLINGS, CASE-INSENSITIVE — review R-HP-1 measured both on
+      # semgrep 1.157.0 and its docs agree (--enable-nosem, on by default, honors a
+      # 'nosem' comment): `nosem` and `nosemgrep`, any case, each suppresses. An
+      # earlier revision matched only lowercase `nosemgrep` and claimed under-detection
+      # impossible — refuted by execution; `// nosem` and `// NOSEMGREP` both landed
+      # sinks with the unqualified receipt. Word-boundary grep stays deliberately
+      # imprecise in the SAFE direction: over-detection (the bare word in prose) only
+      # ever QUALIFIES a receipt and adds an audit row, never blocks and never grants.
+      # Every failure mode lands on zero — exactly today's behavior — via the house
+      # `|| …=0` + case-glob plumbing. Counts are LINES carrying a directive.
       soif_sg_supp_n=0
       soif_sg_supp_files=""
       for soif_sp_f in ${soif_idx_files[@]+"${soif_idx_files[@]}"}; do
-        soif_sp_c=$(grep -cw 'nosemgrep' "$soif_sp_f" 2>/dev/null) || soif_sp_c=0
+        soif_sp_c=$(grep -ciwE 'nosem(grep)?' "$soif_sp_f" 2>/dev/null) || soif_sp_c=0
         soif_sp_c=$(printf '%s' "$soif_sp_c" | tr -d '[:space:]') || soif_sp_c=0
         case "$soif_sp_c" in ''|*[!0-9]*) soif_sp_c=0 ;; esac
         if [ "$soif_sp_c" -gt 0 ]; then
@@ -1595,13 +1600,17 @@ if command -v semgrep &>/dev/null; then
     fi
     # BL-185-SUPPRESSION-RECEIPT (record) — printed on EVERY path (a blocked
     # operator about to fix findings should know suppressions ride the same
-    # commit), ledgered only when the commit LANDS (rc!=1): on the [BLOCKED]
-    # path no suppression event occurs, and the block itself is already
-    # ledgered (BL-163). Best-effort append — `|| true`, the BL-163 contract.
+    # commit). The ROW records the SAST-arm OBSERVATION, not the commit's fate:
+    # this arm cannot know whether a LATER gate (project tests, gitleaks, TDD)
+    # will refuse the commit — review R-HP-2 proved a BL-125 refusal landing a
+    # row that claimed "landed". So the row's final_outcome is
+    # "recorded_only" (the schema's documented enum), written on every path
+    # except the SAST arm's own [BLOCKED] (there the block is the event and
+    # BL-163 ledgers it). Best-effort append — `|| true`, the BL-163 contract.
     if [ "${soif_sg_supp_n:-0}" -gt 0 ]; then
-      echo "  BL-185: ${soif_sg_supp_n} 'nosemgrep' suppression directive(s) in:${soif_sg_supp_files} — those lines were skipped BY INSTRUCTION; this commit's SAST verdict does not vouch for them (recorded to .claude/bypass-audit.json when the commit lands)."
+      echo "  BL-185: ${soif_sg_supp_n} staged line(s) carrying a semgrep suppression directive (nosemgrep/nosem, any case) in: ${soif_sg_supp_files# } — those lines were skipped BY INSTRUCTION; this commit's SAST verdict does not vouch for them (observation recorded to .claude/bypass-audit.json)."
       if [ "$soif_sg_rc" -ne 1 ]; then
-        soif_ledger_suppression "$soif_sg_supp_n" "$soif_sg_supp_files" || true   # BL-185-SUPPRESSION-LEDGER
+        soif_ledger_suppression "$soif_sg_supp_n" "${soif_sg_supp_files# }" || true   # BL-185-SUPPRESSION-LEDGER
       fi
     fi
     rm -rf "$soif_idx_tree"

--- a/tests/test-bl132-sast-index-scan.sh
+++ b/tests/test-bl132-sast-index-scan.sh
@@ -3065,6 +3065,215 @@ else
   fi
 fi
 
+# ═══════════════════════════════════════════════════════════════════════════
+# BL-185 + BL-187 (Karl's 2026-07-31 decisions, recorded on their entries)
+# ═══════════════════════════════════════════════════════════════════════════
+# BL-185 "allow it, but log it": a staged `nosemgrep` directive must forfeit
+# the UNQUALIFIED [OK] receipt, print a receipt NAMING file and directive, and
+# append a `sast_suppression` row to .claude/bypass-audit.json — while the
+# commit still LANDS (blocking was explicitly not chosen). BL-187: the
+# per-rule budget is POLICY now — `--timeout=30` on the shipped invocation —
+# and the old skip-shaped timeout proofs are re-armed via a BUDGET-SHRUNK
+# mutant (30→1s) so the detector clause is provable on EVERY host instead of
+# only hosts slow enough to blow a 30s budget.
+
+# _mut_env <src> <dst> <old> <new> <want>: literal replace via ENVIRON — the
+# suite's older _mut_n passes literals through `awk -v`, which PROCESSES
+# ESCAPES; the `--timeout=30 \` literal ends in a lone backslash, the exact
+# BSD-vs-mawk/gawk divergence that broke a CI shard on PR #293. ENVIRON
+# passes bytes untouched everywhere. Numeric `want` stays -v (safe).
+_mut_env() {
+  SOIF_ME_OLD="$3" SOIF_ME_NEW="$4" awk -v want="$5" '
+    { out = ""; rest = $0
+      while ((p = index(rest, ENVIRON["SOIF_ME_OLD"])) > 0) {
+        out = out substr(rest, 1, p-1) ENVIRON["SOIF_ME_NEW"]
+        rest = substr(rest, p + length(ENVIRON["SOIF_ME_OLD"]))
+        c++
+      }
+      print out rest }
+    END { if (c != want) exit 3 }
+  ' "$1" > "$2"
+}
+
+# ── T-bl187-constant: the shipped budget is 30, exactly once, as a real flag ──
+echo "=== T-bl187-constant ==="
+TB_N=$(grep -c -- '--timeout=30 \\' "$EMITTED") || TB_N=0
+if [ "$TB_N" -eq 1 ]; then
+  pass "T-bl187-constant (the emitted invocation carries --timeout=30 exactly once — the decided budget, not semgrep's 5s default)"
+else
+  fail_ "T-bl187-constant" "found $TB_N occurrences of '--timeout=30 \\' in the emitted hook (want exactly 1) — the 2026-07-31 decision sets the per-rule budget to 30s ON the shipped invocation; absent means the 5s default silently returned, duplicated means the invocation was mangled"
+fi
+
+# ── T-bl187-budget-mutant-proof: the timeout detector, provable on EVERY host ─
+# The dense fixture's killing rule needs >5s but well under 30s on measured
+# hosts, so at the shipped budget the sink is BLOCKED outright (strictly better)
+# and the old timeout cases skip as UNPROVEN. This case re-arms the proof:
+# shrink ONLY the budget constant (30 -> 1) in a copy of the shipped hook and
+# the same fixture must FORFEIT with the timeout warn — the detector clause
+# exercised for real, every host, cheaply (a 1s budget is FASTER than today).
+# The intact control accepts the honest host disjunction: BLOCKED (rule fits
+# the budget — the decision's intent) or forfeit-with-warn (a slow host blows
+# even 30s); anything else fails.
+echo "=== T-bl187-budget-mutant-proof ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-bl187-budget-mutant-proof" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  MB="$TOPTMP/mut-budget-1s"
+  if ! _mut_env "$EMITTED" "$MB" '--timeout=30 \' '--timeout=1 \' 1; then
+    fail_ "T-bl187-budget-mutant-proof" "MIS-TARGETED — '--timeout=30 \\' not present exactly once in the emitted hook; retarget in lockstep with T-bl187-constant"
+  elif ! bash -n "$MB" 2>/dev/null; then
+    fail_ "T-bl187-budget-mutant-proof" "mutated hook has a syntax error — a broken mutant proves nothing"
+  else
+    chmod +x "$MB"
+    MBD="$(mktemp -d)"
+    if ! mk_repo "$MBD" "$MB" >/dev/null 2>&1; then
+      fail_ "T-bl187-budget-mutant-proof" "fixture setup failed"
+    else
+      write_oversize_dense "$MBD/dense.ts" "$XSS_TS"
+      if ! is_oversize "$MBD/dense.ts"; then
+        skip_ "T-bl187-budget-mutant-proof" "dense fixture did not clear the oversize threshold on this host — UNPROVEN (skip, not pass)"
+      else
+        ( cd "$MBD" && git add -- dense.ts ) >/dev/null 2>&1
+        if ( cd "$MBD" && git commit -m "feat: dense renderer" ) >"$TOPTMP/mb1.log" 2>&1; then MB_V=COMMITTED; else MB_V=REFUSED; fi
+        if [ "$MB_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/mb1.log"; then
+          skip_ "T-bl187-budget-mutant-proof" "this host finished the killing rule inside ONE second — nothing can time out here; the detector stays pinned only on slower hosts (skip, not pass)"
+        elif [ "$MB_V" = "COMMITTED" ] && ! grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/mb1.log" \
+             && grep -qF 'ABANDONED at least one rule' "$TOPTMP/mb1.log" \
+             && grep -qF 'dense.ts' "$TOPTMP/mb1.log"; then
+          # SECOND HALF — the conjunct-drop proof T-mutation-rule-timeout used to
+          # carry, re-armed under the 1s budget (at the shipped 30s that case now
+          # SKIPS on hosts whose rule fits the budget): drop ONLY the timeout
+          # conjunct from the 1s-budget hook and the same dense sink must buy the
+          # receipt back — the clause carries its own weight on EVERY host.
+          MB2="$TOPTMP/mut-budget-1s-no-conjunct"
+          if ! _mut_env "$MB" "$MB2" '&& [ "$soif_sg_timeouts" -eq 0 ]' '' 1; then
+            fail_ "T-bl187-budget-mutant-proof" "MIS-TARGETED second half — the timeout conjunct is not present exactly once in the budget-mutant hook"
+          elif ! bash -n "$MB2" 2>/dev/null; then
+            fail_ "T-bl187-budget-mutant-proof" "second-half mutant has a syntax error — a broken mutant proves nothing"
+          else
+            chmod +x "$MB2"
+            MBD2="$(mktemp -d)"
+            if ! mk_repo "$MBD2" "$MB2" >/dev/null 2>&1; then
+              fail_ "T-bl187-budget-mutant-proof" "second-half fixture setup failed"
+            else
+              write_oversize_dense "$MBD2/dense.ts" "$XSS_TS"
+              ( cd "$MBD2" && git add -- dense.ts ) >/dev/null 2>&1
+              ( cd "$MBD2" && git commit -m "feat: dense renderer" ) >"$TOPTMP/mb2.log" 2>&1 || true
+              if grep -qF '[OK] semgrep: SAST ran' "$TOPTMP/mb2.log"; then
+                pass "T-bl187-budget-mutant-proof: 1s budget forfeits with the warn naming dense.ts (detector real); dropping the timeout conjunct under the same budget buys the receipt back (clause load-bearing) — both halves proven on THIS host"
+              else
+                fail_ "T-bl187-budget-mutant-proof" "conjunct-drop under the 1s budget did NOT restore the receipt — the clause proof is not isolating its clause: $(tail -6 "$TOPTMP/mb2.log" | tr '\n' '|')"
+              fi
+              rm -rf "$MBD2"
+            fi
+          fi
+        else
+          fail_ "T-bl187-budget-mutant-proof" "at a 1s budget expected COMMITTED + forfeited receipt + timeout warn naming dense.ts; got $MB_V: $(tail -8 "$TOPTMP/mb1.log" | tr '\n' '|')"
+        fi
+      fi
+      rm -rf "$MBD"
+    fi
+  fi
+fi
+
+# ── T-bl185-suppression-receipt: the one unrecorded escape gets its logbook ──
+echo "=== T-bl185-suppression-receipt ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-bl185-suppression-receipt" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  SPD="$(mktemp -d)"
+  if ! mk_repo "$SPD" "$EMITTED" >/dev/null 2>&1; then
+    fail_ "T-bl185-suppression-receipt" "fixture setup failed"
+  else
+    # Generated projects SHIP scripts/lib/bypass-audit.sh (the ledger append
+    # lib); the row half of allow-but-log needs it in the fixture, exactly as
+    # BL-163's row tests do. Without it the hook degrades to its [note] arm.
+    mkdir -p "$SPD/scripts/lib" "$SPD/.claude"
+    cp "$REPO_ROOT/scripts/lib/bypass-audit.sh" "$SPD/scripts/lib/" 2>/dev/null || true
+    printf 'export function render(pane, userText) {\n  // nosemgrep\n  pane.innerHTML = userText;\n}\n' > "$SPD/app.ts"
+    ( cd "$SPD" && git add -- app.ts ) >/dev/null 2>&1
+    if ( cd "$SPD" && git commit -m "feat: renderer with a suppression" ) >"$TOPTMP/sp1.log" 2>&1; then SP_V=COMMITTED; else SP_V=REFUSED; fi
+    SP_ROW=0
+    if command -v jq >/dev/null 2>&1 && [ -f "$SPD/.claude/bypass-audit.json" ]; then
+      SP_ROW=$(jq '[.[] | select(.type == "sast_suppression")] | length' "$SPD/.claude/bypass-audit.json" 2>/dev/null) || SP_ROW=0
+    fi
+    if [ "$SP_V" != "COMMITTED" ]; then
+      fail_ "T-bl185-suppression-receipt" "the suppressed commit was REFUSED — the decision is allow-but-log, never block: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"
+    elif grep -qF 'no ERROR-severity findings."' "$TOPTMP/sp1.log" || grep -qE 'no ERROR-severity findings\.$' "$TOPTMP/sp1.log"; then
+      fail_ "T-bl185-suppression-receipt" "the UNQUALIFIED receipt printed over a suppressed sink — the exact false attestation BL-185 exists to end: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"
+    elif ! grep -qF 'suppression directive' "$TOPTMP/sp1.log" || ! grep -qF 'app.ts' "$TOPTMP/sp1.log"; then
+      fail_ "T-bl185-suppression-receipt" "the receipt does not NAME the suppression and its file — the logbook half of allow-but-log: $(tail -8 "$TOPTMP/sp1.log" | tr '\n' '|')"
+    elif [ "${SP_ROW:-0}" -lt 1 ]; then
+      fail_ "T-bl185-suppression-receipt" "no sast_suppression row in .claude/bypass-audit.json (rows=$SP_ROW) — every other escape in the repo is recorded; this was the last unrecorded one: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"
+    else
+      pass "T-bl185-suppression-receipt: suppressed commit LANDS, unqualified [OK] forfeited, file+directive named, sast_suppression row written"
+    fi
+    rm -rf "$SPD"
+  fi
+fi
+
+# ── T-bl185-clean-control: no suppression => byte-identical today-behavior ──
+echo "=== T-bl185-clean-control ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-bl185-clean-control" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  SCD="$(mktemp -d)"
+  if ! mk_repo "$SCD" "$EMITTED" >/dev/null 2>&1; then
+    fail_ "T-bl185-clean-control" "fixture setup failed"
+  else
+    # The append lib is PRESENT here too — otherwise "no audit row" would pass
+    # vacuously on a fixture that cannot write rows at all.
+    mkdir -p "$SCD/scripts/lib" "$SCD/.claude"
+    cp "$REPO_ROOT/scripts/lib/bypass-audit.sh" "$SCD/scripts/lib/" 2>/dev/null || true
+    printf '%s\n' "$SAFE_TS" > "$SCD/app.ts"
+    ( cd "$SCD" && git add -- app.ts ) >/dev/null 2>&1
+    if ( cd "$SCD" && git commit -m "feat: clean renderer" ) >"$TOPTMP/sc1.log" 2>&1; then SC_V=COMMITTED; else SC_V=REFUSED; fi
+    SC_ROW=0
+    if command -v jq >/dev/null 2>&1 && [ -f "$SCD/.claude/bypass-audit.json" ]; then
+      SC_ROW=$(jq '[.[] | select(.type == "sast_suppression")] | length' "$SCD/.claude/bypass-audit.json" 2>/dev/null) || SC_ROW=0
+    fi
+    if [ "$SC_V" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran on 1 staged file(s) — no ERROR-severity findings.' "$TOPTMP/sc1.log" \
+       && ! grep -qF 'suppression directive' "$TOPTMP/sc1.log" && [ "${SC_ROW:-0}" -eq 0 ]; then
+      pass "T-bl185-clean-control: no directive => the exact unqualified receipt, no BL-185 line, no audit row — the detector does not cry wolf"
+    else
+      fail_ "T-bl185-clean-control" "clean commit disturbed (V=$SC_V rows=$SC_ROW): $(tail -6 "$TOPTMP/sc1.log" | tr '\n' '|')"
+    fi
+    rm -rf "$SCD"
+  fi
+fi
+
+# ── T-bl185-mutation: the detect fence carries its own weight ────────────────
+echo "=== T-bl185-mutation ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-bl185-mutation" "semgrep ABSENT — mutation UNPROVEN here (skip, NOT a pass)"
+else
+  MSP="$TOPTMP/mut-no-suppression-detect"
+  MSP_B=$(grep -c '# BL-185-SUPPRESSION-DETECT-BEGIN' "$EMITTED") || MSP_B=0
+  MSP_E=$(grep -c '# BL-185-SUPPRESSION-DETECT-END' "$EMITTED") || MSP_E=0
+  sed '/# BL-185-SUPPRESSION-DETECT-BEGIN/,/# BL-185-SUPPRESSION-DETECT-END/d' "$EMITTED" > "$MSP"
+  if [ "$MSP_B" -ne 1 ] || [ "$MSP_E" -ne 1 ]; then
+    fail_ "T-bl185-mutation" "MIS-TARGETED — detect fence not present exactly once (begin=$MSP_B end=$MSP_E)"
+  elif ! bash -n "$MSP" 2>/dev/null; then
+    fail_ "T-bl185-mutation" "mutated hook has a syntax error — a broken mutant proves nothing"
+  else
+    chmod +x "$MSP"
+    MSD="$(mktemp -d)"
+    if ! mk_repo "$MSD" "$MSP" >/dev/null 2>&1; then
+      fail_ "T-bl185-mutation" "mutation fixture setup failed"
+    else
+      printf 'export function render(pane, userText) {\n  // nosemgrep\n  pane.innerHTML = userText;\n}\n' > "$MSD/app.ts"
+      ( cd "$MSD" && git add -- app.ts ) >/dev/null 2>&1
+      ( cd "$MSD" && git commit -m "feat: renderer with a suppression" ) >"$TOPTMP/ms1.log" 2>&1 || true
+      if grep -qF 'no ERROR-severity findings."' "$TOPTMP/ms1.log" || grep -qE 'no ERROR-severity findings\.$' "$TOPTMP/ms1.log"; then
+        pass "T-bl185-mutation: excising the detect fence brings the unrecorded escape back (RED — unqualified [OK] over the suppressed sink); the intact GREEN half is T-bl185-suppression-receipt"
+      else
+        fail_ "T-bl185-mutation" "excising the fence did NOT restore the unqualified receipt — this case is not isolating the fence: $(tail -6 "$TOPTMP/ms1.log" | tr '\n' '|')"
+      fi
+      rm -rf "$MSD"
+    fi
+  fi
+fi
+
 echo ""
 if [ "$SKIPPED" -gt 0 ]; then echo "!! $SKIPPED case(s) SKIPPED — skipped != passed."; fi
 echo "Results: $PASSED passed, $FAILED failed ($SKIPPED skipped)"

--- a/tests/test-bl132-sast-index-scan.sh
+++ b/tests/test-bl132-sast-index-scan.sh
@@ -3177,38 +3177,105 @@ else
 fi
 
 # ── T-bl185-suppression-receipt: the one unrecorded escape gets its logbook ──
+# THREE SPELLINGS, one loop — review R-HP-1 proved semgrep honors `nosem`
+# (the legacy short directive, --enable-nosem default per its own docs) and
+# matches case-INSENSITIVELY (`// NOSEMGREP` measured suppressing on 1.157.0),
+# so a case-sensitive nosemgrep-only detector left the escape unrecorded under
+# two sanctioned spellings. Each spelling must forfeit, name, and row.
+# The naming pin is EXACT-MAPPED per R-HP-3: `in: app.ts` (accumulator's
+# leading space) AND a negative assert that no per-index temp segment leaks —
+# the reviewer's sed-neutralized mutant survived the old basename substring.
 echo "=== T-bl185-suppression-receipt ==="
 if [ "$HAVE_SEMGREP" -eq 0 ]; then
   skip_ "T-bl185-suppression-receipt" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
 else
-  SPD="$(mktemp -d)"
-  if ! mk_repo "$SPD" "$EMITTED" >/dev/null 2>&1; then
-    fail_ "T-bl185-suppression-receipt" "fixture setup failed"
-  else
-    # Generated projects SHIP scripts/lib/bypass-audit.sh (the ledger append
-    # lib); the row half of allow-but-log needs it in the fixture, exactly as
-    # BL-163's row tests do. Without it the hook degrades to its [note] arm.
+  SP_ALL=PASS
+  for SP_DIR in '// nosemgrep' '// nosem' '// NOSEMGREP'; do
+    SPD="$(mktemp -d)"
+    if ! mk_repo "$SPD" "$EMITTED" >/dev/null 2>&1; then
+      fail_ "T-bl185-suppression-receipt" "fixture setup failed ($SP_DIR)"; SP_ALL=FAIL; rm -rf "$SPD"; continue
+    fi
+    # Generated projects SHIP scripts/lib/bypass-audit.sh; the row half needs
+    # it in the fixture, exactly as BL-163's row tests do.
     mkdir -p "$SPD/scripts/lib" "$SPD/.claude"
     cp "$REPO_ROOT/scripts/lib/bypass-audit.sh" "$SPD/scripts/lib/" 2>/dev/null || true
-    printf 'export function render(pane, userText) {\n  // nosemgrep\n  pane.innerHTML = userText;\n}\n' > "$SPD/app.ts"
+    printf 'export function render(pane, userText) {\n  %s\n  pane.innerHTML = userText;\n}\n' "$SP_DIR" > "$SPD/app.ts"
     ( cd "$SPD" && git add -- app.ts ) >/dev/null 2>&1
     if ( cd "$SPD" && git commit -m "feat: renderer with a suppression" ) >"$TOPTMP/sp1.log" 2>&1; then SP_V=COMMITTED; else SP_V=REFUSED; fi
     SP_ROW=0
     if command -v jq >/dev/null 2>&1 && [ -f "$SPD/.claude/bypass-audit.json" ]; then
       SP_ROW=$(jq '[.[] | select(.type == "sast_suppression")] | length' "$SPD/.claude/bypass-audit.json" 2>/dev/null) || SP_ROW=0
     fi
+    SP_SINK=$( cd "$SPD" && git show HEAD:app.ts 2>/dev/null | grep -c innerHTML ) || SP_SINK=0
     if [ "$SP_V" != "COMMITTED" ]; then
-      fail_ "T-bl185-suppression-receipt" "the suppressed commit was REFUSED — the decision is allow-but-log, never block: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"
-    elif grep -qF 'no ERROR-severity findings."' "$TOPTMP/sp1.log" || grep -qE 'no ERROR-severity findings\.$' "$TOPTMP/sp1.log"; then
-      fail_ "T-bl185-suppression-receipt" "the UNQUALIFIED receipt printed over a suppressed sink — the exact false attestation BL-185 exists to end: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"
-    elif ! grep -qF 'suppression directive' "$TOPTMP/sp1.log" || ! grep -qF 'app.ts' "$TOPTMP/sp1.log"; then
-      fail_ "T-bl185-suppression-receipt" "the receipt does not NAME the suppression and its file — the logbook half of allow-but-log: $(tail -8 "$TOPTMP/sp1.log" | tr '\n' '|')"
+      fail_ "T-bl185-suppression-receipt" "($SP_DIR) the suppressed commit was REFUSED — allow-but-log, never block: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"; SP_ALL=FAIL
+    elif [ "$SP_SINK" -lt 1 ]; then
+      fail_ "T-bl185-suppression-receipt" "($SP_DIR) fixture defect — the sink did not land in HEAD; the case proves nothing"; SP_ALL=FAIL
+    elif grep -qE 'no ERROR-severity findings\.$' "$TOPTMP/sp1.log"; then
+      fail_ "T-bl185-suppression-receipt" "($SP_DIR) the UNQUALIFIED receipt printed over a suppressed sink — the exact false attestation BL-185 exists to end (semgrep honors this spelling; the detector must too): $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"; SP_ALL=FAIL
+    elif ! grep -qF 'suppression' "$TOPTMP/sp1.log" || ! grep -qF 'in: app.ts' "$TOPTMP/sp1.log"; then
+      fail_ "T-bl185-suppression-receipt" "($SP_DIR) the receipt does not NAME the suppression with the MAPPED path 'in: app.ts': $(tail -8 "$TOPTMP/sp1.log" | tr '\n' '|')"; SP_ALL=FAIL
+    elif grep -qE 'in: .*/[0-9][0-9]*/app\.ts' "$TOPTMP/sp1.log"; then
+      fail_ "T-bl185-suppression-receipt" "($SP_DIR) the receipt leaks the materialized per-index temp path — the mapping sed is broken (R-HP-3's mutant): $(tail -8 "$TOPTMP/sp1.log" | tr '\n' '|')"; SP_ALL=FAIL
     elif [ "${SP_ROW:-0}" -lt 1 ]; then
-      fail_ "T-bl185-suppression-receipt" "no sast_suppression row in .claude/bypass-audit.json (rows=$SP_ROW) — every other escape in the repo is recorded; this was the last unrecorded one: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"
-    else
-      pass "T-bl185-suppression-receipt: suppressed commit LANDS, unqualified [OK] forfeited, file+directive named, sast_suppression row written"
+      fail_ "T-bl185-suppression-receipt" "($SP_DIR) no sast_suppression row (rows=$SP_ROW) — the logbook half: $(tail -6 "$TOPTMP/sp1.log" | tr '\n' '|')"; SP_ALL=FAIL
     fi
     rm -rf "$SPD"
+  done
+  if [ "$SP_ALL" = "PASS" ]; then
+    pass "T-bl185-suppression-receipt: all three semgrep-honored spellings (nosemgrep / nosem / NOSEMGREP) forfeit the unqualified [OK], name 'in: app.ts' mapped, and write the row"
+  fi
+fi
+
+# ── T-bl185-blocked-path: refused commit => info line, NO row (R-HP-5a) ─────
+echo "=== T-bl185-blocked-path ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-bl185-blocked-path" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  BPD="$(mktemp -d)"
+  if ! mk_repo "$BPD" "$EMITTED" >/dev/null 2>&1; then
+    fail_ "T-bl185-blocked-path" "fixture setup failed"
+  else
+    mkdir -p "$BPD/scripts/lib" "$BPD/.claude"
+    cp "$REPO_ROOT/scripts/lib/bypass-audit.sh" "$BPD/scripts/lib/" 2>/dev/null || true
+    printf '%s\n' "$XSS_TS" > "$BPD/vuln.ts"
+    printf 'export function safe(p, t) {\n  // nosemgrep\n  p.textContent = t;\n}\n' > "$BPD/other.ts"
+    ( cd "$BPD" && git add -- vuln.ts other.ts ) >/dev/null 2>&1
+    if ( cd "$BPD" && git commit -m "feat: two files" ) >"$TOPTMP/bp185.log" 2>&1; then BP_V=COMMITTED; else BP_V=REFUSED; fi
+    BP_ROW=0
+    if command -v jq >/dev/null 2>&1 && [ -f "$BPD/.claude/bypass-audit.json" ]; then
+      BP_ROW=$(jq '[.[] | select(.type == "sast_suppression")] | length' "$BPD/.claude/bypass-audit.json" 2>/dev/null) || BP_ROW=0
+    fi
+    if [ "$BP_V" = "REFUSED" ] && grep -qF '[BLOCKED] Semgrep' "$TOPTMP/bp185.log" \
+       && grep -qF 'suppression' "$TOPTMP/bp185.log" && [ "${BP_ROW:-0}" -eq 0 ]; then
+      pass "T-bl185-blocked-path: a blocked commit still SHOWS the suppression info line but writes NO row — the block itself is the BL-163 ledger's event"
+    else
+      fail_ "T-bl185-blocked-path" "want REFUSED + [BLOCKED] + info line + rows=0; got V=$BP_V rows=$BP_ROW: $(tail -8 "$TOPTMP/bp185.log" | tr '\n' '|')"
+    fi
+    rm -rf "$BPD"
+  fi
+fi
+
+# ── T-bl185-trojan-ledger: a trojan append lib cannot change the outcome ────
+echo "=== T-bl185-trojan-ledger ==="
+if [ "$HAVE_SEMGREP" -eq 0 ]; then
+  skip_ "T-bl185-trojan-ledger" "semgrep ABSENT — UNPROVEN here (skip, NOT a pass)"
+else
+  TJD="$(mktemp -d)"
+  if ! mk_repo "$TJD" "$EMITTED" >/dev/null 2>&1; then
+    fail_ "T-bl185-trojan-ledger" "fixture setup failed"
+  else
+    mkdir -p "$TJD/scripts/lib" "$TJD/.claude"
+    printf '#!/bin/sh\nexit 3\n' > "$TJD/scripts/lib/bypass-audit.sh"
+    printf 'export function safe(p, t) {\n  // nosemgrep\n  p.textContent = t;\n}\n' > "$TJD/app.ts"
+    ( cd "$TJD" && git add -- app.ts ) >/dev/null 2>&1
+    if ( cd "$TJD" && git commit -m "feat: safe file with a suppression" ) >"$TOPTMP/tj185.log" 2>&1; then TJ_V=COMMITTED; else TJ_V=REFUSED; fi
+    if [ "$TJ_V" = "COMMITTED" ] && grep -qF '[note] BL-185: ledger append failed' "$TOPTMP/tj185.log"; then
+      pass "T-bl185-trojan-ledger: a trojan/broken append lib degrades to the loud [note] — subshell-confined, commit outcome untouched (the BL-163 T4b discipline)"
+    else
+      fail_ "T-bl185-trojan-ledger" "want COMMITTED + the loud append-failed note; got V=$TJ_V: $(tail -6 "$TOPTMP/tj185.log" | tr '\n' '|')"
+    fi
+    rm -rf "$TJD"
   fi
 fi
 
@@ -3222,10 +3289,13 @@ else
     fail_ "T-bl185-clean-control" "fixture setup failed"
   else
     # The append lib is PRESENT here too — otherwise "no audit row" would pass
-    # vacuously on a fixture that cannot write rows at all.
+    # vacuously on a fixture that cannot write rows at all. The file also
+    # carries word-boundary NEIGHBORS of the directives (nosemantic,
+    # xnosemgrepx) — semgrep ignores them and so must the detector (R-HP-1's
+    # boundary pins).
     mkdir -p "$SCD/scripts/lib" "$SCD/.claude"
     cp "$REPO_ROOT/scripts/lib/bypass-audit.sh" "$SCD/scripts/lib/" 2>/dev/null || true
-    printf '%s\n' "$SAFE_TS" > "$SCD/app.ts"
+    printf '%s\n// the nosemantic xnosemgrepx neighbors must not trip the detector\n' "$SAFE_TS" > "$SCD/app.ts"
     ( cd "$SCD" && git add -- app.ts ) >/dev/null 2>&1
     if ( cd "$SCD" && git commit -m "feat: clean renderer" ) >"$TOPTMP/sc1.log" 2>&1; then SC_V=COMMITTED; else SC_V=REFUSED; fi
     SC_ROW=0
@@ -3233,7 +3303,7 @@ else
       SC_ROW=$(jq '[.[] | select(.type == "sast_suppression")] | length' "$SCD/.claude/bypass-audit.json" 2>/dev/null) || SC_ROW=0
     fi
     if [ "$SC_V" = "COMMITTED" ] && grep -qF '[OK] semgrep: SAST ran on 1 staged file(s) — no ERROR-severity findings.' "$TOPTMP/sc1.log" \
-       && ! grep -qF 'suppression directive' "$TOPTMP/sc1.log" && [ "${SC_ROW:-0}" -eq 0 ]; then
+       && ! grep -qF 'BL-185:' "$TOPTMP/sc1.log" && [ "${SC_ROW:-0}" -eq 0 ]; then
       pass "T-bl185-clean-control: no directive => the exact unqualified receipt, no BL-185 line, no audit row — the detector does not cry wolf"
     else
       fail_ "T-bl185-clean-control" "clean commit disturbed (V=$SC_V rows=$SC_ROW): $(tail -6 "$TOPTMP/sc1.log" | tr '\n' '|')"


### PR DESCRIPTION
Implements Karl's two 2026-07-31 decisions (their DECIDED blocks on the entries are the contracts).

**BL-185 'allow it, but log it':** the emitted hook detects semgrep suppression directives in the MATERIALIZED staged blobs (`# BL-185-SUPPRESSION-DETECT` — `grep -ciwE 'nosem(grep)?'`: BOTH spellings semgrep honors, any case, word-bounded), forfeits the unqualified `[OK]` for an 'outside suppressed lines' receipt, NAMES the mapped file(s) on every path, and writes a `sast_suppression` row via the BL-163-sibling ledger helper (`# BL-185-SUPPRESSION-LEDGER`: best-effort, trojan-exit subshell-confined, `final_outcome:"recorded_only"` — the SAST arm cannot know whether a LATER gate refuses the commit). The commit lands either way; on the SAST arm's own `[BLOCKED]` the info line shows but no row (the block is BL-163's event).

**BL-187:** `--timeout=30` on the shipped invocation; the 5s-deferral comment is now the decision record; the timeout detector STAYS; the dense fixture's sink is BLOCKED outright at 30s here (strictly better), and the old host-dependent timeout proofs are re-armed for EVERY host by a 30→1s budget-shrunk mutant case (ENVIRON `_mut_env` — the awk `-v` trailing-backslash trap) proving both the detector and the conjunct.

**Review arc** (standing gate, fable ×2): round 1 **block** — the reviewer measured semgrep honoring `nosem` and `NOSEMGREP` (the detector missed both: the exact defect class this item closes), caught a false-'landed' ledger row on a BL-125-refused commit, and its sed-neutralize mutant survived a basename-blind naming assert. All fixed: three-spelling suite loop with sink-in-HEAD guards, honest `recorded_only` rows (schema header extended), exact-mapped `in: app.ts` pin + negative temp-segment assert, plus new blocked-path and trojan-ledger cases. Confirm round: **approve** — every fix re-verified by the reviewer's own probes (P1/P2/P4/P7 all closed; fresh attacks found nothing; zero 'landed' strings in any ledger).

Suite 61/0 (+2 loud host-dependent skips); siblings bl147 63/0, bl112 13/0, bl118 7/0, bl125 22/0, bl131 18/0; run-lints 11/11. Entries: BL-185 closes at merge; BL-187 closes at merge. Fable implementer + fable reviewer ×2; supervisor merge on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)