### PR TITLE
fix: walk findings — day-one red CI, the opaque release failure, and the toothless gate in 7 templates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -356,6 +356,7 @@ jobs:
             tests/test-bl147-ci-template-integrity.sh
             tests/test-bl089-doc-foundations.sh
             tests/test-bl137-ci-tools-scope.sh
+            tests/test-walk006-ci-protection-scope.sh
             tests/test-bl138-approval-window.sh
             tests/test-bl170-approval-append-design.sh
             tests/test-bl166-gate-scope.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -373,6 +373,7 @@ jobs:
             tests/test-check-changelog-filter.sh
             tests/test-check-commit-message.sh
             tests/test-check-gate.sh
+            tests/test-walk016-release-env-policy.sh
             tests/test-check-phase-gate-argv-parser.sh
             tests/test-check-phase-gate-backstop-attestation.sh
             tests/test-check-phase-gate-blame-walker.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -430,6 +430,7 @@ jobs:
             tests/test-session-test-gate-check-merge.sh
             tests/test-specs-plans-host-aware-quartet.sh
             tests/test-specs-plans-remaining-quartet.sh
+            tests/test-walk003-update-command-render.sh
             tests/test-test-gate-counter-sanitizer.sh
             tests/test-test-gate-null-handling.sh
             tests/test-tier-crosscheck-6-followup-atomicity-and-jq.sh

--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -1026,7 +1026,14 @@ This is enforced by `init.sh` via the selected host driver and verified by `scri
 scripts/check-gate.sh --setup-ci-token
 ```
 
