### PR TITLE
fix(bl204): happy-path remote UX — probe at selection, explain visibility, ask once, say why, translate the jargon

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -446,6 +446,7 @@ jobs:
             tests/test-validate-counter-sanitizer.sh
             tests/test-validate-phase-2-3-gate.sh
             tests/test-validate-phase-state-gates.sh
+            tests/host-drivers/error-translate.test.sh
           )
 
           # ── BL-190 shard pins ──────────────────────────────────────────

--- a/init.sh
+++ b/init.sh
@@ -4464,6 +4464,46 @@ _resolve_host_visibility_mode() {
 }
 
 # ================================================================
+# BL-204-VISIBILITY-PERSIST — record the visibility answer for the wizard
+# ================================================================
+# R-BL204-2: `.claude/intake-progress.json::answers.repo_visibility` had
+# exactly ONE writer in the whole repo — the intake wizard itself. init
+# RESOLVED the visibility (from --visibility, from a config file, or from its
+# own prompt) and then dropped it on the floor. So on every real first run the
+# wizard's BL-204-PREFILL lookup found nothing and blind-asked, which is the
+# precise thing finding 7 exists to stop: the user answers, then gets asked
+# again as if the answer never saved.
+#
+# Writing it here also feeds scripts/check-gate.sh, which reads the same key
+# with a silent `// "private"` default — a public repo was being described as
+# private there for the same reason.
+#
+# NEVER CLOBBER OPERATOR STATE. If the file exists and parses, merge into
+# .answers and keep every other key. If it exists and does NOT parse, do
+# nothing at all: an unreadable progress file is the operator's to recover,
+# and overwriting it with a one-key stub would destroy a part-finished intake.
+_bl204_persist_visibility_answer() {
+  local visibility="${1:-}"
+  [ -n "$visibility" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  local prog=".claude/intake-progress.json"
+  mkdir -p .claude 2>/dev/null || return 0
+  local tmp built
+  tmp=$(mktemp) || return 0
+  if [ -f "$prog" ]; then
+    jq empty "$prog" >/dev/null 2>&1 || { rm -f "$tmp"; return 0; }
+    built=$(jq --arg v "$visibility" '.answers = ((.answers // {}) + {repo_visibility: $v})' "$prog") \
+      || { rm -f "$tmp"; return 0; }
+  else
+    built=$(jq -n --arg v "$visibility" '{answers: {repo_visibility: $v}}') \
+      || { rm -f "$tmp"; return 0; }
+  fi
+  printf '%s\n' "$built" > "$tmp" && mv "$tmp" "$prog"   # BL-204-VISIBILITY-PERSIST-WRITE
+  rm -f "$tmp" 2>/dev/null || true
+  return 0
+}
+
+# ================================================================
 # BL-204-VISIBILITY-EXPLAIN — plain-language private vs public
 # ================================================================
 # Kept verbatim in step with the wizard's copy of this text
@@ -4550,6 +4590,13 @@ prepare_initial_state_for_commit() {
   _resolve_host_visibility_mode
 
   mkdir -p .claude
+
+  # R-BL204-2: persist the resolved visibility so the intake wizard can
+  # CONFIRM it instead of blind-asking. The host needs no equivalent — it
+  # lands in .claude/manifest.json a few lines below, which is where the
+  # wizard's BL-204-PREFILL reads it from. Visibility has no manifest field,
+  # so without this line the prefill has nothing to find.
+  _bl204_persist_visibility_answer "$_RESOLVED_VISIBILITY"   # BL-204-VISIBILITY-PERSIST
 
   # Seed manifest with all framework-managed fields. remote_url stays "" until
   # create_and_protect_remote actually creates the repo; if it doesn't, the

--- a/init.sh
+++ b/init.sh
@@ -1424,6 +1424,9 @@ create_project() {
   # inside the initialized project (audit: code-init-sh-2).
   mkdir -p scripts/host-drivers
   cp "$SCRIPT_DIR/scripts/lib/host.sh" scripts/lib/
+  # BL-204-ERROR-TRANSLATE: the drivers source ../lib/host-errors.sh relative
+  # to their own location, so it must land in the project alongside host.sh.
+  cp "$SCRIPT_DIR/scripts/lib/host-errors.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
   chmod +x scripts/host-drivers/*.sh
   chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-intake-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
@@ -3118,6 +3121,29 @@ print_next_steps() {
   echo -e "${BOLD}Project:${NC} $PROJECT_NAME"
   echo -e "${BOLD}Location:${NC} $PROJECT_DIR"
   echo ""
+  # BL-204-REMOTE-WHY (finding 8): state plainly what the remote is FOR, at
+  # the one screen every successful run ends on. Pre-fix this framing appeared
+  # ONLY inside the data-loss warning arm — i.e. only to users who had already
+  # hit a failure — so the users whose remote worked never learned what it was
+  # protecting them from, and the users whose remote did NOT work met the idea
+  # for the first time in an error message.
+  local _bl204_remote_url=""
+  if command -v jq >/dev/null 2>&1 && [ -f "$PROJECT_DIR/.claude/manifest.json" ]; then
+    _bl204_remote_url=$(jq -r '.remote_url // empty' "$PROJECT_DIR/.claude/manifest.json" 2>/dev/null || echo "")
+  fi
+  echo -e "${BOLD}Your backup:${NC}"
+  if [ -n "$_bl204_remote_url" ]; then
+    echo "  $_bl204_remote_url"
+    echo "  That remote is your backup — the copy that lives somewhere other than this"
+    echo "  machine. Keep pushing to it. If this disk dies and the work is only here,"
+    echo "  all of it is gone."
+  else
+    echo "  NONE YET — this project exists only on this disk."
+    echo "  A remote is your backup: the copy that lives somewhere other than this"
+    echo "  machine. Until you have one, a lost or failed disk loses all of the work."
+    echo "  Set one up with: cd $PROJECT_DIR && scripts/check-gate.sh --repair"
+  fi
+  echo ""
   echo -e "${BOLD}Next Steps:${NC}"
   echo ""
   echo "  1. AUTHENTICATE (manual — requires browser):"
@@ -4401,8 +4427,24 @@ _resolve_host_visibility_mode() {
   elif [ -f .claude/intake-progress.json ]; then
     _RESOLVED_VISIBILITY=$(jq -r '.answers.repo_visibility // empty' .claude/intake-progress.json 2>/dev/null || echo "")
   fi
+
+  # BL-204-REMOTE-WHY (finding 8): nothing upstream of the choice explained
+  # what a remote is FOR. Say it before the prompt, not inside the failure arm.
+  if [ -z "${_RESOLVED_HOST:-}" ]; then
+    print_info "About this question: your remote is your backup — the copy that lives"
+    print_info "somewhere other than this machine. If this disk dies and there is no"
+    print_info "remote, every bit of the work is gone."
+  fi
   # Fallback: prompt inline if neither source supplied a value (interactive mode only).
   [ -z "${_RESOLVED_HOST:-}" ]       && _RESOLVED_HOST=$(prompt_choice "Git host:" "github" "gitlab" "bitbucket" "other")
+
+  # BL-204-VISIBILITY-EXPLAIN (finding 6): the bare `private|public` prompt
+  # never said what either word means, and never said that private on a
+  # free-tier personal GitHub account forfeits branch protection — a cost that
+  # only reappears much later as an attestation prompt with no context.
+  if [ -z "${_RESOLVED_VISIBILITY:-}" ]; then
+    _bl204_explain_visibility
+  fi
   [ -z "${_RESOLVED_VISIBILITY:-}" ] && _RESOLVED_VISIBILITY=$(prompt_choice "Repository visibility:" "private" "public")
 
   # Map DEPLOYMENT "organizational" → "org" for consistency with spec
@@ -4413,6 +4455,86 @@ _resolve_host_visibility_mode() {
     print_warn "Org mode forces private visibility (overriding '$_RESOLVED_VISIBILITY')"
     _RESOLVED_VISIBILITY="private"
   fi
+
+  # BL-204-PROBE-AT-SELECT (finding 5): the host choice is SETTLED at this
+  # point — probe the CLI/credentials NOW rather than leaving the discovery to
+  # create_and_protect_remote, which runs after every remaining prompt has
+  # been answered and after the whole project tree has been scaffolded.
+  _bl204_probe_host_at_selection "$_RESOLVED_HOST"
+}
+
+# ================================================================
+# BL-204-VISIBILITY-EXPLAIN — plain-language private vs public
+# ================================================================
+# Kept verbatim in step with the wizard's copy of this text
+# (scripts/intake-wizard.sh::_bl204_explain_visibility). Two prompts, one
+# explanation — a user who meets the question in either place gets the same
+# words, including the free-tier cost.
+_bl204_explain_visibility() {
+  print_info "Who can see this code?"
+  print_info "  private — only you and the people you invite can see the code. Most projects."
+  print_info "  public  — anyone on the internet can read the code. Only you can change it."
+  print_info ""
+  print_info "One trade-off worth knowing before you choose:"
+  print_info "  On a free personal GitHub account, a PRIVATE repo cannot have branch protection"
+  print_info "  (the safety rail that stops accidental force-pushes and deletions of main)."
+  print_info "  If you pick private on a free account, the framework will later ask you to"
+  print_info "  attest that you follow those rules by hand instead. A PUBLIC repo on the same"
+  print_info "  free account gets the real thing, and so does a private repo on a paid plan."
+}
+
+# ================================================================
+# BL-204-PROBE-AT-SELECT — probe the host at the moment of choice
+# ================================================================
+# BL-204 finding 5: `host_require_cli` ran ONLY immediately before
+# `host_create_repo`, so choosing a host whose CLI is missing (or whose
+# credentials are not exported — bitbucket without BITBUCKET_API_TOKEN is the
+# audited case) was discovered many prompts later. This probe runs at the
+# selection point and is ADVISORY: it always returns 0, because the
+# pre-create probe in create_and_protect_remote is still the decisive gate and
+# still records the failure via record_init_failure. Making this one fatal
+# would move the gate and change the exit contract; making it loud is enough
+# to fix the discovery problem the finding actually describes.
+_bl204_probe_host_at_selection() {
+  local host="${1:-}"
+  # Nothing to probe when no remote will be created.
+  [ "${NO_REMOTE_CREATION:-false}" = true ] && return 0
+  case "$host" in
+    github|gitlab|bitbucket) ;;
+    *) return 0 ;;   # 'other' has no CLI to probe
+  esac
+  local dispatcher="$SCRIPT_DIR/scripts/lib/host.sh"
+  local driver="$SCRIPT_DIR/scripts/host-drivers/$host.sh"
+  if [ ! -f "$dispatcher" ] || [ ! -f "$driver" ]; then
+    return 0
+  fi
+  # Subshell: the driver defines host_* functions, and create_and_protect_remote
+  # sources them itself later. Keeping them out of this scope means the probe
+  # cannot change which implementation the create path ends up running.
+  local probe_out probe_rc
+  probe_out=$(
+    # shellcheck disable=SC1090
+    source "$dispatcher"
+    # shellcheck disable=SC1090
+    source "$driver"
+    host_require_cli 2>&1
+  ) && probe_rc=0 || probe_rc=$?
+  if [ "$probe_rc" -eq 0 ]; then
+    # Deliberately not "CLI found": bitbucket has no CLI, it checks exported
+    # credentials. One sentence that is true for all three drivers.
+    print_ok "Your $host access is set up and working."
+    return 0
+  fi
+  echo ""
+  print_warn "The tools for '$host' are not ready yet — found this while checking your choice."
+  print_info "Telling you now rather than after the rest of the questions: this is what"
+  print_info "stops the backup copy of your project from being created."
+  [ -n "$probe_out" ] && printf '%s\n' "$probe_out" >&2
+  print_info "Setup will keep going and try again when it creates the repository."
+  print_info "If it still is not ready then, the project stays on this machine and you can"
+  print_info "finish the remote later with: scripts/check-gate.sh --repair"
+  echo ""
+  return 0
 }
 
 # Lay down ALL durable state BEFORE the chore-init commit so it is captured

--- a/scripts/host-drivers/bitbucket.sh
+++ b/scripts/host-drivers/bitbucket.sh
@@ -25,6 +25,17 @@
 #     code-host-bitbucket-5). When unset, behavior matches pre-2026
 #     drivers (Bitbucket uses the workspace's default project, if any).
 
+# BL-204-ERROR-TRANSLATE: load the plain-language host-error translator.
+# Same shape as the github/gitlab drivers — path derived from THIS file's
+# location, with a pass-through fallback so a missing lib cannot break the
+# driver.
+_HOST_ERRORS_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/host-errors.sh"
+if [ -f "$_HOST_ERRORS_LIB" ]; then
+  # shellcheck disable=SC1090
+  . "$_HOST_ERRORS_LIB"
+fi
+command -v host_explain_error >/dev/null 2>&1 || host_explain_error() { [ -n "${1:-}" ] && printf '%s\n' "$1" >&2; return 0; }
+
 host_name() { echo "bitbucket"; }
 
 _bb_api_base="https://api.bitbucket.org/2.0"
@@ -169,8 +180,8 @@ host_create_repo() {
   fi
   local resp
   if ! resp=$(echo "$payload" | _bb_curl POST "$_bb_api_base/repositories/$workspace/$name"); then
-    echo "bitbucket driver: repo create failed" >&2
-    echo "$resp" >&2
+    echo "bitbucket driver: could not create the repository '$name' in workspace '$workspace'." >&2
+    host_explain_error "$resp"   # BL-204-ERROR-TRANSLATE
     return 1
   fi
   echo "$resp" | jq -r '.links.clone[] | select(.name=="https") | .href'

--- a/scripts/host-drivers/bitbucket.sh
+++ b/scripts/host-drivers/bitbucket.sh
@@ -212,6 +212,26 @@ _bb_parse_origin() {
   esac
 }
 
+# _bb_post_restriction <workspace_repo> <kind-label> <payload>
+# BL-204-ERROR-TRANSLATE (R-BL204-1): one place that POSTs a branch
+# restriction, names the kind on failure, and routes the host's response
+# through the plain-language translator. Defined at FILE scope, not nested
+# inside host_configure_protection — a nested definition would leak into the
+# global namespace on first call anyway, and taking the repo as an argument
+# keeps it testable on its own.
+_bb_post_restriction() {
+  local workspace_repo="${1:?workspace_repo required}"
+  local label="${2:?kind label required}"
+  local body="${3:?payload required}"
+  local out
+  if ! out=$(printf '%s' "$body" | _bb_curl POST "$_bb_api_base/repositories/$workspace_repo/branch-restrictions"); then
+    echo "bitbucket driver: failed to set $label restriction on $workspace_repo" >&2
+    host_explain_error "$out"   # BL-204-ERROR-TRANSLATE
+    return 2
+  fi
+  return 0
+}
+
 host_configure_protection() {
   local branch="${1:?}"; local mode="${2:?}"
   local workspace_repo
@@ -240,8 +260,14 @@ host_configure_protection() {
   if [ "$listing_rc" -ne 0 ] || ! echo "$existing" | jq -e '.values | type == "array"' >/dev/null 2>&1; then
     local snippet
     snippet=$(printf '%s' "$existing" | head -c 200)
-    printf 'bitbucket driver: could not list existing restrictions for %s on %s (rc=%s): %s\n' \
-      "$branch" "$workspace_repo" "$listing_rc" "$snippet" >&2
+    printf 'bitbucket driver: could not list existing restrictions for %s on %s (rc=%s).\n' \
+      "$branch" "$workspace_repo" "$listing_rc" >&2
+    # BL-204-ERROR-TRANSLATE (R-BL204-1): the snippet used to be appended raw
+    # to the line above. Bitbucket is the driver with NO CLI — its users are
+    # handling raw API tokens by hand and are the least likely of the three to
+    # read an HTTP body. The 200-char bound is kept: it is what the operator
+    # sees, and status codes appear at the front of every response shape here.
+    host_explain_error "$snippet"
     return 2
   fi
   local delete_diag=""
@@ -262,18 +288,24 @@ host_configure_protection() {
   fi
 
   # Create restrictions: force-push off, delete off (both modes)
-  local kind
+  local kind post_out
   for kind in force delete; do
     local payload="{\"kind\":\"$kind\",\"pattern\":\"$branch\",\"users\":[],\"groups\":[]}"
-    echo "$payload" | _bb_curl POST "$_bb_api_base/repositories/$workspace_repo/branch-restrictions" >/dev/null || {
+    # BL-204-ERROR-TRANSLATE (R-BL204-1): capture the POST body instead of
+    # discarding it to /dev/null. Pre-fix this arm printed a generic
+    # "failed to set <kind> restriction" and threw the host's own words away,
+    # so the operator learned THAT it failed and never why.
+    if ! post_out=$(echo "$payload" | _bb_curl POST "$_bb_api_base/repositories/$workspace_repo/branch-restrictions"); then
       # PR #90 verifier MAJOR fix: flush the buffered delete-diagnostic
       # on POST failure too — operator running without SOIF_DEBUG must
       # still see which leftover restriction blocked creation. Before:
       # only the SOIF_DEBUG branch flushed; this path lost the timing
       # context permanently.
       [ -n "$delete_diag" ] && printf '%s' "$delete_diag" >&2
-      echo "bitbucket driver: failed to set $kind restriction" >&2; return 2
-    }
+      echo "bitbucket driver: failed to set $kind restriction" >&2
+      host_explain_error "$post_out"   # BL-204-ERROR-TRANSLATE
+      return 2
+    fi
   done
 
   # Org mode: require approvals on PRs + block direct push + require
@@ -284,9 +316,15 @@ host_configure_protection() {
     local payload_push='{"kind":"push","pattern":"'"$branch"'","users":[],"groups":[]}'
     local payload_approve='{"kind":"require_approvals_to_merge","pattern":"'"$branch"'","value":1,"users":[],"groups":[]}'
     local payload_builds='{"kind":"require_passing_builds_to_merge","pattern":"'"$branch"'","value":1,"users":[],"groups":[]}'
-    echo "$payload_push"    | _bb_curl POST "$_bb_api_base/repositories/$workspace_repo/branch-restrictions" >/dev/null || return 2
-    echo "$payload_approve" | _bb_curl POST "$_bb_api_base/repositories/$workspace_repo/branch-restrictions" >/dev/null || return 2
-    echo "$payload_builds"  | _bb_curl POST "$_bb_api_base/repositories/$workspace_repo/branch-restrictions" >/dev/null || return 2
+    # BL-204-ERROR-TRANSLATE (R-BL204-1): these three were bare
+    # `| _bb_curl … >/dev/null || return 2` — a SILENT non-zero. Org-mode
+    # protection could fail with nothing whatsoever on stderr, which is the
+    # worst shape of all: init reports "Remote setup did not complete
+    # cleanly" and the operator has no thread to pull. Route each through the
+    # shared helper so the kind is named and the host's words are translated.
+    _bb_post_restriction "$workspace_repo" "push"                          "$payload_push"    || return 2
+    _bb_post_restriction "$workspace_repo" "require_approvals_to_merge"    "$payload_approve" || return 2
+    _bb_post_restriction "$workspace_repo" "require_passing_builds_to_merge" "$payload_builds"  || return 2
   fi
   return 0
 }

--- a/scripts/host-drivers/github.sh
+++ b/scripts/host-drivers/github.sh
@@ -4,6 +4,19 @@
 # Implements the solo-orchestrator host driver contract defined in spec
 # docs/superpowers/specs/2026-04-21-host-aware-repo-gate-design.md.
 
+# BL-204-ERROR-TRANSLATE: load the plain-language host-error translator. The
+# path is derived from THIS file's location, so it resolves both in the
+# framework repo and inside a scaffolded project (init.sh ships both files
+# into scripts/lib + scripts/host-drivers). The fallback definition keeps the
+# driver usable if the lib is ever missing — a driver must never die because
+# an explanation is unavailable.
+_HOST_ERRORS_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/host-errors.sh"
+if [ -f "$_HOST_ERRORS_LIB" ]; then
+  # shellcheck disable=SC1090
+  . "$_HOST_ERRORS_LIB"
+fi
+command -v host_explain_error >/dev/null 2>&1 || host_explain_error() { [ -n "${1:-}" ] && printf '%s\n' "$1" >&2; return 0; }
+
 host_name() { echo "github"; }
 
 host_require_cli() {
@@ -22,9 +35,18 @@ host_require_cli() {
       'Re-run whatever invoked this after install+auth completes.' >&2
     return 1
   fi
-  if ! gh auth status >/dev/null 2>&1; then
+  # BL-204-ERROR-TRANSLATE: capture what `gh auth status` actually said. The
+  # pre-fix code discarded it, so an EXPIRED token and a never-logged-in
+  # machine produced byte-identical output — two different problems, one
+  # message. The translator classifies the expired/revoked case; the
+  # install/login guidance below still prints either way.
+  local auth_err
+  if ! auth_err=$(gh auth status 2>&1); then
     printf '%s\n' \
       'github driver: `gh` installed but not authenticated.' \
+      '' >&2
+    host_explain_error "$auth_err"
+    printf '%s\n' \
       '' \
       'Authenticate with: gh auth login' \
       '' \
@@ -47,7 +69,8 @@ host_create_repo() {
   esac
   local result
   if ! result=$(gh repo create "$name" "--$visibility" 2>&1); then
-    echo "$result" >&2
+    echo "github driver: could not create the repository '$name' on GitHub." >&2
+    host_explain_error "$result"   # BL-204-ERROR-TRANSLATE
     return 1
   fi
   # gh prints the URL as the last line
@@ -133,7 +156,7 @@ host_configure_protection() {
       return 3
     fi
     echo "github driver: failed to configure protection on $owner_repo#$branch ($mode mode)" >&2
-    [ -n "$gh_err" ] && printf '  %s\n' "$gh_err" >&2
+    host_explain_error "$gh_err"   # BL-204-ERROR-TRANSLATE
     return 2
   fi
   return 0

--- a/scripts/host-drivers/gitlab.sh
+++ b/scripts/host-drivers/gitlab.sh
@@ -57,6 +57,17 @@
 #   here surfaces the gap loudly with options, instead of returning the
 #   bare exit-3 "approvals config failed" message.
 
+# BL-204-ERROR-TRANSLATE: load the plain-language host-error translator.
+# Same shape as the github driver — path derived from THIS file's location so
+# it resolves in the framework repo and in a scaffolded project alike, with a
+# pass-through fallback so a missing lib can never break the driver.
+_HOST_ERRORS_LIB="$(dirname "${BASH_SOURCE[0]}")/../lib/host-errors.sh"
+if [ -f "$_HOST_ERRORS_LIB" ]; then
+  # shellcheck disable=SC1090
+  . "$_HOST_ERRORS_LIB"
+fi
+command -v host_explain_error >/dev/null 2>&1 || host_explain_error() { [ -n "${1:-}" ] && printf '%s\n' "$1" >&2; return 0; }
+
 host_name() { echo "gitlab"; }
 
 host_require_cli() {
@@ -75,9 +86,15 @@ host_require_cli() {
       '(Self-hosted instances: `glab auth login --hostname gitlab.your-company.com`)' >&2
     return 1
   fi
-  if ! glab auth status >/dev/null 2>&1; then
+  # BL-204-ERROR-TRANSLATE: keep what glab said so an EXPIRED token reads
+  # differently from a never-logged-in machine (see the github driver).
+  local auth_err
+  if ! auth_err=$(glab auth status 2>&1); then
     printf '%s\n' \
       'gitlab driver: `glab` installed but not authenticated.' \
+      '' >&2
+    host_explain_error "$auth_err"
+    printf '%s\n' \
       '' \
       'Authenticate with: glab auth login' >&2
     return 2
@@ -95,7 +112,9 @@ host_create_repo() {
   esac
   local result
   if ! result=$(glab repo create "$name" "--$visibility" 2>&1); then
-    echo "$result" >&2; return 1
+    echo "gitlab driver: could not create the project '$name' on GitLab." >&2
+    host_explain_error "$result"   # BL-204-ERROR-TRANSLATE
+    return 1
   fi
   echo "$result" | tail -n 1
 }
@@ -169,7 +188,7 @@ host_configure_protection() {
   local glab_err
   if ! glab_err=$(glab api -X POST "projects/$project/protected_branches" --input - <<<"$payload" 2>&1 >/dev/null); then
     echo "gitlab driver: failed to configure protection on $project#$branch ($mode mode)" >&2
-    [ -n "$glab_err" ] && printf '  %s\n' "$glab_err" >&2
+    host_explain_error "$glab_err"   # BL-204-ERROR-TRANSLATE
     return 2
   fi
 

--- a/scripts/intake-wizard.sh
+++ b/scripts/intake-wizard.sh
@@ -77,6 +77,10 @@ FRAMEWORK_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # override PROGRESS_FILE/INTAKE_FILE before calling save_answer etc.
 PROGRESS_FILE="${PROJECT_ROOT:-}/.claude/intake-progress.json"
 INTAKE_FILE="${PROJECT_ROOT:-}/PROJECT_INTAKE.md"
+# BL-204-PREFILL: the framework manifest is where the git host chosen during
+# init already lives. Declared beside PROGRESS_FILE (and overridable the same
+# way) so run_section_1_repo_setup can be exercised in isolation by tests.
+MANIFEST_FILE="${MANIFEST_FILE:-${PROJECT_ROOT:-}/.claude/manifest.json}"
 SUGGESTIONS_DIR="$FRAMEWORK_ROOT/templates/intake-suggestions"
 
 # Project context (loaded from progress file or phase-state.json)
@@ -573,17 +577,90 @@ run_section_1() {
   repo_url=$(prompt_input "Repository URL (if already created, or Enter to skip)" "")
   save_answer "repo_url" "${repo_url:-TBD}"
 
+  run_section_1_repo_setup
+
+  save_section 1
+  echo ""
+}
+
+# ================================================================
+# BL-204-VISIBILITY-EXPLAIN — plain-language private vs public
+# ================================================================
+# BL-204 finding 6: the visibility prompt was a bare `private|public` with
+# zero explanation, and choosing "private" on a free-tier personal GitHub
+# account silently forfeits branch protection — a cost that only surfaces
+# much later in the run, as an attestation prompt the user has no context
+# for. Say it HERE, where the choice is actually made.
+_bl204_explain_visibility() {
+  print_info "Who can see this code?"
+  print_info "  private — only you and the people you invite can see the code. Most projects."
+  print_info "  public  — anyone on the internet can read the code. Only you can change it."
+  print_info ""
+  print_info "One trade-off worth knowing before you choose:"
+  print_info "  On a free personal GitHub account, a PRIVATE repo cannot have branch protection"
+  print_info "  (the safety rail that stops accidental force-pushes and deletions of main)."
+  print_info "  If you pick private on a free account, the framework will later ask you to"
+  print_info "  attest that you follow those rules by hand instead. A PUBLIC repo on the same"
+  print_info "  free account gets the real thing, and so does a private repo on a paid plan."
+}
+
+# ================================================================
+# SECTION 1 (repo half): git host + repository visibility
+# ================================================================
+# Split out of run_section_1 by BL-204 so the whole repo-setup exchange —
+# the "why", the prefill, the probe, the visibility explanation — is one
+# reviewable unit that tests can drive in isolation.
+run_section_1_repo_setup() {
+  # BL-204-REMOTE-WHY (finding 8): say why any of this matters BEFORE asking
+  # which host. Pre-fix this framing existed ONLY inside the data-loss warning
+  # arm, i.e. only after something had already gone wrong.
+  print_info "About the next two questions: your remote is your backup."
+  print_info "It is the copy of this project that lives somewhere other than this machine."
+  print_info "If this disk dies and there is no remote, every bit of the work is gone."
+  echo ""
+
   # --- Git host selection (spec 2026-04-21 host-aware repo gate) ---
-  local git_host
-  git_host=$(prompt_choice "Git host for this project:" \
-    "github" \
-    "gitlab" \
-    "bitbucket" \
-    "other")
+  # BL-204-PREFILL (finding 7): the host was already chosen during init and
+  # recorded in .claude/manifest.json — by the time this wizard runs the
+  # remote usually EXISTS. Asking again, blind, reads to a novice as "my
+  # earlier answer didn't save". Show what is remembered and confirm it.
+  local git_host="" remembered_host="" host_was_remembered=0
+  if [ -f "$MANIFEST_FILE" ] && command -v jq >/dev/null 2>&1; then
+    :  # guard: keeps the block well-formed when the marked read is excised
+    remembered_host=$(jq -r '.host // empty' "$MANIFEST_FILE" 2>/dev/null || echo "")  # BL-204-PREFILL-READ
+  fi
+  if [ -n "$remembered_host" ]; then
+    host_was_remembered=1
+    print_info "Remembered from your setup answers — git host: $remembered_host"
+    print_info "(recorded in .claude/manifest.json; you are confirming it, not re-answering it)"
+    local host_confirm
+    host_confirm=$(prompt_choice "Keep '$remembered_host' as the git host?" \
+      "keep it" \
+      "change it")
+    if [ "$host_confirm" = "change it" ]; then
+      host_was_remembered=0
+      git_host=$(prompt_choice "Git host for this project:" \
+        "github" \
+        "gitlab" \
+        "bitbucket" \
+        "other")
+    else
+      git_host="$remembered_host"
+    fi
+  else
+    git_host=$(prompt_choice "Git host for this project:" \
+      "github" \
+      "gitlab" \
+      "bitbucket" \
+      "other")
+  fi
   save_answer "git_host" "$git_host"
 
-  # Probe CLI availability for first-class hosts (github/gitlab/bitbucket)
-  if [ "$git_host" != "other" ]; then
+  # BL-204-PROBE-AT-SELECT (wizard half of finding 5): probe only when the
+  # host is genuinely being CHOSEN here. A remembered host means init already
+  # created the remote against it, so a second probe is noise at best and, if
+  # the CLI has since been uninstalled, an alarming false problem.
+  if [ "$host_was_remembered" -eq 0 ] && [ "$git_host" != "other" ]; then
     local dispatcher="$SCRIPT_DIR/lib/host.sh"
     local driver="$SCRIPT_DIR/host-drivers/$git_host.sh"
     if [ -f "$dispatcher" ] && [ -f "$driver" ]; then
@@ -610,7 +687,14 @@ run_section_1() {
             save_answer "git_host" "$git_host"
             ;;
           continue)
-            echo "Continuing intake — CLI will be verified again at init.sh." >&2
+            # BL-204 finding 5: the pre-fix line here promised the CLI would
+            # "be verified again at init.sh". That is backwards — this wizard
+            # runs AFTER init, so nothing downstream re-verifies. Name the
+            # actual remediation instead.
+            echo "Continuing intake — the wizard itself does not need the host CLI." >&2
+            echo "Setting up the remote already happened during setup. If that step did" >&2
+            echo "not finish, install and authenticate the CLI, then run:" >&2
+            echo "  bash scripts/check-gate.sh --repair" >&2
             ;;
         esac
       fi
@@ -619,12 +703,32 @@ run_section_1() {
   fi
 
   # --- Repository visibility ---
-  local repo_visibility
-  repo_visibility=$(prompt_choice "Repository visibility:" "private" "public")
+  # BL-204-PREFILL (finding 7): visibility lives only in
+  # .claude/intake-progress.json::answers.repo_visibility — the manifest never
+  # records it. Same confirm-don't-re-ask treatment as the host above; the two
+  # halves prefill independently because their sources are independent.
+  local repo_visibility="" remembered_visibility=""
+  if [ -f "$PROGRESS_FILE" ] && command -v jq >/dev/null 2>&1; then
+    :  # guard: keeps the block well-formed when the marked read is excised
+    remembered_visibility=$(jq -r '.answers.repo_visibility // empty' "$PROGRESS_FILE" 2>/dev/null || echo "")  # BL-204-PREFILL-READ
+  fi
+  if [ -n "$remembered_visibility" ]; then
+    print_info "Remembered from your setup answers — repository visibility: $remembered_visibility"
+    local vis_confirm
+    vis_confirm=$(prompt_choice "Keep '$remembered_visibility' as the repository visibility?" \
+      "keep it" \
+      "change it")
+    if [ "$vis_confirm" = "change it" ]; then
+      _bl204_explain_visibility
+      repo_visibility=$(prompt_choice "Repository visibility:" "private" "public")
+    else
+      repo_visibility="$remembered_visibility"
+    fi
+  else
+    _bl204_explain_visibility
+    repo_visibility=$(prompt_choice "Repository visibility:" "private" "public")
+  fi
   save_answer "repo_visibility" "$repo_visibility"
-
-  save_section 1
-  echo ""
 }
 
 # ================================================================

--- a/scripts/lib/host-errors.sh
+++ b/scripts/lib/host-errors.sh
@@ -42,9 +42,18 @@ host_explain_error() {
   local raw="${1:-}"
   local what="" action=""
 
-  if grep -qiE 'saml|(^|[^[:alnum:]])sso([^[:alnum:]]|$)|single[ -]sign[ -]on|enabled or enforced' <<<"$raw"; then
+  # R-BL204-4: `enabled or enforced` was carried here as a fragment of
+  # GitHub's SAML sentence, but it is ordinary English that GitHub also uses
+  # in abuse-detection and org-policy messages — a measured false positive
+  # ("abuse detection is enabled or enforced" got an SSO runaround) that adds
+  # zero true positives the SAML/SSO/single-sign-on tokens do not already
+  # catch. Match on the NAMES of the mechanism, never on prose around it.
+  if grep -qiE 'saml|(^|[^[:alnum:]])sso([^[:alnum:]]|$)|single[ -]sign[ -]on' <<<"$raw"; then
     what="Your organization makes you authorize a login before it will work on the organization's repositories. Your login is fine; it just has not been authorized there yet."
-    action="Open the authorization link in the raw text below and click Authorize, or re-run 'gh auth login' and pick the organization when prompted."
+    # R-BL204-6: `gh auth login` does not prompt for an organization — the
+    # org authorization happens on the browser page the login flow opens.
+    # Describing a prompt that does not exist sends the user hunting for it.
+    action="Open the authorization link in the raw text below and click Authorize, or re-run 'gh auth login' and grant access to the organization on the browser page that opens."
   elif grep -qiE 'rate limit|rate-limit|secondary rate|abuse detection|(^|[^0-9])429([^0-9]|$)|too many requests|retry-after' <<<"$raw"; then
     what="You made too many requests to the host in a short time, so it is turning you away for a while. Nothing is broken and nothing was lost."
     action="Wait a few minutes, then run the same command again."

--- a/scripts/lib/host-errors.sh
+++ b/scripts/lib/host-errors.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# scripts/lib/host-errors.sh — BL-204-ERROR-TRANSLATE
+#
+# Plain-language translation of the host errors a first-time user actually
+# hits. BL-204's audit found host jargon (403s, rate limits, SSO/SAML org
+# authorization, expired auth) surfaced RAW to exactly the audience the
+# framework exists for. This turns each common cause into ONE plain sentence
+# plus ONE action, printed ABOVE the host's own words — which stay below,
+# verbatim, because they are what a search engine or a support person needs.
+#
+# PRECEDENT AND PRECEDENCE. The shape is copied from the free-tier-403 block
+# in scripts/host-drivers/github.sh (marker `# BL-002`). That block is NOT
+# replaced and still classifies FIRST: it is more specific (it names a price
+# and three concrete options) and it carries a distinct exit code (3) that
+# init.sh routes to the attestation flow. This translator is the generic
+# fallback underneath it.
+#
+# CONTRACT
+#   host_explain_error <raw-host-output>
+#     • writes to STDERR only
+#     • always returns 0 (callers keep their own exit codes; several call it
+#       from inside `if ! …` arms where a non-zero return would be read as
+#       the operation's own status)
+#     • emits at most ONE cause — the first arm that matches
+#     • emits the raw text under a label whenever it is non-empty, whether or
+#       not a cause matched. An unrecognised error is never given a
+#       fabricated explanation.
+#
+# CLASSIFICATION ORDER IS LOAD-BEARING. SSO/SAML failures and rate limits are
+# BOTH reported by GitHub as HTTP 403, and an expired token is reported as
+# 403 by some hosts. Ordering specific-before-generic is what keeps a
+# "authorize this token for your org" failure from being mis-explained as
+# "you don't have permission" — a translation that would send the user down
+# the wrong road with more confidence than the raw text did.
+#
+# PORTABILITY: every match uses a here-string, never `printf … | grep -q`.
+# A producer piped into `grep -q` dies of SIGPIPE, and under `set -o pipefail`
+# (which init.sh and every driver caller runs with) that turns a SUCCESSFUL
+# match into a 141 the `if` reads as false.
+
+host_explain_error() {
+  local raw="${1:-}"
+  local what="" action=""
+
+  if grep -qiE 'saml|(^|[^[:alnum:]])sso([^[:alnum:]]|$)|single[ -]sign[ -]on|enabled or enforced' <<<"$raw"; then
+    what="Your organization makes you authorize a login before it will work on the organization's repositories. Your login is fine; it just has not been authorized there yet."
+    action="Open the authorization link in the raw text below and click Authorize, or re-run 'gh auth login' and pick the organization when prompted."
+  elif grep -qiE 'rate limit|rate-limit|secondary rate|abuse detection|(^|[^0-9])429([^0-9]|$)|too many requests|retry-after' <<<"$raw"; then
+    what="You made too many requests to the host in a short time, so it is turning you away for a while. Nothing is broken and nothing was lost."
+    action="Wait a few minutes, then run the same command again."
+  elif grep -qiE 'bad credentials|(^|[^0-9])401([^0-9]|$)|token[^.]*(expired|invalid|revoked)|(expired|invalid|revoked)[^.]*token|authentication (failed|required)|not logged in|requires authentication|re-authenticat' <<<"$raw"; then
+    what="The saved login for this host is no longer valid — it expired, or it was revoked."
+    action="Log in again: 'gh auth login' for GitHub, 'glab auth login' for GitLab, or re-create and re-export your Bitbucket API token."
+  elif grep -qiE '(^|[^0-9])403([^0-9]|$)|permission|forbidden|not accessible|insufficient|denied' <<<"$raw"; then
+    what="You are logged in, but this account is not allowed to do this here — usually because the repository belongs to an organization you do not have write access to."
+    action="Ask an owner of that organization to grant you access, or create the repository under your own account instead."
+  fi
+
+  if [ -n "$what" ]; then
+    :  # guard: keeps the block well-formed when the marked lines are excised
+    printf '%s\n' "  What this means: $what" >&2   # BL-204-ERROR-TRANSLATE-EMIT
+    printf '%s\n' "  What to do:      $action" >&2 # BL-204-ERROR-TRANSLATE-EMIT
+    printf '\n' >&2                                # BL-204-ERROR-TRANSLATE-EMIT
+  fi
+
+  if [ -n "$raw" ]; then
+    printf '%s\n' "  Raw response from the host (for reference):" >&2
+    printf '%s\n' "$raw" | sed 's/^/    /' >&2
+  fi
+
+  return 0
+}

--- a/tests/host-drivers/error-translate.test.sh
+++ b/tests/host-drivers/error-translate.test.sh
@@ -162,7 +162,42 @@ e6_order_sso_beats_403() {
   if ! grep -qiE 'too many requests|short time' <<<"$t" || grep -qi 'not allowed' <<<"$t"; then
     fail_ "E6b" "a 403 that is really a rate limit was classified as generic permission: $t"; return
   fi
-  pass "E6: SSO and rate-limit 403s outrank the generic-permission arm"
+  # R-BL204-5: the header calls the ORDER load-bearing, but only
+  # specific-before-generic was pinned. Nothing pinned which of the two
+  # SPECIFIC arms wins when a message matches BOTH. Pin the intended winner:
+  # SSO is first because it is the one with a concrete, one-click fix; a
+  # rate-limit explanation would send the user off to wait for a wall that
+  # is not the actual blocker.
+  t=$(xlat 'HTTP 403: rate limit exceeded while the acme-corp organization SAML authorization check ran')
+  if ! grep -qi 'authoriz' <<<"$t"; then
+    fail_ "E6c" "a message matching BOTH the SSO and rate-limit arms must be explained as SSO (first arm wins): $t"; return
+  fi
+  if grep -qiE 'too many requests|short time' <<<"$t"; then
+    fail_ "E6c" "both-match message produced the rate-limit explanation — arm order regressed: $t"; return
+  fi
+  pass "E6: SSO and rate-limit 403s outrank generic permission, and SSO outranks rate-limit on a both-match"
+}
+
+# ── E6d (R-BL204-4): the SSO arm must not fire on unrelated prose ──
+#
+# `enabled or enforced` was carried in the SSO pattern as a fragment of
+# GitHub's SAML sentence. It is ordinary English: GitHub's own secondary-rate-
+# limit and org-policy messages use it too, and the fragment names no
+# SSO-specific concept at all. Measured: it adds zero true positives that
+# `saml`/`sso`/`single sign-on` do not already catch, and at least one false
+# positive that hands a rate-limited user an SSO runaround.
+e6d_sso_arm_does_not_overreach() {
+  local t
+  t=$(xlat 'HTTP 403: abuse detection is enabled or enforced for this endpoint; please retry later')
+  if grep -qi 'authoriz' <<<"$t"; then
+    fail_ "E6d" "the SSO arm fired on prose that has nothing to do with single sign-on: $t"; return
+  fi
+  # And the genuine SAML sentence must still classify as SSO without it.
+  t=$(xlat 'HTTP 403: the `acme` organization has enabled or enforced SAML SSO for this resource')
+  if ! grep -qi 'authoriz' <<<"$t"; then
+    fail_ "E6d" "narrowing the SSO pattern lost a genuine SAML message: $t"; return
+  fi
+  pass "E6d: the SSO arm fires on SAML/SSO tokens, not on the ordinary phrase 'enabled or enforced'"
 }
 
 # ── E7: the raw text stays BELOW the translation, never above it ──
@@ -326,6 +361,120 @@ STUB
   rm -rf "$T"
 }
 
+# ── E14 (R-BL204-1): bitbucket's PROTECTION arms, not just create ──
+#
+# The first pass wired exactly ONE bitbucket call site (host_create_repo) while
+# the commit message claimed "create + auth + protection" for all three
+# drivers. host_configure_protection had three raw-output arms: the listing
+# failure printed a 200-char API-body snippet, the force/delete POST failure
+# printed a generic line with the host's words dropped entirely, and the
+# org-mode POSTs returned 2 with NO diagnostic at all. Bitbucket is also the
+# driver whose users are least likely to read curl output, since it is the one
+# with no CLI — they are handling raw API tokens by hand.
+#
+# Hermetic: a curl stub on PATH, a git repo in mktemp. No network.
+e14_bitbucket_protection_routes_through_translator() {
+  local T; T=$(mktemp -d)
+  stub_bin "$T/bin" curl <<'STUB'
+#!/usr/bin/env bash
+# Dispatch on argv: the listing GET carries `pattern=`, the creates carry POST.
+case "$*" in
+  *"branch-restrictions?pattern="*)
+    if [ -n "${BB_LIST_FAIL:-}" ]; then
+      echo 'HTTP 401: Unauthorized — the API token is invalid or has expired' >&2
+      echo 'HTTP 401: Unauthorized — the API token is invalid or has expired'
+      exit 22
+    fi
+    echo '{"values":[]}'
+    exit 0 ;;
+  *"-X POST"*)
+    echo 'HTTP 403: Forbidden — your account lacks admin permission on this repository' >&2
+    echo 'HTTP 403: Forbidden — your account lacks admin permission on this repository'
+    exit 22 ;;
+  *) echo '{}'; exit 0 ;;
+esac
+STUB
+  (
+    cd "$T"
+    git init -q
+    git config user.email t@t.local
+    git config user.name t
+    git remote add origin https://bitbucket.org/ws/repo.git
+  ) >/dev/null 2>&1
+
+  # ── E14a: the LISTING failure arm (returns 2 before any POST) ──
+  local out_a
+  out_a=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    export BITBUCKET_API_TOKEN=tok BITBUCKET_API_TOKEN_EMAIL=a@b.c BITBUCKET_WORKSPACE=ws
+    export BB_LIST_FAIL=1
+    # shellcheck disable=SC1090
+    source "$BB_DRIVER"
+    host_configure_protection main personal 2>&1 >/dev/null
+    printf 'RC=%s' "$?"
+  )
+  case "$out_a" in
+    *"RC=2"*) ;;
+    *) fail_ "E14a" "the listing-failure arm must still return 2: $out_a"; rm -rf "$T"; return ;;
+  esac
+  case "$out_a" in
+    *"could not list existing restrictions"*) ;;
+    *) fail_ "E14a" "the listing-failure diagnostic lost its name (pre-existing contract): $out_a"; rm -rf "$T"; return ;;
+  esac
+  case "$out_a" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E14a" "bitbucket's protection listing failure is still raw jargon: $out_a"; rm -rf "$T"; return ;;
+  esac
+
+  # ── E14b: the restriction-POST failure arm ──
+  local out_b
+  out_b=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    export BITBUCKET_API_TOKEN=tok BITBUCKET_API_TOKEN_EMAIL=a@b.c BITBUCKET_WORKSPACE=ws
+    # shellcheck disable=SC1090
+    source "$BB_DRIVER"
+    host_configure_protection main personal 2>&1 >/dev/null
+    printf 'RC=%s' "$?"
+  )
+  case "$out_b" in
+    *"RC=2"*) ;;
+    *) fail_ "E14b" "the POST-failure arm must still return 2: $out_b"; rm -rf "$T"; return ;;
+  esac
+  case "$out_b" in
+    *"failed to set force restriction"*) ;;
+    *) fail_ "E14b" "the POST-failure arm lost its pre-existing message: $out_b"; rm -rf "$T"; return ;;
+  esac
+  case "$out_b" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E14b" "bitbucket's restriction-POST failure drops the host's words entirely: $out_b"; rm -rf "$T"; return ;;
+  esac
+  case "$out_b" in
+    *"lacks admin permission"*) ;;
+    *) fail_ "E14b" "the raw API body must still reach the operator: $out_b"; rm -rf "$T"; return ;;
+  esac
+
+  # ── E14c: the ORG-mode POSTs were silent (bare `|| return 2`) ──
+  local out_c
+  out_c=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    export BITBUCKET_API_TOKEN=tok BITBUCKET_API_TOKEN_EMAIL=a@b.c BITBUCKET_WORKSPACE=ws
+    # shellcheck disable=SC1090
+    source "$BB_DRIVER"
+    host_configure_protection main org 2>&1 >/dev/null
+    printf 'RC=%s' "$?"
+  )
+  case "$out_c" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E14c" "org-mode protection failure is still silent/raw: $out_c"; rm -rf "$T"; return ;;
+  esac
+
+  pass "E14: bitbucket host_configure_protection routes listing, restriction-POST and org-mode failures through the translator (exit 2 and the pre-existing messages preserved)"
+  rm -rf "$T"
+}
+
 # ── E12: the BL-002 free-tier block still classifies FIRST and returns 3 ──
 
 e12_bl002_precedence_preserved() {
@@ -412,11 +561,13 @@ e3_expired_auth
 e4_permission_403
 e5_unknown_is_raw_only
 e6_order_sso_beats_403
+e6d_sso_arm_does_not_overreach
 e7_raw_below_translation
 e8_github_create_routes_through_translator
 e9_github_auth_probe_routes_through_translator
 e10_gitlab_create_routes_through_translator
 e11_bitbucket_create_routes_through_translator
+e14_bitbucket_protection_routes_through_translator
 e12_bl002_precedence_preserved
 e13_mutation_translation_is_load_bearing
 

--- a/tests/host-drivers/error-translate.test.sh
+++ b/tests/host-drivers/error-translate.test.sh
@@ -52,64 +52,79 @@ fi
 # shellcheck disable=SC1090
 source "$LIB"
 
-# explain <raw> — capture the translator's stderr.
+# explain <raw> — capture the translator's stderr (translation + raw block).
 explain() { host_explain_error "$1" 2>&1; }
+
+# xlat <raw> — capture ONLY the two translated lines.
+#
+# WHY THIS EXISTS. The content assertions below originally matched against the
+# whole of `explain`'s output, which INCLUDES the host's raw text echoed back.
+# A mutation run caught the consequence: disabling the SSO arm entirely left
+# E1 green, because the word "authorize" it was looking for lives in the raw
+# GitHub message, not in the translation. Every content assertion about what
+# the translation SAYS must read the translation alone; assertions about the
+# raw passthrough (E5, E7-E11) still read the full output on purpose.
+xlat() { explain "$1" | grep -E "^  (What this means|What to do):"; }
 
 # ── E1-E4: each of the four named causes gets a sentence + an action ──
 
 e1_sso() {
-  local out
-  out=$(explain 'HTTP 403: Although you appear to have the correct authorization credentials, the `acme-corp` organization has enabled or enforced SAML SSO. To access this resource, you must use the full-repository-scope token and authorize it for this organization.')
-  case "$out" in
+  local t
+  t=$(xlat 'HTTP 403: Although you appear to have the correct authorization credentials, the `acme-corp` organization has enabled or enforced SAML SSO. To access this resource, you must use the full-repository-scope token and authorize it for this organization.')
+  case "$t" in
     *"$WHAT_ANCHOR"*) ;;
-    *) fail_ "E1" "SSO/SAML text produced no plain-language translation: $out"; return ;;
+    *) fail_ "E1" "SSO/SAML text produced no plain-language translation: $t"; return ;;
   esac
-  case "$out" in
+  case "$t" in
     *"$DO_ANCHOR"*) ;;
-    *) fail_ "E1" "SSO/SAML translation has no action line: $out"; return ;;
+    *) fail_ "E1" "SSO/SAML translation has no action line: $t"; return ;;
   esac
   # The sentence must be about ORG AUTHORIZATION, not generic permission.
-  if ! grep -qi 'authoriz' <<<"$out"; then
-    fail_ "E1" "SSO translation does not mention authorizing the login for the organization: $out"; return
+  if ! grep -qi 'authoriz' <<<"$t"; then
+    fail_ "E1" "SSO translation does not mention authorizing the login for the organization: $t"; return
   fi
   pass "E1: SAML/SSO org-authorization 403 gets a plain sentence + an action"
 }
 
 e2_rate_limit() {
-  local out
-  out=$(explain 'HTTP 403: API rate limit exceeded for user ID 12345. (https://api.github.com/user/repos)')
-  case "$out" in
+  local t
+  t=$(xlat 'HTTP 403: API rate limit exceeded for user ID 12345. (https://api.github.com/user/repos)')
+  case "$t" in
     *"$WHAT_ANCHOR"*) ;;
-    *) fail_ "E2" "rate-limit text produced no translation: $out"; return ;;
+    *) fail_ "E2" "rate-limit text produced no translation: $t"; return ;;
   esac
-  if ! grep -qiE 'wait|again|later|minute' <<<"$out"; then
-    fail_ "E2" "rate-limit action must tell the user to wait and retry: $out"; return
+  if ! grep -qiE 'wait|again|later|minute' <<<"$t"; then
+    fail_ "E2" "rate-limit action must tell the user to wait and retry: $t"; return
   fi
   pass "E2: rate limit gets a plain sentence + a wait-and-retry action"
 }
 
 e3_expired_auth() {
-  local out
-  out=$(explain 'HTTP 401: Bad credentials (https://api.github.com/user)')
-  case "$out" in
+  local t
+  t=$(xlat 'HTTP 401: Bad credentials (https://api.github.com/user)')
+  case "$t" in
     *"$WHAT_ANCHOR"*) ;;
-    *) fail_ "E3" "401/bad-credentials produced no translation: $out"; return ;;
+    *) fail_ "E3" "401/bad-credentials produced no translation: $t"; return ;;
   esac
-  if ! grep -qiE 'log in|login|sign in|authenticate' <<<"$out"; then
-    fail_ "E3" "expired-auth action must tell the user to log in again: $out"; return
+  if ! grep -qiE 'log in|login|sign in|authenticate' <<<"$t"; then
+    fail_ "E3" "expired-auth action must tell the user to log in again: $t"; return
+  fi
+  # Must NOT be mistaken for the permission arm — the fixes are different.
+  if grep -qi 'not allowed' <<<"$t"; then
+    fail_ "E3" "an expired login was explained as a permission problem: $t"; return
   fi
   pass "E3: expired/invalid auth gets a plain sentence + a log-in-again action"
 }
 
 e4_permission_403() {
-  local out
-  out=$(explain 'HTTP 403: Resource not accessible by personal access token')
-  case "$out" in
+  local t
+  t=$(xlat 'HTTP 403: Resource not accessible by personal access token')
+  case "$t" in
     *"$WHAT_ANCHOR"*) ;;
-    *) fail_ "E4" "generic 403 produced no translation: $out"; return ;;
+    *) fail_ "E4" "generic 403 produced no translation: $t"; return ;;
   esac
-  if ! grep -qiE 'allowed|permission|access' <<<"$out"; then
-    fail_ "E4" "permission translation must say the account is not allowed to do this: $out"; return
+  if ! grep -qiE 'not allowed|permission' <<<"$t"; then
+    fail_ "E4" "permission translation must say the account is not allowed to do this: $t"; return
   fi
   pass "E4: generic 403 permission failure gets a plain sentence + an action"
 }
@@ -134,14 +149,18 @@ e5_unknown_is_raw_only() {
 #        '403', and must not be swallowed by the generic-permission arm. ──
 
 e6_order_sso_beats_403() {
-  local out
-  out=$(explain 'HTTP 403: SAML SSO enforcement — permission denied until you authorize the token for the organization')
-  if ! grep -qi 'organization' <<<"$out"; then
-    fail_ "E6a" "a 403 that is really an SSO failure was classified as generic permission: $out"; return
+  local t
+  # Both inputs are 403s whose real cause is something else. Assert the
+  # DISTINGUISHING sentence, and assert the generic-permission sentence is
+  # absent — "contains the word organization" is not enough, because the
+  # permission sentence mentions organizations too.
+  t=$(xlat 'HTTP 403: SAML SSO enforcement — permission denied until you authorize the token for the organization')
+  if ! grep -qi 'authoriz' <<<"$t" || grep -qi 'not allowed' <<<"$t"; then
+    fail_ "E6a" "a 403 that is really an SSO failure was classified as generic permission: $t"; return
   fi
-  out=$(explain 'HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.')
-  if ! grep -qiE 'too many requests|rate|short time' <<<"$out"; then
-    fail_ "E6b" "a 403 that is really a rate limit was classified as generic permission: $out"; return
+  t=$(xlat 'HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.')
+  if ! grep -qiE 'too many requests|short time' <<<"$t" || grep -qi 'not allowed' <<<"$t"; then
+    fail_ "E6b" "a 403 that is really a rate limit was classified as generic permission: $t"; return
   fi
   pass "E6: SSO and rate-limit 403s outrank the generic-permission arm"
 }

--- a/tests/host-drivers/error-translate.test.sh
+++ b/tests/host-drivers/error-translate.test.sh
@@ -377,7 +377,14 @@ e14_bitbucket_protection_routes_through_translator() {
   local T; T=$(mktemp -d)
   stub_bin "$T/bin" curl <<'STUB'
 #!/usr/bin/env bash
-# Dispatch on argv: the listing GET carries `pattern=`, the creates carry POST.
+# Dispatch on argv for the verb, and on the PAYLOAD (stdin) for the kind —
+# every restriction POST shares one URL, so argv alone cannot tell the
+# force/delete pair from the three org-mode kinds.
+#
+# BB_ORG_ONLY_FAIL exists because of a mutation finding: without it the
+# force POST fails first and host_configure_protection returns before the
+# org-mode block is ever reached, so the org case was passing on the force
+# arm's translation and proving nothing about the org arms.
 case "$*" in
   *"branch-restrictions?pattern="*)
     if [ -n "${BB_LIST_FAIL:-}" ]; then
@@ -388,6 +395,12 @@ case "$*" in
     echo '{"values":[]}'
     exit 0 ;;
   *"-X POST"*)
+    body=$(cat)
+    if [ -n "${BB_ORG_ONLY_FAIL:-}" ]; then
+      case "$body" in
+        *'"kind":"force"'*|*'"kind":"delete"'*) echo '{"id":1}'; exit 0 ;;
+      esac
+    fi
     echo 'HTTP 403: Forbidden — your account lacks admin permission on this repository' >&2
     echo 'HTTP 403: Forbidden — your account lacks admin permission on this repository'
     exit 22 ;;
@@ -456,16 +469,29 @@ STUB
   esac
 
   # ── E14c: the ORG-mode POSTs were silent (bare `|| return 2`) ──
+  # BB_ORG_ONLY_FAIL lets force/delete succeed so control actually REACHES the
+  # org block. Without it this case passed on the force arm's translation and
+  # proved nothing about the org arms — caught by mutation M22.
   local out_c
   out_c=$(
     cd "$T"
     PATH="$T/bin:$PATH"
     export BITBUCKET_API_TOKEN=tok BITBUCKET_API_TOKEN_EMAIL=a@b.c BITBUCKET_WORKSPACE=ws
+    export BB_ORG_ONLY_FAIL=1
     # shellcheck disable=SC1090
     source "$BB_DRIVER"
     host_configure_protection main org 2>&1 >/dev/null
     printf 'RC=%s' "$?"
   )
+  case "$out_c" in
+    *"RC=2"*) ;;
+    *) fail_ "E14c" "the org-mode arm must still return 2: $out_c"; rm -rf "$T"; return ;;
+  esac
+  # Proof control reached the ORG block: only the org helper names these kinds.
+  case "$out_c" in
+    *"failed to set push restriction"*) ;;
+    *) fail_ "E14c" "org-mode failure does not name the kind that failed — the case did not reach the org block, or the arm is still silent: $out_c"; rm -rf "$T"; return ;;
+  esac
   case "$out_c" in
     *"$WHAT_ANCHOR"*) ;;
     *) fail_ "E14c" "org-mode protection failure is still silent/raw: $out_c"; rm -rf "$T"; return ;;

--- a/tests/host-drivers/error-translate.test.sh
+++ b/tests/host-drivers/error-translate.test.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# tests/host-drivers/error-translate.test.sh — BL-204 jargon-translation tests.
+#
+# BL-204 (the "Plus:" item on the entry): host-error jargon — 403 permission,
+# rate limits, SSO/SAML org authorization, expired auth — is surfaced RAW to
+# exactly the users the framework exists for. Translate the common causes into
+# ONE plain sentence + ONE action each, printed ABOVE the raw output, which
+# stays below. The precedent is the free-tier-403 block in
+# scripts/host-drivers/github.sh (marker `# BL-002`), which this deliberately
+# does NOT replace: that block is more specific and still classifies first.
+#
+# The translator is `host_explain_error` in scripts/lib/host-errors.sh
+# (marker `# BL-204-ERROR-TRANSLATE`). Every driver's create/auth/protection
+# failure path routes its captured host output through it.
+#
+# Registered implicitly via tests/host-drivers/run-all.sh's `*.test.sh` glob
+# (the same wiring github-free-tier-403.test.sh uses); the aggregator itself
+# is registered in tests/full-project-test-suite.sh.
+#
+# HERMETIC: no network, no repo creation. `gh`, `glab` and `curl` are stubbed
+# on PATH; the only git operations are `git init` + `git remote add` inside a
+# mktemp dir.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/host-errors.sh"
+GH_DRIVER="$REPO_ROOT/scripts/host-drivers/github.sh"
+GL_DRIVER="$REPO_ROOT/scripts/host-drivers/gitlab.sh"
+BB_DRIVER="$REPO_ROOT/scripts/host-drivers/bitbucket.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+# The one phrase every translated block must carry. Tests assert on this
+# rather than on the individual sentences so the wording can be tuned
+# without a test rewrite, while the CONTRACT (a plain sentence + an action,
+# above the raw text) stays pinned.
+WHAT_ANCHOR="What this means:"
+DO_ANCHOR="What to do:"
+RAW_ANCHOR="Raw response from the host"
+
+if [ ! -f "$LIB" ]; then
+  echo "  [FAIL] scripts/lib/host-errors.sh not found — BL-204-ERROR-TRANSLATE unimplemented" >&2
+  echo ""
+  echo "== Total: 1 | Passed: 0 | Failed: 1 =="
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+source "$LIB"
+
+# explain <raw> — capture the translator's stderr.
+explain() { host_explain_error "$1" 2>&1; }
+
+# ── E1-E4: each of the four named causes gets a sentence + an action ──
+
+e1_sso() {
+  local out
+  out=$(explain 'HTTP 403: Although you appear to have the correct authorization credentials, the `acme-corp` organization has enabled or enforced SAML SSO. To access this resource, you must use the full-repository-scope token and authorize it for this organization.')
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E1" "SSO/SAML text produced no plain-language translation: $out"; return ;;
+  esac
+  case "$out" in
+    *"$DO_ANCHOR"*) ;;
+    *) fail_ "E1" "SSO/SAML translation has no action line: $out"; return ;;
+  esac
+  # The sentence must be about ORG AUTHORIZATION, not generic permission.
+  if ! grep -qi 'authoriz' <<<"$out"; then
+    fail_ "E1" "SSO translation does not mention authorizing the login for the organization: $out"; return
+  fi
+  pass "E1: SAML/SSO org-authorization 403 gets a plain sentence + an action"
+}
+
+e2_rate_limit() {
+  local out
+  out=$(explain 'HTTP 403: API rate limit exceeded for user ID 12345. (https://api.github.com/user/repos)')
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E2" "rate-limit text produced no translation: $out"; return ;;
+  esac
+  if ! grep -qiE 'wait|again|later|minute' <<<"$out"; then
+    fail_ "E2" "rate-limit action must tell the user to wait and retry: $out"; return
+  fi
+  pass "E2: rate limit gets a plain sentence + a wait-and-retry action"
+}
+
+e3_expired_auth() {
+  local out
+  out=$(explain 'HTTP 401: Bad credentials (https://api.github.com/user)')
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E3" "401/bad-credentials produced no translation: $out"; return ;;
+  esac
+  if ! grep -qiE 'log in|login|sign in|authenticate' <<<"$out"; then
+    fail_ "E3" "expired-auth action must tell the user to log in again: $out"; return
+  fi
+  pass "E3: expired/invalid auth gets a plain sentence + a log-in-again action"
+}
+
+e4_permission_403() {
+  local out
+  out=$(explain 'HTTP 403: Resource not accessible by personal access token')
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E4" "generic 403 produced no translation: $out"; return ;;
+  esac
+  if ! grep -qiE 'allowed|permission|access' <<<"$out"; then
+    fail_ "E4" "permission translation must say the account is not allowed to do this: $out"; return
+  fi
+  pass "E4: generic 403 permission failure gets a plain sentence + an action"
+}
+
+# ── E5: unknown text is NOT mistranslated — raw only, no invented cause ──
+
+e5_unknown_is_raw_only() {
+  local out
+  out=$(explain 'something entirely unclassifiable happened on the far end')
+  case "$out" in
+    *"$WHAT_ANCHOR"*)
+      fail_ "E5" "unknown host output was given a fabricated cause: $out"; return ;;
+  esac
+  case "$out" in
+    *"something entirely unclassifiable happened"*) ;;
+    *) fail_ "E5" "unknown host output must still be surfaced verbatim: $out"; return ;;
+  esac
+  pass "E5: unclassifiable output is passed through raw with no invented cause"
+}
+
+# ── E6: classification ORDER — SSO and rate-limit messages both contain
+#        '403', and must not be swallowed by the generic-permission arm. ──
+
+e6_order_sso_beats_403() {
+  local out
+  out=$(explain 'HTTP 403: SAML SSO enforcement — permission denied until you authorize the token for the organization')
+  if ! grep -qi 'organization' <<<"$out"; then
+    fail_ "E6a" "a 403 that is really an SSO failure was classified as generic permission: $out"; return
+  fi
+  out=$(explain 'HTTP 403: You have exceeded a secondary rate limit. Please wait a few minutes before you try again.')
+  if ! grep -qiE 'too many requests|rate|short time' <<<"$out"; then
+    fail_ "E6b" "a 403 that is really a rate limit was classified as generic permission: $out"; return
+  fi
+  pass "E6: SSO and rate-limit 403s outrank the generic-permission arm"
+}
+
+# ── E7: the raw text stays BELOW the translation, never above it ──
+
+e7_raw_below_translation() {
+  local out what_line raw_line
+  out=$(explain 'HTTP 401: Bad credentials')
+  # No `producer | grep -q` anywhere in this file: under `set -o pipefail` a
+  # `grep -q` that exits early can SIGPIPE its producer into a 141 the caller
+  # reads as "no match". These two use `grep -n` (reads to EOF, no early exit)
+  # against a here-string, then slice the line numbers.
+  what_line=$(grep -n "$WHAT_ANCHOR" <<<"$out" | sed -n '1s/:.*//p')
+  raw_line=$(grep -n "Bad credentials" <<<"$out" | sed -n '$s/:.*//p')
+  if [ -z "$what_line" ] || [ -z "$raw_line" ]; then
+    fail_ "E7" "could not locate both the translation and the raw text: $out"; return
+  fi
+  if [ "$what_line" -ge "$raw_line" ]; then
+    fail_ "E7" "translation must be printed ABOVE the raw output (what=$what_line raw=$raw_line)"; return
+  fi
+  case "$out" in
+    *"$RAW_ANCHOR"*) ;;
+    *) fail_ "E7" "the raw block must be labelled so the user knows what it is: $out"; return ;;
+  esac
+  pass "E7: plain-language block prints above a labelled raw block"
+}
+
+# ── E8-E10: the drivers actually ROUTE their failures through it ──
+
+# stub_bin DIR NAME BODY — write an executable stub.
+stub_bin() {
+  local dir="$1" name="$2"
+  mkdir -p "$dir"
+  cat > "$dir/$name"
+  chmod +x "$dir/$name"
+}
+
+e8_github_create_routes_through_translator() {
+  local T; T=$(mktemp -d)
+  stub_bin "$T/bin" gh <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"repo create"*)
+    echo 'HTTP 403: Although you appear to have the correct authorization credentials, the acme organization has enabled or enforced SAML SSO.' >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  local out
+  out=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    # shellcheck disable=SC1090
+    source "$GH_DRIVER"
+    host_create_repo demo private 2>&1 >/dev/null
+  )
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E8" "github host_create_repo failure is still raw jargon: $out"; rm -rf "$T"; return ;;
+  esac
+  case "$out" in
+    *"SAML SSO"*) ;;
+    *) fail_ "E8" "github host_create_repo dropped the raw host text: $out"; rm -rf "$T"; return ;;
+  esac
+  pass "E8: github host_create_repo routes its failure through the translator"
+  rm -rf "$T"
+}
+
+e9_github_auth_probe_routes_through_translator() {
+  local T; T=$(mktemp -d)
+  stub_bin "$T/bin" gh <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    echo 'error: The token in keyring is invalid or has expired. Try re-authenticating with: gh auth login' >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  local out rc
+  out=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    # shellcheck disable=SC1090
+    source "$GH_DRIVER"
+    host_require_cli 2>&1 >/dev/null
+  )
+  rc=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    # shellcheck disable=SC1090
+    source "$GH_DRIVER"
+    host_require_cli >/dev/null 2>&1
+    echo $?
+  )
+  if [ "$rc" != "2" ]; then
+    fail_ "E9" "host_require_cli must keep returning 2 for an unauthenticated gh (got $rc)"; rm -rf "$T"; return
+  fi
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E9" "an expired gh token is still reported as raw jargon: $out"; rm -rf "$T"; return ;;
+  esac
+  pass "E9: github host_require_cli translates the expired/invalid-token case (rc=2 preserved)"
+  rm -rf "$T"
+}
+
+e10_gitlab_create_routes_through_translator() {
+  local T; T=$(mktemp -d)
+  stub_bin "$T/bin" glab <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*) exit 0 ;;
+  *"repo create"*)
+    echo '403 Forbidden: insufficient permissions to create a project in this namespace' >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  local out
+  out=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    # shellcheck disable=SC1090
+    source "$GL_DRIVER"
+    host_create_repo demo private 2>&1 >/dev/null
+  )
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E10" "gitlab host_create_repo failure is still raw jargon: $out"; rm -rf "$T"; return ;;
+  esac
+  case "$out" in
+    *"insufficient permissions"*) ;;
+    *) fail_ "E10" "gitlab host_create_repo dropped the raw host text: $out"; rm -rf "$T"; return ;;
+  esac
+  pass "E10: gitlab host_create_repo routes its failure through the translator"
+  rm -rf "$T"
+}
+
+e11_bitbucket_create_routes_through_translator() {
+  local T; T=$(mktemp -d)
+  stub_bin "$T/bin" curl <<'STUB'
+#!/usr/bin/env bash
+echo 'curl: (22) The requested URL returned error: 401 Unauthorized — token expired' >&2
+echo 'curl: (22) The requested URL returned error: 401 Unauthorized — token expired'
+exit 22
+STUB
+  local out
+  out=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    export BITBUCKET_API_TOKEN=tok BITBUCKET_API_TOKEN_EMAIL=a@b.c BITBUCKET_WORKSPACE=ws
+    # shellcheck disable=SC1090
+    source "$BB_DRIVER"
+    host_create_repo demo private 2>&1 >/dev/null
+  )
+  case "$out" in
+    *"$WHAT_ANCHOR"*) ;;
+    *) fail_ "E11" "bitbucket host_create_repo failure is still raw jargon: $out"; rm -rf "$T"; return ;;
+  esac
+  pass "E11: bitbucket host_create_repo routes its failure through the translator"
+  rm -rf "$T"
+}
+
+# ── E12: the BL-002 free-tier block still classifies FIRST and returns 3 ──
+
+e12_bl002_precedence_preserved() {
+  local T; T=$(mktemp -d)
+  stub_bin "$T/bin" gh <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"branches/"*"/protection"*)
+    echo 'HTTP 403: Upgrade to GitHub Pro or make this repository public to enable this feature.' >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+STUB
+  (
+    cd "$T"
+    git init -q
+    git config user.email t@t.local
+    git config user.name t
+    git remote add origin https://github.com/test/repo.git
+  ) >/dev/null 2>&1
+  local rc out
+  out=$(
+    cd "$T"
+    PATH="$T/bin:$PATH"
+    # shellcheck disable=SC1090
+    source "$GH_DRIVER"
+    host_configure_protection main personal 2>&1 >/dev/null
+    printf 'RC=%s' "$?"
+  )
+  rc=$(printf '%s' "$out" | sed -n 's/.*RC=\([0-9]*\)$/\1/p')
+  if [ "$rc" != "3" ]; then
+    fail_ "E12" "the BL-002 free-tier arm must still return 3 (got '$rc'): $out"; rm -rf "$T"; return
+  fi
+  case "$out" in
+    *"GitHub Pro"*) ;;
+    *) fail_ "E12" "the BL-002 remediation text was lost: $out"; rm -rf "$T"; return ;;
+  esac
+  pass "E12: BL-002 free-tier 403 still classifies first (exit 3, remediation intact)"
+  rm -rf "$T"
+}
+
+# ── E13: mutation proof — excising the marked translation emit makes the
+#        translator inert again while leaving the file runnable. ──
+
+e13_mutation_translation_is_load_bearing() {
+  local T; T=$(mktemp -d)
+  local marks left
+  marks=$(grep -c '# BL-204-ERROR-TRANSLATE-EMIT$' "$LIB" 2>/dev/null) || marks=0
+  if [ "${marks:-0}" -lt 1 ]; then
+    fail_ "E13" "no '# BL-204-ERROR-TRANSLATE-EMIT' marker in host-errors.sh — nothing to excise (mis-targeted)"
+    rm -rf "$T"; return
+  fi
+  sed '/# BL-204-ERROR-TRANSLATE-EMIT$/d' "$LIB" > "$T/mut.sh"
+  left=$(grep -c '# BL-204-ERROR-TRANSLATE-EMIT$' "$T/mut.sh" 2>/dev/null) || left=0
+  if [ "${left:-0}" -ne 0 ]; then
+    fail_ "E13" "excision left $left marker(s) — vacuous mutant"; rm -rf "$T"; return
+  fi
+  if ! bash -n "$T/mut.sh" 2>/dev/null; then
+    fail_ "E13" "mutant has a syntax error — a broken mutant proves nothing"; rm -rf "$T"; return
+  fi
+  local mut_out
+  mut_out=$( bash -c '
+    set -uo pipefail
+    . "$1"
+    host_explain_error "HTTP 401: Bad credentials" 2>&1
+  ' _ "$T/mut.sh" )
+  case "$mut_out" in
+    *"$WHAT_ANCHOR"*)
+      fail_ "E13" "mutant still emits the translation — the marked line is not load-bearing: $mut_out"
+      rm -rf "$T"; return ;;
+  esac
+  case "$mut_out" in
+    *"Bad credentials"*) ;;
+    *) fail_ "E13" "mutant no longer runs at all (raw text gone) — non-decisive mutation: $mut_out"; rm -rf "$T"; return ;;
+  esac
+  pass "E13: excising the marked emit makes the translator inert (mutation is decisive and non-vacuous)"
+  rm -rf "$T"
+}
+
+echo "== tests/host-drivers/error-translate.test.sh (BL-204 jargon translation) =="
+e1_sso
+e2_rate_limit
+e3_expired_auth
+e4_permission_403
+e5_unknown_is_raw_only
+e6_order_sso_beats_403
+e7_raw_below_translation
+e8_github_create_routes_through_translator
+e9_github_auth_probe_routes_through_translator
+e10_gitlab_create_routes_through_translator
+e11_bitbucket_create_routes_through_translator
+e12_bl002_precedence_preserved
+e13_mutation_translation_is_load_bearing
+
+echo ""
+echo "== Total: $((PASSED + FAILED)) | Passed: $PASSED | Failed: $FAILED =="
+[ "$FAILED" -eq 0 ] && exit 0 || exit 1

