### PR TITLE
feat(brownfield): WP3 — in-core enabling arms, bounded TDD exemption, loud loss detection

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -509,6 +509,7 @@ jobs:
             tests/test-validate-phase-state-gates.sh
             tests/test-walk-phase-lifecycle.sh
             tests/test-brownfield-wp2-scout-sections.sh
+            tests/test-brownfield-wp3-adoption-arms.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/init.sh
+++ b/init.sh
@@ -1419,9 +1419,21 @@ create_project() {
   #     upgrade. The source-closure check (tests/test-scaffold-source-closure.sh)
   #     is the class fix: it fails if any shipped script sources an unshipped
   #     sibling.
+  #   • adoption-stamp.sh — BOTH check-phase-gate.sh and pre-commit-gate.sh
+  #     source it (the brownfield adoption enabling arms: the `adopted` flag
+  #     accessor, the pre-adoption TDD bound, the regenerate-path loss
+  #     detector). It is a sourced lib like its neighbours above, so it gets NO
+  #     chmod — the `chmod +x` list below is entry scripts only. Shipping it is
+  #     NOT a behaviour change for a greenfield project: with no adoption block
+  #     in the manifest the accessor reads NOT ADOPTED and every arm no-ops
+  #     (pinned by A2/T5 in tests/test-brownfield-wp3-adoption-arms.sh). It
+  #     closes a DANGLING SOURCE in two shipped gates — and the closure test is
+  #     what caught it after two reviews had both graded the omission
+  #     "harmless today". It was not: it is a hard gate.
   cp "$SCRIPT_DIR/scripts/lib/tdd-classify.sh"      scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/phase2-state.sh"      scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/cdf-refresh.sh"       scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/adoption-stamp.sh"    scripts/lib/
   cp "$SCRIPT_DIR/scripts/install-filesystem-gates.sh" scripts/
   cp "$SCRIPT_DIR/scripts/detect-out-of-band-commits.sh" scripts/
   cp "$SCRIPT_DIR/scripts/hooks/record-claude-commit.sh" scripts/hooks/

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -16,6 +16,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # BL-046: uses run_with_timeout + prompt_yes_no only — source core subset.
 source "$SCRIPT_DIR/lib/helpers-core.sh"
+# Brownfield adoption WP3 — the in-core enabling arms (the `adopted` flag
+# accessor and the regenerate-path loss detector). Guarded: a checkout that
+# predates adoption simply has no such file, and the arm below no-ops.
+if [ -f "$SCRIPT_DIR/lib/adoption-stamp.sh" ]; then
+  # shellcheck source=scripts/lib/adoption-stamp.sh
+  source "$SCRIPT_DIR/lib/adoption-stamp.sh"
+fi
 
 # ── Argv parser (BL-060) ─────────────────────────────────────────
 # Adversarial cert re-walker-4 surfaced that scenarios invoke this
@@ -2532,6 +2539,50 @@ if [ "$current_phase" -ge 2 ] && [ -f "PRODUCT_MANIFESTO.md" ]; then
   fi
 fi
 # BL-102-MARKET-SIGNAL-END
+
+# --- Brownfield adoption: stamp acceptance + loss detection ---
+# BF-ADOPT-GATE-BEGIN
+# The gate's half of the brownfield enabling arms (design §10-WP3 deliverable
+# 4, §12-12). It READS the adoption flag through the single accessor and adds
+# no logic to any existing predicate (§9).
+#
+# THE [WARN] TRAP APPLIES HERE AND THE CHOICE IS DELIBERATE. In this script the
+# label is cosmetic — the exit predicate is `if [ $issues -eq 0 ]`, so an
+# exemption is the ABSENCE of an increment and a block is its presence. This
+# arm INCREMENTS, on purpose: a project whose committed manifest records an
+# adoption while the live manifest no longer does has silently un-adopted, and
+# a silent un-adoption is precisely the failure §12-12 says cannot be prevented
+# and must therefore never be quiet. The upstream regenerating writer lives in
+# another repository; the only thing in this design's control is refusing to
+# pass the gate while the record is missing. Removing the increment — or the
+# detector it calls — turns the failure back into silence.
+#
+# DELIBERATELY NOT FENCED BY `skip_later_gate`. BL-166 confines a `--gate`
+# scoped run to the NAMED gate's checks, and that fence is right for checks
+# that BELONG to a later gate. This one belongs to no gate: the adoption record
+# is a precondition of every arm that reads the flag, so a scoped run that
+# passed while the record was missing would be the same silence under a
+# narrower heading. Stated here because the omission is a decision, not an
+# oversight.
+if command -v soif_adoption_integrity_lost >/dev/null 2>&1; then
+  if soif_adoption_integrity_lost ".claude/manifest.json"; then
+    echo ""
+    echo -e "${BOLD}Adoption Stamp Integrity${NC}"
+    soif_adoption_report_loss ".claude/manifest.json"
+    issues=$((issues + 1))   # BF-ADOPT-GATE-ISSUES
+  elif soif_adoption_adopted ".claude/manifest.json"; then
+    echo ""
+    echo -e "${BOLD}Adoption Stamp Integrity${NC}"
+    # `|| var=…` is not decoration: this script runs under `set -e`, and a bare
+    # `var=$(cmd)` takes cmd's exit status, so a jq that failed here would abort
+    # the WHOLE gate mid-run — a reporting line taking the enforcement down with
+    # it. The fallbacks keep a cosmetic read cosmetic.
+    cpg_adopt_scenario=$(soif_adoption_read ".claude/manifest.json" '.adoption.scenario // "unknown"') || cpg_adopt_scenario="unknown"
+    cpg_adopt_at=$(soif_adoption_read ".claude/manifest.json" '.adoption.adoptedAt // "unknown"') || cpg_adopt_at="unknown"
+    echo -e "${GREEN}[OK]${NC} Adoption stamp present and intact (scenario: $cpg_adopt_scenario, adopted: $cpg_adopt_at)"
+  fi
+fi
+# BF-ADOPT-GATE-END
 
 echo ""
 if [ $issues -eq 0 ]; then

--- a/scripts/lib/adoption-stamp.sh
+++ b/scripts/lib/adoption-stamp.sh
@@ -1,0 +1,283 @@
+#!/usr/bin/env bash
+# scripts/lib/adoption-stamp.sh
+#
+# Brownfield adoption — THE IN-CORE ENABLING ARMS (design
+# docs/designs/2026-08-02-brownfield-adoption-v1.md §3.1/§3.2, §8.5, §10-WP3).
+#
+# This file is CORE, not module code. §3.2 settles why the arms cannot live in
+# an external kit: an outsider can only fake history, and a key nothing reads
+# is not enforcement. The arms here are deliberately tiny — §10 calls WP3
+# "three arms and a stamp" against a driver (WP4–WP7) that is most of the
+# build. Nothing in this file sources module code, and nothing here knows the
+# driver exists; the driver sources this, never the reverse (M3).
+#
+# Four things live here, and only four:
+#   1. soif_adoption_adopted          — THE `adopted` flag accessor. One
+#                                       function, one place, so every gate arm
+#                                       reads the flag through a single surface
+#                                       and a mutation proof has ONE thing to
+#                                       neuter.
+#   2. soif_adoption_stamp            — the writer. One additive jq merge,
+#                                       EXACTLY the soif_currency_stamp filter
+#                                       form, written ONCE at adoption from a
+#                                       single call site in the driver. It is
+#                                       NOT a backfill and must never become
+#                                       one (the operating-model design's F1
+#                                       correction on soif_currency_stamp:
+#                                       birth-stamp-only, never a backfill
+#                                       precedent).
+#   3. soif_adoption_pre_adoption_commit — the BOUND the TDD arm honours.
+#   4. soif_adoption_integrity_lost / _report_loss — the regenerate-path
+#                                       detector.
+#
+# ── WHY THE MANIFEST, AND WHY A MERGE (§8.5, C2) ────────────────────────────
+# The home is `.claude/manifest.json`'s top-level `adoption` block. The reason
+# is merge-versus-re-stamp, NOT "the manifest has no wholesale writer" — that
+# v1.0 rationale was REFUTED (§0.2 R-BF-1): fix_framework_manifest() delegates
+# to the upstream CDF init script, which rewrites the manifest wholesale from a
+# hardcoded key set carrying no Solo keys at all. BOTH state files have a
+# regenerate-on-missing writer and neither location is categorically safe. What
+# separates them: `phase-state.json` is additionally RE-STAMPED on every
+# upgrade against a file that exists (`review_gate_enforced = True`,
+# unconditional), while every writer that touches an EXISTING manifest is an
+# additive merge — `.host = $h` (check-gate.sh, upgrade-project.sh),
+# `. + {deployment, poc_mode, enforcement_level}` (the BL-030 backfill),
+# `. + {deployment, poc_mode}` (the BL-061 refresh), and soif_currency_stamp's
+# `.currency = $currency`.
+#
+# ── THE LOSS CANNOT BE PREVENTED (§12-12) ───────────────────────────────────
+# The upstream manifest writer lives in a DIFFERENT REPOSITORY and is outside
+# this design's control. When the manifest is lost to any cause and
+# regenerated, the stamp is gone with it and the project silently becomes
+# un-adopted. This file therefore does not pretend to prevent that. It DETECTS
+# it and REPORTS IT LOUDLY, using the one witness that survives a wholesale
+# rewrite of the working copy: the manifest is a TRACKED file, so the copy
+# committed at HEAD still carries the block the working copy lost. The honest
+# statement of the property: the design cannot stop the erasure, so it refuses
+# to be quiet about it.
+#
+# The real assumption underneath, worth stating plainly (§12-12): that the
+# upstream manifest writer stays MISSING-FILE-GATED. If it ever becomes
+# unconditional, every adopted project un-adopts on the next repair run — and
+# the detector here is what makes that visible on the very next gate.
+#
+# bash-3.2 safe: no associative arrays, no `${var,,}`, no `[[ -v ]]`, no
+# `((x++))` under set -e. Every helper is set -e safe — the return-1 arms are
+# only ever reached through an `if` condition at the call sites.
+
+# soif_adoption_read <manifest> <jq-filter> — thin jq -r reader over the block.
+# Mirrors soif_currency_read. Empty output on any failure.
+soif_adoption_read() {
+  jq -r "$2" "$1" 2>/dev/null
+}
+
+# ── 1. THE ACCESSOR ─────────────────────────────────────────────────────────
+# soif_adoption_adopted [manifest] — returns 0 iff this project is ADOPTED.
+#
+# ABSENT FLAG ⇒ NOT ADOPTED, and that is load-bearing: a greenfield project
+# must be unaffected by every arm in this WP. So a missing manifest, a manifest
+# with no `adoption` block, `adopted: false`, malformed JSON, and a host with
+# no jq ALL read NOT ADOPTED. The predicate fails CLOSED in the direction that
+# leaves existing behaviour exactly as it was.
+soif_adoption_adopted() {
+  local manifest="${1:-.claude/manifest.json}"
+  command -v jq >/dev/null 2>&1 || return 1
+  [ -f "$manifest" ] || return 1
+  jq -e '.adoption.adopted == true' "$manifest" >/dev/null 2>&1 || return 1   # BF-ADOPT-FLAG-READ
+  return 0
+}
+
+# ── 2. THE STAMP ────────────────────────────────────────────────────────────
+# soif_adoption_stamp <manifest> <scenario> <landed_phase> \
+#                     <kindA_json> <kindB_json> <kindC_json> \
+#                     <blockers_json> <scanner_report_sha256>
+#
+# Assembles §8.5's block and jq-merges it into <manifest> with the
+# atomic-rename pattern, exactly as soif_currency_stamp does. Additive: every
+# pre-existing manifest field is preserved.
+#
+# EXACTLY ONE CALL SITE, in the driver, marked. Written once, at adoption,
+# never re-stamped. That call site DOES NOT EXIST YET and its absence is
+# correct, not an oversight: WP3 ships the enabling arms and WP4 ships the
+# driver that calls this. Until then the only callers are the WP3 suites. When
+# the driver lands, ONE marked call is the whole budget — a second one turns a
+# birth stamp into a backfill, which is the mistake soif_currency_stamp's own
+# F1 correction exists to forbid.
+#
+# Two computed fields are NOT parameters, deliberately:
+#   adoptedAt        — the stamp's own clock. A caller-supplied date is a
+#                      caller-supplied lie waiting to happen.
+#   adoptedAtCommit  — `git rev-parse HEAD` at stamp time: the PRE-ADOPTION
+#                      TIP, i.e. the parent the adoption commit will land on.
+#                      §8.5's content list is author-proposed and carries no
+#                      commit anchor, but the TDD arm's BOUND is defined
+#                      against the adoption commit and a bound needs an anchor.
+#                      It is recorded HERE, in the stamp, and NOT read from
+#                      `.claude/last-checked-commit.txt`: that file is the
+#                      §8.7 detection baseline and the shipped
+#                      `--reset-detection-baseline` operator surface rewrites
+#                      it, which would silently MOVE the TDD exemption
+#                      boundary. Two controls, two anchors.
+#
+# No-ops (rc 0, nothing written) when jq is unavailable or the manifest does
+# not exist — the `[ -f "$manifest" ] || return 0` idiom. REFUSES (rc 1,
+# nothing written) on a scenario outside §8.5's enum: a durable record that
+# says how a project got here must not be written malformed.
+soif_adoption_stamp() {
+  local manifest="${1:-.claude/manifest.json}"
+  local scenario="${2:-}"
+  local landed_phase="${3:-0}"
+  local kind_a="${4:-[]}" kind_b="${5:-[]}" kind_c="${6:-[]}"
+  local blockers="${7:-[]}" scanner_sha="${8:-}"
+
+  case "$scenario" in
+    completed|in-flight) : ;;
+    *) return 1 ;;   # BF-ADOPT-SCENARIO-ENUM
+  esac
+  case "$landed_phase" in ''|*[!0-9]*) landed_phase=0 ;; esac
+
+  command -v jq >/dev/null 2>&1 || return 0
+  [ -f "$manifest" ] || return 0
+
+  local adopted_at anchor
+  adopted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || adopted_at=""
+  anchor="$(git rev-parse HEAD 2>/dev/null)" || anchor=""
+
+  local adoption_json
+  adoption_json="$(jq -n \
+    --arg at "$adopted_at" \
+    --arg anchor "$anchor" \
+    --arg scenario "$scenario" \
+    --argjson landed "$landed_phase" \
+    --argjson kindA "$kind_a" \
+    --argjson kindB "$kind_b" \
+    --argjson kindC "$kind_c" \
+    --argjson blockers "$blockers" \
+    --arg sha "$scanner_sha" \
+    '{schemaVersion: 1, adopted: true, adoptedAt: $at, adoptedAtCommit: $anchor,
+      scenario: $scenario, landedPhase: $landed,
+      certification: {kindA: $kindA, kindB: $kindB, kindC: $kindC},
+      blockersAccepted: $blockers, scannerReportSha256: $sha}')" || return 1
+
+  # Merge — atomic rename, the soif_currency_stamp filter's own form.
+  jq --argjson adoption "$adoption_json" '.adoption = $adoption' \
+    "$manifest" > "$manifest.tmp" && mv "$manifest.tmp" "$manifest"   # BF-ADOPT-STAMP-MERGE
+}
+
+# ── 3. THE BOUND ────────────────────────────────────────────────────────────
+# soif_adoption_pre_adoption_commit [manifest] — returns 0 iff the commit about
+# to be authored belongs to PRE-ADOPTION history, i.e. sits at or before the
+# adoption commit (§5.3's kind (c) scope, in as many words).
+#
+# THE BOUND IS THE WHOLE DESIGN. An exemption scoped to pre-adoption commits is
+# what §5.3 specifies; an UNBOUNDED one is a permanent TDD waiver wearing an
+# adoption badge, and §4.5 is explicit that no arm anywhere exempts a commit
+# written after adoption day.
+#
+# Mechanics. The commit-msg surface judges a PROSPECTIVE commit whose parent is
+# HEAD, so "at or before the adoption commit" is decided against HEAD. Let P be
+# the recorded pre-adoption tip (`adoptedAtCommit`) and A the adoption commit,
+# P's child:
+#   • HEAD == P            — the adoption window: the stamp exists, A has not
+#                            landed. The prospective commit is AT the boundary.
+#                            EXEMPT.
+#   • P is a strict
+#     ancestor of HEAD     — A has landed and is in this commit's history.
+#                            POST-adoption. NOT EXEMPT. This is the bound.
+#   • P not an ancestor    — a branch cut before adoption. Pre-adoption history.
+#                            EXEMPT.
+#
+# HONEST REACHABILITY NOTE, because a reviewer will ask and the answer is not
+# obvious: the gate only ever judges PROSPECTIVE commits, so an adoptee's
+# existing history is never re-judged by construction and this arm's exempting
+# window is genuinely narrow — chiefly the adoption run itself, and commits made
+# on a tree that carries the stamp but not yet the adoption commit. That is
+# exactly the set §5.3 names, and the arm claims nothing wider.
+#
+# Every unknown fails CLOSED (NOT exempt): not adopted, no anchor recorded, an
+# anchor this repository does not contain, an unborn HEAD, or no git at all.
+soif_adoption_pre_adoption_commit() {
+  local manifest="${1:-.claude/manifest.json}"
+  soif_adoption_adopted "$manifest" || return 1
+
+  local anchor head
+  anchor="$(soif_adoption_read "$manifest" '.adoption.adoptedAtCommit // ""')" || anchor=""
+  [ -n "$anchor" ] || return 1
+  anchor="$(git rev-parse --verify --quiet "${anchor}^{commit}" 2>/dev/null)" || anchor=""
+  [ -n "$anchor" ] || return 1
+  head="$(git rev-parse --verify --quiet 'HEAD^{commit}' 2>/dev/null)" || head=""
+  [ -n "$head" ] || return 1
+
+  if [ "$anchor" != "$head" ] && git merge-base --is-ancestor "$anchor" "$head" 2>/dev/null; then   # BF-ADOPT-BOUND
+    return 1
+  fi
+  return 0
+}
+
+# ── 4. THE REGENERATE-PATH DETECTOR ─────────────────────────────────────────
+# soif_adoption_integrity_lost [manifest] — returns 0 iff this project's
+# COMMITTED manifest records an adoption but the WORKING COPY no longer does.
+#
+# That is the signature of the regenerate path (§12-12): the manifest is lost
+# to some cause, the repair path regenerates it wholesale from an upstream key
+# set carrying no Solo keys, and the project silently un-adopts. The committed
+# copy at HEAD is the witness — it is not rewritten by a working-copy
+# regeneration, and it needs no second state file, so the dual-source ban holds.
+#
+# Every arm fails QUIET (rc 1, no finding) rather than risk a false alarm: no
+# jq, no git, a manifest never committed, or a HEAD copy that never claimed
+# adoption. The one honest residual is stated here rather than hidden: a stamp
+# written but not yet COMMITTED has no witness, so a manifest regenerated
+# inside the adoption window is a loss this cannot see. That window is minutes
+# long and ends at the adoption commit.
+soif_adoption_integrity_lost() {
+  local manifest="${1:-.claude/manifest.json}"
+  command -v jq >/dev/null 2>&1 || return 1
+  git rev-parse --git-dir >/dev/null 2>&1 || return 1
+
+  # Both halves of the comparison must name the SAME file. `git show HEAD:<p>`
+  # resolves <p> from the REPO ROOT, while `[ -f <p> ]` in the accessor
+  # resolves it from the CWD. Called from a subdirectory those are different
+  # files, and the mismatch reads as "committed but missing from the working
+  # tree" — a FALSE ALARM, the failure direction this repo has already paid for
+  # twice (the false-FAIL doctrine behind BL-122/BL-149). `--show-prefix` is
+  # empty only at the top level and, unlike comparing `--show-toplevel` to
+  # $PWD, it is immune to symlinked temp roots.
+  local prefix
+  prefix="$(git rev-parse --show-prefix 2>/dev/null)" || return 1
+  [ -z "$prefix" ] || return 1
+
+  local head_copy
+  head_copy="$(git show "HEAD:$manifest" 2>/dev/null)" || return 1
+  [ -n "$head_copy" ] || return 1
+  printf '%s' "$head_copy" | jq -e '.adoption.adopted == true' >/dev/null 2>&1 || return 1
+
+  # HEAD says adopted. If the working copy still says so, nothing was lost.
+  if soif_adoption_adopted "$manifest"; then
+    return 1
+  fi
+  return 0   # BF-ADOPT-LOSS-DETECT
+}
+
+# soif_adoption_report_loss [manifest] — the LOUD report. stderr, named cause,
+# concrete repair. Printing is all this does; the CALLER owns the verdict (in
+# check-phase-gate.sh that means an `issues` increment, because in that script
+# the [WARN]/[FAIL] label is cosmetic and the increment is the whole gate).
+soif_adoption_report_loss() {
+  local manifest="${1:-.claude/manifest.json}"
+  {
+    echo "[FAIL] Adoption stamp LOST from $manifest."
+    echo "       The copy committed at HEAD records this project as ADOPTED; the working"
+    echo "       copy does not. The project has silently un-adopted: every gate arm that"
+    echo "       reads the adoption flag now reads FALSE, and the certification record of"
+    echo "       how this project entered the framework is gone from the live manifest."
+    echo "       LIKELY CAUSE: the manifest was missing and a repair path regenerated it"
+    echo "       wholesale from the upstream framework's own key set, which carries none"
+    echo "       of this framework's keys. That writer is upstream and cannot be stopped"
+    echo "       from here — which is why this is reported rather than prevented."
+    echo "       REPAIR (re-merges only the adoption block, keeps the regenerated rest):"
+    echo "         git show HEAD:$manifest | jq '.adoption' > /tmp/adoption.json && \\"
+    echo "         jq --slurpfile a /tmp/adoption.json '.adoption = \$a[0]' $manifest \\"
+    echo "           > $manifest.tmp && mv $manifest.tmp $manifest"
+  } >&2
+}

