### PR TITLE
feat(brownfield): severable-module contract (M1-M5) + module-dependency lint (WP0)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,11 @@
 #
 # Every job here is a PAIR of steps: a GATING step that runs the lint and
 # fails the job, and an INVENTORY step that re-runs the SAME lint with
-# `--list` to print the per-file PASS/FAIL roster. There are TWELVE such
+# `--list` to print the per-file PASS/FAIL roster. There are THIRTEEN such
 # pairs — one per job; BL-197's diagnostic-destruction-lint was the tenth,
-# BL-196's bl-markers-lint the eleventh, and the delta track's D1
-# delta-boundary-lint the twelfth —
+# BL-196's bl-markers-lint the eleventh, the delta track's D1
+# delta-boundary-lint the twelfth, and brownfield WP0's
+# module-dependencies-lint the thirteenth —
 # and under `if: always()` the inventory step re-ran
 # the full scan on GREEN runs too, where nobody reads it. That doubled
 # every lint job. Measured on the counter-antipattern job (run 30297887996,
@@ -352,3 +353,36 @@ jobs:
       - name: Show PASS/FAIL inventory (on failure)
         if: failure()
         run: bash scripts/lint-delta-boundary.sh --list || true
+
+  # Brownfield adoption (WP0): the module-dependency lint for Scout and the
+  # adoption driver. Same severability argument as the job above and a
+  # deliberate SIBLING of it rather than a generalisation — a module stops
+  # being severable one convenience call at a time, and no test fails when it
+  # does. Two match tiers (literal manifest paths, then the path-shaped
+  # segment tokens `scout/`/`adopt/` that catch the variable-composition
+  # family), M5's scout-only zero-dependency arm, a core allowlist whose
+  # cardinality is asserted at exactly ZERO — the brownfield module declares no
+  # seam — and two vacuity floors that exit 2 rather than let a collapsed scan
+  # report a pass. See scripts/lint-module-dependencies.sh header,
+  # docs/module-contract.md, and
+  # docs/designs/2026-08-02-brownfield-adoption-v1.md §3.3 for the spec, and
+  # tests/test-lint-module-dependencies.sh for the behavior suite (incl. the
+  # cardinality, empty-manifest and arm-neutering mutations).
+  #
+  # NOT a required status check — adding this job does not make it one. Branch
+  # protection is Karl's call and is deliberately untouched here. Same
+  # job-name-is-required-check convention as the jobs above: if it IS promoted,
+  # keep the name stable.
+  module-dependencies-lint:
+    name: module-dependencies-lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7 (v7.0.1)
+
+      - name: Lint the core -> module dependency direction (M3) and M5
+        run: bash scripts/lint-module-dependencies.sh
+
+      - name: Show PASS/FAIL inventory (on failure)
+        if: failure()
+        run: bash scripts/lint-module-dependencies.sh --list || true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -404,6 +404,7 @@ jobs:
             tests/test-lint-diagnostic-destruction.sh
             tests/test-lint-doc-anchors.sh
             tests/test-lint-fix-functions-stderr.sh
+            tests/test-lint-module-dependencies.sh
             tests/test-lint-no-live-remote.sh
             tests/test-lint-raw-read-prompt.sh
             tests/test-lint-tests-registered.sh

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -80,6 +80,16 @@ read-only scanner, the completed-vs-in-flight scenario chooser, the certificatio
 grandfathering, full-history secret scanning with redacted findings, and the archive-and-disclose
 collision policy. v1.1 post-review, r1 folded; nothing is built).
 
+## Module contract (`docs/module-contract.md`)
+
+[module-contract.md](module-contract.md) — the normative **M1–M5 severable-module
+contract**, transcribed from the brownfield design's §3.3 and binding on every
+severable module in the repo (the delta track, Scout, the adoption driver). One
+rule per section with its enforcement pointer: the two sibling boundary lints
+(`scripts/lint-delta-boundary.sh`, `scripts/lint-module-dependencies.sh`), the
+marker lint, and M5's zero-dependency arm. Read it before adding a module file
+or touching either lint's manifest.
+
 ## Reports (`Reports/`)
 
 Dated, point-in-time artifacts — evidence, not living docs. Naming convention is

--- a/docs/module-contract.md
+++ b/docs/module-contract.md
@@ -16,7 +16,7 @@ edit is a red check instead of a silent regression.
 
 | Module | Directory | Entry script | Zero-dependency (M5)? | Enforcing lint |
 |---|---|---|---|---|
-| Post-MVP delta track | `scripts/lib/` (flat `delta-*.sh` set) | `scripts/delta.sh` | no | `scripts/lint-delta-boundary.sh` |
+| Post-MVP delta track | `scripts/lib/` (flat `delta-*.sh` set — **grandfathered, see below**) | `scripts/delta.sh` (plus `scripts/cut-release.sh`) | no | `scripts/lint-delta-boundary.sh` |
 | Scout (brownfield scanner) | `scripts/lib/scout/` | `scripts/scout.sh` | **yes** | `scripts/lint-module-dependencies.sh` |
 | Adoption driver | `scripts/lib/adopt/` | `scripts/adopt-project.sh` | no | `scripts/lint-module-dependencies.sh` |
 
@@ -30,6 +30,16 @@ lints share the architecture — literal manifest, executed-lines-only comment
 stripping, two match tiers, reasoned exact-token allowlist, vacuity floor,
 `--list`, `--root` — and neither can be weakened by an edit aimed at the other.
 A single generalised engine remains available later as a rename-level change.
+
+**The delta module is GRANDFATHERED against M1**, and the table says so rather
+than leaving a reader to hit the contradiction. M1 as written requires an owned
+`scripts/lib/<module>/` directory and exactly one entry script; the delta module
+has neither — its files are a flat `delta-*.sh` set directly in `scripts/lib/`,
+and `scripts/cut-release.sh` sits beside `scripts/delta.sh` as a second entry
+point (it is in the delta manifest because it reads `delta-state.json`).
+**M1 binds NEW modules.** The delta module keeps its flat layout; its
+severability is enforced by its own lint's manifest, which does not depend on
+the directory shape. M2–M5 bind it normally.
 
 ---
 
@@ -82,10 +92,18 @@ In-core arms that support a module are *not* part of it. They are listed by
 marker in the module's header so severance has an explicit, short interface to
 preserve.
 
-*Enforced by:* review, plus `scripts/lint-bl-markers.sh`, which resolves marker
-citations in both directions — a named arm that is deleted or renamed reds. The
-brownfield arms land in WP3 and the list is empty until then; the delta module's
-seam is named in its lint's seam allowlist with its reason.
+*Enforced by:* **review.** `scripts/lint-bl-markers.sh` helps, but read what it
+actually delivers before relying on it: a marker cited in the **prose** surface
+reds when its last occurrence anywhere in the **code** surface disappears, and a
+marker in code reds when it names a `## BL-NNN:` entry nobody filed. The module
+header where M4 says the arms are listed **is itself in the code surface**, so
+that listing keeps its own markers alive — delete or rename an arm and the stale
+listing still satisfies both directions. **The lint does not red on a stale arm
+list; a human reading the list is the check.** (§3.3's own M4 row claims only
+"Review + the marker lint" — this page previously strengthened that into a
+guarantee the mechanism does not provide.) The brownfield arms land in WP3 and
+the list is empty until then; the delta module's seam is named in its lint's
+seam allowlist with its reason.
 
 ### M5 — The scanner depends on nothing
 
@@ -120,5 +138,14 @@ specified as **reuse-by-extraction** — copy the *predicate*, not the
   backstop there is behavioural, not lexical: the severability test that deletes
   the module and reverts the seam fails on a fused module however the fusion is
   spelled.
+- **What M5 does not currently catch, disclosed:** its forbidden set is core
+  **lib** basenames (`scripts/lib/*.sh`) only. A Scout file that invokes a core
+  **entry script** (`scripts/*.sh`) or `init.sh` itself passes the arm clean —
+  verified, `rc=0`. That is faithful to M5's first sentence and violates its
+  second, and it survives the behavioural backstop too: moving `scripts/lib/`
+  aside leaves `scripts/*.sh` in place, so **WP1-brownfield's hermetic test must
+  move `scripts/*.sh` aside as well, or assert against a bare tree.** Widening
+  the token set is a design decision, not an implementation detail, and is
+  pending rather than taken.
 - Run `bash scripts/lint-module-dependencies.sh --list` (or the delta sibling's
   `--list`) for the per-file PASS/FAIL roster and the population counts.