-It explains what the token is for, walks you through a **least-privilege fine-grained PAT** (Repository access: this repo only; Repository permissions → **Administration: Read-only** — that one permission is the whole requirement, no write anywhere), **verifies the token can actually read protection before storing anything** (a stored-but-powerless token would turn today's honest WARN into a hard FAIL), stores it as the Actions secret `SOIF_PROTECTION_TOKEN` with the value on stdin rather than argv, and confirms your workflow reads it. The generated `ci.yml` already maps it into the phase-gate step (`GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}`), so the next push enforces. An unset secret evaluates to the empty string, which the gate reads as "no credential" — exactly today's warning.
+It explains what the token is for, walks you through a **least-privilege fine-grained PAT** (Repository access: this repo only; Repository permissions → **Administration: Read-only** — that one permission is the whole requirement, no write anywhere), **verifies the token can actually read protection before storing anything** (a stored-but-powerless token would turn today's honest WARN into a hard FAIL), stores it as the Actions secret `SOIF_PROTECTION_TOKEN` with the value on stdin rather than argv, and then checks your workflow against **both** conditions that enforcement depends on. An unset secret evaluates to the empty string, which the gate reads as "no credential" — exactly today's warning.
+
+Enforcement needs two things, and the command reports on each rather than assuming them:
+
+1. **The workflow maps the secret** into the phase-gate step (`GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}`). The generated `ci.yml` does.
+2. **The gate's exit code decides that step.** Until 2026-08-02, seven of the ten generated GitHub workflows ran the gate as `bash scripts/check-phase-gate.sh 2>/dev/null || echo "…skipping"`, which throws the verdict away — the gate could print `[FAIL]` and exit 1 while the step graded green (and the "not found" message was a lie: the script *was* found, its verdict failed). All ten now use the strict shape. **If you scaffolded before that date, `--setup-ci-token` will detect the swallowing `run:` line and print the replacement** — a token cannot enforce anything through a discarded exit code.
+
+When both hold, the next push enforces.
 
 Non-interactive: `SOIF_PROTECTION_TOKEN=<token> scripts/check-gate.sh --setup-ci-token`. GitLab and Bitbucket need **both** a token variable **and** the host CLI installed in the governance job (`glab` / `curl`); the same command prints those steps for those hosts. Local runs are unaffected throughout — the gate has always blocked on the dev workstation and still does.
 

--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -1757,6 +1757,18 @@ Artifacts marked "No" in the Gate-Checked column are included in the snapshot fo
 
 **Evaluation prompts:** Run the Security Review (`evaluation-prompts/Projects/bases/03-security.md`) and Red Team Review (`evaluation-prompts/Projects/bases/06-red-team-review.md`) evaluation prompts (or the full six-reviewer suite via `evaluation-prompts/Projects/run-reviews.sh`, which writes `docs/eval-results/review-manifest.json`). Results should be archived to `docs/eval-results/`.
 
+> **Two supported routes — pick by who is running it.** Bare `run-reviews.sh <module>` launches six nested `claude -p` CLI sessions and assumes an **interactive shell that owns the terminal**. If the caller is **already an agent** (a Claude Code session, a subagent, any headless runner), use the compose route instead — it is a first-class alternative, not a fallback, and it is what the 2026-08-02 walk used for all six reviewers (ISSUE-014):
+>
+> ```bash
+> run-reviews.sh <module> --compose-only        # writes docs/eval-results/prompts/*.md, starts nothing
+> # run each prompt on the surface you already have — one subagent per reviewer, in parallel —
+> # and save each output at the artifact filename its prompt demands
+> run-reviews.sh <module> --assemble-manifest   # builds the manifest from the artifacts on disk
+> bash scripts/lint-review-manifest.sh docs/eval-results/review-manifest.json
+> ```
+>
+> Never hand-write `review-manifest.json`: `--assemble-manifest` derives it from the files that actually exist, which is what keeps the Phase 3 → 4 gate's verdict honest. Full details: `evaluation-prompts/Projects/README.md` § Usage.
+
 **Track-specific enforcement (BL-073):** the Security and Red Team reviews are a **hard Phase 3 → 4 gate** for `track=standard` and `track=full` — `scripts/check-phase-gate.sh` reads the review manifest and **FAILs the gate** if either the Security or Red Team review is missing or not `complete`. Full Track additionally requires all six reviewers (the other four WARN but still block). `track=light` / personal projects are WARN-only (POC preserved) and the bypass is logged; enforcement flips to FAIL if the project is later upgraded to `standard`/`full`. Pre-existing projects (created before this enforcement shipped, keyed on `phase-state.json::review_gate_enforced`) are grandfathered — WARN-only, never retroactively blocked. To ship an enforced project with a documented reviewer gap, attest with `SOLO_REVIEWERS_ATTESTED=1 SOLO_REVIEWERS_ATTESTED_REASON="<reason>"` (recorded to `.claude/process-state.json::phase3.attestations.reviewers`). See the Phase 3 → 4 gate checklist above for the full contract.
 
 ---

--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -1016,6 +1016,16 @@ Interactively (no flag), init prompts and defaults to **do not proceed** (treat 
 
 This is enforced by `init.sh` via the selected host driver and verified by `scripts/check-phase-gate.sh` at every Phase 1→2 check. Drift detection is automatic — if protection is loosened later, the gate blocks until `scripts/check-gate.sh --repair` restores it.
 
+**In CI, that same check WARNs instead of enforcing until you give it a token — please clear it (walk ISSUE-006).** Verifying branch protection is an authenticated API read, and a workflow runner holds no credential for it: GitHub Actions puts no token in a step's environment, and the built-in `secrets.GITHUB_TOKEN` **cannot** read branch protection at all (the workflow `permissions:` block has no `administration` key). Rather than fail a check that is structurally impossible there, the gate prints a loud `[WARN] … COULD NOT RUN` — honest, but not enforcement, and a warning nobody clears becomes a check nobody reads. One guided command sets up the real thing:
+
+```bash
+scripts/check-gate.sh --setup-ci-token
+```
+
+It explains what the token is for, walks you through a **least-privilege fine-grained PAT** (Repository access: this repo only; Repository permissions → **Administration: Read-only** — that one permission is the whole requirement, no write anywhere), **verifies the token can actually read protection before storing anything** (a stored-but-powerless token would turn today's honest WARN into a hard FAIL), stores it as the Actions secret `SOIF_PROTECTION_TOKEN` with the value on stdin rather than argv, and confirms your workflow reads it. The generated `ci.yml` already maps it into the phase-gate step (`GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}`), so the next push enforces. An unset secret evaluates to the empty string, which the gate reads as "no credential" — exactly today's warning.
+
+Non-interactive: `SOIF_PROTECTION_TOKEN=<token> scripts/check-gate.sh --setup-ci-token`. GitLab and Bitbucket need **both** a token variable **and** the host CLI installed in the governance job (`glab` / `curl`); the same command prints those steps for those hosts. Local runs are unaffected throughout — the gate has always blocked on the dev workstation and still does.
+
 **Existing projects that predate this gate:**  The first time you upgrade or cross Phase 1→2, you may need to backfill manifest + protection:
 
 ```bash

--- a/docs/platform-modules/web.md
+++ b/docs/platform-modules/web.md
@@ -259,6 +259,46 @@ So the receipt asserts five things, enforced in five different places: the filte
 
 **Database backup:** Configure daily automated backups. Test restoration.
 
+### 5.1a Releasing — tag deploys and deployment environments
+
+`.github/workflows/release.yml` is **tag-triggered** (`on: push: tags: ['v*']`),
+and the framework's documented release action is `git tag v1.0.0 && git push --tags`.
+
+**The trap (walk ISSUE-016).** If your deploy step targets a GitHub deployment
+**environment** — `environment: github-pages` on the job, which is what every
+GitHub Pages workflow uses — the environment's **deployment branch policy**
+decides whether a *tag* may deploy at all. Enabling Pages **auto-creates** a
+`github-pages` environment whose default policy admits **the default branch
+only**. A tag-triggered run is then rejected by the environment's protection
+rules **before any step executes**: the run fails at job setup with an **empty
+step list** and no readable error in `gh run view`. Nothing in the workflow can
+catch this — a rejected run never starts a job, so an in-workflow preflight step
+is unreachable by construction.
+
+**Check it before you tag** (dry run reports; exit 1 means tag deploys would be
+rejected):
+
+```bash
+scripts/check-gate.sh --release-env-policy          # report
+scripts/check-gate.sh --release-env-policy --fix    # apply
+```
+
+**The one-line manual equivalent** — admit the release tag pattern:
+
+```bash
+gh api -X POST repos/OWNER/REPO/environments/github-pages/deployment-branch-policies \
+  -f name='v*' -f type='tag'
+```
+
+Then re-run the failed workflow. If the environment is set to *protected
+branches only*, switch it to custom policies first (the check prints the exact
+`gh api -X PUT` for that case). Non-default environment names and tag patterns:
+`--env <name>` and `--tag-pattern <glob>`.
+
+This is GitHub-specific. GitLab protected environments and Bitbucket deployment
+permissions are opt-in and are not auto-created, so the check reports
+NOT APPLICABLE (exit 0) on those hosts.
+
 ### 5.2 Go-Live Checklist (Web-Specific)
 
 In addition to the Builder's Guide Phase 4.2:

--- a/docs/security-scan-guide.md
+++ b/docs/security-scan-guide.md
@@ -174,6 +174,22 @@ window.addEventListener('message', (event) => {
 
 ## Snyk — 5 Most Common Findings
 
+### Authenticating Snyk (and what to do when you cannot)
+
+Snyk needs a token before it will scan. `snyk auth` opens a **browser OAuth flow**, so an autonomous agent session cannot complete it — the framework's setup instructions say "`snyk auth`, one-time per machine" and stop there, which leaves an agent with no path (walk 2026-08-02, ISSUE-002). Three options, in order of preference:
+
+1. **A human runs `snyk auth` once** on the machine. This is the normal path; do it at setup, not at the Phase 3 gate.
+2. **Supply a token non-interactively** — set `SNYK_TOKEN` in the environment (the CI convention), or `snyk config set api=<token>`. The Phase 3 scanner detects either form (`SNYK_TOKEN`, or a stored token via `snyk config get api`) and never triggers the interactive flow.
+3. **Attest the skip.** If neither is available, the scanner does **not** silently pass: it records an *unauthenticated* SKIP that BLOCKS the Phase 3 → 4 gate until you sign for it. That is the supported agent path — an honest, on-the-record skip:
+
+   ```bash
+   bash scripts/run-phase3-validation.sh --attest snyk \
+     --reason "snyk auth requires a browser OAuth flow this session cannot complete; no SNYK_TOKEN provisioned" \
+     --signoff "<who>"
+   ```
+
+   The attestation lands in `.claude/phase-state.json::phase3.attestations.snyk` and the summary reports `SKIP(attested)` — visible to every later reviewer. Attesting is not a way to make the finding go away; it is a way to say *who* decided to ship without this scan.
+
 ### 1. Prototype Pollution (lodash, minimist, qs, or similar)
 
 **What it means:** A dependency has a vulnerability where an attacker can inject properties into JavaScript object prototypes, potentially causing unexpected behavior or security bypasses.

--- a/docs/uat-authoring-guide.md
+++ b/docs/uat-authoring-guide.md
@@ -2,6 +2,12 @@
 
 Reference for generating usable UAT test scenarios in solo-orchestrator projects. Complements the embedded comments in `templates/uat/test-session-template.html` — read both together when filling out a UAT session.
 
+## 0. Before you fill anything in: the placeholder manifest
+
+The template's **first HTML comment** is an `AGENT: PLACEHOLDER MANIFEST` block listing **all seven** `__TOKEN__` placeholders and where each one lives. Work that list — it is the only complete enumeration.
+
+Six of the seven are announced by a block comment sitting next to the markup they fill. The seventh, `__FEATURE_OPTIONS__`, is **mid-file inside the `addBug()` JavaScript function** (it supplies the `<option>` list for the bug form's Feature select), and it is the one authors miss (walk 2026-08-02 ISSUE-008). `scripts/lint-uat-scenarios.sh` does catch a survivor — but it reports a line number in **your populated output file**, and the edit belongs at a different place in the **template**, so the linter's line number does not lead you to the fix. Use the manifest to prevent the miss; use the linter to confirm you did.
+
 ## 1. Why UAT quality matters
 
 UAT scenarios that are schema-valid but operationally broken waste real human time. On the lancache project's first UAT session (2026-04-22), an AI agent generated scenarios that passed the template schema but failed as tester instructions: no system context, implicit working directory, cross-scenario dependencies, vague pass/fail criteria, non-deterministic expected output, informal cleanup, unmarked optional dependencies. The Orchestrator's feedback: *"The tests are not stating what system this is done on, it doesn't walk through the tests step by step and makes assumption the tester knows where everything is."* The rewrite recovered usability but cost substantial Orchestrator time. This guide codifies the rewrite recipe so every future project inherits the floor.

--- a/evaluation-prompts/Projects/README.md
+++ b/evaluation-prompts/Projects/README.md
@@ -63,6 +63,41 @@ cd /path/to/your-project
 /path/to/evaluation-prompts/Projects/run-reviews.sh web-app
 ```
 
+### Run all 6 reviews from inside an agent session (`--compose-only`)
+
+**Use this route whenever the caller is already an agent** — a Claude Code
+session, a subagent, or any headless runner. The command above launches nested
+`claude -p` CLI instances, which assumes an interactive shell that owns the
+terminal; from inside an agent session those nested headless sessions are
+fragile (auth/session reuse, no TTY, spend limits) and a single mid-run failure
+loses the whole suite. `--compose-only` is a first-class alternative, not a
+fallback: same prompts, same provenance headers, same manifest contract.
+
+```bash
+cd /path/to/your-project
+
+# 1. Emit all six prompts. No sessions started; `claude` need not be installed.
+/path/to/evaluation-prompts/Projects/run-reviews.sh web-app --compose-only
+#    -> docs/eval-results/prompts/{engineer,cio,security,legal,techuser,redteam}-prompt.md
+
+# 2. Run each prompt on whatever surface you already have — one subagent per
+#    reviewer is the natural shape, and they are independent, so dispatch them
+#    in parallel. Save each output at the artifact filename its prompt demands
+#    (see the Output table below).
+
+# 3. Build + validate the manifest from the artifacts on disk.
+/path/to/evaluation-prompts/Projects/run-reviews.sh web-app --assemble-manifest
+bash scripts/lint-review-manifest.sh docs/eval-results/review-manifest.json
+```
+
+Step 3 writes `docs/eval-results/review-manifest.json` — the artifact the
+Phase 3 → 4 gate reads (`scripts/check-phase-gate.sh`). Do not hand-write it;
+`--assemble-manifest` derives it from the files that actually exist, which is
+what makes the gate's verdict honest.
+
+Walk 2026-08-02 (ISSUE-014) ran exactly this route for all six reviewers and it
+is what produced the walk's highest-value finding.
+
 ### Run specific reviewers
 
 ```bash

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -63,10 +63,11 @@ Subcommands:
                     can actually read protection before storing anything, sets
                     it as the Actions secret SOIF_PROTECTION_TOKEN, and confirms
                     the workflow reads it. GitHub-only.
-                      --secret-name <n>  secret name (default SOIF_PROTECTION_TOKEN)
-                      --token-env <VAR>  read the token from $VAR instead of
-                                         prompting (scriptable opt-in)
-                      --skip-verify      store without the read-protection probe
+                      --secret-name <name>  secret name
+                                            (default SOIF_PROTECTION_TOKEN)
+                      --token-env <VAR>     read the token from $VAR instead of
+                                            prompting (scriptable opt-in)
+                      --skip-verify         store without the read-protection probe
   --release-env-policy
                     Check that the release deployment ENVIRONMENT admits
                     tag deploys before you push a version tag (walk
@@ -79,7 +80,13 @@ Subcommands:
                       --fix                 apply the policy instead of
                                             just reporting it
                       --env <name>          environment (default github-pages)
-                      --tag-pattern <glob>  tag pattern (default v*)
+                      --tag-pattern <glob>  the tag class your release must be
+                                            able to deploy (default v*). An
+                                            existing policy SATISFIES it when the
+                                            policy, read as a glob, matches this
+                                            value — so a `v*` policy satisfies
+                                            both `v*` and `v1.0.0`, while a
+                                            `v1.0.0` policy does not satisfy `v*`.
                     GitHub-only; other hosts report NOT APPLICABLE (exit 0).
 
 Flags:
@@ -588,8 +595,10 @@ cmd_setup_ci_token() {
 
   WHAT HAPPENS NEXT
     The value is stored as the Actions secret \`$secret_name\` on $owner_repo
-    and nothing else. Your generated workflow already maps it into the
-    phase-gate step as GH_TOKEN, so the very next push re-arms the check.
+    and nothing else. This command then CHECKS your workflow — it must both map
+    the secret into the phase-gate step as GH_TOKEN and let the gate's exit code
+    decide that step — and tells you exactly what to add if either is missing.
+    When both hold, the very next push re-arms the check.
     An UNSET secret evaluates to the empty string, which the gate reads as
     "no credential" — which is exactly today's warning.
 
@@ -666,12 +675,37 @@ EOM
     print_warn "Secret write reported success but '$secret_name' is not listed — check Settings > Secrets and variables > Actions."
   fi
 
-  # The last link in the chain: the workflow has to READ it. A generated
-  # project scaffolded before this shipped will not have the mapping, and a
-  # secret nothing reads is a silent no-op.
+  # The last links in the chain, and BOTH are required before this command may
+  # claim the check now enforces (adversarial review R-1):
+  #   (a) the workflow READS the secret — a secret nothing reads is a silent
+  #       no-op wearing a success message;
+  #   (b) the gate's EXIT CODE still decides the step. Generated projects
+  #       scaffolded before this shipped ran the gate as
+  #         bash scripts/check-phase-gate.sh 2>/dev/null || echo "…skipping"
+  #       which throws the verdict away: the gate can print [FAIL] and exit 1
+  #       while the step grades GREEN, and the "not found" message is a lie
+  #       (the script was found; its verdict failed). Under that shape a
+  #       correctly-scoped token changes NOTHING, so saying "the next push
+  #       enforces" would be false.
   local wf=".github/workflows/ci.yml"
-  if [ -f "$wf" ] && grep -q "secrets.$secret_name" "$wf"; then
-    print_ok "$wf already maps $secret_name into the phase-gate step. The next push enforces the check."
+  local wf_maps=0 wf_swallows=0
+  if [ -f "$wf" ]; then
+    grep -q "secrets.$secret_name" "$wf" && wf_maps=1
+    if grep -E '^[^#]*bash scripts/check-phase-gate\.sh' "$wf" \
+         | grep -Eq '\|\|[[:space:]]*(echo|true|:)'; then
+      wf_swallows=1
+    fi
+  fi
+  if [ "$wf_maps" -eq 1 ] && [ "$wf_swallows" -eq 0 ]; then
+    print_ok "$wf maps $secret_name into the phase-gate step AND lets the gate's exit code decide it. The next push enforces the check."
+  elif [ "$wf_maps" -eq 1 ] && [ "$wf_swallows" -eq 1 ]; then
+    print_warn "$wf maps $secret_name, but its phase-gate step DISCARDS the gate's exit code, so the token cannot enforce anything. Replace the swallowing 'run:' line with:"
+    echo "        run: |"
+    echo "          if [ ! -f scripts/check-phase-gate.sh ]; then"
+    echo "            echo \"::error::Phase gate check script missing. Framework integrity compromised.\""
+    echo "            exit 1"
+    echo "          fi"
+    echo "          bash scripts/check-phase-gate.sh"
   else
     print_warn "$wf does not map $secret_name yet — the secret would be stored but unread. Add these lines to the 'Governance - Phase gate check' step:"
     echo "        env:"
@@ -788,10 +822,29 @@ cmd_release_env_policy() {
     print_fail "Could not list deployment branch policies for '$env_name': $(printf '%s' "$pol_json" | head -2 | tr '\n' ' ')"
     return 1
   fi
-  local have_tag
-  have_tag=$(printf '%s' "$pol_json" \
-    | jq -r --arg p "$tag_pattern" '[.branch_policies[]? | select(.type=="tag" and (.name==$p or .name=="*"))] | length' 2>/dev/null || echo 0)
-  case "$have_tag" in ''|*[!0-9]*) have_tag=0 ;; esac
+  # Adversarial review R-3: matching by literal string equality false-failed a
+  # correctly-configured repo — an existing `v*` policy plainly admits a
+  # `--tag-pattern v1.0.0` release, but `"v*" = "v1.0.0"` is false. The POLICY
+  # is a glob and the requested pattern is the subject, which gets all four
+  # cases right:
+  #   policy v*      vs request v*      -> match (glob `v*` matches "v*")
+  #   policy v*      vs request v1.0.0  -> match (the policy admits that tag)
+  #   policy v1.0.0  vs request v*      -> NO match, correctly: a single-tag
+  #                                        policy does not admit the whole class
+  #   policy *       vs request anything-> match
+  # The policy name is repo-controlled data, so it is used as the unquoted RHS
+  # of `[[ == ]]` (bash's pattern position) and never spliced into `case` syntax.
+  local have_tag=0 _pol
+  while IFS= read -r _pol; do
+    [ -n "$_pol" ] || continue
+    # shellcheck disable=SC2053
+    if [ "$_pol" = "$tag_pattern" ] || [[ $tag_pattern == $_pol ]]; then
+      have_tag=1
+      break
+    fi
+  done <<EOF
+$(printf '%s' "$pol_json" | jq -r '.branch_policies[]? | select(.type=="tag") | .name' 2>/dev/null || true)
+EOF
 
   if [ "$have_tag" -gt 0 ]; then
     print_ok "Environment '$env_name' admits tag deployments matching '$tag_pattern' — tag-triggered releases will run."

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -53,6 +53,20 @@ Subcommands:
                     project that met the free-tier 403 unattested can recover
                     without destroy-and-recreate.
   --backfill-host   Infer host from git remote URL and write to manifest.
+  --release-env-policy
+                    Check that the release deployment ENVIRONMENT admits
+                    tag deploys before you push a version tag (walk
+                    ISSUE-016). Enabling GitHub Pages auto-creates a
+                    `github-pages` environment whose default policy admits
+                    the default branch only, so a tag-triggered release is
+                    rejected before any step runs — empty step list, no
+                    readable error. Exits 1 when tag deploys would be
+                    rejected and prints the exact remediation.
+                      --fix                 apply the policy instead of
+                                            just reporting it
+                      --env <name>          environment (default github-pages)
+                      --tag-pattern <glob>  tag pattern (default v*)
+                    GitHub-only; other hosts report NOT APPLICABLE (exit 0).
 
 Flags:
   --yes, -y         Skip confirmation prompts (for non-interactive use,
@@ -459,6 +473,136 @@ cmd_repair() {
   print_ok "Repair complete"
 }
 
+# WALK-ISSUE-016-RELEASE-ENV-POLICY-BEGIN
+# Walk 2026-08-02, ISSUE-016 (Major): the documented happy path — "release is
+# triggered by version tags: git tag v1.0.0 && git push --tags" — HARD-FAILS on
+# a fresh GitHub Pages repo, opaquely. Enabling Pages auto-creates a
+# `github-pages` deployment environment whose default branch policy admits the
+# DEFAULT BRANCH ONLY, so a run triggered from a TAG is rejected by the
+# environment's protection rules BEFORE any step executes: an empty step list,
+# no readable error in `gh run view`, and no doc anywhere connecting the two.
+#
+# WHY THIS LIVES IN A SCRIPT AND NOT IN release.yml: a run that the environment
+# rejects never starts a job, so an in-workflow preflight step is unreachable by
+# construction. The check has to run somewhere that CAN execute — here, from the
+# workstation, before the tag is pushed.
+#
+# Dry-run by default (report + exact commands, exit 1 when tag deploys would be
+# rejected); `--fix` applies. Non-github hosts are NOT APPLICABLE, not failures:
+# GitLab protected environments and Bitbucket deployment permissions are
+# different mechanisms and neither auto-creates a default-branch-only policy on
+# a fresh repo.
+cmd_release_env_policy() {
+  _require_manifest || return 1
+
+  local env_name="github-pages" tag_pattern="v*" do_fix=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --fix)         do_fix=1 ;;
+      --env)         shift; env_name="${1:-github-pages}" ;;
+      --env=*)       env_name="${1#--env=}" ;;
+      --tag-pattern) shift; tag_pattern="${1:-v*}" ;;
+      --tag-pattern=*) tag_pattern="${1#--tag-pattern=}" ;;
+      *) print_fail "--release-env-policy: unknown flag '$1'"; return 1 ;;
+    esac
+    shift || true
+  done
+
+  local host
+  host=$(jq -r '.host // empty' .claude/manifest.json 2>/dev/null || echo "")
+  if [ "$host" != "github" ]; then
+    print_info "Release environment policy: NOT APPLICABLE for host='${host:-unset}' — the default-branch-only deployment policy that rejects tag deploys is a GitHub environments behavior. (GitLab protected environments / Bitbucket deployment permissions are opt-in and are not auto-created.)"
+    return 0
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    print_fail "Release environment policy: \`gh\` CLI not found — install it and re-run (this check is a GitHub API read)."
+    return 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_DIR/lib/host.sh"
+  host_load_driver || {
+    print_fail "Dispatcher load failed — check manifest host field (scripts/check-gate.sh --backfill-host)"
+    return 1
+  }
+  local owner_repo
+  owner_repo=$(_github_parse_origin) || {
+    print_fail "Could not parse a GitHub owner/repo from 'origin'"
+    return 1
+  }
+
+  print_step "Release environment policy: $owner_repo environment '$env_name'"
+
+  local env_json
+  if ! env_json=$(gh api "repos/$owner_repo/environments/$env_name" 2>&1); then
+    if printf '%s' "$env_json" | grep -q 'Not Found'; then
+      print_ok "Environment '$env_name' does not exist yet — nothing can reject a tag deploy. Re-run this check AFTER you enable Pages (or first create the environment); GitHub creates it with a default-branch-only policy."
+      return 0
+    fi
+    print_fail "Could not read environment '$env_name': $(printf '%s' "$env_json" | head -2 | tr '\n' ' ')"
+    return 1
+  fi
+
+  local protected custom
+  protected=$(printf '%s' "$env_json" | jq -r '.deployment_branch_policy.protected_branches // false' 2>/dev/null || echo false)
+  custom=$(printf '%s' "$env_json" | jq -r '.deployment_branch_policy.custom_branch_policies // false' 2>/dev/null || echo false)
+
+  if [ "$protected" != "true" ] && [ "$custom" != "true" ]; then
+    print_ok "Environment '$env_name' has no deployment branch policy — every branch AND tag may deploy. Tag-triggered releases are fine."
+    return 0
+  fi
+
+  local post_cmd="gh api -X POST repos/$owner_repo/environments/$env_name/deployment-branch-policies -f name='$tag_pattern' -f type='tag'"
+
+  if [ "$protected" = "true" ]; then
+    # protected_branches:true admits protected BRANCHES only and refuses
+    # custom policies outright — a tag can never deploy until the env is
+    # switched to custom policies.
+    print_fail "Environment '$env_name' allows PROTECTED BRANCHES only — a tag-triggered release ('$tag_pattern') is rejected before any step runs (that is the empty-step-list failure with no readable error)."
+    echo "  Switch the environment to custom policies, then admit the tag pattern:"
+    echo "    gh api -X PUT repos/$owner_repo/environments/$env_name --input - <<'JSON'"
+    echo "    {\"deployment_branch_policy\":{\"protected_branches\":false,\"custom_branch_policies\":true}}"
+    echo "    JSON"
+    echo "    $post_cmd"
+    if [ "$do_fix" -eq 1 ]; then
+      printf '{"deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}' \
+        | gh api -X PUT "repos/$owner_repo/environments/$env_name" --input - >/dev/null || {
+          print_fail "Could not switch '$env_name' to custom branch policies"; return 1; }
+    else
+      return 1
+    fi
+  fi
+
+  local pol_json
+  if ! pol_json=$(gh api "repos/$owner_repo/environments/$env_name/deployment-branch-policies" 2>&1); then
+    print_fail "Could not list deployment branch policies for '$env_name': $(printf '%s' "$pol_json" | head -2 | tr '\n' ' ')"
+    return 1
+  fi
+  local have_tag
+  have_tag=$(printf '%s' "$pol_json" \
+    | jq -r --arg p "$tag_pattern" '[.branch_policies[]? | select(.type=="tag" and (.name==$p or .name=="*"))] | length' 2>/dev/null || echo 0)
+  case "$have_tag" in ''|*[!0-9]*) have_tag=0 ;; esac
+
+  if [ "$have_tag" -gt 0 ]; then
+    print_ok "Environment '$env_name' admits tag deployments matching '$tag_pattern' — tag-triggered releases will run."
+    return 0
+  fi
+
+  print_fail "Environment '$env_name' has NO tag deployment policy — 'git push --tags' will be rejected by the environment before any step runs (empty step list, no readable error in \`gh run view\`)."
+  echo "  Admit the release tag pattern:"
+  echo "    $post_cmd"
+  echo "  Or apply it now:  scripts/check-gate.sh --release-env-policy --fix"
+  if [ "$do_fix" -eq 1 ]; then
+    gh api -X POST "repos/$owner_repo/environments/$env_name/deployment-branch-policies" \
+      -f "name=$tag_pattern" -f 'type=tag' >/dev/null || {
+        print_fail "Could not add the '$tag_pattern' tag deployment policy"; return 1; }
+    print_ok "Added tag deployment policy '$tag_pattern' to '$env_name' — re-run the failed release workflow."
+    return 0
+  fi
+  return 1
+}
+# WALK-ISSUE-016-RELEASE-ENV-POLICY-END
+
 ASSUME_YES=0
 ARGS=()
 for arg in "$@"; do
@@ -473,6 +617,7 @@ case "${1:-}" in
   --preflight)     shift || true; cmd_preflight "$@" ;;
   --repair)        shift || true; cmd_repair "$@" ;;
   --backfill-host) shift || true; cmd_backfill_host "$@" ;;
+  --release-env-policy) shift || true; cmd_release_env_policy "$@" ;;
   -h|--help|"")    usage; exit 0 ;;
   *)               echo "Unknown subcommand: $1" >&2; usage; exit 1 ;;
 esac

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -53,6 +53,20 @@ Subcommands:
                     project that met the free-tier 403 unattested can recover
                     without destroy-and-recreate.
   --backfill-host   Infer host from git remote URL and write to manifest.
+  --setup-ci-token  RECOMMENDED. Guided end-to-end setup of the CI branch-
+                    protection token (walk ISSUE-006). A workflow runner has no
+                    credential to verify branch protection — the built-in
+                    secrets.GITHUB_TOKEN cannot read it at all — so that one
+                    gate check WARNs instead of enforcing until you finish this.
+                    Walks you through creating a least-privilege fine-grained
+                    PAT (Administration: Read-only, this repo only), VERIFIES it
+                    can actually read protection before storing anything, sets
+                    it as the Actions secret SOIF_PROTECTION_TOKEN, and confirms
+                    the workflow reads it. GitHub-only.
+                      --secret-name <n>  secret name (default SOIF_PROTECTION_TOKEN)
+                      --token-env <VAR>  read the token from $VAR instead of
+                                         prompting (scriptable opt-in)
+                      --skip-verify      store without the read-protection probe
   --release-env-policy
                     Check that the release deployment ENVIRONMENT admits
                     tag deploys before you push a version tag (walk
@@ -473,6 +487,189 @@ cmd_repair() {
   print_ok "Repair complete"
 }
 
+# WALK-ISSUE-006-SETUP-CI-TOKEN-BEGIN
+# Walk 2026-08-02, ISSUE-006 remediation, part 3 of 3. Part 1 stops the gate's
+# branch-protection backstop from blocking a runner that structurally cannot
+# perform the check (`grep -n 'WALK-ISSUE-006' scripts/check-phase-gate.sh`);
+# part 2 makes every generated ci.yml SAY so at the step. Neither of those
+# RESTORES the check — and a permanently-warning check is a check on its way to
+# being ignored. This arm is the guided path back to hard enforcement: it
+# explains what the token is for, names the MINIMUM permission, stores it as an
+# Actions secret, and verifies the workflow will actually read it.
+#
+# WHY A WALKTHROUGH AND NOT A DOC LINE: the failure mode this closes is not
+# ignorance of the option, it is the five separate steps between knowing and
+# having (which token type, which permission, where it goes, what it is called,
+# what reads it) — each of which is a place to stop.
+#
+# GitHub-only: `gh secret set` has no gitlab/bitbucket equivalent worth
+# pretending about here, so those hosts get the manual instruction and exit 0.
+cmd_setup_ci_token() {
+  _require_manifest || return 1
+
+  local secret_name="SOIF_PROTECTION_TOKEN"
+  local token_env="SOIF_PROTECTION_TOKEN"
+  local skip_verify=0
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --secret-name)   shift; secret_name="${1:?--secret-name requires a value}" ;;
+      --secret-name=*) secret_name="${1#--secret-name=}" ;;
+      --token-env)     shift; token_env="${1:?--token-env requires a value}" ;;
+      --token-env=*)   token_env="${1#--token-env=}" ;;
+      --skip-verify)   skip_verify=1 ;;
+      *) print_fail "--setup-ci-token: unknown flag '$1'"; return 1 ;;
+    esac
+    shift || true
+  done
+
+  local host
+  host=$(jq -r '.host // empty' .claude/manifest.json 2>/dev/null || echo "")
+  if [ "$host" != "github" ]; then
+    print_info "CI protection token: NOT APPLICABLE for host='${host:-unset}' — this walkthrough drives \`gh secret set\`."
+    case "$host" in
+      gitlab)
+        echo "  GitLab: add a masked, protected CI/CD variable GITLAB_TOKEN (Settings > CI/CD > Variables)"
+        echo "          holding a PAT with the \`api\` scope, AND install \`glab\` in the governance job."
+        echo "          GitLab injects CI/CD variables into the job environment automatically, so no"
+        echo "          workflow wiring is needed — but WITHOUT glab the check still cannot run."
+        ;;
+      bitbucket)
+        echo "  Bitbucket: add repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL"
+        echo "             (Repository settings > Repository variables), AND install curl in the"
+        echo "             Governance step. Both are required before the check can run."
+        ;;
+    esac
+    return 0
+  fi
+
+  if ! command -v gh >/dev/null 2>&1; then
+    print_fail "CI protection token: \`gh\` CLI not found — install it, run \`gh auth login\`, then re-run."
+    return 1
+  fi
+  if ! gh auth status >/dev/null 2>&1; then
+    print_fail "CI protection token: \`gh\` is not authenticated — run \`gh auth login\`, then re-run."
+    return 1
+  fi
+
+  # shellcheck disable=SC1090
+  source "$SCRIPT_DIR/lib/host.sh"
+  host_load_driver || {
+    print_fail "Dispatcher load failed — check manifest host field (scripts/check-gate.sh --backfill-host)"
+    return 1
+  }
+  local owner_repo
+  owner_repo=$(_github_parse_origin) || {
+    print_fail "Could not parse a GitHub owner/repo from 'origin'"
+    return 1
+  }
+
+  print_step "CI protection token for $owner_repo"
+  cat <<EOM
+
+  WHAT THIS IS FOR
+    Your CI's phase-gate step verifies that branch protection on main is still
+    configured. That is an AUTHENTICATED GitHub API read, and a workflow runner
+    has no credential for it: Actions puts no token in a step's environment, and
+    the built-in secrets.GITHUB_TOKEN CANNOT read branch protection at all —
+    there is no \`administration\` key in the workflow \`permissions:\` block.
+    Until you finish this, that one check WARNS on every run instead of
+    enforcing. Everything else in the gate keeps blocking as normal.
+
+  THE TOKEN YOU NEED (least privilege — read-only, one repo)
+    1. Open:  https://github.com/settings/personal-access-tokens/new
+    2. Token name:        soif-protection-read ($owner_repo)
+       Expiration:        your policy (90 days is a reasonable default)
+       Repository access: "Only select repositories" -> $owner_repo
+    3. Repository permissions -> Administration: **Read-only**
+       That single permission is the whole requirement. Do NOT grant write.
+       (A classic PAT with the \`repo\` scope also works but is far broader —
+       prefer the fine-grained token.)
+    4. Generate, then copy the value once.
+
+  WHAT HAPPENS NEXT
+    The value is stored as the Actions secret \`$secret_name\` on $owner_repo
+    and nothing else. Your generated workflow already maps it into the
+    phase-gate step as GH_TOKEN, so the very next push re-arms the check.
+    An UNSET secret evaluates to the empty string, which the gate reads as
+    "no credential" — which is exactly today's warning.
+
+EOM
+
+  # Token source. An exported \$$token_env is an explicit, scriptable opt-in
+  # (and is how the hermetic tests drive this arm); otherwise prompt with echo
+  # OFF. `read -rs` carries no -p, so the raw-prompt lint's target does not
+  # apply — but the non-interactive guard it exists to enforce still does, and
+  # is implemented here explicitly rather than inherited.
+  local token=""
+  eval "token=\${$token_env:-}"
+  if [ -n "$token" ]; then
+    print_info "Using the token from \$$token_env (explicit opt-in — no prompt)."
+  else
+    if [ "${ASSUME_YES:-0}" -ne 1 ]; then
+      if ! prompt_yes_no "Create the $secret_name secret on $owner_repo now? [y/N]" N; then
+        print_info "Nothing changed. Re-run this command when you have the token, or export $token_env=<token> and re-run non-interactively."
+        return 0
+      fi
+    fi
+    if [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${SOIF_NONINTERACTIVE:-}" ]; then
+      print_fail "No terminal to read the token from. Export it instead and re-run:  $token_env=<token> scripts/check-gate.sh --setup-ci-token"
+      return 1
+    fi
+    printf '  Paste the token (input hidden), then press Enter: ' >&2
+    read -rs token
+    printf '\n' >&2
+  fi
+  if [ -z "$token" ]; then
+    print_fail "Empty token — nothing stored."
+    return 1
+  fi
+
+  # VERIFY BEFORE STORING. A secret that cannot read protection turns today's
+  # honest WARN into tomorrow's hard FAIL, which is strictly worse than the
+  # state we started in — so the walkthrough proves the token works first.
+  if [ "$skip_verify" -eq 0 ]; then
+    local probe
+    if probe=$(GH_TOKEN="$token" gh api "repos/$owner_repo/branches/main/protection" 2>&1); then
+      print_ok "Token verified — it can read branch protection on $owner_repo."
+    else
+      print_fail "That token could NOT read branch protection on $owner_repo — refusing to store it (a stored-but-powerless token converts the current WARN into a hard FAIL)."
+      echo "  GitHub said: $(printf '%s' "$probe" | head -2 | tr '\n' ' ')"
+      echo "  Most likely: the fine-grained token is missing 'Administration: Read-only', or it does not include this repository."
+      echo "  If branch protection is genuinely not configured yet, fix that first: scripts/check-gate.sh --repair"
+      echo "  To store anyway (you accept the risk): scripts/check-gate.sh --setup-ci-token --skip-verify"
+      return 1
+    fi
+  fi
+
+  # The value goes in on STDIN, never on argv — an argv secret is visible to
+  # every other process on the box via `ps`.
+  if ! printf '%s' "$token" | gh secret set "$secret_name" --repo "$owner_repo" >/dev/null 2>&1; then
+    print_fail "Could not set the Actions secret '$secret_name' on $owner_repo (does your gh login have repo admin?)"
+    return 1
+  fi
+  if gh secret list --repo "$owner_repo" 2>/dev/null | grep -q "^$secret_name"; then
+    print_ok "Actions secret '$secret_name' is set on $owner_repo."
+  else
+    print_warn "Secret write reported success but '$secret_name' is not listed — check Settings > Secrets and variables > Actions."
+  fi
+
+  # The last link in the chain: the workflow has to READ it. A generated
+  # project scaffolded before this shipped will not have the mapping, and a
+  # secret nothing reads is a silent no-op.
+  local wf=".github/workflows/ci.yml"
+  if [ -f "$wf" ] && grep -q "secrets.$secret_name" "$wf"; then
+    print_ok "$wf already maps $secret_name into the phase-gate step. The next push enforces the check."
+  else
+    print_warn "$wf does not map $secret_name yet — the secret would be stored but unread. Add these lines to the 'Governance - Phase gate check' step:"
+    echo "        env:"
+    echo "          GH_TOKEN: \${{ secrets.$secret_name }}"
+  fi
+  echo ""
+  print_info "Verify locally any time with: scripts/check-gate.sh --preflight"
+  return 0
+}
+# WALK-ISSUE-006-SETUP-CI-TOKEN-END
+
 # WALK-ISSUE-016-RELEASE-ENV-POLICY-BEGIN
 # Walk 2026-08-02, ISSUE-016 (Major): the documented happy path — "release is
 # triggered by version tags: git tag v1.0.0 && git push --tags" — HARD-FAILS on
@@ -618,6 +815,7 @@ case "${1:-}" in
   --repair)        shift || true; cmd_repair "$@" ;;
   --backfill-host) shift || true; cmd_backfill_host "$@" ;;
   --release-env-policy) shift || true; cmd_release_env_policy "$@" ;;
+  --setup-ci-token)     shift || true; cmd_setup_ci_token "$@" ;;
   -h|--help|"")    usage; exit 0 ;;
   *)               echo "Unknown subcommand: $1" >&2; usage; exit 1 ;;
 esac

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -601,6 +601,16 @@ EOM
   # apply — but the non-interactive guard it exists to enforce still does, and
   # is implemented here explicitly rather than inherited.
   local token=""
+  # The indirect read is an `eval`, so the variable NAME is validated as a
+  # shell identifier first — `--token-env` is operator-supplied and an
+  # unvalidated name would be a command-injection sink.
+  case "$token_env" in
+    [A-Za-z_]*) : ;;
+    *) print_fail "--token-env: '$token_env' is not a valid environment variable name"; return 1 ;;
+  esac
+  case "$token_env" in
+    *[!A-Za-z0-9_]*) print_fail "--token-env: '$token_env' is not a valid environment variable name"; return 1 ;;
+  esac
   eval "token=\${$token_env:-}"
   if [ -n "$token" ]; then
     print_info "Using the token from \$$token_env (explicit opt-in — no prompt)."
@@ -647,7 +657,10 @@ EOM
     print_fail "Could not set the Actions secret '$secret_name' on $owner_repo (does your gh login have repo admin?)"
     return 1
   fi
-  if gh secret list --repo "$owner_repo" 2>/dev/null | grep -q "^$secret_name"; then
+  # -qxF: whole-line, FIXED string. An anchored regex would both mis-handle a
+  # name containing regex metacharacters and match a longer secret that merely
+  # starts with this one.
+  if gh secret list --repo "$owner_repo" 2>/dev/null | cut -f1 | grep -qxF -- "$secret_name"; then
     print_ok "Actions secret '$secret_name' is set on $owner_repo."
   else
     print_warn "Secret write reported success but '$secret_name' is not listed — check Settings > Secrets and variables > Actions."

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1181,10 +1181,62 @@ if [ "$current_phase" -ge 2 ]; then
         if host_verify_protection "main" "$mode" 2>/dev/null; then
           echo -e "${GREEN}  [OK]${NC} Phase 1→2 backstop: repo protection verified for $mode mode"
         else
-          echo -e "${RED}[FAIL]${NC} Phase 1→2 backstop: protection verification failed"
-          echo "        Remediate: scripts/check-gate.sh --repair"
-          echo "        Preflight: scripts/check-gate.sh --preflight"
-          issues=$((issues + 1))
+          # WALK-ISSUE-006-CI-PROTECTION-SCOPE-BEGIN
+          # Walk 2026-08-02, ISSUE-006 (Major): this arm made the generated
+          # project's "Governance - Phase gate check" step STRUCTURALLY
+          # unpassable on the framework's OWN default happy path (a public
+          # personal GitHub repo that init.sh had just created). Branch
+          # protection is an AUTHENTICATED API read on every first-class
+          # host, and a CI runner holds no credential for it unless the
+          # operator exports one:
+          #   • GitHub Actions puts NO token in a step's environment —
+          #     `secrets.GITHUB_TOKEN` has to be mapped explicitly, and even
+          #     mapped it CANNOT read branch protection (the workflow
+          #     `permissions:` block has no `administration` key). Only a
+          #     PAT / App token with admin-read can.
+          #   • The generated gitlab + bitbucket governance jobs run in
+          #     `bash:5` with only jq+git added — no `glab`, no `curl`, no
+          #     credential either.
+          # So the identical command exited 0 on the dev workstation and 1 on
+          # every push. The walker's only escape was SOIF_PHASE_GATES=warn,
+          # which downgrades the WHOLE gate — a far bigger hammer than this.
+          #
+          # SCOPING (mirrors `# BL-137-CI-TOOLS-SCOPE`): keyed STRICTLY on
+          # $CI *plus* the absence of a host credential — NEVER on TTY, so
+          # scripted LOCAL runs (hooks, other gates driving this one) keep
+          # blocking. Export the token and this arm BLOCKS again in CI: that
+          # is the documented hard-enforcement path, and it is spelled out at
+          # the phase-gate step of every generated ci.yml.
+          #
+          # host="other" is deliberately NOT exempt: its host_verify_protection
+          # reads a LOCAL attestation file and needs no credential at all, so
+          # a failure there is equally real on a runner and on a laptop.
+          #
+          # HONESTY: the exempt arm prints "could NOT RUN", never "verified".
+          # The contract is UNVERIFIED on such a run — it is not satisfied.
+          _cpg_walk006_credentialless_ci() {
+            [ -n "${CI:-}" ] || return 1   # WALK-ISSUE-006-CI-KEY
+            case "${1:-}" in
+              github)    [ -z "${GH_TOKEN:-}" ] && [ -z "${GITHUB_TOKEN:-}" ] ;;
+              gitlab)    [ -z "${GITLAB_TOKEN:-}" ] && [ -z "${GL_TOKEN:-}" ] ;;
+              bitbucket) [ -z "${BITBUCKET_API_TOKEN:-}" ] && [ -z "${BITBUCKET_APP_PASSWORD:-}" ] ;;
+              *)         return 1 ;;
+            esac
+          }
+          backstop_host=$(jq -r '.host // empty' .claude/manifest.json 2>/dev/null || echo "")
+          if _cpg_walk006_credentialless_ci "$backstop_host"; then
+            echo -e "${YELLOW}[WARN]${NC} Phase 1→2 backstop: protection verification COULD NOT RUN here — \$CI is set and no ${backstop_host:-host} API credential is exported on this runner."
+            echo "        This is NOT a pass. The protection contract is UNVERIFIED on this run; it is enforced on the dev workstation, where this same arm BLOCKS (WALK-ISSUE-006)."
+            echo "        Hard enforcement in CI: export a host API token that can READ branch protection, then this arm blocks again."
+            echo "          GitHub: a PAT / App token with admin read — the built-in GITHUB_TOKEN can NOT read protection. Set GH_TOKEN on the phase-gate step."
+            echo "        Verify locally: scripts/check-gate.sh --preflight"
+          else
+            echo -e "${RED}[FAIL]${NC} Phase 1→2 backstop: protection verification failed"
+            echo "        Remediate: scripts/check-gate.sh --repair"
+            echo "        Preflight: scripts/check-gate.sh --preflight"
+            issues=$((issues + 1))
+          fi
+          # WALK-ISSUE-006-CI-PROTECTION-SCOPE-END
         fi
       else
         echo -e "${YELLOW}[WARN]${NC} Phase 1→2 backstop: could not load host driver (manifest host field may be missing; run scripts/check-gate.sh --backfill-host)"

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1201,8 +1201,16 @@ if [ "$current_phase" -ge 2 ]; then
           # every push. The walker's only escape was SOIF_PHASE_GATES=warn,
           # which downgrades the WHOLE gate — a far bigger hammer than this.
           #
