### PR TITLE
fix(bl191): single-pass scan_file — the per-PR lint drops from ~5-7 minutes to ~3-4 seconds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -110,11 +110,16 @@ jobs:
   # four — the inventory prints exactly when someone needs it. The remaining
   # duplication is genuine merge gates the suites own, so nothing is
   # removed; (3) and (4) are merely moved off each other's critical path.
-  # The root cost is still scripts/lint-counter-antipattern.sh's
-  # `scan_file`, which forks `echo "$line" | grep -Eq` PER LINE of every
-  # file it walks; making that a single-pass scan is an enforcement-script
-  # change (TDD + mutation proof) and stays out of scope for a CI rebalance.
-  # BL-191 stays Open for it.
+  # The root cost WAS scripts/lint-counter-antipattern.sh's `scan_file`,
+  # which forked `echo "$line" | grep -Eq` PER LINE of every file it walks.
+  # That half of BL-191 has since SHIPPED: `scan_file` now runs one
+  # `grep -naE` pass per RULE per FILE, verified byte-identical (stdout,
+  # stderr and exit code) on the clean tree, on a seeded full-tree copy
+  # carrying 32 FAIL rows and 10 sed-alternation rows, and on five seeded
+  # fixtures. Measured on the macOS host, 3 runs each: 407.6/425.6/468.7s
+  # before, 3.84/4.05/3.93s after. The CI seconds recorded in this file
+  # PRE-DATE that change — re-measure before trusting any of them for
+  # rebalancing.
   #
   # SHARDS. Only the measured long poles are pinned; `rest` is the
   # COMPLEMENT of the pins, so a newly added test needs no edit here — it
@@ -153,8 +158,11 @@ jobs:
   # The lint floor drops below the unit lane, so the expected new
   # PR-blocking critical path is ~6 min, SET BY THIS LANE's lint-sweep
   # shard — the first time it has been the unit lane's number to own.
-  # Lowering it further means making the scan itself cheap: BL-191's
-  # per-line-fork rewrite, still Open.
+  # Lowering it further meant making the scan itself cheap, and BL-191's
+  # per-line-fork rewrite has now landed (~110x on the macOS host). Every
+  # second figure above therefore pre-dates it and is an UPPER bound; the
+  # lane's new long pole has not been measured on CI. Re-measure before
+  # repinning shards — do not derive from this table.
   unit-shard:
     name: unit-shard (${{ matrix.shard }})
     runs-on: ubuntu-latest
@@ -465,7 +473,7 @@ jobs:
             tests/test-run-lints.sh                    # 318s — runs the WHOLE lint sweep over the real repo
           )
           pin_lint_scan=(
-            tests/test-lint-counter-antipattern.sh     # 243s — T9 re-scans the real repo
+            tests/test-lint-counter-antipattern.sh     # 243s at pin time — T9 re-scans the real repo; BL-191 made that scan single-pass, so re-measure before repinning
             tests/test-lint-raw-read-prompt.sh         #  41s — real-repo arm
             tests/test-lint-doc-anchors.sh             #  16s — real-repo arm
           )

--- a/scripts/lint-counter-antipattern.sh
+++ b/scripts/lint-counter-antipattern.sh
@@ -172,37 +172,132 @@ should_skip_file() {
   return 1
 }
 
