### PR TITLE
feat(delta): WP4 — per-class close gates, the rubric bind, the close ratchet

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -388,6 +388,7 @@ jobs:
             tests/test-delta-wp0-inherited-predicates.sh
             tests/test-delta-wp2-state-policy.sh
             tests/test-delta-wp3-era-classify.sh
+            tests/test-delta-wp4-close-rubric.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -122,22 +122,39 @@ set -euo pipefail
 #      because it needs the brief to exist, and `brief` is itself a gate that
 #      step 4 is still able to be waiting on.
 #
-# REFUSAL RESIDUE — THE STANDARD THIS FILE'S OPEN FLOW SET, AND THE ONE HONEST
-# EXCEPTION. Every refusal above prints some form of "nothing was closed", and
-# for 6/7/8/9 that sentence is true of the WHOLE TREE: no file is created,
-# modified or removed. That is asserted with a find-based manifest in
-# tests/test-delta-wp4-close-rubric.sh::N1, exactly as the open flow's E2/T2 are.
+# REFUSAL RESIDUE — THE STANDARD THIS FILE'S OPEN FLOW SET, SCOPED TO WHAT
+# EXECUTION ACTUALLY SHOWS.
 #
-# THE EXCEPTION IS THE RATCHET (exit 10), AND IT IS STATED RATHER THAN SMOOTHED.
-# §4.2 requires the close-time raise to be RECORDED — the attribute is raised
-# and the newly toggled gates are appended to `gates_required`. So that one
-# refusal writes. It is bounded and it is idempotent: it touches the delta's own
-# `attributes`, `gates_required` and `ratcheted_at` and nothing else anywhere,
-# and a second close re-measures to the same bracket, appends nothing, and does
-# not write again. N2 pins both halves. The alternative — announce the new
-# obligations without recording them — was rejected: the operator would be told
-# about a larger checklist that the record does not contain, and every
-# subsequent close would re-announce it as though it were news.
+# READ THIS AS A PROPERTY OF THE RAISE, NOT OF THE EXIT CODE. An earlier version
+# of this block said "for 6/7/8/9 that sentence is true of the WHOLE TREE", and
+# an adversarial review REFUTED it by execution. The refutation is worth keeping
+# because the mistake is the natural one to make: the ratchet writes whenever an
+# attribute ROSE, while exit 10 fires only when a gate was ALSO APPENDED, and
+# those are different conditions. A raise that toggles nothing — small ->
+# significant, which no toggle answers; or risk -> core on a class already
+# carrying brief_review — records itself and then falls through to the exit-7 or
+# exit-8 refusal. So:
+#
+#   6 and 9   ALWAYS leave the whole tree pristine. 6 returns before anything is
+#             measured, and 9 is ordered BEFORE the ratchet precisely so that a
+#             configuration error can never write. N1 pins both.
+#   7 and 8   leave the tree pristine WHEN NO RAISE OCCURRED (N1), and carry
+#             exactly the bounded ratchet record when one did (N3, N4).
+#   10        always carries that record, by construction (N2).
+#
+# THE RECORD IS BOUNDED, IDEMPOTENT AND ANNOUNCED, and those three are what make
+# the exception safe rather than merely admitted. Bounded: it touches the
+# delta's own `attributes`, `gates_required` and `ratcheted_at`, and nothing
+# else anywhere — asserted in both directions by N2/N3/N4. Idempotent: a second
+# close re-measures to the same bracket and writes nothing at all, so the record
+# cannot accrete one stamp per attempt. Announced: the transcript names the
+# old -> new value every time, so the operator is never the last to know their
+# own record moved.
+#
+# The alternative — announce the new obligations without recording them — was
+# rejected: the operator would be told about a larger checklist the record does
+# not contain, and every subsequent close would re-announce it as news. §4.2 is
+# explicit that the raise is recorded.
 #
 # GATES ARE ATTESTED, AND THE HELP TEXT MUST NOT PRETEND OTHERWISE. §5.3 tiers
 # the review honestly: the rubric is MECHANICAL, the reviewer is ADVISORY.
@@ -162,11 +179,20 @@ set -euo pipefail
 # The brief is `docs/deltas/DELTA-NNN-slug.md` (§6.3). This flow reads exactly
 # one section of it:
 #
-#   • THE SECTION is the first heading whose text begins `Done-observable`,
-#     case-insensitively, at any heading depth (`## Done-observable`, and a
-#     trailing parenthetical is fine). It ENDS at the next heading of the same
-#     depth or shallower — so a `### Nice-to-have` subsection inside it is still
-#     part of the rubric, and the next `## …` is not.
+#   • A RUBRIC SECTION is opened by ANY heading whose text begins
+#     `Done-observable`, case-insensitively, at any heading depth
+#     (`## Done-observable`, and a trailing parenthetical is fine). It ENDS at
+#     the next heading of the same depth or shallower — so a `### Nice-to-have`
+#     subsection inside it is still part of the rubric, and the next `## …` is
+#     not. A brief carrying TWO such headings has BOTH read, and the criteria
+#     are pooled.
+#     THIS SENTENCE USED TO SAY "the FIRST heading" and the code disagreed with
+#     it; an adversarial review found the mismatch by execution. The SENTENCE
+#     moved, not the code, and deliberately: the implementation is the stricter
+#     of the two readings, and a criterion the operator wrote under a second
+#     Done-observable heading is still a criterion — a first-only reader would
+#     have ignored it and closed. B5 pins both directions so it cannot drift
+#     back. WP8's template codifies THIS wording.
 #   • A CRITERION is a list item whose marker is `-`, `*` or `+`, at any indent,
 #     followed by a bracketed single character: `- [x]` / `- [X]` is CHECKED,
 #     `- [ ]` is NOT. Anything else between the brackets is treated as NOT
@@ -943,6 +969,23 @@ EOF
       print_fail "The delta record refused the re-measurement, so nothing was closed."
       return 1
     fi
+
+    # ANNOUNCE THE RAISE — ALWAYS, INCLUDING WHEN NO GATE WAS TOGGLED.
+    # This sits ABOVE the `n_appended` branch on purpose. The write above
+    # happens whenever an attribute rose; the rc-10 refusal below happens only
+    # when a gate was ALSO appended. Those two conditions are not the same, and
+    # an adversarial review found the gap by execution: a raise that toggles
+    # nothing (small -> significant, which no toggle answers; or risk -> core on
+    # a class that already carries brief_review) rewrote the operator's recorded
+    # attributes and then returned 7 or 8 without a word about it. The record
+    # changing under someone who was never told is the half of that defect that
+    # is not about doctrine, and this is the whole fix for it. Pinned by N3/N4.
+    echo ""
+    print_info "Re-measured from what you actually changed:"
+    if [ "$nrisk" != "$risk" ];   then print_info "  how risky:  $risk -> $nrisk"; fi
+    if [ "$nlevel" != "$level" ]; then print_info "  how big:    $level -> $nlevel"; fi
+    print_info "That is on the record now. It only ever goes up — a smaller change later never talks it back down."
+
     gates_req="$(printf '%s\n' "$gates_req" | jq -c ". + $appended")"
     risk="$nrisk"
     level="$nlevel"
@@ -1017,6 +1060,12 @@ EOF
   fi
 
   # ── THE CLOSE WRITE — ONE SEAM CALL, ONE ATOMIC RENAME ───────────────────
+  # "ONE" IS A CLAIM ABOUT THIS WRITE, NOT ABOUT THE INVOCATION. A close that
+  # was preceded by a silent raise performs TWO seam writes: the ratchet record
+  # above, then this one. That is fine and is not what the property is about —
+  # the load-bearing guarantee is that the `closed` APPEND and the slot NULL are
+  # a single filter and therefore a single atomic rename, so no crash can land
+  # between them. m3 kills the split; W1/W2 pin the result.
   # THE `closed` APPEND AND THE SLOT NULL ARE ONE FILTER, and that is not
   # tidiness. `_next_id` reads ids out of closed[] + hotfix_retros[] +
   # active_delta, so a close that empties the slot without appending ERASES the

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -96,14 +96,118 @@ set -euo pipefail
 # person reading it has just shipped a product and wants to fix a bug.
 #
 # ═════════════════════════════════════════════════════════════════════════════
+# ═════════════════════════════════════════════════════════════════════════════
+# THE CLOSE FLOW (WP4) — FIVE REFUSALS, IN THIS ORDER, AND WHY THE ORDER IS THE
+# DESIGN
+#
+# `--close` walks the delta's own record and refuses at the first thing that is
+# not true. The ORDER is load-bearing, not cosmetic:
+#
+#   1. NOTHING OPEN                    exit 6.  Nothing to reason about.
+#   2. UNKNOWN GATE TOKEN              exit 9.  A configuration error, and it
+#      goes FIRST among the substantive checks because it is the only one whose
+#      answer cannot be trusted otherwise: if a token is meaningless, so is
+#      "outstanding" and so is "complete". It fails CLOSED and writes nothing.
+#   3. CLOSE-TIME RE-DERIVATION        exit 10 (only when it appends).
+#      §4.2: the open-time derivation was a FORECAST; this measures the real
+#      diff. A higher bracket RAISES the attribute and APPENDS the gates that
+#      raise toggles on. It never lowers. It runs BEFORE the outstanding-gates
+#      check because the whole point is that the checklist may have grown —
+#      running it after would let a delta opened `small` and grown into an auth
+#      rewrite close on the small checklist, which is §11-WP4's own mutation.
+#   4. GATES OUTSTANDING               exit 7.  gates_required minus
+#      gates_completed, named.
+#   5. THE RUBRIC BIND                 exit 8.  §5.3's strongest sentence: "the
+#      brief's acceptance criteria ARE the close review's rubric". It runs LAST
+#      because it needs the brief to exist, and `brief` is itself a gate that
+#      step 4 is still able to be waiting on.
+#
+# REFUSAL RESIDUE — THE STANDARD THIS FILE'S OPEN FLOW SET, AND THE ONE HONEST
+# EXCEPTION. Every refusal above prints some form of "nothing was closed", and
+# for 6/7/8/9 that sentence is true of the WHOLE TREE: no file is created,
+# modified or removed. That is asserted with a find-based manifest in
+# tests/test-delta-wp4-close-rubric.sh::N1, exactly as the open flow's E2/T2 are.
+#
+# THE EXCEPTION IS THE RATCHET (exit 10), AND IT IS STATED RATHER THAN SMOOTHED.
+# §4.2 requires the close-time raise to be RECORDED — the attribute is raised
+# and the newly toggled gates are appended to `gates_required`. So that one
+# refusal writes. It is bounded and it is idempotent: it touches the delta's own
+# `attributes`, `gates_required` and `ratcheted_at` and nothing else anywhere,
+# and a second close re-measures to the same bracket, appends nothing, and does
+# not write again. N2 pins both halves. The alternative — announce the new
+# obligations without recording them — was rejected: the operator would be told
+# about a larger checklist that the record does not contain, and every
+# subsequent close would re-announce it as though it were news.
+#
+# GATES ARE ATTESTED, AND THE HELP TEXT MUST NOT PRETEND OTHERWISE. §5.3 tiers
+# the review honestly: the rubric is MECHANICAL, the reviewer is ADVISORY.
+# `--complete-gate` records that the OPERATOR SAYS a gate is satisfied. The
+# framework does not verify that the adversarial review happened, that the
+# changelog entry is under the right heading, or that the repro test was RED
+# first. The two things it does check itself are the two this WP makes real: the
+# brief's done-observable boxes, and the close-time re-measurement of size and
+# risk. Do not widen the wording beyond those two.
+#
+# `retro_review` IS CLOSE-REFUSING BUT NOT YET IMPLEMENTABLE, and that is
+# deliberate at this WP. A hotfix carries it (§7.2) and this flow will refuse
+# the close until it is attested — but the retro LEDGER (`hotfix_retros[]`, the
+# `due_by` arithmetic, the release-cut refusal that collateralises the deferral)
+# is §11-WP5's. Until then the token is satisfiable only by attestation, which
+# is a weaker thing than the design promises. Recorded here rather than papered
+# over.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE RUBRIC PARSE CONTRACT (§5.3/§6.2) — WP8's template must match this
+#
+# The brief is `docs/deltas/DELTA-NNN-slug.md` (§6.3). This flow reads exactly
+# one section of it:
+#
+#   • THE SECTION is the first heading whose text begins `Done-observable`,
+#     case-insensitively, at any heading depth (`## Done-observable`, and a
+#     trailing parenthetical is fine). It ENDS at the next heading of the same
+#     depth or shallower — so a `### Nice-to-have` subsection inside it is still
+#     part of the rubric, and the next `## …` is not.
+#   • A CRITERION is a list item whose marker is `-`, `*` or `+`, at any indent,
+#     followed by a bracketed single character: `- [x]` / `- [X]` is CHECKED,
+#     `- [ ]` is NOT. Anything else between the brackets is treated as NOT
+#     checked and named — an undefined marker is a criterion nobody has decided
+#     about, and guessing in the permissive direction is how a rubric quietly
+#     stops being one.
+#   • ONLY that section is read. Checkboxes under What / Must-not-change /
+#     Touched surfaces are ignored, which is pinned in both directions (the
+#     refusal never names them; a brief whose rubric is fully checked closes
+#     even though other sections carry unchecked boxes).
+#   • IT FAILS CLOSED. No brief file, two files matching the id, no
+#     Done-observable section, or a section containing NO checkboxes at all are
+#     each a refusal. A rubric that cannot be read is not a rubric that passed —
+#     and the zero-checkbox case is the one worth naming, because it is the
+#     shape a brief takes when the section heading was copied from the template
+#     and never filled in.
+#
+# ═════════════════════════════════════════════════════════════════════════════
 # EXIT CODES — CODES, NEVER LABELS
-#   0  the delta was opened, or `--status` reported successfully
+#   0  the delta was opened or closed, a gate was recorded, or `--status`
+#      reported successfully
 #   1  an operation failed (the seam refused a write, jq is missing, …)
-#   2  invocation error: bad flag, missing argument, or a confirmation that
-#      could not be obtained (no terminal and no `--confirm`)
+#   2  invocation error: bad flag, missing argument, a gate this delta does not
+#      owe, or a confirmation that could not be obtained (no terminal and no
+#      `--confirm`)
 #   3  ERA REFUSAL — the project is not at phase 4          (§10.1)
 #   4  SECOND-ACTIVATION REFUSAL — a delta is already open  (§7.1)
 #   5  an attribute was LOWERED with no reason recorded     (§4.2)
+#   6  there is nothing open to close or to record against  (§7.1)
+#   7  required gates are still outstanding                 (§5.2)
+#   8  the brief's rubric has an unchecked or unreadable criterion  (§5.3)
+#   9  an unknown gate token — a configuration error, failing CLOSED (§5.2)
+#  10  the close-time re-measurement RAISED an attribute and added obligations,
+#      so the close refuses on the LARGER checklist          (§4.2)
+#
+# There is NO era refusal on `--close`, and that is a decision. §10.1 places the
+# invariant's enforcement at OPEN (load-bearing) and in scripts/validate.sh
+# (report-only). An `active_delta` at phase < 4 is already the inconsistency
+# validate.sh reports, and closing it is the ONLY path back to a consistent
+# record — a close that refused there would strand the delta permanently in the
+# state the invariant forbids. Pinned by W3.
 #
 # BASH 3.2: no associative arrays, no ${var,,} (hence `tr`), no `((x++))`.
 
@@ -131,8 +235,17 @@ USAGE="Usage:
                    [--risk core|feature-local] [--level small|significant|evolution]
                    [--severity SEV-1|SEV-2|SEV-3|SEV-4] [--reason TEXT]
                    [--touched-file FILE]
+  scripts/delta.sh --complete-gate TOKEN
+  scripts/delta.sh --close
   scripts/delta.sh --status
-  scripts/delta.sh --help"
+  scripts/delta.sh --help
+
+  --complete-gate records that YOU say a check is done. Most of them are
+  attested that way: the framework does not re-run your review, re-read your
+  changelog entry or watch your test go red. The two it checks itself are the
+  brief's done-observable boxes and the size/risk re-measurement at close.
+
+  --close runs those two checks and refuses while anything is outstanding."
 
 # ── The seam, and nothing but the seam ──────────────────────────────────────
 # Every state read and every state write in this file goes through here. The
@@ -557,6 +670,387 @@ cmd_open() {
 }
 
 # ═════════════════════════════════════════════════════════════════════════════