-          # SCOPING (mirrors `# BL-137-CI-TOOLS-SCOPE`): keyed STRICTLY on
-          # $CI *plus* the absence of a host credential — NEVER on TTY, so
+          # SCOPING mirrors the BL-137 "Tools needed" fence further down this
+          # same file — `grep -n 'BL-137' "$0"` finds it. Its marker token is
+          # deliberately NOT spelled out here: tests/test-bl137-ci-tools-scope.sh
+          # ::T5 excises that fence by line range and then asserts NO residual
+          # occurrence of the marker text anywhere in the script, so a second
+          # mention of it — even in a comment, even as a citation — fails the
+          # excision guard. Do not "helpfully" add one back.
+          #
+          # Keyed STRICTLY on $CI *plus* the absence of a host credential —
+          # NEVER on TTY, so
           # scripted LOCAL runs (hooks, other gates driving this one) keep
           # blocking. Export the token and this arm BLOCKS again in CI: that
           # is the documented hard-enforcement path, and it is spelled out at
@@ -1227,9 +1235,17 @@ if [ "$current_phase" -ge 2 ]; then
           if _cpg_walk006_credentialless_ci "$backstop_host"; then
             echo -e "${YELLOW}[WARN]${NC} Phase 1→2 backstop: protection verification COULD NOT RUN here — \$CI is set and no ${backstop_host:-host} API credential is exported on this runner."
             echo "        This is NOT a pass. The protection contract is UNVERIFIED on this run; it is enforced on the dev workstation, where this same arm BLOCKS (WALK-ISSUE-006)."
-            echo "        Hard enforcement in CI: export a host API token that can READ branch protection, then this arm blocks again."
-            echo "          GitHub: a PAT / App token with admin read — the built-in GITHUB_TOKEN can NOT read protection. Set GH_TOKEN on the phase-gate step."
-            echo "        Verify locally: scripts/check-gate.sh --preflight"
+            echo ""
+            echo "        >> FIX THIS ONCE, and this warning is replaced by real enforcement:"
+            echo "               scripts/check-gate.sh --setup-ci-token"
+            echo "           A guided, least-privilege walkthrough: it explains what the token is for, walks"
+            echo "           you through a fine-grained PAT with the ONE permission needed (Administration:"
+            echo "           Read-only, this repo only), proves the token can read protection BEFORE storing"
+            echo "           it, and sets it as the Actions secret your workflow already reads."
+            echo "           The built-in GITHUB_TOKEN cannot do this — it has no admin-read permission."
+            echo "           A warning nobody clears is a check nobody reads. Please clear it."
+            echo ""
+            echo "        Verify locally any time: scripts/check-gate.sh --preflight"
           else
             echo -e "${RED}[FAIL]${NC} Phase 1→2 backstop: protection verification failed"
             echo "        Remediate: scripts/check-gate.sh --repair"

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -34,6 +34,35 @@ else
   print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 fi
 
+# WALK-ISSUE-003-UPDATE-CMD-BEGIN
+# Walk 2026-08-02, ISSUE-003: "Update commands (run manually):" printed the
+# RAW jq output of `.install.<key>`, and BL-033 explicitly allows that value to
+# be an ARRAY of stages. Colima therefore surfaced as
+#     Colima: [ "brew install colima", "brew services start colima" ]
+# — a JSON literal under a heading that promises a runnable command. A junior
+# cannot tell whether that is one command, two, or an error.
+#
+# _cv_jq_install_cmd is the jq tail that normalizes the two BL-033 shapes into
+# ONE runnable string, joined with ` && ` exactly as
+# scripts/resolve-tools.sh's `install_cmd` does — the two readers of the same
+# matrix must not disagree about what a multi-stage install means.
+#
+# _cv_render_update_cmd is the DISPLAY side, shared by the interactive and
+# non-interactive printers so they cannot drift: an empty value and a bare URL
+# are both NOT commands, and this heading must never present them as if they
+# were. A plain string is echoed VERBATIM (the `<name>: <cmd>` grammar that
+# tests/test-specs-plans-remaining-quartet.sh::T-CV-MULTIWORD pins).
+_cv_jq_install_cmd='if type=="array" then (map(select(type=="string")) | join(" && ")) else . end'
+
+_cv_render_update_cmd() {
+  case "${1:-}" in
+    "")                 echo "(no install command in the tool matrix — see the tool's own docs)" ;;
+    http://*|https://*) echo "see $1" ;;
+    *)                  echo "$1" ;;
+  esac
+}
+# WALK-ISSUE-003-UPDATE-CMD-END
+
 # --- Argument parsing ---
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -424,10 +453,10 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       # Find update command
       local_update_cmd=""
       if command -v brew &>/dev/null; then
-        local_update_cmd=$(echo "$TOOL" | jq -r '.install.darwin_brew // empty')
+        local_update_cmd=$(echo "$TOOL" | jq -r "(.install.darwin_brew // empty) | $_cv_jq_install_cmd")
       fi
       if [ -z "$local_update_cmd" ]; then
-        local_update_cmd=$(echo "$TOOL" | jq -r '.install.npm // .install.linux_pip // .install.manual // empty')
+        local_update_cmd=$(echo "$TOOL" | jq -r "(.install.npm // .install.linux_pip // .install.manual // empty) | $_cv_jq_install_cmd")
       fi
       UPDATES+=("$NAME $INSTALLED → ${LATEST:-latest} (BELOW MINIMUM)")
       UPDATE_CMDS+=("$local_update_cmd")
@@ -437,10 +466,10 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       # Find update command
       local_update_cmd=""
       if command -v brew &>/dev/null; then
-        local_update_cmd=$(echo "$TOOL" | jq -r '.install.darwin_brew // empty')
+        local_update_cmd=$(echo "$TOOL" | jq -r "(.install.darwin_brew // empty) | $_cv_jq_install_cmd")
       fi
       if [ -z "$local_update_cmd" ]; then
-        local_update_cmd=$(echo "$TOOL" | jq -r '.install.npm // .install.linux_pip // .install.manual // empty')
+        local_update_cmd=$(echo "$TOOL" | jq -r "(.install.npm // .install.linux_pip // .install.manual // empty) | $_cv_jq_install_cmd")
       fi
       UPDATES+=("$NAME $INSTALLED → $LATEST")
       UPDATE_CMDS+=("$local_update_cmd")
