### PR TITLE
feat(brownfield): WP2 — Scout secrets, collisions, tests-baseline, intake-prefill

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -219,6 +219,46 @@ jobs:
         # project templates float too, sequenced behind BL-198 — see BL-201.
         run: pip install semgrep
 
+      - name: Install gitleaks (pinned + checksum-verified)
+        # R-WP2-1. WITHOUT THIS STEP THE BROWNFIELD LEAK PROOF GATES NOTHING.
+        # The ubuntu runner image does NOT ship gitleaks, and
+        # tests/test-brownfield-wp2-scout-sections.sh degrades its twelve
+        # gitleaks-gated cases — the §6.5 planted-secret byte-absence proof AND
+        # all four mutation proofs — to a loud SKIP. Loud in the log, and still
+        # exit 0: a green required check credited with a proof that never ran.
+        # That is the silent-success class one level up, sitting on the highest-
+        # stakes property in the brownfield design, whose failure mode is a
+        # leaked credential in a committed file. The suite's own CI arm now
+        # FAILS when gitleaks is missing and CI is set, so this step is not
+        # optional — remove it and the lane goes red rather than quietly blind.
+        #
+        # PINNED, unlike semgrep two steps up, and the difference is deliberate.
+        # BL-192's reasoning for floating semgrep is that a stale SCANNER stops
+        # catching new vulnerabilities — it is used there as a live detector.
+        # gitleaks is used here as a FIXTURE ORACLE: the suite asserts exact
+        # finding counts, an exact 18-field report shape, and the precise
+        # BASE32 rule behaviour that makes the plants valid. A floating version
+        # that changed its report schema or its aws-access-token rule would not
+        # find new secrets in this repository — it would silently invalidate
+        # the proof's fixtures. 8.30.1 is the version every fixture fact in
+        # §13-V3 and in the WP2 suite was verified against.
+        #
+        # The checksum is the release's own published value for this asset,
+        # confirmed by downloading the tarball and hashing it (2026-08-03).
+        # Verifying it means a replaced release asset breaks the lane instead
+        # of silently changing what the proof runs against.
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL --retry 3 -o /tmp/gitleaks.tar.gz "$url"
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
       - name: Run fast unit tests — shard ${{ matrix.shard }}
         env:
           SHARD: ${{ matrix.shard }}
@@ -736,6 +776,28 @@ jobs:
         # filesystem gate would silently degrade to the fallback driver.
         # Install failure fails the shard LOUDLY rather than quietly downgrading.
         run: sudo apt-get update && sudo apt-get install -y expect
+
+      - name: Install gitleaks (pinned + checksum-verified)
+        # R-WP2-1, full-lane half. This lane reaches the same suite through
+        # tests/full-project-test-suite.sh, on the same runner image that does
+        # not ship gitleaks — so the twelve gitleaks-gated cases were skipping
+        # here too. Since the suite now FAILS rather than skips when gitleaks
+        # is absent and CI is set, this step is REQUIRED for the lane to pass;
+        # it is not a nice-to-have that can be dropped to save 2 seconds.
+        # Pinned for the same fixture-oracle reason as the unit-shard copy —
+        # see the long comment on that step; 8.30.1 is the version every WP2
+        # fixture fact was verified against.
+        env:
+          GITLEAKS_VERSION: "8.30.1"
+          GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"
+        run: |
+          set -euo pipefail
+          url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl -sSfL --retry 3 -o /tmp/gitleaks.tar.gz "$url"
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
 
       - name: Run shard — ${{ matrix.shard }}
         # SKIP_KNOWN_FAILING left unset -> 0, so known-RED guards still run.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -458,6 +458,7 @@ jobs:
             tests/test-validate-phase-2-3-gate.sh
             tests/test-validate-phase-state-gates.sh
             tests/test-walk-phase-lifecycle.sh
+            tests/test-brownfield-wp2-scout-sections.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -254,7 +254,12 @@ jobs:
           set -euo pipefail
           url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           curl -sSfL --retry 3 -o /tmp/gitleaks.tar.gz "$url"
-          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          # NOT `sha256sum -c` (R-WP2-6): a malformed pin makes that spelling
+          # warn and exit 0, silently verifying nothing. The script computes and
+          # compares in the shell, rejects a badly-formed value on EITHER side,
+          # and — being a script — has its failure modes executed by the K cases
+          # in tests/test-brownfield-wp2-scout-sections.sh.
+          bash scripts/ci-verify-sha256.sh /tmp/gitleaks.tar.gz "${GITLEAKS_SHA256}"
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version
@@ -794,7 +799,12 @@ jobs:
           set -euo pipefail
           url="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
           curl -sSfL --retry 3 -o /tmp/gitleaks.tar.gz "$url"
-          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum -c -
+          # NOT `sha256sum -c` (R-WP2-6): a malformed pin makes that spelling
+          # warn and exit 0, silently verifying nothing. The script computes and
+          # compares in the shell, rejects a badly-formed value on EITHER side,
+          # and — being a script — has its failure modes executed by the K cases
+          # in tests/test-brownfield-wp2-scout-sections.sh.
+          bash scripts/ci-verify-sha256.sh /tmp/gitleaks.tar.gz "${GITLEAKS_SHA256}"
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
           gitleaks version

--- a/scripts/ci-verify-sha256.sh
+++ b/scripts/ci-verify-sha256.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# scripts/ci-verify-sha256.sh FILE EXPECTED_SHA256
+#
+# Verify a downloaded artifact against a pinned SHA-256, by COMPUTING the hash
+# and COMPARING IT IN THE SHELL — never by handing a checklist to `sha256sum -c`.
+#
+# WHY THIS EXISTS AS A SCRIPT RATHER THAN THREE LINES IN A WORKFLOW (R-WP2-6).
+#
+# The obvious spelling is a check that cannot fail:
+#
+#   $ echo "THIS-IS-NOT-A-HASH  gl.tgz" | sha256sum -c -
+#   sha256sum: WARNING: 1 line is improperly formatted
+#   rc=0
+#
+# Measured on this host (Darwin, /sbin/sha256sum). A MALFORMED pin — a typo, a
+# truncated paste, a variable that expanded to nothing — makes the verification
+# silently pass while verifying NOTHING. GNU coreutils is documented to exit
+# non-zero for that case, but the CI step this protects would then be relying on
+# which platform's binary happened to answer, and "it fails on the runner" is
+# not a property you can execute on a laptop. Compute-and-compare has identical
+# behaviour everywhere and needs no platform assumption.
+#
+# It is a SCRIPT because it has to be executable by a test. A verification step
+# embedded in workflow YAML cannot be run by anything except CI, which means its
+# failure modes cannot be proven — and an unprovable security check on the path
+# that gates a planted-secret proof is precisely the shape of defect the WP2
+# package exists to prevent. Both workflow jobs call this file; the K cases in
+# tests/test-brownfield-wp2-scout-sections.sh execute every one of its failure
+# modes.
+#
+# EXIT CODES, never labels: 0 the file matches the pin; 1 it does not, or
+# either value is not a well-formed hash; 2 bad usage.
+set -uo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: ci-verify-sha256.sh <file> <expected-sha256>" >&2
+  exit 2
+fi
+
+_file="$1"
+_expected="$2"
+
+if [ ! -f "$_file" ]; then
+  echo "ci-verify-sha256: no such file: $_file" >&2
+  exit 1
+fi
+
+# _is_sha256 VALUE — exactly 64 lowercase hex characters.
+#
+# Both sides are checked, not just the pin. An empty or truncated COMPUTED
+# value is the other half of the same defect: if the hashing tool is missing or
+# its output shape changes, an unchecked `computed` could compare equal to an
+# equally-empty `expected` and report success having hashed nothing.
+_is_sha256() {
+  case "$1" in
+    ""|*[!0-9a-f]*) return 1 ;;
+  esac
+  [ "${#1}" -eq 64 ]
+}
+
+if ! _is_sha256 "$_expected"; then
+  echo "ci-verify-sha256: the PINNED hash is not 64 lowercase hex characters — refusing to treat this as verified." >&2
+  echo "ci-verify-sha256:   pin was: '$_expected'" >&2
+  exit 1
+fi
+
+# GNU first, BSD second — the house portability rule. `awk` takes field 1
+# because the two tools disagree about the rest of the line.
+_computed=$( { sha256sum "$_file" 2>/dev/null || shasum -a 256 "$_file" 2>/dev/null; } | awk '{print $1; exit}' )
+
+if ! _is_sha256 "$_computed"; then
+  echo "ci-verify-sha256: could not compute a SHA-256 for $_file (no usable sha256sum/shasum, or unexpected output)." >&2
+  echo "ci-verify-sha256:   got: '$_computed'" >&2
+  exit 1
+fi
+
+if [ "$_computed" != "$_expected" ]; then
+  echo "ci-verify-sha256: CHECKSUM MISMATCH for $_file" >&2
+  echo "ci-verify-sha256:   expected $_expected" >&2
+  echo "ci-verify-sha256:   computed $_computed" >&2
+  exit 1
+fi
+
+echo "ci-verify-sha256: OK $_file ($_computed)"
+exit 0

--- a/scripts/lib/scout/scout-collisions.sh
+++ b/scripts/lib/scout/scout-collisions.sh
@@ -1,0 +1,345 @@
+#!/usr/bin/env bash
+# scripts/lib/scout/scout-collisions.sh — §8.2's `collisions` section: what the
+# adoptee already has that the framework's writers would land on, each sorted
+# into one of §7.1's four buckets. REPORT-ONLY. Scout still writes nothing.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §1.2 (the measured
+# collision surface — this file's inventory is that table), §7.1 (the four
+# buckets, and the vocabulary is reused rather than reinvented), §7.2 (the
+# archived-hook description), §7.3 (the archive's own secret hazard), §7.4 (the
+# CI carve-out and its four SDLC-undermining detector rules), §7.5 (project
+# files: keep theirs), §8.2 (the schema).
+#
+# M5: sources nothing. See scripts/lib/scout/scout-core.sh's header.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE INVENTORY IS THE DESIGN'S TABLE, NOT A GUESS. §1.2 read every write in
+# the scaffolder from its write primitive — `cat >` / `cp` / `printf >` versus
+# a marker-guarded `>>` — so the behaviour-on-a-pre-existing-file column is
+# measured, not inferred. This file reports which of those surfaces the target
+# actually HAS. A surface that is absent produces NO ROW: "we looked and there
+# is nothing there" is expressed by the row not existing, never by a row saying
+# so, because a reader counting rows must be counting real collisions.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# CONTENT IS NEVER QUOTED INTO THE REPORT, AND THAT IS THE SAME RULE AS §6.2.
+#
+# Two surfaces here would naively want to quote bytes, and both are refused:
+#
+#   THE HOOK DESCRIPTION. §7.2 requires a what-it-invokes description for every
+#   archived git hook, and §7.3 names the hazard in as many words — the archive
+#   promotes an untracked `.git/hooks/` file into version control, and a
+#   hand-rolled hook can contain a token. So the description is assembled from
+#   a FIXED TOOL VOCABULARY: the generator emits names it recognises and
+#   nothing else. A hook line reading `export AWS_KEY=…` contributes exactly
+#   nothing, because no allowlisted token matches it. It is advisory and says
+#   so — a hook can do anything, and this is a summary, not a specification.
+#
+#   THE CI FINDINGS. A workflow line can carry a credential just as easily as a
+#   hook line. Each finding therefore reports the RULE, the PATH and the LINE
+#   NUMBER — enough to open the file at the right place — and never the matched
+#   text. §6.2's doctrine, applied to a surface §6.2 does not mention.
+
+# ── The four buckets (§7.1), spelled once ───────────────────────────────────
+# archive-and-replace  their AI-layer surfaces and their git hooks: inventory,
+#                      archive with a MANIFEST, install the clean set, disclose
+#                      plainly, permit recorded re-adds
+# marker-composed      where the framework already composes by marker-fenced
+#                      append, with an uninstall
+# audit-only           their pipelines: never archived, never touched (§7.4)
+# keep-theirs          project files; the framework's artifacts adapt (§7.5)
+
+# _scout_col_add WORK PATH CLASS BUCKET DESC NOTE FINDINGS — one inventory row.
+#
+# AN EMPTY COLUMN IS WRITTEN AS `-`, AND THAT IS NOT COSMETIC. Tab is an IFS
+# WHITESPACE character, so `IFS=$'\t' read -r a b c` collapses a run of tabs
+# into ONE delimiter even when IFS was set explicitly — a row with an empty
+# middle field silently shifts every column after it into the wrong variable.
+# Measured here: the CI rows' empty description put the note into `description`
+# and the rule list into `note`, and the report emitted `findings: []` for a
+# workflow that had a finding. The reader turns `-` back into an empty string.
+_scout_col_add() {
+  local desc="$5" note="$6" findings="$7"
+  [ -n "$desc" ]     || desc="-"
+  [ -n "$note" ]     || note="-"
+  [ -n "$findings" ] || findings="-"
+  printf '%s\t%s\t%s\t%s\t%s\t%s\n' "$2" "$3" "$4" "$desc" "$note" "$findings" >> "$1/colentries"
+}
+
+# _scout_col_unblank VALUE — the reader half of the `-` sentinel above.
+_scout_col_unblank() {
+  [ "$1" = "-" ] && { printf ''; return 0; }
+  printf '%s' "$1"
+}
+
+# _scout_hook_vocabulary — the tool names a hook description may contain.
+#
+# A CLOSED LIST IS THE WHOLE MECHANISM. Anything a hook invokes that is not on
+# this list is reported as "and other commands" rather than named, which costs
+# a little fidelity and buys the guarantee that no byte of a hook can reach the
+# report through this path. Adding a row here is a deliberate act with a
+# readable diff; that is the intended cost.
+_scout_hook_vocabulary() {
+  cat <<'VOCAB'
+husky
+lefthook
+pre-commit
+lint-staged
+commitlint
+gitleaks
+semgrep
+trufflehog
+shellcheck
+shfmt
+npx
+npm
+pnpm
+yarn
+bun
+node
+deno
+tsc
+eslint
+prettier
+jest
+vitest
+mocha
+python
+python3
+pytest
+pip
+poetry
+uv
+black
+ruff
+mypy
+flake8
+isort
+cargo
+clippy
+rustfmt
+go
+gofmt
+golangci-lint
+make
+gradle
+mvn
+dotnet
+php
+composer
+bundle
+rspec
+rubocop
+swiftlint
+ktlint
+detekt
+clang-format
+terraform
+tflint
+docker
+VOCAB
+}
+
+# _scout_hook_description FILE — the §7.2 advisory description.
+#
+# Shallow and static by contract: it reads which recognised tools the file
+# names, and draws no conclusion about control flow, conditions or exit codes.
+_scout_hook_description() {
+  local file="$1" tok found="" n=0
+  [ -f "$file" ] || { printf ''; return 0; }
+  while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    if grep -qE "(^|[^A-Za-z0-9_.-])$tok([^A-Za-z0-9_.-]|$)" "$file" 2>/dev/null; then
+      if [ -z "$found" ]; then found="$tok"; else found="$found, $tok"; fi
+      n=$((n + 1))
+    fi
+  done <<VOCABIN
+$(_scout_hook_vocabulary)
+VOCABIN
+  if [ "$n" -eq 0 ]; then
+    printf 'Runs commands Scout does not recognise. Advisory only — read the file before replacing it.'
+  else
+    printf 'Invokes %s. Advisory only: a hook can do anything, and this names only the tools Scout recognises.' "$found"
+  fi
+}
+
+# ── §7.4's detector rules ───────────────────────────────────────────────────
+#
+# All four are REPORT-ONLY and all four are heuristics over YAML text rather
+# than a parse of the workflow graph — which is stated here rather than implied,
+# because the operator answers keep-or-retire on the strength of these rows.
+# Their failure direction is a false POSITIVE (a row to dismiss), never a false
+# negative that quietly certifies a pipeline that undermines the gates.
+#
+# _scout_ci_rule_line RULE FILE — the first line number matching RULE, or empty.
+_scout_ci_rule_line() {
+  local rule="$1" file="$2" n=""
+  case "$rule" in
+    auto-merge)
+      # Defeats "no merge on red", the framework's first house rule.
+      n=$(grep -nE 'merge[[:space:]]+--auto|--auto-merge|enable-pull-request-automerge|automerge|auto_merge' "$file" 2>/dev/null | head -1 | cut -d: -f1)
+      ;;
+    deploy-around-the-release-lane)
+      # A deploy reached by a BRANCH PUSH rather than a tag or a dispatch skips
+      # the Phase 3->4 gate entirely: code reaches production without crossing
+      # it. The presence of `tags:` or `workflow_dispatch` is treated as the
+      # release lane being in play, which is deliberately generous.
+      if grep -qiE '(^|[^a-z])deploy' "$file" 2>/dev/null \
+         && grep -qE '^[[:space:]]*push:' "$file" 2>/dev/null \
+         && grep -qE '^[[:space:]]*branches:' "$file" 2>/dev/null \
+         && ! grep -qE '^[[:space:]]*tags:|workflow_dispatch' "$file" 2>/dev/null; then
+        n=$(grep -nE '^[[:space:]]*push:' "$file" 2>/dev/null | head -1 | cut -d: -f1)
+      fi
+      ;;
+    force-push-or-history-rewrite-in-ci)
+      # Destroys the tamper-evidence the whole audit story rests on.
+      n=$(grep -nE 'push[[:space:]]+(-f|--force|--force-with-lease)|filter-repo|filter-branch' "$file" 2>/dev/null | head -1 | cut -d: -f1)
+      ;;
+    check-skipping)
+      # Turns a red gate green silently — the exact defect class this
+      # repository's own [WARN] trap embodies.
+      n=$(grep -nE '^[[:space:]]*continue-on-error:[[:space:]]*true|^[[:space:]]*if:[[:space:]]*(\$\{\{[[:space:]]*)?always\(\)' "$file" 2>/dev/null | head -1 | cut -d: -f1)
+      ;;
+  esac
+  printf '%s' "$n"
+}
+
+# _scout_ci_rule_why RULE — the fixed sentence for one rule. Fixed, because a
+# generated explanation would be an invitation to interpolate file content.
+_scout_ci_rule_why() {
+  case "$1" in
+    auto-merge)      printf 'Merges without depending on a required check, which defeats "no merge on red".' ;;
+    deploy-around-the-release-lane)
+                     printf 'A deploy triggered by a branch push rather than a tag or a dispatch reaches production without crossing the release gate.' ;;
+    force-push-or-history-rewrite-in-ci)
+                     printf 'Rewriting history from CI destroys the tamper-evidence the audit trail depends on.' ;;
+    check-skipping)  printf 'A security or test step that cannot fail the run turns a red gate green silently.' ;;
+    *)               printf '' ;;
+  esac
+}
+
+# _scout_ci_files ROOT — the pipeline files present, relative, one per line.
+_scout_ci_files() {
+  local root="$1" f
+  for f in "$root/.github/workflows"/*.yml "$root/.github/workflows"/*.yaml; do
+    [ -f "$f" ] && printf '%s\n' "${f#$root/}"
+  done
+  for f in .gitlab-ci.yml bitbucket-pipelines.yml azure-pipelines.yml Jenkinsfile .circleci/config.yml; do
+    [ -f "$root/$f" ] && printf '%s\n' "$f"
+  done
+  return 0
+}
+
+# scout_collisions_scan ROOT WORK — fills WORK with the collisions data.
+#
+# Writes:
+#   colentries  `<path>\t<class>\t<bucket>\t<description>\t<note>\t<findings>`
+#   coldetail   `<rule>\t<path>\t<line>\t<why>`
+scout_collisions_scan() {
+  local root="$1" work="$2" f n rules line why nsamples desc hookbase
+  : > "$work/colentries"
+  : > "$work/coldetail"
+
+  # ── AI-layer surfaces: archive-and-replace (§7.1) ─────────────────────────
+  [ -f "$root/.claude/settings.json" ] && _scout_col_add "$work" \
+    ".claude/settings.json" "ai-settings" "archive-and-replace" "" \
+    "The scaffolder OVERWRITES this file, then merges its own hook registrations into its own output — theirs is not consulted." ""
+  [ -f "$root/.claude/settings.local.json" ] && _scout_col_add "$work" \
+    ".claude/settings.local.json" "ai-settings-local" "archive-and-replace" "" \
+    "OVERWRITTEN today. This is the conventional home for a developer's personal MCP roster and it is UNTRACKED, so the loss is not recoverable from git." ""
+  [ -f "$root/.mcp.json" ] && _scout_col_add "$work" \
+    ".mcp.json" "mcp" "archive-and-replace" "" \
+    "Their MCP connections. Archived and restorable; re-adds are permitted and recorded." ""
+  for f in session-handoff sweep-triage zoom-out grill-with-docs; do
+    [ -f "$root/.claude/skills/$f/SKILL.md" ] && _scout_col_add "$work" \
+      ".claude/skills/$f/SKILL.md" "skill" "archive-and-replace" "" \
+      "A same-named skill is clobbered by an unguarded copy." ""
+  done
+  [ -f "$root/.claude/phase-state.json" ] && _scout_col_add "$work" \
+    ".claude/phase-state.json" "framework-state" "archive-and-replace" "" \
+    "Framework state that the scaffolder rewrites wholesale." ""
+  if [ -d "$root/.claude-backup" ]; then
+    _scout_col_add "$work" ".claude-backup/" "backup-dir" "archive-and-replace" "" \
+      "The scaffolder REMOVES this directory outright, on a justification that only holds for a brand-new project. On an existing one it is the vendored framework's pre-merge backup of .claude/ — the operator's own work." ""
+  fi
+
+  # ── Git hooks (§7.1: archive-and-replace, except where the framework
+  #    already composes politely) ──────────────────────────────────────────
+  if [ -d "$root/.git/hooks" ]; then
+    if [ -f "$root/.git/hooks/pre-commit" ]; then
+      desc=$(_scout_hook_description "$root/.git/hooks/pre-commit")
+      _scout_col_add "$work" ".git/hooks/pre-commit" "git-hook" "archive-and-replace" \
+        "$desc" \
+        "OVERWRITTEN today, unguarded. Husky, lefthook, pre-commit-framework and hand-rolled hooks are all destroyed." ""
+    fi
+    if [ -f "$root/.git/hooks/commit-msg" ]; then
+      desc=$(_scout_hook_description "$root/.git/hooks/commit-msg")
+      _scout_col_add "$work" ".git/hooks/commit-msg" "git-hook" "marker-composed" \
+        "$desc" \
+        "The framework already composes here: a marker-fenced append, idempotent. Their hook keeps running." ""
+    fi
+    for f in "$root/.git/hooks"/*; do
+      [ -f "$f" ] || continue
+      hookbase="${f##*/}"
+      case "$hookbase" in
+        *.sample|pre-commit|commit-msg) continue ;;
+      esac
+      desc=$(_scout_hook_description "$f")
+      _scout_col_add "$work" ".git/hooks/$hookbase" "git-hook" "archive-and-replace" \
+        "$desc" "Their hook. Archived with a restore line before the framework's set is installed." ""
+    done
+    nsamples=$(ls -1 "$root/.git/hooks"/*.sample 2>/dev/null | grep -c '')
+    case "$nsamples" in ''|*[!0-9]*) nsamples=0 ;; esac
+    if [ "$nsamples" -gt 0 ]; then
+      _scout_col_add "$work" ".git/hooks/*.sample" "git-hook-sample" "archive-and-replace" \
+        "" "$nsamples sample hooks git wrote at init. The scaffolder DELETES them (rm -f) so it does not misdetect the tree as an existing project." ""
+    fi
+  fi
+
+  # ── Their pipelines: audit-only, never touched (§7.4) ────────────────────
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    rules=""
+    for r in auto-merge deploy-around-the-release-lane force-push-or-history-rewrite-in-ci check-skipping; do
+      line=$(_scout_ci_rule_line "$r" "$root/$f")
+      [ -n "$line" ] || continue
+      why=$(_scout_ci_rule_why "$r")
+      printf '%s\t%s\t%s\t%s\n' "$r" "$f" "$line" "$why" >> "$work/coldetail"
+      if [ -z "$rules" ]; then rules="$r"; else rules="$rules,$r"; fi
+    done
+    _scout_col_add "$work" "$f" "ci" "audit-only" "" \
+      "Never archived, never touched. The framework installs its gates as its own files so a working pipeline is not taken offline on day one." "$rules"
+  done <<CIIN
+$(_scout_ci_files "$root")
+CIIN
+
+  # ── Project files: keep theirs (§7.5) ────────────────────────────────────
+  for f in FEATURES.md CHANGELOG.md BUGS.md RELEASE_NOTES.md; do
+    [ -f "$root/$f" ] && _scout_col_add "$work" "$f" "project-doc" "keep-theirs" "" \
+      "OVERWRITTEN from a template today. Under adoption it is treated as theirs: kept, and reconciled by the interview." ""
+  done
+  for f in CLAUDE.md PROJECT_INTAKE.md; do
+    [ -f "$root/$f" ] && _scout_col_add "$work" "$f" "framework-doc" "keep-theirs" "" \
+      "Notice-only when present: no sidecar, no backup copy, no template overwrite. Adoption creates these only when they are absent." ""
+  done
+  if [ -f "$root/.gitignore" ]; then
+    _scout_col_add "$work" ".gitignore" "project-file" "marker-composed" "" \
+      "Replaced by a template copy today, and their rules are lost. §7.1 names no row for .gitignore; the composing-writer precedent (a marker-fenced append) is what this report proposes, and an operator can disagree with it here rather than discover it afterwards." ""
+  fi
+
+  # ── Uncommitted work (§1.2's last row) ───────────────────────────────────
+  # `--no-optional-locks` is load-bearing: a plain `git status` refreshes and
+  # REWRITES `.git/index`, which would make a read-only scanner write to the
+  # operator's repository on every run. The suite's R1 tree hash is what keeps
+  # this flag here.
+  if command -v git >/dev/null 2>&1 \
+     && git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    n=$(git --no-optional-locks -C "$root" status --porcelain 2>/dev/null | grep -c '')
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    if [ "$n" -gt 0 ]; then
+      _scout_col_add "$work" "(uncommitted working tree)" "working-tree" "audit-only" "" \
+        "$n path(s) are uncommitted. The scaffolder sweeps existing uncommitted work into a 'chore: initialize' commit WITH VERIFICATION BYPASSED. Commit or stash it yourself first — Scout will not touch it." ""
+    fi
+  fi
+  return 0
+}

--- a/scripts/lib/scout/scout-collisions.sh
+++ b/scripts/lib/scout/scout-collisions.sh
@@ -236,7 +236,7 @@ _scout_ci_files() {
 #   colentries  `<path>\t<class>\t<bucket>\t<description>\t<note>\t<findings>`
 #   coldetail   `<rule>\t<path>\t<line>\t<why>`
 scout_collisions_scan() {
-  local root="$1" work="$2" f n rules line why nsamples desc hookbase
+  local root="$1" work="$2" f n r rules line why nsamples desc hookbase
   : > "$work/colentries"
   : > "$work/coldetail"
 

--- a/scripts/lib/scout/scout-core.sh
+++ b/scripts/lib/scout/scout-core.sh
@@ -33,12 +33,14 @@
 # scan time there may be no framework installed at all. A literal here is the
 # whole mechanism.
 #
-# The `-wp1` suffix is load-bearing information, not decoration: this build
-# emits three of §8.2's seven sections. A consumer that finds no `secrets` key
-# must be able to tell "not scanned yet" from "scanned and clean", and the
-# report says so twice — here, and in the `sectionsNotEmitted` array.
+# The `-wp2` suffix is load-bearing information, not decoration: this build
+# emits all seven of §8.2's sections, where `-wp1` emitted three. A consumer
+# holding an older report must be able to tell "this scanner had not been
+# taught to look yet" from "it looked and found nothing" — and within the
+# secrets section that same distinction is carried at finer grain by `status`,
+# because "gitleaks was not installed" is not a clean bill of health.
 scout_module_version() {
-  printf '%s\n' "0.2.0-wp1"
+  printf '%s\n' "0.3.0-wp2"
 }
 
 # ── JSON encoding ───────────────────────────────────────────────────────────

--- a/scripts/lib/scout/scout-prefill.sh
+++ b/scripts/lib/scout/scout-prefill.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# scripts/lib/scout/scout-prefill.sh — §8.2's `intakePrefill` section and
+# §8.3's REVERSE INTAKE mapping: one row per intake section, classified.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §8.3 (scan-derived /
+# judgment / data-classification), §8.2 (the schema and the extraction table),
+# §10-WP4 (this table is that package's REQUIRED deliverable, enumerated at
+# fifteen runners), §4.2 (evidence carries its provenance).
+#
+# M5: sources nothing. See scripts/lib/scout/scout-core.sh's header.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE ORDINARY INTAKE ASKS A PERSON AND WRITES A DOCUMENT. REVERSE INTAKE
+# STARTS FROM THE DOCUMENT THE SCAN ALREADY DERIVED AND ASKS THE PERSON TO
+# CONFIRM IT — for the parts that are derivable, and only those.
+#
+# Three classes, and the boundary between them is the whole point:
+#
+#   scan-derived    Prefilled and confirmed. Two disclosure lines naming the
+#                   value AND ITS PROVENANCE, then keep-it / change-it, with
+#                   "change it" falling through to the ordinary question.
+#   judgment        Human-mandatory. No prefill, no default, no skip. The
+#                   prefill pattern is right for facts the framework recorded
+#                   and WRONG for judgments it has never made. A guessed
+#                   business context is worse than an empty one, because it
+#                   gets confirmed away by a tired operator.
+#   non-skippable   No default, no inference, no "confirm" arm at all. This is
+#                   a mechanical necessity rather than a policy preference: the
+#                   Phase 1->2 ZDR backstop is a hard FAIL, so a project that
+#                   reached phase 2 without answering it cannot pass its gate.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE TABLE IS A STATIC DATA BLOCK, AND THAT IS AN M5 CONSEQUENCE, NOT LAZINESS.
+#
+# Scout must run in a clone that has never had the framework applied to it, so
+# it cannot read the wizard at scan time to enumerate its sections. The table
+# is therefore transcribed here — which creates exactly one risk, that the
+# wizard grows a section and this table does not. The suite closes it: case P1
+# derives the runner list from the real scripts/intake-wizard.sh (the SUITE may
+# read it; Scout may not) and fails if the two disagree. That is the currency
+# canary this file depends on, and it is the reason a row may never be added
+# here without running the suite.
+#
+# NEVER A GUESSED VALUE. A judgment row carries value:null. Not "TBD", not an
+# empty string, not a plausible-looking default — null, so that a consumer
+# cannot mistake absence for an answer.
+
+# _scout_prefill_table — the §8.3 mapping, as TSV data.
+#
+#   <id> <runner> <title> <kind> <field> <sourceHint>
+#
+# WP4-brownfield consumes this. `sourceHint` names the scan field that feeds a
+# scan-derived row and is `-` for the rows nothing feeds.
+_scout_prefill_table() {
+  cat <<'PREFILL'
+1	run_section_1	Project Identity	scan-derived	project_name	stack.buildFiles (package.json name) or the project directory
+1_repo_setup	run_section_1_repo_setup	Repo Setup	scan-derived	repo_remote_configured	reality.probes remote_repo_created
+2	run_section_2	Business Context	judgment	problem_statement	-
+3	run_section_3	Constraints	judgment	timeline	-
+4	run_section_4	Features & Requirements	judgment	mvp_features	-
+5	run_section_5	Data & Integrations (incl. 5.5 Data Classification & ZDR)	non-skippable	data_classification	-
+6	run_section_6	Technical Preferences	judgment	competency_matrix	-
+7	run_section_7	Revenue Model	judgment	revenue_model	-
+8	run_section_8	Governance Pre-Flight	judgment	governance	-
+9	run_section_9	Accessibility & UX Constraints	judgment	accessibility	-
+10	run_section_10	Distribution & Operations	judgment	uptime	-
+11	run_section_11	Known Risks & Concerns	judgment	known_risks	-
+11_5	run_section_11_5	Testing & Bug Tracking	scan-derived	test_command	stack.testCommand
+12	run_section_12	Tooling Configuration	scan-derived	tooling	stack.packageManagers
+13	run_section_13	Agent Initialization Prompt	scan-derived	agent_init_prompt	generated from the completed intake
+PREFILL
+}
+
+# _scout_json_top_string FILE KEY — the value of a TOP-LEVEL JSON string key.
+#
+# Depth-aware on purpose: a whole-file grep for `"name"` reads the first
+# dependency's name on most real package.json files, and a prefilled project
+# name that is silently the name of a transitive dependency is precisely the
+# kind of confident wrong answer §4.2 exists to prevent.
+_scout_json_top_string() {
+  local file="$1" key="$2"
+  [ -f "$file" ] || return 0
+  awk -v key="$key" '
+    function readstr(   body, c) {
+      i++
+      body = ""
+      while (i <= L) {
+        c = substr(buf, i, 1)
+        if (c == "\\") { body = body substr(buf, i + 1, 1); i += 2; continue }
+        if (c == "\"") { i++; return body }
+        body = body c; i++
+      }
+      return body
+    }
+    { buf = buf $0 "\n" }
+    END {
+      L = length(buf); i = 1; depth = 0; awaiting = 0; curkey = ""
+      while (i <= L) {
+        ch = substr(buf, i, 1)
+        if (ch == "\"") {
+          s = readstr()
+          if (depth == 1) {
+            if (awaiting == 0) { curkey = s; awaiting = 1 }
+            else { if (curkey == key) { print s; exit } awaiting = 0; curkey = "" }
+          }
+          continue
+        }
+        if (ch == "{" || ch == "[") { depth++; i++; continue }
+        if (ch == "}" || ch == "]") { if (depth > 0) depth--; i++; continue }
+        if (ch == ",") { if (depth == 1) awaiting = 0; i++; continue }
+        i++
+      }
+    }
+  ' "$file"
+}
+
+# scout_prefill_scan ROOT WORK — fills WORK with the intakePrefill rows.
+#
+# Writes `prefill` as `<id>\t<runner>\t<title>\t<kind>\t<field>\t<value>\t<source>`
+# where an EMPTY value column means the JSON literal null.
+scout_prefill_scan() {
+  local root="$1" work="$2"
+  local id runner title kind field hint value source pm rr
+  : > "$work/prefill"
+
+  while IFS="$(printf '\t')" read -r id runner title kind field hint; do
+    [ -n "$id" ] || continue
+    value=""; source=""
+    if [ "$kind" = "scan-derived" ]; then
+      case "$id" in
+        1)
+          value=$(_scout_json_top_string "$root/package.json" name)
+          if [ -n "$value" ]; then
+            source="package.json name"
+          else
+            value="${root##*/}"
+            source="the project directory's own name — no manifest declared one"
+          fi
+          ;;
+        1_repo_setup)
+          # THE URL IS NEVER EMITTED. An https remote can carry a token in its
+          # userinfo, and a scan report that helpfully quoted the operator's
+          # origin URL would be the §6.2 leak wearing a different hat. The
+          # answer the interview needs is whether a remote exists.
+          rr=$(awk -F'\t' '$1=="remote_repo_created" { print $2; exit }' "$work/probes" 2>/dev/null)
+          if [ "$rr" = "pass" ]; then value="yes"; else value="no"; fi
+          source="reality.probes remote_repo_created (the URL itself is deliberately not recorded)"
+          ;;
+        11_5)
+          if [ -s "$work/testcmd" ]; then
+            value=$(cut -f1 < "$work/testcmd")
+            source=$(cut -f2 < "$work/testcmd")
+          else
+            value="(none detected)"
+            source="Scout found no declared test command and no language convention that applies"
+          fi
+          ;;
+        12)
+          pm=$( [ -s "$work/pkgmgr" ] && tr '\n' ' ' < "$work/pkgmgr" | sed -e 's/ *$//' )
+          if [ -n "$pm" ]; then
+            value="$pm"; source="stack.packageManagers"
+          else
+            value="(none detected)"; source="no package manager was in evidence"
+          fi
+          ;;
+        13)
+          value="(generated from the completed intake)"
+          source="run_section_13 writes it from the answers above; it asks no question of its own"
+          ;;
+      esac
+    fi
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$id" "$runner" "$title" "$kind" "$field" "$value" "$source" >> "$work/prefill"
+  done <<PFIN
+$(_scout_prefill_table)
+PFIN
+  return 0
+}