--- a/tests/test-bl108-bl117-ship-closure.sh
+++ b/tests/test-bl108-bl117-ship-closure.sh
@@ -63,6 +63,34 @@ shipped_scripts() {
     | grep -oE 'scripts/[a-z][a-z0-9-]*\.sh' \
     | sed 's|scripts/||' | sort -u
 }
+# R-BL204-3 — THE THIRD ARTIFACT SHAPE: a shipped script that reaches a
+# dependency by RELATIVE path out of its own subdirectory.
+#
+# The host drivers live in scripts/host-drivers/ and source their libs as
+# `../lib/<name>.sh`. Neither extractor above can see that: one looks for
+# templates/generated/*.tmpl, the other for scripts/<tool>.sh. So a driver
+# could depend on a lib init.sh never ships and the whole closure stayed
+# green — which is exactly what happened. Deleting init.sh's
+# `cp .../host-errors.sh` line left this suite, both BL-204 suites, the
+# bitbucket driver suite and every lint GREEN.
+#
+# And the loss is SILENT downstream, not loud: each driver carries a
+# pass-through fallback (`command -v host_explain_error || host_explain_error()
+# { …raw… }`) so a scaffolded project with the lib missing degrades quietly
+# back to raw jargon — no error, no missing-file message, just the defect the
+# lib existed to fix, reintroduced in every generated project.
+shipped_libs() {
+  grep -E '^[[:space:]]*cp .*"?\$SCRIPT_DIR"?/scripts/lib/[A-Za-z0-9._-]+\.sh' "$REPO_ROOT/init.sh" \
+    | grep -oE 'scripts/lib/[A-Za-z0-9._-]+\.sh' \
+    | sed 's|.*/||' | sort -u
+}
+host_driver_lib_deps() {
+  # Executed lines only — a comment naming a lib is not a dependency.
+  grep -hE '\.\./lib/[A-Za-z0-9._-]+\.sh' "$REPO_ROOT"/scripts/host-drivers/*.sh 2>/dev/null \
+    | grep -vE '^[[:space:]]*#' \
+    | grep -ohE '\.\./lib/[A-Za-z0-9._-]+\.sh' \
+    | sed 's|.*/||' | sort -u
+}
 
 # ── T-template-closure ───────────────────────────────────────────────────────
 echo "=== T-template-closure ==="
