### PR TITLE
feat(delta): WP7 — cut-release.sh, the severability test, and BL-214

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -437,6 +437,7 @@ jobs:
             tests/test-delta-wp5-hotfix-retro.sh
             tests/test-delta-wp6-cadence.sh
             tests/test-delta-wp7-cut-release.sh
+            tests/test-delta-severability.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -436,6 +436,7 @@ jobs:
             tests/test-delta-wp4-close-rubric.sh
             tests/test-delta-wp5-hotfix-retro.sh
             tests/test-delta-wp6-cadence.sh
+            tests/test-delta-wp7-cut-release.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh
             tests/test-escalate-to-user.sh

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -447,6 +447,7 @@ jobs:
             tests/test-host-verify-protection-date-parse.sh
             tests/test-bl202-readme-kickoff-consolidation.sh
             tests/test-bl202-session-intake-check.sh
+            tests/test-bl214-gate-snapshot-staleness.sh
             tests/test-intake-wizard-fixes.sh
             tests/test-lint-backlog-references.sh
             tests/test-lint-bl-markers.sh

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1739,6 +1739,14 @@ _cpg_phase3_attested() {
 # porcelain scope already → exclusion skipped. Not a git repo → conservative
 # "yes". Kept textually identical to _p3_scoped_dirty in
 # scripts/run-phase3-validation.sh.
+#
+# BL-214-SNAPSHOT-EXCLUDE: `docs/snapshots` is excluded for the SAME reason
+# `.claude/` is — `create_gate_snapshot` writes there on PASS, so without this
+# a fully passing gate run planted its own next failure: run 1 exits 0 and
+# leaves `?? docs/snapshots/`, run 2 reports the summary STALE and FAILs when
+# auto-regeneration is off. THIS FUNCTION AND ITS SIBLING MUST CHANGE TOGETHER;
+# tests/test-bl214-gate-snapshot-staleness.sh::B1 compares the two bodies
+# byte-for-byte so an edit to one alone goes RED even where it behaves.
 _cpg_scoped_dirty() {
   local rdir out
   rdir="${1:-}"
@@ -1748,9 +1756,9 @@ _cpg_scoped_dirty() {
   fi
   case "$rdir" in
     ""|/*|../*|..)
-      out=$(git status --porcelain -- . ':(exclude).claude' 2>/dev/null || true) ;;
+      out=$(git status --porcelain -- . ':(exclude).claude' ':(exclude)docs/snapshots' 2>/dev/null || true) ;;
     *)
-      out=$(git status --porcelain -- . ':(exclude).claude' ":(exclude)$rdir" 2>/dev/null || true) ;;
+      out=$(git status --porcelain -- . ':(exclude).claude' ':(exclude)docs/snapshots' ":(exclude)$rdir" 2>/dev/null || true) ;;
   esac
   if [ -n "$out" ]; then echo "yes"; else echo "no"; fi
   return 0

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -82,10 +82,28 @@ set -euo pipefail
 # THE FAIL-CLOSED DIRECTION IS THE SAME EVERYWHERE. Refusal 2 refuses on
 # anything that is not a definite "none owed" — an UNDETERMINED ledger refuses
 # too. Refusal 3 refuses on any non-zero the checker can produce, not on a
-# whitelist of two. An unmapped class refuses rather than defaulting to patch.
-# Every one of those is the same judgement: under-refusing ships a release over
-# an obligation nobody could see, and over-refusing costs an operator one
-# command and a clear message.
+# whitelist of two. An unmapped class refuses rather than defaulting to patch,
+# and so does a class nobody could READ. Every one of those is the same
+# judgement: under-refusing ships a release over an obligation nobody could
+# see, and over-refusing costs an operator one command and a clear message.
+#
+# REFUSAL 3's `*)` ARM IS NOT DECORATION, AND IT IS THE ONE MOST EASILY
+# MISTAKEN FOR IT. `# CUTREL-CADENCE-OTHER` catches every exit code the checker
+# is not documented to produce — including 127, which is what `bash` answers
+# when the checker HAS BEEN DELETED. Without that arm, `rm
+# scripts/check-maintenance.sh` is cadence forgiveness in one keystroke: the
+# same `rm`-as-loan-forgiveness class WP5's strict read was built to close, one
+# surface over. An adversarial review found the arm unpinned and its weakening
+# mutant surviving the whole suite; R11 and m6 exist because of that.
+#
+# WHERE REFUSAL 2's rc-3 HALF IS REACHABLE FROM, STATED RATHER THAN LEFT
+# UNEXPLAINED. Through this script's own flow it is NOT reachable, and the
+# argument is a subset one: `_delta_cadence_readable` accepts an object with a
+# `hotfix_retros` ARRAY, which is a STRICT SUBSET of what `DELTA_STATE_SHAPE`
+# accepts, so any document that survived the strict read above also satisfies
+# the predicate. The arm is a backstop for a caller that acquired the document
+# some other way — delta-cadence.sh's header makes the same argument about its
+# own rc 3 — and A5 pins it AT THE LINE rather than leaving it merely unkilled.
 #
 # ═════════════════════════════════════════════════════════════════════════════
 # THE TAG IS CONSTRAINED, NOT CHOSEN (§9.3 + C7) — DO NOT "IMPROVE" IT
@@ -139,6 +157,23 @@ set -euo pipefail
 #     `--no-verify` is never an option in this framework. So the cut ends by
 #     telling the operator, in order, to commit what it wrote and to move the
 #     (unpushed, therefore free to move) tag onto that commit before pushing.
+#     THE COMMIT-VS-NO-COMMIT QUESTION IS KARL'S, AND IT IS OPEN. An
+#     adversarial review independently recommended committing then tagging.
+#     Until it is decided this flow ships as-is, and the `git tag -f` step is
+#     printed as the LOUDEST line on the screen — because an operator who does
+#     steps 1, 2 and 4 and skips 3 pushes a tag naming a tree without its own
+#     changelog entry, and the pipelines go green over it.
+#
+# TWO GAPS THAT ARE TRACKED ELSEWHERE, POINTED AT HERE SO THE NEXT READER OF
+# THIS FILE FINDS THEM RATHER THAN REDISCOVERING THEM:
+#   • THE `breaking` MARKER HAS NO WRITER. §9.1's major row and §8.2's full
+#     revalidation lane are fully built and tested but production-unreachable
+#     in v1: nothing in delta.sh's close pathway sets the field this file
+#     reads. Filed as a tracked item; the writer belongs to the close/confirm
+#     surface, not here.
+#   • SEVERING THE MODULE TAKES check-maintenance.sh's ONLY BEHAVIOUR COVERAGE
+#     WITH IT (tests/test-delta-wp6-cadence.sh is a delta suite that is also a
+#     core script's only rc-contract tests). Filed as a tracked item.
 #
 # ═════════════════════════════════════════════════════════════════════════════
 # EXIT CODES ARE THE ANSWER; THE LABELS ARE DECORATION
@@ -490,7 +525,32 @@ if [ -n "$UNMAPPED" ]; then
   exit 9
 fi
 
-if [ -z "$BUMP" ]; then BUMP=patch; fi
+# AND THE SAME REFUSAL WHEN NOTHING COULD BE SCORED AT ALL. This looks like a
+# defensive impossibility and is not: `UNSHIPPED_IDS` and `ROW_TOKENS` are two
+# jq programs over the same document, and only the second one uses `@tsv`. A
+# closed row whose `class` is an OBJECT (`"class": {}`) makes `@tsv` error out
+# and takes the WHOLE program with it — so `ROW_TOKENS` is empty while
+# `UNSHIPPED_IDS` happily lists the row. The loop then never runs, `UNMAPPED`
+# stays empty because nothing reached it, and `BUMP` is unset.
+#
+# THE ORIGINAL SPELLING HERE WAS `BUMP=patch`, and it was wrong in the exact
+# direction this file's own header calls dangerous: a release whose classes
+# nobody could read would have shipped as a PATCH. An adversarial review
+# flagged the fallback on principle; the reachable fixture above is what turns
+# the principle into a defect. S9 pins it.
+if [ -z "$BUMP" ]; then                                              # CUTREL-SEMVER-UNREADABLE
+  _refuse 9 "The closed work could not be read well enough to compute a version." || true
+  echo "  $UNSHIPPED_N change(s) are waiting to be released, and not one of them yielded a class"
+  echo "  this tool could score. That usually means a row in the record has a malformed 'class'"
+  echo "  (an object or a list where a name should be)."
+  echo ""
+  echo "  Defaulting to a patch release here would be the dangerous guess: it would ship work"
+  echo "  nobody could classify under the version number that promises nothing changed."
+  echo ""
+  echo "To clear this: check the 'closed' rows in .claude/delta-state.json — each one needs a"
+  echo "  'class' that is a plain name (feature, fix, hotfix, security-patch) — then run this again."
+  exit 9
+fi
 
 case "$BUMP" in
   major) NEXT_MAJOR=$((CUR_MAJOR + 1)); NEXT_MINOR=0;                  NEXT_PATCH=0 ;;
@@ -667,13 +727,31 @@ fi
 echo ""
 print_ok "$TAG is cut."
 echo ""
+# THE LOUDEST LINE ON THE SCREEN, and deliberately so. An adversarial review
+# named the natural mistake precisely: an operator who does 1, 2 and 4 and
+# skips 3 pushes a tag naming a tree WITHOUT its own changelog entry, the
+# pipelines go green, and wrong content is published — the same "green on the
+# host you tested" shape C7 exists to prevent, guarded here only by prose. So
+# the warning comes BEFORE the steps, is banner-weight, and step 3 is repeated
+# inside it. If the commit-vs-no-commit question is ever decided in favour of
+# committing, this whole block goes away rather than getting quieter.
+echo -e "${YELLOW}${BOLD}=======================================================================${NC}"
+echo -e "${YELLOW}${BOLD} READ THIS BEFORE YOU PUSH: $TAG POINTS AT THE WRONG COMMIT RIGHT NOW${NC}"
+echo -e "${YELLOW}${BOLD}=======================================================================${NC}"
+echo -e "${YELLOW}${BOLD} The tag names the commit you were on BEFORE the changelog was promoted.${NC}"
+echo -e "${YELLOW}${BOLD} Push it as it stands and your pipeline builds a release whose changelog${NC}"
+echo -e "${YELLOW}${BOLD} does not contain this version. It goes GREEN while publishing the wrong${NC}"
+echo -e "${YELLOW}${BOLD} thing, which is the failure you would not notice.${NC}"
+echo ""
+echo -e "${YELLOW}${BOLD}   >>>  git tag -f $TAG   <<<  is NOT optional. Do it in step 3 below.${NC}"
+echo -e "${YELLOW}${BOLD}        The tag has not been pushed, so moving it costs nothing.${NC}"
+echo -e "${YELLOW}${BOLD}=======================================================================${NC}"
+echo ""
 echo "What happens next, in this order:"
 echo "  1. git add $CHANGELOG .claude/delta-state.json"
 echo "  2. git commit -m \"chore(release): $TAG\""
-echo "  3. git tag -f $TAG          # the tag is not pushed yet, so moving it onto the commit is free"
+echo "  3. git tag -f $TAG          <-- the step above. Do not skip it."
 echo "  4. git push && git push origin $TAG"
 echo ""
-echo "  Step 3 is not optional: the tag currently names the commit you were on BEFORE the changelog"
-echo "  was promoted, so a pipeline building from it would publish a changelog without this version"
-echo "  in it. Your release pipeline fires on the tag push in step 4."
+echo "  Your release pipeline fires on the tag push in step 4, and not before."
 exit 0

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,679 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# scripts/cut-release.sh — the post-1.0 release cut.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §9.1 (semver, decided by the
+# TOOL — the class->bump map is retunable, the PRECEDENCE is machinery, and
+# there is NO override in v1), §9.2 (THE THREE REFUSALS AND THEIR ORDER, and
+# "performs no write of any kind before all three pass"), §9.3 (promotion, and
+# the tag format C7 forces), §8.2 (a major bump re-runs run-phase3-validation.sh
+# in full BEFORE the tag is written), §8.3 (overdue and unmeasurable are both
+# refusals), §7.1 (`shipped_in` recorded at cut time THROUGH THE SEAM, never by
+# touching the file), §3.1 (this file is a DELTA-MODULE file despite its
+# core-sounding name), §0.3-C7, §0.3-C8, §11-WP7.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose — no backlog
+# entry exists for this build, and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1-WP6
+# precedent. The grep-able CUTREL-* markers below are this file's citation
+# primitive and its mutation addresses.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE ONE PROPERTY THIS FILE IS ORGANISED AROUND
+#
+# NO WRITE OF ANY KIND HAPPENS BEFORE ALL THREE REFUSALS PASS (§9.2's last
+# line). Not the changelog, not the state record, not the tag, not a scanner
+# summary. The reason is stated in the design rather than assumed: "a
+# partially-cut release (changelog promoted, tag absent) is a worse state than
+# a refused one" — a refusal is a situation you can read and fix, while a
+# half-cut release is a repository whose changelog claims a version that no tag
+# names and no pipeline ever built.
+#
+# The whole script is therefore two phases with a hard line between them, and
+# the line is marked. PHASE A reads and refuses; it opens no file for writing
+# and runs no tool that writes. PHASE B writes, in an order chosen so that the
+# most recoverable write happens first. tests/test-delta-wp7-cut-release.sh
+# asserts Phase A's emptiness with a whole-tree `find` + per-file md5 manifest
+# taken across every refusal path, singly and in combination, PLUS a separate
+# count of the repository's tags — because `git tag` writes into `.git/`, which
+# a working-tree manifest cannot see.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE THREE REFUSALS, IN §9.2's ORDER, AND WHY THE ORDER IS THAT ONE
+#
+# The order is author-proposed in the design and chosen so the cheapest and
+# clearest refusal speaks first. An operator who has a delta open does not need
+# to sit through a maintenance-cadence scan to be told so.
+#
+#   1. AN OPEN DELTA (`active_delta != null`). Instant, no I/O beyond the state
+#      read every refusal needs anyway. "Finish or abandon DELTA-NNN first."
+#   2. AN UNFILED HOTFIX RETRO. This is D3's collateral being called in: the
+#      hotfix lane ships fast by BORROWING the checks a normal change goes
+#      through, `hotfix_retros[]` is the loan, and this refusal is the only
+#      thing that ever collects. §7.1 makes the array outlive `active_delta`
+#      deliberately for this one moment.
+#   3. AN OVERDUE OR UNMEASURABLE CADENCE. The expensive one — it shells out to
+#      scripts/check-maintenance.sh, which walks git history and the evidence
+#      directory.
+#
+# TWO CONSUMED CONTRACTS. Neither is re-derived here, and both were written for
+# this file by the WPs that shipped them; read their headers before changing a
+# line below.
+#
+#   • scripts/lib/delta-cadence.sh — WP5's retro predicates, and the calling
+#     shape at the top of that file. THE STRICT READ IS MANDATORY: the tolerant
+#     `--delta-state-read` answers a corrupt file with the EMPTY SCHEMA at rc 0
+#     and an ABSENT file in complete silence, so with a retro owed, corrupting
+#     the record — or `rm`-ing it — would make "is anything owed?" answer "no"
+#     and refusal 2 would never fire. `rm` as loan forgiveness in one keystroke.
+#     `--delta-state-read-strict` answers rc 0 + document, rc 3 unreadable, rc 4
+#     absent, with nothing on stdout in either failure. THIS FILE REFUSES ON
+#     BOTH 3 AND 4. On 4: a project that has never opened a delta has nothing to
+#     release either (§9.1 refuses "nothing closed since the last tag"), so
+#     refusing costs a real project nothing and closes the erasure path.
+#   • scripts/check-maintenance.sh — WP6's exit contract: 0 measured-current,
+#     1 overdue, 2 unmeasurable. THIS FILE REFUSES ON BOTH 1 AND 2 (§8.3:
+#     "overdue and unmeasurable are both refusals"). Its report NAMES every arm
+#     it could not measure even inside an rc-1 answer, so the report is
+#     surfaced verbatim rather than replaced by a headline of our own.
+#
+# THE FAIL-CLOSED DIRECTION IS THE SAME EVERYWHERE. Refusal 2 refuses on
+# anything that is not a definite "none owed" — an UNDETERMINED ledger refuses
+# too. Refusal 3 refuses on any non-zero the checker can produce, not on a
+# whitelist of two. An unmapped class refuses rather than defaulting to patch.
+# Every one of those is the same judgement: under-refusing ships a release over
+# an obligation nobody could see, and over-refusing costs an operator one
+# command and a clear message.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE TAG IS CONSTRAINED, NOT CHOSEN (§9.3 + C7) — DO NOT "IMPROVE" IT
+#
+# C7 measured the shipped release lanes. GitHub's four templates and
+# Bitbucket's four match `v*`. GitLab's four match `/^v\d+\.\d+\.\d+$/` —
+# three numeric components, no pre-release suffix, no two-component tag. So a
+# `v1.2.0-rc1` would build on two hosts and SILENTLY DO NOTHING on the third:
+# green on the host you tested, nothing at all on the one you did not. That is
+# the worst available failure mode, and it is why this emits exactly
+# `vMAJOR.MINOR.PATCH` and then checks its own output against the regex before
+# using it. Pre-release tags are §13-R3's business, not v1's.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# SEMVER: THE MAP IS POLICY, THE PRECEDENCE IS MACHINERY (§9.1)
+#
+# Each closed row not yet shipped contributes ONE token: `breaking` if the row
+# carries a breaking marker, otherwise its class. `delta-policy.json::semver`
+# maps tokens to bumps and a project may retune it — a `0.x` project can make
+# every fix a minor. What a project may NOT do is reorder how the bumps
+# COMBINE: major beats minor beats patch, always, because a project that could
+# reorder that could make a feature release a patch (§9.1 says so in as many
+# words). There is no policy key for it and no flag for it; the rank function
+# below is the whole of it.
+#
+# NO OVERRIDE, AND THE COST IS REAL. An operator who disagrees with the
+# computed bump has no flag in v1. §13-R2 records what that costs: a project
+# that wants a marketing-driven major has to change the class of what it
+# shipped or tag by hand outside this tool. That is the decision; do not soften
+# it with a `--version` flag, and do not add one "just for CI".
+#
+# WHAT "SINCE THE LAST TAG" MEANS OPERATIONALLY. A closed row whose
+# `shipped_in` is null has not been carried by any release — that IS the
+# question, and it is a stronger reading than a date comparison against the
+# last tag, because it survives clock skew, a re-tagged history and a tag
+# created by hand. The two coincide in every ordinary case. `shipped_in` is
+# write-once at the seam, so a row can never be double-counted.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# TWO ADJACENCIES, RECORDED RATHER THAN WIRED
+#
+#   • `check-phase-gate.sh --finalize-phase 4` (§0.3-C8) is the natural pre-tag
+#     check and is invoked by NOTHING today — a second orphan sitting beside
+#     the cadence checker this file now calls. Karl did not decide to wire it
+#     (design Q3 asks), so it is named here and nowhere else. No executed line
+#     in this file references it, and the test suite asserts that.
+#   • THE TAG NAMES HEAD, AND HEAD DOES NOT YET CONTAIN THE PROMOTION. This
+#     tool deliberately does not COMMIT. Committing would run the project's own
+#     pre-commit gate, which can refuse for reasons that have nothing to do
+#     with the release and would leave exactly the half-cut state above; and
+#     `--no-verify` is never an option in this framework. So the cut ends by
+#     telling the operator, in order, to commit what it wrote and to move the
+#     (unpushed, therefore free to move) tag onto that commit before pushing.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES ARE THE ANSWER; THE LABELS ARE DECORATION
+#
+#   0   the release was cut
+#   2   invocation / environment error
+#   3   REFUSAL 1 — a delta is open
+#   4   REFUSAL 2 — an unfiled hotfix retro (or a ledger nobody can read)
+#   5   REFUSAL 3 — cadence overdue or unmeasurable
+#   6   REFUSAL — the delta record exists and cannot be read (strict rc 3)
+#   7   REFUSAL — there is no delta record at all (strict rc 4)
+#   8   REFUSAL — nothing closed since the last tag (§9.1)
+#   9   REFUSAL — a closed row's class maps to no bump (fail-closed)
+#  10   REFUSAL — major bump, and the §8.2 revalidation did not pass
+#  11   a write FAILED after every refusal passed — the cut is incomplete, and
+#       the message says exactly how far it got
+#
+# CLAUDE.md's `[WARN]` trap is that a printed label and an exit predicate can
+# disagree — in check-phase-gate.sh two arms printing the same word have
+# opposite gate outcomes. Every assertion in the WP7 suite is on one of these
+# codes, on a file's bytes, on a whole-tree manifest, or on `git tag --list`.
+#
+# DEPENDENCY DIRECTION (D1). This file is a DELTA-MODULE file (§3.1) even
+# though its name sounds core: it reads `delta-state.json`, and classifying it
+# as core would create a second core -> delta edge. delta -> core is allowed and
+# unasserted, which is why it may call check-maintenance.sh and
+# run-phase3-validation.sh directly. It sources the module's OWN policy and
+# cadence libs directly (delta -> delta, the scripts/delta.sh precedent) and
+# reaches `delta-state.json` ONLY through the seam.
+#
+# BASH 3.2: no associative arrays, no ${var,,}, no `((x++))`, no `nullglob`.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/lib/helpers-core.sh"
+
+# This script promotes the project's changelog and tags the project's history.
+# Running it from the framework clone would cut a release OF THE FRAMEWORK from
+# a downstream project's record. Refuse early — the same guard, for the same
+# reason, as scripts/delta.sh's and scripts/process-checklist.sh's.
+guard_not_in_framework || exit 1
+
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/delta-policy.sh"
+# shellcheck source=/dev/null
+. "$SCRIPT_DIR/lib/delta-cadence.sh"
+
+SEAM="$SCRIPT_DIR/process-checklist.sh"
+CHECKER="$SCRIPT_DIR/check-maintenance.sh"
+REVALIDATOR="$SCRIPT_DIR/run-phase3-validation.sh"
+CHANGELOG="CHANGELOG.md"
+
+USAGE="Usage:
+  scripts/cut-release.sh
+  scripts/cut-release.sh --help
+
+  Cuts the next release. It works out the version number from the work you
+  have closed, moves your changelog's Unreleased section under that version,
+  records which release carried each closed change, and creates the tag your
+  release pipeline watches for.
+
+  It refuses, and does nothing at all, while any of these is true:
+    - a delta is still open
+    - a hotfix still owes its write-up
+    - a maintenance cadence is overdue, or could not be measured
+
+  THERE IS NO WAY TO CHOOSE THE VERSION BY HAND. The tool decides it from the
+  classes of what you closed. That is deliberate and it is written down:
+  see §9.1 and §13-R2 of docs/designs/2026-08-02-delta-track-v1.md."
+
+# ── Arguments ───────────────────────────────────────────────────────────────
+# The surface is one command. Every unrecognised argument is an invocation
+# error, INCLUDING the version-override spellings someone will reach for first:
+# answering them with "unknown option" rather than silently ignoring them is
+# the difference between a decision the operator can read and a flag they think
+# worked.
+case "${1:-}" in
+  "") : ;;
+  --help|-h) printf '%s\n' "$USAGE"; exit 0 ;;
+  *)
+    print_fail "cut-release.sh: '$1' is not something this command takes."
+    printf '%s\n' "$USAGE" >&2
+    exit 2
+    ;;
+esac
+
+# ── Environment ─────────────────────────────────────────────────────────────
+if ! command -v jq >/dev/null 2>&1; then
+  print_fail "jq is required to read the delta record, and it is not on PATH."
+  echo "To clear this: install jq (https://jqlang.github.io/jq/), then run this again." >&2
+  exit 2
+fi
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  print_fail "This is not a git repository, so there is nowhere to put a release tag."
+  echo "To clear this: run this from inside your project's git repository." >&2
+  exit 2
+fi
+if [ ! -f "$CHANGELOG" ]; then
+  print_fail "There is no $CHANGELOG here, so there is nothing to promote."
+  echo "To clear this: create $CHANGELOG with an '## [Unreleased]' section (the framework's" >&2
+  echo "  template is templates/generated/changelog.tmpl), then run this again." >&2
+  exit 2
+fi
+
+# _refuse <code> <headline> — the one shape every refusal takes. The remedy is
+# printed by the caller immediately after; `To clear this:` is the anchor the
+# suite asserts on, so every refusal has to earn it.
+_refuse() {
+  local code="$1"; shift
+  echo ""
+  print_fail "$*"
+  return "$code"
+}
+
+echo -e "${BOLD}Cutting a release${NC}"
+echo ""
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PHASE A — READ AND REFUSE. NOTHING BELOW THIS LINE WRITES ANYTHING, ALL THE
+# WAY DOWN TO THE `PHASE B` BANNER. Adding a write here is the defect §9.2 is
+# about; the WP7 suite's whole-tree manifest is what would catch it.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# ── The state read: STRICT, never tolerant (WP5's R-WP5-2) ──────────────────
+STATE_RC=0
+STATE_DOC="$(bash "$SEAM" --delta-state-read-strict </dev/null 2>/dev/null)" || STATE_RC=$?
+case "$STATE_RC" in
+  0) : ;;
+  4)
+    _refuse 7 "There is no delta record in this project, so there is nothing this tool can honestly release." || true
+    echo "  A release cut reads .claude/delta-state.json to work out what shipped and what is still"
+    echo "  owed. With no record at all it cannot tell an empty release from an erased one, and it"
+    echo "  will not guess."
+    echo ""
+    echo "To clear this: open and close your work with scripts/delta.sh so there is a record to"
+    echo "  release — or, if the record was deleted by accident, restore it from git."
+    exit 7
+    ;;
+  *)
+    _refuse 6 "The delta record exists and cannot be read, so this release is refused." || true
+    echo "  .claude/delta-state.json is present but is not a readable delta record (the strict read"
+    echo "  answered $STATE_RC). An unreadable record is NOT the same as an empty one, and treating"
+    echo "  it as empty is how an outstanding obligation disappears silently."
+    echo ""
+    echo "To clear this: repair .claude/delta-state.json — 'git diff .claude/delta-state.json' and"
+    echo "  'git checkout -- .claude/delta-state.json' will usually do it — then run this again."
+    exit 6
+    ;;
+esac
+
+# ── REFUSAL 1 — an open delta (§9.2). Instant, no I/O. ──────────────────────
+ACTIVE_ID="$(printf '%s\n' "$STATE_DOC" \
+  | jq -r 'if (.active_delta // null) == null then "__none__" else (.active_delta.id // "an unnamed delta") end' 2>/dev/null)" \
+  || ACTIVE_ID="__none__"
+[ -n "$ACTIVE_ID" ] || ACTIVE_ID="__none__"
+ACTIVE_OPEN=n
+if [ "$ACTIVE_ID" != "__none__" ]; then ACTIVE_OPEN=y; fi   # CUTREL-REFUSE-ACTIVE
+if [ "$ACTIVE_OPEN" = y ]; then
+  _refuse 3 "$ACTIVE_ID is still open, so there is nothing settled enough to release." || true
+  echo "  A release names what is finished. Work that is still open is neither in this release nor"
+  echo "  out of it, and whichever the tag implied would be wrong."
+  echo ""
+  echo "To clear this: finish or abandon $ACTIVE_ID first —"
+  echo "  scripts/delta.sh --status     to see what it is still waiting on"
+  echo "  scripts/delta.sh --close      when everything it needs is done"
+  exit 3
+fi
+
+# ── REFUSAL 2 — an unfiled hotfix retro (§9.2). D3's collateral. ────────────
+# FAIL-CLOSED: anything that is not a definite "none owed" refuses. WP5's
+# predicate answers rc 1 for "none", rc 0 for "at least one open", and rc 3 for
+# "that document is not a readable ledger" — and rc 3 must never be read as
+# absolution. The strict read above makes rc 3 unreachable in practice; this is
+# the backstop, because a contract that only holds when everyone uses the right
+# front door is a convention and not a property.
+RETRO_RC=0
+delta_any_open_retro "$STATE_DOC" || RETRO_RC=$?
+RETRO_REFUSE=n
+if [ "$RETRO_RC" -ne 1 ]; then RETRO_REFUSE=y; fi   # CUTREL-REFUSE-RETRO
+if [ "$RETRO_REFUSE" = y ]; then
+  _refuse 4 "A hotfix still owes its write-up, so this release is refused." || true
+  if [ "$RETRO_RC" -eq 0 ]; then
+    echo "  Shipping a hotfix borrows the checks a normal change goes through. The write-up is how"
+    echo "  that gets paid back, and a release is the moment it comes due. Still outstanding:"
+    echo ""
+    delta_retro_rows "$STATE_DOC" | while IFS="$(printf '\t')" read -r rid rdue rstate rdays; do
+      [ -n "$rid" ] || continue
+      case "$rstate" in
+        overdue)      echo "    $rid — was due $rdue, $rdays day(s) overdue" ;;
+        current)      echo "    $rid — due $rdue, $rdays day(s) from now" ;;
+        *)            echo "    $rid — due date '$rdue' could not be read, so it is treated as overdue" ;;
+      esac
+    done
+  else
+    echo "  The hotfix ledger could not be read at all (the predicate answered $RETRO_RC), and an"
+    echo "  unreadable ledger is not the same as an empty one."
+  fi
+  echo ""
+  echo "To clear this: file each write-up with"
+  echo "  scripts/delta.sh --retro DELTA-NNN --record \"what happened, and what stops it happening again\""
+  exit 4
+fi
+
+# ── REFUSAL 3 — cadence overdue OR unmeasurable (§9.2 + §8.3) ───────────────
+# The checker's own report names each arm and its remediation, including the
+# arms it could not measure INSIDE an rc-1 answer, so it is surfaced verbatim.
+# Replacing it with a headline of our own would drop exactly the detail that
+# tells the operator which cadence to go and fix.
+CADENCE_RC=0
+CADENCE_OUT="$(bash "$CHECKER" </dev/null 2>&1)" || CADENCE_RC=$?
+CADENCE_REFUSE=n
+case "$CADENCE_RC" in
+  0) : ;;
+  1) CADENCE_REFUSE=y ;;   # CUTREL-CADENCE-OVERDUE
+  2) CADENCE_REFUSE=y ;;   # CUTREL-CADENCE-UNMEASURABLE
+  *) CADENCE_REFUSE=y ;;   # CUTREL-CADENCE-OTHER
+esac
+if [ "$CADENCE_REFUSE" = y ]; then
+  case "$CADENCE_RC" in
+    1) _refuse 5 "A maintenance cadence is overdue, so this release is refused." || true ;;
+    2) _refuse 5 "A maintenance cadence could not be measured, so this release is refused." || true ;;
+    *) _refuse 5 "The maintenance check did not complete (it exited $CADENCE_RC), so this release is refused." || true ;;
+  esac
+  echo "  What the check reported, verbatim:"
+  echo ""
+  printf '%s\n' "$CADENCE_OUT" | sed -e 's/^/    /'
+  echo ""
+  echo "To clear this: do the maintenance the report names above, commit it so the dates move,"
+  echo "  and run 'bash scripts/check-maintenance.sh' until it exits 0. An unmeasurable cadence"
+  echo "  needs a signal the check can read, not an exemption."
+  exit 5
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# THE THREE REFUSALS HAVE PASSED. Everything from here to the PHASE B banner is
+# still read-only — the version arithmetic and its own two refusals.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# _cutrel_last_tag — the highest `vMAJOR.MINOR.PATCH` tag in this repository,
+#   with the `v` stripped, or the empty string when there is none.
+#
+#   Non-conforming tags are IGNORED rather than refused: a project may carry
+#   `nightly`, `v1.2` or `release-2024` from before it adopted this tool, and
+#   none of them is a version this arithmetic can build on. `sort -t. -kN,Nn`
+#   is numeric per component, so v1.10.0 correctly outranks v1.9.0 — a plain
+#   lexical sort gets that backwards and would cut a release that goes
+#   BACKWARDS. Each stage absolves itself with `|| true` because bash's
+#   `pipefail` promotes a no-match `grep` (rc 1) into the substitution, and
+#   under `set -e` that is an abort rather than "no tags yet".
+_cutrel_last_tag() {
+  local out=""
+  out="$( { git tag --list 2>/dev/null || true; } \
+        | { grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' || true; } \
+        | sed -e 's/^v//' \
+        | sort -t. -k1,1n -k2,2n -k3,3n \
+        | awk 'END { if (NR > 0) print }' )" || out=""
+  printf '%s' "$out"
+}
+
+# THE PRECEDENCE — machinery, not policy (§9.1). One line, on purpose: it is
+# the whole of "how bumps combine", it has no configuration surface, and the
+# WP7 suite's m4 changes exactly this line to prove a feature can be made to
+# ship as a patch when it is wrong.
+_cutrel_rank() { case "${1:-}" in major) printf 3 ;; minor) printf 2 ;; *) printf 1 ;; esac; }   # CUTREL-SEMVER-PRECEDENCE
+
+LAST_VERSION="$(_cutrel_last_tag)"
+if [ -n "$LAST_VERSION" ]; then
+  CUR_MAJOR="$(printf '%s' "$LAST_VERSION" | cut -d. -f1)"
+  CUR_MINOR="$(printf '%s' "$LAST_VERSION" | cut -d. -f2)"
+  CUR_PATCH="$(printf '%s' "$LAST_VERSION" | cut -d. -f3)"
+else
+  CUR_MAJOR=0; CUR_MINOR=0; CUR_PATCH=0
+fi
+case "$CUR_MAJOR" in ''|*[!0-9]*) CUR_MAJOR=0 ;; esac
+case "$CUR_MINOR" in ''|*[!0-9]*) CUR_MINOR=0 ;; esac
+case "$CUR_PATCH" in ''|*[!0-9]*) CUR_PATCH=0 ;; esac
+
+# ── What is being released: every closed row with no `shipped_in` ───────────
+UNSHIPPED_IDS="$(printf '%s\n' "$STATE_DOC" \
+  | jq -r '[.closed[]? | select(type == "object") | select((.shipped_in // null) == null)] | .[] | (.id // "")' 2>/dev/null)" \
+  || UNSHIPPED_IDS=""
+UNSHIPPED_N="$(printf '%s\n' "$UNSHIPPED_IDS" | grep -c . || true)"
+case "$UNSHIPPED_N" in ''|*[!0-9]*) UNSHIPPED_N=0 ;; esac
+
+if [ "$UNSHIPPED_N" -eq 0 ]; then
+  _refuse 8 "Nothing has been closed since the last release, so there is nothing to cut." || true
+  if [ -n "$LAST_VERSION" ]; then
+    echo "  The last release was v$LAST_VERSION and every closed change already records the release"
+    echo "  that carried it. A tag with nothing behind it is noise in the history."
+  else
+    echo "  There are no closed changes on the record at all yet."
+  fi
+  echo ""
+  echo "To clear this: close some work first —"
+  echo "  scripts/delta.sh --open       to start the next change"
+  echo "  scripts/delta.sh --close      when it is done"
+  exit 8
+fi
+
+# ── The bump (§9.1) ─────────────────────────────────────────────────────────
+# The token per row: `breaking` when the row carries a breaking marker,
+# otherwise its class. The map from token to bump is project policy; the
+# combination of bumps is not.
+SEMVER_MAP="$(delta_policy_get "." semver 2>/dev/null)" || SEMVER_MAP=""
+[ -n "$SEMVER_MAP" ] || SEMVER_MAP='{}'
+
+ROW_TOKENS="$(printf '%s\n' "$STATE_DOC" \
+  | jq -r '.closed[]? | select(type == "object") | select((.shipped_in // null) == null)
+           | [ (.id // "?"), (if (.breaking // false) == true then "breaking" else (.class // "") end) ] | @tsv' 2>/dev/null)" \
+  || ROW_TOKENS=""
+
+BUMP=""
+BUMP_RANK=0
+UNMAPPED=""
+RELEASE_LINES=""
+while IFS= read -r line; do
+  [ -n "$line" ] || continue
+  rid="$(printf '%s' "$line" | cut -f1)"
+  tok="$(printf '%s' "$line" | cut -f2)"
+  rbump="$(printf '%s\n' "$SEMVER_MAP" | jq -r --arg t "$tok" '.[$t] // ""' 2>/dev/null)" || rbump=""
+  case "$rbump" in
+    major|minor|patch) : ;;
+    *) UNMAPPED="${UNMAPPED}    $rid — class '$tok'
+"; continue ;;
+  esac
+  RELEASE_LINES="${RELEASE_LINES}    $rid ($tok -> $rbump)
+"
+  r="$(_cutrel_rank "$rbump")"
+  if [ "$r" -gt "$BUMP_RANK" ]; then BUMP_RANK="$r"; BUMP="$rbump"; fi
+done <<EOF
+$ROW_TOKENS
+EOF
+
+# FAIL-CLOSED on a class nobody scored. The tempting default is `patch`, and it
+# is the wrong one: the whole danger in this arithmetic is UNDER-bumping, and a
+# class the policy never heard of is precisely the case where nobody has said
+# whether it breaks anything.
+if [ -n "$UNMAPPED" ]; then
+  _refuse 9 "Some of the closed work has a class this project's policy does not score, so the version cannot be computed." || true
+  echo "  Unscored:"
+  echo ""
+  printf '%s' "$UNMAPPED"
+  echo ""
+  echo "  Guessing here would mean guessing whether those changes break anything, and the safe"
+  echo "  guess and the honest one are not the same guess."
+  echo ""
+  echo "To clear this: add the class to the 'semver' object in .claude/delta-policy.json (values:"
+  echo "  major, minor or patch), or correct the class on the closed row."
+  exit 9
+fi
+
+if [ -z "$BUMP" ]; then BUMP=patch; fi
+
+case "$BUMP" in
+  major) NEXT_MAJOR=$((CUR_MAJOR + 1)); NEXT_MINOR=0;                  NEXT_PATCH=0 ;;
+  minor) NEXT_MAJOR=$CUR_MAJOR;         NEXT_MINOR=$((CUR_MINOR + 1)); NEXT_PATCH=0 ;;
+  *)     NEXT_MAJOR=$CUR_MAJOR;         NEXT_MINOR=$CUR_MINOR;         NEXT_PATCH=$((CUR_PATCH + 1)) ;;
+esac
+
+# THE TAG FORMAT — exactly three numeric components, nothing else (§9.3 + C7).
+TAG="v${NEXT_MAJOR}.${NEXT_MINOR}.${NEXT_PATCH}"   # CUTREL-TAG-FORMAT
+VERSION="${TAG#v}"
+
+# The C7 defence in depth: whatever the line above produced, refuse to use it
+# unless it is the shape GitLab's release lane will actually match. A tag that
+# only two of the three hosts build is worse than no tag, because two of them
+# go green. A glob would NOT do here — `v[0-9]*.[0-9]*.[0-9]*` matches
+# `v1.2.0-rc1` perfectly well, since `*` spans the suffix — so the check is the
+# same anchored ERE the GitLab lane itself uses.
+if ! printf '%s' "$TAG" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then   # CUTREL-TAG-STRICT
+  print_fail "cut-release.sh computed the tag '$TAG', which is not the vMAJOR.MINOR.PATCH form the release lanes require."
+  echo "To clear this: this is a bug in cut-release.sh — report it. GitLab's release lanes match" >&2
+  echo "  /^v[0-9]+\\.[0-9]+\\.[0-9]+\$/, so a tag of any other shape silently never builds there." >&2
+  exit 2
+fi
+
+if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null 2>&1; then
+  print_fail "The tag $TAG already exists in this repository, but the record says its work has not been released."
+  echo "To clear this: the tag and .claude/delta-state.json disagree. Decide which is right —" >&2
+  echo "  delete the tag if it was created by mistake, or record the release against the closed" >&2
+  echo "  rows — and run this again." >&2
+  exit 2
+fi
+
+echo "  Last release:      ${LAST_VERSION:-none}"
+echo "  Closed since then: $UNSHIPPED_N change(s)"
+printf '%s' "$RELEASE_LINES"
+echo "  Version:           $TAG  (a $BUMP release, decided from the classes above)"
+echo ""
+
+# ═════════════════════════════════════════════════════════════════════════════
+# PHASE B — WRITES. Everything above refused without touching anything.
+#
+# THE ORDER IS DELIBERATE, cheapest-to-undo first:
+#   1. the §8.2 revalidation (major only) — it writes its OWN scan summaries,
+#      which is why it is here and not in Phase A;
+#   2. the changelog promotion — a text edit, visible in `git diff`;
+#   3. `shipped_in`, one write-once seam call per released row;
+#   4. the tag — last, because it is the thing the release pipelines watch, so
+#      nothing fires until everything else is on disk.
+# ═════════════════════════════════════════════════════════════════════════════
+
+# ── §8.2: a major bump re-runs the FULL Phase 3 validation, before the tag ──
+# "Composes with D6's 'breaking => major + full revalidation' as the same
+# sentence seen from two sides." All five scanners, the same attest-on-skip
+# contract as the 3->4 gate; this file does not re-implement any of it.
+NEED_REVALIDATION=n
+if [ "$BUMP" = major ]; then NEED_REVALIDATION=y; fi   # CUTREL-MAJOR-REVALIDATE
+if [ "$NEED_REVALIDATION" = y ]; then
+  if [ ! -f "$REVALIDATOR" ]; then
+    _refuse 10 "This is a breaking release, and the full validation re-run it requires is not installed." || true
+    echo "  Expected: $REVALIDATOR"
+    echo ""
+    echo "To clear this: reinstall the framework scripts, or re-run 'bash scripts/upgrade-project.sh'."
+    exit 10
+  fi
+  print_info "A breaking change is in this release, so the full Phase 3 validation runs again before the tag."
+  echo ""
+  REVAL_RC=0
+  bash "$REVALIDATOR" </dev/null || REVAL_RC=$?
+  if [ "$REVAL_RC" -ne 0 ]; then
+    _refuse 10 "The full validation re-run did not pass (it exited $REVAL_RC), so the breaking release is refused." || true
+    echo "  A major version is the one release where the promise to your users changes. It does not"
+    echo "  go out over a failing scan."
+    echo ""
+    echo "To clear this: fix what the run above reported, or attest each skipped scanner with a"
+    echo "  reason and a sign-off, then run this again. Nothing has been written."
+    exit 10
+  fi
+  echo ""
+fi
+
+# ── §9.3: promotion ─────────────────────────────────────────────────────────
+# The categories are HARVESTED from the project's own `## [Unreleased]` block
+# rather than retyped here. In a stock project that is the eight headings
+# templates/generated/changelog.tmpl ships; in a project that added a ninth it
+# is the ninth too. Retyping the list would have made this tool the second
+# place the categories live, and the two would drift — exactly the class of
+# split C2 measured between check-maintenance.sh and the builders' guide.
+# The fallback list exists only for a changelog whose Unreleased block has no
+# headings at all, and it is the template's list verbatim.
+_cutrel_promote() {
+  local file="$1" ver="$2" date="$3" n cats tmp
+  n="$(awk '/^## \[Unreleased\]/ { print NR; exit }' "$file")" || n=""
+  [ -n "$n" ] || return 1
+  cats="$(awk -v s="$n" 'NR > s { if ($0 ~ /^## /) exit; if ($0 ~ /^### /) print }' "$file")" || cats=""
+  if [ -z "$cats" ]; then                                            # CUTREL-PROMOTE-CATEGORIES
+    cats="$(printf '### Security\n### Data Model\n### Added\n### Changed\n### Fixed\n### Removed\n### Infrastructure\n### Documentation')"
+  fi
+  tmp="$file.cutrel.tmp"
+  rm -f "$tmp" 2>/dev/null || true
+  {
+    awk -v s="$n" 'NR < s { print }' "$file"
+    printf '## [Unreleased]\n\n'
+    printf '%s\n' "$cats"
+    printf '\n'
+    # The separator is passed as an ARGUMENT, never spliced next to a `$`
+    # expansion — CLAUDE.md's portability rule about multibyte characters
+    # adjacent to expansions under `set -u`.
+    printf '## [%s] %s %s\n' "$ver" "—" "$date"
+    awk -v s="$n" 'NR > s { print }' "$file"
+  } > "$tmp" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
+  mv "$tmp" "$file" || { rm -f "$tmp" 2>/dev/null || true; return 1; }
+  return 0
+}
+
+TODAY="$(date -u +%Y-%m-%d)"
+if ! _cutrel_promote "$CHANGELOG" "$VERSION" "$TODAY"; then
+  _refuse 11 "The changelog could not be promoted, so the cut stopped here." || true
+  echo "  Nothing else has been written: no release was recorded and no tag was created."
+  echo ""
+  echo "To clear this: make sure $CHANGELOG has a line reading exactly '## [Unreleased]' and that"
+  echo "  the file is writable, then run this again."
+  exit 11
+fi
+print_ok "Promoted $CHANGELOG: '## [Unreleased]' is now '## [$VERSION] — $TODAY', with a fresh empty Unreleased above it."
+
+# ── §7.1: `shipped_in`, through WP2's write-once ship pathway ────────────────
+# Never a generic state write and never a direct file touch. The seam permits
+# exactly ONE mutation shape here — one closed row's shipped_in going null to a
+# non-empty string with everything else byte-identical — and refuses a row that
+# already carries a version rather than overwriting it. That is D7's
+# single-writer rule applied at the one place it is easiest to break.
+SHIPPED_N=0
+SHIP_FAILED=""
+while IFS= read -r rid; do
+  [ -n "$rid" ] || continue
+  if bash "$SEAM" --delta-state-ship "$rid" "$TAG" </dev/null >/dev/null 2>&1; then
+    SHIPPED_N=$((SHIPPED_N + 1))
+  else
+    SHIP_FAILED="${SHIP_FAILED}    $rid
+"
+  fi
+done <<EOF
+$UNSHIPPED_IDS
+EOF
+
+if [ -n "$SHIP_FAILED" ]; then
+  _refuse 11 "The changelog was promoted, but the delta record refused to accept part of this release." || true
+  echo "  Recorded: $SHIPPED_N of $UNSHIPPED_N. Refused:"
+  echo ""
+  printf '%s' "$SHIP_FAILED"
+  echo ""
+  echo "  NO TAG WAS CREATED, so no release pipeline has fired and nothing has been published."
+  echo ""
+  echo "To clear this: check .claude/delta-state.json for those ids (a row that already carries a"
+  echo "  'shipped_in' is refused rather than overwritten, on purpose), fix it, and run this again."
+  exit 11
+fi
+print_ok "Recorded $TAG against $SHIPPED_N closed change(s) in the delta record."
+
+# ── §9.3: the tag. LAST, because this is what the pipelines watch. ──────────
+# Created LOCALLY and never pushed. Pushing is the operator's decision and the
+# moment the release becomes public; a tool that pushed would take that
+# decision away and would also need a remote, which no test in this framework
+# is allowed to create.
+if ! git tag "$TAG" >/dev/null 2>&1; then
+  _refuse 11 "The changelog and the delta record were both written, but the tag $TAG could not be created." || true
+  echo ""
+  echo "To clear this: create it yourself with 'git tag $TAG' once git will accept it. Do NOT"
+  echo "  change the name — GitLab's release lanes match /^v[0-9]+\\.[0-9]+\\.[0-9]+\$/ exactly, so"
+  echo "  any other shape silently never builds there."
+  exit 11
+fi
+
+echo ""
+print_ok "$TAG is cut."
+echo ""
+echo "What happens next, in this order:"
+echo "  1. git add $CHANGELOG .claude/delta-state.json"
+echo "  2. git commit -m \"chore(release): $TAG\""
+echo "  3. git tag -f $TAG          # the tag is not pushed yet, so moving it onto the commit is free"
+echo "  4. git push && git push origin $TAG"
+echo ""
+echo "  Step 3 is not optional: the tag currently names the commit you were on BEFORE the changelog"
+echo "  was promoted, so a pipeline building from it would publish a changelog without this version"
+echo "  in it. Your release pipeline fires on the tag push in step 4."
+exit 0

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -255,6 +255,15 @@ _p3_is_registered() {
 # exclusion is skipped (a repo-external path never appears in porcelain). Not a
 # git repo / git error → conservative "yes". Kept textually identical to
 # _cpg_scoped_dirty in scripts/check-phase-gate.sh.
+#
+# BL-214-SNAPSHOT-EXCLUDE: `docs/snapshots` is excluded for the SAME reason
+# `.claude/` is — check-phase-gate.sh's create_gate_snapshot writes there on
+# PASS, so without this a fully passing gate run planted its own next failure:
+# run 1 exits 0 and leaves `?? docs/snapshots/`, run 2 reports the summary STALE
+# and FAILs when auto-regeneration is off. THIS FUNCTION AND ITS SIBLING MUST
+# CHANGE TOGETHER; tests/test-bl214-gate-snapshot-staleness.sh::B1 compares the
+# two bodies byte-for-byte so an edit to one alone goes RED even where it
+# behaves.
 _p3_scoped_dirty() {
   local rdir out
   rdir="${1:-}"
@@ -264,9 +273,9 @@ _p3_scoped_dirty() {
   fi
   case "$rdir" in
     ""|/*|../*|..)
-      out=$(git status --porcelain -- . ':(exclude).claude' 2>/dev/null || true) ;;
+      out=$(git status --porcelain -- . ':(exclude).claude' ':(exclude)docs/snapshots' 2>/dev/null || true) ;;
     *)
-      out=$(git status --porcelain -- . ':(exclude).claude' ":(exclude)$rdir" 2>/dev/null || true) ;;
+      out=$(git status --porcelain -- . ':(exclude).claude' ':(exclude)docs/snapshots' ":(exclude)$rdir" 2>/dev/null || true) ;;
   esac
   if [ -n "$out" ]; then echo "yes"; else echo "no"; fi
   return 0

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1807,6 +1807,23 @@ run_child_suite "tests/test-delta-wp6-cadence.sh" \
 # -> both lanes.
 run_child_suite "tests/test-delta-wp7-cut-release.sh" \
   "tests/test-delta-wp7-cut-release.sh"
+
+# Delta Track §3.1's SEVERABILITY test (WP7). Builds a real severed tree —
+# every §3.1 module file deleted, the seam reverted in all FOUR core consumers
+# — and proves the framework still parses, still behaves, and carries not one
+# dangling reference. The module inventory is READ OUT OF
+# scripts/lint-delta-boundary.sh's own manifest rather than retyped, so the two
+# can never disagree about what "the module" is. §3.1 says the revert is "the
+# seam block in process-checklist.sh", singular; running this test enumerates
+# the real set (process-checklist.sh, upgrade-project.sh, validate.sh,
+# check-maintenance.sh) and V1's completeness sweep is what keeps that list
+# honest when a fifth consumer arrives. The §11-WP7 mutation — delete a module
+# file but NOT the seam revert — is killed by V1 and ONLY by V1, and m1
+# measures why: every consumer fails soft by design, so the probes stay
+# identical to the intact tree and no functional arm could ever see it.
+# Never executes the init script -> both lanes.
+run_child_suite "tests/test-delta-severability.sh" \
+  "tests/test-delta-severability.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1808,6 +1808,20 @@ run_child_suite "tests/test-delta-wp6-cadence.sh" \
 run_child_suite "tests/test-delta-wp7-cut-release.sh" \
   "tests/test-delta-wp7-cut-release.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
+
+# BL-214 — the gate stalled its own next run. create_gate_snapshot writes into
+# docs/snapshots/ at PASS time and BL-082's scoped porcelain did not exclude it,
+# so a fully PASSING gate run left `?? docs/snapshots/` behind and the next run
+# reported the Phase 3 summary STALE. The fix is one pathspec in TWO sync
+# siblings (`# BL-214-SNAPSHOT-EXCLUDE` in _cpg_scoped_dirty and
+# _p3_scoped_dirty), and B1 makes "kept textually identical" a checked property
+# by comparing the two bodies byte-for-byte. Dual-direction, both files, four
+# mutants built and run: remove the pathspec from any ONE of the four call sites
+# -> snapshot-only dirt stales again -> B2 RED while B3 (real dirt) stays green,
+# which is what shows the mutant broke the fix and not the predicate. Never
+# executes the init script -> both lanes.
+run_child_suite "tests/test-bl214-gate-snapshot-staleness.sh" \
+  "tests/test-bl214-gate-snapshot-staleness.sh"
 run_child_suite "tests/test-check-phase-gate-poc-block-contract.sh" \
   "tests/test-check-phase-gate-poc-block-contract.sh"
 run_child_suite "tests/test-check-phase-gate-counter-sanitizer.sh" \

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1786,6 +1786,27 @@ run_child_suite "tests/test-delta-wp5-hotfix-retro.sh" \
 # init script -> both lanes.
 run_child_suite "tests/test-delta-wp6-cadence.sh" \
   "tests/test-delta-wp6-cadence.sh"
+
+# Delta Track WP7 — scripts/cut-release.sh (§9). The three refusals in §9.2's
+# order, each fired alone AND in combination, every one asserted with a
+# whole-tree find + per-file md5 manifest PLUS a separate tag-set count (a
+# `git tag` writes into .git/, which a working-tree manifest cannot see); the
+# semver arithmetic, where the class->bump MAP is project policy and the
+# PRECEDENCE is machinery with no configuration surface at all; the §9.3
+# promotion, whose eight categories are compared against the template's own
+# bytes rather than a list retyped in the test; and the C7 tag constraint —
+# exactly vMAJOR.MINOR.PATCH, because GitLab's release lanes are version-strict
+# while GitHub's and Bitbucket's are not, so a pre-release suffix builds on two
+# hosts and silently does nothing on the third. Mutation-proved IN THE SUITE
+# (m1-m5, m7, each mutant built and run): suppress the open-retro refusal -> a
+# release cuts over an unfiled retro -> R2 RED; emit `v1.2.0-rc1` -> T1 RED (the
+# C7 defence); collapse the cadence checker's rc 2 into a pass -> R4 RED
+# (BL-213's fail-open, one level up); reorder the semver precedence -> a feature
+# ships as a patch -> S1/S6 RED; suppress the open-delta refusal -> R1/R5 RED;
+# neuter the §8.2 major revalidation -> S3 RED. Never executes the init script
+# -> both lanes.
+run_child_suite "tests/test-delta-wp7-cut-release.sh" \
+  "tests/test-delta-wp7-cut-release.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 run_child_suite "tests/test-check-phase-gate-poc-block-contract.sh" \
   "tests/test-check-phase-gate-poc-block-contract.sh"

--- a/tests/test-bl214-gate-snapshot-staleness.sh
+++ b/tests/test-bl214-gate-snapshot-staleness.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# tests/test-bl214-gate-snapshot-staleness.sh — BL-214.
+#
+# THE DEFECT, IN ONE SENTENCE: a PASSING phase gate plants the seed of its own
+# next failure.
+#
+# `check-phase-gate.sh::create_gate_snapshot` writes into `docs/snapshots/` at
+# PASS time. `_cpg_scoped_dirty` — the scoped porcelain that BL-082's freshness
+# check reads to decide whether a Phase 3 summary is still fresh — excluded
+# `.claude/` and the results directory but NOT `docs/snapshots/`. So on any
+# project where `docs/snapshots/` is not gitignored, gate run 1 exits 0 and
+# prints `[OK] Phase gate snapshot created: docs/snapshots/phase-N-to-M_<date>`,
+# `git status` then shows `?? docs/snapshots/`, and gate run 2 reports
+# `[STALE] … there are uncommitted changes since this summary was generated`
+# and FAILs when auto-regeneration is off or unavailable. The operator eats a
+# spurious stale-fail, or a costly re-validation, until they commit the
+# snapshot the gate itself made.
+#
+# THE FIX IS ONE PATHSPEC IN TWO PLACES, AND THE TWO ARE SYNC SIBLINGS.
+# `_cpg_scoped_dirty` (scripts/check-phase-gate.sh) and `_p3_scoped_dirty`
+# (scripts/run-phase3-validation.sh) are kept TEXTUALLY IDENTICAL, and each
+# one's own comment says so about the other. `# BL-214-SNAPSHOT-EXCLUDE` marks
+# both. B1 below is the pin that makes "textually identical" a checked property
+# rather than a hope: it extracts both function bodies and compares them modulo
+# the function name, so a future edit to one alone goes RED here even if the
+# behaviour rows all still pass on the file that was edited.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHY THE FIXTURE PATH IS DERIVED AND NOT RETYPED
+#
+# The row that matters is "the directory the gate ITSELF writes at PASS time no
+# longer stales the next run". A test that hard-codes `docs/snapshots/foo` is
+# asserting something weaker — that some path under that prefix is excluded —
+# and would stay green if `create_gate_snapshot` were later changed to write
+# somewhere else. So B2 reads the `snapshot_dir=` assignment out of
+# check-phase-gate.sh, expands it against a real phase pair and today's date,
+# and dirties THAT. If the two ever part company the fixture stops being about
+# the gate and the extraction guard says so.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# BOTH DIRECTIONS, ALWAYS
+#
+# An exclusion is only correct if it excludes the right thing AND still catches
+# everything else. Every behaviour row below is paired: snapshot-only dirt
+# answers "no", real dirt answers "yes", and the four mutants each remove the
+# new pathspec from exactly one call site and are killed by the "no" side while
+# the "yes" side stays green — which is what shows the mutant broke the fix and
+# not the whole predicate.
+#
+# EXIT CODES / VALUES, NEVER LABELS. These two functions do not print a banner;
+# they echo `yes` or `no`, and that string is the predicate under test.
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name the init script.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-bl214-gate-snapshot-staleness.sh" >&2
+  exit 2
+fi
+
+GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+DRIVER="$REPO_ROOT/scripts/run-phase3-validation.sh"
+
+# ── Extraction ──────────────────────────────────────────────────────────────
+# The two predicates live inside scripts that run top to bottom when sourced,
+# so they cannot simply be sourced. They are lifted out by name — from the
+# `name() {` line to the first `}` at column zero — and the lift is VERIFIED,
+# because an extraction that silently produced nothing would make every row
+# below pass against an empty function.
+_extract_fn() {   # <file> <fn-name>
+  awk -v fn="$2" '
+    $0 ~ "^" fn "\\(\\) \\{" { on = 1 }
+    on { print }
+    on && /^\}$/ { exit }
+  ' "$1"
+}
+
+# _harness <file> <fn-name> <out> — a runnable one-function script.
+_harness() {
+  local file="$1" fn="$2" out="$3" body
+  body="$(_extract_fn "$file" "$fn")"
+  case "$body" in
+    *"git status --porcelain"*) : ;;
+    *) echo "  [FIXTURE] could not extract $fn from $file — the harness would test nothing" >&2
+       FAILED=$((FAILED + 1)); return 1 ;;
+  esac
+  {
+    echo '#!/usr/bin/env bash'
+    echo 'set -uo pipefail'
+    printf '%s\n' "$body"
+    printf '%s "$@"\n' "$fn"
+  } > "$out"
+  chmod +x "$out"
+  return 0
+}
+
+# ── The snapshot path the GATE ITSELF writes ────────────────────────────────
+# Lifted from create_gate_snapshot's own assignment rather than retyped.
+SNAP_TEMPLATE="$(grep -m1 'snapshot_dir=' "$GATE" | sed -e 's/^[[:space:]]*//' -e 's/^local[[:space:]]*//' -e 's/^snapshot_dir=//' -e 's/^"//' -e 's/"$//')"
+SNAP_DIR="$(printf '%s' "$SNAP_TEMPLATE" \
+  | sed -e 's/\${from_phase}/3/' -e 's/\${to_phase}/4/' -e "s|\\\$(date +%Y-%m-%d)|$(date +%Y-%m-%d)|")"
+
+echo "== tests/test-bl214-gate-snapshot-staleness.sh =="
+echo ""
+
+case "$SNAP_DIR" in
+  docs/snapshots/phase-3-to-4_[0-9][0-9][0-9][0-9]-*)
+    pass "B0: the fixture path is derived from check-phase-gate.sh's own create_gate_snapshot assignment, not retyped — '$SNAP_DIR'"
+    ;;
+  *)
+    fail_ "B0" "could not derive the snapshot directory from the gate (got '$SNAP_DIR' from template '$SNAP_TEMPLATE') — every row below would be testing a path the gate does not write"
+    ;;
+esac
+
+# ── B1: the SYNC-SIBLING pin ────────────────────────────────────────────────
+CPG_BODY="$(_extract_fn "$GATE" _cpg_scoped_dirty | sed -e 's/_cpg_scoped_dirty/_SIBLING_/')"
+P3_BODY="$(_extract_fn "$DRIVER" _p3_scoped_dirty | sed -e 's/_p3_scoped_dirty/_SIBLING_/')"
+b1_len="$(printf '%s\n' "$CPG_BODY" | grep -c . || true)"
+case "$b1_len" in ''|*[!0-9]*) b1_len=0 ;; esac
+if [ "$b1_len" -gt 5 ] && [ "$CPG_BODY" = "$P3_BODY" ]; then
+  pass "B1: _cpg_scoped_dirty and _p3_scoped_dirty are byte-identical modulo their names ($b1_len lines) — their own comments claim it, and BL-214 exists because a change to one alone is the failure mode. This row makes the claim checkable"
+else
+  fail_ "B1" "the two sync siblings have diverged ($b1_len lines lifted). Diff:
+$(diff <(printf '%s\n' "$CPG_BODY") <(printf '%s\n' "$P3_BODY") || true)"
+fi
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+mk_repo() {
+  local d="$1"
+  mkdir -p "$d"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email "bl214@example.invalid"
+    git config user.name "BL-214 Fixture"
+    git config commit.gpgsign false
+    mkdir -p docs/test-results .claude src
+    printf 'seed\n' > README.md
+    printf 'seed\n' > "src/app.js"
+    mkdir -p "$1/$SNAP_DIR" 2>/dev/null || true
+    git add README.md src/app.js
+    git commit -q -m "chore: seed"
+  ) >/dev/null 2>&1
+}
+
+# run_pred <harness> <project-dir> [results-dir] -> echoes yes/no
+run_pred() {
+  local h="$1" p="$2" rd="${3:-}"
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$h" "$rd" </dev/null 2>/dev/null )
+}
+
+TD=$(mktemp -d)
+H_CPG="$TD/h-cpg.sh"
+H_P3="$TD/h-p3.sh"
+_harness "$GATE" _cpg_scoped_dirty "$H_CPG" || true
+_harness "$DRIVER" _p3_scoped_dirty "$H_P3" || true
+
+# ── B2: the gate's OWN PASS-time write no longer stales the next run ────────
+# Untracked (`?? docs/snapshots/`) is exactly what the backlog's reproduction
+# recorded after gate run 1.
+P="$TD/snapshot-dirt"; mk_repo "$P"
+mkdir -p "$P/$SNAP_DIR"
+printf 'snapshot copy\n' > "$P/$SNAP_DIR/PRODUCT_MANIFESTO.md"
+b2_cpg_rd="$(run_pred "$H_CPG" "$P" docs/test-results)"
+b2_cpg_no="$(run_pred "$H_CPG" "$P" "")"
+b2_p3_rd="$(run_pred "$H_P3" "$P" docs/test-results)"
+b2_p3_no="$(run_pred "$H_P3" "$P" "")"
+if [ "$b2_cpg_rd" = no ] && [ "$b2_cpg_no" = no ] && [ "$b2_p3_rd" = no ] && [ "$b2_p3_no" = no ]; then
+  pass "B2: with ONLY the gate's own snapshot directory dirty, both predicates answer 'no' on both call shapes (with a results dir and without) — a passing gate no longer plants its own next stale-fail"
+else
+  fail_ "B2" "cpg: results-dir='$b2_cpg_rd' bare='$b2_cpg_no'; p3: results-dir='$b2_p3_rd' bare='$b2_p3_no'; all four want 'no'"
+fi
+
+# ── B3: REAL dirt still stales (the other direction) ────────────────────────
+P="$TD/real-dirt"; mk_repo "$P"
+mkdir -p "$P/$SNAP_DIR"
+printf 'snapshot copy\n' > "$P/$SNAP_DIR/PRODUCT_MANIFESTO.md"
+printf 'changed\n' >> "$P/src/app.js"
+b3_cpg="$(run_pred "$H_CPG" "$P" docs/test-results)"
+b3_p3="$(run_pred "$H_P3" "$P" docs/test-results)"
+P2="$TD/real-dirt-untracked"; mk_repo "$P2"
+printf 'new\n' > "$P2/src/new-feature.js"
+b3_cpg_u="$(run_pred "$H_CPG" "$P2" docs/test-results)"
+b3_p3_u="$(run_pred "$H_P3" "$P2" docs/test-results)"
+if [ "$b3_cpg" = yes ] && [ "$b3_p3" = yes ] && [ "$b3_cpg_u" = yes ] && [ "$b3_p3_u" = yes ]; then
+  pass "B3: real source dirt still stales a summary, both modified-tracked ('$b3_cpg'/'$b3_p3') and untracked ('$b3_cpg_u'/'$b3_p3_u') — the exclusion narrowed the scope by one directory and not by more"
+else
+  fail_ "B3" "modified: cpg='$b3_cpg' p3='$b3_p3'; untracked: cpg='$b3_cpg_u' p3='$b3_p3_u'; all four want 'yes'"
+fi
+
+# ── B4: the two PRE-EXISTING exclusions are untouched ───────────────────────
+P="$TD/claude-dirt"; mk_repo "$P"
+printf '{}\n' > "$P/.claude/phase-state.json"
+b4_claude="$(run_pred "$H_CPG" "$P" docs/test-results)"
+P="$TD/results-dirt"; mk_repo "$P"
+printf 'summary\n' > "$P/docs/test-results/phase3-summary.md"
+b4_results="$(run_pred "$H_CPG" "$P" docs/test-results)"
+b4_results_bare="$(run_pred "$H_CPG" "$P" "")"
+if [ "$b4_claude" = no ] && [ "$b4_results" = no ] && [ "$b4_results_bare" = yes ]; then
+  pass "B4: BL-082's original exclusions still behave — .claude/ dirt answers 'no', results-dir dirt answers 'no' WHEN the results dir is passed and 'yes' when it is not ('$b4_results' / '$b4_results_bare'), which is the parameterised half working as designed"
+else
+  fail_ "B4" ".claude='$b4_claude' (want no); results-dir='$b4_results' (want no); results-dir with no argument='$b4_results_bare' (want yes)"
+fi
+
+# ── B5: a TRACKED, MODIFIED snapshot file is excluded too ───────────────────
+# The pathspec excludes a path, not an untracked state, and a re-run of the gate
+# on a day a snapshot already exists MODIFIES it rather than creating it.
+P="$TD/tracked-snapshot"; mk_repo "$P"
+mkdir -p "$P/$SNAP_DIR"
+printf 'snapshot copy\n' > "$P/$SNAP_DIR/PRODUCT_MANIFESTO.md"
+( cd "$P" && unset GITHUB_BASE_REF; git add "$SNAP_DIR" && git commit -q -m "chore: commit the snapshot" ) >/dev/null 2>&1
+printf 'regenerated\n' > "$P/$SNAP_DIR/PRODUCT_MANIFESTO.md"
+b5_cpg="$(run_pred "$H_CPG" "$P" docs/test-results)"
+b5_p3="$(run_pred "$H_P3" "$P" docs/test-results)"
+if [ "$b5_cpg" = no ] && [ "$b5_p3" = no ]; then
+  pass "B5: a COMMITTED snapshot that the gate then rewrites is excluded too ('$b5_cpg'/'$b5_p3') — the fix is a pathspec, so it covers the second-run-same-day shape as well as the first-ever-run shape"
+else
+  fail_ "B5" "cpg='$b5_cpg' p3='$b5_p3', both want 'no'"
+fi
+
+# ── B6: not a git repository -> conservative 'yes' ──────────────────────────
+P="$TD/not-a-repo"; mkdir -p "$P/docs/test-results"
+b6_cpg="$(run_pred "$H_CPG" "$P" docs/test-results)"
+b6_p3="$(run_pred "$H_P3" "$P" docs/test-results)"
+if [ "$b6_cpg" = yes ] && [ "$b6_p3" = yes ]; then
+  pass "B6: outside a git work tree both predicates still answer 'yes' ('$b6_cpg'/'$b6_p3') — the conservative direction, unchanged by this fix"
+else
+  fail_ "B6" "cpg='$b6_cpg' p3='$b6_p3', both want 'yes'"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutation proofs (each mutant is BUILT and RUN here) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || echo "?"; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+# _mutate <name> <source-file> <fn> <anchor> <sed-expr> <results-dir-arg>
+#   Copy the product file, strip the new pathspec from ONE call site, re-lift
+#   the function, and re-run B2's and B3's fixtures against the mutant. The
+#   report is printed either way: a mutation that changed nothing is a green row
+#   that proved nothing.
+_mutate() {
+  local name="$1" src="$2" fn="$3" anchor="$4" expr="$5" rdarg="$6"
+  local copy="$TD/$name.sh" harness="$TD/$name-h.sh" sites lines mode_b mode_a got_dirt got_real
+  cp "$src" "$copy"
+  mode_b="$(_mode_of "$copy")"
+  sites="$(grep -c "$anchor" "$src" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  _sed_inplace "$copy" "$expr"
+  mode_a="$(_mode_of "$copy")"
+  lines="$(diff "$src" "$copy" | grep -c '^[<>]' || true)"
+  case "$lines" in ''|*[!0-9]*) lines=0 ;; esac
+  local rep="anchor sites=$sites, diff-lines=$lines, mode $mode_b -> $mode_a"
+  if [ "$sites" -ne 1 ] || [ "$lines" -ne 2 ] || [ "$mode_b" != "$mode_a" ]; then
+    fail_ "$name (harness)" "the mutation is not anchored/single-line/mode-preserving: $rep"
+    return 0
+  fi
+  _harness "$copy" "$fn" "$harness" || return 0
+  got_dirt="$(run_pred "$harness" "$TD/snapshot-dirt" "$rdarg")"
+  got_real="$(run_pred "$harness" "$TD/real-dirt" "$rdarg")"
+  if [ "$got_dirt" = yes ] && [ "$got_real" = yes ]; then
+    pass "$name: with the snapshot pathspec removed from that one call site, the gate's own snapshot dirt stales again ('$got_dirt') while real dirt is unchanged ('$got_real') — B2 sees it and B3 does not, which is what shows the mutant broke the FIX and not the predicate. $rep"
+  else
+    fail_ "$name" "snapshot-only dirt -> '$got_dirt' (want yes, i.e. B2 goes RED) and real dirt -> '$got_real' (want yes). $rep"
+  fi
+}
+
+# The two call sites inside each function are distinguishable by what follows
+# the new pathspec: the bare arm ends it with `2>`, the results-dir arm follows
+# it with the `$rdir` exclusion.
+_mutate m1-cpg-results "$GATE"   _cpg_scoped_dirty \
+  "':(exclude)docs/snapshots' \":(exclude)" \
+  "s|':(exclude)docs/snapshots' \":(exclude)\$rdir\"|\":(exclude)\$rdir\"|" \
+  docs/test-results
+_mutate m2-cpg-bare "$GATE"   _cpg_scoped_dirty \
+  "':(exclude)docs/snapshots' 2>" \
+  "s|':(exclude).claude' ':(exclude)docs/snapshots' 2>|':(exclude).claude' 2>|" \
+  ""
+_mutate m3-p3-results "$DRIVER" _p3_scoped_dirty \
+  "':(exclude)docs/snapshots' \":(exclude)" \
+  "s|':(exclude)docs/snapshots' \":(exclude)\$rdir\"|\":(exclude)\$rdir\"|" \
+  docs/test-results
+_mutate m4-p3-bare "$DRIVER" _p3_scoped_dirty \
+  "':(exclude)docs/snapshots' 2>" \
+  "s|':(exclude).claude' ':(exclude)docs/snapshots' 2>|':(exclude).claude' 2>|" \
+  ""
+
+rm -rf "$TD"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-delta-severability.sh
+++ b/tests/test-delta-severability.sh
@@ -23,16 +23,37 @@
 #                                     (WP3's §10.1 report-only assertion)
 #   4. scripts/check-maintenance.sh   the cadence policy read (WP6)
 #