--- a/scripts/lib/adoption-stamp.sh
+++ b/scripts/lib/adoption-stamp.sh
@@ -61,6 +61,16 @@
 # unconditional, every adopted project un-adopts on the next repair run — and
 # the detector here is what makes that visible on the very next gate.
 #
+# ── FORWARD DEPENDENCY FOR WP4 — READ THIS BEFORE SHIPPING THE DRIVER ───────
+# `init.sh` copies `scripts/lib/` files into a scaffolded project BY EXPLICIT
+# NAME, and THIS FILE IS NOT ON THAT LIST. Downstream that is harmless today:
+# the gate copies guard their source with `[ -f … ]` and their calls with
+# `command -v`, so every arm here no-ops and greenfield behaviour is unchanged
+# (pinned by A2 and T5). But it means WP4's driver MUST ship
+# `scripts/lib/adoption-stamp.sh` into the adoptee — otherwise every arm in
+# this WP silently no-ops on the very projects it was built for, which is the
+# same silence §12-12 is written against, arriving by a different door.
+#
 # bash-3.2 safe: no associative arrays, no `${var,,}`, no `[[ -v ]]`, no
 # `((x++))` under set -e. Every helper is set -e safe — the return-1 arms are
 # only ever reached through an `if` condition at the call sites.
@@ -69,6 +79,45 @@
 # Mirrors soif_currency_read. Empty output on any failure.
 soif_adoption_read() {
   jq -r "$2" "$1" 2>/dev/null
+}
+
+# ── The committed witness (shared primitive) ────────────────────────────────
+# _soif_adoption_head_copy_adopted [manifest] — 0 iff the copy of <manifest>
+# COMMITTED AT HEAD records an adoption.
+#
+# ONE primitive, TWO consumers, and that is deliberate: the loss detector uses
+# it to tell "the record was here and is gone" from "there was never a record",
+# and the BOUND uses it to tell the adoption window from everything after it.
+# Both questions are the same question — "has the adoption already landed in
+# history?" — and answering it in one place means one thing to mutate and no
+# second state file, so the dual-source ban holds.
+#
+# Returns non-zero both when HEAD's copy is NOT adopted and when the question
+# cannot be answered at all (no jq, no git, off-root, never committed). The
+# two consumers want opposite things from "cannot answer" and each says so at
+# its own call site rather than pushing a third state through this one.
+_soif_adoption_head_copy_adopted() {
+  local manifest="${1:-.claude/manifest.json}"
+  command -v jq >/dev/null 2>&1 || return 1
+  git rev-parse --git-dir >/dev/null 2>&1 || return 1
+
+  # Both halves of every comparison built on this must name the SAME file.
+  # `git show HEAD:<p>` resolves <p> from the REPO ROOT while `[ -f <p> ]`
+  # resolves it from the CWD; called from a subdirectory those are different
+  # files, and the mismatch reads as "committed but missing from the working
+  # tree" — a FALSE ALARM, the failure direction this repo has already paid for
+  # twice (the false-FAIL doctrine behind BL-122/BL-149). `--show-prefix` is
+  # empty only at the top level and, unlike comparing `--show-toplevel` to
+  # $PWD, it is immune to symlinked temp roots.
+  local prefix
+  prefix="$(git rev-parse --show-prefix 2>/dev/null)" || return 1
+  [ -z "$prefix" ] || return 1
+
+  local head_copy
+  head_copy="$(git show "HEAD:$manifest" 2>/dev/null)" || return 1
+  [ -n "$head_copy" ] || return 1
+  printf '%s' "$head_copy" | jq -e '.adoption.adopted == true' >/dev/null 2>&1 || return 1
+  return 0
 }
 
 # ── 1. THE ACCESSOR ─────────────────────────────────────────────────────────