@@ -173,6 +201,47 @@ else
       fail_ "T-mutation-bl117-smoke" "mutant still blocks (rc=$rc) — the fence does not contain the arm"
     fi
   fi
+fi
+
+# ── T-host-driver-lib-closure (R-BL204-3) ────────────────────────────────────
+echo "=== T-host-driver-lib-closure ==="
+# Same vacuity guard as the two closures above: a blind extractor certifies an
+# empty set. The drivers reference at least one lib today, so 0 means the
+# regex drifted (a rename of scripts/host-drivers/, or a driver switching to
+# some other path shape) — not that the dependency went away.
+dep_n=$(host_driver_lib_deps | grep -c .)
+lib_missing=""
+for l in $(host_driver_lib_deps); do
+  if ! shipped_libs | grep -qx "$l"; then
+    lib_missing="$lib_missing $l"
+  fi
+done
+if [ "$dep_n" -eq 0 ]; then
+  fail_ "T-host-driver-lib-closure" "host_driver_lib_deps extracted ZERO items — the extractor went blind and the closure would certify an empty set"
+elif [ -z "$lib_missing" ]; then
+  pass "T-host-driver-lib-closure ($dep_n driver lib dependency/ies all shipped)"
+else
+  fail_ "T-host-driver-lib-closure" "scripts/host-drivers/*.sh source libs init.sh never ships:$lib_missing (R-BL204-3 — the driver's pass-through fallback makes the loss SILENT in every generated project)"
+fi
+
+# ── T-host-driver-lib-extractor-bites ────────────────────────────────────────
+# Self-test for BOTH halves: prove each extractor sees a line shaped like the
+# real thing. A closure between two blind extractors passes vacuously.
+echo "=== T-host-driver-lib-extractor-bites ==="
+dep_probe=$(printf '_X="$(dirname "${BASH_SOURCE[0]}")/../lib/zz-bogus-dep.sh"\n' \
+  | grep -vE '^[[:space:]]*#' \
+  | grep -ohE '\.\./lib/[A-Za-z0-9._-]+\.sh' | sed 's|.*/||')
+ship_probe=$(printf '  cp "$SCRIPT_DIR/scripts/lib/zz-bogus-ship.sh" scripts/lib/\n' \
+  | grep -E '^[[:space:]]*cp .*"?\$SCRIPT_DIR"?/scripts/lib/[A-Za-z0-9._-]+\.sh' \
+  | grep -oE 'scripts/lib/[A-Za-z0-9._-]+\.sh' | sed 's|.*/||')
+# And a comment naming a lib must NOT be counted as a dependency.
+comment_probe=$(printf '# the drivers source ../lib/zz-comment-only.sh at load\n' \
+  | grep -vE '^[[:space:]]*#' \
+  | grep -ohE '\.\./lib/[A-Za-z0-9._-]+\.sh' | sed 's|.*/||')
+if [ "$dep_probe" = "zz-bogus-dep.sh" ] && [ "$ship_probe" = "zz-bogus-ship.sh" ] && [ -z "$comment_probe" ]; then
+  pass "T-host-driver-lib-extractor-bites (dep + ship extractors both bite; a comment-only mention does not)"
+else
+  fail_ "T-host-driver-lib-extractor-bites" "an extractor is blind or over-eager (dep='$dep_probe' want zz-bogus-dep.sh; ship='$ship_probe' want zz-bogus-ship.sh; comment='$comment_probe' want empty) — the closure would pass vacuously"
 fi
 
 echo ""

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -912,12 +912,27 @@ HEOF
   [ "$C_HOST" = "bitbucket" ] || C_OK=0
   [ "$C_VIS" = "public" ] || C_OK=0
 
