### PR TITLE
feat(delta): WP6 — wire the cadence orphan, close BL-213's fail-open

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -435,6 +435,7 @@ jobs:
             tests/test-delta-wp3-era-classify.sh
             tests/test-delta-wp4-close-rubric.sh
             tests/test-delta-wp5-hotfix-retro.sh
+            tests/test-delta-wp6-cadence.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh

--- a/docs/builders-guide.md
+++ b/docs/builders-guide.md
@@ -2003,35 +2003,66 @@ always refuse. Fixing the evidence is usually faster than the escalation.
 
 ### Step 4.4: Ongoing Maintenance Cadence
 
-**Schedule these cadences proactively** — create recurring calendar events for each application. Do not rely on memory. Run `scripts/check-maintenance.sh` to verify whether any cadence is overdue.
+**Schedule these cadences proactively** — create recurring calendar events for each application. Do not rely on memory. `scripts/check-maintenance.sh` is the tool that says whether any of them is overdue, and you can run it by hand at any time.
 
-**Weekly (30 minutes):**
+**Does it also run on its own? That depends on how this project got here.**
+
+- **Scaffolded by `init.sh`:** yes. `scripts/session-cadence-check.sh` is registered as a SessionStart hook, so every session opens with a check.
+- **Upgraded from an older version by `scripts/upgrade-project.sh`:** the upgrade delivers **both scripts** — so the checker itself is current, including the repaired exit codes below — but it does **not** add the SessionStart registration. Until it does, run the checker by hand on your own cadence, or register the hook yourself by adding `bash "$CLAUDE_PROJECT_DIR"/scripts/session-cadence-check.sh` to `hooks.SessionStart` in `.claude/settings.json`.
+
+#### The two cadences the tool measures
+
+Two of the buckets below are **mechanically checked**; the rest are practice the tool cannot see. Both windows are **policy, not constants** — a project on a slower schedule changes a config, it does not fork the script:
+
+| Cadence | Signal it reads | Default window | Policy key |
+|---|---|---|---|
+| **Routine review** | the last commit that touched `CHANGELOG.md`, and the last that touched `sbom.json` | 14 days | `cadence.routine_review_days` |
+| **Deep security scan** (the dependency audit is folded into it) | the newest dated file in `docs/test-results/` matching `*snyk*`, `*dep*`, `*audit*`, `*semgrep*` or `*sast*` | 95 days | `cadence.deep_security_days` |
+
+Both keys live in the project's post-1.0 policy file (`.claude/delta-policy.json`, `cadence` block). An absent file, an absent key — or a project that has never opened any post-release work at all — falls back to the defaults above, so the checker works everywhere.
+
+**Its three exit codes, and what they mean.** Read the code, not the closing sentence:
+
+- **0** — every applicable cadence was **measured** and is current.
+- **1** — one or more cadences are **overdue**.
+- **2** — one or more **could not be measured**, and none is overdue. A `CHANGELOG.md` with no git history, an empty `docs/test-results/`, a scan file with no date in its name, or a date no parser accepts all land here.
+
+A release cut **refuses on 1 and on 2**. Unmeasurable is not a pass: before this was fixed, an unreadable date was silently skipped and reported as current, so a cadence nobody had actually measured could sail through a tag.
+
+**What the check does NOT prove.** Two of these signals are **dates parsed out of filenames**. A file named with today's date and containing nothing satisfies the cadence completely. The windows above make the *schedule* stricter; they do not make the *evidence* stronger. Treat a green run as "the calendar is being kept", never as "the scan found nothing".
+
+**A cadence surface you do not have is not a failure.** No `CHANGELOG.md`, no `sbom.json` or no `docs/test-results/` is reported as *not applicable* and does not move any counter — the tool measures a cadence, it does not audit whether you have a maintenance practice. Where the session-start nag is registered, it stays completely quiet unless something is wrong, and says nothing at all until the project reaches Phase 4 — none of this applies to a product that has not launched. It also stays quiet if the checker itself fails to run: a hook that cannot measure anything reports nothing rather than guessing.
+
+#### The practice
+
+**Weekly (30 minutes) — habit, not checked:**
 - Review error dashboard and monitoring alerts
 - Health check: application is up and responsive
 - Review any user feedback or support requests
 
-**Monthly (1-2 hours):**
-- Dependency and security audit
+**Routine review (1-2 hours, every 14 days by default) — CHECKED:**
 - Apply non-breaking security patches
 - Review error dashboard. Fix recurring errors.
 - Rotate API keys/tokens approaching expiration
-- Update SBOM
-- Run full E2E test suite before each maintenance release
+- Update the SBOM (`sbom.json`)
+- Run the full E2E test suite before each maintenance release
 - Triage incoming bugs from production monitoring (same severity classification as Phase 2)
+- Write the CHANGELOG entry — it is half of what the check reads
 
-**Quarterly (2-3 hours):**
+**Quarterly (2-3 hours) — habit, not checked:**
 - Review usage: what are users doing? What are they requesting?
 - Performance comparison to last quarter
 - Infrastructure/distribution cost review
 - Prioritize post-MVP backlog based on real user signals
 - Run full regression test suite (all Phase 2 + Phase 3 tests)
 
-**Biannually (3-4 hours):**
-- Full dependency audit. Identify deprecated packages.
+**Deep security scan (3-4 hours, every 95 days by default) — CHECKED:**
+- **Full dependency audit. Identify deprecated packages.** (This used to sit under a separate biannual bucket and a separate 95-day check; it is one activity on one clock now.)
 - Plan version upgrades.
-- Re-run full Phase 3 security and performance audit.
+- Re-run the full Phase 3 security and performance audit.
 - Verify AI provider terms (if using AI in development).
 - Review platform requirements (SDK versions, OS support, store policies).
+- **Leave the evidence where the tool looks:** a dated artefact in `docs/test-results/` (for example `2026-08-03_semgrep_pass.txt`). A scan you ran and did not record is a scan the cadence cannot see.
 
 ---
 

--- a/init.sh
+++ b/init.sh
@@ -1365,6 +1365,10 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/session-freshness-check.sh" scripts/   # BL-109 S2 (Currency System, Layer 1)
   cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-intake-check.sh" scripts/   # BL-202 (intake/Phase-0 dead-air)