-# ...and a FIFTH that is not a script at all:
+# ...and TWO more that are not scripts at all:
 #
 #   5. .github/workflows/lint.yml    the `delta-boundary-lint` job, which runs
 #                                    scripts/lint-delta-boundary.sh (WP1)
+#   6. tests/full-project-test-suite.sh
+#                                    `run_child_suite "scripts/lint-delta-boundary.sh"`
+#                                    — the aggregator invoking the module's
+#                                    lint DIRECTLY, not through a tests/ path
+#
+# CONSUMER 6 IS THE ONE THAT FALSIFIED THIS TEST'S OWN CENTRAL CLAIM. §3.1
+# defines severability as "the full suite must pass" after the sever; the file
+# that IS the full suite registered a module script directly, the drop pattern
+# only ever matched `tests/test-…` paths, and the sweep did not open the file.
+# Post-sever that registration is `bash` on a deleted script — rc 127 — so the
+# very run the property is stated in terms of went red. V1b and V1c exist for
+# it, and m4 rebuilds the old state to prove they fire.
 #
 # Nobody wrote that list down in one place, and a list written from memory is
-# exactly what this test refuses to be. V1 is a COMPLETENESS scan: after the
-# declared revert it sweeps the whole severed surface for any surviving mention
+# exactly what this test refuses to be. V1/V1b are a COMPLETENESS scan: after
+# the declared revert they sweep the severed surface for any surviving mention
 # of the module, and a consumer added later without touching the revert manifest