--- a/scripts/lib/scout/scout-report.sh
+++ b/scripts/lib/scout/scout-report.sh
@@ -15,16 +15,21 @@
 # disagree about what was found; if they ever do, it is a rendering bug and not
 # a data question.
 #
-# THE ABSENT SECTIONS ARE DECLARED, NOT MISSING. This build emits three of
-# §8.2's seven sections. `sections` names what is here and `sectionsNotEmitted`
-# names what is not, so a consumer can tell "not scanned yet" from "scanned and
-# found nothing". For `secrets` that distinction is the whole difference
-# between a survey and a false clean bill of health, which is why the absence
-# is spelled out in the document rather than left to be inferred from a missing
-# key.
+# THE ABSENT SECTIONS ARE DECLARED, NOT MISSING. This build emits all seven of
+# §8.2's sections, so `sectionsNotEmitted` is empty — and it is KEPT, empty,
+# rather than removed. A consumer written against the WP1 report reads that key
+# to tell "not scanned yet" from "scanned and found nothing"; deleting it the
+# moment the list went empty would break that reader on the one release where
+# the answer finally became "everything was scanned".
+#
+# WITHIN `secrets` THE SAME DISTINCTION IS CARRIED BY `status`, at finer grain
+# and for higher stakes: `scanned` is a positive result, `tool-unavailable`
+# means nobody looked, and `scan-failed` means somebody looked and it broke.
+# Collapsing any of those into an empty findings array would be a false clean
+# bill of health with a credential behind it.
 
-SCOUT_SECTIONS_EMITTED="stack phaseMap reality"
-SCOUT_SECTIONS_NOT_EMITTED="testsBaseline secrets collisions intakePrefill"
+SCOUT_SECTIONS_EMITTED="stack phaseMap reality secrets collisions testsBaseline intakePrefill"
+SCOUT_SECTIONS_NOT_EMITTED=""
 
 # _scout_meta WORK KEY — one metadata value staged by the entry script.
 _scout_meta() {
@@ -119,8 +124,200 @@ scout_emit_json() {
     "$(scout_json_str "$rollup_result")" "$rollup_pass" "$rollup_total" "$(scout_json_str "$rollup_how")"
   printf '    "omitted": [{"name": "data_model_applied", "why": %s}]\n' \
     "$(scout_json_str "not probeable from the filesystem — whether a data model was applied and a restore was tested is a question only a person can answer, so it is omitted rather than guessed")"
-  printf '  }\n'
+  printf '  },\n'
+
+  # ── secrets (§6.2's projection, §8.2's object) ───────────────────────────
+  # EVERY FINDING OBJECT IS PRE-RENDERED BY scout-secrets.sh AND COPIED HERE
+  # VERBATIM. This function does not see field names, does not choose which to
+  # print, and has no access to anything the allowlist refused — so no bug in
+  # this renderer can leak a value it was never handed. That is the point of
+  # doing the projection at extraction time rather than at print time.
+  _scout_emit_secrets "$work"
+
+  # ── collisions (§1.2's inventory, §7.1's buckets) ────────────────────────
+  _scout_emit_collisions "$work"
+
+  # ── testsBaseline (§8.2) ─────────────────────────────────────────────────
+  _scout_emit_tests "$work"
+
+  # ── intakePrefill (§8.3) ─────────────────────────────────────────────────
+  _scout_emit_prefill "$work"
+
   printf '}\n'
+  return 0
+}
+
+# _scout_emit_secrets WORK — the `secrets` object, trailing comma included.
+_scout_emit_secrets() {
+  local work="$1" status cfg count first line
+  status=$(_scout_meta "$work" secstatus)
+  cfg=$(_scout_meta "$work" secconfig)
+  count=$(_scout_meta "$work" seccount)
+
+  printf '  "secrets": {\n'
+  printf '    "tool": %s,\n'        "$(scout_json_str "$(_scout_meta "$work" sectool)")"
+  printf '    "toolVersion": %s,\n' "$(scout_json_str_or_null "$(_scout_meta "$work" secversion)")"
+  printf '    "status": %s,\n'      "$(scout_json_str "$status")"
+  printf '    "scope": %s,\n'       "$(scout_json_str_or_null "$(_scout_meta "$work" secscope)")"
+  printf '    "configFile": %s,\n'  "$(scout_json_str_or_null "$cfg")"
+  if [ -n "$cfg" ]; then
+    printf '    "configNote": %s,\n' \
+      "$(scout_json_str "This project ships its own gitleaks configuration and the scan honoured it, which is correct — it is their configuration. It is disclosed because a count produced under rules written by the thing being audited is a different claim from a clean scan: an allowlist rule in that file can take a real finding to zero.")"
+  else
+    printf '    "configNote": null,\n'
+  fi
+  printf '    "redaction": %s,\n' \
+    "$(scout_json_str "field allowlist projection — each finding is built from RuleID, File, Commit, Fingerprint, StartLine, Date and Description, and the tool's report is never passed through. There is no secret field in this schema to forget to strip, and the commit message (which the scanner does NOT redact) is refused.")"
+  printf '    "fieldsMissing": %s,\n' "$(scout_json_array_from_file "$work/secmissing")"
+  printf '    "note": %s,\n' "$(scout_json_str "$(_scout_meta "$work" secnote)")"
+  if [ "$status" = "scanned" ]; then
+    printf '    "remediation": null,\n'
+  else
+    printf '    "remediation": %s,\n' "$(scout_json_str "$(_scout_meta "$work" secnote)")"
+  fi
+  # §6.4: the instructions are PRINTED, never executed. Scout runs no rewrite,
+  # and the sentence that matters most is that a rewrite does not un-leak
+  # anything already fetched — so rotation comes first, always.
+  if [ "$status" = "scanned" ] && [ -n "$count" ] && [ "$count" != "0" ]; then
+    printf '    "historyRewrite": %s,\n' \
+      "$(scout_json_str "ROTATE FIRST. A history rewrite (git filter-repo, or BFG) followed by a force-push and a re-clone by every collaborator removes the value from the repository, but it does NOT un-leak anything already cloned or fetched by anyone. Rotation at the source of truth is the fix; the rewrite is housekeeping afterwards. Scout prints this and runs none of it.")"
+  else
+    printf '    "historyRewrite": null,\n'
+  fi
+  if [ "$status" = "scanned" ]; then
+    printf '    "findingCount": %s,\n' "${count:-0}"
+    printf '    "findings": ['
+    first=1
+    if [ -s "$work/secjson" ]; then
+      while IFS= read -r line; do
+        [ -n "$line" ] || continue
+        [ "$first" -eq 1 ] || printf ', '
+        printf '%s' "$line"
+        first=0
+      done < "$work/secjson"
+    fi
+    printf ']\n'
+  else
+    # NOT `[]`. An empty array reads as "scanned and clean" to every consumer
+    # that does not also check status, and that misreading is the entire
+    # silent-success defect class this section is written against.
+    printf '    "findingCount": null,\n'
+    printf '    "findings": null\n'
+  fi
+  printf '  },\n'
+  return 0
+}
+
+# _scout_emit_collisions WORK — the `collisions` object, trailing comma.
+_scout_emit_collisions() {
+  local work="$1" TAB first path class bucket desc note findings
+  local rule dpath dline dwhy
+  TAB=$(printf '\t')
+
+  printf '  "collisions": {\n'
+  printf '    "entries": ['
+  first=1
+  if [ -s "$work/colentries" ]; then
+    while IFS="$TAB" read -r path class bucket desc note findings; do
+      [ -n "$path" ] || continue
+      desc=$(_scout_col_unblank "$desc")
+      note=$(_scout_col_unblank "$note")
+      findings=$(_scout_col_unblank "$findings")
+      [ "$first" -eq 1 ] || printf ', '
+      printf '{"path": %s, "class": %s, "bucket": %s, "description": %s, "note": %s, "findings": %s}' \
+        "$(scout_json_str "$path")" "$(scout_json_str "$class")" "$(scout_json_str "$bucket")" \
+        "$(scout_json_str_or_null "$desc")" "$(scout_json_str_or_null "$note")" \
+        "$(scout_json_array_from_words "$(printf '%s' "$findings" | tr ',' ' ')")"
+      first=0
+    done < "$work/colentries"
+  fi
+  printf '],\n'
+  # THE DETAIL ROWS CARRY A LINE NUMBER AND NEVER THE LINE. A workflow step can
+  # hold a credential as easily as a hook can; quoting the matched text to be
+  # helpful would reintroduce §6.2's leak in a section that does not mention it.
+  printf '    "findingDetail": ['
+  first=1
+  if [ -s "$work/coldetail" ]; then
+    while IFS="$TAB" read -r rule dpath dline dwhy; do
+      [ -n "$rule" ] || continue
+      [ "$first" -eq 1 ] || printf ', '
+      printf '{"rule": %s, "path": %s, "line": %s, "why": %s}' \
+        "$(scout_json_str "$rule")" "$(scout_json_str "$dpath")" "${dline:-0}" \
+        "$(scout_json_str "$dwhy")"
+      first=0
+    done < "$work/coldetail"
+  fi
+  printf '],\n'
+  printf '    "note": %s\n' \
+    "$(scout_json_str "Report-only. Scout changed none of these files and adoption would not change the audit-only ones at all. Findings name the rule, the file and the line; the matched text is deliberately not quoted.")"
+  printf '  },\n'
+  return 0
+}
+
+# _scout_emit_tests WORK — the `testsBaseline` object, trailing comma.
+_scout_emit_tests() {
+  local work="$1" ran rc dur value source
+  ran=$(_scout_meta "$work" tbran)
+  rc=$(_scout_meta "$work" tbrc)
+  dur=$(_scout_meta "$work" tbdur)
+  value=""; source=""
+  if [ -s "$work/testcmd" ]; then
+    value=$(cut -f1 < "$work/testcmd")
+    source=$(cut -f2 < "$work/testcmd")
+  fi
+
+  printf '  "testsBaseline": {\n'
+  printf '    "testCommand": {"value": %s, "source": %s},\n' \
+    "$(scout_json_str_or_null "$value")" "$(scout_json_str_or_null "$source")"
+  printf '    "commandRan": %s,\n' "$(_scout_bool "$ran")"
+  printf '    "reason": %s,\n'     "$(scout_json_str "$(_scout_meta "$work" tbreason)")"
+  if [ "$ran" = "1" ] && [ -n "$rc" ]; then
+    printf '    "exitCode": %s,\n' "$rc"
+  else
+    printf '    "exitCode": null,\n'
+  fi
+  if [ "$ran" = "1" ] && [ -n "$dur" ]; then
+    printf '    "durationSeconds": %s,\n' "$dur"
+  else
+    printf '    "durationSeconds": null,\n'
+  fi
+  printf '    "timedOut": %s,\n' "$(_scout_bool "$(_scout_meta "$work" tbtimeout)")"
+  printf '    "totalSourceFiles": %s,\n'    "$(_scout_meta "$work" tbtotal)"
+  printf '    "testFiles": %s,\n'           "$(_scout_meta "$work" tbtests)"
+  printf '    "untestedSourceFiles": %s,\n' "$(_scout_meta "$work" tbuntested)"
+  printf '    "classifier": %s,\n' "$(scout_json_str "tdd-classify parity (extracted, not sourced)")"
+  printf '    "classifierParity": {"carried": %s, "simplified": %s},\n' \
+    "$(scout_json_array_from_file "$work/tbcarried")" \
+    "$(scout_json_array_from_file "$work/tbsimplified")"
+  printf '    "untestedMethod": %s\n' "$(scout_json_str "$(scout_testsbaseline_method)")"
+  printf '  },\n'
+  return 0
+}
+
+# _scout_emit_prefill WORK — the `intakePrefill` object, NO trailing comma
+# (it is the last section in the document).
+_scout_emit_prefill() {
+  local work="$1" TAB first id runner title kind field value source
+  TAB=$(printf '\t')
+
+  printf '  "intakePrefill": {\n'
+  printf '    "note": %s,\n' \
+    "$(scout_json_str "One row per intake section. A scan-derived row carries a value AND where it came from, so the operator can check it rather than take it on trust; a judgment or non-skippable row carries null, because a guessed answer is worse than an absent one — it gets confirmed away.")"
+  printf '    "sections": ['
+  first=1
+  if [ -s "$work/prefill" ]; then
+    while IFS="$TAB" read -r id runner title kind field value source; do
+      [ -n "$id" ] || continue
+      [ "$first" -eq 1 ] || printf ', '
+      printf '{"id": %s, "runner": %s, "title": %s, "kind": %s, "field": %s, "value": %s, "source": %s}' \
+        "$(scout_json_str "$id")" "$(scout_json_str "$runner")" "$(scout_json_str "$title")" \
+        "$(scout_json_str "$kind")" "$(scout_json_str "$field")" \
+        "$(scout_json_str_or_null "$value")" "$(scout_json_str_or_null "$source")"
+      first=0
+    done < "$work/prefill"
+  fi
+  printf ']\n'
+  printf '  }\n'
   return 0
 }
 
@@ -155,9 +352,14 @@ scout_emit_markdown() {
   printf '| Scout version | %s |\n' "$(scout_module_version)"
   printf '| Latest commit | %s |\n' "$( [ -n "$(_scout_meta "$work" headCommit)" ] && _scout_meta "$work" headCommit || printf 'not a git repository' )"
   printf '\n'
-  printf 'This version reports on **%s**. It does *not* yet report on %s — those are not "clean", they are **not looked at yet**.\n\n' \
-    "$(printf '%s' "$SCOUT_SECTIONS_EMITTED" | sed -e 's/ /, /g')" \
-    "$(printf '%s' "$SCOUT_SECTIONS_NOT_EMITTED" | sed -e 's/ /, /g')"
+  if [ -n "$SCOUT_SECTIONS_NOT_EMITTED" ]; then
+    printf 'This version reports on **%s**. It does *not* yet report on %s — those are not "clean", they are **not looked at yet**.\n\n' \
+      "$(printf '%s' "$SCOUT_SECTIONS_EMITTED" | sed -e 's/ /, /g')" \
+      "$(printf '%s' "$SCOUT_SECTIONS_NOT_EMITTED" | sed -e 's/ /, /g')"
+  else
+    printf 'This version looked at everything it knows how to look at: **%s**.\n\n' \
+      "$(printf '%s' "$SCOUT_SECTIONS_EMITTED" | sed -e 's/ /, /g')"
+  fi
 
   # ── What it is built with ────────────────────────────────────────────────
   printf -- '---\n\n## What this project is built with\n\n'
@@ -223,6 +425,202 @@ scout_emit_markdown() {
   printf '**Overall: %s** — %s. (%s of %s passed; internal name `initialization_verified`.)\n\n' \
     "$rollup_result" "$rollup_how" "$rollup_pass" "$rollup_total"
   printf 'One check is deliberately left unanswered. Scout will not sign in to your git host or use your credentials, so it cannot see whether your main branch is protected. "Unknown" means exactly that — not "no".\n\n'
-  printf 'One more check is missing on purpose: whether a data model was applied and a restore was tested. Nothing on disk can answer that, so Scout does not guess.\n'
+  printf 'One more check is missing on purpose: whether a data model was applied and a restore was tested. Nothing on disk can answer that, so Scout does not guess.\n\n'
+
+  _scout_md_secrets    "$work"
+  _scout_md_collisions "$work"
+  _scout_md_tests      "$work"
+  _scout_md_prefill    "$work"
+  return 0
+}
+
+# _scout_md_unescape BODY — a JSON string body rendered for a person.
+#
+# The projection keeps values in their original JSON escaping so the machine
+# view can re-emit them without a lossy round trip. The human view undoes the
+# two escapes that actually occur in a path or a rule name. `\uXXXX` is left
+# visible rather than decoded: a mangled character in a filename is a cosmetic
+# problem, and a hand-rolled unicode decoder is a real one.
+_scout_md_unescape() {
+  printf '%s' "$1" | sed -e 's/\\"/"/g' -e 's/\\\\/\\/g' -e 's|\\/|/|g'
+}
+
+# _scout_secfield WORK IDX FIELD — one projected value, for display.
+_scout_secfield() {
+  local v
+  v=$(awk -F'\t' -v i="$2" -v k="$3" '$1==i && $2==k { sub(/^[^\t]*\t[^\t]*\t[^\t]*\t/, ""); print; exit }' \
+        "$1/secfields" 2>/dev/null)
+  _scout_md_unescape "$v"
+}
+
+# _scout_md_secrets WORK — §4.1's register: no jargon, and the consequence
+# stated plainly. §6.3 (a disposition per finding) and §6.4 (the rewrite is
+# printed, never run) both live here, because this is the view a person reads.
+_scout_md_secrets() {
+  local work="$1" status count idx cfg
+  status=$(_scout_meta "$work" secstatus)
+  count=$(_scout_meta "$work" seccount)
+  cfg=$(_scout_meta "$work" secconfig)
+
+  printf -- '---\n\n'
+  printf "## Secrets in this project's history\n\n"
+  case "$status" in
+    tool-unavailable)
+      printf '**Nobody looked.** %s\n\n' "$(_scout_meta "$work" secnote)"
+      return 0
+      ;;
+    scan-failed)
+      printf '**The scan did not finish.** %s\n\n' "$(_scout_meta "$work" secnote)"
+      return 0
+      ;;
+  esac
+
+  if [ -n "$cfg" ]; then
+    printf 'Note: this project has its own `%s`, and the scan obeyed it. If that file allows a pattern, anything matching it was not counted.\n\n' "$cfg"
+  fi
+
+  if [ -z "$count" ] || [ "$count" = "0" ]; then
+    printf 'Scout scanned %s and found **nothing**. That is a real result, not a blank: the scanner ran and reported no matches.\n\n' \
+      "$( [ "$(_scout_meta "$work" secscope)" = "full-history" ] && printf 'every commit in this project, not just the current files' || printf 'the current files (this is not a git repository, so there is no history to read)' )"
+    return 0
+  fi
+
+  printf '  ┌────────────────────────────────────────────────────────────────┐\n'
+  # The box interior is 64 columns. This line is 2 + 40 + 1 of literal text
+  # plus the pad plus one trailing space, so the pad is 20 — measured, because
+  # the border characters are three BYTES and one COLUMN each and eyeballing
+  # the alignment of a mixed-width box is how it ends up crooked.
+  printf '  │  SECRETS FOUND IN YOUR PROJECT'"'"'S HISTORY: %-20s │\n' "$count"
+  printf '  │                                                                │\n'
+  printf '  │  Your history is visible to anyone who has ever cloned this    │\n'
+  printf '  │  project. Deleting the line does not help — the old commit     │\n'
+  printf '  │  still contains it.                                            │\n'
+  printf '  │                                                                │\n'
+  printf '  │  ROTATION, NOT DELETION, IS THE FIX. Change the credential     │\n'
+  printf '  │  where it lives (AWS, your database, the API provider) and     │\n'
+  printf '  │  the copy in this history stops being worth anything.          │\n'
+  printf '  └────────────────────────────────────────────────────────────────┘\n\n'
+
+  printf 'The value itself is **not printed below and is not stored anywhere in this report** — only where to find it.\n\n'
+  # The RULE ID, not the Description. Both are allowlisted and both are in the
+  # JSON, but gitleaks' `Description` is a full sentence of risk prose — three
+  # of them in a table column make the table unreadable, and the id
+  # (`aws-access-token`) is also the string an operator greps for.
+  printf '| What matched | Where | Line | Commit | When |\n|---|---|---|---|---|\n'
+  idx=1
+  while [ "$idx" -le "$count" ]; do
+    printf '| `%s` | `%s` | %s | `%s` | %s |\n' \
+      "$(_scout_secfield "$work" "$idx" RuleID)" \
+      "$(_scout_secfield "$work" "$idx" File)" \
+      "$(_scout_secfield "$work" "$idx" StartLine)" \
+      "$(printf '%s' "$(_scout_secfield "$work" "$idx" Commit)" | cut -c1-10)" \
+      "$(_scout_secfield "$work" "$idx" Date)"
+    idx=$((idx + 1))
+  done
+  printf '\n'
+  printf 'Each one needs an answer recorded against it: **rotated** (with the date), **false alarm** (with a reason — the rule name is not a reason), or **accepted risk** (with the name of the person accepting it).\n\n'
+  printf 'Rewriting the history is possible (`git filter-repo` or BFG, a force-push, and every collaborator re-clones) but it **does not un-leak anything already fetched**, so rotation comes first. Scout does not run any of that.\n\n'
+  return 0
+}
+
+# _scout_md_bucket_phrase BUCKET — §7.1's bucket, said without the vocabulary.
+#
+# A FUNCTION AND NOT AN INLINE `case`, for a measured reason: bash 3.2 — the
+# floor this repository targets — cannot parse a multi-line `case` inside a
+# `$( )` substitution used as a printf argument, and fails it at RUNTIME with
+# `syntax error near unexpected token'. The report still rendered (the
+# substitution simply produced nothing), so the only thing that caught it was
+# the suite's stderr-must-be-empty case. That is what that case is for.
+_scout_md_bucket_phrase() {
+  case "$1" in
+    archive-and-replace) printf 'kept a copy, then replaced' ;;
+    marker-composed)     printf 'left alone; the framework adds to it' ;;
+    audit-only)          printf 'not touched at all' ;;
+    keep-theirs)         printf 'yours stays' ;;
+    *)                   printf '%s' "$1" ;;
+  esac
+}
+
+# _scout_md_collisions WORK
+_scout_md_collisions() {
+  local work="$1" TAB path class bucket desc note findings n
+  TAB=$(printf '\t')
+  printf -- '---\n\n'
+  printf '## What would collide with the framework\n\n'
+  n=$(grep -c '' "$work/colentries" 2>/dev/null)
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  if [ "$n" -eq 0 ]; then
+    printf 'Nothing. This project has none of the files the framework writes, so there is nothing to move out of the way.\n\n'
+    return 0
+  fi
+  printf 'Scout found **%s** things here that the framework also has an opinion about. It moved none of them.\n\n' "$n"
+  printf '| What you have | What would happen to it | Why |\n|---|---|---|\n'
+  while IFS="$TAB" read -r path class bucket desc note findings; do
+    [ -n "$path" ] || continue
+    desc=$(_scout_col_unblank "$desc")
+    note=$(_scout_col_unblank "$note")
+    printf '| `%s` | %s | %s |\n' "$path" "$(_scout_md_bucket_phrase "$bucket")" "$note"
+    if [ -n "$desc" ]; then
+      printf '| | *(what it does today)* | %s |\n' "$desc"
+    fi
+  done < "$work/colentries"
+  printf '\n'
+  if [ -s "$work/coldetail" ]; then
+    printf 'Some of your automated checks do things that would work against the safety rails. **Nothing was changed** — this is for you to decide:\n\n'
+    printf '| File | Line | Concern |\n|---|---|---|\n'
+    while IFS="$TAB" read -r r p l w; do
+      [ -n "$r" ] || continue
+      printf '| `%s` | %s | %s |\n' "$p" "$l" "$w"
+    done < "$work/coldetail"
+    printf '\n'
+  fi
+  return 0
+}
+
+# _scout_md_tests WORK
+_scout_md_tests() {
+  local work="$1" ran total unt
+  printf -- '---\n\n'
+  printf '## What the tests do today\n\n'
+  ran=$(_scout_meta "$work" tbran)
+  total=$(_scout_meta "$work" tbtotal)
+  unt=$(_scout_meta "$work" tbuntested)
+  if [ "$ran" = "1" ]; then
+    if [ "$(_scout_meta "$work" tbtimeout)" = "1" ]; then
+      printf 'Scout ran your test command and **stopped it** after it went on too long. %s\n\n' \
+        "$(_scout_meta "$work" tbreason)"
+    else
+      printf 'Scout ran your test command once. It finished with exit code **%s** after %s second(s). Zero means they passed.\n\n' \
+        "$(_scout_meta "$work" tbrc)" "$(_scout_meta "$work" tbdur)"
+    fi
+  else
+    printf '**Scout did not run anything.** %s\n\n' "$(_scout_meta "$work" tbreason)"
+  fi
+  printf -- '- **Source files:** %s\n' "$total"
+  printf -- '- **Test files:** %s\n' "$(_scout_meta "$work" tbtests)"
+  printf -- '- **Source files with no test that names them:** %s\n\n' "$unt"
+  printf 'That last number is a rough count, not a coverage figure. %s\n\n' "$(scout_testsbaseline_method)"
+  return 0
+}
+
+# _scout_md_prefill WORK
+_scout_md_prefill() {
+  local work="$1" TAB id runner title kind field value source
+  TAB=$(printf '\t')
+  printf -- '---\n\n'
+  printf '## What the interview can skip\n\n'
+  printf 'The setup interview asks about fifteen things. Scout already knows the answer to some of them from your files, and it will show you each one with where it got it so you can correct it. The rest are decisions only you can make, and it will not guess at those.\n\n'
+  printf '| Topic | Scout already knows | Where it got that |\n|---|---|---|\n'
+  while IFS="$TAB" read -r id runner title kind field value source; do
+    [ -n "$id" ] || continue
+    if [ "$kind" = "scan-derived" ]; then
+      printf '| %s | `%s` | %s |\n' "$title" "$value" "$source"
+    elif [ "$kind" = "non-skippable" ]; then
+      printf '| %s | **you must answer this one** | there is no way to work it out from your files, and the project cannot move forward without it |\n' "$title"
+    else
+      printf '| %s | — | this is a judgement call, so Scout leaves it to you |\n' "$title"
+    fi
+  done < "$work/prefill"
+  printf '\n'
   return 0
 }

