### PR TITLE
feat(delta): WP5 — hotfix fast lane + the retro ledger

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -389,6 +389,7 @@ jobs:
             tests/test-delta-wp2-state-policy.sh
             tests/test-delta-wp3-era-classify.sh
             tests/test-delta-wp4-close-rubric.sh
+            tests/test-delta-wp5-hotfix-retro.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -165,13 +165,76 @@ set -euo pipefail
 # brief's done-observable boxes, and the close-time re-measurement of size and
 # risk. Do not widen the wording beyond those two.
 #
-# `retro_review` IS CLOSE-REFUSING BUT NOT YET IMPLEMENTABLE, and that is
-# deliberate at this WP. A hotfix carries it (§7.2) and this flow will refuse
-# the close until it is attested — but the retro LEDGER (`hotfix_retros[]`, the
-# `due_by` arithmetic, the release-cut refusal that collateralises the deferral)
-# is §11-WP5's. Until then the token is satisfiable only by attestation, which
-# is a weaker thing than the design promises. Recorded here rather than papered
-# over.
+# ═════════════════════════════════════════════════════════════════════════════
+# THE HOTFIX FAST LANE AND THE RETRO LEDGER (WP5) — §5.2's LOAN
+#
+# A hotfix ships on the floor (§5.1: gitleaks, semgrep, project tests, TDD
+# ordering — all four already shipped, in the generated hook and in
+# pre-commit-gate.sh) plus an audit row, and NOTHING heavier: no brief, no
+# pre-build review, no Build Loop. The delta track adds NO floor arm and no
+# second copy of any of them.
+#
+# §5.2 is careful about what that is: "The hotfix lane ships on the floor alone
+# plus an audit row. It does not skip review — it DEFERS it, by exactly 3 days
+# (Karl set 3, not 7), and the deferral is COLLATERALISED: cut-release.sh
+# refuses while any retro is open (§9.2). That is what makes the fast lane a
+# loan rather than a leak." Everything below follows from reading that as a
+# loan:
+#
+#   THE AUDIT ROW IS WRITTEN AT OPEN — `# DELTA-OPEN-AUDIT-ROW`. The token is
+#   spelled `audit_row_at_open` and it means it. The stamp goes on the delta's
+#   own record in the SAME atomic write that opens it, and the gate is recorded
+#   COMPLETE at that moment. It is the one gate in the system nobody attests,
+#   because the framework wrote it rather than asking — which is exactly what
+#   distinguishes it from `ledger_row`, the operator's own BUGS.md row, which
+#   stays attested like every other class's. A hotfix that is never closed still
+#   left its trace.
+#
+#   THE OBLIGATION IS BOOKED AT OPEN — `# DELTA-OPEN-RETRO-APPEND`. One row in
+#   `hotfix_retros[]`, §7.1's five keys exactly, `due_by = shipped_at +
+#   classes.hotfix.retro_due_days` read from policy. Booked at open and not at
+#   close, because a hotfix that never reaches its close is precisely the one
+#   whose write-up nobody would otherwise be waiting for.
+#
+#   AND THE LEDGER OUTLIVES THE CLOSE — `# DELTA-CLOSE-ATOMIC-WRITE`. §7.1:
+#   "`hotfix_retros` is an array and outlives `active_delta` deliberately: an
+#   open retro must block a release cut long after its delta closed." The close
+#   filter touches `.closed` and `.active_delta` and NOTHING ELSE. If closing
+#   the delta also closed the retro, the loan would be forgiven the instant it
+#   was taken out — and every visible surface would still say the right thing.
+#   That is the defect tests/test-delta-wp5-hotfix-retro.sh's m2 builds.
+#
+#   `retro_review` IS SATISFIED BY THE OBLIGATION, NOT BY A TICK-BOX —
+#   `# DELTA-CLOSE-RETRO-BIND` and `# DELTA-GATE-RETRO-NOT-ATTESTABLE`. §7.2:
+#   "hotfix has no `close_review` because `retro_review` carries it … a separate
+#   `close_review` token on the hotfix row would either double-charge the review
+#   or, worse, let a hotfix satisfy `close_review` at ship time and make the
+#   retro optional — which is precisely the loan going unrepaid." So
+#   `--complete-gate retro_review` is REFUSED, and the close waives the token
+#   when — and only when — this delta's row is on the ledger. No row, no waiver:
+#   an obligation nobody is holding is not a deferral, it is a disappearance,
+#   and the close fails CLOSED (exit 7) rather than archiving a hotfix with no
+#   collateral behind it.
+#
+# WHY THE CLOSE IS ALLOWED TO SUCCEED WITH THE RETRO STILL OPEN, spelled out
+# because the opposite reading is the tempting one: a close that refused until
+# the retro was filed would hold the single `active_delta` slot for three days,
+# so the 3am operator who just shipped a hotfix could not open ANYTHING else
+# until they had written it up. That trades the fast lane away to enforce the
+# repayment, when §9.2 already enforces it at the only place that matters — the
+# release. The debt is announced at close, surfaced by `--status`, and called in
+# by `cut-release.sh`.
+#
+# THE INCIDENT-RESPONSE SEAM (§5.2) — DO NOT FUSE THE TWO CLOCKS.
+# `templates/generated/incident-response.tmpl` already owns the SEV→response
+# chain (Immediate / 1 h / 4 h / next window), the escalation rule, and a
+# post-incident review "within 48 hours of resolution" filed at
+# `docs/incidents/YYYY-MM-DD-<slug>.md`. None of it is duplicated here. The two
+# clocks differ ON PURPOSE and neither is wrong: 48 h governs the INCIDENT
+# write-up, `retro_due_days` governs the CODE retro. §7.2 makes both readable
+# from one place so a project can align them if it wants — that alignment is the
+# project's decision, not the framework's, so this flow neither reads the
+# template nor teaches the template to read the policy.
 #
 # ═════════════════════════════════════════════════════════════════════════════
 # THE RUBRIC PARSE CONTRACT (§5.3/§6.2) — WP8's template must match this
@@ -227,6 +290,10 @@ set -euo pipefail
 #   9  an unknown gate token — a configuration error, failing CLOSED (§5.2)
 #  10  the close-time re-measurement RAISED an attribute and added obligations,
 #      so the close refuses on the LARGER checklist          (§4.2)
+#  11  `--retro` names an id no retro on the record carries  (§7.1)
+#  12  that retro is already filed — the write-up is WRITE-ONCE, for the same
+#      reason `shipped_in` is (§7.1): overwriting it would destroy the only
+#      record of what was decided at the time
 #
 # There is NO era refusal on `--close`, and that is a decision. §10.1 places the
 # invariant's enforcement at OPEN (load-bearing) and in scripts/validate.sh
@@ -251,6 +318,8 @@ guard_not_in_framework || exit 1
 . "$SCRIPT_DIR/lib/delta-policy.sh"
 # shellcheck source=/dev/null
 . "$SCRIPT_DIR/lib/delta-classify.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/delta-cadence.sh"
 
 SEAM="$SCRIPT_DIR/process-checklist.sh"
 PHASE_STATE=".claude/phase-state.json"
@@ -263,6 +332,7 @@ USAGE="Usage:
                    [--touched-file FILE]
   scripts/delta.sh --complete-gate TOKEN
   scripts/delta.sh --close
+  scripts/delta.sh --retro DELTA-NNN --record FILE-OR-TEXT
   scripts/delta.sh --status
   scripts/delta.sh --help
 
@@ -271,7 +341,12 @@ USAGE="Usage:
   changelog entry or watch your test go red. The two it checks itself are the
   brief's done-observable boxes and the size/risk re-measurement at close.
 
-  --close runs those two checks and refuses while anything is outstanding."
+  --close runs those two checks and refuses while anything is outstanding.
+
+  --retro files the write-up a hotfix owes. Shipping a hotfix borrows the
+  checks a normal change goes through; the write-up is how you pay that
+  back, and nothing can be released until every one of them is filed.
+  Point it at a file you wrote, or type the short version in quotes."
 
 # ── The seam, and nothing but the seam ──────────────────────────────────────
 # Every state read and every state write in this file goes through here. The
@@ -504,6 +579,45 @@ _slugify() {
 # ═════════════════════════════════════════════════════════════════════════════
 # --status
 # ═════════════════════════════════════════════════════════════════════════════
+# _render_retros <state-document> — the outstanding-write-up block (§7.1/§9.2).
+#
+# Rendered in BOTH `--status` branches, because the ledger outlives the delta: a
+# surface that only showed it when nothing was open would hide the debt exactly
+# when the operator is busiest. Silent when nothing is owed — a project with no
+# outstanding write-ups should not have to read a line saying so.
+#
+# The classification is delta-cadence.sh's, not this file's, so the words the
+# operator reads and the verdict `cut-release.sh` will act on can never
+# disagree. Note `undetermined` renders as OVERDUE and SAYS WHY: a date nobody
+# can read is not a deadline that has not arrived, and rendering it as a day
+# count would invent a number the record does not contain.
+_render_retros() {
+  local doc="${1:-}" rows line id due state days
+  rows="$(delta_retro_rows "$doc")" || rows=""
+  [ -n "$rows" ] || return 0
+  echo ""
+  print_info "Write-ups you still owe — nothing can be released until these are filed:"
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    id="$(printf '%s' "$line" | cut -f1)"
+    due="$(printf '%s' "$line" | cut -f2)"
+    state="$(printf '%s' "$line" | cut -f3)"
+    days="$(printf '%s' "$line" | cut -f4)"
+    case "$state" in
+      overdue)
+        printf '  %-12s was due %s — OVERDUE by %s day(s)\n' "$id" "$due" "$days" ;;
+      current)
+        printf '  %-12s due %s — %s day(s) left\n' "$id" "$due" "$days" ;;
+      *)
+        printf '  %-12s due "%s" — that date cannot be read, so it counts as OVERDUE\n' "$id" "$due" ;;
+    esac
+  done <<EOF
+$rows
+EOF
+  print_info "File one with: scripts/delta.sh --retro <id> --record \"what happened, and what stops it happening again\""
+  return 0
+}
+
 cmd_status() {
   local doc phase
   phase="$(_current_phase)"
@@ -515,6 +629,7 @@ cmd_status() {
   print_info "Project phase: ${phase:-unknown}"
   if [ "$(printf '%s\n' "$doc" | jq -r '.active_delta == null')" = "true" ]; then
     print_info "No delta is open. Start one with: scripts/delta.sh --open"
+    _render_retros "$doc"
     echo ""
     return 0
   fi
@@ -529,6 +644,7 @@ cmd_status() {
       "  Still to do: " + (( ($d.gates_required // []) - ($d.gates_completed // []) ) | join(", ")),
       "  Done:        " + ((($d.gates_completed // []) | join(", ")) | if . == "" then "nothing yet" else . end)
   '
+  _render_retros "$doc"
   echo ""
   return 0
 }
@@ -538,6 +654,7 @@ cmd_status() {
 # ═════════════════════════════════════════════════════════════════════════════
 cmd_open() {
   local phase doc active_id pair touched lines gates obj now id slug reasons rc
+  local retro_days retro_due retro_row audit_at gates_done filter
 
   command -v jq >/dev/null 2>&1 || { print_fail "jq is required to open a delta."; return 1; }
 
@@ -662,6 +779,42 @@ cmd_open() {
       level: (if $l == "" then null else $l end),
       severity: (if $s == "" then null else $s end) }')"
 
+  # ── §5.2's HOTFIX FAST LANE (WP5) ────────────────────────────────────────
+  # Two things happen at OPEN for a hotfix and for no other class: the audit
+  # row is stamped, and the retro obligation is booked. Both ride the same
+  # atomic write as the delta itself, so there is no window in which a hotfix
+  # exists without its trace or without its debt.
+  retro_row=""
+  audit_at="null"
+  gates_done="[]"
+  if [ "$CLASS" = "hotfix" ]; then
+    # §7.2, read per key with fallback: the window is the PROJECT's number, not
+    # a literal. Neuter this read and a project that retuned it silently keeps
+    # the framework's deadline — no error, no warning, just a date nobody chose.
+    retro_days="$(delta_policy_get "." "classes.$CLASS.retro_due_days")" || retro_days=3   # DELTA-OPEN-RETRO-DUE-DAYS
+    case "$retro_days" in
+      ''|*[!0-9]*)
+        print_info "Your project's retro window is not a whole number of days, so this is using the standard 3."
+        retro_days=3 ;;
+    esac
+    if ! retro_due="$(delta_cadence_due_by "$now" "$retro_days")"; then
+      print_fail "Could not work out when the write-up would be due, so nothing was opened."
+      return 1
+    fi
+    # THE AUDIT ROW, AT OPEN. Written by the framework, so the gate is complete
+    # the moment the delta exists — the one gate nobody attests. `ledger_row`,
+    # the operator's own BUGS.md row, is untouched by this and stays attested
+    # like every other class's.
+    audit_at="$(_json_str "$now")"                                    # DELTA-OPEN-AUDIT-ROW
+    gates_done='["audit_row_at_open"]'
+    # §7.1's row, five keys, in the schema's order.
+    if ! retro_row="$(jq -c -n --arg id "$id" --arg at "$now" --arg due "$retro_due" '
+        { id: $id, shipped_at: $at, due_by: $due, closed_at: null, record: null }')"; then
+      print_fail "Could not write down the write-up you would owe, so nothing was opened."
+      return 1
+    fi
+  fi
+
   # `brief` and `ledger` stay null on purpose: §11-WP8 owns the brief template
   # and the guided intake's ledger-row write. Materialising them here would
   # invent a path to a file nothing creates yet.
@@ -669,7 +822,8 @@ cmd_open() {
     --arg id "$id" --arg slug "$slug" --arg class "$CLASS" \
     --arg at "$now" --arg via "guided" \
     --arg risk "$RISK" --arg level "$LEVEL" --arg sev "$SEV" \
-    --argjson gates "$gates" --argjson reasons "$reasons" '
+    --argjson gates "$gates" --argjson reasons "$reasons" \
+    --argjson audit "$audit_at" --argjson done "$gates_done" '
     { id: $id, slug: $slug, class: $class,
       brief: null, ledger: null,
       opened_at: $at, opened_via: $via,
@@ -677,12 +831,21 @@ cmd_open() {
                     severity: (if $sev == "" then null else $sev end) },
       attributes_confirmed_at: $at,
       attribute_reasons: $reasons,
+      audit_row_at_open: $audit,
       gates_required: $gates,
-      gates_completed: [] }')"
+      gates_completed: $done }')"
 
   # THE ONLY WRITE IN THIS FILE, AND IT IS NOT A WRITE — it is a request to the
   # single writer (§7.1/D7). delta.sh never opens the state file.
-  if ! _seam --delta-state-update ".active_delta = $obj"; then
+  #
+  # ONE filter, therefore ONE atomic rename: the delta and its obligation land
+  # together or not at all. Splitting them would leave a crash window in which a
+  # hotfix had shipped and owed nothing.
+  filter=".active_delta = $obj"
+  if [ -n "$retro_row" ]; then
+    filter="$filter | .hotfix_retros += [$retro_row]"                 # DELTA-OPEN-RETRO-APPEND
+  fi
+  if ! _seam --delta-state-update "$filter"; then
     print_fail "The delta record refused the change, so nothing was opened."
     return 1
   fi
@@ -690,6 +853,14 @@ cmd_open() {
   echo ""
   print_ok "Opened $id — $slug ($CLASS)."
   printf '%s\n' "$gates" | jq -r '"  Before this can ship: " + join(", ")'
+  if [ -n "$retro_row" ]; then
+    # §4.3's plain register, and it is read at 3am: say what was borrowed, when
+    # it is owed back, and the exact command that repays it.
+    print_info "This is the fast lane: it ships on the standard safety checks and nothing heavier."
+    print_info "That borrows the checking a normal change goes through, so you owe a write-up of what happened by $retro_due — $retro_days day(s) from now."
+    print_info "It is already on the record. Nothing can be released until you file it:"
+    print_info "  scripts/delta.sh --retro $id --record \"what happened, and what stops it happening again\""
+  fi
   print_info "Check where you are at any time with: scripts/delta.sh --status"
   echo ""
   return 0
@@ -842,6 +1013,22 @@ cmd_complete_gate() {
     return 2
   fi
 
+  # `retro_review` IS NOT ATTESTABLE (§7.2). It is the hotfix's close review,
+  # arriving late, and §7.2 names the exact failure a tick-box here would be:
+  # letting a hotfix "satisfy close_review at ship time and make the retro
+  # optional — which is precisely the loan going unrepaid". The only thing that
+  # repays it is the write-up, so the refusal points at the command that files
+  # one rather than explaining a policy.
+  if [ "$token" = "retro_review" ]; then                              # DELTA-GATE-RETRO-NOT-ATTESTABLE
+    echo ""
+    print_fail "The write-up is not something you can tick off — it is something you write."
+    print_info "Shipping fast borrowed the checking a normal change goes through, and the write-up is how you pay it back. Ticking a box here would be the borrowing with none of the paying."
+    print_info "File it with: scripts/delta.sh --retro $id --record \"what happened, and what stops it happening again\""
+    print_info "You can close $id before then — the write-up stays owed, and nothing can be released until it is filed."
+    echo ""
+    return 2
+  fi
+
   # Idempotent by design. Re-recording is the most likely repeat invocation
   # there is, and making it an error would teach the operator to fear the tool.
   already=n
@@ -877,6 +1064,7 @@ cmd_close() {
   local touched lines measured mrisk mlevel nrisk nlevel
   local newgates appended n_appended now row filter
   local brief brc boxes unchecked
+  local audit retro_state retro_q waived retro_due
 
   command -v jq >/dev/null 2>&1 || { print_fail "jq is required to close a delta."; return 1; }
 
@@ -1001,9 +1189,49 @@ EOF
     fi
   fi
 
+  # ── THE RETRO BIND (§7.2), COMPUTED BEFORE THE OUTSTANDING SET ───────────
+  # `retro_review` is not a gate the operator finishes; it is a gate the LEDGER
+  # answers. §7.2: "retro_review IS that close review, arriving late and
+  # collateralised by the §9.2 release refusal." So the token is WAIVED at close
+  # exactly when this delta's obligation is on the record — filed or still owed,
+  # both are the deferral working — and it is NOT waived when no row exists.
+  #
+  # THE NO-ROW CASE IS THE LOAD-BEARING ONE AND IT FAILS CLOSED. A hotfix whose
+  # ledger row has been erased has nothing collateralising it: closing it would
+  # archive a delta that skipped the review and owes nobody anything, which is
+  # the leak §5.2 says the fast lane must not be. That falls through to REFUSAL
+  # 3 below and refuses (7) naming retro_review, rather than being waived by the
+  # class. Neuter this line and that distinction is gone — m6.
+  #
+  # THE LOOKUP LIVES IN A VARIABLE so the VERDICT below is a SINGLE, SELF-
+  # CONTAINED LINE. That is not cosmetic: a marker sitting on the tail of a
+  # multi-line command substitution cannot be neutered by a one-line
+  # counterfactual — replacing it leaves the opening lines dangling and the
+  # mutant dies of a syntax error instead of exhibiting the defect, which reads
+  # as "the mutation was caught" while proving nothing at all.
+  retro_state="none"
+  waived="[]"
+  retro_q='
+      [ .hotfix_retros[]? | select(type == "object") | select(.id == $id) ] as $r
+    | if ($r | length) == 0 then "none"
+      elif ($r[0].closed_at == null) then "open"
+      else "filed" end'
+  if printf '%s\n' "$gates_req" | jq -e 'index("retro_review") != null' >/dev/null 2>&1; then
+    retro_state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$retro_q" 2>/dev/null)" || retro_state="none"   # DELTA-CLOSE-RETRO-BIND
+    case "$retro_state" in
+      open|filed) waived='["retro_review"]' ;;
+      *) waived="[]" ;;
+    esac
+  fi
+
   # ── REFUSAL 3 — REQUIRED GATES STILL OUTSTANDING (§5.2) ──────────────────
+  # `waived` is held SEPARATELY from `gates_completed` rather than folded into
+  # it, and that is the honest spelling: the archived checklist must not claim
+  # the operator did a write-up they have not written. The obligation's record
+  # is the ledger row, and it stays open.
   if ! outstanding="$(jq -r -n --argjson req "$gates_req" --argjson done "$gates_done" \
-      '[ $req[] | . as $g | select(($done | index($g)) == null) ] | join(", ")')"; then
+      --argjson waived "$waived" \
+      '[ $req[] | . as $g | select((($done + $waived) | index($g)) == null) ] | join(", ")')"; then
     print_fail "Could not work out what is left to do, so nothing was closed."
     return 1
   fi
@@ -1074,17 +1302,29 @@ EOF
   # would notice. Splitting this into two seam calls would additionally make the
   # window between them a crash away from exactly that state.
   now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  audit="$(printf '%s\n' "$doc" | jq -r '.active_delta.audit_row_at_open // ""')"
   if ! row="$(jq -c -n --arg id "$id" --arg class "$class" --arg sev "$sev" \
-      --arg at "$now" --arg risk "$risk" --arg level "$level" --argjson done "$gates_done" '
+      --arg at "$now" --arg risk "$risk" --arg level "$level" --argjson done "$gates_done" \
+      --arg audit "$audit" '
       ($sev | if . == "" then null else . end) as $s
       | { id: $id, class: $class, severity: $s,
           closed_at: $at, shipped_in: null,
+          audit_row_at_open: ($audit | if . == "" then null else . end),
           attributes: { risk: $risk, level: $level, severity: $s },
           gates_completed: $done }')"; then
     print_fail "Could not write up the finished record, so nothing was closed."
     return 1
   fi
 
+  # THE FILTER TOUCHES `.closed` AND `.active_delta`, AND NOTHING ELSE — most
+  # pointedly not `.hotfix_retros`. §7.1: "hotfix_retros is an array and outlives
+  # active_delta deliberately: an open retro must block a release cut long after
+  # its delta closed." A hotfix ships fast by BORROWING rigor and the retro is
+  # the repayment; a close that also closed the retro would forgive the loan the
+  # instant it was taken out, and every visible surface would still say the
+  # right thing — the delta closes, the audit tail grows, --status is clean, and
+  # nothing anywhere is ever going to ask for the write-up again. That is the
+  # mutation tests/test-delta-wp5-hotfix-retro.sh's m2 builds against this line.
   filter=".closed += [$row] | .active_delta = null"                   # DELTA-CLOSE-ATOMIC-WRITE
   if ! _seam --delta-state-update "$filter"; then
     print_fail "The delta record refused the change, so nothing was closed."
@@ -1094,7 +1334,152 @@ EOF
   echo ""
   print_ok "Closed $id ($class)."
   print_info "It is on the record with everything you ticked off, and it will be listed in the next release you cut."
+  if [ "$retro_state" = "open" ]; then
+    # ANNOUNCED, NOT MERELY RECORDED. The operator has just been allowed to
+    # close something while still owing the write-up; being told so here is the
+    # difference between a deferral and a thing they find out about at the next
+    # release cut.
+    retro_due="$(delta_retro_rows "$doc" | awk -F'\t' -v want="$id" \
+      '$1 == want { if (!f) { d = $2; f = 1 } } END { if (f) print d }')" || retro_due=""
+    echo ""
+    # Spelled as two branches rather than one `${retro_due:+…}` expansion: the
+    # house portability rule forbids a multibyte character adjacent to a
+    # variable expansion under `set -u` on bash 3.2, and the dash in the
+    # alternate word would sit exactly there.
+    if [ -n "$retro_due" ]; then
+      printf '%s\n' "  You still owe the write-up for $id, due $retro_due."
+    else
+      printf '%s\n' "  You still owe the write-up for $id."
+    fi
+    print_info "Closing this did not clear it, and nothing can be released until it is filed:"
+    print_info "  scripts/delta.sh --retro $id --record \"what happened, and what stops it happening again\""
+  fi
   print_info "Start the next one with: scripts/delta.sh --open"
+  echo ""
+  return 0
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# --retro — filing the write-up a hotfix owes (§5.2's repayment)
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# THE RECORD'S CONTRACT, STATED RATHER THAN IMPLIED. `record` is an object with
+# a `kind` and a `value`, and the kind is the honest part:
+#
+#   {"kind":"file","value":"docs/incidents/2026-08-03-checkout.md"}
+#       the value named a file THAT EXISTS when this ran. The framework has not
+#       read it and does not claim to — §5.3's tiering applies here exactly as
+#       it does to every other gate — but it did check that there is something
+#       at that path.
+#   {"kind":"attested","value":"the gateway timed out; we retry twice now"}
+#       anything else, including a path that did not resolve. A path stored as
+#       `attested` is SAID to be, out loud, at the moment it is filed: a typo'd
+#       filename recorded as though a document existed would be the framework
+#       inventing evidence.
+#
+# WRITE-ONCE, for the same reason `shipped_in` is (§7.1): a second write-up
+# claiming the same incident is a bug worth stopping, and overwriting the first
+# would destroy the only record of what was decided at the time.
+#
+# THE RETRO IS FOUND ON THE LEDGER, NOT ON `active_delta` — it outlives its
+# delta, so filing it must work long after the delta closed, and while a
+# completely different delta is open.
+cmd_retro() {
+  local doc id state state_q now kind record_json filter
+
+  id="$RETRO_ID"
+  command -v jq >/dev/null 2>&1 || { print_fail "jq is required to file a write-up."; return 1; }
+  if [ -z "$id" ]; then
+    print_fail "Name the piece of work you are writing up: scripts/delta.sh --retro DELTA-003 --record \"…\""
+    return 2
+  fi
+  if [ -z "$RECORD" ]; then
+    echo ""
+    print_fail "A write-up needs something in it."
+    print_info "Either point at the file you wrote — --record docs/incidents/2026-08-03-checkout.md — or type the short version in quotes after --record."
+    print_info "Nothing was filed."
+    echo ""
+    return 2
+  fi
+
+  if ! doc="$(_seam --delta-state-read)"; then
+    print_fail "Could not read the delta record."
+    return 1
+  fi
+
+  # ONE read of the ledger answers both refusals, and it is the mutation address
+  # for the write-once property: force it to "OPEN" and a second filing reports
+  # success while the jq filter below quietly declines to touch the already-
+  # filed row — the operator is told their write-up is on the record and it is
+  # not. That is m4.
+  #
+  # The query lives in a variable so that verdict is a SINGLE, SELF-CONTAINED
+  # LINE; a marker on the tail of a multi-line substitution cannot be neutered
+  # by a one-line counterfactual without leaving a dangling continuation, and a
+  # mutant that dies of a syntax error proves nothing.
+  state_q='
+      [ .hotfix_retros[]? | select(type == "object") | select(.id == $id) ] as $r
+    | if ($r | length) == 0 then "NOROW"
+      elif ($r[0].closed_at == null) then "OPEN"
+      else "FILED" end'
+  state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$state_q" 2>/dev/null)" || state="NOROW"   # DELTA-RETRO-STATE-GUARD
+
+  case "$state" in
+    OPEN) : ;;
+    FILED)
+      echo ""
+      print_fail "The write-up for $id is already filed."
+      printf '%s\n' "$doc" | jq -r --arg id "$id" '
+        [ .hotfix_retros[]? | select(.id == $id) ][0] as $r
+        | "  Filed \($r.closed_at // "at an unrecorded time"): \($r.record.value // "no detail recorded")"'
+      print_info "It is kept as it was written. If there is more to say, add it to that write-up rather than replacing what you decided at the time. Nothing was changed."
+      echo ""
+      return 12 ;;
+    NOROW)
+      echo ""
+      print_fail "Nothing on the record owes a write-up under the name $id."
+      print_info "Write-ups are owed by hotfixes only. See what is outstanding with: scripts/delta.sh --status"
+      print_info "Nothing was filed."
+      echo ""
+      return 11 ;;
+    *)
+      print_fail "Could not read the list of write-ups you owe. Nothing was filed."
+      return 1 ;;
+  esac
+
+  kind="attested"
+  if [ -f "$RECORD" ]; then kind="file"; fi
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  if ! record_json="$(jq -c -n --arg k "$kind" --arg v "$RECORD" '{ kind: $k, value: $v }')"; then
+    print_fail "Could not write down what you filed, so nothing was recorded."
+    return 1
+  fi
+
+  # ONE seam call, therefore ONE atomic rename. The array is rebuilt rather than
+  # indexed so the write cannot depend on a position the document might not
+  # have; every other row passes through untouched.
+  filter=".hotfix_retros = [ .hotfix_retros[]
+            | if (.id == $(_json_str "$id")) and (.closed_at == null)
+              then (.closed_at = $(_json_str "$now") | .record = $record_json)
+              else . end ]"                                           # DELTA-RETRO-CLOSE-WRITE
+  if ! _seam --delta-state-update "$filter"; then
+    print_fail "The delta record refused the change, so nothing was filed."
+    return 1
+  fi
+
+  echo ""
+  print_ok "Filed the write-up for $id."
+  if [ "$kind" = "file" ]; then
+    print_info "The record points at $RECORD."
+  else
+    print_info "Recorded as your own summary — there is no file at \"$RECORD\", so the words you typed are what is on the record."
+  fi
+  doc="$(_seam --delta-state-read)" || doc=""
+  if [ -n "$doc" ] && delta_any_open_retro "$doc"; then
+    _render_retros "$doc"
+  else
+    print_info "Nothing else is outstanding — releases are clear."
+  fi
   echo ""
   return 0
 }
@@ -1115,6 +1500,8 @@ TOUCHED_FILE=""
 TOUCHED_TMP=""
 LINES_OVERRIDE=""
 GATE_TOKEN=""
+RETRO_ID=""
+RECORD=""
 
 CLASS=""; CLASS_WHY=""
 SEV="";   SEV_WHY=""
@@ -1135,6 +1522,13 @@ while [ $# -gt 0 ]; do
     --open)     ACTION="open"; shift ;;
     --close)    ACTION="close"; shift ;;
     --complete-gate) _need "$1" $#; ACTION="complete-gate"; GATE_TOKEN="$2"; shift 2 ;;
+    --retro)    _need "$1" $#; ACTION="retro"; RETRO_ID="$2"; shift 2 ;;
+    # `--record` deliberately accepts an EMPTY value rather than rejecting it in
+    # the parser: `--record ""` and a missing `--record` are the same mistake
+    # from the operator's side, and cmd_retro answers both with one sentence
+    # about what a write-up needs. A parser-level refusal here would give the
+    # two spellings different messages for no reason.
+    --record)   _need "$1" $#; RECORD="$2"; shift 2 ;;
     --status)   ACTION="status"; shift ;;
     --describe) _need "$1" $#; DESCRIBE="$2"; shift 2 ;;
     --slug)     _need "$1" $#; SLUG="$2"; shift 2 ;;