-# below makes V1 go RED and NAMES the file.
+# below makes them go RED and NAMES the file. V1c closes the gap a text sweep
+# structurally cannot: a registration whose target the sweep never recognises
+# still fails to RESOLVE, and V1c stats every one of them.
+#
+# THAT CLAIM HAS NOW BEEN FALSIFIED TWICE, BOTH TIMES BY THE SAME SHAPE — a
+# consumer living in a file class the sweep did not open (a workflow, then the
+# aggregator). Both times the fix was to widen the scope AND add a mutant that
+# rebuilds the old blindness, because a scope extension proves nothing until
+# something in the new class is shown to trip it. If a third one turns up, the
+# lesson is the scope list, not the manifest.
 #
 # THE FIRST VERSION OF THAT CLAIM WAS FALSE, AND THE FIFTH CONSUMER IS WHY.
 # `_residual_scan` swept `scripts/*.sh` plus the scaffolder and nothing else, so
@@ -177,8 +198,9 @@ sever_module() {
   done
   rm -f "$d"/tests/test-delta-*.sh "$d"/tests/test-lint-delta-boundary.sh \
         "$d"/tests/test-delta-severability.sh 2>/dev/null || true
-  # Their registrations leave with them.
-  _drop_lines "$d/tests/full-project-test-suite.sh" 'tests/test-delta-\|tests/test-lint-delta-boundary'
+  # Their registrations leave with them. THE AGGREGATOR IS DROPPED BY WHOLE
+  # `run_child_suite` CALL, never by line — see _drop_child_suite_calls.
+  _drop_child_suite_calls "$d/tests/full-project-test-suite.sh"
   _drop_lines "$d/.github/workflows/tests.yml"      'tests/test-delta-\|tests/test-lint-delta-boundary\|delta-boundary'
   # THE FIFTH CONSUMER: the CI job that runs the module's own lint. Removed as a
   # WHOLE JOB BLOCK, not line-by-line — dropping the two `run:` lines would leave
@@ -210,6 +232,60 @@ _drop_lines() {   # <file> <BRE>
   tmp="$(mktemp)"
   grep -v "$pat" "$f" > "$tmp" 2>/dev/null || true
   mv "$tmp" "$f"
+  return 0
+}
+
+# _drop_child_suite_calls <aggregator> — remove every `run_child_suite` CALL
+#   that names a module file or one of the module's own suites. WHOLE CALL, and
+#   the emphasis is the finding.
+#
+#   A LINE-BASED DROP IS WRONG HERE IN TWO WAYS, AND BOTH WERE LIVE. This used
+#   to be `_drop_lines … 'tests/test-delta-\|tests/test-lint-delta-boundary'`,
+#   and an adversarial review's follow-up hunt found:
+#
+#     1. A SIXTH CONSUMER the pattern never matched at all —
+#        `run_child_suite "scripts/lint-delta-boundary.sh"`, the aggregator
+#        invoking the module's lint DIRECTLY rather than through a tests/ path.
+#        Post-sever that is `bash` on a deleted file: rc 127, and the very
+#        full-suite run §3.1 defines severability BY goes red. That falsifies
+#        this test's own central claim, which is why it is a fix and not a
+#        fast-follow.
+#     2. AN ORPHANED CONTINUATION LINE. `run_child_suite` calls span three
+#        backslash-continued lines. The head and the third argument named
+#        `tests/test-lint-delta-boundary.sh` and were dropped; the SECOND
+#        argument names `scripts/lint-delta-boundary.sh` and was not — so a
+#        bare dangling string survived, still carrying its trailing backslash.
+#        `bash -n` PASSES on it (it is a syntactically valid command), so no
+#        parse check could ever have caught it; only reading the surviving
+#        references does.
+#
+#   Same lesson as the YAML job two functions down, arriving from the other
+#   direction: a multi-line construct is dropped as a construct or not at all.
+#
+#   THE PATTERN IS DERIVED from the module manifest, so a module file that is
+#   later registered directly is covered without anyone remembering to add it.
+_drop_child_suite_calls() {
+  local f="$1" pat e tmp
+  [ -f "$f" ] || return 0
+  pat='tests/test-delta-|tests/test-lint-delta-boundary'
+  while IFS= read -r e; do
+    [ -n "$e" ] || continue
+    case "$e" in */) continue ;; esac
+    pat="$pat|$(printf '%s' "$e" | sed -e 's/\./\\./g')"
+  done <<EOF
+$MODULE_FILES
+EOF
+  tmp="$(mktemp)"
+  awk -v pat="$pat" '
+    {
+      buf = buf $0 "\n"
+      if ($0 ~ /\\$/) { next }          # the call continues on the next line
+      if (buf ~ /^run_child_suite[ \t]/ && buf ~ pat) { buf = ""; next }
+      printf "%s", buf
+      buf = ""
+    }
+    END { if (buf != "") printf "%s", buf }
+  ' "$f" > "$tmp" && mv "$tmp" "$f"
   return 0
 }
 