-  if [ "$A_OK" -eq 1 ] && [ "$B_OK" -eq 1 ] && [ "$C_OK" -eq 1 ]; then
-    pass "T-bl204-prefill (remembered values are confirmed not re-asked; with neither source the original prompts + the free-tier note still run; the two halves prefill independently)"
+  # ── Case D: visibility remembered but the user says CHANGE IT → the
+  # explanation must run on THAT path too. Added after a mutation run showed
+  # the "change it" arm's _bl204_explain_visibility call could be deleted
+  # with every case still green: A/C never reach it and B reaches the OTHER
+  # call site, so a user who actively wants to reconsider — precisely the one
+  # who needs the free-tier note — was unprotected.
+  D4=$(mktemp -d)
+  _bl204_harness "$D4"
+  printf '{"answers":{"repo_visibility":"private"}}\n' > "$D4/intake-progress.json"
+  D_ERR=$(printf '1\n2\n2\n' | bash "$D4/harness.sh" 2>&1 >/dev/null)
+  D_VIS=$(jq -r '.answers.repo_visibility // "MISSING"' "$D4/intake-progress.json")
+  D_OK=1
+  [ "$D_VIS" = "public" ] || D_OK=0
+  grep -qF "$BL204_FREETIER_ANCHOR" <<<"$D_ERR" || D_OK=0
+
+  if [ "$A_OK" -eq 1 ] && [ "$B_OK" -eq 1 ] && [ "$C_OK" -eq 1 ] && [ "$D_OK" -eq 1 ]; then
+    pass "T-bl204-prefill (remembered values are confirmed not re-asked; with neither source the original prompts + the free-tier note still run; the two halves prefill independently; 'change it' also gets the explanation)"
   else