+# CLOSE-FLOW HELPERS (§4.2 / §5.3)
+# ═════════════════════════════════════════════════════════════════════════════
+
+# _json_str <value> — the value as a JSON string literal, quoting and escaping
+# included. Every value this file splices into a jq filter goes through here.
+# Some of them originate in `.claude/delta-state.json`, which a human can edit,
+# so "it came from our own record" is not the same as "it is safe to paste into
+# a program". One helper is cheaper than one audit per splice site.
+_json_str() { jq -c -n --arg v "${1:-}" '$v'; }
+
+# _higher <attribute> <a> <b> — whichever of the two ranks HIGHER on that
+# attribute's ordering, `a` on a tie or when neither ranks. THE RATCHET, as one
+# expression (§4.2: "it never lowers"). An unrecognised value ranks -1, so a
+# measurement that could not be taken can only ever lose — which is the
+# fail-safe direction here and is what makes the m1 mutant's `measured=""` a
+# clean, total neuter rather than a crash.
+_higher() {
+  local attr="$1" a="$2" b="$3" ra rb
+  ra="$(_rank "$attr" "$a")"
+  rb="$(_rank "$attr" "$b")"
+  if [ "$rb" -gt "$ra" ]; then printf '%s' "$b"; else printf '%s' "$a"; fi
+}
+
+# _close_measure <root> <touched-file-list> <changed-lines>
+#   `<risk><TAB><level>` measured from the REAL diff at close, using the SAME
+#   formulas the open flow used on its forecast (§4.2 is explicit that
+#   delta-classify.sh "computes the same way at both moments; it does not know
+#   which moment it is in"). The ratchet is applied to these outputs, not here.
+_close_measure() {
+  local root="${1:-.}" files="${2:-}" lines="${3:-0}" r l
+  r="$(delta_classify_risk "$root" "$files" | cut -f1)"
+  l="$(delta_classify_level "$root" "$lines" | cut -f1)"
+  printf '%s\t%s' "$r" "$l"
+}
+
+# _brief_path <delta-id> <recorded-path>
+#   Echo the brief's path. rc 0 = found; 1 = none; 2 = AMBIGUOUS (two files
+#   claim the same id — the paths are echoed so the operator can see both).
+#
+#   The recorded path wins when there is one: §11-WP8 owns the guided intake
+#   that writes `active_delta.brief`, and a delta that names its own brief is
+#   not to be second-guessed by a glob. Until WP8 lands, that field is null and
+#   the glob over §6.3's `docs/deltas/DELTA-NNN-slug.md` is the whole answer.
+#   Ambiguity is a refusal rather than a first-match: picking one of two briefs
+#   silently means the close review ran against a document the operator may not
+#   have been looking at.
+_brief_path() {
+  local id="$1" recorded="${2:-}" hits n
+  if [ -n "$recorded" ] && [ "$recorded" != "null" ]; then
+    printf '%s' "$recorded"
+    return 0
+  fi
+  [ -d "docs/deltas" ] || return 1
+  hits="$(find docs/deltas -maxdepth 1 -type f \( -name "$id-*.md" -o -name "$id.md" \) 2>/dev/null | LC_ALL=C sort)"
+  [ -n "$hits" ] || return 1
+  n="$(printf '%s\n' "$hits" | grep -c '' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s' "$hits"
+  [ "$n" -eq 1 ] || return 2
+  return 0
+}
+
+# _rubric_boxes <brief-file>
+#   One `checked<TAB>text` or `unchecked<TAB>text` line per criterion in the
+#   brief's Done-observable section, in document order. Empty output means the
+#   section is absent OR carries no checkboxes — the caller treats both as a
+#   refusal, so this function does not need to tell them apart.
+#
+#   THE CONTRACT IS SPELLED OUT IN THIS FILE'S HEADER and WP8's
+#   `delta-brief.tmpl` must match it. The two decisions worth restating at the
+#   code: the section ends at the next heading of the same depth or SHALLOWER
+#   (so a `###` sub-list is still rubric), and a bracket holding anything other
+#   than `x`/`X` counts as NOT checked. A permissive reading of an undefined
+#   marker is how a rubric quietly stops being one.
+_rubric_boxes() {
+  local f="$1"
+  [ -f "$f" ] || return 1
+  awk '
+    function hashes(s,   n) { n = 0; while (substr(s, n + 1, 1) == "#") n++; return n }
+    {
+      line = $0
+      sub(/^[ \t]+/, "", line)
+      if (line ~ /^#+[ \t]/) {
+        d = hashes(line)
+        rest = substr(line, d + 1)
+        sub(/^[ \t]+/, "", rest)
+        if (tolower(rest) ~ /^done-observable/) { insec = 1; depth = d; next }
+        if (insec == 1 && d <= depth) { insec = 0 }
+        next
+      }
+      if (insec != 1) next
+      if (line ~ /^[-*+][ \t]+\[.\]/) {
+        mark = substr(line, index(line, "[") + 1, 1)
+        text = substr(line, index(line, "]") + 1)
+        sub(/^[ \t]+/, "", text)
+        sub(/[ \t]+$/, "", text)
+        if (mark == "x" || mark == "X") printf "checked\t%s\n", text
+        else printf "unchecked\t%s\n", text
+      }
+    }
+  ' "$f" 2>/dev/null
+  return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# --complete-gate
+# ═════════════════════════════════════════════════════════════════════════════
+cmd_complete_gate() {
+  local doc id token gates_req present already
+
+  token="$GATE_TOKEN"
+  command -v jq >/dev/null 2>&1 || { print_fail "jq is required to record a check."; return 1; }
+  if [ -z "$token" ]; then
+    print_fail "Name the check you finished: scripts/delta.sh --complete-gate ledger_row"
+    return 2
+  fi
+
+  if ! doc="$(_seam --delta-state-read)"; then
+    print_fail "Could not read the delta record."
+    return 1
+  fi
+  if [ "$(printf '%s\n' "$doc" | jq -r '.active_delta == null')" = "true" ]; then
+    echo ""
+    print_fail "There is nothing open, so there is no check to record against."
+    print_info "Start a piece of work with: scripts/delta.sh --open"
+    echo ""
+    return 6
+  fi
+
+  id="$(printf '%s\n' "$doc" | jq -r '.active_delta.id // "unknown"')"
+  gates_req="$(printf '%s\n' "$doc" | jq -c '.active_delta.gates_required // []')"
+
+  # A token this delta does not owe is an INVOCATION error, not a config one:
+  # the vocabulary may well know the word, this delta simply is not carrying it.
+  present=n
+  if printf '%s\n' "$gates_req" | jq -r '.[]? | select(type == "string")' | grep -qxF "$token"; then
+    present=y
+  fi
+  if [ "$present" = n ]; then
+    echo ""
+    print_fail "$id does not need '$token'."
+    printf '%s\n' "$gates_req" | jq -r '"  What it does need: " + join(", ")'
+    echo ""
+    return 2
+  fi
+
+  # Idempotent by design. Re-recording is the most likely repeat invocation
+  # there is, and making it an error would teach the operator to fear the tool.
+  already=n
+  if printf '%s\n' "$doc" | jq -r '.active_delta.gates_completed[]? | select(type == "string")' | grep -qxF "$token"; then
+    already=y
+  fi
+  if [ "$already" = y ]; then
+    print_ok "$token was already recorded for $id — nothing to do."
+    return 0
+  fi
+
+  if ! _seam --delta-state-update ".active_delta.gates_completed += [$(_json_str "$token")]"; then
+    print_fail "The delta record refused the change, so nothing was recorded."
+    return 1
+  fi
+
+  echo ""
+  print_ok "Recorded: $token is done for $id."
+  # §5.3's honest tiering, in the operator's own words. Do not widen this.
+  print_info "This is your word for it — the record now says you did it, and nothing here re-checks it."
+  print_info "The two things this tool does check for itself are the tick-boxes in your brief and how big the change actually turned out to be, both when you close."
+  print_info "See where you are with: scripts/delta.sh --status"
+  echo ""
+  return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# --close
+# ═════════════════════════════════════════════════════════════════════════════
+cmd_close() {
+  local doc id class sev risk level recorded gates_req gates_done
+  local vocab unknown g outstanding
+  local touched lines measured mrisk mlevel nrisk nlevel
+  local newgates appended n_appended now row filter
+  local brief brc boxes unchecked
+
+  command -v jq >/dev/null 2>&1 || { print_fail "jq is required to close a delta."; return 1; }
+
+  if ! doc="$(_seam --delta-state-read)"; then
+    print_fail "Could not read the delta record."
+    return 1
+  fi
+
+  # ── REFUSAL 1 — NOTHING IS OPEN ──────────────────────────────────────────
+  if [ "$(printf '%s\n' "$doc" | jq -r '.active_delta == null')" = "true" ]; then
+    echo ""
+    print_fail "There is nothing open to close."
+    print_info "Start a piece of work with: scripts/delta.sh --open"
+    echo ""
+    return 6
+  fi
+
+  id="$(printf '%s\n' "$doc" | jq -r '.active_delta.id // "unknown"')"
+  class="$(printf '%s\n' "$doc" | jq -r '.active_delta.class // ""')"
+  sev="$(printf '%s\n' "$doc" | jq -r '.active_delta.attributes.severity // ""')"
+  risk="$(printf '%s\n' "$doc" | jq -r '.active_delta.attributes.risk // ""')"
+  level="$(printf '%s\n' "$doc" | jq -r '.active_delta.attributes.level // ""')"
+  recorded="$(printf '%s\n' "$doc" | jq -r '.active_delta.brief // ""')"
+  gates_req="$(printf '%s\n' "$doc" | jq -c '.active_delta.gates_required // []')"
+  gates_done="$(printf '%s\n' "$doc" | jq -c '.active_delta.gates_completed // []')"
+
+  # ── REFUSAL 2 — AN UNKNOWN GATE TOKEN, FAILING CLOSED ────────────────────
+  # FIRST among the substantive checks, deliberately: if a token is meaningless
+  # then "outstanding" and "complete" are both meaningless too, so every answer
+  # downstream of it is untrustworthy. It also means this refusal is reached
+  # before the ratchet, which is what keeps its residue at zero.
+  vocab="$(delta_classify_gate_vocabulary ".")"
+  unknown=""
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    if printf '%s\n' "$vocab" | grep -qxF "$g"; then continue; fi
+    unknown="$unknown $g"
+  done <<EOF
+$(printf '%s\n' "$gates_req" | jq -r '.[]? | select(type == "string")')
+EOF
+  if [ -n "$unknown" ]; then                                          # DELTA-CLOSE-VOCAB-GUARD
+    echo ""
+    print_fail "This piece of work lists a check nothing here recognises:$unknown."
+    print_info "That is not something you can finish — nothing in the project knows what would satisfy it, so it would block you forever."
+    print_info "It is almost always a typo. Fix the spelling in .claude/delta-policy.json and re-open, or correct the delta's own record. Nothing was closed."
+    echo ""
+    return 9
+  fi
+
+  # ── THE CLOSE-TIME RE-DERIVATION AND ITS RATCHET (§4.2) ──────────────────
+  # The open-time values were a FORECAST measured against an empty diff. This is
+  # the measurement. A higher bracket raises the attribute and appends whatever
+  # gates that raise toggles on; a lower one changes nothing at all.
+  touched="$TOUCHED_FILE"
+  if [ -z "$touched" ]; then
+    touched="$(mktemp)"
+    TOUCHED_TMP="$touched"
+    delta_classify_touched "." > "$touched" 2>/dev/null || : > "$touched"
+  fi
+  lines="$LINES_OVERRIDE"
+  [ -n "$lines" ] || lines="$(delta_classify_lines ".")"
+
+  measured="$(_close_measure "." "$touched" "$lines")"                # DELTA-CLOSE-RATCHET
+  mrisk="$(printf '%s' "$measured" | cut -f1)"
+  mlevel="$(printf '%s' "$measured" | cut -f2)"
+  nrisk="$(_higher risk "$risk" "$mrisk")"
+  nlevel="$(_higher level "$level" "$mlevel")"
+
+  if [ "$nrisk" != "$risk" ] || [ "$nlevel" != "$level" ]; then
+    if ! newgates="$(delta_classify_gates "." "$class" "$nrisk" "$nlevel")"; then
+      print_fail "Could not work out what the bigger change needs, so nothing was closed."
+      return 1
+    fi
+    # APPEND-ONLY, never recompute-and-replace (§7.1): a policy edit mid-delta
+    # must not be able to drop a gate the operator was already told about, so
+    # the recomputed set contributes only what is NEW.
+    if ! appended="$(jq -c -n --argjson have "$gates_req" --argjson want "$newgates" \
+        '[ $want[] | . as $g | select(($have | index($g)) == null) ]')"; then
+      print_fail "Could not work out what the bigger change needs, so nothing was closed."
+      return 1
+    fi
+    n_appended="$(printf '%s' "$appended" | jq -r 'length' 2>/dev/null)" || n_appended=0
+    case "$n_appended" in ''|*[!0-9]*) n_appended=0 ;; esac
+    now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    if ! _seam --delta-state-update \
+        ".active_delta.attributes.risk = $(_json_str "$nrisk") \
+       | .active_delta.attributes.level = $(_json_str "$nlevel") \
+       | .active_delta.gates_required = (.active_delta.gates_required + $appended) \
+       | .active_delta.ratcheted_at = $(_json_str "$now")"; then
+      print_fail "The delta record refused the re-measurement, so nothing was closed."
+      return 1
+    fi
+    gates_req="$(printf '%s\n' "$gates_req" | jq -c ". + $appended")"
+    risk="$nrisk"
+    level="$nlevel"
+
+    if [ "$n_appended" -gt 0 ]; then
+      echo ""
+      print_fail "This turned out to be a bigger change than it looked when you started, so it needs more checking before it can close."
+      printf '%s\n' "$appended" | jq -r '"  Now also needed: " + join(", ")'
+      print_info "That is measured from what you actually changed, not from what you said at the start — and it only ever goes up."
+      print_info "Do those, mark them done with --complete-gate, then close again."
+      echo ""
+      return 10
+    fi
+  fi
+
+  # ── REFUSAL 3 — REQUIRED GATES STILL OUTSTANDING (§5.2) ──────────────────
+  if ! outstanding="$(jq -r -n --argjson req "$gates_req" --argjson done "$gates_done" \
+      '[ $req[] | . as $g | select(($done | index($g)) == null) ] | join(", ")')"; then
+    print_fail "Could not work out what is left to do, so nothing was closed."
+    return 1
+  fi
+  if [ -n "$outstanding" ]; then                                      # DELTA-CLOSE-GATES-GUARD
+    echo ""
+    print_fail "$id is not finished yet."
+    print_info "Still to do: $outstanding"
+    print_info "Mark one done with: scripts/delta.sh --complete-gate <name>"
+    echo ""
+    return 7
+  fi
+
+  # ── REFUSAL 4 — THE RUBRIC BIND (§5.3) ───────────────────────────────────
+  # Keyed on the GATE, not on the class: a fix that grew past the evolution
+  # threshold gains `brief` at the ratchet above and gains this check with it.
+  if printf '%s\n' "$gates_req" | jq -e 'index("brief") != null' >/dev/null 2>&1; then
+    brc=0
+    brief="$(_brief_path "$id" "$recorded")" || brc=$?
+    if [ "$brc" -eq 2 ]; then
+      echo ""
+      print_fail "More than one write-up claims to be $id's, so it is not clear which one to check against."
+      printf '%s\n' "$brief" | sed -e 's/^/  /'
+      print_info "Keep one and rename or remove the other. Nothing was closed."
+      echo ""
+      return 8
+    fi
+    if [ "$brc" -ne 0 ] || [ -z "$brief" ] || [ ! -f "$brief" ]; then
+      echo ""
+      print_fail "$id needs a written-up plan and there isn't one to check against."
+      print_info "It should be at docs/deltas/$id-<short-name>.md, with a '## Done-observable' section listing what has to be true when this is finished."
+      print_info "Nothing was closed."
+      echo ""
+      return 8
+    fi
+    boxes="$(_rubric_boxes "$brief")" || boxes=""
+    if [ -z "$boxes" ]; then
+      echo ""
+      print_fail "$brief has no list of things that have to be true when this is done, so there is nothing to check it against."
+      print_info "Add a '## Done-observable' section with one '- [ ] …' line per thing you will be able to see working."
+      print_info "An empty list would let this close on nothing at all, so it is refused rather than passed. Nothing was closed."
+      echo ""
+      return 8
+    fi
+    unchecked="$(printf '%s\n' "$boxes" | awk -F'\t' '$1 == "unchecked" { print "  - " $2 }')"
+    if [ -n "$unchecked" ]; then                                      # DELTA-CLOSE-RUBRIC-GUARD
+      echo ""
+      print_fail "You wrote down what would be true when $id is done, and some of it is not ticked off yet."
+      printf '%s\n' "$unchecked"
+      print_info "That list is in $brief, and it is the whole review — you wrote it before you were invested in how you built this."
+      print_info "Finish those, tick them, then close. Nothing was closed."
+      echo ""
+      return 8
+    fi
+  fi
+
+  # ── THE CLOSE WRITE — ONE SEAM CALL, ONE ATOMIC RENAME ───────────────────
+  # THE `closed` APPEND AND THE SLOT NULL ARE ONE FILTER, and that is not
+  # tidiness. `_next_id` reads ids out of closed[] + hotfix_retros[] +
+  # active_delta, so a close that empties the slot without appending ERASES the
+  # id from the record and the very next open is handed it again — two pieces of
+  # work sharing one identifier in the audit tail, with nothing anywhere that
+  # would notice. Splitting this into two seam calls would additionally make the
+  # window between them a crash away from exactly that state.
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if ! row="$(jq -c -n --arg id "$id" --arg class "$class" --arg sev "$sev" \
+      --arg at "$now" --arg risk "$risk" --arg level "$level" --argjson done "$gates_done" '
+      ($sev | if . == "" then null else . end) as $s
+      | { id: $id, class: $class, severity: $s,
+          closed_at: $at, shipped_in: null,
+          attributes: { risk: $risk, level: $level, severity: $s },
+          gates_completed: $done }')"; then
+    print_fail "Could not write up the finished record, so nothing was closed."
+    return 1
+  fi
+
+  filter=".closed += [$row] | .active_delta = null"                   # DELTA-CLOSE-ATOMIC-WRITE
+  if ! _seam --delta-state-update "$filter"; then
+    print_fail "The delta record refused the change, so nothing was closed."
+    return 1
+  fi
+
+  echo ""
+  print_ok "Closed $id ($class)."
+  print_info "It is on the record with everything you ticked off, and it will be listed in the next release you cut."
+  print_info "Start the next one with: scripts/delta.sh --open"
+  echo ""
+  return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
 # Argument parsing
 # ═════════════════════════════════════════════════════════════════════════════
 ACTION=""
@@ -571,6 +1065,7 @@ REASON=""
 TOUCHED_FILE=""
 TOUCHED_TMP=""
 LINES_OVERRIDE=""
+GATE_TOKEN=""
 
 CLASS=""; CLASS_WHY=""
 SEV="";   SEV_WHY=""
@@ -589,6 +1084,8 @@ _need() {
 while [ $# -gt 0 ]; do
   case "$1" in
     --open)     ACTION="open"; shift ;;
+    --close)    ACTION="close"; shift ;;
+    --complete-gate) _need "$1" $#; ACTION="complete-gate"; GATE_TOKEN="$2"; shift 2 ;;
     --status)   ACTION="status"; shift ;;
     --describe) _need "$1" $#; DESCRIBE="$2"; shift 2 ;;
     --slug)     _need "$1" $#; SLUG="$2"; shift 2 ;;