+  # The SessionStart nag arm for the cadence checker (design v1 §8.3's second
+  # enforcement point). check-maintenance.sh itself is already copied below —
+  # §0.3-C1: the orphan was never the shipping, only the invocation.
+  cp "$SCRIPT_DIR/scripts/session-cadence-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-end-qdrant-reminder.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-mcp-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/process-checklist.sh" scripts/
@@ -1434,7 +1438,7 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/host-errors.sh" scripts/lib/
   cp "$SCRIPT_DIR/scripts/host-drivers/"*.sh scripts/host-drivers/
   chmod +x scripts/host-drivers/*.sh
-  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-intake-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
+  chmod +x scripts/validate.sh scripts/check-phase-gate.sh scripts/run-phase3-validation.sh scripts/check-gate.sh scripts/check-updates.sh scripts/resume.sh scripts/intake-wizard.sh scripts/resolve-tools.sh scripts/upgrade-project.sh scripts/reconfigure-project.sh scripts/verify-install.sh scripts/test-gate.sh scripts/check-versions.sh scripts/session-version-check.sh scripts/session-freshness-check.sh scripts/session-test-gate-check.sh scripts/session-intake-check.sh scripts/session-cadence-check.sh scripts/session-end-qdrant-reminder.sh scripts/session-mcp-gate.sh scripts/process-checklist.sh scripts/pre-commit-gate.sh scripts/track-tool-usage.sh scripts/pending-approval.sh scripts/lint-uat-scenarios.sh scripts/check-maintenance.sh scripts/lint-backlog-references.sh scripts/lint-counter-antipattern.sh scripts/lint-review-manifest.sh
 
   # Copy intake suggestion files
   mkdir -p templates/intake-suggestions
@@ -1911,6 +1915,18 @@ PERMEOF
           hooks_added=true
         fi
         # BL-202-INTAKE-HOOK-END
+        # CADENCE-NAG-HOOK-BEGIN — the maintenance-cadence nag (design v1 §8.3's
+        # SessionStart enforcement point, the soft half of the pair whose hard
+        # half is the release cut). Silent when every cadence is current,
+        # zero-network, fail-open (exit 0 under every failure mode). Injected
+        # exactly like the four hooks above; fenced so the registration is
+        # excisable for a mutation proof without touching its siblings.
+        if ! jq -e '.hooks.SessionStart[0].hooks[] | select(.command | contains("session-cadence-check.sh"))' .claude/settings.json >/dev/null 2>&1; then
+          jq '.hooks.SessionStart[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-cadence-check.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
+            && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
+        fi
+        # CADENCE-NAG-HOOK-END
         # Add Qdrant reminder to Stop hook
         if jq -e '.hooks.Stop' .claude/settings.json >/dev/null 2>&1; then
           if ! jq -e '.hooks.Stop[0].hooks[] | select(.command | contains("session-end-qdrant-reminder.sh"))' .claude/settings.json >/dev/null 2>&1; then

--- a/scripts/check-maintenance.sh
+++ b/scripts/check-maintenance.sh
@@ -2,119 +2,385 @@
 set -euo pipefail
 
 # Solo Orchestrator — Maintenance Cadence Check
-# Checks whether scheduled maintenance activities are overdue
-# by reading CHANGELOG.md dates and SBOM modification time.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §8.3 (the CALENDAR-based
+# re-fire trigger — the threshold table, the three notes, the author-proposed
+# `exit 2`, and the two enforcement points), §0.3-C1 (this script ALREADY
+# SHIPS: WP6 wires its invocation and does not re-ship it), §0.3-C2 (the
+# script/guide split), §7.2 (the `cadence` policy keys), §11-WP6, §13-R14 (the
+# honest evidence residual, restated below rather than quietly dropped).
+# Closes BL-213.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose — no backlog
+# entry exists for this build, and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1-WP5
+# precedent. The grep-able `CADENCE-*` markers below are this file's citation
+# primitive and its mutation addresses. BL-213 is named in prose because it is
+# the BUG this file closes, not a code marker.)
 #
 # Usage: bash scripts/check-maintenance.sh
 #
-# Exit codes:
-#   0 — all maintenance cadences current
-#   1 — one or more cadences overdue
-#   2 — could not determine (missing data)
+# ═════════════════════════════════════════════════════════════════════════════
+# THE EXIT CONTRACT — WRITTEN FOR WP7, READ IT BEFORE CHANGING AN ARM
+#
+#   0  every APPLICABLE cadence was MEASURED and is current
+#   1  one or more cadences are OVERDUE
+#   2  one or more cadences COULD NOT BE MEASURED, and none is overdue
+#
+# WP7's release cut (§9.2) REFUSES ON 1 AND ON 2. Unmeasurable is not a pass:
+# a cadence nobody could read must not be silently satisfiable at a tag. 2 is
+# deliberately the ZERO-OVERDUE code — when both are true the answer is 1, so a
+# real overdue is never hidden behind an unreadable date; the unmeasurable ones
+# are still named in the report either way.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHY 2 EXISTS AT ALL — BL-213, AND THE DEFECT THIS FILE USED TO BE
+#
+# Until WP6 every verdict here sat inside `if [ "$last_epoch" -gt 0 ]`, and
+# `last_epoch` came from a `date -j -f … || date -d … || echo "0"` tail. A date
+# neither parser accepted therefore resolved to 0, the guard was false, and THE
+# WHOLE ARM WAS SKIPPED IN SILENCE: no print, no counter — and the script closed
+# with "All maintenance cadences current." at exit 0 over evidence it had never
+# read. §14-V13 logs the executed run (an untracked CHANGELOG.md plus a lone
+# `2026-13-45_semgrep_pass.txt`): one INFO line, nothing at all for the security
+# arm, rc 0. The docblock advertised a "2 — could not determine" that no code
+# path produced.
+#
+# THE DIRECTION IS THE POINT. That was fail-OPEN: an unreadable signal was
+# indistinguishable from a fresh one. A design reviewer proposed the opposite
+# mechanism — an unparseable date falling through into a huge `days_since` and
+# exiting 1 — and the `-gt 0` guard refutes it. A fail-CLOSED checker would have
+# over-blocked a release cut (annoying, safe); the fail-OPEN one that shipped
+# would have let a release pass a cadence that was never really measured.
+#
+# The repair has three parts and all three are load-bearing:
+#   1. `cadence_epoch` returns NON-ZERO AND PRINTS NOTHING when neither parser
+#      accepts its input. There is no default and no third answer — a
+#      `|| echo "0"` tail is the exact shape that manufactured the sentinel.
+#   2. Every arm that cannot date its signal calls `mark_undetermined`, which
+#      holds the ONLY line that moves the counter (`# CADENCE-UNDETERMINED-COUNTER`).
+#      tests/test-delta-wp6-cadence.sh::m2 removes that one line and asserts the
+#      unparseable fixture reports "All maintenance cadences current" at rc 0
+#      again — on the EXIT CODE, never on the sentence.
+#   3. The closing verdict reports the counter as exit 2.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# APPLICABLE vs UNMEASURABLE — ONE RULE, STATED ONCE
+#
+#   A signal surface that DOES NOT EXIST is NOT APPLICABLE. A project with no
+#   CHANGELOG.md, no sbom.json or no docs/test-results/ is told so, and no
+#   counter moves. Absence of an artefact is a legitimate project shape and the
+#   framework does not invent a verdict for it.
+#
+#   A signal surface that EXISTS but cannot be DATED is UNDETERMINED. A
+#   CHANGELOG.md or sbom.json with no git history, a docs/test-results/ holding
+#   no scan artefact at all (the policy-expected-but-missing signal), an
+#   artefact whose filename carries no date, and a date no parser accepts are
+#   all the same answer — "I could not measure this" — and all of them reach
+#   exit 2.
+#
+#   RESIDUAL, STATED RATHER THAN HIDDEN: a project that has never produced ANY
+#   of the three surfaces still exits 0. This checker measures a CADENCE; it
+#   does not audit whether a maintenance practice exists. Widening that would
+#   make every pre-Phase-3 tree unmeasurable and is a design change, not a
+#   tweak — tests/test-delta-wp6-cadence.sh::E8 pins the boundary so it can only
+#   move deliberately.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THE SIGNALS ACTUALLY PROVE (§13-R14) — DO NOT OVERSELL THIS
+#
+#   The deep-scan cadence reads a DATE PARSED OUT OF A FILENAME in
+#   docs/test-results/. A file named with today's date and containing nothing
+#   satisfies it completely. Tightening the clock (185 -> 95 days, and 35 -> 14
+#   on the routine arms) makes the SCHEDULE stricter; it does NOT make the
+#   EVIDENCE stronger, and nothing here should be read as a security
+#   improvement. The one honest evidence gain in WP6 is negative: a filename
+#   whose date nobody can read is no longer reported as fresh.
+#
+#   THREE SHAPES OF THAT RESIDUAL, MEASURED BY THE WP6 REVIEW AND NAMED HERE SO
+#   THE DISCLOSURE IS NOT NARROWER THAN THE BEHAVIOUR. Filed as backlog lines;
+#   none is changed by this WP, and the glob set is inherited verbatim from the
+#   pre-WP6 script:
+#     • SUBSTRING BREADTH (R-WP6-4). `*dep*` matches far more than a dependency
+#       audit — `deployment-notes-<date>.md` satisfies the cadence completely.
+#       The fold raises the stakes: one stray match now satisfies the WHOLE
+#       deep-security clock, which is what the release cut reads.
+#     • NON-FILE ARTEFACTS (R-WP6-7). A fresh-dated empty DIRECTORY, or a
+#       dangling symlink, satisfies it too — `ls` supplies the name and the date
+#       is read off the name. One shape wider than "a dated empty file".
+#     • CROSS-HOST DATE DIVERGENCE (R-WP6-5). `2026-13-45` is refused by both
+#       parsers, but an in-range impossibility like `2026-02-30` NORMALISES on
+#       BSD (to 2026-03-02) and is refused by GNU. Both answers refuse a release
+#       cut — measured or undetermined — so neither host skips anything
+#       silently. Recorded so nobody later "fixes" the divergence by loosening
+#       the fail-closed side.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE THRESHOLDS ARE POLICY, NOT CONSTANTS (§8.3 note 3, §7.2)
+#
+#   routine_review_days  (default 14)  CHANGELOG.md and sbom.json — both were
+#                                      35 before D5 tightened them.
+#   deep_security_days   (default 95)  the quarterly deep security scan, WITH
+#                                      THE DEPENDENCY AUDIT FOLDED IN (§8.3's
+#                                      table: the separate 95-day dependency row
+#                                      and the 185-day biannual row become ONE
+#                                      cadence at 95).
+#
+#   WHAT "FOLDED IN" COSTS, SAID OUT LOUD: one cadence means one clock over the
+#   UNION of the two artefact families (`*snyk*`/`*dep*`/`*audit*` and
+#   `*semgrep*`/`*sast*`), so a fresh artefact of either family satisfies it.
+#   That is weaker than two independent clocks were at spotting a stale
+#   dependency scan behind a fresh SAST run. The alternative — requiring BOTH
+#   families — would permanently exit 2 for every project that legitimately
+#   attests a skipped dependency scanner under run-phase3-validation.sh's
+#   attest-on-skip contract, which is a worse failure than the one it fixes.
+#
+#   THE READ ROUTES THROUGH THE ONE SEAM, and that is not a style choice. This
+#   script is CORE. The post-1.0 track is a SEVERABLE MODULE (D1) and
+#   scripts/lint-delta-boundary.sh forbids every core file from naming a module
+#   path on an executed line (§3.3 clause 2, tier T1 — NOT inline-waivable),
+#   with a file-level seam allowlist whose cardinality is asserted at exactly
+#   ONE. So the obvious implementations — a `jq` straight at the policy JSON, or
+#   sourcing the module's policy lib — are both unavailable. The read delegates
+#   core -> core through the ONE seam, exactly as scripts/upgrade-project.sh's
+#   policy notice and scripts/validate.sh's era assertion already do; this is
+#   the THIRD instance of that waived routing. The residue is the one waived
+#   line below: reaching the seam means naming a seam ACTION FLAG, every seam
+#   action carries the `delta-` prefix by design (§3.1), and that prefix is what
+#   tier T2 scans for. T2 exists WITH a reason-required inline waiver for
+#   exactly this case. Do not rename the action to hide the prefix — that evades
+#   the scan below the prefix boundary (§13-R15) and buys nothing.
+#
+#   ABSENT POLICY — AND AN ABSENT MODULE — MEAN THE FRAMEWORK DEFAULTS. A
+#   project that never opened a post-release change still gets a working
+#   checker: the seam may be missing, may be an older vendored copy that does
+#   not know the action, or may refuse outright, and every one of those falls
+#   back to the constants below. The checker does not require the delta module,
+#   and today's `init.sh` does not ship it.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE DATE LAYER IS A DELIBERATE DUPLICATE, AND THE REASON IS THE BOUNDARY
+#
+#   scripts/lib/delta-cadence.sh's `delta_cadence_epoch` is the same idiom with
+#   the same no-default contract, and reusing it would be the better
+#   engineering. It is a MODULE file, so naming it from here is a tier-T1
+#   violation and T1 is not waivable — routing a date parse through the seam
+#   instead would make basic arithmetic depend on an optional module and would
+#   still need this fallback anyway. The duplication is the price of
+#   severability, recorded here so the next reader does not "fix" it by adding a
+#   core -> module edge. If the two ever disagree they are wrong together.
+#
+#   BOTH normalise a bare `YYYY-MM-DD` to `T00:00:00Z` BEFORE either parser sees
+#   it, and that is a real bug fix, not tidiness: BSD's `date -j -f` fills fields
+#   the format did not specify FROM THE CURRENT TIME, so the pre-WP6 spelling in
+#   this file answered a different number on every call and a different number
+#   from GNU's answer for the same input. The two hosts now agree exactly.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # BL-046: uses print_info / print_ok / print_warn only — source core subset.
 source "$SCRIPT_DIR/lib/helpers-core.sh"
 
+# ── Framework defaults (§7.2). A project overrides these in ITS policy file,
+# never by editing this script. ────────────────────────────────────────────────
+ROUTINE_DEFAULT_DAYS=14                                                        # CADENCE-DEFAULT-ROUTINE
+DEEP_DEFAULT_DAYS=95                                                           # CADENCE-DEFAULT-DEEP
+
+overdue=0
+undetermined=0
+UNMEASURED=""
+now_epoch="$(date -u +%s)"
+
+# cadence_policy_days <cadence-key> <framework-default>
+#   The project's threshold for one cadence, or the framework default when the
+#   policy, the key, the module or the seam is absent. Fail-soft in every
+#   direction — see the seam block in this file's header for why the read is a
+#   delegation and not a `jq`.
+cadence_policy_days() {
+  local key="$1" def="$2" seam="$SCRIPT_DIR/process-checklist.sh" v=""
+  if [ -f "$seam" ]; then
+    v="$( bash "$seam" --delta-policy-get "cadence.$key" </dev/null 2>/dev/null )" || v=""   # CADENCE-POLICY-READ  # lint-delta-boundary: allow core->core delegation to the ONE declared seam — this names the seam's action FLAG, never a module path (T1 is clean) and the seam allowlist stays at cardinality 1 (§3.1/§3.3)
+  fi
+  # A non-numeric, empty or multi-line answer is not a threshold. It falls back
+  # rather than reaching the arithmetic below, where it would abort the script
+  # under `set -e` and take every remaining cadence with it.
+  case "$v" in ''|*[!0-9]*) v="$def" ;; esac
+  printf '%s\n' "$v"
+}
+
+# cadence_epoch <stamp>
+#   `YYYY-MM-DD` or `YYYY-MM-DDTHH:MM:SSZ` -> UTC epoch seconds on stdout, rc 0.
+#   rc 1 AND NOTHING ON STDOUT when neither parser accepts it.
+#
+#   The `case` gate is a SHAPE check, not a validity check: it rejects inputs
+#   that are not date-shaped at all (empty, `banana`, a stamp with a numeric
+#   offset instead of `Z`) and passes date-SHAPED nonsense like `2026-13-45`
+#   through to the real parser, which is what must refuse it. A gate that tried
+#   to validate month and day ranges here would be a second, worse date library.
+cadence_epoch() {
+  local s="${1:-}" e=""
+  case "$s" in
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9])
+      s="${s}T00:00:00Z" ;;                                                    # CADENCE-BARE-DATE
+    [0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9]Z)
+      : ;;
+    *) return 1 ;;
+  esac
+  e="$(date -u -d "$s" +%s 2>/dev/null)" || e=""
+  if [ -z "$e" ]; then
+    e="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$s" +%s 2>/dev/null)" || e=""
+  fi
+  case "$e" in ''|*[!0-9]*) return 1 ;; esac
+  printf '%s\n' "$e"
+  return 0
+}
+
+# mark_undetermined <cadence-label> <why>
+#   THE ONLY PLACE THE UNDETERMINED COUNTER MOVES. This is BL-213's repair: with
+#   the marked line removed the arm still prints, and the script still closes
+#   with "All maintenance cadences current." at rc 0 — a clean bill of health
+#   over evidence nobody read. That mutant is m2 in the WP6 suite and it asserts
+#   on the exit code, because the printed label and the exit predicate are
+#   exactly the pair CLAUDE.md's `[WARN]` trap warns can disagree.
+mark_undetermined() {
+  undetermined=$((undetermined + 1))                                           # CADENCE-UNDETERMINED-COUNTER
+  UNMEASURED="${UNMEASURED}  - $1: $2
+"
+  print_warn "$1 — CANNOT MEASURE: $2"
+}
+
+# cadence_verdict <label> <threshold-days> <date-string>
+#   One arm's whole answer. An unreadable date is UNDETERMINED, never skipped —
+#   the arm that used to disappear here is the defect.
+cadence_verdict() {
+  local label="$1" limit="$2" d="$3" e days
+  if ! e="$(cadence_epoch "$d")"; then                                         # CADENCE-FAIL-CLOSED-DATE
+    mark_undetermined "$label" "the recorded date '$d' is not one any date parser on this host accepts"
+    return 0
+  fi
+  days=$(( (now_epoch - e) / 86400 ))
+  if [ "$days" -gt "$limit" ]; then
+    print_warn "$label OVERDUE: last signal $days days ago (threshold: $limit days)"
+    overdue=$((overdue + 1))
+  else
+    print_ok "$label current: last signal $days days ago (threshold: $limit days)"
+  fi
+  return 0
+}
+
+# cadence_git_date <path>
+#   The `YYYY-MM-DD` of the newest commit that touched <path>, or the EMPTY
+#   STRING when there is no history to read (untracked file, or not a repo).
+#   Empty is not a date and the caller turns it into UNDETERMINED — which is the
+#   whole difference from the shipped behaviour, where it became an INFO line
+#   and an unchanged verdict.
+cadence_git_date() {
+  local p="$1" line=""
+  line="$(git log -1 --format='%ai' -- "$p" 2>/dev/null)" || line=""
+  printf '%s\n' "$line" | awk '{ print $1 }'
+}
+
 echo -e "${BOLD}Maintenance Cadence Check${NC}"
 echo ""
 
-overdue=0
-warnings=0
-now_epoch=$(date +%s)
+ROUTINE_DAYS="$(cadence_policy_days routine_review_days "$ROUTINE_DEFAULT_DAYS")"
+DEEP_DAYS="$(cadence_policy_days deep_security_days "$DEEP_DEFAULT_DAYS")"
 
-# --- Monthly check: CHANGELOG.md should have an entry within 35 days ---
+signal_date=""
+latest_scan=""
+
+# --- Routine review: CHANGELOG.md (§8.3, was 35 days) ------------------------
 if [ -f "CHANGELOG.md" ]; then
-  # Get the last modification date of CHANGELOG.md from git
-  last_changelog_date=$(git log -1 --format='%ai' -- CHANGELOG.md 2>/dev/null | cut -d' ' -f1 || echo "")
-  if [ -n "$last_changelog_date" ]; then
-    last_epoch=$(date -j -f "%Y-%m-%d" "$last_changelog_date" +%s 2>/dev/null || date -d "$last_changelog_date" +%s 2>/dev/null || echo "0")
-    if [ "$last_epoch" -gt 0 ]; then
-      days_since=$(( (now_epoch - last_epoch) / 86400 ))
-      if [ "$days_since" -gt 35 ]; then
-        print_warn "Monthly maintenance overdue: CHANGELOG.md last updated $days_since days ago (threshold: 35 days)"
-        overdue=$((overdue + 1))
-      else
-        print_ok "CHANGELOG.md updated $days_since days ago (monthly cadence: current)"
-      fi
-    fi
+  signal_date="$(cadence_git_date CHANGELOG.md)"
+  if [ -n "$signal_date" ]; then
+    cadence_verdict "Routine review (CHANGELOG.md)" "$ROUTINE_DAYS" "$signal_date"
   else
-    print_info "CHANGELOG.md has no git history — cannot determine age"
+    mark_undetermined "Routine review (CHANGELOG.md)" \
+      "the file is present but has no git history, so its age cannot be read"
   fi
 else
-  print_info "No CHANGELOG.md — maintenance check not applicable"
+  print_info "No CHANGELOG.md — the routine-review cadence has no signal here (not applicable)"
 fi
 
-# --- Monthly check: SBOM should be regenerated within 35 days ---
+# --- Routine review: sbom.json (§8.3, was 35 days) ---------------------------
 if [ -f "sbom.json" ]; then
-  last_sbom_date=$(git log -1 --format='%ai' -- sbom.json 2>/dev/null | cut -d' ' -f1 || echo "")
-  if [ -n "$last_sbom_date" ]; then
-    last_epoch=$(date -j -f "%Y-%m-%d" "$last_sbom_date" +%s 2>/dev/null || date -d "$last_sbom_date" +%s 2>/dev/null || echo "0")
-    if [ "$last_epoch" -gt 0 ]; then
-      days_since=$(( (now_epoch - last_epoch) / 86400 ))
-      if [ "$days_since" -gt 35 ]; then
-        print_warn "SBOM refresh overdue: sbom.json last updated $days_since days ago (threshold: 35 days)"
-        overdue=$((overdue + 1))
-      else
-        print_ok "sbom.json updated $days_since days ago (monthly cadence: current)"
-      fi
-    fi
+  signal_date="$(cadence_git_date sbom.json)"
+  if [ -n "$signal_date" ]; then
+    cadence_verdict "Routine review (sbom.json)" "$ROUTINE_DAYS" "$signal_date"
+  else
+    mark_undetermined "Routine review (sbom.json)" \
+      "the file is present but has no git history, so its age cannot be read"
   fi
+else
+  print_info "No sbom.json — the SBOM refresh cadence has no signal here (not applicable)"
 fi
 
-# --- Quarterly check: last dependency audit ---
-# Look for recent pip-audit/snyk/dependency scan results
+# --- Deep security scan, dependency audit FOLDED IN (§8.3, was 185 + 95) -----
+# The date comes out of the FILENAME (§13-R14): a dated empty file satisfies
+# this completely. `ls -t` is drained by awk rather than `head -1` on purpose —
+# an early-exiting downstream stage SIGPIPEs the writer and `pipefail` promotes
+# rc 141 into the substitution, which under `set -e` is an abort, not a verdict.
+#
+# AND `ls` IS EXPLICITLY ABSOLVED (`|| true`) RATHER THAN LEFT TO THE OUTER `||`.
+# Five globs are passed and most projects match only one or two; the unmatched
+# ones reach `ls` as literals and make it exit 1. With `pipefail` that promotes
+# to the substitution, and an outer `|| latest_scan=""` would then WIPE a
+# perfectly good filename — turning "one fresh scan, four families absent" into
+# "no evidence at all", which is an exit 2 nobody could explain. Caught by E1
+# going rc 2 on an all-current fixture.
 if [ -d "docs/test-results" ]; then
-  latest_dep_scan=$(ls -t docs/test-results/*snyk* docs/test-results/*dep* docs/test-results/*audit* 2>/dev/null | head -1 || echo "")
-  if [ -n "$latest_dep_scan" ]; then
-    scan_date=$(echo "$latest_dep_scan" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || echo "")
-    if [ -n "$scan_date" ]; then
-      last_epoch=$(date -j -f "%Y-%m-%d" "$scan_date" +%s 2>/dev/null || date -d "$scan_date" +%s 2>/dev/null || echo "0")
-      if [ "$last_epoch" -gt 0 ]; then
-        days_since=$(( (now_epoch - last_epoch) / 86400 ))
-        if [ "$days_since" -gt 95 ]; then
-          print_warn "Quarterly dependency audit overdue: last scan $days_since days ago (threshold: 95 days)"
-          overdue=$((overdue + 1))
-        else
-          print_ok "Dependency scan $days_since days ago (quarterly cadence: current)"
-        fi
-      fi
+  latest_scan="$( { ls -t docs/test-results/*snyk* docs/test-results/*dep* \
+                         docs/test-results/*audit* docs/test-results/*semgrep* \
+                         docs/test-results/*sast* 2>/dev/null || true; } \
+                 | awk 'NR == 1 { r = $0 } END { if (r != "") print r }')" || latest_scan=""
+  if [ -n "$latest_scan" ]; then
+    signal_date="$(printf '%s\n' "$latest_scan" \
+      | awk 'match($0, /[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]/) { print substr($0, RSTART, RLENGTH) }')" \
+      || signal_date=""
+    if [ -n "$signal_date" ]; then
+      cadence_verdict "Deep security scan (dependency audit folded in)" "$DEEP_DAYS" "$signal_date"
+    else
+      mark_undetermined "Deep security scan (dependency audit folded in)" \
+        "the newest artefact '$latest_scan' carries no date in its filename"
     fi
+  else
+    mark_undetermined "Deep security scan (dependency audit folded in)" \
+      "docs/test-results/ exists but holds no dependency- or security-scan artefact"
   fi
-fi
-
-# --- Biannual check: full security re-audit ---
-# Look for Phase 3-style security scan results within 185 days
-if [ -d "docs/test-results" ]; then
-  latest_security=$(ls -t docs/test-results/*semgrep* docs/test-results/*sast* 2>/dev/null | head -1 || echo "")
-  if [ -n "$latest_security" ]; then
-    scan_date=$(echo "$latest_security" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' | head -1 || echo "")
-    if [ -n "$scan_date" ]; then
-      last_epoch=$(date -j -f "%Y-%m-%d" "$scan_date" +%s 2>/dev/null || date -d "$scan_date" +%s 2>/dev/null || echo "0")
-      if [ "$last_epoch" -gt 0 ]; then
-        days_since=$(( (now_epoch - last_epoch) / 86400 ))
-        if [ "$days_since" -gt 185 ]; then
-          print_warn "Biannual security re-audit overdue: last full scan $days_since days ago (threshold: 185 days)"
-          overdue=$((overdue + 1))
-        else
-          print_ok "Security scan $days_since days ago (biannual cadence: current)"
-        fi
-      fi
-    fi
-  fi
+else
+  print_info "No docs/test-results/ — the deep-security cadence has no evidence surface here (not applicable)"
 fi
 
 echo ""
+if [ "$undetermined" -gt 0 ]; then
+  echo -e "${YELLOW}${BOLD}$undetermined maintenance cadence(s) COULD NOT BE MEASURED:${NC}"
+  printf '%s' "$UNMEASURED"
+  echo ""
+fi
+
 if [ "$overdue" -gt 0 ]; then
   echo -e "${YELLOW}${BOLD}$overdue maintenance cadence(s) overdue.${NC}"
   echo ""
   echo "Recommended actions:"
-  echo "  Monthly: Run dependency audit, security patches, SBOM update, error dashboard review"
-  echo "  Quarterly: Performance comparison, cost review, post-MVP backlog prioritization"
-  echo "  Biannually: Full dependency audit, Phase 3 re-run, platform requirement review"
+  echo "  Routine review (default every 14 days): dependency and security patches, SBOM refresh,"
+  echo "    error-dashboard review, CHANGELOG entry"
+  echo "  Deep security scan (default every 95 days): full dependency audit, Phase 3 re-run,"
+  echo "    platform-requirement review"
   echo ""
-  echo "After maintenance, commit changes with 'chore: monthly maintenance [date]' to update the timestamps."
+  # The policy FILE is deliberately not named on this line: it is a module path,
+  # and T1 (scripts/lint-delta-boundary.sh) is not waivable even for prose in a
+  # string. The keys are enough for anyone who has the file, and a project
+  # without the module has nothing to open anyway.
+  echo "Both windows are policy, not constants: cadence.routine_review_days and"
+  echo "cadence.deep_security_days in the project's post-1.0 policy file. After maintenance,"
+  echo "commit with 'chore: routine maintenance [date]' so the timestamps move."
   exit 1
+elif [ "$undetermined" -gt 0 ]; then                                           # CADENCE-EXIT-UNDETERMINED
+  echo "Nothing above is overdue — but the cadences named there were never measured, so"
+  echo "'current' is not something this check can claim. Give each one a signal it can read"
+  echo "(commit the file, or re-run the scan so a correctly dated artefact lands in"
+  echo "docs/test-results/) and run this again. A release cut refuses on this exit code."
+  exit 2
 else
   echo -e "${GREEN}${BOLD}All maintenance cadences current.${NC}"
   exit 0

--- a/scripts/session-cadence-check.sh
+++ b/scripts/session-cadence-check.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# scripts/session-cadence-check.sh — the SessionStart NAG arm of §8.3's
+# calendar re-fire trigger.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §8.3 ("Two enforcement points
+# (D5) … At session start — nag. A new arm reports overdue cadences once."),
+# §11-WP6. It is the SOFT half of the pair; the hard half is WP7's release cut,
+# which refuses on the same two exit codes.
+#
+# (No `# BL-NNN-…` marker on purpose: no backlog entry exists for the delta
+# build and minting one would red scripts/lint-bl-markers.sh. The design-doc
+# path above is the citation, per the WP1-WP5 precedent.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE HOUSE CONTRACT FOR EVERY SessionStart HOOK THE FRAMEWORK SHIPS
+#
+#   • SILENT WHEN NOTHING IS WRONG — zero bytes on stdout AND stderr. A hook
+#     that "only prints a little" when healthy is a hook every session learns
+#     to skim past, and the one time it matters it is buried.
+#   • FAIL-OPEN — exit 0 under EVERY failure mode. A broken checker must never
+#     brick a session. That guarantee is a LINE, not a promise in a header:
+#     `# CADENCE-NAG-FAILOPEN` below, and tests/test-delta-wp6-cadence.sh::m4
+#     neuters it and asserts the crash reaches SessionStart.
+#   • ZERO NETWORK — ever. Everything it reads is local: a git log, a directory
+#     listing, and a JSON file. The WP6 suite asserts this by SHADOWING
+#     curl/wget/nc/ping/ssh in PATH rather than by reading this source.
+#
+# It joins session-version-check.sh, session-test-gate-check.sh,
+# session-freshness-check.sh, session-intake-check.sh and
+# detect-out-of-band-commits.sh in `.hooks.SessionStart`, injected by the same
+# idempotent `jq` merge init.sh already uses for all five.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHY IT REPORTS TWO CODES AND NOT ONE
+#
+# scripts/check-maintenance.sh answers 0 current / 1 overdue / 2 UNMEASURABLE.
+# The third code is BL-213's repair: before WP6 a date neither parser accepted
+# was skipped in silence and reported as current at rc 0. A nag that only spoke
+# for rc 1 would inherit exactly that blind spot at the surface where a human
+# might have caught it, so 2 gets its own sentence — and it says why it is not
+# the same as "fine".
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE NAG IS A POST-LAUNCH SURFACE, AND THAT GATE IS WHY DAY ZERO IS SILENT
+#
+# A maintenance cadence is a property of a SHIPPED product. The whole post-1.0
+# track lives at phase 4 (D7's era invariant), and §8.3's two enforcement points
+# are a release cut and this nag — both after launch.
+#
+# It is not a theoretical tidiness. `init.sh` creates `docs/test-results/` at
+# birth, so a brand-new project has the evidence SURFACE with nothing in it,
+# which the checker correctly reports as unmeasurable (exit 2). Measured on a
+# real scaffold: an ungated nag printed 354 bytes at the first SessionStart of
+# every generated project, about a security scan a phase-0 project has no
+# business having run. A noisy day zero is what the freshness hook's day-zero
+# silence rule exists to prevent, and a hook nobody reads is worth less than no
+# hook at all.
+#
+# The gate is on the NAG, never on the checker: `check-maintenance.sh` still
+# answers honestly at any phase, and WP7's release cut — which calls it
+# directly, at phase 4 by construction — is untouched. An unreadable or absent
+# phase record is SILENT, which is the same fail-open direction as everything
+# else here; the hard refusal lives at the cut, not at a session greeting.
+#
+# NOT under `set -e` — fail-open is the whole point; a mid-check error must
+# degrade to exit 0, not abort the shell.
+
+set -uo pipefail   # deliberately NO -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || SCRIPT_DIR=""
+[ -n "$SCRIPT_DIR" ] || exit 0
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-}"
+if [ -z "$PROJECT_DIR" ]; then
+  PROJECT_DIR="$(cd "$SCRIPT_DIR/.." 2>/dev/null && pwd)" || PROJECT_DIR=""
+fi
+[ -n "$PROJECT_DIR" ] || exit 0
+[ -d "$PROJECT_DIR" ] || exit 0
+
+checker="$SCRIPT_DIR/check-maintenance.sh"
+[ -f "$checker" ] || exit 0
+
+# The era gate — see the block above. jq when it is there, a digit scrape when
+# it is not, and silence when neither can produce a phase.
+phase=""
+if [ -f "$PROJECT_DIR/.claude/phase-state.json" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    phase="$(jq -r '.current_phase // ""' "$PROJECT_DIR/.claude/phase-state.json" 2>/dev/null)" || phase=""
+  else
+    phase="$(awk -F'"current_phase"' 'NF > 1 { s = $2; gsub(/[^0-9]/, " ", s); split(s, a, " "); for (i in a) if (a[i] != "") { print a[i]; exit } }' \
+      "$PROJECT_DIR/.claude/phase-state.json" 2>/dev/null)" || phase=""
+  fi
+fi
+case "$phase" in ''|*[!0-9]*) exit 0 ;; esac
+[ "$phase" -ge 4 ] || exit 0                                                   # CADENCE-NAG-ERA-GATE
+
+out=""
+rc=0
+out="$( cd "$PROJECT_DIR" 2>/dev/null && bash "$checker" </dev/null 2>/dev/null )" || rc=$?
+
+headline=""
+case "$rc" in
+  0) exit 0 ;;
+  1) headline="[maintenance] a cadence is OVERDUE. A release cut will refuse until it is cleared." ;;
+  2) headline="[maintenance] a cadence COULD NOT BE MEASURED. Unmeasurable is not current — a release cut refuses on this too." ;;
+  *) exit 0 ;;                                                                 # CADENCE-NAG-FAILOPEN
+esac
+
+# The verdict lines the headline is ABOUT — built BEFORE anything is printed, and
+# capped so a pathological tree cannot flood a session's opening context. awk
+# drains its input rather than `head` closing the pipe early (the SIGPIPE trap).
+body="$(printf '%s\n' "$out" \
+  | awk '/OVERDUE|CANNOT MEASURE|COULD NOT BE MEASURED/ { if (n < 10) { print "  " $0; n = n + 1 } }')"
+
+# NO EVIDENCE, NO HEADLINE (R-WP6-3).
+#
+# rc 1 is also what a shell hands back when it aborts under `set -e`, so a
+# checker that DIED is indistinguishable from one that measured an overdue —
+# by the exit code alone. A crash that printed nothing therefore used to produce
+# "a cadence is OVERDUE" with nothing underneath it: a claim this hook cannot
+# support, at the surface where a human forms their first impression of the
+# project's health. Fail-open held (it still exited 0) but the sentence was
+# false, which is the same disease as the one this whole WP exists to close,
+# one surface up.
+#
+# So the verdict lines are the evidence, and no evidence means the silent
+# fail-open path rather than a louder guess. It costs nothing real: the checker
+# prints at least one OVERDUE line whenever it means 1 and at least one CANNOT
+# MEASURE line whenever it means 2, so a healthy refusal always carries its
+# reason with it. H8 pins both directions and m6 is its mutant.
+[ -n "$body" ] || exit 0                                                       # CADENCE-NAG-EVIDENCE
+
+printf '%s\n' "$headline"
+printf '%s\n' "$body"
+printf '%s\n' "  Run: bash scripts/check-maintenance.sh"
+exit 0

--- a/templates/generated/identifiers.tmpl
+++ b/templates/generated/identifiers.tmpl
@@ -18,6 +18,7 @@ commit that first uses it. Cross-namespace references are always qualified
 | `BUG-` | A bug | `BUGS.md` (the `#` column, bare integer — cite as `BUG-<#>`, no zero-padding) | `BUG-7` |
 | `UAT-` | A user-acceptance-testing session (RESERVED citation form — session logs currently say "Session N") | UAT results (`scripts/process-checklist.sh --start-uat N`) | `UAT-3` |
 | `SEV-1`…`SEV-4` | Bug severity classes (fixed vocabulary, not sequential IDs) | `BUGS.md` / PROJECT_BIBLE.md Bug Severity Classification | `SEV-2` |
+| `DELTA-` | One unit of post-release work after v1.0 — a feature, fix, hotfix or security patch, opened and closed one at a time | `.claude/delta-state.json` (the ledger); the brief, when the class demands one, at `docs/deltas/DELTA-NNN-<slug>.md` | `DELTA-001` |
 
 ## The three rules
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1769,6 +1769,23 @@ run_child_suite "tests/test-delta-wp4-close-rubric.sh" \
 # executes init.sh -> both lanes.
 run_child_suite "tests/test-delta-wp5-hotfix-retro.sh" \
   "tests/test-delta-wp5-hotfix-retro.sh"
+# Delta Track WP6 (§8.3) — the calendar trigger, and BL-213's fail-open repair.
+# The thresholds move to `.claude/delta-policy.json::cadence` and are read
+# through the ONE seam (the checker is CORE, so it may not name the module);
+# absent policy or an absent module still measures on the framework defaults.
+# The exit contract WP7's release cut consumes is pinned on the EXIT CODE, never
+# on the printed sentence: 0 measured-and-current, 1 overdue, 2 UNMEASURABLE —
+# the code §14-V13 proved did not exist, where a date neither parser accepted
+# was skipped in silence and reported as "All maintenance cadences current" at
+# rc 0. Mutation-proved IN THE SUITE (m1-m4, each mutant built and run): revert
+# the routine default 14 -> 35 -> the 15-day fixture passes -> P1 RED; REMOVE
+# THE UNDETERMINED COUNTER -> the unparseable fixture reports all-current at
+# rc 0 -> E3 RED (the pin that matters most); neuter the seam read -> the
+# retune stops moving the boundary -> P2 RED; neuter the nag's fail-open arm ->
+# a crashing checker takes SessionStart with it -> H4 RED. Never executes the
+# init script -> both lanes.
+run_child_suite "tests/test-delta-wp6-cadence.sh" \
+  "tests/test-delta-wp6-cadence.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 run_child_suite "tests/test-check-phase-gate-poc-block-contract.sh" \
   "tests/test-check-phase-gate-poc-block-contract.sh"

--- a/tests/test-delta-wp6-cadence.sh
+++ b/tests/test-delta-wp6-cadence.sh
@@ -96,6 +96,11 @@
 #     H5  ZERO NETWORK: curl/wget/nc/ping shadowed in PATH are never invoked
 #     H6  registered and shipped by init.sh the way its five siblings are —
 #         and check-maintenance.sh is NOT re-shipped (§0.3-C1)
+#     H7  DAY-ZERO SILENCE: the nag is post-launch only, so a pre-launch
+#         project is byte-silent even while the checker says 2   KILLS m5
+#     H8  NO EVIDENCE, NO HEADLINE: rc 1 is also `set -e`'s abort code, so a
+#         checker that DIED must not be announced as an overdue — and an rc 1
+#         that carries a real OVERDUE line still speaks         KILLS m6
 #
 #   I — IDENTIFIERS (§11-WP6's template deliverable)
 #     I1  the generated identifier registry carries the DELTA- row
@@ -108,6 +113,10 @@
 #     m3  neuter the policy read                -> the retune stops moving
 #     m4  neuter the hook's fail-open arm       -> a crashing checker takes
 #         the session's SessionStart with it
+#     m5  neuter the era gate                   -> day zero gets noisy again,
+#         at rc 0 both ways, so only a byte count can see it
+#     m6  neuter the evidence guard             -> a checker that merely died is
+#         announced to the session as an overdue cadence
 #
 # LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
 # `unit-shard` list. Its executed lines never name the init script — H6 reads
@@ -157,6 +166,8 @@ epoch_of() {   # <YYYY-MM-DDTHH:MM:SSZ> -> epoch seconds, computed INDEPENDENTLY
 mk_proj() {    # a git repo with an identity and a .claude dir, and NOTHING else
   local d="$1"
   mkdir -p "$d/.claude"
+  # Phase 4 by default: the cadence surfaces are post-launch by construction,
+  # and H7 is the row that sets it lower on purpose.
   (
     cd "$d" && unset GITHUB_BASE_REF
     git init -q .
@@ -168,15 +179,44 @@ mk_proj() {    # a git repo with an identity and a .claude dir, and NOTHING else
     > "$d/.claude/phase-state.json"
 }
 
-commit_dated() {   # <dir> <file> <days-ago> — commit with a fixed +0000 author date
-  local d="$1" f="$2" n="$3" stamp
-  stamp="$(days_ago "$n")T12:00:00+0000"
-  printf 'fixture content for %s\n' "$f" > "$d/$f"
+# commit_dated <dir> <file> <days-ago>
+#   Commit <file> with a fixed +0000 author date <days-ago> days back.
+#
+#   THE VERIFICATION IS THE LIVE HALF; THE VARYING CONTENT IS BELT AND BRACES.
+#   Several rows below re-date a file the baseline fixture already committed,
+#   and with identical bytes `git commit` is a SILENT no-op: the tip stays at
+#   the old date and a threshold test passes without ever crossing the
+#   threshold. That is what happened on the first draft of this suite — eight
+#   rows agreed the checker was fine because none of their 15-day fixtures had
+#   taken. So the call VERIFIES that the tree records the date it asked for and
+#   counts a loud failure if it does not.
+#
+#   Measured, not assumed, and the review re-measured it: removing FIXTURE_SEQ
+#   ALONE does not reproduce the no-op, because the days-back text in the line
+#   below still varies the bytes. Forcing the content genuinely constant makes
+#   the guard fire ten times and the suite go RED. Both belong here — the seq
+#   makes collisions unlikely, the guard is what would catch one anyway.
+#
+#   A fixture that quietly did not happen is the same silent-success class this
+#   whole WP exists to close; a suite that cannot see it in its own scaffolding
+#   has no business asserting it about a product.
+FIXTURE_SEQ=0
+commit_dated() {
+  local d="$1" f="$2" n="$3" stamp want got
+  FIXTURE_SEQ=$((FIXTURE_SEQ + 1))
+  want="$(days_ago "$n")"
+  stamp="${want}T12:00:00+0000"
+  printf 'fixture content for %s - revision %s, dated %s days back\n' "$f" "$FIXTURE_SEQ" "$n" > "$d/$f"
   (
     cd "$d" && unset GITHUB_BASE_REF
     GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git add "$f"
-    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git commit -q -m "chore: $f"
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git commit -q -m "chore: $f r$FIXTURE_SEQ"
   ) >/dev/null 2>&1
+  got="$( cd "$d" && git log -1 --format='%ai' -- "$f" 2>/dev/null | awk '{ print $1 }' )"
+  if [ "$got" != "$want" ]; then
+    echo "  [FIXTURE] commit_dated $f wanted $want but the tree records '$got' — the fixture did not take" >&2
+    FAILED=$((FAILED + 1))
+  fi
   return 0
 }
 
@@ -197,6 +237,22 @@ mk_current_proj() {   # every surface present, every one fresh -> the rc 0 basel
 write_policy() { printf '%s\n' "$2" > "$1/.claude/delta-policy.json"; }
 
 mk_scripts_tree() { mkdir -p "$1"; cp -R "$REPO_ROOT/scripts" "$1/scripts"; }
+
+# strip_delta_module <tree> — remove the post-1.0 module from a copied scripts
+#   tree, so the seam refuses every `--delta-*` action.
+#
+#   THIS IS THE SHIPPED DOWNSTREAM SHAPE, NOT AN EXOTIC ONE: init.sh copies the
+#   checker and the seam but ships no delta libs at all today, so in every
+#   generated project the seam answers "the delta module is not installed" and
+#   the checker's OWN default constants are the live values. With the module
+#   present the seam answers from §7.2's defaults instead — the same 14 and 95,
+#   from a different file. Two sources for one number is a drift waiting to
+#   happen, so P1 measures BOTH and requires them to agree.
+strip_delta_module() {
+  rm -f "$1/scripts/lib/delta-state.sh" "$1/scripts/lib/delta-policy.sh" \
+        "$1/scripts/lib/delta-classify.sh" "$1/scripts/lib/delta-cadence.sh" 2>/dev/null
+  return 0
+}
 
 # ── Runners ─────────────────────────────────────────────────────────────────
 
@@ -269,10 +325,18 @@ mk_current_proj "$T/under"; commit_dated "$T/under" CHANGELOG.md 13
 run_check "$REPO_ROOT/scripts" "$T/under"; under_rc=$CHK_RC
 had_policy=n
 [ -f "$T/over/.claude/delta-policy.json" ] && had_policy=y
-if [ "$over_rc" -eq 1 ] && [ "$under_rc" -eq 0 ] && [ "$had_policy" = n ]; then
-  pass "P1: with NO policy file anywhere (had_policy=$had_policy) the framework default of 14 days still measures — 15 days is overdue (rc $over_rc) and 13 days is current (rc $under_rc). The checker does not require the post-1.0 module"
+# And again with the module GONE — the shape init.sh actually ships today, where
+# the seam refuses and the checker's own constants are the live values. Both
+# sources of the same default must give the same answer, or the drift between
+# them is silent.
+NOMOD="$T/nomod"; mk_scripts_tree "$NOMOD"; strip_delta_module "$NOMOD"
+run_check "$NOMOD/scripts" "$T/over"; nm_over_rc=$CHK_RC
+run_check "$NOMOD/scripts" "$T/under"; nm_under_rc=$CHK_RC
+if [ "$over_rc" -eq 1 ] && [ "$under_rc" -eq 0 ] && [ "$had_policy" = n ] \
+   && [ "$nm_over_rc" -eq 1 ] && [ "$nm_under_rc" -eq 0 ]; then
+  pass "P1: with NO policy file anywhere (had_policy=$had_policy) the 14-day default still measures — 15 days overdue (rc $over_rc), 13 days current (rc $under_rc) — and it measures identically with the whole post-1.0 module deleted (rc $nm_over_rc / $nm_under_rc), which is the shape init.sh ships today. The checker does not require the module, and the two places that hold the same default agree"
 else
-  fail_ "P1" "15-day rc=$over_rc (expect 1); 13-day rc=$under_rc (expect 0); policy file present=$had_policy (expect n)"
+  fail_ "P1" "module present: 15-day rc=$over_rc (expect 1), 13-day rc=$under_rc (expect 0); policy file present=$had_policy (expect n); module DELETED: 15-day rc=$nm_over_rc (expect 1), 13-day rc=$nm_under_rc (expect 0 — a disagreement here means the seam's defaults and the script's constants have drifted)"
 fi
 rm -rf "$T"
 
@@ -553,18 +617,30 @@ rm -rf "$T"
 # ── D4: STRUCTURAL ABSENCE of the two atoms that made the defect ──────────
 # An absence has to be discriminated structurally, and both halves are named
 # because either one alone would have been survivable: the `|| echo "0"` tail
-# is what manufactured the sentinel and the `-gt 0` guard is what turned the
+# is what manufactured the sentinel, and the epoch guard is what turned the
 # sentinel into silence.
-tail_hits="$(grep -c '|| echo "\{0,1\}0"\{0,1\}' "$CHECKER" || true)"
+#
+# COUNTED ON EXECUTED LINES ONLY, with the repo's own two-stage stripper. The
+# file DESCRIBES the defect at length in its header — quoting the dead idiom is
+# how the next reader learns not to reintroduce it — so a whole-file grep would
+# fail this row for documenting the bug it fixes, which is precisely backwards.
+T=$(mktemp -d)
+sed -e 's/^[[:space:]]*#.*$//' -e 's/\([^[:space:]]\)[[:space:]][[:space:]]*#.*$/\1/' \
+  "$CHECKER" > "$T/stripped"
+tail_hits="$(grep -c '|| echo "\{0,1\}0"\{0,1\}' "$T/stripped" || true)"
 case "$tail_hits" in ''|*[!0-9]*) tail_hits=0 ;; esac
-guard_hits="$(grep -c 'last_epoch' "$CHECKER" || true)"
+guard_hits="$(grep -c 'last_epoch' "$T/stripped" || true)"
 case "$guard_hits" in ''|*[!0-9]*) guard_hits=0 ;; esac
-gt0_hits="$(grep -c -- '-gt 0 \]' "$CHECKER" || true)"
-case "$gt0_hits" in ''|*[!0-9]*) gt0_hits=0 ;; esac
-if [ "$tail_hits" -eq 0 ] && [ "$guard_hits" -eq 0 ] && [ "$gt0_hits" -eq 0 ]; then
-  pass "D4: neither half of the shipped defect survives anywhere in the file — no '|| echo 0' capture tail ($tail_hits), no last_epoch sentinel ($guard_hits), no '-gt 0 ]' arm guard ($gt0_hits). The counters are compared with -gt at the verdict, which is a different shape and deliberately not matched here"
+epoch_guard_hits="$(grep -c -- '[Ee]poch[a-z_]*" \{0,1\}-gt 0 \]' "$T/stripped" || true)"
+case "$epoch_guard_hits" in ''|*[!0-9]*) epoch_guard_hits=0 ;; esac
+stripped_lines="$(grep -c . "$T/stripped" || true)"
+case "$stripped_lines" in ''|*[!0-9]*) stripped_lines=0 ;; esac
+rm -rf "$T"
+if [ "$tail_hits" -eq 0 ] && [ "$guard_hits" -eq 0 ] && [ "$epoch_guard_hits" -eq 0 ] \
+   && [ "$stripped_lines" -gt 40 ]; then
+  pass "D4: across $stripped_lines executed lines neither half of the shipped defect survives — no '|| echo 0' capture tail ($tail_hits), no last_epoch sentinel ($guard_hits), no '\$…epoch -gt 0' arm guard ($epoch_guard_hits). The two '-gt 0' tests that DO remain are the overdue/undetermined counters at the closing verdict, which is a different shape and deliberately not matched"
 else
-  fail_ "D4" "'|| echo 0' tails=$tail_hits (expect 0); last_epoch mentions=$guard_hits (expect 0); '-gt 0 ]' guards=$gt0_hits (expect 0)"
+  fail_ "D4" "'|| echo 0' tails=$tail_hits (expect 0); last_epoch mentions=$guard_hits (expect 0); epoch '-gt 0' guards=$epoch_guard_hits (expect 0); executed lines seen=$stripped_lines (expect >40 — a stripper that ate the file would make this row vacuous)"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -652,6 +728,77 @@ else
   fi
   rm -rf "$T"
 
+  # ── H8: NO EVIDENCE, NO HEADLINE (R-WP6-3) ─────────────────────────────
+  # rc 1 is also the code a shell hands back when it aborts under `set -e`, so a
+  # checker that DIED looks exactly like one that measured an overdue — until
+  # you look for the verdict line. The pre-review hook printed "a cadence is
+  # OVERDUE" over a crash that had said nothing at all. Asserted in BOTH
+  # directions from the same exit code, which is the only way to tell "suppress
+  # a false headline" apart from "suppress the headline": a bare rc 1 is silent,
+  # and an rc 1 that carries a real OVERDUE line still speaks.
+  T=$(mktemp -d); mk_current_proj "$T/p"
+  h8_ok=y; h8_detail=""
+  for kind in crash1-silent crash1-noisy crash2-silent real1; do
+    ST="$T/tree-$kind"; mk_scripts_tree "$ST"
+    case "$kind" in
+      crash1-silent) printf '#!/usr/bin/env bash\nexit 1\n' > "$ST/scripts/check-maintenance.sh"; want=quiet ;;
+      crash1-noisy)  printf '#!/usr/bin/env bash\nprintf "%%s\\n" "[WARN] Routine review (CHANGELOG.md) OVERDUE: last signal 40 days ago (threshold: 14 days)"\nexit 1\n' \
+                       > "$ST/scripts/check-maintenance.sh"; want=loud ;;
+      crash2-silent) printf '#!/usr/bin/env bash\nprintf "%%s\\n" "some unrelated chatter"\nexit 2\n' > "$ST/scripts/check-maintenance.sh"; want=quiet ;;
+      real1)         : ;;   # the SHIPPED checker against a genuinely overdue tree
+    esac
+    if [ "$kind" = real1 ]; then
+      commit_dated "$T/p" CHANGELOG.md 40; want=loud
+    fi
+    run_hook "$ST/scripts" "$T/p"
+    h8_detail="$h8_detail ${kind}->rc$HOOK_RC/${#HOOK_OUT}b"
+    case "$want" in
+      quiet) { [ "$HOOK_RC" -eq 0 ] && [ "${#HOOK_OUT}" -eq 0 ] && [ "${#HOOK_ERR}" -eq 0 ]; } || h8_ok=n ;;
+      loud)  { [ "$HOOK_RC" -eq 0 ] && [ "${#HOOK_OUT}" -gt 0 ]; } || h8_ok=n ;;
+    esac
+  done
+  if [ "$h8_ok" = y ]; then
+    pass "H8: a headline is only spoken when the verdict line it is about actually exists —$h8_detail. A checker that dies at rc 1 saying nothing is silent (it is a crash, not a measurement), one that dies at rc 1 having genuinely printed an OVERDUE line still speaks, and the shipped checker against a real 40-day-old CHANGELOG speaks too. The suppression is of the false claim, not of the report"
+  else
+    fail_ "H8" "crash-with-no-verdict-line must be silent while a real verdict must still speak:$h8_detail"
+  fi
+  rm -rf "$T"
+
+  # ── H7: DAY-ZERO SILENCE — the nag is a POST-LAUNCH surface ────────────
+  # Found by scaffolding a real project rather than by reasoning about one:
+  # init.sh creates docs/test-results/ at birth, so a brand-new tree has the
+  # evidence surface with nothing in it, the checker correctly answers 2, and
+  # an ungated nag printed 354 bytes at the FIRST SessionStart of every
+  # generated project — about a security scan a phase-0 project has never had
+  # any reason to run. Silence is asserted at every pre-launch phase and for a
+  # record that cannot be read at all, on BOTH streams; and the checker itself
+  # must keep answering honestly underneath, or the gate has been put in the
+  # wrong place.
+  T=$(mktemp -d)
+  h7_ok=y; h7_detail=""
+  for ph in 0 1 2 3 missing garbage; do
+    P="$T/p$ph"
+    mk_proj "$P"                                   # writes current_phase 4
+    commit_dated "$P" CHANGELOG.md 1
+    mkdir -p "$P/docs/test-results"                # the birth shape: surface, no artefact
+    case "$ph" in
+      missing) rm -f "$P/.claude/phase-state.json" ;;
+      garbage) printf 'not json at all\n' > "$P/.claude/phase-state.json" ;;
+      *)       printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":%s,"phases":{}}\n' "$ph" \
+                 > "$P/.claude/phase-state.json" ;;
+    esac
+    run_hook "$REPO_ROOT/scripts" "$P"
+    run_check "$REPO_ROOT/scripts" "$P"
+    h7_detail="$h7_detail ${ph}->nag(rc$HOOK_RC/${#HOOK_OUT}b/${#HOOK_ERR}e,check rc$CHK_RC)"
+    { [ "$HOOK_RC" -eq 0 ] && [ "${#HOOK_OUT}" -eq 0 ] && [ "${#HOOK_ERR}" -eq 0 ] && [ "$CHK_RC" -eq 2 ]; } || h7_ok=n
+  done
+  if [ "$h7_ok" = y ]; then
+    pass "H7: at every pre-launch phase — and for a phase record that is missing or unreadable — the nag is byte-silent on both streams while the checker underneath still answers 2:$h7_detail. The gate is on the ADVISORY surface only, so WP7's release cut, which calls the checker directly at phase 4, is untouched"
+  else
+    fail_ "H7" "each case must be a silent rc 0 nag over an honest rc 2 checker:$h7_detail"
+  fi
+  rm -rf "$T"
+
   # ── H6: shipped and registered the way its five siblings are ───────────
   # THE SPLIT TOKEN IS LOAD-BEARING, and it is the house idiom (the identical
   # split and the identical reason are in tests/test-intake-wizard-fixes.sh):
@@ -704,18 +851,25 @@ echo "=== M — mutations: anchored, sites==1, one line changed, mode preserved 
 # ════════════════════════════════════════════════════════════════════════════
 
 # ── m1: revert the routine default 14 -> 35 ────────────────────────────────
-T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+# BOTH trees have the module stripped, and that is the whole point of the row
+# rather than a convenience. With the module present the seam answers the same
+# 14 from §7.2 and the script's constant is dead code — a first version of this
+# mutant reverted the constant to 35 and NOTHING MOVED, which is how the second
+# source got found. The stripped tree is the shape init.sh ships, so this row
+# tests the value that is actually live in a generated project.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"; PT="$T/pri"; mk_scripts_tree "$PT"
+strip_delta_module "$MT"; strip_delta_module "$PT"
 pre_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
-_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-DEFAULT-ROUTINE.*$|ROUTINE_DEFAULT_DAYS=35|'
+_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-DEFAULT-ROUTINE$|ROUTINE_DEFAULT_DAYS=35|'
 post_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
-rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-DEFAULT-ROUTINE')"
+rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-DEFAULT-ROUTINE$')"
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
-run_check "$REPO_ROOT/scripts" "$T/p"; pri_rc=$CHK_RC
+run_check "$PT/scripts" "$T/p"; pri_rc=$CHK_RC
 run_check "$MT/scripts" "$T/p"; mut_rc=$CHK_RC
 if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
    && [ "$pri_rc" -eq 1 ] && [ "$mut_rc" -eq 0 ]; then
-  pass "m1: with the routine default reverted to the shipped 35, a CHANGELOG untouched for 15 days passes clean (rc $mut_rc) where the tuned tree refuses it (rc $pri_rc). P1 goes RED — the 35 -> 14 retune is load-bearing and not decoration (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+  pass "m1: with the routine default reverted to the shipped 35 — in the module-less tree init.sh actually produces — a CHANGELOG untouched for 15 days passes clean (rc $mut_rc) where the tuned tree refuses it (rc $pri_rc). P1's second arm goes RED; the 35 -> 14 retune is load-bearing and not decoration (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
 else
   fail_ "m1" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE rc=$pri_rc (expect 1); MUTANT rc=$mut_rc (expect 0)"
 fi
@@ -727,9 +881,9 @@ rm -rf "$T"
 # and it is the sentence BL-213 was filed about — but the predicate is the code.
 T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
 pre_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
-_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-UNDETERMINED-COUNTER.*$|  :|'
+_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-UNDETERMINED-COUNTER$|  :|'
 post_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
-rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-UNDETERMINED-COUNTER')"
+rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-UNDETERMINED-COUNTER$')"
 sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
 mk_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 1; commit_dated "$T/p" sbom.json 1
 add_scan "$T/p" "2026-13-45_semgrep_pass.txt"
@@ -756,13 +910,22 @@ mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
 write_policy "$T/p" '{"schemaVersion":1,"cadence":{"routine_review_days":30,"deep_security_days":95}}'
 run_check "$REPO_ROOT/scripts" "$T/p"; pri_rc=$CHK_RC
 run_check "$MT/scripts" "$T/p"; mut_rc=$CHK_RC
-mut_silent=y
-printf '%s' "$CHK_OUT" | grep -qi 'policy\|could not read' && mut_silent=n
+# WHAT THE MUTANT DOES NOT SAY, PROBED HONESTLY (R-WP6-6). A bare `policy` grep
+# is useless here and the first version of this row used one: EVERY rc-1 run
+# prints the standing recommendation "Both windows are policy, not constants",
+# so the probe matched the boilerplate and the narrative then claimed a silence
+# its own token was reporting as absent. The probe is now the set of phrases a
+# script would use to REPORT a failed read, and the boilerplate is measured
+# separately so the sentence can name what the match actually was.
+mut_diag=n
+printf '%s' "$CHK_OUT" | grep -qiE 'could not read|could not resolve|falling back|fall back|unavailable|ignoring' && mut_diag=y
+mut_boiler=n
+printf '%s' "$CHK_OUT" | grep -qF 'Both windows are policy, not constants' && mut_boiler=y
 if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
-   && [ "$pri_rc" -eq 0 ] && [ "$mut_rc" -eq 1 ]; then
-  pass "m3: with the seam read neutered, a project whose own policy says 30 days is refused at 15 anyway (rc $mut_rc) where the tuned tree honours it (rc $pri_rc) — and the failure is SILENT, measured rather than asserted: the mutant's transcript says nothing about a policy it could not read (silent=$mut_silent). P2 goes RED (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+   && [ "$pri_rc" -eq 0 ] && [ "$mut_rc" -eq 1 ] && [ "$mut_diag" = n ]; then
+  pass "m3: with the seam read neutered, a project whose own policy says 30 days is refused at 15 anyway (rc $mut_rc) where the tuned tree honours it (rc $pri_rc) — and the damage is SILENT: the mutant's transcript carries no diagnostic that a read failed (diagnostic phrases=$mut_diag), and the only mention of the word 'policy' in it is the standing recommendation every overdue run prints (boilerplate=$mut_boiler). P2 goes RED (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
 else
-  fail_ "m3" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE rc=$pri_rc (expect 0); MUTANT rc=$mut_rc (expect 1); mutant silent about the lost policy=$mut_silent"
+  fail_ "m3" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE rc=$pri_rc (expect 0); MUTANT rc=$mut_rc (expect 1); mutant diagnostic about the lost policy=$mut_diag (expect n); rc-1 boilerplate present=$mut_boiler"
 fi
 rm -rf "$T"
 
@@ -770,9 +933,9 @@ rm -rf "$T"
 if [ -f "$HOOK" ]; then
   T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"; PT="$T/pri"; mk_scripts_tree "$PT"
   pre_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
-  _sed_inplace "$MT/scripts/session-cadence-check.sh" 's|^.*CADENCE-NAG-FAILOPEN.*$|  *) exit "$rc" ;;|'
+  _sed_inplace "$MT/scripts/session-cadence-check.sh" 's|^.*CADENCE-NAG-FAILOPEN$|  *) exit "$rc" ;;|'
   post_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
-  rep="$(_mutation_report "$HOOK" "$MT/scripts/session-cadence-check.sh" 'CADENCE-NAG-FAILOPEN')"
+  rep="$(_mutation_report "$HOOK" "$MT/scripts/session-cadence-check.sh" 'CADENCE-NAG-FAILOPEN$')"
   sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
   # BOTH trees get the identical crashing checker, so the only difference
   # between the two runs is the mutated line.
@@ -785,6 +948,55 @@ if [ -f "$HOOK" ]; then
     pass "m4: with the fail-open arm neutered, a checker that crashes takes SessionStart down with it (hook rc $mut_rc) where the shipped hook stays inert (rc $pri_rc). H4 goes RED — fail-open is a line, not a promise in a header (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
   else
     fail_ "m4" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE hook rc=$pri_rc (expect 0); MUTANT hook rc=$mut_rc (expect 42)"
+  fi
+  rm -rf "$T"
+fi
+
+# ── m5: neuter the era gate -> day zero gets noisy again ──────────────────
+if [ -f "$HOOK" ]; then
+  T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"; PT="$T/pri"; mk_scripts_tree "$PT"
+  pre_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
+  _sed_inplace "$MT/scripts/session-cadence-check.sh" 's|^.*CADENCE-NAG-ERA-GATE$|:|'
+  post_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
+  rep="$(_mutation_report "$HOOK" "$MT/scripts/session-cadence-check.sh" 'CADENCE-NAG-ERA-GATE$')"
+  sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+  # The birth shape, exactly: phase 0, one commit, an empty evidence surface.
+  P="$T/p"; mk_proj "$P"; commit_dated "$P" CHANGELOG.md 1
+  mkdir -p "$P/docs/test-results"
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":0,"phases":{}}\n' \
+    > "$P/.claude/phase-state.json"
+  run_hook "$PT/scripts" "$P"; pri_rc=$HOOK_RC; pri_len=${#HOOK_OUT}
+  run_hook "$MT/scripts" "$P"; mut_rc=$HOOK_RC; mut_len=${#HOOK_OUT}
+  if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
+     && [ "$pri_len" -eq 0 ] && [ "$mut_len" -gt 0 ] && [ "$pri_rc" -eq 0 ] && [ "$mut_rc" -eq 0 ]; then
+    pass "m5: with the era gate neutered, a phase-0 project one commit old is nagged about a quarterly security scan at its very first SessionStart — $mut_len bytes where the shipped hook writes $pri_len. H7 goes RED. Both still exit 0, which is the point: this failure is invisible to an exit-code assertion and needs a BYTE COUNT to see (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+  else
+    fail_ "m5" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE bytes=$pri_len rc=$pri_rc (expect 0 bytes, rc 0); MUTANT bytes=$mut_len rc=$mut_rc (expect >0 bytes, rc 0)"
+  fi
+  rm -rf "$T"
+fi
+
+# ── m6: neuter the evidence guard -> a crash speaks as an overdue again ───
+if [ -f "$HOOK" ]; then
+  T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"; PT="$T/pri"; mk_scripts_tree "$PT"
+  pre_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
+  _sed_inplace "$MT/scripts/session-cadence-check.sh" 's|^.*CADENCE-NAG-EVIDENCE$|:|'
+  post_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
+  rep="$(_mutation_report "$HOOK" "$MT/scripts/session-cadence-check.sh" 'CADENCE-NAG-EVIDENCE$')"
+  sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+  # Both trees get the identical silently-crashing checker: rc 1, no output.
+  for t in "$PT" "$MT"; do printf '#!/usr/bin/env bash\nexit 1\n' > "$t/scripts/check-maintenance.sh"; done
+  P="$T/p"; mk_current_proj "$P"
+  run_hook "$PT/scripts" "$P"; pri_rc=$HOOK_RC; pri_len=${#HOOK_OUT}
+  run_hook "$MT/scripts" "$P"; mut_rc=$HOOK_RC; mut_len=${#HOOK_OUT}
+  mut_claims=n
+  printf '%s' "$HOOK_OUT" | grep -qF 'a cadence is OVERDUE' && mut_claims=y
+  if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
+     && [ "$pri_len" -eq 0 ] && [ "$mut_len" -gt 0 ] && [ "$mut_claims" = y ] \
+     && [ "$pri_rc" -eq 0 ] && [ "$mut_rc" -eq 0 ]; then
+    pass "m6: with the evidence guard neutered, a checker that simply died — rc 1, not one byte of output — is announced to the session as 'a cadence is OVERDUE' (claim present=$mut_claims, $mut_len bytes) where the shipped hook stays silent ($pri_len bytes). H8 goes RED. Both exit 0, so like m5 this failure is invisible to an exit-code assertion; it needs the byte count and the claim probe (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+  else
+    fail_ "m6" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE bytes=$pri_len rc=$pri_rc (expect 0 bytes, rc 0); MUTANT bytes=$mut_len rc=$mut_rc (expect >0 bytes, rc 0) claiming OVERDUE=$mut_claims (expect y)"
   fi
   rm -rf "$T"
 fi

--- a/tests/test-delta-wp6-cadence.sh
+++ b/tests/test-delta-wp6-cadence.sh
@@ -1,0 +1,794 @@
+#!/usr/bin/env bash
+# tests/test-delta-wp6-cadence.sh — Delta Track WP6.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §8.3 (the CALENDAR-based
+# re-fire trigger — the threshold table, the three notes, the author-proposed
+# `exit 2` design addition, and the two enforcement points), §0.3-C1 (the
+# orphan is INVOCATION-only: the script already ships, so this WP wires callers
+# and must NOT re-ship it), §0.3-C2 (the script/guide split), §7.2 (`cadence`
+# policy keys and per-key fallback), §11-WP6, §13-R14 (the filename-derived
+# evidence residual), §14-V13 (the executed run this suite refuses to let come
+# back). Closes BL-213.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose: no backlog
+# entry exists for this build and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1,
+# WP2, WP3, WP4 and WP5 precedent. BL-213 is named in prose here because it is
+# the BUG this WP closes, not a code marker.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE ONE PROPERTY THIS SUITE EXISTS FOR
+#
+# "Unmeasurable" and "measured and fine" must never be the same answer.
+#
+# §14-V13 recorded the shipped defect by execution: every verdict in
+# scripts/check-maintenance.sh sat inside `if [ "$last_epoch" -gt 0 ]`, and
+# `last_epoch` came from a `date … || date … || echo "0"` tail. A date neither
+# parser accepted resolved to 0, the guard was false, and THE WHOLE ARM WAS
+# SKIPPED IN SILENCE — the script then printed "All maintenance cadences
+# current." and exited 0 over evidence it had never read. That is fail-OPEN,
+# and WP7's release cut is the consumer that would have been fooled by it.
+#
+# E3/E5/E6 are that fixture, now answering 2; m2 is the mutant that proves E3
+# can see the counter's removal. m2 is the pin that matters most in this file.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES, NEVER LABELS
+#
+# Every cadence verdict below is asserted on a process EXIT CODE. None is
+# asserted on a printed `[OK]`/`[WARN]` banner or on the closing sentence —
+# CLAUDE.md's `[WARN]` trap is exactly that the label and the exit predicate
+# can disagree, and the whole BL-213 defect is a closing sentence that lied.
+# Where a mutant's printed text is quoted in a pass narrative it is MEASURED
+# for the reader, never part of the predicate.
+#
+# The contract under test (scripts/check-maintenance.sh, for WP7):
+#     0  every applicable cadence was MEASURED and is current
+#     1  one or more cadences are OVERDUE
+#     2  one or more could NOT BE MEASURED and none is overdue
+#   WP7's cut-release.sh refuses on 1 AND on 2.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THIS SUITE PINS, AND WHICH MUTANT EACH ROW KILLS
+#
+#   P — POLICY ROUTING (§8.3 note 3, §7.2)
+#     P1  absent policy -> the framework defaults still measure (15d -> 1,
+#         13d -> 0). A project that never opened a post-release change still
+#         gets a working checker                                     KILLS m1
+#     P2  a project that retunes routine_review_days 14 -> 30 moves the
+#         boundary: the SAME 15-day fixture goes 1 -> 0               KILLS m3
+#     P3  deep_security_days is read too, and independently
+#     P4  a policy file WITHOUT the cadence key falls back per-key
+#     P5  the boundary lint stays rc 0 and the seam allowlist stays at ONE —
+#         the routing is composed, not allowlisted
+#
+#   E — THE EXIT CONTRACT (§8.3 note 1 — BL-213)
+#     E1  everything present and fresh -> 0
+#     E2  CHANGELOG 15 days old -> 1
+#     E3  a scan artefact dated 2026-13-45 -> 2, NOT the silent 0    KILLS m2
+#     E4  docs/test-results/ present but holding no artefact -> 2
+#         (the policy-expected-but-missing signal)
+#     E5  CHANGELOG present but with no git history -> 2
+#     E6  §14-V13's fixture verbatim -> 2
+#     E7  overdue AND unmeasurable -> 1 (overdue dominates; 2 is the
+#         zero-overdue code by design)
+#     E8  a project with NO signal surface at all -> 0, and the residual is
+#         stated rather than hidden: this checker measures a CADENCE, it does
+#         not audit whether a maintenance practice exists
+#     E9  sbom.json is the second routine arm and reads the same policy key
+#     E10 the deep cadence fires at its own threshold (96 -> 1, 94 -> 0)
+#
+#   D — THE DATE LAYER (the no-default contract)
+#     D1  a bare `YYYY-MM-DD` normalises to MIDNIGHT UTC before either parser
+#         sees it — BSD's `date -j -f` otherwise fills unspecified fields FROM
+#         NOW, so the pre-WP6 spelling answered a different number every call
+#     D2  `2026-13-45` -> rc 1 and ZERO BYTES of output (no `|| echo 0` tail)
+#     D3  empty / `banana` / an offset-bearing stamp -> rc 1, no output
+#     D4  STRUCTURAL ABSENCE: neither the `|| echo "0"` tail nor the
+#         `-gt 0` guard survives anywhere in the shipped script
+#
+#   H — THE SessionStart NAG ARM (§8.3's second enforcement point)
+#     H1  SILENT when nothing is wrong — zero bytes on stdout AND stderr
+#     H2  speaks on overdue, still rc 0
+#     H3  speaks on unmeasurable, still rc 0
+#     H4  FAIL-OPEN: a forced internal crash still exits 0             KILLS m4
+#     H5  ZERO NETWORK: curl/wget/nc/ping shadowed in PATH are never invoked
+#     H6  registered and shipped by init.sh the way its five siblings are —
+#         and check-maintenance.sh is NOT re-shipped (§0.3-C1)
+#
+#   I — IDENTIFIERS (§11-WP6's template deliverable)
+#     I1  the generated identifier registry carries the DELTA- row
+#
+#   M — MUTATIONS (anchored, sites==1, one line changed, mode preserved,
+#       fresh fixtures, both trees executed)
+#     m1  revert the routine default 14 -> 35   -> the 15-day fixture passes
+#     m2  remove the undetermined counter       -> the unparseable fixture
+#         reports "All maintenance cadences current" at rc 0 — THE pin
+#     m3  neuter the policy read                -> the retune stops moving
+#     m4  neuter the hook's fail-open arm       -> a crashing checker takes
+#         the session's SessionStart with it
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name the init script — H6 reads
+# that file through a SPLIT token for exactly that reason (see the comment
+# there; the same idiom and the same reason are already in
+# tests/test-intake-wizard-fixes.sh).
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-delta-wp6-cadence.sh" >&2
+  exit 2
+fi
+
+CHECKER="$REPO_ROOT/scripts/check-maintenance.sh"
+HOOK="$REPO_ROOT/scripts/session-cadence-check.sh"
+
+# ── Dates ───────────────────────────────────────────────────────────────────
+# GNU-first, BSD fallback — the house pattern, spelled here so the FIXTURES do
+# not depend on the product's own parser to build the inputs that test it.
+
+days_ago() {   # <n> -> YYYY-MM-DD, n whole days before now, UTC
+  local n="$1" e
+  e=$(( $(date -u +%s) - n * 86400 ))
+  date -u -d "@$e" +%Y-%m-%d 2>/dev/null || date -u -r "$e" +%Y-%m-%d
+}
+
+epoch_of() {   # <YYYY-MM-DDTHH:MM:SSZ> -> epoch seconds, computed INDEPENDENTLY
+  local s="$1" e
+  e="$(date -u -d "$s" +%s 2>/dev/null)" || e=""
+  if [ -z "$e" ]; then e="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$s" +%s 2>/dev/null)" || e=""; fi
+  printf '%s\n' "$e"
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+# EVERY case builds its own tree and removes it. Nothing is shared, so a case
+# can never inherit a surface it did not ask for — and a surface it did not ask
+# for is exactly what would make a "not applicable" verdict look like a pass.
+
+mk_proj() {    # a git repo with an identity and a .claude dir, and NOTHING else
+  local d="$1"
+  mkdir -p "$d/.claude"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email "wp6@example.invalid"
+    git config user.name "WP6 Fixture"
+    git config commit.gpgsign false
+  ) >/dev/null 2>&1
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":4,"phases":{}}\n' \
+    > "$d/.claude/phase-state.json"
+}
+
+commit_dated() {   # <dir> <file> <days-ago> — commit with a fixed +0000 author date
+  local d="$1" f="$2" n="$3" stamp
+  stamp="$(days_ago "$n")T12:00:00+0000"
+  printf 'fixture content for %s\n' "$f" > "$d/$f"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git add "$f"
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git commit -q -m "chore: $f"
+  ) >/dev/null 2>&1
+  return 0
+}
+
+add_scan() {   # <dir> <filename> — one artefact under the evidence surface
+  local d="$1" n="$2"
+  mkdir -p "$d/docs/test-results"
+  printf 'scan artefact\n' > "$d/docs/test-results/$n"
+}
+
+mk_current_proj() {   # every surface present, every one fresh -> the rc 0 baseline
+  local d="$1"
+  mk_proj "$d"
+  commit_dated "$d" CHANGELOG.md 2
+  commit_dated "$d" sbom.json 2
+  add_scan "$d" "$(days_ago 10)_semgrep_pass.txt"
+}
+
+write_policy() { printf '%s\n' "$2" > "$1/.claude/delta-policy.json"; }
+
+mk_scripts_tree() { mkdir -p "$1"; cp -R "$REPO_ROOT/scripts" "$1/scripts"; }
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+CHK_RC=0
+CHK_OUT=""
+run_check() {   # <scripts-dir> <project-dir> — sets CHK_RC / CHK_OUT
+  local sd="$1" p="$2"
+  CHK_RC=0
+  CHK_OUT="$( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/check-maintenance.sh" </dev/null 2>&1 )" || CHK_RC=$?
+  return 0
+}
+
+HOOK_RC=0
+HOOK_OUT=""
+HOOK_ERR=""
+run_hook() {   # <scripts-dir> <project-dir> [err-file]
+  local sd="$1" p="$2" errf="${3:-}"
+  local tmperr; tmperr="${errf:-$(mktemp)}"
+  HOOK_RC=0
+  HOOK_OUT="$( cd "$p" && unset GITHUB_BASE_REF; CLAUDE_PROJECT_DIR="$p" bash "$sd/session-cadence-check.sh" </dev/null 2>"$tmperr" )" || HOOK_RC=$?
+  HOOK_ERR="$(cat "$tmperr" 2>/dev/null || true)"
+  [ -n "$errf" ] || rm -f "$tmperr" 2>/dev/null || true
+  return 0
+}
+
+# ── Mutation harness (inherited from the WP2/WP3/WP4/WP5 suites) ────────────
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_mutation_report() {
+  local orig="$1" mut="$2" marker="$3" sites changed n
+  sites="$(grep -c "$marker" "$orig" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  if diff "$orig" "$mut" >/dev/null 2>&1; then changed=n; else changed=y; fi
+  n="$(diff "$orig" "$mut" | grep -c '^[<>]' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s|%s|%s' "$sites" "$changed" "$n"
+}
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || echo "?"; }
+
+echo "== tests/test-delta-wp6-cadence.sh =="
+echo ""
+
+# The suite is meaningless if the two product files are not there at all — say
+# so once, loudly, rather than letting thirty rows report the same absence.
+if [ ! -f "$CHECKER" ]; then
+  echo "  [FAIL] scripts/check-maintenance.sh is missing — WP6 wires it, it must exist" >&2
+  exit 1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== P — the thresholds are POLICY, read through the ONE seam (§8.3 note 3) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── P1: absent policy -> the framework defaults still MEASURE ───────────────
+# Asserted in BOTH directions from the same default. One direction alone would
+# pass for a checker that always answers 1 (or always 0).
+T=$(mktemp -d)
+mk_current_proj "$T/over"; commit_dated "$T/over" CHANGELOG.md 15
+run_check "$REPO_ROOT/scripts" "$T/over"; over_rc=$CHK_RC
+mk_current_proj "$T/under"; commit_dated "$T/under" CHANGELOG.md 13
+run_check "$REPO_ROOT/scripts" "$T/under"; under_rc=$CHK_RC
+had_policy=n
+[ -f "$T/over/.claude/delta-policy.json" ] && had_policy=y
+if [ "$over_rc" -eq 1 ] && [ "$under_rc" -eq 0 ] && [ "$had_policy" = n ]; then
+  pass "P1: with NO policy file anywhere (had_policy=$had_policy) the framework default of 14 days still measures — 15 days is overdue (rc $over_rc) and 13 days is current (rc $under_rc). The checker does not require the post-1.0 module"
+else
+  fail_ "P1" "15-day rc=$over_rc (expect 1); 13-day rc=$under_rc (expect 0); policy file present=$had_policy (expect n)"
+fi
+rm -rf "$T"
+
+# ── P2: a retune MOVES the boundary — this is the policy read, proved ───────
+# The SAME 15-day fixture, the only difference being the project's own file.
+T=$(mktemp -d)
+mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
+run_check "$REPO_ROOT/scripts" "$T/p"; before_rc=$CHK_RC
+write_policy "$T/p" '{"schemaVersion":1,"cadence":{"routine_review_days":30,"deep_security_days":95}}'
+run_check "$REPO_ROOT/scripts" "$T/p"; after_rc=$CHK_RC
+if [ "$before_rc" -eq 1 ] && [ "$after_rc" -eq 0 ]; then
+  pass "P2: one fixture, one file changed — a project that retunes routine_review_days 14 -> 30 turns the same 15-day-old CHANGELOG from overdue (rc $before_rc) into current (rc $after_rc). The threshold is the project's, not the script's"
+else
+  fail_ "P2" "rc before the retune=$before_rc (expect 1); rc after routine_review_days=30=$after_rc (expect 0)"
+fi
+rm -rf "$T"
+
+# ── P3: deep_security_days is a SEPARATE key, read independently ────────────
+T=$(mktemp -d)
+mk_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 1; commit_dated "$T/p" sbom.json 1
+add_scan "$T/p" "$(days_ago 20)_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/p"; deep_default_rc=$CHK_RC
+write_policy "$T/p" '{"schemaVersion":1,"cadence":{"routine_review_days":14,"deep_security_days":10}}'
+run_check "$REPO_ROOT/scripts" "$T/p"; deep_tuned_rc=$CHK_RC
+if [ "$deep_default_rc" -eq 0 ] && [ "$deep_tuned_rc" -eq 1 ]; then
+  pass "P3: a 20-day-old scan is current under the framework's 95 (rc $deep_default_rc) and overdue the moment the project sets deep_security_days=10 (rc $deep_tuned_rc) — the two cadence keys are read separately, and the routine arms stayed fresh throughout"
+else
+  fail_ "P3" "rc under the default 95=$deep_default_rc (expect 0); rc under deep_security_days=10=$deep_tuned_rc (expect 1)"
+fi
+rm -rf "$T"
+
+# ── P4: PER-KEY fallback — a policy file without the cadence key ────────────
+# §7.2's read-time fallback is per KEY, not per FILE. A project that seeded a
+# policy for some other reason must not lose the cadence defaults.
+T=$(mktemp -d)
+mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
+write_policy "$T/p" '{"schemaVersion":1,"size_thresholds":{"small":50}}'
+run_check "$REPO_ROOT/scripts" "$T/p"; rc_nokey=$CHK_RC
+if [ "$rc_nokey" -eq 1 ]; then
+  pass "P4: a policy file that carries no cadence block at all still measures on the framework defaults (rc $rc_nokey on a 15-day fixture) — the fallback is per key, not per file"
+else
+  fail_ "P4" "rc=$rc_nokey (expect 1 — the 14-day default must survive a policy file that never mentions cadence)"
+fi
+rm -rf "$T"
+
+# ── P5: the routing is COMPOSED, not allowlisted ───────────────────────────
+# The T1 rule this WP had to design around is only worth anything if it is
+# still green afterwards, with the seam's cardinality untouched.
+lint_rc=0
+( cd "$REPO_ROOT" && bash scripts/lint-delta-boundary.sh ) >/dev/null 2>&1 || lint_rc=$?
+seam_n="$(sed -n '/^SEAM_ALLOWLIST=(/,/^)/p' "$REPO_ROOT/scripts/lint-delta-boundary.sh" | grep -c '^  "' || true)"
+case "$seam_n" in ''|*[!0-9]*) seam_n=0 ;; esac
+t1_hit=n
+grep -n 'delta-policy\.json\|delta-policy\.sh\|delta-cadence\.sh\|delta-state\.sh' "$CHECKER" \
+  | grep -v '^[0-9]*:[[:space:]]*#' >/dev/null 2>&1 && t1_hit=y
+if [ "$lint_rc" -eq 0 ] && [ "$seam_n" -eq 1 ] && [ "$t1_hit" = n ]; then
+  pass "P5: scripts/lint-delta-boundary.sh is still rc $lint_rc with the seam allowlist at exactly $seam_n entry, and the checker names no module path on any executed line (t1_hit=$t1_hit) — the policy read is composed through the seam, not allowlisted around the boundary"
+else
+  fail_ "P5" "boundary lint rc=$lint_rc (expect 0); seam allowlist entries=$seam_n (expect 1); module path on a non-comment line of the checker=$t1_hit (expect n)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== E — the exit contract, and BL-213's fail-open repair (§8.3 note 1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── E1: the rc 0 baseline ──────────────────────────────────────────────────
+T=$(mktemp -d); mk_current_proj "$T/p"
+run_check "$REPO_ROOT/scripts" "$T/p"; rc1=$CHK_RC
+if [ "$rc1" -eq 0 ]; then
+  pass "E1: every surface present and fresh -> rc $rc1. This is the baseline every row below perturbs by exactly one thing, so a non-zero answer is attributable"
+else
+  fail_ "E1" "rc=$rc1 (expect 0) — the all-current baseline must be clean or every row below is unreadable:\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E2: overdue -> 1 ───────────────────────────────────────────────────────
+T=$(mktemp -d); mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
+run_check "$REPO_ROOT/scripts" "$T/p"; rc2=$CHK_RC
+if [ "$rc2" -eq 1 ]; then
+  pass "E2: a CHANGELOG.md last touched 15 days ago against a 14-day cadence -> rc $rc2 (the design's own number)"
+else
+  fail_ "E2" "rc=$rc2 (expect 1):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E3: THE BL-213 PIN — an unparseable date -> 2, not the silent 0 ────────
+# §14-V13's own fixture string. Both `date -j -f` and `date -d` reject
+# 2026-13-45 on this host, which is why it was chosen: it is date-SHAPED but
+# not a date, so a shape check passes it through to the real parser and the
+# real parser is what must refuse it.
+T=$(mktemp -d); mk_proj "$T/p"
+commit_dated "$T/p" CHANGELOG.md 1; commit_dated "$T/p" sbom.json 1
+add_scan "$T/p" "2026-13-45_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/p"; rc3=$CHK_RC
+# MEASURED for the narrative, never asserted: the sentence the shipped script used to print.
+said_current=n
+printf '%s' "$CHK_OUT" | grep -qF 'All maintenance cadences current' && said_current=y
+if [ "$rc3" -eq 2 ]; then
+  pass "E3: the ONLY security artefact is dated 2026-13-45 — a string neither date parser accepts — and every other cadence is fresh, so the script answers rc $rc3, the code that means 'I could not measure this'. §14-V13 recorded rc 0 here (all-current sentence printed now: $said_current). Unmeasurable is no longer spelled the same as fine"
+else
+  fail_ "E3" "rc=$rc3 (expect 2 — this is BL-213; rc 0 is the shipped defect, rc 1 would be the fail-CLOSED collapse the design refuted):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E4: a policy-expected signal that is MISSING -> 2 ──────────────────────
+# The evidence surface exists — the project adopted the convention — and holds
+# nothing the deep cadence can read. That is not "current".
+T=$(mktemp -d); mk_proj "$T/p"
+commit_dated "$T/p" CHANGELOG.md 1; commit_dated "$T/p" sbom.json 1
+mkdir -p "$T/p/docs/test-results"
+printf 'unrelated\n' > "$T/p/docs/test-results/README.md"
+run_check "$REPO_ROOT/scripts" "$T/p"; rc4=$CHK_RC
+if [ "$rc4" -eq 2 ]; then
+  pass "E4: docs/test-results/ exists and holds no dependency- or security-scan artefact at all -> rc $rc4. A signal the policy expects and cannot find is unmeasurable, not satisfied"
+else
+  fail_ "E4" "rc=$rc4 (expect 2):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E5: a signal file with no git history -> 2 ─────────────────────────────
+T=$(mktemp -d); mk_proj "$T/p"
+commit_dated "$T/p" sbom.json 1
+add_scan "$T/p" "$(days_ago 5)_semgrep_pass.txt"
+printf '# Changelog\n' > "$T/p/CHANGELOG.md"        # present, untracked, undatable
+run_check "$REPO_ROOT/scripts" "$T/p"; rc5=$CHK_RC
+if [ "$rc5" -eq 2 ]; then
+  pass "E5: a CHANGELOG.md that is present but has no git history cannot be dated -> rc $rc5. The shipped script printed one INFO line here and still closed at rc 0"
+else
+  fail_ "E5" "rc=$rc5 (expect 2):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E6: §14-V13's fixture, verbatim -> 2 ───────────────────────────────────
+# "a git repo with an untracked CHANGELOG.md and a docs/test-results/ file
+# dated 2026-13-45". The design logged rc 0. This row is the regression pin on
+# the exact tree that produced the bug report.
+T=$(mktemp -d); mk_proj "$T/p"
+printf '# Changelog\n' > "$T/p/CHANGELOG.md"
+add_scan "$T/p" "2026-13-45_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/p"; rc6=$CHK_RC
+if [ "$rc6" -eq 2 ]; then
+  pass "E6: §14-V13's fixture verbatim — untracked CHANGELOG.md plus a lone 2026-13-45 artefact — answers rc $rc6 where the executed design log recorded rc 0 over two cadences it had never read"
+else
+  fail_ "E6" "rc=$rc6 (expect 2 — this is the exact tree §14-V13 ran):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E7: overdue AND unmeasurable -> 1 ──────────────────────────────────────
+# §8.3 is explicit: 2 is the code for a non-zero undetermined with ZERO
+# overdue. Both refuse a release cut, so the ordering costs nothing — but a
+# checker that answered 2 here would hide a REAL overdue behind an unreadable
+# date, which is the same disease pointing the other way.
+T=$(mktemp -d); mk_proj "$T/p"
+commit_dated "$T/p" CHANGELOG.md 15
+commit_dated "$T/p" sbom.json 1
+add_scan "$T/p" "2026-13-45_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/p"; rc7=$CHK_RC
+named_both=n
+printf '%s' "$CHK_OUT" | grep -qi 'could not be measured' && named_both=y
+if [ "$rc7" -eq 1 ]; then
+  pass "E7: a genuinely overdue cadence and an unreadable one in the same tree -> rc $rc7, because 2 is by design the ZERO-overdue code — and the unmeasurable one is still named in the report (named=$named_both) rather than lost behind the louder answer"
+else
+  fail_ "E7" "rc=$rc7 (expect 1):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E8: no signal surface at all -> 0, and the residual is STATED ──────────
+# Recorded as a row rather than left implicit: absence of an artefact is a
+# legitimate project shape, so the checker says "not applicable" and does not
+# invent a verdict. It measures a CADENCE; it does not audit whether a
+# maintenance practice exists. If that boundary ever moves, this row moves
+# with it — deliberately, not by accident.
+T=$(mktemp -d); mk_proj "$T/p"
+run_check "$REPO_ROOT/scripts" "$T/p"; rc8=$CHK_RC
+na="$(printf '%s' "$CHK_OUT" | grep -c 'not applicable' || true)"
+case "$na" in ''|*[!0-9]*) na=0 ;; esac
+if [ "$rc8" -eq 0 ] && [ "$na" -eq 3 ]; then
+  pass "E8: a project with no CHANGELOG.md, no sbom.json and no docs/test-results/ answers rc $rc8 and says 'not applicable' $na times — the stated residual: an absent surface is a project shape, not a failure, and this checker does not audit whether a maintenance practice exists"
+else
+  fail_ "E8" "rc=$rc8 (expect 0); 'not applicable' lines=$na (expect 3 — one per surface, so the silence is legible):\n$CHK_OUT"
+fi
+rm -rf "$T"
+
+# ── E9: sbom.json is the second routine arm, on the same key ──────────────
+T=$(mktemp -d); mk_current_proj "$T/p"; commit_dated "$T/p" sbom.json 15
+run_check "$REPO_ROOT/scripts" "$T/p"; rc9=$CHK_RC
+write_policy "$T/p" '{"schemaVersion":1,"cadence":{"routine_review_days":30}}'
+run_check "$REPO_ROOT/scripts" "$T/p"; rc9b=$CHK_RC
+if [ "$rc9" -eq 1 ] && [ "$rc9b" -eq 0 ]; then
+  pass "E9: sbom.json is the routine cadence's second arm and reads the SAME policy key — 15 days is overdue (rc $rc9) and the 30-day retune clears it (rc $rc9b), with CHANGELOG fresh throughout"
+else
+  fail_ "E9" "sbom 15-day rc=$rc9 (expect 1); after routine_review_days=30 rc=$rc9b (expect 0)"
+fi
+rm -rf "$T"
+
+# ── E10: the deep cadence fires at ITS threshold, both sides ──────────────
+T=$(mktemp -d)
+mk_proj "$T/a"; commit_dated "$T/a" CHANGELOG.md 1; commit_dated "$T/a" sbom.json 1
+add_scan "$T/a" "$(days_ago 96)_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/a"; rc10a=$CHK_RC
+mk_proj "$T/b"; commit_dated "$T/b" CHANGELOG.md 1; commit_dated "$T/b" sbom.json 1
+add_scan "$T/b" "$(days_ago 94)_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/b"; rc10b=$CHK_RC
+# The dependency audit is FOLDED IN (§8.3's table): one clock over the union of
+# both artefact families, so a snyk artefact satisfies the same cadence.
+mk_proj "$T/c"; commit_dated "$T/c" CHANGELOG.md 1; commit_dated "$T/c" sbom.json 1
+add_scan "$T/c" "$(days_ago 94)_snyk_report.json"
+run_check "$REPO_ROOT/scripts" "$T/c"; rc10c=$CHK_RC
+if [ "$rc10a" -eq 1 ] && [ "$rc10b" -eq 0 ] && [ "$rc10c" -eq 0 ]; then
+  pass "E10: the deep cadence answers overdue at 96 days (rc $rc10a) and current at 94 (rc $rc10b) against the framework's 95, and the dependency audit is FOLDED IN — a lone snyk artefact satisfies the same one clock (rc $rc10c) instead of the separate 95-day row the shipped script kept"
+else
+  fail_ "E10" "96-day semgrep rc=$rc10a (expect 1); 94-day semgrep rc=$rc10b (expect 0); 94-day snyk rc=$rc10c (expect 0 — the folded family)"
+fi
+rm -rf "$T"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== D — the date layer, and the no-default contract ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# The parse helper is exercised DIRECTLY, extracted from the shipped file. It
+# is the one place where "returns nothing" and "returns 0" have to be
+# distinguishable, and a whole-script run cannot see the difference: both would
+# read as "that arm did not fire".
+T=$(mktemp -d)
+sed -n '/^cadence_epoch() {$/,/^}$/p' "$CHECKER" > "$T/lib.sh"
+extracted="$(grep -c . "$T/lib.sh" || true)"
+case "$extracted" in ''|*[!0-9]*) extracted=0 ;; esac
+
+_epoch_call() {   # <arg…> -> prints "<rc>|<stdout-bytes>|<stdout>"
+  local out rc=0
+  out="$( . "$T/lib.sh"; cadence_epoch "$@" 2>/dev/null )" || rc=$?
+  printf '%s|%s|%s' "$rc" "${#out}" "$out"
+}
+
+if [ "$extracted" -lt 8 ]; then
+  fail_ "D0" "could not extract cadence_epoch() from scripts/check-maintenance.sh (got $extracted non-blank lines) — the date layer must be a named function so it can be tested where a whole-script run cannot see it"
+else
+  # ── D1: a bare date normalises to MIDNIGHT UTC ──────────────────────────
+  # BSD's `date -j -f '%Y-%m-%d'` fills unspecified fields FROM THE CURRENT
+  # TIME, so without the normalisation the same bare date answers a different
+  # number every call and a different number from GNU's answer. The expected
+  # value is computed here from the EXPLICIT stamp, independently.
+  bare="$(days_ago 5)"
+  got="$(_epoch_call "$bare")"; got_rc="${got%%|*}"; got_val="${got##*|}"
+  want="$(epoch_of "${bare}T00:00:00Z")"
+  again="$(_epoch_call "$bare")"; again_val="${again##*|}"
+  if [ "$got_rc" -eq 0 ] && [ -n "$want" ] && [ "$got_val" = "$want" ] && [ "$again_val" = "$got_val" ]; then
+    pass "D1: the bare date $bare resolves to $got_val, which is exactly midnight UTC computed independently ($want), and twice in a row to the same number — the BSD 'fill the missing fields from now' nondeterminism the shipped spelling carried is gone"
+  else
+    fail_ "D1" "rc=$got_rc (expect 0); value=$got_val; independently-computed midnight=$want; second call=$again_val (all three must agree)"
+  fi
+
+  # ── D2: the unparseable date returns NOTHING ───────────────────────────
+  bad="$(_epoch_call '2026-13-45')"; bad_rc="${bad%%|*}"; bad_rest="${bad#*|}"; bad_len="${bad_rest%%|*}"
+  if [ "$bad_rc" -ne 0 ] && [ "$bad_len" -eq 0 ]; then
+    pass "D2: 2026-13-45 — date-SHAPED but not a date — returns rc $bad_rc and $bad_len bytes of output. A caller that ignored the return code has nothing to misread as a date, which is exactly what the '|| echo 0' tail gave it"
+  else
+    fail_ "D2" "rc=$bad_rc (expect non-zero); stdout bytes=$bad_len (expect 0 — printing a 0 here IS the defect)"
+  fi
+
+  # ── D3: every other non-date is the same answer ────────────────────────
+  d3_ok=y; d3_detail=""
+  for cand in "" "banana" "2026-08-03T00:00:00+02:00" "20260803" "2026-8-3"; do
+    r="$(_epoch_call "$cand")"; r_rc="${r%%|*}"; r_rest="${r#*|}"; r_len="${r_rest%%|*}"
+    d3_detail="$d3_detail '$cand'->rc$r_rc/${r_len}b"
+    { [ "$r_rc" -ne 0 ] && [ "$r_len" -eq 0 ]; } || d3_ok=n
+  done
+  if [ "$d3_ok" = y ]; then
+    pass "D3: every non-date refuses the same way —$d3_detail. There is no third answer and no default"
+  else
+    fail_ "D3" "each candidate must give a non-zero rc and zero bytes:$d3_detail"
+  fi
+fi
+rm -rf "$T"
+
+# ── D4: STRUCTURAL ABSENCE of the two atoms that made the defect ──────────
+# An absence has to be discriminated structurally, and both halves are named
+# because either one alone would have been survivable: the `|| echo "0"` tail
+# is what manufactured the sentinel and the `-gt 0` guard is what turned the
+# sentinel into silence.
+tail_hits="$(grep -c '|| echo "\{0,1\}0"\{0,1\}' "$CHECKER" || true)"
+case "$tail_hits" in ''|*[!0-9]*) tail_hits=0 ;; esac
+guard_hits="$(grep -c 'last_epoch' "$CHECKER" || true)"
+case "$guard_hits" in ''|*[!0-9]*) guard_hits=0 ;; esac
+gt0_hits="$(grep -c -- '-gt 0 \]' "$CHECKER" || true)"
+case "$gt0_hits" in ''|*[!0-9]*) gt0_hits=0 ;; esac
+if [ "$tail_hits" -eq 0 ] && [ "$guard_hits" -eq 0 ] && [ "$gt0_hits" -eq 0 ]; then
+  pass "D4: neither half of the shipped defect survives anywhere in the file — no '|| echo 0' capture tail ($tail_hits), no last_epoch sentinel ($guard_hits), no '-gt 0 ]' arm guard ($gt0_hits). The counters are compared with -gt at the verdict, which is a different shape and deliberately not matched here"
+else
+  fail_ "D4" "'|| echo 0' tails=$tail_hits (expect 0); last_epoch mentions=$guard_hits (expect 0); '-gt 0 ]' guards=$gt0_hits (expect 0)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== H — the SessionStart nag arm (§8.3's second enforcement point) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+if [ ! -f "$HOOK" ]; then
+  fail_ "H0" "scripts/session-cadence-check.sh is missing — §8.3's second enforcement point is the SessionStart nag, and the whole H section depends on it"
+else
+  # ── H1: SILENT when nothing is wrong ────────────────────────────────────
+  # Zero bytes on BOTH streams. A hook that "only prints a little" when healthy
+  # is a hook every session learns to skim past.
+  T=$(mktemp -d); mk_current_proj "$T/p"
+  run_hook "$REPO_ROOT/scripts" "$T/p"
+  if [ "$HOOK_RC" -eq 0 ] && [ "${#HOOK_OUT}" -eq 0 ] && [ "${#HOOK_ERR}" -eq 0 ]; then
+    pass "H1: against an all-current project the hook exits $HOOK_RC having written ${#HOOK_OUT} bytes to stdout and ${#HOOK_ERR} to stderr — silent when nothing is wrong, the house contract for every SessionStart hook the framework ships"
+  else
+    fail_ "H1" "rc=$HOOK_RC (expect 0); stdout bytes=${#HOOK_OUT} (expect 0); stderr bytes=${#HOOK_ERR} (expect 0); stdout='$HOOK_OUT'; stderr='$HOOK_ERR'"
+  fi
+  rm -rf "$T"
+
+  # ── H2 / H3: it speaks on BOTH refusal codes, and never non-zero ────────
+  T=$(mktemp -d)
+  mk_current_proj "$T/over"; commit_dated "$T/over" CHANGELOG.md 40
+  run_hook "$REPO_ROOT/scripts" "$T/over"; o_rc=$HOOK_RC; o_len=${#HOOK_OUT}
+  mk_proj "$T/und"; commit_dated "$T/und" CHANGELOG.md 1; commit_dated "$T/und" sbom.json 1
+  add_scan "$T/und" "2026-13-45_semgrep_pass.txt"
+  run_hook "$REPO_ROOT/scripts" "$T/und"; u_rc=$HOOK_RC; u_len=${#HOOK_OUT}
+  if [ "$o_rc" -eq 0 ] && [ "$o_len" -gt 0 ] && [ "$u_rc" -eq 0 ] && [ "$u_len" -gt 0 ]; then
+    pass "H2/H3: the nag speaks on BOTH refusal codes — $o_len bytes for an overdue project and $u_len for an unmeasurable one — and exits 0 either way (rc $o_rc / $u_rc). A session hook reports; it never blocks"
+  else
+    fail_ "H2/H3" "overdue: rc=$o_rc (expect 0) bytes=$o_len (expect >0); unmeasurable: rc=$u_rc (expect 0) bytes=$u_len (expect >0)"
+  fi
+  rm -rf "$T"
+
+  # ── H4: FAIL-OPEN under a forced internal crash ────────────────────────
+  # Three separate ways for the thing it calls to be broken. A hook that
+  # exits non-zero at SessionStart is a hook that can brick a session, so the
+  # guarantee has to hold for a crash nobody anticipated — not just for the
+  # one shape the author thought of.
+  T=$(mktemp -d); mk_current_proj "$T/p"
+  h4_ok=y; h4_detail=""
+  for kind in exit42 syntax missing notadir; do
+    ST="$T/tree-$kind"; mk_scripts_tree "$ST"
+    case "$kind" in
+      exit42)   printf '#!/usr/bin/env bash\nexit 42\n' > "$ST/scripts/check-maintenance.sh" ;;
+      syntax)   printf '#!/usr/bin/env bash\nif [ \n' > "$ST/scripts/check-maintenance.sh" ;;
+      missing)  rm -f "$ST/scripts/check-maintenance.sh" ;;
+      notadir)  rm -f "$ST/scripts/check-maintenance.sh"; mkdir -p "$ST/scripts/check-maintenance.sh" ;;
+    esac
+    run_hook "$ST/scripts" "$T/p"
+    h4_detail="$h4_detail $kind->rc$HOOK_RC"
+    [ "$HOOK_RC" -eq 0 ] || h4_ok=n
+  done
+  if [ "$h4_ok" = y ]; then
+    pass "H4: every forced internal crash still exits 0 —$h4_detail. A broken checker is inert at SessionStart, never a blocked session"
+  else
+    fail_ "H4" "each crash shape must still exit 0:$h4_detail"
+  fi
+  rm -rf "$T"
+
+  # ── H5: ZERO NETWORK ───────────────────────────────────────────────────
+  # Asserted by SHADOWING, not by reading the source: four network binaries
+  # are put ahead of the real ones in PATH and each records its own invocation.
+  # The fixture is the overdue one on purpose — the path that does the most
+  # work is the one worth watching.
+  T=$(mktemp -d); mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 40
+  mkdir -p "$T/shim"
+  for b in curl wget nc ping ssh; do
+    printf '#!/usr/bin/env bash\nprintf "%%s\\n" "%s" >> "%s"\nexit 0\n' "$b" "$T/called" > "$T/shim/$b"
+    chmod +x "$T/shim/$b"
+  done
+  net_rc=0
+  net_out="$( cd "$T/p" && unset GITHUB_BASE_REF; PATH="$T/shim:$PATH" CLAUDE_PROJECT_DIR="$T/p" \
+    bash "$REPO_ROOT/scripts/session-cadence-check.sh" </dev/null 2>&1 )" || net_rc=$?
+  called="$(cat "$T/called" 2>/dev/null | tr '\n' ' ' || true)"
+  shim_live=n
+  ( PATH="$T/shim:$PATH"; curl --version >/dev/null 2>&1 ) && shim_live=y
+  rm -f "$T/called"
+  if [ "$net_rc" -eq 0 ] && [ -z "$called" ] && [ "$shim_live" = y ]; then
+    pass "H5: with curl/wget/nc/ping/ssh shadowed ahead of the real binaries in PATH — and the shims proved reachable (shim_live=$shim_live) — the hook made no call at all ('$called') and still exited $net_rc on the busiest path it has"
+  else
+    fail_ "H5" "rc=$net_rc (expect 0); network binaries invoked='$called' (expect none); shims reachable=$shim_live (expect y — an unreachable shim would make this row vacuous); output:\n$net_out"
+  fi
+  rm -rf "$T"
+
+  # ── H6: shipped and registered the way its five siblings are ───────────
+  # THE SPLIT TOKEN IS LOAD-BEARING, and it is the house idiom (the identical
+  # split and the identical reason are in tests/test-intake-wizard-fixes.sh):
+  # the BL-154/BL-181 unit-lane predicate reads NAMES ON EXECUTED LINES, so
+  # spelling the init script's filename here would silently exempt this whole
+  # file from the tests.yml membership lint. This suite never RUNS that script
+  # — it reads it. Do not "simplify" this back.
+  INITF="$REPO_ROOT/init"; INITF="${INITF}.sh"
+  h6_ok=1; h6_detail=""
+  grep -qF "# CADENCE-NAG-HOOK-BEGIN" "$INITF" || { h6_ok=0; h6_detail="$h6_detail no-fence"; }
+  grep -qF "# CADENCE-NAG-HOOK-END" "$INITF"   || { h6_ok=0; h6_detail="$h6_detail no-fence-end"; }
+  grep -qF 'session-cadence-check.sh"))' "$INITF" || { h6_ok=0; h6_detail="$h6_detail no-idempotent-guard"; }
+  grep -qF 'cp "$SCRIPT_DIR/scripts/session-cadence-check.sh" scripts/' "$INITF" || { h6_ok=0; h6_detail="$h6_detail not-shipped"; }
+  grep -q 'chmod +x .*scripts/session-cadence-check\.sh' "$INITF" || { h6_ok=0; h6_detail="$h6_detail not-chmodded"; }
+  # §0.3-C1: the orphan is INVOCATION-only. Re-shipping the checker would
+  # re-fix a closed defect (BL-117 F20), so the cp count must stay at one.
+  cm_cp="$(grep -c 'cp "\$SCRIPT_DIR/scripts/check-maintenance.sh"' "$INITF" || true)"
+  case "$cm_cp" in ''|*[!0-9]*) cm_cp=0 ;; esac
+  [ "$cm_cp" -eq 1 ] || { h6_ok=0; h6_detail="$h6_detail check-maintenance-cp=$cm_cp"; }
+  hook_mode="$(_mode_of "$HOOK")"
+  case "$hook_mode" in *7*|*5*|*1*) : ;; *) h6_ok=0; h6_detail="$h6_detail hook-not-executable($hook_mode)" ;; esac
+  if [ "$h6_ok" -eq 1 ]; then
+    pass "H6: the nag is copied, chmodded and merged into .hooks.SessionStart under its own excisable fence by the same idempotent contains-guard its five siblings use, the hook file itself is executable ($hook_mode), and check-maintenance.sh is still copied exactly $cm_cp time — §0.3-C1's orphan is wired, not re-shipped"
+  else
+    fail_ "H6" "missing wiring:$h6_detail"
+  fi
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I — the identifier registry (§11-WP6) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+IDT="$REPO_ROOT/templates/generated/identifiers.tmpl"
+i1_ok=1
+[ -f "$IDT" ] || i1_ok=0
+if [ "$i1_ok" -eq 1 ]; then
+  grep -qF '`DELTA-' "$IDT" || i1_ok=0
+  grep -qF 'DELTA-001' "$IDT" || i1_ok=0
+fi
+if [ "$i1_ok" -eq 1 ]; then
+  pass "I1: the generated identifier registry carries the DELTA- row with its example, so the post-release namespace is registered before anything mints an id in it — the registry's own rule three"
+else
+  fail_ "I1" "templates/generated/identifiers.tmpl must carry a DELTA- row with a DELTA-001 example (file present=$( [ -f "$IDT" ] && echo y || echo n ))"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutations: anchored, sites==1, one line changed, mode preserved ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── m1: revert the routine default 14 -> 35 ────────────────────────────────
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+pre_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
+_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-DEFAULT-ROUTINE.*$|ROUTINE_DEFAULT_DAYS=35|'
+post_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
+rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-DEFAULT-ROUTINE')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
+run_check "$REPO_ROOT/scripts" "$T/p"; pri_rc=$CHK_RC
+run_check "$MT/scripts" "$T/p"; mut_rc=$CHK_RC
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
+   && [ "$pri_rc" -eq 1 ] && [ "$mut_rc" -eq 0 ]; then
+  pass "m1: with the routine default reverted to the shipped 35, a CHANGELOG untouched for 15 days passes clean (rc $mut_rc) where the tuned tree refuses it (rc $pri_rc). P1 goes RED — the 35 -> 14 retune is load-bearing and not decoration (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+else
+  fail_ "m1" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE rc=$pri_rc (expect 1); MUTANT rc=$mut_rc (expect 0)"
+fi
+rm -rf "$T"
+
+# ── m2: REMOVE THE UNDETERMINED COUNTER — the pin that matters most ────────
+# The design names this mutant explicitly and requires it to be asserted on the
+# EXIT CODE. The mutant's printed sentence is measured below for the reader,
+# and it is the sentence BL-213 was filed about — but the predicate is the code.
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+pre_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
+_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-UNDETERMINED-COUNTER.*$|  :|'
+post_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
+rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-UNDETERMINED-COUNTER')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+mk_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 1; commit_dated "$T/p" sbom.json 1
+add_scan "$T/p" "2026-13-45_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$T/p"; pri_rc=$CHK_RC
+run_check "$MT/scripts" "$T/p"; mut_rc=$CHK_RC
+mut_said=n
+printf '%s' "$CHK_OUT" | grep -qF 'All maintenance cadences current' && mut_said=y
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
+   && [ "$pri_rc" -eq 2 ] && [ "$mut_rc" -eq 0 ]; then
+  pass "m2: with the undetermined counter removed — ONE line — a security artefact dated 2026-13-45 stops being an answer the script owes anyone: rc $mut_rc where the repaired tree answers rc $pri_rc, and the closing sentence is 'All maintenance cadences current' again (measured, not asserted: $mut_said). E3 goes RED. This is BL-213 re-opened in a single line, and the assertion is the exit code (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+else
+  fail_ "m2" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE rc=$pri_rc (expect 2); MUTANT rc=$mut_rc (expect 0); mutant printed the all-current sentence=$mut_said"
+fi
+rm -rf "$T"
+
+# ── m3: neuter the policy read ─────────────────────────────────────────────
+T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"
+pre_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
+_sed_inplace "$MT/scripts/check-maintenance.sh" 's|^.*CADENCE-POLICY-READ.*$|    v=""|'
+post_mode="$(_mode_of "$MT/scripts/check-maintenance.sh")"
+rep="$(_mutation_report "$REPO_ROOT/scripts/check-maintenance.sh" "$MT/scripts/check-maintenance.sh" 'CADENCE-POLICY-READ')"
+sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+mk_current_proj "$T/p"; commit_dated "$T/p" CHANGELOG.md 15
+write_policy "$T/p" '{"schemaVersion":1,"cadence":{"routine_review_days":30,"deep_security_days":95}}'
+run_check "$REPO_ROOT/scripts" "$T/p"; pri_rc=$CHK_RC
+run_check "$MT/scripts" "$T/p"; mut_rc=$CHK_RC
+mut_silent=y
+printf '%s' "$CHK_OUT" | grep -qi 'policy\|could not read' && mut_silent=n
+if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
+   && [ "$pri_rc" -eq 0 ] && [ "$mut_rc" -eq 1 ]; then
+  pass "m3: with the seam read neutered, a project whose own policy says 30 days is refused at 15 anyway (rc $mut_rc) where the tuned tree honours it (rc $pri_rc) — and the failure is SILENT, measured rather than asserted: the mutant's transcript says nothing about a policy it could not read (silent=$mut_silent). P2 goes RED (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+else
+  fail_ "m3" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE rc=$pri_rc (expect 0); MUTANT rc=$mut_rc (expect 1); mutant silent about the lost policy=$mut_silent"
+fi
+rm -rf "$T"
+
+# ── m4: neuter the hook's fail-open arm ────────────────────────────────────
+if [ -f "$HOOK" ]; then
+  T=$(mktemp -d); MT="$T/mut"; mk_scripts_tree "$MT"; PT="$T/pri"; mk_scripts_tree "$PT"
+  pre_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
+  _sed_inplace "$MT/scripts/session-cadence-check.sh" 's|^.*CADENCE-NAG-FAILOPEN.*$|  *) exit "$rc" ;;|'
+  post_mode="$(_mode_of "$MT/scripts/session-cadence-check.sh")"
+  rep="$(_mutation_report "$HOOK" "$MT/scripts/session-cadence-check.sh" 'CADENCE-NAG-FAILOPEN')"
+  sites="${rep%%|*}"; rest="${rep#*|}"; changed="${rest%%|*}"; nlines="${rest##*|}"
+  # BOTH trees get the identical crashing checker, so the only difference
+  # between the two runs is the mutated line.
+  for t in "$PT" "$MT"; do printf '#!/usr/bin/env bash\nexit 42\n' > "$t/scripts/check-maintenance.sh"; done
+  mk_current_proj "$T/p"
+  run_hook "$PT/scripts" "$T/p"; pri_rc=$HOOK_RC
+  run_hook "$MT/scripts" "$T/p"; mut_rc=$HOOK_RC
+  if [ "$sites" = "1" ] && [ "$changed" = y ] && [ "$nlines" -eq 2 ] && [ "$pre_mode" = "$post_mode" ] \
+     && [ "$pri_rc" -eq 0 ] && [ "$mut_rc" -eq 42 ]; then
+    pass "m4: with the fail-open arm neutered, a checker that crashes takes SessionStart down with it (hook rc $mut_rc) where the shipped hook stays inert (rc $pri_rc). H4 goes RED — fail-open is a line, not a promise in a header (marker sites=$sites, one line changed=$nlines/2, mode $pre_mode -> $post_mode)"
+  else
+    fail_ "m4" "marker sites=$sites (expect 1); applied=$changed (expect y); diff lines=$nlines (expect 2); mode $pre_mode -> $post_mode; PRISTINE hook rc=$pri_rc (expect 0); MUTANT hook rc=$mut_rc (expect 42)"
+  fi
+  rm -rf "$T"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-freshness-birth.sh
+++ b/tests/test-freshness-birth.sh
@@ -102,6 +102,28 @@ else
   fail_ "bl202-hook-birth" "shipped=$( [ -f "$PROJ/scripts/session-intake-check.sh" ] && echo yes || echo no ) exec=$( [ -x "$PROJ/scripts/session-intake-check.sh" ] && echo yes || echo no ) injected=$( jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("session-intake-check.sh"))' "$PROJ/.claude/settings.json" >/dev/null 2>&1 && echo yes || echo no )"
 fi
 
+# ── WP6 (delta §8.3): the cadence nag must SHIP, INJECT and STAY SILENT ─────
+# Same birth-level obligation as the BL-202 row above, plus a third clause this
+# hook needs and that no fixture could have supplied: init.sh CREATES
+# docs/test-results/ at birth, so a day-zero project has the evidence surface
+# with nothing in it and check-maintenance.sh correctly answers 2. An ungated
+# nag therefore printed 354 bytes at the first SessionStart of every generated
+# project — measured on this very scaffold, which is how the era gate came to
+# exist. tests/test-delta-wp6-cadence.sh::H7/m5 pin the gate itself; this row is
+# the end-to-end statement that a REAL new project is quiet.
+echo "=== WP6 cadence nag shipped + injected + day-zero silent ==="
+_wp6_out="$( cd "$PROJ" && CLAUDE_PROJECT_DIR="$PROJ" bash scripts/session-cadence-check.sh 2>"$TOPTMP/wp6.err" )"
+_wp6_rc=$?
+_wp6_err="$(cat "$TOPTMP/wp6.err" 2>/dev/null || true)"
+if [ -f "$PROJ/scripts/session-cadence-check.sh" ] && [ -x "$PROJ/scripts/session-cadence-check.sh" ] \
+   && jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("session-cadence-check.sh"))' \
+        "$PROJ/.claude/settings.json" >/dev/null 2>&1 \
+   && [ "$_wp6_rc" -eq 0 ] && [ "${#_wp6_out}" -eq 0 ] && [ "${#_wp6_err}" -eq 0 ]; then
+  pass "session-cadence-check.sh shipped (executable), injected into SessionStart, and byte-silent at day zero"
+else
+  fail_ "wp6-cadence-hook-birth" "shipped=$( [ -f "$PROJ/scripts/session-cadence-check.sh" ] && echo yes || echo no ) exec=$( [ -x "$PROJ/scripts/session-cadence-check.sh" ] && echo yes || echo no ) injected=$( jq -e '.hooks.SessionStart[]?.hooks[]? | select(.command | contains("session-cadence-check.sh"))' "$PROJ/.claude/settings.json" >/dev/null 2>&1 && echo yes || echo no ) rc=$_wp6_rc stdout=${#_wp6_out}b stderr=${#_wp6_err}b"
+fi
+
 # ── DAY-ZERO SILENCE — zero bytes stdout+stderr, exit 0 ──────────────────────
 echo "=== day-zero silence ==="
 d0_out="$(CDF_HOME="$NOCDF" CLAUDE_PROJECT_DIR="$PROJ" bash "$SUT" 2>"$TOPTMP/d0.err")"; d0_rc=$?


### PR DESCRIPTION
## What

Delta Track **WP6** (design of record: `docs/designs/2026-08-02-delta-track-v1.md` §8.3, §0.3-C1/C2, §13-R14, §11-WP6) — wires the orphaned cadence checker and **closes `BL-213`**.

**The defect BL-213 describes, reproduced on `main` during this review:** every cadence verdict sat inside `if [ "$last_epoch" -gt 0 ]`, so a date neither parser accepts yielded `last_epoch=0`, the guard was false, and **the arm was skipped in silence** — the script then printed `All maintenance cadences current.` at **rc 0**, over evidence it never read.

- **`exit 2` — the fix.** `cadence_epoch` returns non-zero and prints nothing (no `|| echo 0` tail, the shape that caused this); a single `mark_undetermined` counter line holds the state; a non-zero `undetermined` with zero `overdue` exits **2** naming the cadence it could not read. **WP7 contract: 0 measured-current / 1 overdue / 2 unmeasurable — the release cut refuses on 1 *and* 2.** Unmeasurable arms are still named inside an rc-1 report.
- **Thresholds are project policy** (35→14 CHANGELOG and SBOM, 185→95, dependency audit folded per §8.3), read through the **one seam** — the third reasoned inline T2 waiver, with the boundary lint rc 0 and the seam allowlist still at one. Absent policy, absent module, **and a refusing seam** all fall back to framework defaults, so a project that never opened a delta still gets a working checker.
- **SessionStart nag** `scripts/session-cadence-check.sh` — silent when current, fail-open, zero-network, registered by the same idempotent `jq` merge as its five siblings, and **gated to phase ≥ 4**.
- **Guide reconciled** (Step 4.4 now splits the birth and upgrade install paths honestly) and a `DELTA-` row added to `identifiers.tmpl`.

## Four defects the work surfaced, all fixed

1. **Day-zero noise**, found by scaffolding a real project: `init.sh` creates `docs/test-results/` at birth, so a brand-new tree has the surface with nothing in it, the checker correctly answers 2, and an ungated nag printed 354 bytes at the **first SessionStart of every generated project**. Era-gated; re-derived independently by the reviewer (0 bytes at phase 0; 418-byte nag at a phase-4 overdue).
2. An `ls` partial-glob failure under `pipefail` + an outer `||` wiped a good filename, turning "one fresh scan" into "no evidence at all".
3. An **unwaivable T1 path name sitting in a message string** (the rc-1 text named the policy file).
4. **Silent fixture no-ops** in the suite's own harness — identical bytes made `git commit` a no-op, so eight threshold rows never crossed their threshold. `commit_dated` now fails loudly; proven live with ten forced no-ops.

## Verification trail (fable pr-reviewer, xhigh, two rounds)

- **Round 1 (major_concerns)** — everything functional survived: BL-213 reproduced on `main` and confirmed repaired at the tip, the `undetermined`-counter-removal mutation confirmed as *the* pin, and the reviewer's **four novel mutants all killed with zero survivors**. The blocker was a **claim-accuracy defect in the history**: a commit message claimed `31 passed, 0 failed` where that commit actually ran 30/1 (one test depended on a tmpl row riding the later docs commit).
- **Fix round:** made the claim **true** rather than softening it — the `identifiers.tmpl` row moved into the feat commit so it carries every deliverable its own suite asserts, with the message naming the original error rather than papering over it. Every commit's attestation then re-derived by detached checkout. Plus: the nag no longer announces "a cadence is OVERDUE" when the checker merely crashed (its pin uses a byte count and a claim probe, because that defect is **rc 0 either way** and invisible to an exit-code assertion), a test narrative corrected to match its own measured token, and the guide corrected for upgraded projects.
- **Re-review: approve** — per-commit claims all reproduce at their own commits; the reviewer's original mutants still die and the kill surface widened. Review record: `.superpowers/sdd/2026-08-02-delta-track-v1/wp6-review.md` (session artifact).

Suite 33/0; neighbours green (WP0 13/0, WP2 31/0, WP3 29/0, WP4 29/0, WP5 34/0, boundary 29/0); run-lints 15/15.

## Honestly recorded, deliberately not fixed here

Per §13-R14 the tightening does **not** improve evidence quality — two thresholds read dates parsed out of filenames, so a dated empty file satisfies the cadence. Three measured shapes of that residual are now named in the checker's own header, with glob behaviour **unchanged** (verified by execution): a `deployment-notes-<date>.md` satisfying the deep-security clock via the broad `*dep*` glob, fresh-dated empty directories and dangling symlinks, and a BSD/GNU divergence on in-range impossible dates. Also recorded: upgraded projects receive both scripts (so the repaired checker *does* reach them) but not the hook registration — filed as a scoped backlog line rather than widened into this WP.

Closes BL-213.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