-    fail_ "T-bl204-prefill" "A(ok=$A_OK host=$A_HOST vis=$A_VIS) B(ok=$B_OK host=$B_HOST vis=$B_VIS) C(ok=$C_OK host=$C_HOST vis=$C_VIS) — BL-204 finding 7"
+    fail_ "T-bl204-prefill" "A(ok=$A_OK host=$A_HOST vis=$A_VIS) B(ok=$B_OK host=$B_HOST vis=$B_VIS) C(ok=$C_OK host=$C_HOST vis=$C_VIS) D(ok=$D_OK vis=$D_VIS) — BL-204 finding 7"
   fi
-  rm -rf "$D" "$D2" "$D3"
+  rm -rf "$D" "$D2" "$D3" "$D4"
 fi
 
 echo ""

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -749,8 +749,11 @@ for _f in "$WIZARD" "$INITSH"; do
   grep -qF '# BL-204-VISIBILITY-EXPLAIN' "$_f" || BL204_VIS_OK=0
   grep -qF "$BL204_FREETIER_ANCHOR" "$_f" || BL204_VIS_OK=0
   # Plain-language private/public, not a bare `private|public` menu.
-  grep -qiE 'private[^\n]*only you' "$_f" || BL204_VIS_OK=0
-  grep -qiE 'public[^\n]*anyone' "$_f" || BL204_VIS_OK=0
+  # `.*` not `[^\n]*`: grep is line-based so they mean the same thing here,
+  # but BSD ERE reads `\n` inside a bracket as the literal chars n and \,
+  # which would silently stop matching if the copy ever gained an "n".
+  grep -qiE 'private.*only you' "$_f" || BL204_VIS_OK=0
+  grep -qiE 'public.*anyone' "$_f" || BL204_VIS_OK=0
   # Name the later cost by the name the user will actually see (BL-032/BL-002
   # surface it as an attestation prompt much later in the run).
   grep -qiF 'attest' "$_f" || BL204_VIS_OK=0

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -927,12 +927,54 @@ HEOF
   [ "$D_VIS" = "public" ] || D_OK=0
   grep -qF "$BL204_FREETIER_ANCHOR" <<<"$D_ERR" || D_OK=0
 