@@ -541,7 +570,10 @@ if [ ${#UPDATES[@]} -gt 0 ] && [ -t 0 ]; then
           # `${UPDATES[$idx]%%  *}` (two-space split) which left the
           # whole display string ("Claude Code 0.0.1 → latest (BELOW
           # MINIMUM)") in front of the colon.
-          echo "  ${UPDATE_NAMES[$idx]}: ${UPDATE_CMDS[$idx]}"
+          # WALK-ISSUE-003: render, never echo raw — a multi-stage install is
+          # joined into one runnable line, and a URL / missing entry is labelled
+          # instead of masquerading as a command.
+          echo "  ${UPDATE_NAMES[$idx]}: $(_cv_render_update_cmd "${UPDATE_CMDS[$idx]}")"
         done
       fi
       ;;
@@ -553,7 +585,9 @@ elif [ ${#UPDATES[@]} -gt 0 ]; then
   echo ""
   echo "Update commands (run manually):"
   for idx in "${!UPDATES[@]}"; do
-    echo "  ${UPDATE_NAMES[$idx]}: ${UPDATE_CMDS[$idx]}"
+    # WALK-ISSUE-003: same renderer as the interactive branch — the two
+    # printers of this heading must not disagree about what is runnable.
+    echo "  ${UPDATE_NAMES[$idx]}: $(_cv_render_update_cmd "${UPDATE_CMDS[$idx]}")"
   done
 fi
 

--- a/templates/pipelines/ci/bitbucket/csharp.yml
+++ b/templates/pipelines/ci/bitbucket/csharp.yml
@@ -16,4 +16,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/csharp.yml
+++ b/templates/pipelines/ci/bitbucket/csharp.yml
@@ -22,7 +22,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/dart.yml
+++ b/templates/pipelines/ci/bitbucket/dart.yml
@@ -18,7 +18,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/dart.yml
+++ b/templates/pipelines/ci/bitbucket/dart.yml
@@ -12,4 +12,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/go.yml
+++ b/templates/pipelines/ci/bitbucket/go.yml
@@ -21,4 +21,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/go.yml
+++ b/templates/pipelines/ci/bitbucket/go.yml
@@ -27,7 +27,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/java.yml
+++ b/templates/pipelines/ci/bitbucket/java.yml
@@ -20,7 +20,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/java.yml
+++ b/templates/pipelines/ci/bitbucket/java.yml
@@ -14,4 +14,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/kotlin.yml
+++ b/templates/pipelines/ci/bitbucket/kotlin.yml
@@ -18,7 +18,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/kotlin.yml
+++ b/templates/pipelines/ci/bitbucket/kotlin.yml
@@ -12,4 +12,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/other.yml
+++ b/templates/pipelines/ci/bitbucket/other.yml
@@ -16,4 +16,13 @@ pipelines:
         name: Governance
         script:
           - apk add --no-cache jq git
+          # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+          # This step installs only jq+git: there is no curl client and no Bitbucket
+          # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+          # instead of failing the step. It is UNVERIFIED on this runner, NOT
+          # satisfied, and it still BLOCKS on the dev workstation
+          # (scripts/check-gate.sh --preflight).
+          # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+          # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+          # install curl in this step — the backstop blocks again.
           - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/bitbucket/other.yml
+++ b/templates/pipelines/ci/bitbucket/other.yml
@@ -22,7 +22,12 @@ pipelines:
           # instead of failing the step. It is UNVERIFIED on this runner, NOT
           # satisfied, and it still BLOCKS on the dev workstation
           # (scripts/check-gate.sh --preflight).
-          # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-          # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-          # install curl in this step — the backstop blocks again.
+          # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+          # required, and the check still cannot run with only one of them:
+          #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+          #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+          #      Repository settings > Repository variables;
+          #   2. curl installed in this step.
+          # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+          # A warning nobody clears is a check nobody reads.
           - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/bitbucket/python.yml
+++ b/templates/pipelines/ci/bitbucket/python.yml
@@ -43,4 +43,13 @@ pipelines:
         image: bash:5
         script:
           - apk add --no-cache jq git
+          # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+          # This step installs only jq+git: there is no curl client and no Bitbucket
+          # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+          # instead of failing the step. It is UNVERIFIED on this runner, NOT
+          # satisfied, and it still BLOCKS on the dev workstation
+          # (scripts/check-gate.sh --preflight).
+          # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+          # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+          # install curl in this step — the backstop blocks again.
           - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/bitbucket/python.yml
+++ b/templates/pipelines/ci/bitbucket/python.yml
@@ -49,7 +49,12 @@ pipelines:
           # instead of failing the step. It is UNVERIFIED on this runner, NOT
           # satisfied, and it still BLOCKS on the dev workstation
           # (scripts/check-gate.sh --preflight).
-          # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-          # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-          # install curl in this step — the backstop blocks again.
+          # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+          # required, and the check still cannot run with only one of them:
+          #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+          #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+          #      Repository settings > Repository variables;
+          #   2. curl installed in this step.
+          # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+          # A warning nobody clears is a check nobody reads.
           - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/bitbucket/rust.yml
+++ b/templates/pipelines/ci/bitbucket/rust.yml
@@ -21,4 +21,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/rust.yml
+++ b/templates/pipelines/ci/bitbucket/rust.yml
@@ -27,7 +27,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/swift.yml
+++ b/templates/pipelines/ci/bitbucket/swift.yml
@@ -20,7 +20,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/swift.yml
+++ b/templates/pipelines/ci/bitbucket/swift.yml
@@ -14,4 +14,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/typescript.yml
+++ b/templates/pipelines/ci/bitbucket/typescript.yml
@@ -37,4 +37,13 @@ pipelines:
     - step:
         name: Governance
         image: bash:5
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # This step installs only jq+git: there is no curl client and no Bitbucket
+        # credential. So that ONE check prints a loud [WARN] "could NOT run" here
+        # instead of failing the step. It is UNVERIFIED on this runner, NOT
+        # satisfied, and it still BLOCKS on the dev workstation
+        # (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
+        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
+        # install curl in this step — the backstop blocks again.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/bitbucket/typescript.yml
+++ b/templates/pipelines/ci/bitbucket/typescript.yml
@@ -43,7 +43,12 @@ pipelines:
         # instead of failing the step. It is UNVERIFIED on this runner, NOT
         # satisfied, and it still BLOCKS on the dev workstation
         # (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, add repository variables BITBUCKET_API_TOKEN +
-        # BITBUCKET_API_TOKEN_EMAIL (or BITBUCKET_APP_PASSWORD + BITBUCKET_USER) and
-        # install curl in this step — the backstop blocks again.
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+        # required, and the check still cannot run with only one of them:
+        #   1. repository variables BITBUCKET_API_TOKEN + BITBUCKET_API_TOKEN_EMAIL
+        #      (or the legacy BITBUCKET_APP_PASSWORD + BITBUCKET_USER), set under
+        #      Repository settings > Repository variables;
+        #   2. curl installed in this step.
+        # `scripts/check-gate.sh --setup-ci-token` prints these steps for Bitbucket.
+        # A warning nobody clears is a check nobody reads.
         script: [apk add --no-cache jq git, bash scripts/check-phase-gate.sh]

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -131,8 +131,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -140,7 +144,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -112,6 +112,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/csharp.yml
+++ b/templates/pipelines/ci/github/csharp.yml
@@ -119,12 +119,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -111,6 +111,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -118,12 +118,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/dart.yml
+++ b/templates/pipelines/ci/github/dart.yml
@@ -130,8 +130,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -139,7 +143,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -121,12 +121,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -133,8 +133,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -142,7 +146,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/go.yml
+++ b/templates/pipelines/ci/github/go.yml
@@ -114,6 +114,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -119,6 +119,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -138,8 +138,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -147,7 +151,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/java.yml
+++ b/templates/pipelines/ci/github/java.yml
@@ -126,12 +126,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -119,6 +119,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -138,8 +138,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -147,7 +151,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/kotlin.yml
+++ b/templates/pipelines/ci/github/kotlin.yml
@@ -126,12 +126,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -125,6 +125,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: |
           if [ ! -f scripts/check-phase-gate.sh ]; then

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -132,12 +132,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: |
           if [ ! -f scripts/check-phase-gate.sh ]; then
             echo "::error::Phase gate check script missing. Framework integrity compromised."

--- a/templates/pipelines/ci/github/other.yml
+++ b/templates/pipelines/ci/github/other.yml
@@ -144,8 +144,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -141,8 +141,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -122,6 +122,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: |
           if [ ! -f scripts/check-phase-gate.sh ]; then

--- a/templates/pipelines/ci/github/python.yml
+++ b/templates/pipelines/ci/github/python.yml
@@ -129,12 +129,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: |
           if [ ! -f scripts/check-phase-gate.sh ]; then
             echo "::error::Phase gate check script missing. Framework integrity compromised."

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -117,6 +117,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -136,8 +136,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -145,7 +149,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/rust.yml
+++ b/templates/pipelines/ci/github/rust.yml
@@ -124,12 +124,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -134,6 +134,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -141,12 +141,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
 
       - name: Governance - Changelog check

--- a/templates/pipelines/ci/github/swift.yml
+++ b/templates/pipelines/ci/github/swift.yml
@@ -153,8 +153,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
@@ -162,7 +166,12 @@ jobs:
           # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
           # `administration` permission and cannot read branch protection.
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
-        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found — skipping"
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh
 
       - name: Governance - Changelog check
         run: bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -142,8 +142,12 @@ jobs:
         # The wiring is LIVE below — no editing needed. An unset secret
         # evaluates to the empty string, which the gate reads as "no
         # credential" (that is today's warning); once the secret exists the
-        # backstop enforces on the very next push. A warning nobody clears is
-        # a check nobody reads.
+        # backstop enforces on the very next push. That claim holds because
+        # the `run:` below lets the gate's EXIT CODE decide this step — do not
+        # "soften" it with `|| echo` / `|| true`: that discards the verdict, so
+        # the gate can print [FAIL] and exit 1 while the step still grades
+        # GREEN, and no token can enforce anything through it.
+        # A warning nobody clears is a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
         env:
           # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -123,6 +123,18 @@ jobs:
           fi
 
       - name: Governance - Phase gate check
+        # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+        # GitHub Actions exports NO token into a step environment, and even a mapped
+        # secrets.GITHUB_TOKEN cannot read branch protection — the workflow
+        # `permissions:` block has no `administration` key. So that ONE check prints a
+        # loud [WARN] "could NOT run" here instead of failing the job. It is
+        # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
+        # workstation (scripts/check-gate.sh --preflight).
+        # For HARD enforcement in CI, hand it a token that CAN read protection — a
+        # fine-grained PAT / GitHub App token with admin read, never
+        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
+        #   env:
+        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
         if: hashFiles('.claude/phase-state.json') != ''
         run: |
           if [ ! -f scripts/check-phase-gate.sh ]; then

--- a/templates/pipelines/ci/github/typescript.yml
+++ b/templates/pipelines/ci/github/typescript.yml
@@ -130,12 +130,27 @@ jobs:
         # loud [WARN] "could NOT run" here instead of failing the job. It is
         # UNVERIFIED on this runner, NOT satisfied, and it still BLOCKS on the dev
         # workstation (scripts/check-gate.sh --preflight).
-        # For HARD enforcement in CI, hand it a token that CAN read protection — a
-        # fine-grained PAT / GitHub App token with admin read, never
-        # secrets.GITHUB_TOKEN — and the backstop blocks here again:
-        #   env:
-        #     GH_TOKEN: ${{ secrets.PROTECTION_READ_TOKEN }}
+        # >> STRONGLY RECOMMENDED — clear this warning permanently. ONE guided
+        # command sets up real enforcement end to end: it explains what the
+        # token is for, walks you through a least-privilege fine-grained PAT
+        # (Administration: Read-only, this repository only), PROVES the token
+        # can read protection before storing anything, and sets the Actions
+        # secret this step already reads:
+        #
+        #     scripts/check-gate.sh --setup-ci-token
+        #
+        # The wiring is LIVE below — no editing needed. An unset secret
+        # evaluates to the empty string, which the gate reads as "no
+        # credential" (that is today's warning); once the secret exists the
+        # backstop enforces on the very next push. A warning nobody clears is
+        # a check nobody reads.
         if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          # WALK-ISSUE-006 wiring: set by `scripts/check-gate.sh --setup-ci-token`.
+          # Unset -> empty string -> the gate WARNs (cannot verify). Set -> the
+          # gate enforces. secrets.GITHUB_TOKEN would NOT work here: it has no
+          # `administration` permission and cannot read branch protection.
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: |
           if [ ! -f scripts/check-phase-gate.sh ]; then
             echo "::error::Phase gate check script missing. Framework integrity compromised."

--- a/templates/pipelines/ci/gitlab/csharp.yml
+++ b/templates/pipelines/ci/gitlab/csharp.yml
@@ -34,6 +34,12 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/csharp.yml
+++ b/templates/pipelines/ci/gitlab/csharp.yml
@@ -28,4 +28,12 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/dart.yml
+++ b/templates/pipelines/ci/gitlab/dart.yml
@@ -38,6 +38,12 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/dart.yml
+++ b/templates/pipelines/ci/gitlab/dart.yml
@@ -32,4 +32,12 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/go.yml
+++ b/templates/pipelines/ci/gitlab/go.yml
@@ -37,5 +37,13 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/gitlab/go.yml
+++ b/templates/pipelines/ci/gitlab/go.yml
@@ -43,7 +43,13 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/gitlab/java.yml
+++ b/templates/pipelines/ci/gitlab/java.yml
@@ -27,4 +27,12 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/java.yml
+++ b/templates/pipelines/ci/gitlab/java.yml
@@ -33,6 +33,12 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/kotlin.yml
+++ b/templates/pipelines/ci/gitlab/kotlin.yml
@@ -27,4 +27,12 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/kotlin.yml
+++ b/templates/pipelines/ci/gitlab/kotlin.yml
@@ -33,6 +33,12 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/other.yml
+++ b/templates/pipelines/ci/gitlab/other.yml
@@ -21,4 +21,12 @@ governance:
   stage: governance
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/other.yml
+++ b/templates/pipelines/ci/gitlab/other.yml
@@ -27,6 +27,12 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/python.yml
+++ b/templates/pipelines/ci/gitlab/python.yml
@@ -73,8 +73,14 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true
     # APPROVAL_LOG.md append-only enforcement

--- a/templates/pipelines/ci/gitlab/python.yml
+++ b/templates/pipelines/ci/gitlab/python.yml
@@ -67,6 +67,14 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true
     # APPROVAL_LOG.md append-only enforcement

--- a/templates/pipelines/ci/gitlab/rust.yml
+++ b/templates/pipelines/ci/gitlab/rust.yml
@@ -38,5 +38,13 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/gitlab/rust.yml
+++ b/templates/pipelines/ci/gitlab/rust.yml
@@ -44,7 +44,13 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true

--- a/templates/pipelines/ci/gitlab/swift.yml
+++ b/templates/pipelines/ci/gitlab/swift.yml
@@ -23,4 +23,12 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/swift.yml
+++ b/templates/pipelines/ci/gitlab/swift.yml
@@ -29,6 +29,12 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh

--- a/templates/pipelines/ci/gitlab/typescript.yml
+++ b/templates/pipelines/ci/gitlab/typescript.yml
@@ -70,6 +70,14 @@ governance:
   image: bash:5
   script:
     - apk add --no-cache jq git
+    # PHASE-GATE CREDENTIALS (walk ISSUE-006): the Phase 1-2 branch-protection backstop needs a host API token this runner does not have.
+    # This job installs only jq+git: there is no `glab` client, and CI_JOB_TOKEN
+    # cannot read protected-branch settings. So that ONE check prints a loud
+    # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
+    # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
+    # (scripts/check-gate.sh --preflight).
+    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
+    # with `api` scope) and install glab in this job — the backstop blocks again.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true
     - |

--- a/templates/pipelines/ci/gitlab/typescript.yml
+++ b/templates/pipelines/ci/gitlab/typescript.yml
@@ -76,8 +76,14 @@ governance:
     # [WARN] "could NOT run" here instead of failing the job. It is UNVERIFIED on
     # this runner, NOT satisfied, and it still BLOCKS on the dev workstation
     # (scripts/check-gate.sh --preflight).
-    # For HARD enforcement in CI, add a masked CI/CD variable GITLAB_TOKEN (a PAT
-    # with `api` scope) and install glab in this job — the backstop blocks again.
+    # >> STRONGLY RECOMMENDED — clear this warning permanently. BOTH halves are
+    # required, and the check still cannot run with only one of them:
+    #   1. a masked, protected CI/CD variable GITLAB_TOKEN holding a PAT with
+    #      the `api` scope (Settings > CI/CD > Variables — GitLab injects it
+    #      into this job's environment automatically, no wiring needed);
+    #   2. `glab` installed in this job.
+    # `scripts/check-gate.sh --setup-ci-token` prints these steps for GitLab.
+    # A warning nobody clears is a check nobody reads.
     - bash scripts/check-phase-gate.sh
     - bash scripts/check-changelog.sh 2>/dev/null || true
     - |

--- a/templates/pipelines/release/github/web.yml
+++ b/templates/pipelines/release/github/web.yml
@@ -7,6 +7,28 @@ name: Release — __PROJECT_NAME__
 # Light-track projects: this pipeline is optional for internal-only use.
 # ─────────────────────────────────────────────────────────────────
 
+# ─────────────────────────────────────────────────────────────────
+# TAG DEPLOYS vs DEPLOYMENT ENVIRONMENTS (walk ISSUE-016) — read this BEFORE
+# your first `git push --tags`, not after it fails.
+# This workflow is TAG-triggered. If your deploy step targets a GitHub
+# deployment ENVIRONMENT (`environment:` on the job — GitHub Pages is the
+# common case), the environment's deployment BRANCH POLICY decides whether a
+# tag may deploy at all. Enabling Pages auto-creates a `github-pages`
+# environment that admits the DEFAULT BRANCH ONLY, so a tag-triggered run is
+# rejected by the protection rules BEFORE any step executes: the run fails at
+# job setup with an EMPTY step list and no readable error in `gh run view`.
+# There is no in-workflow fix — a rejected run never starts a job, so a
+# preflight step here could never execute. Check it from your workstation
+# before you tag:
+#     scripts/check-gate.sh --release-env-policy          # report
+#     scripts/check-gate.sh --release-env-policy --fix    # apply
+# The one-line manual equivalent:
+#     gh api -X POST repos/OWNER/REPO/environments/github-pages/deployment-branch-policies \
+#       -f name='v*' -f type='tag'
+# See docs/platform-modules/web.md § "Releasing — tag deploys and deployment
+# environments".
+# ─────────────────────────────────────────────────────────────────
+
 on:
   push:
     tags: ['v*']

--- a/templates/uat/test-session-template.html
+++ b/templates/uat/test-session-template.html
@@ -1,4 +1,30 @@
 <!DOCTYPE html>
+<!--
+  AGENT: PLACEHOLDER MANIFEST — every token you must replace, in ONE place.
+  There are SEVEN. Each also carries its own instructions where it appears;
+  this list exists so none of them can be discovered late.
+
+    1. __SESSION_TITLE__      <title> and <h1>
+    2. __SESSION_DATE__       the meta line, and again in exportResults()
+    3. __SESSION_FEATURES__   the meta line, and again in exportResults()
+    4. __TESTER_PRE_FLIGHT__  the fixture-ref block above the progress bar
+    5. __FEATURE_SECTIONS__   one <h2> + <div id="featureN"> block per feature
+    6. __SCENARIOS_JSON__     the `const scenarios = …` array in <script>
+    7. __FEATURE_OPTIONS__    MID-FILE, inside the addBug() function — one
+                              <option> per feature for the bug form's Feature
+                              select. This is the one that gets missed (walk
+                              ISSUE-008): it is the only placeholder whose
+                              instructions live down in the JS rather than in
+                              a block comment near the markup it fills.
+
+  Backstop, not a substitute for this list: `scripts/lint-uat-scenarios.sh
+  <your-populated-file>` exits 1 with "file-level: unreplaced placeholder" on
+  any survivor — but it reports a line in YOUR OUTPUT file, which is not where
+  the fix goes. Work this list; use the linter to confirm.
+
+  Authoring rules, quality checklist and the co-build protocol for 'other'
+  platforms: docs/reference/uat-authoring-guide.md
+-->
 <html lang="en">
 <head>
 <meta charset="UTF-8">

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -835,6 +835,17 @@ run_child_suite "tests/test-bl106-golive-checklist.sh" "tests/test-bl106-golive-
 # lanes.
 run_child_suite "tests/test-bl137-ci-tools-scope.sh" "tests/test-bl137-ci-tools-scope.sh"
 
+# Walk 2026-08-02 ISSUE-006 (Major): BL-137's twin one arm down — the Phase
+# 1→2 PROTECTION backstop. Branch protection is an authenticated API read; a
+# runner holds no credential for it (Actions exports no token, and the
+# built-in GITHUB_TOKEN cannot read protection at all), so the generated
+# governance job could never pass on the framework's own default happy path.
+# Credential-less CI now WARNs ("could NOT run", never "verified") without
+# incrementing issues; local, token-bearing CI, and host=other all still
+# BLOCK. Real github driver + `gh` stub; three in-suite mutants (drop the $CI
+# key / blind the token probe / pre-fix repro). No init.sh -> both lanes.
+run_child_suite "tests/test-walk006-ci-protection-scope.sh" "tests/test-walk006-ci-protection-scope.sh"
+
 # BL-125 (Dogfood-2 F-DF2-009): the emitted pre-commit hook RUNS the
 # project's test command — RED tests block the commit ([BLOCKED]), green
 # tests land with a receipt, not-runnable (unconfigured / exit 127) is a

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1553,6 +1553,13 @@ run_child_suite "tests/test-escalate-to-user.sh" "tests/test-escalate-to-user.sh
 
 # Gate / check family.
 run_child_suite "tests/test-check-gate.sh" "tests/test-check-gate.sh"
+# Walk 2026-08-02 ISSUE-016 (Major): `--release-env-policy` — the GitHub Pages
+# environment's default branch policy rejects TAG deploys before any job
+# starts (empty step list, no readable error), which hard-fails the
+# framework's own "git tag v1.0.0 && git push --tags" happy path. Dry-run
+# reports + exits 1; --fix applies. `gh` stub + call log; in-suite mutant
+# blinds the tag-policy detection. No init.sh -> both lanes.
+run_child_suite "tests/test-walk016-release-env-policy.sh" "tests/test-walk016-release-env-policy.sh"
 run_child_suite "tests/test-check-changelog-filter.sh" "tests/test-check-changelog-filter.sh"
 run_child_suite "tests/test-check-commit-message.sh" "tests/test-check-commit-message.sh"
 # BL-010: the BL-006 Build-Loop commit-message check now runs at the git

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1521,6 +1521,15 @@ section "BL-035 C: docs / specs / lint suites"
 run_child_suite "tests/test-docs-cluster-six-pack.sh" "tests/test-docs-cluster-six-pack.sh (28/28)"
 run_child_suite "tests/test-specs-plans-remaining-quartet.sh" \
   "tests/test-specs-plans-remaining-quartet.sh (10/10)"
+
+# Walk 2026-08-02 ISSUE-003 (Minor): check-versions.sh printed the RAW jq
+# output of `install.<key>`, and BL-033 allows that value to be an ARRAY — so
+# five shipped tools surfaced as JSON literals under "Update commands (run
+# manually)". Array now joins with " && " (resolve-tools parity); URLs and
+# missing entries are labelled instead of masquerading as commands. In-suite
+# mutant drops the normalizer and the raw JSON returns. No init.sh -> both lanes.
+run_child_suite "tests/test-walk003-update-command-render.sh" \
+  "tests/test-walk003-update-command-render.sh"
 run_child_suite "tests/test-lint-uat-scenarios.sh" "tests/test-lint-uat-scenarios.sh (12/12)"
 # --- end BL-035 wiring C ---
 

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1350,7 +1350,14 @@ fi
 #   Cw6-floor       every CI template across the three hosts runs the gate
 #   Cw6-block       each carries the signature line, AS A COMMENT
 #   Cw6-honest      each says UNVERIFIED (never "verified") about the skip
-#   Cw6-remedy      each names its host's hard-enforcement credential
+#   Cw6-guided      each names the guided walkthrough (--setup-ci-token) — the
+#                   token path is RECOMMENDED, not merely available
+#   Cw6-credential  each names its host's hard-enforcement credential
+#   Cw6-wiring      github templates map the secret LIVE (executable YAML under
+#                   an `env:` key, not a commented example). This is the pin
+#                   that makes the walkthrough's result real: if the mapping is
+#                   a comment, `--setup-ci-token` stores a secret NOTHING reads
+#                   and the check keeps warning forever.
 echo "Cw6: every CI template that runs check-phase-gate.sh explains the credential model"
 CPG_FILES=()
 for f in "${GH_FILES[@]}" "${GL_FILES[@]}" "${BB_FILES[@]}"; do
@@ -1363,7 +1370,7 @@ if [ "$CPG_COUNT" -ge 30 ]; then
 else
   fail_ "Cw6-floor" "only $CPG_COUNT CI templates execute check-phase-gate.sh (floor 30) — derivation is vacuous"
 fi
-w6_noblock=""; w6_nothonest=""; w6_noremedy=""
+w6_noblock=""; w6_nothonest=""; w6_nocred=""; w6_noguide=""; w6_nowire=""
 if [ "$CPG_COUNT" -gt 0 ]; then
   for f in "${CPG_FILES[@]}"; do
     # The signature must sit on a COMMENT line: an executable line that
@@ -1372,15 +1379,22 @@ if [ "$CPG_COUNT" -gt 0 ]; then
       || w6_noblock="$w6_noblock ${f#*/ci/}"
     grep -Eq '^[[:space:]]*#.*UNVERIFIED' "$f" \
       || w6_nothonest="$w6_nothonest ${f#*/ci/}"
+    grep -Eq '^[[:space:]]*#.*check-gate\.sh --setup-ci-token' "$f" \
+      || w6_noguide="$w6_noguide ${f#*/ci/}"
     case "$f" in
-      */ci/github/*)    _w6_tok='GH_TOKEN' ;;
-      */ci/gitlab/*)    _w6_tok='GITLAB_TOKEN' ;;
-      */ci/bitbucket/*) _w6_tok='BITBUCKET_API_TOKEN' ;;
-      *)                _w6_tok='' ;;
+      */ci/github/*)
+        # github's credential is the LIVE mapping, not prose — assert the
+        # executable form (no leading `#`) under the step.
+        grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{[[:space:]]*secrets\.SOIF_PROTECTION_TOKEN[[:space:]]*\}\}[[:space:]]*$' "$f" \
+          || w6_nocred="$w6_nocred ${f#*/ci/}"
+        grep -Eq '^[[:space:]]*env:[[:space:]]*$' "$f" \
+          || w6_nowire="$w6_nowire ${f#*/ci/}"
+        ;;
+      */ci/gitlab/*)
+        grep -Eq '^[[:space:]]*#.*GITLAB_TOKEN' "$f" || w6_nocred="$w6_nocred ${f#*/ci/}" ;;
+      */ci/bitbucket/*)
+        grep -Eq '^[[:space:]]*#.*BITBUCKET_API_TOKEN' "$f" || w6_nocred="$w6_nocred ${f#*/ci/}" ;;
     esac
-    if [ -n "$_w6_tok" ]; then
-      grep -Eq "^[[:space:]]*#.*$_w6_tok" "$f" || w6_noremedy="$w6_noremedy ${f#*/ci/}"
-    fi
   done
 fi
 if [ -z "$w6_noblock" ]; then
@@ -1393,10 +1407,20 @@ if [ -z "$w6_nothonest" ]; then
 else
   fail_ "Cw6-honest" "the block never says UNVERIFIED — a skip that reads as a pass — in:$w6_nothonest"
 fi
-if [ -z "$w6_noremedy" ]; then
-  pass "Cw6-remedy (each block names its host's hard-enforcement credential)"
+if [ -z "$w6_noguide" ]; then
+  pass "Cw6-guided (every block RECOMMENDS the guided walkthrough by name)"
 else
-  fail_ "Cw6-remedy" "no hard-enforcement credential named in:$w6_noremedy"
+  fail_ "Cw6-guided" "no 'check-gate.sh --setup-ci-token' recommendation in:$w6_noguide"
+fi
+if [ -z "$w6_nocred" ]; then
+  pass "Cw6-credential (each names its host's hard-enforcement credential)"
+else
+  fail_ "Cw6-credential" "no hard-enforcement credential named in:$w6_nocred"
+fi
+if [ -z "$w6_nowire" ]; then
+  pass "Cw6-wiring (github phase-gate steps map the secret LIVE, not as a commented example)"
+else
+  fail_ "Cw6-wiring" "no executable 'env:' key carrying the secret mapping in:$w6_nowire"
 fi
 
 # ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1423,6 +1423,38 @@ else
   fail_ "Cw6-wiring" "no executable 'env:' key carrying the secret mapping in:$w6_nowire"
 fi
 
+# ── Cw6-strict (adversarial review R-1): a mapped secret must reach a gate
+# whose EXIT CODE still counts. 7 of the 10 github templates ran the gate as
+#     bash scripts/check-phase-gate.sh 2>/dev/null || echo "…not found — skipping"
+# which discards the exit code entirely: a probe showed the gate printing [FAIL]
+# and exiting 1 while the step graded GREEN, and the swallow message LIED (the
+# script was found — it was the gate's verdict that failed, not the file). Under
+# that shape "set the secret and the backstop enforces" is FALSE: the check
+# would run with a real credential and its verdict would still be thrown away.
+# So the credential wiring and the exit-code contract are ONE pin, not two.
+#
+# Deliberately scoped to templates that MAP the secret: those are exactly the
+# ones making the enforcement claim. `[ ! -f … ] && exit 1` + a bare invocation
+# is the strict shape python/typescript/other already used.
+w6_swallow=""
+if [ "$CPG_COUNT" -gt 0 ]; then
+  for f in "${CPG_FILES[@]}"; do
+    case "$f" in */ci/github/*) ;; *) continue ;; esac
+    grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{' "$f" || continue
+    # Any EXECUTABLE gate invocation whose exit status is discarded — `|| echo`,
+    # `|| true`, `|| :`, or a trailing `2>/dev/null` swallow on the same line.
+    if grep -E '^[^#]*bash scripts/check-phase-gate\.sh' "$f" \
+         | grep -Eq '\|\|[[:space:]]*(echo|true|:)'; then
+      w6_swallow="$w6_swallow ${f#*/ci/}"
+    fi
+  done
+fi
+if [ -z "$w6_swallow" ]; then
+  pass "Cw6-strict (every secret-mapping github template lets the gate's EXIT CODE decide the step)"
+else
+  fail_ "Cw6-strict" "the gate's exit code is discarded (\`|| echo/true/:\`) — a mapped secret cannot enforce anything — in:$w6_swallow"
+fi
+
 # ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────
 # The emitted release.yml is TAG-triggered, and enabling GitHub Pages
 # auto-creates a `github-pages` environment whose default deployment branch

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1335,6 +1335,70 @@ if [ "$cp2_bad" -eq 0 ]; then
   pass "Cp2-all-pinned (every action-bearing RELEASE_SETUP_ACTION is SHA-pinned + commented)"
 fi
 
