### PR TITLE
fix(docs): 15 broken references in the docs every generated project ships

### DIFF
--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -73,7 +73,7 @@ The following are outside the current scope. They are content gaps addressable t
 - **Large-scale distributed systems** (microservices, multi-region) — Addressable through new platform modules. The extensibility model supports this; the modules have not been written.
 - **Enterprise integration projects** (SAP, Salesforce, custom ERP) — Specialized domains addressable through dedicated platform modules and intake suggestion files.
 
-Additional platform modules can be added following the [Extending Platforms Guide](extending-platforms.md).
+Additional platform modules can be added following the [Extending Platforms Guide](https://github.com/kraulerson/solo-orchestrator/blob/main/docs/extending-platforms.md).
 
 ### How This Differs From "Vibe Coding"
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -14,27 +14,27 @@
 
 This guide walks you through using the Solo Orchestrator Framework from first setup to production maintenance. It covers what you do, when, and why — with separate paths for personal projects and organizational deployments.
 
-For what the framework *is*, how it works at a conceptual level, and what it is not suited for, see the [README](../README.md). This guide assumes you have read that and decided to proceed.
+For what the framework *is*, how it works at a conceptual level, and what it is not suited for, see the [README](https://github.com/kraulerson/solo-orchestrator#readme). This guide assumes you have read that and decided to proceed.
 
 ### Document Map
 
 | Document | Priority | What It Contains | When You Need It |
 |---|---|---|---|
 | **This guide** (user-guide.md) | **Follow** | What you do, step by step, from setup to maintenance | Start here |
-| [**Project Intake**](../templates/project-intake.md) | **Fill out** | Your product definition — wizard available | Pre-Phase 0 |
-| [**Platform Module**](platform-modules/) | **Reference** | Platform-specific architecture, tooling, testing, distribution | Phases 1-4 |
-| [**README**](../README.md) | Skim | Framework overview, prerequisites, platform/language support | Before starting |
+| **Project Intake** (`PROJECT_INTAKE.md`, created by `init.sh` in your project root) | **Fill out** | Your product definition — wizard available | Pre-Phase 0 |
+| [**Platform Module**](https://github.com/kraulerson/solo-orchestrator/tree/main/docs/platform-modules) | **Reference** | Platform-specific architecture, tooling, testing, distribution | Phases 1-4 |
+| [**README**](https://github.com/kraulerson/solo-orchestrator#readme) | Skim | Framework overview, prerequisites, platform/language support | Before starting |
 | [**Builder's Guide**](builders-guide.md) | Reference | The complete methodology — deep reference for phases, glossary, and advanced procedures | When you need detail beyond what this guide provides |
 | [**CLI Setup Addendum**](cli-setup-addendum.md) | Reference | Claude Code configuration, Superpowers, MCP servers | After init, before Phase 0 |
 | [**Security Scan Guide**](security-scan-guide.md) | Reference | Plain-language guide to common scan findings | When you get scan results |
 | [**Governance Framework**](governance-framework.md) | Org only | Approval authorities, compliance, risk, portfolio governance | Organizational deployments |
 | [**Executive Review**](executive-review.md) | Org only | Business case for CIO evaluation | Organizational evaluation |
 | [**Example Project**](https://github.com/kraulerson/solo-orchestrator-example-project) | Browse | Complete artifact trail from building MeshScope — see what each phase produces | Before starting, or anytime |
-| [**Extending Platforms**](extending-platforms.md) | Contributor | How to add a new platform type to the framework | When adding platforms |
-| [**Framework Evaluation Prompts**](../evaluation-prompts/Framework/) | Evaluation | Adversarial reviews of the framework itself from 6 professional perspectives | After framework updates or retooling |
-| [**Project Evaluation Prompts**](../evaluation-prompts/Projects/) | Evaluation | Adversarial reviews of any project built with the framework from 6 professional perspectives | Phase 3 validation, before production deployment |
+| [**Extending Platforms**](https://github.com/kraulerson/solo-orchestrator/blob/main/docs/extending-platforms.md) | Contributor | How to add a new platform type to the framework | When adding platforms |
+| [**Framework Evaluation Prompts**](https://github.com/kraulerson/solo-orchestrator/tree/main/evaluation-prompts/Framework) | Evaluation | Adversarial reviews of the framework itself from 6 professional perspectives | After framework updates or retooling |
+| [**Project Evaluation Prompts**](https://github.com/kraulerson/solo-orchestrator/tree/main/evaluation-prompts/Projects) | Evaluation | Adversarial reviews of any project built with the framework from 6 professional perspectives | Phase 3 validation, before production deployment |
 
-**What you actually need open:** This guide, the [Project Intake](../templates/project-intake.md), and your [Platform Module](platform-modules/). Everything else is reference material — the table above tells you when each document becomes relevant.
+**What you actually need open:** This guide, your project's `PROJECT_INTAKE.md`, and your [Platform Module](https://github.com/kraulerson/solo-orchestrator/tree/main/docs/platform-modules). Everything else is reference material — the table above tells you when each document becomes relevant.
 
 **How to read this guide:** Follow it step by step. Read the section for your current step, do the step, then read the next section. You do not need to read this guide end-to-end before starting. Each section tells you exactly what to do, what the AI agent does, and what to review before moving on.
 
@@ -46,11 +46,11 @@ For what the framework *is*, how it works at a conceptual level, and what it is 
 
 ### What This Framework Is
 
-A structured methodology for a single experienced technologist to build MVP-quality applications with a clear path to production, using AI as the execution layer. You define intent, constraints, and validation. The AI generates architecture, code, tests, and documentation within those constraints. It is phase-gated, test-driven, and security-scanned at every step. The output is a functional, tested, security-scanned MVP — production deployment requires additional hardening, operational readiness, and (for organizational projects) governance completion. See the [README](../README.md) for the full overview.
+A structured methodology for a single experienced technologist to build MVP-quality applications with a clear path to production, using AI as the execution layer. You define intent, constraints, and validation. The AI generates architecture, code, tests, and documentation within those constraints. It is phase-gated, test-driven, and security-scanned at every step. The output is a functional, tested, security-scanned MVP — production deployment requires additional hardening, operational readiness, and (for organizational projects) governance completion. See the [README](https://github.com/kraulerson/solo-orchestrator#readme) for the full overview.
 
 ### What You Should Know Before You Start
 
-**AI-generated code IP:** Software built using this framework is generated in part by AI. The copyright status of AI-generated code is legally unsettled under current U.S. and international law. The framework's human-directed phase gates strengthen copyright claims but do not guarantee protection. Do not assume full copyright protection for AI-generated code without consulting qualified IP counsel. See the [README Legal Notices](../README.md#legal-notices) for the full disclosure.
+**AI-generated code IP:** Software built using this framework is generated in part by AI. The copyright status of AI-generated code is legally unsettled under current U.S. and international law. The framework's human-directed phase gates strengthen copyright claims but do not guarantee protection. Do not assume full copyright protection for AI-generated code without consulting qualified IP counsel. See the [README Legal Notices](https://github.com/kraulerson/solo-orchestrator#legal-notices) for the full disclosure.
 
 **AI-generated legal documents:** Any Privacy Policies, Terms of Service, or other legal documents produced during the build process must be reviewed by qualified legal counsel before deployment.
 
@@ -318,7 +318,7 @@ The script prompts for 7 inputs (6 if you passed `--project-dir`):
 |---|---|---|
 | **Project name** | Lowercase, no spaces (e.g., `invoice-tool`) | This becomes the directory name and appears in generated files. |
 | **One-sentence description** | What does it do, in plain language | Used in CLAUDE.md and the Intake template. |
-| **Platform type** | Web / Desktop / Mobile / MCP Server / Other | Determines which Platform Module is loaded and which release pipeline is generated. Pick the primary delivery surface. See the [Extending Platforms Guide](extending-platforms.md) to add new platform types. |
+| **Platform type** | Web / Desktop / Mobile / MCP Server / Other | Determines which Platform Module is loaded and which release pipeline is generated. Pick the primary delivery surface. See the [Extending Platforms Guide](https://github.com/kraulerson/solo-orchestrator/blob/main/docs/extending-platforms.md) to add new platform types. |
 | **Project track** | Light / Standard / Full | **Light:** internal tools, <10 users, skip market audit. **Standard:** external users, moderate complexity. **Full:** enterprise buyers, sensitive data, pen testing mandatory. |
 | **Personal or Organizational** | Personal / Organizational | Organizational adds governance pre-flight requirements and approval authority structures. |
 | **Primary language** | TypeScript, Python, Rust, C#, Kotlin, Java, Go, Dart, Swift, Other | Determines the CI pipeline template (testing, linting, SAST, dependency audit). |
@@ -611,7 +611,7 @@ AI coding agents have context limits. For long-running projects:
 
 ## 5. Phase-by-Phase Walkthrough
 
-This section covers what **you** do at each phase — not what the agent does. For the agent's process, prompts, and remediation procedures, see the [Builder's Guide](builders-guide.md). For platform-specific instructions at each phase, see your [Platform Module](platform-modules/).
+This section covers what **you** do at each phase — not what the agent does. For the agent's process, prompts, and remediation procedures, see the [Builder's Guide](builders-guide.md). For platform-specific instructions at each phase, see your [Platform Module](https://github.com/kraulerson/solo-orchestrator/tree/main/docs/platform-modules).
 
 **How to read this section:** Each phase has a table showing your actions with separate columns for personal and organizational paths. "Same" means no difference between paths. Where the organizational path has additional requirements, they are listed explicitly.
 
@@ -1556,7 +1556,7 @@ npm install -g snyk
 
 **"My project is too complex for one person."**
 
-If your project needs multiple concurrent developers, microservices, or 99.99%+ SLA, it is outside the framework's current scope. Regulated-industry compliance (SOC 2, HIPAA, PCI-DSS) is a planned extension — the governance structure already provides role-based approval gate separation, but compliance-specific modules have not yet been built. See "What This Is Not (Today)" in the [README](../README.md).
+If your project needs multiple concurrent developers, microservices, or 99.99%+ SLA, it is outside the framework's current scope. Regulated-industry compliance (SOC 2, HIPAA, PCI-DSS) is a planned extension — the governance structure already provides role-based approval gate separation, but compliance-specific modules have not yet been built. See "What This Is Not (Today)" in the [README](https://github.com/kraulerson/solo-orchestrator#readme).
 
 ---
 

--- a/tests/test-currency-birth-stamp.sh
+++ b/tests/test-currency-birth-stamp.sh
@@ -229,6 +229,27 @@ mcp="$(jq -r '.currency.mcpProbe.context7' "$MAN")"
   && pass "pre-commit hook present" \
   || fail_ "pre-commit" "not present"
 
+# — BL-090 ref-integrity arm, exercised against a REAL generated project —
+# scripts/lint-doc-anchors.sh's cross-file reference arm (# BL-090-DOC-REFS)
+# had only ever been dogfooded against the FRAMEWORK repo's OWN docs/ tree,
+# where docs/user-guide.md and docs/builders-guide.md live ONE LEVEL
+# SHALLOWER (docs/) than where init.sh ships them (docs/reference/ — one
+# level deeper). A relative link that resolves at one depth silently breaks
+# at the other, and the framework's own dogfood run can never catch it,
+# because it never scans a SHIPPED copy — only a generated project's docs/
+# tree exercises the depth the reader actually sees. Run the ref-integrity
+# arm in --strict-refs mode against THIS scaffold's real docs/ tree (root
+# docs + docs/reference + docs/platform-modules) so a future edit to either
+# guide that reintroduces a depth-mismatched or ghost relative link fails
+# HERE, not silently in every downstream project.
+doc_refs_out="$(bash "$REPO_ROOT/scripts/lint-doc-anchors.sh" --docs-dir "$TS" --strict-refs 2>&1)"
+doc_refs_rc=$?
+if [ "$doc_refs_rc" -eq 0 ]; then
+  pass "generated project docs/ tree: BL-090 ref-integrity arm clean (--strict-refs)"
+else
+  fail_ "generated project doc-ref integrity" "lint-doc-anchors --strict-refs exited $doc_refs_rc against $TS — $(printf '%s' "$doc_refs_out" | tail -6 | tr '\n' '|')"
+fi
+
 # ════════════════════════════════════════════════════════════════════════════
 # Scaffold 2 — rust: commit-msg hook is PRESENT. Pre-BL-107 rust got no TDD gate
 # (inline tests → empty soif_lang_test_pattern → install skipped, recorded as


### PR DESCRIPTION
## What

An audit scaffolded a real generated project and ran the BL-090 ref-integrity checker (`--docs-dir`, `--strict-refs`) over the tree a user actually reads: **15 unresolved references across the shipped `docs/reference/{user-guide,builders-guide}.md`** — before: exit 1; after: clean at 52 files. Root cause: init.sh ships these guides one directory DEEPER than the framework lints them (`docs/` → `docs/reference/`), so framework-depth relative links break at shipped depth and the dogfood lint is structurally blind to the class. Plus ghost links to files init never ships (`extending-platforms.md`, `evaluation-prompts/Framework/`).

Fixes are SOURCE-side (absolute GitHub URLs / de-linked mentions) because `upgrade-project.sh::_bl099_process_doc` and `test-upgrade-sync-framework.sh` byte-compare (`cmp -s`) shipped copies against sources — a post-copy rewrite would read as user customization on every future sync. Regression pin: a `# BL-090-DOC-REFS` assertion in `tests/test-currency-birth-stamp.sh` runs the checker against the suite's real scaffold (RED 18/1 with a fix reverted, GREEN 19/0).

## Review record (pre-PR adversarial gate)

**minor_concerns — safe to open; zero refuted claims.** Reviewer independently: re-derived all 15 breaks from main's files against init.sh's cp block (exactly 15); confirmed the verbatim invariant (the absolute-URL choice is forced); verified all new URLs via live `gh api` against remote main incl. the `#legal-notices` anchor; re-proved the test with its own distinct mutation (different file, different root-cause class — caught, naming the shipped path); confirmed the framework dogfood lint stays green at 98 files.

Findings + dispositions:
- **R-1 (minor):** the pin is full-lane-only (the suite legitimately invokes init.sh, exempting it from the unit lane) — a reintroduced break survives PR-blocking checks. Recorded as optional hardening in the follow-ups list: a hermetic unit-lane sibling mirroring the ship layout via `scaffold-shipped-set.sh`.
- **R-2 (minor):** absolute URLs hard-pin owner/repo/branch and leave BL-090's scope (rot invisible to lints). The trade-off sentence lands on the `## BL-090:` entry in the post-merge closures pass.
- **R-3 (info):** assertion covers the typescript scaffold only; reviewer verified all platform modules currently carry zero relative links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)