-  if [ "$A_OK" -eq 1 ] && [ "$B_OK" -eq 1 ] && [ "$C_OK" -eq 1 ] && [ "$D_OK" -eq 1 ]; then
-    pass "T-bl204-prefill (remembered values are confirmed not re-asked; with neither source the original prompts + the free-tier note still run; the two halves prefill independently; 'change it' also gets the explanation)"
+  # ── Case E (R-BL204-2): the PRIMARY flow — a project fresh out of init,
+  # seeded with ONLY what init itself writes.
+  #
+  # THE GAP THIS CLOSES. Cases A/C/D hand-seed answers.repo_visibility, and
+  # the only writer of that key in the whole repo was the wizard. init
+  # resolved _RESOLVED_VISIBILITY (from --visibility, or a prompt) and threw
+  # it away, so on every real first run the wizard found nothing and
+  # blind-asked — the visibility half of "ask once" was a no-op everywhere
+  # except in this file's own fixtures. That is the fixture-masks-gap class:
+  # the test seeded the very state whose absence was the defect.
+  #
+  # So this case does NOT hand-write the key. It runs init's own persistence
+  # function to produce the file, then feeds THAT file to the wizard. The only
+  # test plumbing is the copy from .claude/ (where init writes) to the flat
+  # path the harness reads; the CONTENT is exactly what init produced.
+  D5=$(mktemp -d)
+  mkdir -p "$D5/run"
+  cat > "$D5/persist.sh" <<PEOF
+#!/usr/bin/env bash
+set -uo pipefail
+PEOF
+  awk '/^_bl204_persist_visibility_answer\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$INITSH" >> "$D5/persist.sh"
+  echo '_bl204_persist_visibility_answer "public"' >> "$D5/persist.sh"
+  ( cd "$D5/run" && bash "$D5/persist.sh" ) >/dev/null 2>&1
+  E_OK=1
+  E_WROTE=$(jq -r '.answers.repo_visibility // "MISSING"' "$D5/run/.claude/intake-progress.json" 2>/dev/null) || E_WROTE="NOFILE"
+  [ "$E_WROTE" = "public" ] || E_OK=0
+  # Now the wizard, against init's real output plus the manifest init writes.
+  _bl204_harness "$D5"
+  printf '{"host":"github","mode":"personal"}\n' > "$D5/manifest.json"
+  cp "$D5/run/.claude/intake-progress.json" "$D5/intake-progress.json" 2>/dev/null || printf '{"answers":{}}\n' > "$D5/intake-progress.json"
+  E_ERR=$(printf '1\n1\n' | bash "$D5/harness.sh" 2>&1 >/dev/null)
+  E_VIS=$(jq -r '.answers.repo_visibility // "MISSING"' "$D5/intake-progress.json")
+  [ "$E_VIS" = "public" ] || E_OK=0
+  # The decisive assertion: a CONFIRM, not a blind private|public menu.
+  grep -qE '^[[:space:]]*2\.[[:space:]]*public$' <<<"$E_ERR" && E_OK=0
+  grep -qi 'remembered from your setup answers — repository visibility' <<<"$E_ERR" || E_OK=0
+  # And init must actually CALL the persistence function — a function nobody
+  # invokes is the same no-op wearing a different hat.
+  grep -qF '_bl204_persist_visibility_answer' \
+    <<<"$(_bl204_fnbody "$INITSH" prepare_initial_state_for_commit)" || E_OK=0
+
+  if [ "$A_OK" -eq 1 ] && [ "$B_OK" -eq 1 ] && [ "$C_OK" -eq 1 ] && [ "$D_OK" -eq 1 ] && [ "$E_OK" -eq 1 ]; then
+    pass "T-bl204-prefill (remembered values are confirmed not re-asked; with neither source the original prompts + the free-tier note still run; the two halves prefill independently; 'change it' also gets the explanation; and the PRIMARY flow works off what init itself persists)"
   else