--- a/docs/module-contract.md
+++ b/docs/module-contract.md
@@ -1,0 +1,124 @@
+# The severable-module contract (M1–M5)
+
+**Status:** normative. Transcribed from
+[designs/2026-08-02-brownfield-adoption-v1.md](designs/2026-08-02-brownfield-adoption-v1.md)
+§3.3, where the rules were authored as a proposal co-owned with the delta
+track. This page is the standing version: it binds **every severable module in
+this repository**, present and future.
+
+A severable module is one that could be lifted out with a `git mv` rather than a
+refactor. The property is easy to state and easy to lose — nobody decides to
+fuse a module into the framework; someone adds one convenience call on a Tuesday
+and the property is gone with no test failing. These five rules exist so that
+edit is a red check instead of a silent regression.
+
+**Modules in scope**
+
+| Module | Directory | Entry script | Zero-dependency (M5)? | Enforcing lint |
+|---|---|---|---|---|
+| Post-MVP delta track | `scripts/lib/` (flat `delta-*.sh` set) | `scripts/delta.sh` | no | `scripts/lint-delta-boundary.sh` |
+| Scout (brownfield scanner) | `scripts/lib/scout/` | `scripts/scout.sh` | **yes** | `scripts/lint-module-dependencies.sh` |
+| Adoption driver | `scripts/lib/adopt/` | `scripts/adopt-project.sh` | no | `scripts/lint-module-dependencies.sh` |
+
+**The delta module predates this page**, and is enforced by its own sibling
+lint rather than by the one this page introduces. That is a deliberate
+convergence decision, not an oversight: `lint-delta-boundary.sh` was written
+against the delta design and survived two adversarial review rounds, so the
+brownfield lint was built as a SIBLING in the same proven shape rather than as a
+generalisation that would have churned freshly reviewed enforcement code. Both
+lints share the architecture — literal manifest, executed-lines-only comment
+stripping, two match tiers, reasoned exact-token allowlist, vacuity floor,
+`--list`, `--root` — and neither can be weakened by an edit aimed at the other.
+A single generalised engine remains available later as a rename-level change.
+
+---
+
+## The rules
+
+### M1 — One directory per module
+
+A severable module owns `scripts/lib/<module>/` and exactly one entry script.
+No module code lives outside its directory.
+
+*Enforced by:* the module manifest in each boundary lint — a path that is not in
+the manifest is core, and core naming a module path is an M3 violation, so
+scattered module code reds from the other direction. Grep the
+`MODULE-DEPS-MANIFEST` fence for the brownfield inventory.
+
+### M2 — Declared dependencies
+
+Each module's entry script carries a fenced header listing the core libs it may
+source. Anything not listed is a violation.
+
+*Enforced by:* the boundary lints. For a zero-dependency module the declared set
+is empty and M5 is the whole of M2; for the others the header is the declaration
+and review is the check until a module actually accrues a listed dependency.
+
+### M3 — Direction
+
+`module → core` is permitted. **`core → module` is forbidden**: no file outside
+`scripts/lib/<module>/` may source or invoke module code. This is the property
+that makes severance a `git mv`, not a refactor.
+
+*Enforced by:* both lints, in two match tiers. T1 is the literal manifest path
+and is **not** waivable. T2 is a path-shaped token that catches runtime
+composition (`"$SCRIPT_DIR/lib/scout/${part}.sh"` carries no literal manifest
+path but still carries the module's path segment) and takes an inline allowlist
+that **requires a reason**. Both tiers read EXECUTED lines only — see the
+`MODULE-DEPS-STRIP` fence, and treat its width and spelling as load-bearing: the
+sibling predicate `# BL-181-UNIT-LANE-PREDICATE` was re-opened three times by
+one-character narrowings that passed every PR-blocking check.
+
+**Seam allowlists are per-module and their cardinality is asserted.** The delta
+module declares exactly ONE seam and its lint fails if the array grows. The
+brownfield module declares **NONE**, and its lint asserts cardinality **zero** —
+the in-core enabling arms are core code that reads an `adopted` flag and never
+sources module code, so they are not seams and need no exemption. Growing either
+number is a design change to be argued in the design doc, not a row to append.
+
+### M4 — The enabling arms are core, and are named
+
+In-core arms that support a module are *not* part of it. They are listed by
+marker in the module's header so severance has an explicit, short interface to
+preserve.
+
+*Enforced by:* review, plus `scripts/lint-bl-markers.sh`, which resolves marker
+citations in both directions — a named arm that is deleted or renamed reds. The
+brownfield arms land in WP3 and the list is empty until then; the delta module's
+seam is named in its lint's seam allowlist with its reason.
+
+### M5 — The scanner depends on nothing
+
+Scout sources **no** core lib. Its bootstrap must work in a clone that has never
+run `init.sh`.
+
+*Enforced by:* the zero-dependency arm of `scripts/lint-module-dependencies.sh`
+(grep the `MODULE-DEPS-M5-CALL` marker), which forbids any Scout file from
+naming a `scripts/lib/*.sh` core lib on an executed line — plus, from
+WP1-brownfield, a hermetic test that runs the scanner with `scripts/lib/` moved
+aside. **The arm is scout-only and that bound is itself pinned**: the adoption
+driver may source core freely, and an M5 applied to every module would forbid
+what M3 explicitly permits.
+
+M5 is the load-bearing rule and it has a cost worth restating: Scout cannot
+reuse `helpers-core.sh`'s printers, the `soif_read_*` state readers, or the host
+drivers. It re-implements the small subset it needs. That is deliberate
+duplication in exchange for a tool that runs anywhere, and it is why reuse is
+specified as **reuse-by-extraction** — copy the *predicate*, not the
+*dependency*.
+
+---
+
+## Working on a module
+
+- **Adding a module file** is a one-line edit to the lint's manifest fence.
+- **Both lints exit 2, not 0, on a collapsed scan.** A boundary lint that scans
+  nothing passes trivially, and a passing lint that proves nothing is worse than
+  no lint. If you get exit 2, the manifest or the `--root` is wrong.
+- **What no grep-based lint can catch:** a reference composed below the token
+  boundary — a path assembled from a variable holding the module name. The
+  backstop there is behavioural, not lexical: the severability test that deletes
+  the module and reverts the seam fails on a fused module however the fusion is
+  spelled.
+- Run `bash scripts/lint-module-dependencies.sh --list` (or the delta sibling's
+  `--list`) for the per-file PASS/FAIL roster and the population counts.

--- a/scripts/lib/scout/scout-core.sh
+++ b/scripts/lib/scout/scout-core.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# scripts/lib/scout/scout-core.sh — the first file of the Scout module.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §3.1 (Scout is the
+# read-only scanner, packaged as a standalone tool) and §3.3 M1/M5. The
+# standing rules are transcribed in docs/module-contract.md.
+#
+# WHY THIS FILE EXISTS NOW, AHEAD OF THE SCANNER ITSELF (WP1-brownfield).
+# scripts/lint-module-dependencies.sh has a vacuity floor: it exits 2 unless it
+# finds at least one module file to scan. Landing the boundary lint before any
+# module file would leave the repo's lint sweep red on main, and relaxing the
+# floor to avoid that would defeat the floor. So the module opens with one
+# honest stub instead — small, real, and bound by M5 from birth rather than
+# retrofitted to it later.
+#
+# M5 APPLIES TO THIS FILE ALREADY: it sources NOTHING. Scout must run in a
+# clone that has never had init.sh applied to it, so it may not reach for
+# scripts/lib/*.sh — not for the shared printers, not for the state readers,
+# not for the host drivers. §8.2's reuse is specified as reuse-by-EXTRACTION:
+# copy the predicate, never the dependency. That duplication is the price of a
+# survey tool that costs nothing to run, and it is deliberate.
+#
+# M1 APPLIES TOO: everything Scout owns lives under this directory, with
+# scripts/scout.sh as its single entry script (WP1-brownfield). No Scout code
+# belongs anywhere else in the tree.
+
+# scout_module_version — the module's own version marker.
+#
+# Scout reports the version of the scanner that produced a report, and it has
+# to do so without reading .claude/manifest.json or any framework state: at
+# scan time there may be no framework installed at all. A literal here is the
+# whole mechanism.
+scout_module_version() {
+  printf '%s\n' "0.1.0-wp0-stub"
+}

--- a/scripts/lint-module-dependencies.sh
+++ b/scripts/lint-module-dependencies.sh
@@ -1,0 +1,722 @@
+#!/usr/bin/env bash
+# scripts/lint-module-dependencies.sh — the module-dependency lint for the
+# BROWNFIELD module set: Scout (the read-only scanner) and the adoption driver.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §3.3 (M1-M5,
+# normative), with the module inventory at §3.1 and the build-plan row at
+# §10-WP0. The rules are transcribed as a standing contract in
+# docs/module-contract.md; this script is M2/M3/M5's enforcement half.
+#
+# (Deliberately NO `# BL-NNN-…` marker: no backlog entry exists for the
+# brownfield build, and CLAUDE.md's citation rule is satisfied by the
+# design-doc path above plus the grep-able `MODULE-DEPS-*` fences below. Do not
+# mint a BL marker here — scripts/lint-bl-markers.sh would red on an id nobody
+# filed.)
+#
+# WHY A SIBLING AND NOT A GENERALISATION
+#   The post-MVP delta track ships its own boundary lint, whose architecture
+#   this file follows deliberately: literal manifest at the top, executed-lines
+#   -only comment stripping at every width and spelling, two match tiers, a
+#   reasoned exact-token allowlist, a vacuity floor that exits 2, `--list`, and
+#   a `--root` override for hermetic fixtures. That shape survived two
+#   adversarial fix rounds. The WP0 convergence decision was to build a SIBLING
+#   in the same shape rather than generalise the freshly reviewed delta lint
+#   into a parameterised engine — both designs stay honored as written, and
+#   neither track's boundary can be weakened by an edit aimed at the other.
+#
+# THE DEFECT CLASS
+#   A severable module stops being severable one convenience call at a time.
+#   Nobody decides to fuse the adoption driver into the framework; someone adds
+#   a source line to a core gate script on a Tuesday because it was easier, and
+#   the severability property is gone with no test failing. This lint makes
+#   that fusion a red check.
+#
+# THE PREDICATE — three arms (§3.3)
+#   1. MODULE -> CORE: permitted (M3 clause 1), and deliberately UNASSERTED for
+#      the DRIVER. The adoption driver may source helpers-core.sh, read
+#      phase-state.json, call the host drivers. Asserting it would be busywork.
+#   2. CORE -> MODULE: forbidden (M3 clause 2). For every file in the CORE set,
+#      no EXECUTED line may name any brownfield-module path.
+#   3. M5, THE ZERO-DEPENDENCY ARM, SCOUT ONLY. "The scanner sources no core
+#      lib. Its bootstrap must work in a clone that has never run init.sh."
+#      Scout's files may not name any `scripts/lib/*.sh` core lib on an
+#      executed line. The DRIVER is exempt — M5 binds the scanner, and an arm
+#      applied to both would forbid something §3.3 explicitly permits. That
+#      bound is a pin in its own right (tests/test-lint-module-dependencies.sh
+#      case M3), because an unbounded exemption and an unbounded rule are the
+#      same class of error.
+#
+#   PLUS TWO GUARDS
+#   4. CORE ALLOWLIST, CARDINALITY EXACTLY ZERO. Unlike the delta track — whose
+#      module has one declared seam — the brownfield module has NONE. §3.1's
+#      in-core enabling arms are NOT seams: they are core code that reads an
+#      `adopted` flag and never sources module code, so they need no exemption.
+#      The array's length IS the assertion. Growth is a design change to be
+#      argued in §3.1, not a row to append.
+#   5. VACUITY FLOOR. Exit 2 unless at least one module file AND at least one
+#      core file were found — and, when zero-dependency module files are
+#      present, at least one core lib to check them against. A boundary lint
+#      that scans nothing passes trivially, and a passing lint that proves
+#      nothing is worse than no lint — this repo has the scar (the BL-104
+#      scoring inversions in CLAUDE.md, where an empty manifest scored better
+#      than no manifest).
+#
+# THE SETS — one manifest, so they can never disagree
+#   MODULE = the §3.1/§3.3 inventory, spelled ONCE in the MODULE-DEPS-MANIFEST
+#            fence below as `<module>|<path>` rows. The module column is what
+#            makes M5's scout-only bound derivable from the same list instead
+#            of from a second one that could drift out of step with it.
+#   CORE   = init.sh + scripts/*.sh + scripts/lib/*.sh + scripts/hooks/*.sh,
+#            MINUS the module inventory, MINUS this script, and MINUS sibling
+#            boundary lints. scripts/host-drivers/*.sh is NOT in the CORE set:
+#            §3.3's co-owned contract names four globs and this is the
+#            fourth-glob-faithful reading, kept at exact parity with the delta
+#            lint. The gap is a known, pending design question for BOTH lints —
+#            widen it only by amending the design, and then in both places.
+#
+#   SELF-EXCLUSION IS BY EXACT PATH, and that is deliberate: a RENAMED COPY of
+#   this script inside scripts/ is NOT self-excluded. A copy is a core file
+#   that names every module path, so it reds. Fail-closed is the right
+#   direction for a boundary lint.
+#
+#   SIBLING BOUNDARY LINTS are excluded BY SHAPE (`scripts/lint-*-boundary.sh`)
+#   rather than by name, and the reason is worth recording because it is the
+#   sibling lint's own predicate talking. That lint's manifest lists its own
+#   filename, so its basename is one of its T1 literal tokens — and T1 is
+#   non-waivable there by design. Writing the sibling's literal path on an
+#   executed line of this file would therefore red the sibling lint with a
+#   violation no allowlist row can waive. The shape glob is the only spelling
+#   available, and it happens to be the more general rule anyway: any future
+#   module's boundary lint is excluded without an edit here.
+#   KNOWN COST, stated rather than hidden: the glob is broader than a name, so
+#   a core file that genuinely fused a module WOULD go unseen if it were named
+#   `scripts/lint-<something>-boundary.sh`. The exposure is one filename shape
+#   that only lint infrastructure uses.
+#
+# TWO MATCH TIERS, because literal paths are evadable
+#   T1  LITERAL PATH, tokens DERIVED from the manifest (basename for file
+#       entries, the whole prefix for directory entries) on an executed line of
+#       a CORE file. Verdict: FAIL. Unambiguous — a core file names a module
+#       file. T1 is NOT inline-allowlistable; with the allowlist cardinality at
+#       zero there is no sanctioned escape for a T1-class reference at all.
+#   T2  PATH-SHAPED MODULE TOKEN on an executed line that T1 did not already
+#       catch. Verdict: FAIL, with an inline allowlist that REQUIRES a reason.
+#
+#       WHY THESE TOKENS AND NOT `scout`/`adopt`. The delta module is a set of
+#       flat `delta-*.sh` files, so its T2 tier is the bare `delta-` prefix.
+#       The brownfield module is a DIRECTORY module, and the analogous bare
+#       English words are measurably wrong: a bare `adopt` token fires on TWO
+#       executed lines of the core tree TODAY — an operator warning in
+#       scripts/upgrade-project.sh's legacy-hook arm ("diff, then adopt
+#       manually") and a printf in scripts/lib/plan-staging.sh ("Decide by hand
+#       which to adopt") — neither of which is a reference to anything. Worse,
+#       §3.2's in-core enabling arms are named around the `adopted` flag, so a
+#       bare token would fire on every arm WP3 adds, permanently, by design.
+#
+#       The T2 tokens are therefore PATH-SEGMENT shaped: `scout/` and `adopt/`
+#       carry a trailing slash, so they are path syntax and not the English
+#       words. Measured on the current core surface, both have ZERO occurrences
+#       outside this (self-excluded) file, and §7.2's archive path is
+#       `.claude/adoption-archive/`, which contains neither.
+#
+#       WHY A SEGMENT AND NOT `lib/scout/`, which is the more obvious choice.
+#       T1's directory token is the full `scripts/lib/scout/`, and the house's
+#       dominant sourcing idiom drops the `scripts/` segment —
+#       `"$SCRIPT_DIR/lib/<name>.sh"`, 17 of the top call sites in scripts/ —
+#       so T1 alone is blind to it. `lib/scout/` fixes that spelling and ONLY
+#       that spelling: `"$LIBDIR/scout/scout-core.sh"`, where the variable
+#       already ends in `lib`, evades it too. That was not a hypothetical —
+#       the first draft of this lint used `lib/scout/`, and case S3 of the test
+#       suite, written independently with the natural `$LIBDIR` spelling,
+#       caught it on the first run. The bare segment closes the whole family
+#       for the cost of a token that matches nothing else in the tree.
+#
+#       The two entry-script tokens duplicate T1 on purpose: T1's tokens are
+#       DERIVED from the manifest, so deleting a manifest row disarms T1 for
+#       that path, while this list is an INDEPENDENT literal and still fires.
+#       The cheapest way to silence a violation must not silence the lint
+#       (case E1).
+#
+#   NAMED RESIDUAL, restated so nobody reads this lint as complete: a reference
+#   composed BELOW the token boundary — a path assembled from a variable
+#   holding `scout` — evades both tiers, and no grep-based lint can catch it.
+#   The backstop is behavioural, not lexical: WP1-brownfield's hermetic test
+#   runs the scanner with scripts/lib/ moved aside, which fails on a fused
+#   module however the fusion is spelled. Second residual: matching is
+#   CASE-SENSITIVE, because every path in the inventory is lower-case and a
+#   case-insensitive tier would fire on ordinary prose.
+#   Third residual, specific to the M5 arm: its forbidden tokens are core-lib
+#   BASENAMES, so a module file that reused a core lib's basename inside its
+#   own directory would false-positive on a legitimate same-dir source. M1
+#   gives each module its own directory precisely so it can name its files
+#   freely; do not reuse a core lib basename inside a module.
+#
+# EXECUTED LINES ONLY — and why the exact spelling is load-bearing
+#   Every arm matches against a STRIPPED copy of each file: whole-line comments
+#   blanked, trailing comments truncated, at any indent and any whitespace
+#   width, with and without a space after `#`. The stripper is the
+#   MODULE-DEPS-STRIP expression below and it is two sed expressions, in this
+#   order:
+#     E1  s/^[[:space:]]*#.*$//                        whole-line comments
+#     E2  s/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/   trailing comments
+#   E1 BLANKS rather than DELETES, so the stripped file has the same number of
+#   lines as the original and `grep -n` on it yields true source line numbers.
+#   That is the whole reason for the blank-not-delete choice; do not "simplify"
+#   it to `grep -v`. (Note what "blanks" does and does NOT mean: `s///` replaces
+#   only the MATCHED REGION. On a whole-line comment the match spans the line so
+#   the result is empty; on any other line it removes only what it matched. A
+#   mutation to this expression therefore truncates lines, it does not erase
+#   them.)
+#
+#   This predicate has repo scar tissue. scripts/lint-tests-registered.sh
+#   carries the sibling version (`# BL-181-UNIT-LANE-PREDICATE`) and CLAUDE.md
+#   records that a ONE-CHARACTER narrowing of it — a quantifier, a character
+#   class, or `#` -> `#[[:space:]]` — re-opened the same hole THREE times while
+#   passing both PR-blocking checks every time.
+#
+#   BOTH DIRECTIONS ARE HAZARDS, AND THEY ARE NOT SYMMETRIC IN COST TO DETECT:
+#     • NARROWING (strips too little) -> false POSITIVES -> any clean fixture
+#       reds. Cheap to catch; cases X2/X3/X4/X5/X9 do it.
+#     • WIDENING (strips too much) -> false NEGATIVES -> the tree goes QUIETER,
+#       and no clean fixture can ever notice. Caught only by a VIOLATION
+#       fixture positioned where the widened match would reach: cases X8 (the
+#       direction arms) and X10 (the M5 arm).
+#   Each atom is pinned for WIDTH and SPELLING — not merely presence — by
+#   tests/test-lint-module-dependencies.sh cases X1-X10; that file's header
+#   maps atom -> case IN BOTH DIRECTIONS and records which named mutant each
+#   row kills. Before changing one character here, read it — and if you add a
+#   stripper atom, add its widening pin too, not just its narrowing pin.
+#
+#   The stripper is applied at TWO independent call sites (the direction arms
+#   and the M5 arm). X9/X10 exist because a fix or a regression applied to one
+#   site and not the other is exactly the half-edit a single-site pin misses.
+#
+#   Both stages require the `#` to sit at line start or after whitespace, which
+#   is bash's own rule: `echo "ref=x#lib/scout/core.sh"` is one WORD, not a
+#   comment, so the path is genuinely referenced (cases X7 and X8 — X7 guards
+#   the line from being deleted wholesale, X8 guards the token after the `#`
+#   from being truncated away).
+#   Known limit, inherited from the sibling predicate: a `#` inside a quoted
+#   string that follows whitespace (`sed 's/ #.*//'`) truncates the line early,
+#   so a module token AFTER such a `#` is missed. Quote-awareness costs a
+#   char-by-char scan; the trade is the same one lint-tests-registered.sh made.
+#
+# ALLOWLIST — inline, T2 ONLY, reason REQUIRED, marker matched as an EXACT TOKEN
+#   Append `# lint-module-dependencies: allow <reason>` to a T2-flagged line.
+#   The marker must be followed by whitespace or end-of-line: `allowed because
+#   …` and `allowlist …` are NOT the marker and do not waive anything (case
+#   L5). Prefix matching would have parsed `allowed because x` as the marker
+#   with reason "ed because x", so a typo could silently waive a real
+#   violation. An empty reason FAILS, matching the allowlist semantics of
+#   lint-fix-functions-stderr.sh and lint-bl-markers.sh. The marker lives in a
+#   comment, so it is read off the RAW line after the tiers have matched
+#   against the STRIPPED one.
+#   T1 and M5 are NOT allowlistable. "Depends on nothing" has no reasoned
+#   exceptions — a waived dependency is a dependency, and a waivable M5 would
+#   become the standard way to add "just one" core call.
+#
+# EXIT CODES
+#   0 — no core -> module edge and no scout dependency.
+#   1 — one or more violations, OR the core allowlist failed its integrity
+#       check (cardinality != 0, or a row with no reason). Both are "a human
+#       must argue this", which is the exit-1 class; a malformed allowlist is
+#       not an invocation error.
+#   2 — invocation / I/O error, OR the vacuity floor tripped.
+#   Order of checks: allowlist integrity (a property of this script, checkable
+#   without the tree) -> vacuity floor (a property of the tree) -> the scan.
+#
+# USAGE
+#   bash scripts/lint-module-dependencies.sh              # quiet pass/fail
+#   bash scripts/lint-module-dependencies.sh --list       # PASS/FAIL table
+#   bash scripts/lint-module-dependencies.sh --root DIR   # scan an alternate tree
+#       (hermetic fixtures; used by tests/test-lint-module-dependencies.sh).
+#       The vacuity floor is NOT relaxed under --root — the floor is one of the
+#       things the fixtures exist to prove.
+#
+# BASH 3.2 COMPATIBILITY
+#   macOS ships bash 3.2.57 as /bin/bash. No associative arrays, no ${var,,},
+#   no `((x++))`, no nullglob (unmatched globs survive literally and are
+#   filtered with `[ -f ]`). Every array VALUE expansion is length-guarded,
+#   because `"${arr[@]}"` on an EMPTY array is an unbound-variable error under
+#   `set -u` in 3.2 — verified on this host. That hazard is not theoretical
+#   here: CORE_ALLOWLIST is empty BY DESIGN, permanently, so every one of its
+#   expansions is a live tripwire. (`${#arr[@]}` on an empty array is safe;
+#   only the value expansion is not.)
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SELF_REL="scripts/lint-module-dependencies.sh"
+
+LIST_MODE=0
+ROOT_OVERRIDE=""
+USAGE="Usage: $0 [--list] [--root DIR]"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --list) LIST_MODE=1; shift ;;
+    --root)
+      [ $# -ge 2 ] || { echo "$USAGE" >&2; exit 2; }
+      ROOT_OVERRIDE="$2"; shift 2 ;;
+    -h|--help) echo "$USAGE"; exit 0 ;;
+    *) echo "$USAGE" >&2; exit 2 ;;
+  esac
+done
+
+ROOT="${ROOT_OVERRIDE:-$REPO_ROOT}"
+if [ ! -d "$ROOT" ]; then
+  echo "lint-module-dependencies: root not found: $ROOT" >&2
+  exit 2
+fi
+# Canonicalize: every reported path is produced by stripping "$ROOT/" off an
+# absolute path, so a trailing slash or a relative --root would leave the
+# prefix un-stripped and every diagnostic absolute.
+ROOT="$(cd "$ROOT" && pwd)" || { echo "lint-module-dependencies: cannot enter root: $ROOT" >&2; exit 2; }
+
+# ── MODULE-DEPS-MANIFEST-BEGIN ──────────────────────────────────────────
+# The §3.1/§3.3 inventory, spelled ONCE, as `<module>|<path>` rows. Every set
+# derives from it: MODULE is this list, CORE is the four globs MINUS this list,
+# and M5's population is the subset whose module column is in ZERO_DEP_MODULES.
+# Entries ending in `/` are directory prefixes; everything else is a file path
+# relative to the root.
+#
+# M1 gives each module one directory and exactly one entry script, which is why
+# every row is one of those two shapes. Naming is §3.3's author-proposed set and
+# is one-edit changeable: Scout is the read-only scanner, and the driver keeps
+# Karl's name exactly.
+MODULE_MANIFEST=(
+  "scout|scripts/scout.sh"
+  "scout|scripts/lib/scout/"
+  "adopt|scripts/adopt-project.sh"
+  "adopt|scripts/lib/adopt/"
+)
+# The modules M5 binds. Scout only: §3.3 makes zero-dependency a property of
+# the SCANNER, and the driver is severable, not isolated.
+ZERO_DEP_MODULES="scout"
+# Every module name that may appear in the manifest's first column. A typo'd
+# row would otherwise drop silently out of M5's population while still looking
+# like a manifest entry.
+KNOWN_MODULES="scout adopt"
+# ── MODULE-DEPS-MANIFEST-END ────────────────────────────────────────────
+
+# ── MODULE-DEPS-T2-TOKENS-BEGIN ─────────────────────────────────────────
+# T2's path-shaped tokens. INDEPENDENT of the manifest on purpose — see the
+# TWO MATCH TIERS section above for the measured false-positive analysis that
+# rejected bare `scout`/`adopt`, and case E1 for why the two entry-script
+# tokens duplicate T1 rather than being pruned as redundant.
+T2_TOKENS=(
+  "scout/"
+  "adopt/"
+  "scout.sh"
+  "adopt-project.sh"
+)
+# ── MODULE-DEPS-T2-TOKENS-END ───────────────────────────────────────────
+
+# ── MODULE-DEPS-CORE-ALLOWLIST-BEGIN ────────────────────────────────────
+# Core files permitted to reference module paths. Rows would be `path|reason`.
+# CARDINALITY IS ZERO AND THE EMPTINESS IS THE POINT (§3.1): the brownfield
+# module declares no seam, because §3.2's in-core enabling arms read an
+# `adopted` flag and never source module code. A row here is a design change.
+CORE_ALLOWLIST=()
+# ── MODULE-DEPS-CORE-ALLOWLIST-END ──────────────────────────────────────
+
+VIOLATIONS=0
+LIST_ROWS=""
+MODULE_PRESENT=0
+CORE_COUNT=0
+CORE_SCANNED=0
+ZERODEP_COUNT=0
+CORELIB_COUNT=0
+
+# Pre-initialised above because emit_list is reachable from the cardinality and
+# vacuity exits, both of which fire BEFORE the counts are computed — and an
+# unset variable there would be a `set -u` crash instead of a diagnostic.
+# "in scope" and "scanned" are reported separately on purpose: on a vacuity
+# exit they differ (nothing is scanned), and collapsing them would hide which
+# of the populations actually failed the floor.
+emit_list() {
+  [ "$LIST_MODE" -eq 1 ] || return 0
+  printf 'STATUS\tTIER\tFILE:LINE\tDETAIL\n'
+  printf '%b' "$LIST_ROWS"
+  printf 'INFO\tpopulation\t-\t%s module file(s) present, %s core file(s) in scope, %s scanned, %s zero-dep module file(s), %s core lib(s)\n' \
+    "$MODULE_PRESENT" "$CORE_COUNT" "$CORE_SCANNED" "$ZERODEP_COUNT" "$CORELIB_COUNT"
+}
+
+# ── MODULE-DEPS-CARDINALITY ─────────────────────────────────────────────
+# Guard 4. The array length IS the assertion; a seam must be argued in the
+# design, not appended here.
+ALLOW_COUNT=${#CORE_ALLOWLIST[@]}
+if [ "$ALLOW_COUNT" -ne 0 ]; then
+  echo "lint-module-dependencies: core allowlist cardinality is $ALLOW_COUNT, must be exactly 0." >&2
+  echo "§3.1: the brownfield module declares NO seam — the in-core enabling arms read an 'adopted' flag and never source module code, so they need no exemption. A seam is a design change: amend docs/designs/2026-08-02-brownfield-adoption-v1.md §3.1 and argue it, do not append a row." >&2
+  LIST_ROWS="${LIST_ROWS}FAIL\tallowlist\t${SELF_REL}\tcardinality ${ALLOW_COUNT}, must be exactly 0\n"
+  emit_list
+  exit 1
+fi
+LIST_ROWS="${LIST_ROWS}INFO\tallowlist\t-\tcore allowlist is empty (cardinality 0/0, as §3.1 requires)\n"
+
+# Reason integrity for any row that ever appears. Unreachable while the
+# cardinality is zero and deliberately kept anyway: the day someone argues a
+# seam through the design, the row they add must still carry a reason, and a
+# check written only when it is first needed is a check written under pressure.
+# The length guard is not decoration — `"${CORE_ALLOWLIST[@]}"` on the empty
+# array is a `set -u` abort in bash 3.2.
+if [ "${#CORE_ALLOWLIST[@]}" -gt 0 ]; then
+  for row in "${CORE_ALLOWLIST[@]}"; do
+    row_path="${row%%|*}"
+    row_reason="${row#*|}"
+    if [ -z "$row_reason" ] || [ "$row_reason" = "$row" ]; then
+      echo "lint-module-dependencies: core allowlist row '$row_path' carries no reason. Every allowlist row requires a reason string (see this script's ALLOWLIST section)." >&2
+      LIST_ROWS="${LIST_ROWS}FAIL\tallowlist\t${row_path}\tallowlist row has an empty reason\n"
+      emit_list
+      exit 1
+    fi
+  done
+fi
+
+# ── Set derivation ──────────────────────────────────────────────────────
+
+# is_known_module NAME — manifest integrity: a row whose module column is a
+# typo would silently vanish from M5's population while still contributing to
+# MODULE and T1. Checked, not assumed.
+is_known_module() {
+  local name="$1" m
+  for m in $KNOWN_MODULES; do
+    [ "$name" = "$m" ] && return 0
+  done
+  return 1
+}
+
+is_zero_dep_module() {
+  local name="$1" m
+  for m in $ZERO_DEP_MODULES; do
+    [ "$name" = "$m" ] && return 0
+  done
+  return 1
+}
+
+# is_module_path REL — true when REL is a module file (or lives under a module
+# directory), is this script, or is a sibling boundary lint. All three are
+# outside the CORE set; see the SETS section for why each.
+is_module_path() {
+  local rel="$1" row entry
+  [ "$rel" = "$SELF_REL" ] && return 0
+  case "$rel" in
+    scripts/lint-*-boundary.sh) return 0 ;;
+  esac
+  [ "${#MODULE_MANIFEST[@]}" -gt 0 ] || return 1
+  for row in "${MODULE_MANIFEST[@]}"; do
+    entry="${row#*|}"
+    case "$entry" in
+      */) case "$rel" in "$entry"*) return 0 ;; esac ;;
+      *)  [ "$rel" = "$entry" ] && return 0 ;;
+    esac
+  done
+  return 1
+}
+
+TMPD=$(mktemp -d) || { echo "lint-module-dependencies: mktemp failed" >&2; exit 2; }
+trap 'rm -rf "$TMPD"' EXIT
+
+# Manifest integrity, and the T1 token set DERIVED from the manifest so the two
+# can never disagree: a directory entry contributes its whole prefix, a file
+# entry its basename (the basename is a substring of any spelling of the full
+# path, so matching on it is strictly more sensitive than matching the path as
+# written).
+T1_TOKENS="$TMPD/t1-tokens"
+: > "$T1_TOKENS"
+if [ "${#MODULE_MANIFEST[@]}" -gt 0 ]; then
+  for row in "${MODULE_MANIFEST[@]}"; do
+    mod="${row%%|*}"
+    entry="${row#*|}"
+    if ! is_known_module "$mod"; then
+      echo "lint-module-dependencies: manifest row '$row' names unknown module '$mod' (known: $KNOWN_MODULES)." >&2
+      exit 2
+    fi
+    case "$entry" in
+      */) printf '%s\n' "$entry" >> "$T1_TOKENS" ;;
+      *)  printf '%s\n' "${entry##*/}" >> "$T1_TOKENS" ;;
+    esac
+  done
+fi
+
+T2_TOKEN_FILE="$TMPD/t2-tokens"
+: > "$T2_TOKEN_FILE"
+if [ "${#T2_TOKENS[@]}" -gt 0 ]; then
+  for entry in "${T2_TOKENS[@]}"; do
+    printf '%s\n' "$entry" >> "$T2_TOKEN_FILE"
+  done
+fi
+
+# MODULE population: manifest entries that actually EXIST.
+if [ "${#MODULE_MANIFEST[@]}" -gt 0 ]; then
+  for row in "${MODULE_MANIFEST[@]}"; do
+    entry="${row#*|}"
+    case "$entry" in
+      */) [ -d "$ROOT/$entry" ] || continue ;;
+      *)  [ -f "$ROOT/$entry" ] || continue ;;
+    esac
+    MODULE_PRESENT=$((MODULE_PRESENT + 1))
+  done
+fi
+
+# ZERO-DEP population (M5): every existing file of every module in
+# ZERO_DEP_MODULES. Directory entries are walked; file entries are taken as-is.
+ZERODEP_FILES="$TMPD/zerodep-files"
+: > "$ZERODEP_FILES"
+FIND_OUT="$TMPD/find-out"
+if [ "${#MODULE_MANIFEST[@]}" -gt 0 ]; then
+  for row in "${MODULE_MANIFEST[@]}"; do
+    mod="${row%%|*}"
+    entry="${row#*|}"
+    is_zero_dep_module "$mod" || continue
+    case "$entry" in
+      */)
+        [ -d "$ROOT/$entry" ] || continue
+        # Piping find into a while-read would run the loop in a SUBSHELL under
+        # bash 3.2 and every append would be lost; stage it in a file instead.
+        find "$ROOT/$entry" -type f -name '*.sh' -print > "$FIND_OUT" 2>/dev/null
+        while IFS= read -r abs; do
+          [ -n "$abs" ] || continue
+          printf '%s\n' "${abs#"$ROOT"/}" >> "$ZERODEP_FILES"
+        done < "$FIND_OUT"
+        ;;
+      *)
+        [ -f "$ROOT/$entry" ] && printf '%s\n' "$entry" >> "$ZERODEP_FILES"
+        ;;
+    esac
+  done
+fi
+ZERODEP_COUNT=$(grep -c '' "$ZERODEP_FILES")
+case "$ZERODEP_COUNT" in ''|*[!0-9]*) ZERODEP_COUNT=0 ;; esac
+
+# CORE population. bash 3.2 has no nullglob, so an unmatched glob survives as a
+# literal and is filtered by the `[ -f ]` test.
+CORE_FILES="$TMPD/core-files"
+: > "$CORE_FILES"
+CORE_GLOBS=(
+  "$ROOT/init.sh"
+  "$ROOT/scripts"/*.sh
+  "$ROOT/scripts/lib"/*.sh
+  "$ROOT/scripts/hooks"/*.sh
+)
+for entry in "${CORE_GLOBS[@]}"; do
+  [ -f "$entry" ] || continue
+  rel="${entry#"$ROOT"/}"
+  is_module_path "$rel" && continue
+  printf '%s\n' "$rel" >> "$CORE_FILES"
+done
+CORE_COUNT=$(grep -c '' "$CORE_FILES")
+case "$CORE_COUNT" in ''|*[!0-9]*) CORE_COUNT=0 ;; esac
+
+# M5's forbidden-token set: the BASENAMES of the core libs, derived from the
+# scanned tree rather than hardcoded, so it cannot drift as scripts/lib/ grows.
+M5_TOKENS="$TMPD/m5-tokens"
+: > "$M5_TOKENS"
+for entry in "$ROOT/scripts/lib"/*.sh; do
+  [ -f "$entry" ] || continue
+  rel="${entry#"$ROOT"/}"
+  is_module_path "$rel" && continue
+  printf '%s\n' "${rel##*/}" >> "$M5_TOKENS"
+done
+CORELIB_COUNT=$(grep -c '' "$M5_TOKENS")
+case "$CORELIB_COUNT" in ''|*[!0-9]*) CORELIB_COUNT=0 ;; esac
+
+# ── MODULE-DEPS-VACUITY ─────────────────────────────────────────────────
+# Guard 5, checked BEFORE the scan so a collapsed set can never be reported as
+# a clean pass under any ordering of the code below.
+if [ "$MODULE_PRESENT" -lt 1 ] || [ "$CORE_COUNT" -lt 1 ]; then
+  emit_list
+  echo "" >&2
+  echo "lint-module-dependencies: VACUOUS SCAN — found $MODULE_PRESENT module file(s) (floor 1) and $CORE_COUNT core file(s) (floor 1)." >&2
+  echo "A boundary lint that scans nothing passes trivially, so this is an error, not a pass. Check the MODULE-DEPS-MANIFEST fence and the CORE globs in this script, and that --root points at a real tree." >&2
+  exit 2
+fi
+# The same defect class, one level down: an empty forbidden-token set makes the
+# M5 arm match nothing and pass trivially. Only asserted when there is
+# something for it to govern.
+if [ "$ZERODEP_COUNT" -ge 1 ] && [ "$CORELIB_COUNT" -lt 1 ]; then
+  emit_list
+  echo "" >&2
+  echo "lint-module-dependencies: VACUOUS M5 ARM — $ZERODEP_COUNT zero-dependency module file(s) present but 0 core lib(s) to check them against." >&2
+  echo "M5 would pass trivially. Check the scripts/lib/*.sh glob in this script and that --root points at a real tree." >&2
+  exit 2
+fi
+
+# ── The scan ────────────────────────────────────────────────────────────
+
+STRIPPED="$TMPD/stripped"
+
+# strip_file SRC — writes the executed-lines-only copy to $STRIPPED.
+#
+# ── MODULE-DEPS-STRIP ─────────────────────────────────────────────────
+# E1 blanks whole-line comments (any indent width, with or without a space
+# after `#`); E2 truncates trailing comments (one-or-more whitespace before the
+# `#`, any width, with or without a space after it) while KEEPING the executed
+# prefix via the capture + \1. Order matters: E1 first, so E2 never sees a line
+# that is comment-only. Line COUNT is preserved on purpose.
+#
+# ONE FUNCTION, TWO CALL SITES. The direction arms and the M5 arm both go
+# through here, which is what makes the X9/X10 pins meaningful: there is one
+# expression to regress and one to fix, and neither arm can drift from the
+# other.
+strip_file() {
+  sed -e 's/^[[:space:]]*#.*$//' \
+      -e 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/' \
+      "$1" > "$STRIPPED" 2>/dev/null
+}
+
+# parse_allow RAW — echoes "<has_marker>\t<reason>" for the inline T2 allowlist.
+#
+# EXACT-TOKEN matching, not prefix matching. A bare substring test accepts
+# `# lint-module-dependencies: allowed because …` as a marker and silently
+# parses the reason as "ed because …", so a typo'd or merely similar-looking
+# marker waives a real violation. The token must be followed by whitespace or
+# by end-of-line — nothing else — which fails CLOSED: a near-miss spelling is
+# not a marker at all, so the line stays a violation.
+#
+# The empty-reason case must still REGISTER as a marker (tail = ""), because an
+# empty reason is REJECTED loudly rather than ignored; treating it as "no
+# marker" would downgrade it to an ordinary unexplained violation and lose the
+# specific diagnostic.
+ALLOW_MARKER="# lint-module-dependencies: allow"
+parse_allow() {
+  local line="$1"
+  local reason=""
+  local has=0
+  local tail
+  case "$line" in
+    *"$ALLOW_MARKER"*)
+      tail="${line##*"$ALLOW_MARKER"}"
+      case "$tail" in
+        ""|[[:space:]]*)
+          has=1
+          reason="${tail#"${tail%%[![:space:]]*}"}"
+          reason="${reason%"${reason##*[![:space:]]}"}"
+          ;;
+      esac
+      ;;
+  esac
+  printf '%d\t%s\n' "$has" "$reason"
+}
+
+# first_token LINE TOKENFILE — the first token from TOKENFILE occurring in LINE.
+# `sed -n '1p'` and not `head -1`: head exits on its first line, the upstream
+# grep dies of SIGPIPE, and `pipefail` (set at the top of this script) promotes
+# rc=141 into the substitution. `sed -n 1p` consumes all of its input, so
+# nothing upstream ever sees a closed pipe. Keep every stage a full-input
+# consumer.
+first_token() {
+  printf '%s\n' "$1" | grep -o -F -f "$2" | sed -n '1p'
+}
+
+scan_core_file() {
+  local rel="$1"
+  local file="$ROOT/$rel"
+  local hits line n raw tok parsed has reason
+  local t1_lines="|"
+
+  if ! strip_file "$file"; then
+    echo "lint-module-dependencies: cannot read $rel" >&2
+    return 2
+  fi
+
+  # T1 — literal manifest tokens. Fixed-string matching: the tokens contain `.`
+  # and `-`, and a BRE would let `scout.sh` match `scoutXsh`.
+  if [ -s "$T1_TOKENS" ]; then
+    hits=$(grep -n -F -f "$T1_TOKENS" "$STRIPPED")
+    if [ -n "$hits" ]; then
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        n="${line%%:*}"
+        t1_lines="${t1_lines}${n}|"
+        tok=$(first_token "${line#*:}" "$T1_TOKENS")
+        echo "${rel}:${n}: lint-module-dependencies: T1 — core file names module path '${tok}'. Core must never reference a severable module (M3); the brownfield module declares no seam, so remove the call or move the logic into the module." >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\tT1\t${rel}:${n}\tnames module path '${tok}'\n"
+      done <<< "$hits"
+    fi
+  fi
+
+  # T2 — the path-shaped tokens, on lines T1 did not already claim.
+  if [ -s "$T2_TOKEN_FILE" ]; then
+    hits=$(grep -n -F -f "$T2_TOKEN_FILE" "$STRIPPED")
+    if [ -n "$hits" ]; then
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        n="${line%%:*}"
+        case "$t1_lines" in *"|${n}|"*) continue ;; esac
+        tok=$(first_token "${line#*:}" "$T2_TOKEN_FILE")
+        # The allowlist marker lives in the COMMENT the stripper just removed,
+        # so it is read off the RAW line — after the tiers have matched against
+        # the stripped one.
+        raw=$(sed -n "${n}p" "$file")
+        parsed=$(parse_allow "$raw")
+        has="$(printf '%s' "$parsed" | cut -f1)"
+        reason="$(printf '%s' "$parsed" | cut -f2-)"
+        if [ "$has" = "1" ]; then
+          if [ -z "$reason" ]; then
+            echo "${rel}:${n}: lint-module-dependencies: T2 allowlist marker present but the reason is empty. Write '# lint-module-dependencies: allow <why this is not a module reference>'." >&2
+            VIOLATIONS=$((VIOLATIONS + 1))
+            LIST_ROWS="${LIST_ROWS}FAIL\tT2\t${rel}:${n}\tallowlist marker with an empty reason\n"
+          else
+            LIST_ROWS="${LIST_ROWS}PASS\tT2\t${rel}:${n}\tallowlisted: ${reason}\n"
+          fi
+          continue
+        fi
+        echo "${rel}:${n}: lint-module-dependencies: T2 — path-shaped module token '${tok}' on an executed line of a core file. A runtime-composed reference (\"\$SCRIPT_DIR/lib/scout/\${part}.sh\") fuses the module exactly as thoroughly as a literal path. Remove it, or append '# lint-module-dependencies: allow <reason>' if this is prose in a string." >&2
+        VIOLATIONS=$((VIOLATIONS + 1))
+        LIST_ROWS="${LIST_ROWS}FAIL\tT2\t${rel}:${n}\tmodule token '${tok}' on an executed line\n"
+      done <<< "$hits"
+    fi
+  fi
+  return 0
+}
+
+# scan_zero_dep_file REL — M5. A scout file may name NO core lib on an executed
+# line. Not allowlistable: see the ALLOWLIST section.
+scan_zero_dep_file() {
+  local rel="$1"
+  local file="$ROOT/$rel"
+  local hits line n tok
+
+  if ! strip_file "$file"; then
+    echo "lint-module-dependencies: cannot read $rel" >&2
+    return 2
+  fi
+
+  [ -s "$M5_TOKENS" ] || return 0
+  hits=$(grep -n -F -f "$M5_TOKENS" "$STRIPPED")
+  [ -n "$hits" ] || return 0
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    n="${line%%:*}"
+    tok=$(first_token "${line#*:}" "$M5_TOKENS")
+    echo "${rel}:${n}: lint-module-dependencies: M5 — the scanner names core lib '${tok}' on an executed line. M5 requires the scanner to source NO core lib so its bootstrap works in a clone that has never run init.sh; re-implement the small subset you need (reuse-by-extraction: copy the predicate, not the dependency)." >&2
+    VIOLATIONS=$((VIOLATIONS + 1))
+    LIST_ROWS="${LIST_ROWS}FAIL\tM5\t${rel}:${n}\tscanner names core lib '${tok}'\n"
+  done <<< "$hits"
+  return 0
+}
+
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  CORE_SCANNED=$((CORE_SCANNED + 1))
+  scan_core_file "$rel" || { emit_list; exit 2; }   # MODULE-DEPS-DIRECTION-CALL
+done < "$CORE_FILES"
+
+while IFS= read -r rel; do
+  [ -n "$rel" ] || continue
+  scan_zero_dep_file "$rel" || { emit_list; exit 2; }   # MODULE-DEPS-M5-CALL
+done < "$ZERODEP_FILES"
+
+emit_list
+
+if [ "$VIOLATIONS" -gt 0 ]; then
+  echo "" >&2
+  echo "$VIOLATIONS module-dependency violation(s). Scout and the adoption driver are SEVERABLE modules (D1/§3.3): a module may import core, core may never import a module, and the scanner imports nothing. See scripts/lint-module-dependencies.sh header, docs/module-contract.md, and docs/designs/2026-08-02-brownfield-adoption-v1.md §3.3." >&2
+  exit 1
+fi
+
+echo "OK: no core -> module edge and no scanner dependency ($CORE_SCANNED core file(s) scanned against $MODULE_PRESENT module path(s); $ZERODEP_COUNT zero-dep file(s) checked against $CORELIB_COUNT core lib(s); core allowlist empty)."
+exit 0