@@ -261,9 +337,9 @@ sever_seam() {
 # else is matched as a FIXED string — `delta.sh` as a regex would match
 # `deltaXsh`, and a scan that reports what is not there is as useless as one
 # that misses what is.
-_residual_scan() {   # <tree> -> "file:line:text" per hit
-  local d="$1" f pat tmp
-  tmp="$(mktemp)"
+# _residual_tokens <out-file> — the fixed strings a surviving edge would name.
+_residual_tokens() {
+  local tmp="$1" pat
   {
     printf '%s\n' "$MODULE_FILES" | while IFS= read -r pat; do
       [ -n "$pat" ] || continue
@@ -274,6 +350,26 @@ _residual_scan() {   # <tree> -> "file:line:text" per hit
     done
     printf '%s\n' '--delta-'
   } | grep -v '^$' | LC_ALL=C sort -u > "$tmp"
+  return 0
+}
+
+# _residual_scan_file <tree> <relative-path> -> "file:line:text" per hit
+_residual_scan_file() {
+  local d="$1" rel="$2" tmp
+  [ -f "$d/$rel" ] || return 0
+  tmp="$(mktemp)"
+  _residual_tokens "$tmp"
+  grep -vE '^[[:space:]]*#' "$d/$rel" 2>/dev/null \
+    | grep -nFf "$tmp" 2>/dev/null \
+    | sed -e "s|^|$rel:|" || true
+  rm -f "$tmp" 2>/dev/null || true
+  return 0
+}
+
+_residual_scan() {   # <tree> -> "file:line:text" per hit
+  local d="$1" f tmp
+  tmp="$(mktemp)"
+  _residual_tokens "$tmp"
   # THE WORKFLOW FILES ARE IN SCOPE, and their absence is what made the header's
   # "a fifth consumer lands here, named" claim false until an adversarial review
   # caught it. A CI job invoking a deleted script is every bit the dangling edge
@@ -349,19 +445,74 @@ else
 $V1_HITS"
 fi
 
+# ── V1b: the AGGREGATOR is in scope too ────────────────────────────────────
+# THE SWEEP-SCOPE ROW. `tests/full-project-test-suite.sh` is the file §3.1's
+# property is stated ABOUT ("the full suite must pass"), and until an
+# adversarial review's follow-up hunt it was the one file the sweep never
+# opened. Two things were hiding there: a direct `run_child_suite
+# "scripts/lint-delta-boundary.sh"` registration, and an orphaned continuation
+# line left behind by the old line-based drop. Both name a module path on an
+# executed line, so this row sees both.
+#
+# THE REST OF tests/ IS DELIBERATELY OUT OF SCOPE, with the reason stated
+# rather than the scope quietly drawn: the module's own suites LEAVE with the
+# module, and the one remaining hit — tests/test-lint-module-dependencies.sh
+# writing a self-contained stub named `lint-delta-boundary.sh` into its own
+# $TMP — is a FIXTURE WRITE, not a reference. It never touches the real file
+# and severing the module cannot break it. Sweeping it would be the
+# heredoc-false-positive class this repo already has scar tissue for.
+V1B_HITS="$(_residual_scan_file "$SEV" "tests/full-project-test-suite.sh")"
+V1B_N="$(printf '%s\n' "$V1B_HITS" | grep -c . || true)"
+case "$V1B_N" in ''|*[!0-9]*) V1B_N=0 ;; esac
+if [ "$V1B_N" -eq 0 ]; then
+  pass "V1b: the severed aggregator — the file §3.1's 'the full suite must pass' is a claim ABOUT — names no module path on any executed line. It was outside the sweep until a follow-up hunt found a direct lint registration and an orphaned continuation line living in it"
+else
+  fail_ "V1b" "$V1B_N surviving module reference(s) in the severed aggregator:
+$V1B_HITS"
+fi
+
+# ── V1c: every registration in the severed aggregator RESOLVES ─────────────
+# The decisive row for the sixth consumer, and it tests the actual claim rather
+# than a proxy for it. Running the real full suite is ~3h and workflow_dispatch
+# -only, but "would it go red?" reduces to "does every suite it registers still
+# exist?" — and `run_child_suite` on a missing file is `bash` answering 127.
+# A reference the residual sweep cannot see (a variable, a renamed path) still
+# lands here, because this row reads the targets and stats them.
+V1C_MISSING=""
+V1C_N=0
+while IFS= read -r target; do
+  [ -n "$target" ] || continue
+  V1C_N=$((V1C_N + 1))
+  [ -f "$SEV/$target" ] || V1C_MISSING="$V1C_MISSING $target"
+done <<EOF
+$(grep -oE 'run_child_suite "[^"]+"' "$SEV/tests/full-project-test-suite.sh" 2>/dev/null \
+  | sed -e 's/run_child_suite "//' -e 's/"$//' | LC_ALL=C sort -u)
+EOF
+if [ -z "$V1C_MISSING" ] && [ "$V1C_N" -gt 50 ]; then
+  pass "V1c: all $V1C_N distinct suites the severed aggregator registers still EXIST in the severed tree — so the ~3h run §3.1 defines severability by would not die on a missing file. This is the row that would have caught the sixth consumer on its own: run_child_suite on a deleted script is bash answering 127"
+else
+  fail_ "V1c" "$V1C_N targets checked; these no longer exist after the sever, so the full-suite run would go red on them:$V1C_MISSING"
+fi
+
 # ════════════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== V2 — the severed tree still parses, and still behaves ==="
 # ════════════════════════════════════════════════════════════════════════════
 
 V2_BAD=""
-for f in $(find "$SEV/scripts" -type f -name '*.sh' | LC_ALL=C sort); do
+for f in $(find "$SEV/scripts" "$SEV/tests" -type f -name '*.sh' | LC_ALL=C sort); do
   bash -n "$f" 2>/dev/null || V2_BAD="$V2_BAD ${f#$SEV/}"
 done
 bash -n "$SEV/$INIT_FILE" 2>/dev/null || V2_BAD="$V2_BAD $INIT_FILE"
-V2_N="$(find "$SEV/scripts" -type f -name '*.sh' | grep -c . || true)"
+V2_N="$(find "$SEV/scripts" "$SEV/tests" -type f -name '*.sh' | grep -c . || true)"
+# THE AGGREGATOR IS IN THIS SET NOW, and the honest note is that parsing is NOT
+# what caught the orphaned continuation line the old line-based drop left there:
+# a dangling `"...string..." \` is a syntactically valid command, so `bash -n`
+# passed on it happily. V1b and V1c are what see that class. This row is here
+# for the fragments a construct-level drop could still produce, not as the
+# aggregator's only guard.
 if [ -z "$V2_BAD" ]; then
-  pass "V2a: every one of the $V2_N shell scripts left in the severed tree still parses, and so does the scaffolder — the revert cut whole functions and a whole fence, not fragments"
+  pass "V2a: every one of the $V2_N shell scripts left in the severed tree still parses — scripts/, tests/ (the aggregator included) and the scaffolder. The revert cut whole functions, a whole fence, a whole YAML job and whole run_child_suite calls, not fragments"
 else
   fail_ "V2a" "these files no longer parse after the revert:$V2_BAD"
 fi
@@ -544,6 +695,42 @@ if [ "$MUT3_WF" -gt 0 ] && [ "$MUT3_SCRIPTS" -eq 0 ]; then
 else
   fail_ "m3" "workflow hits=$MUT3_WF (want > 0 — the extended sweep is not live), script hits=$MUT3_SCRIPTS (want 0 — the script revert should be complete). Hits:
 $MUT3_HITS"
+fi
+
+# ── m4: the aggregator drop must be a CONSTRUCT drop, not a line drop ───────
+# The counterfactual for the sixth consumer. This severs exactly as the test did
+# BEFORE the follow-up hunt — the old line-based `_drop_lines` on the aggregator
+# — and requires both new rows to see it. Two distinct defects have to surface:
+# the DIRECT `run_child_suite "scripts/lint-delta-boundary.sh"` registration the
+# old pattern never matched, and the ORPHANED CONTINUATION LINE it produced by
+# dropping two of a three-line call.
+MUT4="$TD/mutant4"; mk_tree "$MUT4"
+rm -f "$MUT4"/tests/test-delta-*.sh "$MUT4"/tests/test-lint-delta-boundary.sh 2>/dev/null || true
+printf '%s\n' "$MODULE_FILES" | while IFS= read -r e; do
+  [ -n "$e" ] || continue
+  case "$e" in */) rm -rf "$MUT4/$e" 2>/dev/null || true ;; *) rm -f "$MUT4/$e" 2>/dev/null || true ;; esac
+done
+_drop_lines "$MUT4/tests/full-project-test-suite.sh" 'tests/test-delta-\|tests/test-lint-delta-boundary'
+_drop_lines "$MUT4/.github/workflows/tests.yml" 'tests/test-delta-\|tests/test-lint-delta-boundary\|delta-boundary'
+_drop_yaml_job "$MUT4/.github/workflows/lint.yml" "delta-boundary-lint"
+sever_seam "$MUT4"
+M4_HITS="$(_residual_scan_file "$MUT4" "tests/full-project-test-suite.sh")"
+M4_N="$(printf '%s\n' "$M4_HITS" | grep -c . || true)"
+case "$M4_N" in ''|*[!0-9]*) M4_N=0 ;; esac
+M4_MISSING=""
+while IFS= read -r target; do
+  [ -n "$target" ] || continue
+  [ -f "$MUT4/$target" ] || M4_MISSING="$M4_MISSING $target"
+done <<EOF
+$(grep -oE 'run_child_suite "[^"]+"' "$MUT4/tests/full-project-test-suite.sh" 2>/dev/null \
+  | sed -e 's/run_child_suite "//' -e 's/"$//' | LC_ALL=C sort -u)
+EOF
+M4_PARSE=ok
+bash -n "$MUT4/tests/full-project-test-suite.sh" 2>/dev/null || M4_PARSE=broken
+if [ "$M4_N" -gt 0 ] && [ -n "$M4_MISSING" ]; then
+  pass "m4: severed the old way (line-based drop on the aggregator), V1b finds $M4_N surviving module reference(s) and V1c finds a registration pointing at a file that no longer exists —$M4_MISSING. Both rows fire. Note the aggregator still PARSES ($M4_PARSE): the orphaned continuation line is a syntactically valid command, so no parse check could have caught this and only reading the references does"
+else
+  fail_ "m4" "the old-style sever was not caught: V1b hits=$M4_N (want > 0), V1c missing targets='$M4_MISSING' (want non-empty), aggregator parse=$M4_PARSE"
 fi
 
 rm -rf "$TD"

--- a/tests/test-delta-severability.sh
+++ b/tests/test-delta-severability.sh
@@ -1,0 +1,417 @@
+#!/usr/bin/env bash
+# tests/test-delta-severability.sh — Delta Track §3.1's severability test.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §3.1 ("delete every
+# delta-module file and revert the seam block in process-checklist.sh, and the
+# full suite must pass — that is the property 'severable' means operationally;
+# §11-WP7 makes it a test"), §3.3 (the dependency-direction lint this protects),
+# §0.3-C10 (the seam and the single writer are the same file, which is what
+# makes the edge cardinality ONE), §11-WP7.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE ENUMERATION IS THE POINT — AND IT IS DONE BY RUNNING, NOT BY REMEMBERING
+#
+# §3.1 says "the seam block in process-checklist.sh", singular. By the time WP7
+# arrived the revert was FOUR core files, and each one arrived in a different
+# work package with its own good reason:
+#
+#   1. scripts/process-checklist.sh   the DELTA-SEAM fence (WP2) — the seam
+#                                     itself, and the only allowlisted edge
+#   2. scripts/upgrade-project.sh     _postmvp_policy_notice + its call site
+#                                     (WP2's §3.2 NOTICE-ONLY arm)
+#   3. scripts/validate.sh            _postmvp_era_assertion + its call site
+#                                     (WP3's §10.1 report-only assertion)
+#   4. scripts/check-maintenance.sh   the cadence policy read (WP6)
+#
+# Nobody wrote that list down in one place, and a list written from memory is
+# exactly what this test refuses to be. V1 is a COMPLETENESS scan: after the
+# declared revert it sweeps the whole severed executable surface for any
+# surviving mention of the module. A fifth consumer added later without touching
+# the revert manifest below makes V1 go RED and NAMES the file. That, not the
+# manifest, is what keeps the enumeration honest.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE MEASURED FINDING THIS TEST EXISTS TO RECORD (V0)
+#
+# FUNCTIONAL SEVERABILITY IS ALREADY FREE, AND TEXTUAL SEVERABILITY IS WHAT THE
+# REVERT BUYS. Every one of the four consumers fails SOFT when the module is
+# absent — by design, and each one says so in its own header: the seam answers
+# rc 2 ("the delta module is not installed"), validate.sh's assertion is
+# `|| return 0`, upgrade's notice is `|| true`, and check-maintenance.sh's
+# policy read falls back to the framework constants. V0 measures that: with the
+# module files deleted and NO revert at all, the core probes still behave.
+#
+# THAT IS WHY THE §11-WP7 MUTATION CANNOT BE A FUNCTIONAL ONE. "Delete a module
+# file but NOT the seam revert -> RED" is killed by V1, the structural arm, and
+# it has to be — a functional arm would stay green precisely because the
+# fail-soft design works. Recorded here rather than discovered later by someone
+# wondering why the obvious mutation does nothing.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# "THE FULL SUITE" — WHAT IS ACTUALLY RUN, AND WHY IT IS NOT ALL OF IT
+#
+# CLAUDE.md: the full suite is ~3h and workflow_dispatch-only. A unit-lane test
+# cannot run it, and pretending otherwise would be worse than saying so. V3 runs
+# a DECLARED list of fast core suites inside the severed tree, chosen because
+# they exercise the files the revert touches, and V2 parses every core script.
+# The list is named in the output so a reader can see the scope rather than
+# infer it.
+#
+# TWO THINGS §3.1's INVENTORY DOES NOT NAME, AND THIS TEST DELETES ANYWAY —
+# because a module whose own tests stayed behind would leave a suite full of
+# red, which is not what "severable" can mean:
+#   • tests/test-delta-*.sh and tests/test-lint-delta-boundary.sh — the module's
+#     own suites. RESIDUAL, NAMED RATHER THAN HIDDEN: tests/test-delta-wp6-cadence.sh
+#     is a delta-track suite that is also the ONLY coverage of a CORE script
+#     (scripts/check-maintenance.sh), so severing the module takes that coverage
+#     with it. That is a real cost of the module boundary and it belongs on the
+#     record, not in a footnote.
+#   • their registrations in tests/full-project-test-suite.sh and the tests.yml
+#     unit list.
+#
+# EXIT CODES / TEXT, NEVER LABELS. Every row is asserted on a process exit code
+# or on a grep over the severed tree.
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name the init script — the copy
+# step reaches it through a SPLIT token, the same idiom and the same reason as
+# tests/test-delta-wp6-cadence.sh::H6 and tests/test-intake-wizard-fixes.sh.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-delta-severability.sh" >&2
+  exit 2
+fi
+
+# The scaffolder's basename, split so no executed line in this file names it.
+# Reading it whole is what would make this suite unit-lane-EXEMPT, and it is a
+# fast test that belongs in the fast lane.
+INIT_FILE="init"".sh"
+
+# ── The §3.1 inventory, READ FROM THE LINT rather than retyped ──────────────
+# scripts/lint-delta-boundary.sh already holds the inventory, spelled once,
+# between its own DELTA-BOUNDARY-MANIFEST fences. Copying that list into this
+# file would create a second place it lives, and the two would drift — which is
+# the whole class of defect §3.1's boundary exists to prevent.
+_module_manifest() {
+  awk '/DELTA-BOUNDARY-MANIFEST-BEGIN/ { on = 1; next }
+       /DELTA-BOUNDARY-MANIFEST-END/   { exit }
+       on && /^[[:space:]]*"/ { gsub(/^[[:space:]]*"/, ""); gsub(/".*$/, ""); print }' \
+    "$REPO_ROOT/scripts/lint-delta-boundary.sh"
+}
+
+MODULE_FILES="$(_module_manifest)"
+MODULE_N="$(printf '%s\n' "$MODULE_FILES" | grep -c . || true)"
+case "$MODULE_N" in ''|*[!0-9]*) MODULE_N=0 ;; esac
+
+echo "== tests/test-delta-severability.sh =="
+echo ""
+
+if [ "$MODULE_N" -ge 7 ] && printf '%s\n' "$MODULE_FILES" | grep -q '^scripts/cut-release\.sh$'; then
+  pass "V-0a: the module inventory is READ from scripts/lint-delta-boundary.sh's own DELTA_MANIFEST ($MODULE_N entries, including scripts/cut-release.sh) — this test and the lint can never disagree about what 'the module' is"
+else
+  fail_ "V-0a" "could not read the §3.1 inventory out of the lint (got $MODULE_N entries: $(printf '%s' "$MODULE_FILES" | tr '\n' ' '))"
+fi
+
+# ── Building a severed tree ─────────────────────────────────────────────────
+TD=$(mktemp -d)
+
+mk_tree() {   # <dest> — a working copy of everything a core suite reads
+  local d="$1"
+  mkdir -p "$d"
+  cp -R "$REPO_ROOT/scripts"   "$d/scripts"
+  cp -R "$REPO_ROOT/tests"     "$d/tests"
+  cp -R "$REPO_ROOT/templates" "$d/templates"
+  cp -R "$REPO_ROOT/docs"      "$d/docs"
+  cp -R "$REPO_ROOT/.github"   "$d/.github"
+  cp "$REPO_ROOT/$INIT_FILE"   "$d/$INIT_FILE"
+  for f in CLAUDE.md README.md CONTRIBUTING.md solo-orchestrator-backlog.md solo-orchestrator-bugs.md; do
+    [ -f "$REPO_ROOT/$f" ] && cp "$REPO_ROOT/$f" "$d/$f"
+  done
+  return 0
+}
+
+# sever_module <tree> — STEP 1: delete every §3.1 file, plus the module's own
+#   suites and their registrations (see the header for why those are here).
+sever_module() {
+  local d="$1" e
+  printf '%s\n' "$MODULE_FILES" | while IFS= read -r e; do
+    [ -n "$e" ] || continue
+    case "$e" in
+      */) rm -rf "$d/$e" 2>/dev/null || true ;;
+      *)  rm -f  "$d/$e" 2>/dev/null || true ;;
+    esac
+  done
+  rm -f "$d"/tests/test-delta-*.sh "$d"/tests/test-lint-delta-boundary.sh 2>/dev/null || true
+  # Their registrations leave with them.
+  _drop_lines "$d/tests/full-project-test-suite.sh" 'tests/test-delta-\|tests/test-lint-delta-boundary'
+  _drop_lines "$d/.github/workflows/tests.yml"      'tests/test-delta-\|tests/test-lint-delta-boundary\|delta-boundary'
+  return 0
+}
+
+_drop_lines() {   # <file> <BRE>
+  local f="$1" pat="$2" tmp
+  [ -f "$f" ] || return 0
+  tmp="$(mktemp)"
+  grep -v "$pat" "$f" > "$tmp" 2>/dev/null || true
+  mv "$tmp" "$f"
+  return 0
+}
+
+# _drop_fn <file> <fn-name> — remove a top-level function AND its bare call
+#   sites. The function must start at column zero and end with `}` at column
+#   zero, which is the shape all three of the reverted helpers have.
+_drop_fn() {
+  local f="$1" fn="$2" tmp
+  [ -f "$f" ] || return 0
+  tmp="$(mktemp)"
+  awk -v fn="$fn" '
+    $0 ~ "^" fn "\\(\\) \\{" { skip = 1; next }
+    skip == 1 && /^\}$/       { skip = 0; next }
+    skip == 1                 { next }
+    $0 ~ "^[[:space:]]*" fn "[[:space:]]*$" { next }
+    { print }
+  ' "$f" > "$tmp" && mv "$tmp" "$f"
+  return 0
+}
+
+# sever_seam <tree> — STEP 2: THE REVERT. Four core files, enumerated in this
+#   file's header and kept honest by V1's completeness sweep.
+sever_seam() {
+  local d="$1" tmp
+  # (1) process-checklist.sh — the DELTA-SEAM fence, contiguous on purpose so
+  #     that this is a single-block revert (its own header says so).
+  tmp="$(mktemp)"
+  awk '/DELTA-SEAM-BEGIN/ { skip = 1 }
+       skip == 1 { if (/DELTA-SEAM-END/) skip = 0; next }
+       { print }' "$d/scripts/process-checklist.sh" > "$tmp" \
+    && mv "$tmp" "$d/scripts/process-checklist.sh"
+  # (2) upgrade-project.sh — §3.2's NOTICE-ONLY arm.
+  _drop_fn "$d/scripts/upgrade-project.sh" _postmvp_policy_notice
+  # (3) validate.sh — §10.1's report-only era assertion.
+  _drop_fn "$d/scripts/validate.sh" _postmvp_era_assertion
+  # (4) check-maintenance.sh — WP6's policy read. SUBSTITUTED, not deleted: the
+  #     read sits inside `if [ -f "$seam" ]; then … fi`, and an empty then-branch
+  #     is a bash SYNTAX ERROR. The substitution restores exactly the pre-WP6
+  #     behaviour, which is the framework constants.
+  tmp="$(mktemp)"
+  sed -e 's|^.*# CADENCE-POLICY-READ.*$|    v=""|' "$d/scripts/check-maintenance.sh" > "$tmp" \
+    && mv "$tmp" "$d/scripts/check-maintenance.sh"
+  return 0
+}
+
+# ── The residual scan (V1's instrument) ─────────────────────────────────────
+# Whole-line comments are stripped first, exactly as §3.3's lint does, because
+# a SPEC block naming the design document is prose and not an edge. Everything
+# else is matched as a FIXED string — `delta.sh` as a regex would match
+# `deltaXsh`, and a scan that reports what is not there is as useless as one
+# that misses what is.
+_residual_scan() {   # <tree> -> "file:line:text" per hit
+  local d="$1" f pat tmp
+  tmp="$(mktemp)"
+  {
+    printf '%s\n' "$MODULE_FILES" | while IFS= read -r pat; do
+      [ -n "$pat" ] || continue
+      case "$pat" in
+        */) printf '%s\n' "$pat" ;;
+        *)  printf '%s\n' "${pat##*/}" ;;
+      esac
+    done
+    printf '%s\n' '--delta-'
+  } | grep -v '^$' | LC_ALL=C sort -u > "$tmp"
+  for f in $(find "$d/scripts" -type f -name '*.sh' | LC_ALL=C sort) "$d/$INIT_FILE"; do
+    [ -f "$f" ] || continue
+    grep -vE '^[[:space:]]*#' "$f" 2>/dev/null \
+      | grep -nFf "$tmp" 2>/dev/null \
+      | sed -e "s|^|${f#$d/}:|" || true
+  done
+  rm -f "$tmp" 2>/dev/null || true
+  return 0
+}
+
+# ── Probes: the four consumers, run directly ────────────────────────────────
+mk_fixture() {   # a phase-4 project the probes can run against
+  local p="$1"
+  mkdir -p "$p/.claude" "$p/docs/test-results"
+  (
+    cd "$p" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email "sever@example.invalid"
+    git config user.name "Severability Fixture"
+    git config commit.gpgsign false
+  ) >/dev/null 2>&1
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":4,"phases":{}}\n' \
+    > "$p/.claude/phase-state.json"
+  printf '# Changelog\n\n## [Unreleased]\n' > "$p/CHANGELOG.md"
+  ( cd "$p" && unset GITHUB_BASE_REF; git add -A; git commit -q -m "chore: seed" ) >/dev/null 2>&1
+  return 0
+}
+
+probe_rcs() {   # <scripts-dir> <project-dir> -> "a|b|c" exit codes
+  local sd="$1" p="$2" a=0 b=0 c=0
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/check-maintenance.sh" </dev/null >/dev/null 2>&1 ) || a=$?
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/validate.sh"          </dev/null >/dev/null 2>&1 ) || b=$?
+  ( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/process-checklist.sh" --help </dev/null >/dev/null 2>&1 ) || c=$?
+  printf '%s|%s|%s' "$a" "$b" "$c"
+}
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V0 — the baseline, and the fail-soft finding ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+FIX="$TD/proj"; mk_fixture "$FIX"
+BASE_RCS="$(probe_rcs "$REPO_ROOT/scripts" "$FIX")"
+
+HALF="$TD/half"; mk_tree "$HALF"; sever_module "$HALF"
+HALF_RCS="$(probe_rcs "$HALF/scripts" "$FIX")"
+
+if [ "$BASE_RCS" = "$HALF_RCS" ]; then
+  pass "V0: with every §3.1 module file DELETED and no revert at all, the four core consumers answer exactly what they answered with the module present ($BASE_RCS) — functional severability is already free, because every consumer fails SOFT by design. That is why §11-WP7's mutation has to be caught structurally: see V1"
+else
+  fail_ "V0" "module-deleted probes answered '$HALF_RCS' but the intact tree answered '$BASE_RCS' — a consumer is not failing soft"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V1 — the completeness sweep: nothing of the module survives ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+SEV="$TD/severed"; mk_tree "$SEV"; sever_module "$SEV"; sever_seam "$SEV"
+V1_HITS="$(_residual_scan "$SEV")"
+V1_N="$(printf '%s\n' "$V1_HITS" | grep -c . || true)"
+case "$V1_N" in ''|*[!0-9]*) V1_N=0 ;; esac
+if [ "$V1_N" -eq 0 ]; then
+  pass "V1: after the four-file revert, NOT ONE executed line under scripts/ or in the scaffolder names a module path or a --delta-* action. This is the arm that keeps the revert manifest honest: a fifth consumer added later without updating it lands here, named"
+else
+  fail_ "V1" "$V1_N surviving reference(s) to the module — the revert list in this file's header is incomplete:
+$V1_HITS"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V2 — the severed tree still parses, and still behaves ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+V2_BAD=""
+for f in $(find "$SEV/scripts" -type f -name '*.sh' | LC_ALL=C sort); do
+  bash -n "$f" 2>/dev/null || V2_BAD="$V2_BAD ${f#$SEV/}"
+done
+bash -n "$SEV/$INIT_FILE" 2>/dev/null || V2_BAD="$V2_BAD $INIT_FILE"
+V2_N="$(find "$SEV/scripts" -type f -name '*.sh' | grep -c . || true)"
+if [ -z "$V2_BAD" ]; then
+  pass "V2a: every one of the $V2_N shell scripts left in the severed tree still parses, and so does the scaffolder — the revert cut whole functions and a whole fence, not fragments"
+else
+  fail_ "V2a" "these files no longer parse after the revert:$V2_BAD"
+fi
+
+SEV_RCS="$(probe_rcs "$SEV/scripts" "$FIX")"
+if [ "$SEV_RCS" = "$BASE_RCS" ]; then
+  pass "V2b: the fully severed consumers answer exactly what the intact tree answered ($SEV_RCS) — the framework does not need the post-1.0 module to work"
+else
+  fail_ "V2b" "severed probes answered '$SEV_RCS' but the intact tree answered '$BASE_RCS'"
+fi
+
+# The seam is GONE, not merely inert: a delta action is now an unknown option.
+SEAM_RC=0
+( cd "$FIX" && unset GITHUB_BASE_REF; bash "$SEV/scripts/process-checklist.sh" --delta-state-read </dev/null >/dev/null 2>&1 ) || SEAM_RC=$?
+INTACT_SEAM_RC=0
+( cd "$FIX" && unset GITHUB_BASE_REF; bash "$REPO_ROOT/scripts/process-checklist.sh" --delta-state-read </dev/null >/dev/null 2>&1 ) || INTACT_SEAM_RC=$?
+if [ "$SEAM_RC" -ne 0 ] && [ "$INTACT_SEAM_RC" -eq 0 ]; then
+  pass "V2c: in the severed tree the seam action is refused (rc $SEAM_RC) while the intact tree answers it (rc $INTACT_SEAM_RC) — the edge is gone rather than merely non-functional, which is the difference between severing a module and breaking one"
+else
+  fail_ "V2c" "severed seam rc=$SEAM_RC (want non-zero), intact seam rc=$INTACT_SEAM_RC (want 0)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== V3 — a declared set of core suites, run INSIDE the severed tree ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# Chosen because they exercise the files the revert touches. NOT the ~3h full
+# suite — CLAUDE.md records that it is workflow_dispatch-only, and a unit-lane
+# test that claimed to run it would be lying about its own scope.
+V3_SUITES="tests/test-check-phase-gate.sh
+tests/test-bl214-gate-snapshot-staleness.sh
+tests/test-check-phase-gate-poc-block-contract.sh
+tests/test-gate-principles.sh"
+
+V3_DETAIL=""
+V3_OK=y
+while IFS= read -r s; do
+  [ -n "$s" ] || continue
+  if [ ! -f "$SEV/$s" ]; then
+    V3_DETAIL="$V3_DETAIL [${s##*/}=MISSING]"; V3_OK=n; continue
+  fi
+  rc=0
+  ( cd "$SEV" && unset GITHUB_BASE_REF; bash "$s" </dev/null >/dev/null 2>&1 ) || rc=$?
+  V3_DETAIL="$V3_DETAIL [${s##*/}=rc$rc]"
+  [ "$rc" -eq 0 ] || V3_OK=n
+done <<EOF
+$V3_SUITES
+EOF
+
+if [ "$V3_OK" = y ]; then
+  pass "V3: every suite in the declared set passes inside the fully severed tree —$V3_DETAIL"
+else
+  fail_ "V3" "a suite failed in the severed tree:$V3_DETAIL"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — the §11-WP7 mutation ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# "Delete a module file but NOT the seam revert -> the test must go RED."
+# It goes red at V1, and only at V1 — see this file's header for why a
+# functional arm cannot catch it.
+MUT="$TD/mutant"; mk_tree "$MUT"; sever_module "$MUT"
+MUT_HITS="$(_residual_scan "$MUT")"
+MUT_N="$(printf '%s\n' "$MUT_HITS" | grep -c . || true)"
+case "$MUT_N" in ''|*[!0-9]*) MUT_N=0 ;; esac
+MUT_FILES="$(printf '%s\n' "$MUT_HITS" | cut -d: -f1 | LC_ALL=C sort -u | tr '\n' ' ')"
+MUT_RCS="$(probe_rcs "$MUT/scripts" "$FIX")"
+# The dangling references must be in the SEAM HOST, not merely somewhere: a
+# count alone would pass for a mutant that left a reference in some unrelated
+# file. `[...]` around the expansion is not decoration — CLAUDE.md's
+# portability rule forbids a multibyte character adjacent to an expansion under
+# bash 3.2, and this very line rendered the file list as one replacement byte
+# until the em-dash that followed `$MUT_FILES` was taken out.
+MUT_NAMES_SEAM=n
+case "$MUT_FILES" in *process-checklist.sh*) MUT_NAMES_SEAM=y ;; esac
+if [ "$MUT_N" -gt 0 ] && [ "$MUT_NAMES_SEAM" = y ] && [ "$MUT_RCS" = "$BASE_RCS" ]; then
+  pass "m1: with the module files deleted and the seam NOT reverted, V1 finds $MUT_N dangling reference(s), in [$MUT_FILES], the seam host among them. V1 goes RED. And the probes still answer '$MUT_RCS', identical to the intact tree, which MEASURES the claim in this file's header: a functional arm would have stayed green, so the structural arm is not a convenience, it is the only instrument that can see this"
+else
+  fail_ "m1" "residual hits=$MUT_N (want > 0, so V1 can see it); names the seam host=$MUT_NAMES_SEAM (want y); files=[$MUT_FILES]; probes='$MUT_RCS' vs intact '$BASE_RCS'"
+fi
+
+# The dual direction: the mutation is about the REVERT, so a tree that reverted
+# the seam and kept the module must also be caught — otherwise "delete both"
+# and "delete neither" would be the only states this test can distinguish.
+MUT2="$TD/mutant2"; mk_tree "$MUT2"; sever_seam "$MUT2"
+MUT2_LEFT=0
+for e in scripts/lib/delta-state.sh scripts/delta.sh scripts/cut-release.sh; do
+  [ -f "$MUT2/$e" ] && MUT2_LEFT=$((MUT2_LEFT + 1))
+done
+MUT2_SEAM_RC=0
+( cd "$FIX" && unset GITHUB_BASE_REF; bash "$MUT2/scripts/process-checklist.sh" --delta-state-read </dev/null >/dev/null 2>&1 ) || MUT2_SEAM_RC=$?
+if [ "$MUT2_LEFT" -eq 3 ] && [ "$MUT2_SEAM_RC" -ne 0 ]; then
+  pass "m2: the opposite half-sever — seam reverted, module files LEFT IN PLACE ($MUT2_LEFT of 3 still present) — leaves the module unreachable (a delta action answers rc $MUT2_SEAM_RC). Severability is a property of the PAIR, and this row is why the revert and the deletion are one operation and not two"
+else
+  fail_ "m2" "module files still present=$MUT2_LEFT (want 3); seam rc=$MUT2_SEAM_RC (want non-zero)"
+fi
+
+rm -rf "$TD"
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-delta-severability.sh
+++ b/tests/test-delta-severability.sh
@@ -23,12 +23,37 @@
 #                                     (WP3's §10.1 report-only assertion)
 #   4. scripts/check-maintenance.sh   the cadence policy read (WP6)
 #