--- a/scripts/lib/scout/scout-secrets.sh
+++ b/scripts/lib/scout/scout-secrets.sh
@@ -102,11 +102,22 @@ _scout_secret_json_key() {
 # THE ALLOWLIST IS ENFORCED HERE, AT THE POINT OF EXTRACTION, not later at the
 # point of rendering. A refused field is never read into a variable, never
 # staged in a temp file, and never present to be leaked by a downstream bug.
+#
+# RETURNS NON-ZERO WHEN THE REPORT DID NOT PARSE (R-WP2-3). The walker emits a
+# terminal `E ok` sentinel only when the document really was a JSON array that
+# opened and closed — the first non-whitespace character was `[` and container
+# depth returned to zero at EOF. Without that, a truncated or corrupt report
+# (gitleaks exiting 0 having written garbage — the disk-full/truncation class)
+# parsed to zero findings and was reported as `scanned` with a clean count.
+# A false clean bill of health in the one section where that has a credential
+# behind it is the exact silent-success class this file is written against, so
+# it is now `scan-failed`. awk's own exit status is checked for the same
+# reason: a walker crash must not take the clean path either.
 _scout_secrets_project() {
-  local report="$1" work="$2"
+  local report="$1" work="$2" _awkrc
   : > "$work/secfields"
   : > "$work/secmissing"
-  [ -f "$report" ] || return 0
+  [ -f "$report" ] || return 1
 
   awk -v want="$_SCOUT_SECRET_FIELDS" '
     function readstr(   body, c) {
@@ -133,8 +144,17 @@ _scout_secrets_project() {
     { buf = buf $0 "\n" }
     END {
       L = length(buf); i = 1; depth = 0; idx = 0; curkey = ""; awaiting = 0
+      opened = 0
       while (i <= L) {
         ch = substr(buf, i, 1)
+        # The document must BEGIN as a JSON array. Checking only that depth
+        # returns to 0 would accept `this is not json` — no braces, depth never
+        # moves — as a well-formed empty report.
+        if (!opened) {
+          if (ch == " " || ch == "\t" || ch == "\r" || ch == "\n") { i++; continue }
+          if (ch != "[") { exit 0 }
+          opened = 1
+        }
         if (ch == "\"") {
           s = readstr()
           if (depth == 2 && stk[2] == "{") {
@@ -164,11 +184,18 @@ _scout_secrets_project() {
       # reporting seven renamed fields for a clean scan would be a loud false
       # alarm in a section whose whole value is that its alarms are true.
       if (idx > 0) for (k = 1; k <= n; k++) if (!(W[k] in seen)) printf "M\t%s\n", W[k]
+      # The completion sentinel. Reached only by falling off the end of a
+      # document that opened as an array and closed every container it opened.
+      if (opened && depth == 0) printf "E\tok\n"
     }
-  ' "$report" > "$work/secraw" 2>/dev/null
+  ' "$report" > "$work/secraw"
+  _awkrc=$?
 
   grep '	F	' "$work/secraw" 2>/dev/null | sed -e 's/	F	/	/' > "$work/secfields"
   grep '^M	' "$work/secraw" 2>/dev/null | cut -f2 > "$work/secmissing"
+
+  [ "$_awkrc" -eq 0 ] || return 1
+  grep -q '^E	ok$' "$work/secraw" 2>/dev/null || return 1
   return 0
 }
 
@@ -228,7 +255,7 @@ _scout_secrets_render() {
 # false clean bill of health has a credential behind it.
 scout_secrets_scan() {
   local root="$1" work="$2"
-  local _bin _mode _scope _flags _rc _version _count _cfg
+  local _bin _mode _scope _flags _rc _version _count _cfg f
 
   printf 'gitleaks\n' > "$work/sectool"
   : > "$work/secjson"
@@ -299,7 +326,17 @@ scout_secrets_scan() {
     return 0
   fi
 
-  _scout_secrets_project "$work/gl.json" "$work"
+  # A report that exists and an exit code of 0 are NOT the same thing as a
+  # report that parsed (R-WP2-3). Degrading a corrupt one to "scanned, zero
+  # findings" would issue a clean bill of health on the strength of garbage.
+  if ! _scout_secrets_project "$work/gl.json" "$work"; then
+    : > "$work/secjson"
+    : > "$work/secmissing"
+    printf 'scan-failed\n' > "$work/secstatus"
+    printf '%s\n' "The scanner exited cleanly but its report did not parse, so NOTHING here can be trusted — treat this as unknown, not as clean. A truncated or corrupt report is usually a full disk or a killed process; re-run Scout." \
+      > "$work/secnote"
+    return 0
+  fi
   _scout_secrets_render "$work"
   _count=$(grep -c '' "$work/secjson" 2>/dev/null)
   case "$_count" in ''|*[!0-9]*) _count=0 ;; esac

--- a/scripts/lib/scout/scout-secrets.sh
+++ b/scripts/lib/scout/scout-secrets.sh
@@ -1,0 +1,311 @@
+#!/usr/bin/env bash
+# scripts/lib/scout/scout-secrets.sh — §8.2's `secrets` section: a full-history
+# secret scan, projected through an explicit field ALLOWLIST.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §6.1 (scope: full
+# history via `gitleaks git`, degrading to `gitleaks dir` off a repository),
+# §6.2 (REDACTION IS A PROJECTION, NOT A FLAG — the allowlist table below is
+# normative), §6.5 (the planted-secret test), §8.2 (the schema), §12-13 (the
+# schema-stability assumption this file's failure modes are designed around),
+# §13-V3 (the executed evidence).
+#
+# M5: sources nothing. See scripts/lib/scout/scout-core.sh's header.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE ONE SENTENCE THIS FILE EXISTS TO IMPLEMENT
+#
+# Every artifact built from a gitleaks report is assembled by naming the fields
+# that may appear — NEVER by passing the tool's report through, and never by
+# removing the fields that may not.
+#
+# WHY A DENYLIST IS THE WRONG SHAPE, IN ONE MEASUREMENT. gitleaks 8.30.1 emits
+# EIGHTEEN fields per finding. `--redact` covers exactly two of them, `Secret`
+# and `Match`. It does NOT touch `Message` — the full commit message — and a
+# key planted in a commit message therefore survives into a "redacted" report
+# intact. A denylist that stripped `Secret`, `Match` and `Message` today would
+# silently pass through whatever field the next gitleaks release adds. The
+# allowlist has the two failure modes worth having: it fails SAFE when a field
+# is added (the new field is simply never read) and LOUD when a field is
+# renamed (it lands in `fieldsMissing`, which the report prints).
+#
+# THE SCHEMA HAS NO `secret` FIELD TO FORGET TO STRIP. That is §8.2's own
+# sentence and it is the design property, not a coding convention: there is no
+# code path from the tool's `Secret` value to any byte Scout writes.
+#
+# THE PROOF IS NOT THIS COMMENT. tests/test-brownfield-wp2-scout-sections.sh
+# plants four BASE32-valid synthetic AWS keys — one in a diff, one in a commit
+# MESSAGE, one carrying the message plant's commit, one inside a git hook — and
+# asserts that none of them occurs in any byte of any artifact, temp residue
+# included. XB neuters the one line below marked SCOUT-SECRETS-ALLOWLIST and
+# watches the message plant walk out.
+
+# ── THE ALLOWLIST (§6.2's table, and the only thing that decides) ───────────
+#
+# RuleID       what matched
+# File         where
+# Commit       when, in history terms
+# Fingerprint  <commit>:<file>:<ruleid>:<startline> — the stable per-finding key
+#              a disposition file joins on (§6.3)
+# StartLine    locates it WITHOUT quoting it
+# Date         ordering, and "is this still live"
+# Description  the human-readable rule name
+#
+# REFUSED, each for a stated reason: Secret and Match (the value — never);
+# Message (not redacted by the tool, operator-authored free text, DEMONSTRATED
+# to carry a secret); Author and Email (attribution of a leak to a named person
+# is the operator's decision, not a default in a committed file); Entropy,
+# EndLine, EndColumn, StartColumn, SymlinkFile, Tags (not load-bearing — and
+# every field kept is a field that can leak).
+#
+# ONE LINE, DELIBERATELY. It is the mutation target: replace it with the tool's
+# full field list and the projection becomes a passthrough.
+_SCOUT_SECRET_FIELDS="RuleID File Commit Fingerprint StartLine Date Description"  # SCOUT-SECRETS-ALLOWLIST
+
+# _scout_secret_json_key FIELD — the report's key for one allowlisted field.
+#
+# Generic on purpose: it lower-cases the first character and keeps the rest, so
+# a field ADDED to the allowlist gets a key without a second edit. If it were a
+# closed table, the XB mutation would rename nothing, emit nothing, and pass
+# while the projection was in fact a passthrough — the mutation has to be able
+# to bite for the proof to mean anything.
+_scout_secret_json_key() {
+  case "$1" in
+    RuleID)    printf 'ruleId' ;;
+    StartLine) printf 'startLine' ;;
+    *)         printf '%s%s' \
+                 "$(printf '%s' "$1" | cut -c1 | tr 'A-Z' 'a-z')" \
+                 "$(printf '%s' "$1" | cut -c2-)" ;;
+  esac
+}
+
+# _scout_secrets_project REPORT WORK — THE PROJECTION.
+#
+# Reads a gitleaks JSON report and writes, into WORK:
+#   secfields   `<idx>\t<Field>\t<S|N>\t<value>` for ALLOWLISTED fields only
+#   secmissing  one allowlisted field name per line that the report never
+#               carried (empty when the schema is what we expect)
+#
+# `S` marks a JSON string whose value is kept in its ORIGINAL ESCAPED FORM —
+# it came out of a valid JSON string literal, so it is re-emitted verbatim
+# between quotes and cannot be double-escaped or under-escaped by a round trip
+# through a hand-rolled encoder. `N` marks a bare token (number, true, false,
+# null), emitted unquoted.
+#
+# WHY A CHARACTER-LEVEL WALKER AND NOT `grep '"RuleID"'`. jq is forbidden here
+# (M5), and a line-oriented parse of a pretty-printed report is a guess about
+# the tool's formatter, not a parse. This walker tracks string state, escape
+# state and container depth, so `Message` values containing braces, quotes or
+# the literal text `"Fingerprint":` cannot be misread as structure — and a
+# value nested one level deeper (a `Tags` array member) is never mistaken for a
+# field of the finding.
+#
+# THE ALLOWLIST IS ENFORCED HERE, AT THE POINT OF EXTRACTION, not later at the
+# point of rendering. A refused field is never read into a variable, never
+# staged in a temp file, and never present to be leaked by a downstream bug.
+_scout_secrets_project() {
+  local report="$1" work="$2"
+  : > "$work/secfields"
+  : > "$work/secmissing"
+  [ -f "$report" ] || return 0
+
+  awk -v want="$_SCOUT_SECRET_FIELDS" '
+    function readstr(   body, c) {
+      i++
+      body = ""
+      while (i <= L) {
+        c = substr(buf, i, 1)
+        if (c == "\\") { body = body c substr(buf, i + 1, 1); i += 2; continue }
+        if (c == "\"") { i++; return body }
+        body = body c; i++
+      }
+      return body
+    }
+    function readtok(   start, c) {
+      start = i
+      while (i <= L) {
+        c = substr(buf, i, 1)
+        if (c == "," || c == "}" || c == "]" || c == " " || c == "\t" || c == "\r" || c == "\n") break
+        i++
+      }
+      return substr(buf, start, i - start)
+    }
+    BEGIN { n = split(want, W, " "); for (k = 1; k <= n; k++) keep[W[k]] = 1 }
+    { buf = buf $0 "\n" }
+    END {
+      L = length(buf); i = 1; depth = 0; idx = 0; curkey = ""; awaiting = 0
+      while (i <= L) {
+        ch = substr(buf, i, 1)
+        if (ch == "\"") {
+          s = readstr()
+          if (depth == 2 && stk[2] == "{") {
+            if (awaiting == 0) { curkey = s; awaiting = 1 }
+            else {
+              if (curkey in keep) { printf "%d\tF\t%s\tS\t%s\n", idx, curkey, s; seen[curkey] = 1 }
+              awaiting = 0; curkey = ""
+            }
+          }
+          continue
+        }
+        if (ch == "{") { depth++; stk[depth] = "{"; if (depth == 2) { idx++; awaiting = 0 }; i++; continue }
+        if (ch == "[") { depth++; stk[depth] = "["; i++; continue }
+        if (ch == "}" || ch == "]") { if (depth > 0) depth--; i++; continue }
+        if (ch == ",") { if (depth == 2 && stk[2] == "{") awaiting = 0; i++; continue }
+        if (ch == ":") { i++; continue }
+        if (depth == 2 && stk[2] == "{" && awaiting == 1 && index("-0123456789tfn", ch) > 0) {
+          t = readtok()
+          if (curkey in keep) { printf "%d\tF\t%s\tN\t%s\n", idx, curkey, t; seen[curkey] = 1 }
+          awaiting = 0; curkey = ""
+          continue
+        }
+        i++
+      }
+      # A field is only "missing" if there was a finding it could have been
+      # missing FROM. On an empty report every field is trivially unseen, and
+      # reporting seven renamed fields for a clean scan would be a loud false
+      # alarm in a section whose whole value is that its alarms are true.
+      if (idx > 0) for (k = 1; k <= n; k++) if (!(W[k] in seen)) printf "M\t%s\n", W[k]
+    }
+  ' "$report" > "$work/secraw" 2>/dev/null
+
+  grep '	F	' "$work/secraw" 2>/dev/null | sed -e 's/	F	/	/' > "$work/secfields"
+  grep '^M	' "$work/secraw" 2>/dev/null | cut -f2 > "$work/secmissing"
+  return 0
+}
+
+# _scout_secrets_render WORK — the findings array's ELEMENTS, one JSON object
+# per line, into $work/secjson.
+#
+# Iterates the ALLOWLIST, not the report: a field that is in the data but not
+# in the allowlist has already been dropped at extraction, and a field in the
+# allowlist that is not in the data is simply absent from the object (and named
+# in `fieldsMissing`). Key order is the allowlist's order, so two reports of
+# the same findings are byte-identical.
+_scout_secrets_render() {
+  local work="$1" idx maxidx first f kind val line
+  : > "$work/secjson"
+  maxidx=$(cut -f1 < "$work/secfields" 2>/dev/null | LC_ALL=C sort -n | tail -1)
+  case "$maxidx" in ''|*[!0-9]*) maxidx=0 ;; esac
+  idx=1
+  while [ "$idx" -le "$maxidx" ]; do
+    line='{'
+    first=1
+    for f in $_SCOUT_SECRET_FIELDS; do
+      kind=$(awk -F'\t' -v i="$idx" -v k="$f" '$1==i && $2==k { print $3; exit }' "$work/secfields")
+      [ -n "$kind" ] || continue
+      val=$(awk -F'\t' -v i="$idx" -v k="$f" '$1==i && $2==k { sub(/^[^\t]*\t[^\t]*\t[^\t]*\t/, ""); print; exit }' "$work/secfields")
+      [ "$first" -eq 1 ] || line="$line, "
+      if [ "$kind" = "N" ]; then
+        line="$line\"$(_scout_secret_json_key "$f")\": $val"
+      else
+        line="$line\"$(_scout_secret_json_key "$f")\": \"$val\""
+      fi
+      first=0
+    done
+    line="$line}"
+    printf '%s\n' "$line" >> "$work/secjson"
+    idx=$((idx + 1))
+  done
+  return 0
+}
+
+# scout_secrets_scan ROOT WORK — fills WORK with the secrets section's data.
+#
+# Writes (all inside WORK, which the entry script owns and removes):
+#   secstatus   scanned | tool-unavailable | scan-failed
+#   secscope    full-history | working-tree-only | (empty when not scanned)
+#   secversion  the tool's own version string
+#   seccount    the finding count, or empty when nothing was scanned
+#   secconfig   a repo-local gitleaks config path, or empty
+#   secnote     a one-line honest explanation of whatever the status is
+#   secjson     one JSON finding object per line (the projection)
+#   secmissing  allowlisted fields the report did not carry
+#
+# THE STATUS VOCABULARY IS THREE WORDS BECAUSE THE CLAIMS ARE DIFFERENT.
+# `scanned` with zero findings is a positive result. `tool-unavailable` is
+# "nobody looked". `scan-failed` is "we looked and something went wrong".
+# Collapsing any two of these into an empty findings array is the
+# silent-success defect class, aimed at the one section of this report where a
+# false clean bill of health has a credential behind it.
+scout_secrets_scan() {
+  local root="$1" work="$2"
+  local _bin _mode _scope _flags _rc _version _count _cfg
+
+  printf 'gitleaks\n' > "$work/sectool"
+  : > "$work/secjson"
+  : > "$work/secmissing"
+  : > "$work/secscope"
+  : > "$work/seccount"
+  : > "$work/secconfig"
+  : > "$work/secversion"
+
+  # SCOUT_GITLEAKS_BIN exists so the suite can point Scout at a name that is
+  # not installed, and prove the tool-unavailable arm without uninstalling
+  # anything on the host running the tests.
+  _bin="${SCOUT_GITLEAKS_BIN:-gitleaks}"
+
+  if ! command -v "$_bin" >/dev/null 2>&1; then
+    printf 'tool-unavailable\n' > "$work/secstatus"
+    printf '%s\n' "gitleaks is not installed, so NOTHING WAS SCANNED. This is not a clean result — it is the absence of a result. Install it (macOS: brew install gitleaks; other hosts: https://github.com/gitleaks/gitleaks/releases) and run Scout again before treating this project as free of committed credentials." \
+      > "$work/secnote"
+    return 0
+  fi
+
+  _version=$("$_bin" version 2>/dev/null | head -1 | tr -d '\r')
+  printf '%s\n' "$_version" > "$work/secversion"
+
+  # §6.1: history is the point. `gitleaks git` walks it — a key present only in
+  # a superseded commit and absent from the working tree is found — and that is
+  # precisely what the emitted GitLab/Bitbucket templates never do. Off a
+  # repository there is no history to walk, and the scope field says so rather
+  # than letting a working-tree scan be read as a history scan.
+  _mode="dir"; _scope="working-tree-only"
+  if command -v git >/dev/null 2>&1 \
+     && git -C "$root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    _mode="git"; _scope="full-history"
+  fi
+  printf '%s\n' "$_scope" > "$work/secscope"
+
+  # A project's OWN gitleaks config can suppress findings entirely — measured:
+  # a `.gitleaks.toml` allowlisting `AKIA[A-Z2-7]{16}` takes a two-plant
+  # fixture to zero. gitleaks picks it up from the working directory, so the
+  # scan honours it (that is correct — it is their configuration) and the
+  # report DISCLOSES it, because a clean bill of health issued under rules
+  # written by the thing being audited is a different claim from a clean scan.
+  _cfg=""
+  for f in .gitleaks.toml gitleaks.toml; do
+    if [ -f "$root/$f" ]; then _cfg="$f"; break; fi
+  done
+  printf '%s\n' "$_cfg" > "$work/secconfig"
+
+  # `--exit-code 0` makes "leaks were found" a rc of 0, so a NON-zero rc means
+  # the scan itself failed and can be reported as such. Without it, findings
+  # and failures are the same exit code and the honest statuses collapse.
+  # `--redact` is defence in depth and is NOT what makes this safe: the field
+  # allowlist is. The suite's XA1 case drops this flag alone and asserts the
+  # artifacts stay clean.
+  _flags="--no-banner --redact --exit-code 0"  # SCOUT-SECRETS-REDACT
+
+  # stderr is captured, never inherited: gitleaks writes INF/WRN progress lines
+  # on every run, and Scout's contract is an EMPTY stderr on a successful scan.
+  ( cd "$root" 2>/dev/null || exit 2
+    "$_bin" "$_mode" $_flags -f json -r "$work/gl.json" . ) \
+    >"$work/gl.out" 2>"$work/gl.err"
+  _rc=$?
+
+  if [ "$_rc" -ne 0 ] || [ ! -f "$work/gl.json" ]; then
+    printf 'scan-failed\n' > "$work/secstatus"
+    printf '%s\n' "The secret scan did not complete (gitleaks exited $_rc). NOTHING was scanned — treat this as unknown, not as clean, and re-run Scout once the scanner works on this host." \
+      > "$work/secnote"
+    return 0
+  fi
+
+  _scout_secrets_project "$work/gl.json" "$work"
+  _scout_secrets_render "$work"
+  _count=$(grep -c '' "$work/secjson" 2>/dev/null)
+  case "$_count" in ''|*[!0-9]*) _count=0 ;; esac
+  printf '%s\n' "$_count" > "$work/seccount"
+  printf 'scanned\n' > "$work/secstatus"
+  printf '%s\n' "Every finding below is built from a fixed list of seven fields. The secret VALUE is never one of them, and neither is the commit message — which the scanner does not redact and which has been demonstrated to carry one." \
+    > "$work/secnote"
+  return 0
+}

--- a/scripts/lib/scout/scout-testsbaseline.sh
+++ b/scripts/lib/scout/scout-testsbaseline.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# scripts/lib/scout/scout-testsbaseline.sh — §8.2's `testsBaseline` section:
+# what the adoptee's tests do today, and how much of its source has none.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §8.2 (the schema, and
+# the reuse-by-EXTRACTION rule), §10-WP2, §5.4 (the test-debt ledger this
+# section's count later feeds).
+#
+# M5: sources no CORE library. It does use its own module's sibling
+# (`_scout_lang_table` from scout-stack.sh), which is the same program.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THIS IS THE ONLY PLACE SCOUT EXECUTES PROJECT CODE, AND IT IS OPT-IN.
+#
+# A scanner you point at a stranger's repository must not run that repository's
+# `npm test` because it felt like knowing the answer. Default: `commandRan` is
+# false and the reason says so. With `--run-tests`, and only then, the detected
+# command runs — bounded by SCOUT_TEST_TIMEOUT (default 300s) and with its
+# output DISCARDED rather than captured, because test output is exactly the
+# kind of free text that carries a credential and §6.2's rule does not stop
+# being true one section further down the report.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# REUSE BY EXTRACTION, AND AN HONEST LEDGER OF WHAT CHANGED (§8.2).
+#
+# The classifier below is lifted from the shared BL-072 file-classification
+# core — copied, not sourced, because Scout has to run in a clone that has
+# never had the framework applied to it. Copying a predicate creates a drift
+# risk, and the only defence against a silent one is to say plainly what was
+# carried and what was altered. The report itself carries that ledger, in
+# `classifierParity`, so the person reading the number can see the shape of it.
+# `# BL-107-RUST-INLINE-TESTS` is the interesting row: idiomatic Rust unit
+# tests live INSIDE the implementation file, invisible to any path-only
+# classifier, and the original gate carries a content probe for exactly that.
+# Dropping it here would report every inline-tested Rust file as untested — a
+# large, confident, wrong number.
+
+# _scout_is_test_file PATH — extracted verbatim from the BL-072 classifier's
+# test-file predicate. Path-only, deliberately: a content-aware rule could not
+# be applied identically by the original's two callers, and the copy keeps the
+# property so the two stay comparable.
+_scout_is_test_file() {
+  local p="$1" base
+  base="${p##*/}"
+  case "$p" in
+    tests/*|*/tests/*)         return 0 ;;
+    test/*|*/test/*)           return 0 ;;
+    __tests__/*|*/__tests__/*) return 0 ;;
+    spec/*|*/spec/*)           return 0 ;;
+  esac
+  case "$base" in
+    *_test.go)                                            return 0 ;;
+    *.test.ts|*.test.tsx|*.test.js|*.test.jsx|*.test.mjs) return 0 ;;
+    *.spec.ts|*.spec.tsx|*.spec.js|*.spec.jsx)            return 0 ;;
+    test_*.py|*_test.py)                                  return 0 ;;
+    *Test.kt|*Test.java|*Tests.kt|*Tests.java)            return 0 ;;
+    *Spec.kt|*Spec.groovy|*Spec.scala)                    return 0 ;;
+    *_test.rb|*_spec.rb)                                  return 0 ;;
+    *_test.rs)                                            return 0 ;;
+    *_test.sh|*-test.sh|test-*.sh)                        return 0 ;;
+  esac
+  return 1
+}
+
+# _scout_is_impl_file PATH — extracted from the BL-072 implementation
+# predicate: not a test, and not under one of the exempt trees or shapes.
+_scout_is_impl_file() {
+  local p="$1" base
+  base="${p##*/}"
+  _scout_is_test_file "$p" && return 1
+  case "$p" in
+    docs/*|*/docs/*)       return 1 ;;
+    .github/*)             return 1 ;;
+    .claude/*|*/.claude/*) return 1 ;;
+    Reports/*)             return 1 ;;
+    templates/*)           return 1 ;;
+    scripts/lint-*.sh)     return 1 ;;
+    *.md)                  return 1 ;;
+  esac
+  case "$base" in
+    package-lock.json)   return 1 ;;
+    yarn.lock)           return 1 ;;
+    *.lock)              return 1 ;;
+  esac
+  return 0
+}
+
+# _scout_is_source_ext PATH — THE ONE NARROWING, AND WHY IT IS HERE.
+#
+# The original classifies a DIFF, where a changed `package.json` or a
+# regenerated lockfile is legitimately implementation that shipped. This
+# section takes a CENSUS OF A TREE, and in a census `package.json`,
+# `pnpm-lock.yaml` and `Cargo.toml` are not source files — counting them would
+# inflate `totalSourceFiles` and make `untestedSourceFiles` a number about
+# manifests. A file is source here only if its extension names a programming
+# language, which is the same table the `stack` section counts languages with,
+# so the two sections cannot disagree about what a source file is.
+_scout_is_source_ext() {
+  local base ext
+  base="${1##*/}"
+  case "$base" in *.*) ext=$(printf '%s' "${base##*.}" | tr 'A-Z' 'a-z') ;; *) return 1 ;; esac
+  _scout_lang_table | grep -q "^$ext " 2>/dev/null
+}
+
+# _scout_has_inline_tests FILE — `# BL-107-RUST-INLINE-TESTS`, re-aimed from a
+# staged diff to file content.
+#
+# The gate's version greps the ADDED lines of a staged `.rs` diff for a test
+# attribute; there is no diff at scan time, so the copy asks the same question
+# of the file itself. The attribute family is carried across unchanged: std
+# `#[test]` / `#[cfg(test)]` / `#![cfg(test)]` / `cfg(all(test,…))` /
+# `cfg(any(test,…))`, the runtime family (anything `::test]` — tokio, async_std,
+# actix_rt, googletest), and the popular harness macros.
+_scout_has_inline_tests() {
+  case "$1" in *.rs) ;; *) return 1 ;; esac
+  grep -qE '#!?\[(test|cfg\((all\(|any\()?test|([A-Za-z_][A-Za-z0-9_]*::)+test\]|rstest|wasm_bindgen_test|quickcheck|proptest)' \
+    "$1" 2>/dev/null
+}
+
+# _scout_run_test_command ROOT WORK CMD — run it, bounded. Writes testrc,
+# testdur and (on expiry) testtimedout into WORK.
+#
+# THE BOUND IS HAND-ROLLED ON PURPOSE. There is no portable `timeout` binary —
+# it is absent from a stock macOS, and wrapping a command in one that does not
+# exist yields a command-not-found that reads exactly like a real timeout. So
+# the command is backgrounded in its own PROCESS GROUP (`set -m`), a sentinel
+# file records its exit status the moment it finishes, and the group is
+# signalled on expiry. The sentinel is what makes completion detectable: a
+# finished-but-unreaped child still answers `kill -0`, so polling liveness
+# alone would wait out the full timeout on every fast test suite.
+#
+# HONEST LIMIT: the group kill reaches the processes the command started, not
+# anything it deliberately detached. A test suite that daemonises something is
+# beyond a scanner's reach, and this bound does not claim otherwise.
+_scout_run_test_command() {
+  local root="$1" work="$2" cmd="$3"
+  local _to _start _end _pid _waited
+  _to="${SCOUT_TEST_TIMEOUT:-300}"
+  case "$_to" in ''|*[!0-9]*) _to=300 ;; esac
+  rm -f "$work/testrc" "$work/testtimedout" 2>/dev/null
+  _start=$(date +%s)
+
+  set -m 2>/dev/null
+  ( cd "$root" 2>/dev/null || { printf '127\n' > "$work/testrc"; exit 127; }
+    sh -c "$cmd" >/dev/null 2>&1
+    printf '%s\n' "$?" > "$work/testrc" ) >/dev/null 2>&1 &
+  _pid=$!
+  set +m 2>/dev/null
+
+  _waited=0
+  while [ ! -f "$work/testrc" ]; do
+    if [ "$_waited" -ge "$_to" ]; then
+      kill -TERM -"$_pid" 2>/dev/null || kill -TERM "$_pid" 2>/dev/null
+      sleep 1
+      kill -KILL -"$_pid" 2>/dev/null || kill -KILL "$_pid" 2>/dev/null
+      printf '1\n' > "$work/testtimedout"
+      break
+    fi
+    kill -0 "$_pid" 2>/dev/null || break
+    sleep 1
+    _waited=$((_waited + 1))
+  done
+  wait "$_pid" 2>/dev/null
+  _end=$(date +%s)
+  printf '%s\n' "$((_end - _start))" > "$work/testdur"
+  return 0
+}
+
+# scout_testsbaseline_scan ROOT WORK RUN_TESTS — fills WORK with the section.
+#
+# Writes:
+#   tbran      1|0        whether the command was executed
+#   tbreason   the sentence explaining a 0
+#   tbrc       the exit code, or empty
+#   tbdur      seconds, or empty
+#   tbtimeout  1|0
+#   tbtotal / tbtests / tbuntested   the census
+scout_testsbaseline_scan() {
+  local root="$1" work="$2" run="$3"
+  local cmd="" src total=0 ntest=0 nuntested=0 stem base tested
+
+  : > "$work/tbreason"; : > "$work/tbrc"; : > "$work/tbdur"
+  printf '0\n' > "$work/tbran"
+  printf '0\n' > "$work/tbtimeout"
+  scout_testsbaseline_parity carried    > "$work/tbcarried"
+  scout_testsbaseline_parity simplified > "$work/tbsimplified"
+
+  # The test command is REUSED, not re-derived: the stack section already
+  # found it and recorded where it came from. Two derivations of one fact are
+  # two chances to disagree about it.
+  [ -s "$work/testcmd" ] && cmd=$(cut -f1 < "$work/testcmd")
+
+  # ── The census ───────────────────────────────────────────────────────────
+  : > "$work/tbimpl"
+  : > "$work/tbtestnames"
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    _scout_is_source_ext "$src" || continue
+    if _scout_is_test_file "$src"; then
+      base="${src##*/}"
+      printf '%s\n' "$base" >> "$work/tbtestnames"
+      ntest=$((ntest + 1))
+    elif _scout_is_impl_file "$src"; then
+      printf '%s\n' "$src" >> "$work/tbimpl"
+      total=$((total + 1))
+    fi
+  done < "$work/files"
+
+  while IFS= read -r src; do
+    [ -n "$src" ] || continue
+    if _scout_has_inline_tests "$root/$src"; then continue; fi
+    base="${src##*/}"
+    stem="${base%.*}"
+    tested=0
+    if [ -n "$stem" ] && [ -s "$work/tbtestnames" ]; then
+      grep -qF -- "$stem" "$work/tbtestnames" 2>/dev/null && tested=1
+    fi
+    [ "$tested" -eq 0 ] && nuntested=$((nuntested + 1))
+  done < "$work/tbimpl"
+
+  printf '%s\n' "$total"     > "$work/tbtotal"
+  printf '%s\n' "$ntest"     > "$work/tbtests"
+  printf '%s\n' "$nuntested" > "$work/tbuntested"
+
+  # ── The run, or the reason there wasn't one ──────────────────────────────
+  if [ -z "$cmd" ]; then
+    printf '%s\n' "No test command could be detected, so there was nothing to run. Scout looks for a declared command first (package.json scripts.test, a Makefile test target) and falls back to a language convention only when the project has not said." \
+      > "$work/tbreason"
+    return 0
+  fi
+  if [ "$run" != "1" ]; then
+    printf '%s\n' "--run-tests was not given, so Scout did not execute anything. This is the only part of Scout that would run your project's own code, and it stays off until you ask for it: a scanner that runs an unknown repository's test command by default is a trap, not a convenience." \
+      > "$work/tbreason"
+    return 0
+  fi
+
+  _scout_run_test_command "$root" "$work" "$cmd"
+  printf '1\n' > "$work/tbran"
+  [ -f "$work/tbdur" ] || : > "$work/tbdur"
+  [ -f "$work/testdur" ] && cp "$work/testdur" "$work/tbdur"
+  if [ -f "$work/testtimedout" ]; then
+    printf '1\n' > "$work/tbtimeout"
+    printf '%s\n' "The command was still running after ${SCOUT_TEST_TIMEOUT:-300}s and was stopped, so there is no exit code to report. Raise SCOUT_TEST_TIMEOUT if this suite is legitimately that slow." \
+      > "$work/tbreason"
+  elif [ -f "$work/testrc" ]; then
+    head -1 "$work/testrc" > "$work/tbrc"
+    printf '%s\n' "Run once, with its output discarded rather than captured — test output is free text and free text is where a credential ends up." \
+      > "$work/tbreason"
+  fi
+  return 0
+}
+
+# scout_testsbaseline_parity WHICH — the classifierParity ledger, one line per
+# entry. WHICH is `carried` or `simplified`.
+#
+# DATA, NOT PROSE IN A COMMENT, because §8.2 asks for the statement to be IN
+# THE REPORT: the person reading `untestedSourceFiles: 137` is the person who
+# needs to know the classifier was copied and where the copy diverges.
+scout_testsbaseline_parity() {
+  case "$1" in
+    carried)
+      cat <<'CARRIED'
+The path-only test-file predicate: the tests/, test/, __tests__/ and spec/ trees, plus the per-language naming conventions (*_test.go, *.test.ts, *.spec.js, test_*.py, *Test.java, *_spec.rb, *_test.rs, test-*.sh).
+The implementation-file exclusions: docs/, .github/, .claude/, Reports/, templates/, scripts/lint-*.sh, every *.md anywhere, and generated lockfiles.
+The BL-107 Rust inline-test attribute family, so a file whose only tests are #[cfg(test)] blocks is not reported as untested.
+CARRIED
+      ;;
+    simplified)
+      cat <<'SIMPLIFIED'
+The git name-status entry point is gone: this is a census of a working tree, not a diff, so the pure-deletion carve-out and the rename/copy path have nothing to apply to.
+The branch axis (a second look at base...HEAD for a test that rode earlier) is gone: there is no branch under review at scan time.
+A source-extension gate was ADDED, which the original does not have: the original reads a diff, where package.json and a lockfile are legitimately implementation, and a tree census that counted them as source files would make the untested figure a number about manifests.
+The BL-107 probe reads FILE CONTENT rather than the added lines of a staged diff, which is the same question asked of a tree instead of a change.
+SIMPLIFIED
+      ;;
+  esac
+}
+
+# scout_testsbaseline_method — the sentence that keeps the number honest.
+scout_testsbaseline_method() {
+  printf '%s' "An implementation file counts as untested when no test file's NAME contains its basename stem and it carries no inline test attribute. This is a name-match heuristic, not coverage: it cannot see a test that exercises a file without naming it, and it will call a file tested on a coincidental name match. It is a starting figure for the interview, never a coverage number."
+}