--- a/scripts/lint-module-dependencies.sh
+++ b/scripts/lint-module-dependencies.sh
@@ -145,6 +145,26 @@
 #   module however the fusion is spelled. Second residual: matching is
 #   CASE-SENSITIVE, because every path in the inventory is lower-case and a
 #   case-insensitive tier would fire on ordinary prose.
+#
+#   FOURTH RESIDUAL, AND THE WIDEST ONE — M5's forbidden set is core LIB
+#   basenames only. A Scout file that invokes a core ENTRY SCRIPT
+#   (`scripts/*.sh`) or `init.sh` itself passes this arm clean. Reproduced:
+#   a scout file carrying
+#       bash "$(dirname "$0")/../../check-gate.sh" --probe
+#       out=$(bash "$(dirname "$0")/../../../init.sh")
+#   scans to rc=0.
+#   That is faithful to §3.3 M5's FIRST sentence ("sources no core lib") and
+#   violates its SECOND ("its bootstrap must work in a clone that has never run
+#   init.sh") together with §3.1's "zero dependency on the installer". The
+#   escape survives the planned behavioural backstop too: moving scripts/lib/
+#   aside does not disturb scripts/*.sh, so WP1-brownfield's hermetic test as
+#   currently specified would ALSO miss it — that test should move
+#   scripts/*.sh aside as well, or assert against a bare tree.
+#   Widening M5_TOKENS to `scripts/*.sh` basenames plus `init.sh` is a
+#   DESIGN-LEVEL call — it would make every Scout file that so much as names a
+#   core entry script a violation — and is deliberately NOT taken unilaterally
+#   here. It sits in the same pending queue as the host-drivers glob question.
+#   Named now so the gap is disclosed rather than discovered.
 #   Third residual, specific to the M5 arm: its forbidden tokens are core-lib
 #   BASENAMES, so a module file that reused a core lib's basename inside its
 #   own directory would false-positive on a legitimate same-dir source. M1

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -567,6 +567,30 @@ run_child_suite "scripts/lint-delta-boundary.sh" \
   "No core -> delta dependency edge outside the one declared seam" \
   "Delta boundary lint found a core -> delta edge (see scripts/lint-delta-boundary.sh --list)"
 
