### PR TITLE
feat(delta): dependency-direction boundary lint + first module stub (WP1)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,9 +17,10 @@
 #
 # Every job here is a PAIR of steps: a GATING step that runs the lint and
 # fails the job, and an INVENTORY step that re-runs the SAME lint with
-# `--list` to print the per-file PASS/FAIL roster. There are ELEVEN such
-# pairs — one per job; BL-197's diagnostic-destruction-lint was the tenth
-# and BL-196's bl-markers-lint is the eleventh —
+# `--list` to print the per-file PASS/FAIL roster. There are TWELVE such
+# pairs — one per job; BL-197's diagnostic-destruction-lint was the tenth,
+# BL-196's bl-markers-lint the eleventh, and the delta track's D1
+# delta-boundary-lint the twelfth —
 # and under `if: always()` the inventory step re-ran
 # the full scan on GREEN runs too, where nobody reads it. That doubled
 # every lint job. Measured on the counter-antipattern job (run 30297887996,
@@ -320,3 +321,34 @@ jobs:
       - name: Show PASS/FAIL inventory (on failure)
         if: failure()
         run: bash scripts/lint-bl-markers.sh --list || true
+
+  # Delta track (D1): the dependency-direction boundary lint. The delta track
+  # is a SEVERABLE module — delta may import core, core may never import delta
+  # — and settled decision D1 requires that boundary lint-enforced FROM THE
+  # FIRST COMMIT, because a severable module stops being severable one
+  # convenience call at a time and no test fails when it does. Two match tiers
+  # (literal module paths, then the bare `delta-` prefix that catches the
+  # variable-composition family), a seam allowlist whose cardinality is
+  # asserted at exactly one, and a vacuity floor that exits 2 rather than let a
+  # collapsed scan report a pass. See scripts/lint-delta-boundary.sh header and
+  # docs/designs/2026-08-02-delta-track-v1.md §3.3 for the spec, and
+  # tests/test-lint-delta-boundary.sh for the behavior suite (incl. the
+  # cardinality and empty-manifest mutations).
+  #
+  # NOT a required status check — adding this job does not make it one.
+  # Branch protection is Karl's call and is deliberately untouched here. Same
+  # job-name-is-required-check convention as the jobs above: if it IS promoted,
+  # keep the name stable.
+  delta-boundary-lint:
+    name: delta-boundary-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
+
+      - name: Lint the core -> delta dependency direction (D1)
+        run: bash scripts/lint-delta-boundary.sh
+
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
+        run: bash scripts/lint-delta-boundary.sh --list || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -400,6 +400,7 @@ jobs:
             tests/test-lint-backlog-references.sh
             tests/test-lint-bl-markers.sh
             tests/test-lint-counter-antipattern.sh
+            tests/test-lint-delta-boundary.sh
             tests/test-lint-diagnostic-destruction.sh
             tests/test-lint-doc-anchors.sh
             tests/test-lint-fix-functions-stderr.sh

--- a/scripts/lib/delta-state.sh
+++ b/scripts/lib/delta-state.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# scripts/lib/delta-state.sh — read/write the delta module's live state.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §7.1 (the
+# `.claude/delta-state.json` schema) and §3.1 (this file is the first member of
+# the severable delta module's inventory). WP2 fills the body in; WP1 lands
+# this stub so the boundary lint at scripts/lint-delta-boundary.sh has a real
+# module member to find — its vacuity floor refuses to pass a scan that found
+# no delta-module file, and it deliberately does not count itself.
+#
+# (No `# BL-NNN-…` marker on purpose: no backlog entry exists for the delta
+# build, and minting one would red scripts/lint-bl-markers.sh, whose first pass
+# resolves every marker to a `## BL-NNN:` entry. The design-doc path above is
+# the citation.)
+#
+# ROLE
+#   Sole reader/writer of `.claude/delta-state.json` — the project-owned,
+#   machine-written record of open deltas, their class and materialised gate
+#   set, and the hotfix retro ledger. The file is never overwritten by
+#   `scripts/upgrade-project.sh` (§3.2, the NOTICE-ONLY treatment modelled on
+#   the `# BL-099-DOC-GUARD` rendered-doc fence).
+#
+# WRITE DISCIPLINE (WP2 implements; stated here so the stub is honest about
+# what it is a stub FOR)
+#   Every write is atomic: render to `<file>.tmp` in the SAME directory, fsync
+#   is not available portably so the guarantee is the rename, then `mv` over
+#   the target. A partial write must leave the previous state intact — a
+#   truncated state file would strand an open delta with no way to close it.
+#   This is the house pattern (see scripts/lib/phase2-state.sh).
+#
+# DEPENDENCY DIRECTION (D1)
+#   This file may source and call CORE freely — delta -> core is allowed and
+#   deliberately unasserted. The reverse is forbidden and lint-enforced: no
+#   core file may name this path on an executed line, except the one declared
+#   seam, `scripts/process-checklist.sh`. See scripts/lint-delta-boundary.sh.
+#
+# BASH 3.2 COMPATIBILITY
+#   macOS ships bash 3.2.57. No associative arrays, no ${var,,}, no `((x++))`.
+
+# delta_state_path [project_root]
+#   Echo the absolute path of the state file for a project root (default: the
+#   current directory). Pure; creates nothing. WP2's read/write entry points
+#   both resolve through here so the location is spelled once.
+delta_state_path() {
+  local root="${1:-.}"
+  printf '%s\n' "${root%/}/.claude/delta-state.json"
+}
+
+# delta_state_exists [project_root]
+#   Return 0 when the state file is present, 1 otherwise. Callers use this to
+#   distinguish "no delta track yet" from "state file unreadable"; WP2 adds the
+#   parse/validate layer that tells those apart properly.
+delta_state_exists() {
+  local f
+  f="$(delta_state_path "${1:-.}")"
+  [ -f "$f" ]
+}