--- a/scripts/scout.sh
+++ b/scripts/scout.sh
@@ -133,7 +133,24 @@ fi
 # The private work directory. Everything Scout computes is staged here as
 # tab-separated files and removed on exit — bash 3.2 has no associative arrays,
 # and staging beats trying to thread a dozen parallel arrays through five libs.
-SCOUT_WORK="$(mktemp -d 2>/dev/null)" || {
+#
+# THE TEMPLATE FORM IS LOAD-BEARING AND THE BARE FORM IS A LIE ON THIS PLATFORM.
+# BSD `mktemp -d` (macOS) IGNORES an overridden `TMPDIR` and always allocates
+# under the per-user temp dir; GNU honours it. Measured here:
+#
+#   $ TMPDIR="$P" mktemp -d                      -> /var/folders/…/T/tmp.4EvtJVKmHQ   (NOT $P)
+#   $ mktemp -d "${TMPDIR:-/tmp}/scout-work.XXXXXXXX" -> $P/scout-work.PPrvG4S0        (honoured)
+#
+# That difference is not cosmetic. This directory holds the RAW gitleaks report,
+# whose `Message` field carries the unredacted commit message — the one place a
+# planted secret genuinely exists on disk during a scan. A caller that sets
+# TMPDIR to a directory it owns in order to prove no residue is left behind was,
+# under the bare form, auditing a directory Scout never touched: the WP2 review
+# neutered the cleanup trap below and the whole suite stayed green while
+# plant-bearing work dirs piled up in shared temp, unseen. The template form
+# makes the promise in this header ("a private working directory under
+# $TMPDIR") true on both platforms, and makes that audit real.
+SCOUT_WORK="$(mktemp -d "${TMPDIR:-/tmp}/scout-work.XXXXXXXX" 2>/dev/null)" || {
   echo "scout: could not create a temporary working directory." >&2
   exit 2
 }

--- a/scripts/scout.sh
+++ b/scripts/scout.sh
@@ -39,11 +39,19 @@
 # core LIB basenames only, so a Scout file that shelled out to a core entry
 # script would pass the lint clean.
 #
-# WHAT IT REPORTS, AND WHAT IT DOES NOT YET
-# This build emits three of §8.2's seven sections: `stack`, `phaseMap`,
-# `reality`. The other four are named in `sectionsNotEmitted`, because "we have
-# not looked yet" and "we looked and it was clean" are different claims and for
-# the secrets section the difference matters a great deal.
+# WHAT IT REPORTS
+# This build emits all seven of §8.2's sections: `stack`, `phaseMap`,
+# `reality`, `secrets`, `collisions`, `testsBaseline`, `intakePrefill`.
+# `sectionsNotEmitted` survives as an empty array rather than being deleted,
+# because "we have not looked yet" and "we looked and it was clean" are
+# different claims and a consumer must keep being able to tell them apart —
+# for the secrets section that difference has a credential behind it. Within
+# `secrets` the same distinction is carried by `status`, which is
+# `tool-unavailable` when nobody looked and `scanned` when somebody did.
+#
+# THE ONE PLACE SCOUT RUNS PROJECT CODE is `--run-tests`, and it is opt-in for
+# that reason. Without it `testsBaseline.commandRan` is false and the report
+# says why.
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # `set -e` IS DELIBERATELY ABSENT, and this is the one place worth arguing.
@@ -59,7 +67,9 @@ set -uo pipefail
 SCOUT_SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
 SCOUT_LIB_DIR="$SCOUT_SELF_DIR/lib/scout"
 
-for _part in scout-core scout-stack scout-phasemap scout-reality scout-report; do
+for _part in scout-core scout-stack scout-phasemap scout-reality \
+             scout-secrets scout-collisions scout-testsbaseline scout-prefill \
+             scout-report; do
   if [ ! -f "$SCOUT_LIB_DIR/$_part.sh" ]; then
     echo "scout: missing $SCOUT_LIB_DIR/$_part.sh — Scout needs its own lib directory beside it." >&2
     exit 2
@@ -78,11 +88,16 @@ Scout — a read-only look at a codebase.
   --markdown    print the human-readable report instead of the JSON one
   --out DIR     write BOTH reports into DIR as scout-report.json and
                 scout-report.md, and print where they went
+  --run-tests   ALSO run the project's own test command, once, to record
+                whether it passes today. This is the only thing Scout does
+                that runs your code, so it is off unless you ask. Bounded by
+                SCOUT_TEST_TIMEOUT seconds (default 300).
   --version     print Scout's version and exit
   --help        print this and exit
 
 Scout never changes the project it looks at. Without --out it writes nothing
-at all except its own output.
+at all except its own output. It needs `gitleaks` for the secrets section; if
+that is missing the section says so rather than reporting a clean scan.
 
 Exit codes: 0 a scan completed (findings are not errors); 2 bad usage or an
 unreadable target.
@@ -92,6 +107,7 @@ USAGE
 ROOT="."
 MODE="json"
 OUTDIR=""
+RUN_TESTS=0
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -101,6 +117,7 @@ while [ "$#" -gt 0 ]; do
     --out=*)     OUTDIR="${1#--out=}"; shift ;;
     --markdown)  MODE="markdown"; shift ;;
     --json)      MODE="json"; shift ;;
+    --run-tests) RUN_TESTS=1; shift ;;
     --version)   scout_module_version; exit 0 ;;
     -h|--help)   usage; exit 0 ;;
     *)           echo "scout: unrecognised option '$1'" >&2; echo "" >&2; usage >&2; exit 2 ;;
@@ -138,6 +155,15 @@ printf '%s\n' "$(scout_head_commit "$ROOT_ABS")" > "$SCOUT_WORK/headCommit"
 scout_stack_scan    "$ROOT_ABS" "$SCOUT_WORK"
 scout_phasemap_scan "$ROOT_ABS" "$SCOUT_WORK"
 scout_reality_probes "$ROOT_ABS" "$SCOUT_WORK"
+
+# The WP2 sections, and their order is a dependency order too. `testsBaseline`
+# reuses the test command the stack scan discovered rather than re-deriving it
+# — two derivations of one fact are two chances to disagree about it — and
+# `intakePrefill` reads both that and the reality probes' remote answer.
+scout_secrets_scan       "$ROOT_ABS" "$SCOUT_WORK"
+scout_collisions_scan    "$ROOT_ABS" "$SCOUT_WORK"
+scout_testsbaseline_scan "$ROOT_ABS" "$SCOUT_WORK" "$RUN_TESTS"
+scout_prefill_scan       "$ROOT_ABS" "$SCOUT_WORK"
 
 if [ -n "$OUTDIR" ]; then
   if ! mkdir -p "$OUTDIR" 2>/dev/null; then

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -613,6 +613,31 @@ run_child_suite "tests/test-brownfield-wp1-scout.sh" \
   "Scout read-only scanner (stack, phaseMap, reality)" \
   "Scout scanner tests FAILED (run tests/test-brownfield-wp1-scout.sh for details)"
 
+# Brownfield adoption WP2: tests/test-brownfield-wp2-scout-sections.sh — the
+# remaining four report sections (§8.2 secrets / collisions / testsBaseline /
+# intakePrefill), and the package where a defect is worst: its failure mode is
+# a leaked credential in a committed file.
+# THE PLANTED-SECRET PROOF (§6.5) is the reason this suite exists. Four
+# BASE32-valid synthetic AWS keys are planted — one in a DIFF, one in a COMMIT
+# MESSAGE, one carrying that message's commit so the message reaches the report
+# at all, and one inside a git hook — and NONE of them may occur in any byte of
+# any artifact Scout writes, temp residue included. The non-zero finding count
+# on the diff plant is asserted FIRST, because a dud plant (a non-BASE32
+# character, or the allowlisted AKIAIOSFODNN7EXAMPLE) yields zero findings and
+# makes every later assertion pass for the wrong reason.
+# Mutation-proved IN THE SUITE: dropping --redact alone leaves the artifacts
+# clean (the allowlist holds); adding Secret/Match to the allowlist alone
+# leaves them clean (--redact holds); doing BOTH leaks the diff plant; and
+# replacing the allowlist with the tool's full 18-field report — ONE line, with
+# --redact still on — leaks the COMMIT MESSAGE plant, which is C7 and the
+# mutation that matters. gitleaks is detected, and a skip is LOUD: the tally
+# line reports it and the suite prints a banner, because a silently-skipped
+# planted-secret proof is the defect class this package is written against.
+# Never touches the scaffolder -> both lanes.
+run_child_suite "tests/test-brownfield-wp2-scout-sections.sh" \
+  "Scout secrets/collisions/tests/prefill (planted-secret allowlist proof)" \
+  "Scout WP2 section tests FAILED (run tests/test-brownfield-wp2-scout-sections.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-brownfield-wp1-scout.sh
+++ b/tests/test-brownfield-wp1-scout.sh
@@ -304,23 +304,36 @@ else
   fail_ "A2" "schemaVersion=$sv scannedAt=$at scannerVersion=$ver repoRoot=$rr headCommit=$hc"
 fi
 
-# ── A3: WP2's four sections are declared ABSENT, not silently missing ───────
-# The brief's requirement: this version emits three sections and says which
-# four it does not. A consumer that reads `sections` can tell "not scanned yet"
-# apart from "scanned and found nothing" — which for `secrets` is the whole
+# ── A3: the sections / sectionsNotEmitted contract is COHERENT ─────────────
+# A consumer that reads `sections` must be able to tell "not scanned yet" apart
+# from "scanned and found nothing" — which for `secrets` is the whole
 # difference between a survey and a false clean bill of health.
+#
+# RE-AIMED AT WP2, DELIBERATELY. This case used to pin the literal list
+# `stack,phaseMap,reality` and the literal four-name pending list, which made
+# it a snapshot of the build it was written against: WP2 emits the other four
+# sections and the case went red for being RIGHT. The property it was actually
+# protecting is the INVARIANT between the two arrays, so that is what it
+# asserts now — every name in `sections` is a key that exists, every name in
+# `sectionsNotEmitted` is a key that does not, the two never overlap, and
+# together they account for all seven of §8.2's sections. That holds for the
+# WP1 build, this one, and any build that finishes the set.
 emitted=$(jqv "$out" '.sections | join(",")')
 pending=$(jqv "$out" '.sectionsNotEmitted | join(",")')
-absent=1
-for k in testsBaseline secrets collisions intakePrefill; do
-  printf '%s' "$out" | jq -e "has(\"$k\")" >/dev/null 2>&1 && absent=0
+coherent=1
+for k in $(jqv "$out" '.sections[]'); do
+  printf '%s' "$out" | jq -e "has(\"$k\")" >/dev/null 2>&1 || coherent=0
 done