+# Brownfield adoption WP0: tests/test-lint-module-dependencies.sh — behavior
+# suite for the module-dependency lint covering Scout and the adoption driver.
+# Pins both match tiers (literal manifest paths, then the path-shaped segment
+# tokens that catch variable composition), M5's scout-only zero-dependency arm
+# IN BOTH DIRECTIONS, the CORE surface, the core allowlist's cardinality-of-
+# ZERO, the reason-bearing inline allowlist, two vacuity floors, and — case by
+# case, atom by atom, in both the narrowing and the widening direction — the
+# executed-lines stripper whose sibling predicate re-opened the same hole three
+# times (CLAUDE.md, `# BL-181-UNIT-LANE-PREDICATE`). See
+# docs/module-contract.md and
+# docs/designs/2026-08-02-brownfield-adoption-v1.md §3.3.
+section "Module-dependency lint (brownfield severability backstop)"
+run_child_suite "tests/test-lint-module-dependencies.sh" \
+  "scripts/lint-module-dependencies.sh behavior tests" \
+  "scripts/lint-module-dependencies.sh behavior tests FAILED (run tests/test-lint-module-dependencies.sh for details)"
+
+# Brownfield adoption WP0: repo-wide lint invocation. Fails when a core file
+# names a brownfield-module path on an executed line (M3), or when a Scout file
+# names a core lib (M5) — the two fusions that would silently end the module's
+# severability and Scout's run-anywhere property.
+run_child_suite "scripts/lint-module-dependencies.sh" \
+  "No core -> module dependency edge, and the scanner depends on nothing" \
+  "Module-dependency lint found a violation (see scripts/lint-module-dependencies.sh --list)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-lint-module-dependencies.sh
+++ b/tests/test-lint-module-dependencies.sh
@@ -1,0 +1,1102 @@
+#!/usr/bin/env bash
+# tests/test-lint-module-dependencies.sh
+#
+# Behavior tests for scripts/lint-module-dependencies.sh — the module-dependency
+# lint for the BROWNFIELD module set (Scout + the adoption driver), specified by
+# docs/designs/2026-08-02-brownfield-adoption-v1.md §3.3 (M1-M5) and transcribed
+# as a contract in docs/module-contract.md.
+#
+# Each case stages a hermetic mini-tree under mktemp -d, points the lint at it
+# with --root, and asserts on the EXIT CODE (never on a printed label — the
+# repo's [WARN] trap is that labels and exit predicates disagree).
+#
+# This suite is a SIBLING of tests/test-lint-delta-boundary.sh and deliberately
+# inherits its discipline, including two adversarial-review rounds of lessons it
+# paid for. Where the two lints genuinely differ, the difference is MEASURED and
+# recorded below rather than copied over — see the X6 note in particular.
+#
+# WHAT THE SUITE PINS, and which named mutant each row kills
+#
+#   DIRECTION — M3, `core -> module` forbidden
+#     D1  clean tree                                          -> 0
+#     D2  core names a literal module dir (T1)                -> 1   kills M-DIR
+#     D3  `$SCRIPT_DIR/lib/scout/${p}.sh` composition (T2)    -> 1   kills M-T2S
+#     D4  `$SCRIPT_DIR/lib/adopt/${p}.sh` composition (T2)    -> 1   kills M-T2A
+#     D5  core invokes the scout entry script (T1 basename)   -> 1
+#     D6  core invokes the adopt entry script (T1 basename)   -> 1
+#     D7  `module -> core` is permitted for the DRIVER        -> 0
+#     D8  T1 and T2 do not double-report the same line        -> exactly one row
+#
+#   SURFACE — the four CORE globs, minus module files and BOTH boundary lints
+#     S1  init.sh is scanned
+#     S2  scripts/hooks/*.sh is scanned
+#     S3  scripts/lib/*.sh (non-module members) is scanned
+#     S4  the two boundary lints are NOT scanned (self + sibling exclusion)
+#     A narrowed surface would pass D1-D8 while seeing nothing; S1-S3 are the
+#     anti-vacuity pins for the CORE half specifically.
+#
+#   M5 — the scanner depends on NOTHING
+#     M1  a scout module file sourcing a core lib             -> 1   kills M-M5
+#     M2  the scout ENTRY script sourcing a core lib          -> 1
+#     M3  an ADOPT module file sourcing a core lib            -> 0
+#         (M5 is scout-only; the driver may source core, like the delta module)
+#     M4  M5 is not inline-allowlistable                      -> 1
+#
+#   THE EXECUTED-LINES STRIPPER
+#     Same predicate, same scar tissue: CLAUDE.md records that a ONE-CHARACTER
+#     narrowing of the sibling predicate in scripts/lint-tests-registered.sh
+#     (`# BL-181-UNIT-LANE-PREDICATE`) re-opened the same hole THREE times while
+#     passing both PR-blocking checks each time. The pins below name each ATOM
+#     of the two sed expressions and pin its WIDTH and its SPELLING, not merely
+#     its presence.
+#
+#     TWO DIRECTIONS, AND ONLY ONE OF THEM IS CHEAP TO CATCH:
+#       • NARROWING (strips too LITTLE) leaves comments looking executed ->
+#         FALSE POSITIVES. Any exit-0 fixture catches it. X2/X3/X4/X5/X9 are
+#         all of this kind and they are easy.
+#       • WIDENING (strips too MUCH) eats executed code -> FALSE NEGATIVES. NO
+#         exit-0 fixture can ever see it, because an over-stripped tree is a
+#         QUIETER tree. It is caught only by a VIOLATION fixture whose token
+#         sits where the widened match would reach. X8 and X10 are those
+#         fixtures and they are the load-bearing ones. This suite ships them
+#         from day one rather than relearning the lesson.
+#
+#       E1 = 's/^[[:space:]]*#.*$//'                     (whole-line comments)
+#         C1  the `^` anchor          -> pinned by X8, NOT by X7. Dropping `^`
+#             blanks nothing: sed's s/// replaces only the MATCHED REGION, so
+#             the leftmost match simply starts at the `#` and `x#token`
+#             truncates to `x`. A widening — only a violation fixture sees it.
+#             (Mutant M-A.)
+#         C2  `[[:space:]]*` WIDTH    -> pinned by X2 (0, 1, 4, 8 spaces, tab,
+#             tab+spaces). `*` cannot be widened further, so C2's only failure
+#             mode is the narrowing X2 catches.
+#         C3  `#` SPELLING            -> pinned by X3 (no space after `#`).
+#         C4  the WHOLE-EXPRESSION widening (`s/#.*$//`) -> pinned by X8.
+#             (Mutant M-B.)
+#
+#       E2 = 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/'  (trailing)
+#         C5  `[[:space:]][[:space:]]*` WIDTH -> pinned in BOTH directions:
+#               narrowing to two-or-more false-positives on the single-space
+#               form -> X4;
+#               widening to zero-or-more makes `x#token` strippable -> X8.
+#               (Mutant M-H.)
+#         C6  `#` SPELLING            -> pinned by X5.
+#         C7  `\([^[:space:]]\)` guard + `\1` back-reference — the executed
+#             PREFIX must survive -> pinned at TWO resolutions:
+#               X1 (COARSE): a mutation that discards the whole line whenever a
+#               trailing comment is present (M-C7C) loses the violation
+#               outright. Measured: M-C7C kills X1, X6, M4, L2, L4 and L5.
+#               X6 (FINE): dropping the capture (M-C7F) eats exactly ONE
+#               character. Measured: kills X6 and nothing else.
+#             Both are kept: an edit that eats everything and one that eats a
+#             single byte are different mutations and X1 cannot see the latter.
+#
+#             MEASURED DIFFERENCE FROM THE DELTA SUITE, recorded rather than
+#             copied. There, dropping the capture merely DEMOTES a hit from T1
+#             to T2, so the exit code cannot see it and X6 must assert the
+#             TIER. Here it is rc-VISIBLE instead, because this lint's T2
+#             directory tokens are a SUFFIX-SUBSET of its T1 set (`scout/` is a
+#             suffix of `scripts/lib/scout/`; the two entry tokens are
+#             IDENTICAL in both tiers). Eating the last character of a line
+#             that ENDS at a module token therefore breaks T1 and T2 together
+#             and the line goes green.
+#             X6's FIXTURE QUOTING IS PART OF THE PIN — see the case body. The
+#             first draft quoted the path, M-C7F ate the closing `"` instead of
+#             the token's slash, and the mutant survived at 39/0.
+#         C8  `#` INSIDE a word is not a comment -> pinned by X7 and X8, which
+#             cover OPPOSITE failure modes and are deliberately not folded:
+#               X7 = the DELETION direction (token BEFORE the `#`; a `grep -v`
+#               refactor drops the whole line). X7 does NOT pin over-stripping.
+#               X8 = the TRUNCATION direction (token AFTER the `#`).
+#
+#     X9/X10 pin the SAME stripper on the M5 arm, which is a second, independent
+#     call site. A stripper fix applied to one arm and not the other is exactly
+#     the kind of half-edit these two catch.
+#
+#   ALLOWLISTS
+#     L1  T2 inline allow WITH a reason is honored             -> 0
+#     L2  T2 inline allow with an EMPTY reason                 -> 1
+#     L3  the core allowlist's cardinality is exactly ZERO     -> 1 when it grows
+#         (mutation M-CARD, executed against a lint COPY)
+#     L4  T1 is NOT inline-allowlistable
+#     L5  a NEAR-MISS marker (`allowed`, `allowlist`) does not allowlist -> 1
+#
+#   VACUITY FLOOR
+#     V1  no module file present                               -> 2
+#     V2  no core file present                                 -> 2
+#     V3  mutation M-MAN: empty the MODULE manifest in a lint COPY, run against
+#         the REAL repo root                                   -> 2 (not 0)
+#     V4  zero-dependency module files present but NO core lib -> 2
+#         (the M5 arm's own anti-vacuity clause: an empty forbidden-token set
+#         would let M5 pass trivially)
+#
+#   MANIFEST EROSION
+#     E1  deleting a manifest ROW does not fully disarm the lint: the T2 token
+#         list is an INDEPENDENT literal, so an entry-script reference is still
+#         caught. This is the reason the two entry tokens appear in BOTH tiers
+#         despite looking redundant — without this case that redundancy is
+#         unjustified dead weight.
+#
+#   INTERFACE
+#     I1  --list emits the STATUS table incl. the population INFO row
+#     I2  an unknown flag                                      -> 2
+#     I3  the REAL tree passes                                 -> 0
+#
+# HAZARD NOTE — why this file may safely contain module paths.
+# The lint's CORE surface is init.sh + scripts/*.sh + scripts/lib/*.sh +
+# scripts/hooks/*.sh. tests/ is NOT in it, so the literals below never become
+# violations on the real tree. (Contrast tests/test-lint-bl-markers.sh, whose
+# fixtures DO land in that lint's surface and must be built by concatenation.)
+#
+# Style mirrors tests/test-lint-delta-boundary.sh: set -uo pipefail, mktemp
+# fixtures, pass/fail counters, teardown after each case, bash 3.2 only.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-module-dependencies.sh"
+
+if [ ! -f "$LINTER" ]; then
+  echo "FATAL: linter not found at $LINTER" >&2
+  exit 2
+fi
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TAB=$(printf '\t')
+
+# ── Fixture builder ─────────────────────────────────────────────────────
+# A minimal tree carrying every population the floors demand: CORE files, a
+# CORE LIB (so the M5 forbidden-token set is non-empty), and BOTH module
+# halves (so the module floor is met and the scout/adopt asymmetry is
+# exercisable).
+setup_fixture() {
+  TMP=$(mktemp -d)
+  mkdir -p "$TMP/scripts/lib" "$TMP/scripts/hooks" \
+           "$TMP/scripts/lib/scout" "$TMP/scripts/lib/adopt"
+  cat > "$TMP/init.sh" <<'SH'
+#!/usr/bin/env bash
+echo "scaffold"
+SH
+  cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/lib/helpers-core.sh"
+echo "gate"
+SH
+  cat > "$TMP/scripts/lib/helpers-core.sh" <<'SH'
+#!/usr/bin/env bash
+helper() { echo "help"; }
+SH
+  cat > "$TMP/scripts/hooks/record-thing.sh" <<'SH'
+#!/usr/bin/env bash
+echo "hook"
+SH
+  # The MODULE half of the floor: the scout module (zero-dependency by M5)
+  # and the adoption driver's lib (module -> core permitted).
+  cat > "$TMP/scripts/lib/scout/scout-core.sh" <<'SH'
+#!/usr/bin/env bash
+scout_probe() { echo "probe"; }
+SH
+  cat > "$TMP/scripts/lib/adopt/adopt-core.sh" <<'SH'
+#!/usr/bin/env bash
+adopt_run() { echo "run"; }
+SH
+}
+teardown_fixture() { rm -rf "$TMP"; }
+
+run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
+# --list asserts on the TABLE, so stderr is dropped: the per-violation
+# diagnostics carry the same file:line text and would double every row count.
+run_fixture_list() { bash "$LINTER" --root "$TMP" --list 2>/dev/null; return $?; }
+
+# ════════════════════════════════════════════════════════════════════
+echo "=== D1: a clean tree -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "D1: clean fixture exits 0"
+else
+  fail_ "D1" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D2 (mutant M-DIR): core names a literal module path (T1) -> 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# M3's worked example: someone adds a convenience source line to a core gate
+# script on a Tuesday and severability is gone with no test failing. Deleting
+# the direction check makes this case pass — that is mutation m1.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+REPO="$(cd "$(dirname "$0")/.." && pwd)"
+source "$REPO/scripts/lib/scout/scout-core.sh"
+echo "gate"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:3' \
+   && echo "$out" | grep -q 'scripts/lib/scout/'; then
+  pass "D2: T1 literal-path reference exits 1 naming file:line and the token"
+else
+  fail_ "D2" "expected rc=1 + check-gate.sh:3 + the token; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D3 (mutant M-T2S): '\$SCRIPT_DIR/lib/scout/' composition -> T2, 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# The measured reason T2 exists for a DIRECTORY module. `$SCRIPT_DIR/lib/...`
+# is the house's dominant sourcing idiom (17 of the top call sites in
+# scripts/*.sh spell it that way), and it carries NO `scripts/` segment — so
+# T1's full-prefix token `scripts/lib/scout/` cannot see it. Drop the `scout/`
+# T2 token and this case goes green. S3 covers the sibling spelling
+# (`$LIBDIR/scout/`) that a narrower `lib/scout/` token would still miss.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+part="core"
+source "$SCRIPT_DIR/lib/scout/scout-${part}.sh"
+echo "gate"
+SH
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^FAIL.*T2.*scripts/check-gate\.sh:4'; then
+  pass "D3: '\$SCRIPT_DIR/lib/scout/' composition caught at tier T2"
+else
+  fail_ "D3" "expected rc=1 with a T2 row for line 4; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D4 (mutant M-T2A): '\$SCRIPT_DIR/lib/adopt/' composition -> T2, 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/hooks/record-thing.sh" <<'SH'
+#!/usr/bin/env bash
+D="$(cd "$(dirname "$0")/.." && pwd)"
+kind="core"
+. "$D/lib/adopt/adopt-${kind}.sh"
+SH
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^FAIL.*T2.*scripts/hooks/record-thing\.sh:4'; then
+  pass "D4: '\$D/lib/adopt/' composition caught at tier T2"
+else
+  fail_ "D4" "expected rc=1 with a T2 row for line 4; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D5: core invokes the scout ENTRY script -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/init.sh" <<'SH'
+#!/usr/bin/env bash
+bash "$SCRIPT_DIR/scripts/scout.sh" --report
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'init\.sh:2'; then
+  pass "D5: a core file invoking scout.sh is a violation"
+else
+  fail_ "D5" "expected rc=1 naming init.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D6: core invokes the adopt ENTRY script -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+bash "$(dirname "$0")/adopt-project.sh" --resume
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "D6: a core file invoking adopt-project.sh is a violation"
+else
+  fail_ "D6" "expected rc=1 naming check-gate.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D7: 'module -> core' is permitted for the DRIVER -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# M3 clause 1. The driver is severable, not isolated: it may source core libs
+# and name core paths freely. Only the SCANNER is zero-dependency (M5).
+setup_fixture
+cat > "$TMP/scripts/lib/adopt/adopt-core.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/../helpers-core.sh"
+. "$(dirname "$0")/../enforcement-level.sh"
+adopt_run() { helper; }
+SH
+cat > "$TMP/scripts/adopt-project.sh" <<'SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/helpers-core.sh"
+source "$SCRIPT_DIR/lib/adopt/adopt-core.sh"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "D7: the adoption driver may source core and its own module dir"
+else
+  fail_ "D7" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D8: a T1 line is not ALSO reported as T2 (tier discrimination) ==="
+# ════════════════════════════════════════════════════════════════════
+# Double-reporting would inflate the count and make the operator chase one
+# defect twice. It also matters semantically: T2 is inline-allowlistable and
+# T1 is not, so a duplicated row offers a waiver for an unwaivable finding.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+source "scripts/lib/scout/scout-core.sh"
+SH
+out=$(run_fixture_list); rc=$?
+rows=$(echo "$out" | grep -c 'scripts/check-gate\.sh:2')
+if [ "$rc" -eq 1 ] && [ "$rows" -eq 1 ]; then
+  pass "D8: the T1 line yields exactly one row (no T2 double-report)"
+else
+  fail_ "D8" "expected rc=1 and exactly 1 row for that line; rc=$rc rows=$rows; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S1: init.sh is inside the CORE surface ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/init.sh" <<'SH'
+#!/usr/bin/env bash
+cp -R "$SRC/scripts/lib/scout/" "$TARGET/scripts/lib/"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'init\.sh:2'; then
+  pass "S1: init.sh is scanned"
+else
+  fail_ "S1" "expected rc=1 naming init.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S2: scripts/hooks/*.sh is inside the CORE surface ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/hooks/record-thing.sh" <<'SH'
+#!/usr/bin/env bash
+bash scripts/adopt-project.sh --audit
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/hooks/record-thing\.sh:2'; then
+  pass "S2: scripts/hooks/*.sh is scanned"
+else
+  fail_ "S2" "expected rc=1 naming the hook; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S3: scripts/lib/*.sh non-module members are inside CORE, and the"
+echo "    '\$LIBDIR/scout/' spelling is caught -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# TWO PINS IN ONE FIXTURE, and the second one was EARNED rather than designed.
+#
+# The surface pin: scripts/lib/*.sh members that are not module files are core
+# and must be scanned.
+#
+# The token pin: this case was written with the natural `$LIBDIR/scout/…`
+# spelling — a variable that already ends in `lib` — and it FAILED against the
+# lint's first draft, whose T2 token was `lib/scout/`. That token only covers
+# the `$SCRIPT_DIR/lib/…` idiom; it is blind to this one, and T1's
+# `scripts/lib/scout/` is blind to both. The fix was to make T2's directory
+# tokens bare path SEGMENTS (`scout/`, `adopt/`), which closes the whole
+# variable-prefix family. Narrow either token back to `lib/scout/` and this
+# case goes green again — it is the pin for that decision, not incidental
+# coverage.
+setup_fixture
+cat > "$TMP/scripts/lib/helpers-core.sh" <<'SH'
+#!/usr/bin/env bash
+helper() { . "$LIBDIR/scout/scout-core.sh"; }
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/lib/helpers-core\.sh:2'; then
+  pass "S3: a non-module scripts/lib member is scanned, and '\$LIBDIR/scout/' is caught"
+else
+  fail_ "S3" "expected rc=1 naming helpers-core.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S4: BOTH boundary lints are outside the CORE surface -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Each boundary lint names every path of the module it guards, by construction.
+# This lint self-excludes (SELF_REL) and excludes its delta-track sibling for
+# the same reason — the sibling's manifest and prose are lint infrastructure,
+# not a core dependency edge. Both exclusions are by EXACT PATH, so a renamed
+# copy elsewhere in scripts/ is still scanned and still reds: fail-closed is
+# the right direction for a boundary lint.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'MODULE_MANIFEST=("scripts/lib/scout/" "scripts/adopt-project.sh")\n'
+} > "$TMP/scripts/lint-module-dependencies.sh"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "sibling lint mentions scripts/lib/adopt/ and scout.sh"\n'
+} > "$TMP/scripts/lint-delta-boundary.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "S4: neither boundary lint is scanned as a core file"
+else
+  fail_ "S4" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M1 (mutant M-M5): a scout module file sourcing a core lib -> 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# M5: "The scanner sources NO core lib. Its bootstrap must work in a clone that
+# has never run init.sh." This is mutation m4 executed as a permanent test:
+# neuter the M5 arm and this fixture passes, silently converting Scout from a
+# standalone survey tool into something that only runs inside an installed
+# framework — the exact property §3.1 says makes "let me just look" cost
+# nothing.
+setup_fixture
+cat > "$TMP/scripts/lib/scout/scout-core.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/../helpers-core.sh"
+scout_probe() { helper; }
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/lib/scout/scout-core\.sh:2' \
+   && echo "$out" | grep -q 'M5'; then
+  pass "M1: a scout module file sourcing a core lib is an M5 violation"
+else
+  fail_ "M1" "expected rc=1 + the file:line + an M5 tier; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M2: the scout ENTRY script is inside the M5 surface -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# M5 binds the module, not just its lib subtree. An arm that only walked
+# scripts/lib/scout/ would let the entry script — the very file a bootstrap
+# invocation runs — source anything it liked.
+setup_fixture
+cat > "$TMP/scripts/scout.sh" <<'SH'
+#!/usr/bin/env bash
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "$SCRIPT_DIR/lib/helpers-core.sh"
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/scout\.sh:3'; then
+  pass "M2: the scout entry script is bound by M5"
+else
+  fail_ "M2" "expected rc=1 naming scripts/scout.sh:3; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M3: M5 is SCOUT-ONLY — the adopt module may source core -> 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# The bound matters as much as the rule. An M5 arm applied to every module
+# would forbid the driver from using helpers-core.sh, which §3.3 explicitly
+# permits (module -> core is direction-legal; only the SCANNER is isolated).
+# This is the exemption half of the dual-direction proof.
+setup_fixture
+cat > "$TMP/scripts/lib/adopt/adopt-core.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/../helpers-core.sh"
+. "$(dirname "$0")/../enforcement-level.sh"
+adopt_run() { helper; }
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "M3: the adopt module sourcing core libs is not an M5 violation"
+else
+  fail_ "M3" "expected rc=0 — M5 must be scout-only; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M4: M5 is NOT inline-allowlistable -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# "Depends on nothing" has no reasoned exceptions — a waived dependency is a
+# dependency. If the marker worked here it would become the standard way to
+# add "just one" core call, which is the fusion-by-a-thousand-cuts this whole
+# lint exists to stop.
+setup_fixture
+cat > "$TMP/scripts/lib/scout/scout-core.sh" <<'SH'
+#!/usr/bin/env bash
+. "$(dirname "$0")/../helpers-core.sh"  # lint-module-dependencies: allow it was easier
+SH
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "M4: an inline allow cannot waive an M5 zero-dependency violation"
+else
+  fail_ "M4" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X1 (atom C7, coarse form): stripping a trailing comment must leave"
+echo "    the EXECUTED PREFIX intact -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# Mutate E2 to `s/.*[[:space:]][[:space:]]*#.*$//` — which discards the whole
+# line whenever a trailing comment is present — and this case goes RED. X1 is
+# the COARSE form of the C7 pin and X6 is the FINE one.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'source "$SCRIPT_DIR/lib/scout/scout-core.sh"  # convenience, just this once\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X1: the executed prefix survives a trailing-comment strip"
+else
+  fail_ "X1" "expected rc=1; an E2 that discards the code half loses this violation; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X2 (atom C2, E1 '[[:space:]]*' WIDTH): whole-line comments are"
+echo "    ignored at EVERY indent width -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Six widths in one file: column 0, one space, four spaces, eight spaces, a
+# TAB, and TAB+spaces. Narrowing E1 to `^#` reds on five of the six; narrowing
+# to `^[[:space:]]` reds on the first.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# source "$SCRIPT_DIR/lib/scout/scout-core.sh" would fuse the module\n'
+  printf ' # one space: scripts/lib/adopt/adopt-core.sh\n'
+  printf '    # four spaces: scripts/scout.sh\n'
+  printf '        # eight spaces: scripts/adopt-project.sh\n'
+  printf '%s# a tab: scripts/lib/scout/\n' "$TAB"
+  printf '%s   # tab plus spaces: lib/adopt/\n' "$TAB"
+  printf 'echo gate\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X2: E1 strips whole-line comments at 0/1/4/8-space, tab and tab+space indents"
+else
+  fail_ "X2" "expected rc=0 — a narrowed E1 width false-positives here; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X3 (atom C3, E1 '#' SPELLING): no space is required after '#' ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '#source "$SCRIPT_DIR/lib/scout/scout-core.sh"\n'
+  printf '    #source "$SCRIPT_DIR/lib/adopt/adopt-core.sh"\n'
+  printf '%s#scripts/scout.sh sketch\n' "$TAB"
+  printf 'echo gate\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X3: E1 strips '#comment' with no space after the hash, at any indent"
+else
+  fail_ "X3" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X4 (atom C5, E2 whitespace WIDTH): trailing comments strip after"
+echo "    ONE space, a TAB, and many spaces -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# The single-space form is the commonest spelling in this repo, and it is the
+# one a two-or-more narrowing silently drops.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo one #see scripts/lib/scout/scout-core.sh\n'
+  printf 'echo two  # see lib/adopt/adopt-core.sh\n'
+  printf 'echo three%s# see scripts/scout.sh\n' "$TAB"
+  printf 'echo four      # see scripts/adopt-project.sh and lib/scout/\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X4: E2 strips trailing comments at 1-space, 2-space, tab and 6-space widths"
+else
+  fail_ "X4" "expected rc=0 — a widened E2 minimum false-positives on the 1-space form; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X5 (atom C6, E2 '#' SPELLING): trailing '#token' with no space ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo one #lib/scout/scout-core.sh\n'
+  printf 'echo two%s#scripts/adopt-project.sh\n' "$TAB"
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X5: E2 strips a trailing comment with no space after the hash"
+else
+  fail_ "X5" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X6 (atom C7, E2's capture + '\\1' back-reference): the last code"
+echo "    character must survive the strip -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# Drop the `\([^[:space:]]\)` capture and the `\1` replacement — i.e. mutate
+# E2 to `s/[^[:space:]][[:space:]][[:space:]]*#.*$//` (mutant M-C7F) — and the
+# strip eats exactly ONE character of executed code: the last one before the
+# whitespace that precedes the comment.
+#
+# THE FIXTURE'S QUOTING IS LOAD-BEARING, and the first version of this case got
+# it wrong. It was written as
+#     ls "$REPO/scripts/lib/scout/"   # inventory the module
+# and M-C7F SURVIVED it — measured, 39/0 with the mutant installed. The
+# character M-C7F eats there is the closing DOUBLE QUOTE, not the token's
+# trailing slash, so `scripts/lib/scout/` was still intact on the stripped line
+# and the case stayed green while the atom it claimed to pin was unpinned. This
+# is the same failure the delta suite's adversarial review found in its own X1
+# (R-WP1-2): a pin asserted by reasoning about sed rather than by running it.
+# The line below is UNQUOTED so the final `/` is the last executed character,
+# which is what M-C7F then eats. Re-verified by execution: M-C7F now dies here.
+#
+# HERE THE ATOM IS rc-VISIBLE, and the difference from the delta suite is
+# measured, not assumed. In tests/test-lint-delta-boundary.sh the same mutation
+# only DEMOTES a hit from T1 to T2 (the truncated token stops matching a
+# literal path but still carries the `delta-` prefix), so X6 there must assert
+# the TIER because rc cannot see it. This lint's T2 directory tokens are a
+# SUFFIX-SUBSET of its T1 tokens — `scout/` is a suffix of
+# `scripts/lib/scout/`, and the two entry tokens are identical across tiers —
+# so eating the final `/` breaks BOTH tiers at once and the line goes green.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'ls $REPO/scripts/lib/scout/   # inventory the module\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X6: E2 keeps the last executed character, so the module token still matches"
+else
+  fail_ "X6" "expected rc=1; a capture-less E2 eats the trailing '/' and both tiers go blind; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X7 (atom C8, whole-line-deletion direction): a line carrying a"
+echo "    mid-word '#' is not discarded wholesale -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# `echo scripts/lib/scout/x.sh#frag` is a single bash WORD; bash executes it.
+# This case guards the DELETION direction — a refactor to `grep -v '#'`, or an
+# E1 rewritten as `s/^.*#.*$//`, drops the entire line and the reference with
+# it. It does NOT guard the truncation direction: the token here sits BEFORE
+# the `#`, so an over-stripping mutant leaves it intact and X7 still passes.
+# X8 covers truncation, and the two are deliberately kept apart.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo scripts/lib/scout/scout-core.sh#fragment\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X7: a line with a mid-word '#' is not deleted wholesale"
+else
+  fail_ "X7" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X8 (atoms C1/C4/C5/C8, the OVER-STRIP direction): a module token"
+echo "    AFTER a mid-word '#' must still be seen -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# THE CASE THAT PINS THE STRIPPER'S UPPER BOUND, shipped with the suite rather
+# than added after a regression. Every other X case pins a NARROWING (the
+# stripper doing too little, producing false positives, which any exit-0
+# fixture catches). This one pins a WIDENING — the stripper doing too MUCH,
+# silently eating executed code, which no exit-0 fixture can ever see because
+# an over-stripped tree is a QUIETER tree.
+#
+# `echo "ref=x#scripts/lib/scout/scout-core.sh"` is one bash WORD after `ref=`:
+# bash does not treat that `#` as a comment (a comment `#` must start a word),
+# so the module path is genuinely referenced on an executed line. Three
+# separate one-character-class mutations all make the stripper eat from that
+# `#` onward:
+#
+#   M-A  E1 `s/^[[:space:]]*#.*$//` -> `s/[[:space:]]*#.*$//`  (drop `^`)
+#        sed's s/// replaces only the MATCHED REGION, not the line, so the
+#        leftmost match simply starts at the `#` and truncates there.
+#   M-B  E1 -> `s/#.*$//`                              (strip from any `#`)
+#   M-H  E2 `[[:space:]][[:space:]]*` -> `[[:space:]]*`  (one-or-more becomes
+#        zero-or-more, so `x#word` becomes strippable)
+#
+# All three survive every other case in this file. If this case is ever deleted
+# or its `#` given a leading space, all three holes open silently — which is
+# precisely how BL-181 was re-opened three times.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "ref=x#scripts/lib/scout/scout-core.sh"\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/check-gate\.sh:2'; then
+  pass "X8: a module token AFTER a mid-word '#' is still on an executed line"
+else
+  fail_ "X8" "expected rc=1 — an over-stripping mutant eats the token; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X9 (M5 arm, NARROWING direction): a commented core-lib mention in a"
+echo "    scout file is not a dependency -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# The M5 arm is a SECOND, independent call site of the same stripper. A fix or
+# a regression applied to one arm and not the other is exactly the half-edit
+# X9/X10 exist to catch — and M5's whole point is that Scout re-implements what
+# it needs, so its files WILL carry comments naming the core libs they
+# deliberately do not use.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf '# M5: deliberately does NOT source scripts/lib/helpers-core.sh\n'
+  printf '    # nor host.sh, nor enforcement-level.sh\n'
+  printf 'scout_probe() { echo "probe"; }  # not helpers-core.sh\n'
+} > "$TMP/scripts/lib/scout/scout-core.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "X9: commented core-lib mentions in a scout file are not dependencies"
+else
+  fail_ "X9" "expected rc=0 — the M5 arm must use the same stripper; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X10 (M5 arm, WIDENING direction): a core-lib token AFTER a mid-word"
+echo "    '#' in a scout file is still a dependency -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# X9's mirror, and the load-bearing half. Without it, an over-stripping mutant
+# applied to the M5 arm makes Scout look zero-dependency while it sources
+# whatever it likes — the quieter-tree failure mode again, on the arm the
+# design calls "the load-bearing one".
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'src="$D#helpers-core.sh"; . "$src"\n'
+} > "$TMP/scripts/lib/scout/scout-core.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/lib/scout/scout-core\.sh:2'; then
+  pass "X10: a core-lib token after a mid-word '#' is still an M5 dependency"
+else
+  fail_ "X10" "expected rc=1 — an over-stripping mutant on the M5 arm eats it; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L1: a T2 inline allow WITH a reason is honored -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# T2 is deliberately coarse and will occasionally fire on prose in a string.
+# The trade is explicit — a false positive costs one allowlist row with a
+# reason; a false negative costs the severability property silently.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "run lib/scout/ yourself to survey first"  # lint-module-dependencies: allow prose in an operator message, not a reference\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "L1: reasoned inline allow suppresses the T2 hit"
+else
+  fail_ "L1" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L2: a T2 inline allow with an EMPTY reason is rejected -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "run lib/adopt/ yourself"  # lint-module-dependencies: allow\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'reason'; then
+  pass "L2: an empty allowlist reason fails and says so"
+else
+  fail_ "L2" "expected rc=1 mentioning the reason; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L3 (mutation M-CARD): the core allowlist's cardinality is ZERO ==="
+# ════════════════════════════════════════════════════════════════════
+# §3.1 + the WP0 convergence decision: the brownfield module has NO seam. The
+# in-core enabling arms of §3.2 (WP3) read an `adopted` flag and never source
+# module code, so they are ordinary core files, not allowlisted seams. The
+# array's length IS the assertion and it starts — and must stay — at zero.
+# Growing it is a design change to be argued in §3.1, not a row to append.
+#
+# Executed here against a COPY so the real lint is never mutated. The fixture
+# is CLEAN, so the ONLY thing that can red is the cardinality assertion — that
+# is what makes this a proof and not a coincidence.
+#
+# NOTE ON THE MUTATION MECHANISM, because the first version of this case was a
+# FALSE PROOF. The delta suite's sibling mutation appends a row after the
+# `SEAM_ALLOWLIST=(` opening line, which works because that array spans several
+# lines. This array is EMPTY, so it is written closed on one line —
+# `CORE_ALLOWLIST=()` — and appending after it emitted the row as a COMMAND,
+# not an element. The array stayed empty, the lint stayed green, and the case
+# reported a failure to grow the allowlist rather than a failure of the
+# assertion. The mutation now REWRITES the whole declaration, and `grew` below
+# asserts the mutant really is mutated, so a no-op edit can never be read as a
+# proof again.
+setup_fixture
+COPY="$TMP/lint-copy-cardinality.sh"
+awk '/^CORE_ALLOWLIST=\(\)$/ {
+       print "CORE_ALLOWLIST=("
+       print "  \"scripts/check-gate.sh|an invented seam\""
+       print ")"
+       next
+     }
+     { print }' "$LINTER" > "$COPY"
+grew=$(grep -c 'an invented seam' "$COPY")
+out=$(bash "$COPY" --root "$TMP" 2>&1); rc=$?
+# Control: the unmutated lint on the same fixture is green.
+out_ctl=$(run_fixture); rc_ctl=$?
+if [ "$rc" -eq 1 ] && [ "$rc_ctl" -eq 0 ] && [ "$grew" -eq 1 ] \
+   && echo "$out" | grep -q -i 'cardinal'; then
+  pass "L3: growing the core allowlist reds on the cardinality assertion (control green)"
+else
+  fail_ "L3" "expected mutated rc=1 (cardinality), control rc=0, grew=1; rc=$rc rc_ctl=$rc_ctl grew=$grew; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L4: T1 is NOT inline-allowlistable -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# The inline allowlist belongs to T2 only. T1 is unambiguous — a core file
+# names a module file — and the brownfield module has no sanctioned escape at
+# all, because its allowlist cardinality is zero. Without this pin the marker
+# would quietly become a universal opt-out and the zero would mean nothing.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'source "scripts/lib/scout/scout-core.sh"  # lint-module-dependencies: allow it was easier\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ]; then
+  pass "L4: an inline allow cannot suppress a T1 literal-path reference"
+else
+  fail_ "L4" "expected rc=1; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L5: a near-miss allowlist marker does NOT allowlist -> exit 1 ==="
+# ════════════════════════════════════════════════════════════════════
+# The marker is matched as an EXACT TOKEN, not as a prefix. Under a prefix
+# test, `allowed because …` parses as marker + reason "ed because …" and waives
+# the violation — a typo, or a sentence that merely starts with the right
+# letters, becomes a silent opt-out. Exact-token matching fails CLOSED.
+setup_fixture
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'echo "see lib/scout/"  # lint-module-dependencies: allowed because it is prose\n'
+  printf 'echo "see lib/adopt/"  # lint-module-dependencies: allowlist prose too\n'
+} > "$TMP/scripts/check-gate.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:2' \
+   && echo "$out" | grep -q 'scripts/check-gate\.sh:3'; then
+  pass "L5: 'allowed'/'allowlist' are not the 'allow' token — both stay violations"
+else
+  fail_ "L5" "expected rc=1 naming BOTH lines; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V1 (vacuity floor): no module file present -> exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+# The floor is the whole point: a passing lint that proves nothing is worse
+# than no lint (CLAUDE.md's BL-104 scar — an empty manifest scored better than
+# no manifest). Asserted as exit 2 EXACTLY: 0 and 1 are both wrong answers and
+# only the code distinguishes them.
+setup_fixture
+rm -rf "$TMP/scripts/lib/scout" "$TMP/scripts/lib/adopt"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V1: a scan with no module file exits 2, not 0"
+else
+  fail_ "V1" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V2 (vacuity floor): no core file present -> exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+rm -f "$TMP/init.sh" "$TMP/scripts/check-gate.sh" \
+      "$TMP/scripts/lib/helpers-core.sh" "$TMP/scripts/hooks/record-thing.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V2: a scan with no core file exits 2, not 0"
+else
+  fail_ "V2" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V3 (mutation M-MAN): an EMPTY module manifest -> exit 2, not 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# Run against the REAL repo root, so this also proves the floor is what stops a
+# manifest-shaped regression on the tree we actually ship.
+setup_fixture
+COPY="$TMP/lint-copy-emptymanifest.sh"
+awk '
+  /MODULE-DEPS-MANIFEST-BEGIN/ { skip = 1; print; next }
+  /MODULE-DEPS-MANIFEST-END/   { skip = 0; print "MODULE_MANIFEST=()"; print; next }
+  skip != 1 { print }
+' "$LINTER" > "$COPY"
+out=$(bash "$COPY" --root "$REPO_ROOT" 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V3: emptying the MODULE manifest exits 2 on the real tree"
+else
+  fail_ "V3" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V4 (M5 anti-vacuity): zero-dep module files but NO core lib -> 2 ==="
+# ════════════════════════════════════════════════════════════════════
+# The M5 arm's forbidden-token set is DERIVED from the scanned tree's
+# scripts/lib/*.sh. If that set is empty the arm matches nothing and passes
+# trivially — the same defect class as the main floor, one level down. A tree
+# with a scout module and no core libs is therefore an error, not a pass.
+setup_fixture
+rm -f "$TMP/scripts/lib/helpers-core.sh"
+out=$(run_fixture); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "V4: an empty M5 forbidden-token set exits 2, not 0"
+else
+  fail_ "V4" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== E1 (manifest erosion): deleting a manifest row does not disarm T2 ==="
+# ════════════════════════════════════════════════════════════════════
+# WHY THE TWO ENTRY TOKENS APPEAR IN BOTH TIERS. T1's tokens are DERIVED from
+# the manifest, so the manifest and the tokens can never disagree — but that
+# also means deleting a row disarms T1 for that path. T2's token list is an
+# INDEPENDENT literal, so it still fires. Without this case that duplication is
+# unjustified dead weight; with it, the duplication is a measured fail-closed
+# property: the cheapest way to silence a violation (drop the manifest row)
+# does not silence the lint.
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+bash "$(dirname "$0")/adopt-project.sh" --resume
+SH
+COPY="$TMP/lint-copy-erosion.sh"
+grep -v '"adopt|scripts/adopt-project.sh"' "$LINTER" > "$COPY"
+# Guard: the row really was removed, so a no-op grep cannot fake this pass.
+removed=$(grep -c '"adopt|scripts/adopt-project.sh"' "$COPY")
+out=$(bash "$COPY" --root "$TMP" --list 2>/dev/null); rc=$?
+if [ "$rc" -eq 1 ] && [ "$removed" -eq 0 ] \
+   && echo "$out" | grep -q '^FAIL.*T2.*scripts/check-gate\.sh:2'; then
+  pass "E1: an eroded manifest still catches the entry script at tier T2"
+else
+  fail_ "E1" "expected rc=1 with a T2 row and the row removed; rc=$rc removed=$removed; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I1: --list emits the STATUS table and the population row ==="
+# ════════════════════════════════════════════════════════════════════
+setup_fixture
+cat > "$TMP/scripts/check-gate.sh" <<'SH'
+#!/usr/bin/env bash
+source "scripts/lib/scout/scout-core.sh"
+SH
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^STATUS' \
+   && echo "$out" | grep -q '^FAIL' \
+   && echo "$out" | grep -q 'population' \
+   && echo "$out" | grep -q 'allowlist'; then
+  pass "I1: --list prints the header, the FAIL row, the allowlist row and the population row"
+else
+  fail_ "I1" "expected the full --list shape; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I2: an unknown flag -> exit 2 ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" --not-a-flag 2>&1); rc=$?
+if [ "$rc" -eq 2 ]; then
+  pass "I2: unknown flag exits 2"
+else
+  fail_ "I2" "expected rc=2; rc=$rc; output:\n$out"
+fi
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I3: the REAL tree passes -> exit 0 ==="
+# ════════════════════════════════════════════════════════════════════
+out=$(bash "$LINTER" 2>&1); rc=$?
+if [ "$rc" -eq 0 ]; then
+  pass "I3: the real repository has no core -> module edge and no M5 dependency"
+else
+  fail_ "I3" "expected rc=0 on the real tree; rc=$rc; output:\n$out"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-lint-module-dependencies.sh
+++ b/tests/test-lint-module-dependencies.sh
@@ -129,6 +129,11 @@
 #     V4  zero-dependency module files present but NO core lib -> 2
 #         (the M5 arm's own anti-vacuity clause: an empty forbidden-token set
 #         would let M5 pass trivially)