@@ -600,7 +1097,12 @@ while [ $# -gt 0 ]; do
     # An explicit touched-file list and an explicit line count exist so the
     # derivations can be exercised against a KNOWN input. At open the real diff
     # is usually empty (§4.2's forecast), so a test that relied on the ambient
-    # git state would be pinning the host, not the formula.
+    # git state would be pinning the host, not the formula. BOTH FLOWS honour
+    # them — `--close` re-measures with the same two functions, so the same
+    # override is the same override there. The WP4 ratchet cases deliberately do
+    # NOT use them: the design's own mutation is about a REAL diff crossing a
+    # bracket, and feeding that measurement by hand would prove the arithmetic
+    # while assuming away the thing being measured.
     --touched-file) _need "$1" $#; TOUCHED_FILE="$2"; shift 2 ;;
     --lines)        _need "$1" $#; LINES_OVERRIDE="$2"; shift 2 ;;
     --confirm)  CONFIRMED=1; shift ;;
@@ -614,8 +1116,10 @@ trap _cleanup EXIT
 
 RC=0
 case "$ACTION" in
-  open)   cmd_open   || RC=$? ;;
-  status) cmd_status || RC=$? ;;
-  *)      echo "$USAGE" >&2; RC=2 ;;
+  open)          cmd_open          || RC=$? ;;
+  close)         cmd_close         || RC=$? ;;
+  complete-gate) cmd_complete_gate || RC=$? ;;
+  status)        cmd_status        || RC=$? ;;
+  *)             echo "$USAGE" >&2; RC=2 ;;
 esac
 exit "$RC"