+# ── BL-191-SINGLE-PASS-SCAN ───────────────────────────────────────────
+# scan_file matches ONE `grep -naE` pass per RULE per FILE. It used to
+# run `echo "$line" | grep -Eq "$RE"` for EVERY line of every walked
+# file — ~100k lines across the walk, two pipelines each, on the order
+# of 400k forks. Measured cost of one full-tree scan before this
+# rewrite: 243s on ubuntu-latest (BL-191), ~300s on the macOS host.
+#
+# WHAT DID NOT CHANGE — this is a fork-count rewrite, not a rule
+# rewrite. The matcher is still `grep -E`, the regex constants are
+# untouched, and each rule still sees the raw bytes of one whole line,
+# so verdicts, diagnostic text, line numbers and LIST_ROWS order are
+# byte-identical. Deliberately NOT awk: keeping grep -E keeps the ENGINE
+# identical across the rewrite (that is what makes byte-identity
+# provable rather than argued), and it sidesteps the gawk / mawk /
+# BSD-awk divergence this file already exists to police (BL-121).
+#
+# `-a` (--text; GNU and BSD grep both have it) is load-bearing. Whole-
+# file grep can classify a file with an invalid multibyte sequence as
+# binary and print "Binary file … matches" INSTEAD of numbered lines;
+# the old per-line form fed grep one already-decoded line on stdin and
+# so never met that path. `-a` pins the text path unconditionally.
+#
+# THE TWO `continue`s of the old per-line loop are load-bearing and are
+# preserved verbatim as `do_sed=0` / the comment short-circuit below:
+#   1. a pure-comment line is skipped for BOTH rules (the counter regex
+#      is ^-anchored to an identifier so it can never match a comment,
+#      but the sed regex is unanchored — the skip is all that holds it
+#      off);
+#   2. a line whose counter capture carries an allowlist marker is NOT
+#      evaluated against the BL-121 sed rule at all — marker or empty
+#      reason alike.
+# Both are pinned by T14/T15/T18 in tests/test-lint-counter-antipattern.sh.
 scan_file() {
   local file="$1"
   [ -f "$file" ] || return 0
   should_skip_file "$file" && return 0
 
-  # Read all lines into an array so we can look at N+1.
-  local -a LINES=()
-  local line
-  while IFS= read -r line || [ -n "$line" ]; do
-    LINES+=("$line")
-  done < "$file"
+  # BL-191-UNREADABLE-IS-EXIT-2. The rule passes below originally carried
+  # `2>/dev/null`, which turned an UNREADABLE target into a SILENT clean
+  # pass: grep's diagnostic suppressed, zero hits recorded, file reported
+  # fine. The pre-BL-191 loop was false-clean on this path too, but
+  # LOUDLY — bash printed its own redirect error. Silence is the worse
+  # failure mode, and this script's header already documents
+  # `2 — invocation / I/O error`, so honour that contract instead of
+  # guessing about a file we cannot read. The `2>/dev/null`s are gone
+  # with it, so any residual grep diagnostic now surfaces. T22 pins this.
+  if [ ! -r "$file" ]; then
+    echo "lint-counter-antipattern: cannot read ${file} — refusing to report it clean" >&2
+    exit 2
+  fi
 
-  local i n
-  n=${#LINES[@]}
-  for ((i = 0; i < n; i++)); do
-    line="${LINES[i]}"
+  local rel="${file#"$REPO_ROOT"/}"
+
+  # Rule-level whole-file passes. grep -n emits `LINENO:CONTENT`; the
+  # single-file form never prefixes a filename, so `%%:*` / `#*:` split
+  # it exactly.
+  local -a ANTI_NO=() ANTI_TXT=()
+  local -a SED_NO=() SED_TXT=()
+  local SED_ERE_SET=":"
+  local hit
+
+  while IFS= read -r hit || [ -n "$hit" ]; do
+    ANTI_NO+=("${hit%%:*}")
+    ANTI_TXT+=("${hit#*:}")
+  done < <(grep -naE "$ANTIPATTERN_RE" "$file")
+
+  while IFS= read -r hit || [ -n "$hit" ]; do
+    SED_NO+=("${hit%%:*}")
+    SED_TXT+=("${hit#*:}")
+  done < <(grep -naE "$SED_BRE_ALT_RE" "$file")
+
+  local an=${#ANTI_NO[@]} bn=${#SED_NO[@]}
+  [ "$an" -eq 0 ] && [ "$bn" -eq 0 ] && return 0
+
+  # The `sed -E` exemption is evaluated PER LINE (T19), so it needs the
+  # exempt line NUMBERS, not a whole-file boolean. Only worth a fork
+  # where the basic-mode rule actually hit.
+  if [ "$bn" -gt 0 ]; then
+    while IFS= read -r hit || [ -n "$hit" ]; do
+      SED_ERE_SET="${SED_ERE_SET}${hit%%:*}:"
+    done < <(grep -naE "$SED_ERE_FLAG_RE" "$file")
+  fi
+
+  # The N+1 sanitizer lookahead still needs the file body, and it must
+  # be the SAME `read -r` decode the old loop used. Load it lazily: on
+  # the current tree only 34 of 243 walked files have a counter hit.
+  local -a LINES=()
+  local lines_loaded=0
+
+  # Ordered merge of the two hit lists. grep emits ascending line
+  # numbers, so a two-index walk reproduces the old single for-loop's
+  # visit order exactly, including "counter rule before sed rule" when
+  # one line trips both.
+  local ai=0 bi=0
+  local lineno line do_anti do_sed
+  while [ "$ai" -lt "$an" ] || [ "$bi" -lt "$bn" ]; do
+    do_anti=0
+    do_sed=0
+    if [ "$ai" -lt "$an" ] && { [ "$bi" -ge "$bn" ] || [ "${ANTI_NO[$ai]}" -le "${SED_NO[$bi]}" ]; }; then
+      lineno="${ANTI_NO[$ai]}"
+      line="${ANTI_TXT[$ai]}"
+      do_anti=1
+      ai=$((ai + 1))
+      if [ "$bi" -lt "$bn" ] && [ "${SED_NO[$bi]}" -eq "$lineno" ]; then
+        do_sed=1
+        bi=$((bi + 1))
+      fi
+    else
+      lineno="${SED_NO[$bi]}"
+      line="${SED_TXT[$bi]}"
+      do_sed=1
+      bi=$((bi + 1))
+    fi
+
     # Skip lines that are pure comments (no var=$( ... ) shape).
     case "${line#"${line%%[![:space:]]*}"}" in
       '#'*) continue ;;
     esac
 
-    if echo "$line" | grep -Eq "$ANTIPATTERN_RE"; then
+    if [ "$do_anti" -eq 1 ]; then
       # Parse var name + allowlist.
       local parsed var_name allow_reason has_marker
       parsed=$(parse_line "$line")
       var_name="$(printf '%s' "$parsed" | cut -f1)"
       allow_reason="$(printf '%s' "$parsed" | cut -f2)"
       has_marker="$(printf '%s' "$parsed" | cut -f3)"
-
-      local lineno=$((i + 1))
-      local rel="${file#"$REPO_ROOT"/}"
 
       if [ "$has_marker" = "1" ]; then
         if [ -z "$allow_reason" ]; then
@@ -212,48 +307,62 @@ scan_file() {
         else
           LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\t${var_name}\tallowlist:${allow_reason}\n"
         fi
-        continue
-      fi
-
-      # Check next line for the case-statement sanitizer with matching var.
-      local next="${LINES[i+1]:-}"
-      local sanitizer_re
-      sanitizer_re="$(sanitizer_regex_for "$var_name")"
-      if echo "$next" | grep -Eq "$sanitizer_re"; then
-        LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\t${var_name}\tsanitized\n"
+        # The old per-line loop `continue`d here, which ALSO skipped the
+        # BL-121 sed rule for this line — on BOTH arms above, marker with
+        # a reason and marker with an empty one alike. Dropping this is
+        # the one silent divergence a merged walk invites, and it is
+        # invisible on a clean tree (main has zero sed-alternation rows).
+        # T14 pins it. # BL-191-ALLOWLIST-SHORT-CIRCUIT
+        do_sed=0
       else
-        # Identify the failure subtype for a clearer message.
-        local subtype="missing-sanitizer"
-        # If next line is ALSO a case statement but for a different var,
-        # call that out — that's the copy-paste bug class T5 protects.
-        if echo "$next" | grep -Eq '^[[:space:]]*case[[:space:]]+"\$[A-Za-z_][A-Za-z0-9_]*"[[:space:]]+in[[:space:]]+'\'''\''[[:space:]]*\|'; then
-          subtype="sanitizer-var-mismatch"
-          echo "${rel}:${lineno}: lint-counter-antipattern: capture of '\$${var_name}' is not sanitized — next-line case-statement uses a different var name" >&2
-        else
-          echo "${rel}:${lineno}: lint-counter-antipattern: capture of '\$${var_name}' is not sanitized — add 'case \"\$${var_name}\" in '\'''\''|*[!0-9]*) ${var_name}=0 ;; esac' on the next line, or append '# lint-counter-antipattern: allow <reason>'" >&2
+        # Check next line for the case-statement sanitizer with matching var.
+        if [ "$lines_loaded" -eq 0 ]; then
+          local body_line
+          while IFS= read -r body_line || [ -n "$body_line" ]; do
+            LINES+=("$body_line")
+          done < "$file"
+          lines_loaded=1
         fi
-        VIOLATIONS=$((VIOLATIONS + 1))
-        LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\t${var_name}\t${subtype}\n"
+        # LINES is 0-based, so element [$lineno] IS line $lineno+1.
+        local next="${LINES[$lineno]:-}"
+        local sanitizer_re
+        sanitizer_re="$(sanitizer_regex_for "$var_name")"
+        if echo "$next" | grep -Eq "$sanitizer_re"; then
+          LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\t${var_name}\tsanitized\n"
+        else
+          # Identify the failure subtype for a clearer message.
+          local subtype="missing-sanitizer"
+          # If next line is ALSO a case statement but for a different var,
+          # call that out — that's the copy-paste bug class T5 protects.
+          if echo "$next" | grep -Eq '^[[:space:]]*case[[:space:]]+"\$[A-Za-z_][A-Za-z0-9_]*"[[:space:]]+in[[:space:]]+'\'''\''[[:space:]]*\|'; then
+            subtype="sanitizer-var-mismatch"
+            echo "${rel}:${lineno}: lint-counter-antipattern: capture of '\$${var_name}' is not sanitized — next-line case-statement uses a different var name" >&2
+          else
+            echo "${rel}:${lineno}: lint-counter-antipattern: capture of '\$${var_name}' is not sanitized — add 'case \"\$${var_name}\" in '\'''\''|*[!0-9]*) ${var_name}=0 ;; esac' on the next line, or append '# lint-counter-antipattern: allow <reason>'" >&2
+          fi
+          VIOLATIONS=$((VIOLATIONS + 1))
+          LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\t${var_name}\t${subtype}\n"
+        fi
       fi
     fi
 
     # BL-121: basic-mode sed alternation (constants + rationale at
     # SED_BRE_ALT_RE above). Independent of the counter-capture rule — a
     # line can violate either.
-    if echo "$line" | grep -Eq "$SED_BRE_ALT_RE" \
-       && ! echo "$line" | grep -Eq "$SED_ERE_FLAG_RE"; then
-      local sparsed sreason smarker slineno srel
+    case "$SED_ERE_SET" in
+      *":${lineno}:"*) do_sed=0 ;;
+    esac
+    if [ "$do_sed" -eq 1 ]; then
+      local sparsed sreason smarker
       sparsed=$(parse_line "$line")
       sreason="$(printf '%s' "$sparsed" | cut -f2)"
       smarker="$(printf '%s' "$sparsed" | cut -f3)"
-      slineno=$((i + 1))
-      srel="${file#"$REPO_ROOT"/}"
       if [ "$smarker" = "1" ] && [ -n "$sreason" ]; then
-        LIST_ROWS="${LIST_ROWS}PASS\t${srel}:${slineno}\tsed-alternation\tallowlist:${sreason}\n"
+        LIST_ROWS="${LIST_ROWS}PASS\t${rel}:${lineno}\tsed-alternation\tallowlist:${sreason}\n"
       else
-        echo "${srel}:${slineno}: lint-counter-antipattern: GNU-only sed alternation — a backslash-pipe in a BASIC-regex sed program is alternation on GNU but a LITERAL on BSD/macOS, so a range terminator carrying it never matches and the range runs to EOF (BL-121). Use an awk range/ERE, or sed -E with a real alternation, or append '# lint-counter-antipattern: allow <reason>'" >&2
+        echo "${rel}:${lineno}: lint-counter-antipattern: GNU-only sed alternation — a backslash-pipe in a BASIC-regex sed program is alternation on GNU but a LITERAL on BSD/macOS, so a range terminator carrying it never matches and the range runs to EOF (BL-121). Use an awk range/ERE, or sed -E with a real alternation, or append '# lint-counter-antipattern: allow <reason>'" >&2
         VIOLATIONS=$((VIOLATIONS + 1))
-        LIST_ROWS="${LIST_ROWS}FAIL\t${srel}:${slineno}\tsed-alternation\tgnu-only-sed-alternation\n"
+        LIST_ROWS="${LIST_ROWS}FAIL\t${rel}:${lineno}\tsed-alternation\tgnu-only-sed-alternation\n"
       fi
     fi
   done

--- a/scripts/run-lints.sh
+++ b/scripts/run-lints.sh
@@ -14,9 +14,12 @@
 #   of the 8 CI-required lint jobs in .github/workflows/lint.yml, so running it
 #   here would spuriously fail the sweep.
 #
-#   NOTE: two of the scanned lints are slow full-tree scans —
-#   lint-counter-antipattern.sh (~90s) and lint-raw-read-prompt.sh (~40s) — so a
-#   full run is a couple of minutes. That is expected.
+#   NOTE: lint-raw-read-prompt.sh (~40s) is a slow full-tree scan — it still
+#   forks `echo "$line" | grep -Eq` PER LINE of every file it walks.
+#   lint-counter-antipattern.sh USED to be the worse of the two (~90s when this
+#   note was written; 407-469s on the tree as of 2026-07-31, 3 runs), but BL-191
+#   made its scan single-pass and it now runs in ~4s. A full run is still a
+#   couple of minutes — measured 1m58s on the macOS host. That is expected.
 #
 # NOT A SHIPPED SCRIPT
 #   This is a DEV tool. It is deliberately NOT in any init.sh copy list and is

--- a/tests/test-lint-counter-antipattern.sh
+++ b/tests/test-lint-counter-antipattern.sh
@@ -49,6 +49,23 @@ run_lint() {
   return $?
 }
 
+# Same, but `--list` and STDOUT ONLY — the PASS/FAIL inventory table.
+# T14-T19 (BL-191) assert on ROW CONTENT and ROW ORDER, which stderr
+# diagnostics would interleave into, so they need the clean table.
+run_lint_list() {
+  ( cd "$PROJ" && bash scripts/lint-counter-antipattern.sh --list 2>/dev/null )
+  return $?
+}
+
+# Data rows only. Two non-row lines share the table's STDOUT and must
+# both come off: the STATUS/FILE:LINE/VAR/DETAIL header, and — on a
+# clean run — the trailing "OK: no counter-capture antipatterns found."
+# success line, which the linter prints AFTER the table.
+list_rows() {
+  printf '%s\n' "$1" | sed '1d' \
+    | grep -v '^OK: no counter-capture antipatterns found\.$'
+}
+
 # ════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== T1: clean fixture (sanitized site) → exit 0 ==="
@@ -368,6 +385,303 @@ if [ $rc -eq 0 ]; then
 else
   fail_ "T13" "expected exit 0 with allowlist marker; rc=$rc; output:\n$out"
 fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+# T14-T19 — BL-191 single-pass characterization guards.
+#
+# `scan_file` used to fork `echo "$line" | grep -Eq …` once PER LINE for
+# each of the two rules; BL-191 replaced that with ONE `grep -naE` pass
+# per RULE per FILE plus an ordered merge of the two hit lists. These
+# six cases pin the properties that the per-line → per-file move can
+# silently break and that NOTHING ELSE in this suite covers. They are
+# characterization tests: each one passes against the pre-BL-191
+# implementation too, which is the point — they are the byte-identity
+# contract, not a new feature.
+#
+#   T14  the allowlist `continue` — a line carrying BOTH rules with an
+#        allowlist marker evaluates the counter rule and then SKIPS the
+#        BL-121 sed rule entirely. Easy to lose: a merged walk that
+#        evaluates both rules unconditionally emits an extra row.
+#   T15  a line carrying BOTH rules WITHOUT a marker fires both, and the
+#        counter row is emitted BEFORE the sed row. Pins rule order.
+#   T16  a violation on the FINAL line of a file with NO trailing
+#        newline: the N+1 lookahead must read as empty, not fall off.
+#   T17  walk order — the LIST_ROWS sequence is TARGET_GLOBS order, then
+#        ascending line number within a file.
+#   T18  pure-comment lines are skipped for the sed rule (the counter
+#        regex is `^`-anchored to an identifier so it can never match a
+#        comment; the sed regex is NOT anchored, so the comment skip is
+#        the only thing holding it off).
+#   T19  the `sed -E` exemption is PER LINE, not per file — an exempt
+#        ERE invocation on one line must not exempt a basic-mode
+#        alternation on another. A whole-file boolean fails this.
+# ════════════════════════════════════════════════════════════════════
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T14: BL-191 — allowlisted counter line ALSO matching the sed rule → sed rule suppressed ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/both-allowed.sh" <<'SH'
+#!/usr/bin/env bash
+items=$(sed -n '/A\|B/p' FILE.md | grep -c x || echo "0") # lint-counter-antipattern: allow gnu-sed-only fixture, exercised on Linux CI only
+SH
+rows=$(run_lint_list); rc=$?
+data=$(list_rows "$rows")
+nrows=$(printf '%s\n' "$data" | grep -c .)
+if [ $rc -eq 0 ] \
+   && [ "$nrows" -eq 1 ] \
+   && printf '%s\n' "$data" | grep -q "items" \
+   && ! printf '%s\n' "$data" | grep -q "sed-alternation"; then
+  pass "T14: allowlist marker short-circuits the line — counter row only, no sed row"
+else
+  fail_ "T14" "expected exit 0 and exactly 1 counter row with NO sed-alternation row; rc=$rc; nrows=$nrows; rows:\n$data"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T15: BL-191 — unmarked line matching BOTH rules fires both, counter row FIRST ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/both-bad.sh" <<'SH'
+#!/usr/bin/env bash
+items=$(sed -n '/A\|B/p' FILE.md | grep -c x || echo "0")
+echo "$items"
+SH
+rows=$(run_lint_list); rc=$?
+data=$(list_rows "$rows")
+first=$(printf '%s\n' "$data" | sed -n '1p')
+second=$(printf '%s\n' "$data" | sed -n '2p')
+if [ $rc -eq 1 ] \
+   && printf '%s' "$first"  | grep -q 'scripts/both-bad.sh:2.*items.*missing-sanitizer' \
+   && printf '%s' "$second" | grep -q 'scripts/both-bad.sh:2.*sed-alternation.*gnu-only-sed-alternation'; then
+  pass "T15: both rules fire on one line, counter row emitted before sed row"
+else
+  fail_ "T15" "expected 2 rows for line 2, counter first then sed; rc=$rc; rows:\n$data"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T16: BL-191 — violation on the LAST line, file has no trailing newline → still flagged ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+printf '#!/usr/bin/env bash\ntail_count=$(grep -c "X" file.txt 2>/dev/null || echo "0")' \
+  > "$PROJ/scripts/tail-nonl.sh"
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/tail-nonl.sh:2" \
+   && echo "$out" | grep -q "tail_count"; then
+  pass "T16: last-line violation without trailing newline is flagged at the right line"
+else
+  fail_ "T16" "expected exit 1 naming scripts/tail-nonl.sh:2 and tail_count; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T17: BL-191 — row order is TARGET_GLOBS walk order, then ascending line number ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+mkdir -p "$PROJ/scripts/lib" "$PROJ/tests"
+cat > "$PROJ/scripts/aaa.sh" <<'SH'
+#!/usr/bin/env bash
+one=$(grep -c "X" f.txt 2>/dev/null || echo "0")
+case "$one" in ''|*[!0-9]*) one=0 ;; esac
+echo "$one"
+two=$(grep -c "Y" f.txt 2>/dev/null || echo "0")
+case "$two" in ''|*[!0-9]*) two=0 ;; esac
+SH
+cat > "$PROJ/scripts/lib/zzz.sh" <<'SH'
+#!/usr/bin/env bash
+three=$(grep -c "X" f.txt 2>/dev/null || echo "0")
+case "$three" in ''|*[!0-9]*) three=0 ;; esac
+SH
+cat > "$PROJ/tests/ttt.sh" <<'SH'
+#!/usr/bin/env bash
+four=$(grep -c "X" f.txt 2>/dev/null || echo "0")
+case "$four" in ''|*[!0-9]*) four=0 ;; esac
+SH
+cat > "$PROJ/init.sh" <<'SH'
+#!/usr/bin/env bash
+echo "scaffolder"
+five=$(grep -c "X" f.txt 2>/dev/null || echo "0")
+case "$five" in ''|*[!0-9]*) five=0 ;; esac
+SH
+rows=$(run_lint_list); rc=$?
+actual=$(list_rows "$rows" | cut -f2)
+expected='scripts/aaa.sh:2
+scripts/aaa.sh:5
+scripts/lib/zzz.sh:2
+tests/ttt.sh:2
+init.sh:3'
+if [ $rc -eq 0 ] && [ "$actual" = "$expected" ]; then
+  pass "T17: inventory row order follows the glob walk then line number"
+else
+  fail_ "T17" "row order drifted; rc=$rc\nexpected:\n$expected\nactual:\n$actual"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T18: BL-191 — sed alternation inside a pure COMMENT line is skipped ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# legacy: items=$(sed -n %s/Must-Have/,/Should-Have\\|---/p%s F.md | grep -c x)\n' "'" "'"
+  printf '\t# tab-indented note about sed -n %s/A\\|B/p%s\n' "'" "'"
+  printf '   # space-indented note about sed -n %s/C\\|D/p%s\n' "'" "'"
+  printf 'echo ok\n'
+} > "$PROJ/scripts/commented.sh"
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ]; then
+  pass "T18: commented-out sed alternation (tab- and space-indented) is skipped"
+else
+  fail_ "T18" "expected exit 0 — comment lines must be skipped for BOTH rules; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T19: BL-191 — the 'sed -E' exemption is PER LINE, not per file ==="
+# ════════════════════════════════════════════════════════════════════
+setup
+cat > "$PROJ/scripts/mixed-sed.sh" <<'SH'
+#!/usr/bin/env bash
+cell=$(echo "$row" | sed -E 's/a\|b/x/')
+items=$(sed -n '/A\|B/p' FILE.md)
+SH
+out=$(run_lint); rc=$?
+hits=$(printf '%s\n' "$out" | grep -c 'lint-counter-antipattern: GNU-only sed alternation')
+if [ $rc -eq 1 ] \
+   && [ "$hits" -eq 1 ] \
+   && echo "$out" | grep -q "scripts/mixed-sed.sh:3" \
+   && ! echo "$out" | grep -q "scripts/mixed-sed.sh:2"; then
+  pass "T19: line 3 flagged, line 2's sed -E exemption does not leak to it"
+else
+  fail_ "T19" "expected exactly one sed diagnostic, on line 3 only; rc=$rc; hits=$hits; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T20: BL-191 — a NUL byte must not hide a violation (pins grep -a) ==="
+# ════════════════════════════════════════════════════════════════════
+# BL-191's rewrite diverges from the pre-BL-191 lint on exactly one
+# input domain: NUL-BEARING LINES. This case pins the two arms where it
+# catches MORE. T21 pins the arm where it catches LESS — read both
+# before concluding anything about the direction of the change.
+#
+#   • BEFORE: `scan_file` read each line into a bash variable. A bash
+#     string cannot hold a NUL, so a NUL anywhere on a line TRUNCATED
+#     it there. `near_count=$(grep -c "X<NUL>Y" f || echo "0")` became
+#     `near_count=$(grep -c "X` — which matches nothing, so the
+#     unsanitized capture was silently NOT reported.
+#   • AFTER, without `-a`: whole-file grep classifies a NUL-bearing
+#     file as binary and answers "Binary file … matches" instead of
+#     numbered lines. That is WORSE than the old miss — the line-number
+#     parse then feeds a non-number to `[ … -le … ]`, and the run ends
+#     "OK: no counter-capture antipatterns found." with EXIT 0. A false
+#     clean over a file that contains a real violation.
+#   • AFTER, with `-a`: the raw line is matched and the violation is
+#     reported. That is the behaviour pinned here.
+#
+# Both arms below therefore go RED if `-a` is dropped from the rule
+# passes. Case (a) also holds on the old implementation; case (b) is
+# the intentional improvement.
+setup
+# (a) NUL on an unrelated line — old and new agree, file still scanned
+printf '#!/usr/bin/env bash\n# nul here: \000 end\nfar_count=$(grep -c "X" f.txt 2>/dev/null || echo "0")\n' \
+  > "$PROJ/scripts/nul-far.sh"
+# (b) NUL ON the violating line — the truncation blind spot
+printf '#!/usr/bin/env bash\nnear_count=$(grep -c "X\000Y" f.txt 2>/dev/null || echo "0")\n' \
+  > "$PROJ/scripts/nul-near.sh"
+out=$(run_lint); rc=$?
+if [ $rc -eq 1 ] \
+   && echo "$out" | grep -q "scripts/nul-far.sh:3" \
+   && echo "$out" | grep -q "scripts/nul-near.sh:2" \
+   && ! echo "$out" | grep -qi "binary file" \
+   && ! echo "$out" | grep -q "OK: no counter-capture antipatterns found"; then
+  pass "T20: NUL-bearing files are scanned as text — both violations reported"
+else
+  fail_ "T20" "expected exit 1 naming nul-far.sh:3 AND nul-near.sh:2, with no 'Binary file' and no false OK; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T21: BL-191 — NUL-bearing line where the rewrite catches LESS (widened exemption) ==="
+# ════════════════════════════════════════════════════════════════════
+# THE COUNTERWEIGHT TO T20, and the reason the divergence must be
+# described as "NUL-bearing lines behave differently" rather than
+# "the rewrite catches more".
+#
+# The fixture is one raw line: a REAL basic-mode sed alternation, then a
+# NUL, then a `sed -E` mention in a trailing comment.
+#   • pre-BL-191: bash `read` truncated the line at the NUL, so the
+#     exemption string was never seen -> the BL-121 rule FIRED (exit 1).
+#   • post-BL-191: raw-byte evaluation sees the whole line, and
+#     SED_ERE_FLAG_RE is UNANCHORED — any `sed -E` string anywhere on the
+#     line exempts it — so the line is EXEMPT (exit 0).
+#
+# ROOT CAUSE IS PRE-EXISTING, NOT INTRODUCED. Strip the NUL from this
+# same line and both implementations exempt it, byte-identically. What
+# BL-191 changed is how much of a NUL-bearing line the exemption can
+# see, not the exemption's scope.
+#
+# This asserts the CURRENT (exit 0) behaviour deliberately, as
+# characterization. It is NOT an endorsement: narrowing
+# SED_ERE_FLAG_RE — e.g. anchoring it to the sed invocation rather than
+# the whole line, or stripping trailing comments first — is a live
+# improvement, and it SHOULD flip this test. A failure here means
+# someone tightened the exemption; update this case, do not widen the
+# regex back.
+setup
+printf '#!/usr/bin/env bash\nitems=$(sed -n %s/A\\|B/p%s F.md)\000# sed -E note\n' "'" "'" \
+  > "$PROJ/scripts/nul-ere.sh"
+out=$(run_lint); rc=$?
+if [ $rc -eq 0 ] && ! echo "$out" | grep -q "nul-ere.sh"; then
+  pass "T21: NUL-bearing line with a post-NUL 'sed -E' string is exempt (documented widened-exemption arm)"
+else
+  fail_ "T21" "expected exit 0 with no nul-ere.sh row — if the exemption scope was deliberately TIGHTENED, update this case rather than reverting; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T22: BL-191 — an UNREADABLE target exits 2, never a silent clean pass ==="
+# ════════════════════════════════════════════════════════════════════
+# The single-pass rule passes originally carried `2>/dev/null`, which
+# made an unreadable file report clean with NO diagnostic at all. The
+# header documents `2 — invocation / I/O error`; BL-191-UNREADABLE-IS-
+# EXIT-2 honours it. Pinned here because "reports clean" is precisely
+# the failure a lint must never have.
+setup
+cat > "$PROJ/scripts/unreadable.sh" <<'SH'
+#!/usr/bin/env bash
+hidden=$(grep -c "X" f.txt 2>/dev/null || echo "0")
+SH
+chmod 000 "$PROJ/scripts/unreadable.sh"
+if [ -r "$PROJ/scripts/unreadable.sh" ]; then
+  # Running as root (or on a filesystem that ignores mode bits): chmod
+  # 000 is not enforceable, so the precondition cannot be staged. Say so
+  # LOUDLY rather than passing a test that proved nothing.
+  echo "  [SKIP] T22: chmod 000 is not enforceable here (root or permissive fs) — arm not exercised"
+else
+  out=$(run_lint); rc=$?
+  if [ $rc -eq 2 ] \
+     && echo "$out" | grep -q "cannot read" \
+     && echo "$out" | grep -q "unreadable.sh" \
+     && ! echo "$out" | grep -q "OK: no counter-capture antipatterns found"; then
+    pass "T22: unreadable target exits 2 with a diagnostic, not a silent clean pass"
+  else
+    fail_ "T22" "expected exit 2 naming the unreadable file, with no clean-pass line; rc=$rc; output:\n$out"
+  fi
+fi
+chmod 644 "$PROJ/scripts/unreadable.sh" 2>/dev/null
 teardown
 
 echo ""


### PR DESCRIPTION
Quick-sweep item; BL-191's open half. `scan_file` in `lint-counter-antipattern.sh` forked a subshell+pipe PER LINE (~100k forks per run); it is now one `grep -naE` pass per rule per file with an ordered merge (`# BL-191-SINGLE-PASS-SCAN`) — deliberately grep-not-awk so the ENGINE is identical and byte-identity is provable rather than argued. Measured ~110-112x (297-469s → 2.6-4s, both sides re-timed by the reviewer); the pre-commit gate runs this lint on every commit, so the win lands locally too.

**Byte-identity** proven on SEEDED corpora (real tree + injected violations exercising FAIL rows, sed-alternation rows, stderr — a clean-tree diff alone proves almost nothing), all four streams SHA-identical; the reviewer replicated and extended with its own nasties (CRLF, final-line/no-newline violations, dense interleaves, invalid UTF-8): identical. **The one divergence domain is NUL-bearing lines, and the record now says it CUTS BOTH WAYS** (the reviewer falsified the original 'strictly catches more' claim by construction): the old truncating read silently missed a real violation AND could accidentally hide a `sed -E` exemption string — so the rewrite catches more on T20's arms and less on T21's (flagged→exempt when the exemption text sat past a NUL; root cause is the PRE-EXISTING unanchored exemption scope, verified byte-identical on NUL-free lines; narrowing it is a live follow-up that SHOULD flip T21's characterization pin). Also fixed in-round: unreadable files now exit 2 loudly (`# BL-191-UNREADABLE-IS-EXIT-2`, T22 with a real chmod-000 case) instead of the old silent-false-clean — the exact class BL-197's new lint polices.

Review arc (standing gate): **major_concerns** (the falsified wording + the silent-skip) → both fixed with the reviewer's prescriptions; its independent verification: seven-mutant battery zero survivors (three claimed + four of its own), characterization non-vacuity proven (the suite run against the OLD lint fails exactly T20), timing re-measured, merged-state green (clean auto-merge; 12/12 lints incl. the new ones over this branch's files), GNU-grep first-contact residual honestly flagged (-a is not POSIX; both platforms carry it; regexes unchanged — CI on this PR is the real check). Final battery: 8 atoms, suite 24/0.

Entry closes at merge (its own condition: 'flip to Closed only when scan_file is single-pass'). Noted follow-up: `lint-raw-read-prompt.sh` carries the identical per-line fork (~40s, now the slowest lint). Opus implementer + fable review; supervisor merge on verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)