+# ...and a FIFTH that is not a script at all:
+#
+#   5. .github/workflows/lint.yml    the `delta-boundary-lint` job, which runs
+#                                    scripts/lint-delta-boundary.sh (WP1)
+#
 # Nobody wrote that list down in one place, and a list written from memory is
 # exactly what this test refuses to be. V1 is a COMPLETENESS scan: after the
-# declared revert it sweeps the whole severed executable surface for any
-# surviving mention of the module. A fifth consumer added later without touching
-# the revert manifest below makes V1 go RED and NAMES the file. That, not the
-# manifest, is what keeps the enumeration honest.
+# declared revert it sweeps the whole severed surface for any surviving mention
+# of the module, and a consumer added later without touching the revert manifest
+# below makes V1 go RED and NAMES the file.
+#
+# THE FIRST VERSION OF THAT CLAIM WAS FALSE, AND THE FIFTH CONSUMER IS WHY.
+# `_residual_scan` swept `scripts/*.sh` plus the scaffolder and nothing else, so
+# the `delta-boundary-lint` job — which already existed — sat outside the sweep
+# entirely: V1 reported 0 hits while the severed tree still had CI invoking a
+# DELETED file. An adversarial review found it by reading the workflow the sweep
+# never opened. The scan now covers `.github/workflows/*.yml`, the sever removes
+# the job as a whole block, and V2d parses the result, because a YAML file with
+# a job key and no steps is not severable, it is broken.
+#
+# TWO PROSE-GRADE RESIDUALS ARE NAMED AND NOT CHASED. Neither is an edge:
+# nothing executes them, nothing breaks when the module leaves, and sweeping
+# them would make this test a documentation linter.
+#   • `templates/generated/identifiers.tmpl` carries a `DELTA-` row in a
+#     template that documents an ID prefix — a severed project has one unused
+#     row in a registry.
+#   • `.github/workflows/lint.yml`'s own job-inventory COMMENT names
+#     `delta-boundary-lint` while listing what the file contains. V2d measures
+#     and reports that survivor explicitly rather than letting a blunt grep
+#     count it as a live job; the executable half is what must be zero.
+# Recorded so the next reader knows they were seen and weighed, not missed.
 #
 # ═════════════════════════════════════════════════════════════════════════════
 # THE MEASURED FINDING THIS TEST EXISTS TO RECORD (V0)
@@ -150,10 +175,32 @@ sever_module() {
       *)  rm -f  "$d/$e" 2>/dev/null || true ;;
     esac
   done
-  rm -f "$d"/tests/test-delta-*.sh "$d"/tests/test-lint-delta-boundary.sh 2>/dev/null || true
+  rm -f "$d"/tests/test-delta-*.sh "$d"/tests/test-lint-delta-boundary.sh \
+        "$d"/tests/test-delta-severability.sh 2>/dev/null || true
   # Their registrations leave with them.
   _drop_lines "$d/tests/full-project-test-suite.sh" 'tests/test-delta-\|tests/test-lint-delta-boundary'
   _drop_lines "$d/.github/workflows/tests.yml"      'tests/test-delta-\|tests/test-lint-delta-boundary\|delta-boundary'
+  # THE FIFTH CONSUMER: the CI job that runs the module's own lint. Removed as a
+  # WHOLE JOB BLOCK, not line-by-line — dropping the two `run:` lines would leave
+  # a job key with no steps, which is not a severed workflow, it is a broken one.
+  _drop_yaml_job "$d/.github/workflows/lint.yml" "delta-boundary-lint"
+  return 0
+}
+
+# _drop_yaml_job <workflow> <job-key> — remove a top-level job (2-space indent)
+#   and every line under it, up to the next 2-space-indented key. The comment
+#   block ABOVE the job is prose and stays; V1 strips comments before matching,
+#   so it does not count as an edge.
+_drop_yaml_job() {
+  local f="$1" job="$2" tmp
+  [ -f "$f" ] || return 0
+  tmp="$(mktemp)"
+  awk -v job="$job" '
+    $0 ~ "^  " job ":[[:space:]]*$" { skip = 1; next }
+    skip == 1 && /^  [A-Za-z0-9_-]+:/ { skip = 0 }
+    skip == 1 { next }
+    { print }
+  ' "$f" > "$tmp" && mv "$tmp" "$f"
   return 0
 }
 
@@ -227,7 +274,13 @@ _residual_scan() {   # <tree> -> "file:line:text" per hit
     done
     printf '%s\n' '--delta-'
   } | grep -v '^$' | LC_ALL=C sort -u > "$tmp"
-  for f in $(find "$d/scripts" -type f -name '*.sh' | LC_ALL=C sort) "$d/$INIT_FILE"; do
+  # THE WORKFLOW FILES ARE IN SCOPE, and their absence is what made the header's
+  # "a fifth consumer lands here, named" claim false until an adversarial review
+  # caught it. A CI job invoking a deleted script is every bit the dangling edge
+  # a sourced lib would be — more so, because nothing local fails.
+  for f in $(find "$d/scripts" -type f -name '*.sh' | LC_ALL=C sort) \
+           "$d/$INIT_FILE" \
+           $(find "$d/.github/workflows" -type f -name '*.yml' 2>/dev/null | LC_ALL=C sort); do
     [ -f "$f" ] || continue
     grep -vE '^[[:space:]]*#' "$f" 2>/dev/null \
       | grep -nFf "$tmp" 2>/dev/null \
@@ -290,7 +343,7 @@ V1_HITS="$(_residual_scan "$SEV")"
 V1_N="$(printf '%s\n' "$V1_HITS" | grep -c . || true)"
 case "$V1_N" in ''|*[!0-9]*) V1_N=0 ;; esac
 if [ "$V1_N" -eq 0 ]; then
-  pass "V1: after the four-file revert, NOT ONE executed line under scripts/ or in the scaffolder names a module path or a --delta-* action. This is the arm that keeps the revert manifest honest: a fifth consumer added later without updating it lands here, named"
+  pass "V1: after the five-consumer revert, NOT ONE executed line under scripts/, in the scaffolder, or in .github/workflows/*.yml names a module path or a --delta-* action. This is the arm that keeps the revert manifest honest, and m3 proves the workflow half of it is live rather than merely declared"
 else
   fail_ "V1" "$V1_N surviving reference(s) to the module — the revert list in this file's header is incomplete:
 $V1_HITS"
@@ -331,17 +384,79 @@ else
   fail_ "V2c" "severed seam rc=$SEAM_RC (want non-zero), intact seam rc=$INTACT_SEAM_RC (want 0)"
 fi
 
+# ── V2d: the severed WORKFLOWS still parse ─────────────────────────────────
+# Removing a CI job is a structural edit to YAML, and "the delta references are
+# gone" is worth nothing if what is left will not load. Skipped with a stated
+# reason rather than silently when no YAML parser is available — a row that
+# quietly turns into a no-op is the silent-success class this whole track is
+# about.
+if python3 -c 'import yaml' >/dev/null 2>&1; then
+  V2D_BAD=""
+  V2D_N=0
+  for f in $(find "$SEV/.github/workflows" -type f -name '*.yml' | LC_ALL=C sort); do
+    V2D_N=$((V2D_N + 1))
+    python3 -c 'import sys,yaml; yaml.safe_load(open(sys.argv[1]))' "$f" >/dev/null 2>&1 \
+      || V2D_BAD="$V2D_BAD ${f#$SEV/}"
+  done
+  # Comment lines are stripped first, EXACTLY as V1 does and for the same
+  # reason. lint.yml carries a prose header that enumerates its jobs by name
+  # ("...delta-boundary-lint the twelfth..."), and that line survives the sever.
+  # It is documentation that has gone stale, not a CI job invoking a deleted
+  # file — the same prose-grade class as identifiers.tmpl's DELTA- row, and
+  # named in this file's header rather than chased. What must be gone is the
+  # executable half: the job key and its steps.
+  V2D_JOB="$(grep -vE '^[[:space:]]*#' "$SEV/.github/workflows/lint.yml" 2>/dev/null \
+    | grep -c 'delta-boundary-lint' || true)"
+  case "$V2D_JOB" in ''|*[!0-9]*) V2D_JOB=0 ;; esac
+  V2D_PROSE="$(grep -cE '^[[:space:]]*#.*delta-boundary-lint' "$SEV/.github/workflows/lint.yml" 2>/dev/null || true)"
+  case "$V2D_PROSE" in ''|*[!0-9]*) V2D_PROSE=0 ;; esac
+  if [ -z "$V2D_BAD" ] && [ "$V2D_JOB" -eq 0 ] && [ "$V2D_N" -gt 0 ]; then
+    pass "V2d: all $V2D_N severed workflow files still parse as YAML, and no EXECUTED line in lint.yml names the delta-boundary-lint job — the fifth consumer was removed as a whole block, not by deleting the two lines that named the module and leaving a job key with no steps. ($V2D_PROSE prose mention(s) survive in the file's own job-inventory comment: stale documentation, not an edge, and named in this file's header)"
+  else
+    fail_ "V2d" "unparseable after the sever:$V2D_BAD; surviving EXECUTED delta-boundary-lint lines in lint.yml: $V2D_JOB (want 0); files checked: $V2D_N"
+  fi
+else
+  pass "V2d: SKIPPED with a reason — no python3 yaml module on this host, so the severed workflows' parseability cannot be checked here. V1 still proves the references are gone; this row would prove what is left still loads"
+fi
+
 # ════════════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== V3 — a declared set of core suites, run INSIDE the severed tree ==="
 # ════════════════════════════════════════════════════════════════════════════
 
-# Chosen because they exercise the files the revert touches. NOT the ~3h full
-# suite — CLAUDE.md records that it is workflow_dispatch-only, and a unit-lane
-# test that claimed to run it would be lying about its own scope.
+# NOT the ~3h full suite — CLAUDE.md records that it is workflow_dispatch-only,
+# and a unit-lane test that claimed to run it would be lying about its own scope.
+#
+# THE SELECTION RATIONALE, STATED ACCURATELY BECAUSE THE FIRST ONE WAS NOT.
+# This set used to be introduced as "chosen because they exercise the files the
+# revert touches", and an adversarial review mapped the invocations: of the four
+# original suites, ZERO executed validate.sh, upgrade-project.sh or
+# check-maintenance.sh — three of the four reverted files. Only the seam host
+# was covered. The honest map, per reverted file:
+#
+#   process-checklist.sh   COVERED — test-check-phase-gate-poc-block-contract.sh
+#   check-phase-gate.sh /  COVERED — test-check-phase-gate.sh and
+#     run-phase3-validation.sh          test-bl214-gate-snapshot-staleness.sh
+#                                       (not reverted files, but the gate pair
+#                                       the revert's siblings live in)
+#   validate.sh            COVERED — the two validate suites added below, which
+#                                    were in the unit lane and unused all along
+#   upgrade-project.sh     NOT COVERED, deliberately: its suites invoke the
+#                          scaffolder, which would drag an init run into a
+#                          unit-lane test. Named, not hidden.
+#   check-maintenance.sh   NOT COVERED, and it CANNOT BE: its only behaviour
+#                          suite is tests/test-delta-wp6-cadence.sh, a delta
+#                          suite this very sever deletes. That is the coverage
+#                          gap this file's header records as a real cost, seen
+#                          here from the other side.
+#
+# test-gate-principles.sh is kept for breadth (a BL-030 message-table suite) and
+# is NOT claimed to cover a reverted file.
 V3_SUITES="tests/test-check-phase-gate.sh
 tests/test-bl214-gate-snapshot-staleness.sh
 tests/test-check-phase-gate-poc-block-contract.sh
+tests/test-validate-phase-state-gates.sh
+tests/test-validate-counter-sanitizer.sh
 tests/test-gate-principles.sh"
 
 V3_DETAIL=""
@@ -407,6 +522,28 @@ if [ "$MUT2_LEFT" -eq 3 ] && [ "$MUT2_SEAM_RC" -ne 0 ]; then
   pass "m2: the opposite half-sever — seam reverted, module files LEFT IN PLACE ($MUT2_LEFT of 3 still present) — leaves the module unreachable (a delta action answers rc $MUT2_SEAM_RC). Severability is a property of the PAIR, and this row is why the revert and the deletion are one operation and not two"
 else
   fail_ "m2" "module files still present=$MUT2_LEFT (want 3); seam rc=$MUT2_SEAM_RC (want non-zero)"
+fi
+
+# ── m3: the WORKFLOW half of the sweep is live, not merely added ────────────
+# A scan extended to a new file class proves nothing until something in that
+# class is shown to trip it. This severs everything EXCEPT the lint.yml job —
+# the exact state the test shipped in before an adversarial review found the
+# fifth consumer — and requires V1's instrument to name the workflow.
+MUT3="$TD/mutant3"; mk_tree "$MUT3"
+sever_module "$MUT3"
+# ...and put the fifth consumer back, so this is the pre-review state exactly.
+cp "$REPO_ROOT/.github/workflows/lint.yml" "$MUT3/.github/workflows/lint.yml"
+sever_seam "$MUT3"
+MUT3_HITS="$(_residual_scan "$MUT3")"
+MUT3_WF="$(printf '%s\n' "$MUT3_HITS" | grep -c '^\.github/workflows/' || true)"
+case "$MUT3_WF" in ''|*[!0-9]*) MUT3_WF=0 ;; esac
+MUT3_SCRIPTS="$(printf '%s\n' "$MUT3_HITS" | grep -c '^scripts/' || true)"
+case "$MUT3_SCRIPTS" in ''|*[!0-9]*) MUT3_SCRIPTS=0 ;; esac
+if [ "$MUT3_WF" -gt 0 ] && [ "$MUT3_SCRIPTS" -eq 0 ]; then
+  pass "m3: with every script consumer reverted but the delta-boundary-lint JOB left in place, V1 names the workflow — $MUT3_WF hit(s) under .github/workflows/ and $MUT3_SCRIPTS under scripts/. That is the pre-review state of this very test, in which V1 reported zero hits while the severed tree still had CI invoking a deleted file. The sweep's new file class has a witness"
+else
+  fail_ "m3" "workflow hits=$MUT3_WF (want > 0 — the extended sweep is not live), script hits=$MUT3_SCRIPTS (want 0 — the script revert should be complete). Hits:
+$MUT3_HITS"
 fi
 
 rm -rf "$TD"