--- a/scripts/lib/delta-classify.sh
+++ b/scripts/lib/delta-classify.sh
@@ -436,3 +436,51 @@ delta_classify_gates() {
   printf '%s\n' "$out"
   return 0
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THE GATE-TOKEN VOCABULARY (§5.2) — what the close gate validates against
+# ─────────────────────────────────────────────────────────────────────────────
+
+# delta_classify_gate_vocabulary <project_root>
+#   Every gate token this project can legitimately carry, one per line, sorted
+#   and de-duplicated. Always rc 0.
+#
+#   WHY THIS IS A UNION AND NOT §5.2's TABLE. The obvious implementation is the
+#   thirteen tokens of §5.2, compiled in. It is wrong, and the repo already
+#   proves it wrong: tests/test-delta-wp3-era-classify.sh::G4 pins that a
+#   project may retune `attribute_toggles.risk_core` to `["second_reviewer"]`
+#   and get ITS gate materialised (§7.2 — "every key is overridable"). A close
+#   gate holding that project's own token against a framework table would
+#   refuse every close it ever attempts, and the operator's only escape would be
+#   to un-retune the policy the framework told them was theirs.
+#
+#   So the vocabulary is the UNION of two things:
+#     • THE FRAMEWORK FLOOR — §5.2's table, spelled out below. It is here so a
+#       project whose policy file omits a class row (or omits `classes`
+#       entirely) still recognises the tokens the framework's own defaults can
+#       produce, and so the floor is greppable from one place.
+#     • THE RESOLVED POLICY — every string under `classes.*.gates` and under
+#       `attribute_toggles.*`, read through delta_policy_get so a project value
+#       wins per key and an absent key falls back (§3.2).
+#
+#   WHAT IS STILL REFUSED, which is the point: a token that appears in NEITHER.
+#   That is a hand-edited state file or a typo in a policy edit — `close_reviw`
+#   would otherwise become a gate that can never be completed and never be
+#   questioned, because nothing else in the system reads these strings. It fails
+#   CLOSED at the close gate, named, which is the only place the operator is
+#   still able to act on it.
+delta_classify_gate_vocabulary() {
+  local root="${1:-.}" classes toggles
+  classes="$(delta_policy_get "$root" "classes")" || classes="{}"                    # DELTA-CLASSIFY-VOCAB-CLASSES
+  toggles="$(delta_policy_get "$root" "attribute_toggles")" || toggles="{}"          # DELTA-CLASSIFY-VOCAB-TOGGLES
+  {
+    # §5.2's table, read top to bottom. THE FRAMEWORK FLOOR.
+    printf '%s\n' \
+      brief brief_review ledger_row build_loop repro_test_red_first \
+      audit_row_at_open retro_review threat_model_refresh dependency_scan \
+      sbom_refresh flagged_release_note close_review changelog
+    printf '%s\n' "$classes" | jq -r '.[]?.gates[]? | select(type == "string")' 2>/dev/null || true
+    printf '%s\n' "$toggles" | jq -r '.[]?[]? | select(type == "string")' 2>/dev/null || true
+  } | sed '/^$/d' | LC_ALL=C sort -u
+  return 0
+}

--- a/scripts/lib/delta-state.sh
+++ b/scripts/lib/delta-state.sh
@@ -137,10 +137,16 @@ DELTA_STATE_EMPTY_EOF
 # WHAT IT DELIBERATELY DOES NOT ENFORCE — stated so the comment stops
 # over-claiming (R-WP2-3), because "refuses anything that violates the schema"
 # was never true:
-#   • THE SECOND-ACTIVATION REFUSAL IS WP3's, NOT THIS LAYER'S. Overwriting an
-#     OPEN active_delta (losing its gates_completed) is accepted here. §11-WP3
-#     owns open/confirm and owns that business-logic refusal; one-at-a-time is
-#     only structural until then. This is a recorded deferral, not an oversight.
+#   • THE SECOND-ACTIVATION REFUSAL IS WP3's, NOT THIS LAYER'S — it is the
+#     OPERATOR-FACING one, and scripts/delta.sh's DELTA-OPEN-ACTIVE-GUARD is
+#     where it lives, because only the caller can name the delta in the way and
+#     tell the operator what to do about it. SUPERSEDED IN PART BY WP4: the
+#     shape predicate still says nothing about active_delta beyond
+#     object-or-null, but the WRITE path now carries a narrow structural atom of
+#     its own — see _delta_state_active_is_not_replaced below, which refuses a
+#     candidate that swaps a DIFFERENT id into an occupied slot. Mutating the
+#     open delta in place stays fully allowed; that is what every legitimate
+#     write does.
 #   • cadence's INNER keys and date formats — §8.3/WP6 defines them.
 #   • hotfix_retros' ROW shape — §11-WP5 materialises those rows.
 #   • active_delta's inner fields — WP3/WP4 materialise them at open.
@@ -295,6 +301,47 @@ _delta_state_closed_is_ship_fill() {
   ' >/dev/null 2>&1
 }
 
+# ── THE `active_delta` REPLACEMENT REFUSAL (R-WP3-3, added in WP4) ───────────
+#
+# WHAT CHANGED, AND WHY THE DEFERRAL ABOVE IS NOW ONLY HALF TRUE. The "WHAT IT
+# DELIBERATELY DOES NOT ENFORCE" block says overwriting an OPEN active_delta is
+# accepted here because §11-WP3 owns the business refusal. WP3 delivered that
+# refusal — scripts/delta.sh's DELTA-OPEN-ACTIVE-GUARD — and an adversarial
+# review of it named the residual precisely: the guard lives in the CALLER, and
+# `--delta-state-update` is a GENERAL primitive, so a crafted filter still
+# replaces the open delta at the seam and takes its `gates_completed` with it.
+# The audit trail of everything already done is exactly what is lost, which is
+# the loss the WP3 guard exists to prevent — so the invariant belongs in both
+# places, and this is the second one.
+#
+# THE ATOM KEYS ON THE ID, NOT ON NULLNESS, AND THAT IS THE WHOLE DESIGN. The
+# two-character-shorter spelling — refuse every non-null -> non-null transition
+# — is WRONG, and wrong in a way that would have shipped green: every legitimate
+# write against an OPEN delta has that exact shape. `--complete-gate` appends to
+# `gates_completed`; WP4's close-time ratchet raises `attributes` and appends to
+# `gates_required`; WP5's retro arm will touch the row again. All of them keep
+# the id. Only a SWAP changes it, and only a swap is refused.
+#
+#   old.active_delta == null      -> allowed (an open)
+#   new.active_delta == null      -> allowed (a close)
+#   ids equal                     -> allowed (the delta mutating itself)
+#   ids differ                    -> REFUSED
+#
+# The tolerance branch mirrors the append rule's, for the same reason: a
+# previous file that is not a well-formed state document has no defensible open
+# delta to protect, and holding it against the candidate would let one bad hand
+# edit lock the single writer out of the only file it owns.
+_delta_state_active_is_not_replaced() {
+  local old="$1" new="$2"
+  jq -e "( $DELTA_STATE_SHAPE )" "$old" >/dev/null 2>&1 || return 0   # DELTA-STATE-ACTIVE-TOLERANT
+  jq -e -n --slurpfile o "$old" --slurpfile n "$new" '
+      ($o[0].active_delta) as $oa
+    | ($n[0].active_delta) as $na
+    | (true)
+      and (($oa == null) or ($na == null) or ($oa.id == $na.id))   # ACTIVE-ATOM-NO-REPLACE
+  ' >/dev/null 2>&1
+}
+
 # delta_state_write [project_root] [closed_rule]  < candidate-document-on-stdin
 #   THE atomic write. Reads a whole candidate document on stdin, validates it,
 #   and only then lets it become the state file.
@@ -337,6 +384,11 @@ delta_state_write() {
       if [ -f "$f" ] && ! _delta_state_closed_is_append "$f" "$target"; then
         rm -f "$target" 2>/dev/null || true
         printf '%s\n' "delta-state: refusing to write $f — 'closed' is an APPEND-ONLY audit tail and the candidate drops, reorders or rewrites an already-closed row. To record shipped_in on a closed delta, use the dedicated seam action --delta-state-ship. The previous file was NOT touched." >&2
+        return 1
+      fi
+      if [ -f "$f" ] && ! _delta_state_active_is_not_replaced "$f" "$target"; then
+        rm -f "$target" 2>/dev/null || true
+        printf '%s\n' "delta-state: refusing to write $f — the candidate swaps a DIFFERENT delta into an already-occupied active_delta slot, which would discard the open delta's gates_completed history. One delta at a time (§7.1). Close the open one first; the slot may be emptied, filled or mutated in place, but not replaced. The previous file was NOT touched." >&2
         return 1
       fi
       ;;

--- a/scripts/lib/delta-state.sh
+++ b/scripts/lib/delta-state.sh
@@ -327,6 +327,21 @@ _delta_state_closed_is_ship_fill() {
 #   ids equal                     -> allowed (the delta mutating itself)
 #   ids differ                    -> REFUSED
 #
+# WHAT THIS ATOM DELIBERATELY DOES NOT ENFORCE, recorded in the same style as
+# the deferrals above rather than left as an unstated hole (found and assessed
+# by adversarial review, R-WP4-3):
+#   • IT PROTECTS IDENTITY, NOT CONTENT. A same-id write may gut the row —
+#     `.active_delta.gates_required = [] | .active_delta.gates_completed = []`
+#     is accepted, and the delta then closes with an empty archived checklist.
+#     That is consistent with D7 and is not a hole this layer should close: the
+#     file is the PROJECT's, a hand edit is exactly equivalent, and every
+#     legitimate caller mutates this row (see below), so a content predicate
+#     here would have to encode each caller's intent and would be a second copy
+#     of the business logic. The cheat is also legible after the fact — an empty
+#     `gates_completed` is archived into the audit tail rather than hidden.
+#   • A CANDIDATE WITH NO `id` reads as a differing id and is REFUSED, which is
+#     the fail-closed direction and is intentional.
+#
 # The tolerance branch mirrors the append rule's, for the same reason: a
 # previous file that is not a well-formed state document has no defensible open
 # delta to protect, and holding it against the candidate would let one bad hand

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -103,16 +103,24 @@ _set_current_phase_min() {
 #                                   hotfix_retros / closed that are not arrays;
 #                                   cadence that is not an object; a closed row
 #                                   that is not an object; and any drop, reorder
-#                                   or rewrite of an existing closed row.
+#                                   or rewrite of an existing closed row. WP4
+#                                   added one more: a candidate that swaps a
+#                                   DIFFERENT delta id into an already-occupied
+#                                   active_delta slot, which would discard the
+#                                   open delta's gates_completed history. The
+#                                   operator-facing refusal stays in delta.sh
+#                                   where it can name the delta in the way; this
+#                                   one closes the crafted-filter path into the
+#                                   same loss.
 #                                   WHAT IT DOES NOT REFUSE, deliberately:
-#                                   replacing an OPEN active_delta. One-at-a-time
-#                                   is structural here; the business refusal is
-#                                   §11-WP3's, which owns open/confirm. Recorded
-#                                   as a deferral, not an omission. Inner shapes
-#                                   of cadence / hotfix_retros / active_delta are
-#                                   likewise later WPs' — see the WHAT IT
-#                                   DELIBERATELY DOES NOT ENFORCE block in
-#                                   scripts/lib/delta-state.sh.
+#                                   MUTATING an open active_delta in place — a
+#                                   gates_completed append, a close-time
+#                                   attribute raise. Every legitimate write has
+#                                   that shape, so only the id swap is refused.
+#                                   Inner shapes of cadence / hotfix_retros /
+#                                   active_delta are likewise later WPs' — see
+#                                   the WHAT IT DELIBERATELY DOES NOT ENFORCE
+#                                   block in scripts/lib/delta-state.sh.
 #   --delta-state-ship <id> <ver>   record `shipped_in` on an already-closed
 #                                   delta — §7.1's cut-time write, which
 #                                   `cut-release.sh` (§9) reaches through here

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1703,6 +1703,27 @@ run_child_suite "tests/test-delta-wp2-state-policy.sh" \
 # the waiver's absence and nothing else. Never executes init.sh -> both lanes.
 run_child_suite "tests/test-delta-wp3-era-classify.sh" \
   "tests/test-delta-wp3-era-classify.sh"
+# Delta Track WP4: the CLOSE flow — the per-class gate refusal (§5.2), the
+# gate-token vocabulary (policy-derived, so a project's retuned token is KNOWN
+# and only a typo fails closed), the close-time re-derivation and its RATCHET
+# (§4.2: raises and appends, never lowers), the RUBRIC BIND (§5.3 — the brief's
+# Done-observable checkboxes are the close review, and an unchecked box refuses
+# the close), and the ONE atomic seam write that appends to `closed` as the slot
+# nulls. Five refusal codes, told apart by CODE and never by label: 6 nothing
+# open, 7 gates outstanding, 8 rubric, 9 unknown token, 10 the ratchet added
+# obligations. Every PURE refusal leaves the whole tree byte-identical
+# (find-based manifest); the ratchet is the one refusal that records, and its
+# residue is bounded and asserted. Also carries R-WP3-3: the seam now refuses a
+# crafted active_delta REPLACEMENT (id swap) while still allowing every in-place
+# mutation. Mutation-proved IN THE SUITE (m1-m6, each mutant built and run):
+# drop the close-time re-derivation -> a delta grown to evolution closes on the
+# small checklist -> X1 RED; neuter the unchecked-box refusal -> B1 RED; null
+# the slot without appending -> the audit tail stays empty and the next open
+# REUSES the id -> W1/W2 RED; neuter the vocabulary check -> U1 RED; neuter the
+# outstanding-gates refusal -> C1 RED; neuter the seam's replacement atom -> R1
+# RED. Never executes init.sh -> both lanes.
+run_child_suite "tests/test-delta-wp4-close-rubric.sh" \
+  "tests/test-delta-wp4-close-rubric.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 run_child_suite "tests/test-check-phase-gate-poc-block-contract.sh" \
   "tests/test-check-phase-gate-poc-block-contract.sh"

--- a/tests/test-delta-wp3-era-classify.sh
+++ b/tests/test-delta-wp3-era-classify.sh
@@ -781,10 +781,32 @@ else
 fi
 rm -rf "$T"
 
-# ── m2: neuter the SECOND-ACTIVATION refusal -> double-open succeeds -> A1 RED
+# ── m2: neuter the SECOND-ACTIVATION refusal -> A1 RED ─────────────────────
 # FRESH FIXTURE AT PHASE 4 on purpose: at any lower phase the era guard refuses
 # first, this guard never executes, and the mutant would look pinned when it is
 # not. That masking is the failure WP2's per-atom sweep found twice.
+#
+# RE-AIMED BY WP4, AND THE REASON MATTERS MORE THAN THE EDIT. This row used to
+# assert that the mutant's second `--open` SUCCEEDS and OVERWRITES the open
+# delta — "bytes moved; class now feature". That was true of the tree it was
+# written against and is no longer true of this one, because WP4 took the
+# R-WP3-3 carry-forward: `scripts/lib/delta-state.sh`'s ACTIVE-ATOM-NO-REPLACE
+# now refuses, AT THE SEAM, any candidate that swaps a different id into an
+# occupied slot. So the overwrite is caught twice, and the honest question this
+# row now answers is what the BUSINESS guard uniquely delivers once the data
+# loss is prevented elsewhere.
+#
+# The answer, asserted below, is the whole operator-facing outcome: a dedicated
+# exit code (4) that a caller can branch on, and a sentence that NAMES the delta
+# in the way. With the guard neutered the operator instead gets rc 1 and "the
+# delta record refused the change" — a generic write failure that tells them
+# nothing about what to do next. A1 asserts rc == 4 AND that the output names
+# DELTA-001, so A1 still goes RED on both halves.
+#
+# AND THE THIRD CORNER, because "the mutant refused" is also what a
+# comprehensively broken tree would report: the SAME mutant tree opens a delta
+# cleanly (rc 0) in a fixture where nothing is open. The mutant is not broken;
+# it has lost exactly one behaviour.
 T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
 _sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-ACTIVE-GUARD$/s@.*@  if false; then@'
 rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-OPEN-ACTIVE-GUARD$')"
@@ -792,15 +814,21 @@ sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}
 P="$T/proj"; mk_proj "$P" 4
 delta_run "$MT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
 before="$(_md5file "$P/.claude/delta-state.json")"
-delta_run "$MT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+mut_out=$(delta_run "$MT/scripts" "$P" --open --describe "add dark mode" --confirm)
 mut_rc=$?
 after="$(_md5file "$P/.claude/delta-state.json")"
 second_class="$(active_json "$P" -r '.active_delta.class')"
+names=n; printf '%s' "$mut_out" | grep -qF 'DELTA-001' && names=y
+# The third corner: the same mutant tree still opens normally.
+Pf="$T/fresh"; mk_proj "$Pf" 4
+delta_run "$MT/scripts" "$Pf" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+fresh_rc=$?
 if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
-   && [ "$mut_rc" -eq 0 ] && [ "$before" != "$after" ] && [ "$second_class" = "feature" ]; then
-  pass "m2: with the second-activation guard neutered, a second --open SUCCEEDS (rc $mut_rc) and OVERWRITES the open delta (bytes moved; class now $second_class) — A1 goes RED, and this is exactly the loss WP2 deferred to WP3 (marker sites=$sites, one line changed=$nlines/2)"
+   && [ "$mut_rc" -eq 1 ] && [ "$names" = n ] \
+   && [ "$before" = "$after" ] && [ "$second_class" = "fix" ] && [ "$fresh_rc" -eq 0 ]; then
+  pass "m2: with the second-activation guard neutered, a second --open no longer produces the refusal the operator can act on — rc $mut_rc instead of 4, and the open delta is never named (names=$names) — so A1 goes RED on both of its halves. The record itself survives (bytes identical, still a $second_class) because WP4's ACTIVE-ATOM-NO-REPLACE catches the same overwrite at the seam: the loss WP2 deferred to WP3 is now guarded twice, and this guard's remaining job is telling the operator WHICH delta is in the way. The mutant tree is otherwise healthy — it opens cleanly with nothing active (rc $fresh_rc) (marker sites=$sites, one line changed=$nlines/2)"
 else
-  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc=$mut_rc (expect 0); bytes before=$before after=$after (must DIFFER); overwritten class=$second_class (expect feature)"
+  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc=$mut_rc (expect 1 — the seam's generic refusal, NOT 4); names the open delta=$names (expect n); bytes before=$before after=$after (must MATCH — the seam atom holds the record); class still=$second_class (expect fix); mutant opens cleanly on a fresh fixture rc=$fresh_rc (expect 0)"
 fi
 rm -rf "$T"
 

--- a/tests/test-delta-wp4-close-rubric.sh
+++ b/tests/test-delta-wp4-close-rubric.sh
@@ -668,6 +668,55 @@ else
 fi
 rm -rf "$T"
 
+# ── B5: EVERY Done-observable heading opens a rubric section, not just the
+#        first ───────────────────────────────────────────────────────────────
+# THE CONTRACT SENTENCE WAS WRONG, NOT THE CODE. The header used to say "the
+# FIRST heading whose text begins Done-observable"; the awk re-enters the
+# section on any later matching heading, so a brief with two of them has BOTH
+# read. An adversarial review found the mismatch by execution.
+#
+# Which one moves matters, because this header is the normative contract WP8's
+# delta-brief.tmpl will codify. The implementation is the STRICTER of the two —
+# a criterion the operator wrote under a second Done-observable heading is still
+# a criterion, and a first-only reader would silently ignore it — so the
+# sentence moved to match the mechanism. This row is what stops it drifting
+# back, and it pins BOTH directions: the later section's unchecked box refuses
+# (a first-only reader would have closed), and two fully-checked sections close
+# (so "read them all" did not become "refuse anything with two headings").
+T=$(mktemp -d)
+_b5_brief() {
+  local p="$1" second="$2"
+  mkdir -p "$p/docs/deltas"
+  {
+    printf '# DELTA-001 — dark-mode\n\n'
+    printf '## Done-observable\n\n- [x] the settings screen offers a dark theme\n\n'
+    printf '## Notes\n\nsome prose that is not a rubric\n\n'
+    printf '## Done-observable (continued)\n\n%s\n\n' "$second"
+    printf '## Must-not-change\n\n- [ ] never read, wrong section\n'
+  } > "$p/docs/deltas/DELTA-001-dark-mode.md"
+}
+Pu="$T/unchecked"; mk_proj "$Pu" 4
+delta_run "$REPO_ROOT/scripts" "$Pu" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+_b5_brief "$Pu" '- [ ] the choice survives a restart'
+complete_gates "$REPO_ROOT/scripts" "$Pu"
+out_u=$(delta_run "$REPO_ROOT/scripts" "$Pu" --close); rc_u=$?
+names_u=n; printf '%s' "$out_u" | grep -qF 'the choice survives a restart' && names_u=y
+leaks_u=n; printf '%s' "$out_u" | grep -qF 'wrong section' && leaks_u=y
+
+Pc="$T/checked"; mk_proj "$Pc" 4
+delta_run "$REPO_ROOT/scripts" "$Pc" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+_b5_brief "$Pc" '- [x] the choice survives a restart'
+complete_gates "$REPO_ROOT/scripts" "$Pc"
+delta_run "$REPO_ROOT/scripts" "$Pc" --close >/dev/null 2>&1; rc_c=$?
+n_closed="$(active_json "$Pc" -r '.closed | length')"
+if [ "$rc_u" -eq 8 ] && [ "$names_u" = y ] && [ "$leaks_u" = n ] \
+   && [ "$rc_c" -eq 0 ] && [ "$n_closed" = "1" ]; then
+  pass "B5: a SECOND '## Done-observable' heading opens a second rubric section — its unchecked criterion refuses the close (rc $rc_u) and is named, where a first-heading-only reader would have closed clean; with both sections ticked the same brief closes (rc $rc_c). The intervening '## Notes' section and the trailing Must-not-change box are still out of scope (leaked=$leaks_u)"
+else
+  fail_ "B5" "second-section-unchecked rc=$rc_u (expect 8) names it=$names_u (expect y) leaked an out-of-scope box=$leaks_u (expect n); both-checked rc=$rc_c (expect 0) closed length=$n_closed (expect 1)"
+fi
+rm -rf "$T"
+
 # ════════════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== U — the gate-token vocabulary (§5.2) ==="
@@ -721,11 +770,32 @@ echo ""
 echo "=== N — refusal residue: every refused close leaves the tree as found ==="
 # ════════════════════════════════════════════════════════════════════════════
 
-# The WP3 standard, applied to all five refusal shapes at once. `find` over the
-# WHOLE tree with a per-file md5 — not `[ -e ]` on one expected filename, which
-# cannot see a file nobody thought to look for. The ratchet refusal (10) is
-# deliberately EXCLUDED from this list and gets its own honest treatment below:
-# it is the one refusal that is SUPPOSED to record something.
+# THE RESIDUE DOCTRINE, SCOPED TO WHAT EXECUTION SHOWS (R-WP4-1).
+#
+# The first cut of this section claimed that "every PURE refusal leaves the tree
+# byte-for-byte as found" and let the reader infer that exits 6/7/8/9 never
+# write. An adversarial review REFUTED the generalization by execution, and it
+# was right: the ratchet writes whenever the re-measure RAISES an attribute,
+# while exit 10 fires only when gates were also APPENDED. A raise whose toggled
+# gates are already on the list — a SILENT RAISE — records itself and then falls
+# through to the exit-7 or exit-8 refusal. So the true doctrine is not about
+# which exit code you got; it is about whether a raise happened:
+#
+#   6 and 9   ALWAYS whole-tree pristine. 6 returns before anything is measured
+#             and 9 runs BEFORE the ratchet, deliberately (see delta.sh) — which
+#             is the whole reason the vocabulary check is ordered first.
+#   7 and 8   pristine WHEN NO RAISE OCCURRED (this section), and carrying
+#             exactly the bounded ratchet record when one did (N3, N4).
+#  10         always carries that record, by construction (N2).
+#
+# N1's fixtures are non-git on purpose, so `git diff` measures nothing, no raise
+# is possible, and these four paths are the no-raise ones. That is a FIXTURE
+# PROPERTY and not a property of the exit codes — N3 and N4 build the other half
+# rather than leaving it to the reader.
+#
+# The instrument is unchanged: `find` over the WHOLE tree with a per-file md5,
+# not `[ -e ]` on one expected filename, which cannot see a file nobody thought
+# to look for.
 T=$(mktemp -d)
 n1_detail=""; n1_ok=y
 _n1() {
@@ -758,7 +828,7 @@ n1_detail="$n1_detail [nothing-open=rc$rc]"
 [ "$rc" -eq 6 ] || n1_ok=n
 [ "$before" = "$after" ] || { n1_ok=n; n1_detail="$n1_detail(TREE MOVED)"; }
 if [ "$n1_ok" = y ]; then
-  pass "N1: every PURE refusal —$n1_detail — leaves the whole tree byte-for-byte as it found it, asserted as a find-based manifest with a per-file md5 and not against one expected filename"
+  pass "N1: with NO raise in play —$n1_detail — every refusal leaves the whole tree byte-for-byte as it found it, asserted as a find-based manifest with a per-file md5 and not against one expected filename. (These fixtures are non-git, so nothing can be measured and nothing can raise; N3/N4 build the composite where one does.)"
 else
   fail_ "N1" "expected rc 7/8/9/6 with an unchanged tree; got:$n1_detail"
 fi
@@ -797,6 +867,107 @@ else
   fail_ "N2" "rc=$rc (expect 10); a file other than the state file moved=$others_moved (expect n); the state change is confined to attributes+gates_required=$confined (expect true); state file actually changed=$([ "$before" != "$after" ] && echo y || echo n) (expect y)"
 fi
 rm -rf "$T"
+
+# ── N3 / N4: THE SILENT-RAISE COMPOSITE — a refusal that is NOT rc 10 and
+#             STILL carries the ratchet record ────────────────────────────────
+# THE CASE THE FIRST CUT OF THIS SUITE DID NOT BUILD, and the one an adversarial
+# review found by execution. The ratchet write is gated on "an attribute rose";
+# the rc-10 refusal is gated on "and a gate was appended". Those two conditions
+# are NOT the same, and every attribute raise that toggles nothing falls through
+# the gap: the record is updated and then a LATER refusal returns.
+#
+# There are exactly two ways to raise without appending, and both are built:
+#   N3  a level raise into a bracket that toggles nothing. Only
+#       `level: evolution` carries a toggle (§5.2), so small -> significant is
+#       structurally silent — it can never append.
+#   N4  a raise whose toggled gate is ALREADY on the list. `risk: core` toggles
+#       brief_review, which a feature already carries, so the append set is
+#       empty by set arithmetic rather than by policy.
+# Two different mechanisms reaching the same state; pinning one would have left
+# the other free to drift.
+#
+# Each asserts FOUR things, and the last two are what make it a bound rather
+# than an observation: the raise LANDED, gates_required did NOT grow (which is
+# what distinguishes this from X1 and is the reason the exit code is 7/8 and not
+# 10), no file outside the state document moved, and inside it nothing but
+# attributes / gates_required / ratcheted_at changed. Plus IDEMPOTENCE on N3: a
+# second close re-measures to the same bracket and writes nothing at all, so the
+# record cannot accrete across repeated refused closes.
+
+_silent_raise_case() {
+  # $1 label · $2 want-rc · $3 project dir · sets: sr_ok / sr_detail
+  local label="$1" want="$2" P="$3"
+  local before after b_others a_others others_moved snapshot now_json confined
+  local rc out grew attr_after
+  before="$(tree_manifest "$P")"
+  snapshot="$(active_json "$P" -c '.')"
+  out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+  after="$(tree_manifest "$P")"
+  b_others="$(printf '%s\n' "$before" | grep -v 'delta-state.json' || true)"
+  a_others="$(printf '%s\n' "$after"  | grep -v 'delta-state.json' || true)"
+  others_moved=n; [ "$b_others" = "$a_others" ] || others_moved=y
+  now_json="$(active_json "$P" -c '.')"
+  confined=$(jq -n --argjson a "$snapshot" --argjson b "$now_json" '
+      ($a | .active_delta |= (del(.attributes) | del(.gates_required) | del(.ratcheted_at)))
+   == ($b | .active_delta |= (del(.attributes) | del(.gates_required) | del(.ratcheted_at)))' 2>/dev/null)
+  confined="${confined:-READ-FAILED}"
+  grew=$(jq -n --argjson a "$snapshot" --argjson b "$now_json" \
+    '($b.active_delta.gates_required | length) > ($a.active_delta.gates_required | length)' 2>/dev/null)
+  grew="${grew:-READ-FAILED}"
+  attr_after="$(active_json "$P" -c '.active_delta.attributes | {risk, level}')"
+  # The raise must be ANNOUNCED. An operator whose recorded attributes were
+  # rewritten with no word about it would have to diff the state file to find
+  # out — which is the half of this defect that is not about doctrine.
+  sr_announced=n; printf '%s' "$out" | grep -qiE 're-measured|re-measure' && sr_announced=y
+  sr_detail="$sr_detail [$label rc=$rc changed=$([ "$before" != "$after" ] && echo y || echo n) others=$others_moved confined=$confined grew=$grew attrs=$attr_after announced=$sr_announced]"
+  [ "$rc" -eq "$want" ]        || sr_ok=n
+  [ "$before" != "$after" ]    || sr_ok=n
+  [ "$others_moved" = n ]      || sr_ok=n
+  [ "$confined" = "true" ]     || sr_ok=n
+  [ "$grew" = "false" ]        || sr_ok=n
+  [ "$sr_announced" = y ]      || sr_ok=n
+  return 0
+}
+
+sr_ok=y; sr_detail=""; sr_announced=n
+
+# N3 — a LEVEL raise that no toggle answers: small -> significant, exit 7.
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":[],"size_thresholds":{"small":5,"significant":20}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the export is broken" --class fix --slug export --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P" repro_test_red_first
+grow "$P/src/ui/theme.ts" 10
+_silent_raise_case "level-raise/rc7" 7 "$P"
+lvl_after="$(active_json "$P" -r '.active_delta.attributes.level')"
+[ "$lvl_after" = "significant" ] || { sr_ok=n; sr_detail="$sr_detail(LEVEL DID NOT RISE)"; }
+# Idempotence: a second refused close re-measures to the same bracket and must
+# write nothing, or the record accretes one ratcheted_at per attempt.
+stamp1="$(active_json "$P" -r '.active_delta.ratcheted_at')"
+md1="$(_md5file "$P/.claude/delta-state.json")"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc2=$?
+md2="$(_md5file "$P/.claude/delta-state.json")"
+stamp2="$(active_json "$P" -r '.active_delta.ratcheted_at')"
+[ "$rc2" -eq 7 ] && [ "$md1" = "$md2" ] && [ "$stamp1" = "$stamp2" ] \
+  || { sr_ok=n; sr_detail="$sr_detail(NOT IDEMPOTENT rc2=$rc2 md $md1->$md2 stamp $stamp1->$stamp2)"; }
+rm -rf "$T"
+
+# N4 — a RISK raise whose toggled gate the class already carries, exit 8.
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"],"size_thresholds":{"small":500,"significant":900}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+write_brief "$P" DELTA-001 dark-mode '- [ ] the choice survives a restart'
+complete_gates "$REPO_ROOT/scripts" "$P"
+grow "$P/src/auth/login.ts" 3
+_silent_raise_case "risk-raise/rc8" 8 "$P"
+risk_after="$(active_json "$P" -r '.active_delta.attributes.risk')"
+[ "$risk_after" = "core" ] || { sr_ok=n; sr_detail="$sr_detail(RISK DID NOT RISE)"; }
+rm -rf "$T"
+
+if [ "$sr_ok" = y ]; then
+  pass "N3/N4: a raise that appends NO gate still records itself and then refuses with a LATER code —$sr_detail — so 'rc 7/8 means nothing was written' is false and this suite says so. Both mechanisms are built (a bracket with no toggle; a toggle the class already carries), the residue is bounded exactly as N2's is, gates_required does NOT grow (which is why the code is 7/8 and not 10), the raise is ANNOUNCED to the operator rather than applied silently, and a second refused close writes nothing at all"
+else
+  fail_ "N3/N4" "each case must be rc 7 / rc 8 respectively WITH the state file changed, no other file moved, the change confined to attributes+gates_required+ratcheted_at, gates_required NOT grown, and the raise announced in the transcript; got:$sr_detail"
+fi
 
 # ════════════════════════════════════════════════════════════════════════════
 echo ""

--- a/tests/test-delta-wp4-close-rubric.sh
+++ b/tests/test-delta-wp4-close-rubric.sh
@@ -1,0 +1,1058 @@
+#!/usr/bin/env bash
+# tests/test-delta-wp4-close-rubric.sh — Delta Track WP4.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §5.2 (the per-class gate
+# table and its token vocabulary), §5.3 (the brief's done-observable section IS
+# the close review's rubric — "the close gate reads the brief's criteria
+# section and refuses an unchecked box"), §4.2 (the two honest limits: the
+# close-time re-derivation RATCHETS and never lowers, and a raise APPENDS
+# gates), §6.2 (the brief's five sections; done-observable is the rubric),
+# §7.1 (gates_required / gates_completed, the append-only `closed` tail, the
+# single-writer rule), §7.2 (every gate list and threshold is READ FROM
+# POLICY), §11-WP4.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose: no backlog
+# entry exists for this build and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1,
+# WP2 and WP3 precedent.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES, NEVER LABELS
+#
+# Every assertion below reads a process EXIT CODE, a JSON value read back off
+# disk, or a byte-level md5 / whole-tree manifest. None reads a printed
+# [OK]/[WARN]/[FAIL] banner. CLAUDE.md's `[WARN]` trap is exactly that the label
+# and the exit predicate can disagree. The close flow has SIX distinct refusal
+# outcomes and they are told apart by their codes:
+#
+#     6   nothing is open to close
+#     7   required gates are still outstanding
+#     8   the brief's rubric has an unchecked (or unreadable) criterion
+#     9   an unknown gate token — a configuration error, failing CLOSED
+#    10   the close-time re-measurement RAISED an attribute and added
+#         obligations, so the close refuses on the LARGER checklist
+#
+# Codes 7 and 9 are deliberately different, and U2 is the case that needs the
+# difference: a project that retunes `attribute_toggles` to a token the
+# framework has never heard of must get "you still owe this" (7) and never
+# "this is not a gate" (9). A suite that asserted "the close was refused" could
+# not tell those two apart, and the wrong one of them is a project locked out
+# of closing its own deltas.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THIS SUITE PINS, AND WHICH MUTANT EACH ROW KILLS
+#
+#   C — THE PER-CLASS GATE REFUSAL (§5.2)
+#     C1  a FEATURE with brief_review outstanding is refused (7), named  KILLS m5
+#     C2  a FIX with repro_test_red_first outstanding is refused (7), named
+#     C3  a close with nothing open is refused (6) and creates nothing
+#     C4  every gate complete => the close proceeds (rc 0). Without this the
+#         refusals could be a script that always refuses, which is not a gate
+#
+#   K — --complete-gate, AND ITS HONEST NOTE
+#     K1  a listed token is recorded, idempotently; a token this delta does not
+#         owe is an invocation error (2) that writes nothing; nothing open is 6
+#     K2  the surface does not OVERCLAIM: it says the gate is ATTESTED and
+#         names the two mechanical exceptions this WP actually makes real
+#
+#   W — THE ATOMIC CLOSE WRITE (§7.1, and carry-forward (a))
+#     W1  ONE seam write: `closed` grows by exactly one AND the slot nulls,
+#         with class / severity / closed_at / attributes / gates_completed
+#         archived on the row                                            KILLS m3
+#     W2  THE ID-REUSE PIN: the next open takes DELTA-002, because the closed
+#         row is what `_next_id` reads. A close that nulls without appending
+#         hands the NEXT delta the id of the one just closed
+#     W3  the close is NOT era-guarded. §10.1 puts the era refusal at OPEN; an
+#         open delta at phase < 4 is already the inconsistency validate.sh
+#         reports, and closing it is the only way to restore the invariant
+#
+#   X — THE CLOSE-TIME RE-DERIVATION AND ITS RATCHET (§4.2)
+#     X1  a delta opened small/feature-local whose REAL diff at close crosses
+#         into evolution/core raises both attributes, APPENDS the newly toggled
+#         gates, and refuses (10) naming them                            KILLS m1
+#     X2  the ratchet is not a dead end: completing the new obligations (and
+#         satisfying the brief the ratchet just demanded) closes the delta
+#     X3  RATCHET DIRECTION: a shrunken diff does NOT lower a confirmed
+#         attribute, and removes no gate
+#
+#   B — THE RUBRIC BIND (§5.3)
+#     B1  a brief with one unchecked box refuses the close (8) and NAMES the
+#         criterion                                                      KILLS m2
+#     B2  all boxes checked => the close proceeds
+#     B3  a class with no `brief` gate is unaffected — it closes with no
+#         docs/deltas directory in the tree at all
+#     B4  FAIL-CLOSED, four ways: no brief file; no Done-observable section;
+#         a section with zero checkboxes; a malformed marker. A rubric that
+#         cannot be read is not a rubric that passed
+#
+#   U — THE GATE-TOKEN VOCABULARY (§5.2)
+#     U1  an unknown token in gates_required is a config error (9) even when it
+#         is also marked complete — it fails CLOSED                      KILLS m4
+#     U2  and the vocabulary is POLICY-DERIVED, not a hardcoded table: a project
+#         that retunes attribute_toggles to `second_reviewer` gets 7, not 9,
+#         and closes once it completes it
+#
+#   N — REFUSAL RESIDUE (the WP3 standard, inherited verbatim)
+#     N1  every refused close leaves the tree EXACTLY as it found it — asserted
+#         as a whole-tree `find` manifest with a per-file md5, not against one
+#         expected filename
+#
+#   R — R-WP3-3: THE SEAM-LEVEL REPLACEMENT REFUSAL (carry-forward (b), taken)
+#     R1  --delta-state-update REPLACING an open active_delta with a different
+#         id is refused at the SEAM, file byte-identical                 KILLS m6
+#     R2  and the atom refuses REPLACEMENT, not MUTATION: the same delta's
+#         gates_completed append still writes. Without R2 the atom could be a
+#         blanket non-null->non-null refusal, which would break --complete-gate
+#         and the ratchet write — both of which are exactly that shape
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# COUNTERFACTUAL DISCIPLINE — how the mutations below are built
+#
+# Inherited from tests/test-delta-wp3-era-classify.sh and unchanged, because it
+# is what makes a mutation proof a proof:
+#
+#   • ANCHORED SINGLE-SITE addresses. Every marker is pinned to END-OF-LINE
+#     (`/# DELTA-CLOSE-RATCHET$/`), never a bare substring — WP2's suite records
+#     what over-matching costs: an unanchored `/SHAPE-ATOM-CLOSED/` also matches
+#     SHAPE-ATOM-CLOSED-ROWS and credits one RED to two atoms.
+#   • THREE PROPERTIES ASSERTED BEFORE THE RESULT IS BELIEVED: the marker
+#     resolves to EXACTLY ONE line in the pristine file; the mutant DIFFERS from
+#     it; and EXACTLY ONE LINE changed (one `<` and one `>`).
+#   • MODE-PRESERVING harness. `_sed_inplace` reads each file's mode and puts it
+#     back; the obvious `chmod +x` spelling silently turns a sourced 0644 lib
+#     into 0755 and the mode rides along in the next commit.
+#   • FRESH-FIXTURE ISOLATION. Every mutation builds its own mktemp project, and
+#     — this is the part that bites in a close flow — the fixture must reach the
+#     guard under test. m2's brief-rubric fixture must have every gate COMPLETE,
+#     or the outstanding-gates refusal fires two guards earlier and the mutant
+#     looks pinned when it is not. m4's fixture must mark the unknown token
+#     COMPLETE for the same reason.
+#   • STRUCTURAL DISCRIMINATORS WHERE THE EXPECTED RESULT IS AN ABSENCE. Four of
+#     the six mutants below expect "the refusal did not happen", which is the
+#     same answer a fixture that never reached the guard would give. Each of
+#     those rows therefore also asserts a POSITIVE consequence of the mutation
+#     having landed — the closed row's attributes are still the SMALL ones while
+#     the real diff in the same fixture measures evolution (m1); the brief in
+#     the mutant's own tree still carries an unchecked box (m2); the next id is
+#     REUSED (m3); the closed row's gates_completed lacks the gate that was
+#     outstanding (m5) — and every one of them is measured against the PRISTINE
+#     tree run on an identical fixture in the same case.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# HERMETICITY: every fixture is a mktemp -d project carrying NO init.sh and NO
+# templates/generated, so guard_not_in_framework sees a project and not the
+# framework. Git fixtures configure an identity and unset GITHUB_BASE_REF. No
+# remote is ever created; nothing reaches the network; nothing is written inside
+# the checkout. bash-3.2 safe: no associative arrays, no ${var,,}, no ((x++)).
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name init.sh.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for tests/test-delta-wp4-close-rubric.sh" >&2
+  exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-delta-wp4-close-rubric.sh" >&2
+  exit 2
+fi
+
+# Portable md5 of a single file (macOS `md5 -q`, Linux `md5sum`) — house pattern.
+_md5file() {
+  if command -v md5 >/dev/null 2>&1; then md5 -q "$1"
+  else md5sum "$1" | awk '{print $1}'; fi
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+mk_proj() {
+  local d="$1" phase="$2"
+  mkdir -p "$d/.claude"
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":%s,"phases":{}}\n' \
+    "$phase" > "$d/.claude/phase-state.json"
+}
+
+# A REAL git project, so the close-time re-derivation runs against a real
+# `git diff --name-only` / `--shortstat`. One tracked file under a path a
+# project would plausibly call a risk surface, one that plainly is not.
+mk_git_proj() {
+  local d="$1" phase="$2"
+  mk_proj "$d" "$phase"
+  mkdir -p "$d/src/auth" "$d/src/ui"
+  printf 'base\n' > "$d/src/auth/login.ts"
+  printf 'base\n' > "$d/src/ui/theme.ts"
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.local && git config user.name T \
+      && unset GITHUB_BASE_REF && git add -A && git commit -q -m init ) >/dev/null 2>&1
+}
+
+# grow <file> <n> — append exactly n lines, so `git diff --shortstat` reports a
+# KNOWN insertion count and the level bracket is a measurement, not a guess.
+grow() {
+  local f="$1" n="$2" i=1
+  while [ "$i" -le "$n" ]; do printf 'added line %s\n' "$i" >> "$f"; i=$((i + 1)); done
+}
+
+write_policy() { printf '%s\n' "$2" > "$1/.claude/delta-policy.json"; }
+
+# write_brief <project> <id> <slug> [done-observable lines…]
+#   §6.2's five-section brief, rendered in the convention this WP parses and
+#   WP8's template must match: checkbox rows under a `## Done-observable`
+#   heading. The other four sections are present so the parser is proved to
+#   SCOPE to the rubric rather than scanning the whole file — Must-not-change
+#   below deliberately carries an unchecked box of its own.
+write_brief() {
+  local p="$1" id="$2" slug="$3" l
+  shift 3
+  mkdir -p "$p/docs/deltas"
+  {
+    printf '# %s — %s\n\n' "$id" "$slug"
+    printf '## What\n\n- [ ] this box is not a criterion and must be ignored\n\n'
+    printf '## Why\n\nA user asked for it.\n\n'
+    printf '## Done-observable\n\n'
+    for l in "$@"; do printf '%s\n' "$l"; done
+    printf '\n## Must-not-change\n\n- [ ] nor is this one\n\n'
+    printf '## Touched surfaces\n\nsrc/\n'
+  } > "$p/docs/deltas/$id-$slug.md"
+}
+
+mk_scripts_tree() {
+  mkdir -p "$1"
+  cp -R "$REPO_ROOT/scripts" "$1/scripts"
+}
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+delta_run() {
+  local sd="$1" p="$2"; shift 2
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/delta.sh" "$@" </dev/null 2>&1 )
+}
+
+seam() {
+  local sd="$1" p="$2"; shift 2
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/process-checklist.sh" "$@" </dev/null 2>/dev/null )
+}
+
+# active_json <project-dir> [jq-flags…] <filter> — read an assertion straight
+# off the state file the seam wrote. A missing or unreadable file yields the
+# literal READ-FAILED, which no expectation below ever matches: a helper that
+# returned "" would let an absent file satisfy any negative assertion.
+active_json() {
+  local p="$1"; shift
+  jq "$@" "$p/.claude/delta-state.json" 2>/dev/null || printf 'READ-FAILED'
+}
+
+# complete_gates <scripts-dir> <project-dir> [skip-token]
+#   Attest every gate this delta owes, optionally leaving ONE outstanding. Every
+#   completion goes through the production surface, never a hand-written file.
+complete_gates() {
+  local sd="$1" p="$2" skip="${3:-}" g
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    [ "$g" = "$skip" ] && continue
+    delta_run "$sd" "$p" --complete-gate "$g" >/dev/null 2>&1
+  done <<EOF
+$(jq -r '.active_delta.gates_required[]? // empty' "$p/.claude/delta-state.json" 2>/dev/null)
+EOF
+  return 0
+}
+
+# tree_files <project-dir> — every file in the tree, one per line, sorted.
+# `.git/**` is excluded and that exclusion is not a convenience: `git diff` is
+# allowed to refresh the index's stat cache, so `.git/index` can legitimately
+# change bytes during a read-only measurement. Including it would make the
+# residue assertion fail for a reason that has nothing to do with the close.
+tree_files() {
+  ( cd "$1" && find . -type f ! -path './.git/*' | LC_ALL=C sort )
+}
+
+# tree_manifest <project-dir> — every file in the tree with its md5. THE
+# refusal-residue instrument: a refusal that says "nothing was closed" is a
+# claim about the whole filesystem, and checking one expected filename cannot
+# see a file nobody thought to look for.
+tree_manifest() {
+  local p="$1" f
+  tree_files "$p" | while IFS= read -r f; do
+    printf '%s  %s\n' "$(_md5file "$p/$f")" "$f"
+  done
+}
+
+# ── Mutation harness (inherited from the WP2/WP3 suites) ────────────────────
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_mutation_report() {
+  local orig="$1" mut="$2" marker="$3" sites changed n
+  sites="$(grep -c "$marker" "$orig" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  if diff "$orig" "$mut" >/dev/null 2>&1; then changed=n; else changed=y; fi
+  n="$(diff "$orig" "$mut" | grep -c '^[<>]' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s|%s|%s' "$sites" "$changed" "$n"
+}
+
+echo "== tests/test-delta-wp4-close-rubric.sh =="
+echo ""
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== C — the per-class gate refusal (§5.2) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── C1: a FEATURE with brief_review outstanding  [KILLS m5] ─────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P" brief_review
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+names=n; printf '%s' "$out" | grep -qF 'brief_review' && names=y
+still_open="$(active_json "$P" -r '.active_delta.id')"
+if [ "$rc" -eq 7 ] && [ "$names" = y ] && [ "$before" = "$after" ] && [ "$still_open" = "DELTA-001" ]; then
+  pass "C1: a feature whose brief_review is still outstanding cannot close (rc $rc), the refusal NAMES the outstanding gate, and the record is byte-identical afterwards — the delta is still open ($still_open)"
+else
+  fail_ "C1" "rc=$rc (expect 7); names the gate=$names; bytes before=$before after=$after (must MATCH); active id=$still_open (expect DELTA-001); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── C2: a FIX with repro_test_red_first outstanding ─────────────────────────
+# The other §5.2 row, and a different token: the refusal reads the delta's OWN
+# materialised list, it does not carry a per-class table of its own.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P" repro_test_red_first
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+names=n; printf '%s' "$out" | grep -qF 'repro_test_red_first' && names=y
+leaks=n; printf '%s' "$out" | grep -qF 'brief_review' && leaks=y
+if [ "$rc" -eq 7 ] && [ "$names" = y ] && [ "$leaks" = n ]; then
+  pass "C2: a fix whose repro_test_red_first is outstanding is refused (rc $rc) naming that token and no other — the outstanding set is gates_required minus gates_completed on THIS delta's row"
+else
+  fail_ "C2" "rc=$rc (expect 7); names repro_test_red_first=$names; mentions a gate this class does not owe=$leaks (expect n); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── C3: nothing open ────────────────────────────────────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+left="$( ( cd "$P" && find . -type f | LC_ALL=C sort ) | tr '\n' ' ')"
+if [ "$rc" -eq 6 ] && [ "$left" = "./.claude/phase-state.json " ]; then
+  pass "C3: --close with nothing open is refused (rc $rc) and creates nothing — the tree still holds exactly the one file it started with"
+else
+  fail_ "C3" "rc=$rc (expect 6); files after='$left' (expect exactly './.claude/phase-state.json ')"
+fi
+rm -rf "$T"
+
+# ── C4: every gate complete => the close proceeds ───────────────────────────
+# Without this the refusals above are consistent with a --close that always
+# refuses, which is not a gate.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+slot="$(active_json "$P" -r '.active_delta')"
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 0 ] && [ "$slot" = "null" ] && [ "$n_closed" = "1" ]; then
+  pass "C4: with every §5.2 gate attested the close proceeds (rc $rc), the slot empties and the audit tail grows to $n_closed row"
+else
+  fail_ "C4" "rc=$rc (expect 0); active_delta=$slot (expect null); closed length=$n_closed (expect 1); output:\n$out"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== K — --complete-gate, and its honest note ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── K1: record, idempotence, a gate this delta does not owe, nothing open ───
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --complete-gate ledger_row >/dev/null 2>&1; rc_none=$?
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+delta_run "$REPO_ROOT/scripts" "$P" --complete-gate ledger_row >/dev/null 2>&1; rc_first=$?
+delta_run "$REPO_ROOT/scripts" "$P" --complete-gate ledger_row >/dev/null 2>&1; rc_again=$?
+done_once="$(active_json "$P" -c '[.active_delta.gates_completed[] | select(. == "ledger_row")] | length')"
+before="$(_md5file "$P/.claude/delta-state.json")"
+delta_run "$REPO_ROOT/scripts" "$P" --complete-gate build_loop >/dev/null 2>&1; rc_notowed=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+if [ "$rc_none" -eq 6 ] && [ "$rc_first" -eq 0 ] && [ "$rc_again" -eq 0 ] \
+   && [ "$done_once" = "1" ] && [ "$rc_notowed" -eq 2 ] && [ "$before" = "$after" ]; then
+  pass "K1: --complete-gate is refused with nothing open (rc $rc_none), records a listed token (rc $rc_first), is IDEMPOTENT (rc $rc_again, recorded $done_once time), and refuses a token this delta does not owe (rc $rc_notowed) without touching the record"
+else
+  fail_ "K1" "nothing-open rc=$rc_none (expect 6); first rc=$rc_first (expect 0); repeat rc=$rc_again (expect 0); times recorded=$done_once (expect 1); not-owed rc=$rc_notowed (expect 2); bytes $before -> $after (must MATCH)"
+fi
+rm -rf "$T"
+
+# ── K2: the surface does not OVERCLAIM ──────────────────────────────────────
+# §5.3 tiers the review honestly: the RUBRIC is mechanical, everything else is
+# advisory. A --complete-gate that printed "verified" would be exactly the
+# overclaim the design refuses to make.
+#
+# WHAT THIS ASSERTS, AND WHAT IT DELIBERATELY DOES NOT. It does not require any
+# particular word — an earlier cut demanded the literal "attest" and was pinning
+# its own prose, which §4.3's plain register can legitimately reword tomorrow.
+# The two DURABLE properties are: (a) the surface never claims a check it does
+# not perform, and (b) it names BOTH of the two things this WP does check
+# mechanically — the brief's boxes and the close-time re-measurement — so a
+# future edit cannot quietly drop one and leave the operator believing the
+# remaining half is everything.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --complete-gate ledger_row)
+help_out=$(delta_run "$REPO_ROOT/scripts" "$P" --help)
+no_verify=y; printf '%s' "$out" | grep -qiE 'verified|we checked|checked for you|confirmed by the framework|guarantee' && no_verify=n
+names_brief=n;  printf '%s' "$out" | grep -qi 'brief' && names_brief=y
+names_close=n;  printf '%s' "$out" | grep -qi 'close' && names_close=y
+help_close=n;   printf '%s' "$help_out" | grep -qF -- '--close' && help_close=y
+help_gate=n;    printf '%s' "$help_out" | grep -qF -- '--complete-gate' && help_gate=y
+help_honest=y;  printf '%s' "$help_out" | grep -qiE 'verified|we checked|checked for you|guarantee' && help_honest=n
+if [ "$no_verify" = y ] && [ "$names_brief" = y ] && [ "$names_close" = y ] \
+   && [ "$help_close" = y ] && [ "$help_gate" = y ] && [ "$help_honest" = y ]; then
+  pass "K2: recording a gate claims no check the framework does not perform, and names BOTH mechanical exceptions (the brief's boxes and the close-time re-measurement); --help names both new surfaces and is free of the same overclaim"
+else
+  fail_ "K2" "free of a verification overclaim=$no_verify (expect y); names the brief check=$names_brief; names the close-time check=$names_close; help names --close=$help_close, --complete-gate=$help_gate, help free of overclaim=$help_honest; output:\n$out"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== W — the atomic close write (§7.1) and the id-reuse pin ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── W1/W2: ONE write; the tail grows by one as the slot empties  [KILLS m3] ─
+# CARRY-FORWARD (a), the id-reuse hazard, stated as the thing it actually is:
+# `_next_id` computes max(existing ids) + 1 over closed[] + hotfix_retros[] +
+# active_delta. A close that empties the slot WITHOUT appending to closed erases
+# the id from the record entirely — so the next open legitimately reuses it, and
+# two different pieces of work end up sharing one identifier in the audit tail.
+# The append and the null must therefore land in ONE seam write, and W2 is what
+# makes the consequence observable rather than asserted.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+row="$(active_json "$P" -c '.closed[0]')"
+# NOTE the unquoted `$(` on this assignment: bash 3.2 mis-parses a MULTI-LINE
+# command substitution that carries nested double quotes when it sits inside an
+# outer pair of them. `x=$( … )` is exactly as safe on the right-hand side of an
+# assignment and parses; `x="$( … )"` is a syntax error before it is anything
+# else. (Same reason the WP2 suite spells its multi-line jq reads this way.)
+shape=$(printf '%s' "$row" | jq -r '
+  [ (.id == "DELTA-001"),
+    (.class == "fix"),
+    (.severity == "SEV-2"),
+    ((.closed_at | type) == "string"), ((.closed_at | length) > 0),
+    (.shipped_in == null),
+    (.attributes.risk == "feature-local"), (.attributes.level == "small"),
+    ((.gates_completed | type) == "array"),
+    ((.gates_completed | index("repro_test_red_first")) != null),
+    ((.gates_completed | index("changelog")) != null) ] | all' 2>/dev/null)
+shape="${shape:-READ-FAILED}"
+slot="$(active_json "$P" -r '.active_delta')"
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+next_id="$(active_json "$P" -r '.active_delta.id')"
+if [ "$rc" -eq 0 ] && [ "$shape" = "true" ] && [ "$slot" = "null" ] && [ "$next_id" = "DELTA-002" ]; then
+  pass "W1/W2: the close appends a full audit row (class, severity, closed_at, shipped_in null, the ratcheted attributes and the archived gates_completed) AND empties the slot in one write; the NEXT open takes $next_id, so the id is not reused"
+else
+  fail_ "W1/W2" "rc=$rc (expect 0); closed row shape=$shape (expect true) row=$row; active_delta=$slot (expect null); next id=$next_id (expect DELTA-002)"
+fi
+rm -rf "$T"
+
+# ── W3: the close is NOT era-guarded ────────────────────────────────────────
+# §10.1 places the era refusal at OPEN, and only there. An `active_delta` at
+# phase < 4 is the inconsistency scripts/validate.sh reports — and closing it is
+# the only way to restore `active_delta != null => current_phase == 4`. A close
+# that refused below phase 4 would strand the delta in the very state the
+# invariant forbids, forever.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+mk_proj "$P" 2
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+slot="$(active_json "$P" -r '.active_delta')"
+if [ "$rc" -eq 0 ] && [ "$slot" = "null" ]; then
+  pass "W3: an open delta at phase 2 CAN be closed (rc $rc, slot now $slot) — the era refusal is at open only, so closing is the one path back to a consistent record"
+else
+  fail_ "W3" "rc=$rc (expect 0); active_delta=$slot (expect null) — a close refused below phase 4 would strand the delta in exactly the state §10.1 forbids"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X — close-time re-derivation and the ratchet (§4.2) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── X1: grown past both brackets => raise, append, refuse  [KILLS m1] ───────
+# THE DESIGN'S OWN CASE (§11-WP4), built from a REAL diff: opened with an empty
+# working tree (small, feature-local), then thirty lines land in a risk surface.
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"],"size_thresholds":{"small":5,"significant":20}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "token check is wrong" --class fix --slug token-check --confirm >/dev/null 2>&1
+open_attrs="$(active_json "$P" -c '.active_delta.attributes | {risk, level}')"
+complete_gates "$REPO_ROOT/scripts" "$P"
+grow "$P/src/auth/login.ts" 30
+files_before="$(tree_files "$P" | tr '\n' ' ')"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+files_after="$(tree_files "$P" | tr '\n' ' ')"
+close_attrs="$(active_json "$P" -c '.active_delta.attributes | {risk, level}')"
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+n_closed="$(active_json "$P" -r '.closed | length')"
+names=n
+printf '%s' "$out" | grep -qF 'brief_review' && printf '%s' "$out" | grep -qF 'brief' && names=y
+if [ "$rc" -eq 10 ] \
+   && [ "$open_attrs" = '{"risk":"feature-local","level":"small"}' ] \
+   && [ "$close_attrs" = '{"risk":"core","level":"evolution"}' ] \
+   && [ "$gates" = '["ledger_row","repro_test_red_first","close_review","changelog","brief_review","brief"]' ] \
+   && [ "$n_closed" = "0" ] && [ "$names" = y ] && [ "$files_before" = "$files_after" ]; then
+  pass "X1: a delta opened $open_attrs whose real diff at close measures $close_attrs raises BOTH attributes, appends the newly toggled gates ($gates) and refuses (rc $rc) naming them — the audit tail is still empty ($n_closed rows) and no file was created or removed"
+else
+  fail_ "X1" "rc=$rc (expect 10); at open=$open_attrs (expect feature-local/small); at close=$close_attrs (expect core/evolution); gates=$gates; closed length=$n_closed (expect 0); names the new obligations=$names; files before='$files_before' after='$files_after'"
+fi
+rm -rf "$T"
+
+# ── X2: the ratchet is not a dead end ───────────────────────────────────────
+# The appended gates include `brief`, which turns the rubric bind ON for a class
+# that did not have it at open. Satisfying both closes the delta — and the
+# closed row records the RAISED attributes, not the ones confirmed at open.
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"],"size_thresholds":{"small":5,"significant":20}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "token check is wrong" --class fix --slug token-check --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+grow "$P/src/auth/login.ts" 30
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc_first=$?
+write_brief "$P" DELTA-001 token-check '- [x] the token check rejects an expired token' '- [x] the regression test covers it'
+complete_gates "$REPO_ROOT/scripts" "$P"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc_second=$?
+row_attrs="$(active_json "$P" -c '.closed[0].attributes | {risk, level}')"
+n_gates="$(active_json "$P" -r '.closed[0].gates_completed | length')"
+slot="$(active_json "$P" -r '.active_delta')"
+if [ "$rc_first" -eq 10 ] && [ "$rc_second" -eq 0 ] && [ "$slot" = "null" ] \
+   && [ "$row_attrs" = '{"risk":"core","level":"evolution"}' ] && [ "$n_gates" = "6" ]; then
+  pass "X2: after the ratchet refusal (rc $rc_first) the operator completes the two new obligations and satisfies the brief the ratchet demanded, and the close proceeds (rc $rc_second) recording the RAISED attributes $row_attrs and all $n_gates attested gates"
+else
+  fail_ "X2" "first close rc=$rc_first (expect 10); second rc=$rc_second (expect 0); active_delta=$slot (expect null); closed attributes=$row_attrs (expect core/evolution); archived gate count=$n_gates (expect 6)"
+fi
+rm -rf "$T"
+
+# ── X3: RATCHET DIRECTION — a shrunken diff never lowers ────────────────────
+# The operator raised risk to core at open; the real diff at close touches
+# nothing sensitive and measures feature-local. §4.2 is explicit that the
+# re-derivation "never lowers", so the confirmed value stands and the gate it
+# toggled stays on the list.
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"],"size_thresholds":{"small":5,"significant":20}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the theme toggle is wrong" --class fix --risk core --confirm >/dev/null 2>&1
+gates_open="$(active_json "$P" -c '.active_delta.gates_required')"
+complete_gates "$REPO_ROOT/scripts" "$P"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+row_risk="$(active_json "$P" -r '.closed[0].attributes.risk')"
+row_gates="$(active_json "$P" -c '.closed[0].gates_completed')"
+if [ "$rc" -eq 0 ] && [ "$row_risk" = "core" ] \
+   && [ "$gates_open" = '["ledger_row","repro_test_red_first","close_review","changelog","brief_review"]' ] \
+   && [ "$row_gates" = "$gates_open" ]; then
+  pass "X3: a delta confirmed at risk=core whose close-time diff measures feature-local closes (rc $rc) STILL AT core — the re-derivation ratchets up only, and the brief_review the raise toggled on is still on the archived list"
+else
+  fail_ "X3" "rc=$rc (expect 0); closed attributes.risk=$row_risk (expect core — a lower would mean the ratchet runs both ways); gates at open=$gates_open; archived=$row_gates (must match)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== B — the rubric bind: the brief's Done-observable section (§5.3) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── B1: one unchecked box refuses the close and NAMES it  [KILLS m2] ───────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+write_brief "$P" DELTA-001 dark-mode \
+  '- [x] the settings screen offers a dark theme' \
+  '- [ ] the choice survives a restart' \
+  '- [x] the contrast ratio passes AA'
+complete_gates "$REPO_ROOT/scripts" "$P"
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+names=n; printf '%s' "$out" | grep -qF 'the choice survives a restart' && names=y
+leaks=n; printf '%s' "$out" | grep -qF 'must be ignored' && leaks=y
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 8 ] && [ "$names" = y ] && [ "$leaks" = n ] && [ "$before" = "$after" ] && [ "$n_closed" = "0" ]; then
+  pass "B1: a brief with one unchecked criterion refuses the close (rc $rc) and NAMES the criterion verbatim; the checkbox in another section is correctly ignored ($leaks), the record is byte-identical and the audit tail is still empty"
+else
+  fail_ "B1" "rc=$rc (expect 8); names the unchecked criterion=$names; scanned outside Done-observable=$leaks (expect n); bytes $before -> $after (must MATCH); closed length=$n_closed (expect 0); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── B2: all boxes checked => the close proceeds ────────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+write_brief "$P" DELTA-001 dark-mode \
+  '- [x] the settings screen offers a dark theme' \
+  '- [X] the choice survives a restart' \
+  '- [x] the contrast ratio passes AA'
+complete_gates "$REPO_ROOT/scripts" "$P"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 0 ] && [ "$n_closed" = "1" ]; then
+  pass "B2: with every criterion checked (upper and lower case markers both accepted) the same feature closes (rc $rc) and the audit tail grows to $n_closed"
+else
+  fail_ "B2" "rc=$rc (expect 0); closed length=$n_closed (expect 1); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── B3: a class with no `brief` gate is unaffected ─────────────────────────
+# Asserted in a tree with no docs/deltas directory AT ALL, so a rubric check
+# that fired unconditionally could not possibly pass this case.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+had_dir=n; [ -d "$P/docs/deltas" ] && had_dir=y
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 0 ] && [ "$had_dir" = n ] && [ "$n_closed" = "1" ]; then
+  pass "B3: a fix carries no brief gate, so it closes (rc $rc) in a tree that has no docs/deltas directory at all (present=$had_dir) — the rubric bind is keyed on the gate, not on the class"
+else
+  fail_ "B3" "rc=$rc (expect 0); docs/deltas present=$had_dir (expect n); closed length=$n_closed (expect 1)"
+fi
+rm -rf "$T"
+
+# ── B4: fail CLOSED, four ways ─────────────────────────────────────────────
+# A rubric that cannot be READ is not a rubric that PASSED. Each arm gets its
+# own fixture: sharing one would let an earlier arm's leftover brief satisfy a
+# later one.
+T=$(mktemp -d)
+b4_detail=""; b4_ok=y
+_b4() {
+  local name="$1" rc P
+  shift
+  P="$T/$name"; mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+  "$@" "$P"
+  complete_gates "$REPO_ROOT/scripts" "$P"
+  delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+  b4_detail="$b4_detail [$name=rc$rc]"
+  [ "$rc" -eq 8 ] || b4_ok=n
+}
+_b4_nofile()   { :; }
+_b4_nosection(){ mkdir -p "$1/docs/deltas"; printf '# DELTA-001\n\n## What\n\nSomething.\n' > "$1/docs/deltas/DELTA-001-dark-mode.md"; }
+_b4_noboxes()  { mkdir -p "$1/docs/deltas"; printf '# DELTA-001\n\n## Done-observable\n\nIt should feel nicer.\n\n## Must-not-change\n\nx\n' > "$1/docs/deltas/DELTA-001-dark-mode.md"; }
+_b4_malformed(){ write_brief "$1" DELTA-001 dark-mode '- [x] a real one' '- [?] a marker nobody defined'; }
+# Two files claim the same id, and BOTH are fully checked — so a first-match
+# implementation would close cleanly here and the arm would look like a
+# formality. It is not: picking one of two silently means the close review ran
+# against a document the operator may never have opened.
+_b4_ambiguous(){ write_brief "$1" DELTA-001 dark-mode '- [x] all done'
+                 write_brief "$1" DELTA-001 dark-theme '- [x] all done'; }
+_b4 nofile    _b4_nofile
+_b4 nosection _b4_nosection
+_b4 noboxes   _b4_noboxes
+_b4 malformed _b4_malformed
+_b4 ambiguous _b4_ambiguous
+if [ "$b4_ok" = y ]; then
+  pass "B4: the rubric fails CLOSED five ways —$b4_detail — a missing brief, a brief with no Done-observable section, a section with no checkboxes at all, an undefined marker, and two briefs claiming the same delta (both fully checked, so first-match would have passed) are each a refusal, never a silent pass"
+else
+  fail_ "B4" "expected rc 8 from every arm; got:$b4_detail"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== U — the gate-token vocabulary (§5.2) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── U1: an unknown token fails CLOSED  [KILLS m4] ──────────────────────────
+# Marked COMPLETE as well as required, on purpose: otherwise the
+# outstanding-gates refusal fires first and the vocabulary check is never
+# reached, which is precisely the masking that makes a mutant look pinned.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update \
+  '.active_delta.gates_required += ["frobnicate"] | .active_delta.gates_completed += ["frobnicate"]' >/dev/null 2>&1
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+names=n; printf '%s' "$out" | grep -qF 'frobnicate' && names=y
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 9 ] && [ "$names" = y ] && [ "$before" = "$after" ] && [ "$n_closed" = "0" ]; then
+  pass "U1: a gate token that is in neither §5.2's table nor this project's policy is a CONFIGURATION error (rc $rc), named, refused even though it is marked complete, and nothing is written"
+else
+  fail_ "U1" "rc=$rc (expect 9); names the token=$names; bytes $before -> $after (must MATCH); closed length=$n_closed (expect 0); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── U2: the vocabulary is POLICY-DERIVED, not a hardcoded table ────────────
+# WP3's G4 pins that a project may retune `attribute_toggles.risk_core` to a
+# token of its own. A vocabulary check reading only §5.2's table would answer 9
+# and lock that project out of ever closing a delta. The right answer is 7 —
+# "you still owe this" — and then a clean close once it is attested.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"attribute_toggles":{"risk_core":["second_reviewer"],"level_evolution":["brief"]}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the export is broken" --class fix --risk core --confirm >/dev/null 2>&1
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+complete_gates "$REPO_ROOT/scripts" "$P" second_reviewer
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc_outstanding=$?
+delta_run "$REPO_ROOT/scripts" "$P" --complete-gate second_reviewer >/dev/null 2>&1; rc_mark=$?
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc_close=$?
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$gates" = '["ledger_row","repro_test_red_first","close_review","changelog","second_reviewer"]' ] \
+   && [ "$rc_outstanding" -eq 7 ] && [ "$rc_mark" -eq 0 ] && [ "$rc_close" -eq 0 ] && [ "$n_closed" = "1" ]; then
+  pass "U2: a project-defined gate token (second_reviewer, from its own attribute_toggles) is KNOWN — the close says 'still outstanding' (rc $rc_outstanding) and not 'unknown token' (9), --complete-gate accepts it (rc $rc_mark) and the delta then closes (rc $rc_close)"
+else
+  fail_ "U2" "gates=$gates; outstanding rc=$rc_outstanding (expect 7, NOT 9 — a 9 here means the vocabulary is a hardcoded table and the project is locked out); --complete-gate rc=$rc_mark (expect 0); close rc=$rc_close (expect 0); closed length=$n_closed (expect 1); output:\n$out"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== N — refusal residue: every refused close leaves the tree as found ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# The WP3 standard, applied to all five refusal shapes at once. `find` over the
+# WHOLE tree with a per-file md5 — not `[ -e ]` on one expected filename, which
+# cannot see a file nobody thought to look for. The ratchet refusal (10) is
+# deliberately EXCLUDED from this list and gets its own honest treatment below:
+# it is the one refusal that is SUPPOSED to record something.
+T=$(mktemp -d)
+n1_detail=""; n1_ok=y
+_n1() {
+  local name="$1" want="$2" P before after rc
+  shift 2
+  P="$T/$name"; mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+  "$@" "$P"
+  before="$(tree_manifest "$P")"
+  delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+  after="$(tree_manifest "$P")"
+  n1_detail="$n1_detail [$name=rc$rc]"
+  [ "$rc" -eq "$want" ] || n1_ok=n
+  [ "$before" = "$after" ] || { n1_ok=n; n1_detail="$n1_detail(TREE MOVED)"; }
+}
+_n1_outstanding() { complete_gates "$REPO_ROOT/scripts" "$1" brief_review; }
+_n1_rubric()      { write_brief "$1" DELTA-001 dark-mode '- [ ] not done yet'; complete_gates "$REPO_ROOT/scripts" "$1"; }
+_n1_unknown()     { complete_gates "$REPO_ROOT/scripts" "$1"
+                    seam "$REPO_ROOT/scripts" "$1" --delta-state-update \
+                      '.active_delta.gates_required += ["frobnicate"] | .active_delta.gates_completed += ["frobnicate"]' >/dev/null 2>&1; }
+_n1 outstanding 7 _n1_outstanding
+_n1 rubric      8 _n1_rubric
+_n1 unknown     9 _n1_unknown
+# The fifth shape needs no arrangement at all — and no open delta.
+P="$T/nothing"; mk_proj "$P" 4
+before="$(tree_manifest "$P")"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+after="$(tree_manifest "$P")"
+n1_detail="$n1_detail [nothing-open=rc$rc]"
+[ "$rc" -eq 6 ] || n1_ok=n
+[ "$before" = "$after" ] || { n1_ok=n; n1_detail="$n1_detail(TREE MOVED)"; }
+if [ "$n1_ok" = y ]; then
+  pass "N1: every PURE refusal —$n1_detail — leaves the whole tree byte-for-byte as it found it, asserted as a find-based manifest with a per-file md5 and not against one expected filename"
+else
+  fail_ "N1" "expected rc 7/8/9/6 with an unchanged tree; got:$n1_detail"
+fi
+rm -rf "$T"
+
+# ── N2: the ratchet refusal's residue is EXACTLY the ratchet record ────────
+# Stated rather than smoothed. §4.2 requires the close-time raise to be RECORDED
+# — "it never lowers", and a raise the operator is told about but that is not
+# written would be re-derived and re-announced on every subsequent close. So the
+# ratchet refusal is the ONE refusal that writes, and what it writes is bounded:
+# the delta's own attributes and its gates_required, and nothing else anywhere.
+T=$(mktemp -d); P="$T/proj"; mk_git_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"],"size_thresholds":{"small":5,"significant":20}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "token check is wrong" --class fix --slug token-check --confirm >/dev/null 2>&1
+complete_gates "$REPO_ROOT/scripts" "$P"
+grow "$P/src/auth/login.ts" 30
+before="$(tree_manifest "$P")"
+snapshot="$(active_json "$P" -c '.')"
+delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1; rc=$?
+after="$(tree_manifest "$P")"
+# Which FILES moved — everything except the state file must be byte-identical.
+b_others="$(printf '%s\n' "$before" | grep -v 'delta-state.json' || true)"
+a_others="$(printf '%s\n' "$after"  | grep -v 'delta-state.json' || true)"
+others_moved=n; [ "$b_others" = "$a_others" ] || others_moved=y
+# And WITHIN the state file, nothing but the delta's own attributes and
+# gates_required: strip exactly those three fields from both documents and the
+# remainder must be equal.
+now_json="$(active_json "$P" -c '.')"
+confined=$(jq -n --argjson a "$snapshot" --argjson b "$now_json" '
+    ($a | .active_delta |= (del(.attributes) | del(.gates_required) | del(.ratcheted_at)))
+ == ($b | .active_delta |= (del(.attributes) | del(.gates_required) | del(.ratcheted_at)))' 2>/dev/null)
+confined="${confined:-READ-FAILED}"
+if [ "$rc" -eq 10 ] && [ "$others_moved" = n ] && [ "$confined" = "true" ] && [ "$before" != "$after" ]; then
+  pass "N2: the ratchet refusal (rc $rc) is the ONE close refusal that records something, and its residue is bounded — no file outside .claude/delta-state.json moved, and inside it nothing but the delta's attributes and gates_required changed"
+else
+  fail_ "N2" "rc=$rc (expect 10); a file other than the state file moved=$others_moved (expect n); the state change is confined to attributes+gates_required=$confined (expect true); state file actually changed=$([ "$before" != "$after" ] && echo y || echo n) (expect y)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== R — R-WP3-3: the seam refuses a crafted active_delta REPLACEMENT ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# CARRY-FORWARD (b), taken. WP2 recorded that the state layer accepts
+# overwriting an OPEN active_delta and deferred the refusal to WP3's business
+# layer — which delivered it in delta.sh. The residual R-WP3-3 named the hole
+# that leaves: `--delta-state-update` is a general primitive, so a crafted
+# filter still replaces the open delta AT THE SEAM, taking its gates_completed
+# with it. This is the seam-level atom, and it is narrower than "refuse
+# non-null -> non-null" on purpose (see R2).
+
+# ── R1: a different id in the slot is refused  [KILLS m6] ──────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+delta_run "$REPO_ROOT/scripts" "$P" --complete-gate ledger_row >/dev/null 2>&1
+before="$(_md5file "$P/.claude/delta-state.json")"
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update \
+  '.active_delta = {"id":"DELTA-002","slug":"stolen","class":"feature","gates_required":[],"gates_completed":[]}' >/dev/null 2>&1
+rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+id="$(active_json "$P" -r '.active_delta.id')"
+kept="$(active_json "$P" -c '.active_delta.gates_completed')"
+if [ "$rc" -ne 0 ] && [ "$before" = "$after" ] && [ "$id" = "DELTA-001" ] && [ "$kept" = '["ledger_row"]' ]; then
+  pass "R1: a crafted --delta-state-update that swaps a DIFFERENT delta into the open slot is refused at the SEAM (rc $rc), the file is byte-identical, and DELTA-001 keeps its completed-gate history ($kept)"
+else
+  fail_ "R1" "rc=$rc (expect non-zero); bytes $before -> $after (must MATCH); id now=$id (expect DELTA-001); gates_completed=$kept (expect [\"ledger_row\"])"
+fi
+rm -rf "$T"
+
+# ── R2: it refuses REPLACEMENT, not MUTATION ───────────────────────────────
+# The load-bearing half. A blanket non-null -> non-null refusal would have been
+# two characters shorter and would break BOTH of this WP's own writes:
+# --complete-gate appends to gates_completed and the ratchet raises attributes,
+# and each of those is a non-null -> non-null write on the SAME delta. The atom
+# keys on the ID, so the same delta may be mutated freely and only a swap is
+# refused. Without this case the atom could tighten into that blanket form and
+# the suite would stay green while the product stopped working.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+before="$(_md5file "$P/.claude/delta-state.json")"
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update \
+  '.active_delta.gates_completed += ["ledger_row"] | .active_delta.attributes.level = "significant"' >/dev/null 2>&1
+rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+lvl="$(active_json "$P" -r '.active_delta.attributes.level')"
+# And the OTHER two legal transitions the atom must not touch.
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update \
+  '.closed += [{"id": .active_delta.id, "class": "fix", "closed_at": "2026-08-03T00:00:00Z", "shipped_in": null}] | .active_delta = null' >/dev/null 2>&1
+rc_null=$?
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1; rc_reopen=$?
+new_id="$(active_json "$P" -r '.active_delta.id')"
+if [ "$rc" -eq 0 ] && [ "$before" != "$after" ] && [ "$lvl" = "significant" ] \
+   && [ "$rc_null" -eq 0 ] && [ "$rc_reopen" -eq 0 ] && [ "$new_id" = "DELTA-002" ]; then
+  pass "R2: the same delta's own row is still freely mutable through the seam (rc $rc, level now $lvl) — which is exactly the shape --complete-gate and the ratchet write use — and both non-null->null (rc $rc_null) and null->non-null (rc $rc_reopen, $new_id) still pass. The atom refuses a SWAP, not a write"
+else
+  fail_ "R2" "same-id mutation rc=$rc (expect 0); bytes $before -> $after (must DIFFER); level=$lvl (expect significant); close-to-null rc=$rc_null (expect 0); reopen rc=$rc_reopen (expect 0); new id=$new_id (expect DELTA-002)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutation proofs (each mutant is BUILT and RUN here) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── m1: drop the close-time re-derivation  [X1 RED] ────────────────────────
+# THE DESIGN'S OWN MUTATION (§11-WP4): "drop the close-time re-derivation -> a
+# delta opened `small` and grown to `evolution` closes on the small checklist".
+# `measured=""` is exactly that: the ratchet arithmetic still runs, and with
+# nothing measured to compare against it can only ever keep the open-time values.
+#
+# THE STRUCTURAL DISCRIMINATOR. "It closed" is also what a fixture that never
+# reached the ratchet would report. So this row runs the PRISTINE tree on an
+# IDENTICAL fixture in the same breath (rc 10, nothing closed) and asserts the
+# mutant's closed row still carries the SMALL attributes — the checklist it
+# closed on, named.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-CLOSE-RATCHET$/s@.*@  measured=""@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-RATCHET$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m1_fixture() {
+  local P="$1"
+  mk_git_proj "$P" 4
+  write_policy "$P" '{"schemaVersion":1,"risk_surfaces":["src/auth/**"],"size_thresholds":{"small":5,"significant":20}}'
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "token check is wrong" --class fix --slug token-check --confirm >/dev/null 2>&1
+  complete_gates "$REPO_ROOT/scripts" "$P"
+  grow "$P/src/auth/login.ts" 30
+}
+Pp="$T/pristine"; _m1_fixture "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
+pri_closed="$(active_json "$Pp" -r '.closed | length')"
+Pm="$T/mutant";   _m1_fixture "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_closed="$(active_json "$Pm" -r '.closed | length')"
+mut_attrs="$(active_json "$Pm" -c '.closed[0].attributes | {risk, level}')"
+mut_gates="$(active_json "$Pm" -c '.closed[0].gates_completed')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 10 ] && [ "$pri_closed" = "0" ] \
+   && [ "$mut_rc" -eq 0 ] && [ "$mut_closed" = "1" ] \
+   && [ "$mut_attrs" = '{"risk":"feature-local","level":"small"}' ] \
+   && [ "$mut_gates" = '["ledger_row","repro_test_red_first","close_review","changelog"]' ]; then
+  pass "m1: with the close-time re-derivation dropped, the SAME fixture — thirty lines added to a risk surface — closes clean (rc $mut_rc) on the SMALL checklist ($mut_gates, attributes $mut_attrs) where the pristine tree refuses (rc $pri_rc, nothing closed). X1 goes RED, and the failure mode is silent: no error, just a delta that never had to justify what it grew into (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m1" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 10) closed=$pri_closed (expect 0); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 1) attributes=$mut_attrs (expect feature-local/small) gates=$mut_gates (expect the bare fix row)"
+fi
+rm -rf "$T"
+
+# ── m2: neuter the unchecked-box refusal  [B1 RED] ─────────────────────────
+# FRESH FIXTURE WITH EVERY GATE COMPLETE, on purpose: with brief_review still
+# outstanding the gates refusal fires two guards earlier, the rubric bind never
+# executes, and the mutant looks pinned when it is not.
+# STRUCTURAL DISCRIMINATOR: the mutant's OWN tree is re-read to confirm the brief
+# it closed against still carries an unchecked box.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-CLOSE-RUBRIC-GUARD$/s@.*@  if false; then@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-RUBRIC-GUARD$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m2_fixture() {
+  local P="$1"
+  mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+  write_brief "$P" DELTA-001 dark-mode '- [x] the settings screen offers a dark theme' '- [ ] the choice survives a restart'
+  complete_gates "$REPO_ROOT/scripts" "$P"
+}
+Pp="$T/pristine"; _m2_fixture "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
+Pm="$T/mutant";   _m2_fixture "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_closed="$(active_json "$Pm" -r '.closed | length')"
+still_unchecked=n
+grep -qF -- '- [ ] the choice survives a restart' "$Pm/docs/deltas/DELTA-001-dark-mode.md" && still_unchecked=y
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 8 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_closed" = "1" ] && [ "$still_unchecked" = y ]; then
+  pass "m2: with the unchecked-box refusal neutered, a feature closes (rc $mut_rc, audit row written) against a brief whose 'the choice survives a restart' criterion is STILL unchecked in the mutant's own tree (present=$still_unchecked), where the pristine tree refuses (rc $pri_rc). B1 goes RED — and §5.3's one mechanical review surface is gone (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 8); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 1); brief still carries the unchecked box=$still_unchecked (expect y — if n the fixture never violated the rubric and this row proves nothing)"
+fi
+rm -rf "$T"
+
+# ── m3: null the slot WITHOUT appending  [W1/W2 RED — carry-forward (a)] ───
+# The id-reuse hazard, executed. The mutant's close still "works" from the
+# operator's side — rc 0, the slot empties, --status says there is nothing open —
+# and the delta has been erased from the record rather than archived, so the very
+# next open is handed DELTA-001 again.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-CLOSE-ATOMIC-WRITE$/s@.*@  filter=".active_delta = null"@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-ATOMIC-WRITE$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m3_fixture() {
+  local P="$1"
+  mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+  complete_gates "$REPO_ROOT/scripts" "$P"
+}
+Pp="$T/pristine"; _m3_fixture "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1
+delta_run "$REPO_ROOT/scripts" "$Pp" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+pri_next="$(active_json "$Pp" -r '.active_delta.id')"
+pri_closed="$(active_json "$Pp" -r '.closed | length')"
+Pm="$T/mutant";   _m3_fixture "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_closed="$(active_json "$Pm" -r '.closed | length')"
+mut_slot="$(active_json "$Pm" -r '.active_delta')"
+delta_run "$MT/scripts" "$Pm" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+mut_next="$(active_json "$Pm" -r '.active_delta.id')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_closed" = "1" ] && [ "$pri_next" = "DELTA-002" ] \
+   && [ "$mut_rc" -eq 0 ] && [ "$mut_closed" = "0" ] && [ "$mut_slot" = "null" ] \
+   && [ "$mut_next" = "DELTA-001" ]; then
+  pass "m3: with the append half of the close write removed the close still reports success (rc $mut_rc) and still empties the slot ($mut_slot), but the audit tail stays at $mut_closed rows and the NEXT open is handed $mut_next — the id the just-closed delta had — where the pristine tree archives one row and issues $pri_next. W1/W2 go RED. This is carry-forward (a) executed rather than argued (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m3" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE closed=$pri_closed (expect 1) next id=$pri_next (expect DELTA-002); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 0) slot=$mut_slot (expect null) next id=$mut_next (expect DELTA-001, the reuse)"
+fi
+rm -rf "$T"
+
+# ── m4: neuter the vocabulary check  [U1 RED] ──────────────────────────────
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-CLOSE-VOCAB-GUARD$/s@.*@  if false; then@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-VOCAB-GUARD$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m4_fixture() {
+  local P="$1"
+  mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+  complete_gates "$REPO_ROOT/scripts" "$P"
+  seam "$REPO_ROOT/scripts" "$P" --delta-state-update \
+    '.active_delta.gates_required += ["frobnicate"] | .active_delta.gates_completed += ["frobnicate"]' >/dev/null 2>&1
+}
+Pp="$T/pristine"; _m4_fixture "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
+Pm="$T/mutant";   _m4_fixture "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_closed="$(active_json "$Pm" -r '.closed | length')"
+mut_archived="$(active_json "$Pm" -r '.closed[0].gates_completed | index("frobnicate") != null')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 9 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_closed" = "1" ] && [ "$mut_archived" = "true" ]; then
+  pass "m4: with the vocabulary check neutered a delta carrying the meaningless token 'frobnicate' closes clean (rc $mut_rc) and archives it into the audit tail (present=$mut_archived), where the pristine tree fails CLOSED (rc $pri_rc). U1 goes RED — a typo in a project's policy would silently become a gate nobody can ever fail (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m4" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 9); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 1) archived the bogus token=$mut_archived (expect true)"
+fi
+rm -rf "$T"
+
+# ── m5: neuter the outstanding-gates refusal  [C1 RED] ─────────────────────
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-CLOSE-GATES-GUARD$/s@.*@  if false; then@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-GATES-GUARD$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m5_fixture() {
+  local P="$1"
+  mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --class feature --slug dark-mode --confirm >/dev/null 2>&1
+  write_brief "$P" DELTA-001 dark-mode '- [x] the settings screen offers a dark theme'
+  complete_gates "$REPO_ROOT/scripts" "$P" brief_review
+}
+Pp="$T/pristine"; _m5_fixture "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
+Pm="$T/mutant";   _m5_fixture "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_closed="$(active_json "$Pm" -r '.closed | length')"
+mut_missing="$(active_json "$Pm" -r '.closed[0].gates_completed | index("brief_review") == null')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 7 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_closed" = "1" ] && [ "$mut_missing" = "true" ]; then
+  pass "m5: with the outstanding-gates refusal neutered a feature closes (rc $mut_rc) with brief_review never attested — the archived gates_completed is missing it (missing=$mut_missing) — where the pristine tree refuses (rc $pri_rc). C1 goes RED, and §5.3's pre-build adversarial review is silently optional (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 7); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 1) brief_review absent from the archive=$mut_missing (expect true)"
+fi
+rm -rf "$T"
+
+# ── m6: neuter the seam's replacement atom  [R1 RED] ───────────────────────
+# The atom lives inside a jq program, so the neuter is the WP2 form — replace the
+# marked line with `and (true)` so the program stays syntactically whole and
+# exactly one atom stops asserting.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/lib/delta-state.sh" '/# ACTIVE-ATOM-NO-REPLACE$/s@.*@      and (true)@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/lib/delta-state.sh" "$MT/scripts/lib/delta-state.sh" 'ACTIVE-ATOM-NO-REPLACE$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+P="$T/proj"; mk_proj "$P" 4
+delta_run "$MT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+delta_run "$MT/scripts" "$P" --complete-gate ledger_row >/dev/null 2>&1
+before="$(_md5file "$P/.claude/delta-state.json")"
+seam "$MT/scripts" "$P" --delta-state-update \
+  '.active_delta = {"id":"DELTA-002","slug":"stolen","class":"feature","gates_required":[],"gates_completed":[]}' >/dev/null 2>&1
+mut_rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+mut_id="$(active_json "$P" -r '.active_delta.id')"
+mut_lost="$(active_json "$P" -r '.active_delta.gates_completed | length')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$mut_rc" -eq 0 ] && [ "$before" != "$after" ] && [ "$mut_id" = "DELTA-002" ] && [ "$mut_lost" = "0" ]; then
+  pass "m6: with the replacement atom neutered the crafted seam write SUCCEEDS (rc $mut_rc), the open slot now holds $mut_id and DELTA-001's completed-gate history is gone ($mut_lost rows left). R1 goes RED — which is R-WP3-3 exactly: the business refusal in delta.sh never sees this write (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m6" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); mutant rc=$mut_rc (expect 0); bytes $before -> $after (must DIFFER); id now=$mut_id (expect DELTA-002); surviving gates_completed rows=$mut_lost (expect 0)"
+fi
+rm -rf "$T"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