--- a/scripts/lint-delta-boundary.sh
+++ b/scripts/lint-delta-boundary.sh
@@ -1,0 +1,444 @@
+#!/usr/bin/env bash
+# scripts/lint-delta-boundary.sh — the dependency-direction boundary lint for
+# the post-MVP delta track.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §3.3 (normative), with the
+# module inventory at §3.1 and the build-plan row at §11-WP1. Settled decision
+# D1 requires this lint FROM THE FIRST COMMIT, which is why it lands alongside
+# the first module file rather than at the end of the track.
+#
+# (Deliberately NO `# BL-NNN-…` marker: no backlog entry exists for the delta
+# build, and CLAUDE.md's citation rule is satisfied by the design-doc path
+# above plus the grep-able `DELTA-BOUNDARY-*` fences below. Do not mint a BL
+# marker here — scripts/lint-bl-markers.sh would red on an id nobody filed.)
+#
+# THE DEFECT CLASS
+#   A severable module stops being severable one convenience call at a time.
+#   Nobody decides to fuse the delta module into the framework; someone adds
+#   `source scripts/lib/delta-state.sh` to check-phase-gate.sh on a Tuesday
+#   because it was easier, and the severability property is gone with no test
+#   failing. This lint makes that fusion a red check.
+#
+# THE PREDICATE — two directions plus two guards (§3.3)
+#   1. DELTA -> CORE: allowed, and deliberately UNASSERTED. The module may
+#      source helpers-core.sh, call guard_not_in_framework, read
+#      phase-state.json. Asserting it would be busywork.
+#   2. CORE -> DELTA: forbidden. For every file in the CORE set, no EXECUTED
+#      line may name any delta-module path.
+#   3. SEAM ALLOWLIST, CARDINALITY EXACTLY ONE. scripts/process-checklist.sh is
+#      the sole allowlisted core file. This script asserts the array length is
+#      1 and fails if it grows. A second seam is a design change and must be
+#      argued, not merged.
+#   4. VACUITY FLOOR. Exit 2 unless at least one delta-module file AND at least
+#      one core file were found. A boundary lint that scans nothing passes
+#      trivially, and a passing lint that proves nothing is worse than no lint
+#      — this repo has the scar (see the BL-104 scoring inversions in
+#      CLAUDE.md, where an empty manifest scored better than no manifest).
+#
+# THE SETS — one manifest, so they can never disagree
+#   DELTA = the §3.1 inventory, spelled once in the DELTA-BOUNDARY-MANIFEST
+#           fence below. Adding a module file is a one-line edit there.
+#   CORE  = init.sh + scripts/*.sh + scripts/lib/*.sh + scripts/hooks/*.sh,
+#           MINUS the delta inventory and MINUS this script (which names every
+#           delta path by construction). The self-exclusion is by BOTH manifest
+#           membership and the explicit SELF_REL path, per §3.3.
+#           scripts/host-drivers/*.sh is NOT in the CORE set: §3.3 names four
+#           globs and this is the fourth-glob-faithful reading. Widen it only
+#           by amending the design.
+#
+#   A RENAMED COPY of this script inside scripts/ is NOT self-excluded, and
+#   that is deliberate. Unlike scripts/lint-bl-markers.sh — where a copy could
+#   silently satisfy the lint's own resolution check — a copy here is a core
+#   file that names every delta path, so it reds. Fail-closed is the right
+#   direction for a boundary lint.
+#
+# TWO MATCH TIERS, because literal paths are evadable (R-DT-6)
+#   T1  LITERAL PATH. Any manifest-derived token (basename for file entries,
+#       the whole prefix for directory entries) on an executed line of a CORE
+#       file. Verdict: FAIL. Unambiguous — a core file names a module file.
+#       T1 is NOT inline-allowlistable. The single sanctioned escape for a
+#       T1-class reference is the file-level seam, whose cardinality is one.
+#   T2  BARE `delta-` TOKEN on an executed line that T1 did not already catch.
+#       Verdict: FAIL, with an inline allowlist that REQUIRES a reason. This is
+#       what catches the variable-composition family — `"$LIB/delta-${kind}.sh"`
+#       carries no literal path but still carries the prefix.
+#       T2 is deliberately coarse and will occasionally fire on prose in a
+#       string (an error message that says "delta-state"). That is the right
+#       trade: a false positive costs one allowlist row with a reason; a false
+#       negative costs the severability property silently.
+#
+#   NAMED RESIDUAL (§13-R15, restated so nobody reads this lint as complete):
+#   a reference composed BELOW the prefix boundary — `"$LIB/del""ta-state.sh"`,
+#   or a path assembled from a variable holding `delta` — evades both tiers,
+#   and no grep-based lint can catch it. The backstop is behavioural, not
+#   lexical: WP7's severability test (delete the module, revert the seam, the
+#   full suite must pass) fails on a fused module however the fusion is spelled.
+#   Second residual: matching is CASE-SENSITIVE, because every path in the
+#   inventory is lower-case and a case-insensitive T2 would fire on ordinary
+#   prose like "DELTA-001".
+#
+# EXECUTED LINES ONLY — and why the exact spelling is load-bearing
+#   Both tiers match against a STRIPPED copy of each file: whole-line comments
+#   blanked, trailing comments truncated, at any indent and any whitespace
+#   width, with and without a space after `#`. The stripper is the
+#   DELTA-BOUNDARY-STRIP expression below and it is two sed expressions, in
+#   this order:
+#     E1  s/^[[:space:]]*#.*$//                        whole-line comments
+#     E2  s/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/   trailing comments
+#   E1 BLANKS rather than DELETES, so the stripped file has the same number of
+#   lines as the original and `grep -n` on it yields true source line numbers.
+#   That is the whole reason for the blank-not-delete choice; do not "simplify"
+#   it to `grep -v`.
+#
+#   This predicate has repo scar tissue. scripts/lint-tests-registered.sh
+#   carries the sibling version (`# BL-181-UNIT-LANE-PREDICATE`) and CLAUDE.md
+#   records that a ONE-CHARACTER narrowing of it — a quantifier, a character
+#   class, or `#` -> `#[[:space:]]` — re-opened the same hole THREE times while
+#   passing both PR-blocking checks every time. Each atom is therefore pinned
+#   for WIDTH and SPELLING (not merely presence) by tests/test-lint-delta-
+#   boundary.sh cases X1-X7; that file's header maps atom -> case. Before
+#   changing one character here, read it.
+#
+#   Both stages require the `#` to sit at line start or after whitespace, which
+#   is bash's own rule: `echo delta-state.sh#frag` is one WORD, not a comment,
+#   and stripping it would be an over-strip and a false negative (case X7).
+#   Known limit, inherited from the sibling predicate: a `#` inside a quoted
+#   string that follows whitespace (`sed 's/ #.*//'`) truncates the line early,
+#   so a delta token AFTER such a `#` is missed. Quote-awareness costs a
+#   char-by-char scan; the trade is the same one lint-tests-registered.sh made.
+#
+# ALLOWLIST — inline, reason REQUIRED
+#   Append `# lint-delta-boundary: allow <reason>` to a T2-flagged line. An
+#   empty reason FAILS, matching the allowlist semantics of
+#   lint-fix-functions-stderr.sh and lint-bl-markers.sh. The marker lives in a
+#   comment, so it is read off the RAW line after the tiers have matched
+#   against the STRIPPED one.
+#
+# EXIT CODES
+#   0 — no core -> delta edge.
+#   1 — one or more violations, OR the seam allowlist failed its integrity
+#       check (cardinality != 1, or a row with no reason). Both are "a human
+#       must argue this", which is the exit-1 class; a malformed allowlist is
+#       not an invocation error.
+#   2 — invocation / I/O error, OR the vacuity floor tripped.
+#   Order of checks: seam integrity (a property of this script, checkable
+#   without the tree) -> vacuity floor (a property of the tree) -> the scan.
+#
+# USAGE
+#   bash scripts/lint-delta-boundary.sh              # quiet pass/fail
+#   bash scripts/lint-delta-boundary.sh --list       # PASS/FAIL table
+#   bash scripts/lint-delta-boundary.sh --root DIR   # scan an alternate tree
+#       (hermetic fixtures; used by tests/test-lint-delta-boundary.sh).
+#       The vacuity floor is NOT relaxed under --root — the floor is one of
+#       the things the fixtures exist to prove.
+#
+# BASH 3.2 COMPATIBILITY
+#   macOS ships bash 3.2.57 as /bin/bash. No associative arrays, no ${var,,},
+#   no `((x++))`, no nullglob (unmatched globs survive literally and are
+#   filtered with `[ -f ]`). Every array expansion is length-guarded because
+#   `"${arr[@]}"` on an EMPTY array is an unbound-variable error under `set -u`
+#   in 3.2 — and the empty-manifest mutation (V3) walks straight into it.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_REL="scripts/lint-delta-boundary.sh"
+
+LIST_MODE=0
+ROOT_OVERRIDE=""
+USAGE="Usage: $0 [--list] [--root DIR]"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list) LIST_MODE=1; shift ;;
+    --root)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      ROOT_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) echo "$USAGE"; exit 0 ;;
+    *) echo "$USAGE" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="${ROOT_OVERRIDE:-$REPO_ROOT}"
+if [ ! -d "$ROOT" ]; then
+  echo "lint-delta-boundary: root not found: $ROOT" >&2
+  exit 2
+fi
+# Canonicalize: every reported path is produced by stripping "$ROOT/" off an
+# absolute path, so a trailing slash or a relative --root would leave the
+# prefix un-stripped and every diagnostic absolute.
+ROOT="$(cd "$ROOT" && pwd)" || { echo "lint-delta-boundary: cannot enter root: $ROOT" >&2; exit 2; }
+
+# ── DELTA-BOUNDARY-MANIFEST-BEGIN ───────────────────────────────────────
+# The §3.1 inventory, spelled ONCE. Both sets derive from it: DELTA is this
+# list, CORE is the four globs MINUS this list. Entries ending in `/` are
+# directory prefixes; everything else is a file path relative to the root.
+# scripts/cut-release.sh is here despite its core-sounding name because it
+# reads delta-state.json — classifying it as core would create a second
+# core -> delta edge (§3.1).
+DELTA_MANIFEST=(
+  "scripts/lib/delta-state.sh"
+  "scripts/lib/delta-policy.sh"
+  "scripts/lib/delta-classify.sh"
+  "scripts/lib/delta-cadence.sh"
+  "scripts/delta.sh"
+  "scripts/cut-release.sh"
+  "scripts/lint-delta-boundary.sh"
+  "docs/deltas/"
+  ".claude/delta-state.json"
+  ".claude/delta-policy.json"
+)
+# ── DELTA-BOUNDARY-MANIFEST-END ─────────────────────────────────────────
+
+# ── DELTA-BOUNDARY-SEAM-BEGIN ───────────────────────────────────────────
+# The ONE seam (§3.1). Rows are `path|reason`; the reason is REQUIRED and is
+# rendered by --list so the exemption is reviewable rather than silent.
+# Cardinality is asserted at exactly one immediately below.
+SEAM_ALLOWLIST=(
+  "scripts/process-checklist.sh|D1 §3.1 — the single declared seam: process-checklist.sh is both the commit-gate classifier pre-commit-gate.sh calls and D7's designated single writer of delta-state.json, so the module's one core edge lands here or nowhere"
+)
+# ── DELTA-BOUNDARY-SEAM-END ─────────────────────────────────────────────
+
+VIOLATIONS=0
+LIST_ROWS=""
+DELTA_PRESENT=0
+CORE_COUNT=0
+CORE_SCANNED=0
+
+# Pre-initialised above because emit_list is reachable from the cardinality and
+# vacuity exits, both of which fire BEFORE the counts are computed — and an
+# unset variable there would be a `set -u` crash instead of a diagnostic.
+# "in scope" and "scanned" are reported separately on purpose: on a vacuity
+# exit they differ (nothing is scanned), and collapsing them would hide which
+# of the two populations actually failed the floor.
+emit_list() {
+  [ "$LIST_MODE" -eq 1 ] || return 0
+  printf 'STATUS\tTIER\tFILE:LINE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+  printf 'INFO\tpopulation\t-\t%s delta-module file(s) present, %s core file(s) in scope, %s scanned\n' \
+    "$DELTA_PRESENT" "$CORE_COUNT" "$CORE_SCANNED"
+}
+
+# ── DELTA-BOUNDARY-CARDINALITY ──────────────────────────────────────────
+# Clause 3. The array length IS the assertion; a second seam must be argued in
+# the design, not appended here.
+SEAM_COUNT=0
+[ "${#SEAM_ALLOWLIST[@]}" -gt 0 ] && SEAM_COUNT=${#SEAM_ALLOWLIST[@]}
+if [ "$SEAM_COUNT" -ne 1 ]; then
+  echo "lint-delta-boundary: seam allowlist cardinality is $SEAM_COUNT, must be exactly 1." >&2
+  echo "§3.3 clause 3: scripts/process-checklist.sh is the sole allowlisted core file. A second seam is a design change — amend docs/designs/2026-08-02-delta-track-v1.md §3.1 and argue it, do not append a row." >&2
+  LIST_ROWS="${LIST_ROWS}FAIL\tseam\t${SELF_REL}\tcardinality ${SEAM_COUNT}, must be exactly 1\n"
+  emit_list
+  exit 1
+fi
+
+SEAM_PATH="${SEAM_ALLOWLIST[0]%%|*}"
+SEAM_REASON="${SEAM_ALLOWLIST[0]#*|}"
+if [ -z "$SEAM_REASON" ] || [ "$SEAM_REASON" = "${SEAM_ALLOWLIST[0]}" ]; then
+  echo "lint-delta-boundary: seam allowlist row '$SEAM_PATH' carries no reason. Every allowlist row requires a reason string (see this script's ALLOWLIST section)." >&2
+  LIST_ROWS="${LIST_ROWS}FAIL\tseam\t${SEAM_PATH}\tallowlist row has an empty reason\n"
+  emit_list
+  exit 1
+fi
+LIST_ROWS="${LIST_ROWS}INFO\tseam\t${SEAM_PATH}\tallowlisted (cardinality 1/1): ${SEAM_REASON}\n"
+
+# ── Set derivation ──────────────────────────────────────────────────────
+
+# is_delta_path REL — true when REL is a delta-module file (or lives under a
+# delta-module directory), or is this script.
+is_delta_path() {
+  local rel="$1" e
+  [ "$rel" = "$SELF_REL" ] && return 0
+  [ "${#DELTA_MANIFEST[@]}" -gt 0 ] || return 1
+  for e in "${DELTA_MANIFEST[@]}"; do
+    case "$e" in
+      */) case "$rel" in "$e"*) return 0 ;; esac ;;
+      *)  [ "$rel" = "$e" ] && return 0 ;;
+    esac
+  done
+  return 1
+}
+
+TMPD=$(mktemp -d) || { echo "lint-delta-boundary: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TMPD"' EXIT
+
+# T1 token set, DERIVED from the manifest so the two can never disagree:
+# a directory entry contributes its whole prefix, a file entry its basename
+# (the basename is a substring of any spelling of the full path, so matching
+# on it is strictly more sensitive than matching the path as written).
+T1_TOKENS="$TMPD/t1-tokens"
+: > "$T1_TOKENS"
+if [ "${#DELTA_MANIFEST[@]}" -gt 0 ]; then
+  for entry in "${DELTA_MANIFEST[@]}"; do
+    case "$entry" in
+      */) printf '%s\n' "$entry" >> "$T1_TOKENS" ;;
+      *)  printf '%s\n' "${entry##*/}" >> "$T1_TOKENS" ;;
+    esac
+  done
+fi
+
+# DELTA population: manifest entries that actually EXIST, excluding this
+# script. Excluding self is what keeps the floor honest — this file always
+# exists, so counting it would make clause 4 self-satisfying and vacuous.
+if [ "${#DELTA_MANIFEST[@]}" -gt 0 ]; then
+  for entry in "${DELTA_MANIFEST[@]}"; do
+    [ "$entry" = "$SELF_REL" ] && continue
+    case "$entry" in
+      */) [ -d "$ROOT/$entry" ] || continue ;;
+      *)  [ -f "$ROOT/$entry" ] || continue ;;
+    esac
+    DELTA_PRESENT=$((DELTA_PRESENT + 1))
+  done
+fi
+
+# CORE population. bash 3.2 has no nullglob, so an unmatched glob survives as
+# a literal and is filtered by the `[ -f ]` test.
+CORE_FILES="$TMPD/core-files"
+: > "$CORE_FILES"
+CORE_GLOBS=(
+  "$ROOT/init.sh"
+  "$ROOT/scripts"/*.sh
+  "$ROOT/scripts/lib"/*.sh
+  "$ROOT/scripts/hooks"/*.sh
+)
+for entry in "${CORE_GLOBS[@]}"; do
+  [ -f "$entry" ] || continue
+  rel="${entry#"$ROOT"/}"
+  is_delta_path "$rel" && continue
+  printf '%s\n' "$rel" >> "$CORE_FILES"
+done
+CORE_COUNT=$(grep -c '' "$CORE_FILES")
+case "$CORE_COUNT" in ''|*[!0-9]*) CORE_COUNT=0 ;; esac
+
+# ── DELTA-BOUNDARY-VACUITY ──────────────────────────────────────────────
+# Clause 4, checked BEFORE the scan so a collapsed set can never be reported
+# as a clean pass under any ordering of the code below.
+if [ "$DELTA_PRESENT" -lt 1 ] || [ "$CORE_COUNT" -lt 1 ]; then
+  emit_list
+  echo "" >&2
+  echo "lint-delta-boundary: VACUOUS SCAN — found $DELTA_PRESENT delta-module file(s) (floor 1) and $CORE_COUNT core file(s) (floor 1)." >&2
+  echo "A boundary lint that scans nothing passes trivially, so this is an error, not a pass. Check the DELTA-BOUNDARY-MANIFEST fence and the CORE globs in this script, and that --root points at a real tree." >&2
+  exit 2
+fi
+
+# ── The scan ────────────────────────────────────────────────────────────
+
+STRIPPED="$TMPD/stripped"
+
+# parse_allow RAW — echoes "<has_marker>\t<reason>" for the inline T2 allowlist.
+parse_allow() {
+  local line="$1"
+  local reason=""
+  local has=0
+  case "$line" in
+    *"# lint-delta-boundary: allow"*)
+      has=1
+      reason="${line##*# lint-delta-boundary: allow}"
+      reason="${reason#"${reason%%[![:space:]]*}"}"
+      reason="${reason%"${reason##*[![:space:]]}"}"
+      ;;
+  esac
+  printf '%d\t%s\n' "$has" "$reason"
+}
+
+scan_core_file() {
+  local rel="$1"
+  local file="$ROOT/$rel"
+  local hits line n raw tok parsed has reason
+  local t1_lines="|"
+
+  # The one seam is exempt from BOTH tiers. §3.3 clause 3 names it "the sole
+  # allowlisted core file" without qualifying by tier, and that is the honest
+  # reading: the seam block is delta references BY DESIGN (a declared set of
+  # `--delta-*` actions that source delta-state.sh), so linting inside it would
+  # demand an allowlist row per line and mean nothing. The real control here is
+  # the cardinality assertion above — you cannot add a SECOND such file — plus
+  # WP7's behavioural severability test, which is what pins that the seam block
+  # is actually revertible.
+  [ "$rel" = "$SEAM_PATH" ] && return 0
+
+  # ── DELTA-BOUNDARY-STRIP ──────────────────────────────────────────────
+  # E1 blanks whole-line comments (any indent width, with or without a space
+  # after `#`); E2 truncates trailing comments (one-or-more whitespace before
+  # the `#`, any width, with or without a space after it) while KEEPING the
+  # executed prefix via the capture + \1. Order matters: E1 first, so E2 never
+  # sees a line that is comment-only. Line COUNT is preserved on purpose.
+  if ! sed -e 's/^[[:space:]]*#.*$//' \
+           -e 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/' \
+           "$file" > "$STRIPPED" 2>/dev/null; then
+    echo "lint-delta-boundary: cannot read $rel" >&2
+    return 2
+  fi
+
+  # T1 — literal manifest tokens. Fixed-string matching: the tokens contain
+  # `.` and `-`, and a BRE would let `delta.sh` match `deltaXsh`.
+  if [ -s "$T1_TOKENS" ]; then
+    hits=$(grep -n -F -f "$T1_TOKENS" "$STRIPPED")
+    if [ -n "$hits" ]; then
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        n="${line%%:*}"
+        t1_lines="${t1_lines}${n}|"
+        # `sed -n '1p'` and not `head -1`: head exits on its first line, the
+        # upstream grep dies of SIGPIPE, and `pipefail` (set at the top of this
+        # script) promotes rc=141 into the substitution. `sed -n 1p` consumes
+        # all of its input, so nothing upstream ever sees a closed pipe. This
+        # is the trap written up on `# BL-181-UNIT-LANE-PREDICATE`'s sibling
+        # note in scripts/lint-tests-registered.sh — keep every stage a
+        # full-input consumer.
+        tok=$(printf '%s\n' "${line#*:}" | grep -o -F -f "$T1_TOKENS" | sed -n '1p')
+        echo "${rel}:${n}: lint-delta-boundary: T1 — core file names delta-module path '${tok}'. Core must never reference the delta module (§3.3 clause 2); move the call behind the one seam (scripts/process-checklist.sh) or drop it." >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\tT1\t${rel}:${n}\tnames delta-module path '${tok}'\n"
+      done <<< "$hits"
+    fi
+  fi
+
+  # T2 — the bare prefix, on lines T1 did not already claim.
+  hits=$(grep -n -F -e 'delta-' "$STRIPPED")
+  if [ -n "$hits" ]; then
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      n="${line%%:*}"
+      case "$t1_lines" in *"|${n}|"*) continue ;; esac
+      # The allowlist marker lives in the COMMENT the stripper just removed, so
+      # it is read off the RAW line — after the tiers have matched against the
+      # stripped one.
+      raw=$(sed -n "${n}p" "$file")
+      parsed=$(parse_allow "$raw")
+      has="$(printf '%s' "$parsed" | cut -f1)"
+      reason="$(printf '%s' "$parsed" | cut -f2-)"
+      if [ "$has" = "1" ]; then
+        if [ -z "$reason" ]; then
+          echo "${rel}:${n}: lint-delta-boundary: T2 allowlist marker present but the reason is empty. Write '# lint-delta-boundary: allow <why this is not a module reference>'." >&2
+          VIOLATIONS=$((VIOLATIONS + 1))
+          LIST_ROWS="${LIST_ROWS}FAIL\tT2\t${rel}:${n}\tallowlist marker with an empty reason\n"
+        else
+          LIST_ROWS="${LIST_ROWS}PASS\tT2\t${rel}:${n}\tallowlisted: ${reason}\n"
+        fi
+        continue
+      fi
+      echo "${rel}:${n}: lint-delta-boundary: T2 — bare 'delta-' token on an executed line of a core file. A runtime-composed reference (\"\$LIB/delta-\${kind}.sh\") fuses the module exactly as thoroughly as a literal path. Remove it, or append '# lint-delta-boundary: allow <reason>' if this is prose in a string." >&2
+      VIOLATIONS=$((VIOLATIONS + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\tT2\t${rel}:${n}\tbare 'delta-' token on an executed line\n"
+    done <<< "$hits"
+  fi
+  return 0
+}
+
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  CORE_SCANNED=$((CORE_SCANNED + 1))
+  scan_core_file "$rel" || { emit_list; exit 2; }
+done < "$CORE_FILES"
+
+emit_list
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS core -> delta boundary violation(s). The delta track is a SEVERABLE module (D1): delta may import core, core may never import delta. See scripts/lint-delta-boundary.sh header and docs/designs/2026-08-02-delta-track-v1.md §3.3." >&2
+  exit 1
+fi
+
+echo "OK: no core -> delta edge ($CORE_SCANNED core file(s) scanned against $DELTA_PRESENT delta-module file(s); seam: $SEAM_PATH)."
+exit 0

--- a/scripts/lint-delta-boundary.sh
+++ b/scripts/lint-delta-boundary.sh
@@ -88,27 +88,50 @@
 #   E1 BLANKS rather than DELETES, so the stripped file has the same number of
 #   lines as the original and `grep -n` on it yields true source line numbers.
 #   That is the whole reason for the blank-not-delete choice; do not "simplify"
-#   it to `grep -v`.
+#   it to `grep -v`. (Note what "blanks" does and does NOT mean: `s///` replaces
+#   only the MATCHED REGION. On a whole-line comment the match spans the line so
+#   the result is empty; on any other line it removes only what it matched. A
+#   mutation to this expression therefore truncates lines, it does not erase
+#   them — an earlier version of this header claimed otherwise and an
+#   adversarial review refuted it.)
 #
 #   This predicate has repo scar tissue. scripts/lint-tests-registered.sh
 #   carries the sibling version (`# BL-181-UNIT-LANE-PREDICATE`) and CLAUDE.md
 #   records that a ONE-CHARACTER narrowing of it — a quantifier, a character
 #   class, or `#` -> `#[[:space:]]` — re-opened the same hole THREE times while
-#   passing both PR-blocking checks every time. Each atom is therefore pinned
-#   for WIDTH and SPELLING (not merely presence) by tests/test-lint-delta-
-#   boundary.sh cases X1-X7; that file's header maps atom -> case. Before
-#   changing one character here, read it.
+#   passing both PR-blocking checks every time.
+#
+#   BOTH DIRECTIONS ARE HAZARDS, AND THEY ARE NOT SYMMETRIC IN COST TO DETECT:
+#     • NARROWING (strips too little) -> false POSITIVES -> any clean fixture
+#       reds. Cheap to catch; cases X2/X3/X4/X5 do it.
+#     • WIDENING (strips too much) -> false NEGATIVES -> the tree goes QUIETER,
+#       and no clean fixture can ever notice. Caught only by a VIOLATION fixture
+#       positioned where the widened match would reach: case X8. Three separate
+#       one-character-class widenings (drop E1's `^`; E1 -> `s/#.*$//`; E2's
+#       `[[:space:]][[:space:]]*` -> `[[:space:]]*`) each survived the other 27
+#       cases and every PR-blocking check until X8 existed.
+#   Each atom is pinned for WIDTH and SPELLING (not merely presence) by
+#   tests/test-lint-delta-boundary.sh cases X1-X8; that file's header maps
+#   atom -> case, IN BOTH DIRECTIONS, and records which mutant each row kills.
+#   Before changing one character here, read it — and if you add a stripper
+#   atom, add its widening pin too, not just its narrowing pin.
 #
 #   Both stages require the `#` to sit at line start or after whitespace, which
-#   is bash's own rule: `echo delta-state.sh#frag` is one WORD, not a comment,
-#   and stripping it would be an over-strip and a false negative (case X7).
+#   is bash's own rule: `echo "ref=x#delta-state.sh"` is one WORD, not a
+#   comment, so the path is genuinely referenced (cases X7 and X8 — X7 guards
+#   the line from being deleted wholesale, X8 guards the token after the `#`
+#   from being truncated away).
 #   Known limit, inherited from the sibling predicate: a `#` inside a quoted
 #   string that follows whitespace (`sed 's/ #.*//'`) truncates the line early,
 #   so a delta token AFTER such a `#` is missed. Quote-awareness costs a
 #   char-by-char scan; the trade is the same one lint-tests-registered.sh made.
 #
-# ALLOWLIST — inline, reason REQUIRED
-#   Append `# lint-delta-boundary: allow <reason>` to a T2-flagged line. An
+# ALLOWLIST — inline, reason REQUIRED, marker matched as an EXACT TOKEN
+#   Append `# lint-delta-boundary: allow <reason>` to a T2-flagged line. The
+#   marker must be followed by whitespace or end-of-line: `allowed because …`
+#   and `allowlist …` are NOT the marker and do not waive anything (case L7).
+#   Prefix matching would have parsed `allowed because x` as the marker with
+#   reason "ed because x", so a typo could silently waive a real violation. An
 #   empty reason FAILS, matching the allowlist semantics of
 #   lint-fix-functions-stderr.sh and lint-bl-markers.sh. The marker lives in a
 #   comment, so it is read off the RAW line after the tiers have matched
@@ -326,16 +349,34 @@ fi
 STRIPPED="$TMPD/stripped"
 
 # parse_allow RAW — echoes "<has_marker>\t<reason>" for the inline T2 allowlist.
+#
+# EXACT-TOKEN matching, not prefix matching. A bare substring test accepts
+# `# lint-delta-boundary: allowed because …` as a marker and silently parses
+# the reason as "ed because …", so a typo'd or merely similar-looking marker
+# waives a real violation. The token must be followed by whitespace or by
+# end-of-line — nothing else — which fails CLOSED: a near-miss spelling is not
+# a marker at all, so the line stays a violation.
+#
+# The empty-reason case must still REGISTER as a marker (tail = ""), because an
+# empty reason is REJECTED loudly rather than ignored; treating it as "no
+# marker" would downgrade it to an ordinary unexplained violation and lose the
+# specific diagnostic.
+ALLOW_MARKER="# lint-delta-boundary: allow"
 parse_allow() {
   local line="$1"
   local reason=""
   local has=0
+  local tail
   case "$line" in
-    *"# lint-delta-boundary: allow"*)
-      has=1
-      reason="${line##*# lint-delta-boundary: allow}"
-      reason="${reason#"${reason%%[![:space:]]*}"}"
-      reason="${reason%"${reason##*[![:space:]]}"}"
+    *"$ALLOW_MARKER"*)
+      tail="${line##*"$ALLOW_MARKER"}"
+      case "$tail" in
+        ""|[[:space:]]*)
+          has=1
+          reason="${tail#"${tail%%[![:space:]]*}"}"
+          reason="${reason%"${reason##*[![:space:]]}"}"
+          ;;
+      esac
       ;;
   esac
   printf '%d\t%s\n' "$has" "$reason"

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -547,6 +547,26 @@ run_child_suite "scripts/lint-bl-markers.sh" \
   "Every live marker citation resolves to a marker in code" \
   "Marker-citation lint found broken citation(s) (see scripts/lint-bl-markers.sh --list)"
 
+# Delta track D1: tests/test-lint-delta-boundary.sh — behavior suite for the
+# dependency-direction boundary lint. Pins both match tiers (literal module
+# path, then the bare `delta-` prefix that catches variable composition), the
+# CORE surface, the seam allowlist's cardinality-of-one, the reason-bearing
+# inline allowlist, the vacuity floor, and — case by case, atom by atom — the
+# executed-lines stripper whose sibling predicate re-opened the same hole three
+# times (CLAUDE.md, `# BL-181-UNIT-LANE-PREDICATE`). See
+# docs/designs/2026-08-02-delta-track-v1.md §3.3.
+section "Delta boundary lint (D1 severability backstop)"
+run_child_suite "tests/test-lint-delta-boundary.sh" \
+  "scripts/lint-delta-boundary.sh behavior tests" \
+  "scripts/lint-delta-boundary.sh behavior tests FAILED (run tests/test-lint-delta-boundary.sh for details)"
+
+# Delta track D1: repo-wide lint invocation. Fails when a core file names a
+# delta-module path (or carries a bare `delta-` token) on an executed line —
+# the fusion that would silently end the module's severability.
+run_child_suite "scripts/lint-delta-boundary.sh" \
+  "No core -> delta dependency edge outside the one declared seam" \
+  "Delta boundary lint found a core -> delta edge (see scripts/lint-delta-boundary.sh --list)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-lint-delta-boundary.sh
+++ b/tests/test-lint-delta-boundary.sh
@@ -32,38 +32,74 @@
 #     scripts/lint-tests-registered.sh (# BL-181-UNIT-LANE-PREDICATE) re-opened
 #     the same hole THREE times while passing both PR-blocking checks each
 #     time. So the pins below name each ATOM of the two sed expressions and
-#     pin its WIDTH and its SPELLING, not merely its presence:
+#     pin its WIDTH and its SPELLING, not merely its presence.
+#
+#     TWO DIRECTIONS, AND ONLY ONE OF THEM IS CHEAP TO CATCH. Read this before
+#     trusting any row of the map:
+#       • NARROWING (the stripper does too LITTLE) leaves comments looking
+#         executed, so it produces FALSE POSITIVES. Any exit-0 fixture catches
+#         it. X2/X3/X4/X5 are all of this kind and they are easy.
+#       • WIDENING (the stripper does too MUCH) eats executed code, so it
+#         produces FALSE NEGATIVES. NO exit-0 fixture can ever see it, because
+#         an over-stripped tree is a QUIETER tree. It is caught only by a
+#         VIOLATION fixture whose token sits where the widened match would
+#         reach. X8 is that fixture and it is the load-bearing one.
+#
+#     The original version of this map got two rows wrong, and an adversarial
+#     review caught it (WP1 R-WP1-1/R-WP1-2). The false claim was that dropping
+#     E1's `^` "blanks the whole line": sed's s/// replaces only the MATCHED
+#     REGION, never the line, so the code prefix and its token survive and the
+#     case that claimed to pin the anchor did not. Three separate mutations
+#     survived all 27 cases as a result. The rows below describe what each case
+#     ACTUALLY kills, verified by executing the mutants.
 #
 #       E1 = 's/^[[:space:]]*#.*$//'                     (whole-line comments)
-#         C1  the `^` anchor          -> pinned by X1 (a violation carrying a
-#             trailing comment must STILL fail; without `^`, E1 matches the
-#             ` #` mid-line and blanks the whole line, so every commented
-#             violation goes silently green — the exact BL-181 hole)
+#         C1  the `^` anchor          -> pinned by X8, NOT by X1. Dropping `^`
+#             does not blank anything; it lets the leftmost match START at any
+#             `#` that has only optional whitespace before it, so `x#token`
+#             truncates to `x` and the reference vanishes. That is a widening,
+#             so only a violation fixture sees it. (Mutant M-A: survives
+#             X1-X7, dies to X8.)
 #         C2  `[[:space:]]*` WIDTH    -> pinned by X2 (0, 1, 4, 8 spaces, tab,
 #             tab+spaces, all ignored). Narrowing to `^#` false-positives on
-#             every indented comment; widening past `*` is not expressible.
+#             every indented comment. NOTE the asymmetry: `*` cannot be widened
+#             further, so C2's only failure mode is the narrowing X2 catches.
 #         C3  `#` SPELLING            -> pinned by X3 (no space required after
 #             `#`). Narrowing to `#[[:space:]]` false-positives on `#code`.
 #         C4  `.*$` reach             -> pinned by X2/X3 implicitly: the token
 #             sits AFTER the `#`, so a non-greedy or anchored variant leaves it
 #             behind and reds.
+#         C4b THE WHOLE-EXPRESSION widening (`s/#.*$//`, any `#` anywhere)
+#             -> pinned by X8. (Mutant M-B: survives X1-X7, dies to X8.)
 #
 #       E2 = 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/'  (trailing)
-#         C5  `[[:space:]][[:space:]]*` WIDTH -> pinned by X4 (ONE space, TAB,
-#             and many spaces all strip). Narrowing to two-or-more
-#             (`[[:space:]][[:space:]][[:space:]]*`) false-positives on the
-#             single-space form, which is the commonest spelling in this repo.
+#         C5  `[[:space:]][[:space:]]*` WIDTH -> pinned in BOTH directions, by
+#             two different cases, because this atom can fail either way:
+#               narrowing to two-or-more
+#               (`[[:space:]][[:space:]][[:space:]]*`) false-positives on the
+#               single-space form -> X4 (which carries ONE space, TAB, two and
+#               six spaces; the single-space form is the commonest spelling in
+#               this repo);
+#               widening to zero-or-more (`[[:space:]]*`) makes `x#token`
+#               strippable and the reference vanishes -> X8. (Mutant M-H:
+#               survives X1-X7, dies to X8.)
 #         C6  `#` SPELLING            -> pinned by X5 (no space after `#`).
-#         C7  `\([^[:space:]]\)` guard + `\1` back-reference -> pinned by X6:
-#             the CODE half of the line must survive the strip. A mutation that
-#             drops the capture (replacing with the empty string) destroys the
-#             code half, so a line that is BOTH a real violation AND carries a
-#             trailing comment stops failing. CLAUDE.md calls this guard
-#             behaviour-neutral in the BL-181 predicate; it is NOT neutral here,
-#             because here the surviving prefix is what the tiers match on.
-#         C8  `#` INSIDE a word is not a comment -> pinned by X7
-#             (`code#word` is a single bash word, not a comment; stripping it
-#             would be an over-strip and a false negative).
+#         C7  `\([^[:space:]]\)` guard + `\1` back-reference -> pinned by X6.
+#             Dropping the capture eats exactly ONE character of executed code,
+#             which is not enough to make the line green — it DEMOTES the hit
+#             from T1 to T2 (the truncated token stops matching a literal path
+#             but still carries the `delta-` prefix). X6 therefore asserts the
+#             TIER, not the exit code: rc alone cannot see this. The demotion
+#             matters because T2 is inline-allowlistable and T1 is not.
+#         C8  `#` INSIDE a word is not a comment -> pinned by X7 and X8, which
+#             cover OPPOSITE failure modes of the same atom and are deliberately
+#             not folded together:
+#               X7 = the DELETION direction (a `grep -v '#'` refactor, or an E1
+#               rewritten `s/^.*#.*$//`, discards the whole line). X7's token
+#               sits BEFORE the `#`, so it survives a truncating mutant — X7
+#               alone does NOT pin over-stripping, and the earlier claim that
+#               it did was the second refuted claim.
+#               X8 = the TRUNCATION direction (token AFTER the `#`).
 #
 #   ALLOWLISTS (§3.3 clause 3 + the T2 row)
 #     L1  T2 inline allow WITH a reason is honored       -> 0
@@ -73,6 +109,8 @@
 #         (mutation, executed here against a lint COPY)
 #     L5  a seam row with no reason                      -> 1
 #     L6  T1 is NOT inline-allowlistable (only the file-level seam is)
+#     L7  a NEAR-MISS marker (`allowed`, `allowlist`) does not allowlist -> 1
+#         (the marker is an exact token, not a prefix)
 #
 #   VACUITY FLOOR (§3.3 clause 4)
 #     V1  no delta-module file present                   -> 2 (not 0, not 1)
@@ -440,12 +478,16 @@ teardown_fixture
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
-echo "=== X7 (atom C8): '#' inside a word is NOT a comment -> exit 1 ==="
+echo "=== X7 (atom C8, whole-line-deletion direction): a line carrying a"
+echo "    mid-word '#' is not discarded wholesale -> exit 1 ==="
 # ════════════════════════════════════════════════════════════════════
-# `echo delta-state.sh#x` is a single bash WORD; bash executes it. A stripper
-# that treated any `#` as a comment start would over-strip and go green on a
-# real reference. Both E1 and E2 require the `#` to follow whitespace (or be
-# at the start of the line), which is exactly bash's own rule.
+# `echo delta-state.sh#x` is a single bash WORD; bash executes it. This case
+# guards the DELETION direction — a refactor to `grep -v '#'`, or an E1
+# rewritten as `s/^.*#.*$//`, drops the entire line and the reference with it.
+# It does NOT guard the truncation direction: the token here sits BEFORE the
+# `#`, so an over-stripping mutant leaves it intact and X7 still passes. X8
+# below is the case that covers truncation, and the two are deliberately kept
+# apart rather than folded, because they die to different mutations.
 setup_fixture
 {
   printf '#!/usr/bin/env bash\n'
@@ -453,9 +495,52 @@ setup_fixture
 } > "$TMP/scripts/check-gate.sh"
 out=$(run_fixture); rc=$?
 if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
-  pass "X7: a mid-word '#' does not start a comment (no over-strip)"
+  pass "X7: a line with a mid-word '#' is not deleted wholesale"
 else
   fail_ "X7" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X8 (atoms C1/C5/C8, the OVER-STRIP direction): a delta token"
+echo "    AFTER a mid-word '#' must still be seen -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# THE CASE THAT PINS THE STRIPPER'S UPPER BOUND. Every other X case pins a
+# narrowing (the stripper doing too little, producing false positives, which
+# any exit-0 fixture catches). This one pins a WIDENING — the stripper doing
+# too MUCH, silently eating executed code, which no exit-0 fixture can ever
+# see because an over-stripped tree is a QUIETER tree.
+#
+# `echo "ref=x#delta-state.sh"` is one bash WORD after `ref=`: bash does not
+# treat that `#` as a comment (a comment `#` must start a word), so the delta
+# path is genuinely referenced on an executed line. Three separate
+# one-character-class mutations all make the stripper eat from that `#`
+# onward, and all three were verified to survive the other 27 cases AND every
+# PR-blocking check before this case existed:
+#
+#   M-A  E1 `s/^[[:space:]]*#.*$//` -> `s/[[:space:]]*#.*$//`  (drop `^`)
+#        sed's s/// replaces only the MATCHED REGION, not the line, so the
+#        leftmost match simply starts at the `#` and truncates there.
+#   M-B  E1 -> `s/#.*$//`                              (strip from any `#`)
+#   M-H  E2 `[[:space:]][[:space:]]*` -> `[[:space:]]*`  (one-or-more becomes
+#        zero-or-more, so `x#word` becomes strippable)
+#
+# Measured on the real tree with the same construct planted in
+# scripts/lib/freshness-detect.sh: shipped lint rc=1, M-A/M-B/M-H rc=0 each.
+# If this case is ever deleted or its `#` given a leading space, all three
+# holes re-open silently — which is precisely how BL-181 was re-opened three
+# times.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "ref=x#delta-state.sh"\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X8: a delta token AFTER a mid-word '#' is still on an executed line"
+else
+  fail_ "X8" "expected rc=1 — an over-stripping mutant eats the token; rc=$rc; output:\n$out"
 fi
 teardown_fixture
 
@@ -577,6 +662,32 @@ if [ "$rc" -eq 1 ]; then
   pass "L6: an inline allow cannot suppress a T1 literal-path reference"
 else
   fail_ "L6" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L7: a near-miss allowlist marker does NOT allowlist -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# The marker is matched as an EXACT TOKEN, not as a prefix. Under a prefix
+# test, `allowed because …` parses as marker + reason "ed because …" and
+# waives the violation — a typo, or a sentence that merely starts with the
+# right letters, becomes a silent opt-out. Exact-token matching fails CLOSED:
+# a near-miss is not a marker, so the line stays a violation. Both spellings
+# below are near-misses of the SAME token and must both be refused.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "unknown delta-class"  # lint-delta-boundary: allowed because it is prose\n'
+  printf 'echo "another delta-class"  # lint-delta-boundary: allowlist prose too\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:2' \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:3'; then
+  pass "L7: 'allowed'/'allowlist' are not the 'allow' token — both stay violations"
+else
+  fail_ "L7" "expected rc=1 naming BOTH lines; rc=$rc; output:\n$out"
 fi
 teardown_fixture
 

--- a/tests/test-lint-delta-boundary.sh
+++ b/tests/test-lint-delta-boundary.sh
@@ -84,13 +84,21 @@
 #               strippable and the reference vanishes -> X8. (Mutant M-H:
 #               survives X1-X7, dies to X8.)
 #         C6  `#` SPELLING            -> pinned by X5 (no space after `#`).
-#         C7  `\([^[:space:]]\)` guard + `\1` back-reference -> pinned by X6.
-#             Dropping the capture eats exactly ONE character of executed code,
-#             which is not enough to make the line green — it DEMOTES the hit
-#             from T1 to T2 (the truncated token stops matching a literal path
-#             but still carries the `delta-` prefix). X6 therefore asserts the
-#             TIER, not the exit code: rc alone cannot see this. The demotion
-#             matters because T2 is inline-allowlistable and T1 is not.
+#         C7  `\([^[:space:]]\)` guard + `\1` back-reference — the executed
+#             PREFIX must survive the strip -> pinned at TWO resolutions:
+#               X1 (COARSE): a mutation that discards the whole line whenever a
+#               trailing comment is present, e.g.
+#               `s/.*[[:space:]][[:space:]]*#.*$//`, loses the violation
+#               outright. Measured: X1, X6, L2, L6 and L7 all go RED (24/5).
+#               X6 (FINE): dropping the capture eats exactly ONE character of
+#               executed code, which is NOT enough to make the line green — it
+#               DEMOTES the hit from T1 to T2 (the truncated token stops
+#               matching a literal path but still carries the `delta-` prefix).
+#               X6 therefore asserts the TIER, not the exit code: rc alone
+#               cannot see this. The demotion matters because T2 is
+#               inline-allowlistable and T1 is not.
+#             Both are kept: an edit that eats everything and one that eats a
+#             single byte are different mutations and X1 cannot see the latter.
 #         C8  `#` INSIDE a word is not a comment -> pinned by X7 and X8, which
 #             cover OPPOSITE failure modes of the same atom and are deliberately
 #             not folded together:
@@ -339,12 +347,30 @@ teardown_fixture
 
 # ════════════════════════════════════════════════════════════════════
 echo ""
-echo "=== X1 (atom C1, the E1 '^' anchor): a violation carrying a trailing"
-echo "    comment must STILL fail -> exit 1 ==="
+echo "=== X1 (atom C7, coarse form): stripping a trailing comment must leave"
+echo "    the EXECUTED PREFIX intact -> exit 1 ==="
 # ════════════════════════════════════════════════════════════════════
-# Drop the `^` from E1 and `[[:space:]]*#` matches the ` #` in the MIDDLE of
-# this line, blanking the whole line — the violation disappears and the lint
-# goes green. That is the BL-181 hole, transplanted. Assert on rc.
+# CORRECTED after adversarial review (R-WP1-2). This case used to claim it
+# pinned E1's `^` anchor, on the theory that an unanchored E1 "blanks the whole
+# line". That theory is wrong about sed: `s///` replaces only the MATCHED
+# REGION, never the line, so an unanchored E1 simply truncates at the ` #` and
+# this fixture's token — which sits BEFORE the comment — survives. X1 stayed
+# green under that mutation and the anchor was unpinned. The `^` anchor and the
+# whole over-strip/widening family are pinned by X8; see the atom -> case map
+# in this file's header.
+#
+# What X1 ACTUALLY pins, verified by executing the mutation rather than
+# reasoning about it: the trailing-comment strip must remove ONLY the comment
+# and never the executed prefix. Mutate E2 to `s/.*[[:space:]][[:space:]]*#.*$//`
+# — which discards the whole line whenever a trailing comment is present — and
+# this case goes RED (measured: X1, X6, L2, L6 and L7 all fail, 24 passed /
+# 5 failed).
+#
+# X1 is the COARSE form of that pin and X6 is the FINE one: X1 catches a
+# mutation that loses the whole prefix, X6 catches one that loses a SINGLE
+# character (by asserting the tier, because one lost character only demotes
+# T1 -> T2 and never changes the exit code). Both are kept — a mutation that
+# eats everything and one that eats one byte are different edits.
 setup_fixture
 cat > "$TMP/scripts/check-gate.sh" <<'SH'
 #!/usr/bin/env bash
@@ -352,9 +378,9 @@ source "$SCRIPT_DIR/lib/delta-state.sh"  # convenience, just this once
 SH
 out=$(run_fixture); rc=$?
 if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
-  pass "X1: E1's '^' anchor holds — a commented violation still fails"
+  pass "X1: the executed prefix survives a trailing-comment strip"
 else
-  fail_ "X1" "expected rc=1; an unanchored E1 would blank the line; rc=$rc; output:\n$out"
+  fail_ "X1" "expected rc=1; an E2 that discards the code half loses this violation; rc=$rc; output:\n$out"
 fi
 teardown_fixture
 

--- a/tests/test-lint-delta-boundary.sh
+++ b/tests/test-lint-delta-boundary.sh
@@ -1,0 +1,682 @@
+#!/usr/bin/env bash
+# tests/test-lint-delta-boundary.sh
+#
+# Behavior tests for scripts/lint-delta-boundary.sh — the dependency-direction
+# boundary lint specified by docs/designs/2026-08-02-delta-track-v1.md §3.3
+# (settled decision D1: the delta track is a SEVERABLE module and the boundary
+# is lint-enforced FROM THE FIRST COMMIT).
+#
+# Each case stages a hermetic mini-tree under mktemp -d, points the lint at it
+# with --root, and asserts on the EXIT CODE (never on a printed label — the
+# repo's [WARN] trap is that labels and exit predicates disagree).
+#
+# WHAT THE SUITE PINS, and why each pin exists
+#
+#   DIRECTION (§3.3 clauses 1-2)
+#     D1  clean tree                                     -> 0
+#     D2  core file names a delta path (T1)              -> 1
+#     D3  variable-composed reference (T2)               -> 1
+#     D4  delta -> core reference is unasserted          -> 0
+#     D5  T1 and T2 do not double-report the same line   -> exactly one row
+#
+#   SURFACE (§3.3 "Set definitions")
+#     S1  init.sh is scanned
+#     S2  scripts/hooks/*.sh is scanned
+#     S3  scripts/lib/*.sh (non-delta members) is scanned
+#     A narrowed surface would pass D1-D5 while seeing nothing; these three are
+#     the anti-vacuity pins for the CORE half specifically.
+#
+#   THE EXECUTED-LINES STRIPPER (§3.3 "Executed lines only")
+#     This predicate has repo scar tissue. CLAUDE.md records that a
+#     ONE-CHARACTER narrowing of the sibling predicate in
+#     scripts/lint-tests-registered.sh (# BL-181-UNIT-LANE-PREDICATE) re-opened
+#     the same hole THREE times while passing both PR-blocking checks each
+#     time. So the pins below name each ATOM of the two sed expressions and
+#     pin its WIDTH and its SPELLING, not merely its presence:
+#
+#       E1 = 's/^[[:space:]]*#.*$//'                     (whole-line comments)
+#         C1  the `^` anchor          -> pinned by X1 (a violation carrying a
+#             trailing comment must STILL fail; without `^`, E1 matches the
+#             ` #` mid-line and blanks the whole line, so every commented
+#             violation goes silently green — the exact BL-181 hole)
+#         C2  `[[:space:]]*` WIDTH    -> pinned by X2 (0, 1, 4, 8 spaces, tab,
+#             tab+spaces, all ignored). Narrowing to `^#` false-positives on
+#             every indented comment; widening past `*` is not expressible.
+#         C3  `#` SPELLING            -> pinned by X3 (no space required after
+#             `#`). Narrowing to `#[[:space:]]` false-positives on `#code`.
+#         C4  `.*$` reach             -> pinned by X2/X3 implicitly: the token
+#             sits AFTER the `#`, so a non-greedy or anchored variant leaves it
+#             behind and reds.
+#
+#       E2 = 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/'  (trailing)
+#         C5  `[[:space:]][[:space:]]*` WIDTH -> pinned by X4 (ONE space, TAB,
+#             and many spaces all strip). Narrowing to two-or-more
+#             (`[[:space:]][[:space:]][[:space:]]*`) false-positives on the
+#             single-space form, which is the commonest spelling in this repo.
+#         C6  `#` SPELLING            -> pinned by X5 (no space after `#`).
+#         C7  `\([^[:space:]]\)` guard + `\1` back-reference -> pinned by X6:
+#             the CODE half of the line must survive the strip. A mutation that
+#             drops the capture (replacing with the empty string) destroys the
+#             code half, so a line that is BOTH a real violation AND carries a
+#             trailing comment stops failing. CLAUDE.md calls this guard
+#             behaviour-neutral in the BL-181 predicate; it is NOT neutral here,
+#             because here the surviving prefix is what the tiers match on.
+#         C8  `#` INSIDE a word is not a comment -> pinned by X7
+#             (`code#word` is a single bash word, not a comment; stripping it
+#             would be an over-strip and a false negative).
+#
+#   ALLOWLISTS (§3.3 clause 3 + the T2 row)
+#     L1  T2 inline allow WITH a reason is honored       -> 0
+#     L2  T2 inline allow with an EMPTY reason           -> 1
+#     L3  the seam file passes                           -> 0
+#     L4  seam allowlist cardinality is exactly 1        -> 1 when it grows
+#         (mutation, executed here against a lint COPY)
+#     L5  a seam row with no reason                      -> 1
+#     L6  T1 is NOT inline-allowlistable (only the file-level seam is)
+#
+#   VACUITY FLOOR (§3.3 clause 4)
+#     V1  no delta-module file present                   -> 2 (not 0, not 1)
+#     V2  no core file present                           -> 2
+#     V3  mutation: empty the DELTA manifest in a lint COPY and run it against
+#         the REAL repo root                             -> 2 (not 0)
+#
+#   INTERFACE
+#     I1  --list emits the STATUS table incl. the population INFO row
+#     I2  an unknown flag                                -> 2
+#     I3  the REAL tree passes                           -> 0
+#
+# HAZARD NOTE — why this file may safely contain delta paths.
+# The lint's CORE surface is init.sh + scripts/*.sh + scripts/lib/*.sh +
+# scripts/hooks/*.sh. tests/ is NOT in it, so the literals below never become
+# violations on the real tree. (Contrast tests/test-lint-bl-markers.sh, whose
+# fixtures DO land in that lint's surface and must be built by concatenation.)
+#
+# Style mirrors tests/test-lint-bl-markers.sh: set -uo pipefail, mktemp
+# fixtures, pass/fail counters, teardown after each case, bash 3.2 only.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-delta-boundary.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TAB=$(printf '\t')
+
+# ── Fixture builder ─────────────────────────────────────────────────────
+# A minimal tree carrying BOTH halves the vacuity floor demands: at least one
+# CORE file and at least one DELTA-module file. Cases add to it.
+setup_fixture() {
+  TMP=$(mktemp -d)
+  mkdir -p "$TMP/scripts/lib" "$TMP/scripts/hooks"
+  cat > "$TMP/init.sh" <<'SH'
+#!/usr/bin/env bash
+echo "scaffold"
+SH
+  cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/lib/helpers-core.sh"
+echo "gate"
+SH
+  cat > "$TMP/scripts/lib/helpers-core.sh" <<'SH'
+#!/usr/bin/env bash
+helper() { echo "help"; }
+SH
+  cat > "$TMP/scripts/hooks/record-thing.sh" <<'SH'
+#!/usr/bin/env bash
+echo "hook"
+SH
+  # The DELTA half of the floor.
+  cat > "$TMP/scripts/lib/delta-state.sh" <<'SH'
+#!/usr/bin/env bash
+delta_state_read() { echo "{}"; }
+SH
+}
+teardown_fixture() { rm -rf "$TMP"; }
+
+run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
+# --list asserts on the TABLE, so stderr is dropped: the per-violation
+# diagnostics carry the same file:line text and would double every row count.
+run_fixture_list() { bash "$LINTER" --root "$TMP" --list 2>/dev/null; return $?; }
+
+# ════════════════════════════════════════════════════════════════════
+echo "=== D1: a clean tree -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "D1: clean fixture exits 0"
+else
+  fail_ "D1" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D2: core file names a delta path (T1) -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# This is mutation m1 executed as a permanent test: the design's worked
+# example is someone adding `source .../lib/delta-state.sh` to a core gate
+# script on a Tuesday and the severability property vanishing silently.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/delta-state.sh"
+echo "gate"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:3' \
+   && echo "$out" | grep -q 'delta-state\.sh'; then
+  pass "D2: T1 literal-path reference exits 1 naming file:line and the token"
+else
+  fail_ "D2" "expected rc=1 + check-gate.sh:3 + the token; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D3: variable-composed reference is caught by T2 -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# R-DT-6: a path-only lint is evadable because bash composes at runtime.
+# The line below carries NO literal delta path, so T1 cannot see it.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+LIB="$(cd "$(dirname "$0")/lib" && pwd)"
+kind="state"
+source "$LIB/delta-${kind}.sh"
+echo "gate"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:4' \
+   && echo "$out" | grep -q 'T2'; then
+  pass "D3: variable-composed reference caught by T2 at the right line"
+else
+  fail_ "D3" "expected rc=1 + check-gate.sh:4 + a T2 tier row; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D4: delta -> core reference is allowed and unasserted -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/lib/delta-state.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/helpers-core.sh"
+. "$(dirname "$0")/enforcement-level.sh"
+delta_state_read() { helper; }
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "D4: a delta-module file sourcing core is not a violation"
+else
+  fail_ "D4" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D5: a T1 line is not ALSO reported as T2 (tier discrimination) ==="
+# ════════════════════════════════════════════════════════════════════
+# §3.3's T2 row reads "on any executed line of a CORE file that T1 did not
+# already catch". Double-reporting would inflate the count and make the
+# operator chase one defect twice.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+source "lib/delta-state.sh"
+SH
+out=$(run_fixture_list); rc=$?
+rows=$(echo "$out" | grep -c 'scripts/check-gate\.sh:2')
+if [ "$rc" -eq 1 ] && [ "$rows" -eq 1 ]; then
+  pass "D5: the T1 line yields exactly one row (no T2 double-report)"
+else
+  fail_ "D5" "expected rc=1 and exactly 1 row for that line; rc=$rc rows=$rows; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S1: init.sh is inside the CORE surface ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/init.sh" <<'SH'
+#!/usr/bin/env bash
+cp "$SCRIPT_DIR/scripts/lib/delta-state.sh" "$TARGET/scripts/lib/"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'init\.sh:2'; then
+  pass "S1: init.sh is scanned"
+else
+  fail_ "S1" "expected rc=1 naming init.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S2: scripts/hooks/*.sh is inside the CORE surface ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/hooks/record-thing.sh" <<'SH'
+#!/usr/bin/env bash
+jq . .claude/delta-state.json
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/hooks/record-thing\.sh:2'; then
+  pass "S2: scripts/hooks/*.sh is scanned"
+else
+  fail_ "S2" "expected rc=1 naming the hook; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S3: scripts/lib/*.sh non-delta members are inside CORE ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/lib/helpers-core.sh" <<'SH'
+#!/usr/bin/env bash
+helper() { cat docs/deltas/DELTA-001.md; }
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/lib/helpers-core\.sh:2'; then
+  pass "S3: a non-delta scripts/lib member is scanned"
+else
+  fail_ "S3" "expected rc=1 naming helpers-core.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X1 (atom C1, the E1 '^' anchor): a violation carrying a trailing"
+echo "    comment must STILL fail -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# Drop the `^` from E1 and `[[:space:]]*#` matches the ` #` in the MIDDLE of
+# this line, blanking the whole line — the violation disappears and the lint
+# goes green. That is the BL-181 hole, transplanted. Assert on rc.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+source "$SCRIPT_DIR/lib/delta-state.sh"  # convenience, just this once
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X1: E1's '^' anchor holds — a commented violation still fails"
+else
+  fail_ "X1" "expected rc=1; an unanchored E1 would blank the line; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X2 (atom C2, E1 '[[:space:]]*' WIDTH): whole-line comments are"
+echo "    ignored at EVERY indent width -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Six widths in one file: column 0, one space, four spaces, eight spaces, a
+# TAB, and TAB+spaces. Narrowing E1 to `^#` reds on five of the six; narrowing
+# to `^[[:space:]]` reds on the first.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# source "$SCRIPT_DIR/lib/delta-state.sh" would fuse the module\n'
+  printf ' # one space: scripts/lib/delta-policy.sh\n'
+  printf '    # four spaces: scripts/delta.sh\n'
+  printf '        # eight spaces: .claude/delta-state.json\n'
+  printf '%s# a tab: docs/deltas/\n' "$TAB"
+  printf '%s   # tab plus spaces: scripts/cut-release.sh\n' "$TAB"
+  printf 'echo gate\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X2: E1 strips whole-line comments at 0/1/4/8-space, tab and tab+space indents"
+else
+  fail_ "X2" "expected rc=0 — a narrowed E1 width false-positives here; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X3 (atom C3, E1 '#' SPELLING): no space is required after '#' ==="
+# ════════════════════════════════════════════════════════════════════
+# Narrowing E1 to `^[[:space:]]*#[[:space:]]` makes every one of these an
+# "executed" line and the lint cries wolf. Both indent widths are present so
+# the mutation cannot be papered over by the width pin alone.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '#source "$SCRIPT_DIR/lib/delta-state.sh"\n'
+  printf '    #source "$SCRIPT_DIR/lib/delta-policy.sh"\n'
+  printf '%s#delta-composed reference sketch\n' "$TAB"
+  printf 'echo gate\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X3: E1 strips '#comment' with no space after the hash, at any indent"
+else
+  fail_ "X3" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X4 (atom C5, E2 whitespace WIDTH): trailing comments strip after"
+echo "    ONE space, a TAB, and many spaces -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# The single-space form is the commonest spelling in this repo, and it is the
+# one a two-or-more narrowing silently drops.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo one #see scripts/lib/delta-state.sh\n'
+  printf 'echo two  # see scripts/lib/delta-policy.sh\n'
+  printf 'echo three%s# see scripts/delta.sh\n' "$TAB"
+  printf 'echo four      # see docs/deltas/ and .claude/delta-policy.json\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X4: E2 strips trailing comments at 1-space, 2-space, tab and 6-space widths"
+else
+  fail_ "X4" "expected rc=0 — a widened E2 minimum false-positives on the 1-space form; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X5 (atom C6, E2 '#' SPELLING): trailing '#token' with no space ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo one #delta-state.sh\n'
+  printf 'echo two%s#delta-cadence.sh\n' "$TAB"
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X5: E2 strips a trailing comment with no space after the hash"
+else
+  fail_ "X5" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X6 (atom C7, E2's capture + '\\1' back-reference): the last code"
+echo "    character must survive the strip -> the hit is still TIER T1 ==="
+# ════════════════════════════════════════════════════════════════════
+# Drop the `\([^[:space:]]\)` capture and the `\1` replacement — i.e. mutate
+# E2 to `s/[^[:space:]][[:space:]][[:space:]]*#.*$//` — and the strip eats ONE
+# character of executed code. The line below then reads `...delta-policy.jso`,
+# the T1 literal token no longer matches, and the reference is demoted to a T2
+# hit: still non-zero, so an rc-only assertion would MISS the regression
+# entirely. Asserting the TIER is what makes this atom pinned. (Note the
+# demotion is not harmless — T2 is inline-allowlistable and T1 is not, so the
+# mutation silently converts an unarguable violation into a waivable one.)
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'jq . .claude/delta-policy.json   # read the policy\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^FAIL.*T1.*scripts/check-gate\.sh:2'; then
+  pass "X6: E2 keeps the last executed character, so the hit stays tier T1"
+else
+  fail_ "X6" "expected rc=1 with a T1 row for line 2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X7 (atom C8): '#' inside a word is NOT a comment -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# `echo delta-state.sh#x` is a single bash WORD; bash executes it. A stripper
+# that treated any `#` as a comment start would over-strip and go green on a
+# real reference. Both E1 and E2 require the `#` to follow whitespace (or be
+# at the start of the line), which is exactly bash's own rule.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo scripts/lib/delta-state.sh#fragment\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X7: a mid-word '#' does not start a comment (no over-strip)"
+else
+  fail_ "X7" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L1: a T2 inline allow WITH a reason is honored -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# §3.3: T2 is deliberately coarse and will occasionally fire on prose in a
+# string. The trade is explicit — a false positive costs one allowlist row
+# with a reason; a false negative costs the severability property silently.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "unknown delta-class; see the policy file"  # lint-delta-boundary: allow prose in an operator message, not a reference\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "L1: reasoned inline allow suppresses the T2 hit"
+else
+  fail_ "L1" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L2: a T2 inline allow with an EMPTY reason is rejected -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "unknown delta-class"  # lint-delta-boundary: allow\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'reason'; then
+  pass "L2: an empty allowlist reason fails and says so"
+else
+  fail_ "L2" "expected rc=1 mentioning the reason; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L3: the seam file may reference delta paths -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/process-checklist.sh" <<'SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+. "$SCRIPT_DIR/lib/delta-state.sh"
+case "${1:-}" in
+  --delta-open) delta_state_open "$@" ;;
+esac
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "L3: scripts/process-checklist.sh is the allowlisted seam"
+else
+  fail_ "L3" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L4 (mutation m2): a SECOND seam allowlist entry -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# §3.3 clause 3: "The lint asserts the allowlist array has length 1 and fails
+# if it grows. A second seam is a design change and must be argued, not
+# merged." Executed here against a COPY so the real lint is never mutated.
+# The fixture is CLEAN, so the ONLY thing that can red is the cardinality
+# assertion — that is what makes this a proof and not a coincidence.
+setup_fixture
+COPY="$TMP/lint-copy-cardinality.sh"
+awk '{ print }
+     /^SEAM_ALLOWLIST=\(/ { print "  \"scripts/check-gate.sh|an invented second seam\"" }' \
+  "$LINTER" > "$COPY"
+out=$(bash "$COPY" --root "$TMP" 2>&1); rc=$?
+# Control: the unmutated lint on the same fixture is green.
+out_ctl=$(run_fixture); rc_ctl=$?
+if [ "$rc" -eq 1 ] && [ "$rc_ctl" -eq 0 ] \
+   && echo "$out" | grep -q -i 'cardinal'; then
+  pass "L4: growing the seam allowlist reds on the cardinality assertion (control green)"
+else
+  fail_ "L4" "expected mutated rc=1 (cardinality) and control rc=0; rc=$rc rc_ctl=$rc_ctl; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L5: a seam allowlist row with no reason -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+COPY="$TMP/lint-copy-noreason.sh"
+sed 's/^  "scripts\/process-checklist\.sh|.*$/  "scripts\/process-checklist.sh|"/' \
+  "$LINTER" > "$COPY"
+out=$(bash "$COPY" --root "$TMP" 2>&1); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'reason'; then
+  pass "L5: a reasonless seam row fails the lint"
+else
+  fail_ "L5" "expected rc=1 mentioning the reason; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L6: T1 is NOT inline-allowlistable -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# §3.3's tier table gives the inline allowlist to T2 only; T1 is
+# "Unambiguous: a core file names a module file". The single sanctioned
+# escape for a T1-class reference is the file-level seam, whose cardinality
+# is pinned at one. Without this pin, the allowlist marker would quietly
+# become a universal opt-out and clause 3 would mean nothing.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'source "lib/delta-state.sh"  # lint-delta-boundary: allow it was easier\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "L6: an inline allow cannot suppress a T1 literal-path reference"
+else
+  fail_ "L6" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V1 (vacuity floor): no delta-module file present -> exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+# The floor is the whole point: "a passing lint that proves nothing is worse
+# than no lint". Asserted as exit 2 EXACTLY — 0 and 1 are both wrong answers
+# and only the code distinguishes them.
+setup_fixture
+rm -f "$TMP/scripts/lib/delta-state.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V1: a scan with no delta-module file exits 2, not 0"
+else
+  fail_ "V1" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V2 (vacuity floor): no core file present -> exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+rm -f "$TMP/init.sh" "$TMP/scripts/check-gate.sh" \
+      "$TMP/scripts/lib/helpers-core.sh" "$TMP/scripts/hooks/record-thing.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V2: a scan with no core file exits 2, not 0"
+else
+  fail_ "V2" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V3 (mutation m3): an EMPTY delta manifest -> exit 2, not 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Run against the REAL repo root, so this also proves the floor is what stops
+# a manifest-shaped regression on the tree we actually ship.
+setup_fixture
+COPY="$TMP/lint-copy-emptymanifest.sh"
+awk '
+  /DELTA-BOUNDARY-MANIFEST-BEGIN/ { skip = 1 }
+  /DELTA-BOUNDARY-MANIFEST-END/   { skip = 0; print "DELTA_MANIFEST=()"; print; next }
+  skip != 1 { print }
+  skip == 1 && /DELTA-BOUNDARY-MANIFEST-BEGIN/ { print }
+' "$LINTER" > "$COPY"
+out=$(bash "$COPY" --root "$REPO_ROOT" 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V3: emptying the DELTA manifest exits 2 on the real tree"
+else
+  fail_ "V3" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I1: --list emits the STATUS table and the population row ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+source "lib/delta-state.sh"
+SH
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^STATUS' \
+   && echo "$out" | grep -q '^FAIL' \
+   && echo "$out" | grep -q 'population' \
+   && echo "$out" | grep -q 'seam'; then
+  pass "I1: --list prints the header, the FAIL row, the seam row and the population row"
+else
+  fail_ "I1" "expected the full --list shape; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I2: an unknown flag -> exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" --not-a-flag 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "I2: unknown flag exits 2"
+else
+  fail_ "I2" "expected rc=2; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I3: the REAL tree passes -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "I3: the real repository has no core -> delta edge"
+else
+  fail_ "I3" "expected rc=0 on the real tree; rc=$rc; output:\n$out"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

Delta Track **WP1** (design of record: `docs/designs/2026-08-02-delta-track-v1.md` §3.3, §11-WP1): the dependency-direction lint settled decision D1 requires **from the first delta commit** — landing with the first module file so no delta code ever exists unguarded.

- `scripts/lint-delta-boundary.sh` — core→delta references forbidden on executed lines: **T1** (literal module paths) + **T2** (bare `delta-` token, reasoned allowlist); seam allowlist asserted at **cardinality exactly one** (`process-checklist.sh`); **vacuity floor** exits 2 when either file set is empty; single literal manifest so the CORE/DELTA sets cannot disagree. `--list` mode per house convention. §13-R15's below-prefix-boundary residual disclosed in the header (WP7's severability test is the designed backstop).
- `scripts/lib/delta-state.sh` — first module stub (WP2 fills it in).
- New non-required CI job `delta-boundary-lint` in lint.yml; `run-lints.sh` discovers the lint by glob with zero wiring (verified: 14/14).
- `tests/test-lint-delta-boundary.sh` — 29 tests, hermetic fixture tree via scan-root override, registered in both lanes. Each pin records which named mutant it kills.

## Verification trail

- Design's three mutation proofs, executed against the REAL tree: core `source` of a module lib → T1 RED; second seam-allowlist row → RED on cardinality; manifest pointed at nothing → **exit 2**, not 0.
- **Adversarial review (fable) before this PR**: initial verdict major_concerns — the lint's *behavior* held under every attack (all above-prefix T2 evasions caught), but three one-character stripper mutations survived the suite while shipped comments claimed those atoms were pinned (the BL-181 false-note hazard). Two fix rounds: **X8** violation fixture (token after mid-word `#`) now kills all three mutants — re-verified by the reviewer by execution; all five false comment sites corrected, with X1's true pin measured rather than asserted (C7-coarse mutant → exactly X1/X6/L2/L6/L7 RED, 24/5). Plus **L7**: allowlist marker tightened to exact-token (`allowed because…` no longer allowlists), pinned. Final verdict: **approve**. Review record: `.superpowers/sdd/2026-08-02-delta-track-v1/wp1-review.md` (session artifact).
- Notable: the tree already carried one bare `delta-` token in a comment (`freshness-detect.sh`) — without the executed-lines stripper this lint would have been red on its own first commit.

## Forward decisions recorded (not defects of this branch)

1. `delta-boundary-lint` is **not** a required check — Karl's call, recommended after a shakedown period (bl-markers precedent).
2. `scripts/host-drivers/*.sh` sits outside the design's four CORE globs (reviewer proved a planted violation there passes) — candidate §3.3 design amendment, surfaced to Karl rather than silently widened.
3. The seam file is exempt from both tiers per §3.3 clause 3 (reading verified against design text); WP7's severability test closes the resulting window behaviorally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)