### PR TITLE
fix(bug-008): shipped backlog lint denied every generated project's first AI commit

### DIFF
--- a/init.sh
+++ b/init.sh
@@ -1387,6 +1387,11 @@ create_project() {
   # copies; the guide describes exactly that) — shipping them activates the
   # documented path. tests/test-bl108-bl117-ship-closure.sh closes the class.
   cp "$SCRIPT_DIR/scripts/check-maintenance.sh" scripts/
+  # Shipped lints MUST behave on a generated tree (no backlog, no tests.yml,
+  # no tests/): see `## BUG-008:` in solo-orchestrator-bugs.md. In particular
+  # lint-tests-registered.sh and lint-no-live-remote-in-tests.sh exit 2 on a
+  # generated tree today — do NOT add them to this list without giving them
+  # the same shipped-tree arm lint-backlog-references.sh carries.
   cp "$SCRIPT_DIR/scripts/lint-backlog-references.sh" scripts/
   cp "$SCRIPT_DIR/scripts/lint-counter-antipattern.sh" scripts/
   cp "$SCRIPT_DIR/scripts/lint-review-manifest.sh" scripts/

--- a/scripts/lint-backlog-references.sh
+++ b/scripts/lint-backlog-references.sh
@@ -94,6 +94,11 @@
 #   structural on the backlog file, independent of git history. This is
 #   the contract scripts/pre-commit-gate.sh relies on when invoking the
 #   lint at commit time.
+#   If the backlog file does NOT exist, pre-commit mode exits 0 with no
+#   output instead of the FATAL below: init.sh ships this lint into
+#   generated projects, which have no backlog by design (BUG-008 — see
+#   `# BUG-008-SHIPPED-TREE-PASS`). Every other mode still treats a
+#   missing backlog as fatal.
 
 set -uo pipefail
 
@@ -150,10 +155,55 @@ if [ "$PRE_COMMIT_MODE" -eq 1 ] && [ -z "$PRE_COMMIT_MSG" ]; then
   PRE_COMMIT_MSG=$(cat)
 fi
 
+# ── BUG-008-SHIPPED-TREE-PASS-BEGIN ──────────────────────────────────
+# An ABSENT backlog means two opposite things depending on the mode, so
+# the existence check is mode-aware rather than unconditional.
+#
+#   --pre-commit-mode → NORMAL. init.sh ships this lint into every
+#     generated project (the `cp "$SCRIPT_DIR/scripts/
+#     lint-backlog-references.sh" scripts/` line, since 2026-07-17), and
+#     the shipped scripts/pre-commit-gate.sh `lints_check` pipes every
+#     AI-issued `git commit -m` message through it in this mode. A
+#     generated project has NO solo-orchestrator-backlog.md by design —
+#     that ledger is the framework repo's own. There is nothing on this
+#     tree to validate the message's BL tokens against, so the only
+#     correct verdict is "not this tree's concern": exit 0, and — on the
+#     gate's own flagless invocation — not one byte on either stream, so
+#     its `br_out=$(... 2>&1)` capture stays empty.
+#
+#     BUG-008: before this arm the FATAL below ran FIRST in every mode.
+#     That invocation exited 2, and lints_check turned the nonzero into
+#     a PreToolUse DENY offering SKIP_LINT=1 — a generated-project
+#     user's first plain `-m` commit was blocked outright. It went
+#     unseen through July because the dogfood walks committed via
+#     heredoc, which yields an empty extracted message that lints_check
+#     skips as the editor case.
+#
+#   any other mode → CATASTROPHE, unchanged. In the FRAMEWORK repo the
+#     backlog is the ledger this lint exists to police; CI's BASE..HEAD
+#     walk, the Closed/Resolved citation scan and the header-uniqueness
+#     arm all require the file. Passing silently there would convert the
+#     repo's own citation gate into a no-op, so the FATAL stays.
+#
+# --list still renders the verdict (house rule: a decisive judgement is
+# reviewable, never silent-on-pass). The gate never passes --list, so
+# this cannot put output back on the DENY-bearing path.
+#
+# Pinned by T21..T25 in tests/test-lint-backlog-references.sh and,
+# end-to-end at the surface that denied, by T12 in
+# tests/test-pre-commit-gate-lints.sh.
 if [ ! -f "$BACKLOG" ]; then
+  if [ "$PRE_COMMIT_MODE" -eq 1 ]; then
+    if [ "$LIST_MODE" -eq 1 ]; then
+      printf 'STATUS\tSOURCE\tTOKEN\tDETAIL\n'
+      printf 'PASS\tpre-commit\t-\tno backlog file at %s (generated project); nothing to validate against\n' "$BACKLOG"
+    fi
+    exit 0
+  fi
   echo "FATAL: backlog file not found at $BACKLOG" >&2
   exit 2
 fi
+# ── BUG-008-SHIPPED-TREE-PASS-END ────────────────────────────────────
 
 # ── Step 1: Build set of valid BL-IDs from backlog headers ─────────
 # Both the valid-set and lookup tokens are upper-cased so the lint is

--- a/solo-orchestrator-bugs.md
+++ b/solo-orchestrator-bugs.md
@@ -599,9 +599,12 @@ before the fix.
 `tests/test-pre-commit-gate-lints.sh`, `solo-orchestrator-bugs.md`.
 
 **Existing generated projects** carry the old copy at
-`scripts/lint-backlog-references.sh`. To remediate without waiting for a
-re-scaffold, copy the fixed framework file over it, or set `SKIP_LINT=1`
-for the affected commit (which is logged to `.claude/bypass-audit.json`).
+`scripts/lint-backlog-references.sh`. The supported remediation is
+`bash scripts/upgrade-project.sh --sync-framework` (its `_bl099_sync_scripts`
+pass re-copies the mechanically-derived shipped set, this lint included, from
+an updated framework clone). Without a framework update at hand: copy the
+fixed framework file over it, or set `SKIP_LINT=1` for the affected commit
+(which is logged to `.claude/bypass-audit.json`).
 
 ---
 

--- a/solo-orchestrator-bugs.md
+++ b/solo-orchestrator-bugs.md
@@ -479,6 +479,132 @@ it doesn't need structured JSON.
 
 ---
 
+## BUG-008: shipped `lint-backlog-references.sh` DENIES a generated project's first plain `-m` commit
+
+**Found:** 2026-08-02
+**Found while:** Auditing what the six lints `lints_check` invokes actually do on a GENERATED project tree (which, by design, has none of the framework's own ledger files)
+**Severity:** High (every generated project since 2026-07-17; blocks the AI's first `git commit -m "..."` outright, with only an emergency `SKIP_LINT=1` bypass offered)
+
+### Prompt to fix
+
+```
+Working in the solo-orchestrator repo.
+
+init.sh ships scripts/lint-backlog-references.sh into every generated
+project (the `cp "$SCRIPT_DIR/scripts/lint-backlog-references.sh" scripts/`
+line, added 2026-07-17 in commit 948d4d5), and the shipped
+scripts/pre-commit-gate.sh `lints_check` extracts the commit message from
+an AI-issued `git commit -m ...` and pipes it to that lint in
+--pre-commit-mode.
+
+A generated project has NO solo-orchestrator-backlog.md — that ledger is
+the framework repo's own. The lint's first act, before any mode-specific
+logic, is an existence check on it:
+
+  FATAL: backlog file not found at <project>/solo-orchestrator-backlog.md
+  (exit 2)
+
+Nonzero → `emit_lint_block` → a PreToolUse deny:
+
+  {"hookSpecificOutput": {"hookEventName": "PreToolUse",
+   "permissionDecision": "deny", "permissionDecisionReason":
+   "pre-commit gate: scripts/lint-backlog-references.sh failed.
+    FATAL: backlog file not found at .../solo-orchestrator-backlog.md
+    Add the missing BL entry, fix the typo, or add the citation/allowlist
+    marker. Run 'SKIP_LINT=1 git commit ...' to bypass in an emergency
+    (logged to .claude/bypass-audit.json)."}}
+
+Observed vs. expected: the deny text tells the operator to "add the
+missing BL entry" or "fix the typo" — but the message is blameless and
+the tree is correctly shaped. The real cause is a framework-repo
+precondition leaking into a shipped artifact. Expected: a generated
+project commits normally.
+
+Reproduce (no init.sh run needed):
+
+  mkdir -p /tmp/fakeproj/scripts
+  cp scripts/lint-backlog-references.sh /tmp/fakeproj/scripts/
+  printf '%s' "feat(auth): add login form" \
+    | bash /tmp/fakeproj/scripts/lint-backlog-references.sh --pre-commit-mode
+  # → FATAL ... ; exit 2
+
+Why it went unseen through July: the dogfood walks wrote commit messages
+via heredoc, and `lints_check` skips the lint entirely when the extracted
+message is empty ("editor case"). Only a plain `-m "..."` message reaches
+the lint.
+
+Please:
+1. Confirm the ship path and the gate path independently (grep the init.sh
+   cp line; read `lints_check` in scripts/pre-commit-gate.sh).
+2. Confirm the FATAL sits ahead of the pre-commit fast path.
+3. Audit the other five lints `lints_check` invokes for the same class
+   (fails on an absent framework artifact rather than on the project).
+4. Propose a fix — do NOT apply until I approve.
+```
+
+### Fix — implemented, pending merge
+
+Branch `fix/shipped-backlog-lint-denies-generated-commits`. **Not yet
+merged**; this entry flips to `**Status:** Fixed.` with a PR # / commit
+SHA citation at merge, per the convention the entries above follow.
+
+**Shape.** The existence check in `scripts/lint-backlog-references.sh` is
+now mode-aware — see the `# BUG-008-SHIPPED-TREE-PASS` fence:
+
+- `--pre-commit-mode` + absent backlog → **exit 0, zero bytes on both
+  streams**. There is no ledger on that tree to validate the message's
+  `BL-NNN` tokens against, so the verdict is "not this tree's concern".
+  Byte-silence keeps the gate's `br_out=$(... 2>&1)` capture empty.
+  `--list` still renders the verdict as a PASS row (the gate never passes
+  `--list`, so the deny-bearing path stays silent).
+- **every other mode → the FATAL and exit 2 are unchanged.** In the
+  framework repo a missing backlog is a genuine catastrophe: the
+  `BASE..HEAD` walk, the Closed/Resolved citation scan and the
+  header-uniqueness arm all depend on the file, and passing silently
+  there would turn the repo's own citation gate into a no-op.
+
+**Sibling audit (the other five lints `lints_check` runs).** Probed on a
+backlog-less, `tests/`-less, `init.sh`-less fixture:
+
+| lint | shipped by init.sh? | on a generated tree | verdict |
+| --- | --- | --- | --- |
+| `lint-counter-antipattern.sh` | yes | exit 0 (`OK: no counter-capture antipatterns found.`) | safe — every target glob is `[ -e ]`-guarded, so absent dirs are skipped |
+| `lint-fix-functions-stderr.sh` | no | exit 0 if present | safe (and unreachable) |
+| `lint-raw-read-prompt.sh` | no | exit 0 if present | safe (and unreachable) |
+| `lint-tests-registered.sh` | no | exit 2 — `cannot read the tests.yml unit list … refusing to claim a clean pass` | same class, but **unreachable**: not shipped, so `lints_check` finds no copy and skips the block |
+| `lint-no-live-remote-in-tests.sh` | no | exit 2 — `scan dir not found: <proj>/tests` | same class, but **unreachable**, same reason |
+
+No sibling has a *reachable* instance of the defect, so nothing else was
+changed. The two latent ones are recorded here because they are one `cp`
+line away from becoming real: **anyone adding `lint-tests-registered.sh`
+or `lint-no-live-remote-in-tests.sh` to init.sh's copy list must first
+give them the same generated-tree arm.** (`lints_check` resolves each
+lint as `$PROJECT_ROOT/scripts/<lint>` then `$SCRIPT_DIR/<lint>`; in a
+generated project both resolve inside the project's own `scripts/`,
+because the hook is wired as `bash "$CLAUDE_PROJECT_DIR"/scripts/pre-commit-gate.sh`.)
+
+The `--terminal-mode` surface is not affected: it deliberately stopped
+feeding a message to this lint when the stale-`COMMIT_EDITMSG` defect was
+fixed (`# BL-119-NO-MSG-AT-PRECOMMIT` in `scripts/pre-commit-gate.sh`).
+
+**Tests.** `tests/test-lint-backlog-references.sh` T21–T25 (silent pass
+for a plain message and for a `BL`-bearing one; repo-mode FATAL
+regression guard; present-backlog negative control; `--list` row) and
+`tests/test-pre-commit-gate-lints.sh` T12 (end-to-end: a shipped-layout
+fixture is no longer denied). T21/T22 and T12 were RED with the FATAL
+before the fix.
+
+**Files touched:** `scripts/lint-backlog-references.sh`,
+`tests/test-lint-backlog-references.sh`,
+`tests/test-pre-commit-gate-lints.sh`, `solo-orchestrator-bugs.md`.
+
+**Existing generated projects** carry the old copy at
+`scripts/lint-backlog-references.sh`. To remediate without waiting for a
+re-scaffold, copy the fixed framework file over it, or set `SKIP_LINT=1`
+for the affected commit (which is logged to `.claude/bypass-audit.json`).
+
+---
+
 ## Template for new entries
 
 When adding a new bug, copy this block and fill it in:

--- a/solo-orchestrator-followups.md
+++ b/solo-orchestrator-followups.md
@@ -16,6 +16,25 @@ Grammar: `## F-NNN:` header, **Raised**, **Status** (`Awaiting decision` |
 
 ---
 
+## F-013: Two pre-existing edge defects in lint-backlog-references.sh
+
+**Raised:** 2026-08-02 (BUG-008 review edge sweep — both confirmed byte-identical
+on main, i.e. NOT introduced by the fix). **Status:** Awaiting decision.
+
+(1) A backlog that exists but has zero `## BL-NNN:` headers (e.g. zero-byte) +
+`--pre-commit-mode` + a BL-citing message crashes (`VALID_IDS[@]: unbound
+variable`, bash-3.2 set -u empty-array expansion in `is_valid_id`, rc=1 → the
+gate denies with a shell error as the reason). Fail-closed, reachable only if a
+generated project creates its own backlog file. Fix: an empty-set guard at the
+head of `is_valid_id`. (2) An UNREADABLE (chmod 000) backlog in repo mode
+passes silently — `[ -f ]` passes and the awk/grep captures are not
+status-checked, so an I/O error prints `OK … consistent.` rc=0: a repo-mode
+silent-pass of exactly the class the FATAL guards against. Fix: `[ -r ]`
+beside the existence check, same mode-aware shape.
+
+**Options:** (a) small follow-up PR with both guards + tests; (b) accept —
+both are edge-reachable only.
+
 ## F-001: Suppression-grammar drift has no canary (BL-201 × BL-185 coupling)
 
 **Raised:** 2026-08-01, post-quick-sweep confidence review.

--- a/tests/test-lint-backlog-references.sh
+++ b/tests/test-lint-backlog-references.sh
@@ -641,6 +641,159 @@ fi
 teardown
 
 # ════════════════════════════════════════════════════════════════════
+# BUG-008 — SHIPPED-TREE PASS (`# BUG-008-SHIPPED-TREE-PASS` in the lint)
+#
+# init.sh ships THIS lint into every generated project (the
+# `cp "$SCRIPT_DIR/scripts/lint-backlog-references.sh" scripts/` line,
+# shipped 2026-07-17), and the shipped scripts/pre-commit-gate.sh
+# `lints_check` pipes every AI-issued `git commit -m` message through it
+# in --pre-commit-mode. A generated project has NO
+# solo-orchestrator-backlog.md — by design; that ledger is the framework
+# repo's own. Before BUG-008 the FATAL ran first in every mode, so that
+# invocation exited 2 and the PreToolUse hook converted the nonzero into
+# a DENY: the user's first plain `-m` commit was blocked outright.
+#
+# T21..T24 pin the split. T21/T22 are the defect itself (both were RED
+# with `FATAL: backlog file not found` + rc=2 before the fix). T23 is
+# the regression guard for the framework repo — repo mode MUST still
+# treat an absent backlog as fatal. T24 is the negative control: with a
+# backlog PRESENT, pre-commit mode behaves exactly as before.
+# T25 pins the --list rendering of the new verdict (house rule: a
+# decisive judgement is reviewable, never silent-on-pass) — and, by
+# construction, that the gate's own flagless invocation stays byte-silent.
+#
+# setup_no_backlog() is the shipped-project shape: a git repo with the
+# lint at scripts/ and NO backlog file anywhere.
+# ════════════════════════════════════════════════════════════════════
+setup_no_backlog() {
+  TMP=$(mktemp -d)
+  PROJ="$TMP/repo"
+  mkdir -p "$PROJ/scripts"
+  cp "$LINTER" "$PROJ/scripts/lint-backlog-references.sh"
+  chmod +x "$PROJ/scripts/lint-backlog-references.sh"
+
+  (
+    cd "$PROJ"
+    git init -q -b main
+    git config user.email "test@example.com"
+    git config user.name "Test"
+    printf '# generated project\n' > README.md
+    git add README.md
+    git commit -q -m "chore: seed"
+    git branch base
+  )
+}
+
+# Run the fixture-local lint EXACTLY as pre-commit-gate.sh's lints_check
+# does — message on stdin, --pre-commit-mode, no other flags — capturing
+# stdout and stderr to SEPARATE files so a zero-byte assertion is real.
+# Sets: PCM_RC, PCM_OUT_BYTES, PCM_ERR_BYTES, PCM_COMBINED.
+run_pre_commit_streams() {
+  local msg="$1"
+  local outf="$TMP/pcm.out" errf="$TMP/pcm.err"
+  PCM_RC=0
+  ( cd "$PROJ" && printf '%s' "$msg" \
+      | bash scripts/lint-backlog-references.sh --pre-commit-mode ) \
+    > "$outf" 2> "$errf" || PCM_RC=$?
+  PCM_OUT_BYTES=$(wc -c < "$outf" | tr -d '[:space:]')
+  PCM_ERR_BYTES=$(wc -c < "$errf" | tr -d '[:space:]')
+  PCM_COMBINED=$(cat "$outf" "$errf")
+}
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T21: BUG-008 — pre-commit-mode + ABSENT backlog + plain feat: message → exit 0, zero bytes ==="
+# ════════════════════════════════════════════════════════════════════
+setup_no_backlog
+run_pre_commit_streams "feat(auth): add login form"
+if [ "$PCM_RC" -eq 0 ] \
+   && [ "$PCM_OUT_BYTES" = "0" ] \
+   && [ "$PCM_ERR_BYTES" = "0" ]; then
+  pass "T21: shipped tree with no backlog passes silently in pre-commit mode"
+else
+  fail_ "T21" "expected rc=0 and 0 bytes on both streams; rc=$PCM_RC stdout=${PCM_OUT_BYTES}B stderr=${PCM_ERR_BYTES}B; output:\n$PCM_COMBINED"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T22: BUG-008 — pre-commit-mode + ABSENT backlog + message citing BL-123 → exit 0, zero bytes ==="
+# ════════════════════════════════════════════════════════════════════
+# A BL token in the message is NOT a violation here: with no ledger on
+# this tree there is nothing to validate the token against, so the
+# unknown-reference verdict would be an artefact of the tree shape, not
+# of the message. Same silent pass as T21.
+setup_no_backlog
+run_pre_commit_streams "fix(api): correct pagination (BL-123)"
+if [ "$PCM_RC" -eq 0 ] \
+   && [ "$PCM_OUT_BYTES" = "0" ] \
+   && [ "$PCM_ERR_BYTES" = "0" ]; then
+  pass "T22: BL token in the message does not resurrect the failure on a backlog-less tree"
+else
+  fail_ "T22" "expected rc=0 and 0 bytes on both streams; rc=$PCM_RC stdout=${PCM_OUT_BYTES}B stderr=${PCM_ERR_BYTES}B; output:\n$PCM_COMBINED"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T23: BUG-008 regression guard — REPO mode + ABSENT backlog → FATAL, exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+# The framework repo's own backlog going missing is a catastrophe, not a
+# shipped-tree fact: CI, --list and the BASE..HEAD walk all require the
+# file. Passing silently there would turn the citation gate into a no-op.
+setup_no_backlog
+out=$( cd "$PROJ" && bash scripts/lint-backlog-references.sh --base base 2>&1 ); rc=$?
+if [ $rc -eq 2 ] && echo "$out" | grep -q "FATAL: backlog file not found"; then
+  pass "T23: repo mode still treats a missing backlog as fatal (exit 2)"
+else
+  fail_ "T23" "expected exit 2 + FATAL diagnostic; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T24: BUG-008 negative control — pre-commit-mode + PRESENT backlog is unchanged ==="
+# ════════════════════════════════════════════════════════════════════
+# The new arm must be reachable ONLY when the file is absent. With a
+# backlog present, pre-commit mode keeps both of its verdicts: a valid
+# reference passes, a bogus one still fails with the same diagnostic.
+setup
+write_backlog '## BL-031: real entry
+**Status:** Resolved (2026-01-01, PR #1)
+Body.
+'
+good_out=$( cd "$PROJ" && bash scripts/lint-backlog-references.sh --pre-commit-mode \
+        --message "feat(init): host-agnostic flow (BL-031)" 2>&1 ); good_rc=$?
+bad_out=$( cd "$PROJ" && bash scripts/lint-backlog-references.sh --pre-commit-mode \
+        --message "fix: typo (BL-999)" 2>&1 ); bad_rc=$?
+if [ $good_rc -eq 0 ] \
+   && [ $bad_rc -eq 1 ] \
+   && echo "$bad_out" | grep -q "unknown BL reference 'BL-999' in prospective commit message"; then
+  pass "T24: with a backlog present, pre-commit mode still passes valid and rejects unknown refs"
+else
+  fail_ "T24" "expected valid rc=0 and unknown rc=1 + diagnostic; good_rc=$good_rc bad_rc=$bad_rc; good:\n$good_out\nbad:\n$bad_out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T25: BUG-008 — --list renders the shipped-tree verdict (not silent-on-pass) ==="
+# ════════════════════════════════════════════════════════════════════
+# The gate never passes --list, so T21/T22's byte-silence is what the
+# DENY-bearing path sees. A reviewer auditing by hand still gets a row.
+setup_no_backlog
+out=$( cd "$PROJ" && printf '%s' "feat: thing" \
+        | bash scripts/lint-backlog-references.sh --pre-commit-mode --list 2>&1 ); rc=$?
+if [ $rc -eq 0 ] \
+   && echo "$out" | grep -q "STATUS" \
+   && echo "$out" | grep -q "no backlog file"; then
+  pass "T25: --list renders the absent-backlog PASS row"
+else
+  fail_ "T25" "expected exit 0 + a rendered absent-backlog row; rc=$rc; output:\n$out"
+fi
+teardown
+
+# ════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== T9: MERGE GATE — run linter against current repo HEAD vs origin/main → exit 0 ==="
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-pre-commit-gate-lints.sh
+++ b/tests/test-pre-commit-gate-lints.sh
@@ -387,6 +387,39 @@ else
 fi
 teardown
 
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T12: BUG-008 — a GENERATED project (no backlog) is not DENIED its first plain -m commit ==="
+# ════════════════════════════════════════════════════════════════════
+# End-to-end reproduction of BUG-008 at the surface that actually
+# denied: PreToolUse. The fixture is reshaped to the SHIPPED layout —
+# init.sh copies only lint-backlog-references.sh and
+# lint-counter-antipattern.sh into a generated project (the other four
+# lints lints_check knows about are framework-only, so their blocks
+# no-op), and a generated project has no solo-orchestrator-backlog.md
+# at all. Before the `# BUG-008-SHIPPED-TREE-PASS` arm the lint's FATAL
+# ran first in every mode, exited 2, and lints_check turned that into a
+# deny offering SKIP_LINT=1 — on a plain, blameless `-m` message.
+#
+# The message deliberately carries NO BL token: that is the generated-
+# project user's normal commit, and it is what the July dogfood walks
+# never exercised (their heredoc habit produced an empty extracted
+# message, which lints_check skips as the editor case).
+setup
+rm -f "$PROJ/solo-orchestrator-backlog.md"
+rm -f "$PROJ/scripts/lint-fix-functions-stderr.sh" \
+      "$PROJ/scripts/lint-raw-read-prompt.sh"
+stage_file "README.md" "# my generated project"
+out=$(run_hook 'git commit -m "docs: describe the project"')
+body="${out#*|}"
+if [[ "$body" != *'"permissionDecision": "deny"'* ]] && \
+   [[ "$body" != *"backlog file not found"* ]]; then
+  pass "T12: backlog-less generated project commits without a lint DENY"
+else
+  fail_ "T12" "expected no deny on a backlog-less generated project; got: $out"
+fi
+teardown
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

**BUG-008 (High):** every project generated since 2026-07-17 (`948d4d5` shipped the lint) carries `scripts/lint-backlog-references.sh`, whose FIRST act on a backlog-less tree was `FATAL … exit 2` — and the shipped gate's `lints_check` converts that to a PreToolUse **deny** on every AI `git commit` with a parseable `-m` message, offering the logged `SKIP_LINT=1` escape. July's dogfood walks escaped only via the heredoc commit-message habit ("editor case; skip"); the live naive-user walk surfaced the class.

Fix (`# BUG-008-SHIPPED-TREE-PASS-BEGIN/-END`): mode-aware existence check — `--pre-commit-mode` + absent backlog = exit 0 with zero bytes on both streams (a generated project has no ledger to validate by design); every other mode keeps FATAL exit 2 verbatim; `--list` renders a PASS row (house "decisive judgement must be renderable" rule — the gate never passes `--list`, so the deny path stays byte-silent, mutation-pinned).

Plus the **five-sibling audit** (required by the plan): counter-antipattern safe (guarded globs); fix-functions-stderr / raw-read-prompt safe and unshipped; tests-registered and no-live-remote **same class but unreachable** (not in init's five-lint cp set — verified by execution, both exit 2 on a generated tree). The standing constraint now lives at the cp decision site in init.sh, not only in the frozen bugs ledger.

## Review record (pre-PR adversarial gate)

**approve — zero refuted claims, eleven failed refutation attempts**, including: independent end-to-end reproduction of the deny on a true shipped-topology fixture (and the allow post-fix); both TDD mutation directions re-run plus two novel reviewer mutations (mode-key inversion; a single stderr byte in the pass arm) — all killed by PR-blocking-lane suites; edge sweep (directory-as-backlog, `--list` combinations); execution verification of every sibling-audit row and the five-line ship list. Four minors, none blocking: two placement improvements applied post-review (`--sync-framework` named as the supported remediation; the init.sh guard comment), and two PRE-EXISTING edge defects (empty-backlog unbound-variable crash; unreadable-backlog silent pass) confirmed byte-identical on main and filed as F-013.

## Evidence

lint suite 27/0 · gate-lints suite 14/0 · run-lints 13/13 · repo-mode lint green in this repo · no new test files (both suites pre-registered in the unit lane). Commits split source/docs throughout.

BUG-008 flips to Fixed with this PR's number at merge, per the ledger's convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)