Delta Track **WP4** (design of record: `docs/designs/2026-08-02-delta-track-v1.md` §5.2, §5.3, §4.2, §11-WP4): `delta.sh --close` and the machinery that makes closing a delta mean something.

- **Per-class gate refusal** — close is refused while any `gates_required` entry is outstanding, naming them. Gate-token validation is a **policy-derived union**, not a compiled table: WP3's own tests pin that a project may retune `attribute_toggles` to custom tokens, and a compiled table would lock such a project out of ever closing a delta (reviewer verified the floor matches §5.2's 13 tokens exactly on both halves).
- **The rubric bind (§5.3)** — a brief-gated delta cannot close with an unchecked Done-observable criterion. The parse contract (all matching headings pooled; unchecked `- [ ]` vs checked `- [x]`) is stated for WP8's template to codify.
- **The close-time ratchet (§4.2)** — attributes are re-derived from the *real* diff at close. A delta opened `small`/`feature-local` that grew into an auth rewrite cannot close on the small checklist: the raise sticks, newly toggled gates append, and the close refuses with the new obligations named. Never lowers.
- **Atomic close write** — slot nulls and `closed` appends in one seam write (the id-reuse pin: a mutant that nulls without appending goes RED).
- **A new seam guard atom** `# ACTIVE-ATOM-NO-REPLACE` (the WP3 carry-forward, taken): replacement of the active slot by a *different* delta is refused at the seam. Deliberately keyed on delta **id**, not nullness — the blanket form would break `--complete-gate` and the ratchet, which legitimately rewrite the same delta's slot (pinned).