@@ -139,6 +188,17 @@ soif_adoption_stamp() {
   command -v jq >/dev/null 2>&1 || return 0
   [ -f "$manifest" ] || return 0
 
+  # ENFORCE "written once, at adoption, never re-stamped" — do not merely
+  # assert it in a header. Left unenforced, "one call site" is convention, and
+  # a second stamp SILENTLY MOVES adoptedAtCommit to the current tip, which
+  # re-opens the TDD exemption window at will; the loss detector cannot see it
+  # because both copies read adopted. Refusing here makes the property
+  # structural. If a driver ever needs a legitimate scenario transition, that is
+  # a design amendment with its own function — not a silent overwrite.
+  if jq -e '.adoption.adopted == true' "$manifest" >/dev/null 2>&1; then
+    return 1   # BF-ADOPT-RESTAMP-REFUSE
+  fi
+
   local adopted_at anchor
   adopted_at="$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || adopted_at=""
   anchor="$(git rev-parse HEAD 2>/dev/null)" || anchor=""
@@ -174,28 +234,66 @@ soif_adoption_stamp() {
 # adoption badge, and §4.5 is explicit that no arm anywhere exempts a commit
 # written after adoption day.
 #
-# Mechanics. The commit-msg surface judges a PROSPECTIVE commit whose parent is
-# HEAD, so "at or before the adoption commit" is decided against HEAD. Let P be
-# the recorded pre-adoption tip (`adoptedAtCommit`) and A the adoption commit,
-# P's child:
-#   • HEAD == P            — the adoption window: the stamp exists, A has not
-#                            landed. The prospective commit is AT the boundary.
-#                            EXEMPT.
-#   • P is a strict
-#     ancestor of HEAD     — A has landed and is in this commit's history.
-#                            POST-adoption. NOT EXEMPT. This is the bound.
-#   • P not an ancestor    — a branch cut before adoption. Pre-adoption history.
-#                            EXEMPT.
+# ── THE REACHABILITY MODEL, corrected (adversarial review R-WP3-1) ──────────
+# The first version of this arm exempted three states, the third being "the
+# anchor is not an ancestor of HEAD — a branch cut before adoption, therefore
+# pre-adoption history". THAT WAS REFUTED, and the refutation is the key to
+# reading this function correctly:
 #
-# HONEST REACHABILITY NOTE, because a reviewer will ask and the answer is not
-# obvious: the gate only ever judges PROSPECTIVE commits, so an adoptee's
-# existing history is never re-judged by construction and this arm's exempting
-# window is genuinely narrow — chiefly the adoption run itself, and commits made
-# on a tree that carries the stamp but not yet the adoption commit. That is
-# exactly the set §5.3 names, and the arm claims nothing wider.
+#   A genuinely pre-adoption branch has the PRE-ADOPTION manifest checked out.
+#   It carries no `adoption` block, so soif_adoption_adopted fails and this
+#   function returns at its first line. The state that arm claimed to serve
+#   CANNOT REACH IT.
+#
+# Which inverts the whole picture. Reaching this code at all requires the
+# WORKING TREE to carry the stamp — and a working tree carries the stamp only
+# because the adoption already happened. So every reachable "not an ancestor"
+# state is POST-adoption with rearranged history: a local `git rebase` or
+# filter-branch that rewrote the anchor commit, a SQUASH-MERGED adoption branch
+# (a GitHub default — and it exempts every subsequent mainline commit forever),
+# an orphan branch carrying the stamped tree, or a cherry-picked adoption
+# commit. Six of ten live attacks exempted a post-adoption commit. §4.5 says no
+# arm anywhere exempts a commit written after adoption day; that arm did
+# nothing else.
+#
+# The corrected predicate is therefore TWO CONJUNCTS, not three cases:
+#
+#   EXEMPT iff  anchor == HEAD                       (the adoption window)
+#          AND  HEAD's COMMITTED manifest is not yet adopted
+#
+# Conjunct 1 alone kills every rearranged history above, because in all of them
+# HEAD is not the recorded anchor. Conjunct 2 is what kills the two attacks
+# that manufacture `anchor == HEAD` after the fact — a second stamp moving the
+# anchor to the current tip, and a working-copy edit doing the same by hand.
+# Once the adoption commit has landed, HEAD's committed manifest is adopted by
+# definition, so conjunct 2 is exactly "the adoption has not landed yet".
+#
+# What remains exempt is one state and one only: the ADOPTION WINDOW — the
+# stamp is written, the adoption commit has not been made. That is the set
+# §5.3 names ("commits at or before the adoption commit"), and the arm claims
+# nothing wider. In particular an adoptee's existing history is never re-judged,
+# because the gate only ever judges PROSPECTIVE commits.
 #
 # Every unknown fails CLOSED (NOT exempt): not adopted, no anchor recorded, an
-# anchor this repository does not contain, an unborn HEAD, or no git at all.
+# anchor this repository does not contain (a bogus 40-hex value, or a shallow
+# clone that lacks the object), an unborn HEAD, or no git at all.
+#
+# KNOWN RESIDUALS — MEASURED, not reasoned about, and recorded rather than
+# papered over. Three tamper states were executed against this predicate:
+#   • anchor tampered to HEAD, manifest COMMITTED (the shipped configuration):
+#     BLOCKED. This is the case R-WP3-3 raised, and conjunct 2 closes it; T7h
+#     pins it.
+#   • `git reset --mixed` back to the anchor: EXEMPT — and correctly so. The
+#     operator has un-committed the adoption commit, which puts the project
+#     genuinely back in the adoption window. It is the window's definition, not
+#     a way around it, and it costs a deliberate destructive command.
+#   • anchor tampered to HEAD on a project whose manifest was NEVER COMMITTED:
+#     EXEMPT. A real residue: with no committed copy there is no witness for
+#     conjunct 2 to consult. It needs an untracked `.claude/manifest.json`,
+#     which is NOT the shipped configuration (the generated .gitignore ignores
+#     only the two `.claude/*.txt` sidecars), plus a hand-edit of the record.
+#     That is §5.4's honest limit 2 exactly: you can route around the block,
+#     not around the record — the edit stays in the file for anyone to read.
 soif_adoption_pre_adoption_commit() {
   local manifest="${1:-.claude/manifest.json}"
   soif_adoption_adopted "$manifest" || return 1
@@ -208,7 +306,7 @@ soif_adoption_pre_adoption_commit() {
   head="$(git rev-parse --verify --quiet 'HEAD^{commit}' 2>/dev/null)" || head=""
   [ -n "$head" ] || return 1
 
-  if [ "$anchor" != "$head" ] && git merge-base --is-ancestor "$anchor" "$head" 2>/dev/null; then   # BF-ADOPT-BOUND
+  if [ "$anchor" != "$head" ] || _soif_adoption_head_copy_adopted "$manifest"; then   # BF-ADOPT-BOUND
     return 1
   fi
   return 0
@@ -232,25 +330,11 @@ soif_adoption_pre_adoption_commit() {
 # long and ends at the adoption commit.
 soif_adoption_integrity_lost() {
   local manifest="${1:-.claude/manifest.json}"
-  command -v jq >/dev/null 2>&1 || return 1
-  git rev-parse --git-dir >/dev/null 2>&1 || return 1
-
-  # Both halves of the comparison must name the SAME file. `git show HEAD:<p>`
-  # resolves <p> from the REPO ROOT, while `[ -f <p> ]` in the accessor
-  # resolves it from the CWD. Called from a subdirectory those are different
-  # files, and the mismatch reads as "committed but missing from the working
-  # tree" — a FALSE ALARM, the failure direction this repo has already paid for
-  # twice (the false-FAIL doctrine behind BL-122/BL-149). `--show-prefix` is
-  # empty only at the top level and, unlike comparing `--show-toplevel` to
-  # $PWD, it is immune to symlinked temp roots.
-  local prefix
-  prefix="$(git rev-parse --show-prefix 2>/dev/null)" || return 1
-  [ -z "$prefix" ] || return 1
-
-  local head_copy
-  head_copy="$(git show "HEAD:$manifest" 2>/dev/null)" || return 1
-  [ -n "$head_copy" ] || return 1
-  printf '%s' "$head_copy" | jq -e '.adoption.adopted == true' >/dev/null 2>&1 || return 1
+  # The committed witness, through the SHARED primitive — the same one the
+  # BOUND consults, so there is one implementation of "has the adoption landed"
+  # and one thing for a mutation proof to neuter. "Cannot answer" lands here as
+  # NO FINDING, which is the quiet direction this consumer wants.
+  _soif_adoption_head_copy_adopted "$manifest" || return 1
 
   # HEAD says adopted. If the working copy still says so, nothing was lost.
   if soif_adoption_adopted "$manifest"; then

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -27,6 +27,20 @@ for _tdd_lib in "$SCRIPT_DIR/lib/tdd-classify.sh"; do
 done
 unset _tdd_lib
 
+# Brownfield adoption WP3 — the in-core enabling arms. Sourced for the
+# `adopted` flag accessor and the pre-adoption BOUND that the BL-072 arm below
+# consults. Absent (an older installed project, or a checkout that predates
+# adoption) -> the helper is simply undefined and the arm no-ops via its
+# `command -v` guard, which is the safe direction: no exemption.
+for _adopt_lib in "$SCRIPT_DIR/lib/adoption-stamp.sh"; do
+  if [ -f "$_adopt_lib" ]; then
+    # shellcheck source=scripts/lib/adoption-stamp.sh
+    . "$_adopt_lib"
+    break
+  fi
+done
+unset _adopt_lib
+
 # ── BL-176: git-dir-aware path resolution ────────────────────────────
 # In a LINKED GIT WORKTREE `.git` is a FILE (a `gitdir:` pointer), not a
 # directory, and the per-worktree state git writes around commit time —
@@ -317,6 +331,51 @@ tdd_terminal_enforce() {
 
   local impl_files
   impl_files=$(printf '%s\n' "$staged_status" | _bl072_impl_files)
+
+  # ── Brownfield adoption: the PRE-ADOPTION exemption ────────────────
+  # BF-ADOPT-TDD-BEGIN
+  # Design §5.3 classifies TDD ordering as kind (c) — INHERENTLY HISTORICAL.
+  # The ordering of an adoptee's 2023 commits is not a re-runnable fact, so
+  # nothing is measured for it; what is recorded instead is a dated exemption
+  # SCOPED to commits at or before the adoption commit. That scope is the whole
+  # design: soif_adoption_pre_adoption_commit owns the bound, and an unbounded
+  # version of this arm would be a permanent TDD waiver wearing an adoption
+  # badge (§4.5: no arm anywhere exempts a commit written after adoption day).
+  #
+  # THIS IS ONE ARM AND IT CHANGES NOTHING ELSE (§9). The trigger predicate
+  # (_tdd_triggers), the tier behaviour (_bl072_tier_bypassable and both
+  # emitters) and the ledger rows are untouched — this arm deliberately writes
+  # NO ledger row, because the row vocabulary is part of what §9 keeps fixed.
+  # It is placed AFTER the trigger so it only ever speaks when the gate would
+  # otherwise fire, and BEFORE the tier split because the exemption is a fact
+  # about history, not a severity.
+  #
+  # HONEST LIMIT, stated rather than implied: kind (c)'s forward equivalent is
+  # the test-debt ledger and its ratchet (§5.4). It is NAMED here and it is NOT
+  # IMPLEMENTED — WP5b owns it. Until it lands, this exemption's forward
+  # counterpart does not exist, and the arm claims only what it does: it
+  # exempts pre-adoption commits and nothing else.
+  #
+  # The decision is computed FIRST and the guard is a single line, so the
+  # dual-direction mutation proof can neuter exactly one line without splicing
+  # a multi-line `if` condition into nonsense — a "one-line" edit that lands
+  # mid-continuation changes the parse, not the semantics, and a proof built on
+  # it measures the wrong thing. `A && B && var=1` is set -e safe (the AND-OR
+  # list exemption), and it is the shape the BL-072 `_fire=1` line above uses.
+  local _bf_preadopt=0
+  command -v soif_adoption_pre_adoption_commit >/dev/null 2>&1 \
+    && soif_adoption_pre_adoption_commit && _bf_preadopt=1
+  if [ "$_bf_preadopt" = "1" ]; then   # BF-ADOPT-TDD-GUARD
+    {
+      echo "[OK] BL-072 TDD ordering: PRE-ADOPTION commit — exempt (brownfield adoption, design §5.3 kind (c))."
+      echo "[OK]   Subject: $subject"
+      echo "[OK]   This commit sits at or before the adoption commit recorded in"
+      echo "[OK]   .claude/manifest.json::adoption.adoptedAtCommit. Commits written after"
+      echo "[OK]   adoption day are fully enforced — this exemption does not extend to them."
+    } >&2
+    return 0
+  fi
+  # BF-ADOPT-TDD-END
 
   if _bl072_tier_bypassable; then
     tdd_emit_warn_term "$subject" "$impl_files"

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -649,7 +649,17 @@ run_child_suite "tests/test-brownfield-wp2-scout-sections.sh" \
 # The TDD arm is proved in BOTH DIRECTIONS and direction (ii) is the one that
 # matters: neuter the exemption and a pre-adoption commit blocks; neuter the
 # BOUND and a POST-adoption commit with no test passes — an unbounded exemption
-# is a permanent TDD waiver wearing an adoption badge. The stamp is proved
+# is a permanent TDD waiver wearing an adoption badge.
+# T7 IS THE ATTACK BATTERY AND IT IS NOT OPTIONAL. The first cut of this WP
+# shipped 19/19 green with a bound that everyday git defeated: the T-series
+# never constructed a divergent history, and six of ten histories exempted a
+# POST-adoption commit — a local rebase, a SQUASH MERGE (a GitHub default, and
+# the worst: it exempts every subsequent mainline commit forever), an orphan
+# branch, a cherry-pick, a second stamp, and a working-copy anchor tamper. All
+# ten are pinned here, T1 stays as the control that a predicate which merely
+# blocked everything would fail, and T8 proves EACH of the corrected bound's two
+# conjuncts load-bearing separately — one conjunct proven only jointly can be
+# dead code, and dead code here is a reopened hole. The stamp is proved
 # additive against a foreign top-level key AND against all five §8.5
 # existing-file writers run in sequence, each writer's jq filter pinned at
 # sites==1 in its own shipped source so a changed writer fails loudly instead

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -638,6 +638,48 @@ run_child_suite "tests/test-brownfield-wp2-scout-sections.sh" \
   "Scout secrets/collisions/tests/prefill (planted-secret allowlist proof)" \
   "Scout WP2 section tests FAILED (run tests/test-brownfield-wp2-scout-sections.sh for details)"
 
+# Brownfield adoption WP3: tests/test-brownfield-wp3-adoption-arms.sh — the
+# IN-CORE ENABLING ARMS, and the design's own named LINCHPIN: the only
+# brownfield package that touches a gate. The `adopted` flag accessor,
+# soif_adoption_stamp, the TDD pre-adoption exemption, and stamp acceptance in
+# check-phase-gate.sh.
+# EVERY VERDICT IS AN EXIT CODE. In check-phase-gate.sh the [WARN]/[FAIL] label
+# is cosmetic and an exemption is the ABSENCE of an `issues` increment, so a
+# test that greps a label proves nothing.
+# The TDD arm is proved in BOTH DIRECTIONS and direction (ii) is the one that
+# matters: neuter the exemption and a pre-adoption commit blocks; neuter the
+# BOUND and a POST-adoption commit with no test passes — an unbounded exemption
+# is a permanent TDD waiver wearing an adoption badge. The stamp is proved
+# additive against a foreign top-level key AND against all five §8.5
+# existing-file writers run in sequence, each writer's jq filter pinned at
+# sites==1 in its own shipped source so a changed writer fails loudly instead
+# of leaving a stale copy under test. Every mutant is anchored at sites==1,
+# line-counted at exactly one changed line, mode-preserving, run in a FRESH
+# fixture, and asserted TO STILL PARSE — the first cut of one mutation landed
+# mid-continuation of a two-line `if`, counted 2 changed lines, and proved a
+# syntax error. Never touches the scaffolder -> both lanes.
+run_child_suite "tests/test-brownfield-wp3-adoption-arms.sh" \
+  "Adoption enabling arms (flag, stamp, bounded TDD exemption, gate acceptance)" \
+  "Adoption WP3 arm tests FAILED (run tests/test-brownfield-wp3-adoption-arms.sh for details)"
+
+# Brownfield adoption WP3: tests/test-brownfield-wp3-regenerate-path.sh — the
+# regenerate-path proof, RE-AIMED at v1.1 (design §0.2 R-BF-1) because v1.0's
+# version was refuted as trivially green: it ran fix_phase_state(), which never
+# touches manifest.json and so could not have failed.
+# The real path is exercised for real: a committed adoption stamp, the manifest
+# deleted, and the SHIPPED fix_framework_manifest executed, which delegates to
+# the UPSTREAM framework installer and rewrites the manifest wholesale from a
+# key set carrying none of this framework's keys. The loss CANNOT be prevented
+# — the writer is in a different repository — so what is proved is that it is
+# DETECTED AND REPORTED LOUDLY, and that removing the detection makes the
+# project SILENTLY un-adopt. R2 is a non-vacuity gate for R3/R4: a manifest that
+# never regenerated would make the detector fire for the wrong reason.
+# EXECUTES the upstream installer, so it is legitimately unit-lane exempt and
+# lives here only; it SKIPS cleanly when the upstream clone is absent.
+run_child_suite "tests/test-brownfield-wp3-regenerate-path.sh" \
+  "Adoption stamp regenerate path (loud detection of an unpreventable loss)" \
+  "Adoption WP3 regenerate-path tests FAILED (run tests/test-brownfield-wp3-regenerate-path.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-bl166-gate-scope.sh
+++ b/tests/test-bl166-gate-scope.sh
@@ -15,6 +15,18 @@
 # gate whose TARGET is below 4, the 3→4 readiness region is announced as ONE
 # non-counted [NEXT] line and its block-counting checks do not run.
 #
+# KNOWN CARVE-OUT ON BL-166's CONTRACT — recorded here so it is discoverable
+# from BL-166's own side, not only from the arm that takes it. The brownfield
+# adoption arm in check-phase-gate.sh (`# BF-ADOPT-GATE-BEGIN`) is deliberately
+# NOT fenced by `skip_later_gate`: the adoption record is a PRECONDITION of
+# every arm that reads the adoption flag rather than any one gate's check, so a
+# scoped run passing while that record was silently lost would be the same
+# silence under a narrower heading. Measured harmless when the stamp is intact —
+# a scoped `--gate phase_1_to_2` run on an adopted fixture and on an unadopted
+# control produce the SAME issue count, the only difference being one cosmetic
+# `[OK] Adoption stamp present and intact` line. It counts an issue only when
+# the committed manifest records an adoption the working copy has lost.
+#
 # BL-158 (header label): under a --gate override the header printed
 # "Current phase: <forced>" — reading like recorded state on an audit trail even
 # when phase-state.json records a different phase. The fix (# BL-158-GATE-LABEL)

--- a/tests/test-brownfield-wp3-adoption-arms.sh
+++ b/tests/test-brownfield-wp3-adoption-arms.sh
@@ -272,6 +272,33 @@ else
   fi
 fi
 
+# ── S5: "written once, at adoption, never re-stamped" is ENFORCED ──────────
+# §8.5 states the property; the first cut only asserted it in a header, and a
+# second stamp was accepted — silently moving adoptedAtCommit to the current
+# tip, which re-opens the TDD exemption window at will (adversarial review
+# R-WP3-2). Both directions are pinned here: the FIRST stamp must succeed
+# (otherwise a refusal that refused everything would pass this test), and the
+# SECOND must be refused with the anchor unmoved.
+S5D="$(newtmp)"
+( cd "$S5D" && git init -q . && git config user.email s5@t.invalid && git config user.name S5 \
+    && echo x > f.txt && git add f.txt && git commit -q -m "chore: base" ) >/dev/null 2>&1
+printf '%s\n' '{"host":"github"}' > "$S5D/manifest.json"
+s5_first=0
+( cd "$S5D" && soif_adoption_stamp "manifest.json" "completed" 1 '[]' '[]' '[]' '[]' "one" ) >/dev/null 2>&1 && s5_first=1
+s5_anchor_1=$(jq -r '.adoption.adoptedAtCommit // "MISSING"' "$S5D/manifest.json" 2>/dev/null)
+s5_sha_1=$(jq -r '.adoption.scannerReportSha256 // "MISSING"' "$S5D/manifest.json" 2>/dev/null)
+( cd "$S5D" && echo y > g.txt && git add g.txt && git commit -q -m "chore: adopt" ) >/dev/null 2>&1
+s5_second_rc=0
+( cd "$S5D" && soif_adoption_stamp "manifest.json" "in-flight" 4 '[]' '[]' '[]' '[]' "two" ) >/dev/null 2>&1 || s5_second_rc=$?
+s5_anchor_2=$(jq -r '.adoption.adoptedAtCommit // "MISSING"' "$S5D/manifest.json" 2>/dev/null)
+s5_sha_2=$(jq -r '.adoption.scannerReportSha256 // "MISSING"' "$S5D/manifest.json" 2>/dev/null)
+if [ "$s5_first" -eq 1 ] && [ "$s5_second_rc" -ne 0 ] \
+   && [ "$s5_anchor_1" = "$s5_anchor_2" ] && [ "$s5_sha_1" = "one" ] && [ "$s5_sha_2" = "one" ]; then
+  pass "S5: the FIRST stamp is written and the SECOND is REFUSED (rc $s5_second_rc) with the anchor and the whole block unmoved — §8.5's 'never re-stamped' is structural, not a convention"
+else
+  fail_ "S5" "first_stamp_ok=$s5_first (want 1) second_rc=$s5_second_rc (want non-zero) anchor_before=$s5_anchor_1 anchor_after=$s5_anchor_2 (want equal) sha_before=$s5_sha_1 sha_after=$s5_sha_2 (want both 'one')"
+fi
+
 echo ""
 echo "=== T — the TDD pre-adoption arm (§5.3 kind (c); dual-direction) ==="
 
@@ -445,6 +472,255 @@ else
     pass "T6: tier behaviour is UNTOUCHED — a bypassable tier still warns-and-allows post-adoption (rc 0, BL-072 line emitted)"
   else
     fail_ "T6" "rc=$t6_rc (want 0) bl072_line_emitted=$t6_warned (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== T7 — THE BOUND ATTACK BATTERY (adversarial review R-WP3-1) ==="
+# WHY THIS SECTION EXISTS. T1-T6 shipped 19/19 green while the bound was
+# DEFEATABLE BY EVERYDAY GIT. The refuted model was this file's own first
+# comment: "P not an ancestor => a branch cut before adoption => EXEMPT". That
+# state is UNREACHABLE for a genuinely pre-adoption branch — such a branch has
+# the PRE-adoption manifest checked out, so the accessor reads NOT ADOPTED and
+# the arm never runs. Every state that actually reaches the "not an ancestor"
+# arm carries the STAMPED tree, which means adoption already happened. The old
+# arm therefore exempted only post-adoption commits — the exact inversion of
+# §4.5.
+#
+# The T-series never constructed a divergent history, which is precisely why
+# the hole and a green suite coexisted. So this battery is not one regression
+# for one attack: it pins ALL TEN histories the reviewer drove, six of which
+# produced an exempt post-adoption commit (rc 0 + the exemption banner) against
+# the shipped code. Four of the six need no intent at all — a local `git
+# rebase`, a SQUASH MERGE (a GitHub default, and the worst: it exempts every
+# subsequent mainline commit forever), an orphan branch, and a cherry-pick.
+#
+# T1 remains the indispensable control: a predicate that simply blocked
+# everything would pass all ten of these and be just as wrong.
+# Verdicts are EXIT CODES. Non-zero = the gate refused the commit = correct.
+
+# atk_base DIR — an adopted project whose adoption commit HAS LANDED.
+# C1 "chore: their history" (the anchor) -> stamp -> C2 "chore: adopt project".
+atk_base() {
+  local d="$1"
+  mk_tdd_proj "$d" || return 1
+  adopt_proj "$d" >/dev/null 2>&1 || return 1
+  ( cd "$d" && git add -A .claude && git commit -q -m "chore: adopt project" ) || return 1
+}
+
+# atk_verdict DIR — stage an impl-only change, run the real commit-msg surface
+# with a post-adoption `feat:` subject, echo "<rc>|<exempt-banner-seen>".
+atk_verdict() {
+  local d="$1" out rc=0 banner=0
+  stage_impl_only "$d" >/dev/null 2>&1
+  out=$(run_tdd "$d" "feat: work written AFTER adoption day") || rc=$?
+  printf '%s' "$out" | grep -q 'PRE-ADOPTION commit' && banner=1
+  printf '%s|%s\n' "$rc" "$banner"
+}
+
+# atk_report LABEL DIR EXPECT — EXPECT is `blocked` (rc non-zero) or `exempt`.
+atk_report() {
+  local label="$1" d="$2" expect="$3" v rc banner
+  v="$(atk_verdict "$d")"
+  rc="${v%%|*}"; banner="${v##*|}"
+  ATK_RCS="${ATK_RCS}${label}=rc:${rc} "
+  if [ "$expect" = "blocked" ]; then
+    if [ "$rc" -ne 0 ] && [ "$banner" -eq 0 ]; then
+      pass "$label: BLOCKED (rc=$rc, no exemption banner) — the bound holds"
+    else
+      fail_ "$label" "rc=$rc (want non-zero) exemption_banner=$banner (want 0) — a POST-adoption commit was exempted"
+    fi
+  else
+    if [ "$rc" -eq 0 ] && [ "$banner" -eq 1 ]; then
+      pass "$label: EXEMPT (rc=0, banner printed) — the adoption window is preserved"
+    else
+      fail_ "$label" "rc=$rc (want 0) exemption_banner=$banner (want 1)"
+    fi
+  fi
+}
+ATK_RCS=""
+
+# ── T7a — local `git rebase` rewrites the anchor commit ────────────────────
+D="$(newtmp)/p"
+if ! mk_tdd_proj "$D"; then fail_ "T7a" "fixture setup failed"; else
+  ( cd "$D" && git checkout -q -b adopt-work \
+      && echo work > work.txt && git add work.txt && git commit -q -m "chore: pre-stamp work" ) >/dev/null 2>&1
+  adopt_proj "$D" >/dev/null 2>&1
+  ( cd "$D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  ( cd "$D" && git checkout -q main 2>/dev/null || git checkout -q master ) >/dev/null 2>&1
+  ( cd "$D" && git commit -q --allow-empty -m "chore: mainline moves on" ) >/dev/null 2>&1
+  ( cd "$D" && git checkout -q adopt-work && git rebase -q main ) >/dev/null 2>&1
+  atk_report "T7a [local git rebase rewrote the anchor]" "$D" blocked
+fi
+
+# ── T7b — SQUASH-MERGED adoption branch (a GitHub default; the worst hole) ─
+D="$(newtmp)/p"
+if ! mk_tdd_proj "$D"; then fail_ "T7b" "fixture setup failed"; else
+  ( cd "$D" && git checkout -q -b adopt-branch \
+      && echo work > work.txt && git add work.txt && git commit -q -m "chore: pre-stamp work" ) >/dev/null 2>&1
+  adopt_proj "$D" >/dev/null 2>&1
+  ( cd "$D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  ( cd "$D" && ( git checkout -q main 2>/dev/null || git checkout -q master ) \
+      && git merge -q --squash adopt-branch && git commit -q -m "chore: adopt project (squashed)" ) >/dev/null 2>&1
+  atk_report "T7b [squash-merged adoption branch]" "$D" blocked
+fi
+
+# ── T7c — orphan branch carrying the stamped tree ──────────────────────────
+D="$(newtmp)/p"
+if ! atk_base "$D"; then fail_ "T7c" "fixture setup failed"; else
+  ( cd "$D" && git checkout -q --orphan orph && git commit -q -m "chore: orphan root" ) >/dev/null 2>&1
+  atk_report "T7c [orphan branch]" "$D" blocked
+fi
+
+# ── T7d — adoption commit cherry-picked onto a branch that diverged earlier ─
+# `.claude/` is TRACKED before the branch point on purpose. Left untracked, the
+# cherry-pick aborts ("untracked working tree file would be overwritten"), git
+# leaves CHERRY_PICK_HEAD behind, and `tdd_terminal_enforce` returns 0 at its
+# derivative-resume sentinel WITHOUT EVER REACHING THE BOUND — rc 0 and no
+# banner, which reads exactly like a hole while proving nothing about one. The
+# first cut of this fixture did precisely that.
+D="$(newtmp)/p"
+if ! mk_tdd_proj "$D"; then fail_ "T7d" "fixture setup failed"; else
+  ( cd "$D" && git add -A .claude && git commit -q -m "chore: their tooling" ) >/dev/null 2>&1
+  ( cd "$D" && git branch divergent ) >/dev/null 2>&1
+  ( cd "$D" && echo more > more.txt && git add more.txt && git commit -q -m "chore: their later history" ) >/dev/null 2>&1
+  adopt_proj "$D" >/dev/null 2>&1
+  ( cd "$D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  adopt_sha=$( cd "$D" && git rev-parse HEAD )
+  ( cd "$D" && git checkout -q divergent && git commit -q --allow-empty -m "chore: divergent work" \
+      && git cherry-pick "$adopt_sha" ) >/dev/null 2>&1
+  d7d_clean=0
+  [ -f "$D/.git/CHERRY_PICK_HEAD" ] || d7d_clean=1
+  if [ "$d7d_clean" -eq 0 ]; then
+    fail_ "T7d" "cherry-pick did not complete (CHERRY_PICK_HEAD present) — the fixture would hit the derivative-resume skip and prove nothing about the bound"
+  else
+    atk_report "T7d [cherry-picked adoption onto a divergent branch]" "$D" blocked
+  fi
+fi
+
+# ── T7e — bogus 40-hex anchor (fail-closed; defeats the any-40-hex class) ──
+D="$(newtmp)/p"
+if ! atk_base "$D"; then fail_ "T7e" "fixture setup failed"; else
+  ( cd "$D" && jq '.adoption.adoptedAtCommit = "0123456789abcdef0123456789abcdef01234567"' .claude/manifest.json > m.tmp && mv m.tmp .claude/manifest.json ) >/dev/null 2>&1
+  atk_report "T7e [bogus 40-hex anchor]" "$D" blocked
+fi
+
+# ── T7f — shallow clone: the anchor object is not in this repository ───────
+D="$(newtmp)"
+if ! atk_base "$D/src"; then fail_ "T7f" "fixture setup failed"; else
+  ( cd "$D/src" && git add -A && git commit -q -m "chore: track everything" ) >/dev/null 2>&1
+  ( cd "$D/src" && echo later > later.txt && git add later.txt && git commit -q -m "chore: later work" ) >/dev/null 2>&1
+  if ( cd "$D" && git clone -q --depth 1 "file://$D/src" shallow ) >/dev/null 2>&1; then
+    cp "$PCG" "$D/shallow/scripts/" 2>/dev/null
+    cp "$REPO_ROOT/scripts/lib/helpers.sh" "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+       "$REPO_ROOT/scripts/lib/helpers-full.sh" "$REPO_ROOT/scripts/lib/tdd-classify.sh" \
+       "$LIB" "$D/shallow/scripts/lib/" 2>/dev/null
+    ( cd "$D/shallow" && git config user.email "wp3@test.invalid" && git config user.name "WP3 Test" ) >/dev/null 2>&1
+    atk_report "T7f [shallow clone, anchor object absent]" "$D/shallow" blocked
+  else
+    fail_ "T7f" "shallow clone fixture could not be built"
+  fi
+fi
+
+# ── T7g — a SECOND adoption stamp (re-stamp silently moving the anchor) ────
+D="$(newtmp)/p"
+if ! atk_base "$D"; then fail_ "T7g" "fixture setup failed"; else
+  before=$( cd "$D" && jq -r '.adoption.adoptedAtCommit' .claude/manifest.json )
+  restamp_rc=0
+  ( cd "$D" && soif_adoption_stamp ".claude/manifest.json" "completed" 3 '[]' '[]' '[]' '[]' "sha2" ) >/dev/null 2>&1 || restamp_rc=$?
+  after=$( cd "$D" && jq -r '.adoption.adoptedAtCommit' .claude/manifest.json )
+  atk_report "T7g [second adoption stamp]" "$D" blocked
+  if [ "$restamp_rc" -ne 0 ] && [ "$before" = "$after" ]; then
+    pass "T7g-stamp: the re-stamp itself was REFUSED (rc $restamp_rc) and the anchor did not move — §8.5's 'written once, never re-stamped' is enforced, not merely asserted"
+  else
+    fail_ "T7g-stamp" "restamp_rc=$restamp_rc (want non-zero) anchor_before=$before anchor_after=$after (want equal)"
+  fi
+fi
+
+# ── T7h — working-copy anchor tamper (no commit needed) ────────────────────
+D="$(newtmp)/p"
+if ! atk_base "$D"; then fail_ "T7h" "fixture setup failed"; else
+  head_sha=$( cd "$D" && git rev-parse HEAD )
+  ( cd "$D" && jq --arg h "$head_sha" '.adoption.adoptedAtCommit = $h' .claude/manifest.json > m.tmp && mv m.tmp .claude/manifest.json ) >/dev/null 2>&1
+  atk_report "T7h [working-copy anchor tampered to HEAD]" "$D" blocked
+fi
+
+# ── T7i — detached HEAD at the adoption commit ─────────────────────────────
+D="$(newtmp)/p"
+if ! atk_base "$D"; then fail_ "T7i" "fixture setup failed"; else
+  ( cd "$D" && git checkout -q --detach HEAD ) >/dev/null 2>&1
+  atk_report "T7i [detached HEAD at the adoption commit]" "$D" blocked
+fi
+
+# ── T7j — a pre-adoption branch that has since MERGED adopted main ─────────
+D="$(newtmp)/p"
+if ! mk_tdd_proj "$D"; then fail_ "T7j" "fixture setup failed"; else
+  ( cd "$D" && git branch feature ) >/dev/null 2>&1
+  adopt_proj "$D" >/dev/null 2>&1
+  ( cd "$D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  mainref=$( cd "$D" && git rev-parse --abbrev-ref HEAD )
+  ( cd "$D" && git checkout -q feature && git merge -q --no-edit "$mainref" ) >/dev/null 2>&1
+  atk_report "T7j [pre-adoption branch after merging adopted main]" "$D" blocked
+fi
+
+echo "  [rc table] $ATK_RCS"
+
+echo ""
+echo "=== T8 — each conjunct of the corrected bound is load-bearing ==="
+# T4 mutates the WHOLE bound line, which proves the line matters but not that
+# BOTH halves do. A two-conjunct predicate needs two proofs, or one half can be
+# dead code that nothing would notice — and a dead conjunct here is a reopened
+# hole. Each mutation below deletes exactly ONE conjunct from the single
+# `# BF-ADOPT-BOUND` line and pairs it with the fixture that ONLY that conjunct
+# defends, plus the unmutated control on the same fixture.
+
+# ── T8a — drop conjunct 2 (the committed witness) ──────────────────────────
+# Fixture: the working-copy anchor tamper. anchor == HEAD, so conjunct 1 lets it
+# through; only "HEAD's committed manifest is already adopted" refuses it.
+T8A="$(newtmp)"; T8AD="$T8A/p"
+if ! atk_base "$T8AD"; then fail_ "T8a" "fixture setup failed"; else
+  h=$( cd "$T8AD" && git rev-parse HEAD )
+  ( cd "$T8AD" && jq --arg h "$h" '.adoption.adoptedAtCommit = $h' .claude/manifest.json > m.tmp && mv m.tmp .claude/manifest.json ) >/dev/null 2>&1
+  ctl="$(atk_verdict "$T8AD")"; ctl_rc="${ctl%%|*}"
+  MUT8A="$T8AD/scripts/lib/adoption-stamp.sh"
+  bound_sites=$(grep -c 'BF-ADOPT-BOUND$' "$LIB" 2>/dev/null); bound_sites=$(_num "$bound_sites")
+  cp "$LIB" "$T8A/orig-lib.ref"
+  _sed_inplace "$MUT8A" 's|^.*BF-ADOPT-BOUND$|  if [ "$anchor" != "$head" ]; then   # BF-ADOPT-BOUND|'
+  chg8a=$(_changed_lines "$T8A/orig-lib.ref" "$MUT8A")
+  p8a=$(_parses "$MUT8A")
+  ( cd "$T8AD" && git reset -q ) >/dev/null 2>&1
+  mut="$(atk_verdict "$T8AD")"; mut_rc="${mut%%|*}"; mut_banner="${mut##*|}"
+  if [ "$ctl_rc" -ne 0 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_banner" -eq 1 ] \
+     && [ "$chg8a" -eq 2 ] && [ "$bound_sites" -eq 1 ] && [ "$p8a" -eq 1 ]; then
+    pass "T8a: dropping the COMMITTED-WITNESS conjunct (1 line, mutant parses) lets a tampered anchor exempt a post-adoption commit (rc 0, banner); the unmutated control blocks (rc $ctl_rc) — conjunct 2 is load-bearing"
+  else
+    fail_ "T8a" "control_rc=$ctl_rc (want non-zero) mutant_rc=$mut_rc (want 0) mutant_banner=$mut_banner (want 1) changed_lines=$chg8a (want 2) bound_sites=$bound_sites (want 1) parses=$p8a (want 1)"
+  fi
+fi
+
+# ── T8b — drop conjunct 1 (anchor == HEAD) ─────────────────────────────────
+# Fixture: the stamp is written, then an UNRELATED commit lands (src only, the
+# manifest still uncommitted). anchor != HEAD, but HEAD's committed manifest is
+# not adopted — so only conjunct 1 refuses. Without it every commit after the
+# stamp stays exempt until the manifest is finally committed.
+T8B="$(newtmp)"; T8BD="$T8B/p"
+if ! mk_tdd_proj "$T8BD"; then fail_ "T8b" "fixture setup failed"; else
+  adopt_proj "$T8BD" >/dev/null 2>&1
+  ( cd "$T8BD" && mkdir -p src && echo 'export const a=1;' > src/unrelated.js \
+      && git add src/unrelated.js && git commit -q -m "chore: unrelated work" ) >/dev/null 2>&1
+  ctl="$(atk_verdict "$T8BD")"; ctl_rc="${ctl%%|*}"
+  MUT8B="$T8BD/scripts/lib/adoption-stamp.sh"
+  cp "$LIB" "$T8B/orig-lib.ref"
+  _sed_inplace "$MUT8B" 's|^.*BF-ADOPT-BOUND$|  if _soif_adoption_head_copy_adopted "$manifest"; then   # BF-ADOPT-BOUND|'
+  chg8b=$(_changed_lines "$T8B/orig-lib.ref" "$MUT8B")
+  p8b=$(_parses "$MUT8B")
+  ( cd "$T8BD" && git reset -q ) >/dev/null 2>&1
+  mut="$(atk_verdict "$T8BD")"; mut_rc="${mut%%|*}"; mut_banner="${mut##*|}"
+  if [ "$ctl_rc" -ne 0 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_banner" -eq 1 ] \
+     && [ "$chg8b" -eq 2 ] && [ "$p8b" -eq 1 ]; then
+    pass "T8b: dropping the anchor==HEAD conjunct (1 line, mutant parses) exempts a commit made AFTER the stamp on a still-uncommitted manifest (rc 0, banner); the unmutated control blocks (rc $ctl_rc) — conjunct 1 is load-bearing"
+  else
+    fail_ "T8b" "control_rc=$ctl_rc (want non-zero) mutant_rc=$mut_rc (want 0) mutant_banner=$mut_banner (want 1) changed_lines=$chg8b (want 2) parses=$p8b (want 1)"
   fi
 fi
 

--- a/tests/test-brownfield-wp3-adoption-arms.sh
+++ b/tests/test-brownfield-wp3-adoption-arms.sh
@@ -1,0 +1,581 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp3-adoption-arms.sh
+#
+# Brownfield adoption WP3 — the IN-CORE ENABLING ARMS. Design:
+# docs/designs/2026-08-02-brownfield-adoption-v1.md §10-WP3 (deliverables and
+# proofs), §3.1/§3.2 (why the arms are in-core), §5.3 (the per-gate mapping;
+# the TDD ordering row is kind (c)), §8.5 (the stamp's home, its
+# merge-versus-re-stamp reasoning, and the five existing-file writers), §9
+# (what does not change).
+#
+# WP3 is the design's own named LINCHPIN: it is the only brownfield package
+# that touches a gate.
+#
+# ── THE [WARN] TRAP (repo CLAUDE.md; §10's preamble) ────────────────────────
+# In check-phase-gate.sh the `[WARN]` / `[FAIL]` text is COSMETIC — the exit
+# predicate is `if [ $issues -eq 0 ]`. An exemption is the ABSENCE of an
+# `issues=$((issues + 1))`; a block is its presence. Of the 66 increment sites,
+# 34 print `[WARN]` and 10 print `[FAIL]`. So EVERY verdict in this file is
+# asserted on an EXIT CODE. Printed strings appear only as PATH DISCRIMINATORS
+# (see below) and never as a verdict.
+#
+# ── Structural discriminators (this wave's harness standard) ────────────────
+# Three of the proofs below expect an ABSENCE as the mutant's result (no block,
+# no finding, no report). Several DIFFERENT edits share that one downstream
+# silence — a mutant that dies on a syntax error is also silent. Every such
+# proof therefore carries a discriminator that only the INTENDED path can
+# satisfy: the mutant must still load its library and still answer the accessor
+# correctly, and (where the path is observable) must print the arm's own
+# message. The exit code remains the verdict; the discriminator only proves
+# WHICH path produced it.
+#
+# ── Scenarios ───────────────────────────────────────────────────────────────
+#   A1..A4  The `adopted` flag accessor. Absent file, absent block and
+#           `adopted:false` all read NOT ADOPTED — a greenfield project must be
+#           untouched by every arm in this WP (§10-WP3 deliverable 1).
+#   S1      soif_adoption_stamp is an ADDITIVE merge: a foreign top-level
+#           manifest key survives it, and the written block carries §8.5's
+#           schema.
+#   S2      No-op on a missing manifest (the `[ -f … ] || return 0` idiom
+#           soif_currency_stamp uses).
+#   S3      The five existing-file manifest writers named in §8.5 are run IN
+#           SEQUENCE over a stamped manifest and the stamp is still present
+#           afterwards. Each writer's jq filter is PINNED at sites==1 in its
+#           own shipped source, so a writer that changes shape fails this test
+#           loudly instead of leaving it exercising a stale copy.
+#   S4      A scenario outside §8.5's `completed|in-flight` enum is REFUSED —
+#           a durable record must not be written malformed.
+#   T1/T2   TDD arm, DIRECTION (i): an adopted project's pre-adoption commit is
+#           exempt (T1, rc 0); neuter the exemption guard and the SAME fixture
+#           blocks (T2, rc 1).
+#   T3/T4   TDD arm, DIRECTION (ii) — THE ONE THAT MATTERS. A post-adoption
+#           commit with no test BLOCKS (T3, rc 1); neuter the BOUND and it
+#           PASSES (T4, rc 0). An unbounded exemption is a permanent TDD waiver
+#           wearing an adoption badge, so T4 is the proof this WP turns on.
+#   T5      Greenfield regression: no adoption block ⇒ the gate behaves exactly
+#           as it did before this WP (rc 1 on a non-bypassable tier).
+#   T6      Tier behaviour is UNTOUCHED (§9): a bypassable tier still warns and
+#           allows post-adoption.
+#   G1..G4  Stamp acceptance in the gate, and the loss detector: intact ⇒ no
+#           finding (G1); committed-at-HEAD but gone from the working tree ⇒
+#           the gate exits NON-ZERO (G2); neuter the detector ⇒ the project
+#           SILENTLY un-adopts and the gate exits 0 (G3); a mid-adoption
+#           project whose stamp is not yet committed raises no false alarm
+#           (G4).
+#
+# The REAL regenerate path (delete the manifest → verify-install.sh --auto-fix
+# → fix_framework_manifest → the upstream CDF writer rewrites it wholesale) is
+# proved in tests/test-brownfield-wp3-regenerate-path.sh, which is deliberately
+# a separate suite: it executes the upstream installer and is therefore
+# unit-lane exempt, while everything here stays in the fast lane.
+#
+# Hermetic: temp dirs only, no network, no remote creation.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/adoption-stamp.sh"
+GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+PCG="$REPO_ROOT/scripts/pre-commit-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+# newtmp — a FRESH directory per scenario. `mktemp -d`, not an incrementing
+# counter: newtmp is always called in a command substitution, i.e. a SUBSHELL,
+# so a counter variable never survives back to the parent and every scenario
+# silently lands in the same directory. That is not a hypothetical — it is what
+# this file did on its first run, and it made one mutation proof pass against a
+# fixture the previous scenario had already committed into.
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+# _mode_of FILE — octal permission bits, GNU-first then BSD (house portability
+# rule). "?" when neither answers.
+_mode_of() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'
+}
+
+# _sed_inplace FILE SED-EXPR — in-place sed PRESERVING the file's mode. The
+# obvious spelling ends in `chmod +x`, which silently widens a 0644 lib to 0755
+# and rides along in the next commit.
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+# _changed_lines A B — lines diff reports added or removed. A one-line
+# SUBSTITUTION is 2. Asserting it stops a mutation from becoming a rewrite and
+# stops a NO-OP edit from being read as a proof.
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+# _num VALUE — a shell-comparable integer (jq prints a missing field as the
+# four-character string "null", which `[ "$x" -eq 1 ]` rejects with a
+# diagnostic AND a false branch — a missing field would otherwise take the same
+# path as a zero).
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+
+# _parses FILE — 1 iff the mutant is still valid shell. THE discriminator this
+# file exists to carry, and it is not theoretical: the first cut of T2 replaced
+# a line that sat MID-CONTINUATION of a two-line `if` condition. diff reported
+# the expected 2 changed lines, the anchor resolved at sites==1, and the result
+# was a MANGLED PARSE that took the exemption branch for a reason having nothing
+# to do with the exemption. A mutation proof whose mutant does not parse is
+# measuring a syntax error. Every mutant below must parse.
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+
+if [ ! -f "$LIB" ]; then
+  echo "  [FAIL] setup — $LIB not found (WP3 deliverable 1/2 missing)"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# shellcheck source=/dev/null
+. "$LIB"
+
+echo "=== A — the adopted flag accessor (§10-WP3 deliverable 1) ==="
+
+A="$(newtmp)"
+if soif_adoption_adopted "$A/nope.json"; then
+  fail_ "A1" "a missing manifest read as ADOPTED"
+else
+  pass "A1: a missing manifest reads NOT ADOPTED (rc non-zero)"
+fi
+
+printf '%s\n' '{"host":"github","frameworkVersion":"1"}' > "$A/greenfield.json"
+if soif_adoption_adopted "$A/greenfield.json"; then
+  fail_ "A2" "a manifest with no adoption block read as ADOPTED — every arm in this WP would fire on a greenfield project"
+else
+  pass "A2: absent adoption block reads NOT ADOPTED (greenfield unaffected)"
+fi
+
+printf '%s\n' '{"adoption":{"adopted":true,"schemaVersion":1}}' > "$A/adopted.json"
+if soif_adoption_adopted "$A/adopted.json"; then
+  pass "A3: adoption.adopted=true reads ADOPTED (rc 0)"
+else
+  fail_ "A3" "adoption.adopted=true did not read as ADOPTED"
+fi
+
+printf '%s\n' '{"adoption":{"adopted":false,"schemaVersion":1}}' > "$A/notadopted.json"
+if soif_adoption_adopted "$A/notadopted.json"; then
+  fail_ "A4" "adoption.adopted=false read as ADOPTED"
+else
+  pass "A4: adoption.adopted=false reads NOT ADOPTED"
+fi
+
+echo ""
+echo "=== S — soif_adoption_stamp (§8.5: one additive merge, one call site) ==="
+
+S="$(newtmp)"
+( cd "$S" && git init -q . && git config user.email s@t.invalid && git config user.name S \
+    && echo x > f.txt && git add f.txt && git commit -q -m "chore: base" ) >/dev/null 2>&1
+printf '%s\n' '{"foreignKey":"keep-me","host":"gitlab","currency":{"schemaVersion":1}}' > "$S/manifest.json"
+
+( cd "$S" && soif_adoption_stamp "manifest.json" "completed" 3 \
+    '["phase-0-docs"]' '["sponsor-approval"]' '["tdd-ordering"]' '[]' "deadbeef" ) >/dev/null 2>&1
+s1_foreign=$(jq -r '.foreignKey // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_currency=$(jq -r '.currency.schemaVersion // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_adopted=$(jq -r '.adoption.adopted // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_scenario=$(jq -r '.adoption.scenario // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_landed=$(jq -r '.adoption.landedPhase // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_kc=$(jq -r '.adoption.certification.kindC[0] // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_sha=$(jq -r '.adoption.scannerReportSha256 // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_at=$(jq -r '.adoption.adoptedAt // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_anchor=$(jq -r '.adoption.adoptedAtCommit // "MISSING"' "$S/manifest.json" 2>/dev/null)
+s1_head=$( cd "$S" && git rev-parse HEAD 2>/dev/null )
+if [ "$s1_foreign" = "keep-me" ] && [ "$s1_currency" = "1" ] && [ "$s1_adopted" = "true" ] \
+   && [ "$s1_scenario" = "completed" ] && [ "$s1_landed" = "3" ] && [ "$s1_kc" = "tdd-ordering" ] \
+   && [ "$s1_sha" = "deadbeef" ] && [ "$s1_anchor" = "$s1_head" ] \
+   && printf '%s' "$s1_at" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T'; then
+  pass "S1: the stamp is ADDITIVE — foreignKey and .currency both survive — and the block carries §8.5's schema (adoptedAtCommit = the pre-adoption tip)"
+else
+  fail_ "S1" "foreign=$s1_foreign currency=$s1_currency adopted=$s1_adopted scenario=$s1_scenario landed=$s1_landed kindC=$s1_kc sha=$s1_sha adoptedAt=$s1_at anchor=$s1_anchor head=$s1_head"
+fi
+
+S2D="$(newtmp)"
+if ( cd "$S2D" && soif_adoption_stamp "absent-manifest.json" "completed" 1 '[]' '[]' '[]' '[]' "" ) >/dev/null 2>&1; then
+  if [ -e "$S2D/absent-manifest.json" ]; then
+    fail_ "S2" "the stamp CREATED a manifest that did not exist"
+  else
+    pass "S2: no-op on a missing manifest (rc 0, nothing created)"
+  fi
+else
+  fail_ "S2" "the stamp returned non-zero on a missing manifest (expected a silent no-op)"
+fi
+
+# ── S3: the five §8.5 existing-file writers, run IN SEQUENCE ────────────────
+# Each writer is exercised by the jq filter EXTRACTED from its own shipped
+# source, and each anchor is asserted at sites==1 first. That pin is the point:
+# if any writer changes shape, this test fails loudly rather than continuing to
+# exercise a hard-coded copy that no longer matches the tree. (Invoking the
+# whole surrounding script instead would drag an installer into a fast-lane
+# suite; the property under test is the ADDITIVITY OF THE FILTER.)
+W_CG="$REPO_ROOT/scripts/check-gate.sh"
+W_UP="$REPO_ROOT/scripts/upgrade-project.sh"
+W_CM="$REPO_ROOT/scripts/lib/currency-manifest.sh"
+F_HOST_CG='jq --arg h "$inferred" '"'"'.host = $h'"'"''
+F_HOST_UP='jq --arg h "$inferred_host" '"'"'.host = $h'"'"''
+F_BL030="'. + {deployment: \$dep, poc_mode: \$pm, enforcement_level: \"strict\"}'"
+F_BL061="'. + {deployment: \$dep, poc_mode: \$pm}'"
+F_CURR="'.currency = \$currency'"
+n_cg=$(grep -cF -- "$F_HOST_CG" "$W_CG" 2>/dev/null); n_cg=$(_num "$n_cg")
+n_up=$(grep -cF -- "$F_HOST_UP" "$W_UP" 2>/dev/null); n_up=$(_num "$n_up")
+n_30=$(grep -cF -- "$F_BL030" "$W_UP" 2>/dev/null); n_30=$(_num "$n_30")
+n_61=$(grep -cF -- "$F_BL061" "$W_UP" 2>/dev/null); n_61=$(_num "$n_61")
+n_cu=$(grep -cF -- "$F_CURR" "$W_CM" 2>/dev/null); n_cu=$(_num "$n_cu")
+
+S3D="$(newtmp)"
+cp "$S/manifest.json" "$S3D/manifest.json"
+_w() { # _w <jq-filter> <args...>  — apply one writer with the atomic-rename pattern
+  local filter="$1"; shift
+  jq "$@" "$filter" "$S3D/manifest.json" > "$S3D/manifest.json.tmp" && mv "$S3D/manifest.json.tmp" "$S3D/manifest.json"
+}
+w_ok=1
+_w '.host = $h' --arg h "github"                                                        || w_ok=0
+_w '.host = $h' --arg h "gitlab"                                                        || w_ok=0
+_w '. + {deployment: $dep, poc_mode: $pm, enforcement_level: "strict"}' --arg dep organizational --arg pm sponsored_poc || w_ok=0
+_w '. + {deployment: $dep, poc_mode: $pm}' --arg dep organizational --arg pm sponsored_poc || w_ok=0
+_w '.currency = $currency' --argjson currency '{"schemaVersion":1,"files":{}}'           || w_ok=0
+s3_adopted=$(jq -r '.adoption.adopted // "MISSING"' "$S3D/manifest.json" 2>/dev/null)
+s3_scen=$(jq -r '.adoption.scenario // "MISSING"' "$S3D/manifest.json" 2>/dev/null)
+s3_foreign=$(jq -r '.foreignKey // "MISSING"' "$S3D/manifest.json" 2>/dev/null)
+if [ "$w_ok" -eq 1 ] && [ "$s3_adopted" = "true" ] && [ "$s3_scen" = "completed" ] \
+   && [ "$s3_foreign" = "keep-me" ] \
+   && [ "$n_cg" -eq 1 ] && [ "$n_up" -eq 1 ] && [ "$n_30" -eq 1 ] && [ "$n_61" -eq 1 ] && [ "$n_cu" -eq 1 ]; then
+  pass "S3: all five §8.5 existing-file writers run in sequence (host×2, BL-030 backfill, BL-061 refresh, .currency) and the adoption block survives every one; each filter pinned at sites==1 in its shipped source"
+else
+  fail_ "S3" "writers_ok=$w_ok adopted=$s3_adopted scenario=$s3_scen foreign=$s3_foreign sites: check-gate=$n_cg upgrade-host=$n_up bl030=$n_30 bl061=$n_61 currency=$n_cu (each want 1)"
+fi
+
+S4D="$(newtmp)"
+printf '%s\n' '{"host":"github"}' > "$S4D/manifest.json"
+if ( cd "$S4D" && soif_adoption_stamp "manifest.json" "sideways" 1 '[]' '[]' '[]' '[]' "" ) >/dev/null 2>&1; then
+  fail_ "S4" "a scenario outside completed|in-flight was ACCEPTED"
+else
+  if jq -e '.adoption' "$S4D/manifest.json" >/dev/null 2>&1; then
+    fail_ "S4" "the stamp refused (rc non-zero) but still wrote an adoption block"
+  else
+    pass "S4: a scenario outside §8.5's completed|in-flight enum is refused and nothing is written"
+  fi
+fi
+
+echo ""
+echo "=== T — the TDD pre-adoption arm (§5.3 kind (c); dual-direction) ==="
+
+# mk_tdd_proj DIR TIER — a scratch project on the NON-bypassable tier by
+# default, so a firing TDD gate HARD-BLOCKS (rc 1) rather than warns and the
+# exit code is an unambiguous verdict. current_phase=1 keeps the BL-006
+# message check short-circuited (< 2) so the TDD arm alone decides.
+mk_tdd_proj() {
+  local d="$1" tier="${2:-strict}"
+  mkdir -p "$d/.claude" "$d/scripts/lib"
+  ( cd "$d" \
+      && git init -q \
+      && git config user.email "wp3@test.invalid" \
+      && git config user.name  "WP3 Test" \
+      && echo "# scratch" > README.md \
+      && git add README.md \
+      && git commit -q -m "chore: their history" ) || return 1
+  if [ "$tier" = "strict" ]; then
+    printf '%s\n' '{"current_phase":1,"track":"full","deployment":"organizational","poc_mode":"sponsored_poc","phases":{}}' > "$d/.claude/phase-state.json"
+  else
+    printf '%s\n' '{"current_phase":1,"track":"light","deployment":"personal","poc_mode":null,"phases":{}}' > "$d/.claude/phase-state.json"
+  fi
+  printf '%s\n' '{"phase2_init":{"steps_completed":[],"verified":false},"build_loop":{"feature":null,"step":0,"steps_completed":[]},"uat_session":{},"phase3_validation":{},"phase4_release":{}}' > "$d/.claude/process-state.json"
+  printf '%s\n' '{"frameworkVersion":"test","host":"other","mode":"personal"}' > "$d/.claude/manifest.json"
+  cp "$PCG" "$d/scripts/"
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-full.sh" \
+     "$REPO_ROOT/scripts/lib/tdd-classify.sh" \
+     "$LIB" "$d/scripts/lib/"
+  chmod +x "$d/scripts/pre-commit-gate.sh"
+}
+
+# adopt_proj DIR — write a real adoption stamp into the fixture's manifest with
+# the anchor at the CURRENT tip (this is the adoption window: the stamp exists,
+# the adoption commit has not landed yet).
+adopt_proj() {
+  local d="$1"
+  ( cd "$d" && soif_adoption_stamp ".claude/manifest.json" "completed" 3 '[]' '[]' '["tdd-ordering"]' '[]' "sha" )
+}
+
+# stage_impl_only DIR — one implementation file, no test, staged.
+stage_impl_only() {
+  local d="$1"
+  mkdir -p "$d/src"
+  printf 'export function add(a,b){return a+b;}\n' > "$d/src/add.js"
+  ( cd "$d" && git add src/add.js )
+}
+
+# run_tdd DIR SUBJECT — the commit-msg surface. Echoes output; rc is the verdict.
+run_tdd() {
+  local d="$1" subject="$2"
+  printf '%s\n' "$subject" > "$d/.git/COMMIT_EDITMSG"
+  ( cd "$d" && bash scripts/pre-commit-gate.sh --terminal-mode --tdd-only 2>&1 )
+}
+
+# ── T1 — direction (i) CONTROL: a pre-adoption commit is exempt ─────────────
+T1D="$(newtmp)/p"
+if ! mk_tdd_proj "$T1D"; then
+  fail_ "T1" "fixture setup failed"
+else
+  adopt_proj "$T1D" >/dev/null 2>&1
+  stage_impl_only "$T1D"
+  t1_out=$(run_tdd "$T1D" "feat: their pre-adoption work"); t1_rc=$?
+  if [ "$t1_rc" -eq 0 ]; then
+    pass "T1 (direction i, control): an adopted project's PRE-adoption commit is exempt on a NON-bypassable tier — rc 0"
+  else
+    fail_ "T1" "rc=$t1_rc (want 0). Output: $(printf '%s' "$t1_out" | tail -3 | tr '\n' ' ')"
+  fi
+fi
+
+# ── T2 — direction (i) MUTATION: neuter the exemption guard ────────────────
+T2R="$(newtmp)"; T2D="$T2R/p"
+if ! mk_tdd_proj "$T2D"; then
+  fail_ "T2" "fixture setup failed"
+else
+  adopt_proj "$T2D" >/dev/null 2>&1
+  stage_impl_only "$T2D"
+  MUT="$T2D/scripts/pre-commit-gate.sh"
+  guard_sites=$(grep -c 'BF-ADOPT-TDD-GUARD$' "$PCG" 2>/dev/null); guard_sites=$(_num "$guard_sites")
+  cp "$PCG" "$T2R/orig.ref"
+  _sed_inplace "$MUT" 's|^.*BF-ADOPT-TDD-GUARD$|  if false; then   # BF-ADOPT-TDD-GUARD|'
+  chg2=$(_changed_lines "$T2R/orig.ref" "$MUT")
+  p2=$(_parses "$MUT")
+  t2_out=$(run_tdd "$T2D" "feat: their pre-adoption work"); t2_rc=$?
+  if [ "$t2_rc" -ne 0 ] && [ "$chg2" -eq 2 ] && [ "$guard_sites" -eq 1 ] && [ "$p2" -eq 1 ]; then
+    pass "T2 (direction i, mutation): with the exemption guard neutered (1 line, mutant still parses), the SAME pre-adoption fixture BLOCKS — rc $t2_rc; the exemption is load-bearing"
+  else
+    fail_ "T2" "rc=$t2_rc (want non-zero) changed_lines=$chg2 (want 2) guard_anchor_sites=$guard_sites (want 1) mutant_parses=$p2 (want 1)"
+  fi
+fi
+
+# ── T3 — direction (ii) CONTROL: a POST-adoption commit blocks ─────────────
+# The adoption commit has landed, so the anchor is a STRICT ancestor of HEAD.
+T3R="$(newtmp)"; T3D="$T3R/p"
+if ! mk_tdd_proj "$T3D"; then
+  fail_ "T3" "fixture setup failed"
+else
+  adopt_proj "$T3D" >/dev/null 2>&1
+  ( cd "$T3D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  stage_impl_only "$T3D"
+  t3_out=$(run_tdd "$T3D" "feat: work written AFTER adoption day"); t3_rc=$?
+  if [ "$t3_rc" -ne 0 ]; then
+    pass "T3 (direction ii, control): a POST-adoption commit with no test BLOCKS — rc $t3_rc. §4.5: no arm exempts a commit written after adoption day"
+  else
+    fail_ "T3" "rc=$t3_rc (want non-zero) — the exemption leaked past the adoption commit"
+  fi
+fi
+
+# ── T4 — direction (ii) MUTATION: neuter the BOUND. THE PROOF THAT MATTERS ──
+# An unbounded exemption is a permanent TDD waiver wearing an adoption badge.
+# The expected mutant result is an ABSENCE (no block), so this carries a
+# structural discriminator: the mutant must PRINT the arm's own exemption line,
+# which only the exemption path can emit. rc is still the verdict.
+T4R="$(newtmp)"; T4D="$T4R/p"
+if ! mk_tdd_proj "$T4D"; then
+  fail_ "T4" "fixture setup failed"
+else
+  adopt_proj "$T4D" >/dev/null 2>&1
+  ( cd "$T4D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  stage_impl_only "$T4D"
+  MUT4="$T4D/scripts/lib/adoption-stamp.sh"
+  bound_sites=$(grep -c 'BF-ADOPT-BOUND$' "$LIB" 2>/dev/null); bound_sites=$(_num "$bound_sites")
+  cp "$LIB" "$T4R/orig-lib.ref"
+  _sed_inplace "$MUT4" 's|^.*BF-ADOPT-BOUND$|  if false; then   # BF-ADOPT-BOUND|'
+  chg4=$(_changed_lines "$T4R/orig-lib.ref" "$MUT4")
+  p4=$(_parses "$MUT4")
+  t4_out=$(run_tdd "$T4D" "feat: work written AFTER adoption day"); t4_rc=$?
+  # Discriminator 1: the mutant library still LOADS and still answers the
+  # accessor — so an rc 0 cannot be a crashed-and-silent mutant.
+  d4_load=0
+  ( . "$MUT4" && soif_adoption_adopted "$T4D/.claude/manifest.json" ) >/dev/null 2>&1 && d4_load=1
+  # Discriminator 2: the EXEMPTION path announced itself. rc 0 alone is shared
+  # by "exempted" and "the gate never fired"; only the exemption emits this.
+  d4_msg=0
+  printf '%s' "$t4_out" | grep -q 'PRE-ADOPTION commit' && d4_msg=1
+  if [ "$t4_rc" -eq 0 ] && [ "$chg4" -eq 2 ] && [ "$bound_sites" -eq 1 ] \
+     && [ "$p4" -eq 1 ] && [ "$d4_load" -eq 1 ] && [ "$d4_msg" -eq 1 ]; then
+    pass "T4 (direction ii, mutation — THE ONE THAT MATTERS): with the BOUND neutered (1 line, mutant still parses), a POST-adoption commit with no test PASSES (rc 0) via the exemption path; the unmutated control (T3) blocks"
+  else
+    fail_ "T4" "rc=$t4_rc (want 0) changed_lines=$chg4 (want 2) bound_anchor_sites=$bound_sites (want 1) mutant_parses=$p4 (want 1) mutant_lib_loads=$d4_load (want 1) exemption_path_announced=$d4_msg (want 1)"
+  fi
+fi
+
+# ── T5 — greenfield regression: the arm must not leak ──────────────────────
+T5R="$(newtmp)"; T5D="$T5R/p"
+if ! mk_tdd_proj "$T5D"; then
+  fail_ "T5" "fixture setup failed"
+else
+  stage_impl_only "$T5D"
+  t5_out=$(run_tdd "$T5D" "feat: ordinary greenfield work"); t5_rc=$?
+  if [ "$t5_rc" -ne 0 ]; then
+    pass "T5: a project with NO adoption block behaves exactly as before — rc $t5_rc on a non-bypassable tier"
+  else
+    fail_ "T5" "rc=$t5_rc (want non-zero) — the WP3 arm changed greenfield behaviour"
+  fi
+fi
+
+# ── T6 — tier behaviour untouched (§9) ─────────────────────────────────────
+T6R="$(newtmp)"; T6D="$T6R/p"
+if ! mk_tdd_proj "$T6D" bypassable; then
+  fail_ "T6" "fixture setup failed"
+else
+  adopt_proj "$T6D" >/dev/null 2>&1
+  ( cd "$T6D" && git add -A .claude && git commit -q -m "chore: adopt project" ) >/dev/null 2>&1
+  stage_impl_only "$T6D"
+  t6_out=$(run_tdd "$T6D" "feat: post-adoption on a bypassable tier"); t6_rc=$?
+  t6_warned=0
+  printf '%s' "$t6_out" | grep -q 'BL-072 TDD ordering' && t6_warned=1
+  if [ "$t6_rc" -eq 0 ] && [ "$t6_warned" -eq 1 ]; then
+    pass "T6: tier behaviour is UNTOUCHED — a bypassable tier still warns-and-allows post-adoption (rc 0, BL-072 line emitted)"
+  else
+    fail_ "T6" "rc=$t6_rc (want 0) bl072_line_emitted=$t6_warned (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== G — stamp acceptance in the gate + the loss detector ==="
+
+# mk_gate_proj DIR — a project check-phase-gate.sh will actually evaluate.
+mk_gate_proj() {
+  local d="$1"
+  mkdir -p "$d/.claude" "$d/scripts/lib" "$d/docs"
+  ( cd "$d" \
+      && git init -q \
+      && git config user.email "wp3g@test.invalid" \
+      && git config user.name  "WP3 Gate Test" ) || return 1
+  printf '%s\n' '{"current_phase":0,"track":"light","deployment":"personal","poc_mode":null,"gates":{}}' > "$d/.claude/phase-state.json"
+  printf '%s\n' '# Approval Log' > "$d/APPROVAL_LOG.md"
+  printf '%s\n' '{"frameworkVersion":"test","host":"other","mode":"personal"}' > "$d/.claude/manifest.json"
+  cp "$GATE" "$d/scripts/"
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-full.sh" \
+     "$LIB" "$d/scripts/lib/"
+  chmod +x "$d/scripts/check-phase-gate.sh"
+}
+
+run_gate() { ( cd "$1" && bash scripts/check-phase-gate.sh 2>&1 ); }
+
+# ── G1 — intact adoption ⇒ no finding (baseline parity) ────────────────────
+G1D="$(newtmp)/p"
+if ! mk_gate_proj "$G1D"; then
+  fail_ "G1" "fixture setup failed"
+else
+  g1_base_out=$(run_gate "$G1D"); g1_base_rc=$?
+  ( cd "$G1D" && soif_adoption_stamp ".claude/manifest.json" "completed" 0 '[]' '[]' '[]' '[]' "sha" ) >/dev/null 2>&1
+  ( cd "$G1D" && git add -A && git commit -q -m "chore: adopt" ) >/dev/null 2>&1
+  g1_out=$(run_gate "$G1D"); g1_rc=$?
+  if [ "$g1_rc" -eq "$g1_base_rc" ] && [ "$g1_rc" -eq 0 ]; then
+    pass "G1: an adopted project with an INTACT stamp exits exactly as the unadopted control (rc $g1_rc) — the arm adds no finding when nothing is wrong"
+  else
+    fail_ "G1" "adopted_rc=$g1_rc unadopted_control_rc=$g1_base_rc (want both 0)"
+  fi
+fi
+
+# ── G2 — the stamp is committed at HEAD but gone from the working tree ─────
+G2D="$(newtmp)/p"
+if ! mk_gate_proj "$G2D"; then
+  fail_ "G2" "fixture setup failed"
+else
+  ( cd "$G2D" && soif_adoption_stamp ".claude/manifest.json" "completed" 0 '[]' '[]' '[]' '[]' "sha" ) >/dev/null 2>&1
+  ( cd "$G2D" && git add -A && git commit -q -m "chore: adopt" ) >/dev/null 2>&1
+  # Simulate the wholesale regeneration: an upstream key set with no Solo keys.
+  printf '%s\n' '{"frameworkVersion":"9","frameworkRepo":"kraulerson/claude-dev-framework","files":{}}' > "$G2D/.claude/manifest.json"
+  g2_out=$(run_gate "$G2D"); g2_rc=$?
+  g2_named=0
+  printf '%s' "$g2_out" | grep -q 'adoption' && g2_named=1
+  if [ "$g2_rc" -ne 0 ] && [ "$g2_named" -eq 1 ]; then
+    pass "G2: a manifest regenerated without the adoption block makes the gate exit NON-ZERO (rc $g2_rc) and the report names the loss — detected, not prevented"
+  else
+    fail_ "G2" "rc=$g2_rc (want non-zero) loss_reported=$g2_named (want 1)"
+  fi
+fi
+
+# ── G3 — MUTATION: remove the detection ⇒ the project SILENTLY un-adopts ───
+# Expected mutant result is an ABSENCE, so the discriminators matter: the
+# mutant gate must still RUN to completion (it prints its own consistency
+# verdict) and the mutant library must still answer the accessor.
+G3R="$(newtmp)"; G3D="$G3R/p"
+if ! mk_gate_proj "$G3D"; then
+  fail_ "G3" "fixture setup failed"
+else
+  ( cd "$G3D" && soif_adoption_stamp ".claude/manifest.json" "completed" 0 '[]' '[]' '[]' '[]' "sha" ) >/dev/null 2>&1
+  ( cd "$G3D" && git add -A && git commit -q -m "chore: adopt" ) >/dev/null 2>&1
+  printf '%s\n' '{"frameworkVersion":"9","frameworkRepo":"kraulerson/claude-dev-framework","files":{}}' > "$G3D/.claude/manifest.json"
+  MUT3="$G3D/scripts/lib/adoption-stamp.sh"
+  det_sites=$(grep -c 'BF-ADOPT-LOSS-DETECT$' "$LIB" 2>/dev/null); det_sites=$(_num "$det_sites")
+  cp "$LIB" "$G3R/orig-lib.ref"
+  _sed_inplace "$MUT3" 's|^.*BF-ADOPT-LOSS-DETECT$|  return 1   # BF-ADOPT-LOSS-DETECT|'
+  chg3=$(_changed_lines "$G3R/orig-lib.ref" "$MUT3")
+  p3=$(_parses "$MUT3")
+  g3_out=$(run_gate "$G3D"); g3_rc=$?
+  d3_ran=0
+  printf '%s' "$g3_out" | grep -q 'Phase gates consistent' && d3_ran=1
+  d3_load=0
+  ( . "$MUT3" && ! soif_adoption_adopted "$G3D/.claude/manifest.json" ) >/dev/null 2>&1 && d3_load=1
+  if [ "$g3_rc" -eq 0 ] && [ "$chg3" -eq 2 ] && [ "$det_sites" -eq 1 ] && [ "$p3" -eq 1 ] \
+     && [ "$d3_ran" -eq 1 ] && [ "$d3_load" -eq 1 ]; then
+    pass "G3 (mutation): with the post-regeneration detection removed (1 line), the project SILENTLY un-adopts — the gate exits 0 on the same fixture G2 blocks; the mutant gate still ran to its own verdict and the mutant library still loads"
+  else
+    fail_ "G3" "rc=$g3_rc (want 0) changed_lines=$chg3 (want 2) detect_anchor_sites=$det_sites (want 1) mutant_parses=$p3 (want 1) gate_ran_to_verdict=$d3_ran (want 1) mutant_lib_loads=$d3_load (want 1)"
+  fi
+fi
+
+# ── G4 — mid-adoption: the stamp is not committed yet ⇒ no false alarm ─────
+G4D="$(newtmp)/p"
+if ! mk_gate_proj "$G4D"; then
+  fail_ "G4" "fixture setup failed"
+else
+  ( cd "$G4D" && git add -A && git commit -q -m "chore: their history" ) >/dev/null 2>&1
+  ( cd "$G4D" && soif_adoption_stamp ".claude/manifest.json" "in-flight" 0 '[]' '[]' '[]' '[]' "sha" ) >/dev/null 2>&1
+  g4_out=$(run_gate "$G4D"); g4_rc=$?
+  if [ "$g4_rc" -eq 0 ]; then
+    pass "G4: a mid-adoption project (stamp written, not yet committed) raises NO loss finding — rc 0"
+  else
+    fail_ "G4" "rc=$g4_rc (want 0) — false alarm before the adoption commit lands"
+  fi
+fi
+
+# ── G5 — no FALSE ALARM from a subdirectory ────────────────────────────────
+# `git show HEAD:<p>` resolves from the REPO ROOT; `[ -f <p> ]` resolves from
+# the CWD. Off-root those name different files, and the mismatch reads exactly
+# like "committed but missing from the working tree". A false FAIL is the
+# failure direction this repo has already paid for twice, so the guard against
+# it gets its own pin rather than riding on the happy path.
+G5D="$(newtmp)/p"
+if ! mk_gate_proj "$G5D"; then
+  fail_ "G5" "fixture setup failed"
+else
+  ( cd "$G5D" && soif_adoption_stamp ".claude/manifest.json" "completed" 0 '[]' '[]' '[]' '[]' "sha" ) >/dev/null 2>&1
+  ( cd "$G5D" && git add -A && git commit -q -m "chore: adopt" ) >/dev/null 2>&1
+  mkdir -p "$G5D/src/deep"
+  g5_root_lost=0
+  ( cd "$G5D" && soif_adoption_integrity_lost ".claude/manifest.json" ) >/dev/null 2>&1 && g5_root_lost=1
+  g5_sub_lost=0
+  ( cd "$G5D/src/deep" && soif_adoption_integrity_lost ".claude/manifest.json" ) >/dev/null 2>&1 && g5_sub_lost=1
+  if [ "$g5_root_lost" -eq 0 ] && [ "$g5_sub_lost" -eq 0 ]; then
+    pass "G5: an intact adopted project reports no loss from the repo root AND none from a subdirectory — the off-root path mismatch cannot manufacture a false FAIL"
+  else
+    fail_ "G5" "loss_at_root=$g5_root_lost (want 0) loss_in_subdir=$g5_sub_lost (want 0)"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-brownfield-wp3-adoption-arms.sh
+++ b/tests/test-brownfield-wp3-adoption-arms.sh
@@ -509,32 +509,55 @@ atk_base() {
 }
 
 # atk_verdict DIR — stage an impl-only change, run the real commit-msg surface
-# with a post-adoption `feat:` subject, echo "<rc>|<exempt-banner-seen>".
+# with a post-adoption `feat:` subject, echo "<rc>|<banner>|<blocked-for-reason>".
+#
+# THE THIRD FIELD IS THE POINT (adversarial re-review R-WP3-7). "rc non-zero and
+# no exemption banner" is satisfied by a row that never reached the gate at all
+# — a fixture that rots and exits 127 scores rc=127, banner=0 and would be
+# credited as BLOCKED. That is the same vacuity class that let the original
+# bound hole hide behind 19/19 green, and its cousin already bit this file once
+# (T7d's aborted cherry-pick died at the derivative-resume sentinel, rc 0 and no
+# banner, reading exactly like a hole while proving nothing). So a row only
+# counts as blocked when the BL-072 gate itself says it blocked. `grep -F` is
+# load-bearing here: `[FAIL]` is a character class in a basic regex and would
+# never match the literal text.
 atk_verdict() {
-  local d="$1" out rc=0 banner=0
+  local d="$1" out rc=0 banner=0 reason=0
   stage_impl_only "$d" >/dev/null 2>&1
   out=$(run_tdd "$d" "feat: work written AFTER adoption day") || rc=$?
   printf '%s' "$out" | grep -q 'PRE-ADOPTION commit' && banner=1
-  printf '%s|%s\n' "$rc" "$banner"
+  printf '%s' "$out" | grep -qF '[FAIL] BL-072 TDD ordering' && reason=1
+  printf '%s|%s|%s\n' "$rc" "$banner" "$reason"
 }
 
-# atk_report LABEL DIR EXPECT — EXPECT is `blocked` (rc non-zero) or `exempt`.
+# _atk_split VALUE — parse atk_verdict's triple into ATK_RC/ATK_BANNER/
+# ATK_REASON. Called from the PARENT shell (never a subshell) so the globals
+# survive; `${v##*|}` alone silently reads the wrong field once there are three.
+_atk_split() {
+  local v="$1" rest
+  ATK_RC="${v%%|*}"; rest="${v#*|}"
+  ATK_BANNER="${rest%%|*}"; ATK_REASON="${rest##*|}"
+}
+
+# atk_report LABEL DIR EXPECT — EXPECT is `blocked` or `exempt`. Verdict is the
+# EXIT CODE; the banner and the block-reason are discriminators that say WHICH
+# path produced it.
 atk_report() {
-  local label="$1" d="$2" expect="$3" v rc banner
-  v="$(atk_verdict "$d")"
-  rc="${v%%|*}"; banner="${v##*|}"
+  local label="$1" d="$2" expect="$3" rc banner reason
+  _atk_split "$(atk_verdict "$d")"
+  rc="$ATK_RC"; banner="$ATK_BANNER"; reason="$ATK_REASON"
   ATK_RCS="${ATK_RCS}${label}=rc:${rc} "
   if [ "$expect" = "blocked" ]; then
-    if [ "$rc" -ne 0 ] && [ "$banner" -eq 0 ]; then
-      pass "$label: BLOCKED (rc=$rc, no exemption banner) — the bound holds"
+    if [ "$rc" -ne 0 ] && [ "$banner" -eq 0 ] && [ "$reason" -eq 1 ]; then
+      pass "$label: BLOCKED (rc=$rc, no exemption banner, blocked BY the BL-072 gate) — the bound holds"
     else
-      fail_ "$label" "rc=$rc (want non-zero) exemption_banner=$banner (want 0) — a POST-adoption commit was exempted"
+      fail_ "$label" "rc=$rc (want non-zero) exemption_banner=$banner (want 0) blocked_by_tdd_gate=$reason (want 1) — either a POST-adoption commit was exempted, or the fixture never reached the gate and the row would have false-passed"
     fi
   else
-    if [ "$rc" -eq 0 ] && [ "$banner" -eq 1 ]; then
-      pass "$label: EXEMPT (rc=0, banner printed) — the adoption window is preserved"
+    if [ "$rc" -eq 0 ] && [ "$banner" -eq 1 ] && [ "$reason" -eq 0 ]; then
+      pass "$label: EXEMPT (rc=0, banner printed, no gate block) — the adoption window is preserved"
     else
-      fail_ "$label" "rc=$rc (want 0) exemption_banner=$banner (want 1)"
+      fail_ "$label" "rc=$rc (want 0) exemption_banner=$banner (want 1) blocked_by_tdd_gate=$reason (want 0)"
     fi
   fi
 }
@@ -681,7 +704,7 @@ T8A="$(newtmp)"; T8AD="$T8A/p"
 if ! atk_base "$T8AD"; then fail_ "T8a" "fixture setup failed"; else
   h=$( cd "$T8AD" && git rev-parse HEAD )
   ( cd "$T8AD" && jq --arg h "$h" '.adoption.adoptedAtCommit = $h' .claude/manifest.json > m.tmp && mv m.tmp .claude/manifest.json ) >/dev/null 2>&1
-  ctl="$(atk_verdict "$T8AD")"; ctl_rc="${ctl%%|*}"
+  _atk_split "$(atk_verdict "$T8AD")"; ctl_rc="$ATK_RC"; ctl_reason="$ATK_REASON"
   MUT8A="$T8AD/scripts/lib/adoption-stamp.sh"
   bound_sites=$(grep -c 'BF-ADOPT-BOUND$' "$LIB" 2>/dev/null); bound_sites=$(_num "$bound_sites")
   cp "$LIB" "$T8A/orig-lib.ref"
@@ -689,12 +712,12 @@ if ! atk_base "$T8AD"; then fail_ "T8a" "fixture setup failed"; else
   chg8a=$(_changed_lines "$T8A/orig-lib.ref" "$MUT8A")
   p8a=$(_parses "$MUT8A")
   ( cd "$T8AD" && git reset -q ) >/dev/null 2>&1
-  mut="$(atk_verdict "$T8AD")"; mut_rc="${mut%%|*}"; mut_banner="${mut##*|}"
-  if [ "$ctl_rc" -ne 0 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_banner" -eq 1 ] \
+  _atk_split "$(atk_verdict "$T8AD")"; mut_rc="$ATK_RC"; mut_banner="$ATK_BANNER"
+  if [ "$ctl_rc" -ne 0 ] && [ "$ctl_reason" -eq 1 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_banner" -eq 1 ] \
      && [ "$chg8a" -eq 2 ] && [ "$bound_sites" -eq 1 ] && [ "$p8a" -eq 1 ]; then
-    pass "T8a: dropping the COMMITTED-WITNESS conjunct (1 line, mutant parses) lets a tampered anchor exempt a post-adoption commit (rc 0, banner); the unmutated control blocks (rc $ctl_rc) — conjunct 2 is load-bearing"
+    pass "T8a: dropping the COMMITTED-WITNESS conjunct (1 line, mutant parses) lets a tampered anchor exempt a post-adoption commit (rc 0, banner); the unmutated control blocks BY the BL-072 gate (rc $ctl_rc) — conjunct 2 is load-bearing"
   else
-    fail_ "T8a" "control_rc=$ctl_rc (want non-zero) mutant_rc=$mut_rc (want 0) mutant_banner=$mut_banner (want 1) changed_lines=$chg8a (want 2) bound_sites=$bound_sites (want 1) parses=$p8a (want 1)"
+    fail_ "T8a" "control_rc=$ctl_rc (want non-zero) control_blocked_by_gate=$ctl_reason (want 1) mutant_rc=$mut_rc (want 0) mutant_banner=$mut_banner (want 1) changed_lines=$chg8a (want 2) bound_sites=$bound_sites (want 1) parses=$p8a (want 1)"
   fi
 fi
 
@@ -708,19 +731,19 @@ if ! mk_tdd_proj "$T8BD"; then fail_ "T8b" "fixture setup failed"; else
   adopt_proj "$T8BD" >/dev/null 2>&1
   ( cd "$T8BD" && mkdir -p src && echo 'export const a=1;' > src/unrelated.js \
       && git add src/unrelated.js && git commit -q -m "chore: unrelated work" ) >/dev/null 2>&1
-  ctl="$(atk_verdict "$T8BD")"; ctl_rc="${ctl%%|*}"
+  _atk_split "$(atk_verdict "$T8BD")"; ctl_rc="$ATK_RC"; ctl_reason="$ATK_REASON"
   MUT8B="$T8BD/scripts/lib/adoption-stamp.sh"
   cp "$LIB" "$T8B/orig-lib.ref"
   _sed_inplace "$MUT8B" 's|^.*BF-ADOPT-BOUND$|  if _soif_adoption_head_copy_adopted "$manifest"; then   # BF-ADOPT-BOUND|'
   chg8b=$(_changed_lines "$T8B/orig-lib.ref" "$MUT8B")
   p8b=$(_parses "$MUT8B")
   ( cd "$T8BD" && git reset -q ) >/dev/null 2>&1
-  mut="$(atk_verdict "$T8BD")"; mut_rc="${mut%%|*}"; mut_banner="${mut##*|}"
-  if [ "$ctl_rc" -ne 0 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_banner" -eq 1 ] \
+  _atk_split "$(atk_verdict "$T8BD")"; mut_rc="$ATK_RC"; mut_banner="$ATK_BANNER"
+  if [ "$ctl_rc" -ne 0 ] && [ "$ctl_reason" -eq 1 ] && [ "$mut_rc" -eq 0 ] && [ "$mut_banner" -eq 1 ] \
      && [ "$chg8b" -eq 2 ] && [ "$p8b" -eq 1 ]; then
-    pass "T8b: dropping the anchor==HEAD conjunct (1 line, mutant parses) exempts a commit made AFTER the stamp on a still-uncommitted manifest (rc 0, banner); the unmutated control blocks (rc $ctl_rc) — conjunct 1 is load-bearing"
+    pass "T8b: dropping the anchor==HEAD conjunct (1 line, mutant parses) exempts a commit made AFTER the stamp on a still-uncommitted manifest (rc 0, banner); the unmutated control blocks BY the BL-072 gate (rc $ctl_rc) — conjunct 1 is load-bearing"
   else
-    fail_ "T8b" "control_rc=$ctl_rc (want non-zero) mutant_rc=$mut_rc (want 0) mutant_banner=$mut_banner (want 1) changed_lines=$chg8b (want 2) parses=$p8b (want 1)"
+    fail_ "T8b" "control_rc=$ctl_rc (want non-zero) control_blocked_by_gate=$ctl_reason (want 1) mutant_rc=$mut_rc (want 0) mutant_banner=$mut_banner (want 1) changed_lines=$chg8b (want 2) parses=$p8b (want 1)"
   fi
 fi
 

--- a/tests/test-brownfield-wp3-regenerate-path.sh
+++ b/tests/test-brownfield-wp3-regenerate-path.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp3-regenerate-path.sh
+#
+# Brownfield adoption WP3 — THE REGENERATE-PATH PROOF. Design
+# docs/designs/2026-08-02-brownfield-adoption-v1.md §10-WP3 and §12-12.
+#
+# ── WHY THIS SUITE EXISTS, AND WHY IT IS AIMED WHERE IT IS ──────────────────
+# The design's v1.0 regression proof for WP3 was "run fix_phase_state(), assert
+# the adoption stamp survives". It was REFUTED as trivially green and
+# worthless: that function never touches .claude/manifest.json, so it could not
+# have failed. v1.1 (R-BF-1) re-aimed it at the path that actually erases the
+# stamp:
+#
+#   .claude/manifest.json goes missing
+#     -> verify-install.sh registers fix_framework_manifest as the repair
+#     -> fix_framework_manifest delegates to the UPSTREAM framework installer
+#     -> that installer rewrites the manifest WHOLESALE from a hardcoded key
+#        set carrying no Solo keys at all
+#     -> the adoption stamp and the `adopted` flag are gone.
+#
+# THE LOSS CANNOT BE PREVENTED. The writer lives in a different repository and
+# is outside this design's control. So the deliverable is not prevention — it
+# is that the loss is DETECTED AND REPORTED LOUDLY, and that removing the
+# detection makes a project SILENTLY UN-ADOPT. That is the honest shape: the
+# design cannot stop the erasure, so it must refuse to be quiet about it.
+#
+# ── Verdicts are EXIT CODES ────────────────────────────────────────────────
+# check-phase-gate.sh's [WARN]/[FAIL] labels are cosmetic — the exit predicate
+# is `if [ $issues -eq 0 ]`, so an exemption is the ABSENCE of an increment.
+# Every verdict below is an exit code; printed text is only ever a path
+# discriminator.
+#
+# ── Scenarios ──────────────────────────────────────────────────────────────
+#   R1  WIRING PIN. The repair really is reachable from the repair tool, and it
+#       really is MISSING-FILE-GATED — §12-12's narrow, load-bearing
+#       assumption. Registration and delegation each pinned at sites==1.
+#   R2  THE UPSTREAM WRITER, MEASURED. The REAL fix_framework_manifest,
+#       extracted from the shipped script, is executed against a fixture whose
+#       committed manifest carried a real adoption stamp. Assert the manifest
+#       comes back, comes back from the upstream key set, and comes back
+#       carrying NONE of this framework's keys. R2 is the NON-VACUITY GATE for
+#       R3/R4: if the regeneration did not happen, a missing manifest would
+#       make the detector fire for the wrong reason and R3 would pass having
+#       proved nothing.
+#   R3  DETECTION. On that REAL regenerated manifest the gate exits NON-ZERO
+#       and names the loss.
+#   R4  MUTATION. Remove the detection (one line) and the same fixture exits 0
+#       — the project silently un-adopts.
+#
+# ── Why this is a separate suite from test-brownfield-wp3-adoption-arms.sh ──
+# It EXECUTES the upstream installer, so it is legitimately unit-lane exempt
+# and belongs to the aggregator only. Everything provable without the installer
+# lives in the sibling suite and stays in the fast lane. It also SKIPS cleanly
+# (exit 0) when the upstream clone is absent, so a runner without it is not a
+# false red.
+#
+# HERMETICITY: fixtures are temp dirs; the installer writes only inside them;
+# no network and no remote creation (it copies from the existing local clone).
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/adoption-stamp.sh"
+GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+VERIFY="$REPO_ROOT/scripts/verify-install.sh"
+CDF_CLONE="${SOIF_CDF_CLONE:-$HOME/.claude-dev-framework}"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+skip()  { echo "  [SKIP] $1"; SKIPPED=$((SKIPPED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+
+if [ ! -f "$LIB" ]; then
+  echo "  [FAIL] setup — $LIB not found (WP3 library missing)"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+# shellcheck source=/dev/null
+. "$LIB"
+
+echo "=== R1 — the repair is wired, and it is missing-file-gated (§12-12) ==="
+
+REG_ANCHOR='register_fixable "Development Guardrails manifest missing" "fix_framework_manifest"'
+# The allow marker is the sanctioned escape and the reason is load-bearing, so
+# state it precisely rather than string-splitting the token to duck the lint
+# (that trick is the very hole CLAUDE.md records against the unit-lane
+# predicate). This line is a GREP ANCHOR, not an execution. The suite DOES run
+# the upstream installer later, via the extracted repair function — and that
+# installer has NO host-API or remote-creation path at all: measured, it
+# contains no `gh`, no `glab`, no `curl`, and no `git remote add`. Its single
+# `git push` sits in the profile-detector's "type 'new' to create a profile"
+# branch, which is unreachable here twice over: the fixture carries a
+# detectable profile signal so the no-signal branch never opens, and the suite
+# feeds "y" rather than "new".
+DEL_ANCHOR='bash "$FRAMEWORK_CLONE/scripts/init.sh"'   # lint-no-live-remote: allow grep anchor, not a run; the upstream installer it names has no host-API or remote-creation path (no gh/glab/curl/git remote add)
+r1_reg=$(grep -cF -- "$REG_ANCHOR" "$VERIFY" 2>/dev/null); r1_reg=$(_num "$r1_reg")
+r1_del=$(grep -cF -- "$DEL_ANCHOR" "$VERIFY" 2>/dev/null); r1_del=$(_num "$r1_del")
+r1_fn=$(grep -c '^fix_framework_manifest() {$' "$VERIFY" 2>/dev/null); r1_fn=$(_num "$r1_fn")
+# Missing-file-gated: the registration must sit in the ELSE arm of a bare
+# `[ -f ".claude/manifest.json" ]` test. §12-12's real assumption is exactly
+# this — that the upstream writer is only ever reached when the file is already
+# gone, so it never DESTROYS a stamp that was present. If this gate ever
+# disappears, every adopted project un-adopts on the next repair run.
+r1_gated=0
+grep -B 3 -F -- "$REG_ANCHOR" "$VERIFY" 2>/dev/null \
+  | grep -q 'if \[ -f "\.claude/manifest\.json" \]; then' && r1_gated=1
+if [ "$r1_reg" -eq 1 ] && [ "$r1_del" -eq 1 ] && [ "$r1_fn" -eq 1 ] && [ "$r1_gated" -eq 1 ]; then
+  pass "R1: the missing-manifest repair is registered exactly once, delegates to the upstream installer exactly once, and is MISSING-FILE-GATED — it can never destroy a stamp that is present"
+else
+  fail_ "R1" "registration_sites=$r1_reg (want 1) delegation_sites=$r1_del (want 1) function_sites=$r1_fn (want 1) missing_file_gated=$r1_gated (want 1)"
+fi
+
+# ── Extract the REAL repair function ────────────────────────────────────────
+# The whole repair tool is NOT run: under --auto-fix its other registered fixes
+# include package-manager installs, which is a real side effect on whoever runs
+# the suite and is not something a hermetic test may trigger. So the ONE
+# function under test is lifted verbatim from the shipped script and executed
+# for real, with R1 above pinning that it is genuinely the function the tool
+# dispatches for a missing manifest.
+FIXSRC="$TOPTMP/fix_framework_manifest.sh"
+awk '/^fix_framework_manifest\(\) \{$/{f=1} f{print} f&&/^\}$/{exit}' "$VERIFY" > "$FIXSRC"
+r_extract_ok=0
+if [ -s "$FIXSRC" ] && grep -qF -- "$DEL_ANCHOR" "$FIXSRC" && bash -n "$FIXSRC" 2>/dev/null; then
+  r_extract_ok=1
+fi
+
+echo ""
+echo "=== R2 — the upstream writer, measured against a real adoption stamp ==="
+
+CDF_OK=1
+[ -d "$CDF_CLONE/.git" ] || CDF_OK=0
+[ -f "$CDF_CLONE/scripts/init.sh" ] || CDF_OK=0
+
+# mk_adopted_project DIR — a committed, genuinely adopted project the upstream
+# installer will accept: a git repo with a profile signal it can detect.
+mk_adopted_project() {
+  local d="$1"
+  mkdir -p "$d/.claude" "$d/scripts/lib"
+  ( cd "$d" \
+      && git init -q \
+      && git config user.email "wp3r@test.invalid" \
+      && git config user.name  "WP3 Regen Test" ) || return 1
+  printf '%s\n' '{"current_phase":0,"track":"light","deployment":"personal","poc_mode":null,"gates":{}}' > "$d/.claude/phase-state.json"
+  printf '%s\n' '# Approval Log' > "$d/APPROVAL_LOG.md"
+  printf '%s\n' '{"name":"fixture","dependencies":{"express":"^4"}}' > "$d/package.json"
+  printf '%s\n' '{"frameworkVersion":"test","host":"other","mode":"personal","deployment":"personal"}' > "$d/.claude/manifest.json"
+  cp "$GATE" "$d/scripts/"
+  cp "$REPO_ROOT/scripts/lib/helpers.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-core.sh" \
+     "$REPO_ROOT/scripts/lib/helpers-full.sh" \
+     "$LIB" "$d/scripts/lib/"
+  chmod +x "$d/scripts/check-phase-gate.sh"
+  ( cd "$d" && soif_adoption_stamp ".claude/manifest.json" "completed" 0 '[]' '[]' '["tdd-ordering"]' '[]' "reportsha" ) || return 1
+  ( cd "$d" && git add -A && git commit -q -m "chore: adopt project" ) || return 1
+}
+
+run_gate() { ( cd "$1" && bash scripts/check-phase-gate.sh 2>&1 ); }
+
+R2D=""
+R2_READY=0
+if [ "$CDF_OK" -eq 0 ]; then
+  skip "R2 — upstream framework clone not found at $CDF_CLONE (set SOIF_CDF_CLONE to override); the regenerate path cannot be exercised"
+elif [ "$r_extract_ok" -eq 0 ]; then
+  fail_ "R2" "could not extract a runnable fix_framework_manifest from $VERIFY"
+else
+  R2D="$(newtmp)/p"
+  if ! mk_adopted_project "$R2D"; then
+    fail_ "R2" "fixture setup failed"
+  else
+    # NON-VACUITY, asserted before anything else: the fixture really is adopted
+    # and the stamp really is committed, so the witness R3 depends on exists.
+    pre_adopted=0
+    soif_adoption_adopted "$R2D/.claude/manifest.json" && pre_adopted=1
+    pre_witness=0
+    ( cd "$R2D" && git show "HEAD:.claude/manifest.json" | jq -e '.adoption.adopted == true' ) >/dev/null 2>&1 && pre_witness=1
+
+    rm -f "$R2D/.claude/manifest.json"
+    regen_rc=0
+    ( cd "$R2D" && . "$FIXSRC" && printf 'y\n' | fix_framework_manifest ) >"$TOPTMP/regen.log" 2>&1 || regen_rc=$?
+
+    regen_exists=0
+    [ -f "$R2D/.claude/manifest.json" ] && regen_exists=1
+    regen_upstream=0
+    jq -e '.frameworkRepo and .profile and .activeHooks' "$R2D/.claude/manifest.json" >/dev/null 2>&1 && regen_upstream=1
+    # The measurement the design rests on: the upstream key set carries NONE of
+    # this framework's keys.
+    solo_keys_left=0
+    jq -e '.adoption' "$R2D/.claude/manifest.json" >/dev/null 2>&1 && solo_keys_left=$((solo_keys_left + 1))
+    jq -e '.host'     "$R2D/.claude/manifest.json" >/dev/null 2>&1 && solo_keys_left=$((solo_keys_left + 1))
+    jq -e '.deployment' "$R2D/.claude/manifest.json" >/dev/null 2>&1 && solo_keys_left=$((solo_keys_left + 1))
+
+    if [ "$pre_adopted" -eq 1 ] && [ "$pre_witness" -eq 1 ] && [ "$regen_exists" -eq 1 ] \
+       && [ "$regen_upstream" -eq 1 ] && [ "$solo_keys_left" -eq 0 ]; then
+      R2_READY=1
+      pass "R2: the REAL repair function regenerated the manifest from the upstream key set, and every one of this framework's keys — adoption, host, deployment — is GONE. The stamp's loss is real, upstream, and unpreventable from here"
+    else
+      fail_ "R2" "pre_adopted=$pre_adopted (want 1) committed_witness=$pre_witness (want 1) regen_rc=$regen_rc manifest_regenerated=$regen_exists (want 1) is_upstream_keyset=$regen_upstream (want 1) solo_keys_surviving=$solo_keys_left (want 0) — see $TOPTMP/regen.log"
+    fi
+  fi
+fi
+
+echo ""
+echo "=== R3 — the loss is DETECTED and REPORTED LOUDLY ==="
+
+if [ "$R2_READY" -eq 0 ]; then
+  skip "R3 — no real regenerated manifest to judge (R2 skipped or failed); asserting on a fixture that was never regenerated would prove nothing"
+else
+  r3_out=$(run_gate "$R2D"); r3_rc=$?
+  r3_named=0
+  printf '%s' "$r3_out" | grep -q 'Adoption stamp LOST' && r3_named=1
+  r3_repair=0
+  printf '%s' "$r3_out" | grep -q 'REPAIR' && r3_repair=1
+  if [ "$r3_rc" -ne 0 ] && [ "$r3_named" -eq 1 ] && [ "$r3_repair" -eq 1 ]; then
+    pass "R3: after the REAL upstream regeneration the gate exits NON-ZERO (rc $r3_rc), names the lost stamp and prints a concrete repair — detected and loud, not prevented"
+  else
+    fail_ "R3" "rc=$r3_rc (want non-zero) loss_named=$r3_named (want 1) repair_printed=$r3_repair (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== R4 — MUTATION: remove the detection, the project silently un-adopts ==="
+
+if [ "$R2_READY" -eq 0 ]; then
+  skip "R4 — no real regenerated manifest to mutate against (R2 skipped or failed)"
+else
+  MUT="$R2D/scripts/lib/adoption-stamp.sh"
+  det_sites=$(grep -c 'BF-ADOPT-LOSS-DETECT$' "$LIB" 2>/dev/null); det_sites=$(_num "$det_sites")
+  REF="$TOPTMP/orig-lib.ref"
+  cp "$LIB" "$REF"
+  _sed_inplace "$MUT" 's|^.*BF-ADOPT-LOSS-DETECT$|  return 1   # BF-ADOPT-LOSS-DETECT|'
+  chg=$(_changed_lines "$REF" "$MUT")
+  p=$(_parses "$MUT")
+  r4_out=$(run_gate "$R2D"); r4_rc=$?
+  # Structural discriminators. The expected mutant result is an ABSENCE, and
+  # several unrelated edits share that silence: a gate that died early is also
+  # silent, and so is a library that failed to load. Both are excluded here.
+  d_ran=0
+  printf '%s' "$r4_out" | grep -q 'Phase gates consistent' && d_ran=1
+  d_load=0
+  ( . "$MUT" && ! soif_adoption_adopted "$R2D/.claude/manifest.json" ) >/dev/null 2>&1 && d_load=1
+  d_quiet=1
+  printf '%s' "$r4_out" | grep -q 'Adoption stamp LOST' && d_quiet=0
+  if [ "$r4_rc" -eq 0 ] && [ "$chg" -eq 2 ] && [ "$det_sites" -eq 1 ] && [ "$p" -eq 1 ] \
+     && [ "$d_ran" -eq 1 ] && [ "$d_load" -eq 1 ] && [ "$d_quiet" -eq 1 ]; then
+    pass "R4 (mutation): with the post-regeneration detection removed (1 line, mutant parses and still loads), the SAME really-regenerated project passes the gate (rc 0) in silence — it has silently un-adopted, and every gate arm now reads the flag as false. R3 is the control"
+  else
+    fail_ "R4" "rc=$r4_rc (want 0) changed_lines=$chg (want 2) detect_anchor_sites=$det_sites (want 1) mutant_parses=$p (want 1) gate_ran_to_verdict=$d_ran (want 1) mutant_lib_loads=$d_load (want 1) report_suppressed=$d_quiet (want 1)"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What

Brownfield Adoption **WP3** — the design's own named linchpin for that track, and the only brownfield package that touches a gate: `scripts/lib/adoption-stamp.sh` (core, sources nothing), one arm in `tdd_terminal_enforce`, and stamp acceptance in `check-phase-gate.sh`.

- **The `adopted` flag** and **`soif_adoption_stamp`** — one call site, sited beside `soif_currency_stamp`, additive merge into `.claude/manifest.json`'s `adoption` block per §8.5 (the reasoning is merge-versus-re-stamp, *not* the refuted "the manifest has no wholesale writer"). Absent flag ⇒ not adopted, so a greenfield project is untouched by every arm here.
- **The bounded TDD pre-adoption exemption** — pre-adoption code is exempt from test-first ordering; **nothing written after adoption day ever is** (§4.5). The trigger predicate, tier behaviour and ledger rows are untouched (§9).
- **Loud loss detection** — when the manifest is regenerated, the upstream CDF installer rewrites it wholesale from a key set containing no Solo keys, so the stamp's loss **cannot be prevented**; the deliverable is that it is **detected and reported loudly**. Measured for real: `adoption`, `host` and `deployment` all gone. The mutation removing detection makes a project silently un-adopt.

## The block, and why this PR reads the way it does

Review round 1 returned **block** — the session's only one. The bound's fallback rested on "if the anchor isn't an ancestor of HEAD we must be on pre-adoption history, so exempt." **Refuted**: a genuinely pre-adoption branch has no stamp in its checked-out manifest and can never reach that arm, so *every* state reaching it is post-adoption. Six of ten attack histories produced an exempt post-adoption commit — including a **squash-merged adoption branch**, GitHub's default merge button, which would have exempted every subsequent mainline commit **forever**. A permanent test-first waiver, reachable by accident.

The fix is the reviewer's verified two-conjunct bound: exempt iff `anchor == HEAD` **and** HEAD's committed manifest is not already adopted. Also fixed: `soif_adoption_stamp` accepted a **second** stamp, silently moving the anchor (§8.5 says written once, never re-stamped) — now refused.

**Fifteen attack histories now land correctly**, verified independently by the reviewer with a consult-tracer: rebase-rewrite, squash-merge, orphan branch, cherry-pick, bogus anchor, shallow clone, second stamp, working-copy tamper, detached HEAD, merged main, plus three new ones it invented (amended adoption commit; full clone of squashed history with the anchor present but non-ancestral; `rebase --onto` dropping the adoption commit — dissected as a *pre-existing* state-less tier default, not a WP3 leak) and a window-base amend. The legitimate adoption window still exempts, so it is not a block-everything.

## Then the battery had to stop believing its own fixtures

The attack rows credited a block on "non-zero exit + no banner" — without checking *why*. Proven both directions by sabotaging one fixture to exit 127: **with** the discriminator the row fails; **without** it the dead fixture was credited `[PASS] … blocked BY the BL-072 gate` at rc=127 — a row asserting the exact thing that never happened. Two companion defects fell out of that fix: `grep -F` is load-bearing (`[FAIL]` is a character class in a basic regex, so the naive spelling matches nothing and silently reads 0 on every row), and a positional verdict parse needed a companion fix once a third field arrived.

The reviewer confirmed both fixes were necessary while **correcting the implementer's reasoning on each** — the BRE would have matched `L BL-072 TDD ordering` rather than the described text, and the parse defect would have failed *loudly* rather than silently. Conclusions right, stories wrong; both corrected in place.

Suites: arms **33/33**, regenerate-path **4/4** (0 skipped — the real installer runs), **15/15** lints, twenty regression suites at their prior tallies. Both conjuncts proven load-bearing by the reviewer's own knockouts. Review record: `.superpowers/sdd/2026-08-02-brownfield-adoption-v1/wp3-review.md` (session artifact).

## Recorded, not fixed here

- **Upstream (CDF) bug, verified by the reviewer** — `detect-profile.sh` has five unguarded `read -rp` calls; under `set -euo pipefail` with stdin at `/dev/null` the installer exits 1, so a headless `verify-install.sh --auto-fix` leaves the manifest **missing** rather than regenerated. WP3's proof survives it: detection fires on both terminal states. For the CDF repo, not this one.
- `init.sh`'s explicit lib-copy list does **not** ship `adoption-stamp.sh` — harmless today (the guards no-op) but **WP4 must ship it**, or these arms no-op on the very adoptees they serve. Carried into WP4's brief and the open shipping decision.
- `adoptedAtCommit` extends §8.5's author-proposed content list (the bound needs an anchor; §8.5 carries none) — design-amendment candidate, and the amendment should also codify the two-conjunct bound.
- The gate arm is deliberately **not** fenced by BL-166's `skip_later_gate` (adoption integrity belongs to no single gate); measured harmless when intact.
- The regenerate proof is aggregator-only (it names `init.sh` on an executed line); the *detection* half is PR-blocking. Evading the lint's predicate to fast-lane it was explicitly refused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