-    fail_ "T-bl204-prefill" "A(ok=$A_OK host=$A_HOST vis=$A_VIS) B(ok=$B_OK host=$B_HOST vis=$B_VIS) C(ok=$C_OK host=$C_HOST vis=$C_VIS) D(ok=$D_OK vis=$D_VIS) — BL-204 finding 7"
+    fail_ "T-bl204-prefill" "A(ok=$A_OK host=$A_HOST vis=$A_VIS) B(ok=$B_OK host=$B_HOST vis=$B_VIS) C(ok=$C_OK host=$C_HOST vis=$C_VIS) D(ok=$D_OK vis=$D_VIS) E(ok=$E_OK wrote=$E_WROTE vis=$E_VIS) — BL-204 finding 7 / R-BL204-2"
   fi
-  rm -rf "$D" "$D2" "$D3" "$D4"
+  rm -rf "$D" "$D2" "$D3" "$D4" "$D5"
 fi
 
 echo ""

--- a/tests/test-intake-wizard-fixes.sh
+++ b/tests/test-intake-wizard-fixes.sh
@@ -686,6 +686,291 @@ else
 fi
 rm -rf "$D"
 
+# ----------------------------------------------------------------
+# BL-204 — happy-path remote-setup UX (findings 5, 6, 7, 8).
+#
+# Findings 1-4 (repair/auth/collision/org-namespace FAILURE paths) are
+# deliberately NOT covered here — they are a separate wave.
+#
+#   5  probe at the SELECTION moment (`# BL-204-PROBE-AT-SELECT`)
+#   6  visibility explained, incl. the free-tier cost (`# BL-204-VISIBILITY-EXPLAIN`)
+#   7  ask once — prefill/confirm instead of a blind re-ask (`# BL-204-PREFILL`)
+#   8  say WHY a remote matters, upstream of the choice (`# BL-204-REMOTE-WHY`)
+#
+# The init-script token is assembled from parts on every executed line below,
+# exactly as the BL-202 case above does: the BL-181/BL-154 unit-lane predicate
+# reads names-on-executed-lines and a literal token here would silently exempt
+# this whole file from the tests.yml membership lint. Do not "simplify" it.
+# ----------------------------------------------------------------
+INITSH="$REPO_ROOT/init"; INITSH="${INITSH}.sh"
+INITTOK="init"; INITTOK="${INITTOK}.sh"
+
+# _bl204_fnbody <file> <function-name> — echo one shell function's body.
+#
+# NEVER `awk … | grep -q` here. This file runs under `set -o pipefail`, and
+# `grep -q` exits at the first match: whether the producer finishes first or
+# takes SIGPIPE (exit 141, which pipefail promotes to the pipeline's status)
+# is a RACE. That race made two of the cases below flap PASS/FAIL on identical
+# trees before this helper existed. Capture, then match with a here-string.
+_bl204_fnbody() {
+  awk -v fn="$2" '
+    $0 ~ ("^" fn "\\(\\) \\{") { inside=1 }
+    inside { print; if ($0 == "}") { exit } }
+  ' "$1"
+}
+
+# The two cross-surface anchors. Both the wizard and the init script must
+# carry them VERBATIM, so a fix applied to only one surface fails.
+BL204_FREETIER_ANCHOR='On a free personal GitHub account, a PRIVATE repo cannot have branch protection'
+BL204_BACKUP_ANCHOR='your remote is your backup'
+
+echo ""
+echo "T-bl204-remote-why: the backup framing is stated upstream of the host choice, and in Next Steps"
+BL204_WHY_OK=1
+grep -qiF "$BL204_BACKUP_ANCHOR" "$WIZARD" || BL204_WHY_OK=0
+grep -qiF "$BL204_BACKUP_ANCHOR" "$INITSH" || BL204_WHY_OK=0
+grep -qF '# BL-204-REMOTE-WHY' "$WIZARD" || BL204_WHY_OK=0
+grep -qF '# BL-204-REMOTE-WHY' "$INITSH" || BL204_WHY_OK=0
+# The sentence must name the data-loss consequence, not just say "backup".
+grep -qiE 'lost .*(disk|drive|laptop|machine)|(disk|drive|laptop|machine) (dies|fails|is lost)' "$WIZARD" || BL204_WHY_OK=0
+grep -qiE 'lost .*(disk|drive|laptop|machine)|(disk|drive|laptop|machine) (dies|fails|is lost)' "$INITSH" || BL204_WHY_OK=0
+# And it must reach print_next_steps, not only the create path (finding 8).
+grep -qF '# BL-204-REMOTE-WHY' <<<"$(_bl204_fnbody "$INITSH" print_next_steps)" || BL204_WHY_OK=0
+if [ "$BL204_WHY_OK" -eq 1 ]; then
+  pass "T-bl204-remote-why (both surfaces say the remote IS the backup and name the data-loss consequence; the Next Steps copy is inside print_next_steps)"
+else
+  fail_ "T-bl204-remote-why" "BL-204 finding 8: the 'why a remote' sentence is missing from the wizard, the init script, or print_next_steps"
+fi
+
+echo ""
+echo "T-bl204-visibility-explain: private/public is explained, with the free-tier branch-protection cost"
+BL204_VIS_OK=1
+for _f in "$WIZARD" "$INITSH"; do
+  grep -qF '# BL-204-VISIBILITY-EXPLAIN' "$_f" || BL204_VIS_OK=0
+  grep -qF "$BL204_FREETIER_ANCHOR" "$_f" || BL204_VIS_OK=0
+  # Plain-language private/public, not a bare `private|public` menu.
+  grep -qiE 'private[^\n]*only you' "$_f" || BL204_VIS_OK=0
+  grep -qiE 'public[^\n]*anyone' "$_f" || BL204_VIS_OK=0
+  # Name the later cost by the name the user will actually see (BL-032/BL-002
+  # surface it as an attestation prompt much later in the run).
+  grep -qiF 'attest' "$_f" || BL204_VIS_OK=0
+done
+if [ "$BL204_VIS_OK" -eq 1 ]; then
+  pass "T-bl204-visibility-explain (both prompts explain private vs public AND the free-tier branch-protection cost, naming the attestation it turns into)"
+else
+  fail_ "T-bl204-visibility-explain" "BL-204 finding 6: a visibility prompt is still bare, or one surface lacks the free-tier note"
+fi
+
+echo ""
+echo "T-bl204-probe-at-select: the CLI/credential probe fires when the host is chosen, and the pre-create backstop survives"
+BL204_PROBE_OK=1
+grep -qF '# BL-204-PROBE-AT-SELECT' "$INITSH" || BL204_PROBE_OK=0
+# The probe must be reached from the host-resolution function, not only from
+# the pre-create block (finding 5).
+grep -qF '_bl204_probe_host_at_selection' \
+  <<<"$(_bl204_fnbody "$INITSH" _resolve_host_visibility_mode)" || BL204_PROBE_OK=0
+# BACKSTOP: create_and_protect_remote must still probe immediately before create.
+grep -qF 'host_require_cli' \
+  <<<"$(_bl204_fnbody "$INITSH" create_and_protect_remote)" || BL204_PROBE_OK=0
+if [ "$BL204_PROBE_OK" -eq 1 ]; then
+  pass "T-bl204-probe-at-select (the probe is wired into _resolve_host_visibility_mode AND the pre-create host_require_cli backstop is intact)"
+else
+  fail_ "T-bl204-probe-at-select" "BL-204 finding 5: the probe is not at the selection point, or the pre-create backstop was removed"
+fi
+
+echo ""
+echo "T-bl204-probe-functional: an unauthenticated CLI is reported AT selection, without aborting init"
+D=$(mktemp -d)
+mkdir -p "$D/bin"
+cat > "$D/bin/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+case "$*" in
+  *"auth status"*)
+    echo 'error: The token in keyring is invalid or has expired. Try: gh auth login' >&2
+    exit 1 ;;
+  *) exit 0 ;;
+esac
+GHSTUB
+chmod +x "$D/bin/gh"
+cat > "$D/probe.sh" <<PROBEEOF
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$REPO_ROOT"
+NON_INTERACTIVE=true
+BOLD=''; NC=''; CYAN=''; GREEN=''; BLUE=''; YELLOW=''; RED=''
+log_line()   { :; }
+print_step() { echo "[STEP] \$1"; }
+print_ok()   { echo "[OK] \$1"; }
+print_warn() { echo "[WARN] \$1"; }
+print_fail() { echo "[FAIL] \$1"; }
+print_info() { echo "[INFO] \$1"; }
+PROBEEOF
+awk '/^_bl204_probe_host_at_selection\(\) \{/{f=1} f{print} f&&/^\}$/{exit}' "$INITSH" >> "$D/probe.sh"
+echo '_bl204_probe_host_at_selection "github"; echo "RC=$?"' >> "$D/probe.sh"
+PROBE_OUT=$( cd "$D" && PATH="$D/bin:$PATH" bash "$D/probe.sh" 2>&1 </dev/null )
+if grep -qF 'RC=0' <<<"$PROBE_OUT" \
+   && grep -qiE 'github' <<<"$PROBE_OUT" \
+   && grep -qiE 'auth|log in|sign in|credential' <<<"$PROBE_OUT"; then
+  pass "T-bl204-probe-functional (a failing probe warns at selection time, names the host and the auth fix, and returns 0 so init continues to the backstop)"
+else
+  fail_ "T-bl204-probe-functional" "the selection-time probe did not report an unauthenticated CLI (or aborted init): $(printf '%s' "$PROBE_OUT" | tr '\n' '|' | cut -c1-300)"
+fi
+rm -rf "$D"
+
+echo ""
+echo "T-bl204-wizard-sentence: the backwards 'verified again' sentence is gone and replaced with the truth"
+# Assembled from parts: a literal init-script token on an executed line would
+# exempt this file from the unit lane (see the header note above).
+BL204_BACKWARDS="CLI will be verified again at $INITTOK"
+if grep -qF "$BL204_BACKWARDS" "$WIZARD"; then
+  fail_ "T-bl204-wizard-sentence" "the wizard still claims the CLI will be verified again later — it runs AFTER the init script, so nothing re-verifies (BL-204 finding 5)"
+elif grep -qF 'check-gate.sh --repair' \
+       <<<"$(_bl204_fnbody "$WIZARD" run_section_1_repo_setup)"; then
+  pass "T-bl204-wizard-sentence (the continue arm now points at the real remediation, check-gate.sh --repair)"
+else
+  fail_ "T-bl204-wizard-sentence" "the backwards sentence is gone but the continue arm names no real next step"
+fi
+
+echo ""
+echo "T-bl204-prefill: remembered host/visibility are shown and CONFIRMED, never re-asked blind"
+if ! command -v jq >/dev/null 2>&1 || ! command -v python3 >/dev/null 2>&1; then
+  echo "  [SKIP] T-bl204-prefill — jq or python3 unavailable"
+else
+  # Build a harness that runs the wizard's repo-setup block against a
+  # controlled MANIFEST_FILE + PROGRESS_FILE. SCRIPT_DIR points at an EMPTY
+  # dir so the host-driver probe block is inert — this test is about the
+  # prefill, and the probe has its own case above. Hermetic: no network.
+  _bl204_harness() {  # <dir>
+    local d="$1"
+    mkdir -p "$d/emptyscripts"
+    cat > "$d/harness.sh" <<HEOF
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$d/emptyscripts"
+PROGRESS_FILE="$d/intake-progress.json"
+MANIFEST_FILE="$d/manifest.json"
+_PAUSE_FILE="$d/.pause-sentinel"
+BOLD=''; NC=''; CYAN=''; GREEN=''; BLUE=''; YELLOW=''; RED=''
+print_info() { echo "\$1" >&2; }
+print_ok()   { echo "\$1" >&2; }
+print_warn() { echo "\$1" >&2; }
+print_fail() { echo "\$1" >&2; }
+print_step() { echo "\$1" >&2; }
+log_line()   { :; }
+save_section() { :; }
+HEOF
+    local fn
+    for fn in prompt_input prompt_choice _request_pause check_pause_requested save_answer _bl204_explain_visibility run_section_1_repo_setup; do
+      awk -v fn="$fn" '
+        $0 ~ ("^" fn "\\(\\) \\{") { inside=1 }
+        inside { print; if ($0 == "}") { inside=0; print ""; exit } }
+      ' "$WIZARD" >> "$d/harness.sh"
+    done
+    echo 'run_section_1_repo_setup' >> "$d/harness.sh"
+  }
+
+  # ── Case A: BOTH remembered → confirm, keep, no blind re-ask ──
+  D=$(mktemp -d)
+  _bl204_harness "$D"
+  printf '{"host":"gitlab","mode":"personal"}\n' > "$D/manifest.json"
+  printf '{"answers":{"repo_visibility":"public"}}\n' > "$D/intake-progress.json"
+  A_ERR=$(printf '1\n1\n' | bash "$D/harness.sh" 2>&1 >/dev/null)
+  A_HOST=$(jq -r '.answers.git_host // "MISSING"' "$D/intake-progress.json")
+  A_VIS=$(jq -r '.answers.repo_visibility // "MISSING"' "$D/intake-progress.json")
+  A_OK=1
+  [ "$A_HOST" = "gitlab" ] || A_OK=0
+  [ "$A_VIS" = "public" ] || A_OK=0
+  grep -qi 'remember' <<<"$A_ERR" || A_OK=0
+  # A blind re-ask would list all four hosts; a confirm must not.
+  grep -qE '^[[:space:]]*3\.[[:space:]]*bitbucket' <<<"$A_ERR" && A_OK=0
+
+  # ── Case B: NEITHER source → the original blind prompts, unchanged ──
+  D2=$(mktemp -d)
+  _bl204_harness "$D2"
+  printf '{"answers":{}}\n' > "$D2/intake-progress.json"
+  B_ERR=$(printf '1\n1\n' | bash "$D2/harness.sh" 2>&1 >/dev/null)
+  B_HOST=$(jq -r '.answers.git_host // "MISSING"' "$D2/intake-progress.json")
+  B_VIS=$(jq -r '.answers.repo_visibility // "MISSING"' "$D2/intake-progress.json")
+  B_OK=1
+  [ "$B_HOST" = "github" ] || B_OK=0
+  [ "$B_VIS" = "private" ] || B_OK=0
+  grep -qE '^[[:space:]]*3\.[[:space:]]*bitbucket' <<<"$B_ERR" || B_OK=0
+  grep -qF "$BL204_FREETIER_ANCHOR" <<<"$B_ERR" || B_OK=0
+
+  # ── Case C: host remembered, visibility NOT → mixed, each half independent ──
+  D3=$(mktemp -d)
+  _bl204_harness "$D3"
+  printf '{"host":"bitbucket"}\n' > "$D3/manifest.json"
+  printf '{"answers":{}}\n' > "$D3/intake-progress.json"
+  C_ERR=$(printf '1\n2\n' | bash "$D3/harness.sh" 2>&1 >/dev/null)
+  C_HOST=$(jq -r '.answers.git_host // "MISSING"' "$D3/intake-progress.json")
+  C_VIS=$(jq -r '.answers.repo_visibility // "MISSING"' "$D3/intake-progress.json")
+  C_OK=1
+  [ "$C_HOST" = "bitbucket" ] || C_OK=0
+  [ "$C_VIS" = "public" ] || C_OK=0
+
+  if [ "$A_OK" -eq 1 ] && [ "$B_OK" -eq 1 ] && [ "$C_OK" -eq 1 ]; then
+    pass "T-bl204-prefill (remembered values are confirmed not re-asked; with neither source the original prompts + the free-tier note still run; the two halves prefill independently)"
+  else
+    fail_ "T-bl204-prefill" "A(ok=$A_OK host=$A_HOST vis=$A_VIS) B(ok=$B_OK host=$B_HOST vis=$B_VIS) C(ok=$C_OK host=$C_HOST vis=$C_VIS) — BL-204 finding 7"
+  fi
+  rm -rf "$D" "$D2" "$D3"
+fi
+
+echo ""
+echo "T-bl204-mutation: excising the marked prefill reads restores the blind double-ask"
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] T-bl204-mutation — jq unavailable"
+else
+  D=$(mktemp -d)
+  MARKS=$(grep -c '# BL-204-PREFILL-READ$' "$WIZARD" 2>/dev/null) || MARKS=0
+  sed '/# BL-204-PREFILL-READ$/d' "$WIZARD" > "$D/wizard.mut.sh"
+  LEFT=$(grep -c '# BL-204-PREFILL-READ$' "$D/wizard.mut.sh" 2>/dev/null) || LEFT=0
+  if [ "${MARKS:-0}" -lt 2 ]; then
+    fail_ "T-bl204-mutation" "expected a '# BL-204-PREFILL-READ' marker on BOTH prefill reads (host + visibility); found ${MARKS:-0}"
+  elif [ "${LEFT:-0}" -ne 0 ]; then
+    fail_ "T-bl204-mutation" "excision left $LEFT marker(s) — vacuous mutant"
+  elif ! bash -n "$D/wizard.mut.sh" 2>/dev/null; then
+    fail_ "T-bl204-mutation" "mutant has a syntax error — a broken mutant proves nothing (the marked lines need their : guard)"
+  else
+    mkdir -p "$D/emptyscripts"
+    cat > "$D/harness.sh" <<MHEOF
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$D/emptyscripts"
+PROGRESS_FILE="$D/intake-progress.json"
+MANIFEST_FILE="$D/manifest.json"
+_PAUSE_FILE="$D/.pause-sentinel"
+BOLD=''; NC=''; CYAN=''; GREEN=''; BLUE=''; YELLOW=''; RED=''
+print_info() { echo "\$1" >&2; }
+print_ok()   { echo "\$1" >&2; }
+print_warn() { echo "\$1" >&2; }
+print_fail() { echo "\$1" >&2; }
+print_step() { echo "\$1" >&2; }
+log_line()   { :; }
+save_section() { :; }
+MHEOF
+    for fn in prompt_input prompt_choice _request_pause check_pause_requested save_answer _bl204_explain_visibility run_section_1_repo_setup; do
+      awk -v fn="$fn" '
+        $0 ~ ("^" fn "\\(\\) \\{") { inside=1 }
+        inside { print; if ($0 == "}") { inside=0; print ""; exit } }
+      ' "$D/wizard.mut.sh" >> "$D/harness.sh"
+    done
+    echo 'run_section_1_repo_setup' >> "$D/harness.sh"
+    printf '{"host":"gitlab"}\n' > "$D/manifest.json"
+    printf '{"answers":{"repo_visibility":"public"}}\n' > "$D/intake-progress.json"
+    MUT_ERR=$(printf '1\n1\n' | bash "$D/harness.sh" 2>&1 >/dev/null)
+    MUT_HOST=$(jq -r '.answers.git_host // "MISSING"' "$D/intake-progress.json")
+    MUT_VIS=$(jq -r '.answers.repo_visibility // "MISSING"' "$D/intake-progress.json")
+    if [ "$MUT_HOST" = "github" ] && [ "$MUT_VIS" = "private" ]; then
+      pass "T-bl204-mutation (without the marked reads the wizard blind-asks again and overwrites gitlab/public with the menu's first option — the reads are load-bearing)"
+    else
+      fail_ "T-bl204-mutation" "mutant still honored the remembered values (host=$MUT_HOST vis=$MUT_VIS) — the mutation is not cutting the prefill path"
+    fi
+  fi
+  rm -rf "$D"
+fi
+
 echo ""
 echo "==============================="
 echo "Passed: $PASSED   Failed: $FAILED"