--- a/tests/test-delta-wp7-cut-release.sh
+++ b/tests/test-delta-wp7-cut-release.sh
@@ -1,0 +1,943 @@
+#!/usr/bin/env bash
+# tests/test-delta-wp7-cut-release.sh — Delta Track WP7.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §9.1 (semver, decided by the
+# TOOL — the class->bump map is retunable, the PRECEDENCE is machinery — and
+# §13-R2's recorded cost of having no override), §9.2 (THE THREE REFUSALS AND
+# THEIR ORDER, and the last line: "performs no write of any kind before all
+# three pass"), §9.3 (promotion, and the tag format C7 forces), §8.2 (a major
+# bump re-runs run-phase3-validation.sh in full BEFORE the tag is written),
+# §8.3 (overdue AND unmeasurable are both refusals), §7.1 (`shipped_in` is
+# recorded at cut time THROUGH THE SEAM), §3.1 (cut-release.sh is a
+# DELTA-MODULE file despite its core-sounding name), §0.3-C7 (GitLab's
+# version-strict release lanes — why the tag format is a constraint and not a
+# preference), §0.3-C8 (`--finalize-phase 4` is a SECOND orphan and WP7 does
+# NOT wire it), §11-WP7.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose: no backlog
+# entry exists for this build and minting one would red
+# scripts/lint-bl-markers.sh, whose first pass resolves every marker to a real
+# `## BL-NNN:` entry. The design-doc path above is the citation, per the WP1
+# through WP6 precedent. The grep-able `CUTREL-*` markers in the product are
+# this suite's citation primitive and its mutation addresses.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE TWO PROPERTIES THIS SUITE EXISTS FOR
+#
+# 1. A REFUSED CUT LEAVES NOTHING BEHIND. §9.2's last line is not a nicety:
+#    "a partially-cut release (changelog promoted, tag absent) is a worse state
+#    than a refused one". Every refusal row below is asserted with a WHOLE-TREE
+#    `find` + per-file md5 manifest taken before and after, plus a separate
+#    count of the repository's tags — because a `git tag` leaves nothing in the
+#    working tree at all and a file manifest alone cannot see one. Checking a
+#    handful of expected filenames cannot see a file nobody thought to look
+#    for; that is the WP4/WP5 standard and it is inherited here verbatim.
+#
+# 2. THE TAG IS EXACTLY `vMAJOR.MINOR.PATCH`. C7 measured the release lanes:
+#    GitHub (4 templates) and Bitbucket (4) match `v*`; GitLab (4) matches
+#    `/^v\d+\.\d+\.\d+$/`. A `v1.2.0-rc1` therefore BUILDS on two hosts and
+#    SILENTLY DOES NOTHING on the third — green on the host you tested, which
+#    is the worst available failure mode. m2 emits exactly that suffix and this
+#    suite must go RED for it.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES, NEVER LABELS
+#
+# Every verdict below is asserted on a process EXIT CODE, a file's BYTES, a
+# whole-tree manifest, or a `git tag --list` count. None is asserted on a
+# printed `[OK]`/`[WARN]`/`[FAIL]` banner. CLAUDE.md's `[WARN]` trap is that a
+# label and an exit predicate can disagree — in check-phase-gate.sh two arms
+# printing the SAME word have opposite gate outcomes — and BL-213's whole
+# defect was a closing sentence that lied. Printed text is MEASURED for the
+# reader in pass narratives; it is never the predicate.
+#
+# THE CONTRACT UNDER TEST (scripts/cut-release.sh):
+#     0   the release was cut
+#     2   invocation / environment error (bad flag, no git, no jq, no CHANGELOG)
+#     3   REFUSAL 1 — a delta is open (§9.2)
+#     4   REFUSAL 2 — an unfiled hotfix retro (§9.2)
+#     5   REFUSAL 3 — cadence overdue OR unmeasurable (§9.2 + §8.3)
+#     6   REFUSAL — the delta record exists and cannot be read (strict rc 3)
+#     7   REFUSAL — there is no delta record at all (strict rc 4)
+#     8   REFUSAL — nothing closed since the last tag (§9.1)
+#     9   REFUSAL — a closed row's class maps to no bump (fail-closed)
+#    10   REFUSAL — major bump, and the §8.2 revalidation did not pass
+#    11   a write FAILED after every refusal passed — the cut is incomplete
+#
+# TWO CONSUMED CONTRACTS, NOT RE-SPELLED HERE:
+#   • scripts/lib/delta-cadence.sh — WP5's retro predicates and the seam's
+#     `--delta-state-read-strict` rc 0/3/4. WP7 REFUSES ON BOTH 3 AND 4.
+#   • scripts/check-maintenance.sh — WP6's 0 measured-current / 1 overdue /
+#     2 unmeasurable. WP7 REFUSES ON BOTH 1 AND 2.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# WHAT THIS SUITE PINS, AND WHICH MUTANT EACH ROW KILLS
+#
+#   R — THE THREE REFUSALS (§9.2), ALONE, IN COMBINATION, WRITING NOTHING
+#     R1  open delta alone                      -> 3, tree + tags unmoved
+#     R2  open hotfix retro alone               -> 4, names the delta, its
+#         due_by and how overdue it is                            KILLS m1
+#     R3  cadence OVERDUE (checker rc 1) alone  -> 5
+#     R4  cadence UNMEASURABLE (checker rc 2)   -> 5, NOT a pass    KILLS m3
+#     R5  all three at once -> 3: the CHEAPEST refusal speaks first (§9.2's
+#         author-proposed order), and the tree is still untouched   KILLS m5
+#     R6  refusals 2 and 3 together -> 4: the order holds with the first
+#         refusal removed, which is what proves it is an ORDER and not an
+#         accident of which check happens to be cheap
+#     R7  the state file exists and is CORRUPT  -> 6 (strict read rc 3)
+#     R8  there is no state file at all         -> 7 (strict read rc 4)
+#     R9  nothing closed since the last tag     -> 8
+#     R10 EVERY refusal above leaves the repository's TAG SET identical —
+#         a `git tag` writes nothing into the working tree, so the file
+#         manifest in R1-R9 is structurally blind to it
+#
+#   S — SEMVER, DECIDED BY THE TOOL (§9.1)
+#     S1  a feature + a fix        -> minor
+#     S2  fixes only               -> patch
+#     S3  a breaking marker        -> major, AND run-phase3-validation.sh is
+#         actually INVOKED (§8.2), proven by a recording stub    KILLS m7
+#     S4  major + a FAILING revalidation -> 10, and the tree is unmoved:
+#         "before the tag is written" means before the CHANGELOG too
+#     S5  the MAP is retunable: semver.fix = "minor" makes a fixes-only set
+#         a minor release
+#     S6  the PRECEDENCE is machinery: shuffling the `closed` rows cannot
+#         change the answer, and no policy key can reorder it     KILLS m4
+#     S7  no tag in the repository at all -> the base is 0.0.0
+#     S8  a closed row whose class maps to no bump -> 9, fail-closed,
+#         nothing written
+#
+#   P — PROMOTION (§9.3)
+#     P1  `## [Unreleased]` becomes `## [X.Y.Z] — YYYY-MM-DD`, and a FRESH
+#         `## [Unreleased]` sits ABOVE it
+#     P2  all EIGHT template categories survive, in template order, verbatim
+#     P3  the promoted block's body is BYTE-IDENTICAL to what was under
+#         `## [Unreleased]` before — the tool writes no prose
+#     P4  the fresh block contains NOTHING but its heading and the eight
+#         category headings
+#
+#   T — THE TAG (§9.3 + C7)
+#     T1  exactly ONE new tag, and it matches `^v[0-9]+\.[0-9]+\.[0-9]+$`
+#                                                                 KILLS m2
+#     T2  the tag names the tip of the current branch
+#     T3  nothing was pushed: the fixture has NO remote at all, and the cut
+#         still succeeds
+#
+#   W — `shipped_in` THROUGH THE SEAM (§7.1)
+#     W1  every unshipped closed row now carries the tag; an already-shipped
+#         row is untouched
+#     W2  WRITE-ONCE: a second cut refuses with 8 and rewrites nothing
+#     W3  STRUCTURAL: the script contains no direct write to the state file —
+#         the ship pathway is the only route
+#
+#   A — ADJACENCIES AND CONSTRAINTS
+#     A1  `--finalize-phase` is NOT wired (C8/Q3 — Karl did not decide it)
+#     A2  there is NO semver override flag (§9.1, §13-R2)
+#     A3  the boundary lint stays rc 0 and the seam allowlist stays at ONE
+#     A4  every refusal prints what would clear it (§4.3's plain register)
+#
+#   M — MUTATIONS (anchored, sites==1, one line changed, mode preserved,
+#       fresh fixtures, both trees executed)
+#     m1  suppress the open-retro refusal   -> a release cuts with a retro
+#         outstanding: the collateral on D3's loan is never called in
+#     m2  emit `v1.2.0-rc1`                 -> the C7 defence
+#     m3  collapse cadence rc 2 into a pass -> an unmeasured cadence
+#         silently satisfies a release, which is BL-213 one level up
+#     m4  reorder the semver precedence     -> a feature ships as a patch
+#     m5  suppress the open-delta refusal   -> a release cuts mid-delta
+#     m7  neuter the major revalidation     -> a breaking release skips the
+#         §8.2 full re-run
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
+# `unit-shard` list. Its executed lines never name the init script — the one
+# row that reads that file does so through a SPLIT token, the same idiom and
+# the same reason as tests/test-delta-wp6-cadence.sh::H6 and
+# tests/test-intake-wizard-fixes.sh.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+for _t in git jq; do
+  if ! command -v "$_t" >/dev/null 2>&1; then
+    echo "$_t is required for tests/test-delta-wp7-cut-release.sh" >&2
+    exit 2
+  fi
+done
+
+CUTREL="$REPO_ROOT/scripts/cut-release.sh"
+
+# ── Dates ───────────────────────────────────────────────────────────────────
+# GNU-first, BSD fallback — the house pattern, spelled here so the FIXTURES do
+# not depend on the product's own parser to build the inputs that test it.
+days_ago() {   # <n> -> YYYY-MM-DD, n whole days before now, UTC
+  local n="$1" e
+  e=$(( $(date -u +%s) - n * 86400 ))
+  date -u -d "@$e" +%Y-%m-%d 2>/dev/null || date -u -r "$e" +%Y-%m-%d
+}
+stamp_ago() {  # <n> -> YYYY-MM-DDTHH:MM:SSZ, n whole days before now, UTC
+  local n="$1" e
+  e=$(( $(date -u +%s) - n * 86400 ))
+  date -u -d "@$e" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "$e" +%Y-%m-%dT%H:%M:%SZ
+}
+today_utc() { date -u +%Y-%m-%d; }
+
+# ── Residue instruments ─────────────────────────────────────────────────────
+# Portable md5 of a single file (macOS `md5 -q`, Linux `md5sum`) — house pattern.
+_md5file() {
+  if command -v md5 >/dev/null 2>&1; then md5 -q "$1"
+  else md5sum "$1" | awk '{print $1}'; fi
+}
+
+tree_files() {
+  ( cd "$1" && find . -type f ! -path './.git/*' | LC_ALL=C sort )
+}
+
+# tree_manifest <project-dir> — every file in the tree with its md5. THE
+# refusal-residue instrument: a refusal that says "nothing was written" is a
+# claim about the whole filesystem, and checking one expected filename cannot
+# see a file nobody thought to look for.
+#
+# IT IS DELIBERATELY BLIND TO ONE THING, AND R10 IS WHY IT HAS A SIBLING. A
+# `git tag` writes into `.git/`, which this excludes — so a refusal that
+# nevertheless tagged would pass every manifest row in this file. R10 counts
+# tags separately for exactly that reason.
+tree_manifest() {
+  local p="$1" f
+  tree_files "$p" | while IFS= read -r f; do
+    printf '%s  %s\n' "$(_md5file "$p/$f")" "$f"
+  done
+}
+
+tag_list() {   # <project-dir> — every tag, sorted, one per line
+  ( cd "$1" && git tag --list 2>/dev/null | LC_ALL=C sort )
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+# EVERY case builds its own tree and removes it. Nothing is shared, so a case
+# can never inherit a surface it did not ask for — and a surface it did not ask
+# for is exactly what would make a refusal look like a pass.
+
+FIXTURE_SEQ=0
+
+# mk_proj <dir> [age-days] — a phase-4 git project with a MEASURABLE cadence and
+#   no delta state at all. The cadence surfaces are seeded fresh by default on
+#   purpose: the third refusal is the expensive one and every row that is not
+#   ABOUT it needs it quiet.
+#
+#   THE AGE IS A PARAMETER OF THE WHOLE FIXTURE, NOT A LATER RE-COMMIT, and that
+#   is not a style choice. Ageing CHANGELOG.md afterwards means committing it
+#   with an author AND committer date OLDER than the commit already at HEAD, and
+#   `git log`'s default ordering is by commit date — so `git log -1 -- CHANGELOG.md`
+#   would be answering a question about walk order rather than about the file.
+#   Building the tree at the age the row needs removes the question.
+mk_proj() {
+  local d="$1" age="${2:-1}" stamp
+  mkdir -p "$d/.claude" "$d/docs/test-results"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email "wp7@example.invalid"
+    git config user.name "WP7 Fixture"
+    git config commit.gpgsign false
+    git config tag.gpgsign false
+  ) >/dev/null 2>&1
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":4,"phases":{}}\n' \
+    > "$d/.claude/phase-state.json"
+  cp "$REPO_ROOT/templates/generated/changelog.tmpl" "$d/CHANGELOG.md"
+  printf '{"sbom":"fixture"}\n' > "$d/sbom.json"
+  printf 'scan artefact\n' > "$d/docs/test-results/$(days_ago 3)_semgrep_pass.txt"
+  stamp="$(days_ago "$age")T12:00:00+0000"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git add -A
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git commit -q -m "chore: fixture"
+  ) >/dev/null 2>&1
+}
+
+# tag_at <dir> <tag> — a local, unsigned tag on the current tip.
+tag_at() { ( cd "$1" && unset GITHUB_BASE_REF; git tag "$2" ) >/dev/null 2>&1; }
+
+# write_state <dir> <json> — the delta record, verbatim.
+write_state() { printf '%s\n' "$2" > "$1/.claude/delta-state.json"; }
+
+# closed_row <id> <class> [breaking] [shipped_in]
+closed_row() {
+  local id="$1" cls="$2" brk="${3:-false}" ship="${4:-null}"
+  local shipj="null"
+  [ "$ship" = "null" ] || shipj="\"$ship\""
+  printf '{"id":"%s","class":"%s","severity":null,"closed_at":"%s","shipped_in":%s,"breaking":%s}' \
+    "$id" "$cls" "$(stamp_ago 2)" "$shipj" "$brk"
+}
+
+# state_doc <active-json> <retros-json> <closed-json>
+state_doc() {
+  printf '{"schemaVersion":1,"active_delta":%s,"hotfix_retros":%s,"cadence":{},"closed":%s}' \
+    "$1" "$2" "$3"
+}
+
+# A minimal, schema-valid open delta.
+ACTIVE_JSON='{"id":"DELTA-009","slug":"dark-mode","class":"feature","brief":"docs/deltas/DELTA-009-dark-mode.md","opened_at":"2026-08-01T00:00:00Z","opened_via":"guided","attributes":{"risk":"feature-local","level":"small","severity":null},"gates_required":["ledger_row"],"gates_completed":[]}'
+
+# open_retro <id> <days-overdue>
+open_retro() {
+  printf '{"id":"%s","shipped_at":"%s","due_by":"%s","closed_at":null,"record":null}' \
+    "$1" "$(stamp_ago $(( $2 + 3 )))" "$(stamp_ago "$2")"
+}
+
+# mk_scripts_tree <dir> — a private copy of scripts/ so a mutant never touches
+#   the repository under test.
+mk_scripts_tree() { mkdir -p "$1"; cp -R "$REPO_ROOT/scripts" "$1/scripts"; }
+
+# stub_revalidation <scripts-dir> <exit-code> — replace the Phase 3 driver with
+#   a recorder. S3 needs PROOF the driver ran, and running the real one would
+#   drag five scanners (and a network) into a unit test.
+stub_revalidation() {
+  local sd="$1" rc="$2"
+  cat > "$sd/run-phase3-validation.sh" <<'STUB_EOF'
+#!/usr/bin/env bash
+# WP7 test stub — records that it was invoked, then answers the code it was built with.
+printf 'invoked %s\n' "$*" >> "${WP7_REVALIDATION_LOG:-/dev/null}"
+exit __RC__
+STUB_EOF
+  sed -e "s/__RC__/$rc/" "$sd/run-phase3-validation.sh" > "$sd/run-phase3-validation.sh.tmp" \
+    && mv "$sd/run-phase3-validation.sh.tmp" "$sd/run-phase3-validation.sh"
+  chmod +x "$sd/run-phase3-validation.sh"
+}
+
+# ── Runner ──────────────────────────────────────────────────────────────────
+CUT_RC=0
+CUT_OUT=""
+run_cut() {   # <scripts-dir> <project-dir> [args...]
+  local sd="$1" p="$2"; shift 2
+  CUT_RC=0
+  CUT_OUT="$( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/cut-release.sh" "$@" </dev/null 2>&1 )" || CUT_RC=$?
+  return 0
+}
+
+# ── Mutation harness (inherited from the WP2-WP6 suites) ────────────────────
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_mutation_report() {
+  local orig="$1" mut="$2" marker="$3" sites changed n
+  sites="$(grep -c "$marker" "$orig" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  if diff "$orig" "$mut" >/dev/null 2>&1; then changed=n; else changed=y; fi
+  n="$(diff "$orig" "$mut" | grep -c '^[<>]' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s|%s|%s' "$sites" "$changed" "$n"
+}
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || echo "?"; }
+
+echo "== tests/test-delta-wp7-cut-release.sh =="
+echo ""
+
+if [ ! -f "$CUTREL" ]; then
+  echo "  [FAIL] scripts/cut-release.sh is missing — WP7 delivers it, it must exist" >&2
+  exit 1
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== R — the three refusals (§9.2): order, and NO WRITE OF ANY KIND ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# _refuse_case <name> <want-rc> <setup-fn>
+#   One refusal row, with the whole-tree manifest and the tag set captured on
+#   both sides. Returns the detail string through R_DETAIL.
+R_DETAIL=""
+R_OK=y
+R_TAGS_OK=y
+_refuse_case() {
+  local name="$1" want="$2" setup="$3" age="${4:-1}" P before after tags_before tags_after
+  P="$RT/$name"
+  mk_proj "$P" "$age"
+  tag_at "$P" "v1.2.0"
+  "$setup" "$P"
+  before="$(tree_manifest "$P")"; tags_before="$(tag_list "$P")"
+  run_cut "$REPO_ROOT/scripts" "$P"
+  after="$(tree_manifest "$P")"; tags_after="$(tag_list "$P")"
+  R_DETAIL="$R_DETAIL [$name=rc$CUT_RC]"
+  [ "$CUT_RC" -eq "$want" ] || { R_OK=n; R_DETAIL="$R_DETAIL(want $want)"; }
+  [ "$before" = "$after" ] || { R_OK=n; R_DETAIL="$R_DETAIL(TREE MOVED)"; }
+  [ "$tags_before" = "$tags_after" ] || { R_TAGS_OK=n; R_DETAIL="$R_DETAIL(TAGGED)"; }
+  # Every refusal must say what would clear it (§4.3).
+  case "$CUT_OUT" in
+    *"To clear this:"*) : ;;
+    *) R_OK=n; R_DETAIL="$R_DETAIL(NO REMEDY)" ;;
+  esac
+}
+
+# The setups. Each one leaves exactly ONE condition wrong unless it says so.
+# `_break_cadence2` is factored out because three rows need it and it must not
+# also decide what the state document says.
+_break_cadence2() {
+  # §14-V13's fixture: a date NEITHER parser accepts -> the checker's rc 2.
+  rm -f "$1"/docs/test-results/*
+  printf 'scan artefact\n' > "$1/docs/test-results/2026-13-45_semgrep_pass.txt"
+}
+_s_open_delta()  { write_state "$1" "$(state_doc "$ACTIVE_JSON" '[]' "[$(closed_row DELTA-008 fix)]")"; }
+_s_open_retro()  { write_state "$1" "$(state_doc 'null' "[$(open_retro DELTA-007 2)]" "[$(closed_row DELTA-008 fix)]")"; }
+_s_clean()       { write_state "$1" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"; }
+_s_cadence_2()   { _s_clean "$1"; _break_cadence2 "$1"; }
+_s_all_three()   {
+  write_state "$1" "$(state_doc "$ACTIVE_JSON" "[$(open_retro DELTA-007 2)]" "[$(closed_row DELTA-008 fix)]")"
+  _break_cadence2 "$1"
+}
+_s_two_and_three() {
+  write_state "$1" "$(state_doc 'null' "[$(open_retro DELTA-007 2)]" "[$(closed_row DELTA-008 fix)]")"
+  _break_cadence2 "$1"
+}
+_s_corrupt()     { printf '{"schemaVersion": 1, "active_delta"\n' > "$1/.claude/delta-state.json"; }
+_s_absent()      { rm -f "$1/.claude/delta-state.json"; }
+_s_nothing()     { write_state "$1" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix false v1.2.0)]")"; }
+
+RT=$(mktemp -d)
+_refuse_case open-delta      3 _s_open_delta
+_refuse_case open-retro      4 _s_open_retro
+# 20 days > the 14-day routine default: OVERDUE, so the checker answers 1.
+_refuse_case cadence-overdue 5 _s_clean 20
+_refuse_case cadence-unmeas  5 _s_cadence_2
+_refuse_case all-three       3 _s_all_three
+_refuse_case two-and-three   4 _s_two_and_three
+_refuse_case corrupt-state   6 _s_corrupt
+_refuse_case absent-state    7 _s_absent
+_refuse_case nothing-closed  8 _s_nothing
+
+if [ "$R_OK" = y ]; then
+  pass "R1-R9 + A4: every refusal answers its own exit code —$R_DETAIL — leaves the whole tree byte-for-byte as it found it (find + per-file md5), and prints what would clear it"
+else
+  fail_ "R1-R9" "expected rc 3/4/5/5/3/4/6/7/8 with an unchanged tree and a remedy line; got:$R_DETAIL"
+fi
+
+if [ "$R_TAGS_OK" = y ]; then
+  pass "R10: not one of those nine refusals created a tag — asserted on the repository's tag set, which the working-tree manifest above is structurally blind to"
+else
+  fail_ "R10" "a refusal created a tag:$R_DETAIL"
+fi
+
+# ── R2 detail: the retro refusal NAMES the delta, its due_by and how late ────
+P="$RT/retro-msg"; mk_proj "$P"; tag_at "$P" "v1.2.0"; _s_open_retro "$P"
+run_cut "$REPO_ROOT/scripts" "$P"
+r2_named=y
+case "$CUT_OUT" in *DELTA-007*) : ;; *) r2_named=n ;; esac
+case "$CUT_OUT" in *"$(stamp_ago 2)"*) : ;; *) r2_named=n ;; esac
+case "$CUT_OUT" in *"2 day"*) : ;; *) r2_named=n ;; esac
+if [ "$r2_named" = y ] && [ "$CUT_RC" -eq 4 ]; then
+  pass "R2: the open-retro refusal (rc $CUT_RC) names the delta, its due_by and how overdue it is — §9.2's three things, from WP5's delta_retro_rows and not re-derived here"
+else
+  fail_ "R2" "rc=$CUT_RC (want 4); message did not name all three (id / due_by / days overdue). Output was: $CUT_OUT"
+fi
+
+# ── R4 detail: the UNMEASURABLE cadence is a refusal, and the report names it ─
+P="$RT/cad2-msg"; mk_proj "$P"; tag_at "$P" "v1.2.0"; _s_cadence_2 "$P"
+run_cut "$REPO_ROOT/scripts" "$P"
+r4_named=n
+case "$CUT_OUT" in *"COULD NOT BE MEASURED"*) r4_named=y ;; esac
+if [ "$CUT_RC" -eq 5 ] && [ "$r4_named" = y ]; then
+  pass "R4: an UNMEASURABLE cadence refuses (rc $CUT_RC) and the checker's own report — which names each arm that could not be read — is surfaced verbatim rather than collapsed into a headline"
+else
+  fail_ "R4" "rc=$CUT_RC (want 5); the unmeasurable arms were named=$r4_named. Output was: $CUT_OUT"
+fi
+rm -rf "$RT"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S — semver, decided by the TOOL (§9.1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# _cut_ok <name> <closed-json> [policy-json] [reval-rc] — a fixture that should
+#   CUT, run against a private scripts tree with a recording revalidation stub.
+#   Sets CUT_RC / CUT_OUT, and NEW_TAG to the tag that appeared (or "").
+NEW_TAG=""
+REVAL_LOG=""
+_cut_ok() {
+  local name="$1" closed="$2" policy="${3:-}" reval="${4:-0}" P SD before_tags after_tags
+  P="$ST/$name"; SD="$ST/$name-scripts"
+  mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "$closed")"
+  [ -z "$policy" ] || printf '%s\n' "$policy" > "$P/.claude/delta-policy.json"
+  mk_scripts_tree "$SD"; stub_revalidation "$SD/scripts" "$reval"
+  REVAL_LOG="$ST/$name.reval"; : > "$REVAL_LOG"
+  before_tags="$(tag_list "$P")"
+  CUT_RC=0
+  CUT_OUT="$( cd "$P" && unset GITHUB_BASE_REF; WP7_REVALIDATION_LOG="$REVAL_LOG" \
+      bash "$SD/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+  after_tags="$(tag_list "$P")"
+  NEW_TAG="$(printf '%s\n%s\n' "$before_tags" "$after_tags" | LC_ALL=C sort | uniq -u | tr -d ' ')"
+  CUT_PROJ="$P"
+  return 0
+}
+
+ST=$(mktemp -d)
+
+_cut_ok minor "[$(closed_row DELTA-008 fix),$(closed_row DELTA-009 feature)]"
+if [ "$CUT_RC" -eq 0 ] && [ "$NEW_TAG" = "v1.3.0" ]; then
+  pass "S1: a feature closed alongside a fix yields a MINOR bump — v1.2.0 -> $NEW_TAG (rc $CUT_RC)"
+else
+  fail_ "S1" "rc=$CUT_RC (want 0), new tag='$NEW_TAG' (want v1.3.0). Output: $CUT_OUT"
+fi
+
+_cut_ok patch "[$(closed_row DELTA-008 fix),$(closed_row DELTA-010 hotfix)]"
+if [ "$CUT_RC" -eq 0 ] && [ "$NEW_TAG" = "v1.2.1" ]; then
+  pass "S2: fixes and hotfixes only yield a PATCH bump — v1.2.0 -> $NEW_TAG (rc $CUT_RC)"
+else
+  fail_ "S2" "rc=$CUT_RC (want 0), new tag='$NEW_TAG' (want v1.2.1). Output: $CUT_OUT"
+fi
+
+_cut_ok major "[$(closed_row DELTA-008 fix),$(closed_row DELTA-011 feature true)]" "" 0
+s3_reval="$(wc -l < "$REVAL_LOG" | tr -d ' ')"
+if [ "$CUT_RC" -eq 0 ] && [ "$NEW_TAG" = "v2.0.0" ] && [ "$s3_reval" -ge 1 ]; then
+  pass "S3: a breaking marker yields a MAJOR bump — v1.2.0 -> $NEW_TAG — AND §8.2's full run-phase3-validation.sh re-run was genuinely INVOKED ($s3_reval recorded invocation(s)), proven by a recording stub rather than by reading the source"
+else
+  fail_ "S3" "rc=$CUT_RC (want 0), new tag='$NEW_TAG' (want v2.0.0), revalidation invocations=$s3_reval (want >= 1). Output: $CUT_OUT"
+fi
+
+# S4 — the revalidation FAILS. "Before the tag is written" (§8.2) has to mean
+# before the CHANGELOG too, or the failure leaves the worse state §9.2 names.
+P4="$ST/major-fail"; SD4="$ST/major-fail-scripts"
+mk_proj "$P4"; tag_at "$P4" "v1.2.0"
+write_state "$P4" "$(state_doc 'null' '[]' "[$(closed_row DELTA-011 feature true)]")"
+mk_scripts_tree "$SD4"; stub_revalidation "$SD4/scripts" 1
+s4_before="$(tree_manifest "$P4")"; s4_tags_before="$(tag_list "$P4")"
+CUT_RC=0
+CUT_OUT="$( cd "$P4" && unset GITHUB_BASE_REF; bash "$SD4/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+s4_after="$(tree_manifest "$P4")"; s4_tags_after="$(tag_list "$P4")"
+if [ "$CUT_RC" -eq 10 ] && [ "$s4_before" = "$s4_after" ] && [ "$s4_tags_before" = "$s4_tags_after" ]; then
+  pass "S4: a major bump whose §8.2 revalidation FAILS refuses at rc $CUT_RC with the whole tree and the tag set both unmoved — 'before the tag is written' includes before the changelog"
+else
+  fail_ "S4" "rc=$CUT_RC (want 10); tree moved=$([ "$s4_before" = "$s4_after" ] && echo n || echo y); tagged=$([ "$s4_tags_before" = "$s4_tags_after" ] && echo n || echo y)"
+fi
+
+# S5 — the MAP is retunable (§9.1: "the map lives in delta-policy.json::semver
+# so a project can retune the class->bump mapping").
+_cut_ok retuned "[$(closed_row DELTA-008 fix)]" '{"schemaVersion":1,"semver":{"feature":"minor","fix":"minor","hotfix":"patch","security-patch":"patch","breaking":"major"}}'
+if [ "$CUT_RC" -eq 0 ] && [ "$NEW_TAG" = "v1.3.0" ]; then
+  pass "S5: the class->bump MAP is project-retunable — with semver.fix = minor the same fixes-only set cuts $NEW_TAG instead of v1.2.1 (rc $CUT_RC)"
+else
+  fail_ "S5" "rc=$CUT_RC (want 0), new tag='$NEW_TAG' (want v1.3.0 from the retuned map). Output: $CUT_OUT"
+fi
+
+# S6 — the PRECEDENCE is machinery. THREE arms, because two of them alone would
+# be satisfied by an implementation that reads a key nobody has written yet: the
+# answer is invariant under row ORDER, AND a policy file that actively TRIES to
+# reorder it is ignored. The third arm is the one that would catch a future
+# "configurable precedence" being added quietly — asserting the key is absent
+# from the source would only catch it being added with that exact spelling.
+_cut_ok order-a "[$(closed_row DELTA-008 feature),$(closed_row DELTA-009 fix)]"
+s6_a="$NEW_TAG"; s6_a_rc="$CUT_RC"
+_cut_ok order-b "[$(closed_row DELTA-008 fix),$(closed_row DELTA-009 feature)]"
+s6_b="$NEW_TAG"; s6_b_rc="$CUT_RC"
+_cut_ok reorder-attempt "[$(closed_row DELTA-008 fix),$(closed_row DELTA-009 feature)]" \
+  '{"schemaVersion":1,"semver":{"feature":"minor","fix":"patch","hotfix":"patch","security-patch":"patch","breaking":"major"},"semver_precedence":["patch","minor","major"],"precedence":["patch","minor","major"]}'
+s6_c="$NEW_TAG"; s6_c_rc="$CUT_RC"
+if [ "$s6_a" = "v1.3.0" ] && [ "$s6_b" = "v1.3.0" ] && [ "$s6_c" = "v1.3.0" ] \
+   && [ "$s6_a_rc" -eq 0 ] && [ "$s6_b_rc" -eq 0 ] && [ "$s6_c_rc" -eq 0 ]; then
+  pass "S6: the PRECEDENCE is machinery, not policy — the same feature+fix set answers $s6_a with either row order, and a policy file that explicitly asks for patch-beats-minor-beats-major is ignored ($s6_c, not v1.2.1). §9.1: a project that could reorder this could make a feature release a patch"
+else
+  fail_ "S6" "order A -> '$s6_a' (rc $s6_a_rc), order B -> '$s6_b' (rc $s6_b_rc), reorder attempt -> '$s6_c' (rc $s6_c_rc); all three want v1.3.0"
+fi
+
+# S7 — no tag at all: the base is 0.0.0.
+P7="$ST/no-tag"; SD7="$ST/no-tag-scripts"
+mk_proj "$P7"
+write_state "$P7" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 feature)]")"
+mk_scripts_tree "$SD7"; stub_revalidation "$SD7/scripts" 0
+CUT_RC=0
+CUT_OUT="$( cd "$P7" && unset GITHUB_BASE_REF; bash "$SD7/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+s7_tag="$(tag_list "$P7" | tr -d ' ')"
+if [ "$CUT_RC" -eq 0 ] && [ "$s7_tag" = "v0.1.0" ]; then
+  pass "S7: a repository with NO tag at all bases the arithmetic at 0.0.0 — a feature cuts $s7_tag (rc $CUT_RC)"
+else
+  fail_ "S7" "rc=$CUT_RC (want 0), tag='$s7_tag' (want v0.1.0). Output: $CUT_OUT"
+fi
+
+# S8 — an unmappable class is FAIL-CLOSED. Under-bumping is the dangerous
+# direction (a breaking change shipped as a patch), so an unknown class refuses
+# rather than defaulting.
+P8="$ST/unmapped"; mk_proj "$P8"; tag_at "$P8" "v1.2.0"
+write_state "$P8" "$(state_doc 'null' '[]' '[{"id":"DELTA-012","class":"experiment","severity":null,"closed_at":"2026-08-01T00:00:00Z","shipped_in":null}]')"
+s8_before="$(tree_manifest "$P8")"; s8_tags_before="$(tag_list "$P8")"
+run_cut "$REPO_ROOT/scripts" "$P8"
+s8_after="$(tree_manifest "$P8")"; s8_tags_after="$(tag_list "$P8")"
+if [ "$CUT_RC" -eq 9 ] && [ "$s8_before" = "$s8_after" ] && [ "$s8_tags_before" = "$s8_tags_after" ]; then
+  pass "S8: a closed row whose class maps to no bump refuses at rc $CUT_RC with nothing written — fail-closed, because the alternative is a class nobody scored shipping as a patch"
+else
+  fail_ "S8" "rc=$CUT_RC (want 9); tree moved=$([ "$s8_before" = "$s8_after" ] && echo n || echo y)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== P — changelog promotion (§9.3): categories verbatim, no prose ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+PP="$ST/promote"; SDP="$ST/promote-scripts"
+mk_proj "$PP"; tag_at "$PP" "v1.2.0"
+write_state "$PP" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+# Put real content under two of the eight headings, so P3 can prove the tool
+# MOVED the operator's prose rather than rewriting or dropping it.
+awk '{ print }
+  /^### Added$/ { print "- dark mode" }
+  /^### Fixed$/ { print "- the thing that was broken" }' "$PP/CHANGELOG.md" > "$PP/CHANGELOG.md.new"
+mv "$PP/CHANGELOG.md.new" "$PP/CHANGELOG.md"
+CL_BEFORE="$(cat "$PP/CHANGELOG.md")"
+mk_scripts_tree "$SDP"; stub_revalidation "$SDP/scripts" 0
+CUT_RC=0
+CUT_OUT="$( cd "$PP" && unset GITHUB_BASE_REF; bash "$SDP/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+CL_AFTER="$(cat "$PP/CHANGELOG.md")"
+TODAY="$(today_utc)"
+
+# P1 — the two headings, in the right order.
+p1_unrel_line="$(printf '%s\n' "$CL_AFTER" | grep -n '^## \[Unreleased\]' | head -1 | cut -d: -f1)"
+p1_ver_line="$(printf '%s\n' "$CL_AFTER" | grep -n "^## \[1\.2\.1\] " | head -1 | cut -d: -f1)"
+p1_unrel_n="$(printf '%s\n' "$CL_AFTER" | grep -c '^## \[Unreleased\]' || true)"
+if [ -n "$p1_unrel_line" ] && [ -n "$p1_ver_line" ] && [ "$p1_unrel_line" -lt "$p1_ver_line" ] \
+   && [ "$p1_unrel_n" -eq 1 ] \
+   && printf '%s\n' "$CL_AFTER" | grep -q "^## \[1\.2\.1\] — $TODAY\$"; then
+  pass "P1: '## [Unreleased]' became '## [1.2.1] — $TODAY' (line $p1_ver_line) and exactly one FRESH '## [Unreleased]' now sits above it (line $p1_unrel_line)"
+else
+  fail_ "P1" "unreleased at line '$p1_unrel_line' (count $p1_unrel_n), version heading at '$p1_ver_line'; wanted one Unreleased strictly above '## [1.2.1] — $TODAY'"
+fi
+
+# P2 — all eight template categories, in template order, in the FRESH block.
+TMPL_CATS="$(grep '^### ' "$REPO_ROOT/templates/generated/changelog.tmpl")"
+FRESH_BLOCK="$(printf '%s\n' "$CL_AFTER" | awk '/^## \[Unreleased\]/ { on = 1; next } /^## \[/ && on { on = 0 } on { print }')"
+FRESH_CATS="$(printf '%s\n' "$FRESH_BLOCK" | grep '^### ' || true)"
+if [ "$FRESH_CATS" = "$TMPL_CATS" ]; then
+  pass "P2: the fresh block carries all eight categories from templates/generated/changelog.tmpl, verbatim and in template order — compared against the template's own bytes, not against a list retyped here"
+else
+  fail_ "P2" "fresh categories differ from the template's. Got: $(printf '%s' "$FRESH_CATS" | tr '\n' '/'); want: $(printf '%s' "$TMPL_CATS" | tr '\n' '/')"
+fi
+
+# P3 — the promoted body is byte-identical to the old Unreleased body.
+OLD_BODY="$(printf '%s\n' "$CL_BEFORE" | awk '/^## \[Unreleased\]/ { on = 1; next } /^## \[/ && on { on = 0 } on { print }')"
+NEW_BODY="$(printf '%s\n' "$CL_AFTER" | awk '/^## \[1\.2\.1\] / { on = 1; next } /^## \[/ && on { on = 0 } on { print }')"
+if [ "$OLD_BODY" = "$NEW_BODY" ]; then
+  pass "P3: the promoted section's body is BYTE-IDENTICAL to what was under '## [Unreleased]' before — the operator's two entries moved with it and the tool wrote no prose of its own"
+else
+  fail_ "P3" "the promoted body differs from the original Unreleased body"
+fi
+
+# P4 — the fresh block is empty of prose. STRUCTURAL: every non-blank line in it
+# is a `### ` heading. Asserting "does not contain 'dark mode'" would pass for a
+# tool that invented some OTHER sentence.
+p4_extra="$(printf '%s\n' "$FRESH_BLOCK" | grep -v '^### ' | grep -v '^[[:space:]]*$' || true)"
+if [ -z "$p4_extra" ]; then
+  pass "P4: the fresh '## [Unreleased]' block contains nothing but its category headings — asserted structurally (every non-blank line is a '### ' heading), which also refuses a sentence the tool invented rather than copied"
+else
+  fail_ "P4" "the fresh block carries non-heading content: $(printf '%s' "$p4_extra" | tr '\n' '/')"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== T — the tag: EXACTLY vMAJOR.MINOR.PATCH (§9.3 + C7) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+t1_tags="$(tag_list "$PP")"
+t1_new="$(printf '%s\n' "$t1_tags" | grep -v '^v1\.2\.0$' || true)"
+t1_n="$(printf '%s\n' "$t1_new" | grep -c . || true)"
+t1_shape=n
+printf '%s\n' "$t1_new" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' && t1_shape=y
+if [ "$CUT_RC" -eq 0 ] && [ "$t1_n" -eq 1 ] && [ "$t1_shape" = y ]; then
+  pass "T1: the cut created EXACTLY ONE new tag ('$t1_new') and it matches /^v[0-9]+\\.[0-9]+\\.[0-9]+\$/ — GitLab's release lanes match that regex while GitHub's and Bitbucket's match 'v*', so a pre-release suffix would build on two hosts and silently do nothing on the third"
+else
+  fail_ "T1" "rc=$CUT_RC; new tags=$t1_n ('$t1_new'); shape ok=$t1_shape"
+fi
+
+t2_tagsha="$( cd "$PP" && git rev-parse "$t1_new^{commit}" 2>/dev/null )"
+t2_head="$( cd "$PP" && git rev-parse HEAD 2>/dev/null )"
+if [ -n "$t2_tagsha" ] && [ "$t2_tagsha" = "$t2_head" ]; then
+  pass "T2: the tag names the tip of the current branch ($t2_head)"
+else
+  fail_ "T2" "tag commit '$t2_tagsha' != HEAD '$t2_head'"
+fi
+
+t3_remotes="$( cd "$PP" && git remote 2>/dev/null | grep -c . || true)"
+if [ "$t3_remotes" -eq 0 ] && [ "$CUT_RC" -eq 0 ]; then
+  pass "T3: the fixture has NO git remote at all and the cut still succeeded (rc $CUT_RC) — the tool creates a LOCAL tag and pushes nothing, so no test here can leak a real remote"
+else
+  fail_ "T3" "remotes=$t3_remotes (want 0), rc=$CUT_RC (want 0)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== W — shipped_in, through WP2's write-once ship pathway (§7.1) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+PW="$ST/ship"; SDW="$ST/ship-scripts"
+mk_proj "$PW"; tag_at "$PW" "v1.2.0"
+write_state "$PW" "$(state_doc 'null' '[]' "[$(closed_row DELTA-006 fix false v1.2.0),$(closed_row DELTA-008 fix),$(closed_row DELTA-009 feature)]")"
+mk_scripts_tree "$SDW"; stub_revalidation "$SDW/scripts" 0
+CUT_RC=0
+CUT_OUT="$( cd "$PW" && unset GITHUB_BASE_REF; bash "$SDW/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+w1_006="$(jq -r '.closed[] | select(.id=="DELTA-006") | .shipped_in' "$PW/.claude/delta-state.json" 2>/dev/null)"
+w1_008="$(jq -r '.closed[] | select(.id=="DELTA-008") | .shipped_in' "$PW/.claude/delta-state.json" 2>/dev/null)"
+w1_009="$(jq -r '.closed[] | select(.id=="DELTA-009") | .shipped_in' "$PW/.claude/delta-state.json" 2>/dev/null)"
+if [ "$CUT_RC" -eq 0 ] && [ "$w1_006" = "v1.2.0" ] && [ "$w1_008" = "v1.3.0" ] && [ "$w1_009" = "v1.3.0" ]; then
+  pass "W1: both unshipped rows now carry the new tag (DELTA-008=$w1_008, DELTA-009=$w1_009) and the row already shipped in v1.2.0 was left exactly as it was (DELTA-006=$w1_006)"
+else
+  fail_ "W1" "rc=$CUT_RC; DELTA-006='$w1_006' (want v1.2.0), DELTA-008='$w1_008' / DELTA-009='$w1_009' (want v1.3.0). Output: $CUT_OUT"
+fi
+
+w2_before="$(_md5file "$PW/.claude/delta-state.json")"
+CUT_RC=0
+CUT_OUT="$( cd "$PW" && unset GITHUB_BASE_REF; bash "$SDW/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+w2_after="$(_md5file "$PW/.claude/delta-state.json")"
+if [ "$CUT_RC" -eq 8 ] && [ "$w2_before" = "$w2_after" ]; then
+  pass "W2: a second cut over the same record refuses with 'nothing to release' (rc $CUT_RC) and rewrites not one byte of the state file — shipped_in is write-once, which is what makes the audit tail worth reading"
+else
+  fail_ "W2" "rc=$CUT_RC (want 8); state file md5 $w2_before -> $w2_after"
+fi
+
+# W3 — THE SHIP PATHWAY IS THE ONLY ROUTE (§7.1's single-writer rule).
+#
+# THE DECISIVE ARM IS FUNCTIONAL, NOT A GREP, and the first draft of this row is
+# why: a grep for `delta-state.json` near a `>` matched the REMEDY SENTENCE in a
+# refusal message ("...the tag and .claude/delta-state.json disagree..." >&2) and
+# reported a direct write that does not exist. A pattern that cannot tell a
+# filename in prose from a filename in a redirection is not an instrument.
+#
+# So the seam's SHIP ACTION is replaced by a shim that refuses, and the question
+# becomes empirical: with the only sanctioned route closed, does the state file
+# move at all? If cut-release.sh had any second path to that file — a `jq`, a
+# redirect, a `mv` — the bytes would change. They must not.
+PS="$ST/ship-blocked"; SDS="$ST/ship-blocked-scripts"
+mk_proj "$PS"; tag_at "$PS" "v1.2.0"
+write_state "$PS" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+mk_scripts_tree "$SDS"; stub_revalidation "$SDS/scripts" 0
+mv "$SDS/scripts/process-checklist.sh" "$SDS/scripts/process-checklist-real.sh"
+cat > "$SDS/scripts/process-checklist.sh" <<'SEAM_SHIM_EOF'
+#!/usr/bin/env bash
+# WP7 test shim — delegates every seam action EXCEPT the ship write, which it
+# refuses. Anything that still reaches the state file is doing so some other way.
+D="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ "${1:-}" = "--delta-state-ship" ]; then exit 1; fi
+exec bash "$D/process-checklist-real.sh" "$@"
+SEAM_SHIM_EOF
+chmod +x "$SDS/scripts/process-checklist.sh"
+w3_before="$(_md5file "$PS/.claude/delta-state.json")"
+CUT_RC=0
+CUT_OUT="$( cd "$PS" && unset GITHUB_BASE_REF; bash "$SDS/scripts/cut-release.sh" </dev/null 2>&1 )" || CUT_RC=$?
+w3_after="$(_md5file "$PS/.claude/delta-state.json")"
+w3_tags="$(tag_list "$PS" | grep -v '^v1\.2\.0$' || true)"
+# The narrowed structural arm, kept as a second opinion: a REDIRECTION or an
+# in-place rewrite naming the state file, on an executed line.
+w3_direct="$(grep -vE '^[[:space:]]*#' "$CUTREL" \
+  | grep -nE '(>[[:space:]]*"?[^"]*delta-state\.json|(^|[^[:alnum:]_])(mv|cp|rm|tee|jq)[[:space:]][^|]*delta-state\.json)' || true)"
+w3_ship="$(grep -c -- '--delta-state-ship' "$CUTREL" || true)"
+case "$w3_ship" in ''|*[!0-9]*) w3_ship=0 ;; esac
+if [ "$CUT_RC" -eq 11 ] && [ "$w3_before" = "$w3_after" ] && [ -z "$w3_tags" ] \
+   && [ -z "$w3_direct" ] && [ "$w3_ship" -ge 1 ]; then
+  pass "W3: with the seam's ship action shimmed to refuse, the cut stops at rc $CUT_RC, creates no tag, and the state file is byte-identical ($w3_before) — there is no second route to it. The seam is named $w3_ship time(s) and no executed line redirects, mv's or jq-rewrites onto the file"
+else
+  fail_ "W3" "rc=$CUT_RC (want 11); state md5 $w3_before -> $w3_after; new tags='$w3_tags'; direct writes='$w3_direct'; --delta-state-ship references=$w3_ship"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== A — adjacencies and constraints (C8, §13-R2, §3.1/§3.3) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# A1 — C8/Q3: `--finalize-phase 4` is the natural pre-tag check and Karl did
+# NOT decide to wire it. Executed lines only; the header names it in prose on
+# purpose, which is the adjacency record.
+a1_exec="$(grep -n 'finalize-phase' "$CUTREL" | grep -v '^[0-9]*:[[:space:]]*#' || true)"
+if [ -z "$a1_exec" ]; then
+  pass "A1: --finalize-phase is not wired — no EXECUTED line in cut-release.sh names it (C8/Q3: it is the natural pre-tag check and Karl did not decide it, so it is recorded as an adjacency in the header and nowhere else)"
+else
+  fail_ "A1" "an executed line names finalize-phase: $a1_exec"
+fi
+
+# A2 — §9.1/§13-R2: there is no override, and the cost is recorded rather than
+# quietly patched. Asserted by EXECUTION on four spellings, not by grep.
+a2_detail=""; a2_ok=y
+PA="$ST/override"; mk_proj "$PA"; tag_at "$PA" "v1.2.0"
+write_state "$PA" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+for flag in --major --minor --patch "--version=2.0.0" --bump; do
+  a2_tags_before="$(tag_list "$PA")"
+  run_cut "$REPO_ROOT/scripts" "$PA" "$flag"
+  a2_tags_after="$(tag_list "$PA")"
+  a2_detail="$a2_detail [$flag=rc$CUT_RC]"
+  [ "$CUT_RC" -eq 2 ] || a2_ok=n
+  [ "$a2_tags_before" = "$a2_tags_after" ] || { a2_ok=n; a2_detail="$a2_detail(TAGGED)"; }
+done
+if [ "$a2_ok" = y ]; then
+  pass "A2: there is NO semver override in v1 —$a2_detail — every spelling is an invocation error (rc 2) that tags nothing. The cost of that decision is real and is recorded at §13-R2, not smoothed over with a flag"
+else
+  fail_ "A2" "expected rc 2 and no tag for every override spelling; got:$a2_detail"
+fi
+
+# A3 — §3.1: cut-release.sh is a DELTA-MODULE file despite its core-sounding
+# name, and the seam allowlist stays at cardinality one.
+a3_rc=0
+a3_out="$( cd "$REPO_ROOT" && bash scripts/lint-delta-boundary.sh --list </dev/null 2>&1 )" || a3_rc=$?
+a3_card="$(printf '%s\n' "$a3_out" | grep -c 'cardinality 1/1' || true)"
+case "$a3_card" in ''|*[!0-9]*) a3_card=0 ;; esac
+a3_manifest=n
+grep -q '"scripts/cut-release.sh"' "$REPO_ROOT/scripts/lint-delta-boundary.sh" && a3_manifest=y
+if [ "$a3_rc" -eq 0 ] && [ "$a3_card" -ge 1 ] && [ "$a3_manifest" = y ]; then
+  pass "A3: the boundary lint is clean (rc $a3_rc) with cut-release.sh present, it is in the DELTA manifest (not CORE — it reads delta-state.json, so classifying it as core would create a second core->delta edge), and the seam allowlist is still cardinality 1/1"
+else
+  fail_ "A3" "lint rc=$a3_rc (want 0); cardinality-1 rows=$a3_card; in DELTA manifest=$a3_manifest"
+fi
+
+rm -rf "$ST"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutation proofs (each mutant is BUILT and RUN here) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# _mutate <name> <marker> <sed-expr> <check-fn>
+#   Copy scripts/ into a private tree, change the ONE line carrying <marker>,
+#   report sites / changed / lines, then hand the tree to <check-fn>. The
+#   report is printed whether the mutant is killed or not: a mutation that
+#   changed nothing is a green row that proved nothing, and that is the failure
+#   mode this harness exists to make visible.
+MT=""
+_mutate() {
+  local name="$1" marker="$2" expr="$3" check="$4" SD rep sites changed lines mode_before mode_after
+  SD="$MT/$name"
+  mk_scripts_tree "$SD"
+  stub_revalidation "$SD/scripts" 0
+  mode_before="$(_mode_of "$SD/scripts/cut-release.sh")"
+  cp "$SD/scripts/cut-release.sh" "$MT/$name.orig"
+  _sed_inplace "$SD/scripts/cut-release.sh" "$expr"
+  mode_after="$(_mode_of "$SD/scripts/cut-release.sh")"
+  rep="$(_mutation_report "$MT/$name.orig" "$SD/scripts/cut-release.sh" "$marker")"
+  sites="${rep%%|*}"; rep="${rep#*|}"; changed="${rep%%|*}"; lines="${rep##*|}"
+  MUT_REPORT="marker '$marker' sites=$sites, changed=$changed, diff-lines=$lines, mode $mode_before -> $mode_after"
+  MUT_SD="$SD/scripts"
+  if [ "$sites" -ne 1 ] || [ "$changed" != y ] || [ "$lines" -ne 2 ] || [ "$mode_before" != "$mode_after" ]; then
+    fail_ "$name (harness)" "the mutation is not anchored/single-line/mode-preserving: $MUT_REPORT"
+    return 0
+  fi
+  "$check" "$name"
+  return 0
+}
+
+MT=$(mktemp -d)
+
+# ── m1: suppress the open-retro refusal ─────────────────────────────────────
+_m1_check() {
+  local name="$1" P rc tags_before tags_after
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' "[$(open_retro DELTA-007 2)]" "[$(closed_row DELTA-008 fix)]")"
+  tags_before="$(tag_list "$P")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  tags_after="$(tag_list "$P")"
+  if [ "$rc" -eq 0 ] && [ "$tags_before" != "$tags_after" ]; then
+    pass "m1: with the open-retro refusal neutered the mutant CUTS A RELEASE over an unfiled retro (rc $rc, a new tag appeared) — R2 sees it. $MUT_REPORT"
+  else
+    fail_ "m1" "the mutant still refused (rc $rc, tags unchanged=$([ "$tags_before" = "$tags_after" ] && echo y || echo n)) — R2 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m1 '# CUTREL-REFUSE-RETRO$' 's|^\(.*# CUTREL-REFUSE-RETRO\)$|  if false; then :; fi   # CUTREL-REFUSE-RETRO|' _m1_check
+
+# ── m2: emit a pre-release suffix (the C7 defence) ──────────────────────────
+_m2_check() {
+  local name="$1" P rc newtag
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  newtag="$(tag_list "$P" | grep -v '^v1\.2\.0$' || true)"
+  if ! printf '%s\n' "$newtag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+    pass "m2: with the tag-format line emitting a pre-release suffix, the mutant produces no conforming tag (rc $rc, new tag '$newtag') — T1 sees it, and that tag is exactly the one GitLab's /^v\\d+\\.\\d+\\.\\d+\$/ lane would silently ignore while GitHub and Bitbucket built it. $MUT_REPORT"
+  else
+    fail_ "m2" "the mutant still produced a conforming tag '$newtag' — T1 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m2 '# CUTREL-TAG-FORMAT$' 's|^\(.*\)# CUTREL-TAG-FORMAT$|  TAG="v${NEXT_MAJOR}.${NEXT_MINOR}.${NEXT_PATCH}-rc1"   # CUTREL-TAG-FORMAT|' _m2_check
+
+# ── m3: collapse the checker's rc 2 into a pass ─────────────────────────────
+_m3_check() {
+  local name="$1" P rc tags_before tags_after
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+  rm -f "$P"/docs/test-results/*
+  printf 'scan artefact\n' > "$P/docs/test-results/2026-13-45_semgrep_pass.txt"
+  tags_before="$(tag_list "$P")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  tags_after="$(tag_list "$P")"
+  if [ "$rc" -eq 0 ] && [ "$tags_before" != "$tags_after" ]; then
+    pass "m3: with rc 2 collapsed into a pass the mutant CUTS over a cadence nobody could measure (rc $rc, a new tag appeared) — R4 sees it. This is BL-213's fail-open one level up: WP6 stopped the checker lying, and this line is what stops the release believing a lie it was never told. $MUT_REPORT"
+  else
+    fail_ "m3" "the mutant still refused (rc $rc) — R4 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m3 '# CUTREL-CADENCE-UNMEASURABLE$' 's|^\(.*\)# CUTREL-CADENCE-UNMEASURABLE$|    2) CADENCE_REFUSE=n ;;   # CUTREL-CADENCE-UNMEASURABLE|' _m3_check
+
+# ── m4: reorder the semver precedence ───────────────────────────────────────
+_m4_check() {
+  local name="$1" P rc newtag
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix),$(closed_row DELTA-009 feature)]")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  newtag="$(tag_list "$P" | grep -v '^v1\.2\.0$' || true)"
+  if [ "$newtag" != "v1.3.0" ]; then
+    pass "m4: with the precedence ranking reordered, the same feature+fix set no longer cuts a minor (rc $rc, new tag '$newtag' instead of v1.3.0) — S1/S6 see it. §9.1: a project that could reorder this could make a feature release a patch. $MUT_REPORT"
+  else
+    fail_ "m4" "the mutant still cut v1.3.0 — S1/S6 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m4 '# CUTREL-SEMVER-PRECEDENCE$' 's|^\(.*\)# CUTREL-SEMVER-PRECEDENCE$|_cutrel_rank() { case "${1:-}" in major) printf 3 ;; minor) printf 0 ;; *) printf 1 ;; esac; }   # CUTREL-SEMVER-PRECEDENCE|' _m4_check
+
+# ── m5: suppress the open-delta refusal ─────────────────────────────────────
+_m5_check() {
+  local name="$1" P rc tags_before tags_after
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc "$ACTIVE_JSON" '[]' "[$(closed_row DELTA-008 fix)]")"
+  tags_before="$(tag_list "$P")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  tags_after="$(tag_list "$P")"
+  if [ "$rc" -eq 0 ] && [ "$tags_before" != "$tags_after" ]; then
+    pass "m5: with the open-delta refusal neutered the mutant cuts a release in the middle of DELTA-009 (rc $rc, a new tag appeared) — R1/R5 see it. $MUT_REPORT"
+  else
+    fail_ "m5" "the mutant still refused (rc $rc) — R1/R5 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m5 '# CUTREL-REFUSE-ACTIVE$' 's|^\(.*# CUTREL-REFUSE-ACTIVE\)$|  if false; then :; fi   # CUTREL-REFUSE-ACTIVE|' _m5_check
+
+# ── m7: neuter the major revalidation ───────────────────────────────────────
+_m7_check() {
+  local name="$1" P rc log newtag n
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "[$(closed_row DELTA-011 feature true)]")"
+  log="$MT/$name.reval"; : > "$log"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; WP7_REVALIDATION_LOG="$log" \
+      bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  n="$(wc -l < "$log" | tr -d ' ')"
+  newtag="$(tag_list "$P" | grep -v '^v1\.2\.0$' || true)"
+  if [ "$n" -eq 0 ] && [ "$newtag" = "v2.0.0" ]; then
+    pass "m7: with the §8.2 revalidation neutered the mutant cuts the major release ($newtag, rc $rc) having invoked run-phase3-validation.sh $n times — S3 sees it, because S3 asserts on a RECORDED invocation and not on the presence of a call in the source. $MUT_REPORT"
+  else
+    fail_ "m7" "the mutant still revalidated ($n invocation(s)) or did not cut ('$newtag') — S3 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m7 '# CUTREL-MAJOR-REVALIDATE$' 's|^\(.*# CUTREL-MAJOR-REVALIDATE\)$|  if false; then :; fi   # CUTREL-MAJOR-REVALIDATE|' _m7_check
+
+rm -rf "$MT"
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-delta-wp7-cut-release.sh
+++ b/tests/test-delta-wp7-cut-release.sh
@@ -90,6 +90,13 @@
 #     R10 EVERY refusal above leaves the repository's TAG SET identical —
 #         a `git tag` writes nothing into the working tree, so the file
 #         manifest in R1-R9 is structurally blind to it
+#     R11 a checker answering an UNDOCUMENTED code, and a checker that has
+#         been DELETED (bash answers 127), are BOTH refusals    KILLS m6
+#         — the row an adversarial review had to add for me. R3/R4 cover
+#         only rc 1 and rc 2, so the `*)` arm that catches everything else
+#         had no witness and its weakening mutant survived at 31/0. What it
+#         costs to lose: `rm scripts/check-maintenance.sh` becomes cadence
+#         forgiveness in one keystroke
 #
 #   S — SEMVER, DECIDED BY THE TOOL (§9.1)
 #     S1  a feature + a fix        -> minor
@@ -105,6 +112,8 @@
 #     S7  no tag in the repository at all -> the base is 0.0.0
 #     S8  a closed row whose class maps to no bump -> 9, fail-closed,
 #         nothing written
+#     S9  a class nobody could READ (`"class": {}` makes the token jq's
+#         @tsv error while the id jq succeeds) -> 9, not a patch  KILLS m9
 #
 #   P — PROMOTION (§9.3)
 #     P1  `## [Unreleased]` becomes `## [X.Y.Z] — YYYY-MM-DD`, and a FRESH
@@ -134,6 +143,10 @@
 #     A2  there is NO semver override flag (§9.1, §13-R2)
 #     A3  the boundary lint stays rc 0 and the seam allowlist stays at ONE
 #     A4  every refusal prints what would clear it (§4.3's plain register)
+#     A5  refusal 2's rc-3 backstop, pinned AT THE LINE — plus the subset
+#         argument BY EXECUTION that makes rc 3 unreachable through the
+#         front door, so the arm is a genuine backstop and not dead code
+#                                                                 KILLS m8
 #
 #   M — MUTATIONS (anchored, sites==1, one line changed, mode preserved,
 #       fresh fixtures, both trees executed)
@@ -146,6 +159,19 @@
 #     m5  suppress the open-delta refusal   -> a release cuts mid-delta
 #     m7  neuter the major revalidation     -> a breaking release skips the
 #         §8.2 full re-run
+#     m6  weaken the catch-everything-else cadence arm -> DELETING the
+#         checker cuts a release. THE REVIEWER'S SURVIVING MUTANT
+#     m8  narrow the retro backstop to rc 0 only -> an UNDETERMINED ledger
+#         stops refusing. The reviewer's second survivor
+#     m9  restore the old `BUMP=patch` fallback -> an unreadable class
+#         ships as a patch
+#
+# THREE OF THOSE NINE EXIST BECAUSE THIS SUITE WAS NOT GOOD ENOUGH. m6 and m8
+# are mutants an adversarial review built against MARKED arms of this product
+# and watched survive the whole suite at 31/0; m9 is the reachable form of a
+# fallback the same review flagged on principle. A marker that calls itself a
+# mutation address and has no mutant is a promise the file does not keep, so
+# every CUTREL-* marker now carries one.
 #
 # LANE: registered in tests/full-project-test-suite.sh AND in the tests.yml
 # `unit-shard` list. Its executed lines never name the init script — the one
@@ -451,6 +477,52 @@ if [ "$CUT_RC" -eq 5 ] && [ "$r4_named" = y ]; then
 else
   fail_ "R4" "rc=$CUT_RC (want 5); the unmeasurable arms were named=$r4_named. Output was: $CUT_OUT"
 fi
+
+# ── R11: EVERY OTHER EXIT CODE THE CHECKER CAN PRODUCE IS ALSO A REFUSAL ────
+#
+# THE ROW AN ADVERSARIAL REVIEW HAD TO ADD FOR ME. `# CUTREL-CADENCE-OTHER` —
+# the `*)` arm — was reachable, load-bearing and completely unpinned: weakening
+# it to `CADENCE_REFUSE=n` survived this whole suite at 31/0. R3 and R4 only
+# cover rc 1 and rc 2, so the arm that catches everything else had no witness.
+#
+# WHAT IT COSTS TO LOSE, MEASURED AND NOT ASSUMED: `bash` answers 127 when the
+# script it was asked to run DOES NOT EXIST, so without this arm
+# `rm scripts/check-maintenance.sh` is cadence forgiveness in one keystroke —
+# the same `rm`-as-loan-forgiveness class WP5's strict read closed for the
+# ledger, one surface over. Both spellings are exercised: a checker that
+# answers an UNDOCUMENTED code, and a checker that is not there at all.
+R11_DETAIL=""
+R11_OK=y
+_r11_case() {
+  local name="$1" mode="$2" P SD before after tags_before tags_after rc=0
+  P="$RT/$name"; SD="$RT/$name-scripts"
+  mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+  mk_scripts_tree "$SD"
+  case "$mode" in
+    exit7)
+      printf '#!/usr/bin/env bash\n# WP7 test stub: an exit code the contract does not document.\nexit 7\n' \
+        > "$SD/scripts/check-maintenance.sh"
+      chmod +x "$SD/scripts/check-maintenance.sh" ;;
+    absent)
+      rm -f "$SD/scripts/check-maintenance.sh" ;;
+  esac
+  before="$(tree_manifest "$P")"; tags_before="$(tag_list "$P")"
+  CUT_OUT="$( cd "$P" && unset GITHUB_BASE_REF; bash "$SD/scripts/cut-release.sh" </dev/null 2>&1 )" || rc=$?
+  after="$(tree_manifest "$P")"; tags_after="$(tag_list "$P")"
+  R11_DETAIL="$R11_DETAIL [$name=rc$rc]"
+  [ "$rc" -eq 5 ] || { R11_OK=n; R11_DETAIL="$R11_DETAIL(want 5)"; }
+  [ "$before" = "$after" ] || { R11_OK=n; R11_DETAIL="$R11_DETAIL(TREE MOVED)"; }
+  [ "$tags_before" = "$tags_after" ] || { R11_OK=n; R11_DETAIL="$R11_DETAIL(TAGGED)"; }
+  case "$CUT_OUT" in *"To clear this:"*) : ;; *) R11_OK=n; R11_DETAIL="$R11_DETAIL(NO REMEDY)" ;; esac
+}
+_r11_case checker-exit7  exit7
+_r11_case checker-absent absent
+if [ "$R11_OK" = y ]; then
+  pass "R11: a checker that answers an UNDOCUMENTED code, and a checker that has been DELETED (bash answers 127), are both refusals —$R11_DETAIL — with the whole tree and the tag set unmoved and a remedy printed. Without this row, 'rm scripts/check-maintenance.sh' would be cadence forgiveness in one keystroke"
+else
+  fail_ "R11" "expected rc 5 from both with an unchanged tree; got:$R11_DETAIL"
+fi
 rm -rf "$RT"
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -576,6 +648,28 @@ if [ "$CUT_RC" -eq 9 ] && [ "$s8_before" = "$s8_after" ] && [ "$s8_tags_before" 
   pass "S8: a closed row whose class maps to no bump refuses at rc $CUT_RC with nothing written — fail-closed, because the alternative is a class nobody scored shipping as a patch"
 else
   fail_ "S8" "rc=$CUT_RC (want 9); tree moved=$([ "$s8_before" = "$s8_after" ] && echo n || echo y)"
+fi
+
+# S9 — a class nobody could READ, as opposed to one nobody scored.
+#
+# THIS FIXTURE IS WHY THE `BUMP=patch` FALLBACK HAD TO GO. An adversarial
+# review flagged the fallback on principle and judged it "practically a
+# jq-crash-only path". It is not: `ROW_TOKENS` runs the closed rows through
+# `@tsv`, and `@tsv` ERRORS on an object — so `"class": {}` takes the whole jq
+# program down while `UNSHIPPED_IDS`, which never touches @tsv, lists the row
+# perfectly happily. The loop then never runs, nothing reaches the unmapped
+# check, and the old code shipped a PATCH release over work whose class nobody
+# could read. Reachable in one hand-edit of the record, and in exactly the
+# under-bump direction the script's own header calls the dangerous one.
+P9="$ST/unreadable-class"; mk_proj "$P9"; tag_at "$P9" "v1.2.0"
+write_state "$P9" '{"schemaVersion":1,"active_delta":null,"hotfix_retros":[],"cadence":{},"closed":[{"id":"DELTA-013","class":{},"severity":null,"closed_at":"2026-08-01T00:00:00Z","shipped_in":null}]}'
+s9_before="$(tree_manifest "$P9")"; s9_tags_before="$(tag_list "$P9")"
+run_cut "$REPO_ROOT/scripts" "$P9"
+s9_after="$(tree_manifest "$P9")"; s9_tags_after="$(tag_list "$P9")"
+if [ "$CUT_RC" -eq 9 ] && [ "$s9_before" = "$s9_after" ] && [ "$s9_tags_before" = "$s9_tags_after" ]; then
+  pass "S9: a closed row whose 'class' is an object — which makes the token jq fail while the id jq succeeds — refuses at rc $CUT_RC with nothing written and no tag. The fallback this replaced would have cut a PATCH over work nobody could classify"
+else
+  fail_ "S9" "rc=$CUT_RC (want 9); tree moved=$([ "$s9_before" = "$s9_after" ] && echo n || echo y); tagged=$([ "$s9_tags_before" = "$s9_tags_after" ] && echo n || echo y). Output: $CUT_OUT"
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -793,6 +887,96 @@ else
   fail_ "A3" "lint rc=$a3_rc (want 0); cardinality-1 rows=$a3_card; in DELTA manifest=$a3_manifest"
 fi
 
+# ── A5: refusal 2's rc-3 half, pinned AT THE LINE ──────────────────────────
+#
+# An adversarial review found this half unkilled: weakening `-ne 1` to `-eq 0`
+# survives the whole suite, because rc 3 is UNREACHABLE through the script's
+# own flow. The review's own mitigation argument is a subset one, and the
+# honest response is not to shrug at it but to make BOTH halves checkable.
+#
+#   (a) THE SUBSET ARGUMENT, BY EXECUTION. WP5's `_delta_cadence_readable`
+#       accepts "an object with a hotfix_retros ARRAY"; WP2's
+#       `DELTA_STATE_SHAPE` accepts strictly less. So every document that
+#       survives --delta-state-read-strict also satisfies the predicate, and
+#       rc 3 cannot arrive through the front door. Asserted, not assumed.
+#   (b) THE ARM ITSELF, DRIVEN DIRECTLY. The marked line is lifted out of the
+#       product and evaluated against each code WP5's predicate can return.
+#       This is what kills the `-eq 0` mutant: it changes rc 3 from a refusal
+#       into a pass, and nothing else in the suite can see that.
+#
+# Pinning an unreachable backstop is worth the twenty lines because that is
+# exactly what a backstop IS — the thing that has no reachable witness until
+# the day the front door changes.
+# _arm_probe <product-file> <rc> — lift the marked line and evaluate it with
+#   RETRO_RC set to <rc>; echo the resulting RETRO_REFUSE.
+#
+#   EVERY STATEMENT GOES ON ITS OWN LINE, and that is not tidiness. The first
+#   draft joined them with `;` and the lifted line ENDS IN ITS OWN TRAILING
+#   COMMENT — so the `printf` that reads the answer was commented out and every
+#   probe returned the empty string. The row went RED, which is the only reason
+#   it was caught; a harness that had defaulted to "n" on an empty read would
+#   have reported a passing pin over a probe that never ran.
+_arm_probe() {
+  local file="$1" rc="$2" line f out
+  line="$(grep -n '# CUTREL-REFUSE-RETRO$' "$file" | head -1 | cut -d: -f2-)"
+  [ -n "$line" ] || { printf 'NOLINE'; return 0; }
+  f="$(mktemp)"
+  {
+    printf 'RETRO_RC=%s\n' "$rc"
+    printf 'RETRO_REFUSE=n\n'
+    printf '%s\n' "$line"
+    printf 'printf "%%s" "$RETRO_REFUSE"\n'
+  } > "$f"
+  out="$(bash "$f" 2>/dev/null)" || out="ERR"
+  rm -f "$f" 2>/dev/null || true
+  [ -n "$out" ] || out="EMPTY"
+  printf '%s' "$out"
+}
+
+a5_arm=""
+a5_arm_ok=y
+for rc in 0 1 2 3; do
+  got="$(_arm_probe "$CUTREL" "$rc")"
+  a5_arm="$a5_arm [$rc=$got]"
+done
+case "$a5_arm" in
+  *"[0=y]"*) : ;; *) a5_arm_ok=n ;;
+esac
+case "$a5_arm" in
+  *"[1=n]"*) : ;; *) a5_arm_ok=n ;;
+esac
+case "$a5_arm" in
+  *"[2=y]"*) : ;; *) a5_arm_ok=n ;;
+esac
+case "$a5_arm" in
+  *"[3=y]"*) : ;; *) a5_arm_ok=n ;;
+esac
+
+# The subset property, by execution: documents that pass the strict read must
+# also satisfy the cadence lib's readability predicate.
+a5_subset=y
+PS5="$ST/subset"; mk_proj "$PS5"
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/delta-cadence.sh"
+for doc in \
+  "$(state_doc 'null' '[]' '[]')" \
+  "$(state_doc "$ACTIVE_JSON" "[$(open_retro DELTA-007 2)]" "[$(closed_row DELTA-008 fix)]")" \
+  "$(state_doc 'null' "[$(open_retro DELTA-007 0)]" '[]')"
+do
+  write_state "$PS5" "$doc"
+  strict_rc=0
+  strict_doc="$( cd "$PS5" && unset GITHUB_BASE_REF; bash "$REPO_ROOT/scripts/process-checklist.sh" --delta-state-read-strict </dev/null 2>/dev/null )" || strict_rc=$?
+  [ "$strict_rc" -eq 0 ] || { a5_subset=n; continue; }
+  pred_rc=0
+  delta_any_open_retro "$strict_doc" || pred_rc=$?
+  [ "$pred_rc" -ne 3 ] || a5_subset=n
+done
+if [ "$a5_arm_ok" = y ] && [ "$a5_subset" = y ]; then
+  pass "A5: refusal 2's arm, lifted from the product and driven directly, refuses every code that is not a definite 'none owed' —$a5_arm (0 open, 1 none, 2 and 3 refuse) — and the subset argument holds by execution: every document the strict read accepts also satisfies WP5's readability predicate, so rc 3 is unreachable through the front door and this is a genuine backstop rather than dead code"
+else
+  fail_ "A5" "arm behaviour:$a5_arm (want [0=y] [1=n] [2=y] [3=y]); strict-read/predicate subset property holds=$a5_subset"
+fi
+
 rm -rf "$ST"
 
 # ════════════════════════════════════════════════════════════════════════════
@@ -933,6 +1117,64 @@ _m7_check() {
   fi
 }
 _mutate m7 '# CUTREL-MAJOR-REVALIDATE$' 's|^\(.*# CUTREL-MAJOR-REVALIDATE\)$|  if false; then :; fi   # CUTREL-MAJOR-REVALIDATE|' _m7_check
+
+# ── m6: the arm that catches every OTHER checker exit code ──────────────────
+# THE REVIEWER'S SURVIVING MUTANT, now with a witness. It weakens `*)` from a
+# refusal to a pass; R11 is the only row that can see it, which is the whole
+# point of adding R11.
+_m6_check() {
+  local name="$1" P SD rc tags_before tags_after
+  P="$MT/$name-proj"; SD="$MT/$name-sd"
+  mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" "$(state_doc 'null' '[]' "[$(closed_row DELTA-008 fix)]")"
+  # The mutant tree already exists in $MUT_SD; give it a checker that is GONE,
+  # which is the keystroke the arm exists to refuse.
+  mkdir -p "$SD"; cp -R "$MUT_SD" "$SD/scripts"
+  rm -f "$SD/scripts/check-maintenance.sh"
+  tags_before="$(tag_list "$P")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$SD/scripts/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  tags_after="$(tag_list "$P")"
+  if [ "$rc" -eq 0 ] && [ "$tags_before" != "$tags_after" ]; then
+    pass "m6: with the catch-everything-else arm weakened to a pass, DELETING scripts/check-maintenance.sh lets the mutant cut a release (rc $rc, a new tag appeared) — cadence forgiveness in one keystroke. R11 sees it; before R11 existed this mutant survived the entire suite at 31/0. $MUT_REPORT"
+  else
+    fail_ "m6" "the mutant still refused (rc $rc, tags unchanged=$([ "$tags_before" = "$tags_after" ] && echo y || echo n)) — R11 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m6 '# CUTREL-CADENCE-OTHER$' 's|^\(.*\)# CUTREL-CADENCE-OTHER$|  *) CADENCE_REFUSE=n ;;   # CUTREL-CADENCE-OTHER|' _m6_check
+
+# ── m8: refusal 2's rc-3 half ───────────────────────────────────────────────
+# The reviewer's second surviving mutant. It is killed by A5's line-level arm
+# and by nothing else, because rc 3 is unreachable through the front door —
+# which is exactly why A5 drives the line directly instead of a fixture.
+_m8_check() {
+  local name="$1" got_3 got_0 got_1
+  got_3="$(_arm_probe "$MUT_SD/cut-release.sh" 3)"
+  got_0="$(_arm_probe "$MUT_SD/cut-release.sh" 0)"
+  got_1="$(_arm_probe "$MUT_SD/cut-release.sh" 1)"
+  if [ "$got_3" = n ] && [ "$got_0" = y ]; then
+    pass "m8: with the backstop narrowed from 'anything but a definite none-owed' to 'only rc 0', an UNDETERMINED ledger (rc 3) stops refusing (rc3=$got_3, rc0=$got_0, rc1=$got_1) — A5 sees it, and only A5 can, since rc 3 has no reachable fixture. $MUT_REPORT"
+  else
+    fail_ "m8" "the mutant still refuses rc 3 (rc3=$got_3, rc0=$got_0, rc1=$got_1) — A5 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m8 '# CUTREL-REFUSE-RETRO$' 's|^\(.*# CUTREL-REFUSE-RETRO\)$|  if [ "$RETRO_RC" -eq 0 ]; then RETRO_REFUSE=y; fi   # CUTREL-REFUSE-RETRO|' _m8_check
+
+# ── m9: the semver fallback that used to be `BUMP=patch` ────────────────────
+_m9_check() {
+  local name="$1" P rc newtag
+  P="$MT/$name-proj"; mk_proj "$P"; tag_at "$P" "v1.2.0"
+  write_state "$P" '{"schemaVersion":1,"active_delta":null,"hotfix_retros":[],"cadence":{},"closed":[{"id":"DELTA-013","class":{},"severity":null,"closed_at":"2026-08-01T00:00:00Z","shipped_in":null}]}'
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/cut-release.sh" </dev/null >/dev/null 2>&1 ) || rc=$?
+  newtag="$(tag_list "$P" | grep -v '^v1\.2\.0$' || true)"
+  if [ "$rc" -eq 0 ] && [ "$newtag" = "v1.2.1" ]; then
+    pass "m9: restoring the old \`BUMP=patch\` fallback makes the mutant cut $newtag (rc $rc) over a row whose class nobody could read — S9 sees it. This is the reachable form of the under-bump the file's own header calls dangerous. $MUT_REPORT"
+  else
+    fail_ "m9" "the mutant did not cut a patch ('$newtag', rc $rc) — S9 cannot see this line. $MUT_REPORT"
+  fi
+}
+_mutate m9 '# CUTREL-SEMVER-UNREADABLE$' 's|^\(.*\)# CUTREL-SEMVER-UNREADABLE$|if [ -z "$BUMP" ]; then BUMP=patch; fi; if false; then   # CUTREL-SEMVER-UNREADABLE|' _m9_check
 
 rm -rf "$MT"
 


### PR DESCRIPTION
## What

Delta Track **WP7** — the design's own named linchpin ("where a bug ships a wrong version number or a release cuts over an open retro"), plus **BL-214**'s fix and §3.1's severability test.

### `scripts/cut-release.sh`

**Two phases with a marked boundary. PHASE A reads and refuses** — opens no file for writing and runs no tool that writes. **PHASE B writes cheapest-to-undo first**: major-only revalidation → changelog promotion → `shipped_in` → the tag *last*, because the tag is what the pipelines watch.

- **The three refusals in §9.2's order**: open delta → open hotfix retro → overdue *or unmeasurable* cadence. This is the first real consumer of two contracts built for it: WP5's strict-read (rc 3 unreadable / rc 4 absent — **both refuse**; an unreadable ledger never renders as "none owed") and WP6's cadence exits (**refuse on 1 and 2**; the checker's report is surfaced *verbatim*, because it names unmeasurable arms even inside an overdue answer).
- **Semver, tool-decided** (§9.1). "Since the last tag" is implemented as `shipped_in == null` — that *is* the question, and it survives clock skew, re-tagged history and hand-made tags where a date comparison does not (all four verified by execution). The class→bump map is retunable policy; **the precedence order is machinery and is not configurable**.
- **Tag format is constrained, not chosen** (C7): exactly `vMAJOR.MINOR.PATCH`, re-checked against `^v[0-9]+\.[0-9]+\.[0-9]+$`. A glob would **not** have worked — `v[0-9]*.[0-9]*.[0-9]*` matches `v1.2.0-rc1` because `*` spans the suffix. GitLab's lanes are version-strict while GitHub's and Bitbucket's are not, so a suffixed tag builds on two hosts and silently does nothing on the third.

### BL-214 — a passing gate no longer plants its own next failure

`:(exclude)docs/snapshots` added at all four call sites across the two sync siblings. Beyond the fix: **B1 makes "kept textually identical" a checked property** (both bodies compared byte-for-byte modulo the name, so a behaviour-neutral edit to one sibling alone goes RED), and B5 covers the committed-snapshot shape an untracked-only test would have missed.

### The severability test — and what running it actually enumerated

§3.1 says the revert is "the seam block in `process-checklist.sh`", singular. Running the test produced the real set: **six consumers**, found across three review rounds — `process-checklist.sh`, `upgrade-project.sh`, `validate.sh`, `check-maintenance.sh`, `.github/workflows/lint.yml`'s job, and a direct registration in `tests/full-project-test-suite.sh`.

Two findings worth carrying forward:

1. **Functional severability is already free** — every consumer fails soft by design (measured: probes answer identically with the module deleted and no revert). So the meaningful instrument is the *reference sweep*, not the behavioural one, and the mutation is measured rather than asserted.
2. **A multi-line construct must be dropped as a construct.** The old line-based drop removed a `run_child_suite` call's head and third argument but not its second, leaving an orphaned continuation line *with its trailing backslash* — and **`bash -n` passes on that**, confirmed by construction, so no parse check could ever have caught it. `_drop_child_suite_calls` now drops whole calls with its pattern **derived from the module manifest** (a future module file registered directly is covered without anyone remembering), and `V1c` resolves every registered target (198 stat'd) — catching even what a text sweep structurally cannot.

## Verification trail (fable pr-reviewer, xhigh, three rounds)

- **Round 1 (major_concerns):** no product behaviour refuted. §9.2 held against an instrument *stronger* than the suite's — 12 refusal paths under whole-tree md5 including `.git`, the scripts tree, and a fresh-`TMPDIR` watch: zero residue everywhere; meta-mutations proved the instruments real. The blocker was a coverage hole: the cadence catch-all arm was reachable and load-bearing (a **deleted** checker → rc 127 → refusal, verified) but unpinned, so a mutant survived 31/0 and `rm scripts/check-maintenance.sh` would have become cadence forgiveness in one keystroke.
- **Fix round 1:** pinned, with the reviewer's own mutant carried in-suite permanently. **And a note both the reviewer and I had under-graded turned out to be a live defect** — `@tsv` errors on an object, so a malformed `"class": {}` killed the token query while the id query succeeded, and the old fallback shipped a **patch** over unclassifiable work. Confirmed by execution: the old product cut `v1.2.1` at rc 0 and backfilled `shipped_in` onto the unclassifiable row. It refuses now.
- **Fix round 2:** the sixth consumer, taken pre-PR rather than as a fast-follow because it falsified the severability test's own defining claim — which then exposed the orphaned-continuation defect above.
- **Final: approve.** Every finding closed with a witness that rebuilds the old blindness and watches the new instrument catch it; the reviewer's seventh-consumer hunt across every unopened file class found nothing. Review record: `.superpowers/sdd/2026-08-02-delta-track-v1/wp7-review.md` (session artifact).

Suites: WP7 37/0, severability 14/0, BL-214 11/0 (watched RED first at 5/6); neighbours green; run-lints 15/15; boundary lint rc 0 with `cut-release.sh` in the DELTA manifest and the seam allowlist still at one; no live remotes and no real tag pushes anywhere.

## Open decision and recorded gaps

- **`cut-release.sh` does not `git commit`** — the tag names a pre-promotion HEAD and the operator finishes with printed steps. Both the implementer and the reviewer independently favour **commit-then-tag** (skipping the final step publishes a tag whose tree lacks its own changelog entry, and it normalizes tag-moving; the feared gate refusal is largely defused by the docs-only bypass, and its worst state is byte-identical to a residual the design already accepts). **Held for Karl** — shipped unchanged here, with the `git tag -f` step now an unmissable banner.
- `--finalize-phase 4` deliberately **not** wired (C8/Q3 — undecided); no semver override flag added (§13-R2).
- Tracked gaps recorded, not fixed here: the `breaking` marker has no writer (the major lane is tested but production-unreachable in v1), and `check-maintenance.sh` loses its only behaviour coverage under a sever.

Closes BL-214.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