+#     V5  mutation M-KNOWN: a typo'd MODULE COLUMN in a lint copy -> 2 (not 0)
+#         Added in the pre-PR review round (R-WP0-1) after the reviewer's novel
+#         mutant — deleting the `is_known_module` guard — survived all 39 of
+#         the original cases. See the case body for why the typo is invisible
+#         to both vacuity floors.
 #
 #   MANIFEST EROSION
 #     E1  deleting a manifest ROW does not fully disarm the lint: the T2 token
@@ -1022,6 +1027,49 @@ if [ "$rc" -eq 2 ]; then
   pass "V4: an empty M5 forbidden-token set exits 2, not 0"
 else
   fail_ "V4" "expected rc=2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V5 (mutation M-KNOWN): a typo'd module column -> exit 2, not 0 ==="
+# ════════════════════════════════════════════════════════════════════
+# ADDED IN THE WP0 PRE-PR REVIEW ROUND (R-WP0-1). The reviewer's novel mutant —
+# delete the `is_known_module` integrity check from the T1-token derivation
+# loop — SURVIVED all 39 cases of the original suite. The guard was load-bearing
+# and unpinned, which is the one thing this suite is built not to allow.
+#
+# WHY THE GUARD MATTERS. The manifest's first column is what binds a row to M5:
+# ZERO_DEP_MODULES names `scout`, and the zero-dependency population is the set
+# of rows whose module column matches. A ONE-CHARACTER typo in that column
+# (`scuot|scripts/lib/scout/`) therefore drops every Scout file out of M5's
+# population — while the row still contributes its T1 token and still counts
+# toward MODULE_PRESENT, so the main vacuity floor is satisfied and nothing
+# looks wrong. The M5 anti-vacuity clause cannot catch it either: that clause is
+# guarded by `ZERODEP_COUNT >= 1`, and the typo makes the count ZERO, so the
+# clause is skipped rather than tripped. The lint would exit 0 with M5 silently
+# disarmed — a one-character edit passing every PR-blocking check, which is
+# precisely the BL-181 scar class (`# BL-181-UNIT-LANE-PREDICATE`).
+#
+# Uses V3's copy mechanism so the real lint is never mutated, and asserts the
+# copy really was mutated (`typoed`) so a no-op edit cannot be read as a proof —
+# the lesson L3 paid for. The control run pins that the same fixture is green
+# under the pristine lint, so exit 2 can only be coming from the guard.
+setup_fixture
+COPY="$TMP/lint-copy-badmodule.sh"
+awk '/^  "scout[|]scripts\/lib\/scout\/"$/ {
+       print "  \"scuot|scripts/lib/scout/\""
+       next
+     }
+     { print }' "$LINTER" > "$COPY"
+typoed=$(grep -c '"scuot|scripts/lib/scout/"' "$COPY")
+out=$(bash "$COPY" --root "$TMP" 2>&1); rc=$?
+out_ctl=$(run_fixture); rc_ctl=$?
+if [ "$rc" -eq 2 ] && [ "$rc_ctl" -eq 0 ] && [ "$typoed" -eq 1 ] \
+   && echo "$out" | grep -q 'scuot'; then
+  pass "V5: a typo'd module column exits 2 naming the unknown module (control green)"
+else
+  fail_ "V5" "expected mutated rc=2 naming 'scuot', control rc=0, typoed=1; rc=$rc rc_ctl=$rc_ctl typoed=$typoed; output:\n$out"
 fi
 teardown_fixture
 