+# ── Cw6 (walk 2026-08-02 ISSUE-006): the phase-gate CREDENTIAL comment block ─
+# The gate's Phase 1→2 backstop verifies branch protection through an
+# AUTHENTICATED host API read that no generated runner can perform: Actions
+# exports no token into a step env (and the built-in GITHUB_TOKEN cannot read
+# protection at all — no `administration` key in `permissions:`), and the
+# gitlab/bitbucket governance jobs install only jq+git. That made the
+# governance job STRUCTURALLY unpassable on the framework's own default happy
+# path. `# WALK-ISSUE-006-CI-PROTECTION-SCOPE` converts that ONE check to a
+# loud WARN in credential-less CI; this case pins the OTHER half — the emitted
+# workflow has to SAY so, and has to name the token that re-arms hard
+# enforcement. A silent exemption is how a downgraded check becomes a
+# forgotten check.
+#   Cw6-floor       every CI template across the three hosts runs the gate
+#   Cw6-block       each carries the signature line, AS A COMMENT
+#   Cw6-honest      each says UNVERIFIED (never "verified") about the skip
+#   Cw6-remedy      each names its host's hard-enforcement credential
+echo "Cw6: every CI template that runs check-phase-gate.sh explains the credential model"
+CPG_FILES=()
+for f in "${GH_FILES[@]}" "${GL_FILES[@]}" "${BB_FILES[@]}"; do
+  # executable invocation only — a commented-out gate line is not a gate
+  grep -Eq '^[^#]*bash scripts/check-phase-gate\.sh' "$f" && CPG_FILES+=("$f")
+done
+CPG_COUNT=${#CPG_FILES[@]}
+if [ "$CPG_COUNT" -ge 30 ]; then
+  pass "Cw6-floor ($CPG_COUNT CI templates execute check-phase-gate.sh, floor 30)"
+else
+  fail_ "Cw6-floor" "only $CPG_COUNT CI templates execute check-phase-gate.sh (floor 30) — derivation is vacuous"
+fi
+w6_noblock=""; w6_nothonest=""; w6_noremedy=""
+if [ "$CPG_COUNT" -gt 0 ]; then
+  for f in "${CPG_FILES[@]}"; do
+    # The signature must sit on a COMMENT line: an executable line that
+    # happened to contain the phrase must not satisfy the pin.
+    grep -Eq '^[[:space:]]*#[[:space:]]*PHASE-GATE CREDENTIALS \(walk ISSUE-006\)' "$f" \
+      || w6_noblock="$w6_noblock ${f#*/ci/}"
+    grep -Eq '^[[:space:]]*#.*UNVERIFIED' "$f" \
+      || w6_nothonest="$w6_nothonest ${f#*/ci/}"
+    case "$f" in
+      */ci/github/*)    _w6_tok='GH_TOKEN' ;;
+      */ci/gitlab/*)    _w6_tok='GITLAB_TOKEN' ;;
+      */ci/bitbucket/*) _w6_tok='BITBUCKET_API_TOKEN' ;;
+      *)                _w6_tok='' ;;
+    esac
+    if [ -n "$_w6_tok" ]; then
+      grep -Eq "^[[:space:]]*#.*$_w6_tok" "$f" || w6_noremedy="$w6_noremedy ${f#*/ci/}"
+    fi
+  done
+fi
+if [ -z "$w6_noblock" ]; then
+  pass "Cw6-block (all $CPG_COUNT templates carry the credential comment block)"
+else
+  fail_ "Cw6-block" "no '# PHASE-GATE CREDENTIALS (walk ISSUE-006)' comment in:$w6_noblock"
+fi
+if [ -z "$w6_nothonest" ]; then
+  pass "Cw6-honest (each block calls the skipped check UNVERIFIED, never verified)"
+else
+  fail_ "Cw6-honest" "the block never says UNVERIFIED — a skip that reads as a pass — in:$w6_nothonest"
+fi
+if [ -z "$w6_noremedy" ]; then
+  pass "Cw6-remedy (each block names its host's hard-enforcement credential)"
+else
+  fail_ "Cw6-remedy" "no hard-enforcement credential named in:$w6_noremedy"
+fi
+
 echo ""
 if [ "${SKIPPED:-0}" -gt 0 ]; then
   echo "!! ${SKIPPED} case(s) SKIPPED — skipped != passed."

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1436,16 +1436,28 @@ fi
 # Deliberately scoped to templates that MAP the secret: those are exactly the
 # ones making the enforcement claim. `[ ! -f … ] && exit 1` + a bare invocation
 # is the strict shape python/typescript/other already used.
-w6_swallow=""
+#
+# Scoped to the STEP, not the file: the phase-gate step is extracted by name and
+# both discard vectors are checked inside it — the shell one (`|| echo/true/:`
+# on the invocation) and the Actions-native one (`continue-on-error: true` on
+# the step, which grades a red step GREEN just as effectively). Other steps may
+# legitimately use either (java/kotlin's Lint step does); this one may not.
+w6_swallow=""; w6_coe=""
 if [ "$CPG_COUNT" -gt 0 ]; then
   for f in "${CPG_FILES[@]}"; do
     case "$f" in */ci/github/*) ;; *) continue ;; esac
     grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{' "$f" || continue
-    # Any EXECUTABLE gate invocation whose exit status is discarded — `|| echo`,
-    # `|| true`, `|| :`, or a trailing `2>/dev/null` swallow on the same line.
-    if grep -E '^[^#]*bash scripts/check-phase-gate\.sh' "$f" \
-         | grep -Eq '\|\|[[:space:]]*(echo|true|:)'; then
+    _w6_step=$(awk '
+      /^      - name: Governance - Phase gate check$/ { inside = 1; next }
+      inside && /^      - name: / { exit }
+      inside { print }
+    ' "$f")
+    if printf '%s\n' "$_w6_step" | grep -E '^[^#]*bash scripts/check-phase-gate\.sh' \
+         | grep -Eq '(\|\||;)[[:space:]]*(echo|true|:)'; then
       w6_swallow="$w6_swallow ${f#*/ci/}"
+    fi
+    if printf '%s\n' "$_w6_step" | grep -Eq '^[[:space:]]*continue-on-error:[[:space:]]*true'; then
+      w6_coe="$w6_coe ${f#*/ci/}"
     fi
   done
 fi
@@ -1453,6 +1465,11 @@ if [ -z "$w6_swallow" ]; then
   pass "Cw6-strict (every secret-mapping github template lets the gate's EXIT CODE decide the step)"
 else
   fail_ "Cw6-strict" "the gate's exit code is discarded (\`|| echo/true/:\`) — a mapped secret cannot enforce anything — in:$w6_swallow"
+fi
+if [ -z "$w6_coe" ]; then
+  pass "Cw6-strict-no-coe (no continue-on-error on the phase-gate step — the Actions-native swallow)"
+else
+  fail_ "Cw6-strict-no-coe" "continue-on-error grades the phase-gate step GREEN regardless of the verdict, in:$w6_coe"
 fi
 
 # ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1399,6 +1399,46 @@ else
   fail_ "Cw6-remedy" "no hard-enforcement credential named in:$w6_noremedy"
 fi
 
+# ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────
+# The emitted release.yml is TAG-triggered, and enabling GitHub Pages
+# auto-creates a `github-pages` environment whose default deployment branch
+# policy admits the DEFAULT BRANCH ONLY — so `git push --tags` is rejected
+# before any step runs (empty step list, no readable error). The workflow
+# cannot self-diagnose it (a rejected run starts no job), so the template's
+# job is to NAME the trap and point at the check that can run. Pinned here
+# because a comment is the only thing standing between a first-time releaser
+# and an unreadable failure — and because the pointer must resolve:
+# Cw16-subcommand asserts the named subcommand actually dispatches.
+echo "Cw16: the web release template names the tag-deploy environment trap + a runnable check"
+REL_WEB_W16="$REPO_ROOT/templates/pipelines/release/github/web.yml"
+CHECK_GATE_W16="$REPO_ROOT/scripts/check-gate.sh"
+if [ -f "$REL_WEB_W16" ] && [ -f "$CHECK_GATE_W16" ]; then
+  pass "Cw16-floor (release/github/web.yml + scripts/check-gate.sh present)"
+else
+  fail_ "Cw16-floor" "a Cw16 target file is missing — the cases below would be vacuous"
+fi
+if grep -Eq '^[[:space:]]*#.*walk ISSUE-016' "$REL_WEB_W16"; then
+  pass "Cw16-block (the tag-deploy/environment trap is documented at the trigger, as a comment)"
+else
+  fail_ "Cw16-block" "release/github/web.yml does not name the walk ISSUE-016 tag-deploy environment trap"
+fi
+w16_missing=""
+grep -Fq 'deployment-branch-policies' "$REL_WEB_W16" || w16_missing="$w16_missing api-path"
+grep -Fq -- '--release-env-policy' "$REL_WEB_W16"    || w16_missing="$w16_missing subcommand"
+grep -Fq "type='tag'" "$REL_WEB_W16"                 || w16_missing="$w16_missing tag-type"
+if [ -z "$w16_missing" ]; then
+  pass "Cw16-remedy (names the API path, the tag policy type, and the runnable check)"
+else
+  fail_ "Cw16-remedy" "release/github/web.yml is missing:$w16_missing"
+fi
+# The pointer must RESOLVE — a comment naming a subcommand that check-gate.sh
+# does not dispatch is worse than no comment.
+if grep -Eq '^[[:space:]]*--release-env-policy\)' "$CHECK_GATE_W16"; then
+  pass "Cw16-subcommand (check-gate.sh actually dispatches --release-env-policy)"
+else
+  fail_ "Cw16-subcommand" "the template points at scripts/check-gate.sh --release-env-policy but check-gate.sh does not dispatch it"
+fi
+
 echo ""
 if [ "${SKIPPED:-0}" -gt 0 ]; then
   echo "!! ${SKIPPED} case(s) SKIPPED — skipped != passed."

--- a/tests/test-check-phase-gate-backstop-attestation.sh
+++ b/tests/test-check-phase-gate-backstop-attestation.sh
@@ -128,7 +128,15 @@ STUB
 teardown_project() { rm -rf "$TMP"; }
 
 run_gate() {
-  ( cd "$PROJ" && PATH="$STUBDIR:$PATH" bash "$SCRIPT" 2>&1 )
+  # `env -u CI -u GH_TOKEN -u GITHUB_TOKEN` — T2 asserts the backstop BLOCKS
+  # when no attestation is recorded, and since
+  # `# WALK-ISSUE-006-CI-PROTECTION-SCOPE` the arm deliberately does NOT block
+  # on a credential-less CI runner. Inheriting this suite's own $CI (it runs in
+  # the tests.yml unit lane) would exempt the arm and turn T2 green-in-CI /
+  # red-locally — the exact split-brain the walk finding is about. These cases
+  # are about the ATTESTATION path, so they are pinned to the local context.
+  ( cd "$PROJ" && PATH="$STUBDIR:$PATH" env -u CI -u GH_TOKEN -u GITHUB_TOKEN \
+      bash "$SCRIPT" 2>&1 )
 }
 
 # ════════════════════════════════════════════════════════════════════

--- a/tests/test-lint-uat-scenarios.sh
+++ b/tests/test-lint-uat-scenarios.sh
@@ -206,6 +206,52 @@ case_12_seed_template_no_placeholder_collision() {
   fi
 }
 