-if [ "$emitted" = "stack,phaseMap,reality" ] \
-   && [ "$pending" = "testsBaseline,secrets,collisions,intakePrefill" ] \
-   && [ "$absent" -eq 1 ]; then
-  pass "A3: sections=[stack,phaseMap,reality]; the four WP2 sections are named as not-emitted and their keys are absent"
+for k in $(jqv "$out" '.sectionsNotEmitted[]'); do
+  printf '%s' "$out" | jq -e "has(\"$k\")" >/dev/null 2>&1 && coherent=0
+done
+overlap=$(printf '%s' "$out" | jq -r '[.sections[]] - ([.sections[]] - [.sectionsNotEmitted[]]) | length' 2>/dev/null)
+accounted=$(printf '%s' "$out" | jq -r '([.sections[]] + [.sectionsNotEmitted[]]) | sort | join(",")' 2>/dev/null)
+want="collisions,intakePrefill,phaseMap,reality,secrets,stack,testsBaseline"
+if [ "$coherent" -eq 1 ] && [ "$overlap" = "0" ] && [ "$accounted" = "$want" ]; then
+  pass "A3: sections=[$emitted] all exist as keys, sectionsNotEmitted=[$pending] all do not, the two are disjoint, and together they account for all seven §8.2 sections"
 else
-  fail_ "A3" "emitted='$emitted' pending='$pending' wp2_keys_absent=$absent"
+  fail_ "A3" "emitted='$emitted' pending='$pending' keys_coherent=$coherent overlap='$overlap' accounted='$accounted' want='$want'"
 fi
 
 # ── A4: --out writes the pair, and writes NOTHING else ─────────────────────