### PR DESCRIPTION
## What

Brownfield Adoption **WP0** (design of record: `docs/designs/2026-08-02-brownfield-adoption-v1.md` §3.3, §10-WP0): the severable-module contract and its enforcement, converging on the delta track's proven lint shape (Q8 resolved: **sibling lint**, both designs honored as written).

- `docs/module-contract.md` — M1–M5 as the normative module-shape contract, each rule with its real enforcement pointer (M2 honestly stated as review-checked until a module declares a non-empty dependency set; M4 claims exactly what `lint-bl-markers.sh` delivers, stale-listing hole named). `docs/INDEX.md` row added.
- `scripts/lint-module-dependencies.sh` — sibling of `lint-delta-boundary.sh` for the future scout/adopt modules: two match tiers, reasoned exact-token allowlist, **core-allowlist asserted at cardinality ZERO**, vacuity floor exit 2, executed-lines-only stripping, **M5 zero-dependency arm** (scout may source no core lib), `--list` mode.
- `scripts/lib/scout/scout-core.sh` — first module file (M5 applies to it from birth).
- `tests/test-lint-module-dependencies.sh` — 40 tests, both lanes, widening pins (X8/X10) included from day one.
- Non-required CI job `module-dependencies-lint`; run-lints discovers by glob (15/15).