+case_13_seed_template_placeholder_manifest_is_complete() {
+  # Walk 2026-08-02 ISSUE-008: the seed template's placeholders were documented
+  # one-by-one next to the markup they fill — except __FEATURE_OPTIONS__, whose
+  # only instructions sit mid-file inside addBug(). An author who worked the
+  # comments near the top replaced six of seven and was caught by the linter,
+  # which reports a line in the OUTPUT file while the fix belongs in a
+  # different, mid-file spot in the TEMPLATE.
+  #
+  # The fix is a top-of-file PLACEHOLDER MANIFEST; this case makes it
+  # self-maintaining. The token list is DERIVED, never retyped: the linter's
+  # own comment-stripper decides which placeholders survive into a populated
+  # file, so a NEW placeholder added to the template with no manifest row
+  # fails here. Floor 7 keeps the derivation from passing vacuously.
+  local template="$REPO_ROOT/templates/uat/test-session-template.html"
+  local manifest tokens count missing=""
+  # The manifest block: from the marker line to the end of that HTML comment.
+  manifest=$(awk '/AGENT: PLACEHOLDER MANIFEST/{f=1} f{print} f&&/-->/{exit}' "$template")
+  if [ -z "$manifest" ]; then
+    echo "  templates/uat/test-session-template.html has no 'AGENT: PLACEHOLDER MANIFEST' block" >&2
+    return 1
+  fi
+  # Placeholders that SURVIVE comment-stripping = the ones an author must
+  # replace. Sourced from the linter itself so the two cannot disagree.
+  set +e
+  tokens=$(bash "$LINTER" "$template" 2>&1 | grep -o '__[A-Z][A-Z_]*__' | sort -u)
+  set -e
+  count=$(printf '%s\n' "$tokens" | grep -c '__')
+  if [ "$count" -lt 7 ]; then
+    echo "  derived only $count placeholder token(s) from the seed template (floor 7) — derivation is vacuous" >&2
+    return 1
+  fi
+  local t
+  for t in $tokens; do
+    case "$manifest" in *"$t"*) ;; *) missing="$missing $t" ;; esac
+  done
+  if [ -n "$missing" ]; then
+    echo "  placeholder(s) present in the template but ABSENT from the manifest:$missing" >&2
+    return 1
+  fi
+  # And the one the walk found must be named as the easy-to-miss one.
+  case "$manifest" in *ISSUE-008*) ;; *)
+    echo "  the manifest does not flag __FEATURE_OPTIONS__ as the mid-file outlier (walk ISSUE-008)" >&2
+    return 1 ;;
+  esac
+}
+
 case_11_multiple_violations() {
   local work; work=$(mktemp -d); trap "rm -rf '$work'" RETURN
   seed_html "$work/bad.html" '[
@@ -234,6 +280,7 @@ run_case "case 9: missing input file"                case_9_missing_file
 run_case "case 10: malformed JSON"                   case_10_malformed_json
 run_case "case 11: multiple violations"              case_11_multiple_violations
 run_case "case 12: seed template no __PLACEHOLDER__" case_12_seed_template_no_placeholder_collision
+run_case "case 13: seed template placeholder manifest is complete" case_13_seed_template_placeholder_manifest_is_complete
 
 echo ""
 echo "═══════════════════════════════════════════"

--- a/tests/test-walk003-update-command-render.sh
+++ b/tests/test-walk003-update-command-render.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# tests/test-walk003-update-command-render.sh — walk 2026-08-02 ISSUE-003:
+# `check-versions.sh` printed a raw JSON array under a heading that promises a
+# runnable command.
+#
+# WHY THIS EXISTS
+#   BL-033 lets each `install.<key>` in the tool matrix be EITHER a string or an
+#   ARRAY of stages, and scripts/resolve-tools.sh normalizes both (joining an
+#   array with " && " for its `install_cmd` field). check-versions.sh did not:
+#   it echoed the raw `jq -r` output, so a five-entry matrix printed
+#       Colima: [ "brew install colima", "brew services start colima" ]
+#   under "Update commands (run manually):". The walker's note is exact — a
+#   junior cannot tell whether that is one command, two, or an error. Five tools
+#   in the shipped matrix carry array-valued install keys (Colima, Docker,
+#   gitleaks, k6, Rust), so this was not a corner case.
+#
+# THE CONTRACT (# WALK-ISSUE-003-UPDATE-CMD)
+#   Every line under that heading is either a runnable command or LABELLED as
+#   not being one:
+#     • array  -> one line, stages joined with " && " (resolve-tools parity)
+#     • string -> verbatim (the `<name>: <cmd>` grammar T-CV-MULTIWORD pins)
+#     • URL    -> "see <url>" — a doc link is not a command
+#     • absent -> an explicit "(no install command in the tool matrix …)"
+#
+# FIXTURE MECHANICS: min_version 99.0.0 + `version_command: echo 0.0.1` forces
+# the BELOW-MINIMUM branch, which pushes onto UPDATES[]/UPDATE_CMDS[] with no
+# network. Each tool carries the SAME shape under darwin_brew AND manual so the
+# suite is portable across brew (macOS dev box) and non-brew (CI) hosts —
+# whichever lookup wins, the shape under test is the one measured. Hermetic.
+#
+# REGISTRATION: no init.sh, not an aggregator → BOTH lists. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CV="$REPO_ROOT/scripts/check-versions.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq required (tool matrix fixtures)"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# mk_fixture <dir> <script> <install-json-or-NONE>
+mk_fixture() {
+  local d="$1" script="$2" install="$3"
+  rm -rf "$d"
+  mkdir -p "$d/templates/tool-matrix" "$d/scripts/lib"
+  if [ "$install" = NONE ]; then
+    cat > "$d/templates/tool-matrix/common.json" <<'JSON'
+{"tools":[{"name":"WalkTool","category":"tooling","required":true,
+  "min_version":"99.0.0","description":"walk003 fixture",
+  "check_command":"true","version_command":"echo 0.0.1",
+  "tracks":["light","standard","full"],"languages":["all"],
+  "platforms":["all"],"dev_os":["darwin","linux"]}]}
+JSON
+  else
+    jq -n --argjson inst "$install" '
+      {tools:[{name:"WalkTool",category:"tooling",required:true,
+        min_version:"99.0.0",description:"walk003 fixture",
+        check_command:"true",version_command:"echo 0.0.1",
+        tracks:["light","standard","full"],languages:["all"],
+        platforms:["all"],dev_os:["darwin","linux"],
+        install:$inst}]}' > "$d/templates/tool-matrix/common.json"
+  fi
+  cp "$script" "$d/scripts/check-versions.sh"
+  chmod +x "$d/scripts/check-versions.sh"
+}
+
+run_cv() { ( cd "$1" && bash scripts/check-versions.sh </dev/null 2>&1 || true ); }
+
+# The same multi-stage value under both lookup keys (brew and non-brew hosts).
+ARRAY_INSTALL='{"darwin_brew":["brew install colima","brew services start colima"],
+                "manual":["brew install colima","brew services start colima"]}'
+STRING_INSTALL='{"darwin_brew":"brew install walktool","manual":"brew install walktool"}'
+URL_INSTALL='{"darwin_brew":"https://example.invalid/install","manual":"https://example.invalid/install"}'
+
+echo "== tests/test-walk003-update-command-render.sh =="
+
+# ── T1: an array install renders as ONE runnable && chain, no JSON ──────────
+echo "=== T1-array-renders-runnable ==="
+P="$TOPTMP/p1"; mk_fixture "$P" "$CV" "$ARRAY_INSTALL"
+out=$(run_cv "$P")
+line=$(printf '%s\n' "$out" | grep '^  WalkTool:' | head -1)
+if printf '%s' "$line" | grep -Fq 'brew install colima && brew services start colima' \
+   && ! printf '%s' "$line" | grep -q '\['; then
+  pass "T1-array-renders-runnable (stages joined with ' && ', resolve-tools parity)"
+else
+  fail_ "T1-array-renders-runnable" "the walk's exact defect: a JSON array under 'Update commands (run manually)'. line=[$line]"
+fi
+
+# ── T2: a plain string is still printed VERBATIM (T-CV-MULTIWORD parity) ───
+echo "=== T2-string-verbatim ==="
+P="$TOPTMP/p2"; mk_fixture "$P" "$CV" "$STRING_INSTALL"
+out=$(run_cv "$P")
+if printf '%s\n' "$out" | grep -qE '^  WalkTool: brew install walktool$'; then
+  pass "T2-string-verbatim (the '<name>: <cmd>' grammar is unchanged)"
+else
+  fail_ "T2-string-verbatim" "the single-command shape must not regress: $(printf '%s\n' "$out" | grep -i walktool | tr '\n' ' ')"
+fi
+
+# ── T3: a documentation URL is labelled, not presented as a command ────────
+echo "=== T3-url-labelled ==="
+P="$TOPTMP/p3"; mk_fixture "$P" "$CV" "$URL_INSTALL"
+out=$(run_cv "$P")
+if printf '%s\n' "$out" | grep -qE '^  WalkTool: see https://example\.invalid/install$'; then
+  pass "T3-url-labelled (a doc link is not a runnable command)"
+else
+  fail_ "T3-url-labelled" "expected 'see <url>': $(printf '%s\n' "$out" | grep -i walktool | tr '\n' ' ')"
+fi
+
+# ── T4: no install block at all → explicit, never a dangling colon ─────────
+echo "=== T4-absent-labelled ==="
+P="$TOPTMP/p4"; mk_fixture "$P" "$CV" NONE
+out=$(run_cv "$P")
+if printf '%s\n' "$out" | grep -q '^  WalkTool: (no install command in the tool matrix'; then
+  pass "T4-absent-labelled (an empty entry says so instead of printing 'WalkTool: ')"
+else
+  fail_ "T4-absent-labelled" "expected the labelled empty case: $(printf '%s\n' "$out" | grep -i walktool | tr '\n' ' ')"
+fi
+
+# ── M1: mutant — drop the array normalizer, the raw JSON comes back ────────
+# Asserted POSITIVELY: the mutant must reproduce the walk's verbatim output.
+echo "=== M1-mutant-drop-normalizer ==="
+MUT="$TOPTMP/cv-mutant.sh"
+sed "s|^_cv_jq_install_cmd=.*|_cv_jq_install_cmd='.'|" "$CV" > "$MUT"
+if grep -q "^_cv_jq_install_cmd='\.'\$" "$MUT"; then
+  P="$TOPTMP/pm1"; mk_fixture "$P" "$MUT" "$ARRAY_INSTALL"
+  out=$(run_cv "$P")
+  if printf '%s\n' "$out" | grep -q 'WalkTool: \['; then
+    pass "M1-mutant-drop-normalizer (without the normalizer the raw JSON array returns — it carries T1)"
+  else
+    fail_ "M1-mutant-drop-normalizer" "the mutant did not reproduce ISSUE-003, so T1 proves nothing: $(printf '%s\n' "$out" | grep -i walktool | tr '\n' ' ')"
+  fi
+else
+  fail_ "M1-mutant-drop-normalizer" "sed did not rewrite _cv_jq_install_cmd — mutant is vacuous"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -198,6 +198,23 @@ else
   fail_ "T2b-ci-warn-is-honest" "the exempt arm must not read as a pass: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
 fi
 
+# ── T2c: an EMPTY GH_TOKEN is the runtime shape of an UNSET secret ─────────
+# The generated workflow maps `GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}`
+# LIVE. Before the operator runs --setup-ci-token that secret does not exist,
+# and Actions substitutes the EMPTY STRING — GH_TOKEN is SET but empty. If the
+# probe tested for set-ness rather than non-emptiness, every generated project
+# would hard-fail the moment the mapping shipped. Distinct input from T2.
+echo "=== T2c-empty-token-is-absent ==="
+P="$TOPTMP/p2c"; mk_proj "$P" github fail
+out=$(run_gate "$P" "$SCRIPT" CI=true GH_TOKEN=); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "$WARN_SIG" \
+   && ! printf '%s' "$out" | grep -q "$FAIL_SIG"; then
+  pass "T2c-empty-token-is-absent (an unset secret substitutes to '' and must read as no credential)"
+else
+  fail_ "T2c-empty-token-is-absent" "rc=$rc — the live secret mapping would hard-fail every project with no secret set yet: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+fi
+
 # ── T3: CI + an exported token → BLOCKS again (hard-enforcement path) ───────
 echo "=== T3-ci-with-token-still-blocks ==="
 P="$TOPTMP/p3"; mk_proj "$P" github fail
@@ -319,6 +336,192 @@ if grep -q 'if false; then' "$M3"; then
   fi
 else
   fail_ "M3-mutant-prefix-repro" "sed did not rewrite the guard call — mutant is vacuous"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# PART 2 — the way BACK to enforcement: `check-gate.sh --setup-ci-token`
+# (# WALK-ISSUE-006-SETUP-CI-TOKEN)
+#
+# Part 1 above stops a structurally-impossible check from blocking. It does NOT
+# restore the check, and a permanently-warning check is a check on its way to
+# being ignored — so the token path is RECOMMENDED, and guided end to end. This
+# section pins the walkthrough's contract and, critically, the LINK between its
+# output and the gate's input: the secret it stores must be the one the emitted
+# workflow maps, or the walkthrough writes a secret nothing reads.
+# ════════════════════════════════════════════════════════════════════════════
+CHECK_GATE="$REPO_ROOT/scripts/check-gate.sh"
+GOOD_TOKEN="ghp_walk006_good"
+BAD_TOKEN="ghp_walk006_bad"
+
+# mk_tok <dir> <host> <auth: ok|unauth> [ci.yml-wires-secret: yes|no]
+mk_tok() {
+  local d="$1" host="$2" auth="$3" wired="${4:-yes}"
+  rm -rf "$d"
+  mkdir -p "$d/.claude" "$d/scripts/lib" "$d/scripts/host-drivers" "$d/bin" "$d/stub" \
+           "$d/.github/workflows"
+  jq -n --arg h "$host" '{frameworkVersion:"test", host:$h, mode:"personal"}' \
+    > "$d/.claude/manifest.json"
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.invalid && git config user.name t \
+      && git remote add origin https://github.com/example/walk006.git ) || return 1
+  cp "$REPO_ROOT/scripts/lib/"*.sh "$d/scripts/lib/"
+  cp "$REPO_ROOT/scripts/host-drivers/github.sh" "$d/scripts/host-drivers/"
+  printf '%s' "$GOOD_TOKEN" > "$d/stub/goodtoken"
+  [ "$auth" = unauth ] && : > "$d/stub/unauth"
+  : > "$d/stub/gh.log"
+  if [ "$wired" = yes ]; then
+    printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n' \
+      > "$d/.github/workflows/ci.yml"
+  else
+    printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n' \
+      > "$d/.github/workflows/ci.yml"
+  fi
+  cat > "$d/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_STUB_DIR/gh.log"
+case "$1 ${2:-}" in
+  "auth status") [ -f "$GH_STUB_DIR/unauth" ] && exit 1; exit 0 ;;
+  "secret set")
+      # value arrives on STDIN, never argv — record what we were handed
+      value=$(cat)
+      printf 'STDIN:%s\n' "$value" >> "$GH_STUB_DIR/gh.log"
+      printf '%s\n' "$3" > "$GH_STUB_DIR/stored"
+      exit 0 ;;
+  "secret list")
+      [ -f "$GH_STUB_DIR/stored" ] && { printf '%s\tUpdated\n' "$(cat "$GH_STUB_DIR/stored")"; exit 0; }
+      exit 0 ;;
+esac
+case "$*" in
+  *protection*)
+      # the probe passes ONLY when the caller actually exported the good token
+      if [ "${GH_TOKEN:-}" = "$(cat "$GH_STUB_DIR/goodtoken")" ]; then
+        echo '{"allow_force_pushes":{"enabled":false},"enforce_admins":{"enabled":true}}'; exit 0
+      fi
+      echo '{"message":"Resource not accessible by personal access token","status":"403"}' >&2
+      exit 1 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/gh"
+}
+
+# run_tok <dir> <token-or-EMPTY> [args...]
+run_tok() {
+  local d="$1" tok="$2"; shift 2
+  if [ "$tok" = EMPTY ]; then
+    ( cd "$d" && PATH="$d/bin:$PATH" GH_STUB_DIR="$d/stub" \
+        env -u SOIF_PROTECTION_TOKEN bash "$CHECK_GATE" --setup-ci-token "$@" </dev/null 2>&1 )
+  else
+    ( cd "$d" && PATH="$d/bin:$PATH" GH_STUB_DIR="$d/stub" \
+        env SOIF_PROTECTION_TOKEN="$tok" bash "$CHECK_GATE" --setup-ci-token "$@" </dev/null 2>&1 )
+  fi
+}
+
+# ── S1: non-github host → NOT APPLICABLE + the manual per-host steps ───────
+echo "=== S1-non-github-not-applicable ==="
+P="$TOPTMP/s1"; mk_tok "$P" gitlab ok
+out=$(run_tok "$P" EMPTY); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "NOT APPLICABLE" \
+   && printf '%s' "$out" | grep -q "GITLAB_TOKEN" \
+   && printf '%s' "$out" | grep -q "glab"; then
+  pass "S1-non-github-not-applicable (prints the GitLab steps, incl. the glab half)"
+else
+  fail_ "S1-non-github-not-applicable" "rc=$rc: $out"
+fi
+
+# ── S2: gh not authenticated → refuse with the actionable next step ────────
+echo "=== S2-gh-unauthenticated ==="
+P="$TOPTMP/s2"; mk_tok "$P" github unauth
+out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "gh auth login"; then
+  pass "S2-gh-unauthenticated (refuses, names the fix)"
+else
+  fail_ "S2-gh-unauthenticated" "rc=$rc: $out"
+fi
+
+# ── S3: happy path — explains, verifies, stores, confirms the wiring ───────
+echo "=== S3-happy-path ==="
+P="$TOPTMP/s3"; mk_tok "$P" github ok yes
+out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+log=$(cat "$P/stub/gh.log")
+ok=1
+[ "$rc" -eq 0 ] || ok=0
+printf '%s' "$out" | grep -q "Administration: \*\*Read-only\*\*" || ok=0
+printf '%s' "$out" | grep -q "Token verified" || ok=0
+printf '%s' "$log" | grep -q "^secret set SOIF_PROTECTION_TOKEN --repo example/walk006$" || ok=0
+printf '%s' "$log" | grep -q "^STDIN:$GOOD_TOKEN$" || ok=0
+printf '%s' "$out" | grep -q "already maps SOIF_PROTECTION_TOKEN" || ok=0
+if [ "$ok" -eq 1 ]; then
+  pass "S3-happy-path (least-privilege explained, token probed, secret stored, wiring confirmed)"
+else
+  fail_ "S3-happy-path" "rc=$rc log=[$(printf '%s' "$log" | tr '\n' ';')] out=$out"
+fi
+
+# ── S3b: the secret VALUE never appears on argv ────────────────────────────
+# `ps` exposes argv to every process on the box. The value must ride stdin.
+echo "=== S3b-secret-not-on-argv ==="
+if printf '%s' "$log" | grep -v '^STDIN:' | grep -q "$GOOD_TOKEN"; then
+  fail_ "S3b-secret-not-on-argv" "the token value appeared in a gh ARGV line: $(printf '%s' "$log" | grep -v '^STDIN:' | grep "$GOOD_TOKEN")"
+else
+  pass "S3b-secret-not-on-argv (value rides stdin; argv carries only the secret NAME)"
+fi
+
+# ── S4: a token that cannot read protection is REFUSED, nothing stored ────
+# Storing a powerless token would convert today's honest WARN into a hard FAIL
+# — strictly worse than the state we started in.
+echo "=== S4-powerless-token-refused ==="
+P="$TOPTMP/s4"; mk_tok "$P" github ok yes
+out=$(run_tok "$P" "$BAD_TOKEN"); rc=$?
+log=$(cat "$P/stub/gh.log")
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "could NOT read branch protection" \
+   && printf '%s' "$out" | grep -q "Administration: Read-only" \
+   && ! printf '%s' "$log" | grep -q "^secret set"; then
+  pass "S4-powerless-token-refused (fails closed — verify BEFORE store)"
+else
+  fail_ "S4-powerless-token-refused" "rc=$rc log=[$(printf '%s' "$log" | tr '\n' ';')] out=$out"
+fi
+
+# ── S5: --skip-verify is the explicit, named escape ────────────────────────
+echo "=== S5-skip-verify-stores ==="
+P="$TOPTMP/s5"; mk_tok "$P" github ok yes
+out=$(run_tok "$P" "$BAD_TOKEN" --skip-verify); rc=$?
+if [ "$rc" -eq 0 ] && grep -q "^secret set SOIF_PROTECTION_TOKEN" "$P/stub/gh.log"; then
+  pass "S5-skip-verify-stores (the escape exists and is opt-in only)"
+else
+  fail_ "S5-skip-verify-stores" "rc=$rc: $out"
+fi
+
+# ── S6: an unwired workflow is CALLED OUT, not silently succeeded ──────────
+# A project scaffolded before the mapping shipped would otherwise get a secret
+# nothing reads — a silent no-op wearing a success message.
+echo "=== S6-unwired-workflow-warned ==="
+P="$TOPTMP/s6"; mk_tok "$P" github ok no
+out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "does not map SOIF_PROTECTION_TOKEN yet" \
+   && printf '%s' "$out" | grep -q 'GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}'; then
+  pass "S6-unwired-workflow-warned (names the gap and prints the exact lines to add)"
+else
+  fail_ "S6-unwired-workflow-warned" "rc=$rc: $out"
+fi
+
+# ── S7: THE CHAIN — the stored secret is the one the templates map ────────
+# The walkthrough's result only "genuinely flips the check to enforcing" if the
+# secret it writes is the secret the emitted workflow reads into GH_TOKEN, and
+# GH_TOKEN is what the gate's credential probe looks at. Three files, one name:
+# assert it end to end rather than trusting three separate string literals.
+echo "=== S7-chain-secret-name-agrees ==="
+chain_ok=1
+grep -q 'secret_name="SOIF_PROTECTION_TOKEN"' "$CHECK_GATE" || chain_ok=0
+grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{[[:space:]]*secrets\.SOIF_PROTECTION_TOKEN[[:space:]]*\}\}' \
+  "$REPO_ROOT/templates/pipelines/ci/github/typescript.yml" || chain_ok=0
+grep -q 'GH_TOKEN' "$REPO_ROOT/scripts/check-phase-gate.sh" || chain_ok=0
+if [ "$chain_ok" -eq 1 ]; then
+  pass "S7-chain-secret-name-agrees (walkthrough writes -> workflow maps -> gate probes, one name)"
+else
+  fail_ "S7-chain-secret-name-agrees" "the walkthrough's secret name, the template's mapping and the gate's probe variable do not line up — the walkthrough would store a secret nothing reads"
 fi
 
 echo ""

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -353,7 +353,7 @@ CHECK_GATE="$REPO_ROOT/scripts/check-gate.sh"
 GOOD_TOKEN="ghp_walk006_good"
 BAD_TOKEN="ghp_walk006_bad"
 
-# mk_tok <dir> <host> <auth: ok|unauth> [ci.yml-wires-secret: yes|no]
+# mk_tok <dir> <host> <auth: ok|unauth> [ci.yml shape: yes|no|swallow]
 mk_tok() {
   local d="$1" host="$2" auth="$3" wired="${4:-yes}"
   rm -rf "$d"
@@ -369,13 +369,19 @@ mk_tok() {
   printf '%s' "$GOOD_TOKEN" > "$d/stub/goodtoken"
   [ "$auth" = unauth ] && : > "$d/stub/unauth"
   : > "$d/stub/gh.log"
-  if [ "$wired" = yes ]; then
-    printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n' \
-      > "$d/.github/workflows/ci.yml"
-  else
-    printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n' \
-      > "$d/.github/workflows/ci.yml"
-  fi
+  case "$wired" in
+    yes)
+      printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n        run: |\n          bash scripts/check-phase-gate.sh\n' \
+        > "$d/.github/workflows/ci.yml" ;;
+    swallow)
+      # The pre-R-1 shape a project scaffolded before this fix still carries:
+      # the secret IS mapped, but the gate's exit code is thrown away.
+      printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found"\n' \
+        > "$d/.github/workflows/ci.yml" ;;
+    *)
+      printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n' \
+        > "$d/.github/workflows/ci.yml" ;;
+  esac
   cat > "$d/bin/gh" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >> "$GH_STUB_DIR/gh.log"