## Verification trail (fable pr-reviewer, xhigh, pre-PR)

- Watched-RED TDD: tests committed first at **1/26** (the single pass being the positive control).
- **Round 1 (major_concerns):** all four of the implementer's judgment calls were **upheld by the reviewer's own execution** — the prior-suite edit's blast radius (WP3's m2, re-aimed because the new seam atom made its original claim false), the narrow id-keyed atom, the vocabulary union, and the ratchet's bounded write. The blocker was a **false doctrine sentence**: "exits 6/7/8/9 leave the tree untouched" is untrue of a raise-without-new-gates, which records the raise and *then* refuses — behaviour correct per §4.2, promise wrong, and later WPs would have built on that sentence.
- **Fix round:** doctrine restated as a property of *the raise* rather than the exit code (6/9 always pristine; 7/8 pristine absent a raise), N3/N4 pinning **both** silent-raise mechanisms, and the raise is now **announced** to the operator (old→new) — its watched-RED failed on the missing announcement alone, which is itself proof the write was already bounded. Rubric contract sentence corrected to the real mechanism with a two-heading fixture; the same-id content-gut acceptance and the two-write invocation recorded in the DOES-NOT-ENFORCE block.
- **Re-review: approve** — the reviewer re-ran its probes, sabotaged the fixes twice (announce-neuter → 28/1 on the announcement alone; bound-widen → 27/2 on confinement), and found no escape. Review record: `.superpowers/sdd/2026-08-02-delta-track-v1/wp4-review.md` (session artifact).

Suite 29/0; prior suites green (WP3 29/0, WP2 31/0, WP0 13/0, boundary 29/0); boundary lint rc 0 at seam cardinality 1; run-lints 15/15.

## Carried forward

- `retro_review` is close-refusing but attestation-only until **WP5** ships the retro ledger.
- WP8's brief template must match the rubric parse contract stated in `delta.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
