### PR TITLE
feat(delta): WP3 — era invariant, second-activation refusal, classification

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -387,6 +387,7 @@ jobs:
             tests/test-currency-manifest.sh
             tests/test-delta-wp0-inherited-predicates.sh
             tests/test-delta-wp2-state-policy.sh
+            tests/test-delta-wp3-era-classify.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -437,11 +437,6 @@ cmd_open() {
     return 4
   fi
 
-  # The policy file is project-owned from birth. Seeding it here is the §7.2
-  # "the first delta.sh --open" moment — and it goes through the seam like every
-  # other write, even though this one is birth-once and never overwrites.
-  _seam --delta-policy-init >/dev/null 2>&1 || true
-
   if [ -z "$DESCRIBE" ]; then
     if [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${SOIF_NONINTERACTIVE:-}" ]; then
       DESCRIBE="$(prompt_input "In your own words — what needs doing?" "")"
@@ -497,6 +492,20 @@ cmd_open() {
     print_info "Re-run in a terminal, or add --confirm to accept the four lines above as they stand."
     return 2
   fi
+
+  # The policy file is project-owned from birth, and this is §7.2's "the first
+  # delta.sh --open" seeding moment. It goes through the seam like every other
+  # write, even though it is birth-once and never overwrites.
+  #
+  # IT SITS AFTER THE CONFIRMATION, DELIBERATELY. Every refusal above says
+  # "nothing was opened", and a refusal that says that while leaving a new file
+  # behind is a refusal the operator cannot trust. Seeding earlier costs nothing
+  # in derivation accuracy — an absent policy file already resolves every key to
+  # the framework default at read time (§3.2), so the transcript the operator
+  # just confirmed was computed from exactly the values this seed writes. Pinned
+  # by T2: after the no-confirmation refusal the project contains exactly the one
+  # file it started with.
+  _seam --delta-policy-init >/dev/null 2>&1 || true
 
   # ── §7.1: gates_required MATERIALISED AT OPEN from class + attributes ────
   if ! gates="$(delta_classify_gates "." "$CLASS" "$RISK" "$LEVEL")"; then

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -1,0 +1,612 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/delta.sh — the post-1.0 delta track's operator front door.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §10.1 (THE ERA INVARIANT —
+# `active_delta != null => current_phase == 4`, and this file is its LOAD-BEARING
+# enforcement point), §7.1 (the state schema, the single-writer rule, and
+# `gates_required` materialised AT OPEN), §4.1–§4.3 (the four classes, the
+# derived-then-confirmed attributes, confirm-not-quiz), §5.2 (the per-class gate
+# subset the materialisation produces), §6.1 (this is the GUIDED creation path),
+# §3.1 (a member of the severable delta module), §11-WP3.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose — no backlog
+# entry exists for this build, and minting one would red
+# scripts/lint-bl-markers.sh. The design-doc path above is the citation, per the
+# WP1/WP2 precedent. The grep-able `DELTA-OPEN-*` markers below are this file's
+# citation primitive and its mutation addresses.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THIS FILE IS FOR, IN ONE PARAGRAPH
+#
+# After a project ships 1.0 it never goes back through Phases 0–3. Everything
+# after that is a DELTA: a feature, a fix, a hotfix, or a security patch. This
+# script opens one. It asks the operator a single question, having already
+# proposed every answer from what they typed and from what the repository can
+# measure — and it refuses, loudly, in the two situations where opening a delta
+# would quietly destroy something.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE TWO REFUSALS, AND WHY EACH ONE EARNS ITS EXIT CODE
+#
+# 1. THE ERA INVARIANT (§10.1) — `# DELTA-OPEN-ERA-GUARD`, exit 3.
+#    `--open` refuses unless `.claude/phase-state.json::current_phase` is
+#    EXACTLY 4. §10.1 calls this "the load-bearing one — it is what makes the
+#    delta track unable to substitute for building the product properly." A
+#    project at phase 2 that could open a delta has discovered a way to do
+#    post-release maintenance ceremony INSTEAD of building the product, and the
+#    ceremony is cheaper, so it would win.
+#
+#    READ THE `[WARN]` TRAP BEFORE TOUCHING THIS (CLAUDE.md, and §10.1 repeats
+#    it). In check-phase-gate.sh the `[WARN]`/`[FAIL]` text is COSMETIC — the
+#    exit predicate is `if [ $issues -eq 0 ]`, so two arms that print the same
+#    label can have opposite gate outcomes. The lesson generalises to here: what
+#    makes this a refusal is the NON-ZERO RETURN, not the red word next to it.
+#    tests/test-delta-wp3-era-classify.sh asserts the exit CODE, never the
+#    label, and its m1 mutation neuters this one line to prove the code moves.
+#
+# 2. THE SECOND-ACTIVATION REFUSAL (§7.1) — `# DELTA-OPEN-ACTIVE-GUARD`, exit 4.
+#    WP2 DEFERRED THIS TO HERE, in as many words: scripts/lib/delta-state.sh's
+#    "WHAT IT DELIBERATELY DOES NOT ENFORCE" block says overwriting an OPEN
+#    active_delta is accepted at the state layer, that §11-WP3 owns open/confirm
+#    and therefore owns the business refusal, and that one-at-a-time is only
+#    STRUCTURAL until then. This is that refusal, and it is where it belongs:
+#    the schema's single `active_delta` slot means a second open would not fail —
+#    it would SUCCEED and silently discard the first delta's `gates_completed`,
+#    which is the audit trail of everything already done. A refusal that names
+#    the open delta is the only outcome that leaves the operator informed.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE SINGLE-WRITER RULE (D7), AND WHAT IT COSTS THIS FILE
+#
+# `.claude/delta-state.json` has exactly ONE writer: scripts/process-checklist.sh
+# (§7.1). This script NEVER touches it — not to read, not to write. Every state
+# operation routes through the seam's `--delta-*` actions. That is more
+# indirection than a direct `jq` would need, and it is bought deliberately: the
+# guard lives in the seam, and a second writer is a guard that can be forgotten.
+# scripts/lint-delta-boundary.sh makes the rule checkable, with a seam allowlist
+# whose cardinality is asserted at exactly one.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# CONFIRM, DO NOT QUIZ (§4.3) — the `# BL-204-PREFILL` pattern
+#
+# The repo's reference implementation is `# BL-204-PREFILL` in
+# scripts/intake-wizard.sh: read the remembered answer, PRINT it, print WHY
+# re-asking would be wrong, and ask the operator to keep or change. This
+# transcript copies it exactly, with one addition §4.3 insists on — every one of
+# the four lines names WHERE ITS VALUE CAME FROM, "because a proposal whose
+# provenance is hidden is a quiz with extra steps." The provenance text is not
+# written here; it is returned alongside each value by
+# scripts/lib/delta-classify.sh, so a caller cannot print the value and drop the
+# reason.
+#
+# RAISES ARE FREE, LOWERS ARE REASON-RECORDED (§4.2). The operator may raise
+# `risk` to core, `level` to evolution, or `severity` toward SEV-1 with no
+# justification at all — they know things the formula does not. Going the other
+# way removes a gate, so it records a reason into the delta's own row. A lower
+# with no reason available (a scripted run with no `--reason`) is REFUSED rather
+# than recorded blank: a blank reason is indistinguishable from a raise nobody
+# noticed, three months later, in the audit tail.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# OPERATOR-FACING TEXT IS PLAIN ENGLISH ON PURPOSE
+# §4.3's transcript is the register for everything this script prints. No
+# framework jargon, no file paths in the confirm flow, no "invariant". The
+# person reading it has just shipped a product and wants to fix a bug.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES — CODES, NEVER LABELS
+#   0  the delta was opened, or `--status` reported successfully
+#   1  an operation failed (the seam refused a write, jq is missing, …)
+#   2  invocation error: bad flag, missing argument, or a confirmation that
+#      could not be obtained (no terminal and no `--confirm`)
+#   3  ERA REFUSAL — the project is not at phase 4          (§10.1)
+#   4  SECOND-ACTIVATION REFUSAL — a delta is already open  (§7.1)
+#   5  an attribute was LOWERED with no reason recorded     (§4.2)
+#
+# BASH 3.2: no associative arrays, no ${var,,} (hence `tr`), no `((x++))`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/helpers-core.sh"
+
+# This script writes into `.claude/` (through the seam) and reads the project's
+# own git history. Running it from the framework clone would classify the
+# FRAMEWORK's diff and open a delta on the framework's state. Refuse early —
+# the same guard, for the same reason, as process-checklist.sh's.
+guard_not_in_framework || exit 1
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/delta-policy.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/delta-classify.sh"
+
+SEAM="$SCRIPT_DIR/process-checklist.sh"
+PHASE_STATE=".claude/phase-state.json"
+
+USAGE="Usage:
+  scripts/delta.sh --open [--describe TEXT] [--slug SLUG] [--confirm]
+                   [--class feature|fix|hotfix|security-patch]
+                   [--risk core|feature-local] [--level small|significant|evolution]
+                   [--severity SEV-1|SEV-2|SEV-3|SEV-4] [--reason TEXT]
+                   [--touched-file FILE]
+  scripts/delta.sh --status
+  scripts/delta.sh --help"
+
+# ── The seam, and nothing but the seam ──────────────────────────────────────
+# Every state read and every state write in this file goes through here. The
+# `if` form suspends errexit for the call so a legitimate refusal returns as
+# itself instead of aborting the script mid-transcript.
+_seam() {
+  if bash "$SEAM" "$@" </dev/null; then return 0; else return $?; fi
+}
+
+# _current_phase — the project's phase as a bare integer, or "" when it cannot
+# be read. An unreadable phase is NOT treated as 4: the era guard below compares
+# for equality, so "unknown" refuses, which is the fail-closed direction.
+_current_phase() {
+  local v=""
+  if [ -f "$PHASE_STATE" ] && command -v jq >/dev/null 2>&1; then
+    v="$(jq -r '.current_phase // empty' "$PHASE_STATE" 2>/dev/null || true)"
+  fi
+  case "$v" in ''|*[!0-9]*) v="" ;; esac
+  printf '%s' "$v"
+}
+
+_phase_words() {
+  local p="${1:-}"
+  case "$p" in
+    "")  printf '%s' "no recorded phase at all" ;;
+    0|1) printf '%s' "phase $p — still designing" ;;
+    2)   printf '%s' "phase $p — still building" ;;
+    3)   printf '%s' "phase $p — still hardening for launch" ;;
+    *)   printf '%s' "phase $p" ;;
+  esac
+}
+
+# ── §4.3's transcript rendering ─────────────────────────────────────────────
+
+# _tline <label> <value> <why> — one line of the confirm transcript: the label,
+# the proposed value, and the parenthetical that names where the value came
+# from. Long provenance wraps under the parenthesis rather than being truncated;
+# a truncated reason is a hidden reason, which §4.3 is specifically about.
+_tline() {
+  local label="$1" value="$2" why="$3" line n=0 text
+  # ASCII placeholder on purpose: `%-15s` pads by BYTES, so a multi-byte dash
+  # here would silently misalign the whole column under `printf`.
+  [ -n "$value" ] || value="none"
+  text="($why)"
+  while IFS= read -r line; do
+    line="$(printf '%s' "$line" | sed -e 's/[[:space:]]*$//')"
+    [ -n "$line" ] || continue
+    if [ "$n" -eq 0 ]; then
+      printf '  %-9s %-15s %s\n' "$label" "$value" "$line"
+      n=1
+    else
+      printf '                            %s\n' "$line"
+    fi
+  done <<EOF
+$(printf '%s\n' "$text" | fold -s -w 58)
+EOF
+  return 0
+}
+
+_render_transcript() {
+  echo ""
+  printf 'You said: "%s"\n' "$DESCRIBE"
+  echo ""
+  _tline "Class:"    "$CLASS" "$CLASS_WHY"
+  _tline "Severity:" "$SEV"   "$SEV_WHY"
+  _tline "Risk:"     "$RISK"  "$RISK_WHY"
+  _tline "Level:"    "$LEVEL" "$LEVEL_WHY"
+  echo ""
+  echo "  [1] Keep all four        [2] Change the class        [3] Change an attribute"
+  echo ""
+  return 0
+}
+
+# ── Raise / lower (§4.2) ────────────────────────────────────────────────────
+# One ordering per attribute, lowest first. `severity` runs BACKWARDS from the
+# spelling — SEV-1 is the most severe, so raising severity means moving toward
+# SEV-1 and the rank has to invert or every raise would read as a lower.
+_rank() {
+  local attr="$1" v="$2"
+  case "$attr" in
+    risk)  case "$v" in feature-local) printf '0' ;; core) printf '1' ;; *) printf '-1' ;; esac ;;
+    level) case "$v" in small) printf '0' ;; significant) printf '1' ;; evolution) printf '2' ;; *) printf '-1' ;; esac ;;
+    severity) case "$v" in SEV-4) printf '0' ;; SEV-3) printf '1' ;; SEV-2) printf '2' ;; SEV-1) printf '3' ;; *) printf '-1' ;; esac ;;
+    *) printf '-1' ;;
+  esac
+}
+
+_valid_values() {
+  case "$1" in
+    risk) printf '%s' "core or feature-local" ;;
+    level) printf '%s' "small, significant or evolution" ;;
+    severity) printf '%s' "SEV-1, SEV-2, SEV-3 or SEV-4" ;;
+    class) printf '%s' "feature, fix, hotfix or security-patch" ;;
+  esac
+}
+
+# _reason_for <attribute> — the recorded reason for lowering, or "" if none can
+# be obtained. `--reason` wins; otherwise an operator at a terminal is asked.
+# A scripted run with no `--reason` gets "", and the caller REFUSES.
+_reason_for() {
+  local attr="$1"
+  if [ -n "$REASON" ]; then printf '%s' "$REASON"; return 0; fi
+  if [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${SOIF_NONINTERACTIVE:-}" ]; then
+    prompt_input "You are lowering $attr, which removes a check. Why is that right here?" ""
+    return 0
+  fi
+  printf '%s' ""
+  return 0
+}
+
+# _set_attr <attribute> <wanted-value> — apply an operator override.
+#   RAISE  -> free, recorded as the operator's own call.
+#   LOWER  -> a reason is required, recorded on the delta's row; refused (5) if
+#             none can be obtained.
+#   Same value -> no-op.
+_set_attr() {
+  local attr="$1" want="$2" cur why rc rw reason
+  case "$attr" in
+    risk)     cur="$RISK" ;;
+    level)    cur="$LEVEL" ;;
+    severity) cur="$SEV" ;;
+    *) print_fail "Unknown attribute '$attr'."; return 2 ;;
+  esac
+
+  rw="$(_rank "$attr" "$want")"
+  if [ "$rw" -lt 0 ]; then
+    print_fail "'$want' is not one of the values $attr can take ($(_valid_values "$attr"))."
+    return 2
+  fi
+  if [ "$attr" = "severity" ] && [ "$CLASS" = "feature" ]; then
+    print_fail "A feature has no severity — severity belongs to a fix, a hotfix or a security patch."
+    return 2
+  fi
+  [ "$want" = "$cur" ] && return 0
+
+  rc="$(_rank "$attr" "$cur")"
+  if [ "$rw" -gt "$rc" ]; then
+    why="you raised this yourself — raising is always allowed, because you know things the measurement does not"
+  else
+    reason="$(_reason_for "$attr")"
+    if [ -z "$reason" ]; then
+      print_fail "Lowering $attr from $cur to $want removes a check, so it needs a reason on the record."
+      print_info "Re-run with --reason \"why this is right here\", or keep $cur."
+      return 5
+    fi
+    why="you lowered this from $cur and recorded: $reason"
+    case "$attr" in
+      risk)     REASON_RISK="$reason" ;;
+      level)    REASON_LEVEL="$reason" ;;
+      severity) REASON_SEVERITY="$reason" ;;
+    esac
+  fi
+
+  case "$attr" in
+    risk)     RISK="$want";  RISK_WHY="$why" ;;
+    level)    LEVEL="$want"; LEVEL_WHY="$why" ;;
+    severity) SEV="$want";   SEV_WHY="$why" ;;
+  esac
+  return 0
+}
+
+# _set_class <class> — changing the class is the ONE question §4.3 asks, so it
+# is always free. Severity is re-proposed for the new class, because the old
+# proposal was reasoned from the old class (and a feature carries none at all).
+_set_class() {
+  local want="$1" pair
+  case "$want" in
+    feature|fix|hotfix|security-patch) : ;;
+    *) print_fail "'$want' is not one of the four classes ($(_valid_values class))."; return 2 ;;
+  esac
+  [ "$want" = "$CLASS" ] && return 0
+  CLASS="$want"
+  CLASS_WHY="you chose this class yourself"
+  pair="$(delta_classify_severity "." "$CLASS" "$DESCRIBE")"
+  SEV="$(printf '%s' "$pair" | cut -f1)"
+  SEV_WHY="$(printf '%s' "$pair" | cut -f2-)"
+  REASON_SEVERITY=""
+  return 0
+}
+
+# ── The interactive confirm loop (§4.3) ─────────────────────────────────────
+_confirm_loop() {
+  local choice attr value rc
+  while :; do
+    _render_transcript
+    choice="$(prompt_choice "One question — is this right?" \
+      "Keep all four" "Change the class" "Change an attribute")" || return 2
+    case "$choice" in
+      "Keep all four") return 0 ;;
+      "Change the class")
+        value="$(prompt_choice "Which class is it?" feature fix hotfix security-patch)" || return 2
+        _set_class "$value" || return $?
+        ;;
+      "Change an attribute")
+        attr="$(prompt_choice "Which one?" risk level severity)" || return 2
+        case "$attr" in
+          risk)     value="$(prompt_choice "Risk:" core feature-local)" || return 2 ;;
+          level)    value="$(prompt_choice "Level:" small significant evolution)" || return 2 ;;
+          severity) value="$(prompt_choice "Severity:" SEV-1 SEV-2 SEV-3 SEV-4)" || return 2 ;;
+        esac
+        rc=0; _set_attr "$attr" "$value" || rc=$?
+        # A refused LOWER is not fatal in the interactive flow: the operator is
+        # right there and can pick again. It IS fatal in a scripted run, which
+        # never reaches this loop.
+        if [ "$rc" -ne 0 ] && [ "$rc" -ne 5 ]; then return "$rc"; fi
+        ;;
+    esac
+  done
+}
+
+# ── Identity (§6.3) ─────────────────────────────────────────────────────────
+_next_id() {
+  printf '%s\n' "$1" | jq -r '
+      [ (.closed[]?.id // empty), (.hotfix_retros[]?.id // empty), (.active_delta.id // empty) ]
+    | map(select(type == "string") | select(test("DELTA-[0-9]+")))
+    | map(capture("DELTA-(?<n>[0-9]+)") | .n | tonumber)
+    | ((max // 0) + 1) as $n
+    | "DELTA-" + (if $n < 10 then "00" elif $n < 100 then "0" else "" end) + ($n | tostring)
+  ' 2>/dev/null || printf 'DELTA-001\n'
+}
+
+_slugify() {
+  local s
+  s="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]' \
+        | sed -e 's/[^a-z0-9]\{1,\}/-/g' -e 's/^-*//' -e 's/-*$//' \
+        | cut -c1-40 | sed -e 's/-*$//')"
+  [ -n "$s" ] && printf '%s' "$s" || printf '%s' "delta"
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# --status
+# ═════════════════════════════════════════════════════════════════════════════
+cmd_status() {
+  local doc phase
+  phase="$(_current_phase)"
+  if ! doc="$(_seam --delta-state-read)"; then
+    print_fail "Could not read the delta record."
+    return 1
+  fi
+  echo ""
+  print_info "Project phase: ${phase:-unknown}"
+  if [ "$(printf '%s\n' "$doc" | jq -r '.active_delta == null')" = "true" ]; then
+    print_info "No delta is open. Start one with: scripts/delta.sh --open"
+    echo ""
+    return 0
+  fi
+  printf '%s\n' "$doc" | jq -r '
+    .active_delta as $d
+    | "  Open delta:  \($d.id)  (\($d.class))",
+      "  What:        \($d.slug)",
+      "  Opened:      \($d.opened_at // "unknown")  via \($d.opened_via // "unknown")",
+      "  Risk:        \($d.attributes.risk // "unknown")",
+      "  Level:       \($d.attributes.level // "unknown")",
+      "  Severity:    \($d.attributes.severity // "—")",
+      "  Still to do: " + (( ($d.gates_required // []) - ($d.gates_completed // []) ) | join(", ")),
+      "  Done:        " + ((($d.gates_completed // []) | join(", ")) | if . == "" then "nothing yet" else . end)
+  '
+  echo ""
+  return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# --open
+# ═════════════════════════════════════════════════════════════════════════════
+cmd_open() {
+  local phase doc active_id pair touched lines gates obj now id slug reasons rc
+
+  command -v jq >/dev/null 2>&1 || { print_fail "jq is required to open a delta."; return 1; }
+
+  # ── REFUSAL 1 — THE ERA INVARIANT (§10.1) ────────────────────────────────
+  # `active_delta != null => current_phase == 4`, enforced where it is
+  # load-bearing: at open. Equality, not `-ge`: §10.2 fixes current_phase at 4
+  # forever (a phase 5 was rejected by decision), so anything else is a project
+  # that has not shipped yet.
+  phase="$(_current_phase)"
+  if [ "$phase" != "4" ]; then                                        # DELTA-OPEN-ERA-GUARD
+    echo ""
+    print_fail "This project is not finished yet, so there is nothing to maintain."
+    print_info "The delta track is for after your product has shipped. This project is at $(_phase_words "$phase")."
+    print_info "Finish the build and the launch first — then every later change comes through here."
+    echo ""
+    return 3
+  fi
+
+  if ! doc="$(_seam --delta-state-read)"; then
+    print_fail "Could not read the delta record."
+    return 1
+  fi
+
+  # ── REFUSAL 2 — SECOND ACTIVATION (§7.1, deferred to WP3 by WP2) ─────────
+  # One delta at a time. The schema's single `active_delta` slot makes a second
+  # open SUCCEED and overwrite — taking the first delta's completed-gate history
+  # with it — so the refusal has to live here, in the business layer, and it has
+  # to name the delta that is in the way.
+  active_id="$(printf '%s\n' "$doc" | jq -r '.active_delta.id // "NONE"' 2>/dev/null || printf 'NONE')"
+  if [ "$active_id" != "NONE" ]; then                                 # DELTA-OPEN-ACTIVE-GUARD
+    echo ""
+    print_fail "You already have one piece of work open: $active_id."
+    print_info "$(printf '%s\n' "$doc" | jq -r '"It is a \(.active_delta.class // "delta") — \(.active_delta.slug // "no description recorded")."')"
+    print_info "Finish it or close it before starting another. Run: scripts/delta.sh --status"
+    echo ""
+    return 4
+  fi
+
+  # The policy file is project-owned from birth. Seeding it here is the §7.2
+  # "the first delta.sh --open" moment — and it goes through the seam like every
+  # other write, even though this one is birth-once and never overwrites.
+  _seam --delta-policy-init >/dev/null 2>&1 || true
+
+  if [ -z "$DESCRIBE" ]; then
+    if [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${SOIF_NONINTERACTIVE:-}" ]; then
+      DESCRIBE="$(prompt_input "In your own words — what needs doing?" "")"
+    fi
+  fi
+  if [ -z "$DESCRIBE" ]; then
+    print_fail "Tell me what needs doing: scripts/delta.sh --open --describe \"the CSV export crashes on unicode\""
+    return 2
+  fi
+
+  # ── §4.2's three derivations, each returning value + provenance ──────────
+  pair="$(delta_classify_class "$DESCRIBE")"
+  CLASS="$(printf '%s' "$pair" | cut -f1)"
+  CLASS_WHY="$(printf '%s' "$pair" | cut -f2-)"
+
+  pair="$(delta_classify_severity "." "$CLASS" "$DESCRIBE")"
+  SEV="$(printf '%s' "$pair" | cut -f1)"
+  SEV_WHY="$(printf '%s' "$pair" | cut -f2-)"
+
+  touched="$TOUCHED_FILE"
+  if [ -z "$touched" ]; then
+    touched="$(mktemp)"
+    delta_classify_touched "." > "$touched" 2>/dev/null || : > "$touched"
+    TOUCHED_TMP="$touched"
+  fi
+  pair="$(delta_classify_risk "." "$touched")"
+  RISK="$(printf '%s' "$pair" | cut -f1)"
+  RISK_WHY="$(printf '%s' "$pair" | cut -f2-)"
+
+  lines="$LINES_OVERRIDE"
+  [ -n "$lines" ] || lines="$(delta_classify_lines ".")"
+  pair="$(delta_classify_level "." "$lines")"
+  LEVEL="$(printf '%s' "$pair" | cut -f1)"
+  LEVEL_WHY="$(printf '%s' "$pair" | cut -f2-)"
+
+  # ── Command-line overrides, applied BEFORE the transcript is shown, so the
+  #    operator confirms what will actually be recorded. Class first: it
+  #    re-proposes severity, and an explicit --severity must survive that.
+  if [ -n "$WANT_CLASS" ]; then _set_class "$WANT_CLASS" || return $?; fi
+  if [ -n "$WANT_RISK" ];  then _set_attr risk "$WANT_RISK" || return $?; fi
+  if [ -n "$WANT_LEVEL" ]; then _set_attr level "$WANT_LEVEL" || return $?; fi
+  if [ -n "$WANT_SEV" ];   then _set_attr severity "$WANT_SEV" || return $?; fi
+
+  # ── §4.3: confirm, do not quiz ──────────────────────────────────────────
+  if [ "$CONFIRMED" -eq 1 ]; then
+    _render_transcript
+  elif [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${SOIF_NONINTERACTIVE:-}" ]; then
+    rc=0; _confirm_loop || rc=$?
+    [ "$rc" -eq 0 ] || return "$rc"
+  else
+    _render_transcript
+    print_fail "Nobody is here to confirm this, so nothing was opened."
+    print_info "Re-run in a terminal, or add --confirm to accept the four lines above as they stand."
+    return 2
+  fi
+
+  # ── §7.1: gates_required MATERIALISED AT OPEN from class + attributes ────
+  if ! gates="$(delta_classify_gates "." "$CLASS" "$RISK" "$LEVEL")"; then
+    print_fail "Could not work out which checks this delta needs, so nothing was opened."
+    return 1
+  fi
+
+  id="$(_next_id "$doc")"
+  slug="$SLUG"
+  [ -n "$slug" ] || slug="$(_slugify "$DESCRIBE")"
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  reasons="$(jq -c -n --arg r "$REASON_RISK" --arg l "$REASON_LEVEL" --arg s "$REASON_SEVERITY" '
+    { risk: (if $r == "" then null else $r end),
+      level: (if $l == "" then null else $l end),
+      severity: (if $s == "" then null else $s end) }')"
+
+  # `brief` and `ledger` stay null on purpose: §11-WP8 owns the brief template
+  # and the guided intake's ledger-row write. Materialising them here would
+  # invent a path to a file nothing creates yet.
+  obj="$(jq -c -n \
+    --arg id "$id" --arg slug "$slug" --arg class "$CLASS" \
+    --arg at "$now" --arg via "guided" \
+    --arg risk "$RISK" --arg level "$LEVEL" --arg sev "$SEV" \
+    --argjson gates "$gates" --argjson reasons "$reasons" '
+    { id: $id, slug: $slug, class: $class,
+      brief: null, ledger: null,
+      opened_at: $at, opened_via: $via,
+      attributes: { risk: $risk, level: $level,
+                    severity: (if $sev == "" then null else $sev end) },
+      attributes_confirmed_at: $at,
+      attribute_reasons: $reasons,
+      gates_required: $gates,
+      gates_completed: [] }')"
+
+  # THE ONLY WRITE IN THIS FILE, AND IT IS NOT A WRITE — it is a request to the
+  # single writer (§7.1/D7). delta.sh never opens the state file.
+  if ! _seam --delta-state-update ".active_delta = $obj"; then
+    print_fail "The delta record refused the change, so nothing was opened."
+    return 1
+  fi
+
+  echo ""
+  print_ok "Opened $id — $slug ($CLASS)."
+  printf '%s\n' "$gates" | jq -r '"  Before this can ship: " + join(", ")'
+  print_info "Check where you are at any time with: scripts/delta.sh --status"
+  echo ""
+  return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Argument parsing
+# ═════════════════════════════════════════════════════════════════════════════
+ACTION=""
+DESCRIBE=""
+SLUG=""
+CONFIRMED=0
+WANT_CLASS=""
+WANT_RISK=""
+WANT_LEVEL=""
+WANT_SEV=""
+REASON=""
+TOUCHED_FILE=""
+TOUCHED_TMP=""
+LINES_OVERRIDE=""
+
+CLASS=""; CLASS_WHY=""
+SEV="";   SEV_WHY=""
+RISK="";  RISK_WHY=""
+LEVEL=""; LEVEL_WHY=""
+REASON_RISK=""; REASON_LEVEL=""; REASON_SEVERITY=""
+
+_need() {
+  if [ "$2" -lt 2 ]; then
+    echo "delta: $1 needs a value." >&2
+    echo "$USAGE" >&2
+    exit 2
+  fi
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --open)     ACTION="open"; shift ;;
+    --status)   ACTION="status"; shift ;;
+    --describe) _need "$1" $#; DESCRIBE="$2"; shift 2 ;;
+    --slug)     _need "$1" $#; SLUG="$2"; shift 2 ;;
+    --class)    _need "$1" $#; WANT_CLASS="$2"; shift 2 ;;
+    --risk)     _need "$1" $#; WANT_RISK="$2"; shift 2 ;;
+    --level)    _need "$1" $#; WANT_LEVEL="$2"; shift 2 ;;
+    --severity) _need "$1" $#; WANT_SEV="$2"; shift 2 ;;
+    --reason)   _need "$1" $#; REASON="$2"; shift 2 ;;
+    # An explicit touched-file list and an explicit line count exist so the
+    # derivations can be exercised against a KNOWN input. At open the real diff
+    # is usually empty (§4.2's forecast), so a test that relied on the ambient
+    # git state would be pinning the host, not the formula.
+    --touched-file) _need "$1" $#; TOUCHED_FILE="$2"; shift 2 ;;
+    --lines)        _need "$1" $#; LINES_OVERRIDE="$2"; shift 2 ;;
+    --confirm)  CONFIRMED=1; shift ;;
+    -h|--help)  echo "$USAGE"; exit 0 ;;
+    *) echo "delta: unknown option '$1'." >&2; echo "$USAGE" >&2; exit 2 ;;
+  esac
+done
+
+_cleanup() { [ -n "$TOUCHED_TMP" ] && rm -f "$TOUCHED_TMP" 2>/dev/null; return 0; }
+trap _cleanup EXIT
+
+RC=0
+case "$ACTION" in
+  open)   cmd_open   || RC=$? ;;
+  status) cmd_status || RC=$? ;;
+  *)      echo "$USAGE" >&2; RC=2 ;;
+esac
+exit "$RC"