@@ -451,7 +457,7 @@ printf '%s' "$out" | grep -q "Administration: \*\*Read-only\*\*" || ok=0
 printf '%s' "$out" | grep -q "Token verified" || ok=0
 printf '%s' "$log" | grep -q "^secret set SOIF_PROTECTION_TOKEN --repo example/walk006$" || ok=0
 printf '%s' "$log" | grep -q "^STDIN:$GOOD_TOKEN$" || ok=0
-printf '%s' "$out" | grep -q "already maps SOIF_PROTECTION_TOKEN" || ok=0
+printf '%s' "$out" | grep -q "maps SOIF_PROTECTION_TOKEN into the phase-gate step" || ok=0
 if [ "$ok" -eq 1 ]; then
   pass "S3-happy-path (least-privilege explained, token probed, secret stored, wiring confirmed)"
 else
@@ -505,6 +511,35 @@ if [ "$rc" -eq 0 ] \
   pass "S6-unwired-workflow-warned (names the gap and prints the exact lines to add)"
 else
   fail_ "S6-unwired-workflow-warned" "rc=$rc: $out"
+fi
+
+# ── S6c (adversarial review R-1): a mapped secret + a SWALLOWED exit code is
+# not enforcement, and this command must not claim it is. The reviewer's probe
+# showed the gate printing [FAIL] and exiting 1 while the step graded GREEN, so
+# on a project carrying the pre-R-1 `|| echo` shape the walkthrough must say the
+# token cannot enforce anything yet — and print the replacement run: block.
+echo "=== S6c-swallowed-exit-code-warned ==="
+P="$TOPTMP/s6c"; mk_tok "$P" github ok swallow
+out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "DISCARDS the gate's exit code" \
+   && printf '%s' "$out" | grep -q 'bash scripts/check-phase-gate.sh' \
+   && ! printf '%s' "$out" | grep -q "The next push enforces the check"; then
+  pass "S6c-swallowed-exit-code-warned (never claims enforcement over a swallowed verdict)"
+else
+  fail_ "S6c-swallowed-exit-code-warned" "rc=$rc: $out"
+fi
+
+# ── S6d: the enforcement claim is made ONLY when both conditions hold ─────
+echo "=== S6d-enforcement-claim-is-earned ==="
+P="$TOPTMP/s6d"; mk_tok "$P" github ok yes
+out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "lets the gate's exit code decide it" \
+   && printf '%s' "$out" | grep -q "The next push enforces the check"; then
+  pass "S6d-enforcement-claim-is-earned (mapped AND exit-code-honouring -> the claim is true)"
+else
+  fail_ "S6d-enforcement-claim-is-earned" "rc=$rc: $out"
 fi
 
 # ── S6b: --token-env rejects a non-identifier (the eval IS an injection sink) ─

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# tests/test-walk006-ci-protection-scope.sh — walk 2026-08-02 ISSUE-006
+# (Major): the Phase 1→2 protection backstop must not BLOCK on a CI runner
+# that holds no host API credential.
+#
+# WHY THIS EXISTS
+#   Every generated project runs `scripts/check-phase-gate.sh` as its CI
+#   governance step (all three host families — see
+#   templates/pipelines/ci/{github,gitlab,bitbucket}/*.yml). Branch-protection
+#   verification is an AUTHENTICATED API read, and a runner has no credential
+#   for it unless the operator exports one:
+#     • GitHub Actions puts no token in a step's env, and the built-in
+#       GITHUB_TOKEN cannot read branch protection even when mapped (there is
+#       no `administration` key in the workflow `permissions:` block).
+#     • The generated gitlab/bitbucket governance jobs run `bash:5` + jq/git
+#       only — no glab, no curl, no credential.
+#   So `[FAIL] Phase 1→2 backstop: protection verification failed` was
+#   guaranteed on every push while the identical command exited 0 locally —
+#   the documented-but-impossible class (same shape as BL-137). The walker's
+#   only escape was SOIF_PHASE_GATES=warn, which downgrades the WHOLE gate.
+#
+# THE CONTRACT (# WALK-ISSUE-006-CI-PROTECTION-SCOPE)
+#   Credential-less CI ($CI set AND no host token env exported, host in
+#   github|gitlab|bitbucket): the arm prints a loud WARN that says the check
+#   COULD NOT RUN (never "verified") + how to get hard enforcement, and does
+#   NOT increment `issues`.
+#   Everywhere else the arm is byte-for-byte the old block:
+#     • locally (CI unset, TTY or not) — BLOCKS;
+#     • in CI WITH a token exported — BLOCKS (that is the hard-enforcement
+#       path the generated ci.yml documents);
+#     • host="other" — BLOCKS, because its host_verify_protection reads a
+#       LOCAL attestation and needs no credential at all.
+#
+# FIXTURE MECHANICS: the phase-2 shape is the proven rc=0 fixture from
+# tests/test-check-phase-gate-backstop-attestation.sh (artifacts seeded so
+# unrelated gate arms do not accumulate `issues` and mask this signal),
+# plus a PATH-prepended `gh` stub so the real github driver runs with no
+# network. `phase2_init.steps_completed` carries remote_repo_created +
+# pushed_initial so the BL-116/BL-084 push backstop stays exempt and never
+# reaches `git ls-remote` (hermetic: no network anywhere in this file).
+#
+# REGISTRATION: no init.sh, not an aggregator → BOTH lists. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-phase-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq required (fixtures + manifest reads)"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+WARN_SIG="protection verification COULD NOT RUN"
+FAIL_SIG="protection verification failed"
+
+# ── Fixture ──────────────────────────────────────────────────────────────────
+# mk_proj <dir> <host> <gh-protection-verdict: fail|ok>
+mk_proj() {
+  local d="$1" host="$2" verdict="$3"
+  rm -rf "$d"
+  mkdir -p "$d/.claude" "$d/docs/phase-0" "$d/scripts/lib" "$d/scripts/host-drivers" "$d/bin"
+  printf 'frd\n'      > "$d/docs/phase-0/frd.md"
+  printf 'journey\n'  > "$d/docs/phase-0/user-journey.md"
+  printf 'contract\n' > "$d/docs/phase-0/data-contract.md"
+
+  jq -n --arg h "$host" '{frameworkVersion:"test", host:$h, mode:"personal"}' \
+    > "$d/.claude/manifest.json"
+
+  cat > "$d/.claude/phase-state.json" <<'JSON'
+{"current_phase":2,"deployment":"personal","gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01"}}
+JSON
+
+  # No branch_protection attestation — the backstop must actually run.
+  # steps_completed keeps the BL-116/BL-084 push backstop exempt (no ls-remote).
+  cat > "$d/.claude/process-state.json" <<'JSON'
+{"phase2_init":{"steps_completed":["remote_repo_created","pushed_initial"]},
+ "phase1_artifacts":{"data_classification":"public","zdr_attested":false}}
+JSON
+
+  cat > "$d/APPROVAL_LOG.md" <<'MD'
+# APPROVAL_LOG
+
+## Phase 0 → Phase 1
+| Field | Value |
+|---|---|
+| Approver | Alice Signer |
+| Date | 2026-01-01 |
+
+## Phase 1 → Phase 2
+| Field | Value |
+|---|---|
+| Approver | Alice Signer |
+| Date | 2026-02-01 |
+MD
+
+  {
+    echo "# PRODUCT_MANIFESTO"; echo ""
+    for i in 1 2 3 4 5 6 7 8; do
+      echo "## ${i}. Section ${i}"; echo "Filled content for section ${i}."; echo ""
+    done
+  } > "$d/PRODUCT_MANIFESTO.md"
+  {
+    echo "# PROJECT_BIBLE"; echo ""
+    for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14; do
+      echo "## ${i}. Section ${i}"; echo "Content."; echo ""
+    done
+  } > "$d/PROJECT_BIBLE.md"
+
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.invalid && git config user.name t \
+      && git remote add origin https://github.com/example/walk006.git ) || return 1
+
+  cp "$REPO_ROOT/scripts/lib/host.sh" "$d/scripts/lib/"
+  cp "$REPO_ROOT/scripts/host-drivers/github.sh" "$d/scripts/host-drivers/"
+
+  # `gh` stub — the ONLY network surface the github driver would touch.
+  if [ "$verdict" = ok ]; then
+    cat > "$d/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == *"protection"* ]]; then
+  echo '{"allow_force_pushes":{"enabled":false},"enforce_admins":{"enabled":true}}'
+  exit 0
+fi
+exit 0
+STUB
+  else
+    cat > "$d/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$*" == *"protection"* ]]; then
+  echo '{"message":"Not Found","status":"404"}' >&2
+  exit 1
+fi
+exit 0
+STUB
+  fi
+  chmod +x "$d/bin/gh"
+}
+
+# run_gate <dir> <script> [env assignments...]
+#   With no env assignments the run is LOCAL: `env -u CI` strips any inherited
+#   $CI so the local cases stay honest when this suite itself runs in CI.
+run_gate() {
+  local d="$1" script="$2"; shift 2
+  if [ "$#" -eq 0 ]; then
+    ( cd "$d" && PATH="$d/bin:$PATH" env -u CI -u GH_TOKEN -u GITHUB_TOKEN \
+        bash "$script" </dev/null 2>&1 )
+  else
+    ( cd "$d" && PATH="$d/bin:$PATH" env -u CI -u GH_TOKEN -u GITHUB_TOKEN "$@" \
+        bash "$script" </dev/null 2>&1 )
+  fi
+}
+
+echo "== tests/test-walk006-ci-protection-scope.sh =="
+
+# ── T1: LOCAL (CI unset) + verify fails → still BLOCKS (byte-for-byte old) ───
+echo "=== T1-local-still-blocks ==="
+P="$TOPTMP/p1"; mk_proj "$P" github fail
+out=$(run_gate "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "$FAIL_SIG" \
+   && ! printf '%s' "$out" | grep -q "$WARN_SIG"; then
+  pass "T1-local-still-blocks (dev workstation is where the contract binds)"
+else
+  fail_ "T1-local-still-blocks" "rc=$rc — a failed protection verify MUST still block locally: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+fi
+
+# ── T2: credential-less CI → loud WARN, NO block (the fix) ──────────────────
+echo "=== T2-ci-credentialless-warns ==="
+P="$TOPTMP/p2"; mk_proj "$P" github fail
+out=$(run_gate "$P" "$SCRIPT" CI=true); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "$WARN_SIG" \
+   && printf '%s' "$out" | grep -q "WALK-ISSUE-006" \
+   && ! printf '%s' "$out" | grep -q "$FAIL_SIG"; then
+  pass "T2-ci-credentialless-warns (could-not-run, not verified; gate not blocked)"
+else
+  fail_ "T2-ci-credentialless-warns" "rc=$rc — the generated CI governance job is STRUCTURALLY unpassable if this blocks: $(printf '%s' "$out" | tail -6 | tr '\n' ' ')"
+fi
+
+# ── T2b: the WARN must never claim the contract was satisfied ───────────────
+echo "=== T2b-ci-warn-is-honest ==="
+if printf '%s' "$out" | grep -q "NOT a pass" \
+   && printf '%s' "$out" | grep -q "UNVERIFIED" \
+   && ! printf '%s' "$out" | grep -qi "backstop: repo protection verified"; then
+  pass "T2b-ci-warn-is-honest (says UNVERIFIED / NOT a pass, never 'verified')"
+else
+  fail_ "T2b-ci-warn-is-honest" "the exempt arm must not read as a pass: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+fi
+
+# ── T3: CI + an exported token → BLOCKS again (hard-enforcement path) ───────
+echo "=== T3-ci-with-token-still-blocks ==="
+P="$TOPTMP/p3"; mk_proj "$P" github fail
+out=$(run_gate "$P" "$SCRIPT" CI=true GH_TOKEN=ghp_fixture); rc=$?
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "$FAIL_SIG" \
+   && ! printf '%s' "$out" | grep -q "$WARN_SIG"; then
+  pass "T3-ci-with-token-still-blocks (supplying a token re-arms the block)"
+else
+  fail_ "T3-ci-with-token-still-blocks" "rc=$rc — the exemption is credential-keyed, not CI-keyed alone: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+fi
+
+# ── T3b: GITHUB_TOKEN counts as an exported credential too ──────────────────
+echo "=== T3b-ci-github-token-still-blocks ==="
+P="$TOPTMP/p3b"; mk_proj "$P" github fail
+out=$(run_gate "$P" "$SCRIPT" CI=true GITHUB_TOKEN=ghs_fixture); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "$FAIL_SIG"; then
+  pass "T3b-ci-github-token-still-blocks"
+else
+  fail_ "T3b-ci-github-token-still-blocks" "rc=$rc — GITHUB_TOKEN must count as exported: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+fi
+
+# ── T4: host="other" in CI → BLOCKS (its verify needs no credential) ────────
+# host=other's host_verify_protection reads .claude/process-state.json's
+# branch_protection attestation — absent here, so it fails, and NOTHING about
+# that failure is a credential problem. The exemption must not fire.
+# origin is re-pointed at a LOCAL bare repo so the BL-084 push backstop's
+# `git ls-remote` (which DOES apply to host=other) stays offline.
+echo "=== T4-ci-host-other-still-blocks ==="
+P="$TOPTMP/p4"; mk_proj "$P" other fail
+git init -q --bare "$TOPTMP/bare.git"
+( cd "$P" && git remote set-url origin "$TOPTMP/bare.git" )
+out=$(run_gate "$P" "$SCRIPT" CI=true); rc=$?
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "$FAIL_SIG" \
+   && ! printf '%s' "$out" | grep -q "$WARN_SIG"; then
+  pass "T4-ci-host-other-still-blocks (local-attestation verify is not credential-gated)"
+else
+  fail_ "T4-ci-host-other-still-blocks" "rc=$rc — 'other' must never be exempted: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+fi
+
+# ── T5: CI + protection genuinely verifies → OK, arm never reached ─────────
+echo "=== T5-ci-verified-clean ==="
+P="$TOPTMP/p5"; mk_proj "$P" github ok
+out=$(run_gate "$P" "$SCRIPT" CI=true); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "backstop: repo protection verified" \
+   && ! printf '%s' "$out" | grep -q "$WARN_SIG"; then
+  pass "T5-ci-verified-clean (baseline: the arm does not fire when verify passes)"
+else
+  fail_ "T5-ci-verified-clean" "rc=$rc — baseline fixture not clean; T2's signal would be unattributable: $(printf '%s' "$out" | tail -4 | tr '\n' ' ')"
+fi
+
+# ── Mutants ────────────────────────────────────────────────────────────────
+# Each mutant is a lib-complete COPY of the script (the bl104 vacuous-mutant
+# trap: a mutant that merely crashes proves nothing), asserted POSITIVELY in
+# both directions.
+mk_mutant() {  # mk_mutant <name> <sed-expr>
+  # bash-3.2: a single `local a=$1 b=$a` expands ALL words before assigning,
+  # so `$m` gets its own statement.
+  local name="$1"
+  local expr="$2"
+  local m="$TOPTMP/mut-$name"
+  mkdir -p "$m/scripts/lib"
+  sed "$expr" "$SCRIPT" > "$m/scripts/check-phase-gate.sh"
+  chmod +x "$m/scripts/check-phase-gate.sh"
+  cp "$REPO_ROOT/scripts/lib/"*.sh "$m/scripts/lib/"
+  echo "$m/scripts/check-phase-gate.sh"
+}
+
+# M1 — delete the $CI key line: the guard stops distinguishing CI from local,
+# so the LOCAL block (T1) evaporates. Proves the key is load-bearing and that
+# it is $CI, not TTY, that scopes the exemption.
+echo "=== M1-mutant-drop-CI-key ==="
+M1=$(mk_mutant m1 '/# WALK-ISSUE-006-CI-KEY$/d')
+if grep -q 'WALK-ISSUE-006-CI-KEY' "$M1"; then
+  fail_ "M1-mutant-drop-CI-key" "sed did not remove the keyed line — mutant is vacuous"
+else
+  P="$TOPTMP/pm1"; mk_proj "$P" github fail
+  out=$(run_gate "$P" "$M1"); rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "$WARN_SIG"; then
+    pass "M1-mutant-drop-CI-key (without the \$CI key the LOCAL run stops blocking — the key carries T1)"
+  else
+    fail_ "M1-mutant-drop-CI-key" "rc=$rc — mutant still blocked locally; the \$CI key is not what scopes the exemption: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+  fi
+fi
+
+# M2 — neuter the credential probe (github arm always says "no credential"):
+# T3's block evaporates. Proves the token probe, not $CI alone, gates the
+# exemption — i.e. the documented hard-enforcement path is real.
+echo "=== M2-mutant-blind-token-probe ==="
+M2=$(mk_mutant m2 's/^\( *\)github)    \[ -z .*$/\1github)    true ;;/')
+if grep -q 'github)    true ;;' "$M2"; then
+  P="$TOPTMP/pm2"; mk_proj "$P" github fail
+  out=$(run_gate "$P" "$M2" CI=true GH_TOKEN=ghp_fixture); rc=$?
+  if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "$WARN_SIG"; then
+    pass "M2-mutant-blind-token-probe (blind to GH_TOKEN, the mutant exempts a credentialed runner — the probe carries T3)"
+  else
+    fail_ "M2-mutant-blind-token-probe" "rc=$rc — mutant still blocked with a token; the probe is not what T3 measures: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+  fi
+else
+  fail_ "M2-mutant-blind-token-probe" "sed did not rewrite the github arm — mutant is vacuous"
+fi
+
+# M3 — pre-fix reproduction: force the guard to false, restoring the exact
+# block this walk finding is about. The credential-less CI run must fail with
+# the walker's verbatim message.
+echo "=== M3-mutant-prefix-repro ==="
+M3=$(mk_mutant m3 's/^\( *\)if _cpg_walk006_credentialless_ci .*$/\1if false; then/')
+if grep -q 'if false; then' "$M3"; then
+  P="$TOPTMP/pm3"; mk_proj "$P" github fail
+  out=$(run_gate "$P" "$M3" CI=true); rc=$?
+  if [ "$rc" -ne 0 ] \
+     && printf '%s' "$out" | grep -q "$FAIL_SIG" \
+     && ! printf '%s' "$out" | grep -q "$WARN_SIG"; then
+    pass "M3-mutant-prefix-repro (pre-fix arm reproduces ISSUE-006 verbatim on a credential-less runner)"
+  else
+    fail_ "M3-mutant-prefix-repro" "rc=$rc — the pre-fix shape did NOT reproduce the walk failure, so T2 proves nothing: $(printf '%s' "$out" | grep -i backstop | tr '\n' ' ')"
+  fi
+else
+  fail_ "M3-mutant-prefix-repro" "sed did not rewrite the guard call — mutant is vacuous"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -507,6 +507,25 @@ else
   fail_ "S6-unwired-workflow-warned" "rc=$rc: $out"
 fi
 
+# ── S6b: --token-env rejects a non-identifier (the eval IS an injection sink) ─
+# The indirect read is `eval "token=\${$token_env:-}"`. Without a name check, a
+# `--token-env` value carrying a command substitution EXECUTES — demonstrated,
+# not asserted: the mutation run below (validation arms deleted) creates the
+# canary file, and this run must not.
+echo "=== S6b-token-env-name-validated ==="
+CANARY="$TOPTMP/s6b-canary"
+rm -f "$CANARY"
+P="$TOPTMP/s6b"; mk_tok "$P" github ok yes
+out=$(run_tok "$P" "$GOOD_TOKEN" --token-env "X:-\$(touch $CANARY)"); rc=$?
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "not a valid environment variable name" \
+   && [ ! -e "$CANARY" ]; then
+  pass "S6b-token-env-name-validated (name validated before eval; canary not created)"
+else
+  fail_ "S6b-token-env-name-validated" "rc=$rc canary=$([ -e "$CANARY" ] && echo CREATED || echo absent): $out"
+fi
+rm -f "$CANARY"
+
 # ── S7: THE CHAIN — the stored secret is the one the templates map ────────
 # The walkthrough's result only "genuinely flips the check to enforcing" if the
 # secret it writes is the secret the emitted workflow reads into GH_TOKEN, and

--- a/tests/test-walk016-release-env-policy.sh
+++ b/tests/test-walk016-release-env-policy.sh
@@ -189,25 +189,90 @@ else
   fail_ "T8-tag-pattern-override" "rc=$rc — the pattern must flow into both the match and the remediation: $out"
 fi
 
+# ── T9 (adversarial review R-3): the POLICY is a glob, not a literal ───────
+# Matching by string equality false-failed a correctly-configured repo: a `v*`
+# policy plainly admits a v1.0.0 release, but "v*" != "v1.0.0". Both directions
+# asserted, because a glob match that is too eager is just as wrong.
+echo "=== T9a-policy-glob-admits-concrete-tag ==="
+P="$TOPTMP/p9a"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_WITH_TAG"
+out=$(run_cmd "$P" "$SCRIPT" --tag-pattern 'v1.0.0'); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "admits tag deployments"; then
+  pass "T9a-policy-glob-admits-concrete-tag (an existing v* policy satisfies a v1.0.0 release)"
+else
+  fail_ "T9a-policy-glob-admits-concrete-tag" "rc=$rc — literal equality false-fails a correctly-configured repo: $out"
+fi
+
+echo "=== T9b-narrow-policy-does-not-satisfy-class ==="
+POL_SINGLE_TAG='{"total_count":1,"branch_policies":[{"id":2,"name":"v1.0.0","type":"tag"}]}'
+P="$TOPTMP/p9b"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_SINGLE_TAG"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "NO tag deployment policy"; then
+  pass "T9b-narrow-policy-does-not-satisfy-class (a single-tag policy does not admit all of v*)"
+else
+  fail_ "T9b-narrow-policy-does-not-satisfy-class" "rc=$rc — the glob must not match in this direction: $out"
+fi
+
+echo "=== T9c-wildcard-policy-admits-everything ==="
+POL_WILDCARD='{"total_count":1,"branch_policies":[{"id":3,"name":"*","type":"tag"}]}'
+P="$TOPTMP/p9c"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_WILDCARD"
+out=$(run_cmd "$P" "$SCRIPT" --tag-pattern 'anything-goes'); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "admits tag deployments"; then
+  pass "T9c-wildcard-policy-admits-everything"
+else
+  fail_ "T9c-wildcard-policy-admits-everything" "rc=$rc: $out"
+fi
+
+echo "=== T9d-branch-typed-policy-never-counts ==="
+# A BRANCH policy named v* must not be read as admitting tags — the type field
+# is load-bearing, and the glob widening must not have loosened it.
+POL_BRANCH_VSTAR='{"total_count":1,"branch_policies":[{"id":4,"name":"v*","type":"branch"}]}'
+P="$TOPTMP/p9d"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_BRANCH_VSTAR"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "NO tag deployment policy"; then
+  pass "T9d-branch-typed-policy-never-counts (type=branch is not type=tag)"
+else
+  fail_ "T9d-branch-typed-policy-never-counts" "rc=$rc — the glob widening must not have dropped the type filter: $out"
+fi
+
+# ── T10 (adversarial review R-4): protected-branches + --fix does PUT then POST
+# Previously the PUT arm had no coverage at all — the one call that rewrites an
+# environment's policy shape was untested. Order matters: the POST is invalid
+# until the PUT has switched the environment to custom policies.
+echo "=== T10-protected-fix-put-then-post ==="
+P="$TOPTMP/p10"; mk_proj "$P" github "$ENV_PROTECTED" "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT" --fix); rc=$?
+put_line=$(grep -n -- '-X PUT' "$P/stub/gh.log" | head -1 | cut -d: -f1)
+post_line=$(grep -n -- '-X POST' "$P/stub/gh.log" | head -1 | cut -d: -f1)
+if [ "$rc" -eq 0 ] \
+   && [ -n "$put_line" ] && [ -n "$post_line" ] \
+   && [ "$put_line" -lt "$post_line" ] \
+   && grep -q -- '-X PUT repos/example/walk016/environments/github-pages' "$P/stub/gh.log" \
+   && grep -q 'deployment-branch-policies' "$P/stub/gh.log"; then
+  pass "T10-protected-fix-put-then-post (switch to custom policies, THEN admit the tag)"
+else
+  fail_ "T10-protected-fix-put-then-post" "rc=$rc put=$put_line post=$post_line log=[$(tr '\n' ';' < "$P/stub/gh.log")] out=$out"
+fi
+
 # ── M1: mutant — blind the tag-policy detection ────────────────────────────
 # If the `.type=="tag"` select never matches, T6 (an already-correct repo) is
 # re-reported as broken. Asserted POSITIVELY on a lib-complete copy.
 echo "=== M1-mutant-blind-tag-detection ==="
 MUT="$TOPTMP/mut/scripts"
 mkdir -p "$MUT/lib"