@@ -1168,6 +1562,7 @@ case "$ACTION" in
   open)          cmd_open          || RC=$? ;;
   close)         cmd_close         || RC=$? ;;
   complete-gate) cmd_complete_gate || RC=$? ;;
+  retro)         cmd_retro         || RC=$? ;;
   status)        cmd_status        || RC=$? ;;
   *)             echo "$USAGE" >&2; RC=2 ;;
 esac

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -324,6 +324,25 @@ guard_not_in_framework || exit 1
 SEAM="$SCRIPT_DIR/process-checklist.sh"
 PHASE_STATE=".claude/phase-state.json"
 
+# ── THE ONE SPELLING OF "WHAT DOES THE LEDGER SAY ABOUT THIS DELTA?" ────────
+# `none` (no row) · `open` (owed) · `filed` (written up). TWO callers need it —
+# the close gate's waiver (`# DELTA-CLOSE-RETRO-BIND`) and `--retro`'s
+# write-once guard (`# DELTA-RETRO-STATE-GUARD`) — and an adversarial review
+# found them spelled out twice with different label vocabularies. That is the
+# sync-sibling hazard the repo has scar tissue for (`# BL-084-TIER-KEY` says
+# "SYNC SIBLINGS" for the same reason): an edit to one — say, tolerating
+# duplicate ids — would silently diverge the close's waiver from `--retro`'s
+# refusal, and nothing would fail. One definition, no siblings to keep in sync.
+#
+# `$id` is a jq variable supplied by each caller with `--arg`; bash does not
+# re-scan the expansion of this variable, so the single quotes here are the
+# whole of the quoting story.
+DELTA_RETRO_ROW_STATE_JQ='
+    [ .hotfix_retros[]? | select(type == "object") | select(.id == $id) ] as $r
+  | if ($r | length) == 0 then "none"
+    elif ($r[0].closed_at == null) then "open"
+    else "filed" end'
+
 USAGE="Usage:
   scripts/delta.sh --open [--describe TEXT] [--slug SLUG] [--confirm]
                    [--class feature|fix|hotfix|security-patch]