--- a/scripts/lib/delta-classify.sh
+++ b/scripts/lib/delta-classify.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# scripts/lib/delta-classify.sh — the §4.2 derivations for the post-MVP delta
+# track: risk, level, severity, the phrase->class PROPOSAL, and the §7.1
+# `gates_required` materialisation that §5.2's table describes.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §4.1 (the four classes),
+# §4.2 (the derived-then-confirmed attributes and their author-proposed
+# formulas), §4.3 (confirm-not-quiz — this file supplies the VALUE and the
+# PROVENANCE for every line of that transcript), §5.2 (the per-class gate
+# subset + the attribute toggles), §7.2 (every threshold and every gate list is
+# READ FROM POLICY, never hardcoded), §3.1 (this file is a member of the
+# severable delta module's inventory), §11-WP3.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose — no backlog
+# entry exists for this build, and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1 and
+# WP2 precedent. The grep-able `DELTA-CLASSIFY-*` markers below are this file's
+# citation primitive and its mutation addresses.)
+#
+# ── EVERY FUNCTION HERE PROPOSES; NOTHING HERE DECIDES ───────────────────────
+# D2 is explicit that the class is "auto-proposed from the user's phrasing where
+# possible and CONFIRMED, never quizzed". So each derivation returns two things
+# on one line, TAB-separated:
+#
+#     <value><TAB><provenance>
+#
+# The provenance half is not decoration and it is not a log line: §4.3 requires
+# that "every one of the four lines names WHERE THE VALUE CAME FROM, because a
+# proposal whose provenance is hidden is a quiz with extra steps." Returning the
+# pair together is what makes it impossible to render the value without its
+# reason — a two-call API (value here, reason there) would let a caller print
+# the number and drop the sentence, which is exactly the failure §4.3 names.
+# Callers split with `cut -f1` / `cut -f2-`.
+#
+# ── THE TWO HONEST LIMITS (§4.2), RESTATED WHERE THEY BITE ───────────────────
+#   1. DERIVATION AT OPEN TIME IS A FORECAST. At `--open` the diff is usually
+#      empty, so `risk` and `level` are proposals from the STATED intent. §4.2
+#      re-derives them at close and RATCHETS (raise only). This file computes
+#      the same way at both moments; it does not know which moment it is in, and
+#      it must not — the ratchet is WP4's, applied to these outputs.
+#   2. `risk_surfaces` IS A PROJECT-AUTHORED GLOB LIST and ships EMPTY (§7.2).
+#      An empty list makes every delta `feature-local`, forever, silently. That
+#      is §13-R4, and delta_classify_risk states it in its own provenance string
+#      rather than quietly answering "feature-local" as though it had looked.
+#
+# ── LINES ARE A POOR PROXY, ON PURPOSE (§7.2) ────────────────────────────────
+# A 12-line auth change is riskier than a 900-line locale file. That is exactly
+# why risk is a SEPARATE axis derived from PATHS, and why the operator may raise
+# either freely (§4.2). Do not "improve" the level formula into a risk formula.
+#
+# ── POLICY IS READ, NEVER HARDCODED ──────────────────────────────────────────
+# Every threshold, every gate list and every toggle comes from
+# delta_policy_get, which falls back per KEY to the framework defaults (§3.2).
+# The literal numbers that appear below are LAST-RESORT fallbacks for the case
+# where the policy layer itself is unavailable, and each one sits on a line whose
+# marker is a mutation address: neuter the read and the policy-retune tests go
+# RED. That is the pin that keeps a "temporary" hardcode from surviving.
+#
+# DEPENDENCY DIRECTION (D1)
+#   delta -> core is allowed and unasserted. core -> delta is forbidden and
+#   lint-enforced by scripts/lint-delta-boundary.sh with ONE allowlisted seam.
+#   This file sources a SIBLING delta lib (delta -> delta), which the lint does
+#   not scan at all; nothing in core may source this file.
+#
+# BASH 3.2 COMPATIBILITY
+#   macOS ships bash 3.2.57. No associative arrays, no ${var,,} (hence the
+#   `tr` lowering below), no `((x++))`, no nullglob. Every function is
+#   errexit-safe: this lib is sourced into scripts/delta.sh, which runs under
+#   `set -euo pipefail`, so no bare command is left to fail on its own.
+
+# The policy reader is a hard dependency and a delta -> delta edge, so sourcing
+# it here is free of boundary consequences. Guarded so a caller that already
+# sourced it does not pay twice.
+if ! command -v delta_policy_get >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/delta-policy.sh"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THE TOUCHED-FILE SET AND THE DIFF SIZE
+# ─────────────────────────────────────────────────────────────────────────────
+
+# _delta_classify_base <project_root>
+#   Echo the merge base to diff against, or nothing. §4.2 says "against the
+#   merge base"; which ref that is depends on the project, so the candidates are
+#   tried in order and the first that resolves wins. DELTA_BASE_REF overrides
+#   for a project whose trunk is named something else — and for tests, which
+#   must not depend on what the host's git happens to have.
+#
+#   NOTHING is an entirely normal answer: at `--open` on trunk the merge base IS
+#   HEAD, the diff is empty, and §4.2's "derivation at open time is a forecast"
+#   is the whole point. A missing base must therefore never be an error.
+_delta_classify_base() {
+  local root="${1:-.}" ref base=""
+  command -v git >/dev/null 2>&1 || return 0
+  git -C "$root" rev-parse --git-dir >/dev/null 2>&1 || return 0
+  for ref in "${DELTA_BASE_REF:-}" origin/HEAD origin/main origin/master main master; do
+    [ -n "$ref" ] || continue
+    git -C "$root" rev-parse --verify --quiet "$ref" >/dev/null 2>&1 || continue
+    base="$(git -C "$root" merge-base HEAD "$ref" 2>/dev/null)" || base=""
+    [ -n "$base" ] && break
+  done
+  [ -n "$base" ] && printf '%s\n' "$base"
+  return 0
+}
+
+# delta_classify_touched <project_root>
+#   The touched-file set, one path per line, sorted and de-duplicated. §4.2's
+#   `git diff --name-only against the merge base`, widened to include the
+#   working tree and the index — a delta is usually opened with work already in
+#   progress, and a formula that only looked at committed history would answer
+#   "nothing touched" for exactly the operator who has the most to declare.
+#   Always rc 0: a non-git directory has an empty touched set, not an error.
+delta_classify_touched() {
+  local root="${1:-.}" base
+  command -v git >/dev/null 2>&1 || return 0
+  git -C "$root" rev-parse --git-dir >/dev/null 2>&1 || return 0
+  base="$(_delta_classify_base "$root")"
+  {
+    if [ -n "$base" ]; then git -C "$root" diff --name-only "$base" 2>/dev/null || true; fi
+    git -C "$root" diff --name-only 2>/dev/null || true
+    git -C "$root" diff --name-only --cached 2>/dev/null || true
+  } | sed '/^$/d' | LC_ALL=C sort -u
+  return 0
+}
+
+# delta_classify_lines <project_root>
+#   Changed lines (insertions + deletions) from `git diff --shortstat`, per
+#   §4.2. Prints a bare integer, always rc 0 — `0` for a non-git tree or an
+#   empty diff, which is the forecast case and not a failure.
+delta_classify_lines() {
+  local root="${1:-.}" base stat="" ins=0 del=0 n
+  if ! command -v git >/dev/null 2>&1 || ! git -C "$root" rev-parse --git-dir >/dev/null 2>&1; then
+    printf '0\n'; return 0
+  fi
+  base="$(_delta_classify_base "$root")"
+  if [ -n "$base" ]; then
+    stat="$(git -C "$root" diff --shortstat "$base" 2>/dev/null)" || stat=""
+  fi
+  if [ -z "$stat" ]; then
+    stat="$(git -C "$root" diff --shortstat 2>/dev/null)" || stat=""
+  fi
+  n="$(printf '%s' "$stat" | grep -o '[0-9][0-9]* insertion' | grep -o '[0-9][0-9]*' || true)"
+  case "$n" in ''|*[!0-9]*) ins=0 ;; *) ins="$n" ;; esac
+  n="$(printf '%s' "$stat" | grep -o '[0-9][0-9]* deletion' | grep -o '[0-9][0-9]*' || true)"
+  case "$n" in ''|*[!0-9]*) del=0 ;; *) del="$n" ;; esac
+  printf '%s\n' "$((ins + del))"
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RISK — the touched-file set intersected with the policy's risk surfaces
+# ─────────────────────────────────────────────────────────────────────────────
+
+# delta_classify_risk_matches <project_root> <touched-file-list-file>
+#   One `path<TAB>glob` line per intersection. §4.2 requires the confirmation be
+#   "shown with the MATCHING PATHS NAMED", so the caller needs the pairs and not
+#   just a count.
+#
+#   Matching is bash `case` pattern matching, which is deliberately NOT
+#   path-aware: `*` crosses `/`. That makes `src/auth/**` match
+#   `src/auth/x/y.ts` (what a project author means) and `**/schema*` match
+#   `db/schema.sql` (likewise). The known consequence is that a leading `**/`
+#   still requires at least one `/` in the path, so a root-level `schema.sql`
+#   does NOT match `**/schema*` — write `schema*` as a second glob if you want
+#   both. Stated rather than smoothed; a glob list the framework silently
+#   reinterpreted would be worse than one the operator can read.
+delta_classify_risk_matches() {
+  local root="${1:-.}" files="${2:-}" surfaces globs path g
+  [ -n "$files" ] && [ -f "$files" ] || return 0
+  surfaces="$(delta_policy_get "$root" "risk_surfaces")" || surfaces="[]"   # DELTA-CLASSIFY-RISK-SURFACES
+  globs="$(mktemp)" || return 0
+  printf '%s\n' "$surfaces" | jq -r '.[]? | select(type == "string")' > "$globs" 2>/dev/null || : > "$globs"
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    while IFS= read -r g; do
+      [ -n "$g" ] || continue
+      # Unquoted on purpose: in pattern position an unquoted expansion IS the
+      # glob. Quoting it here would turn every risk surface into a literal
+      # string compare and silently answer "feature-local" for every project.
+      case "$path" in
+        $g) printf '%s\t%s\n' "$path" "$g" ;;
+      esac
+    done < "$globs"
+  done < "$files"
+  rm -f "$globs" 2>/dev/null || true
+  return 0
+}
+
+# delta_classify_risk <project_root> <touched-file-list-file>
+#   `core` iff the intersection is non-empty, else `feature-local` (§4.2), plus
+#   the provenance §4.3 prints.
+#
+#   §13-R4, NAMED IN THE OUTPUT AND NOT ONLY IN A COMMENT. `risk_surfaces` ships
+#   EMPTY (§7.2), and an empty list makes EVERY delta feature-local for as long
+#   as nobody fills it. The framework cannot compute the right list — it is the
+#   project's threat model — so the honest move is to say so on the line the
+#   operator is being asked to confirm, rather than answering "feature-local" in
+#   a tone that implies something was checked. That distinct provenance string
+#   is the mitigation §13-R4 gets; it is not a cure.
+delta_classify_risk() {
+  local root="${1:-.}" files="${2:-}" surfaces count matches first_path first_glob n
+  surfaces="$(delta_policy_get "$root" "risk_surfaces")" || surfaces="[]"
+  count="$(printf '%s\n' "$surfaces" | jq -r 'if type == "array" then length else 0 end' 2>/dev/null)" || count=0
+  case "$count" in ''|*[!0-9]*) count=0 ;; esac
+  if [ "$count" -eq 0 ]; then
+    printf 'feature-local\tno risk surfaces are configured yet, so nothing can match — every change reads as feature-local until someone lists this project'"'"'s sensitive paths\n'
+    return 0
+  fi
+  matches="$(delta_classify_risk_matches "$root" "$files")" || matches=""
+  if [ -z "$matches" ]; then
+    printf 'feature-local\tnone of the files touched so far match any of the %s configured risk surface(s)\n' "$count"
+    return 0
+  fi
+  n="$(printf '%s\n' "$matches" | grep -c '' || true)"
+  case "$n" in ''|*[!0-9]*) n=1 ;; esac
+  first_path="$(printf '%s\n' "$matches" | sed -n '1p' | cut -f1)"
+  first_glob="$(printf '%s\n' "$matches" | sed -n '1p' | cut -f2)"
+  if [ "$n" -gt 1 ]; then
+    printf 'core\t%s touched file(s) match a risk surface — e.g. %s matches the pattern %s\n' "$n" "$first_path" "$first_glob"
+  else
+    printf 'core\tthe touched file %s matches the risk surface pattern %s\n' "$first_path" "$first_glob"
+  fi
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# LEVEL — changed lines against the policy's size thresholds
+# ─────────────────────────────────────────────────────────────────────────────
+
+# delta_classify_level <project_root> <changed-lines>
+#   §4.2's bracket: below `small` => small; below `significant` => significant;
+#   at or above => evolution.
+#
+#   BOTH THRESHOLDS ARE READ FROM POLICY. The literals on the fallback halves of
+#   those two lines exist only for the case where the policy layer itself cannot
+#   answer, and each line carries a marker so a counterfactual can neuter
+#   EXACTLY ONE of them: with the read gone, a project that retuned
+#   `size_thresholds` keeps getting the framework bracket and nothing else
+#   changes — no error, no warning, just a wrong answer. That is precisely the
+#   defect the retune test + its mutation exist to make loud.
+delta_classify_level() {
+  local root="${1:-.}" lines="${2:-0}" small significant
+  case "$lines" in ''|*[!0-9]*) lines=0 ;; esac
+  small="$(delta_policy_get "$root" "size_thresholds.small")" || small=50                        # DELTA-CLASSIFY-LEVEL-SMALL
+  significant="$(delta_policy_get "$root" "size_thresholds.significant")" || significant=400     # DELTA-CLASSIFY-LEVEL-SIGNIFICANT
+  case "$small" in ''|*[!0-9]*) small=50 ;; esac
+  case "$significant" in ''|*[!0-9]*) significant=400 ;; esac
+  if [ "$lines" -lt "$small" ]; then
+    printf 'small\t%s changed line(s) so far, under this project'"'"'s small threshold of %s; re-measured from the real diff when the delta closes\n' "$lines" "$small"
+  elif [ "$lines" -lt "$significant" ]; then
+    printf 'significant\t%s changed line(s) so far, at or over %s and under %s (this project'"'"'s thresholds); re-measured at close\n' "$lines" "$small" "$significant"
+  else
+    printf 'evolution\t%s changed line(s) so far, at or over this project'"'"'s evolution threshold of %s; re-measured at close\n' "$lines" "$significant"
+  fi
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CLASS — the phrase -> class PROPOSAL (§4.1/§4.3)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# delta_classify_class <phrase>
+#   Four ordered keyword tiers, most-consequential first. Deliberately simple
+#   and transparent: it is a PROPOSAL the operator confirms in one keystroke,
+#   never a decision, so a cleverer classifier would buy accuracy the operator
+#   cannot audit at the cost of an explanation they can. §13-R9 records the
+#   thing that would change this: if the proposal is wrong often enough the
+#   confirm step becomes the quiz D2 rejected, and the fix is BETTER TIERS, not
+#   a second question.
+#
+#   ORDER IS THE WHOLE ALGORITHM. "a security fix for the production outage"
+#   contains all three lower tiers; security wins because a security-patch's
+#   obligations (dependency scan, SBOM, flagged note) are the ones most costly
+#   to discover you skipped. Ties never happen — the first matching tier returns.
+delta_classify_class() {
+  local phrase="${1:-}" p
+  p="$(printf '%s' "$phrase" | tr '[:upper:]' '[:lower:]')"
+  case "$p" in
+    *security*|*vulnerab*|*cve-*|*exploit*|*xss*|*csrf*|*injection*|*cvss*|*attacker*|*"auth bypass"*|*"privilege escalation"*|*"leaks credentials"*)
+      printf 'security-patch\tproposed from your wording, which names a security concern — a security-patch is a fix plus a dependency scan, an SBOM refresh and a flagged release note\n' ;;
+    *hotfix*|*production*|*outage*|*"in prod"*|*urgent*|*emergency*|*"right now"*|*"is down"*|*"are down"*)
+      printf 'hotfix\tproposed from your wording, which says this is live and now — a hotfix ships fast and owes a retro within days; a fix waits for the normal loop\n' ;;
+    *fix*|*broken*|*breaks*|*crash*|*bug*|*fail*|*error*|*regress*|*wrong*|*incorrect*|*"does not work"*|*"doesn't work"*|*throws*|*hang*|*corrupt*)
+      printf 'fix\tproposed from your wording — a fix is something broken that can wait for the normal loop; a hotfix is production, now\n' ;;
+    *)
+      printf 'feature\tproposed from your wording, which describes something new rather than something broken — a feature gets the full ceremony\n' ;;
+  esac
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SEVERITY — the BUGS.md row if one is referenced, else the Severity Guide
+# ─────────────────────────────────────────────────────────────────────────────
+
+# _delta_classify_bug_ref <phrase>
+#   The bare integer of a referenced bug, or nothing. `BUG-12`, `bug 12` and
+#   `bug #12` are all the shipped citation spellings (templates/generated/
+#   bugs.tmpl: "Cite bugs elsewhere as BUG-<#>, the # column, bare integer").
+_delta_classify_bug_ref() {
+  local p
+  p="$(printf '%s' "${1:-}" | tr '[:upper:]' '[:lower:]')"
+  printf '%s' "$p" | sed -n 's/.*bug[-# ]*\([0-9][0-9]*\).*/\1/p' | sed -n '1p'
+  return 0
+}
+
+# _delta_classify_bug_severity <project_root> <bug-number>
+#   The Severity cell of that row of BUGS.md, or nothing. The tracker's column
+#   order is fixed by the template's own "Do NOT change the table format" note
+#   and is already parsed by scripts/test-gate.sh, so reading columns 2 and 3
+#   here is the shipped grammar and not a new one.
+_delta_classify_bug_severity() {
+  local root="${1:-.}" num="${2:-}" f
+  f="${root%/}/BUGS.md"
+  case "$f" in ./*) f="${f#./}" ;; esac
+  [ -f "$f" ] || return 0
+  [ -n "$num" ] || return 0
+  awk -F'|' -v want="$num" '
+    /^[[:space:]]*\|/ {
+      id = $2; sev = $3
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", id)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", sev)
+      gsub(/\*/, "", sev)
+      if (id == want && sev ~ /^SEV-[1-4]$/) { print sev; exit }
+    }' "$f" 2>/dev/null || true
+  return 0
+}
+
+# delta_classify_severity <project_root> <class> <phrase>
+#   §4.2: "Proposed from the BUGS.md row if one exists, else from phrasing
+#   against the shipped Severity Guide's own definitions in
+#   templates/generated/bugs.tmpl". fix / hotfix / security-patch ONLY — a
+#   feature has no severity, and this returns an EMPTY value with a provenance
+#   that says why, so §4.3's transcript can still print four lines.
+#
+#   The keyword sets below are lifted from the Severity Guide's own Definition
+#   and Examples columns, so a project that edits its guide and its rows stays
+#   coherent with what this proposes. The per-class default at the end is the
+#   Guide read literally: a security concern IS the Guide's SEV-1 "security
+#   breach" row; a production outage IS its "app crash on core flow"; and an
+#   ordinary break with a workaround is its SEV-2.
+delta_classify_severity() {
+  local root="${1:-.}" class="${2:-}" phrase="${3:-}" p num sev
+  case "$class" in
+    fix|hotfix|security-patch) : ;;
+    *)
+      printf '\tnot applicable — severity is a fix, hotfix or security-patch attribute (§4.2); a feature does not carry one\n'
+      return 0 ;;
+  esac
+
+  num="$(_delta_classify_bug_ref "$phrase")"
+  if [ -n "$num" ]; then
+    sev="$(_delta_classify_bug_severity "$root" "$num")"
+    if [ -n "$sev" ]; then
+      printf '%s\tread from the BUG-%s row already in BUGS.md — the tracker is the record, this is not a second opinion\n' "$sev" "$num"
+      return 0
+    fi
+  fi
+
+  p="$(printf '%s' "$phrase" | tr '[:upper:]' '[:lower:]')"
+  case "$p" in
+    *"data loss"*|*"security breach"*|*"auth bypass"*|*corrupt*|*"cannot log in"*|*"can't log in"*|*"crash on login"*|*"nobody can"*|*"no one can"*|*"loses data"*|*"losing data"*)
+      printf 'SEV-1\tmatched the Severity Guide'"'"'s SEV-1 definition in BUGS.md (data loss, security breach, or a crash on a core flow) — SEV-1 cannot be deferred\n' ;;
+    *"workaround"*|*"broken but"*|*"wrong data"*|*"layout broken"*|*"significant"*)
+      printf 'SEV-2\tmatched the Severity Guide'"'"'s SEV-2 definition in BUGS.md (feature broken, workaround exists)\n' ;;
+    *minor*|*cosmetic*|*alignment*|*tooltip*|*"edge case"*|*typo*)
+      printf 'SEV-3\tmatched the Severity Guide'"'"'s SEV-3 definition in BUGS.md (minor UX, cosmetic, non-core edge case)\n' ;;
+    *"would be nice"*|*enhancement*|*polish*|*"nice to have"*|*optimi*)
+      printf 'SEV-4\tmatched the Severity Guide'"'"'s SEV-4 definition in BUGS.md (enhancement, suggestion, polish)\n' ;;
+    *)
+      case "$class" in
+        security-patch)
+          printf 'SEV-1\tno severity wording matched, so this defaults to the Severity Guide'"'"'s SEV-1 row, which is where a security breach sits\n' ;;
+        hotfix)
+          printf 'SEV-1\tno severity wording matched, so this defaults to the Severity Guide'"'"'s SEV-1 row — a hotfix is a live break on a core flow\n' ;;
+        *)
+          printf 'SEV-2\tno severity wording matched, so this defaults to the Severity Guide'"'"'s SEV-2 row (feature broken, workaround exists)\n' ;;
+      esac ;;
+  esac
+  return 0
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# gates_required — MATERIALISED AT OPEN (§7.1) FROM CLASS + CONFIRMED ATTRIBUTES
+# ─────────────────────────────────────────────────────────────────────────────
+
+# delta_classify_gates <project_root> <class> <risk> <level>
+#   A compact JSON array: the class's base row from `classes.<class>.gates`
+#   (§5.2), then the attribute toggles §5.2's right-hand column names —
+#   `risk: core` adds `attribute_toggles.risk_core`, `level: evolution` adds
+#   `attribute_toggles.level_evolution`. rc 1 on an unknown class, so a typo can
+#   never materialise an EMPTY gate set (which would be a delta with no
+#   obligations that looked exactly like a well-formed one).
+#
+#   MATERIALISED, NOT RECOMPUTED (§7.1). The result is written into the state
+#   document at open and never re-derived at close: recomputing "would let a
+#   policy edit mid-delta silently drop a gate the operator had already been told
+#   about". Attribute RAISES append to it (WP4); nothing ever removes from it.
+#
+#   `touch_trigger` is deliberately NOT applied here. It is a §8.1 re-fire
+#   trigger keyed on what gets touched during the work, not an attribute
+#   confirmed at open, and WP6 owns it. Materialising it now would put a gate on
+#   the row before anything had triggered it.
+#
+#   ORDER-PRESERVING DE-DUPLICATION, not `unique`. `unique` sorts, and the base
+#   row's order is §5.2's reading order; a sorted row is the same SET and a worse
+#   checklist. A toggle that names a gate the class already carries is a no-op
+#   rather than a duplicate — which is exactly what happens for a `feature` at
+#   `risk: core`, since `brief_review` is already in the feature row.
+delta_classify_gates() {
+  local root="${1:-.}" class="${2:-}" risk="${3:-}" level="${4:-}"
+  local base toggle_core="[]" toggle_evo="[]" out
+  if [ -z "$class" ]; then
+    printf '%s\n' "delta-classify: a class is required to materialise gates_required" >&2
+    return 1
+  fi
+  if ! base="$(delta_policy_get "$root" "classes.$class.gates")"; then
+    printf '%s\n' "delta-classify: no gate list for class '$class' — the four classes are feature, fix, hotfix and security-patch (§4.1). Nothing was materialised." >&2
+    return 1
+  fi
+  toggle_core="$(delta_policy_get "$root" "attribute_toggles.risk_core")" || toggle_core="[]"            # DELTA-CLASSIFY-TOGGLE-RISKCORE
+  toggle_evo="$(delta_policy_get "$root" "attribute_toggles.level_evolution")" || toggle_evo="[]"        # DELTA-CLASSIFY-TOGGLE-LEVELEVO
+  if ! out="$(jq -c -n \
+      --argjson base "$base" --argjson tc "$toggle_core" --argjson te "$toggle_evo" \
+      --arg risk "$risk" --arg level "$level" '
+        (( $base // [] )
+         + (if $risk  == "core"      then ($tc // []) else [] end)
+         + (if $level == "evolution" then ($te // []) else [] end))
+        | map(select(type == "string"))
+        | reduce .[] as $g ([]; if (index($g) != null) then . else . + [$g] end)
+      ' 2>/dev/null)"; then
+    printf '%s\n' "delta-classify: could not materialise gates_required for class '$class'. Nothing was materialised." >&2
+    return 1
+  fi
+  printf '%s\n' "$out"
+  return 0
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -270,6 +270,70 @@ if [ -f ".claude/process-audit.log" ]; then
   fi
 fi
 
+# ── THE ERA ASSERTION — REPORT-ONLY BY CONSTRUCTION ──────────────────────────
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §10.1 (the invariant
+# `active_delta != null => current_phase == 4` and its SECOND enforcement point),
+# §11-WP3.
+#
+# The load-bearing enforcement of that invariant is a REFUSAL at open, in the
+# post-1.0 track's own front door, and it is not here. This is the other half:
+# §10.1 observes that this script "already reads phase-state.json::current_phase
+# and already warns on a phase/artifact mismatch", and that an open piece of
+# post-release work at phase < 4 "is that same class of inconsistency and belongs
+# in that same report."
+#
+# ── THE `[WARN]` TRAP, AND WHY THIS ARM CALLS `warn` AND NOT `fail` ──────────
+# CLAUDE.md's trap is that in check-phase-gate.sh the `[WARN]`/`[FAIL]` TEXT is
+# cosmetic — the exit predicate is a counter, so a "WARN" arm that increments it
+# BLOCKS, and two arms printing the same word can have opposite outcomes. This
+# script has the same shape: it ends `exit $errors`, `fail` increments `errors`,
+# and `warn` increments `warnings`, which nothing reads. So the choice of helper
+# IS the choice of exit behaviour, and this arm is deliberately REPORT-ONLY:
+#   • validate.sh is a drift report an operator runs voluntarily. Turning a
+#     recoverable state inconsistency into a non-zero exit here would fail
+#     pipelines that run it advisorily, for a condition the operator may be
+#     halfway through resolving.
+#   • The refusal that actually protects the invariant is unconditional and
+#     lives at open. This one only has to be SEEN.
+# tests/test-delta-wp3-era-classify.sh pins it in BOTH directions on the EXIT
+# CODE, never the label: the report fires, and the exit code is identical to the
+# same tree without the inconsistency. Its m5 mutation swaps this one `warn` for
+# `fail` and requires the exit-code-unchanged assertion to go RED.
+#
+# ── WHY THE READ IS A SEAM CALL AND NOT A `jq` ──────────────────────────────
+# This script is CORE. The post-1.0 track is a SEVERABLE MODULE (D1) and
+# scripts/lint-delta-boundary.sh forbids every core file from naming a module
+# path on an executed line (§3.3 clause 2, tier T1 — NOT inline-waivable), with a
+# file-level seam allowlist whose cardinality is asserted at exactly ONE. So the
+# obvious implementation — `jq -r '.active_delta.id' .claude/…` — is unavailable:
+# that JSON file is a T1 path, and naming it in a core file is precisely the
+# fusion the lint exists to stop. The read therefore routes core -> core through
+# the ONE seam, exactly as scripts/upgrade-project.sh's policy notice does; this
+# is the SECOND instance of that waived routing, which is expected and recorded.
+# The residue is the one waived line below: reaching the seam means naming a seam
+# ACTION FLAG, and every seam action carries the `delta-` prefix by design, which
+# is exactly what tier T2 scans for. T2 exists WITH a reason-required inline
+# waiver for this case. Do not rename the action to hide the prefix — that evades
+# the scan below the prefix boundary (§13-R15) and buys nothing.
+#
+# FAIL-SOFT: a framework without the module installed, an older vendored seam
+# that does not know the action, or a project with no record at all are all a
+# silent no-op. A validation report must never fail because an advisory read
+# could not be made.
+_postmvp_era_assertion() {
+  local seam="$SCRIPT_DIR/process-checklist.sh" doc="" open_id=""
+  [ -f "$seam" ] || return 0
+  command -v jq >/dev/null 2>&1 || return 0
+  [ "$phase" -lt 4 ] || return 0
+  doc=$( bash "$seam" --delta-state-read </dev/null 2>/dev/null ) || return 0   # lint-delta-boundary: allow core->core delegation to the ONE declared seam — this names the seam's action FLAG, never a module path (T1 is clean) and the seam allowlist stays at cardinality 1 (§3.1/§3.3)
+  [ -n "$doc" ] || return 0
+  open_id=$(printf '%s\n' "$doc" | jq -r '.active_delta.id // ""' 2>/dev/null || echo "")
+  [ -n "$open_id" ] || return 0
+  warn "Post-release work $open_id is recorded as open, but this project is at phase $phase — that work only exists after launch (phase 4). One of the two records is wrong."   # DELTA-ERA-REPORT-ONLY
+  return 0
+}
+_postmvp_era_assertion
+
 # ================================================================
 # 6. Approval Log Completeness
 # ================================================================

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1675,8 +1675,10 @@ run_child_suite "tests/test-delta-wp2-state-policy.sh" \
 # second-activation refusal -> a double-open overwrites -> A1 RED; hardcode a
 # size threshold -> the policy-retune case D3 RED; drop an attribute_toggle
 # read -> risk:core stops adding brief_review -> G2 RED; swap the validate.sh
-# arm's warn for fail -> V1's exit-code-unchanged pin RED; a near-miss waiver
-# spelling -> the boundary lint reds. Never executes init.sh -> both lanes.
+# arm's warn for fail -> the exit code moves while the arm's message body does
+# not, so V1's exit-code-unchanged pin goes RED; replace the waived seam
+# invocation -> the lint un-reds AND the arm falls silent, so V3's rc 0->1 is
+# the waiver's absence and nothing else. Never executes init.sh -> both lanes.
 run_child_suite "tests/test-delta-wp3-era-classify.sh" \
   "tests/test-delta-wp3-era-classify.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1662,6 +1662,23 @@ run_child_suite "tests/test-delta-wp0-inherited-predicates.sh" \
 # lint-delta-boundary rc=1. Copies init.sh (never executes it) -> both lanes.
 run_child_suite "tests/test-delta-wp2-state-policy.sh" \
   "tests/test-delta-wp2-state-policy.sh"
+# Delta Track WP3: the ERA INVARIANT (§10.1) — `active_delta != null =>
+# current_phase == 4` — at both of its enforcement points, plus the
+# second-activation refusal WP2 explicitly deferred here (§7.1), the §4.2
+# derivations in scripts/lib/delta-classify.sh, §5.2's gates_required
+# materialisation, and §4.3's confirm-not-quiz transcript. Exit codes only,
+# never labels: §10.1 repeats CLAUDE.md's [WARN] trap specifically for the
+# scripts/validate.sh arm, which is REPORT-ONLY and is pinned in BOTH
+# directions (the report fires; the exit code does not move). Mutation-proved
+# IN THE SUITE (m1-m6, each mutant built and run): neuter the phase refusal ->
+# an open at phase 2 succeeds -> E1 RED on the exit code; neuter the
+# second-activation refusal -> a double-open overwrites -> A1 RED; hardcode a
+# size threshold -> the policy-retune case D3 RED; drop an attribute_toggle
+# read -> risk:core stops adding brief_review -> G2 RED; swap the validate.sh
+# arm's warn for fail -> V1's exit-code-unchanged pin RED; a near-miss waiver
+# spelling -> the boundary lint reds. Never executes init.sh -> both lanes.
+run_child_suite "tests/test-delta-wp3-era-classify.sh" \
+  "tests/test-delta-wp3-era-classify.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 run_child_suite "tests/test-check-phase-gate-poc-block-contract.sh" \
   "tests/test-check-phase-gate-poc-block-contract.sh"

--- a/tests/test-delta-wp3-era-classify.sh
+++ b/tests/test-delta-wp3-era-classify.sh
@@ -31,7 +31,8 @@
 #
 #   E — THE ERA INVARIANT (§10.1), the load-bearing refusal
 #     E1  --open REFUSED at phases 0, 1, 2, 3 and ALLOWED at 4  KILLS m1
-#     E2  a refused open writes NOTHING — no state file appears
+#     E2  a refused open writes NOTHING — asserted over the WHOLE tree with
+#         `find`, not against one expected filename
 #     E3  an unreadable / absent phase records fails CLOSED (refused), because
 #         "cannot tell" must not read as "phase 4"
 #
@@ -76,7 +77,8 @@
 #         a provenance parenthetical, and the one-question footer. Shape, not
 #         prose — the wording is the design's and may be tuned.
 #     T2  a scripted run with nobody to confirm REFUSES rather than
-#         auto-accepting a side-effectful open (the repo's hard-N policy)
+#         auto-accepting a side-effectful open (the repo's hard-N policy), and
+#         leaves no new file of ANY kind — the same whole-tree evidence E2 owes
 #
 #   S — --status
 #     S1  reports "no delta open" and then the open delta, rc 0 both ways
@@ -101,6 +103,17 @@
 #     intact);
 #   • EXACTLY ONE LINE changed (one `<` and one `>` in the diff), so a mutation
 #     cannot quietly demolish half the file and credit the RED to the guard.
+#
+# AND THE ADDRESS MUST NAME THE THING BEING DISPROVED. Those three checks are
+# necessary and not sufficient: they all pass for a sed that cleanly mutates one
+# line of the WRONG code. m6's first cut did exactly that — it neutered the arm's
+# `warn` line while asserting something about the seam invocation two lines
+# above, which survived untouched, so its assertion could not fail. An
+# adversarial review caught it. A mutation whose expected result is that
+# something does NOT happen (a lint staying clean, a report staying silent) is
+# the shape most at risk, because a mis-aimed sed produces exactly the answer the
+# test wants. Every such row here now also asserts a POSITIVE consequence of the
+# mutation having landed — see m6.
 #
 # FRESH-FIXTURE ISOLATION. Every mutation builds its own mktemp project. m2's
 # case in particular MUST start from a tree where the era guard would pass
@@ -302,15 +315,20 @@ else
 fi
 rm -rf "$T"
 
-# ── E2: a refused open writes NOTHING ───────────────────────────────────────
+# ── E2: a refused open writes NOTHING — the WHOLE tree, not just one file ───
+# `find`, not a single `[ -e ]`: a refusal that says "nothing was opened" is a
+# claim about the FILESYSTEM, and checking one expected filename cannot see a
+# file nobody thought to look for. (That is not hypothetical — the
+# no-confirmation refusal at T2 was leaving a freshly seeded policy file behind
+# while printing exactly that sentence, and only the whole-tree form catches it.)
 T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 2
 delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
 rc=$?
-created=n; [ -e "$P/.claude/delta-state.json" ] && created=y
-if [ "$rc" -eq 3 ] && [ "$created" = n ]; then
-  pass "E2: a refused open creates no state at all (rc $rc, state file created=$created) — the refusal is before the write, not a write that is later undone"
+left="$( ( cd "$P" && find . -type f | LC_ALL=C sort ) | tr '\n' ' ')"
+if [ "$rc" -eq 3 ] && [ "$left" = "./.claude/phase-state.json " ]; then
+  pass "E2: a refused open leaves the project byte-for-byte as it found it (rc $rc; the tree still holds exactly the one file it started with) — the refusal is before every write, not a write that is later undone"
 else
-  fail_ "E2" "rc=$rc (expect 3); state file created=$created (expect n)"
+  fail_ "E2" "rc=$rc (expect 3); files after the refusal='$left' (expect exactly './.claude/phase-state.json ')"
 fi
 rm -rf "$T"
 
@@ -691,12 +709,17 @@ rm -rf "$T"
 # auto-proceed just because the operator was absent.
 T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
 out=$(delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode"); rc=$?
-created=n; [ -e "$P/.claude/delta-state.json" ] && created=y
+# THE SAME WHOLE-TREE ASSERTION E2 MAKES, and for the same reason: this refusal
+# prints "nothing was opened" too, so it owes the same evidence. It used to leave
+# a freshly seeded policy file behind — the seed ran before the confirm gate —
+# and the old single-filename check could not see it. The seed now sits AFTER
+# confirmation; this is what holds it there.
 shown=n; printf '%s' "$out" | grep -qF '[1] Keep all four' && shown=y
-if [ "$rc" -eq 2 ] && [ "$created" = n ] && [ "$shown" = y ]; then
-  pass "T2: a scripted run with no terminal and no --confirm still SHOWS the proposal, then refuses (rc $rc) and opens nothing — confirmation is never assumed from silence"
+left="$( ( cd "$P" && find . -type f | LC_ALL=C sort ) | tr '\n' ' ')"
+if [ "$rc" -eq 2 ] && [ "$left" = "./.claude/phase-state.json " ] && [ "$shown" = y ]; then
+  pass "T2: a scripted run with no terminal and no --confirm still SHOWS the proposal, then refuses (rc $rc) and leaves NO new file of any kind — confirmation is never assumed from silence, and the refusal's own sentence is true of the whole tree"
 else
-  fail_ "T2" "rc=$rc (expect 2); state file created=$created (expect n); transcript shown=$shown (expect y)"
+  fail_ "T2" "rc=$rc (expect 2); files after the refusal='$left' (expect exactly './.claude/phase-state.json '); transcript shown=$shown (expect y)"
 fi
 rm -rf "$T"
 
@@ -819,43 +842,107 @@ fi
 rm -rf "$T"
 
 # ── m5: make the validate.sh arm BLOCKING -> V1's exit-code pin goes RED ───
-# THE `[WARN]` TRAP, IN BOTH DIRECTIONS. One character of intent — `warn` for
-# `fail` — changes nothing about the printed line's meaning and everything about
-# the script's exit status. This is the mutation that proves V1 is asserting the
-# code and not the banner.
+# THE `[WARN]` TRAP, STATED PRECISELY.
+#
+# WHAT MOVES under `warn` -> `fail`, measured rather than assumed: the EXIT CODE
+# (13 -> 14), the printed LABEL (`[WARN]` -> `[FAIL]`, because print_warn and
+# print_fail are different functions), and the summary counter line
+# (13 errors/11 warnings -> 14/10).
+#
+# WHAT DOES NOT MOVE: the arm's own MESSAGE — every character after the label.
+# The operator reads the same sentence in both trees.
+#
+# THAT ASYMMETRY IS THE TRAP. An earlier version of this row claimed the output
+# was "byte-identical", which is false and was refuted by an adversarial review
+# on the first pass. The correction matters beyond tidiness: if the output really
+# were unchanged, a test could not tell the two trees apart at all, and the row
+# would be arguing for something stronger than what is true. What IS true is
+# sharper and is the whole lesson — the visible difference is COSMETIC (a label,
+# a tally) while the consequential difference is the exit status, so a reader
+# checking the banner learns nothing about whether the arm blocks. Hence V1
+# asserts the code. This row now measures all three quantities and asserts each
+# in the direction execution shows.
 T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
 _sed_inplace "$MT/scripts/validate.sh" '/# DELTA-ERA-REPORT-ONLY$/s@warn @fail @'
 rep="$(_mutation_report "$REPO_ROOT/scripts/validate.sh" "$MT/scripts/validate.sh" 'DELTA-ERA-REPORT-ONLY$')"
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 Pn="$T/none"; mk_validate_proj "$Pn" 2
+validate_run "$REPO_ROOT/scripts" "$Pn" >/dev/null 2>&1; pri_none=$?
 validate_run "$MT/scripts" "$Pn" >/dev/null 2>&1; mut_none=$?
 Po="$T/open"; mk_validate_proj "$Po" 2
 printf '%s\n' '{"schemaVersion":1,"active_delta":{"id":"DELTA-007","slug":"dark-mode"},"hotfix_retros":[],"cadence":{},"closed":[]}' \
   > "$Po/.claude/delta-state.json"
+pri_out=$(validate_run "$REPO_ROOT/scripts" "$Po"); pri_open=$?
 mut_out=$(validate_run "$MT/scripts" "$Po"); mut_open=$?
-still_reported=n; printf '%s' "$mut_out" | grep -qF 'DELTA-007' && still_reported=y
+# The message BODY, with the label (and any colour escape before it) cut away:
+# everything from the arm's first content word onward.
+_arm_msg() { printf '%s\n' "$1" | grep -F 'Post-release work' | sed -e 's/^.*Post-release work/Post-release work/'; }
+pri_msg="$(_arm_msg "$pri_out")"
+mut_msg="$(_arm_msg "$mut_out")"
 if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
-   && [ "$mut_open" -ne "$mut_none" ] && [ "$still_reported" = y ]; then
-  pass "m5: swapping the arm's warn for fail moves validate.sh's exit code (rc $mut_none -> $mut_open) while the PRINTED LINE is unchanged (still reported=$still_reported) — V1 goes RED, and this is the [WARN] trap in one line (marker sites=$sites, one line changed=$nlines/2)"
+   && [ "$pri_open" -eq "$pri_none" ] && [ "$mut_open" -ne "$mut_none" ] \
+   && [ -n "$pri_msg" ] && [ "$pri_msg" = "$mut_msg" ]; then
+  pass "m5: swapping the arm's warn for fail moves validate.sh's EXIT CODE (pristine rc $pri_none==$pri_open, mutant rc $mut_none -> $mut_open) while the arm's MESSAGE BODY is character-for-character the same in both trees — only the [WARN]/[FAIL] label and the summary tally move with it. V1 goes RED. That asymmetry IS the [WARN] trap: what a reader sees changes cosmetically, what the exit predicate does changes completely (marker sites=$sites, one line changed=$nlines/2)"
 else
-  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc without delta=$mut_none, with delta=$mut_open (must DIFFER); line still printed=$still_reported (expect y — the point is that the OUTPUT does not move)"
+  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc none=$pri_none open=$pri_open (must be EQUAL — that is V1); MUTANT rc none=$mut_none open=$mut_open (must DIFFER); message body pristine='$pri_msg' mutant='$mut_msg' (must be non-empty and IDENTICAL — the label flips, the sentence does not)"
 fi
 rm -rf "$T"
 
-# ── m6: strip the T2 waiver -> the boundary lint reds -> V3 RED ────────────
-# The lint-forced-routing pin, mutated. Covered inside V3 itself (control vs
-# stripped), so this row asserts the OTHER half: that the waiver's absence is
-# what reds it, and not the seam invocation merely existing.
+# ── m6: the waived line is the ONLY thing the waiver waives -> V3 RED ─────
+# THE TRIANGULATION V3 CANNOT DO ALONE. V3 strips the waiver and keeps the
+# invocation: lint rc 0 -> 1. That alone is consistent with a lint that reds on
+# this tree for some reason having nothing to do with either. The missing leg is
+# the third corner — REMOVE THE INVOCATION and the lint must go clean again.
+#
+# THE FIRST CUT OF THIS ROW AIMED THE WRONG SED. It addressed
+# `# DELTA-ERA-REPORT-ONLY$` — the `warn` line — which leaves the waived seam
+# invocation fully intact at its original line, so the boundary lint's verdict
+# was trivially identical to the control's and `rc 0` COULD NOT FAIL. It was a
+# vacuous assertion that read like a proof, caught by an adversarial review on
+# the first pass. It is the exact defect class this suite's header warns about,
+# committed by this suite. The address now names the WAIVED LINE ITSELF.
+#
+# And because "the lint is clean" is a NEGATIVE result — the same answer a
+# broken lint would give — this arm no longer stops there. It asserts the removal
+# was REAL, in two ways, and the SECOND one is the load-bearing one:
+#
+#   (a) BEHAVIOURAL: with the invocation gone the arm can no longer read the
+#       record, so it falls silent and V1's detection half goes RED.
+#   (b) STRUCTURAL, AND THIS IS THE DISCRIMINATOR: the mutant tree contains
+#       ZERO seam invocations where the pristine tree contains exactly ONE.
+#
+# (b) exists because a meta-counterfactual on this very row showed (a) is NOT
+# enough. Re-aim the sed back at the `warn` line — the refuted first cut — and
+# the arm ALSO falls silent (its printer was just neutered) and the lint is ALSO
+# clean (the invocation it waives is untouched), so every other assertion here
+# still passes and the row goes green while proving nothing. Only counting the
+# invocation itself tells the two mutants apart. Generalise the lesson: when a
+# mutation's expected result is an absence, assert the absence of the THING YOU
+# EDITED, not merely of its downstream effect — several different edits share the
+# same downstream effect.
 T=$(mktemp -d); MT="$T/tree"; mk_scripts_tree "$MT"
-_sed_inplace "$MT/scripts/validate.sh" '/# DELTA-ERA-REPORT-ONLY$/s@.*@  return 0@'
-after_arm_rc=0; bash "$LINTER" --root "$MT" >/dev/null 2>&1 || after_arm_rc=$?
+_sed_inplace "$MT/scripts/validate.sh" '/# lint-delta-boundary: allow/s@.*@  :@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/validate.sh" "$MT/scripts/validate.sh" '# lint-delta-boundary: allow')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+# The seam invocation, counted directly. (tests/ is outside the boundary lint's
+# CORE set, so naming the action here costs nothing.)
+seam_pristine="$(grep -c 'delta-state-read' "$REPO_ROOT/scripts/validate.sh" || true)"
+seam_mutant="$(grep -c 'delta-state-read' "$MT/scripts/validate.sh" || true)"
+no_seam_rc=0; bash "$LINTER" --root "$MT" >/dev/null 2>&1 || no_seam_rc=$?
+Pq="$T/open"; mk_validate_proj "$Pq" 2
+printf '%s\n' '{"schemaVersion":1,"active_delta":{"id":"DELTA-007","slug":"dark-mode"},"hotfix_retros":[],"cadence":{},"closed":[]}' \
+  > "$Pq/.claude/delta-state.json"
+quiet_out=$(validate_run "$MT/scripts" "$Pq"); quiet_rc=$?
+went_quiet=y; printf '%s' "$quiet_out" | grep -qF 'DELTA-007' && went_quiet=n
 MT2="$T/tree2"; mk_scripts_tree "$MT2"
 _sed_inplace "$MT2/scripts/validate.sh" 's|lint-delta-boundary: allow|lint-delta-boundary: allowed because|'
 typo_rc=0; bash "$LINTER" --root "$MT2" >/dev/null 2>&1 || typo_rc=$?
-if [ "$after_arm_rc" -eq 0 ] && [ "$typo_rc" -eq 1 ]; then
-  pass "m6: the waiver is what waives — a NEAR-MISS spelling ('allowed because …') is not the marker and reds the lint (rc $typo_rc), while removing the invocation entirely leaves it clean (rc $after_arm_rc). The exemption fails CLOSED, so a typo cannot silently waive a real edge"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$seam_pristine" = "1" ] && [ "$seam_mutant" = "0" ] \
+   && [ "$no_seam_rc" -eq 0 ] && [ "$went_quiet" = y ] && [ "$typo_rc" -eq 1 ]; then
+  pass "m6: the sed reached the seam invocation itself (pristine carries $seam_pristine, the mutant carries $seam_mutant), which takes the lint back to clean (rc $no_seam_rc) AND silences the arm (rc $quiet_rc, no report) — so V3's rc 0->1 is caused by the waiver's absence and nothing else. A NEAR-MISS marker spelling ('allowed because …') waives nothing and reds the lint (rc $typo_rc), so the exemption fails CLOSED (marker sites=$sites, one line changed=$nlines/2)"
 else
-  fail_ "m6" "lint rc with the arm removed=$after_arm_rc (expect 0); lint rc with a near-miss waiver spelling=$typo_rc (expect 1)"
+  fail_ "m6" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); seam invocations pristine=$seam_pristine (expect 1) mutant=$seam_mutant (expect 0 — if this is 1 the sed missed the invocation and every assertion below is vacuous); lint rc with the invocation replaced=$no_seam_rc (expect 0); arm fell silent=$went_quiet (expect y); lint rc with a near-miss waiver spelling=$typo_rc (expect 1)"
 fi
 rm -rf "$T"
 

--- a/tests/test-delta-wp3-era-classify.sh
+++ b/tests/test-delta-wp3-era-classify.sh
@@ -1,0 +1,864 @@
+#!/usr/bin/env bash
+# tests/test-delta-wp3-era-classify.sh — Delta Track WP3.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §10.1 (the era invariant
+# `active_delta != null => current_phase == 4`, its two enforcement points, and
+# the [WARN]-trap warning), §10.2 (no new machinery for monotonicity), §4.1–§4.3
+# (the four classes, the derived-then-confirmed attributes, confirm-not-quiz on
+# the `# BL-204-PREFILL` pattern), §5.2 (the gate table the classifier feeds),
+# §7.1 (gates_required materialised AT OPEN; the single-writer rule), §7.2 (the
+# policy keys every derivation reads), §11-WP3.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose: no backlog
+# entry exists for this build and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1 and
+# WP2 precedent.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES, NEVER LABELS
+#
+# Every assertion below reads a process EXIT CODE, a JSON value read back off
+# disk, or a byte-level md5. None reads a printed [OK]/[WARN]/[FAIL] banner.
+# CLAUDE.md's `[WARN]` trap is precisely that the label and the exit predicate
+# can disagree — in check-phase-gate.sh two arms printing the same word have
+# opposite gate outcomes because one increments a counter — and §10.1 repeats
+# the warning specifically for this WP. The validate.sh arm (V1/m5) is where it
+# bites hardest, and it is asserted in BOTH directions on the exit code.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THIS SUITE PINS, AND WHICH MUTANT EACH ROW KILLS
+#
+#   E — THE ERA INVARIANT (§10.1), the load-bearing refusal
+#     E1  --open REFUSED at phases 0, 1, 2, 3 and ALLOWED at 4  KILLS m1
+#     E2  a refused open writes NOTHING — no state file appears
+#     E3  an unreadable / absent phase records fails CLOSED (refused), because
+#         "cannot tell" must not read as "phase 4"
+#
+#   A — SECOND ACTIVATION (§7.1) — the refusal WP2 explicitly DEFERRED to WP3
+#     A1  a second --open while a delta is open is REFUSED, names the open
+#         delta, and leaves the first delta's row BYTE-IDENTICAL      KILLS m2
+#     A2  the other direction: nulling active_delta through the seam unblocks
+#         the next open. Without this the refusal could be a script that always
+#         refuses, which is not a guard.
+#
+#   D — THE §4.2 DERIVATIONS
+#     D1  the phrase->class tiers, in order (security > hotfix > fix > feature)
+#     D2  risk: a REAL git diff intersected with the policy's risk_surfaces;
+#         and the §13-R4 residual — an EMPTY risk_surfaces makes every delta
+#         feature-local, stated in the provenance rather than implied
+#     D3  level: measured from a REAL git diff against the policy brackets, and
+#         a policy RETUNE moves the bracket                            KILLS m3
+#     D4  severity: from the BUGS.md row when one is cited; from phrasing
+#         otherwise; NONE for a feature
+#
+#   R — RAISE FREE, LOWER REASON-RECORDED (§4.2)
+#     R1  a raise sticks and toggles the extra gate
+#     R2  a lower with no reason available is REFUSED (exit 5), writes nothing
+#     R3  a lower WITH a reason is recorded on the delta's own row
+#
+#   G — gates_required MATERIALISED AT OPEN (§7.1) FROM §5.2
+#     G1  each of the four classes yields its §5.2 base row, exactly
+#     G2  risk: core adds brief_review                                 KILLS m4
+#     G3  level: evolution adds brief
+#     G4  the toggles are READ FROM POLICY: a project that retunes
+#         attribute_toggles gets ITS gate, not the framework's
+#
+#   V — THE validate.sh ARM (§10.1's second enforcement point)
+#     V1  the report FIRES at phase < 4 with a delta open, and the EXIT CODE is
+#         identical to the same fixture without one                    KILLS m5
+#     V2  at phase 4 the same state is CONSISTENT and nothing is reported
+#     V3  the lint-forced routing is real: validate.sh reaches the state through
+#         the ONE seam and its inline T2 waiver is load-bearing        KILLS m6
+#
+#   T — CONFIRM, DO NOT QUIZ (§4.3)
+#     T1  the transcript's SHAPE: "You said", four labelled lines EACH carrying
+#         a provenance parenthetical, and the one-question footer. Shape, not
+#         prose — the wording is the design's and may be tuned.
+#     T2  a scripted run with nobody to confirm REFUSES rather than
+#         auto-accepting a side-effectful open (the repo's hard-N policy)
+#
+#   S — --status
+#     S1  reports "no delta open" and then the open delta, rc 0 both ways
+#
+#   B — BOUNDARY (D1), cited not re-implemented
+#     B1  the real tree is clean, the seam allowlist is still cardinality ONE,
+#         and both new module files are in the DELTA manifest
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# COUNTERFACTUAL DISCIPLINE — how the mutations below are built
+#
+# Each mutation is an ANCHORED SINGLE-SITE neuter: the address is a marker
+# comment pinned to END-OF-LINE (`/# DELTA-OPEN-ERA-GUARD$/`), never a bare
+# substring. WP2's suite records why: an unanchored `/SHAPE-ATOM-CLOSED/` also
+# matches SHAPE-ATOM-CLOSED-ROWS, neuters two atoms at once, and credits the
+# resulting RED to the wrong one — a sweep that over-matches produces false
+# GREEN pins, which is worse than no sweep. So every mutation here asserts
+# THREE things before it believes its own result:
+#   • the marker resolves to EXACTLY ONE line in the pristine file (site count);
+#   • the mutated file DIFFERS from the pristine one (anti-tautology — a sed
+#     that matched nothing would otherwise "prove" the guard by leaving it
+#     intact);
+#   • EXACTLY ONE LINE changed (one `<` and one `>` in the diff), so a mutation
+#     cannot quietly demolish half the file and credit the RED to the guard.
+#
+# FRESH-FIXTURE ISOLATION. Every mutation builds its own mktemp project. m2's
+# case in particular MUST start from a tree where the era guard would pass
+# (phase 4) — run it at phase 2 and the era guard refuses first, the
+# second-activation guard never executes, and the mutant looks pinned when it is
+# not. That masking is the exact failure WP2's sweep found twice.
+#
+# MODE-PRESERVING HARNESS. `_sed_inplace` reads each file's mode and puts it
+# back. The obvious spelling ends `chmod +x`, which silently turns a sourced
+# 0644 lib into 0755; `git status` shows only "M" and the mode rides along in
+# the next commit. That trap fired three times on this wave — do not
+# "simplify" the mode dance away.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# HERMETICITY: every fixture is a mktemp -d project carrying NO init.sh and NO
+# templates/generated, so guard_not_in_framework sees a project and not the
+# framework. Git fixtures configure an identity and unset GITHUB_BASE_REF. No
+# remote is ever created; nothing reaches the network; nothing is written inside
+# the checkout. bash-3.2 safe: no associative arrays, no ${var,,}, no ((x++)).
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name init.sh — the boundary-lint
+# fixtures satisfy the vacuity floor from scripts/ alone.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LINTER="$REPO_ROOT/scripts/lint-delta-boundary.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for tests/test-delta-wp3-era-classify.sh" >&2
+  exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-delta-wp3-era-classify.sh" >&2
+  exit 2
+fi
+
+# Portable md5 of a single file (macOS `md5 -q`, Linux `md5sum`) — house pattern.
+_md5file() {
+  if command -v md5 >/dev/null 2>&1; then md5 -q "$1"
+  else md5sum "$1" | awk '{print $1}'; fi
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+# A bare project at a given phase: enough for delta.sh and the seam, no git.
+mk_proj() {
+  local d="$1" phase="$2"
+  mkdir -p "$d/.claude"
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":%s,"phases":{}}\n' \
+    "$phase" > "$d/.claude/phase-state.json"
+}
+
+# The same, plus the four framework-file stubs scripts/validate.sh reads before
+# it gets to the phase section. It still reports plenty of missing artifacts —
+# that is fine and deliberate: V1 asserts the exit code is UNCHANGED between two
+# otherwise-identical trees, not that it is zero. A pristine fixture would be a
+# weaker pin, because it would only prove the arm is silent in the one
+# configuration where nothing else has anything to say.
+mk_validate_proj() {
+  local d="$1" phase="$2"
+  mk_proj "$d" "$phase"
+  mkdir -p "$d/docs/reference" "$d/docs/platform-modules"
+  {
+    printf '%s\n' '- **Project:** fixture'
+    printf '%s\n' '- **Platform:** web'
+    printf '%s\n' '- **Track:** light'
+    printf '%s\n' '- **Primary Language:** python'
+  } > "$d/CLAUDE.md"
+}
+
+# A REAL git project, so the §4.2 derivations run against a real
+# `git diff --name-only` / `--shortstat` rather than a hand-fed list. Two
+# tracked files: one under a path a project would plausibly call a risk surface,
+# one that is plainly not.
+mk_git_proj() {
+  local d="$1" phase="$2"
+  mk_proj "$d" "$phase"
+  mkdir -p "$d/src/auth" "$d/src/ui"
+  printf 'base\n' > "$d/src/auth/login.ts"
+  printf 'base\n' > "$d/src/ui/theme.ts"
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.local && git config user.name T \
+      && unset GITHUB_BASE_REF && git add -A && git commit -q -m init ) >/dev/null 2>&1
+}
+
+# grow <file> <n> — append exactly n lines, so `git diff --shortstat` reports a
+# KNOWN insertion count and the level bracket is a measurement and not a guess.
+grow() {
+  local f="$1" n="$2" i=1
+  while [ "$i" -le "$n" ]; do printf 'added line %s\n' "$i" >> "$f"; i=$((i + 1)); done
+}
+
+write_policy() { printf '%s\n' "$2" > "$1/.claude/delta-policy.json"; }
+
+# Copy the framework's scripts/ tree so a MUTATED module can be run without
+# touching the checkout. Nothing else is copied: init.sh is neither referenced
+# nor needed, and the boundary-lint fixtures reach their vacuity floor from
+# scripts/ alone.
+mk_scripts_tree() {
+  mkdir -p "$1"
+  cp -R "$REPO_ROOT/scripts" "$1/scripts"
+}
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+# delta_run <scripts-dir> <project-dir> [args…] — stdout+stderr merged; the
+# subshell's exit code is the script's.
+delta_run() {
+  local sd="$1" p="$2"; shift 2
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/delta.sh" "$@" </dev/null 2>&1 )
+}
+
+# seam <scripts-dir> <project-dir> [args…] — the single writer, used by the
+# tests only where a test must ARRANGE state (A2 closes a delta). Assertions
+# read the file directly; arrangements go through the seam, exactly like
+# production.
+seam() {
+  local sd="$1" p="$2"; shift 2
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/process-checklist.sh" "$@" </dev/null 2>/dev/null )
+}
+
+validate_run() {
+  local sd="$1" p="$2"
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/validate.sh" </dev/null 2>&1 )
+}
+
+# active_json <project-dir> [jq-flags…] <filter> — read an assertion straight
+# off the state file the seam wrote. Assertions read the FILE, never a printed
+# banner. A missing or unreadable file yields the literal READ-FAILED, which no
+# expectation below ever matches — a helper that returned "" would let an
+# absent file satisfy any "must not contain X" assertion, and that is precisely
+# the vacuous-pin class this suite exists to avoid.
+active_json() {
+  local p="$1"; shift
+  jq "$@" "$p/.claude/delta-state.json" 2>/dev/null || printf 'READ-FAILED'
+}
+
+# ── Mutation harness ────────────────────────────────────────────────────────
+
+# _sed_inplace <file> <sed-expr> — portable in-place sed, PRESERVING the mode.
+# (Inherited verbatim from tests/test-delta-wp2-state-policy.sh; see this file's
+# header for why the `chmod +x` spelling is a trap.)
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+# _mutation_report <pristine> <mutant> <marker-regex> — echoes
+# "<sites>|<changed>|<lines-changed>" so every mutation case can assert all
+# three counterfactual properties at once. See this file's header.
+_mutation_report() {
+  local orig="$1" mut="$2" marker="$3" sites changed n
+  sites="$(grep -c "$marker" "$orig" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  if diff "$orig" "$mut" >/dev/null 2>&1; then changed=n; else changed=y; fi
+  n="$(diff "$orig" "$mut" | grep -c '^[<>]' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s|%s|%s' "$sites" "$changed" "$n"
+}
+
+echo "== tests/test-delta-wp3-era-classify.sh =="
+echo ""
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== E — the era invariant: active_delta != null => current_phase == 4 (§10.1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── E1: refused at 0/1/2/3, allowed at 4 — ON THE EXIT CODE  [KILLS m1] ─────
+T=$(mktemp -d)
+e1_detail=""
+e1_ok=y
+for ph in 0 1 2 3; do
+  P="$T/p$ph"; mk_proj "$P" "$ph"
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+  rc=$?
+  e1_detail="$e1_detail phase$ph=rc$rc"
+  [ "$rc" -eq 3 ] || e1_ok=n
+done
+P="$T/p4"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+rc4=$?
+e1_detail="$e1_detail phase4=rc$rc4"
+[ "$rc4" -eq 0 ] || e1_ok=n
+if [ "$e1_ok" = y ]; then
+  pass "E1: --open is refused at phases 0/1/2/3 (rc 3) and allowed at phase 4 (rc 0) —$e1_detail"
+else
+  fail_ "E1" "expected rc 3 at phases 0-3 and rc 0 at phase 4; got:$e1_detail"
+fi
+rm -rf "$T"
+
+# ── E2: a refused open writes NOTHING ───────────────────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 2
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+rc=$?
+created=n; [ -e "$P/.claude/delta-state.json" ] && created=y
+if [ "$rc" -eq 3 ] && [ "$created" = n ]; then
+  pass "E2: a refused open creates no state at all (rc $rc, state file created=$created) — the refusal is before the write, not a write that is later undone"
+else
+  fail_ "E2" "rc=$rc (expect 3); state file created=$created (expect n)"
+fi
+rm -rf "$T"
+
+# ── E3: an unreadable phase fails CLOSED ────────────────────────────────────
+# "I cannot tell what phase this is" must never resolve to 4. Two shapes: no
+# phase-state.json at all, and one whose current_phase is not a number.
+T=$(mktemp -d)
+P1="$T/nofile"; mkdir -p "$P1/.claude"
+delta_run "$REPO_ROOT/scripts" "$P1" --open --describe "add dark mode" --confirm >/dev/null 2>&1; r1=$?
+P2="$T/garbage"; mkdir -p "$P2/.claude"
+printf '%s\n' '{"current_phase":"not-a-number"}' > "$P2/.claude/phase-state.json"
+delta_run "$REPO_ROOT/scripts" "$P2" --open --describe "add dark mode" --confirm >/dev/null 2>&1; r2=$?
+if [ "$r1" -eq 3 ] && [ "$r2" -eq 3 ]; then
+  pass "E3: an absent (rc $r1) or unparseable (rc $r2) phase record fails CLOSED — 'cannot tell' never reads as phase 4"
+else
+  fail_ "E3" "absent rc=$r1, unparseable rc=$r2 (both must be 3)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== A — the second-activation refusal WP2 deferred to WP3 (§7.1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── A1: a second open is refused and destroys nothing  [KILLS m2] ───────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+first_id="$(active_json "$P" '.active_delta.id')"
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm); rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+names=n; printf '%s' "$out" | grep -qF 'DELTA-001' && names=y
+if [ "$rc" -eq 4 ] && [ "$before" = "$after" ] && [ "$names" = y ] && [ "$first_id" = '"DELTA-001"' ]; then
+  pass "A1: a second --open while DELTA-001 is open is refused (rc $rc), names the open delta, and leaves the record BYTE-IDENTICAL — the schema's single slot would otherwise have accepted the overwrite and taken gates_completed with it"
+else
+  fail_ "A1" "rc=$rc (expect 4); bytes before=$before after=$after (must MATCH); names-open-delta=$names; first_id=$first_id"
+fi
+rm -rf "$T"
+
+# ── A2: the other direction — nulling active_delta unblocks the next open ───
+# Without this the refusal could be a script that always refuses.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1; blocked=$?
+# Close it the way a close actually closes (§7.1): the row moves to the
+# append-only `closed` tail AND the slot is emptied, in one seam write. Nulling
+# the slot alone would erase the id from the record entirely, and the next open
+# would legitimately reuse DELTA-001 — which would make this case pass for the
+# wrong reason.
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update \
+  '.closed += [{"id": .active_delta.id, "class": .active_delta.class, "closed_at": "2026-08-03T00:00:00Z", "shipped_in": null}] | .active_delta = null' \
+  >/dev/null 2>&1; closed_rc=$?
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1; unblocked=$?
+second_id="$(active_json "$P" '.active_delta.id')"
+if [ "$blocked" -eq 4 ] && [ "$closed_rc" -eq 0 ] && [ "$unblocked" -eq 0 ] && [ "$second_id" = '"DELTA-002"' ]; then
+  pass "A2: with active_delta nulled through the seam the next open succeeds (rc $blocked -> $unblocked) and takes the NEXT id ($second_id) — the guard tracks state, it does not just always refuse"
+else
+  fail_ "A2" "blocked rc=$blocked (expect 4); close rc=$closed_rc (expect 0); unblocked rc=$unblocked (expect 0); new id=$second_id (expect \"DELTA-002\")"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D — the §4.2 derivations ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── D1: the phrase->class tiers, IN ORDER ───────────────────────────────────
+# Order is the whole algorithm: the last phrase carries fix AND production AND
+# security wording, and security must win because a security-patch's
+# obligations are the ones most costly to discover you skipped.
+T=$(mktemp -d)
+d1_ok=y; d1_detail=""
+_d1() {
+  local phrase="$1" want="$2" P got
+  P="$T/$3"; mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "$phrase" --confirm >/dev/null 2>&1
+  got="$(active_json "$P" -r '.active_delta.class')"
+  d1_detail="$d1_detail [$want<-$got]"
+  [ "$got" = "$want" ] || d1_ok=n
+}
+_d1 "add dark mode to the settings screen"        feature        c1
+_d1 "the CSV export crashes on unicode"           fix            c2
+_d1 "checkout is down in production right now"    hotfix         c3
+_d1 "fix the XSS in the comment box in production" security-patch c4
+if [ "$d1_ok" = y ]; then
+  pass "D1: the phrase->class tiers propose feature/fix/hotfix/security-patch in order, and the all-three-tiers phrase resolves to security-patch —$d1_detail"
+else
+  fail_ "D1" "want<-got:$d1_detail"
+fi
+rm -rf "$T"
+
+# ── D2: risk from a REAL diff x the policy's risk_surfaces, plus §13-R4 ─────
+T=$(mktemp -d)
+Pc="$T/core"; mk_git_proj "$Pc" 4
+write_policy "$Pc" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"]}'
+grow "$Pc/src/auth/login.ts" 3
+delta_run "$REPO_ROOT/scripts" "$Pc" --open --describe "token check is wrong" --confirm >/dev/null 2>&1
+risk_core="$(active_json "$Pc" -r '.active_delta.attributes.risk')"
+
+Pl="$T/local"; mk_git_proj "$Pl" 4
+write_policy "$Pl" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"]}'
+grow "$Pl/src/ui/theme.ts" 3
+delta_run "$REPO_ROOT/scripts" "$Pl" --open --describe "the theme toggle is wrong" --confirm >/dev/null 2>&1
+risk_local="$(active_json "$Pl" -r '.active_delta.attributes.risk')"
+
+# §13-R4, asserted rather than trusted: with risk_surfaces EMPTY, a diff that
+# would otherwise be core reads feature-local — and the transcript says WHY,
+# rather than answering as though something had been checked.
+Pe="$T/empty"; mk_git_proj "$Pe" 4
+write_policy "$Pe" '{"schemaVersion":1,"risk_surfaces":[]}'
+grow "$Pe/src/auth/login.ts" 3
+out_e=$(delta_run "$REPO_ROOT/scripts" "$Pe" --open --describe "token check is wrong" --confirm)
+risk_empty="$(active_json "$Pe" -r '.active_delta.attributes.risk')"
+says_why=n; printf '%s' "$out_e" | grep -qi 'no risk surfaces are configured' && says_why=y
+if [ "$risk_core" = "core" ] && [ "$risk_local" = "feature-local" ] \
+   && [ "$risk_empty" = "feature-local" ] && [ "$says_why" = y ]; then
+  pass "D2: a real diff touching src/auth/** derives risk=core; one touching src/ui/ derives feature-local; and with risk_surfaces EMPTY the same core-ish diff derives feature-local WITH the §13-R4 reason printed (not silently)"
+else
+  fail_ "D2" "core-case=$risk_core (expect core); local-case=$risk_local (expect feature-local); empty-surfaces=$risk_empty (expect feature-local); residual stated=$says_why"
+fi
+rm -rf "$T"
+
+# ── D3: level from a REAL diff against the policy brackets  [KILLS m3] ──────
+# The SAME ten-line diff lands in a different bracket under a different policy.
+# That is the whole claim: the thresholds are READ, not compiled in.
+T=$(mktemp -d)
+Pd="$T/default"; mk_git_proj "$Pd" 4
+grow "$Pd/src/ui/theme.ts" 10
+delta_run "$REPO_ROOT/scripts" "$Pd" --open --describe "the theme toggle is wrong" --confirm >/dev/null 2>&1
+lvl_default="$(active_json "$Pd" -r '.active_delta.attributes.level')"
+
+Pr="$T/retuned"; mk_git_proj "$Pr" 4
+write_policy "$Pr" '{"schemaVersion":1,"size_thresholds":{"small":5}}'
+grow "$Pr/src/ui/theme.ts" 10
+delta_run "$REPO_ROOT/scripts" "$Pr" --open --describe "the theme toggle is wrong" --confirm >/dev/null 2>&1
+lvl_retuned="$(active_json "$Pr" -r '.active_delta.attributes.level')"
+
+Pv="$T/evolution"; mk_git_proj "$Pv" 4
+write_policy "$Pv" '{"schemaVersion":1,"size_thresholds":{"small":2,"significant":5}}'
+grow "$Pv/src/ui/theme.ts" 10
+delta_run "$REPO_ROOT/scripts" "$Pv" --open --describe "the theme toggle is wrong" --confirm >/dev/null 2>&1
+lvl_evo="$(active_json "$Pv" -r '.active_delta.attributes.level')"
+if [ "$lvl_default" = "small" ] && [ "$lvl_retuned" = "significant" ] && [ "$lvl_evo" = "evolution" ]; then
+  pass "D3: the same measured 10-line diff derives level=small on the framework thresholds, significant when the project retunes small to 5, and evolution when it retunes significant to 5 — the brackets are read from policy"
+else
+  fail_ "D3" "default=$lvl_default (expect small); small:5 retune=$lvl_retuned (expect significant); significant:5 retune=$lvl_evo (expect evolution)"
+fi
+rm -rf "$T"
+
+# ── D4: severity — the BUGS.md row wins; phrasing is the fallback ───────────
+T=$(mktemp -d)
+Pb="$T/bugrow"; mk_proj "$Pb" 4
+{
+  printf '%s\n' '| # | Severity | Status | Feature | Description | Session | Disposition | Fix Reference | Verified In |'
+  printf '%s\n' '|---|---|---|---|---|---|---|---|---|'
+  printf '%s\n' '| 12 | SEV-1 | Open | Export | CSV export crashes | Session 3 | Fix Now | | |'
+} > "$Pb/BUGS.md"
+delta_run "$REPO_ROOT/scripts" "$Pb" --open --describe "the crash in BUG-12 is still there" --confirm >/dev/null 2>&1
+sev_row="$(active_json "$Pb" -r '.active_delta.attributes.severity')"
+
+Pp="$T/phrase"; mk_proj "$Pp" 4
+delta_run "$REPO_ROOT/scripts" "$Pp" --open --describe "the export is broken but there is a workaround" --confirm >/dev/null 2>&1
+sev_phrase="$(active_json "$Pp" -r '.active_delta.attributes.severity')"
+
+Pf="$T/feature"; mk_proj "$Pf" 4
+delta_run "$REPO_ROOT/scripts" "$Pf" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+sev_feature="$(active_json "$Pf" -r '.active_delta.attributes.severity')"
+if [ "$sev_row" = "SEV-1" ] && [ "$sev_phrase" = "SEV-2" ] && [ "$sev_feature" = "null" ]; then
+  pass "D4: severity is read from the cited BUGS.md row when one exists (SEV-1, overriding the phrasing default), falls back to the Severity Guide's wording otherwise ($sev_phrase), and is null for a feature"
+else
+  fail_ "D4" "BUGS.md row=$sev_row (expect SEV-1); phrasing=$sev_phrase (expect SEV-2); feature=$sev_feature (expect null)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== R — raises are free, lowers are reason-recorded (§4.2) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── R1: a raise sticks, with no justification required ──────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the export is broken" --risk core --level evolution --confirm >/dev/null 2>&1
+rc=$?
+attrs="$(active_json "$P" -c '.active_delta.attributes')"
+reasons="$(active_json "$P" -c '.active_delta.attribute_reasons')"
+if [ "$rc" -eq 0 ] \
+   && [ "$(printf '%s' "$attrs" | jq -r '.risk')" = "core" ] \
+   && [ "$(printf '%s' "$attrs" | jq -r '.level')" = "evolution" ] \
+   && [ "$(printf '%s' "$reasons" | jq -r '[.risk, .level] | all(. == null)')" = "true" ]; then
+  pass "R1: raising risk to core and level to evolution needs no justification and sticks ($attrs), and records no reason ($reasons) — a raise is the operator knowing something the measurement does not"
+else
+  fail_ "R1" "rc=$rc; attributes=$attrs; reasons=$reasons"
+fi
+rm -rf "$T"
+
+# ── R2: a lower with no reason available is REFUSED, and writes nothing ─────
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"]}'
+grow "$P/src/auth/login.ts" 3
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "token check is wrong" --risk feature-local --confirm >/dev/null 2>&1
+rc=$?
+created=n; [ -e "$P/.claude/delta-state.json" ] && created=y
+if [ "$rc" -eq 5 ] && [ "$created" = n ]; then
+  pass "R2: lowering risk from the derived core with no reason available is refused (rc $rc) and nothing is opened (state file created=$created) — a blank reason is indistinguishable from a raise nobody noticed"
+else
+  fail_ "R2" "rc=$rc (expect 5); state file created=$created (expect n)"
+fi
+rm -rf "$T"
+
+# ── R3: a lower WITH a reason is recorded on the delta's own row ────────────
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"]}'
+grow "$P/src/auth/login.ts" 3
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "token check is wrong" \
+  --risk feature-local --reason "only the log message changed" --confirm >/dev/null 2>&1
+rc=$?
+risk="$(active_json "$P" -r '.active_delta.attributes.risk')"
+reason="$(active_json "$P" -r '.active_delta.attribute_reasons.risk')"
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+has_review=y; printf '%s' "$gates" | grep -qF 'brief_review' || has_review=n
+if [ "$rc" -eq 0 ] && [ "$risk" = "feature-local" ] \
+   && [ "$reason" = "only the log message changed" ] && [ "$has_review" = n ]; then
+  pass "R3: the same lower WITH --reason is accepted, the reason is recorded on the delta's own row, and the gate the raise would have added is correspondingly absent (gates=$gates)"
+else
+  fail_ "R3" "rc=$rc; risk=$risk (expect feature-local); recorded reason='$reason'; brief_review present=$has_review (expect n); gates=$gates"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== G — gates_required materialised at open from §5.2 ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── G1: each class yields its §5.2 base row, exactly and in order ───────────
+T=$(mktemp -d)
+g1_ok=y; g1_detail=""
+_g1() {
+  local class="$1" want="$2" P got
+  P="$T/$class"; mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "something to do" --class "$class" --confirm >/dev/null 2>&1
+  got="$(active_json "$P" -c '.active_delta.gates_required')"
+  [ "$got" = "$want" ] || { g1_ok=n; g1_detail="$g1_detail [$class want=$want got=$got]"; }
+}
+_g1 feature        '["brief","brief_review","ledger_row","build_loop","close_review","changelog"]'
+_g1 fix            '["ledger_row","repro_test_red_first","close_review","changelog"]'
+_g1 hotfix         '["ledger_row","audit_row_at_open","retro_review","changelog"]'
+_g1 security-patch '["ledger_row","repro_test_red_first","dependency_scan","sbom_refresh","flagged_release_note","close_review","changelog"]'
+if [ "$g1_ok" = y ]; then
+  pass "G1: each of the four classes materialises its §5.2 base row exactly, in the table's reading order (no sorting — a sorted row is the same set and a worse checklist)"
+else
+  fail_ "G1" "mismatches:$g1_detail"
+fi
+rm -rf "$T"
+
+# ── G2: risk: core adds brief_review  [KILLS m4] ────────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the export is broken" --class fix --risk core --confirm >/dev/null 2>&1
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+if [ "$gates" = '["ledger_row","repro_test_red_first","close_review","changelog","brief_review"]' ]; then
+  pass "G2: risk: core appends brief_review to the fix row from attribute_toggles.risk_core ($gates)"
+else
+  fail_ "G2" "gates=$gates (expect the fix row plus brief_review)"
+fi
+rm -rf "$T"
+
+# ── G3: level: evolution adds brief ─────────────────────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the export is broken" --class fix --level evolution --confirm >/dev/null 2>&1
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+if [ "$gates" = '["ledger_row","repro_test_red_first","close_review","changelog","brief"]' ]; then
+  pass "G3: level: evolution appends brief to the fix row from attribute_toggles.level_evolution ($gates)"
+else
+  fail_ "G3" "gates=$gates (expect the fix row plus brief)"
+fi
+rm -rf "$T"
+
+# ── G4: the toggles are READ FROM POLICY, not compiled in ───────────────────
+# A project that retunes attribute_toggles gets ITS gate. This is the pin that
+# separates "materialised from policy" from "materialised from a table that
+# happens to agree with policy today".
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"attribute_toggles":{"risk_core":["second_reviewer"],"level_evolution":["brief"]}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the export is broken" --class fix --risk core --confirm >/dev/null 2>&1
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+if [ "$gates" = '["ledger_row","repro_test_red_first","close_review","changelog","second_reviewer"]' ]; then
+  pass "G4: a project that retunes attribute_toggles.risk_core gets ITS gate (second_reviewer) and not the framework's brief_review ($gates)"
+else
+  fail_ "G4" "gates=$gates (expect the fix row plus second_reviewer)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V — the validate.sh assertion: REPORT-ONLY, pinned on the exit code ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── V1: the report fires and the exit code does not move  [KILLS m5] ────────
+# BOTH DIRECTIONS. The report must appear (or the arm is dead), and the exit
+# code must be IDENTICAL to the same tree without the inconsistency (or the arm
+# is a blocking gate wearing a warning's label — CLAUDE.md's `[WARN]` trap).
+T=$(mktemp -d)
+Pn="$T/none"; mk_validate_proj "$Pn" 2
+validate_run "$REPO_ROOT/scripts" "$Pn" >/dev/null 2>&1; rc_none=$?
+Po="$T/open"; mk_validate_proj "$Po" 2
+printf '%s\n' '{"schemaVersion":1,"active_delta":{"id":"DELTA-007","slug":"dark-mode"},"hotfix_retros":[],"cadence":{},"closed":[]}' \
+  > "$Po/.claude/delta-state.json"
+out_open=$(validate_run "$REPO_ROOT/scripts" "$Po"); rc_open=$?
+reported=n; printf '%s' "$out_open" | grep -qF 'DELTA-007' && reported=y
+if [ "$reported" = y ] && [ "$rc_open" -eq "$rc_none" ]; then
+  pass "V1: validate.sh REPORTS an open delta at phase 2 and its exit code is unchanged by it (rc $rc_none with no delta, rc $rc_open with one) — report-only, asserted on the code and not the label"
+else
+  fail_ "V1" "reported=$reported (expect y); rc without delta=$rc_none, rc with delta=$rc_open (must be EQUAL)"
+fi
+rm -rf "$T"
+
+# ── V2: at phase 4 the same state is consistent, so nothing is reported ─────
+T=$(mktemp -d); P="$T/proj"; mk_validate_proj "$P" 4
+printf '%s\n' '{"schemaVersion":1,"active_delta":{"id":"DELTA-007","slug":"dark-mode"},"hotfix_retros":[],"cadence":{},"closed":[]}' \
+  > "$P/.claude/delta-state.json"
+out=$(validate_run "$REPO_ROOT/scripts" "$P")
+silent=y; printf '%s' "$out" | grep -qF 'DELTA-007' && silent=n
+if [ "$silent" = y ]; then
+  pass "V2: the identical state at phase 4 is CONSISTENT and produces no report — the arm asserts the invariant, it does not merely notice an open delta"
+else
+  fail_ "V2" "the arm reported an inconsistency at phase 4, where active_delta != null is exactly what the invariant permits"
+fi
+rm -rf "$T"
+
+# ── V3: the lint-forced routing is real  [KILLS m6] ─────────────────────────
+# validate.sh is CORE, so it may not name a module path (T1, not waivable) and
+# may not join the seam allowlist (cardinality asserted at one). It therefore
+# reaches the state core->core through the ONE seam — and the seam's action
+# flags carry the `delta-` prefix by design, so that line IS a genuine T2 hit
+# carrying the lint's reason-required inline waiver. Strip the marker and the
+# lint must go rc=1: that is what proves the waiver is doing work rather than
+# decorating a line the lint never saw.
+T=$(mktemp -d); MT="$T/tree"; mk_scripts_tree "$MT"
+control_out=$(bash "$LINTER" --root "$MT" 2>&1); control_rc=$?
+_sed_inplace "$MT/scripts/validate.sh" 's|# lint-delta-boundary: allow.*$||'
+mut_out=$(bash "$LINTER" --root "$MT" 2>&1); mut_rc=$?
+waivers="$(grep -c 'lint-delta-boundary: allow' "$REPO_ROOT/scripts/validate.sh" || true)"
+t1_clean=y; printf '%s' "$control_out" | grep -q 'FAIL	T1' && t1_clean=n
+if [ "$control_rc" -eq 0 ] && [ "$mut_rc" -eq 1 ] && [ "$waivers" = "1" ] && [ "$t1_clean" = y ] \
+   && printf '%s' "$mut_out" | grep -q 'T2'; then
+  pass "V3: validate.sh carries EXACTLY ONE inline T2 waiver ($waivers) for its seam invocation, names no module path (T1 clean), and stripping the marker reds the boundary lint (rc $control_rc -> $mut_rc)"
+else
+  fail_ "V3" "control rc=$control_rc (expect 0); mutant rc=$mut_rc (expect 1); waiver rows in validate.sh=$waivers (expect 1); T1 clean=$t1_clean"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T — confirm, do not quiz (§4.3) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── T1: the transcript's SHAPE, with provenance on every line ──────────────
+# Asserted as SHAPE and not prose: the wording is the design's and may be
+# tuned, but §4.3's structural claim — four lines, each naming where its value
+# came from, and ONE question — is what must not silently erode.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm)
+said=n;  printf '%s\n' "$out" | grep -qE '^You said: "the CSV export crashes on unicode"$' && said=y
+onequ=n; printf '%s\n' "$out" | grep -qF '[1] Keep all four' && onequ=y
+prov=0
+for label in Class Severity Risk Level; do
+  printf '%s\n' "$out" | grep -qE "^  $label: +[^ ]+ +\(.+" && prov=$((prov + 1))
+done
+if [ "$said" = y ] && [ "$onequ" = y ] && [ "$prov" -eq 4 ]; then
+  pass "T1: the open transcript echoes the operator's own words, prints all four attributes with a provenance parenthetical on EVERY line ($prov/4), and asks exactly one question"
+else
+  fail_ "T1" "echoes-input=$said; one-question footer=$onequ; lines carrying provenance=$prov/4; transcript:\n$out"
+fi
+rm -rf "$T"
+
+# ── T2: nobody to confirm => REFUSE, never auto-accept ─────────────────────
+# The repo's hard-N policy (helpers-core.sh::prompt_yes_no, after the cycle-7
+# PR #87 unattended-install incident): a side-effectful action must never
+# auto-proceed just because the operator was absent.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode"); rc=$?
+created=n; [ -e "$P/.claude/delta-state.json" ] && created=y
+shown=n; printf '%s' "$out" | grep -qF '[1] Keep all four' && shown=y
+if [ "$rc" -eq 2 ] && [ "$created" = n ] && [ "$shown" = y ]; then
+  pass "T2: a scripted run with no terminal and no --confirm still SHOWS the proposal, then refuses (rc $rc) and opens nothing — confirmation is never assumed from silence"
+else
+  fail_ "T2" "rc=$rc (expect 2); state file created=$created (expect n); transcript shown=$shown (expect y)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S — --status ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+out_empty=$(delta_run "$REPO_ROOT/scripts" "$P" --status); rc_empty=$?
+created=n; [ -e "$P/.claude/delta-state.json" ] && created=y
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+out_open=$(delta_run "$REPO_ROOT/scripts" "$P" --status); rc_open=$?
+names=n; printf '%s' "$out_open" | grep -qF 'DELTA-001' && names=y
+gates=n; printf '%s' "$out_open" | grep -qF 'repro_test_red_first' && gates=y
+if [ "$rc_empty" -eq 0 ] && [ "$created" = n ] && [ "$rc_open" -eq 0 ] && [ "$names" = y ] && [ "$gates" = y ]; then
+  pass "S1: --status reports rc 0 both with no delta (and creates nothing) and with one open, naming the delta and what it still owes"
+else
+  fail_ "S1" "empty rc=$rc_empty, created=$created (expect n); open rc=$rc_open, names delta=$names, lists outstanding gates=$gates"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== B — the boundary holds (D1), cited not re-implemented ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+lint_out=$(bash "$LINTER" --list 2>&1); lint_rc=$?
+seam_rows="$(printf '%s\n' "$lint_out" | grep -c 'INFO	seam' || true)"
+in_manifest=y
+grep -q '"scripts/delta.sh"' "$LINTER" || in_manifest=n
+grep -q '"scripts/lib/delta-classify.sh"' "$LINTER" || in_manifest=n
+if [ "$lint_rc" -eq 0 ] && [ "$seam_rows" = "1" ] && [ "$in_manifest" = y ]; then
+  pass "B1: the boundary lint is clean on the real tree (rc $lint_rc) with the seam allowlist still at cardinality one, and both WP3 module files are in the DELTA manifest — the predicate itself is scripts/lint-delta-boundary.sh's and is mutation-pinned by its own suite"
+else
+  fail_ "B1" "lint rc=$lint_rc (expect 0); seam rows=$seam_rows (expect 1); WP3 files in manifest=$in_manifest"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutation proofs (each mutant is BUILT and RUN here) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── m1: neuter the ERA refusal -> an open at phase 2 SUCCEEDS -> E1 RED ────
+# The design's own mutation (§11-WP3), and §10.1's instruction is explicit:
+# assert the EXIT CODE, not the printed label.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-ERA-GUARD$/s@.*@  if false; then@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-OPEN-ERA-GUARD$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+P="$T/proj"; mk_proj "$P" 2
+delta_run "$MT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+mut_rc=$?
+opened=n; [ -e "$P/.claude/delta-state.json" ] && opened=y
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$mut_rc" -eq 0 ] && [ "$opened" = y ]; then
+  pass "m1: with the era guard neutered, --open at phase 2 SUCCEEDS (rc $mut_rc, state written) instead of rc 3 — E1 goes RED on the EXIT CODE (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m1" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc=$mut_rc (expect 0); state written=$opened (expect y)"
+fi
+rm -rf "$T"
+
+# ── m2: neuter the SECOND-ACTIVATION refusal -> double-open succeeds -> A1 RED
+# FRESH FIXTURE AT PHASE 4 on purpose: at any lower phase the era guard refuses
+# first, this guard never executes, and the mutant would look pinned when it is
+# not. That masking is the failure WP2's per-atom sweep found twice.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-ACTIVE-GUARD$/s@.*@  if false; then@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-OPEN-ACTIVE-GUARD$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+P="$T/proj"; mk_proj "$P" 4
+delta_run "$MT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+before="$(_md5file "$P/.claude/delta-state.json")"
+delta_run "$MT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+mut_rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+second_class="$(active_json "$P" -r '.active_delta.class')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$mut_rc" -eq 0 ] && [ "$before" != "$after" ] && [ "$second_class" = "feature" ]; then
+  pass "m2: with the second-activation guard neutered, a second --open SUCCEEDS (rc $mut_rc) and OVERWRITES the open delta (bytes moved; class now $second_class) — A1 goes RED, and this is exactly the loss WP2 deferred to WP3 (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc=$mut_rc (expect 0); bytes before=$before after=$after (must DIFFER); overwritten class=$second_class (expect feature)"
+fi
+rm -rf "$T"
+
+# ── m3: hardcode the small threshold -> the policy-retune test goes RED ────
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/lib/delta-classify.sh" '/# DELTA-CLASSIFY-LEVEL-SMALL$/s@.*@  small=50@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/lib/delta-classify.sh" "$MT/scripts/lib/delta-classify.sh" 'DELTA-CLASSIFY-LEVEL-SMALL$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"size_thresholds":{"small":5}}'
+grow "$P/src/ui/theme.ts" 10
+delta_run "$MT/scripts" "$P" --open --describe "the theme toggle is wrong" --confirm >/dev/null 2>&1
+mut_level="$(active_json "$P" -r '.active_delta.attributes.level')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$mut_level" = "small" ]; then
+  pass "m3: with the small threshold hardcoded to the framework's 50, a project that retuned it to 5 gets level=$mut_level for a 10-line diff instead of significant — D3 goes RED, and note the failure mode: no error, no warning, just a quietly wrong bracket (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m3" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant level=$mut_level (expect small, i.e. the retune ignored)"
+fi
+rm -rf "$T"
+
+# ── m4: drop the attribute_toggle read -> risk: core stops adding the gate ──
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/lib/delta-classify.sh" '/# DELTA-CLASSIFY-TOGGLE-RISKCORE$/s@.*@  toggle_core="[]"@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/lib/delta-classify.sh" "$MT/scripts/lib/delta-classify.sh" 'DELTA-CLASSIFY-TOGGLE-RISKCORE$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+P="$T/proj"; mk_proj "$P" 4
+delta_run "$MT/scripts" "$P" --open --describe "the export is broken" --class fix --risk core --confirm >/dev/null 2>&1
+mut_gates="$(active_json "$P" -c '.active_delta.gates_required')"
+# EXACT equality, not "does not contain brief_review": a run that produced no
+# state at all would satisfy a negative assertion and credit the RED to the
+# neutered toggle when the delta had in fact never opened.
+lost=n
+[ "$mut_gates" = '["ledger_row","repro_test_red_first","close_review","changelog"]' ] && lost=y
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$lost" = y ]; then
+  pass "m4: with the risk_core toggle read dropped, a delta confirmed at risk: core materialises WITHOUT brief_review ($mut_gates) — G2 goes RED, and the delta would have closed with the pre-build adversarial review silently never demanded (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m4" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant gates=$mut_gates (must be the bare fix row, i.e. brief_review dropped AND the delta still opened)"
+fi
+rm -rf "$T"
+
+# ── m5: make the validate.sh arm BLOCKING -> V1's exit-code pin goes RED ───
+# THE `[WARN]` TRAP, IN BOTH DIRECTIONS. One character of intent — `warn` for
+# `fail` — changes nothing about the printed line's meaning and everything about
+# the script's exit status. This is the mutation that proves V1 is asserting the
+# code and not the banner.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/validate.sh" '/# DELTA-ERA-REPORT-ONLY$/s@warn @fail @'
+rep="$(_mutation_report "$REPO_ROOT/scripts/validate.sh" "$MT/scripts/validate.sh" 'DELTA-ERA-REPORT-ONLY$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+Pn="$T/none"; mk_validate_proj "$Pn" 2
+validate_run "$MT/scripts" "$Pn" >/dev/null 2>&1; mut_none=$?
+Po="$T/open"; mk_validate_proj "$Po" 2
+printf '%s\n' '{"schemaVersion":1,"active_delta":{"id":"DELTA-007","slug":"dark-mode"},"hotfix_retros":[],"cadence":{},"closed":[]}' \
+  > "$Po/.claude/delta-state.json"
+mut_out=$(validate_run "$MT/scripts" "$Po"); mut_open=$?
+still_reported=n; printf '%s' "$mut_out" | grep -qF 'DELTA-007' && still_reported=y
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$mut_open" -ne "$mut_none" ] && [ "$still_reported" = y ]; then
+  pass "m5: swapping the arm's warn for fail moves validate.sh's exit code (rc $mut_none -> $mut_open) while the PRINTED LINE is unchanged (still reported=$still_reported) — V1 goes RED, and this is the [WARN] trap in one line (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc without delta=$mut_none, with delta=$mut_open (must DIFFER); line still printed=$still_reported (expect y — the point is that the OUTPUT does not move)"
+fi
+rm -rf "$T"
+
+# ── m6: strip the T2 waiver -> the boundary lint reds -> V3 RED ────────────
+# The lint-forced-routing pin, mutated. Covered inside V3 itself (control vs
+# stripped), so this row asserts the OTHER half: that the waiver's absence is
+# what reds it, and not the seam invocation merely existing.
+T=$(mktemp -d); MT="$T/tree"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/validate.sh" '/# DELTA-ERA-REPORT-ONLY$/s@.*@  return 0@'
+after_arm_rc=0; bash "$LINTER" --root "$MT" >/dev/null 2>&1 || after_arm_rc=$?
+MT2="$T/tree2"; mk_scripts_tree "$MT2"
+_sed_inplace "$MT2/scripts/validate.sh" 's|lint-delta-boundary: allow|lint-delta-boundary: allowed because|'
+typo_rc=0; bash "$LINTER" --root "$MT2" >/dev/null 2>&1 || typo_rc=$?
+if [ "$after_arm_rc" -eq 0 ] && [ "$typo_rc" -eq 1 ]; then
+  pass "m6: the waiver is what waives — a NEAR-MISS spelling ('allowed because …') is not the marker and reds the lint (rc $typo_rc), while removing the invocation entirely leaves it clean (rc $after_arm_rc). The exemption fails CLOSED, so a typo cannot silently waive a real edge"
+else
+  fail_ "m6" "lint rc with the arm removed=$after_arm_rc (expect 0); lint rc with a near-miss waiver spelling=$typo_rc (expect 1)"
+fi
+rm -rf "$T"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

Delta Track **WP3** (design of record: `docs/designs/2026-08-02-delta-track-v1.md` §10.1–§10.2, §4.1–§4.3, §11-WP3):

- **The era invariant** (D7): `scripts/delta.sh --open` refuses unless `current_phase == 4` — the load-bearing enforcement that the delta track cannot substitute for building the product properly. Fail-closed on unreadable phase state; every refusal path (all five rc's, including non-interactive) leaves the tree md5-identical file-by-file.
- **The second-activation refusal** (deferred to WP3 by WP2's guard, now delivered): opening while a delta is active is refused by name — previously a double-open silently overwrote the active slot.
- **`scripts/lib/delta-classify.sh`**: the §4.2 derivations (risk from touched-files ∩ policy risk_surfaces; level from lines vs policy thresholds; severity for the fix family) plus the phrase→class *proposal* — all policy-read, none hardcoded, and always human-confirmed via the §4.3 confirm-not-quiz transcript, each value carrying its provenance line.
- **`gates_required` materialised at open** from class + attribute toggles, verified key-by-key against §5.2 for all four classes.
- **A report-only `validate.sh` arm**: `active_delta` at phase < 4 reported as an inconsistency — with a both-directions [WARN]-trap pin (exit code unchanged by the arm; the mutation that makes it blocking goes RED on the rc while the arm's message body stays character-identical). Routed through the seam with the second reasoned T2 waiver (mirroring `upgrade-project.sh`'s); seam allowlist still cardinality 1.

## Verification trail (fable pr-reviewer, xhigh, pre-PR)

- **Round 1 (major_concerns):** behavior held everywhere — era guard unflankable via flags/env, zero refusal residue, jq-injection attempts failed, and the reviewer's four novel mutants were all killed by the unit-lane suite. The blockers were two overclaiming proof texts: m5 claimed "byte-identical output" (the label and tally move — the honest claim is rc-divergent + message-body-identical) and m6's first assertion was vacuous (sed aimed at the wrong line, could never fail).
- **Fix round:** both corrected into strictly stronger assertions — and the implementer found the obvious m6 fix was *still* vacuous (several distinct edits share the same downstream silence), so the discriminator is structural (invocation count of the edited line), with three meta-probes proving the corrected rows can fail. The generalized lesson is recorded in the suite header. Bonus: the rc-2 refusal no longer leaves a seeded policy file behind.
- **Re-review: approve.** The reviewer re-applied the old wrong-address mutation and watched the corrected row catch it, re-verified the whole-tree leave-nothing evidence across every refusal path, and confirmed the final claims match execution exactly. Review record: `.superpowers/sdd/2026-08-02-delta-track-v1/wp3-review.md` (session artifact).

Suite: 29/0 (six in-suite anchored mutations, sites==1 + one-line-changed asserted); run-lints 15/15; both boundary lints clean; WP0/WP2 pin suites green.

## Carried forward (recorded, not built)

- Seam-level non-null→non-null replacement refusal (business-layer refusal is delta.sh's today, matching the seam's recorded structural-only posture; §10.1's wording ambiguity noted) → WP4+.
- `--lines`/`--touched-file` derivation overrides have no audit trace (reviewer sharpened this into a concrete exploit sketch) → future WP decides the shipped surface.
- `--slug` sanitisation before WP8 materialises a path from it.
- Repo-host observation: this repo's `.git/hooks/pre-commit` is currently a generated-project hook, not `scripts/pre-commit-gate.sh` per CONTRIBUTING — flagged for Karl, unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)