## Verification trail

- Full mutation matrix, **no surviving mutant**: direction-check deletion, allowlist growth, empty manifest (exit 2), M5-arm deletion, three stripper widenings — every mutant killed by its named case(s), counterfactuals executed. One false pin **self-found and corrected by the implementer** (quoted fixture absorbing the mutation) with the refutation recorded in the suite header.
- **T2 token deviation from the initial brief, evidence-backed and reviewer-reproduced**: bare path segments `scout/`/`adopt/` instead of `lib/scout/` — a test case written in the house `$LIBDIR` idiom *failed* against the narrower token, and bare English words false-positive on two executed core lines that exist today (independently re-verified).
- **Adversarial review (fable) before this PR**: round 1 minor_concerns with every implementer claim reproduced by execution; four findings (an unpinned load-bearing guard — novel mutant survived 39/0 — plus three doc-accuracy items) all fixed and re-verified in round 2, including the reviewer re-executing the new V5 counterfactual (guard deleted → V5 alone RED, silent-disarm demonstrated). **Final whole-branch verdict: approve.** Review record: `.superpowers/sdd/2026-08-02-brownfield-adoption-v1/wp0-review.md` (session artifact).

## Recorded residuals and forward decisions

- M5's token set covers core *libs*; a scout file invoking core *entry scripts* or `init.sh` evades it — disclosed in the lint's NAMED RESIDUAL block and the contract doc; WP1-brownfield's hermetic test must move `scripts/*.sh` aside too. Token-set widening stays in the Karl queue beside the host-drivers glob question (kept at exact parity with the delta lint).
- The two boundary lints exclude each other by filename shape (forced: the delta lint's own filename is one of its non-waivable T1 tokens); cost stated in both headers.
- Known cosmetic nit: one residual block's ordinal is out of document order in the lint header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)