@@ -579,12 +598,52 @@ _slugify() {
 # ═════════════════════════════════════════════════════════════════════════════
 # --status
 # ═════════════════════════════════════════════════════════════════════════════
-# _render_retros <state-document> — the outstanding-write-up block (§7.1/§9.2).
+# _retro_dead_end_advice <class-or-empty>
+#   THE EXIT FROM THE NO-ROW STATE, NAMED (R-WP5-3). §4.3 requires a refusal to
+#   "say exactly what to do next", and an adversarial review found this path
+#   saying three things in a circle at 3am, in the lane built for 3am: `--close`
+#   pointed at `--complete-gate`, which refused and pointed at `--retro`, which
+#   refused with "nothing owes a write-up". Every command named was one that
+#   refuses.
+#
+#   There are exactly TWO ways to be here and they have DIFFERENT exits, so both
+#   are named and the class is used to say which is likely. The second is
+#   reachable with NO hand edit at all — a project that adds `retro_review` to a
+#   non-hotfix class's gates gets a permanently uncloseable delta, because only
+#   a hotfix ever books a row for the waiver to find, and nothing in the old
+#   transcript hinted that the policy was the cause.
+#
+#   ASCII bullets on purpose: these lines interpolate variables, and the house
+#   portability rule keeps multibyte characters away from expansions under
+#   `set -u` on bash 3.2.
+_retro_dead_end_advice() {
+  local class="${1:-}"
+  print_info "A write-up is only ever booked when a HOTFIX opens, and there is no row for this one. That happens in exactly two ways:"
+  print_info "  - it WAS a hotfix and the delta record lost its row. Restore the record: git checkout -- .claude/delta-state.json"
+  print_info "    (there is deliberately no command that re-books it, because a command that could would also be one that restarts the clock)"
+  if [ -n "$class" ] && [ "$class" != "hotfix" ]; then
+    print_info "  - or your own settings ask for it where it can never happen. This is a $class, and no class but hotfix books a row, so remove \"retro_review\" from classes.$class.gates in .claude/delta-policy.json."
+  else
+    print_info "  - or some class other than hotfix lists \"retro_review\" in .claude/delta-policy.json. No class but hotfix books a row, so that check can never be satisfied there — remove it from that class's gates."
+  fi
+  return 0
+}
+
+# _render_retros — the outstanding-write-up block (§7.1/§9.2).
 #
 # Rendered in BOTH `--status` branches, because the ledger outlives the delta: a
 # surface that only showed it when nothing was open would hide the debt exactly
 # when the operator is busiest. Silent when nothing is owed — a project with no
 # outstanding write-ups should not have to read a line saying so.
+#
+# IT READS STRICTLY, AND ON ITS OWN (R-WP5-2). Every other read in this file is
+# the TOLERANT one, deliberately: a corrupt state file must not stop an operator
+# closing a delta. But this block answers the release question — "what do I still
+# owe" — and for that question the tolerant read's empty-schema fallback prints
+# a clean bill of health over a file nobody could parse. So this one asks
+# `--delta-state-read-strict` and says which of the two failures it hit. Its
+# non-zero paths are the operator-facing half of the same fail-closed repair
+# that gives WP7 rc 3 and rc 4.
 #
 # The classification is delta-cadence.sh's, not this file's, so the words the
 # operator reads and the verdict `cut-release.sh` will act on can never
@@ -592,7 +651,16 @@ _slugify() {
 # can read is not a deadline that has not arrived, and rendering it as a day
 # count would invent a number the record does not contain.
 _render_retros() {
-  local doc="${1:-}" rows line id due state days
+  local doc rows line id due state days rc
+  rc=0; doc="$(_seam --delta-state-read-strict 2>/dev/null)" || rc=$?
+  if [ "$rc" -eq 3 ]; then
+    echo ""
+    print_fail "The delta record is there but cannot be read, so any write-ups you owe cannot be listed."
+    print_info "Do not read that as a clean bill of health — releases will refuse until it is repaired."
+    print_info "Restore .claude/delta-state.json from version control: git checkout -- .claude/delta-state.json"
+    return 0
+  fi
+  [ "$rc" -eq 0 ] || return 0
   rows="$(delta_retro_rows "$doc")" || rows=""
   [ -n "$rows" ] || return 0
   echo ""
@@ -629,7 +697,7 @@ cmd_status() {
   print_info "Project phase: ${phase:-unknown}"
   if [ "$(printf '%s\n' "$doc" | jq -r '.active_delta == null')" = "true" ]; then
     print_info "No delta is open. Start one with: scripts/delta.sh --open"
-    _render_retros "$doc"
+    _render_retros
     echo ""
     return 0
   fi
@@ -644,7 +712,7 @@ cmd_status() {
       "  Still to do: " + (( ($d.gates_required // []) - ($d.gates_completed // []) ) | join(", ")),
       "  Done:        " + ((($d.gates_completed // []) | join(", ")) | if . == "" then "nothing yet" else . end)
   '
-  _render_retros "$doc"
+  _render_retros
   echo ""
   return 0
 }
@@ -975,7 +1043,7 @@ _rubric_boxes() {
 # --complete-gate
 # ═════════════════════════════════════════════════════════════════════════════
 cmd_complete_gate() {
-  local doc id token gates_req present already
+  local doc id token gates_req present already gate_state gate_class
 
   token="$GATE_TOKEN"
   command -v jq >/dev/null 2>&1 || { print_fail "jq is required to record a check."; return 1; }
@@ -1023,8 +1091,17 @@ cmd_complete_gate() {
     echo ""
     print_fail "The write-up is not something you can tick off — it is something you write."
     print_info "Shipping fast borrowed the checking a normal change goes through, and the write-up is how you pay it back. Ticking a box here would be the borrowing with none of the paying."
-    print_info "File it with: scripts/delta.sh --retro $id --record \"what happened, and what stops it happening again\""
-    print_info "You can close $id before then — the write-up stays owed, and nothing can be released until it is filed."
+    # DO NOT POINT AT A COMMAND THAT WILL ALSO REFUSE (R-WP5-3). `--retro` is
+    # the right answer only when there IS a row for it to file; when there is
+    # not, that advice completes a circle instead of ending one.
+    gate_state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$DELTA_RETRO_ROW_STATE_JQ" 2>/dev/null)" || gate_state="none"
+    if [ "$gate_state" = "none" ]; then
+      gate_class="$(printf '%s\n' "$doc" | jq -r '.active_delta.class // ""' 2>/dev/null)" || gate_class=""
+      _retro_dead_end_advice "$gate_class"
+    else
+      print_info "File it with: scripts/delta.sh --retro $id --record \"what happened, and what stops it happening again\""
+      print_info "You can close $id before then — the write-up stays owed, and nothing can be released until it is filed."
+    fi
     echo ""
     return 2
   fi
@@ -1211,13 +1288,8 @@ EOF
   # as "the mutation was caught" while proving nothing at all.
   retro_state="none"
   waived="[]"
-  retro_q='
-      [ .hotfix_retros[]? | select(type == "object") | select(.id == $id) ] as $r
-    | if ($r | length) == 0 then "none"
-      elif ($r[0].closed_at == null) then "open"
-      else "filed" end'
   if printf '%s\n' "$gates_req" | jq -e 'index("retro_review") != null' >/dev/null 2>&1; then
-    retro_state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$retro_q" 2>/dev/null)" || retro_state="none"   # DELTA-CLOSE-RETRO-BIND
+    retro_state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$DELTA_RETRO_ROW_STATE_JQ" 2>/dev/null)" || retro_state="none"   # DELTA-CLOSE-RETRO-BIND
     case "$retro_state" in
       open|filed) waived='["retro_review"]' ;;
       *) waived="[]" ;;
@@ -1239,7 +1311,16 @@ EOF
     echo ""
     print_fail "$id is not finished yet."
     print_info "Still to do: $outstanding"
-    print_info "Mark one done with: scripts/delta.sh --complete-gate <name>"
+    # The no-row branch gets its own exit named, because "--complete-gate <name>"
+    # is a refusal for this particular token and pointing at it was a circle.
+    case "$retro_state,$outstanding" in
+      none,*retro_review*)
+        _retro_dead_end_advice "$class"
+        print_info "Anything else on that list is marked done with: scripts/delta.sh --complete-gate <name>"
+        ;;
+      *)
+        print_info "Mark one done with: scripts/delta.sh --complete-gate <name>" ;;
+    esac
     echo ""
     return 7
   fi
@@ -1385,7 +1466,7 @@ EOF
 # delta, so filing it must work long after the delta closed, and while a
 # completely different delta is open.
 cmd_retro() {
-  local doc id state state_q now kind record_json filter
+  local doc id state now kind record_json filter known_class rc
 
   id="$RETRO_ID"
   command -v jq >/dev/null 2>&1 || { print_fail "jq is required to file a write-up."; return 1; }
@@ -1413,20 +1494,18 @@ cmd_retro() {
   # filed row — the operator is told their write-up is on the record and it is
   # not. That is m4.
   #
-  # The query lives in a variable so that verdict is a SINGLE, SELF-CONTAINED
-  # LINE; a marker on the tail of a multi-line substitution cannot be neutered
-  # by a one-line counterfactual without leaving a dangling continuation, and a
-  # mutant that dies of a syntax error proves nothing.
-  state_q='
-      [ .hotfix_retros[]? | select(type == "object") | select(.id == $id) ] as $r
-    | if ($r | length) == 0 then "NOROW"
-      elif ($r[0].closed_at == null) then "OPEN"
-      else "FILED" end'
-  state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$state_q" 2>/dev/null)" || state="NOROW"   # DELTA-RETRO-STATE-GUARD
+  # The query is `$DELTA_RETRO_ROW_STATE_JQ`, defined once at the top of this
+  # file and shared with the close gate's waiver — see the comment there for why
+  # a second spelling is the hazard. Keeping it in a variable also makes this
+  # verdict a SINGLE, SELF-CONTAINED LINE: a marker on the tail of a multi-line
+  # substitution cannot be neutered by a one-line counterfactual without leaving
+  # a dangling continuation, and a mutant that dies of a syntax error proves
+  # nothing.
+  state="$(printf '%s\n' "$doc" | jq -r --arg id "$id" "$DELTA_RETRO_ROW_STATE_JQ" 2>/dev/null)" || state="none"   # DELTA-RETRO-STATE-GUARD
 
   case "$state" in
-    OPEN) : ;;
-    FILED)
+    open) : ;;
+    filed)
       echo ""
       print_fail "The write-up for $id is already filed."
       printf '%s\n' "$doc" | jq -r --arg id "$id" '
@@ -1435,11 +1514,17 @@ cmd_retro() {
       print_info "It is kept as it was written. If there is more to say, add it to that write-up rather than replacing what you decided at the time. Nothing was changed."
       echo ""
       return 12 ;;
-    NOROW)
+    none)
       echo ""
       print_fail "Nothing on the record owes a write-up under the name $id."
-      print_info "Write-ups are owed by hotfixes only. See what is outstanding with: scripts/delta.sh --status"
-      print_info "Nothing was filed."
+      # The class, when the record knows it, turns the generic advice into the
+      # specific one — see _retro_dead_end_advice.
+      known_class="$(printf '%s\n' "$doc" | jq -r --arg id "$id" '
+        [ (.active_delta // empty), (.closed[]? // empty) ]
+        | map(select(type == "object") | select(.id == $id) | .class)
+        | (.[0] // "")' 2>/dev/null)" || known_class=""
+      _retro_dead_end_advice "$known_class"
+      print_info "See what is outstanding with: scripts/delta.sh --status. Nothing was filed."
       echo ""
       return 11 ;;
     *)
@@ -1474,9 +1559,14 @@ cmd_retro() {
   else
     print_info "Recorded as your own summary — there is no file at \"$RECORD\", so the words you typed are what is on the record."
   fi
-  doc="$(_seam --delta-state-read)" || doc=""
-  if [ -n "$doc" ] && delta_any_open_retro "$doc"; then
-    _render_retros "$doc"
+  # rc 3 (the ledger cannot be read) must NOT print "releases are clear" — that
+  # is the fail-open sentence in its most reassuring possible costume. Capture
+  # the code rather than branching on truthiness.
+  rc=0; doc="$(_seam --delta-state-read-strict 2>/dev/null)" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    _render_retros
+  elif delta_any_open_retro "$doc"; then
+    _render_retros
   else
     print_info "Nothing else is outstanding — releases are clear."
   fi

--- a/scripts/lib/delta-cadence.sh
+++ b/scripts/lib/delta-cadence.sh
@@ -25,20 +25,43 @@
 # Names the delta, its `due_by`, and how overdue it is." That sentence names
 # exactly three things, so this file exposes exactly three shapes: a whole-
 # ledger yes/no for the refusal itself, a per-row verdict for a targeted
-# question, and a renderable row list for the message. `cut-release.sh` calls
-# them like this and needs nothing else from here:
+# question, and a renderable row list for the message.
 #
-#     doc="$(bash scripts/process-checklist.sh --delta-state-read)"
+# ★ THE CALLING SHAPE — USE THE STRICT READ, NOT THE TOLERANT ONE (R-WP5-2):
+#
+#     doc="$(bash scripts/process-checklist.sh --delta-state-read-strict)"; rc=$?
+#     case "$rc" in
+#       0) : ;;                        # a real ledger; ask it the questions below
+#       3) refuse "the delta record exists and cannot be read — repair it before
+#                  cutting a release" ;;
+#       4) refuse "there is no delta record at all" ;;   # see the note below
+#     esac
 #     if delta_any_open_retro "$doc"; then
 #       delta_retro_rows "$doc" | while IFS= read -r r; do … done   # the message
 #       exit 1                                                       # the refusal
 #     fi
 #
+# WHY `--delta-state-read-strict` AND NOT `--delta-state-read`. The tolerant
+# read answers a corrupt file with the EMPTY SCHEMA at rc 0 (warning on stderr
+# only) and an ABSENT file with the empty schema in complete silence. An
+# adversarial review walked that straight through the shape this header used to
+# document: with a retro owed, corrupting the state file — or `rm`-ing it —
+# made `delta_any_open_retro` answer "nothing owed", so §9.2's refusal never
+# fired. That is BL-213's fail-open class one level up from the dates this file
+# already refuses it for. Illegibility of a due DATE is treated as overdue;
+# illegibility of the LEDGER must not be treated as absolution.
+#
+# ON rc 4 (no state file at all): a project that has never opened a delta has
+# nothing to release either — §9.1 already refuses a cut with "nothing closed
+# since the last tag" — so treating 4 as a refusal costs a real project nothing
+# and closes the one-keystroke erasure. It is a SEPARATE code from 3 so the
+# caller can say which one happened; do not collapse them.
+#
 # EVERY FUNCTION TAKES THE STATE DOCUMENT, NOT A PROJECT ROOT, and that is the
 # design rather than an inconvenience. `.claude/delta-state.json` has ONE reader
 # and ONE writer (§7.1/D7) — scripts/lib/delta-state.sh, reached through the
 # seam. A cadence lib that opened the file itself would be a second reader, and
-# the single-reader property is what makes the shape fallback in
+# the single-reader property is what makes the fallback contract in
 # delta_state_read a guarantee for every consumer instead of a local courtesy.
 # So callers read once, through the seam, and pass the document down.
 #
@@ -52,22 +75,36 @@
 #         0  OVERDUE — due_by is in the past, OR could not be read at all
 #         1  open and not yet due
 #         2  there is no OPEN retro with that id (filed, or no such row)
+#         3  UNDETERMINED — that document is not a readable ledger
 #     delta_any_open_retro <doc>
-#         0  at least one row has closed_at == null      1  none
+#         0  at least one row has closed_at == null   1  none   3 UNDETERMINED
 #     delta_any_overdue_retro <doc>
-#         0  at least one OPEN row is overdue or unreadable    1  none
+#         0  at least one OPEN row is overdue or unreadable
+#         1  none                                     3 UNDETERMINED
 #     delta_retro_rows <doc>
-#         one TSV row per OPEN retro, always rc 0:
+#         one TSV row per OPEN retro, rc 0:
 #             id <TAB> due_by <TAB> state <TAB> days
 #         state ∈ current | overdue | undetermined
 #         days  = whole days OVERDUE for `overdue`, whole days REMAINING for
 #                 `current`, and the literal `-` for `undetermined` (there is no
 #                 number to give, and inventing one is how a placeholder becomes
 #                 a fact three surfaces downstream)
+#         rc 3 and NOTHING printed when the document is not a readable ledger
 #
-# THE PREDICATES RETURN 1 IN THE ORDINARY CASE, so a caller under `set -e` must
-# use them in an `if`, `||` or `!` context. A bare call would abort the script.
-# That is the shell's own convention for a predicate and is deliberate.
+# ★ rc 3 IS THE SECOND HALF OF THE FAIL-CLOSED REPAIR, and it is deliberately
+# NOT folded into 1 ("none owed") or 2 ("no such open retro"). A caller that
+# treated "I cannot read the ledger" as "nothing is owed" is the defect; a
+# caller that treats it as a refusal is correct. The strict read above is what
+# normally prevents a caller ever seeing it — this is the backstop for a caller
+# that acquired the document some other way (a `cat`, a pipeline, a future
+# surface), because a contract that only holds when everyone uses the right
+# front door is a convention, not a property.
+#
+# THE PREDICATES RETURN NON-ZERO IN THE ORDINARY CASE, so a caller under `set -e`
+# must use them in an `if`, `||` or `!` context — and one that cares about the
+# difference between "no" and "cannot tell" must capture `$?` rather than
+# branching on truthiness alone. That is the shell's own convention for a
+# predicate and is deliberate.
 #
 # ═════════════════════════════════════════════════════════════════════════════
 # FAIL-CLOSED ON AN UNREADABLE DATE — BL-213's CLASS, AND WHY IT IS HERE
@@ -208,6 +245,20 @@ delta_cadence_due_by() {
 # THE LEDGER LAYER — §7.1's `hotfix_retros[]`, read as obligations
 # ─────────────────────────────────────────────────────────────────────────────
 
+# _delta_cadence_readable <state-document>
+#   rc 0 iff the argument is a document this file can answer questions about: it
+#   parses as JSON AND carries a `hotfix_retros` ARRAY. Anything else — an empty
+#   string, a truncated file, a JSON array, a document with no ledger key — is
+#   UNDETERMINED, and every public function below turns that into rc 3 rather
+#   than into an answer.
+#
+#   THE EMPTY LEDGER IS NOT UNDETERMINED. `hotfix_retros: []` is a real, readable
+#   answer meaning "nothing owed"; only an unreadable DOCUMENT is undetermined.
+#   Conflating the two would make every healthy project's release refuse.
+_delta_cadence_readable() {
+  printf '%s\n' "${1:-}" | jq -e '(type == "object") and ((.hotfix_retros | type) == "array")' >/dev/null 2>&1
+}
+
 # _delta_cadence_open_rows <state-document>
 #   `id<TAB>due_by` for every OPEN row (closed_at == null), in ledger order.
 #   A row with no `due_by`, or a null one, yields an EMPTY second field on
@@ -234,6 +285,7 @@ _delta_cadence_open_rows() {
 #   which is the fail-OPEN answer wearing the fail-closed one's clothes.
 delta_retro_rows() {
   local doc="${1:-}" now line id due e delta days state
+  _delta_cadence_readable "$doc" || return 3                          # DELTA-CADENCE-LEDGER-UNDETERMINED-ROWS
   now="$(date -u +%s 2>/dev/null)" || now=""
   case "$now" in ''|*[!0-9]*) now=0 ;; esac
   while IFS= read -r line; do
@@ -271,6 +323,7 @@ EOF
 #   the caller is an abort, not a verdict.
 delta_retro_overdue() {
   local doc="${1:-}" id="${2:-}" row state
+  _delta_cadence_readable "$doc" || return 3                          # DELTA-CADENCE-LEDGER-UNDETERMINED-ONE
   [ -n "$id" ] || return 2
   row="$(delta_retro_rows "$doc" | awk -F'\t' -v want="$id" \
     '$1 == want { if (!found) { r = $0; found = 1 } } END { if (found) print r }')" || row=""
@@ -288,6 +341,7 @@ delta_retro_overdue() {
 #   overdue or not, because the collateral is the obligation itself.
 delta_any_open_retro() {
   local doc="${1:-}" n
+  _delta_cadence_readable "$doc" || return 3                          # DELTA-CADENCE-LEDGER-UNDETERMINED-ANYOPEN
   n="$(printf '%s\n' "$doc" | jq -r \
     '[.hotfix_retros[]? | select(type == "object") | select(.closed_at == null)] | length' 2>/dev/null)" || n=0
   case "$n" in ''|*[!0-9]*) n=0 ;; esac
@@ -300,6 +354,7 @@ delta_any_open_retro() {
 #   the release refusal, which uses the one above.
 delta_any_overdue_retro() {
   local doc="${1:-}" hit
+  _delta_cadence_readable "$doc" || return 3                          # DELTA-CADENCE-LEDGER-UNDETERMINED-ANYOVERDUE
   hit="$(delta_retro_rows "$doc" | awk -F'\t' \
     '$3 == "overdue" || $3 == "undetermined" { n = n + 1 } END { if (n > 0) print "y" }')" || hit=""
   [ -n "$hit" ]

--- a/scripts/lib/delta-cadence.sh
+++ b/scripts/lib/delta-cadence.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# scripts/lib/delta-cadence.sh — the delta module's DATE ARITHMETIC: the hotfix
+# retro ledger's due/overdue predicates, and the parse helper they and §8.3's
+# cadence checker are both built on.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §5.2 (the hotfix row, and
+# "reading the hotfix row honestly" — the fast lane is a LOAN, collateralised by
+# the release refusal), §7.1 (`hotfix_retros[]`, an array that OUTLIVES
+# `active_delta` deliberately: "an open retro must block a release cut long
+# after its delta closed"), §7.2 (`classes.hotfix.retro_due_days`), §9.2 (the
+# release refusals — refusal 2 is this file's whole reason to exist), §3.1 (a
+# member of the severable delta module's inventory), §11-WP5.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose — no backlog
+# entry exists for this build, and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1,
+# WP2, WP3 and WP4 precedent. The grep-able `DELTA-CADENCE-*` markers below are
+# this file's citation primitive and its mutation addresses.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE INTERFACE WP7's `scripts/cut-release.sh` CONSUMES — designed for it
+#
+# §9.2's second refusal is "any `hotfix_retros[]` with `closed_at == null`.
+# Names the delta, its `due_by`, and how overdue it is." That sentence names
+# exactly three things, so this file exposes exactly three shapes: a whole-
+# ledger yes/no for the refusal itself, a per-row verdict for a targeted
+# question, and a renderable row list for the message. `cut-release.sh` calls
+# them like this and needs nothing else from here:
+#
+#     doc="$(bash scripts/process-checklist.sh --delta-state-read)"
+#     if delta_any_open_retro "$doc"; then
+#       delta_retro_rows "$doc" | while IFS= read -r r; do … done   # the message
+#       exit 1                                                       # the refusal
+#     fi
+#
+# EVERY FUNCTION TAKES THE STATE DOCUMENT, NOT A PROJECT ROOT, and that is the
+# design rather than an inconvenience. `.claude/delta-state.json` has ONE reader
+# and ONE writer (§7.1/D7) — scripts/lib/delta-state.sh, reached through the
+# seam. A cadence lib that opened the file itself would be a second reader, and
+# the single-reader property is what makes the shape fallback in
+# delta_state_read a guarantee for every consumer instead of a local courtesy.
+# So callers read once, through the seam, and pass the document down.
+#
+# EXIT CODES ARE THE ANSWER; NOTHING HERE PRINTS PROSE. CLAUDE.md's `[WARN]`
+# trap is that a label and an exit predicate can disagree, so the predicates
+# below have no labels to disagree with. The one function that prints
+# (delta_retro_rows) prints DATA — tab-separated fields for a caller to render —
+# never a sentence.
+#
+#     delta_retro_overdue <doc> <id>
+#         0  OVERDUE — due_by is in the past, OR could not be read at all
+#         1  open and not yet due
+#         2  there is no OPEN retro with that id (filed, or no such row)
+#     delta_any_open_retro <doc>
+#         0  at least one row has closed_at == null      1  none
+#     delta_any_overdue_retro <doc>
+#         0  at least one OPEN row is overdue or unreadable    1  none
+#     delta_retro_rows <doc>
+#         one TSV row per OPEN retro, always rc 0:
+#             id <TAB> due_by <TAB> state <TAB> days
+#         state ∈ current | overdue | undetermined
+#         days  = whole days OVERDUE for `overdue`, whole days REMAINING for
+#                 `current`, and the literal `-` for `undetermined` (there is no
+#                 number to give, and inventing one is how a placeholder becomes
+#                 a fact three surfaces downstream)
+#
+# THE PREDICATES RETURN 1 IN THE ORDINARY CASE, so a caller under `set -e` must
+# use them in an `if`, `||` or `!` context. A bare call would abort the script.
+# That is the shell's own convention for a predicate and is deliberate.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# FAIL-CLOSED ON AN UNREADABLE DATE — BL-213's CLASS, AND WHY IT IS HERE
+#
+# §14-V13 records the shipped sibling defect: scripts/check-maintenance.sh
+# resolves an unparseable date to epoch 0, then guards every arm with
+# `[ "$last_epoch" -gt 0 ]`, so a scan file it could not read is skipped
+# ENTIRELY and the script prints "All maintenance cadences current" and exits 0.
+# A date nobody could read became a clean bill of health. WP6 repairs that
+# script by adding an `undetermined` counter and a new exit 2.
+#
+# This file must not reproduce it, and the direction is not symmetric with
+# check-maintenance's. There, the unreadable value is a LAST-DONE date and the
+# fail-closed answer is "assume it is ancient". Here it is a DUE date and the
+# fail-closed answer is "assume it has passed" — an unreadable `due_by` is
+# OVERDUE, an absent one is OVERDUE, and a `null` one is OVERDUE. The collateral
+# on a loan cannot be released because the paperwork became illegible.
+#
+# Concretely: delta_cadence_epoch returns non-zero AND PRINTS NOTHING when
+# neither parser accepts its input — printing a stale or zero value would let a
+# caller that ignored the return code read it as a date, which is exactly the
+# `|| echo "0"` shape that produced the original defect. Its one caller,
+# delta_retro_rows, turns that failure into `undetermined`, and BOTH overdue
+# predicates count `undetermined` as overdue. The atom is
+# `# DELTA-CADENCE-UNPARSEABLE` and tests/test-delta-wp5-hotfix-retro.sh's m3
+# neuters it to prove the exit code moves.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE TWO CLOCKS ARE DIFFERENT ON PURPOSE, AND NEITHER IS BUILT INTO THE OTHER
+#
+# §5.2: `templates/generated/incident-response.tmpl` already owns the
+# SEV→response-time notification chain (Immediate / 1 h / 4 h / next window),
+# the escalation rule, and a post-incident review "within 48 hours of
+# resolution" filed at `docs/incidents/YYYY-MM-DD-<slug>.md`. NONE of that is
+# duplicated here or anywhere in the delta track. The incident template's 48 h
+# governs the INCIDENT write-up; `retro_due_days` governs the CODE retro; they
+# are deliberately different clocks and both are readable from
+# `.claude/delta-policy.json` so a project can align them if it wants to. Do not
+# make this file read the incident template, and do not make the incident
+# template read this policy — the whole point of §7.2 holding both is that the
+# alignment is the PROJECT's decision and not the framework's.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# DEPENDENCY DIRECTION (D1)
+#   delta -> core is allowed and deliberately unasserted. core -> delta is
+#   forbidden and lint-enforced by scripts/lint-delta-boundary.sh, with ONE
+#   allowlisted seam. This file sources nothing at all.
+#
+# BASH 3.2 COMPATIBILITY
+#   macOS ships bash 3.2.57. No associative arrays, no ${var,,}, no `((x++))`.
+#   Every function is errexit-safe: this lib is sourced into scripts/delta.sh
+#   (and, in WP7, scripts/cut-release.sh), both of which run under
+#   `set -euo pipefail`, so no bare command is left to fail on its own.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THE PARSE LAYER — GNU-first, BSD fallback, and NO third answer
+# ─────────────────────────────────────────────────────────────────────────────
+
+# delta_cadence_epoch <stamp>
+#   Echo the UTC epoch seconds of `YYYY-MM-DDTHH:MM:SSZ` or of a bare
+#   `YYYY-MM-DD`. rc 0 and the number on success; rc 1 AND NO OUTPUT when
+#   neither parser accepts it. There is no third answer and no default — see the
+#   fail-closed block in this file's header for why a `|| echo 0` tail is the
+#   shape that produced the defect this function exists to avoid.
+#
+#   THE ORDER IS GNU-FIRST, AND IT IS SAFE IN BOTH DIRECTIONS BECAUSE EACH
+#   PARSER REJECTS THE OTHER'S SPELLING. On macOS `date -d` is an ILLEGAL OPTION
+#   (rc 1, usage on stderr, nothing on stdout) — it does not silently succeed
+#   with some other meaning, which is the failure that would matter here: BSD's
+#   `-d` sets the kernel's daylight-saving value, and a version of it that
+#   accepted the argument and printed `now` would make every date on this host
+#   parse as today. Verified on the host (GNU bash 3.2.57, Darwin) before this
+#   order was chosen. On GNU, `date -j -f` is likewise rejected. The shipped
+#   idiom in scripts/check-maintenance.sh spells the same pair BSD-first for the
+#   same reason; either order works, and this one matches §11-WP5's brief.
+#
+#   A BARE DATE IS NORMALISED TO MIDNIGHT UTC BEFORE EITHER PARSER SEES IT, and
+#   that is not tidiness. BSD's `date -j -f` fills fields the format did not
+#   specify FROM THE CURRENT TIME, so `date -u -j -f '%Y-%m-%d' 2026-08-03 +%s`
+#   answers "2026-08-03 at whatever o'clock it is right now" — a different
+#   number every time it is called, and a different number from GNU's answer for
+#   the same input. Appending `T00:00:00Z` makes the two hosts agree exactly.
+#
+#   The STRUCTURAL gate below is a shape check, not a validity check: it rejects
+#   inputs that are not date-shaped at all (empty, `banana`, an ISO stamp with
+#   an offset instead of `Z`) and passes date-SHAPED nonsense like `2026-13-45`
+#   through to the real parser, which is what must reject it. A gate that tried
+#   to validate month and day ranges here would be a second, worse date library.
+delta_cadence_epoch() {
+  local s="${1:-}" e=""
+  case "$s" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+      s="${s}T00:00:00Z" ;;                                          # DELTA-CADENCE-BARE-DATE
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z)
+      : ;;
+    *) return 1 ;;
+  esac
+  e="$(date -u -d "$s" +%s 2>/dev/null)" || e=""                     # DELTA-CADENCE-EPOCH-GNU
+  if [ -z "$e" ]; then
+    e="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$s" +%s 2>/dev/null)" || e=""   # DELTA-CADENCE-EPOCH-BSD
+  fi
+  # Digits only. A leading `-` (a pre-1970 stamp) is refused rather than
+  # accepted, which is the fail-closed direction for a DUE date: an obligation
+  # dated before the epoch is not a current one.
+  case "$e" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$e"
+  return 0
+}
+
+# delta_cadence_stamp <epoch-seconds>
+#   The inverse: epoch -> `YYYY-MM-DDTHH:MM:SSZ`, the spelling §7.1's schema
+#   uses. Same two-host pattern, same no-default contract.
+delta_cadence_stamp() {
+  local n="${1:-}" out=""
+  case "$n" in ''|*[!0-9]*) return 1 ;; esac
+  out="$(date -u -d "@$n" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || out=""
+  if [ -z "$out" ]; then
+    out="$(date -u -r "$n" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || out=""
+  fi
+  [ -n "$out" ] || return 1
+  printf '%s\n' "$out"
+  return 0
+}
+
+# delta_cadence_due_by <shipped-at> <days>
+#   §7.1's `due_by = shipped_at + policy.retro_due_days`, as one call. rc 1 when
+#   the stamp cannot be read or `days` is not a whole number — the caller
+#   (scripts/delta.sh's hotfix lane) refuses the open rather than writing a row
+#   whose deadline is a guess.
+delta_cadence_due_by() {
+  local at="${1:-}" days="${2:-}" e
+  case "$days" in ''|*[!0-9]*) return 1 ;; esac
+  e="$(delta_cadence_epoch "$at")" || return 1
+  delta_cadence_stamp "$((e + days * 86400))"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THE LEDGER LAYER — §7.1's `hotfix_retros[]`, read as obligations
+# ─────────────────────────────────────────────────────────────────────────────
+
+# _delta_cadence_open_rows <state-document>
+#   `id<TAB>due_by` for every OPEN row (closed_at == null), in ledger order.
+#   A row with no `due_by`, or a null one, yields an EMPTY second field on
+#   purpose: empty is not date-shaped, so delta_cadence_epoch refuses it and the
+#   row lands in `undetermined`. Absence and illegibility are the same answer
+#   here, which is the fail-closed direction.
+_delta_cadence_open_rows() {
+  printf '%s\n' "${1:-}" | jq -r '
+      .hotfix_retros[]?
+    | select(type == "object")
+    | select(.closed_at == null)
+    | [ (.id // ""), (.due_by // "" | tostring) ]
+    | @tsv' 2>/dev/null || true
+  return 0
+}
+
+# delta_retro_rows <state-document>
+#   `id<TAB>due_by<TAB>state<TAB>days` for every OPEN retro. Always rc 0 — an
+#   empty ledger is not an error, it is the answer "nothing is owed".
+#
+#   The classification lives HERE and not in jq because jq cannot tell a date it
+#   cannot parse from one it can: `strptime` errors out and takes the whole
+#   program with it, so the "unreadable" branch would become "no rows at all",
+#   which is the fail-OPEN answer wearing the fail-closed one's clothes.
+delta_retro_rows() {
+  local doc="${1:-}" now line id due e delta days state
+  now="$(date -u +%s 2>/dev/null)" || now=""
+  case "$now" in ''|*[!0-9]*) now=0 ;; esac
+  while IFS= read -r line; do
+    [ -n "$line" ] || continue
+    id="$(printf '%s' "$line" | cut -f1)"
+    due="$(printf '%s' "$line" | cut -f2)"
+    if e="$(delta_cadence_epoch "$due")"; then
+      delta=$((now - e))
+      if [ "$delta" -ge 0 ]; then
+        state=overdue; days=$((delta / 86400))
+      else
+        state=current; days=$(((0 - delta) / 86400))
+      fi
+    else
+      state=undetermined; days="-"                                   # DELTA-CADENCE-UNPARSEABLE
+    fi
+    printf '%s\t%s\t%s\t%s\n' "$id" "$due" "$state" "$days"
+  done <<EOF
+$(_delta_cadence_open_rows "$doc")
+EOF
+  return 0
+}
+
+# delta_retro_overdue <state-document> <delta-id>
+#   0 OVERDUE (past due, or a due date nobody can read) · 1 open and not yet
+#   due · 2 no OPEN retro with that id. The third code matters to WP7: "this
+#   delta's retro is filed" and "this delta's retro is late" must never collapse
+#   into one answer at a release cut.
+#
+#   The lookup consumes ALL of delta_retro_rows' output (the awk keeps the first
+#   match in a variable and prints it in END rather than calling `exit`). That
+#   is the SIGPIPE trap written up on scripts/lint-delta-boundary.sh's T1 scan:
+#   an early-exiting downstream stage kills the upstream writer, and `pipefail`
+#   promotes rc 141 into the enclosing substitution — which under `set -e` in
+#   the caller is an abort, not a verdict.
+delta_retro_overdue() {
+  local doc="${1:-}" id="${2:-}" row state
+  [ -n "$id" ] || return 2
+  row="$(delta_retro_rows "$doc" | awk -F'\t' -v want="$id" \
+    '$1 == want { if (!found) { r = $0; found = 1 } } END { if (found) print r }')" || row=""
+  [ -n "$row" ] || return 2
+  state="$(printf '%s' "$row" | cut -f3)"
+  case "$state" in
+    overdue|undetermined) return 0 ;;                                # DELTA-CADENCE-OVERDUE-VERDICT
+    *) return 1 ;;
+  esac
+}
+
+# delta_any_open_retro <state-document>
+#   §9.2's second refusal, as a predicate: 0 when ANY retro is unfiled. Note it
+#   asks nothing about due dates — the release refusal fires on an OPEN retro,
+#   overdue or not, because the collateral is the obligation itself.
+delta_any_open_retro() {
+  local doc="${1:-}" n
+  n="$(printf '%s\n' "$doc" | jq -r \
+    '[.hotfix_retros[]? | select(type == "object") | select(.closed_at == null)] | length' 2>/dev/null)" || n=0
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  [ "$n" -gt 0 ]
+}
+
+# delta_any_overdue_retro <state-document>
+#   0 when any OPEN retro is overdue OR undetermined. This is the narrower
+#   signal — for a nag surface (§8.3's SessionStart arm, WP6) rather than for
+#   the release refusal, which uses the one above.
+delta_any_overdue_retro() {
+  local doc="${1:-}" hit
+  hit="$(delta_retro_rows "$doc" | awk -F'\t' \
+    '$3 == "overdue" || $3 == "undetermined" { n = n + 1 } END { if (n > 0) print "y" }')" || hit=""
+  [ -n "$hit" ]
+}

--- a/scripts/lib/delta-state.sh
+++ b/scripts/lib/delta-state.sh
@@ -148,7 +148,19 @@ DELTA_STATE_EMPTY_EOF
 #     open delta in place stays fully allowed; that is what every legitimate
 #     write does.
 #   • cadence's INNER keys and date formats — §8.3/WP6 defines them.
-#   • hotfix_retros' ROW shape — §11-WP5 materialises those rows.
+#   • hotfix_retros' ROW shape — deferred to §11-WP5, and PAID BY WP5, but
+#     deliberately NOT here. The guard lives on the WRITE side only
+#     (DELTA_RETRO_ROW_SHAPE + _delta_state_retros_is_lawful below), and the
+#     reason is this predicate's own read-side fallback: delta_state_read
+#     answers a shape violation with the EMPTY SCHEMA. Put a retro row-shape
+#     atom in here and one malformed row would make the whole ledger read as
+#     zero retros — turning a single bad row into total loan forgiveness, which
+#     is precisely the defect the guard exists to prevent, amplified. So this
+#     predicate keeps saying only "hotfix_retros is an array" (a document that
+#     survives to be repaired), and the write side is where rows are held to
+#     their shape. The same amplification is latent in SHAPE-ATOM-CLOSED-ROWS
+#     above for the audit tail; that is pre-existing and not changed here, but
+#     it is the reason no new row-type atom joins it.
 #   • active_delta's inner fields — WP3/WP4 materialise them at open.
 # Each atom is `and ( … )` on its own line with a trailing marker, so a
 # counterfactual neuters exactly one by replacing the marked line with
@@ -197,6 +209,55 @@ delta_state_read() {
     printf '%s\n' "delta-state: $f parses but is not a state document (schemaVersion present; active_delta object-or-null; hotfix_retros/closed arrays; cadence object) — reading the empty schema instead. The file was NOT modified; repair or delete it." >&2
     delta_state_default_json
     return 0
+  fi
+  jq . "$f"
+}
+
+# delta_state_read_strict [project_root]
+#   THE FAIL-CLOSED READ (R-WP5-2, added in WP5). Same document as
+#   delta_state_read, but it NEVER falls back — because for one class of caller
+#   the fallback is the bug.
+#
+#     file present and a valid state document -> the document, rc 0
+#     file present, unparseable or wrong shape -> NOTHING on stdout, rc 3
+#     file ABSENT                              -> NOTHING on stdout, rc 4
+#
+#   WHY THIS EXISTS AND WHY IT DOES NOT REPLACE delta_state_read. The tolerant
+#   read is correct for every per-delta operation: one bad file must not kill
+#   the whole toolchain, and the warning plus the empty schema keeps `--open`
+#   and `--close` usable. But an adversarial review showed what it costs the ONE
+#   caller whose question is "does anything block a release": with a retro owed,
+#   corrupting `.claude/delta-state.json` makes the read return the empty schema
+#   at rc 0 (warning on stderr only) and DELETING it is completely silent — so
+#   `delta_any_open_retro` answers "nothing owed" and §9.2's refusal never
+#   fires. `rm .claude/delta-state.json` was loan forgiveness in one keystroke,
+#   and the corrupt-file warning's own advice ("repair or delete it") named the
+#   erasure path.
+#
+#   That is BL-213's fail-open class one level up from the dates WP5 already
+#   refused it for: illegibility of a ROW is treated as overdue, so illegibility
+#   of the LEDGER must not be treated as absolution.
+#
+#   THE TWO NON-ZERO CODES ARE DISTINCT ON PURPOSE. 3 means "there is a record
+#   here and I cannot read it" — always a refusal. 4 means "there is no record
+#   at all", which for a project that has never opened a delta is the truth and
+#   not a hazard; the caller decides, and scripts/lib/delta-cadence.sh's header
+#   tells WP7 what to decide. Collapsing them would force one of the two into
+#   the wrong answer.
+#
+#   NOTHING IS PRINTED ON STDOUT IN THE FAILURE CASES. A caller that ignored the
+#   return code would otherwise read a document that does not exist — the same
+#   shape as the `|| echo 0` default WP5's date layer refuses to have.
+delta_state_read_strict() {
+  local root="${1:-.}" f
+  f="$(delta_state_path "$root")"
+  if [ ! -f "$f" ]; then
+    printf '%s\n' "delta-state: $f does not exist. If this project has ever opened a delta, that file is its record and it is gone — restore it from version control before relying on anything that reads it." >&2
+    return 4                                                          # DELTA-STATE-STRICT-ABSENT
+  fi
+  if ! jq -e "( $DELTA_STATE_SHAPE )" "$f" >/dev/null 2>&1; then
+    printf '%s\n' "delta-state: $f exists but cannot be read as a delta record. Nothing may conclude anything from it — least of all that nothing is outstanding. The file was NOT modified; repair it from version control." >&2
+    return 3                                                          # DELTA-STATE-STRICT-UNREADABLE
   fi
   jq . "$f"
 }
@@ -357,6 +418,121 @@ _delta_state_active_is_not_replaced() {
   ' >/dev/null 2>&1
 }
 
+# ── THE RETRO LEDGER'S GUARD (R-WP5-1, added in WP5) ─────────────────────────
+#
+# WHAT WAS WRONG. `closed` is a protected audit tail; `hotfix_retros` is the
+# COLLATERAL that §9.2's release refusal is built on, and until now it had
+# nothing at all. An adversarial review demonstrated the whole family through
+# the seam, every one at rc 0: `.hotfix_retros = []` (wipe), a forged
+# `closed_at` (debt "repaid" with a record nobody wrote), `due_by` pushed to
+# 2999, an id swapped out, and `["paid"]` — string rows, which pass an
+# array-only check AND read as "nothing owed", because every consumer correctly
+# does `select(type == "object")`. The only refusal was making the value not an
+# array at all. Post-close there was no backstop of any kind: nothing ever asks
+# for the row again, so a wipe was permanent, silent loan forgiveness.
+#
+# The deferral note above named §11-WP5 as the owner of this. WP5 materialised
+# the rows and shipped without the guard; this is that debt paid.
+#
+# TWO PREDICATES, NOT ONE, because they answer different questions and deserve
+# different sentences to the operator:
+#   SHAPE     — is every row in the CANDIDATE a well-formed §7.1 row? Needs no
+#               previous file, so it also guards a first-ever write.
+#   LAWFUL    — is the transition from the PREVIOUS ledger to this one one of
+#               the two things that may legitimately happen to it?
+#
+# THE TWO LEGAL MUTATIONS, and nothing else:
+#   • APPEND an OPEN row at the end (closed_at null, record null).
+#   • FILE at most one existing OPEN row: closed_at null -> non-empty string AND
+#     record null -> object, with the rest of that row byte-identical.
+# Everything else — drop, reorder, replace, un-file, re-file, or edit an
+# existing row's id/shipped_at/due_by — is refused.
+#
+# WHAT THIS DELIBERATELY DOES NOT DO, stated so the comment stops over-claiming:
+# it protects the ledger against SILENT LOSS, not against an operator who files
+# a write-up that says nothing true. A crafted filter that files a row with a
+# real record object is indistinguishable at this layer from `--retro`, and it
+# should be — the same boundary ACTIVE-ATOM-NO-REPLACE draws when it says it
+# protects identity and not content. What it buys is that the OBLIGATION cannot
+# be made to disappear, which is the property §9.2 spends.
+#
+# SCOPED TO THE `append` RULE. The `ship` pathway already requires everything
+# outside `closed` to be byte-identical (SHIP-ATOM-OUTSIDE), so retros cannot
+# move there; running these there too would only add a way for a hand-mangled
+# ledger to lock `cut-release.sh` out of recording shipped_in.
+
+# DELTA_RETRO_ROW_SHAPE — every row of the CANDIDATE is a well-formed §7.1 row.
+#
+# EACH ATOM AFTER THE FIRST IS VACUOUS FOR A NON-OBJECT ROW (`(type != "object")
+# or …`), and that is what makes RETRO-ATOM-ROW-OBJECT independently pinnable:
+# without it the later atoms would refuse a string row for their own reasons and
+# neutering it would change nothing observable, which is the "atom that looks
+# like a guard and is not" WP2 deleted three of. The short-circuit also keeps
+# `keys` off a string, where it would ERROR — and an error refuses the write,
+# which is the same masking wearing a different hat.
+DELTA_RETRO_ROW_SHAPE='
+    (true)
+    and (all(.hotfix_retros[]?; type == "object"))                                                                     # RETRO-ATOM-ROW-OBJECT
+    and (all(.hotfix_retros[]?; (type != "object") or ((keys) == ["closed_at","due_by","id","record","shipped_at"])))   # RETRO-ATOM-ROW-KEYS
+    and (all(.hotfix_retros[]?; (type != "object") or (((.id | type) == "string") and ((.id | length) > 0))))           # RETRO-ATOM-ROW-ID
+    and (all(.hotfix_retros[]?; (type != "object") or (((.shipped_at | type) == "string") and ((.due_by | type) == "string"))))   # RETRO-ATOM-ROW-DATES
+    and ([.hotfix_retros[]? | if type == "object" then .id else null end] | (length == (unique | length)))              # RETRO-ATOM-ID-UNIQUE
+'
+
+# _delta_state_retros_are_wellformed <candidate-file>
+_delta_state_retros_are_wellformed() {
+  jq -e "( $DELTA_RETRO_ROW_SHAPE )" "$1" >/dev/null 2>&1
+}
+
+# _delta_state_retros_is_lawful <old-file> <candidate-file>
+#
+#   THE TOLERANCE BRANCH IS WIDER THAN THE APPEND RULE'S, ON PURPOSE. It skips
+#   when the previous document is not a well-formed state document (the same
+#   reason as everywhere else — one bad hand edit must never lock the single
+#   writer out of the only file it owns) AND ALSO when the previous document's
+#   RETRO ROWS are malformed. That second half is load-bearing: a hand edit that
+#   puts `["paid"]` in the ledger passes the top-level shape, so without it the
+#   row-by-row comparison below would run against a string and jq would ERROR on
+#   every subsequent write, forever. With it, the next write through the seam is
+#   free to REPAIR the ledger — and the candidate still has to satisfy
+#   DELTA_RETRO_ROW_SHAPE, so the repair cannot be to something worse.
+#
+#   NO `PREFIX-IDS` ATOM, AND THAT IS DELIBERATE. The first cut carried
+#   `([$pre[]?.id] == [$or[]?.id])`. It is REDUNDANT-UNPINNABLE, the class WP2
+#   deleted rather than shipped: every prefix change it could catch — a drop, a
+#   reorder, a replacement — makes the corresponding row comparison fall to
+#   "bad" first (a differing id fails RETRO-ATOM-FILE-IDENTITY), and a shrink
+#   additionally leaves `$pre[$i]` null, which is likewise "bad". No candidate
+#   exists that only that atom refuses, so no refusal case can ever stand behind
+#   it. The PROPERTY it names is still enforced — by FILE-IDENTITY and NO-BAD,
+#   each of which has its own killing case. Do not re-add it.
+_delta_state_retros_is_lawful() {
+  local old="$1" new="$2"
+  jq -e "( $DELTA_STATE_SHAPE )" "$old" >/dev/null 2>&1 || return 0        # DELTA-STATE-RETROS-TOLERANT
+  jq -e "( $DELTA_RETRO_ROW_SHAPE )" "$old" >/dev/null 2>&1 || return 0    # DELTA-STATE-RETROS-TOLERANT-ROWS
+  jq -e -n --slurpfile o "$old" --slurpfile n "$new" '
+      (($o[0].hotfix_retros) // []) as $or
+    | (($n[0].hotfix_retros) // []) as $nr
+    | ($nr[0:($or | length)]) as $pre
+    | ([range(0; ($or | length))] | map(
+         . as $i
+         | if $or[$i] == $pre[$i] then "same"
+           elif (true)
+                and ((($pre[$i] | type) == "object") and (($or[$i] | del(.closed_at) | del(.record)) == ($pre[$i] | del(.closed_at) | del(.record))))   # RETRO-ATOM-FILE-IDENTITY
+                and ($or[$i].closed_at == null)                                    # RETRO-ATOM-FILE-WRITE-ONCE
+                and (($pre[$i].closed_at | type) == "string")                      # RETRO-ATOM-FILE-STAMP-TYPE
+                and (($pre[$i].closed_at | length) > 0)                            # RETRO-ATOM-FILE-STAMP-NONEMPTY
+                and (($pre[$i].record | type) == "object")                         # RETRO-ATOM-FILE-RECORD-OBJECT
+           then "filed"
+           else "bad"
+           end)) as $codes
+    | (true)
+      and (($codes | index("bad")) == null)                                        # RETRO-ATOM-NO-BAD
+      and (($codes | map(select(. == "filed")) | length) <= 1)                     # RETRO-ATOM-AT-MOST-ONE-FILED
+      and (all($nr[($or | length):][]?; (type != "object") or ((.closed_at == null) and (.record == null))))   # RETRO-ATOM-APPEND-OPEN
+  ' >/dev/null 2>&1
+}
+
 # delta_state_write [project_root] [closed_rule]  < candidate-document-on-stdin
 #   THE atomic write. Reads a whole candidate document on stdin, validates it,
 #   and only then lets it become the state file.
@@ -396,6 +572,18 @@ delta_state_write() {
 
   case "$closed_rule" in
     append)
+      # The retro ledger's SHAPE is checked with no reference to a previous
+      # file, so it guards a first-ever write too.
+      if ! _delta_state_retros_are_wellformed "$target"; then
+        rm -f "$target" 2>/dev/null || true
+        printf '%s\n' "delta-state: refusing to write $f — a hotfix_retros row is not a well-formed retro record. Every row is an object with exactly the five keys id / shipped_at / due_by / closed_at / record, a non-empty string id, string dates, and no two rows may share an id. The previous file was NOT touched." >&2
+        return 1
+      fi
+      if [ -f "$f" ] && ! _delta_state_retros_is_lawful "$f" "$target"; then
+        rm -f "$target" 2>/dev/null || true
+        printf '%s\n' "delta-state: refusing to write $f — the hotfix retro ledger is the COLLATERAL a fast-lane release refusal is built on, and only two things may happen to it: a new OPEN row is appended, or ONE open row is filed (closed_at null -> a timestamp, record null -> an object, nothing else on that row moving). Dropping, reordering, replacing, re-dating, un-filing or re-filing a row is refused. The previous file was NOT touched." >&2
+        return 1
+      fi
       if [ -f "$f" ] && ! _delta_state_closed_is_append "$f" "$target"; then
         rm -f "$target" 2>/dev/null || true
         printf '%s\n' "delta-state: refusing to write $f — 'closed' is an APPEND-ONLY audit tail and the candidate drops, reorders or rewrites an already-closed row. To record shipped_in on a closed delta, use the dedicated seam action --delta-state-ship. The previous file was NOT touched." >&2

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -86,6 +86,26 @@ _set_current_phase_min() {
 # THE SURFACE, AND WHY IT IS THIS SMALL
 #   --delta-state-read              print the state document (§7.1), or the
 #                                   empty schema when there is none. rc 0.
+#                                   TOLERANT ON PURPOSE — a corrupt file warns
+#                                   on stderr and reads as empty, so one bad
+#                                   edit cannot kill the whole toolchain. That
+#                                   is right for every PER-DELTA operation and
+#                                   WRONG for exactly one question; see below.
+#   --delta-state-read-strict       the same document, but NEVER falling back:
+#                                   rc 0 with the document; rc 3 when the file
+#                                   exists and cannot be read as a state
+#                                   document; rc 4 when there is no file at all.
+#                                   Nothing on stdout in either failure case.
+#                                   FOR RELEASE-GATING READS (R-WP5-2). An
+#                                   adversarial review showed that with a hotfix
+#                                   retro owed, corrupting the state file makes
+#                                   the tolerant read answer with the empty
+#                                   schema at rc 0 and DELETING it is silent —
+#                                   so §9.2's "any open retro blocks the cut"
+#                                   never fires and `rm` is loan forgiveness in
+#                                   one keystroke. Illegibility of a due DATE is
+#                                   treated as overdue (WP5); illegibility of
+#                                   the LEDGER must not be treated as absolution.
 #   --delta-state-update <jq>       read -> apply the filter -> ATOMIC write
 #                                   under the APPEND rule. ONE guarded primitive
 #                                   rather than a verb per caller (activation /
@@ -178,6 +198,9 @@ _delta_seam_dispatch() {
     --delta-state-read)
       delta_state_read "."
       ;;
+    --delta-state-read-strict)
+      delta_state_read_strict "."
+      ;;
     --delta-state-update)
       if [ $# -lt 1 ] || [ -z "${1:-}" ]; then
         echo "process-checklist --delta-state-update: a jq filter argument is required." >&2
@@ -217,7 +240,7 @@ _delta_seam_dispatch() {
 # (a refused write, an unknown policy key) reaches `exit` as itself instead of
 # aborting the shell somewhere inside the module.
 case "${1:-}" in
-  --delta-state-read|--delta-state-update|--delta-state-ship|--delta-policy-init|--delta-policy-get|--delta-policy-notice)
+  --delta-state-read|--delta-state-read-strict|--delta-state-update|--delta-state-ship|--delta-policy-init|--delta-policy-get|--delta-policy-notice)
     if _delta_seam_dispatch "$@"; then exit 0; else exit $?; fi
     ;;
 esac

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1724,6 +1724,26 @@ run_child_suite "tests/test-delta-wp3-era-classify.sh" \
 # RED. Never executes init.sh -> both lanes.
 run_child_suite "tests/test-delta-wp4-close-rubric.sh" \
   "tests/test-delta-wp4-close-rubric.sh"
+# Delta Track WP5: the HOTFIX FAST LANE and the RETRO LEDGER that collateralises
+# it (§5.2). A hotfix materialises exactly the §5.2 row and nothing heavier; the
+# audit row is written AT OPEN (a hotfix that never closes still left its
+# trace); `hotfix_retros[]` is appended AT OPEN with due_by = shipped_at +
+# `classes.hotfix.retro_due_days` read from policy; and — the property the whole
+# suite exists for — THE RETRO OUTLIVES THE DELTA'S CLOSE, because a hotfix
+# ships fast by borrowing rigor and the retro is the repayment. `--retro` files
+# the write-up, write-once. scripts/lib/delta-cadence.sh ships the overdue
+# predicates §9.2's release refusal will call (WP7), and an UNREADABLE due_by is
+# OVERDUE, never silently current — BL-213's fail-open class, refused, asserted
+# on the exit code. Mutation-proved IN THE SUITE (m1-m6, each mutant built and
+# run): suppress the retro-row append -> a hotfix ships owing nothing -> L1 RED;
+# make the close ALSO close the retro -> the loan is forgiven the instant it is
+# taken out -> S1 RED; neuter the fail-closed date arm -> O2 RED on the exit
+# code; neuter the write-once guard -> a second write-up reports success and is
+# discarded -> T2 RED; hardcode the retro window -> L2 RED; waive retro_review
+# unconditionally -> a hotfix closes with no collateral -> S2 RED. Never
+# executes init.sh -> both lanes.
+run_child_suite "tests/test-delta-wp5-hotfix-retro.sh" \
+  "tests/test-delta-wp5-hotfix-retro.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 run_child_suite "tests/test-check-phase-gate-poc-block-contract.sh" \
   "tests/test-check-phase-gate-poc-block-contract.sh"

--- a/tests/test-delta-wp5-hotfix-retro.sh
+++ b/tests/test-delta-wp5-hotfix-retro.sh
@@ -286,19 +286,47 @@ ship_hotfix() {
   return 0
 }
 
-# age_retro <scripts-dir> <project-dir> <id> <days>
+# hand_edit <project-dir> <jq-filter>
+#   Rewrite `.claude/delta-state.json` DIRECTLY, bypassing the seam.
+#
+#   THIS IS A SIMULATION OF A HAND EDIT, AND IT HAS TO BE. Since R-WP5-1 the
+#   seam REFUSES to re-date, drop, wipe or forge a retro row (section G), so a
+#   fixture that needs a document in one of those states cannot ask the seam to
+#   produce one — that is the guard working. What these fixtures want is the
+#   resulting DOCUMENT, to prove what the readers do with it; the write path is
+#   not what they are testing. Every fixture that reaches for this is either
+#   simulating an operator with an editor or building the exact state the guard
+#   exists to make unreachable through the tool.
+hand_edit() {
+  local p="$1" filter="$2" tmp
+  tmp="$(mktemp)"
+  if jq "$filter" "$p/.claude/delta-state.json" > "$tmp" 2>/dev/null; then
+    mv "$tmp" "$p/.claude/delta-state.json"
+  else
+    rm -f "$tmp" 2>/dev/null || true
+    return 1
+  fi
+  return 0
+}
+
+# age_retro <project-dir> <id> <days>
 #   Shift one retro row BACK in time by <days>, moving `shipped_at` and `due_by`
 #   by the SAME amount. The interval between them — which is the product's own
 #   arithmetic and the thing under test — is preserved exactly; only the row's
-#   age changes. Through the seam, because the seam is the only writer (§7.1).
+#   age changes.
+#
+#   BY HAND EDIT, NOT THROUGH THE SEAM, and the reason is itself a property this
+#   suite asserts: RETRO-ATOM-FILE-IDENTITY now refuses exactly this rewrite
+#   through the tool (G's `re-date an open row` case). Backdating a ledger is
+#   something only an editor can do, so that is what the fixture uses.
 age_retro() {
-  local sd="$1" p="$2" id="$3" days="$4"
-  seam "$sd" "$p" --delta-state-update "
+  local p="$1" id="$2" days="$3"
+  hand_edit "$p" "
     .hotfix_retros = [ .hotfix_retros[]
       | if .id == \"$id\" then
             .shipped_at = ((.shipped_at | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime) - $days * 86400 | strftime(\"%Y-%m-%dT%H:%M:%SZ\"))
           | .due_by     = ((.due_by     | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime) - $days * 86400 | strftime(\"%Y-%m-%dT%H:%M:%SZ\"))
-        else . end ]" >/dev/null 2>&1
+        else . end ]"
   return 0
 }
 
@@ -564,7 +592,7 @@ rm -rf "$T"
 T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
 open_hotfix "$REPO_ROOT/scripts" "$P" checkout
 complete_gates "$REPO_ROOT/scripts" "$P"
-seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros = []' >/dev/null 2>&1
+hand_edit "$P" '.hotfix_retros = []'
 before="$(_md5file "$P/.claude/delta-state.json")"
 out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
 after="$(_md5file "$P/.claude/delta-state.json")"
@@ -711,7 +739,7 @@ _o1() {
   P="$T/$name"; mk_proj "$P" 4
   [ -n "$policy" ] && write_policy "$P" "$policy"
   ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
-  age_retro "$REPO_ROOT/scripts" "$P" DELTA-001 "$age"
+  age_retro "$P" DELTA-001 "$age"
   doc="$(active_json "$P" -c '.')"
   rc=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || rc=$?
   o1_detail="$o1_detail [$name=rc$rc]"
@@ -735,14 +763,14 @@ rm -rf "$T"
 # failing and not a mocked one. ASSERTED ON THE EXIT CODE, never on the text.
 T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
 ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
-seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-13-45"' >/dev/null 2>&1
+hand_edit "$P" '.hotfix_retros[0].due_by = "2026-13-45"'
 stored="$(active_json "$P" -r '.hotfix_retros[0].due_by')"
 doc="$(active_json "$P" -c '.')"
 rc_one=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || rc_one=$?
 rc_any=0; cad "$REPO_ROOT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || rc_any=$?
 state="$(cad "$REPO_ROOT/scripts" delta_retro_rows "$doc" 2>/dev/null | awk -F'\t' '{ if (NR == 1) s = $3 } END { print s }')"
 # And an ABSENT due_by is the same class of unreadable, not a free pass.
-seam "$REPO_ROOT/scripts" "$P" --delta-state-update 'del(.hotfix_retros[0].due_by)' >/dev/null 2>&1
+hand_edit "$P" 'del(.hotfix_retros[0].due_by)'
 doc2="$(active_json "$P" -c '.')"
 rc_absent=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc2" DELTA-001 >/dev/null 2>&1 || rc_absent=$?
 if [ "$stored" = "2026-13-45" ] && [ "$rc_one" -eq 0 ] && [ "$rc_any" -eq 0 ] \
@@ -776,7 +804,7 @@ ship_hotfix "$REPO_ROOT/scripts" "$Pc" checkout
 _o3 "one-open-current" 0 1 "$Pc"
 Po="$T/overdue"; mk_proj "$Po" 4
 ship_hotfix "$REPO_ROOT/scripts" "$Po" checkout
-age_retro "$REPO_ROOT/scripts" "$Po" DELTA-001 5
+age_retro "$Po" DELTA-001 5
 _o3 "one-open-overdue" 0 0 "$Po"
 delta_run "$REPO_ROOT/scripts" "$Po" --retro DELTA-001 --record "filed" >/dev/null 2>&1
 _o3 "all-filed" 1 1 "$Po"
@@ -832,7 +860,7 @@ T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
 ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
 out_none=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
 v_none=n; printf '%s' "$out_none" | grep -qF 'DELTA-001' && v_none=y
-age_retro "$REPO_ROOT/scripts" "$P" DELTA-001 5
+age_retro "$P" DELTA-001 5
 out_over=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
 v_over=n; printf '%s' "$out_over" | grep -qiE 'overdue|late' && v_over=y
 # With a NEW delta open the retro block must still render — the ledger outlives
@@ -843,11 +871,11 @@ out_busy=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
 v_busy=n; printf '%s' "$out_busy" | grep -qF 'DELTA-001' && v_busy=y
 v_new=n;  printf '%s' "$out_busy" | grep -qF 'DELTA-002' && v_new=y
 # An unreadable date is named as unreadable, not rendered as a day count.
-seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-13-45"' >/dev/null 2>&1
+hand_edit "$P" '.hotfix_retros[0].due_by = "2026-13-45"'
 out_bad=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
 v_bad=n; printf '%s' "$out_bad" | grep -qiE 'cannot be read|OVERDUE' && v_bad=y
 # Filed: gone.
-seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-08-06T00:00:00Z"' >/dev/null 2>&1
+hand_edit "$P" '.hotfix_retros[0].due_by = "2026-08-06T00:00:00Z"'
 delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "filed" >/dev/null 2>&1
 out_filed=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
 v_filed=n; printf '%s' "$out_filed" | grep -qF 'DELTA-001' && v_filed=y
@@ -940,9 +968,19 @@ rm -rf "$T"
 # exactly the right things: the delta closes, the audit tail grows, --status is
 # clean, and the debt has vanished. §5.2's "that is what makes the fast lane a
 # loan rather than a leak" is precisely what this mutant deletes.
+#
+# THE MUTANT FILES THE ROW *LAWFULLY*, AND IT HAS TO — WHICH IS THE POINT.
+# Since R-WP5-1 the seam refuses the crude spelling (`closed_at` set with
+# `record` left null dies on RETRO-ATOM-FILE-RECORD-OBJECT), so an earlier cut
+# of this mutant was killed by the guard instead of by S1 and proved nothing
+# about S1 at all — a mutant dying for the wrong reason. It now writes exactly
+# what `--retro` writes: a stamp and a record object, one row, seam-legal. That
+# is the residual the guard deliberately cannot close (a filing is a filing;
+# the state layer protects identity, not truthfulness), and it is exactly why
+# S1 has to exist as a behavioural assertion of its own.
 T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
 _sed_inplace "$MT/scripts/delta.sh" \
-  '/# DELTA-CLOSE-ATOMIC-WRITE$/s@.*@  filter=".closed += [$row] | .active_delta = null | .hotfix_retros = [.hotfix_retros[] | .closed_at = \\"$now\\"]"@'
+  '/# DELTA-CLOSE-ATOMIC-WRITE$/s@.*@  filter=".closed += [$row] | .active_delta = null | .hotfix_retros = [.hotfix_retros[] | if .closed_at == null then (.closed_at = \\"$now\\" | .record = {\\"kind\\":\\"attested\\",\\"value\\":\\"closed with the delta\\"}) else . end]"@'
 rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-ATOMIC-WRITE$')"
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 _m2_fixture() {
@@ -959,15 +997,16 @@ pri_any=0; cad "$REPO_ROOT/scripts" delta_any_open_retro "$pri_doc" >/dev/null 2
 Pm="$T/mutant"; _m2_fixture "$MT/scripts" "$Pm"
 delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
 mut_open="$(active_json "$Pm" -r '.hotfix_retros[0].closed_at == null')"
-mut_record="$(active_json "$Pm" -r '.hotfix_retros[0].record')"
+mut_record="$(active_json "$Pm" -r '.hotfix_retros[0].record.value')"
 mut_doc="$(active_json "$Pm" -c '.')"
 mut_any=0; cad "$MT/scripts" delta_any_open_retro "$mut_doc" >/dev/null 2>&1 || mut_any=$?
 if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
    && [ "$pri_rc" -eq 0 ] && [ "$pri_open" = "true" ] && [ "$pri_any" -eq 0 ] \
-   && [ "$mut_rc" -eq 0 ] && [ "$mut_open" = "false" ] && [ "$mut_record" = "null" ] && [ "$mut_any" -eq 1 ]; then
-  pass "m2: with the close ALSO closing the retro, the hotfix closes exactly as cleanly (rc $mut_rc) and the debt is GONE — the ledger row is marked filed with a record of $mut_record, and the predicate WP7's release refusal will call reports nothing owed (rc $mut_any) where the pristine tree reports one (rc $pri_any). S1 goes RED. This is the loan forgiven the instant it was taken out, with every surface still saying the right thing (marker sites=$sites, one line changed=$nlines/2)"
+   && [ "$mut_rc" -eq 0 ] && [ "$mut_open" = "false" ] \
+   && [ "$mut_record" = "closed with the delta" ] && [ "$mut_any" -eq 1 ]; then
+  pass "m2: with the close ALSO closing the retro, the hotfix closes exactly as cleanly (rc $mut_rc) and the debt is GONE — the ledger row is marked filed, by the close itself, with a write-up nobody wrote ("$mut_record"), and the predicate WP7's release refusal will call reports nothing owed (rc $mut_any) where the pristine tree reports one (rc $pri_any). S1 goes RED. This is the loan forgiven the instant it was taken out, with every surface still saying the right thing (marker sites=$sites, one line changed=$nlines/2)"
 else
-  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 0) retro still open=$pri_open (expect true) any-open rc=$pri_any (expect 0); MUTANT rc=$mut_rc (expect 0) retro still open=$mut_open (expect false — the mutant closed it) record=$mut_record (expect null — filed with no substance) any-open rc=$mut_any (expect 1 = nothing owed)"
+  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 0) retro still open=$pri_open (expect true) any-open rc=$pri_any (expect 0); MUTANT rc=$mut_rc (expect 0) retro still open=$mut_open (expect false — the mutant closed it) record.value=$mut_record (expect 'closed with the delta' — the write-up the close invented) any-open rc=$mut_any (expect 1 = nothing owed)"
 fi
 rm -rf "$T"
 
@@ -982,7 +1021,7 @@ rep="$(_mutation_report "$REPO_ROOT/scripts/lib/delta-cadence.sh" "$MT/scripts/l
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 P="$T/proj"; mk_proj "$P" 4
 ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
-seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-13-45"' >/dev/null 2>&1
+hand_edit "$P" '.hotfix_retros[0].due_by = "2026-13-45"'
 doc="$(active_json "$P" -c '.')"
 pri_rc=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || pri_rc=$?
 pri_any=0; cad "$REPO_ROOT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || pri_any=$?
@@ -1005,7 +1044,7 @@ rm -rf "$T"
 # told their second write-up is on the record and it is not. That is the worse
 # of the two failure modes and it is the one a rc-only assertion would miss.
 T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
-_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-RETRO-STATE-GUARD$/s@.*@  state="OPEN"@'
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-RETRO-STATE-GUARD$/s@.*@  state="open"@'
 rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-RETRO-STATE-GUARD$')"
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 _m4_fixture() {
@@ -1031,8 +1070,16 @@ fi
 rm -rf "$T"
 
 # ── m5: hardcode the retro window  [L2 RED] ────────────────────────────────
+# THE NEUTER ASSIGNS THE PRODUCT'S OWN VARIABLE (`retro_days`), not a lookalike.
+# An earlier cut wrote `days=3` — a variable nothing reads — and reddened L2 only
+# INDIRECTLY: `retro_days` was then empty, the numeric `case` fell through to its
+# fallback, and that fallback PRINTS a notice. The mutant exhibited the right
+# defect class by luck and its pass-narrative claimed a silence the mutated path
+# did not have. With `retro_days=3` the case matches a numeric, nothing is
+# printed, and the mutant is exactly the defect it claims: a project's retune
+# ignored with no error and no warning.
 T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
-_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-RETRO-DUE-DAYS$/s@.*@    days=3@'
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-RETRO-DUE-DAYS$/s@.*@    retro_days=3@'
 rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-OPEN-RETRO-DUE-DAYS$')"
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 POL='{"schemaVersion":1,"classes":{"hotfix":{"gates":["ledger_row","audit_row_at_open","retro_review","changelog"],"retro_due_days":9}}}'
@@ -1040,14 +1087,19 @@ Pp="$T/pristine"; mk_proj "$Pp" 4; write_policy "$Pp" "$POL"
 open_hotfix "$REPO_ROOT/scripts" "$Pp" checkout
 pri_days="$(interval_days "$Pp" 0)"
 Pm="$T/mutant"; mk_proj "$Pm" 4; write_policy "$Pm" "$POL"
-open_hotfix "$MT/scripts" "$Pm" checkout
+mut_out=$(delta_run "$MT/scripts" "$Pm" --open --describe "checkout is down in production right now" --class hotfix --slug checkout --confirm)
 mut_days="$(interval_days "$Pm" 0)"
 mut_policy="$(jq -r '.classes.hotfix.retro_due_days' "$Pm/.claude/delta-policy.json" 2>/dev/null)"
+# THE SILENCE IS MEASURED, NOT ASSERTED. The narrative's whole point is that the
+# operator gets no signal, so the mutant's own transcript is searched for one.
+mut_silent=y
+printf '%s' "$mut_out" | grep -qiE 'not a whole number|standard 3|could not|warn' && mut_silent=n
 if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
-   && [ "$pri_days" = "9" ] && [ "$mut_days" = "3" ] && [ "$mut_policy" = "9" ]; then
-  pass "m5: with the policy read replaced by a literal, a project whose own file says $mut_policy days gets a $mut_days-day window anyway, where the pristine tree honours it ($pri_days). L2 goes RED — and the failure is silent: no error, no warning, just a deadline the project did not choose (marker sites=$sites, one line changed=$nlines/2)"
+   && [ "$pri_days" = "9" ] && [ "$mut_days" = "3" ] && [ "$mut_policy" = "9" ] \
+   && [ "$mut_silent" = y ]; then
+  pass "m5: with the policy read replaced by a literal, a project whose own file says $mut_policy days gets a $mut_days-day window anyway, where the pristine tree honours it ($pri_days). L2 goes RED — and the failure is SILENT, measured rather than asserted: the mutant's own open transcript carries no notice, warning or fallback message (silent=$mut_silent), just a deadline the project did not choose (marker sites=$sites, one line changed=$nlines/2)"
 else
-  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE interval=$pri_days (expect 9); MUTANT interval=$mut_days (expect 3) while the mutant's own policy file says $mut_policy (expect 9)"
+  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE interval=$pri_days (expect 9); MUTANT interval=$mut_days (expect 3) while the mutant's own policy file says $mut_policy (expect 9); mutant transcript free of any notice=$mut_silent (expect y — if n the neuter is reaching the defect through a fallback that TELLS the operator, which is not the defect claimed):\n$mut_out"
 fi
 rm -rf "$T"
 
@@ -1064,7 +1116,7 @@ _m6_fixture() {
   mk_proj "$P" 4
   open_hotfix "$sd" "$P" checkout
   complete_gates "$sd" "$P"
-  seam "$sd" "$P" --delta-state-update '.hotfix_retros = []' >/dev/null 2>&1
+  hand_edit "$P" '.hotfix_retros = []'
 }
 Pp="$T/pristine"; _m6_fixture "$REPO_ROOT/scripts" "$Pp"
 delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
@@ -1083,6 +1135,443 @@ else
   fail_ "m6" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 7) closed=$pri_closed (expect 0); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 1) ledger rows=$mut_ledger (expect 0) any-open rc=$mut_any (expect 1)"
 fi
 rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== G — the retro ledger's guard at the seam (R-WP5-1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+#
+# EVERY LEGITIMATE COMMAND PATH ALREADY PRESERVED THE RETRO. An adversarial
+# review found the paths that are NOT commands: a crafted --delta-state-update
+# wiped the ledger, forged a `closed_at`, pushed a `due_by` to 2999, swapped an
+# id, and turned rows into the string "paid" — all at rc 0, all silent, and all
+# reading downstream as "nothing owed". `closed` had drop/rewrite protection;
+# the COLLATERAL that §9.2's release refusal is built on had none.
+#
+# _mk_guard_proj builds the ledger every case below attacks: DELTA-001 open,
+# DELTA-002 open, DELTA-003 filed. Two open rows are needed so "file two at
+# once" is constructible; a filed row so un-file and re-file are.
+_mk_guard_proj() {
+  local p="$1"
+  mk_proj "$p" 4
+  ship_hotfix "$REPO_ROOT/scripts" "$p" checkout   # DELTA-001, open
+  ship_hotfix "$REPO_ROOT/scripts" "$p" payments   # DELTA-002, open
+  ship_hotfix "$REPO_ROOT/scripts" "$p" search     # DELTA-003
+  delta_run "$REPO_ROOT/scripts" "$p" --retro DELTA-003 --record "already written up" >/dev/null 2>&1
+}
+
+# _guard_probe <scripts-dir> <project> <filter> — run one crafted seam write and
+# classify the outcome as REFUSED / ACCEPTED / MIXED. REFUSED requires the file
+# to be BYTE-IDENTICAL afterwards, so a "refusal" that half-wrote is not one.
+_guard_probe() {
+  local sd="$1" p="$2" f="$3" before after rc moved
+  before="$(_md5file "$p/.claude/delta-state.json")"
+  seam "$sd" "$p" --delta-state-update "$f" >/dev/null 2>&1; rc=$?
+  after="$(_md5file "$p/.claude/delta-state.json")"
+  moved=n; [ "$before" = "$after" ] || moved=y
+  if [ "$rc" -eq 0 ] && [ "$moved" = y ]; then printf 'ACCEPTED'
+  elif [ "$rc" -ne 0 ] && [ "$moved" = n ]; then printf 'REFUSED'
+  else printf 'MIXED(rc=%s,moved=%s)' "$rc" "$moved"; fi
+}
+
+# A well-formed row literal, parameterised, so the append cases differ from a
+# legal append by exactly the one thing each is testing.
+GOOD_ROW='{"id":"DELTA-009","shipped_at":"2026-08-01T00:00:00Z","due_by":"2026-08-04T00:00:00Z","closed_at":null,"record":null}'
+STAMP='"2026-08-03T12:00:00Z"'
+REC='{"kind":"attested","value":"forged"}'
+
+T=$(mktemp -d)
+g_ok=y; g_detail=""
+_g() {
+  local name="$1" filter="$2" P got
+  P="$T/$name"; _mk_guard_proj "$P"
+  got="$(_guard_probe "$REPO_ROOT/scripts" "$P" "$filter")"
+  [ "$got" = "REFUSED" ] || { g_ok=n; g_detail="$g_detail [$name=$got]"; }
+}
+_g wipe              '.hotfix_retros = []'
+_g drop-one          '.hotfix_retros = [.hotfix_retros[0], .hotfix_retros[1]]'
+_g reorder           '.hotfix_retros = [.hotfix_retros[1], .hotfix_retros[0], .hotfix_retros[2]]'
+_g id-swap           '.hotfix_retros[0].id = "DELTA-999"'
+_g push-due-by       '.hotfix_retros[0].due_by = "2999-01-01T00:00:00Z"'
+_g rewrite-shipped   '.hotfix_retros[0].shipped_at = "2020-01-01T00:00:00Z"'
+_g forge-closed-only ".hotfix_retros[0].closed_at = $STAMP"
+_g un-file           '.hotfix_retros[2].closed_at = null'
+_g re-file           ".hotfix_retros[2].closed_at = $STAMP | .hotfix_retros[2].record = $REC"
+_g file-and-re-date  ".hotfix_retros[0].closed_at = $STAMP | .hotfix_retros[0].record = $REC | .hotfix_retros[0].due_by = \"2999-01-01T00:00:00Z\""
+_g file-empty-stamp  ".hotfix_retros[0].closed_at = \"\" | .hotfix_retros[0].record = $REC"
+_g file-number-stamp ".hotfix_retros[0].closed_at = 12345 | .hotfix_retros[0].record = $REC"
+_g file-two-at-once  ".hotfix_retros[0].closed_at = $STAMP | .hotfix_retros[0].record = $REC | .hotfix_retros[1].closed_at = $STAMP | .hotfix_retros[1].record = $REC"
+_g string-rows       '.hotfix_retros = ["paid"]'
+_g append-string     '.hotfix_retros += ["paid"]'
+_g append-extra-key  ".hotfix_retros += [$GOOD_ROW + {\"note\":\"x\"}]"
+_g append-missing-key ".hotfix_retros += [$GOOD_ROW | del(.due_by)]"
+_g append-number-id  ".hotfix_retros += [$GOOD_ROW | .id = 123]"
+_g append-empty-id   ".hotfix_retros += [$GOOD_ROW | .id = \"\"]"
+_g append-number-due ".hotfix_retros += [$GOOD_ROW | .due_by = 12345]"
+_g append-duplicate  ".hotfix_retros += [$GOOD_ROW | .id = \"DELTA-001\"]"
+_g append-pre-filed  ".hotfix_retros += [$GOOD_ROW | .closed_at = $STAMP | .record = $REC]"
+if [ "$g_ok" = y ]; then
+  pass "G1: every crafted seam write against the retro ledger is REFUSED with the file byte-identical — the wipe, a drop, a reorder, an id swap, a re-dating, a forged closed_at with no write-up, an un-file, a re-file, a file-while-moving-the-deadline, an empty or numeric stamp, filing two at once, string rows, and seven malformed appends. 22 attacks, 22 refusals"
+else
+  fail_ "G1" "every case must be REFUSED (rc non-zero AND the file byte-identical); got:$g_detail"
+fi
+rm -rf "$T"
+
+# ── G2: the guard is not "refuse everything" ───────────────────────────────
+# THE POSITIVE CONTROL, and it is the load-bearing half. Without it every atom
+# above would be satisfied by a predicate that returned false unconditionally,
+# and the product would be broken in a way this whole section could not see.
+T=$(mktemp -d); P="$T/proj"; _mk_guard_proj "$P"
+g2_ok=y; g2_detail=""
+_g2() {
+  local name="$1" got="$2"
+  g2_detail="$g2_detail [$name=$got]"
+  [ "$got" = "ACCEPTED" ] || g2_ok=n
+}
+_g2 legal-append "$(_guard_probe "$REPO_ROOT/scripts" "$P" ".hotfix_retros += [$GOOD_ROW]")"
+_g2 legal-file   "$(_guard_probe "$REPO_ROOT/scripts" "$P" ".hotfix_retros[0].closed_at = $STAMP | .hotfix_retros[0].record = $REC")"
+_g2 unrelated    "$(_guard_probe "$REPO_ROOT/scripts" "$P" '.cadence.last_routine_review = "2026-08-03"')"
+# And through the real commands, end to end, on a fresh project.
+Q="$T/cmds"; mk_proj "$Q" 4
+open_hotfix "$REPO_ROOT/scripts" "$Q" checkout; rc_open=$?
+complete_gates "$REPO_ROOT/scripts" "$Q"
+delta_run "$REPO_ROOT/scripts" "$Q" --close >/dev/null 2>&1; rc_close=$?
+delta_run "$REPO_ROOT/scripts" "$Q" --retro DELTA-001 --record "written up" >/dev/null 2>&1; rc_file=$?
+n_rows="$(active_json "$Q" -r '.hotfix_retros | length')"
+filed="$(active_json "$Q" -r '.hotfix_retros[0].closed_at != null')"
+if [ "$g2_ok" = y ] && [ "$rc_open" -eq 0 ] && [ "$rc_close" -eq 0 ] && [ "$rc_file" -eq 0 ] \
+   && [ "$n_rows" = "1" ] && [ "$filed" = "true" ]; then
+  pass "G2: the guard permits exactly the two legitimate mutations —$g2_detail — and every real command path still works end to end: open (rc $rc_open) books the row, close (rc $rc_close) leaves it, --retro (rc $rc_file) files it ($n_rows row, filed=$filed). Without this row the whole of G1 would be satisfied by a predicate that refused everything"
+else
+  fail_ "G2" "seam probes:$g2_detail (all expect ACCEPTED); open rc=$rc_open close rc=$rc_close retro rc=$rc_file (all expect 0); rows=$n_rows (expect 1); filed=$filed (expect true)"
+fi
+rm -rf "$T"
+
+# ── G3: a hand-mangled ledger does not lock the single writer out ──────────
+# The tolerance doctrine, inherited from the append rule and WIDENED here for a
+# reason the append rule does not have: retro ROW shape is not in the shared
+# read predicate (putting it there would make one bad row read as an empty
+# ledger — total loan forgiveness from a single typo), so a hand edit can leave
+# `["paid"]` on disk. Without the row-level tolerance the row-by-row comparison
+# would then ERROR on every subsequent write, forever, and D7's single writer
+# would be locked out of the only file it owns.
+T=$(mktemp -d); P="$T/proj"; _mk_guard_proj "$P"
+hand_edit "$P" '.hotfix_retros = ["paid"]'
+repair="$(_guard_probe "$REPO_ROOT/scripts" "$P" ".hotfix_retros = [$GOOD_ROW]")"
+after_repair="$(active_json "$P" -c '[.hotfix_retros[].id]')"
+# ...and the repair still has to BE a repair: a write that leaves it malformed
+# is refused even under tolerance.
+Q="$T/still"; _mk_guard_proj "$Q"
+hand_edit "$Q" '.hotfix_retros = ["paid"]'
+still_bad="$(_guard_probe "$REPO_ROOT/scripts" "$Q" '.hotfix_retros = ["paid","also-paid"]')"
+if [ "$repair" = "ACCEPTED" ] && [ "$after_repair" = '["DELTA-009"]' ] && [ "$still_bad" = "REFUSED" ]; then
+  pass "G3: a hand-mangled ledger is tolerated as a PREDECESSOR — the next seam write may repair it ($repair, ledger now $after_repair) — but the candidate still has to be well-formed, so a write that leaves it broken is refused ($still_bad). One bad hand edit cannot lock the single writer out, and cannot be laundered either"
+else
+  fail_ "G3" "repair write=$repair (expect ACCEPTED); ledger after=$after_repair (expect [\"DELTA-009\"]); still-malformed write=$still_bad (expect REFUSED)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== F — an unreadable ledger is never 'nothing owed' (R-WP5-2) ==="
+# ════════════════════════════════════════════════════════════════════════════
+#
+# BL-213's FAIL-OPEN CLASS, ONE LEVEL UP FROM THE DATES. WP5 refused it for a
+# due_by and left it standing for the whole ledger: with a retro owed,
+# corrupting `.claude/delta-state.json` made the tolerant read answer with the
+# empty schema at rc 0 (warning on stderr only), and DELETING the file was
+# completely silent — so `delta_any_open_retro` said "nothing owed" through
+# exactly the calling shape this lib's header documents for WP7, and §9.2's
+# refusal would never have fired. `rm` was loan forgiveness in one keystroke.
+#
+# THE CONTRACT CHOSEN, and it is documented in delta-cadence.sh's header:
+#   the seam grows `--delta-state-read-strict`  -> rc 0 doc · rc 3 unreadable
+#                                                 · rc 4 absent, nothing on stdout
+#   the four predicates answer rc 3 UNDETERMINED on a document they cannot read,
+#   a code deliberately distinct from 1 ("none owed") and 2 ("no such retro").
+
+# ── F1: the strict read tells the three states apart ───────────────────────
+T=$(mktemp -d)
+f1_ok=y; f1_detail=""
+_f1() {
+  local name="$1" want="$2" P="$3" out rc
+  rc=0; out="$(seam "$REPO_ROOT/scripts" "$P" --delta-state-read-strict 2>/dev/null)" || rc=$?
+  f1_detail="$f1_detail [$name=rc$rc/$( [ -n "$out" ] && echo doc || echo empty)]"
+  [ "$rc" -eq "$want" ] || f1_ok=n
+  # Nothing on stdout in either failure case — a caller that ignored the code
+  # must not be handed a document that does not exist.
+  if [ "$want" -ne 0 ] && [ -n "$out" ]; then f1_ok=n; f1_detail="$f1_detail(PRINTED)"; fi
+  if [ "$want" -eq 0 ] && [ -z "$out" ]; then f1_ok=n; f1_detail="$f1_detail(NO DOC)"; fi
+}
+Ph="$T/healthy"; mk_proj "$Ph" 4; ship_hotfix "$REPO_ROOT/scripts" "$Ph" checkout
+_f1 healthy 0 "$Ph"
+Pc="$T/corrupt"; mk_proj "$Pc" 4; ship_hotfix "$REPO_ROOT/scripts" "$Pc" checkout
+printf '{"schemaVersion": 1, "hotfix_' > "$Pc/.claude/delta-state.json"
+_f1 corrupt 3 "$Pc"
+Pw="$T/wrong-shape"; mk_proj "$Pw" 4; ship_hotfix "$REPO_ROOT/scripts" "$Pw" checkout
+printf '[]\n' > "$Pw/.claude/delta-state.json"
+_f1 wrong-shape 3 "$Pw"
+Pa="$T/absent"; mk_proj "$Pa" 4; ship_hotfix "$REPO_ROOT/scripts" "$Pa" checkout
+rm -f "$Pa/.claude/delta-state.json"
+_f1 absent 4 "$Pa"
+Pe="$T/empty-ledger"; mk_proj "$Pe" 4
+delta_run "$REPO_ROOT/scripts" "$Pe" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+_f1 empty-ledger 0 "$Pe"
+if [ "$f1_ok" = y ]; then
+  pass "F1: --delta-state-read-strict tells the three states apart —$f1_detail — 0 with a document, 3 when the file is there and unreadable, 4 when it is gone, and NOTHING on stdout in either failure. An empty ledger stays rc 0: 'nothing owed' is a real answer, 'I cannot read it' is not"
+else
+  fail_ "F1" "expected rc 0 / 3 / 3 / 4 / 0 with a document only on the rc-0 rows; got:$f1_detail"
+fi
+rm -rf "$T"
+
+# ── F2: the predicates answer UNDETERMINED, not "none" ─────────────────────
+# The backstop for a caller that acquired the document some other way. A
+# contract that only holds when everyone uses the right front door is a
+# convention, not a property.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+healthy_doc="$(active_json "$P" -c '.')"
+f2_ok=y; f2_detail=""
+_f2() {
+  local name="$1" doc="$2" want_open="$3" want_over="$4" want_one="$5" want_rows="$6" ro rv r1 rr
+  ro=0; cad "$REPO_ROOT/scripts" delta_any_open_retro "$doc" >/dev/null 2>&1 || ro=$?
+  rv=0; cad "$REPO_ROOT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || rv=$?
+  r1=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || r1=$?
+  rr=0; cad "$REPO_ROOT/scripts" delta_retro_rows "$doc" >/dev/null 2>&1 || rr=$?
+  f2_detail="$f2_detail [$name open=$ro overdue=$rv one=$r1 rows=$rr]"
+  [ "$ro" -eq "$want_open" ] || f2_ok=n
+  [ "$rv" -eq "$want_over" ] || f2_ok=n
+  [ "$r1" -eq "$want_one" ]  || f2_ok=n
+  [ "$rr" -eq "$want_rows" ] || f2_ok=n
+}
+_f2 healthy       "$healthy_doc"                      0 1 1 0
+_f2 empty-string  ""                                  3 3 3 3
+_f2 truncated     '{"schemaVersion": 1, "hotfix_'     3 3 3 3
+_f2 not-an-object '[]'                                3 3 3 3
+_f2 no-ledger-key '{"schemaVersion":1,"closed":[]}'   3 3 3 3
+_f2 empty-ledger  '{"schemaVersion":1,"active_delta":null,"hotfix_retros":[],"cadence":{},"closed":[]}' 1 1 2 0
+if [ "$f2_ok" = y ]; then
+  pass "F2: a document the predicates cannot read answers rc 3 UNDETERMINED on all four —$f2_detail — never 1 ('none owed') and never 2 ('no such retro'). The genuinely empty ledger keeps answering 1/1/2/0, so the fail-closed code costs a healthy project nothing"
+else
+  fail_ "F2" "expected healthy 0/1/1/0, every unreadable shape 3/3/3/3, empty ledger 1/1/2/0; got:$f2_detail"
+fi
+rm -rf "$T"
+
+# ── F3: the operator surface fails closed too ──────────────────────────────
+# The half of the repair the operator can see. `--status` on a corrupt record
+# must not print a clean bill of health over a file nobody could parse.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+out_ok=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+shows=n; printf '%s' "$out_ok" | grep -qF 'DELTA-001' && shows=y
+printf '{"schemaVersion": 1, "hotfix_' > "$P/.claude/delta-state.json"
+out_bad=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+warns=n; printf '%s' "$out_bad" | grep -qi 'cannot be read' && warns=y
+# THE LIE-DETECTOR IS THE PRODUCT'S OWN ALL-CLEAR SENTENCE, VERBATIM, and it is
+# spelled that precisely on purpose: a looser pattern ("nothing.*outstanding")
+# matched the fail-closed WARNING itself, so the first cut of this row failed
+# because the repair announced itself in words the detector read as the defect.
+lies=n;  printf '%s' "$out_bad" | grep -qi 'releases are clear' && lies=y
+if [ "$shows" = y ] && [ "$warns" = y ] && [ "$lies" = n ]; then
+  pass "F3: --status names the outstanding write-up on a healthy record ($shows) and, on a record it cannot parse, says so and refuses to imply anything (warned=$warns, claimed-clear=$lies) — the operator-facing half of the same fail-closed repair"
+else
+  fail_ "F3" "healthy status names the retro=$shows (expect y); corrupt status warns=$warns (expect y); corrupt status claims clear=$lies (expect n); output:\n$out_bad"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D — the no-row refusals name an exit that works (R-WP5-3) ==="
+# ════════════════════════════════════════════════════════════════════════════
+#
+# §4.3: a refusal "must say exactly what to do next". An adversarial review
+# found this path saying three things in a circle, in the lane built for 3am:
+# --close pointed at --complete-gate, which refused and pointed at --retro,
+# which refused with "nothing owes a write-up". Every command named refuses.
+# There are exactly two ways to be here and they have different exits.
+
+# ── D1: the lost-row branch (a hotfix) ─────────────────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+complete_gates "$REPO_ROOT/scripts" "$P"
+hand_edit "$P" '.hotfix_retros = []'
+out_close=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc_close=$?
+out_gate=$(delta_run "$REPO_ROOT/scripts" "$P" --complete-gate retro_review); rc_gate=$?
+out_retro=$(delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "x"); rc_retro=$?
+# Each refusal must name the RESTORE path, and none of the three may send the
+# operator to another command that refuses.
+d1_ok=y; d1_detail=""
+for pair in "close:$out_close" "gate:$out_gate" "retro:$out_retro"; do
+  nm="${pair%%:*}"; body="${pair#*:}"
+  says=n; printf '%s' "$body" | grep -qF 'git checkout -- .claude/delta-state.json' && says=y
+  d1_detail="$d1_detail [$nm restore=$says]"
+  [ "$says" = y ] || d1_ok=n
+done
+circle=n; printf '%s' "$out_gate" | grep -qF -- '--retro' && circle=y
+if [ "$rc_close" -eq 7 ] && [ "$rc_gate" -eq 2 ] && [ "$rc_retro" -eq 11 ] \
+   && [ "$d1_ok" = y ] && [ "$circle" = n ]; then
+  pass "D1: with the row lost, all three refusals (close rc $rc_close, --complete-gate rc $rc_gate, --retro rc $rc_retro) name the ONE thing that actually works —$d1_detail — and --complete-gate no longer points at --retro, which would refuse (circle=$circle). The dead end has an exit named"
+else
+  fail_ "D1" "close rc=$rc_close (expect 7); gate rc=$rc_gate (expect 2); retro rc=$rc_retro (expect 11); each names the restore path:$d1_detail (all expect y); --complete-gate still points at --retro=$circle (expect n); close output:\n$out_close"
+fi
+rm -rf "$T"
+
+# ── D2: the misconfigured-policy branch, reachable with NO hand edit ───────
+# A project that puts `retro_review` on a non-hotfix class gets a permanently
+# uncloseable delta — only a hotfix ever books a row, so the waiver can never
+# arm. The old transcript gave no hint the policy was the cause.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+write_policy "$P" '{"schemaVersion":1,"classes":{"fix":{"gates":["ledger_row","retro_review","changelog"]}}}'
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+klass="$(active_json "$P" -r '.active_delta.class')"
+complete_gates "$REPO_ROOT/scripts" "$P"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+names_policy=n; printf '%s' "$out" | grep -qF 'delta-policy.json' && names_policy=y
+names_class=n;  printf '%s' "$out" | grep -qF "classes.fix.gates" && names_class=y
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 7 ] && [ "$klass" = "fix" ] && [ "$names_policy" = y ] && [ "$names_class" = y ] \
+   && [ "$n_closed" = "0" ]; then
+  pass "D2: a $klass whose policy demands retro_review is refused (rc $rc) and the refusal NAMES the misconfiguration — the file ($names_policy) and the exact key, classes.fix.gates ($names_class). Reachable with no hand edit at all, and previously a silent dead end"
+else
+  fail_ "D2" "rc=$rc (expect 7); class=$klass (expect fix); refusal names delta-policy.json=$names_policy and classes.fix.gates=$names_class (both expect y); closed length=$n_closed (expect 0); output:\n$out"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== A — the atom sweep: every guard atom, neutered, with its killing case ==="
+# ════════════════════════════════════════════════════════════════════════════
+#
+# WP2's discipline, applied to the atoms this WP adds. An atom with no refusal
+# case behind it is a DELETABLE atom that looks like a guard — WP2 found three
+# of those in its own first cut, all three survived the whole PR-blocking check
+# set. So every atom below is neutered in a fresh mutant tree and its killing
+# case is executed against both trees: the pristine must give one answer and the
+# mutant the other. Anchored end-of-line marker, sites==1, exactly one line
+# changed, mode preserved.
+#
+# NO `PREFIX-IDS` ATOM APPEARS HERE because it was not shipped: every prefix
+# change it could catch falls to RETRO-ATOM-FILE-IDENTITY / RETRO-ATOM-NO-BAD
+# first, so no candidate exists that only it refuses. That analysis is recorded
+# at the predicate in scripts/lib/delta-state.sh rather than being papered over
+# with an atom nothing can pin.
+a_ok=y; a_detail=""; a_count=0
+
+# _atom <file-rel> <marker> <neuter-replacement> <probe-fn> <want-pristine> <want-mutant> <label>
+#   The probe is called as `<probe-fn> <scripts-dir> <workdir>` and echoes one
+#   token. Fixtures inside a probe are always built with the PRISTINE tree, so
+#   the mutation is isolated to the operation under test.
+_atom() {
+  local rel="$1" marker="$2" neuter="$3" probe="$4" wp="$5" wm="$6" label="$7"
+  local T MT rep sites rest changed nlines pri mut
+  a_count=$((a_count + 1))
+  T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+  _sed_inplace "$MT/scripts/$rel" "/# ${marker}\$/s@.*@${neuter}@"
+  rep="$(_mutation_report "$REPO_ROOT/scripts/$rel" "$MT/scripts/$rel" "${marker}\$")"
+  sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+  pri="$("$probe" "$REPO_ROOT/scripts" "$T/pri")"
+  mut="$("$probe" "$MT/scripts" "$T/mut-work")"
+  if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+     && [ "$pri" = "$wp" ] && [ "$mut" = "$wm" ]; then
+    a_detail="$a_detail [$label OK]"
+  else
+    a_ok=n
+    a_detail="$a_detail [$label BAD sites=$sites changed=$changed lines=$nlines pri=$pri(want $wp) mut=$mut(want $wm)]"
+  fi
+  rm -rf "$T"
+}
+
+# The seam-guard probes: build the three-row ledger, run one crafted write.
+_ap_wipe()          { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" '.hotfix_retros = []'; }
+_ap_append_string() { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" '.hotfix_retros += ["paid"]'; }
+_ap_extra_key()     { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros += [$GOOD_ROW + {\"note\":\"x\"}]"; }
+_ap_number_id()     { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros += [$GOOD_ROW | .id = 123]"; }
+_ap_number_due()    { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros += [$GOOD_ROW | .due_by = 12345]"; }
+_ap_duplicate()     { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros += [$GOOD_ROW | .id = \"DELTA-001\"]"; }
+_ap_file_re_date()  { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros[0].closed_at = $STAMP | .hotfix_retros[0].record = $REC | .hotfix_retros[0].due_by = \"2999-01-01T00:00:00Z\""; }
+_ap_re_file()       { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros[2].closed_at = $STAMP | .hotfix_retros[2].record = $REC"; }
+_ap_number_stamp()  { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros[0].closed_at = 12345 | .hotfix_retros[0].record = $REC"; }
+_ap_empty_stamp()   { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros[0].closed_at = \"\" | .hotfix_retros[0].record = $REC"; }
+_ap_no_record()     { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros[0].closed_at = $STAMP"; }
+_ap_file_two()      { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros[0].closed_at = $STAMP | .hotfix_retros[0].record = $REC | .hotfix_retros[1].closed_at = $STAMP | .hotfix_retros[1].record = $REC"; }
+_ap_append_filed()  { mkdir -p "$2"; _mk_guard_proj "$2/p"; _guard_probe "$1" "$2/p" ".hotfix_retros += [$GOOD_ROW | .closed_at = $STAMP | .record = $REC]"; }
+# Tolerance probes: the PREVIOUS file is broken and the write REPAIRS it.
+_ap_tol_rows() {
+  mkdir -p "$2"; _mk_guard_proj "$2/p"
+  hand_edit "$2/p" '.hotfix_retros = ["paid"]'
+  _guard_probe "$1" "$2/p" ".hotfix_retros = [$GOOD_ROW]"
+}
+_ap_tol_shape() {
+  mkdir -p "$2"; _mk_guard_proj "$2/p"
+  hand_edit "$2/p" '.schemaVersion = "banana"'
+  _guard_probe "$1" "$2/p" '.schemaVersion = 1 | .hotfix_retros = []'
+}
+# Strict-read probes.
+_ap_strict_absent() {
+  mkdir -p "$2"; mk_proj "$2/p" 4; ship_hotfix "$REPO_ROOT/scripts" "$2/p" checkout
+  rm -f "$2/p/.claude/delta-state.json"
+  local rc=0; seam "$1" "$2/p" --delta-state-read-strict >/dev/null 2>&1 || rc=$?
+  printf 'rc%s' "$rc"
+}
+_ap_strict_unreadable() {
+  mkdir -p "$2"; mk_proj "$2/p" 4; ship_hotfix "$REPO_ROOT/scripts" "$2/p" checkout
+  printf '{"schemaVersion": 1, "hotfix_' > "$2/p/.claude/delta-state.json"
+  local rc=0; seam "$1" "$2/p" --delta-state-read-strict >/dev/null 2>&1 || rc=$?
+  printf 'rc%s' "$rc"
+}
+# Cadence UNDETERMINED probes — a corrupt DOCUMENT handed straight to a predicate.
+_ap_cad() {
+  local sd="$1" fn="$3" rc=0
+  cad "$sd" "$fn" '{"schemaVersion":1,"closed":[]}' >/dev/null 2>&1 || rc=$?
+  printf 'rc%s' "$rc"
+}
+_ap_cad_rows()       { _ap_cad "$1" "$2" delta_retro_rows; }
+_ap_cad_one()        { _ap_cad "$1" "$2" delta_retro_overdue; }
+_ap_cad_anyopen()    { _ap_cad "$1" "$2" delta_any_open_retro; }
+_ap_cad_anyoverdue() { _ap_cad "$1" "$2" delta_any_overdue_retro; }
+
+# ── the row-shape atoms ────────────────────────────────────────────────────
+_atom lib/delta-state.sh RETRO-ATOM-ROW-OBJECT  '    and (true)' _ap_append_string REFUSED ACCEPTED row-object
+_atom lib/delta-state.sh RETRO-ATOM-ROW-KEYS    '    and (true)' _ap_extra_key     REFUSED ACCEPTED row-keys
+_atom lib/delta-state.sh RETRO-ATOM-ROW-ID      '    and (true)' _ap_number_id     REFUSED ACCEPTED row-id
+_atom lib/delta-state.sh RETRO-ATOM-ROW-DATES   '    and (true)' _ap_number_due    REFUSED ACCEPTED row-dates
+_atom lib/delta-state.sh RETRO-ATOM-ID-UNIQUE   '    and (true)' _ap_duplicate     REFUSED ACCEPTED id-unique
+# ── the transition atoms ───────────────────────────────────────────────────
+_atom lib/delta-state.sh RETRO-ATOM-FILE-IDENTITY        '                and (true)' _ap_file_re_date  REFUSED ACCEPTED file-identity
+_atom lib/delta-state.sh RETRO-ATOM-FILE-WRITE-ONCE      '                and (true)' _ap_re_file       REFUSED ACCEPTED write-once
+_atom lib/delta-state.sh RETRO-ATOM-FILE-STAMP-TYPE      '                and (true)' _ap_number_stamp  REFUSED ACCEPTED stamp-type
+_atom lib/delta-state.sh RETRO-ATOM-FILE-STAMP-NONEMPTY  '                and (true)' _ap_empty_stamp   REFUSED ACCEPTED stamp-nonempty
+_atom lib/delta-state.sh RETRO-ATOM-FILE-RECORD-OBJECT   '                and (true)' _ap_no_record     REFUSED ACCEPTED record-object
+_atom lib/delta-state.sh RETRO-ATOM-NO-BAD               '      and (true)' _ap_wipe          REFUSED ACCEPTED no-bad
+_atom lib/delta-state.sh RETRO-ATOM-AT-MOST-ONE-FILED    '      and (true)' _ap_file_two      REFUSED ACCEPTED at-most-one-filed
+_atom lib/delta-state.sh RETRO-ATOM-APPEND-OPEN          '      and (true)' _ap_append_filed  REFUSED ACCEPTED append-open
+# ── the two tolerance atoms (INVERTED: the pristine ACCEPTS, the mutant locks
+#    the single writer out of the only file it owns) ─────────────────────────
+_atom lib/delta-state.sh DELTA-STATE-RETROS-TOLERANT-ROWS '  :' _ap_tol_rows  ACCEPTED REFUSED tolerant-rows
+_atom lib/delta-state.sh DELTA-STATE-RETROS-TOLERANT      '  :' _ap_tol_shape ACCEPTED REFUSED tolerant-shape
+# ── the strict read's two codes ────────────────────────────────────────────
+_atom lib/delta-state.sh DELTA-STATE-STRICT-ABSENT     '    return 0' _ap_strict_absent     rc4 rc0 strict-absent
+_atom lib/delta-state.sh DELTA-STATE-STRICT-UNREADABLE '    return 0' _ap_strict_unreadable rc3 rc0 strict-unreadable
+# ── the four UNDETERMINED atoms ────────────────────────────────────────────
+_atom lib/delta-cadence.sh DELTA-CADENCE-LEDGER-UNDETERMINED-ROWS        '  :' _ap_cad_rows       rc3 rc0 undetermined-rows
+_atom lib/delta-cadence.sh DELTA-CADENCE-LEDGER-UNDETERMINED-ONE         '  :' _ap_cad_one        rc3 rc2 undetermined-one
+_atom lib/delta-cadence.sh DELTA-CADENCE-LEDGER-UNDETERMINED-ANYOPEN     '  :' _ap_cad_anyopen    rc3 rc1 undetermined-anyopen
+_atom lib/delta-cadence.sh DELTA-CADENCE-LEDGER-UNDETERMINED-ANYOVERDUE  '  :' _ap_cad_anyoverdue rc3 rc1 undetermined-anyoverdue
+# ── the date atom WP5 already shipped, swept here with the rest ────────────
+_ap_unparseable() {
+  mkdir -p "$2"; mk_proj "$2/p" 4; ship_hotfix "$REPO_ROOT/scripts" "$2/p" checkout
+  hand_edit "$2/p" '.hotfix_retros[0].due_by = "2026-13-45"'
+  local rc=0
+  cad "$1" delta_retro_overdue "$(active_json "$2/p" -c '.')" DELTA-001 >/dev/null 2>&1 || rc=$?
+  printf 'rc%s' "$rc"
+}
+_atom lib/delta-cadence.sh DELTA-CADENCE-UNPARSEABLE '      state=current; days=999' _ap_unparseable rc0 rc1 date-unparseable
+
+if [ "$a_ok" = y ]; then
+  pass "A1: the atom sweep — $a_count atoms, each neutered alone at an anchored single-site marker (sites==1, exactly one line changed, mode preserved) with its killing case executed against BOTH trees:$a_detail. Every atom moves the answer when it is removed, so none of them is a line that merely looks like a guard"
+else
+  fail_ "A1" "$a_count atoms swept; each must resolve to exactly one marker line and flip its killing case:$a_detail"
+fi
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/tests/test-delta-wp5-hotfix-retro.sh
+++ b/tests/test-delta-wp5-hotfix-retro.sh
@@ -1,0 +1,1089 @@
+#!/usr/bin/env bash
+# tests/test-delta-wp5-hotfix-retro.sh — Delta Track WP5.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §5.2 (the per-class gate
+# table, its hotfix row, and "reading the hotfix row honestly" — the fast lane
+# is a LOAN, collateralised by the release refusal), §5.2's incident-response
+# seam paragraph (the two clocks differ on purpose and neither is built into the
+# other), §7.1 (`hotfix_retros[]` — an array that OUTLIVES `active_delta`
+# deliberately), §7.2 (`retro_due_days`, and the gate-token equivalence note:
+# hotfix carries no `close_review` because `retro_review` IS its close review,
+# arriving late), §9.2 (the release refusals WP7 will build on the predicates
+# this WP ships), §11-WP5.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose: no backlog
+# entry exists for this build and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1,
+# WP2, WP3 and WP4 precedent.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE ONE PROPERTY THIS SUITE EXISTS FOR
+#
+# A hotfix ships fast by BORROWING rigor. The retro is the repayment. So the
+# retro ledger must OUTLIVE the delta's close — if closing the delta also closed
+# the retro, the loan is forgiven the instant it is taken out and the entire
+# §5.2 design intent is gone, silently, with every visible surface still saying
+# the right things. S1 is that property and m2 is the mutant that proves S1 can
+# see it.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES, NEVER LABELS
+#
+# Every assertion below reads a process EXIT CODE, a JSON value read back off
+# disk, or a byte-level md5 / whole-tree manifest. None reads a printed
+# [OK]/[WARN]/[FAIL] banner. CLAUDE.md's `[WARN]` trap is exactly that the label
+# and the exit predicate can disagree — and WP6's sibling defect (BL-213's
+# fail-open class) is the same disease in date form: check-maintenance.sh today
+# prints "All maintenance cadences current" at rc 0 for a date it could not
+# read. O2 and m3 pin the WP5 half of that repair ON THE EXIT CODE.
+#
+# The codes this WP adds to scripts/delta.sh:
+#     11  there is no retro on the record with that id
+#     12  that retro is already filed — the record is write-once
+# and the ones it inherits and re-reads: 0 ok, 2 invocation error, 6 nothing
+# open, 7 gates outstanding.
+#
+# The codes scripts/lib/delta-cadence.sh answers with — the interface WP7's
+# cut-release.sh consumes, asserted here so WP7 can build against it:
+#     delta_retro_overdue     0 OVERDUE (including an unreadable due_by), 1 open
+#                             and not yet due, 2 no OPEN retro with that id
+#     delta_any_open_retro    0 at least one open retro, 1 none
+#     delta_any_overdue_retro 0 at least one open retro that is overdue or
+#                             unreadable, 1 none
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THIS SUITE PINS, AND WHICH MUTANT EACH ROW KILLS
+#
+#   H — THE HOTFIX FAST LANE AT OPEN (§5.2)
+#     H1  a hotfix materialises EXACTLY the §5.2 row and NOTHING heavier — the
+#         set is asserted whole, not as a subset; no brief is demanded anywhere;
+#         and the open writes no file outside the two `.claude/` documents, so
+#         the floor (§5.1) is inherited rather than re-implemented
+#     H2  the AUDIT ROW IS WRITTEN AT OPEN, not at close: the stamp is on the
+#         record and the gate is already complete the moment the delta opens —
+#         it is the one gate in the system nobody attests, because the framework
+#         did it
+#     H3  and the trace survives ABANDONMENT — a hotfix that never closes still
+#         left it, and its id is never handed out again
+#
+#   L — THE RETRO LEDGER, APPENDED AT OPEN (§7.1)
+#     L1  the row is appended AT OPEN with exactly §7.1's five keys and
+#         due_by = shipped_at + 3 days (Karl set 3, not 7)             KILLS m1
+#     L2  `retro_due_days` is READ FROM POLICY: retune it and the date moves
+#                                                                      KILLS m5
+#     L3  no other class writes a retro row
+#
+#   S — THE RETRO OUTLIVES THE CLOSE (the whole point)
+#     S1  closing the hotfix delta nulls `active_delta` and grows `closed` — and
+#         leaves the retro row byte-identically OPEN                   KILLS m2
+#     S2  the close is not BLOCKED by the open retro, but it IS blocked when the
+#         retro row is absent: fail-closed, rc 7, naming retro_review  KILLS m6
+#     S3  `--complete-gate retro_review` is refused — the loan cannot be repaid
+#         by ticking a box, which is §7.2's "the loan going unrepaid" spelled as
+#         the one thing that would make it happen
+#
+#   T — `--retro`
+#     T1  closes EXACTLY one retro; the other open row is untouched; the write
+#         is one atomic seam call and its residue is bounded to that row's two
+#         fields
+#     T2  a second `--retro` on the same id is refused (12)            KILLS m4
+#     T3  an unknown id (11) and a missing record (2) are refused
+#     T4  THE RECORD CONTRACT, honestly kinded: a value that names an existing
+#         file is recorded as `file`, anything else as `attested` — the
+#         framework never claims to have read a write-up it cannot find
+#
+#   O — OVERDUE ARITHMETIC (scripts/lib/delta-cadence.sh)
+#     O1  2 days old is not overdue at the default 3; 4 days old is; a project
+#         that retunes to 7 finds the same 4-day-old retro current
+#     O2  AN UNREADABLE `due_by` IS OVERDUE, NOT SILENTLY CURRENT — BL-213's
+#         fail-open class, refused here                                KILLS m3
+#     O3  the whole-ledger predicates in all four states
+#     O4  the parse helper: GNU-first `date -d`, BSD `date -j -f` fallback,
+#         rc 1 AND NO OUTPUT on garbage, and a bare date normalised to midnight
+#         UTC so BSD's fill-from-now can never leak in
+#
+#   V — `--status` RENDERS OPEN AND OVERDUE RETROS
+#     V1  with nothing open and with a delta open; overdue named as overdue; an
+#         unreadable date named as unreadable AND late; and — the structural
+#         discriminator — a filed retro appears nowhere
+#
+#   N — REFUSAL RESIDUE (the WP4 standard, inherited verbatim)
+#     N1  every `--retro` refusal leaves the WHOLE TREE byte-for-byte as it
+#         found it, asserted as a find-based manifest with a per-file md5
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# COUNTERFACTUAL DISCIPLINE — how the mutations below are built
+#
+# Inherited from tests/test-delta-wp3-era-classify.sh and
+# tests/test-delta-wp4-close-rubric.sh, unchanged, because it is what makes a
+# mutation proof a proof:
+#
+#   • ANCHORED SINGLE-SITE addresses. Every marker is pinned to END-OF-LINE
+#     (`/# DELTA-OPEN-RETRO-APPEND$/`), never a bare substring — WP2's suite
+#     records what over-matching costs.
+#   • THREE PROPERTIES ASSERTED BEFORE THE RESULT IS BELIEVED: the marker
+#     resolves to EXACTLY ONE line in the pristine file; the mutant DIFFERS from
+#     it; and EXACTLY ONE LINE changed (one `<` and one `>`).
+#   • MODE-PRESERVING harness. `_sed_inplace` reads each file's mode and puts it
+#     back; the obvious `chmod +x` spelling silently turns a sourced 0644 lib
+#     into 0755 and the mode rides along in the next commit.
+#   • FRESH-FIXTURE ISOLATION. Every mutation builds its own mktemp project, and
+#     the fixture must REACH the guard under test — m6's fixture has to have the
+#     retro row removed, or the bind is satisfied for the honest reason and the
+#     mutant looks pinned when it is not.
+#   • STRUCTURAL DISCRIMINATORS WHERE THE EXPECTED RESULT IS AN ABSENCE. Five of
+#     the six mutants below expect "the refusal did not happen", which is the
+#     same answer a fixture that never reached the guard would give. Each of
+#     those rows therefore also asserts a POSITIVE consequence of the mutation
+#     having landed — the mutant's ledger is EMPTY while the pristine tree's
+#     carries a row (m1); the mutant's retro is CLOSED with the delta's own
+#     closed_at while the pristine tree's is still open (m2); the mutant's
+#     record still holds the FIRST write-up while reporting the second as saved
+#     (m4); the mutant's due_by interval is 3 days under a policy that says 9
+#     (m5); the mutant closed a hotfix whose ledger has no row at all (m6) — and
+#     every one of them is measured against the PRISTINE tree run on an
+#     identical fixture in the same case.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# HERMETICITY: every fixture is a mktemp -d project carrying NO init.sh and NO
+# templates/generated, so guard_not_in_framework sees a project and not the
+# framework. Git fixtures configure an identity and unset GITHUB_BASE_REF. No
+# remote is ever created; nothing reaches the network; nothing is written inside
+# the checkout. bash-3.2 safe: no associative arrays, no ${var,,}, no ((x++)).
+#
+# TIME: no test overrides "now". Ageing a retro is done by shifting BOTH
+# `shipped_at` and `due_by` back by the same amount through the seam, so the
+# INTERVAL between them — the product's own arithmetic — is preserved exactly
+# and only the row's age moves. A suite that faked `now` would be pinning its
+# own clock.
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name init.sh.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for tests/test-delta-wp5-hotfix-retro.sh" >&2
+  exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-delta-wp5-hotfix-retro.sh" >&2
+  exit 2
+fi
+
+# Portable md5 of a single file (macOS `md5 -q`, Linux `md5sum`) — house pattern.
+_md5file() {
+  if command -v md5 >/dev/null 2>&1; then md5 -q "$1"
+  else md5sum "$1" | awk '{print $1}'; fi
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+mk_proj() {
+  local d="$1" phase="$2"
+  mkdir -p "$d/.claude"
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":%s,"phases":{}}\n' \
+    "$phase" > "$d/.claude/phase-state.json"
+}
+
+# A project carrying DECOYS: a generated pre-commit hook and the two ledgers a
+# real post-1.0 project has. H1 asserts the fast lane touches none of them —
+# §5.1's floor is INHERITED, and the delta track adds no floor arm. A fixture
+# with nothing to disturb could not tell "added no arm" from "found nothing".
+mk_decoy_proj() {
+  local d="$1" phase="$2"
+  mk_proj "$d" "$phase"
+  mkdir -p "$d/.git/hooks" "$d/docs"
+  printf '#!/bin/sh\n# the shipped floor: gitleaks, semgrep, tests, TDD ordering\nexit 0\n' \
+    > "$d/.git/hooks/pre-commit"
+  printf '# BUGS\n\n| # | Severity | Title |\n|---|---|---|\n' > "$d/BUGS.md"
+  printf '# FEATURES\n\n| # | Title |\n|---|---|\n' > "$d/FEATURES.md"
+  printf '# Changelog\n\n## [Unreleased]\n\n### Fixed\n' > "$d/CHANGELOG.md"
+}
+
+mk_scripts_tree() {
+  mkdir -p "$1"
+  cp -R "$REPO_ROOT/scripts" "$1/scripts"
+}
+
+write_policy() { printf '%s\n' "$2" > "$1/.claude/delta-policy.json"; }
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+delta_run() {
+  local sd="$1" p="$2"; shift 2
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/delta.sh" "$@" </dev/null 2>&1 )
+}
+
+seam() {
+  local sd="$1" p="$2"; shift 2
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/process-checklist.sh" "$@" </dev/null 2>/dev/null )
+}
+
+# cad <scripts-dir> <function> [args…] — call one scripts/lib/delta-cadence.sh
+# function the way a real consumer does: sourced into a script running under
+# `set -euo pipefail`, with its EXIT CODE propagated. WP7's cut-release.sh is
+# the consumer this shape is designed for, so the tests call it that way too.
+cad() {
+  local sd="$1"; shift
+  bash -c 'set -euo pipefail
+           . "$0/lib/delta-cadence.sh"
+           fn="$1"; shift
+           "$fn" "$@"' "$sd" "$@"
+}
+
+# active_json <project-dir> [jq-flags…] <filter> — read an assertion straight
+# off the state file the seam wrote. A missing or unreadable file yields the
+# literal READ-FAILED, which no expectation below ever matches: a helper that
+# returned "" would let an absent file satisfy any negative assertion.
+active_json() {
+  local p="$1"; shift
+  jq "$@" "$p/.claude/delta-state.json" 2>/dev/null || printf 'READ-FAILED'
+}
+
+# complete_gates <scripts-dir> <project-dir> [skip-token]
+#   Attest every gate this delta owes, optionally leaving ONE outstanding. Every
+#   completion goes through the production surface, never a hand-written file.
+#   `retro_review` is deliberately NOT special-cased here: the production
+#   surface refuses it (S3), this helper ignores the refusal, and the close
+#   still succeeds because the ledger row is what satisfies it.
+complete_gates() {
+  local sd="$1" p="$2" skip="${3:-}" g
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    [ "$g" = "$skip" ] && continue
+    delta_run "$sd" "$p" --complete-gate "$g" >/dev/null 2>&1
+  done <<EOF
+$(jq -r '.active_delta.gates_required[]? // empty' "$p/.claude/delta-state.json" 2>/dev/null)
+EOF
+  return 0
+}
+
+# open_hotfix <scripts-dir> <project-dir> <slug>
+open_hotfix() {
+  local sd="$1" p="$2" slug="$3"
+  delta_run "$sd" "$p" --open --describe "checkout is down in production right now" \
+    --class hotfix --slug "$slug" --confirm >/dev/null 2>&1
+  return 0
+}
+
+# ship_hotfix <scripts-dir> <project-dir> <slug> — open a hotfix and CLOSE it,
+# which is the state every retro spends most of its life in: the delta is done,
+# the write-up is not.
+ship_hotfix() {
+  local sd="$1" p="$2" slug="$3"
+  open_hotfix "$sd" "$p" "$slug"
+  complete_gates "$sd" "$p"
+  delta_run "$sd" "$p" --close >/dev/null 2>&1
+  return 0
+}
+
+# age_retro <scripts-dir> <project-dir> <id> <days>
+#   Shift one retro row BACK in time by <days>, moving `shipped_at` and `due_by`
+#   by the SAME amount. The interval between them — which is the product's own
+#   arithmetic and the thing under test — is preserved exactly; only the row's
+#   age changes. Through the seam, because the seam is the only writer (§7.1).
+age_retro() {
+  local sd="$1" p="$2" id="$3" days="$4"
+  seam "$sd" "$p" --delta-state-update "
+    .hotfix_retros = [ .hotfix_retros[]
+      | if .id == \"$id\" then
+            .shipped_at = ((.shipped_at | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime) - $days * 86400 | strftime(\"%Y-%m-%dT%H:%M:%SZ\"))
+          | .due_by     = ((.due_by     | strptime(\"%Y-%m-%dT%H:%M:%SZ\") | mktime) - $days * 86400 | strftime(\"%Y-%m-%dT%H:%M:%SZ\"))
+        else . end ]" >/dev/null 2>&1
+  return 0
+}
+
+# interval_days <project-dir> <index> — whole days between shipped_at and due_by
+# on one ledger row, computed from the row itself. This is what proves the
+# product read the policy: the test never states an expected DATE, only an
+# expected INTERVAL.
+interval_days() {
+  local p="$1" i="$2"
+  active_json "$p" -r --argjson i "$i" '
+    .hotfix_retros[$i] as $r
+    | (($r.due_by | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)
+       - ($r.shipped_at | strptime("%Y-%m-%dT%H:%M:%SZ") | mktime)) / 86400
+    | floor'
+}
+
+# tree_files <project-dir> — every file in the tree, one per line, sorted.
+# `.git/**` is excluded and that exclusion is not a convenience: `git diff` is
+# allowed to refresh the index's stat cache, so `.git/index` can legitimately
+# change bytes during a read-only measurement.
+tree_files() {
+  ( cd "$1" && find . -type f ! -path './.git/*' | LC_ALL=C sort )
+}
+
+# tree_manifest <project-dir> — every file in the tree with its md5. THE
+# refusal-residue instrument: a refusal that says "nothing was recorded" is a
+# claim about the whole filesystem, and checking one expected filename cannot
+# see a file nobody thought to look for.
+tree_manifest() {
+  local p="$1" f
+  tree_files "$p" | while IFS= read -r f; do
+    printf '%s  %s\n' "$(_md5file "$p/$f")" "$f"
+  done
+}
+
+# ── Mutation harness (inherited from the WP2/WP3/WP4 suites) ────────────────
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_mutation_report() {
+  local orig="$1" mut="$2" marker="$3" sites changed n
+  sites="$(grep -c "$marker" "$orig" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  if diff "$orig" "$mut" >/dev/null 2>&1; then changed=n; else changed=y; fi
+  n="$(diff "$orig" "$mut" | grep -c '^[<>]' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s|%s|%s' "$sites" "$changed" "$n"
+}
+
+echo "== tests/test-delta-wp5-hotfix-retro.sh =="
+echo ""
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== H — the hotfix fast lane at open (§5.2) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── H1: EXACTLY the §5.2 row, and nothing heavier ───────────────────────────
+# The set is asserted WHOLE. A subset assertion ("it has ledger_row") would pass
+# for a hotfix that also demanded a brief, a brief review and the full Build
+# Loop — which is the entire thing the fast lane is not.
+#
+# And the floor is INHERITED, not re-implemented (§5.1): the decoy tree carries
+# a pre-commit hook and three ledgers, and the whole-tree manifest says the open
+# added exactly the two `.claude/` documents and disturbed nothing else.
+T=$(mktemp -d); P="$T/proj"; mk_decoy_proj "$P" 4
+before="$(tree_manifest "$P")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --open --describe "checkout is down in production right now" --class hotfix --slug checkout --confirm); rc=$?
+after_files="$(tree_files "$P" | tr '\n' ' ')"
+gates="$(active_json "$P" -c '.active_delta.gates_required')"
+klass="$(active_json "$P" -r '.active_delta.class')"
+# Nothing heavier: none of the three heavy tokens anywhere on the row or in the
+# transcript, and no docs/deltas directory conjured into being.
+heavy=n
+printf '%s' "$gates" | grep -qE 'brief|build_loop' && heavy=y
+had_deltas=n; [ -d "$P/docs/deltas" ] && had_deltas=y
+# Everything that existed before is byte-identical afterwards.
+undisturbed=y
+printf '%s\n' "$before" | while IFS= read -r row; do
+  [ -n "$row" ] || continue
+  f="${row#*  }"
+  printf '%s  %s\n' "$(_md5file "$P/$f")" "$f"
+done > "$T/recheck"
+printf '%s\n' "$before" | grep -v '^$' > "$T/before"
+diff -q "$T/before" "$T/recheck" >/dev/null 2>&1 || undisturbed=n
+if [ "$rc" -eq 0 ] && [ "$klass" = "hotfix" ] \
+   && [ "$gates" = '["ledger_row","audit_row_at_open","retro_review","changelog"]' ] \
+   && [ "$heavy" = n ] && [ "$had_deltas" = n ] && [ "$undisturbed" = y ] \
+   && [ "$after_files" = "./.claude/delta-policy.json ./.claude/delta-state.json ./.claude/phase-state.json ./BUGS.md ./CHANGELOG.md ./FEATURES.md " ]; then
+  pass "H1: a hotfix materialises EXACTLY the §5.2 row ($gates) and nothing heavier (no brief, no brief_review, no build_loop: heavy=$heavy, docs/deltas created=$had_deltas); the open adds only the two .claude documents and leaves the pre-commit hook and all three ledgers byte-identical (undisturbed=$undisturbed) — the floor is inherited, not re-implemented"
+else
+  fail_ "H1" "rc=$rc (expect 0); class=$klass; gates=$gates (expect the §5.2 hotfix row EXACTLY); heavy token present=$heavy (expect n); docs/deltas created=$had_deltas (expect n); pre-existing files undisturbed=$undisturbed (expect y); files after='$after_files'; output:\n$out"
+fi
+rm -rf "$T"
+
+# ── H2: the AUDIT ROW is written AT OPEN, not at close ──────────────────────
+# §5.2 spells the token `audit_row_at_open` and means it literally. The trace is
+# on the record the instant the fast lane opens, and the gate is ALREADY
+# COMPLETE — it is the one gate nobody attests, because the framework wrote it
+# rather than asking. Asserted in both directions: the hotfix has it, and the
+# other three classes have neither the stamp nor the pre-completed gate.
+T=$(mktemp -d); P="$T/hotfix"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+stamp="$(active_json "$P" -r '.active_delta.audit_row_at_open')"
+done_at_open="$(active_json "$P" -c '.active_delta.gates_completed')"
+stamp_shape=n
+printf '%s' "$stamp" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$' && stamp_shape=y
+Pf="$T/fix"; mk_proj "$Pf" 4
+delta_run "$REPO_ROOT/scripts" "$Pf" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+fix_stamp="$(active_json "$Pf" -r '.active_delta.audit_row_at_open // "ABSENT"')"
+fix_done="$(active_json "$Pf" -c '.active_delta.gates_completed')"
+if [ "$stamp_shape" = y ] && [ "$done_at_open" = '["audit_row_at_open"]' ] \
+   && [ "$fix_stamp" = "ABSENT" ] && [ "$fix_done" = "[]" ]; then
+  pass "H2: the audit row is stamped AT OPEN ($stamp) and audit_row_at_open is already complete before the operator has done anything ($done_at_open) — while a fix carries neither (stamp=$fix_stamp, completed=$fix_done). It is written, not claimed"
+else
+  fail_ "H2" "hotfix stamp='$stamp' well-formed=$stamp_shape (expect y); gates_completed at open=$done_at_open (expect [\"audit_row_at_open\"]); fix stamp=$fix_stamp (expect ABSENT); fix gates_completed=$fix_done (expect [])"
+fi
+rm -rf "$T"
+
+# ── H3: the trace survives ABANDONMENT ──────────────────────────────────────
+# "A hotfix that never closes still left its trace." Abandonment is spelled the
+# only way it can be — the slot is emptied without a close — and the ledger row
+# is still there afterwards, with its id still reserved so the next delta cannot
+# be handed it.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.active_delta = null' >/dev/null 2>&1
+slot="$(active_json "$P" -r '.active_delta')"
+n_closed="$(active_json "$P" -r '.closed | length')"
+ledger="$(active_json "$P" -c '[.hotfix_retros[] | {id, closed_at}]')"
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+next_id="$(active_json "$P" -r '.active_delta.id')"
+if [ "$slot" = "null" ] && [ "$n_closed" = "0" ] \
+   && [ "$ledger" = '[{"id":"DELTA-001","closed_at":null}]' ] && [ "$next_id" = "DELTA-002" ]; then
+  pass "H3: a hotfix abandoned without ever closing (slot $slot, audit tail $n_closed rows) still left its trace — the ledger holds $ledger — and its id stays reserved, so the next open takes $next_id"
+else
+  fail_ "H3" "slot=$slot (expect null); closed length=$n_closed (expect 0); ledger=$ledger (expect DELTA-001 still open); next id=$next_id (expect DELTA-002)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L — the retro ledger, appended at OPEN (§7.1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── L1: appended at OPEN, §7.1's five keys, three days  [KILLS m1] ─────────
+# THE DESIGN'S OWN MUTATION TARGET (§11-WP5): "the retro row is written at OPEN,
+# not at close". So the row is read back BEFORE anything is closed, and the
+# interval is computed off the row itself rather than compared to a date this
+# test worked out — the test states an INTERVAL, never a DATE.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+n_rows="$(active_json "$P" -r '.hotfix_retros | length')"
+keys="$(active_json "$P" -c '.hotfix_retros[0] | keys_unsorted')"
+row_id="$(active_json "$P" -r '.hotfix_retros[0].id')"
+row_closed="$(active_json "$P" -r '.hotfix_retros[0].closed_at')"
+row_record="$(active_json "$P" -r '.hotfix_retros[0].record')"
+shipped_is_open="$(active_json "$P" -r '.hotfix_retros[0].shipped_at == .active_delta.opened_at')"
+days="$(interval_days "$P" 0)"
+if [ "$n_rows" = "1" ] && [ "$row_id" = "DELTA-001" ] \
+   && [ "$keys" = '["id","shipped_at","due_by","closed_at","record"]' ] \
+   && [ "$row_closed" = "null" ] && [ "$row_record" = "null" ] \
+   && [ "$shipped_is_open" = "true" ] && [ "$days" = "3" ]; then
+  pass "L1: the retro row is on the record the moment the hotfix OPENS — one row, §7.1's five keys in order ($keys), id $row_id, closed_at $row_closed, record $row_record, shipped_at equal to the delta's own opened_at, and due_by exactly $days days later (Karl set 3, not 7)"
+else
+  fail_ "L1" "rows=$n_rows (expect 1); keys=$keys (expect §7.1's five, in order); id=$row_id; closed_at=$row_closed (expect null); record=$row_record (expect null); shipped_at == opened_at: $shipped_is_open (expect true); due_by - shipped_at = $days day(s) (expect 3)"
+fi
+rm -rf "$T"
+
+# ── L2: retro_due_days is READ FROM POLICY  [KILLS m5] ─────────────────────
+# The pin that separates "computed from policy" from "computed from a number
+# that happens to agree with policy today". A project that retunes the window
+# gets ITS window (§7.2 — "every key is overridable").
+T=$(mktemp -d)
+Pd="$T/default"; mk_proj "$Pd" 4
+open_hotfix "$REPO_ROOT/scripts" "$Pd" checkout
+d_default="$(interval_days "$Pd" 0)"
+Pr="$T/retuned"; mk_proj "$Pr" 4
+write_policy "$Pr" '{"schemaVersion":1,"classes":{"hotfix":{"gates":["ledger_row","audit_row_at_open","retro_review","changelog"],"retro_due_days":9}}}'
+open_hotfix "$REPO_ROOT/scripts" "$Pr" checkout
+d_retuned="$(interval_days "$Pr" 0)"
+if [ "$d_default" = "3" ] && [ "$d_retuned" = "9" ]; then
+  pass "L2: the window is READ FROM POLICY — the framework default gives $d_default days and a project that retunes classes.hotfix.retro_due_days to 9 gets $d_retuned, from the same code path"
+else
+  fail_ "L2" "framework default interval=$d_default (expect 3); retuned-to-9 interval=$d_retuned (expect 9) — if both are 3 the number is hardcoded, not read"
+fi
+rm -rf "$T"
+
+# ── L3: no other class writes a retro row ──────────────────────────────────
+# The ledger is the hotfix's alone. A fix, a feature and a security patch each
+# open and close with an EMPTY ledger — asserted after the close, so a row that
+# appeared at either moment would show.
+T=$(mktemp -d)
+l3_ok=y; l3_detail=""
+_l3() {
+  local class="$1" P n
+  P="$T/$class"; mk_proj "$P" 4
+  delta_run "$REPO_ROOT/scripts" "$P" --open --describe "something to do" --class "$class" --confirm >/dev/null 2>&1
+  n="$(active_json "$P" -r '.hotfix_retros | length')"
+  complete_gates "$REPO_ROOT/scripts" "$P"
+  delta_run "$REPO_ROOT/scripts" "$P" --close >/dev/null 2>&1
+  n="$n/$(active_json "$P" -r '.hotfix_retros | length')"
+  l3_detail="$l3_detail [$class=$n]"
+  [ "$n" = "0/0" ] || l3_ok=n
+}
+_l3 fix
+_l3 security-patch
+if [ "$l3_ok" = y ]; then
+  pass "L3: no class but hotfix touches the ledger — at open and again after close, it is empty:$l3_detail"
+else
+  fail_ "L3" "expected 0/0 (rows at open / rows after close) for every non-hotfix class; got:$l3_detail"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S — the retro OUTLIVES the close (§5.2's loan) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── S1: the close does not close the retro  [KILLS m2] ─────────────────────
+# THE PROPERTY THIS WHOLE SUITE EXISTS FOR. A hotfix ships fast by BORROWING
+# rigor; the retro is the repayment. If closing the delta closed the retro, the
+# loan would be forgiven the instant it was taken out — and every visible
+# surface would still say the right thing.
+#
+# Asserted three ways so it cannot be satisfied by accident: the delta really
+# did close (slot null, tail grew), the retro row is byte-identical to what open
+# wrote (not merely "still present"), and the close ANNOUNCES the debt.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+row_at_open="$(active_json "$P" -c '.hotfix_retros[0]')"
+complete_gates "$REPO_ROOT/scripts" "$P"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+slot="$(active_json "$P" -r '.active_delta')"
+n_closed="$(active_json "$P" -r '.closed | length')"
+row_after="$(active_json "$P" -c '.hotfix_retros[0]')"
+still_open="$(active_json "$P" -r '.hotfix_retros[0].closed_at == null')"
+announced=n; printf '%s' "$out" | grep -qi 'write-up' && announced=y
+names_id=n; printf '%s' "$out" | grep -qF 'DELTA-001' && names_id=y
+carried="$(active_json "$P" -r '.closed[0].audit_row_at_open != null')"
+if [ "$rc" -eq 0 ] && [ "$slot" = "null" ] && [ "$n_closed" = "1" ] \
+   && [ "$still_open" = "true" ] && [ "$row_at_open" = "$row_after" ] \
+   && [ "$announced" = y ] && [ "$names_id" = y ] && [ "$carried" = "true" ]; then
+  pass "S1: closing the hotfix delta empties the slot ($slot) and grows the audit tail to $n_closed — and the retro row is byte-identical to what open wrote ($row_after), still open. The close ANNOUNCES the outstanding write-up and names the delta. The loan is not forgiven by being repaid-looking; the audit row is carried onto the closed record ($carried)"
+else
+  fail_ "S1" "rc=$rc (expect 0); slot=$slot (expect null); closed length=$n_closed (expect 1); retro still open=$still_open (expect true); row at open=$row_at_open row after close=$row_after (must MATCH); close announced the debt=$announced names the id=$names_id (both expect y); audit stamp carried onto the closed row=$carried (expect true); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── S2: the bind is on the LEDGER ROW, and it fails CLOSED  [KILLS m6] ─────
+# `retro_review` is satisfied by the OBLIGATION being on the record — that is
+# what §7.2 means by "retro_review IS that close review, arriving late and
+# collateralised by the §9.2 release refusal". So the close proceeds while the
+# retro is open (S1) and REFUSES when the row is gone: a hotfix whose obligation
+# has been erased has nothing collateralising it, and closing it would let the
+# loan disappear from the record entirely.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+complete_gates "$REPO_ROOT/scripts" "$P"
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros = []' >/dev/null 2>&1
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --close); rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+names=n; printf '%s' "$out" | grep -qF 'retro_review' && names=y
+n_closed="$(active_json "$P" -r '.closed | length')"
+if [ "$rc" -eq 7 ] && [ "$names" = y ] && [ "$before" = "$after" ] && [ "$n_closed" = "0" ]; then
+  pass "S2: with the ledger row erased the close is REFUSED (rc $rc) naming retro_review, the record is byte-identical and the audit tail is still empty — the gate is bound to the obligation, and an obligation nobody is holding fails CLOSED"
+else
+  fail_ "S2" "rc=$rc (expect 7); names retro_review=$names; bytes $before -> $after (must MATCH); closed length=$n_closed (expect 0); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── S3: retro_review is not attestable ─────────────────────────────────────
+# §7.2 names the exact failure this prevents: letting a hotfix "satisfy
+# close_review at ship time and make the retro optional — which is precisely the
+# loan going unrepaid". A tick-box would be that. So the surface refuses, and
+# points at the one thing that does repay it.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+open_hotfix "$REPO_ROOT/scripts" "$P" checkout
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --complete-gate retro_review); rc=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+done_list="$(active_json "$P" -c '.active_delta.gates_completed')"
+points=n; printf '%s' "$out" | grep -qF -- '--retro' && points=y
+if [ "$rc" -eq 2 ] && [ "$before" = "$after" ] && [ "$points" = y ] \
+   && [ "$done_list" = '["audit_row_at_open"]' ]; then
+  pass "S3: --complete-gate retro_review is refused (rc $rc) and points the operator at --retro; the record is byte-identical and gates_completed is unchanged ($done_list). The loan cannot be repaid by ticking a box"
+else
+  fail_ "S3" "rc=$rc (expect 2); bytes $before -> $after (must MATCH); refusal points at --retro=$points (expect y); gates_completed=$done_list (expect [\"audit_row_at_open\"]); output:\n$out"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T — --retro: filing the write-up ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── T1: closes EXACTLY one retro, bounded, one write ───────────────────────
+# Two shipped hotfixes, so "exactly one" is observable rather than trivially
+# true. The residue is bounded by stripping precisely the two fields the write
+# is allowed to touch from BOTH documents and requiring the remainders to be
+# equal — the same instrument WP4's N2 uses on the ratchet record.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+ship_hotfix "$REPO_ROOT/scripts" "$P" payments
+n_open_before="$(active_json "$P" -r '[.hotfix_retros[] | select(.closed_at == null)] | length')"
+snapshot="$(active_json "$P" -c '.')"
+files_before="$(tree_manifest "$P" | grep -v 'delta-state.json' || true)"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "the payment gateway timed out; we now retry twice and alert on the second failure"); rc=$?
+files_after="$(tree_manifest "$P" | grep -v 'delta-state.json' || true)"
+now_json="$(active_json "$P" -c '.')"
+n_open_after="$(active_json "$P" -r '[.hotfix_retros[] | select(.closed_at == null)] | length')"
+first_closed="$(active_json "$P" -r '.hotfix_retros[0].closed_at != null')"
+second_open="$(active_json "$P" -r '.hotfix_retros[1].closed_at == null')"
+recorded="$(active_json "$P" -r '.hotfix_retros[0].record.value')"
+confined=$(jq -n --argjson a "$snapshot" --argjson b "$now_json" '
+    ($a | .hotfix_retros |= map(del(.closed_at) | del(.record)))
+ == ($b | .hotfix_retros |= map(del(.closed_at) | del(.record)))' 2>/dev/null)
+confined="${confined:-READ-FAILED}"
+if [ "$rc" -eq 0 ] && [ "$n_open_before" = "2" ] && [ "$n_open_after" = "1" ] \
+   && [ "$first_closed" = "true" ] && [ "$second_open" = "true" ] \
+   && [ "$confined" = "true" ] && [ "$files_before" = "$files_after" ] \
+   && [ "$recorded" = "the payment gateway timed out; we now retry twice and alert on the second failure" ]; then
+  pass "T1: --retro files EXACTLY one write-up — $n_open_before open before, $n_open_after after; DELTA-001 is closed and DELTA-002 untouched; the substance is on the record verbatim; and the residue is bounded to those rows' closed_at and record with no other file in the tree moved"
+else
+  fail_ "T1" "rc=$rc (expect 0); open before=$n_open_before (expect 2) after=$n_open_after (expect 1); first closed=$first_closed second still open=$second_open (both expect true); change confined to closed_at+record=$confined (expect true); other files moved=$([ "$files_before" = "$files_after" ] && echo n || echo y) (expect n); recorded='$recorded'; output:\n$out"
+fi
+rm -rf "$T"
+
+# ── T2: a second --retro on the same id is refused  [KILLS m4] ─────────────
+# WRITE-ONCE, for the same reason `shipped_in` is (§7.1): a second write-up
+# claiming the same incident is a bug worth stopping, and overwriting the first
+# would destroy the only record of what was decided at the time.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "first write-up" >/dev/null 2>&1; rc_first=$?
+before="$(_md5file "$P/.claude/delta-state.json")"
+out=$(delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "second write-up"); rc_second=$?
+after="$(_md5file "$P/.claude/delta-state.json")"
+kept="$(active_json "$P" -r '.hotfix_retros[0].record.value')"
+if [ "$rc_first" -eq 0 ] && [ "$rc_second" -eq 12 ] && [ "$before" = "$after" ] \
+   && [ "$kept" = "first write-up" ]; then
+  pass "T2: the first --retro files (rc $rc_first) and a second on the same id is refused (rc $rc_second) — the record is byte-identical and still holds '$kept'. The write-up is write-once"
+else
+  fail_ "T2" "first rc=$rc_first (expect 0); second rc=$rc_second (expect 12); bytes $before -> $after (must MATCH); record now='$kept' (expect 'first write-up'); output:\n$out"
+fi
+rm -rf "$T"
+
+# ── T3: an unknown id (11) and a missing record (2) ────────────────────────
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+out_u=$(delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-777 --record "never happened"); rc_unknown=$?
+out_r=$(delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001); rc_norecord=$?
+out_n=$(delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record ""); rc_empty=$?
+still_open="$(active_json "$P" -r '.hotfix_retros[0].closed_at == null')"
+if [ "$rc_unknown" -eq 11 ] && [ "$rc_norecord" -eq 2 ] && [ "$rc_empty" -eq 2 ] \
+   && [ "$still_open" = "true" ]; then
+  pass "T3: an id nothing on the record carries is refused (rc $rc_unknown) and a write-up with no substance is an invocation error whether the flag is absent (rc $rc_norecord) or empty (rc $rc_empty) — the real retro is untouched"
+else
+  fail_ "T3" "unknown id rc=$rc_unknown (expect 11); missing --record rc=$rc_norecord (expect 2); empty --record rc=$rc_empty (expect 2); the real retro is still open=$still_open (expect true); outputs:\n$out_u\n$out_r\n$out_n"
+fi
+rm -rf "$T"
+
+# ── T4: the record contract, honestly kinded ───────────────────────────────
+# "State your contract and keep it honest about which it is." A value that names
+# a file THAT EXISTS is recorded as a file; anything else is recorded as the
+# operator's own summary. The framework never claims to have read a write-up it
+# cannot find — which is why a path that does not resolve is stored as
+# `attested` and SAID to be, rather than filed as though a document existed.
+T=$(mktemp -d)
+Pf="$T/file"; mk_proj "$Pf" 4
+ship_hotfix "$REPO_ROOT/scripts" "$Pf" checkout
+mkdir -p "$Pf/docs/incidents"
+printf '# 2026-08-03 checkout\n\nWhat happened.\n' > "$Pf/docs/incidents/2026-08-03-checkout.md"
+out_f=$(delta_run "$REPO_ROOT/scripts" "$Pf" --retro DELTA-001 --record docs/incidents/2026-08-03-checkout.md); rc_f=$?
+kind_f="$(active_json "$Pf" -r '.hotfix_retros[0].record.kind')"
+val_f="$(active_json "$Pf" -r '.hotfix_retros[0].record.value')"
+Pa="$T/attested"; mk_proj "$Pa" 4
+ship_hotfix "$REPO_ROOT/scripts" "$Pa" checkout
+out_a=$(delta_run "$REPO_ROOT/scripts" "$Pa" --retro DELTA-001 --record docs/incidents/never-written.md); rc_a=$?
+kind_a="$(active_json "$Pa" -r '.hotfix_retros[0].record.kind')"
+says_which=n; printf '%s' "$out_a" | grep -qi 'could not find\|no file' && says_which=y
+if [ "$rc_f" -eq 0 ] && [ "$kind_f" = "file" ] && [ "$val_f" = "docs/incidents/2026-08-03-checkout.md" ] \
+   && [ "$rc_a" -eq 0 ] && [ "$kind_a" = "attested" ] && [ "$says_which" = y ]; then
+  pass "T4: a --record naming a file that EXISTS is recorded as kind '$kind_f' pointing at $val_f; a --record naming one that does not is recorded as kind '$kind_a' and the transcript SAYS no such file was found ($says_which) — the framework never files a document it did not see"
+else
+  fail_ "T4" "existing-file rc=$rc_f kind=$kind_f (expect file) value=$val_f; missing-file rc=$rc_a kind=$kind_a (expect attested) transcript says so=$says_which (expect y); outputs:\n$out_f\n$out_a"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== O — overdue arithmetic (scripts/lib/delta-cadence.sh) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── O1: 2 days is not overdue at 3; 4 days is; 7 makes 4 current ───────────
+# The brief's own scenario. Each fixture opens under the policy it is testing,
+# so the WINDOW is the product's; the test only ages the row, moving shipped_at
+# and due_by together so the interval it computed is preserved exactly.
+T=$(mktemp -d)
+o1_ok=y; o1_detail=""
+_o1() {
+  local name="$1" policy="$2" age="$3" want="$4" P doc rc
+  P="$T/$name"; mk_proj "$P" 4
+  [ -n "$policy" ] && write_policy "$P" "$policy"
+  ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+  age_retro "$REPO_ROOT/scripts" "$P" DELTA-001 "$age"
+  doc="$(active_json "$P" -c '.')"
+  rc=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || rc=$?
+  o1_detail="$o1_detail [$name=rc$rc]"
+  [ "$rc" -eq "$want" ] || o1_ok=n
+}
+_o1 "default-2days" "" 2 1
+_o1 "default-4days" "" 4 0
+_o1 "retuned7-4days" '{"schemaVersion":1,"classes":{"hotfix":{"gates":["ledger_row","audit_row_at_open","retro_review","changelog"],"retro_due_days":7}}}' 4 1
+if [ "$o1_ok" = y ]; then
+  pass "O1: at the framework's 3-day window a 2-day-old retro is not yet due (rc 1) and a 4-day-old one is OVERDUE (rc 0); a project that retunes the window to 7 finds the same 4-day-old retro current again —$o1_detail"
+else
+  fail_ "O1" "expected rc 1 / 0 / 1 in order (0 = overdue); got:$o1_detail"
+fi
+rm -rf "$T"
+
+# ── O2: AN UNREADABLE due_by IS OVERDUE  [KILLS m3] ────────────────────────
+# BL-213's fail-open class, refused. §14-V13 records the sibling defect: today
+# check-maintenance.sh prints "All maintenance cadences current" at rc 0 for a
+# date it could not read. The fixture's date is `2026-13-45` — month 13, day 45 —
+# which NEITHER `date -d` nor `date -j -f` accepts, so this is the real parser
+# failing and not a mocked one. ASSERTED ON THE EXIT CODE, never on the text.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-13-45"' >/dev/null 2>&1
+stored="$(active_json "$P" -r '.hotfix_retros[0].due_by')"
+doc="$(active_json "$P" -c '.')"
+rc_one=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || rc_one=$?
+rc_any=0; cad "$REPO_ROOT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || rc_any=$?
+state="$(cad "$REPO_ROOT/scripts" delta_retro_rows "$doc" 2>/dev/null | awk -F'\t' '{ if (NR == 1) s = $3 } END { print s }')"
+# And an ABSENT due_by is the same class of unreadable, not a free pass.
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update 'del(.hotfix_retros[0].due_by)' >/dev/null 2>&1
+doc2="$(active_json "$P" -c '.')"
+rc_absent=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc2" DELTA-001 >/dev/null 2>&1 || rc_absent=$?
+if [ "$stored" = "2026-13-45" ] && [ "$rc_one" -eq 0 ] && [ "$rc_any" -eq 0 ] \
+   && [ "$state" = "undetermined" ] && [ "$rc_absent" -eq 0 ]; then
+  pass "O2: a due_by neither parser can read ($stored) is OVERDUE (rc $rc_one) and not silently current — the ledger predicate agrees (rc $rc_any), the row renders as '$state' rather than as a date, and an ABSENT due_by is the same refusal (rc $rc_absent). This is BL-213's fail-open class, closed"
+else
+  fail_ "O2" "stored due_by='$stored'; delta_retro_overdue rc=$rc_one (expect 0 = OVERDUE); delta_any_overdue_retro rc=$rc_any (expect 0); rendered state='$state' (expect undetermined); absent due_by rc=$rc_absent (expect 0)"
+fi
+rm -rf "$T"
+
+# ── O3: the whole-ledger predicates, in all four states ────────────────────
+# The interface §9.2's second refusal is built on: `cut-release.sh` refuses on
+# ANY open retro, and the cadence nag arm reads the overdue half. Both are
+# asserted here so WP7 can build against a pinned contract.
+T=$(mktemp -d)
+o3_ok=y; o3_detail=""
+_o3() {
+  local name="$1" want_open="$2" want_overdue="$3" P="$4" doc ro rv
+  doc="$(active_json "$P" -c '.')"
+  ro=0; cad "$REPO_ROOT/scripts" delta_any_open_retro "$doc" >/dev/null 2>&1 || ro=$?
+  rv=0; cad "$REPO_ROOT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || rv=$?
+  o3_detail="$o3_detail [$name open=$ro overdue=$rv]"
+  [ "$ro" -eq "$want_open" ] || o3_ok=n
+  [ "$rv" -eq "$want_overdue" ] || o3_ok=n
+}
+Pn="$T/none"; mk_proj "$Pn" 4
+delta_run "$REPO_ROOT/scripts" "$Pn" --open --describe "the CSV export crashes on unicode" --confirm >/dev/null 2>&1
+_o3 "empty-ledger" 1 1 "$Pn"
+Pc="$T/current"; mk_proj "$Pc" 4
+ship_hotfix "$REPO_ROOT/scripts" "$Pc" checkout
+_o3 "one-open-current" 0 1 "$Pc"
+Po="$T/overdue"; mk_proj "$Po" 4
+ship_hotfix "$REPO_ROOT/scripts" "$Po" checkout
+age_retro "$REPO_ROOT/scripts" "$Po" DELTA-001 5
+_o3 "one-open-overdue" 0 0 "$Po"
+delta_run "$REPO_ROOT/scripts" "$Po" --retro DELTA-001 --record "filed" >/dev/null 2>&1
+_o3 "all-filed" 1 1 "$Po"
+if [ "$o3_ok" = y ]; then
+  pass "O3: the whole-ledger predicates answer the four states WP7 needs (0 = yes, 1 = no) —$o3_detail — including the one that matters most: filing the write-up on an OVERDUE retro clears both"
+else
+  fail_ "O3" "expected open/overdue of 1,1 then 0,1 then 0,0 then 1,1; got:$o3_detail"
+fi
+rm -rf "$T"
+
+# ── O4: the parse helper ───────────────────────────────────────────────────
+# GNU-first `date -d`, BSD `date -j -f` fallback — the two spellings this repo
+# has to support, each of which REJECTS the other's input, so the order is safe
+# in both directions. Garbage returns rc 1 AND PRINTS NOTHING: a helper that
+# printed a stale value on failure would let a caller that ignored rc read it as
+# a date. And a bare `YYYY-MM-DD` is normalised to midnight UTC before either
+# parser sees it, because BSD's `-j -f` fills unspecified fields FROM NOW — so
+# the un-normalised spelling would make the same date parse differently every
+# time it was read.
+T=$(mktemp -d)
+o4_ok=y; o4_detail=""
+e_iso="$(cad "$REPO_ROOT/scripts" delta_cadence_epoch "2026-08-03T00:00:00Z" 2>/dev/null)" || e_iso="ERR"
+e_bare="$(cad "$REPO_ROOT/scripts" delta_cadence_epoch "2026-08-03" 2>/dev/null)" || e_bare="ERR"
+rc_bad=0; out_bad="$(cad "$REPO_ROOT/scripts" delta_cadence_epoch "2026-13-45" 2>/dev/null)" || rc_bad=$?
+rc_junk=0; cad "$REPO_ROOT/scripts" delta_cadence_epoch "banana" >/dev/null 2>&1 || rc_junk=$?
+rc_empty=0; cad "$REPO_ROOT/scripts" delta_cadence_epoch "" >/dev/null 2>&1 || rc_empty=$?
+round="$(cad "$REPO_ROOT/scripts" delta_cadence_stamp "$e_iso" 2>/dev/null)" || round="ERR"
+plus3="$(cad "$REPO_ROOT/scripts" delta_cadence_due_by "2026-08-03T00:00:00Z" 3 2>/dev/null)" || plus3="ERR"
+[ "$e_iso" = "$e_bare" ] || { o4_ok=n; o4_detail="$o4_detail(BARE DATE NOT MIDNIGHT: iso=$e_iso bare=$e_bare)"; }
+[ "$rc_bad" -ne 0 ] || { o4_ok=n; o4_detail="$o4_detail(2026-13-45 PARSED)"; }
+[ -z "$out_bad" ] || { o4_ok=n; o4_detail="$o4_detail(GARBAGE PRINTED '$out_bad')"; }
+[ "$rc_junk" -ne 0 ] || { o4_ok=n; o4_detail="$o4_detail(banana PARSED)"; }
+[ "$rc_empty" -ne 0 ] || { o4_ok=n; o4_detail="$o4_detail(EMPTY PARSED)"; }
+[ "$round" = "2026-08-03T00:00:00Z" ] || { o4_ok=n; o4_detail="$o4_detail(ROUND TRIP=$round)"; }
+[ "$plus3" = "2026-08-06T00:00:00Z" ] || { o4_ok=n; o4_detail="$o4_detail(PLUS3=$plus3)"; }
+if [ "$o4_ok" = y ]; then
+  pass "O4: the parse helper reads full ISO and bare dates identically (both $e_iso — the bare form is normalised to midnight UTC, so BSD's fill-from-now can never leak in), round-trips through the formatter ($round), adds days ($plus3), and refuses 2026-13-45 / banana / empty with a non-zero code AND NO OUTPUT"
+else
+  fail_ "O4" "problems:$o4_detail (iso=$e_iso bare=$e_bare bad-rc=$rc_bad bad-out='$out_bad' junk-rc=$rc_junk empty-rc=$rc_empty round=$round plus3=$plus3)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V — --status renders open and overdue retros ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── V1: named when owed, in both branches, and absent when filed ───────────
+# THE STRUCTURAL DISCRIMINATOR is the last arm: a suite that only asserted "the
+# id appears" would pass for a --status that printed the whole ledger including
+# everything already filed, which is the opposite of the surface's job.
+T=$(mktemp -d); P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+out_none=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+v_none=n; printf '%s' "$out_none" | grep -qF 'DELTA-001' && v_none=y
+age_retro "$REPO_ROOT/scripts" "$P" DELTA-001 5
+out_over=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+v_over=n; printf '%s' "$out_over" | grep -qiE 'overdue|late' && v_over=y
+# With a NEW delta open the retro block must still render — the ledger outlives
+# the delta, so a surface that only showed it in the idle branch would hide it
+# exactly when the operator is busy.
+delta_run "$REPO_ROOT/scripts" "$P" --open --describe "add dark mode" --confirm >/dev/null 2>&1
+out_busy=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+v_busy=n; printf '%s' "$out_busy" | grep -qF 'DELTA-001' && v_busy=y
+v_new=n;  printf '%s' "$out_busy" | grep -qF 'DELTA-002' && v_new=y
+# An unreadable date is named as unreadable, not rendered as a day count.
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-13-45"' >/dev/null 2>&1
+out_bad=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+v_bad=n; printf '%s' "$out_bad" | grep -qiE 'cannot be read|OVERDUE' && v_bad=y
+# Filed: gone.
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-08-06T00:00:00Z"' >/dev/null 2>&1
+delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "filed" >/dev/null 2>&1
+out_filed=$(delta_run "$REPO_ROOT/scripts" "$P" --status)
+v_filed=n; printf '%s' "$out_filed" | grep -qF 'DELTA-001' && v_filed=y
+if [ "$v_none" = y ] && [ "$v_over" = y ] && [ "$v_busy" = y ] && [ "$v_new" = y ] \
+   && [ "$v_bad" = y ] && [ "$v_filed" = n ]; then
+  pass "V1: --status names the outstanding write-up with nothing else open ($v_none), calls it overdue once it is ($v_over), still shows it while a DIFFERENT delta is open ($v_busy alongside $v_new), names an unreadable due date rather than rendering it as a day count ($v_bad) — and once filed it appears nowhere ($v_filed)"
+else
+  fail_ "V1" "idle-branch names it=$v_none; overdue named=$v_over; shown while another delta is open=$v_busy (new delta also shown=$v_new); unreadable date named=$v_bad; STILL SHOWN AFTER FILING=$v_filed (expect n); outputs:\n--- idle ---\n$out_none\n--- overdue ---\n$out_over\n--- busy ---\n$out_busy\n--- bad ---\n$out_bad\n--- filed ---\n$out_filed"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== N — refusal residue (the WP4 standard) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── N1: every --retro refusal leaves the WHOLE TREE pristine ───────────────
+# WP4's doctrine, inherited: a pure refusal leaves the tree byte-for-byte as it
+# found it, and the instrument is a `find` over the whole tree with a per-file
+# md5 — not `[ -e ]` on one expected filename, which cannot see a file nobody
+# thought to look for. None of these refusals carries a raise, so unlike the
+# close flow there is no bounded-residue arm here: the answer is zero, always.
+T=$(mktemp -d)
+n1_ok=y; n1_detail=""
+_n1_run() {
+  local name="$1" want="$2" P before after rc
+  shift 2
+  P="$T/$name"; mk_proj "$P" 4
+  ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+  # The already-filed arm needs a filed retro first; every other arm refuses on
+  # the tree as shipped.
+  case "$name" in
+    already) delta_run "$REPO_ROOT/scripts" "$P" --retro DELTA-001 --record "first" >/dev/null 2>&1 ;;
+  esac
+  before="$(tree_manifest "$P")"
+  delta_run "$REPO_ROOT/scripts" "$P" "$@" >/dev/null 2>&1; rc=$?
+  after="$(tree_manifest "$P")"
+  n1_detail="$n1_detail [$name=rc$rc]"
+  [ "$rc" -eq "$want" ] || n1_ok=n
+  [ "$before" = "$after" ] || { n1_ok=n; n1_detail="$n1_detail(TREE MOVED)"; }
+}
+_n1_run unknown-id 11 --retro DELTA-777 --record "x"
+_n1_run no-record   2 --retro DELTA-001
+_n1_run already    12 --retro DELTA-001 --record "second"
+_n1_run no-id       2 --retro
+if [ "$n1_ok" = y ]; then
+  pass "N1: every --retro refusal —$n1_detail — leaves the whole tree byte-for-byte as it found it, asserted as a find-based manifest with a per-file md5"
+else
+  fail_ "N1" "expected rc 11 / 2 / 12 / 2 with an unchanged tree; got:$n1_detail"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutation proofs (each mutant is BUILT and RUN here) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── m1: suppress the retro-row append  [L1 RED] ────────────────────────────
+# THE DESIGN'S OWN MUTATION (§11-WP5): "suppress the retro-row append -> a
+# hotfix ships with no retro obligation -> RED". The failure mode is entirely
+# silent: the hotfix opens, ships and closes, every surface says the right
+# thing, and nothing anywhere is ever going to ask for the write-up again.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-RETRO-APPEND$/s@.*@    filter="$filter"@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-OPEN-RETRO-APPEND$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+Pp="$T/pristine"; mk_proj "$Pp" 4
+open_hotfix "$REPO_ROOT/scripts" "$Pp" checkout
+pri_rows="$(active_json "$Pp" -r '.hotfix_retros | length')"
+Pm="$T/mutant"; mk_proj "$Pm" 4
+open_hotfix "$MT/scripts" "$Pm" checkout
+mut_rows="$(active_json "$Pm" -r '.hotfix_retros | length')"
+mut_open="$(active_json "$Pm" -r '.active_delta.id')"
+complete_gates "$MT/scripts" "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_close_rc=$?
+mut_doc="$(active_json "$Pm" -c '.')"
+mut_any=0; cad "$MT/scripts" delta_any_open_retro "$mut_doc" >/dev/null 2>&1 || mut_any=$?
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rows" = "1" ] && [ "$mut_rows" = "0" ] && [ "$mut_open" = "DELTA-001" ] \
+   && [ "$mut_close_rc" -eq 7 ] && [ "$mut_any" -eq 1 ]; then
+  pass "m1: with the retro-row append suppressed the hotfix still opens ($mut_open) but the ledger is EMPTY ($mut_rows rows, where the pristine tree writes $pri_rows). L1 goes RED. The residual damage is legible in this row too: the close then fails CLOSED (rc $mut_close_rc) because the bind has no obligation to find, and the whole-ledger predicate WP7 will call reports nothing owed (rc $mut_any) (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m1" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE ledger rows=$pri_rows (expect 1); MUTANT rows=$mut_rows (expect 0) open delta=$mut_open; mutant close rc=$mut_close_rc (expect 7); mutant any-open-retro rc=$mut_any (expect 1 = none owed)"
+fi
+rm -rf "$T"
+
+# ── m2: make the close ALSO close the retro  [S1 RED] ──────────────────────
+# THE LOAN-FORGIVENESS BUG, built and run. This is the one mutation that has to
+# be caught, because it is the one that leaves every visible surface saying
+# exactly the right things: the delta closes, the audit tail grows, --status is
+# clean, and the debt has vanished. §5.2's "that is what makes the fast lane a
+# loan rather than a leak" is precisely what this mutant deletes.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" \
+  '/# DELTA-CLOSE-ATOMIC-WRITE$/s@.*@  filter=".closed += [$row] | .active_delta = null | .hotfix_retros = [.hotfix_retros[] | .closed_at = \\"$now\\"]"@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-ATOMIC-WRITE$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m2_fixture() {
+  local sd="$1" P="$2"
+  mk_proj "$P" 4
+  open_hotfix "$sd" "$P" checkout
+  complete_gates "$sd" "$P"
+}
+Pp="$T/pristine"; _m2_fixture "$REPO_ROOT/scripts" "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
+pri_open="$(active_json "$Pp" -r '.hotfix_retros[0].closed_at == null')"
+pri_doc="$(active_json "$Pp" -c '.')"
+pri_any=0; cad "$REPO_ROOT/scripts" delta_any_open_retro "$pri_doc" >/dev/null 2>&1 || pri_any=$?
+Pm="$T/mutant"; _m2_fixture "$MT/scripts" "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_open="$(active_json "$Pm" -r '.hotfix_retros[0].closed_at == null')"
+mut_record="$(active_json "$Pm" -r '.hotfix_retros[0].record')"
+mut_doc="$(active_json "$Pm" -c '.')"
+mut_any=0; cad "$MT/scripts" delta_any_open_retro "$mut_doc" >/dev/null 2>&1 || mut_any=$?
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 0 ] && [ "$pri_open" = "true" ] && [ "$pri_any" -eq 0 ] \
+   && [ "$mut_rc" -eq 0 ] && [ "$mut_open" = "false" ] && [ "$mut_record" = "null" ] && [ "$mut_any" -eq 1 ]; then
+  pass "m2: with the close ALSO closing the retro, the hotfix closes exactly as cleanly (rc $mut_rc) and the debt is GONE — the ledger row is marked filed with a record of $mut_record, and the predicate WP7's release refusal will call reports nothing owed (rc $mut_any) where the pristine tree reports one (rc $pri_any). S1 goes RED. This is the loan forgiven the instant it was taken out, with every surface still saying the right thing (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m2" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 0) retro still open=$pri_open (expect true) any-open rc=$pri_any (expect 0); MUTANT rc=$mut_rc (expect 0) retro still open=$mut_open (expect false — the mutant closed it) record=$mut_record (expect null — filed with no substance) any-open rc=$mut_any (expect 1 = nothing owed)"
+fi
+rm -rf "$T"
+
+# ── m3: neuter the fail-closed unparseable arm  [O2 RED] ───────────────────
+# BL-213's class, executed. §11-WP6's own mutation for the sibling defect is
+# "remove the new undetermined counter -> the unparseable fixture reports 'All
+# maintenance cadences current' at rc=0 -> RED, and it must assert the EXIT
+# CODE, not the printed text". Same discipline here: the assertion is the code.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/lib/delta-cadence.sh" '/# DELTA-CADENCE-UNPARSEABLE$/s@.*@      state=current; days=999@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/lib/delta-cadence.sh" "$MT/scripts/lib/delta-cadence.sh" 'DELTA-CADENCE-UNPARSEABLE$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+P="$T/proj"; mk_proj "$P" 4
+ship_hotfix "$REPO_ROOT/scripts" "$P" checkout
+seam "$REPO_ROOT/scripts" "$P" --delta-state-update '.hotfix_retros[0].due_by = "2026-13-45"' >/dev/null 2>&1
+doc="$(active_json "$P" -c '.')"
+pri_rc=0; cad "$REPO_ROOT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || pri_rc=$?
+pri_any=0; cad "$REPO_ROOT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || pri_any=$?
+mut_rc=0; cad "$MT/scripts" delta_retro_overdue "$doc" DELTA-001 >/dev/null 2>&1 || mut_rc=$?
+mut_any=0; cad "$MT/scripts" delta_any_overdue_retro "$doc" >/dev/null 2>&1 || mut_any=$?
+mut_state="$(cad "$MT/scripts" delta_retro_rows "$doc" 2>/dev/null | awk -F'\t' '{ if (NR == 1) s = $3 } END { print s }')"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 0 ] && [ "$pri_any" -eq 0 ] \
+   && [ "$mut_rc" -eq 1 ] && [ "$mut_any" -eq 1 ] && [ "$mut_state" = "current" ]; then
+  pass "m3: with the fail-closed arm neutered, a due_by of 2026-13-45 — a date NEITHER parser accepts — reads as '$mut_state' and the overdue predicates answer 'no' (rc $mut_rc / $mut_any) where the pristine tree answers 'yes' (rc $pri_rc / $pri_any). O2 goes RED, on the EXIT CODE and not on any printed word. This is BL-213's fail-open class re-opened in one line (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m3" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE overdue rc=$pri_rc any rc=$pri_any (both expect 0 = overdue); MUTANT overdue rc=$mut_rc any rc=$mut_any (both expect 1 = not overdue) state='$mut_state' (expect current)"
+fi
+rm -rf "$T"
+
+# ── m4: neuter the write-once guard on --retro  [T2 RED] ───────────────────
+# STRUCTURAL DISCRIMINATOR: the mutant does not merely stop refusing — it
+# reports SUCCESS for a write-up it did not record, because the filter's own
+# `closed_at == null` guard still skips the already-filed row. The operator is
+# told their second write-up is on the record and it is not. That is the worse
+# of the two failure modes and it is the one a rc-only assertion would miss.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-RETRO-STATE-GUARD$/s@.*@  state="OPEN"@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-RETRO-STATE-GUARD$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m4_fixture() {
+  local sd="$1" P="$2"
+  mk_proj "$P" 4
+  ship_hotfix "$sd" "$P" checkout
+  delta_run "$sd" "$P" --retro DELTA-001 --record "first write-up" >/dev/null 2>&1
+}
+Pp="$T/pristine"; _m4_fixture "$REPO_ROOT/scripts" "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --retro DELTA-001 --record "second write-up" >/dev/null 2>&1; pri_rc=$?
+Pm="$T/mutant"; _m4_fixture "$MT/scripts" "$Pm"
+delta_run "$MT/scripts" "$Pm" --retro DELTA-001 --record "second write-up" >/dev/null 2>&1; mut_rc=$?
+mut_kept="$(active_json "$Pm" -r '.hotfix_retros[0].record.value')"
+mut_unknown=0
+delta_run "$MT/scripts" "$Pm" --retro DELTA-777 --record "never happened" >/dev/null 2>&1 || mut_unknown=$?
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 12 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_kept" = "first write-up" ] \
+   && [ "$mut_unknown" -eq 0 ]; then
+  pass "m4: with the write-once guard neutered a second --retro on a filed retro reports SUCCESS (rc $mut_rc) while the record still holds '$mut_kept' — the operator is told their write-up is filed and it is not — and an id nothing carries also reports success (rc $mut_unknown) instead of refusing. T2 goes RED (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m4" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE second-file rc=$pri_rc (expect 12); MUTANT rc=$mut_rc (expect 0) record kept='$mut_kept' (expect 'first write-up' — the silent discard) unknown-id rc=$mut_unknown (expect 0)"
+fi
+rm -rf "$T"
+
+# ── m5: hardcode the retro window  [L2 RED] ────────────────────────────────
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-OPEN-RETRO-DUE-DAYS$/s@.*@    days=3@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-OPEN-RETRO-DUE-DAYS$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+POL='{"schemaVersion":1,"classes":{"hotfix":{"gates":["ledger_row","audit_row_at_open","retro_review","changelog"],"retro_due_days":9}}}'
+Pp="$T/pristine"; mk_proj "$Pp" 4; write_policy "$Pp" "$POL"
+open_hotfix "$REPO_ROOT/scripts" "$Pp" checkout
+pri_days="$(interval_days "$Pp" 0)"
+Pm="$T/mutant"; mk_proj "$Pm" 4; write_policy "$Pm" "$POL"
+open_hotfix "$MT/scripts" "$Pm" checkout
+mut_days="$(interval_days "$Pm" 0)"
+mut_policy="$(jq -r '.classes.hotfix.retro_due_days' "$Pm/.claude/delta-policy.json" 2>/dev/null)"
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_days" = "9" ] && [ "$mut_days" = "3" ] && [ "$mut_policy" = "9" ]; then
+  pass "m5: with the policy read replaced by a literal, a project whose own file says $mut_policy days gets a $mut_days-day window anyway, where the pristine tree honours it ($pri_days). L2 goes RED — and the failure is silent: no error, no warning, just a deadline the project did not choose (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m5" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE interval=$pri_days (expect 9); MUTANT interval=$mut_days (expect 3) while the mutant's own policy file says $mut_policy (expect 9)"
+fi
+rm -rf "$T"
+
+# ── m6: waive retro_review unconditionally  [S2 RED] ───────────────────────
+# FRESH FIXTURE THAT REACHES THE GUARD: the ledger row must be erased first, or
+# the bind is satisfied for the honest reason and the mutant looks pinned when
+# it is not.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+_sed_inplace "$MT/scripts/delta.sh" '/# DELTA-CLOSE-RETRO-BIND$/s@.*@    retro_state="open"@'
+rep="$(_mutation_report "$REPO_ROOT/scripts/delta.sh" "$MT/scripts/delta.sh" 'DELTA-CLOSE-RETRO-BIND$')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+_m6_fixture() {
+  local sd="$1" P="$2"
+  mk_proj "$P" 4
+  open_hotfix "$sd" "$P" checkout
+  complete_gates "$sd" "$P"
+  seam "$sd" "$P" --delta-state-update '.hotfix_retros = []' >/dev/null 2>&1
+}
+Pp="$T/pristine"; _m6_fixture "$REPO_ROOT/scripts" "$Pp"
+delta_run "$REPO_ROOT/scripts" "$Pp" --close >/dev/null 2>&1; pri_rc=$?
+pri_closed="$(active_json "$Pp" -r '.closed | length')"
+Pm="$T/mutant"; _m6_fixture "$MT/scripts" "$Pm"
+delta_run "$MT/scripts" "$Pm" --close >/dev/null 2>&1; mut_rc=$?
+mut_closed="$(active_json "$Pm" -r '.closed | length')"
+mut_ledger="$(active_json "$Pm" -r '.hotfix_retros | length')"
+mut_doc="$(active_json "$Pm" -c '.')"
+mut_any=0; cad "$MT/scripts" delta_any_open_retro "$mut_doc" >/dev/null 2>&1 || mut_any=$?
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] \
+   && [ "$pri_rc" -eq 7 ] && [ "$pri_closed" = "0" ] \
+   && [ "$mut_rc" -eq 0 ] && [ "$mut_closed" = "1" ] && [ "$mut_ledger" = "0" ] && [ "$mut_any" -eq 1 ]; then
+  pass "m6: with retro_review waived unconditionally, a hotfix whose obligation has been erased closes clean (rc $mut_rc, $mut_closed row archived) over an EMPTY ledger ($mut_ledger rows, nothing owed: rc $mut_any) where the pristine tree fails CLOSED (rc $pri_rc, nothing archived). S2 goes RED — the gate would be satisfied by the class rather than by the obligation, and a hotfix could ship with no collateral at all (marker sites=$sites, one line changed=$nlines/2)"
+else
+  fail_ "m6" "marker sites=$sites (expect 1); mutation applied=$changed (expect y); diff lines=$nlines (expect 2); PRISTINE rc=$pri_rc (expect 7) closed=$pri_closed (expect 0); MUTANT rc=$mut_rc (expect 0) closed=$mut_closed (expect 1) ledger rows=$mut_ledger (expect 0) any-open rc=$mut_any (expect 1)"
+fi
+rm -rf "$T"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

Delta Track **WP5** (design of record: `docs/designs/2026-08-02-delta-track-v1.md` §5.2, §7.1, §7.2, §11-WP5): the hotfix fast lane and the retro ledger that collateralises it.

- **The fast lane** — `hotfix` opens on the §5.2 row and nothing heavier: no brief, no brief_review, no Build Loop. The §5.1 floor (gitleaks / semgrep / project tests / TDD ordering in the generated hook) is inherited untouched; the delta track adds no floor arm.
- **`audit_row_at_open`** — stamped at open in the same atomic write and recorded complete at that moment: the one gate nobody attests, because the framework wrote it rather than asking.
- **The retro ledger** — appended **at open** with `due_by = shipped_at + policy.retro_due_days` (read per-key from policy; retuning moves the interval). `--retro <id> --record FILE-OR-TEXT` files it once, through the seam, atomically. The record contract distinguishes `kind: "file"` (the path exists at filing time) from `"attested"` — **including a path that did not resolve**, and the transcript says so: filing a typo'd filename as though a document existed would be the framework inventing evidence.
- **The property this WP exists for**: the retro **outlives the delta's close**. A hotfix ships fast by borrowing rigor; the retro is the repayment. If closing the delta closed the retro, the loan would be forgiven the moment it was taken out — with every screen still looking correct.
- **Fail-closed dates** (BL-213's class, refused): `delta_cadence_epoch` returns non-zero and prints *nothing* on input neither parser accepts — no `|| echo 0` tail, which is the exact shape that lets `check-maintenance.sh` report "All cadences current" over an unreadable date. Unreadable, absent and null `due_by` are all **overdue**. A bare `YYYY-MM-DD` is normalised to `T00:00:00Z` first, because BSD's `-j -f` fills unspecified fields *from now* and would otherwise answer differently on every call.

## The WP7 interface (this is what `cut-release.sh` will refuse on)

`delta_retro_overdue` / `delta_any_open_retro` / `delta_any_overdue_retro` / `delta_retro_rows`, all taking the state **document**, not a root. New seam action `--delta-state-read-strict`: **rc 0** + document · **rc 3** file exists but is unreadable as a state document · **rc 4** no file at all — with **nothing on stdout** in either failure, so a caller that ignores the code cannot be handed a phantom document. The predicates answer **rc 3 UNDETERMINED** rather than collapsing into "none owed": *an empty ledger is a real answer; "I cannot read it" is not.* WP7 treats both 3 and 4 as refusals.

## Verification trail (fable pr-reviewer, xhigh, two rounds)

- **Round 1 (major_concerns):** every implementer claim reproduced exactly, and **every legitimate command path left the retro byte-identical** — the blockers were the paths that are *not* commands. (1) The seam accepted silent wipes and forgeries of retro rows (`.hotfix_retros = []`, forged `closed_at`, string rows read as "nothing owed") while `closed` rows were already guarded — and `delta-state.sh`'s own deferral note had assigned that guard to this WP. (2) A corrupt state file warned on stderr only, and a **deleted** one was entirely silent: `rm .claude/delta-state.json` was loan forgiveness in one keystroke, through the exact calling shape documented for WP7.
- **Fix round:** **22 guard atoms** (row-shape, transition, tolerance, strict-read, cadence, date), each neutered alone at an anchored marker with `sites==1` and exactly-one-line-changed, each with a named killing case — including the two **tolerance** atoms proven in the inverted direction (pristine accepts a legitimate repair; the mutant locks the single writer out of its own file). Plus the 3am refusal circle given a real exit, and two test-hygiene repairs.
- **Re-review: approve.** All eleven crafted seam attacks (the reviewer's original three plus drop / reorder / id-swap / double-file / append-closed / dup-id / extra-key) refused with the guard's own message and the file byte-identical; the one accepted shape is the documented boundary and is structurally identical to `--retro`. **Mutant attribution audited**: the implementer self-caught that m2 had begun dying on the new guard rather than on its own discriminator and made it file lawfully; the reviewer audited the other five and confirmed each dies for its own reason. Review record: `.superpowers/sdd/2026-08-02-delta-track-v1/wp5-review.md` (session artifact).

Suite 34/0; WP0 13/13, WP2 31/0, WP3 29/0, WP4 29/0, boundary 29/0; run-lints 15/15; merges clean onto current main.

## Reviewer advisories carried

- **Faithful, no gap:** close *succeeding* with the retro open is the only coherent reading — §5.2's hotfix close-review cell is "✅ *(at retro)*" and §9.2's second refusal would be dead code otherwise; refusing at close would hold the single `active_delta` slot hostage for three days.
- **Right posture, low severity:** a surgically hand-edited state file deadlocks that delta's close permanently. No in-product escape hatch is owed — a repair verb would be the erase-and-reset path — and the refusals now name `git checkout -- .claude/delta-state.json`.
- **Routed to Karl, not built:** whether `audit_row_at_open` (§5.2) means a `BUGS.md` append rather than the framework's state-document record. The reviewer's evidence: "ledger row" is a defined term, and the state-document stamp survives neither abandonment nor state-file loss. A ruling is owed before WP8 lands ledger writes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