@@ -766,11 +779,18 @@ core_entries=$(ls "$H1/scripts"/*.sh 2>/dev/null | grep -vc '/scout\.sh$')
 case "$core_entries" in ''|*[!0-9]*) core_entries=0 ;; esac
 h1out=$(bash "$H1/scripts/scout.sh" --root "$NODE" </dev/null 2>/dev/null); rc=$?
 h1sec=$(jqv "$h1out" '.sections | join(",")')
+# The assertion is that WP1's three sections SURVIVE the isolation, not that
+# they are the only ones — a later package adding sections must not make this
+# case red for succeeding. Phrased as a subset test for that reason.
+h1has=1
+for k in stack phaseMap reality; do
+  printf '%s' "$h1out" | jq -e "has(\"$k\")" >/dev/null 2>&1 || h1has=0
+done
 if [ "$rc" -eq 0 ] && [ "$core_libs" -eq 0 ] && [ "$core_entries" -eq 0 ] \
-   && [ "$h1sec" = "stack,phaseMap,reality" ]; then
-  pass "H1: Scout copied ALONE into an empty tree (0 core libs, 0 other entry scripts) emits all three sections"
+   && [ "$h1has" -eq 1 ]; then
+  pass "H1: Scout copied ALONE into an empty tree (0 core libs, 0 other entry scripts) emits its sections: $h1sec"
 else
-  fail_ "H1" "rc=$rc core_libs=$core_libs other_entry_scripts=$core_entries sections='$h1sec'"
+  fail_ "H1" "rc=$rc core_libs=$core_libs other_entry_scripts=$core_entries sections='$h1sec' wp1_sections_present=$h1has"
 fi
 
 # ── H2: the WP0 carry-forward (R-WP0-3) — move the ENTRY SCRIPTS aside too ─
@@ -794,11 +814,17 @@ case "$left_entries" in ''|*[!0-9]*) left_entries=0 ;; esac
 h2out=$(bash "$H2/scripts/scout.sh" --root "$LADDER" </dev/null 2>/dev/null); rc=$?
 h2sp=$(jqv "$h2out" '.phaseMap.suggestedPhase')
 h2sec=$(jqv "$h2out" '.sections | join(",")')
+# Subset, for the same reason as H1: the property is that stripping core does
+# not break Scout, and the ladder still reaches 2.
+h2has=1
+for k in stack phaseMap reality; do
+  printf '%s' "$h2out" | jq -e "has(\"$k\")" >/dev/null 2>&1 || h2has=0
+done
 if [ "$rc" -eq 0 ] && [ "$left_libs" -eq 0 ] && [ "$left_entries" -eq 0 ] \
-   && [ "$h2sec" = "stack,phaseMap,reality" ] && [ "$h2sp" = "2" ]; then
-  pass "H2: with every core lib AND every core entry script moved aside, Scout still reports all three sections (phase $h2sp)"
+   && [ "$h2has" -eq 1 ] && [ "$h2sp" = "2" ]; then
+  pass "H2: with every core lib AND every core entry script moved aside, Scout still reports its sections (phase $h2sp): $h2sec"
 else
-  fail_ "H2" "rc=$rc leftover_libs=$left_libs leftover_entry_scripts=$left_entries sections='$h2sec' phase=$h2sp"
+  fail_ "H2" "rc=$rc leftover_libs=$left_libs leftover_entry_scripts=$left_entries sections='$h2sec' wp1_sections_present=$h2has phase=$h2sp"
 fi
 
 # ── H3: nothing under scripts/lib/scout/ names a core lib, statically ─────

--- a/tests/test-brownfield-wp2-scout-sections.sh
+++ b/tests/test-brownfield-wp2-scout-sections.sh
@@ -1353,6 +1353,115 @@ fi
 
 # ════════════════════════════════════════════════════════════════════════════
 echo ""
+echo "=== K — the gitleaks pin's own verification cannot silently pass ==="
+# ════════════════════════════════════════════════════════════════════════════
+#
+# R-WP2-6. The CI step that installs gitleaks is what makes the planted-secret
+# proof runnable at all, so the integrity check on that download sits on the
+# critical path of this entire package. Written the obvious way it is a check
+# that cannot fail — measured on this host:
+#
+#   $ echo "THIS-IS-NOT-A-HASH  gl.tgz" | sha256sum -c -
+#   sha256sum: WARNING: 1 line is improperly formatted
+#   rc=0
+#
+# A typo in the pin, or a variable that expanded to nothing, and the download is
+# unverified while CI stays green. These cases execute every failure mode of the
+# replacement ON THIS HOST, with no appeal to what some other platform's binary
+# would have done — which is the whole reason the verification lives in a script
+# instead of three lines of workflow YAML.
+
+KV="$REPO_ROOT/scripts/ci-verify-sha256.sh"
+if [ ! -f "$KV" ]; then
+  fail_ "K1-K7" "scripts/ci-verify-sha256.sh does not exist"
+else
+  K=$(newtmp)
+  printf 'the payload\n' > "$K/asset.bin"
+  K_REAL=$( { sha256sum "$K/asset.bin" 2>/dev/null || shasum -a 256 "$K/asset.bin" 2>/dev/null; } | awk '{print $1; exit}' )
+  # A well-formed 64-hex value that is NOT the file's hash. Derived from the
+  # real one so it cannot accidentally BE the real one.
+  K_WRONG=$(printf '%s' "$K_REAL" | tr '0123456789abcdef' '1234567890fedcba')
+
+  # ── K1: the honest positive — a correct pin verifies ────────────────────
+  # Without this, an implementation that failed EVERYTHING would satisfy
+  # K2-K6 perfectly.
+  bash "$KV" "$K/asset.bin" "$K_REAL" >/dev/null 2>&1; k1=$?
+  if [ "$k1" -eq 0 ] && [ "${#K_REAL}" -eq 64 ]; then
+    pass "K1: a correct 64-hex pin verifies (rc=0) — the negative cases below are not vacuous"
+  else
+    fail_ "K1" "rc=$k1 (want 0) computed='$K_REAL' (want 64 hex chars)"
+  fi
+
+  # ── K2: a MALFORMED pin FAILS (the R-WP2-6 defect itself) ───────────────
+  bash "$KV" "$K/asset.bin" "THIS-IS-NOT-A-HASH" >/dev/null 2>&1; k2=$?
+  if [ "$k2" -eq 1 ]; then
+    pass "K2: a MALFORMED pin exits 1 — the spelling this replaced exits 0 on this host and verifies nothing"
+  else
+    fail_ "K2" "rc=$k2 (want 1) — a malformed pin is being treated as verified"
+  fi
+
+  # ── K3: an EMPTY pin FAILS (the expanded-to-nothing case) ───────────────
+  bash "$KV" "$K/asset.bin" "" >/dev/null 2>&1; k3=$?
+  if [ "$k3" -eq 1 ]; then
+    pass "K3: an EMPTY pin exits 1 — an unset or mistyped variable cannot pass as verified"
+  else
+    fail_ "K3" "rc=$k3 (want 1)"
+  fi
+
+  # ── K4: a WRONG BUT WELL-FORMED pin FAILS ──────────────────────────────
+  bash "$KV" "$K/asset.bin" "$K_WRONG" >/dev/null 2>&1; k4=$?
+  if [ "$k4" -eq 1 ] && [ "$K_WRONG" != "$K_REAL" ]; then
+    pass "K4: a well-formed pin that is not this file's hash exits 1"
+  else
+    fail_ "K4" "rc=$k4 (want 1) wrong='$K_WRONG' real='$K_REAL' (must differ)"
+  fi
+
+  # ── K5: a TAMPERED ASSET fails against a correct pin ───────────────────
+  # The threat the pin exists for: the pin is right, the bytes changed.
+  printf 'the payload with one more byte\n' > "$K/asset.bin"
+  bash "$KV" "$K/asset.bin" "$K_REAL" >/dev/null 2>&1; k5=$?
+  if [ "$k5" -eq 1 ]; then
+    pass "K5: a TAMPERED asset exits 1 against the pin that matched it moments earlier"
+  else
+    fail_ "K5" "rc=$k5 (want 1) — a replaced release asset would install silently"
+  fi
+
+  # ── K6: a MISSING file and bad usage are errors, not passes ────────────
+  bash "$KV" "$K/does-not-exist" "$K_REAL" >/dev/null 2>&1; k6a=$?
+  bash "$KV" "$K/asset.bin" >/dev/null 2>&1; k6b=$?
+  if [ "$k6a" -eq 1 ] && [ "$k6b" -eq 2 ]; then
+    pass "K6: a missing file exits 1 and a missing argument exits 2 — neither is mistaken for a verified download"
+  else
+    fail_ "K6" "missing-file rc=$k6a (want 1) missing-arg rc=$k6b (want 2)"
+  fi
+
+  # ── K7: the workflow actually CALLS it, in every job that installs ─────
+  # A verifier nothing invokes is decoration. Asserted against the real
+  # workflow file: every gitleaks download is followed by a verification, and
+  # the superseded `sha256sum -c` spelling is gone from the file entirely.
+  # COMMENTS ARE STRIPPED BEFORE THE LEGACY-SPELLING GREP, and this case caught
+  # its own author: the first version counted the two explanatory comments that
+  # NAME `sha256sum -c` and went red against a workflow that does not run it.
+  # Same defect class as this repository's unit-lane predicate reading a
+  # mention as an invocation (CLAUDE.md, `# BL-181-UNIT-LANE-PREDICATE`) — a
+  # check must read executed lines, not prose about them.
+  WF="$REPO_ROOT/.github/workflows/tests.yml"
+  WF_EXEC="$K/workflow-no-comments.txt"
+  sed -e 's/^[[:space:]]*#.*$//' -e 's/[[:space:]]#[^"'"'"']*$//' "$WF" > "$WF_EXEC"
+  k7_dl=$(grep -c 'gitleaks_.*_linux_x64\.tar\.gz"$' "$WF_EXEC" 2>/dev/null)
+  k7_verify=$(grep -c 'ci-verify-sha256\.sh /tmp/gitleaks\.tar\.gz' "$WF_EXEC" 2>/dev/null)
+  k7_old=$(grep -c 'sha256sum -c' "$WF_EXEC" 2>/dev/null)
+  k7_pin=$(grep -c 'GITLEAKS_SHA256: "551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb"' "$WF_EXEC" 2>/dev/null)
+  if [ "$(_num "$k7_verify")" -eq 2 ] && [ "$(_num "$k7_pin")" -eq 2 ] \
+     && [ "$(_num "$k7_old")" -eq 0 ] && [ "$(_num "$k7_verify")" -eq "$(_num "$k7_dl")" ]; then
+    pass "K7: both jobs that download gitleaks verify it through the script ($k7_dl download(s), $k7_verify verification(s), $k7_pin pinned checksum(s)); the exit-0-on-malformed spelling appears nowhere"
+  else
+    fail_ "K7" "downloads=$k7_dl verifications=$k7_verify (want 2 and equal) pinned_checksums=$k7_pin (want 2) legacy 'sha256sum -c' occurrences=$k7_old (want 0)"
+  fi
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
 if [ "$SKIPPED" -gt 0 ]; then
   echo "!! $SKIPPED case(s) SKIPPED because gitleaks is not installed — the"
   echo "!! planted-secret proof (§6.5) DID NOT RUN. This build is not certified"

--- a/tests/test-brownfield-wp2-scout-sections.sh
+++ b/tests/test-brownfield-wp2-scout-sections.sh
@@ -118,6 +118,25 @@ fi
 HAVE_GITLEAKS=0
 command -v gitleaks >/dev/null 2>&1 && HAVE_GITLEAKS=1
 
+# GITLEAKS-ABSENT IS A SKIP LOCALLY AND A FAILURE IN CI (R-WP2-1).
+#
+# The original posture — detect and skip, loudly — was the brief's, and it
+# produced a hole the review found: the runner image does not ship gitleaks and
+# no workflow installed it, so the §6.5 byte-absence proof and all four
+# mutation proofs skipped in BOTH lanes and the suite still exited 0. A green
+# required check, credited with a proof that never ran, guarding the property
+# whose failure mode is a leaked credential in a committed file.
+#
+# A loud log line does not gate a merge; an exit code does. So the two audiences
+# are separated. A developer without gitleaks gets a banner and a skip, because
+# failing their local run for a missing optional tool teaches them to ignore the
+# suite. CI gets a FAILURE, because CI is the only place the skip is invisible —
+# nobody reads a green check's log. `CI` is set by GitHub Actions (and by every
+# other major provider) and the workflows now install a pinned gitleaks, so this
+# arm fires only if that install is removed or breaks.
+GITLEAKS_ABSENT_IS_FATAL=0
+[ -n "${CI:-}" ] && GITLEAKS_ABSENT_IS_FATAL=1
+
 TMPS=""
 cleanup() { [ -n "$TMPS" ] && rm -rf $TMPS; return 0; }
 trap cleanup EXIT
@@ -362,11 +381,18 @@ echo ""
 if [ "$HAVE_GITLEAKS" -eq 0 ]; then
   echo "  ***********************************************************************"
   echo "  *  gitleaks IS NOT INSTALLED ON THIS HOST.                            *"
-  echo "  *  The PLANTED-SECRET PROOF (§6.5) and BOTH mutation proofs will be   *"
-  echo "  *  SKIPPED. A skipped planted-secret proof is NOT a passing build —   *"
-  echo "  *  the secrets section is the highest-stakes surface in the design.   *"
+  echo "  *  The PLANTED-SECRET PROOF (§6.5) and ALL FOUR mutation proofs       *"
+  echo "  *  cannot run. A skipped planted-secret proof is NOT a passing build  *"
+  echo "  *  — the secrets section is the highest-stakes surface in the design. *"
   echo "  *  Install it:  brew install gitleaks                                 *"
   echo "  ***********************************************************************"
+  if [ "$GITLEAKS_ABSENT_IS_FATAL" -eq 1 ]; then
+    echo "  *  CI IS SET, SO THIS IS A FAILURE, NOT A SKIP. The workflows install *"
+    echo "  *  a pinned gitleaks precisely so this proof cannot sit out a merge.  *"
+    echo "  *  If you are seeing this, that install step is gone or broken.       *"
+    echo "  ***********************************************************************"
+    fail_ "GITLEAKS MISSING IN CI" "the planted-secret proof and all four mutation proofs cannot run, and a green check that skipped them is exactly the silent success this suite exists to prevent"
+  fi
   echo ""
 fi
 
@@ -551,20 +577,15 @@ else
 fi
 
 # ── G8: gitleaks ABSENT is reported as tool-unavailable, never as clean ────
-# The silent-success class, aimed at the one section where it matters most. A
-# shim directory of PATH stubs makes `command -v gitleaks` fail while leaving
-# git and the rest of the environment intact.
-G8=$(newtmp)
-mkdir -p "$G8/bin"
-cat > "$G8/bin/gitleaks" <<'EOF'
-#!/bin/sh
-echo "gitleaks: masked for the tool-unavailable test" >&2
-exit 127
-EOF
-chmod +x "$G8/bin/gitleaks"
-# PATH_MASK makes the binary un-findable rather than merely broken: Scout must
-# key on presence, and reporting "unavailable" for a tool that IS present but
-# failed is a different (also honest) status.
+# The silent-success class, aimed at the one section where it matters most.
+#
+# THE SEAM IS SCOUT_GITLEAKS_BIN, AND THE COMMENT NOW SAYS SO (R-WP2-5). An
+# earlier version of this case also built a PATH-stub gitleaks that nothing
+# ever used, and described a "PATH_MASK" mechanism that was not the one being
+# exercised — dead fixture code plus a comment about a test that did not run.
+# The env seam hits the SAME predicate the real absence would (`command -v`
+# against the configured name), which is what makes it a valid stand-in, and
+# it does not require making the host's real gitleaks unreachable.
 gl_out=$(SCOUT_GITLEAKS_BIN="definitely-not-a-real-binary-name" bash "$SCOUT" --root "$SEC" </dev/null 2>/dev/null)
 gl_st=$(jqv "$gl_out" '.secrets.status')
 gl_fc=$(jqv "$gl_out" '.secrets.findingCount')
@@ -601,6 +622,60 @@ EOF
   fi
 else
   skip_ "G9 (repo-local gitleaks config disclosure)" "gitleaks not installed"
+fi
+
+# ── G10: a CORRUPT report is scan-failed, never a clean read (R-WP2-3) ────
+# The scan-failed arm used to key on `rc != 0 || report missing`, so a scanner
+# that exited 0 having written garbage — the disk-full / truncated-write class
+# — parsed to zero findings and was reported as `scanned` with a clean count.
+# Against a fixture with two live plants in history. That is a false clean bill
+# of health in the one section where the consequence is a credential, and it
+# contradicts the file's own stated doctrine.
+#
+# Three shapes, because the first two failed DIFFERENTLY before the fix: braced
+# garbage produced phantom findings and an all-seven `fieldsMissing`, while
+# brace-free garbage and a bare `[` produced a completely silent clean read.
+# The fourth run is the positive control that keeps the fix from being "call
+# everything corrupt".
+G10=$(newtmp)
+_mk_fake_gitleaks() {
+  cat > "$1" <<FAKEEOF
+#!/bin/sh
+# Emulates gitleaks: writes \$2 of the -r flag, exits 0.
+out=""
+while [ \$# -gt 0 ]; do
+  case "\$1" in
+    -r) out="\$2"; shift 2 ;;
+    version) echo "9.9.9-fake"; exit 0 ;;
+    *) shift ;;
+  esac
+done
+[ -n "\$out" ] && printf '%s' '$2' > "\$out"
+exit 0
+FAKEEOF
+  chmod +x "$1"
+}
+g10_fail=""
+g10_n=0
+for shape in 'this is not json' 'this is not json {{{' '[' '[]'; do
+  g10_n=$((g10_n + 1))
+  _mk_fake_gitleaks "$G10/fake$g10_n" "$shape"
+  g10_out=$(SCOUT_GITLEAKS_BIN="$G10/fake$g10_n" bash "$SCOUT" --root "$SEC" </dev/null 2>/dev/null)
+  g10_st=$(jqv "$g10_out" '.secrets.status')
+  g10_fc=$(jqv "$g10_out" '.secrets.findingCount')
+  if [ "$shape" = "[]" ]; then
+    # The control: a VALID empty report is still a real, positive result.
+    [ "$g10_st" = "scanned" ] && [ "$g10_fc" = "0" ] \
+      || g10_fail="$g10_fail [valid-empty-report got status='$g10_st' count='$g10_fc', want scanned/0]"
+  else
+    [ "$g10_st" = "scan-failed" ] && [ "$g10_fc" = "null" ] \
+      || g10_fail="$g10_fail [corrupt '$shape' got status='$g10_st' count='$g10_fc', want scan-failed/null]"
+  fi
+done
+if [ -z "$g10_fail" ]; then
+  pass "G10: three shapes of corrupt report (brace-free garbage, braced garbage, truncated '[') all report scan-failed with findingCount null; a valid empty report still reports scanned/0"
+else
+  fail_ "G10" "$g10_fail"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -717,8 +792,46 @@ if [ "$HAVE_GITLEAKS" -eq 1 ]; then
   else
     fail_ "XB" "changed_lines=$chg_b (want 2) mutant_files_leaking_MSG=$b_leak (want >=1) control=$b_ctl (want 0) mutant_files_leaking_DIFF=$b_diff_leak (want 0) allowlist_anchor_sites=$allow_sites (want 1)"
   fi
+  # ── XT: neuter the cleanup trap -> G1's TEMP-RESIDUE leg must go RED ─────
+  # THE COUNTERFACTUAL THAT LEG NEVER HAD, and it is here because it was
+  # already exploited. The WP2 review neutered exactly this line and the whole
+  # suite stayed 44/0 GREEN while ~44 work directories — each holding the RAW
+  # gitleaks report with the message plant intact in `Message`, which
+  # `--redact` does not touch — piled up in shared temp, unseen.
+  #
+  # The root cause was not the assertion, it was the address it read. BSD
+  # `mktemp -d` IGNORES an overridden TMPDIR (measured: `TMPDIR=$P mktemp -d`
+  # returns a path under /var/folders, not under $P), so G1 was grepping a
+  # directory Scout had never written to. scout.sh now uses the template form
+  # `mktemp -d "${TMPDIR:-/tmp}/scout-work.XXXXXXXX"`, which both BSD and GNU
+  # honour — and this case is what proves the leg is live rather than merely
+  # re-worded. It asserts BOTH directions in one place: the mutant leaves the
+  # plant-bearing work directory behind under a TMPDIR this case owns, and the
+  # unmutated control leaves that directory empty.
+  XT=$(newtmp); mk_scout_copy "$XT"
+  XTTMP=$(newtmp)
+  XTCTMP=$(newtmp)
+  trap_sites=$(grep -c "^trap 'rm -rf \"\$SCOUT_WORK\"' EXIT INT TERM$" "$SCOUT")
+  _awk_inplace "$XT/scripts/scout.sh" '
+    { if (!done && $0 == "trap '"'"'rm -rf \"$SCOUT_WORK\"'"'"' EXIT INT TERM") {
+        print "trap '"'"':'"'"' EXIT INT TERM"
+        done = 1; next }
+      print }'
+  chg_t=$(_changed_lines "$SCOUT" "$XT/scripts/scout.sh")
+  TMPDIR="$XTTMP" bash "$XT/scripts/scout.sh" --root "$SEC" </dev/null >/dev/null 2>&1
+  xt_leak=$(_grep_tree_for "$XTTMP" "$MSG_PLANT")
+  XTC=$(newtmp); mk_scout_copy "$XTC"
+  TMPDIR="$XTCTMP" bash "$XTC/scripts/scout.sh" --root "$SEC" </dev/null >/dev/null 2>&1
+  xt_ctl=$(_grep_tree_for "$XTCTMP" "$MSG_PLANT")
+  xt_ctl_entries=$( (cd "$XTCTMP" && LC_ALL=C ls -1A 2>/dev/null) | grep -c '')
+  if [ "$chg_t" -eq 2 ] && [ "$xt_leak" -ge 1 ] && [ "$xt_ctl" -eq 0 ] \
+     && [ "$xt_ctl_entries" -eq 0 ] && [ "$trap_sites" -eq 1 ]; then
+    pass "XT: with Scout's cleanup trap neutered (1 line), the raw report carrying the MESSAGE plant is left behind in $xt_leak file(s) under an owned TMPDIR; the unmutated control leaves the directory completely empty — G1's temp-residue leg is live, not decorative"
+  else
+    fail_ "XT" "changed_lines=$chg_t (want 2) mutant_residue_files=$xt_leak (want >=1) control_residue_files=$xt_ctl (want 0) control_tmpdir_entries=$xt_ctl_entries (want 0) trap_anchor_sites=$trap_sites (want 1) — if the mutant leaks 0, Scout is not honouring TMPDIR and the residue leg is scanning a directory it never used"
+  fi
 else
-  skip_ "XA1/XA2/XA/XB (all four mutation proofs)" "gitleaks not installed — see the banner above"
+  skip_ "XA1/XA2/XA/XB/XT (all five mutation proofs)" "gitleaks not installed — see the banner above"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -1244,6 +1357,9 @@ if [ "$SKIPPED" -gt 0 ]; then
   echo "!! $SKIPPED case(s) SKIPPED because gitleaks is not installed — the"
   echo "!! planted-secret proof (§6.5) DID NOT RUN. This build is not certified"
   echo "!! against the defect WP2 exists to prevent. Install gitleaks and re-run."
+  if [ "$GITLEAKS_ABSENT_IS_FATAL" -eq 1 ]; then
+    echo "!! CI is set, so this run is also FAILED, not merely incomplete."
+  fi
 fi
 echo "Results: $PASSED passed, $FAILED failed, $SKIPPED skipped"
 [ "$FAILED" -eq 0 ] || exit 1

--- a/tests/test-brownfield-wp2-scout-sections.sh
+++ b/tests/test-brownfield-wp2-scout-sections.sh
@@ -1,0 +1,1250 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp2-scout-sections.sh — behaviour suite for Scout's
+# remaining four report sections: secrets, collisions, testsBaseline,
+# intakePrefill (WP2-brownfield).
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md — §6.1 (scope: full
+# history when it is a repo), §6.2 (REDACTION IS A PROJECTION, NOT A FLAG — the
+# field allowlist table is normative), §6.5 (the planted-secret test and its two
+# BASE32 fixture facts), §1.2 (the twelve-row collision surface), §7.1 (the four
+# buckets), §7.2 (the shallow hook description), §7.4 (the SDLC-undermining
+# detector rules, report-only), §8.2 (the schema), §8.3 (scan-derived /
+# judgment / non-skippable), §10-WP2, §13-V3 (the executed gitleaks evidence).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT THIS SUITE IS PROTECTING, IN ONE SENTENCE
+#
+# Every artifact Scout writes is built by an explicit field ALLOWLIST — never a
+# passthrough, never a denylist — and this suite proves it with REAL PLANTED
+# SECRETS asserted absent from every byte written.
+#
+# WP2 is the package where a defect is worst (§10's own words): its failure mode
+# is a leaked credential in a committed file, and §0.3-C7 proves the obvious
+# implementation has exactly that bug.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE THREE PLANTS, AND WHY EACH ONE IS SHAPED THE WAY IT IS
+#
+#   DIFF_PLANT  AKIAQZ7X4M2NPLKJ3HRD  — added by commit 1's diff.
+#   CARRIER     AKIA5DPR7HW6TSNQ2FUX  — added by commit 2's diff.
+#   MSG_PLANT   AKIAVX3T6QW2ZLMK4RBS  — ONLY in commit 2's commit MESSAGE.
+#
+# All three match `AKIA[A-Z2-7]{16}`. BASE32-VALIDITY IS LOAD-BEARING (§6.5):
+# the `aws-access-token` rule requires the 16 characters after `AKIA` to be
+# drawn from [A-Z2-7], so a plant containing a `9` yields ZERO findings and
+# makes the whole proof vacuous — the design's own v1.0 shipped that dud.
+# `AKIAIOSFODNN7EXAMPLE` is separately allowlisted by gitleaks' default config
+# and also yields zero. G0 asserts a NON-ZERO finding count BEFORE anything
+# else, so a dud fixture fails loudly instead of certifying nothing.
+#
+# WHY THE CARRIER EXISTS — MEASURED ON THIS HOST, NOT ASSUMED. §13-V3 records
+# that `gitleaks git` scans diffs, not commit messages: a BASE32-valid key
+# present only in a message yields zero findings. What that leaves unsaid, and
+# what an implementer discovers the expensive way, is that the `Message` field
+# of a finding is the message of the commit THAT PRODUCED THAT FINDING. A
+# message plant on a commit whose diff is clean is therefore invisible even
+# under a full report passthrough — Mutation B would go green against a
+# correct implementation and against a broken one alike. The CARRIER key puts a
+# real finding on the same commit as MSG_PLANT, which is what makes that
+# commit's message reach the report at all. Verified against gitleaks 8.30.1:
+# redacted report -> DIFF_PLANT x0, CARRIER x0, MSG_PLANT x1 (in `Message`).
+#
+# A FOURTH PLANT lives in the fixture's `.git/hooks/pre-commit` (HOOK_PLANT).
+# §7.2 requires a what-it-invokes description for every archived git hook, and
+# §7.3 names the hazard in as many words: a hand-rolled hook can contain a
+# token. The description generator therefore emits ONLY names drawn from a
+# fixed tool vocabulary — the §6.2 doctrine generalised — and C3 proves it by
+# planting a secret in the hook and asserting the bytes.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE MUTATIONS. §10-WP2 names two; this suite runs three, because a single
+# one-line neuter CANNOT expose the diff plant against a correct build, and
+# saying so is more useful than shipping a mutation that passes vacuously.
+#
+#   XA1  drop `--redact` ALONE              -> the raw plant reaches the TOOL
+#                                              report, and Scout's artifacts
+#                                              STAY CLEAN. Layer 2 holds.
+#   XA2  add Secret/Match to the allowlist   -> a `secret` key appears in the
+#        ALONE                                 artifact carrying `REDACTED`,
+#                                              never the plant. Layer 1 holds.
+#   XA   BOTH lines at once                  -> THE DIFF PLANT APPEARS -> RED.
+#   XB   allowlist -> report passthrough     -> THE MESSAGE PLANT APPEARS ->
+#        (ONE line)                            RED. **The one that matters.**
+#
+# XA1 and XA2 are not padding: together they are the executable statement of
+# §6.2's claim that `--redact` is NECESSARY AND NOT SUFFICIENT. XB needs no
+# such pairing because the allowlist is the only thing standing between the
+# `Message` field and the artifact — `--redact` does not touch `Message`, which
+# is C7 in one line.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# EXIT CODES AND VALUES, NEVER LABELS (CLAUDE.md's [WARN] trap). Every
+# assertion reads an exit code, a jq-extracted JSON value, a byte grep, or a
+# tree hash.
+#
+# GITLEAKS IS DETECTED, NEVER ASSUMED — and a skip is LOUD. If gitleaks is not
+# installed, the planted-secret cases are skipped with a SKIPPED tally that
+# prints its own banner and is repeated in the final line. A silently-skipped
+# planted-secret proof is the silent-success defect class aimed at the one
+# assertion in this repository that most needs to be visible.
+#
+# HERMETICITY: every fixture is a `mktemp -d` tree; no network, no host CLI, no
+# real remote. bash-3.2 safe: no associative arrays, no `${var,,}`, no
+# `mapfile`, no `((x++))`.
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the
+# .github/workflows/tests.yml `unit-shard` list. This suite never mentions,
+# copies or executes the scaffolder, so it is a unit-lane test outright and
+# must NOT appear in `lint-tests-registered.sh --list | grep unit-lane-exempt`.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SCOUT="$REPO_ROOT/scripts/scout.sh"
+SCOUT_LIB="$REPO_ROOT/scripts/lib/scout"
+WIZARD="$REPO_ROOT/scripts/intake-wizard.sh"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+skip_() { echo "  [SKIP] $1 — $2"; SKIPPED=$((SKIPPED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for tests/test-brownfield-wp2-scout-sections.sh" >&2
+  exit 2
+fi
+
+HAVE_GITLEAKS=0
+command -v gitleaks >/dev/null 2>&1 && HAVE_GITLEAKS=1
+
+TMPS=""
+cleanup() { [ -n "$TMPS" ] && rm -rf $TMPS; return 0; }
+trap cleanup EXIT
+newtmp() { local d; d=$(mktemp -d); TMPS="$TMPS $d"; printf '%s\n' "$d"; }
+
+# ── The plants ──────────────────────────────────────────────────────────────
+# Assembled from halves so that this source file does not itself carry a
+# 20-character AKIA-shaped literal that a secret scanner pointed at THIS
+# repository would report. The halves are inert; the join is what matches.
+DIFF_PLANT="AKIAQZ7X4M2N""PLKJ3HRD"
+CARRIER="AKIA5DPR7HW6""TSNQ2FUX"
+MSG_PLANT="AKIAVX3T6QW2""ZLMK4RBS"
+HOOK_PLANT="AKIA7YB4XM3Q""RVUC6KDN"
+
+# ── Portable primitives (house pattern, WP1 parity) ─────────────────────────
+
+_md5file()  { if command -v md5 >/dev/null 2>&1; then md5 -q "$1"; else md5sum "$1" | awk '{print $1}'; fi; }
+_md5stdin() { if command -v md5 >/dev/null 2>&1; then md5 -q; else md5sum | awk '{print $1}'; fi; }
+_mode_of()  { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || echo "?"; }
+
+# _tree_manifest DIR — one line per filesystem entry: <relpath>|<type>|<mode>[|<md5>]
+# `.git/` INCLUDED on purpose: a scanner that "only" refreshed an index would
+# still have written to the operator's repository.
+_tree_manifest() {
+  ( cd "$1" 2>/dev/null || return 1
+    find . -print 2>/dev/null | LC_ALL=C sort | while IFS= read -r p; do
+      if [ -L "$p" ];   then printf '%s|L|%s\n' "$p" "$(readlink "$p" 2>/dev/null)"
+      elif [ -d "$p" ]; then printf '%s|D|%s\n' "$p" "$(_mode_of "$p")"
+      elif [ -f "$p" ]; then printf '%s|F|%s|%s\n' "$p" "$(_mode_of "$p")" "$(_md5file "$p")"
+      else                   printf '%s|O|-\n' "$p"
+      fi
+    done )
+}
+_tree_hash() { _tree_manifest "$1" | _md5stdin; }
+
+# _awk_inplace FILE AWK-PROGRAM — in-place awk PRESERVING the file's mode. The
+# obvious spelling ends in `chmod +x`, which silently widens a 0644 lib to 0755
+# and rides along in the next commit.
+_awk_inplace() {
+  local file="$1" prog="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  awk "$prog" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+# _changed_lines A B — lines diff reports added or removed. A one-line
+# SUBSTITUTION is 2. Asserting it stops a mutation from becoming a rewrite and
+# stops a NO-OP edit from being read as a proof.
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+# mk_scout_copy DIR — Scout, and only Scout, at its real relative paths.
+mk_scout_copy() {
+  local d="$1"
+  mkdir -p "$d/scripts/lib/scout"
+  cp "$SCOUT" "$d/scripts/scout.sh"
+  cp "$SCOUT_LIB"/*.sh "$d/scripts/lib/scout/"
+  chmod +x "$d/scripts/scout.sh"
+}
+
+# _num VALUE — a shell-comparable integer. jq prints the JSON literal `null`
+# as the four-character string "null", which `[ "$x" -ge 1 ]` rejects with
+# `integer expression expected` — a diagnostic on stderr and a FALSE branch, so
+# a missing field silently takes the same path as a zero. Normalise once, here.
+_num() {
+  case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac
+}
+
+# _grep_tree_for DIR NEEDLE — how many FILES under DIR contain NEEDLE.
+# Binary-safe (`-r` with `-l`), and it counts files rather than lines so an
+# artifact that repeats the string is still exactly one hit to explain.
+_grep_tree_for() {
+  local n
+  n=$(grep -rl -- "$2" "$1" 2>/dev/null | grep -c '')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+# THE PLANTED-SECRET FIXTURE (§6.5). Two commits:
+#   c1  diff introduces DIFF_PLANT     message: "add config"
+#   c2  diff introduces CARRIER        message: "rotate key, old one was <MSG_PLANT>"
+# c2's finding is what carries c2's message into the report. Without it the
+# message plant never appears even under a full passthrough — see the header.
+# The working tree is CLEAN of DIFF_PLANT, so only a history scan can find it,
+# which is also §6.1's full-history claim under test.
+mk_secret_fixture() {
+  local d="$1"
+  ( cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email t@t.local
+    git config user.name T
+    printf 'aws_key = %s\n' "$DIFF_PLANT" > config.ini
+    git add -A && git commit -q -m "add config"
+    printf 'aws_key = ROTATED\n' > config.ini
+    printf 'deploy_key = %s\n' "$CARRIER" > deploy.ini
+    git add -A && git commit -q -m "rotate key, old one was $MSG_PLANT" ) >/dev/null 2>&1
+  # HOOK_PLANT: §7.3's named hazard, in the one file the archive would promote
+  # from untracked into version control.
+  printf '#!/bin/sh\nexport AWS_KEY=%s\nnpx lint-staged\nnpm test -- --bail\n' \
+    "$HOOK_PLANT" > "$d/.git/hooks/pre-commit"
+  chmod +x "$d/.git/hooks/pre-commit"
+}
+
+# A repository with no secrets at all — the discriminator for "scanned and
+# clean" against "not scanned" and against "tool unavailable".
+mk_clean_repo_fixture() {
+  local d="$1"
+  ( cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email t@t.local
+    git config user.name T
+    printf 'hello\n' > a.txt
+    git add -A && git commit -q -m "clean" ) >/dev/null 2>&1
+}
+
+# A NON-git directory carrying a plant in the working tree: §6.1's graceful
+# degradation to `gitleaks dir`, and the scope field that must say so honestly.
+mk_nongit_secret_fixture() {
+  local d="$1"
+  printf 'aws_key = %s\n' "$DIFF_PLANT" > "$d/config.ini"
+}
+
+# THE COLLISION FIXTURE — the §1.2 surfaces, in the shapes a real adoptee has.
+#   husky-style .git/hooks/pre-commit          archive-and-replace
+#   .git/hooks/commit-msg                      marker-composed
+#   .claude/settings.json + settings.local.json archive-and-replace
+#   .claude/skills/session-handoff/SKILL.md    archive-and-replace
+#   .mcp.json                                  archive-and-replace
+#   a FOREIGN .gitlab-ci.yml                   audit-only, never touched
+#   .gitignore, CHANGELOG.md, FEATURES.md      keep-theirs / composed
+#   .claude-backup/, uncommitted work
+mk_collision_fixture() {
+  local d="$1"
+  mkdir -p "$d/.claude/skills/session-handoff" "$d/.claude-backup" "$d/src"
+  ( cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email t@t.local
+    git config user.name T
+    printf 'console.log(1)\n' > src/a.js
+    git add -A && git commit -q -m "initial" ) >/dev/null 2>&1
+  printf '#!/bin/sh\n. "$(dirname "$0")/husky.sh"\nnpx lint-staged\n' > "$d/.git/hooks/pre-commit"
+  chmod +x "$d/.git/hooks/pre-commit"
+  printf '#!/bin/sh\nnpx commitlint --edit "$1"\n' > "$d/.git/hooks/commit-msg"
+  chmod +x "$d/.git/hooks/commit-msg"
+  printf '{"hooks":{}}\n' > "$d/.claude/settings.json"
+  printf '{"mcpServers":{"qdrant":{}}}\n' > "$d/.claude/settings.local.json"
+  printf '# Session handoff\n' > "$d/.claude/skills/session-handoff/SKILL.md"
+  printf '{"mcpServers":{}}\n' > "$d/.mcp.json"
+  printf 'stages:\n  - build\nbuild:\n  script:\n    - make all\n' > "$d/.gitlab-ci.yml"
+  printf 'node_modules/\n' > "$d/.gitignore"
+  printf '# Changelog\n\n## 1.0.0\n' > "$d/CHANGELOG.md"
+  printf '# Features\n' > "$d/FEATURES.md"
+  printf 'old settings\n' > "$d/.claude-backup/settings.json"
+  # uncommitted work, which today is swept into a --no-verify commit
+  printf 'console.log(2)\n' > "$d/src/b.js"
+}
+
+# THE SDLC-UNDERMINING WORKFLOW FIXTURE (§7.4) — one file per rule so a
+# finding can never be credited to the wrong detector, plus a CLEAN workflow so
+# the detectors are shown to discriminate rather than to fire on everything.
+mk_ci_findings_fixture() {
+  local d="$1"
+  mkdir -p "$d/.github/workflows"
+  printf 'name: clean\non:\n  pull_request:\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm test\n' \
+    > "$d/.github/workflows/clean.yml"
+  printf 'name: sec\non:\n  pull_request:\njobs:\n  scan:\n    runs-on: ubuntu-latest\n    steps:\n      - name: security scan\n        run: gitleaks detect\n        continue-on-error: true\n' \
+    > "$d/.github/workflows/skip.yml"
+  printf 'name: am\non:\n  pull_request:\njobs:\n  merge:\n    runs-on: ubuntu-latest\n    steps:\n      - run: gh pr merge --auto --squash\n' \
+    > "$d/.github/workflows/automerge.yml"
+  printf 'name: dep\non:\n  push:\n    branches: [main]\njobs:\n  deploy:\n    runs-on: ubuntu-latest\n    steps:\n      - run: ./deploy.sh production\n' \
+    > "$d/.github/workflows/deploy.yml"
+  printf 'name: rw\non:\n  workflow_dispatch:\njobs:\n  clean:\n    runs-on: ubuntu-latest\n    steps:\n      - run: git push --force origin main\n' \
+    > "$d/.github/workflows/rewrite.yml"
+}
+
+# A node project with a REAL, trivially-runnable test command and a mixed
+# source tree — five implementation files, one test file.
+mk_tests_fixture() {
+  local d="$1" i
+  mkdir -p "$d/src" "$d/tests"
+  cat > "$d/package.json" <<'EOF'
+{
+  "name": "acme-api",
+  "version": "0.4.1",
+  "scripts": { "test": "sh -c 'exit 0'" }
+}
+EOF
+  printf 'lockfileVersion: 6.0\n' > "$d/pnpm-lock.yaml"
+  i=1
+  while [ "$i" -le 5 ]; do
+    printf 'export const v%s = %s;\n' "$i" "$i" > "$d/src/mod$i.ts"
+    i=$((i + 1))
+  done
+  printf "test('v1', () => {});\n" > "$d/tests/mod1.test.ts"
+  printf '# acme-api\n\nBilling API.\n' > "$d/README.md"
+}
+
+# Same shape, but the declared test command FAILS. `commandRan` is about
+# whether Scout ran it, never about whether it passed.
+mk_failing_tests_fixture() {
+  local d="$1"
+  mkdir -p "$d/src"
+  cat > "$d/package.json" <<'EOF'
+{
+  "name": "acme-red",
+  "scripts": { "test": "sh -c 'exit 3'" }
+}
+EOF
+  printf 'export const v = 1;\n' > "$d/src/mod.ts"
+}
+
+# A rust tree whose ONLY tests are inline — `# BL-107-RUST-INLINE-TESTS`
+# parity. A path-only classifier calls every one of these untested.
+mk_rust_fixture() {
+  local d="$1"
+  mkdir -p "$d/src"
+  printf '[package]\nname = "acme"\n' > "$d/Cargo.toml"
+  printf 'pub fn a() -> u8 { 1 }\n\n#[cfg(test)]\nmod tests {\n    #[test]\n    fn t() {}\n}\n' > "$d/src/lib.rs"
+  printf 'pub fn b() -> u8 { 2 }\n' > "$d/src/plain.rs"
+}
+
+mk_bare_fixture() { printf 'hello\n' > "$1/notes.txt"; }
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+scout_json() {
+  local root="$1" entry="${2:-$SCOUT}"
+  bash "$entry" --root "$root" </dev/null 2>/dev/null
+}
+jqv() { printf '%s' "$1" | jq -r "$2" 2>/dev/null; }
+
+echo "== tests/test-brownfield-wp2-scout-sections.sh =="
+echo ""
+if [ "$HAVE_GITLEAKS" -eq 0 ]; then
+  echo "  ***********************************************************************"
+  echo "  *  gitleaks IS NOT INSTALLED ON THIS HOST.                            *"
+  echo "  *  The PLANTED-SECRET PROOF (§6.5) and BOTH mutation proofs will be   *"
+  echo "  *  SKIPPED. A skipped planted-secret proof is NOT a passing build —   *"
+  echo "  *  the secrets section is the highest-stakes surface in the design.   *"
+  echo "  *  Install it:  brew install gitleaks                                 *"
+  echo "  ***********************************************************************"
+  echo ""
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== G — the planted-secret proof (§6.5), the reason this suite exists ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+SEC=$(newtmp);   mk_secret_fixture "$SEC"
+CLEAN=$(newtmp); mk_clean_repo_fixture "$CLEAN"
+NONGIT=$(newtmp); mk_nongit_secret_fixture "$NONGIT"
+
+if [ "$HAVE_GITLEAKS" -eq 1 ]; then
+
+  # ── G0: THE PRECONDITION, ASSERTED BEFORE ANYTHING ELSE ──────────────────
+  # A dud plant yields zero findings, at which point every absence assertion
+  # below passes for the wrong reason and Mutation A can never go RED. §6.5
+  # names this precondition as non-optional and records that the design's own
+  # v1.0 shipped exactly that dud. It is asserted FIRST, on purpose.
+  G0OUT=$(newtmp)
+  bash "$SCOUT" --root "$SEC" --out "$G0OUT" </dev/null >/dev/null 2>&1
+  out=$(scout_json "$SEC")
+  fc=$(jqv "$out" '.secrets.findingCount')
+  st=$(jqv "$out" '.secrets.status')
+  # And the fixture really does still hold the plants where we put them —
+  # an absence proof over a fixture that lost its plants is worth nothing.
+  hist_has_diff=$( ( cd "$SEC" && git log -p 2>/dev/null | grep -c -- "$DIFF_PLANT" ) )
+  hist_has_msg=$( ( cd "$SEC" && git log 2>/dev/null | grep -c -- "$MSG_PLANT" ) )
+  tree_has_diff=$(_grep_tree_for "$SEC" "$DIFF_PLANT")
+  if [ "$(_num "$fc")" -ge 1 ] && [ "$st" = "scanned" ] \
+     && [ "$(_num "$hist_has_diff")" -ge 1 ] && [ "$(_num "$hist_has_msg")" -ge 1 ]; then
+    pass "G0 PRECONDITION: the BASE32-valid diff plant yields findingCount=$fc (non-zero) and both plants are live in the fixture's history"
+  else
+    fail_ "G0 PRECONDITION" "findingCount='$fc' (want >=1) status='$st' (want scanned) diff-plant-in-history=$hist_has_diff msg-plant-in-history=$hist_has_msg working-tree-files-with-diff-plant=$tree_has_diff — a dud plant makes every assertion below vacuous"
+  fi
+
+  # ── G1: NO PLANT STRING IN ANY BYTE OF ANY ARTIFACT ──────────────────────
+  # The assertion §6.5 is written to produce. Scope: every file under the
+  # output directory, and — because Scout stages its intermediate results in a
+  # work directory — every file under a TMPDIR this case owns exclusively, read
+  # AFTER Scout has exited and removed it. Temp residue is an artifact too.
+  G1OUT=$(newtmp)
+  G1TMP=$(newtmp)
+  TMPDIR="$G1TMP" bash "$SCOUT" --root "$SEC" --out "$G1OUT" </dev/null >/dev/null 2>&1
+  g1_rc=$?
+  leak_report=""
+  for plant_name in DIFF_PLANT CARRIER MSG_PLANT HOOK_PLANT; do
+    eval "plant=\$$plant_name"
+    n_out=$(_grep_tree_for "$G1OUT" "$plant")
+    n_tmp=$(_grep_tree_for "$G1TMP" "$plant")
+    [ "$n_out" -eq 0 ] || leak_report="$leak_report [$plant_name in $n_out output file(s)]"
+    [ "$n_tmp" -eq 0 ] || leak_report="$leak_report [$plant_name in $n_tmp temp file(s)]"
+  done
+  artifacts=$( (cd "$G1OUT" && LC_ALL=C ls -1) | tr '\n' ' ')
+  if [ -z "$leak_report" ] && [ "$g1_rc" -eq 0 ] \
+     && [ -f "$G1OUT/scout-report.json" ] && [ -f "$G1OUT/scout-report.md" ]; then
+    pass "G1: none of the four plants occurs in ANY byte of ANY artifact (json, markdown, temp residue); artifacts written: $artifacts"
+  else
+    fail_ "G1" "rc=$g1_rc artifacts='$artifacts' LEAKS:$leak_report"
+  fi
+
+  # ── G2: the finding object's keys ARE the §6.2 allowlist, exactly ────────
+  # Structural, not a spot check: the emitted key set is compared to the
+  # allowlist as a sorted string. An ADDED field fails this even if it happens
+  # to be harmless, which is the point — §6.2's table is normative and the
+  # schema HAS NO `secret` field to forget to strip.
+  keys=$(jqv "$out" '[.secrets.findings[0] | keys[]] | sort | join(",")')
+  want="commit,date,description,file,fingerprint,ruleId,startLine"
+  banned=0
+  for k in secret Secret match Match message Message author Author email Email entropy Entropy tags Tags; do
+    printf '%s' "$out" | jq -e ".secrets.findings[0] | has(\"$k\")" >/dev/null 2>&1 && banned=1
+  done
+  if [ "$keys" = "$want" ] && [ "$banned" -eq 0 ]; then
+    pass "G2: a finding carries EXACTLY the seven allowlisted fields ($want) and none of the fourteen refused ones"
+  else
+    fail_ "G2" "keys='$keys' want='$want' banned_field_present=$banned"
+  fi
+
+  # ── G3: scope is stated honestly, and differs by target ──────────────────
+  # §6.1: `gitleaks git` walks history; a non-repo can only be scanned as a
+  # directory, and a report that called that "full-history" would be a lie in
+  # the direction of false confidence.
+  scope_git=$(jqv "$out" '.secrets.scope')
+  ng=$(scout_json "$NONGIT")
+  scope_dir=$(jqv "$ng" '.secrets.scope')
+  fc_dir=$(jqv "$ng" '.secrets.findingCount')
+  # The history-only proof: DIFF_PLANT is absent from the working tree and
+  # present in history, so a working-tree scan could not have found it.
+  wt_hits=$(grep -rl -- "$DIFF_PLANT" "$SEC" --exclude-dir=.git 2>/dev/null | grep -c '')
+  if [ "$scope_git" = "full-history" ] && [ "$scope_dir" = "working-tree-only" ] \
+     && [ "${wt_hits:-1}" -eq 0 ] && [ "$(_num "$fc_dir")" -ge 1 ]; then
+    pass "G3: a repo scans full-history (and finds a plant that exists ONLY in history); a non-repo degrades to working-tree-only and says so"
+  else
+    fail_ "G3" "repo scope='$scope_git' nonrepo scope='$scope_dir' working-tree-files-with-plant=$wt_hits (want 0) nonrepo findingCount='$fc_dir'"
+  fi
+
+  # ── G4: a clean repo is 'scanned' with 0, not confusable with 'unscanned' ─
+  cl=$(scout_json "$CLEAN")
+  cl_st=$(jqv "$cl" '.secrets.status')
+  cl_fc=$(jqv "$cl" '.secrets.findingCount')
+  cl_type=$(printf '%s' "$cl" | jq -r '.secrets.findings | type' 2>/dev/null)
+  if [ "$cl_st" = "scanned" ] && [ "$cl_fc" = "0" ] && [ "$cl_type" = "array" ]; then
+    pass "G4: a clean repository reports status=scanned, findingCount=0, findings=[] — a positive claim, not an absence"
+  else
+    fail_ "G4" "status='$cl_st' findingCount='$cl_fc' findings type='$cl_type'"
+  fi
+
+  # ── G5: the tool's version is recorded (§12-13's drift assumption) ───────
+  tv=$(jqv "$out" '.secrets.toolVersion')
+  fm=$(printf '%s' "$out" | jq -r '.secrets.fieldsMissing | type' 2>/dev/null)
+  fmn=$(jqv "$out" '.secrets.fieldsMissing | length')
+  if printf '%s' "$tv" | grep -Eq '^[0-9]+\.[0-9]+' && [ "$fm" = "array" ] && [ "$fmn" = "0" ]; then
+    pass "G5: toolVersion='$tv' is recorded and fieldsMissing is an empty array — the allowlist found every field it names"
+  else
+    fail_ "G5" "toolVersion='$tv' fieldsMissing type='$fm' length='$fmn'"
+  fi
+
+else
+  skip_ "G0-G5 (planted-secret proof)" "gitleaks not installed — see the banner above"
+  skip_ "G1 byte assertion" "gitleaks not installed"
+fi
+
+# ── G6: version-drift is LOUD, not silent — a renamed field is REPORTED ────
+# §12-13's assumption made testable: an allowlist fails SAFE on an added field
+# (it is dropped) and must fail LOUD on a renamed one (it goes missing). The
+# fixture is a hand-written report with `Fingerprint` renamed, fed through the
+# projection directly, so the case runs with or without gitleaks installed.
+if [ -f "$SCOUT_LIB/scout-secrets.sh" ]; then
+  G6=$(newtmp)
+  cat > "$G6/report.json" <<'EOF'
+[
+ {
+  "RuleID": "aws-access-token",
+  "Description": "AWS Access Token",
+  "StartLine": 1,
+  "Match": "REDACTED",
+  "Secret": "REDACTED",
+  "File": "config.ini",
+  "Commit": "deadbeef",
+  "Date": "2026-08-02T00:00:00Z",
+  "Message": "irrelevant",
+  "FingerprintV2": "deadbeef:config.ini:aws-access-token:1"
+ }
+]
+EOF
+  ( . "$SCOUT_LIB/scout-secrets.sh"
+    _scout_secrets_project "$G6/report.json" "$G6" ) >/dev/null 2>&1
+  missing=$(cat "$G6/secmissing" 2>/dev/null | tr '\n' ' ')
+  nfind=$(cut -f1 < "$G6/secfields" 2>/dev/null | LC_ALL=C sort -u | grep -c '')
+  if printf '%s' "$missing" | grep -q 'Fingerprint' && [ "${nfind:-0}" -eq 1 ]; then
+    pass "G6: a RENAMED allowlisted field is reported in fieldsMissing ('$missing'), not silently dropped"
+  else
+    fail_ "G6" "fieldsMissing='$missing' (want Fingerprint) findings parsed=$nfind"
+  fi
+
+  # ── G7: an ADDED field is dropped silently and safely (the other half) ───
+  cat > "$G6/added.json" <<'EOF'
+[
+ {
+  "RuleID": "aws-access-token",
+  "Description": "AWS Access Token",
+  "StartLine": 1,
+  "File": "config.ini",
+  "Commit": "deadbeef",
+  "Date": "2026-08-02T00:00:00Z",
+  "Fingerprint": "deadbeef:config.ini:aws-access-token:1",
+  "NewLeakyFieldGitleaksAdded": "SUPERSECRETVALUE",
+  "Tags": ["a", "b"]
+ }
+]
+EOF
+  ( . "$SCOUT_LIB/scout-secrets.sh"
+    _scout_secrets_project "$G6/added.json" "$G6" ) >/dev/null 2>&1
+  leaked=$(grep -c 'SUPERSECRETVALUE' "$G6/secfields" 2>/dev/null)
+  missing2=$(cat "$G6/secmissing" 2>/dev/null | tr '\n' ' ')
+  if [ "${leaked:-1}" -eq 0 ] && [ -z "$(printf '%s' "$missing2" | tr -d ' ')" ]; then
+    pass "G7: a field gitleaks ADDS in a future release is dropped by the allowlist and never reaches the projection"
+  else
+    fail_ "G7" "added-field occurrences in projection=$leaked (want 0) fieldsMissing='$missing2' (want empty)"
+  fi
+else
+  fail_ "G6/G7" "scripts/lib/scout/scout-secrets.sh does not exist"
+fi
+
+# ── G8: gitleaks ABSENT is reported as tool-unavailable, never as clean ────
+# The silent-success class, aimed at the one section where it matters most. A
+# shim directory of PATH stubs makes `command -v gitleaks` fail while leaving
+# git and the rest of the environment intact.
+G8=$(newtmp)
+mkdir -p "$G8/bin"
+cat > "$G8/bin/gitleaks" <<'EOF'
+#!/bin/sh
+echo "gitleaks: masked for the tool-unavailable test" >&2
+exit 127
+EOF
+chmod +x "$G8/bin/gitleaks"
+# PATH_MASK makes the binary un-findable rather than merely broken: Scout must
+# key on presence, and reporting "unavailable" for a tool that IS present but
+# failed is a different (also honest) status.
+gl_out=$(SCOUT_GITLEAKS_BIN="definitely-not-a-real-binary-name" bash "$SCOUT" --root "$SEC" </dev/null 2>/dev/null)
+gl_st=$(jqv "$gl_out" '.secrets.status')
+gl_fc=$(jqv "$gl_out" '.secrets.findingCount')
+gl_ft=$(printf '%s' "$gl_out" | jq -r '.secrets.findings | type' 2>/dev/null)
+gl_rem=$(jqv "$gl_out" '.secrets.remediation')
+if [ "$gl_st" = "tool-unavailable" ] && [ "$gl_fc" = "null" ] && [ "$gl_ft" = "null" ] \
+   && [ -n "$gl_rem" ] && [ "$gl_rem" != "null" ]; then
+  pass "G8: with the scanner unavailable, status=tool-unavailable, findingCount=null, findings=null (NOT []), and a remediation line is printed"
+else
+  fail_ "G8" "status='$gl_st' (want tool-unavailable) findingCount='$gl_fc' (want null) findings type='$gl_ft' (want null) remediation='$gl_rem'"
+fi
+
+# ── G9: a repo-local gitleaks config is DISCLOSED ─────────────────────────
+# Measured on this host: a `.gitleaks.toml` with an allowlist regex reduces the
+# two-plant fixture to ZERO findings. A report that printed "0 findings"
+# without saying the project's own config was in force would be a clean bill of
+# health issued by the thing being audited.
+if [ "$HAVE_GITLEAKS" -eq 1 ]; then
+  G9=$(newtmp); mk_secret_fixture "$G9"
+  cat > "$G9/.gitleaks.toml" <<'EOF'
+title = "suppress everything"
+[allowlist]
+regexes = ['''AKIA[A-Z2-7]{16}''']
+EOF
+  g9=$(scout_json "$G9")
+  g9_cfg=$(jqv "$g9" '.secrets.configFile')
+  g9_fc=$(jqv "$g9" '.secrets.findingCount')
+  g9_note=$(jqv "$g9" '.secrets.configNote')
+  if [ "$g9_cfg" = ".gitleaks.toml" ] && [ "$g9_fc" = "0" ] \
+     && [ -n "$g9_note" ] && [ "$g9_note" != "null" ]; then
+    pass "G9: the project's own .gitleaks.toml is disclosed alongside the (suppressed) count of $g9_fc, with a note"
+  else
+    fail_ "G9" "configFile='$g9_cfg' findingCount='$g9_fc' configNote='$g9_note'"
+  fi
+else
+  skip_ "G9 (repo-local gitleaks config disclosure)" "gitleaks not installed"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== X — the mutation proofs (§10-WP2), anchored and line-counted ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+if [ "$HAVE_GITLEAKS" -eq 1 ]; then
+  ORIG_SEC="$SCOUT_LIB/scout-secrets.sh"
+  # Both anchors must resolve to exactly ONE EXECUTED line. WP1's X1 records
+  # what happens otherwise: a marker-only anchor hit the header comment that
+  # cites it and the mutant died on an unbound variable, reporting nothing at
+  # all — an empty result is not a leak, and asserting on it proves nothing.
+  redact_sites=$(grep -c '_flags=.*# SCOUT-SECRETS-REDACT' "$ORIG_SEC")
+  allow_sites=$(grep -c '_SCOUT_SECRET_FIELDS=.*# SCOUT-SECRETS-ALLOWLIST' "$ORIG_SEC")
+
+  # ── XA1: drop --redact ALONE -> layer 2 (the allowlist) still holds ──────
+  XA1=$(newtmp); mk_scout_copy "$XA1"
+  MUT="$XA1/scripts/lib/scout/scout-secrets.sh"
+  _awk_inplace "$MUT" '
+    { if (!done && index($0, "# SCOUT-SECRETS-REDACT") > 0 && index($0, "_flags=") > 0) {
+        print "  _flags=\"--no-banner --exit-code 0\""
+        done = 1; next }
+      print }'
+  chg_a1=$(_changed_lines "$ORIG_SEC" "$MUT")
+  XA1OUT=$(newtmp)
+  bash "$XA1/scripts/scout.sh" --root "$SEC" --out "$XA1OUT" </dev/null >/dev/null 2>&1
+  a1_leak=$(_grep_tree_for "$XA1OUT" "$DIFF_PLANT")
+  a1_fc=$(jqv "$(bash "$XA1/scripts/scout.sh" --root "$SEC" </dev/null 2>/dev/null)" '.secrets.findingCount')
+  if [ "$chg_a1" -eq 2 ] && [ "$a1_leak" -eq 0 ] && [ "$(_num "$a1_fc")" -ge 1 ] && [ "$redact_sites" -eq 1 ]; then
+    pass "XA1: with --redact DROPPED the artifacts are STILL clean (0 files carry the plant) — the field allowlist alone holds the line (§6.2: --redact is not sufficient, and it is not load-bearing either)"
+  else
+    fail_ "XA1" "changed_lines=$chg_a1 (want 2) files_leaking=$a1_leak (want 0) findingCount=$a1_fc (want >=1) redact_anchor_sites=$redact_sites (want 1)"
+  fi
+
+  # ── XA2: add Secret/Match to the allowlist ALONE -> layer 1 holds ────────
+  XA2=$(newtmp); mk_scout_copy "$XA2"
+  MUT="$XA2/scripts/lib/scout/scout-secrets.sh"
+  _awk_inplace "$MUT" '
+    { if (!done && index($0, "# SCOUT-SECRETS-ALLOWLIST") > 0 && index($0, "_SCOUT_SECRET_FIELDS=") > 0) {
+        print "_SCOUT_SECRET_FIELDS=\"RuleID File Commit Fingerprint StartLine Date Description Secret Match\""
+        done = 1; next }
+      print }'
+  chg_a2=$(_changed_lines "$ORIG_SEC" "$MUT")
+  XA2OUT=$(newtmp)
+  bash "$XA2/scripts/scout.sh" --root "$SEC" --out "$XA2OUT" </dev/null >/dev/null 2>&1
+  a2_leak=$(_grep_tree_for "$XA2OUT" "$DIFF_PLANT")
+  a2_has_secret=$(grep -c '"secret"' "$XA2OUT/scout-report.json" 2>/dev/null)
+  if [ "$chg_a2" -eq 2 ] && [ "$a2_leak" -eq 0 ] && [ "${a2_has_secret:-0}" -ge 1 ] && [ "$allow_sites" -eq 1 ]; then
+    pass "XA2: with Secret/Match ADDED to the allowlist a \`secret\` key does appear ($a2_has_secret occurrence(s)) but carries only REDACTED — --redact holds the line when the allowlist falls"
+  else
+    fail_ "XA2" "changed_lines=$chg_a2 (want 2) files_leaking=$a2_leak (want 0) secret_key_occurrences=$a2_has_secret (want >=1) allowlist_anchor_sites=$allow_sites (want 1)"
+  fi
+
+  # ── XA: BOTH layers down -> THE DIFF PLANT APPEARS -> RED ────────────────
+  # §10-WP2's Mutation A. It is a TWO-line mutation and the suite says so
+  # rather than pretending otherwise: measured against a correct build, NO
+  # single-line neuter can expose the diff plant, because the two layers are
+  # independent and either one alone suppresses it (XA1 and XA2 above are that
+  # measurement). A one-line Mutation A here would pass vacuously — the exact
+  # defect §6.5 exists to prevent, wearing a different hat.
+  XA=$(newtmp); mk_scout_copy "$XA"
+  MUT="$XA/scripts/lib/scout/scout-secrets.sh"
+  _awk_inplace "$MUT" '
+    { if (!done_r && index($0, "# SCOUT-SECRETS-REDACT") > 0 && index($0, "_flags=") > 0) {
+        print "  _flags=\"--no-banner --exit-code 0\""
+        done_r = 1; next }
+      if (!done_a && index($0, "# SCOUT-SECRETS-ALLOWLIST") > 0 && index($0, "_SCOUT_SECRET_FIELDS=") > 0) {
+        print "_SCOUT_SECRET_FIELDS=\"RuleID File Commit Fingerprint StartLine Date Description Secret Match\""
+        done_a = 1; next }
+      print }'
+  chg_a=$(_changed_lines "$ORIG_SEC" "$MUT")
+  XAOUT=$(newtmp)
+  bash "$XA/scripts/scout.sh" --root "$SEC" --out "$XAOUT" </dev/null >/dev/null 2>&1
+  a_leak=$(_grep_tree_for "$XAOUT" "$DIFF_PLANT")
+  # The control: the same fixture, the UNMUTATED copy, in the same case, so a
+  # red mutant can never be a fixture accident.
+  XAC=$(newtmp); mk_scout_copy "$XAC"
+  XACOUT=$(newtmp)
+  bash "$XAC/scripts/scout.sh" --root "$SEC" --out "$XACOUT" </dev/null >/dev/null 2>&1
+  a_ctl=$(_grep_tree_for "$XACOUT" "$DIFF_PLANT")
+  if [ "$chg_a" -eq 4 ] && [ "$a_leak" -ge 1 ] && [ "$a_ctl" -eq 0 ]; then
+    pass "XA (Mutation A): both layers neutered (2 substitutions, $chg_a diff lines) -> the DIFF plant appears in $a_leak artifact file(s); the unmutated control leaks 0"
+  else
+    fail_ "XA" "changed_lines=$chg_a (want 4) mutant_files_leaking=$a_leak (want >=1) control_files_leaking=$a_ctl (want 0)"
+  fi
+
+  # ── XB: THE ONE THAT MATTERS (C7) — allowlist -> report passthrough ──────
+  # ONE line, --redact still ON, and the MESSAGE plant walks straight out. The
+  # `Message` field is the full commit message and `--redact` does not touch
+  # it; §13-V3 records that `gitleaks git` does not scan commit messages at
+  # all, so no finding COUNT can ever reveal this and only an assertion on the
+  # artifact's BYTES catches it. This is the mutation that separates a design
+  # that redacts from a design that projects.
+  XB=$(newtmp); mk_scout_copy "$XB"
+  MUT="$XB/scripts/lib/scout/scout-secrets.sh"
+  _awk_inplace "$MUT" '
+    { if (!done && index($0, "# SCOUT-SECRETS-ALLOWLIST") > 0 && index($0, "_SCOUT_SECRET_FIELDS=") > 0) {
+        print "_SCOUT_SECRET_FIELDS=\"RuleID Description StartLine EndLine StartColumn EndColumn Match Secret File SymlinkFile Commit Entropy Author Email Date Message Tags Fingerprint\""
+        done = 1; next }
+      print }'
+  chg_b=$(_changed_lines "$ORIG_SEC" "$MUT")
+  XBOUT=$(newtmp)
+  bash "$XB/scripts/scout.sh" --root "$SEC" --out "$XBOUT" </dev/null >/dev/null 2>&1
+  b_leak=$(_grep_tree_for "$XBOUT" "$MSG_PLANT")
+  b_diff_leak=$(_grep_tree_for "$XBOUT" "$DIFF_PLANT")
+  XBC=$(newtmp); mk_scout_copy "$XBC"
+  XBCOUT=$(newtmp)
+  bash "$XBC/scripts/scout.sh" --root "$SEC" --out "$XBCOUT" </dev/null >/dev/null 2>&1
+  b_ctl=$(_grep_tree_for "$XBCOUT" "$MSG_PLANT")
+  if [ "$chg_b" -eq 2 ] && [ "$b_leak" -ge 1 ] && [ "$b_ctl" -eq 0 ] \
+     && [ "$b_diff_leak" -eq 0 ] && [ "$allow_sites" -eq 1 ]; then
+    pass "XB (Mutation B, C7): ONE line — allowlist replaced by the tool's full 18-field report — leaks the MESSAGE plant into $b_leak artifact file(s) with --redact still on (the DIFF plant stays redacted, $b_diff_leak); the unmutated control leaks 0"
+  else
+    fail_ "XB" "changed_lines=$chg_b (want 2) mutant_files_leaking_MSG=$b_leak (want >=1) control=$b_ctl (want 0) mutant_files_leaking_DIFF=$b_diff_leak (want 0) allowlist_anchor_sites=$allow_sites (want 1)"
+  fi
+else
+  skip_ "XA1/XA2/XA/XB (all four mutation proofs)" "gitleaks not installed — see the banner above"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== C — the §1.2 collision inventory, bucketed per §7.1, report-only ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+COL=$(newtmp); mk_collision_fixture "$COL"
+col=$(scout_json "$COL")
+
+# _bucket_of JSON PATH — the bucket recorded for one inventory path.
+_bucket_of() {
+  printf '%s' "$1" | jq -r --arg p "$2" '.collisions.entries[] | select(.path==$p) | .bucket' 2>/dev/null
+}
+_class_of() {
+  printf '%s' "$1" | jq -r --arg p "$2" '.collisions.entries[] | select(.path==$p) | .class' 2>/dev/null
+}
+
+# ── C1: the three named fixtures land in the three right buckets ───────────
+b_hook=$(_bucket_of "$col" ".git/hooks/pre-commit")
+b_cm=$(_bucket_of "$col" ".git/hooks/commit-msg")
+b_gl=$(_bucket_of "$col" ".gitlab-ci.yml")
+b_sl=$(_bucket_of "$col" ".claude/settings.local.json")
+b_ch=$(_bucket_of "$col" "CHANGELOG.md")
+if [ "$b_hook" = "archive-and-replace" ] && [ "$b_cm" = "marker-composed" ] \
+   && [ "$b_gl" = "audit-only" ] && [ "$b_sl" = "archive-and-replace" ] \
+   && [ "$b_ch" = "keep-theirs" ]; then
+  pass "C1: husky pre-commit=archive-and-replace, commit-msg=marker-composed, foreign .gitlab-ci.yml=audit-only, settings.local.json=archive-and-replace, CHANGELOG.md=keep-theirs"
+else
+  fail_ "C1" "pre-commit='$b_hook' commit-msg='$b_cm' gitlab-ci='$b_gl' settings.local='$b_sl' CHANGELOG='$b_ch'"
+fi
+
+# ── C2: every bucket value is drawn from §7.1's four, and nothing else ─────
+badbucket=$(printf '%s' "$col" | jq -r '[.collisions.entries[].bucket] | map(select(. != "archive-and-replace" and . != "marker-composed" and . != "audit-only" and . != "keep-theirs")) | join(",")' 2>/dev/null)
+nent=$(jqv "$col" '.collisions.entries | length')
+if [ -z "$badbucket" ] && [ "$(_num "$nent")" -ge 10 ]; then
+  pass "C2: all $nent inventory entries carry one of §7.1's four bucket values and no invented fifth"
+else
+  fail_ "C2" "entries=$nent (want >=10) off-vocabulary buckets='$badbucket'"
+fi
+
+# ── C3: the hook description is built from a TOOL VOCABULARY, never bytes ──
+# §7.2 requires a what-it-invokes description; §7.3 names the hazard — a
+# hand-rolled hook can contain a token. The generator therefore emits only
+# names it recognises. The proof is the secret fixture, whose pre-commit hook
+# carries HOOK_PLANT: G1 already asserted the bytes, and this case asserts the
+# description is nonetheless USEFUL rather than merely empty.
+desc=$(printf '%s' "$col" | jq -r '.collisions.entries[] | select(.path==".git/hooks/pre-commit") | .description' 2>/dev/null)
+if printf '%s' "$desc" | grep -q 'lint-staged' && printf '%s' "$desc" | grep -q 'npx' \
+   && [ -n "$desc" ] && [ "$desc" != "null" ]; then
+  pass "C3: the git-hook description names the tools it recognised ('$desc') — a fixed vocabulary, never a quoted line"
+else
+  fail_ "C3" "description='$desc' (want it to name npx and lint-staged)"
+fi
+
+# ── C4: absence is structural, never fabricated ────────────────────────────
+# A bare tree has none of these surfaces. The discriminator is that the
+# entries array is EMPTY, not that it is full of rows saying "absent".
+BARE=$(newtmp); mk_bare_fixture "$BARE"
+bare=$(scout_json "$BARE")
+bare_n=$(jqv "$bare" '.collisions.entries | length')
+bare_t=$(printf '%s' "$bare" | jq -r '.collisions.entries | type' 2>/dev/null)
+if [ "$bare_n" = "0" ] && [ "$bare_t" = "array" ]; then
+  pass "C4: a tree with none of the §1.2 surfaces reports an EMPTY entries array — absent surfaces are absent, not invented"
+else
+  fail_ "C4" "entries length='$bare_n' (want 0) type='$bare_t'"
+fi
+
+# ── C5: the four §7.4 detectors each fire, on their own file, and only there ─
+CI=$(newtmp); mk_ci_findings_fixture "$CI"
+ci=$(scout_json "$CI")
+_rules_for() {
+  printf '%s' "$1" | jq -r --arg p "$2" '[.collisions.entries[] | select(.path==$p) | .findings[]] | sort | join(",")' 2>/dev/null
+}
+r_skip=$(_rules_for "$ci" ".github/workflows/skip.yml")
+r_am=$(_rules_for "$ci" ".github/workflows/automerge.yml")
+r_dep=$(_rules_for "$ci" ".github/workflows/deploy.yml")
+r_rw=$(_rules_for "$ci" ".github/workflows/rewrite.yml")
+r_clean=$(_rules_for "$ci" ".github/workflows/clean.yml")
+if [ "$r_skip" = "check-skipping" ] && [ "$r_am" = "auto-merge" ] \
+   && [ "$r_dep" = "deploy-around-the-release-lane" ] \
+   && [ "$r_rw" = "force-push-or-history-rewrite-in-ci" ] && [ -z "$r_clean" ]; then
+  pass "C5: each §7.4 rule fires on exactly its own fixture workflow, and the clean workflow draws no finding at all"
+else
+  fail_ "C5" "skip='$r_skip' automerge='$r_am' deploy='$r_dep' rewrite='$r_rw' clean='$r_clean' (want empty)"
+fi
+
+# ── C6: a loud finding, and ZERO EDITS — the carve-out is audit-only ───────
+# §7.4: their pipelines are audited, never touched. Proven by tree hash over
+# the whole fixture, the same instrument WP1 uses for read-only.
+CI2=$(newtmp); mk_ci_findings_fixture "$CI2"
+h_before=$(_tree_hash "$CI2")
+CI2OUT=$(newtmp)
+bash "$SCOUT" --root "$CI2" --out "$CI2OUT" </dev/null >/dev/null 2>&1
+scout_json "$CI2" >/dev/null
+h_after=$(_tree_hash "$CI2")
+det=$(printf '%s' "$ci" | jq -r '[.collisions.findingDetail[] | select(.rule=="check-skipping")] | length' 2>/dev/null)
+det_line=$(printf '%s' "$ci" | jq -r '[.collisions.findingDetail[] | select(.rule=="check-skipping")][0].line' 2>/dev/null)
+if [ "$h_before" = "$h_after" ] && [ "$(_num "$det")" -ge 1 ] \
+   && printf '%s' "$det_line" | grep -Eq '^[0-9]+$'; then
+  pass "C6: a continue-on-error security step draws a loud finding with a line number ($det_line) and the fixture is byte-identical afterwards (tree hash equal)"
+else
+  fail_ "C6" "tree_hash_before=$h_before after=$h_after check-skipping_details=$det line='$det_line'"
+fi
+
+# ── C7: the detail rows carry NO file content — the §6.2 doctrine, generalised ─
+# A workflow line can contain a credential. The detector therefore reports the
+# rule, the path and the LINE NUMBER, and never the matched text. This is the
+# same allowlist discipline as the secrets section and it is asserted the same
+# way: the keys of a detail row are exactly the four named.
+dkeys=$(printf '%s' "$ci" | jq -r '[.collisions.findingDetail[0] | keys[]] | sort | join(",")' 2>/dev/null)
+if [ "$dkeys" = "line,path,rule,why" ]; then
+  pass "C7: a finding detail row carries exactly rule/path/line/why — the matched TEXT is never quoted into the report"
+else
+  fail_ "C7" "detail keys='$dkeys' want='line,path,rule,why'"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T — testsBaseline: the one place Scout may execute project code ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+TST=$(newtmp); mk_tests_fixture "$TST"
+
+# ── T1: BY DEFAULT Scout does not run anything, and says why ───────────────
+# A scanner that executes arbitrary project code by default is a trap. The
+# reason is a positive statement, not an empty field.
+t=$(scout_json "$TST")
+t_ran=$(jqv "$t" '.testsBaseline.commandRan')
+t_reason=$(jqv "$t" '.testsBaseline.reason')
+t_ec=$(jqv "$t" '.testsBaseline.exitCode')
+t_cmd=$(jqv "$t" '.testsBaseline.testCommand.value')
+if [ "$t_ran" = "false" ] && [ -n "$t_reason" ] && [ "$t_reason" != "null" ] \
+   && [ "$t_ec" = "null" ] && [ -n "$t_cmd" ] && [ "$t_cmd" != "null" ]; then
+  pass "T1: by default commandRan=false with a stated reason, exitCode=null — and the command was still DETECTED ('$t_cmd')"
+else
+  fail_ "T1" "commandRan='$t_ran' reason='$t_reason' exitCode='$t_ec' testCommand='$t_cmd'"
+fi
+
+# ── T2: --run-tests is the opt-in, and it really runs ──────────────────────
+tr_out=$(bash "$SCOUT" --root "$TST" --run-tests </dev/null 2>/dev/null); rc=$?
+tr_ran=$(jqv "$tr_out" '.testsBaseline.commandRan')
+tr_ec=$(jqv "$tr_out" '.testsBaseline.exitCode')
+tr_dur=$(jqv "$tr_out" '.testsBaseline.durationSeconds')
+if [ "$rc" -eq 0 ] && [ "$tr_ran" = "true" ] && [ "$tr_ec" = "0" ] \
+   && printf '%s' "$tr_dur" | grep -Eq '^[0-9]+$'; then
+  pass "T2: --run-tests runs the detected command: commandRan=true, exitCode=0, durationSeconds=$tr_dur"
+else
+  fail_ "T2" "scout rc=$rc commandRan='$tr_ran' exitCode='$tr_ec' durationSeconds='$tr_dur'"
+fi
+
+# ── T3: a FAILING test suite is data, not a Scout error ────────────────────
+RED=$(newtmp); mk_failing_tests_fixture "$RED"
+rd=$(bash "$SCOUT" --root "$RED" --run-tests </dev/null 2>/dev/null); rc=$?
+rd_ec=$(jqv "$rd" '.testsBaseline.exitCode')
+rd_ran=$(jqv "$rd" '.testsBaseline.commandRan')
+if [ "$rc" -eq 0 ] && [ "$rd_ran" = "true" ] && [ "$rd_ec" = "3" ]; then
+  pass "T3: a test command that exits 3 is recorded as exitCode=3 and Scout still exits 0 — a red baseline is a finding, not a scanner failure"
+else
+  fail_ "T3" "scout rc=$rc (want 0) commandRan='$rd_ran' exitCode='$rd_ec' (want 3)"
+fi
+
+# ── T4: --run-tests with NO detected command runs nothing ──────────────────
+nb=$(bash "$SCOUT" --root "$BARE" --run-tests </dev/null 2>/dev/null)
+nb_ran=$(jqv "$nb" '.testsBaseline.commandRan')
+nb_reason=$(jqv "$nb" '.testsBaseline.reason')
+if [ "$nb_ran" = "false" ] && printf '%s' "$nb_reason" | grep -qi 'command'; then
+  pass "T4: --run-tests on a tree with no detectable test command runs nothing and says so ('$nb_reason')"
+else
+  fail_ "T4" "commandRan='$nb_ran' reason='$nb_reason'"
+fi
+
+# ── T5: the untested-source count, and the classifier parity statement ─────
+t_total=$(jqv "$t" '.testsBaseline.totalSourceFiles')
+t_test=$(jqv "$t" '.testsBaseline.testFiles')
+t_unt=$(jqv "$t" '.testsBaseline.untestedSourceFiles')
+t_carried=$(jqv "$t" '.testsBaseline.classifierParity.carried | length')
+t_simpl=$(jqv "$t" '.testsBaseline.classifierParity.simplified | length')
+t_meth=$(jqv "$t" '.testsBaseline.untestedMethod')
+# 5 impl files (src/mod1..5.ts), 1 test file; package.json/README.md/lockfile
+# are not implementation under the extracted predicate.
+if [ "$t_total" = "5" ] && [ "$t_test" = "1" ] && [ "$t_unt" = "4" ] \
+   && [ "$(_num "$t_carried")" -ge 1 ] && [ "$(_num "$t_simpl")" -ge 1 ] \
+   && [ -n "$t_meth" ] && [ "$t_meth" != "null" ]; then
+  pass "T5: 5 implementation files, 1 test file, 4 untested — and the report states which parts of the classifier were carried ($t_carried) and which simplified ($t_simpl)"
+else
+  fail_ "T5" "total='$t_total' (want 5) testFiles='$t_test' (want 1) untested='$t_unt' (want 4) carried=$t_carried simplified=$t_simpl method='$t_meth'"
+fi
+
+# ── T6: `# BL-107-RUST-INLINE-TESTS` parity is real, not a claim ───────────
+# The path-only classifier calls an inline-tested .rs file untested. The gate
+# carries a content probe for exactly this; the extraction carries it too, and
+# this case is what keeps it carried: src/lib.rs has inline tests, src/plain.rs
+# does not, so the honest answer is 2 source files and 1 untested.
+RS=$(newtmp); mk_rust_fixture "$RS"
+rs=$(scout_json "$RS")
+rs_total=$(jqv "$rs" '.testsBaseline.totalSourceFiles')
+rs_unt=$(jqv "$rs" '.testsBaseline.untestedSourceFiles')
+if [ "$rs_total" = "2" ] && [ "$rs_unt" = "1" ]; then
+  pass "T6: a .rs file whose only tests are inline (#[cfg(test)]) is NOT counted untested — 2 source files, 1 untested"
+else
+  fail_ "T6" "totalSourceFiles='$rs_total' (want 2) untestedSourceFiles='$rs_unt' (want 1) — the BL-107 content probe is not carried"
+fi
+
+# ── T7: the execution bound is real ────────────────────────────────────────
+SLOW=$(newtmp)
+mkdir -p "$SLOW/src"
+cat > "$SLOW/package.json" <<'EOF'
+{ "name": "acme-slow", "scripts": { "test": "sleep 45" } }
+EOF
+printf 'export const v = 1;\n' > "$SLOW/src/mod.ts"
+sl=$(SCOUT_TEST_TIMEOUT=2 bash "$SCOUT" --root "$SLOW" --run-tests </dev/null 2>/dev/null); rc=$?
+sl_to=$(jqv "$sl" '.testsBaseline.timedOut')
+sl_ran=$(jqv "$sl" '.testsBaseline.commandRan')
+sl_dur=$(jqv "$sl" '.testsBaseline.durationSeconds')
+if [ "$rc" -eq 0 ] && [ "$sl_to" = "true" ] && [ "$sl_ran" = "true" ] \
+   && printf '%s' "$sl_dur" | grep -Eq '^[0-9]+$' && [ "${sl_dur:-99}" -le 10 ]; then
+  pass "T7: a test command that would run for 45s is bounded at SCOUT_TEST_TIMEOUT=2 and reported timedOut=true after ${sl_dur}s"
+else
+  fail_ "T7" "scout rc=$rc timedOut='$sl_to' commandRan='$sl_ran' durationSeconds='$sl_dur' (want <=10)"
+fi
+
+# ── T8: the bound actually KILLS the command, and kills it QUIETLY ─────────
+# Two properties that a reader would reasonably assume and that neither T7 nor
+# A2 covers, both of which are one careless edit away from regressing:
+#
+#   (a) THE DESCENDANT DIES. `sh -c "sleep 3; touch marker"` is stopped at 1s.
+#       If only the wrapper subshell had been signalled, the sleep would
+#       survive and the marker would appear 3 seconds later. The case waits
+#       past that moment and asserts the marker never arrives. This is what
+#       the process-group kill buys, and asserting the absence of the marker is
+#       the only way to see it — the exit code looks identical either way.
+#   (b) IT IS SILENT. The bound uses `set -m` to get the command its own
+#       process group, and job control is exactly the bash feature that
+#       announces itself on stderr ("Terminated"). Scout's contract is an empty
+#       stderr on a successful scan, and A2's loop does not reach this path.
+T8=$(newtmp)
+T8M=$(newtmp)
+mkdir -p "$T8/src"
+printf 'export const v = 1;\n' > "$T8/src/mod.ts"
+cat > "$T8/package.json" <<EOF
+{ "name": "acme-survivor", "scripts": { "test": "sleep 3; touch $T8M/survived" } }
+EOF
+t8err=$(SCOUT_TEST_TIMEOUT=1 bash "$SCOUT" --root "$T8" --run-tests </dev/null 2>&1 >/dev/null); rc=$?
+sleep 4
+if [ "$rc" -eq 0 ] && [ -z "$t8err" ] && [ ! -f "$T8M/survived" ]; then
+  pass "T8: the stopped command's descendant really died (its delayed marker never appeared) and the kill wrote nothing to stderr"
+else
+  fail_ "T8" "rc=$rc stderr='$(printf '%s' "$t8err" | head -2)' survivor_marker_exists=$( [ -f "$T8M/survived" ] && echo yes || echo no ) (want no)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== P — intakePrefill: §8.3's mapping table, one row per wizard runner ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+pf=$(scout_json "$TST")
+
+# ── P1: FIFTEEN rows, and the ids are the REAL runners — a currency canary ──
+# The table is a static data block inside Scout (M5: Scout must run in a tree
+# that has never had the framework, so it cannot read intake-wizard.sh at scan
+# time). This suite lives in the framework repo and CAN read it, so the ids are
+# derived from the wizard itself rather than restated. Add a runner to the
+# wizard without adding a row here and this case goes red — which is the only
+# thing that keeps the table from decaying into a snapshot of 2026.
+wizard_ids=$(grep -o '^run_section_[a-z0-9_]*' "$WIZARD" 2>/dev/null \
+  | sed -e 's/^run_section_//' | LC_ALL=C sort | tr '\n' ' ')
+table_ids=$(printf '%s' "$pf" | jq -r '[.intakePrefill.sections[].id] | sort | join(" ")' 2>/dev/null)
+table_ids="$table_ids "
+nrows=$(jqv "$pf" '.intakePrefill.sections | length')
+if [ "$nrows" = "15" ] && [ "$wizard_ids" = "$table_ids" ]; then
+  pass "P1: 15 rows, one per run_section_* runner, ids derived from scripts/intake-wizard.sh and matching exactly"
+else
+  fail_ "P1" "rows=$nrows (want 15)\n  wizard ids: '$wizard_ids'\n  table  ids: '$table_ids'"
+fi
+
+# ── P2: every row carries a §8.3 class and nothing outside the vocabulary ──
+badkind=$(printf '%s' "$pf" | jq -r '[.intakePrefill.sections[].kind] | map(select(. != "scan-derived" and . != "judgment" and . != "non-skippable")) | join(",")' 2>/dev/null)
+n_scan=$(jqv "$pf" '[.intakePrefill.sections[] | select(.kind=="scan-derived")] | length')
+n_judg=$(jqv "$pf" '[.intakePrefill.sections[] | select(.kind=="judgment")] | length')
+n_non=$(jqv "$pf" '[.intakePrefill.sections[] | select(.kind=="non-skippable")] | length')
+if [ -z "$badkind" ] && [ "$(_num "$n_scan")" -ge 1 ] && [ "$(_num "$n_judg")" -ge 1 ] && [ "$(_num "$n_non")" -ge 1 ]; then
+  pass "P2: every row is scan-derived / judgment / non-skippable (${n_scan} / ${n_judg} / ${n_non}), with no invented fourth class"
+else
+  fail_ "P2" "off-vocabulary kinds='$badkind' scan=$n_scan judgment=$n_judg non-skippable=$n_non"
+fi
+
+# ── P3: judgment rows carry value:null — NEVER A GUESSED VALUE ─────────────
+# §8.3: the prefill pattern is right for facts the framework recorded and wrong
+# for judgments it has never made. A guessed business context is worse than no
+# business context, because it will be confirmed away.
+guessed=$(printf '%s' "$pf" | jq -r '[.intakePrefill.sections[] | select(.kind!="scan-derived") | select(.value != null) | .id] | join(",")' 2>/dev/null)
+# NON-VACUITY: "no row broke the rule" is only a claim if rows were subject to
+# it. An empty table satisfies the emptiness test perfectly.
+n_subject=$(jqv "$pf" '[.intakePrefill.sections[] | select(.kind!="scan-derived")] | length')
+if [ -z "$guessed" ] && [ "$(_num "$n_subject")" -ge 1 ]; then
+  pass "P3: all $n_subject judgment/non-skippable rows carry value:null — Scout never guesses an answer it has no evidence for"
+else
+  fail_ "P3" "rows with a non-null value that should have none: '$guessed'; rows subject to the rule: $n_subject (want >=1)"
+fi
+
+# ── P4: scan-derived rows carry BOTH a value and its provenance ────────────
+# §8.3's shipped pattern discloses the value AND where it came from; a prefill
+# without provenance is an assertion the operator cannot check.
+noprov=$(printf '%s' "$pf" | jq -r '[.intakePrefill.sections[] | select(.kind=="scan-derived") | select((.value == null) or (.source == null)) | .id] | join(",")' 2>/dev/null)
+pname=$(printf '%s' "$pf" | jq -r '.intakePrefill.sections[] | select(.id=="1") | .value' 2>/dev/null)
+if [ -z "$noprov" ] && [ "$pname" = "acme-api" ]; then
+  pass "P4: every scan-derived row carries value+source, and section 1 reads the real project name ('$pname') off the fixture"
+else
+  fail_ "P4" "scan-derived rows missing value or source: '$noprov'; section 1 value='$pname' (want acme-api)"
+fi
+
+# ── P5: data classification is NON-SKIPPABLE, in both scenarios ────────────
+# §8.3 and §4.3: the Phase 1→2 ZDR backstop's hard [FAIL] makes this a
+# mechanical necessity, not a policy preference. Section 5 is where 5.5 lives.
+k5=$(printf '%s' "$pf" | jq -r '.intakePrefill.sections[] | select(.id=="5") | .kind' 2>/dev/null)
+v5=$(printf '%s' "$pf" | jq -r '.intakePrefill.sections[] | select(.id=="5") | .value' 2>/dev/null)
+if [ "$k5" = "non-skippable" ] && [ "$v5" = "null" ]; then
+  pass "P5: the section carrying 5.5 Data Classification & ZDR is non-skippable with no prefilled value"
+else
+  fail_ "P5" "section 5 kind='$k5' (want non-skippable) value='$v5' (want null)"
+fi
+
+# ── P6: the table is a DATA BLOCK Scout owns, readable without a scan ──────
+# §10-WP4 consumes it. It must therefore be addressable as data, not only as a
+# side effect of emitting a report.
+if [ -f "$SCOUT_LIB/scout-prefill.sh" ]; then
+  rows=$( . "$SCOUT_LIB/scout-prefill.sh" 2>/dev/null; _scout_prefill_table 2>/dev/null | grep -c '' )
+  if [ "${rows:-0}" -eq 15 ]; then
+    pass "P6: _scout_prefill_table emits the 15-row mapping as data, independent of any scan (WP4 consumes it)"
+  else
+    fail_ "P6" "_scout_prefill_table emitted $rows rows (want 15)"
+  fi
+else
+  fail_ "P6" "scripts/lib/scout/scout-prefill.sh does not exist"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== R — READ-ONLY still holds, with four more sections in the scan ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── R1: the collision fixture is byte-identical after repeated scans ───────
+# RUN TWICE, deliberately: an idempotent write is invisible to a
+# before/after hash taken across a single run, and WP1 records a case that
+# stayed green under a state-writing mutant for exactly that reason.
+R1F=$(newtmp); mk_collision_fixture "$R1F"
+SIDE=$(newtmp)
+r1_before=$(_tree_hash "$R1F")
+scout_json "$R1F" >/dev/null
+scout_json "$R1F" >/dev/null
+bash "$SCOUT" --root "$R1F" --markdown </dev/null >/dev/null 2>&1
+bash "$SCOUT" --root "$R1F" --out "$SIDE" </dev/null >/dev/null 2>&1
+r1_after=$(_tree_hash "$R1F")
+if [ "$r1_before" = "$r1_after" ]; then
+  pass "R1: the collision fixture (.claude/, .git/hooks/, .mcp.json, CI, uncommitted work) is byte-identical after four scans"
+else
+  _tree_manifest "$R1F" > "$SIDE/after.txt"
+  fail_ "R1" "tree hash changed: $r1_before -> $r1_after"
+fi
+
+# ── R2: the SECRETS scan is read-only over a git repository ───────────────
+# `gitleaks git` walks history through git plumbing. Measured here rather than
+# assumed, `.git/` included, because a scan that refreshed an index would still
+# have written to the operator's repository.
+if [ "$HAVE_GITLEAKS" -eq 1 ]; then
+  R2F=$(newtmp); mk_secret_fixture "$R2F"
+  r2_before=$(_tree_hash "$R2F")
+  scout_json "$R2F" >/dev/null
+  scout_json "$R2F" >/dev/null
+  r2_after=$(_tree_hash "$R2F")
+  if [ "$r2_before" = "$r2_after" ]; then
+    pass "R2: a full-history gitleaks scan leaves the repository byte-identical, .git/ included (run twice)"
+  else
+    fail_ "R2" "tree hash changed: $r2_before -> $r2_after"
+  fi
+else
+  skip_ "R2 (read-only under a full-history secrets scan)" "gitleaks not installed"
+fi
+
+# ── R3: --run-tests, and an HONEST statement of what the hash excludes ─────
+# This is the one flag that executes project code, so the fixture's test
+# command is the only thing that can write — and here it is `sh -c 'exit 0'`,
+# which writes nothing, so the WHOLE tree including .git/ is asserted
+# unchanged. That is the honest scope of this proof: it shows SCOUT writes
+# nothing under --run-tests. It cannot show that somebody else's test suite
+# writes nothing, and no test could — running `npm test` on a real project
+# creates coverage output, caches and lockfile touches by design. The report
+# says so in the section itself; the flag is opt-in for this reason.
+R3F=$(newtmp); mk_tests_fixture "$R3F"
+( cd "$R3F" && unset GITHUB_BASE_REF && git init -q . && git config user.email t@t.local \
+  && git config user.name T && git add -A && git commit -q -m init ) >/dev/null 2>&1
+r3_before=$(_tree_hash "$R3F")
+bash "$SCOUT" --root "$R3F" --run-tests </dev/null >/dev/null 2>&1
+bash "$SCOUT" --root "$R3F" --run-tests </dev/null >/dev/null 2>&1
+r3_after=$(_tree_hash "$R3F")
+if [ "$r3_before" = "$r3_after" ]; then
+  pass "R3: --run-tests with a no-write test command leaves the whole tree (.git/ included) identical — Scout itself writes nothing even on its one executing path"
+else
+  fail_ "R3" "tree hash changed under --run-tests: $r3_before -> $r3_after"
+fi
+
+# ── R4: the instrument is live (non-vacuity control) ──────────────────────
+PROBE=$(newtmp); mk_bare_fixture "$PROBE"
+p1=$(_tree_hash "$PROBE")
+printf 'x\n' >> "$PROBE/notes.txt"
+p2=$(_tree_hash "$PROBE")
+if [ "$p1" != "$p2" ]; then
+  pass "R4: the tree-hash instrument registers a one-byte append (R1-R3 are not vacuous)"
+else
+  fail_ "R4" "the recipe is blind: $p1 == $p2"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== A — interface, stderr hygiene, and M5 with the new libs ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── A1: all SEVEN §8.2 sections are emitted, and none is declared missing ──
+a1=$(scout_json "$COL")
+emitted=$(jqv "$a1" '.sections | sort | join(",")')
+pending=$(jqv "$a1" '.sectionsNotEmitted | length')
+present=1
+for k in stack phaseMap reality secrets collisions testsBaseline intakePrefill; do
+  printf '%s' "$a1" | jq -e "has(\"$k\")" >/dev/null 2>&1 || present=0
+done
+if [ "$emitted" = "collisions,intakePrefill,phaseMap,reality,secrets,stack,testsBaseline" ] \
+   && [ "$pending" = "0" ] && [ "$present" -eq 1 ]; then
+  pass "A1: all seven §8.2 sections are emitted and present as keys; sectionsNotEmitted is now empty"
+else
+  fail_ "A1" "sections='$emitted' sectionsNotEmitted length='$pending' all_keys_present=$present"
+fi
+
+# ── A2: a successful scan is SILENT on stderr, new sections included ───────
+# WP1's A6, extended. gitleaks writes INF/WRN progress lines to stderr on every
+# run — measured on 8.30.1 — so this case is the net that keeps them out of
+# Scout's own stderr. `set -e` is deliberately absent from Scout, which is
+# exactly why an empty stderr is the cheapest available proof that no predicate
+# is quietly failing.
+a2_fail=""
+for f in "$SEC" "$COL" "$CI" "$TST" "$BARE" "$NONGIT" "$CLEAN"; do
+  err=$(bash "$SCOUT" --root "$f" </dev/null 2>&1 >/dev/null); rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$err" ] \
+    || a2_fail="$a2_fail [json rc=$rc err='$(printf '%s' "$err" | head -2)']"
+  err=$(bash "$SCOUT" --root "$f" --markdown </dev/null 2>&1 >/dev/null); rc=$?
+  [ "$rc" -eq 0 ] && [ -z "$err" ] \
+    || a2_fail="$a2_fail [md rc=$rc err='$(printf '%s' "$err" | head -2)']"
+done
+err=$(bash "$SCOUT" --root "$TST" --run-tests </dev/null 2>&1 >/dev/null); rc=$?
+[ "$rc" -eq 0 ] && [ -z "$err" ] \
+  || a2_fail="$a2_fail [run-tests rc=$rc err='$(printf '%s' "$err" | head -2)']"
+if [ -z "$a2_fail" ]; then
+  pass "A2: every successful scan across seven fixture shapes (json, markdown, --run-tests) writes NOTHING to stderr"
+else
+  fail_ "A2" "$a2_fail"
+fi
+
+# ── A3: the Markdown view renders the four new sections ───────────────────
+# The needles are the four EXACT headings, not loose words: "test" and
+# "intake" appear in a WP1 report already, so a substring probe would have
+# passed against a build that emitted none of these sections. It did, in this
+# suite's own first RED run.
+md=$(bash "$SCOUT" --root "$COL" --markdown </dev/null 2>/dev/null)
+md_ok=1
+for needle in \
+  "## Secrets in this project's history" \
+  "## What would collide with the framework" \
+  "## What the tests do today" \
+  "## What the interview can skip"; do
+  printf '%s' "$md" | grep -qF -- "$needle" || md_ok=0
+done
+md_leak=0
+if [ "$HAVE_GITLEAKS" -eq 1 ]; then
+  smd=$(bash "$SCOUT" --root "$SEC" --markdown </dev/null 2>/dev/null)
+  for plant_name in DIFF_PLANT CARRIER MSG_PLANT HOOK_PLANT; do
+    eval "plant=\$$plant_name"
+    printf '%s' "$smd" | grep -q -- "$plant" && md_leak=1
+  done
+fi
+if [ "$md_ok" -eq 1 ] && [ "$md_leak" -eq 0 ]; then
+  pass "A3: the human view renders all four new sections and carries none of the plants"
+else
+  fail_ "A3" "markdown missing a section heading (ok=$md_ok) or leaking a plant (leak=$md_leak)"
+fi
+
+# ── A4: M5 — Scout alone in an EMPTY tree still emits all seven sections ──
+# The new libs inherit the zero-dependency rule: no core lib, no other entry
+# script, no jq. H1's proof, re-run against the WP2 build.
+A4=$(newtmp); mk_scout_copy "$A4"
+A4F=$(newtmp); mk_collision_fixture "$A4F"
+a4=$(bash "$A4/scripts/scout.sh" --root "$A4F" </dev/null 2>/dev/null); rc=$?
+a4_sections=$(jqv "$a4" '.sections | length')
+a4_valid=0
+printf '%s' "$a4" | jq -e . >/dev/null 2>&1 && a4_valid=1
+if [ "$rc" -eq 0 ] && [ "$a4_sections" = "7" ] && [ "$a4_valid" -eq 1 ]; then
+  pass "A4 (M5): scripts/scout.sh + scripts/lib/scout/ copied ALONE into an empty tree emits all 7 sections as valid JSON"
+else
+  fail_ "A4" "rc=$rc sections=$a4_sections (want 7) valid_json=$a4_valid"
+fi
+
+# ── A5: no new Scout lib names a core lib on an executed line ─────────────
+if [ -d "$SCOUT_LIB" ]; then
+  a5_bad=""
+  for f in "$SCOUT_LIB"/scout-secrets.sh "$SCOUT_LIB"/scout-collisions.sh \
+           "$SCOUT_LIB"/scout-testsbaseline.sh "$SCOUT_LIB"/scout-prefill.sh; do
+    [ -f "$f" ] || { a5_bad="$a5_bad [missing $(basename "$f")]"; continue; }
+    if sed -e 's/[[:space:]]*#.*$//' "$f" | grep -qE '(^|[^-a-zA-Z0-9_])(intake-wizard\.sh|pre-commit-gate\.sh|check-phase-gate\.sh|tdd-classify\.sh)'; then
+      a5_bad="$a5_bad [$(basename "$f") names a core script on an executed line]"
+    fi
+  done
+  if [ -z "$a5_bad" ]; then
+    pass "A5 (M5, lexical): none of the four new libs names a core script or lib on an executed line — the prefill table is DATA, not a read of intake-wizard.sh"
+  else
+    fail_ "A5" "$a5_bad"
+  fi
+else
+  fail_ "A5" "$SCOUT_LIB does not exist"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+if [ "$SKIPPED" -gt 0 ]; then
+  echo "!! $SKIPPED case(s) SKIPPED because gitleaks is not installed — the"
+  echo "!! planted-secret proof (§6.5) DID NOT RUN. This build is not certified"
+  echo "!! against the defect WP2 exists to prevent. Install gitleaks and re-run."
+fi
+echo "Results: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0


### PR DESCRIPTION
## What

Brownfield Adoption **WP2** — Scout's remaining four report sections. The design names this the package where a defect would be worst: **its failure mode is a leaked credential in a committed artifact**, and §0.3-C7 proves the obvious implementation has exactly that bug.

- **Secrets** (`scout-secrets.sh`): full-history `gitleaks`, with **redaction as a projection, not a flag** (§6.2) — every finding object is built from exactly the seven allowlisted fields, never a passthrough, never a denylist. The schema has no `secret` field to forget to strip. Tool-absent reports *tool-unavailable*, never an empty-findings clean read; a corrupt/truncated report reports `scan-failed` rather than "0 findings".
- **Collisions** (`scout-collisions.sh`): the §1.2 surfaces inventoried and bucketed per §7.1, plus the §7.4 SDLC-undermining detector (auto-merge, deploy-around-lane, force-push, check-skipping) — loud findings, zero edits.
- **testsBaseline**: opt-in execution only (`--run-tests`); default records `commandRan:false` with the reason. A scanner that runs arbitrary project code by default is a trap.
- **intakePrefill**: the R-BF-6 deliverable — all fifteen `run_section_*` rows classified scan-derived / judgment / non-skippable, judgment rows null-valued.

## The leak-freedom proof

Two BASE32-valid synthetic keys (one in a diff, one in a commit message) plus a **carrier plant**, with the finding-count precondition asserted first so a dud fixture fails loudly instead of certifying nothing. Neither plant may appear in any byte of any artifact.

**A design-level discovery, verified independently by the reviewer:** gitleaks' `Message` field carries only the message of the commit that *produced* a finding — so a message plant on a clean commit scores zero **even under full passthrough**, making the design's own Mutation B vacuous without a carrier plant in the same commit. This is a **§6.5 design-amendment candidate**, along with the finding that the design's literal single-line Mutation A cannot expose the diff plant at all (both defenses must fail together).

Mutation structure, accordingly: XA1/XA2 each neuter one defense layer and prove the artifacts stay clean (§6.2's "necessary and not sufficient", made executable), XA neuters both (diff plant appears), and **XB is the decisive one-liner** — allowlist replaced by an 18-field passthrough leaks the message plant with `--redact` still on.

## Verification trail (fable pr-reviewer, xhigh, three rounds)

- Round 1 **major_concerns** — implementation reproduced claim-for-claim and called excellent; both blockers were in the **safety net around it**: (1) no CI job installed gitleaks, so all twelve gitleaks-gated cases — the byte-absence proof *and* every mutation proof — skipped-but-exited-0 in both lanes, meaning the design's highest-stakes property gated nothing (root cause: the supervisor's brief said "detect-and-skip"); (2) macOS `mktemp -d` ignores `TMPDIR`, so the temp-residue leg scanned a directory Scout never used — proven by neutering the cleanup trap and watching 44/0 stay green while 88 plant-bearing temp dirs accumulated.
- Fix round — gitleaks pinned to **8.30.1** with a checksum the implementer verified by download-and-hash and the reviewer re-verified two independent ways (the real asset + upstream `checksums.txt`), installed in **both** `unit-shard` and `full` (installing in one lane would move the red, not close the hole); tool-absence is now **fatal under CI**, a loud skip only locally; the temp leg repaired and proven non-vacuous by reverting the fix. Pinned deliberately where semgrep floats, with the reason recorded: gitleaks here is a **fixture oracle** (the suite asserts exact counts, the 18-field shape, BASE32 rule behaviour), not a detector.
- Round 2 took one further residual (**R-WP2-6**): a malformed pin exited 0 on Darwin's `sha256sum`, silently disabling verification. Fixed platform-independently and **extracted into `scripts/ci-verify-sha256.sh`** — deliberately, so its failure modes can be executed locally rather than assumed, which is the same unprovable-check defect one level down. Six failure modes pinned; `K7` fails if either lane's call is removed **or replaced by a comment naming it** (the BL-181 mention-vs-invocation trap, which caught its own author first).
- **Final verdict: approve**, nothing remaining at any severity.

Suite 53/0/0-skipped; WP1 35/0; run-lints 15/15; both boundary lints clean; rebased onto current main with zero drift.

## Notes

- WP1's suite rows A3/H1/H2 were re-aimed from a literal section-list snapshot to the sections-coherence invariant (they went red *for being right* once WP2 emitted four more sections). Reviewer-endorsed; blast radius verified as exactly those rows.
- Honest limits documented in-code: `--run-tests` proves *Scout* writes nothing, not the project's test command; the execution bound cannot reach a deliberately detached process; `untestedSourceFiles` is a name-match heuristic, not coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