### PR DESCRIPTION
## What

BL-204 findings 5/6/7/8 + the jargon item (findings 1–4 deliberately untouched — they are the failure-path half of the entry). Five deliverables, each marker-fenced:

- `# BL-204-PROBE-AT-SELECT` — the CLI/credential probe fires the moment the host choice is settled (advisory, always rc=0; the pre-create `host_require_cli` stays decisive), and the wizard's backwards "will be verified again at init.sh" sentence now names `bash scripts/check-gate.sh --repair` truthfully.
- `# BL-204-VISIBILITY-EXPLAIN` — private-vs-public explained in plain language at choice time, including the free-tier cost (private + free personal GitHub = no branch protection, surfacing later as an attestation).
- `# BL-204-PREFILL` / `# BL-204-VISIBILITY-PERSIST` — host and visibility asked ONCE: init now persists the resolved visibility into `.claude/intake-progress.json::answers` (it previously threw it away), the wizard prefills and confirms instead of re-asking.
- `# BL-204-REMOTE-WHY` — one plain sentence: the remote is your backup; plus a `Your backup:` line in Next Steps.
- `# BL-204-ERROR-TRANSLATE` — new `scripts/lib/host-errors.sh`: SSO/SAML, rate-limit, expired auth, 403 → one plain sentence + one action above the raw output, wired into all three drivers' create/auth/protection failure paths, pass-through fallback, shipped downstream (and the ship line is now pinned — see below).

## Review record (pre-PR adversarial gate, two rounds)

- **Round 1: BLOCK**, three findings, all real: (1) the Bitbucket protection path was untranslated against the commit's own claim; (2) visibility ask-once was a NO-OP on the real flow — only the wizard ever wrote the key; fixtures hand-seeded it (fixture-masks-gap); (3) the `cp host-errors.sh` ship line was pinned by NOTHING — deleting it survived the entire test estate silently.
- **Fixes `eab37e4`+`24176b5`**, each watched-RED: Bitbucket arms wired — and the org-mode POSTs turned out to be bare `|| return 2` with NO stderr (fully silent org-protection failure, worse than the finding); the blind visibility re-ask was actively destructive (overwrote `public` with the menu's first option, and `check-gate.sh` reads the same key with a silent `private` default); ship-closure suite gained a third walk (driver-referenced libs × shipped set) with vacuity floor + extractor self-test, closing the class. An indecisive mutant (M22) exposed a defect in the new test itself — the stub never reached the org arms — fixed with payload dispatch + a kind-naming assertion.
- **Confirm round: approve.** Reviewer re-ran its surviving round-1 mutants (all now caught by name), probed the never-clobber contract with corrupt JSON, verified the chore-commit capture of the new file, and ran a fake-unshipped-lib class probe (caught). Six-for-six decisive.

## Evidence

error-translate 15/0 · intake-wizard-fixes 26/0 · ship-closure 7/0 · host-drivers run-all 11/0 · specs-plans quartet 8/0 · run-lints 13/13 — exit codes verified. 23 implementer mutants + 6 reviewer spot-checks decisive.

## Follow-ups named deliberately

- BL-204 findings 1–4 (repair/auth/collision/org-namespace failure paths) remain open on the entry — finding 4 (org-namespace creation) is the most IT-org-relevant residual.
- The post-merge closures pass records 5/6/7/8 + jargon as delivered on the entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)