-sed 's/select(\.type=="tag" and/select(false and/' "$SCRIPT" > "$MUT/check-gate.sh"
+# Neuter the policy-match predicate (the glob comparison R-3 introduced).
+sed 's|^\( *\)if \[ "\$_pol" = "\$tag_pattern" \] .*|\1if false; then|' "$SCRIPT" > "$MUT/check-gate.sh"
 chmod +x "$MUT/check-gate.sh"
 cp "$REPO_ROOT/scripts/lib/"*.sh "$MUT/lib/"
-if grep -q 'select(false and' "$MUT/check-gate.sh"; then
+if grep -q '^ *if false; then$' "$MUT/check-gate.sh"; then
   P="$TOPTMP/pm1"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_WITH_TAG"
   out=$(run_cmd "$P" "$MUT/check-gate.sh"); rc=$?
   if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "NO tag deployment policy"; then
-    pass "M1-mutant-blind-tag-detection (blinded, the mutant re-reports an already-fixed repo — the select carries T6)"
+    pass "M1-mutant-blind-tag-detection (blinded, the mutant re-reports an already-fixed repo — the match carries T6)"
   else
     fail_ "M1-mutant-blind-tag-detection" "rc=$rc — the mutant behaved like the real thing; T6 proves nothing: $out"
   fi
 else
-  fail_ "M1-mutant-blind-tag-detection" "sed did not rewrite the select — mutant is vacuous"
+  fail_ "M1-mutant-blind-tag-detection" "sed did not rewrite the match predicate — mutant is vacuous"
 fi
 
 echo ""

--- a/tests/test-walk016-release-env-policy.sh
+++ b/tests/test-walk016-release-env-policy.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# tests/test-walk016-release-env-policy.sh — walk 2026-08-02 ISSUE-016 (Major):
+# `check-gate.sh --release-env-policy` must catch the GitHub Pages deployment
+# environment policy that silently rejects tag-triggered releases.
+#
+# WHY THIS EXISTS
+#   The framework's documented happy path is "git tag v1.0.0 && git push --tags",
+#   and the emitted release.yml triggers on `tags: ['v*']`. Enabling GitHub Pages
+#   auto-creates a `github-pages` deployment environment whose default branch
+#   policy admits the DEFAULT BRANCH ONLY. A run triggered from a TAG is rejected
+#   by the environment's protection rules BEFORE any job starts: empty step list,
+#   no readable error in `gh run view`. The walker lost 18 minutes and needed an
+#   undocumented API call to escape.
+#
+#   THE FIX HAD TO BE A SCRIPT, NOT A WORKFLOW STEP: a run the environment
+#   rejects never starts a job, so an in-workflow preflight is unreachable by
+#   construction. This subcommand runs from the workstation, before the tag.
+#
+# THE CONTRACT (# WALK-ISSUE-016-RELEASE-ENV-POLICY)
+#   dry-run (default): exit 1 iff a tag deploy would be rejected, printing the
+#   exact remediation; exit 0 when it would be admitted, when the environment
+#   does not exist yet, and when the host is not GitHub. `--fix` applies it.
+#
+# FIXTURE MECHANICS: a PATH-prepended `gh` stub answers from JSON fixture files
+# and APPENDS every invocation to a log, so write calls are asserted by
+# inspection rather than by network effect. Hermetic: no network, no real
+# remote (BL-076), no `gh auth`.
+#
+# REGISTRATION: no init.sh, not an aggregator → BOTH lists. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCRIPT="$REPO_ROOT/scripts/check-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "SKIP: jq required (fixtures + policy parsing)"
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# mk_proj <dir> <host> <env-json|NONE> <policies-json>
+mk_proj() {
+  local d="$1" host="$2" envj="$3" polj="$4"
+  rm -rf "$d"
+  mkdir -p "$d/.claude" "$d/scripts/lib" "$d/scripts/host-drivers" "$d/bin" "$d/stub"
+  jq -n --arg h "$host" '{frameworkVersion:"test", host:$h, mode:"personal"}' \
+    > "$d/.claude/manifest.json"
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.invalid && git config user.name t \
+      && git remote add origin https://github.com/example/walk016.git ) || return 1
+  cp "$REPO_ROOT/scripts/lib/"*.sh "$d/scripts/lib/"
+  cp "$REPO_ROOT/scripts/host-drivers/github.sh" "$d/scripts/host-drivers/"
+
+  [ "$envj" = NONE ] || printf '%s' "$envj" > "$d/stub/env.json"
+  printf '%s' "$polj" > "$d/stub/policies.json"
+  : > "$d/stub/gh.log"
+
+  cat > "$d/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "$GH_STUB_DIR/gh.log"
+case "$*" in
+  *"-X POST"*deployment-branch-policies*) exit 0 ;;
+  *"-X PUT"*environments*)                cat >/dev/null 2>&1; exit 0 ;;
+  *deployment-branch-policies*)           cat "$GH_STUB_DIR/policies.json"; exit 0 ;;
+  *environments/*)
+      if [ -f "$GH_STUB_DIR/env.json" ]; then cat "$GH_STUB_DIR/env.json"; exit 0; fi
+      echo '{"message":"Not Found","status":"404"}' >&2; exit 1 ;;
+esac
+exit 0
+STUB
+  chmod +x "$d/bin/gh"
+}
+
+# run_cmd <dir> <script> [args...]
+run_cmd() {
+  local d="$1" script="$2"; shift 2
+  ( cd "$d" && PATH="$d/bin:$PATH" GH_STUB_DIR="$d/stub" \
+      bash "$script" --release-env-policy "$@" </dev/null 2>&1 )
+}
+
+ENV_NO_POLICY='{"name":"github-pages","deployment_branch_policy":null}'
+ENV_CUSTOM='{"name":"github-pages","deployment_branch_policy":{"protected_branches":false,"custom_branch_policies":true}}'
+ENV_PROTECTED='{"name":"github-pages","deployment_branch_policy":{"protected_branches":true,"custom_branch_policies":false}}'
+POL_MAIN_ONLY='{"total_count":1,"branch_policies":[{"id":1,"name":"main","type":"branch"}]}'
+POL_WITH_TAG='{"total_count":2,"branch_policies":[{"id":1,"name":"main","type":"branch"},{"id":2,"name":"v*","type":"tag"}]}'
+
+echo "== tests/test-walk016-release-env-policy.sh =="
+
+# ── T1: non-github host → NOT APPLICABLE, never a failure ───────────────────
+echo "=== T1-non-github-not-applicable ==="
+P="$TOPTMP/p1"; mk_proj "$P" gitlab NONE "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "NOT APPLICABLE"; then
+  pass "T1-non-github-not-applicable"
+else
+  fail_ "T1-non-github-not-applicable" "rc=$rc — a gitlab/bitbucket project must not be failed by a GitHub environments check: $out"
+fi
+
+# ── T2: environment not created yet → nothing can reject, exit 0 ────────────
+echo "=== T2-env-absent-clean ==="
+P="$TOPTMP/p2"; mk_proj "$P" github NONE "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "does not exist yet"; then
+  pass "T2-env-absent-clean (Pages not enabled — re-run after enabling)"
+else
+  fail_ "T2-env-absent-clean" "rc=$rc — a 404 environment is 'nothing to reject', not a failure: $out"
+fi
+
+# ── T3: no deployment branch policy at all → every ref may deploy ───────────
+echo "=== T3-no-policy-clean ==="
+P="$TOPTMP/p3"; mk_proj "$P" github "$ENV_NO_POLICY" "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "no deployment branch policy"; then
+  pass "T3-no-policy-clean"
+else
+  fail_ "T3-no-policy-clean" "rc=$rc: $out"
+fi
+
+# ── T4: custom policies, branch-only → BLOCKS + prints the exact remediation ─
+echo "=== T4-tag-rejected-reported ==="
+P="$TOPTMP/p4"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "NO tag deployment policy" \
+   && printf '%s' "$out" | grep -q "deployment-branch-policies -f name='v\*' -f type='tag'"; then
+  pass "T4-tag-rejected-reported (names the empty-step-list failure + the one-line fix)"
+else
+  fail_ "T4-tag-rejected-reported" "rc=$rc — this is the walk's exact repo state and it must report, with the runnable command: $out"
+fi
+# and it must NOT have written anything without --fix
+if grep -q -- '-X POST' "$P/stub/gh.log"; then
+  fail_ "T4b-dry-run-is-read-only" "the dry run issued a write call: $(cat "$P/stub/gh.log")"
+else
+  pass "T4b-dry-run-is-read-only (no -X POST without --fix)"
+fi
+
+# ── T5: --fix applies the tag policy ────────────────────────────────────────
+echo "=== T5-fix-applies-policy ==="
+P="$TOPTMP/p5"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT" --fix); rc=$?
+if [ "$rc" -eq 0 ] \
+   && grep -q -- '-X POST' "$P/stub/gh.log" \
+   && grep -q 'deployment-branch-policies' "$P/stub/gh.log" \
+   && grep -q 'type=tag' "$P/stub/gh.log"; then
+  pass "T5-fix-applies-policy (POST .../deployment-branch-policies type=tag)"
+else
+  fail_ "T5-fix-applies-policy" "rc=$rc log=[$(cat "$P/stub/gh.log")] out=$out"
+fi
+
+# ── T6: a v* tag policy already present → clean ────────────────────────────
+echo "=== T6-tag-policy-present-clean ==="
+P="$TOPTMP/p6"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_WITH_TAG"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -eq 0 ] && printf '%s' "$out" | grep -q "admits tag deployments"; then
+  pass "T6-tag-policy-present-clean (the walker's fixed state reads clean)"
+else
+  fail_ "T6-tag-policy-present-clean" "rc=$rc — an already-fixed repo must not be re-reported: $out"
+fi
+
+# ── T7: protected-branches-only → BLOCKS + names the switch to custom ───────
+echo "=== T7-protected-branches-only ==="
+P="$TOPTMP/p7"; mk_proj "$P" github "$ENV_PROTECTED" "$POL_MAIN_ONLY"
+out=$(run_cmd "$P" "$SCRIPT"); rc=$?
+if [ "$rc" -ne 0 ] \
+   && printf '%s' "$out" | grep -q "PROTECTED BRANCHES only" \
+   && printf '%s' "$out" | grep -q "custom_branch_policies"; then
+  pass "T7-protected-branches-only (a tag can never deploy until the env is switched)"
+else
+  fail_ "T7-protected-branches-only" "rc=$rc: $out"
+fi
+
+# ── T8: --tag-pattern is honored end to end ────────────────────────────────
+echo "=== T8-tag-pattern-override ==="
+P="$TOPTMP/p8"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_WITH_TAG"
+out=$(run_cmd "$P" "$SCRIPT" --tag-pattern 'release-*'); rc=$?
+if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "name='release-\*'"; then
+  pass "T8-tag-pattern-override (a v* policy does not satisfy a release-* project)"
+else
+  fail_ "T8-tag-pattern-override" "rc=$rc — the pattern must flow into both the match and the remediation: $out"
+fi
+
+# ── M1: mutant — blind the tag-policy detection ────────────────────────────
+# If the `.type=="tag"` select never matches, T6 (an already-correct repo) is
+# re-reported as broken. Asserted POSITIVELY on a lib-complete copy.
+echo "=== M1-mutant-blind-tag-detection ==="
+MUT="$TOPTMP/mut/scripts"
+mkdir -p "$MUT/lib"
+sed 's/select(\.type=="tag" and/select(false and/' "$SCRIPT" > "$MUT/check-gate.sh"
+chmod +x "$MUT/check-gate.sh"
+cp "$REPO_ROOT/scripts/lib/"*.sh "$MUT/lib/"
+if grep -q 'select(false and' "$MUT/check-gate.sh"; then
+  P="$TOPTMP/pm1"; mk_proj "$P" github "$ENV_CUSTOM" "$POL_WITH_TAG"
+  out=$(run_cmd "$P" "$MUT/check-gate.sh"); rc=$?
+  if [ "$rc" -ne 0 ] && printf '%s' "$out" | grep -q "NO tag deployment policy"; then
+    pass "M1-mutant-blind-tag-detection (blinded, the mutant re-reports an already-fixed repo — the select carries T6)"
+  else
+    fail_ "M1-mutant-blind-tag-detection" "rc=$rc — the mutant behaved like the real thing; T6 proves nothing: $out"
+  fi
+else
+  fail_ "M1-mutant-blind-tag-detection" "sed did not rewrite the select — mutant is vacuous"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## What

Six walk fixes (ISSUE-002/003/006/008/014/016) plus Karl's decided addition, and the wave's biggest catch fixed in-branch:

- **ISSUE-006 (Major):** the generated CI's protection check could never pass in credential-less Actions — on the framework's own default happy path. Now: that ONE check converts to a loud WARN only when `$CI` is set and no host credential is exported (local unchanged, credentialed CI enforces, `host=other` not exempted), across all three host families (all genuinely affected — verified).
- **Karl's addition — the guided token path:** `check-gate.sh --setup-ci-token` walks a least-privilege fine-grained PAT (Administration: Read-only), **verifies the token can read protection before storing anything**, stores via stdin never argv (eight injection payloads rejected in review; the eval sink the author found in its own code is fixed and canary-proven), then confirms the workflow actually consumes it. All 30 templates strongly recommend it by name.
- **The toothless gate (found by this branch's own review): 7 of 10 github templates discarded the gate's exit code** (`2>/dev/null || echo "…skipping"` — `[FAIL]` + exit 1 graded green). All 7 now use the strict shape — **safe precisely because the credential-less WARN arm lands first** — with the class pinned two ways: `Cw6-strict` (the swallow shapes) and `Cw6-strict-no-coe` (the `continue-on-error` vector the author found itself, step-scoped so java/kotlin's legitimate lint-step usage isn't accused). The walkthrough's enforcement claim is now earned: it checks both conditions and refuses the claim on pre-fix-shaped projects with the exact replacement block.
- **ISSUE-016 (Major):** tag releases died opaquely on fresh Pages repos (environment policy rejects tag deploys; zero steps run). New `check-gate.sh --release-env-policy` preflight — glob-matched policies (four directions + type guard pinned; five hostile policy names held in review), `--fix` applies the exact API calls (PUT-before-POST ordered), never false-fails on absent/correct environments — plus docs.
- **ISSUE-003/008/014/002:** runnable update commands instead of raw JSON; the UAT placeholder manifest (linter-derived, floor-pinned); the agent-path reviewer route documented; the snyk browser-auth limitation with the attested-skip named.

## Review record (pre-PR adversarial gate, two rounds)

- **Round 1: major_concerns/BLOCK** — the branch's own new claim ("token setup flips enforcement on") was false in the 7 swallowing templates; reviewer confirmed the 7/3 split and pushed for the real fix. Security surfaces all held (8 injection payloads, env-strip load-bearing, empty-string semantics consistent both sides, currency verified against current GitHub docs).
- **Fix commits:** all 7 strictened with watched-RED naming exactly the seven; the second discard vector closed with its own case; the three claim-texts made true and self-evidencing; glob-match with the asymmetry pinned.
- **Confirm round: approve — fidelity MET 10/10 by execution** (verbatim step extraction under bash -e → RED on real failure). One named residual on the record: **R-C1** — `|| exit 0` would slip the Cw6-strict blacklist (shipped content correct; suggested hardening: allowlist the exact bare invocation line). Plus one cosmetic comment nit (R-C2).

## Evidence

bl147 79/0 · walk006 22/0 · walk016 15/0 · walk003 5/0 · check-gate 5/0 · host-drivers 11/0 · walk-phase-lifecycle 20/0 on this branch · run-lints 13/13 · five genuine mutants, five caught this round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)