### PR TITLE
feat(brownfield): WP4 — the adoption driver, scenario chooser, reverse intake

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -510,6 +510,7 @@ jobs:
             tests/test-walk-phase-lifecycle.sh
             tests/test-brownfield-wp2-scout-sections.sh
             tests/test-brownfield-wp3-adoption-arms.sh
+            tests/test-brownfield-wp4-driver.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/scripts/adopt-project.sh
+++ b/scripts/adopt-project.sh
@@ -46,6 +46,12 @@
 #                                        of framework scripts an adoptee
 #                                        receives is DERIVED from init.sh's own
 #                                        copy list rather than duplicated here
+#   scripts/lib/hook-templates.sh        soif_write_precommit_hook and
+#                                        soif_emit_tdd_commitmsg_block — the
+#                                        SAME emitters init.sh and the
+#                                        framework sync use, so an adopted
+#                                        project's hooks are byte-identical to
+#                                        a scaffolded one's
 #
 # Direction (M3) holds in one direction only: this module sources core, and no
 # core file names this module. That is why `init.sh` does NOT ship
@@ -87,7 +93,7 @@ ADOPT_LIB_DIR="$ADOPT_SELF_DIR/lib/adopt"
 ADOPT_CORE_LIB_DIR="$ADOPT_SELF_DIR/lib"
 
 # ── Core libs (M2's declared set) ───────────────────────────────────────────
-for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh; do
+for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh hook-templates.sh; do
   if [ ! -f "$ADOPT_CORE_LIB_DIR/$_core" ]; then
     echo "adopt-project: missing $ADOPT_CORE_LIB_DIR/$_core — run this from a complete framework clone." >&2
     exit 2

--- a/scripts/adopt-project.sh
+++ b/scripts/adopt-project.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# scripts/adopt-project.sh — the brownfield ADOPTION DRIVER.
+#
+# Point it at a project that already exists and it walks the operator through
+# bringing that project under the framework: it reads Scout's survey, asks the
+# one question only a person can answer, confirms the facts the scan already
+# found, insists on the ones the scan can never find, writes the project's
+# state, stamps the adoption, and commits — exactly the files it wrote and
+# nothing else.
+#
+#   cd /path/to/their-project
+#   bash /path/to/solo-orchestrator/scripts/adopt-project.sh
+#
+#   --root DIR            the project to adopt (default: the current directory)
+#   --scan-report FILE    a Scout JSON report to consume instead of running one
+#   --version / --help
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §8.1 (the driver, and
+# why it is NOT a mode of init.sh), §4.1 (the chooser, in Karl's exact words),
+# §4.2 (the scanner OFFERS evidence, it does not decide), §4.3/§4.4 (S1 and S2
+# landing, and the FLOOR rule), §4.5 (what both scenarios share), §8.3 (reverse
+# intake), §8.4 (the fail-safe state-creation ORDER), §8.5 (explicit staging
+# and the adoption stamp), §5.5 ("adoption does not complete" must be SAFE),
+# §10-WP4. The standing module rules are docs/module-contract.md.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY THIS IS A SEPARATE SCRIPT AND NOT `init.sh --brownfield` (§8.1, §1.2)
+#
+# init.sh's interactive path has NO existence check at all and twelve of its
+# write sites are unguarded overwrites. A `--brownfield` flag would mean
+# auditing every one of those sites for a mode that must never reach them; a
+# separate driver makes them unreachable BY CONSTRUCTION. This driver therefore
+# never calls create_project(), and reuses init's work only BY EXTRACTION.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# M2 — THE DECLARED CORE DEPENDENCIES (docs/module-contract.md)
+#
+# This module is SEVERABLE, not isolated: unlike Scout it may source core, and
+# the complete list of core libs it is permitted to source is:
+#
+#   scripts/lib/helpers-core.sh          print_* and guard_not_in_framework
+#   scripts/lib/adoption-stamp.sh        the WP3 in-core enabling arms — the
+#                                        `adopted` accessor and the stamp. THIS
+#                                        DRIVER IS THE STAMP'S ONE CALL SITE.
+#   scripts/lib/scaffold-shipped-set.sh  soif_parse_shipped_scripts, so the set
+#                                        of framework scripts an adoptee
+#                                        receives is DERIVED from init.sh's own
+#                                        copy list rather than duplicated here
+#
+# Direction (M3) holds in one direction only: this module sources core, and no
+# core file names this module. That is why `init.sh` does NOT ship
+# `adopt-project.sh` — see the SHIPPING note at the bottom of this header.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE GUARD FIRES BEFORE ARGUMENT PARSING, DELIBERATELY (§8.1)
+#
+# process-checklist.sh and reconfigure-project.sh both call
+# guard_not_in_framework at source time, before parsing, so even `--help` exits
+# 1 inside the framework repo. This driver carries the same posture rather than
+# a politer one, because the failure it prevents is writing framework state
+# into the framework. Its tests therefore run in fixtures, never in-tree.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# `set -e` IS DELIBERATELY ABSENT, and the alternative is stated rather than
+# assumed. The driver is a long interactive sequence whose FALSE branches are
+# ordinary data (no CHANGELOG, no tags, an operator who answers "change it").
+# Under errexit each of those is an abort unless individually suppressed, and a
+# missed suppression aborts a WRITER halfway with no message. Instead: nounset
+# and pipefail are on, EVERY write goes through adopt_write_* which checks its
+# own result and refuses loudly, and the exit code is set explicitly.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# SHIPPING: THIS SCRIPT IS NOT SHIPPED INTO SCAFFOLDED PROJECTS, ON PURPOSE.
+# `init.sh` is CORE and `scripts/adopt-project.sh` is MODULE, so a `cp` line for
+# this file in init.sh is exactly the `core -> module` edge M3 forbids and
+# scripts/lint-module-dependencies.sh rejects (T1 on the basename, T2 on the
+# path token). Nothing shipped references this driver, so
+# tests/test-scaffold-source-closure.sh has nothing to say about it either. The
+# driver runs FROM the framework clone against an adoptee, the same way Scout
+# does. What the ADOPTEE receives is the ordinary shipped script set, installed
+# by this driver from init.sh's own copy list (see adopt_install_framework).
+set -uo pipefail
+
+ADOPT_SELF_DIR="$(cd "$(dirname "$0")" && pwd)"
+ADOPT_FRAMEWORK_ROOT="$(cd "$ADOPT_SELF_DIR/.." && pwd)"
+ADOPT_LIB_DIR="$ADOPT_SELF_DIR/lib/adopt"
+ADOPT_CORE_LIB_DIR="$ADOPT_SELF_DIR/lib"
+
+# ── Core libs (M2's declared set) ───────────────────────────────────────────
+for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh; do
+  if [ ! -f "$ADOPT_CORE_LIB_DIR/$_core" ]; then
+    echo "adopt-project: missing $ADOPT_CORE_LIB_DIR/$_core — run this from a complete framework clone." >&2
+    exit 2
+  fi
+  # shellcheck disable=SC1090
+  . "$ADOPT_CORE_LIB_DIR/$_core"
+done
+
+# THE GUARD, BEFORE ARGUMENT PARSING — see the header. Sibling posture, kept.
+guard_not_in_framework || exit 1
+
+for _part in adopt-core adopt-chooser adopt-intake adopt-state adopt-stubs; do
+  if [ ! -f "$ADOPT_LIB_DIR/$_part.sh" ]; then
+    echo "adopt-project: missing $ADOPT_LIB_DIR/$_part.sh — the driver needs its own lib directory." >&2
+    exit 2
+  fi
+  # shellcheck disable=SC1090
+  . "$ADOPT_LIB_DIR/$_part.sh"
+done
+
+usage() {
+  cat <<'USAGE'
+adopt-project — bring an existing project under the framework.
+
+  cd /path/to/their-project
+  bash /path/to/solo-orchestrator/scripts/adopt-project.sh [options]
+
+  --root DIR          the project to adopt (default: the current directory)
+  --scan-report FILE  consume this Scout report instead of running a new scan
+  --version           print the driver's version and exit
+  --help              print this and exit
+
+What it does, in order: reads the survey, offers what the survey found as
+EVIDENCE, asks you the one question the survey cannot answer, confirms the
+answers it already has and insists on the ones it does not, writes the
+project's state, records the adoption, and commits exactly the files it wrote.
+
+If it stops partway — because you stopped it, or because a question had no
+answer — it stops in the SAFE direction: the project ends up more strictly
+gated than it was, never less.
+
+Exit codes: 0 adoption completed; 1 adoption did not complete (a refusal, a
+blocker, or a halt); 2 bad usage or an unusable target.
+USAGE
+}
+
+ADOPT_ROOT="."
+ADOPT_REPORT=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --root)          [ "$#" -ge 2 ] || { echo "adopt-project: --root needs a directory" >&2; exit 2; }; ADOPT_ROOT="$2"; shift 2 ;;
+    --root=*)        ADOPT_ROOT="${1#--root=}"; shift ;;
+    --scan-report)   [ "$#" -ge 2 ] || { echo "adopt-project: --scan-report needs a file" >&2; exit 2; }; ADOPT_REPORT="$2"; shift 2 ;;
+    --scan-report=*) ADOPT_REPORT="${1#--scan-report=}"; shift ;;
+    --version)       adopt_module_version; exit 0 ;;
+    -h|--help)       usage; exit 0 ;;
+    *)               echo "adopt-project: unrecognised option '$1'" >&2; echo "" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+ADOPT_ROOT_ABS="$(cd "$ADOPT_ROOT" 2>/dev/null && pwd)"
+if [ -z "$ADOPT_ROOT_ABS" ]; then
+  echo "adopt-project: '$ADOPT_ROOT' is not a directory this can read." >&2
+  exit 2
+fi
+# The target arm of the same guard: --root must not point at a framework clone
+# either (the security-audits-1 vector that the cwd-only check missed).
+guard_not_in_framework "$ADOPT_ROOT_ABS" || exit 1
+
+adopt_main "$ADOPT_ROOT_ABS" "$ADOPT_REPORT"
+exit $?

--- a/scripts/lib/adopt/adopt-chooser.sh
+++ b/scripts/lib/adopt/adopt-chooser.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-chooser.sh — the scenario chooser (§4.1), the
+# evidence the scanner OFFERS around it (§4.2), and where each scenario lands
+# (§4.3/§4.4, including THE FLOOR RULE).
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §4.1, §4.2, §4.3,
+# §4.4, §8.2 (`phaseMap.suggestedPhase` is the REACHED rung and its own note
+# says "the interview may only lower this").
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE QUESTION IS A DECISION, NOT A PHRASING.
+#
+# It is Karl's own sentence and it is asked VERBATIM. Two properties of it are
+# load-bearing and a well-meaning edit destroys either one:
+#
+#   • It is written for a NON-DEVELOPER — no phase numbers, no framework
+#     vocabulary, no "MVP".
+#   • It asks about the PROJECT'S SITUATION, not the project's artifacts,
+#     because the artifacts are what the scanner already measured and they are
+#     frequently misleading: a mature service with no README.md, a weekend
+#     prototype with a tagged release.
+#
+# tests/test-brownfield-wp4-driver.sh pins the sentence by STRING EQUALITY, and
+# also pins both properties directly, so "I just tidied the wording" is a red
+# check rather than a silent change of meaning.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# AND IT IS NOT PREFILLED. §4.2 considered inferring the scenario from the scan
+# and asking for confirmation, and REJECTED it: the framework's own prefill
+# pattern is right for facts the framework itself recorded earlier and wrong
+# for a judgment it has never made, because presenting a guess as a default
+# makes the most consequential answer in the whole flow the easiest one to
+# accept without reading. So the evidence is printed BEFORE the question, each
+# signal with its own confidence, explicitly labelled as evidence — and the
+# operator's answer overrides all of it.
+
+# BF-ADOPT-CHOOSER-QUESTION — Karl's wording (§4.1), VERBATIM. Do not reflow,
+# do not fix the grammar of "new features add", do not split it across lines.
+ADOPT_CHOOSER_QUESTION="Is the project built out and needs to be able to be supported (i.e. bug fixes, maintenance, new features add), or are you still in the process of building your project?"
+
+# The two answers, in the same register as the question: no phase numbers, no
+# framework words. They are the operator's own two situations, said back.
+ADOPT_CHOOSER_ANSWER_BUILT="It is built out and needs to be supported"
+ADOPT_CHOOSER_ANSWER_BUILDING="I am still in the process of building it"
+
+# ── §4.2 — the evidence the scanner offers ──────────────────────────────────
+#
+# WHAT IS CONSUMED AND WHAT IS DERIVED, stated plainly because the two are easy
+# to confuse. §8.2's report schema — verified against scripts/lib/scout/ — has
+# no chooser-evidence section: it carries `phaseMap`, `reality`, `stack`,
+# `secrets`, `collisions`, `testsBaseline` and `intakePrefill`, and none of
+# them is §4.2's table. So the deploy-lane signal is CONSUMED from the report
+# (rung 4 and the ci_pipeline_configured probe — Scout already derived it and
+# this driver does not re-derive it), while release tags, commit shape and the
+# changelog are read from the adoptee's own git and tree HERE, because nothing
+# reports them. That gap is recorded in the WP4 report as a candidate for a
+# future `chooserEvidence` section in Scout rather than papered over: one fact
+# derived in two places is two chances to disagree about it.
+#
+# Every line below carries its confidence, and the block ends by saying that
+# none of it decides anything.
+adopt_evidence_deploy_lane() {
+  local report="$1"
+  local rung4 probe
+  rung4="$(adopt_report_read "$report" '[.phaseMap.rungs[]? | select(.rung == 4) | .evidence] | first // ""')"
+  probe="$(adopt_report_read "$report" '[.reality.probes[]? | select(.name == "ci_pipeline_configured") | .result] | first // ""')"
+  if [ -n "$rung4" ] && [ "$rung4" != "null" ]; then
+    adopt_note "Deployment: the scan found $rung4."
+    adopt_note "  Points to: built out. Confidence: LOW — this is file presence, not run history;"
+    adopt_note "  Scout is read-only and does not ask the host whether the lane has ever run."
+  elif [ "$probe" = "pass" ]; then
+    adopt_note "Deployment: the scan found a pipeline configured, but no lane out the door."
+    adopt_note "  Points to: nothing on its own. Confidence: LOW."
+  else
+    adopt_note "Deployment: the scan found no way to get this project out the door."
+    adopt_note "  Points to: still building. Confidence: LOW — absence of a file is weak evidence."
+  fi
+}
+
+adopt_evidence_release_tags() {
+  local root="$1"
+  local newest count
+  count="$(cd "$root" 2>/dev/null && git tag 2>/dev/null | grep -cE '^v?[0-9]+\.[0-9]+' )"
+  count="$(adopt_int "$count")"
+  if [ "$count" -gt 0 ]; then
+    newest="$(cd "$root" 2>/dev/null && git for-each-ref --sort=-creatordate --format='%(refname:short) %(creatordate:short)' 'refs/tags/*' 2>/dev/null | head -1)"
+    adopt_note "Release tags: $count version-shaped tag(s); newest ${newest:-unknown}."
+    adopt_note "  Points to: built out. Confidence: MEDIUM — tags are cheap and often abandoned."
+  else
+    adopt_note "Release tags: none that look like a version."
+    adopt_note "  Points to: still building. Confidence: MEDIUM."
+  fi
+}
+
+adopt_evidence_commit_shape() {
+  local root="$1"
+  local feats fixes
+  feats="$(cd "$root" 2>/dev/null && git log -50 --format='%s' 2>/dev/null | grep -c '^feat')"
+  fixes="$(cd "$root" 2>/dev/null && git log -50 --format='%s' 2>/dev/null | grep -c '^fix')"
+  feats="$(adopt_int "$feats")"; fixes="$(adopt_int "$fixes")"
+  adopt_note "Recent work: over the last 50 commits, $feats look like new features and $fixes look like fixes."
+  if [ "$fixes" -gt "$feats" ]; then
+    adopt_note "  Points to: built out. Confidence: LOW — this is a heuristic and it is labelled as one."
+  else
+    adopt_note "  Points to: still building. Confidence: LOW — this is a heuristic and it is labelled as one."
+  fi
+}
+
+adopt_evidence_changelog() {
+  local root="$1"
+  local dated=0
+  if [ -f "$root/CHANGELOG.md" ]; then
+    dated="$(grep -cE '^#{1,3}[[:space:]]*\[?v?[0-9]+\.[0-9]+' "$root/CHANGELOG.md" 2>/dev/null)"
+    dated="$(adopt_int "$dated")"
+  fi
+  if [ "$dated" -gt 0 ]; then
+    adopt_note "Changelog: CHANGELOG.md lists $dated released version(s)."
+    adopt_note "  Points to: built out. Confidence: MEDIUM."
+  else
+    adopt_note "Changelog: no CHANGELOG.md with released versions in it."
+    adopt_note "  Points to: nothing on its own. Confidence: MEDIUM."
+  fi
+}
+
+# adopt_present_evidence ROOT REPORT — the whole §4.2 block.
+adopt_present_evidence() {
+  local root="$1" report="$2"
+  adopt_head "What the scan noticed"
+  adopt_note "None of this is an answer. It is what a read-only look at the code found,"
+  adopt_note "and each line says how much weight it deserves. Your answer to the next"
+  adopt_note "question overrides all of it."
+  adopt_blank
+  adopt_evidence_deploy_lane "$report"
+  adopt_evidence_release_tags "$root"
+  adopt_evidence_commit_shape "$root"
+  adopt_evidence_changelog "$root"
+  adopt_blank
+  adopt_note "Users: the scan cannot measure whether anyone is using this. Only you know that."
+  adopt_blank
+}
+
+# ── The chooser itself ──────────────────────────────────────────────────────
+# adopt_ask_scenario — leaves "completed" or "in-flight" in ADOPT_SCENARIO.
+# The two words are §8.5's stamp enum, not operator-facing vocabulary; the
+# operator never sees either of them.
+ADOPT_SCENARIO=""
+adopt_ask_scenario() {
+  adopt_head "The one question the scan cannot answer"
+  # No default, no preselection, no "(suggested)" — §4.2's rejected alternative.
+  adopt_ask_choice "the project's situation" "$ADOPT_CHOOSER_QUESTION" \
+    "$ADOPT_CHOOSER_ANSWER_BUILT" \
+    "$ADOPT_CHOOSER_ANSWER_BUILDING" || return 1
+  case "$ADOPT_ANSWER" in
+    "$ADOPT_CHOOSER_ANSWER_BUILT")    ADOPT_SCENARIO="completed" ;;
+    "$ADOPT_CHOOSER_ANSWER_BUILDING") ADOPT_SCENARIO="in-flight" ;;
+    *) adopt_refuse "the scenario answer could not be read"; return 1 ;;
+  esac
+  return 0
+}
+
+# ── Placement (§4.3, §4.4) ──────────────────────────────────────────────────
+#
+# S1 lands at 4 and adopted. S2 lands at the phase its artifacts support —
+# Scout's `phaseMap.suggestedPhase`, the REACHED rung — FLOORED by the
+# interview.
+#
+# THE FLOOR RULE IS ONE-DIRECTIONAL AND THAT IS THE WHOLE POINT (§4.4). The
+# interview may only move the placement DOWN, never up. Artifact evidence is a
+# claim about what was BUILT; the operator's answer is a claim about what is
+# TRUE; where they disagree the SAFER number wins, because a project placed too
+# low certifies more than it strictly needed and a project placed too high
+# certifies LESS THAN IT OWED. Scout's own report says so in the field beside
+# the number: "maximum satisfied rung; the interview may only lower this".
+adopt_apply_floor() {
+  local scanned="$1" claimed="$2"
+  scanned="$(adopt_int "$scanned")"
+  claimed="$(adopt_int "$claimed")"
+  if [ "$claimed" -lt "$scanned" ]; then printf '%s' "$claimed"; else printf '%s' "$scanned"; fi   # BF-ADOPT-FLOOR
+}
+
+# The S2 ladder question, in the operator's register: no phase numbers, no
+# framework artifact names. The rungs are the same four Scout measured, said as
+# things a person can recognise about their own project.
+ADOPT_LADDER_Q="How far along is the work itself? Pick the LAST line that is already true."
+ADOPT_LADDER_0="None of these yet"
+ADOPT_LADDER_1="We have written down what this project is for"
+ADOPT_LADDER_2="...and the technical shape of it is written down too"
+ADOPT_LADDER_3="...and there are tests that actually run"
+ADOPT_LADDER_4="...and there is a way to get it out the door"
+
+# adopt_ask_ladder — leaves the operator's claimed rung (0-4) in ADOPT_ANSWER.
+adopt_ask_ladder() {
+  adopt_ask_choice "how far along the work is" "$ADOPT_LADDER_Q" \
+    "$ADOPT_LADDER_0" "$ADOPT_LADDER_1" "$ADOPT_LADDER_2" "$ADOPT_LADDER_3" "$ADOPT_LADDER_4" || return 1
+  case "$ADOPT_ANSWER" in
+    "$ADOPT_LADDER_0") ADOPT_ANSWER=0 ;;
+    "$ADOPT_LADDER_1") ADOPT_ANSWER=1 ;;
+    "$ADOPT_LADDER_2") ADOPT_ANSWER=2 ;;
+    "$ADOPT_LADDER_3") ADOPT_ANSWER=3 ;;
+    "$ADOPT_LADDER_4") ADOPT_ANSWER=4 ;;
+    *) adopt_refuse "the answer about how far along the work is could not be read"; return 1 ;;
+  esac
+  return 0
+}
+
+# adopt_decide_placement REPORT — leaves the landed phase in ADOPT_LANDED_PHASE.
+ADOPT_LANDED_PHASE=""
+adopt_decide_placement() {
+  local report="$1" scanned claimed landed
+  if [ "$ADOPT_SCENARIO" = "completed" ]; then
+    # §4.3: S1 lands at 4, full stop. Its artifacts are not consulted, because
+    # the operator has just said the thing being built is finished, and the
+    # certification pass — every gate 0->1 through 3->4 — is what makes that
+    # claim expensive rather than free.
+    ADOPT_LANDED_PHASE=4
+    adopt_note "This project lands where a finished project lands, and every gate behind it"
+    adopt_note "has to be certified rather than assumed."
+    return 0
+  fi
+
+  scanned="$(adopt_int "$(adopt_report_read "$report" '.phaseMap.suggestedPhase // 0')")"
+  adopt_blank
+  adopt_note "From the code alone, the scan placed this project at rung $scanned of 4."
+  adopt_note "Your answer can move that DOWN if the code flatters the project. It cannot"
+  adopt_note "move it up: evidence you have not produced is not evidence."
+  adopt_blank
+  adopt_ask_ladder || return 1
+  claimed="$ADOPT_ANSWER"
+  landed="$(adopt_apply_floor "$scanned" "$claimed")"
+  ADOPT_LANDED_PHASE="$landed"
+  if [ "$claimed" -gt "$scanned" ]; then
+    adopt_note "You placed it higher than the code supports, so it lands at $landed — the"
+    adopt_note "number the artifacts can back up. Nothing is lost: the rest is earned the"
+    adopt_note "ordinary way, by shipping."
+  elif [ "$claimed" -lt "$scanned" ]; then
+    adopt_note "You placed it lower than the code suggested, so it lands at $landed. The"
+    adopt_note "lower number costs more certification, not less, and that is the safe side."
+  else
+    adopt_note "The code and your answer agree: it lands at $landed."
+  fi
+  return 0
+}

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-core.sh — the driver's own primitives: how it talks,
+# how it asks, how it refuses, and how it remembers what it wrote.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §8.3 (the three
+# section classes and what "no default, no skip" has to mean in code), §8.5
+# (explicit staging — which is why every write is RECORDED here), §5.5 (a run
+# that does not complete must leave a SAFE state), §4.1 (the operator-facing
+# register: this is written for a non-developer).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY THIS FILE DOES NOT USE prompt_input / prompt_yes_no FROM helpers-core.sh
+#
+# Measured, not assumed: both of those return a DEFAULT (and prompt_yes_no a
+# hard "N") the moment stdin is not a terminal, printing a [WARN] and NOT
+# blocking. That behaviour is right for the greenfield installer, where an
+# unattended run should proceed with sane defaults. It is exactly wrong here:
+# §8.3's judgment sections are "human-mandatory, no prefill, no default, no
+# skip", and data classification is "non-skippable in BOTH scenarios". A
+# primitive whose unattended answer is a default cannot express either rule.
+#
+# So the driver reads answers itself, line by line, from stdin — which works
+# identically for a person at a terminal and for a scripted run — and an
+# UNANSWERED mandatory question STOPS THE ADOPTION. Stopping is safe (§5.5);
+# answering on the operator's behalf is not.
+#
+# prompt_choice IS usable (it reads stdin unconditionally) but it loops up to
+# 100 times on invalid input and returns the option TEXT on stdout mixed with
+# prompts on stderr. The driver wants a single refusal on a bad answer and one
+# transcript on stdout that a test can pin verbatim, so it has its own.
+#
+# bash-3.2 safe: no associative arrays, no ${var,,}, no `((x++))`.
+
+# adopt_module_version — the driver's own version marker. A literal, for the
+# same reason Scout's is: at adoption time there may be no framework state to
+# read a version out of. The `-wp4` suffix is information, not decoration —
+# this build carries the skeleton, the chooser, placement and reverse intake,
+# and HONEST STUBS where WP5/WP5b/WP6/WP7 will land.
+adopt_module_version() {
+  printf '%s\n' "0.1.0-wp4"
+}
+
+# ── Output. One transcript, on stdout, so a test can pin it. ────────────────
+adopt_say()  { printf '%s\n' "$1"; }
+adopt_head() { printf '\n══ %s\n' "$1"; }
+adopt_note() { printf '   %s\n' "$1"; }
+adopt_blank() { printf '\n'; }
+
+# ── Refusal ─────────────────────────────────────────────────────────────────
+# THE ONLY WAY THIS DRIVER DECLINES TO CONTINUE. It prints WHY on stderr and
+# returns 1; every caller propagates. §5.5: "adoption does not complete" is a
+# real state and it must be a safe one — refusing before or between writes
+# leaves the project in the §8.4 safe row, never the unsafe one.
+ADOPT_REFUSED_REASON=""
+adopt_refuse() {
+  ADOPT_REFUSED_REASON="$1"
+  printf '\n[REFUSED] %s\n' "$1" >&2
+  printf '          Adoption did not complete. Nothing has been committed.\n' >&2
+  return 1
+}
+
+# The mandatory-question refusal, spelled ONCE so the transcript is consistent
+# and a test has one string to look for.
+ADOPT_MANDATORY_REFUSAL="This question has no default and no skip, and no answer was given:"
+
+# ── Reading one answer ──────────────────────────────────────────────────────
+# ADOPT_ANSWER is the single out-parameter. bash 3.2 has no namerefs and the
+# alternative — echoing the answer and capturing it in $(...) — would put the
+# QUESTION inside the capture too, or force every prompt onto stderr where the
+# verbatim-wording pin could not see it as one transcript.
+ADOPT_ANSWER=""
+
+# THE OPERATOR'S STDIN IS PINNED TO FD 3, AND IT HAS TO BE.
+#
+# The reverse-intake runner walks Scout's rows with `while read … done <<ROWS`,
+# which redirects the WHOLE LOOP BODY's stdin to the row list. A question asked
+# inside that body and reading plain stdin therefore eats the NEXT TABLE ROW as
+# if the operator had typed it — measured, not hypothetical: the first run of
+# this driver answered "Keep 'acme-api'?" with a tab-separated prefill row and
+# refused. Duplicating the real stdin to fd 3 once, at the top of the run, and
+# reading every answer from there makes the questions independent of whatever
+# redirection the surrounding loop needs.
+#
+# AND THE REDIRECTION MUST NOT CARRY A `2>/dev/null`. `exec` with no command
+# applies its redirections to the SHELL ITSELF and keeps them: the first cut
+# read `exec 3<&0 2>/dev/null`, which duplicated stdin correctly and then sent
+# every subsequent byte of stderr to /dev/null for the rest of the run. Three
+# refusal cases went silent — the driver still exited non-zero, so it "worked",
+# and only a `bash -x` trace that stopped mid-function showed why. A failing
+# `exec` here is loud on purpose; there is nothing to suppress.
+ADOPT_STDIN_FD=0
+adopt_stdin_init() {
+  exec 3<&0 || return 0
+  ADOPT_STDIN_FD=3
+  return 0
+}
+
+# _adopt_read_line — one trimmed line of the OPERATOR's input into ADOPT_ANSWER.
+# rc 1 on EOF, with ADOPT_ANSWER emptied. EOF and a blank line are treated
+# identically ON PURPOSE: "the operator walked away" and "the script ran out of
+# answers" are the same event from the driver's point of view, and both must
+# reach the mandatory guard rather than a default.
+_adopt_read_line() {
+  local line=""
+  ADOPT_ANSWER=""
+  if [ "$ADOPT_STDIN_FD" = "3" ]; then
+    IFS= read -r line <&3 || { ADOPT_ANSWER=""; return 1; }
+  else
+    IFS= read -r line || { ADOPT_ANSWER=""; return 1; }
+  fi
+  ADOPT_ANSWER="$(printf '%s' "$line" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+  return 0
+}
+
+# adopt_read_optional — read one answer that is ALLOWED to be empty.
+# Nothing in §8.3 is optional; this exists so that the non-skippability of a
+# question is expressed as its OWN guard at the question's own site, where it
+# can be read, reviewed and mutated, instead of being an emergent property of a
+# shared reader. See BF-ADOPT-DC-MANDATORY in adopt-intake.sh.
+adopt_read_optional() {
+  _adopt_read_line || true
+  return 0
+}
+
+# adopt_offer_choice QUESTION OPT... — print a question and its options and
+# nothing else. NO option is marked, preselected, recommended or defaulted:
+# §4.2 rejects presenting a guess as a default, because that makes the most
+# consequential answer the easiest one to skim past.
+adopt_offer_choice() {
+  local question="$1"; shift
+  local opt i=1
+  adopt_say "$question"
+  for opt in "$@"; do
+    printf '   %s) %s\n' "$i" "$opt"
+    i=$((i + 1))
+  done
+  printf '   Answer with the number or the words: '
+}
+
+# adopt_resolve_choice RAW OPT... — map a raw answer onto one of the options.
+# Accepts the 1-based number or the option text (case-insensitively, because a
+# person typing "Keep It" meant "keep it"). EMPTY IN, EMPTY OUT — resolving is
+# not validating, and the "was this answered at all?" question belongs to the
+# caller's own guard.
+adopt_resolve_choice() {
+  local raw="$1"; shift
+  local opt n=0 lower raw_lower
+  [ -n "$raw" ] || { printf '%s' ""; return 0; }
+  for opt in "$@"; do n=$((n + 1)); done
+  case "$raw" in
+    ''|*[!0-9]*) : ;;
+    *)
+      if [ "$raw" -ge 1 ] && [ "$raw" -le "$n" ]; then
+        n=0
+        for opt in "$@"; do
+          n=$((n + 1))
+          [ "$n" -eq "$raw" ] && { printf '%s' "$opt"; return 0; }
+        done
+      fi
+      ;;
+  esac
+  raw_lower="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]')"
+  for opt in "$@"; do
+    lower="$(printf '%s' "$opt" | tr '[:upper:]' '[:lower:]')"
+    [ "$raw_lower" = "$lower" ] && { printf '%s' "$opt"; return 0; }
+  done
+  printf '%s' ""
+  return 0
+}
+
+# adopt_ask_choice LABEL QUESTION OPT... — offer, read, resolve, and REFUSE on
+# anything that is not one of the offered answers (including nothing at all).
+# Leaves the chosen option in ADOPT_ANSWER.
+adopt_ask_choice() {
+  local label="$1" question="$2"; shift 2
+  local raw resolved
+  adopt_offer_choice "$question" "$@"
+  adopt_read_optional
+  raw="$ADOPT_ANSWER"
+  resolved="$(adopt_resolve_choice "$raw" "$@")"
+  printf '\n'
+  if [ -z "$resolved" ]; then
+    if [ -z "$raw" ]; then
+      adopt_refuse "$ADOPT_MANDATORY_REFUSAL $label"
+      return 1
+    fi
+    adopt_refuse "'$raw' is not one of the answers offered for: $label"
+    return 1
+  fi
+  ADOPT_ANSWER="$resolved"
+  return 0
+}
+
+# adopt_ask_free LABEL QUESTION — a free-text answer that MUST be given.
+# §8.3's judgment class in one function: no prefill, no default, no skip.
+adopt_ask_free() {
+  local label="$1" question="$2"
+  adopt_say "$question"
+  printf '   Your answer: '
+  adopt_read_optional
+  printf '\n'
+  if [ -z "$ADOPT_ANSWER" ]; then
+    adopt_refuse "$ADOPT_MANDATORY_REFUSAL $label"   # BF-ADOPT-JUDGMENT-MANDATORY
+    return 1
+  fi
+  return 0
+}
+
+# ── Remembering what was written (§8.5's explicit staging) ──────────────────
+# EVERY path the driver creates or modifies is recorded HERE, at the moment it
+# is written, relative to the adoptee root. The staging array is built from
+# this ledger and from nothing else, so "anything not in it is never staged" is
+# a property of the code rather than a promise in a comment. The counter-example
+# the design names is create_project()'s `git add -A` followed by
+# `git commit --no-verify`, which on an adoptee would sweep their uncommitted
+# work into a framework commit with verification bypassed.
+ADOPT_WRITTEN_LEDGER=""
+
+adopt_ledger_init() {
+  ADOPT_WRITTEN_LEDGER="$1"
+  : > "$ADOPT_WRITTEN_LEDGER" || return 1
+  return 0
+}
+
+# adopt_record_write RELPATH — one ledger row. Deduplicated at read time.
+adopt_record_write() {
+  [ -n "$ADOPT_WRITTEN_LEDGER" ] || return 0
+  printf '%s\n' "$1" >> "$ADOPT_WRITTEN_LEDGER"
+}
+
+# adopt_written_paths — the ledger, deduplicated, one path per line.
+adopt_written_paths() {
+  [ -n "$ADOPT_WRITTEN_LEDGER" ] || return 0
+  [ -f "$ADOPT_WRITTEN_LEDGER" ] || return 0
+  sort -u "$ADOPT_WRITTEN_LEDGER"
+}
+
+# ── Writes ──────────────────────────────────────────────────────────────────
+# adopt_write_file ROOT RELPATH — copy stdin into ROOT/RELPATH, creating
+# parents, and record it. Refuses loudly on any failure; with errexit off, an
+# unchecked redirect is exactly how a writer loses half its output in silence.
+adopt_write_file() {
+  local root="$1" rel="$2" dir
+  dir="$(dirname "$root/$rel")"
+  mkdir -p "$dir" 2>/dev/null || { adopt_refuse "could not create $dir"; return 1; }
+  cat > "$root/$rel" || { adopt_refuse "could not write $rel"; return 1; }
+  adopt_record_write "$rel"
+  return 0
+}
+
+# adopt_jq_edit ROOT RELPATH FILTER [jq args...] — an in-place jq edit through
+# the atomic-rename pattern the framework's other manifest writers use.
+adopt_jq_edit() {
+  local root="$1" rel="$2" filter="$3"; shift 3
+  local f="$root/$rel"
+  [ -f "$f" ] || { adopt_refuse "cannot edit $rel — it does not exist"; return 1; }
+  command -v jq >/dev/null 2>&1 || { adopt_refuse "jq is required to adopt a project"; return 1; }
+  jq "$@" "$filter" "$f" > "$f.tmp" 2>/dev/null || { rm -f "$f.tmp"; adopt_refuse "jq could not edit $rel"; return 1; }
+  mv "$f.tmp" "$f" || { adopt_refuse "could not replace $rel"; return 1; }
+  adopt_record_write "$rel"
+  return 0
+}
+
+# ── Small shared readers ────────────────────────────────────────────────────
+# adopt_report_read FILE FILTER — one jq -r read of the Scout report. Empty on
+# any failure, because a missing section is data, not a crash.
+adopt_report_read() {
+  jq -r "$2" "$1" 2>/dev/null
+}
+
+# adopt_int VALUE — a shell-comparable integer. jq prints a missing field as
+# the four-character string "null", which `[ "$x" -ge 1 ]` rejects with a
+# diagnostic AND a false branch, so a missing number would otherwise take the
+# same path as a zero.
+adopt_int() {
+  case "$1" in ''|null|*[!0-9]*) printf '0' ;; *) printf '%s' "$1" ;; esac
+}

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -51,16 +51,25 @@ adopt_blank() { printf '\n'; }
 # returns 1; every caller propagates. §5.5: "adoption does not complete" is a
 # real state and it must be a safe one — refusing before or between writes
 # leaves the project in the §8.4 safe row, never the unsafe one.
-ADOPT_REFUSED_REASON=""
+#
+# The reason is PRINTED and not also stashed in a global. An earlier cut kept
+# an ADOPT_REFUSED_REASON that nothing ever read (R-WP4-4): a variable nothing
+# reads is a claim nothing keeps, and it would have been read as a resume seam
+# that does not exist.
 adopt_refuse() {
-  ADOPT_REFUSED_REASON="$1"
   printf '\n[REFUSED] %s\n' "$1" >&2
   printf '          Adoption did not complete. Nothing has been committed.\n' >&2
   return 1
 }
 
-# The mandatory-question refusal, spelled ONCE so the transcript is consistent
-# and a test has one string to look for.
+# The mandatory-question refusal, spelled ONCE so the transcript is consistent.
+#
+# IT IS A PREFIX AND THE LABEL AFTER IT IS THE DISCRIMINATOR. Every mandatory
+# question in the driver prints this same sentence, so a test that greps only
+# this cannot tell WHICH question stopped the run — and one that cannot tell is
+# blind to a default-on-empty in the shared reader below, which is exactly the
+# hole R-WP4-1 found. Callers pass a label; tests match
+# "no answer was given: <label>".
 ADOPT_MANDATORY_REFUSAL="This question has no default and no skip, and no answer was given:"
 
 # ── Reading one answer ──────────────────────────────────────────────────────

--- a/scripts/lib/adopt/adopt-intake.sh
+++ b/scripts/lib/adopt/adopt-intake.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-intake.sh — REVERSE INTAKE (§8.3).
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §8.3 (the three
+# section classes and their precedents), §4.3 (S1 is light on futures and heavy
+# on operations), §4.5 (data classification is non-skippable in BOTH
+# scenarios), §8.2 (`intakePrefill` — the mapping table, which WP2 already
+# authored as a data block in scripts/lib/scout/scout-prefill.sh and which this
+# file CONSUMES rather than re-authors).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# The ordinary intake asks a person and writes a document. REVERSE INTAKE
+# starts from the document the scanner already derived and asks the person to
+# CONFIRM it — for the parts that are derivable, and only those.
+#
+#   scan-derived    Prefilled and confirmed: TWO disclosure lines naming the
+#                   value AND ITS PROVENANCE, then keep-it / change-it, with
+#                   "change it" falling through to the ordinary question.
+#   judgment        Human-mandatory. No prefill, no default, no skip.
+#   non-skippable   Data classification. No default, no inference, and NO
+#                   "confirm" arm at all.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE SHAPE OF THE PREFILL READ IS LOAD-BEARING, AND §8.3 SAYS SO IN ADVANCE.
+#
+# The shipped pattern is `run_section_1_repo_setup()` in scripts/intake-wizard.sh
+# (marker `# BL-204-PREFILL-READ`). Two properties of it are not style:
+#
+#   1. the marked read carries an END-OF-LINE-ANCHORED marker, so a mutation
+#      test can excise exactly that line with `s|^.*MARKER$|...|`; and
+#   2. a bare `:` sits on the line ABOVE it, so the enclosing `if` block stays
+#      syntactically well-formed once the read is excised.
+#
+# That `:` is not dead code and tidying it away removes the test's ability to
+# bite. The copy below preserves both properties under its own marker,
+# `# BF-ADOPT-PREFILL-READ`, for exactly the same reason.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY DATA CLASSIFICATION GETS ITS OWN GUARD RATHER THAN RIDING THE SHARED ONE.
+#
+# It is a MECHANICAL necessity, not a policy preference: scripts/check-phase-gate.sh's
+# Phase 1->2 ZDR backstop is a hard `[FAIL]` (an `issues` increment, which is
+# what a block actually is in that script) whenever `current_phase >= 2` and
+# `.claude/process-state.json::phase1_artifacts.data_classification` is not one
+# of {public, internal, confidential, pii, financial, health, regulated} — plus
+# an attestation for anything above `public`. An S1 adoption lands at 4, i.e.
+# above that threshold on its FIRST commit. So the non-skippability is given
+# its own single-site guard, at the question's own site, where it can be read,
+# reviewed, and neutered by one line in a mutation proof.
+
+# The taxonomy, spelled exactly as the gate spells it. Order is the gate's.
+ADOPT_DC_TAXONOMY="public internal confidential pii financial health regulated"
+
+ADOPT_DC_REFUSAL="Data classification has no default, no guess and no skip — in either scenario. The Phase 1 to 2 gate is a hard FAIL without it, so an adoption that skipped it would produce a project that cannot pass its own next gate."
+
+# ── The answers ledger ──────────────────────────────────────────────────────
+# `<field>\t<title>\t<kind>\t<value>\t<provenance>`, one row per answer, in the
+# order asked. The intake artifacts are rendered from this and nothing else.
+ADOPT_ANSWERS=""
+ADOPT_DATA_CLASSIFICATION=""
+ADOPT_ZDR_ATTESTED="false"
+ADOPT_ZDR_REASON=""
+
+adopt_answers_init() {
+  ADOPT_ANSWERS="$1"
+  : > "$ADOPT_ANSWERS" || return 1
+  return 0
+}
+
+# adopt_record_answer FIELD TITLE KIND VALUE PROVENANCE
+# Tabs and newlines are stripped from the value: the ledger is TSV, and an
+# answer that re-opened a column would silently shift every later field.
+adopt_record_answer() {
+  local field="$1" title="$2" kind="$3" value="$4" prov="$5"
+  value="$(printf '%s' "$value" | tr '\t\n' '  ')"
+  prov="$(printf '%s' "$prov" | tr '\t\n' '  ')"
+  printf '%s\t%s\t%s\t%s\t%s\n' "$field" "$title" "$kind" "$value" "$prov" >> "$ADOPT_ANSWERS"
+}
+
+# ── The question text for the judgment rows ─────────────────────────────────
+# One case arm per intake section. §4.3 makes S1 LIGHT ON FUTURES: there is no
+# MVP cutline to draw for something already shipped, so section 4 asks for a
+# record of what exists instead of a cutline. Everything else is asked of both.
+adopt_judgment_question() {
+  local id="$1" scenario="$2"
+  case "$id" in
+    2)  printf '%s' "What problem does this project solve, and for whom? Say it concretely." ;;
+    3)  printf '%s' "What constrains this work — time, money, people, anything you cannot change?" ;;
+    4)  if [ "$scenario" = "completed" ]; then
+          printf '%s' "What does this project actually do today? List the main things it does, as they are — not as you wish they were."
+        else
+          printf '%s' "What is in the first version you would call finished, and what are you deliberately leaving out of it?"
+        fi ;;
+    6)  printf '%s' "What technology choices are already settled here, and which ones are you unsure about?" ;;
+    7)  printf '%s' "Does this project make or save money, and how? Say 'none' if it does not." ;;
+    8)  printf '%s' "Who has to approve things here, and does anything about this project need sign-off from someone else?" ;;
+    9)  printf '%s' "Who has to be able to use this, and does anyone using it need accommodations?" ;;
+    10) printf '%s' "Where does this run, and who is it distributed to?" ;;
+    11) printf '%s' "What worries you most about this project? Name the thing you would rather not write down." ;;
+    *)  printf '%s' "Tell us about this section." ;;
+  esac
+}
+
+# §4.3's operations weight for S1, as three questions rather than a checklist.
+# They cover incident response and the on-call reality (the first), the backup
+# maintainer (the second) and the release lane (the third); hosting is already
+# asked by section 10's own question above.
+adopt_ops_addendum() {
+  local scenario="$1"
+  [ "$scenario" = "completed" ] || return 0
+  adopt_ask_free "incident response" "When this breaks in production, what happens, and who finds out first?" || return 1
+  adopt_record_answer "incident_response" "Distribution & Operations" "judgment" "$ADOPT_ANSWER" ""
+  adopt_ask_free "backup maintainer" "If you were unavailable for a month, who keeps this running?" || return 1
+  adopt_record_answer "backup_maintainer" "Distribution & Operations" "judgment" "$ADOPT_ANSWER" ""
+  adopt_ask_free "release lane" "How does a change get from your machine into production today?" || return 1
+  adopt_record_answer "release_lane" "Distribution & Operations" "judgment" "$ADOPT_ANSWER" ""
+  return 0
+}
+
+# ── The scan-derived arm — the BL-204 pattern, preserved ────────────────────
+# adopt_confirm_scanned FIELD TITLE VALUE SOURCE
+adopt_confirm_scanned() {
+  local field="$1" title="$2" value="$3" source="$4"
+  local shown=""
+  if [ -n "$value" ] && [ "$value" != "null" ]; then
+    :  # guard: keeps the block well-formed when the marked read is excised
+    shown="$value"   # BF-ADOPT-PREFILL-READ
+  fi
+  if [ -z "$shown" ]; then
+    # Nothing was derivable after all, so this degrades to the ordinary
+    # question rather than confirming an empty value at the operator.
+    adopt_ask_free "$title" "$title — the scan found nothing to offer here. What is the answer?" || return 1
+    adopt_record_answer "$field" "$title" "scan-derived" "$ADOPT_ANSWER" "answered by you; the scan had nothing"
+    return 0
+  fi
+
+  # TWO DISCLOSURE LINES: the value, and where it came from. The provenance
+  # line is the half that makes this a confirmation rather than a nudge — an
+  # operator who cannot see where a value came from cannot check it.
+  adopt_say "$title"
+  adopt_note "The scan found: $shown"
+  adopt_note "Where that came from: ${source:-the scan}"
+  adopt_ask_choice "$title" "Keep '$shown' as the answer?" "keep it" "change it" || return 1
+  if [ "$ADOPT_ANSWER" = "change it" ]; then
+    # "change it" falls through to the ORDINARY question — the same fall-through
+    # the shipped pattern has, and the reason the prefill can never trap anyone.
+    adopt_ask_free "$title" "$title — what is the right answer?" || return 1
+    adopt_record_answer "$field" "$title" "scan-derived" "$ADOPT_ANSWER" "changed by you; the scan had offered '$shown'"
+  else
+    adopt_record_answer "$field" "$title" "scan-derived" "$shown" "${source:-the scan}"
+  fi
+  return 0
+}
+
+# ── The non-skippable arm ───────────────────────────────────────────────────
+adopt_ask_data_classification() {
+  local raw dc
+  adopt_say "The highest classification of any data this system handles."
+  adopt_note "This one cannot be skipped, guessed or deferred, in either scenario."
+  # NO confirm arm and NO preselection: nothing here is prefilled, because the
+  # scan has never seen the data this system handles and §8.3 gives this class
+  # no "confirm" behaviour at all.
+  adopt_offer_choice "Which one describes it?" $ADOPT_DC_TAXONOMY
+  adopt_read_optional
+  raw="$ADOPT_ANSWER"
+  dc="$(adopt_resolve_choice "$raw" $ADOPT_DC_TAXONOMY)"
+  printf '\n'
+  if [ -z "$dc" ]; then
+    adopt_refuse "$ADOPT_DC_REFUSAL"; return 1   # BF-ADOPT-DC-MANDATORY
+  fi
+  ADOPT_DATA_CLASSIFICATION="$dc"
+  adopt_record_answer "data_classification" "Data & Integrations" "non-skippable" "$dc" ""
+
+  ADOPT_ZDR_ATTESTED="false"
+  ADOPT_ZDR_REASON=""
+  if [ "$dc" = "public" ]; then
+    adopt_note "Public data: no zero-retention attestation is required."
+    adopt_record_answer "zdr_attested" "Data & Integrations" "non-skippable" "false" "public data needs no attestation"
+    return 0
+  fi
+
+  adopt_ask_choice "zero data retention" \
+    "Is zero data retention (or a self-hosted model) in place for this project?" "yes" "no" || return 1
+  if [ "$ADOPT_ANSWER" = "yes" ]; then
+    ADOPT_ZDR_ATTESTED="true"
+    adopt_record_answer "zdr_attested" "Data & Integrations" "non-skippable" "true" ""
+    return 0
+  fi
+  adopt_ask_free "the written exception for zero data retention" \
+    "Then a written exception is required. What is it? (for example: a customer contract requires retention)" || return 1
+  ADOPT_ZDR_REASON="$ADOPT_ANSWER"
+  adopt_record_answer "zdr_attested" "Data & Integrations" "non-skippable" "false" ""
+  adopt_record_answer "zdr_attestation_reason" "Data & Integrations" "non-skippable" "$ADOPT_ZDR_REASON" ""
+  return 0
+}
+
+# ── The runner ──────────────────────────────────────────────────────────────
+# adopt_run_reverse_intake REPORT SCENARIO — walks Scout's intakePrefill rows
+# IN THE ORDER SCOUT EMITS THEM and dispatches each to its class.
+adopt_run_reverse_intake() {
+  local report="$1" scenario="$2"
+  local rows id title kind field value source q
+  adopt_head "The interview"
+  adopt_note "Some of this the scan already answered — you will see the answer and where it"
+  adopt_note "came from, and you can keep it or change it. The rest only you can answer, so"
+  adopt_note "there is no default and no way to skip past it."
+  adopt_blank
+
+  rows="$(adopt_report_read "$report" '.intakePrefill.sections[]? | [.id, .title, .kind, .field, (.value // ""), (.source // "")] | @tsv')"
+  if [ -z "$rows" ]; then
+    adopt_refuse "the scan report carries no intakePrefill section — this driver consumes Scout's mapping table and cannot invent one"
+    return 1
+  fi
+
+  local IFS_SAVE="$IFS"
+  while IFS="$(printf '\t')" read -r id title kind field value source; do
+    [ -n "${id:-}" ] || continue
+    IFS="$IFS_SAVE"
+    adopt_blank
+    case "$id" in
+      13)
+        # Section 13 writes itself from the answers above and asks no question
+        # of its own — Scout's own sourceHint says so. Disclosing it and then
+        # offering to "change it" would be inviting an answer to a question
+        # nobody asked, so it is disclosed and recorded, not asked.
+        adopt_say "$title"
+        adopt_note "The scan found: ${value:-generated}"
+        adopt_note "Where that came from: ${source:-generated from the completed intake}"
+        adopt_note "Nothing to answer here — it is written from everything above."
+        adopt_record_answer "$field" "$title" "generated" "${value:-generated}" "${source:-generated from the completed intake}"
+        ;;
+      5)
+        adopt_say "$title"
+        adopt_ask_data_classification || return 1
+        ;;
+      *)
+        case "$kind" in
+          scan-derived)
+            adopt_confirm_scanned "$field" "$title" "$value" "$source" || return 1
+            ;;
+          judgment)
+            q="$(adopt_judgment_question "$id" "$scenario")"
+            adopt_say "$title"
+            adopt_ask_free "$title" "$q" || return 1
+            adopt_record_answer "$field" "$title" "judgment" "$ADOPT_ANSWER" ""
+            [ "$id" = "10" ] && { adopt_ops_addendum "$scenario" || return 1; }
+            ;;
+          non-skippable)
+            # Any future non-skippable row that is not section 5 lands here
+            # rather than being silently treated as judgment.
+            adopt_say "$title"
+            adopt_ask_free "$title" "$(adopt_judgment_question "$id" "$scenario")" || return 1
+            adopt_record_answer "$field" "$title" "non-skippable" "$ADOPT_ANSWER" ""
+            ;;
+          *)
+            adopt_refuse "the scan report classifies '$title' as '$kind', which this driver does not know how to ask"
+            return 1
+            ;;
+        esac
+        ;;
+    esac
+  done <<INTAKE_ROWS
+$rows
+INTAKE_ROWS
+  IFS="$IFS_SAVE"
+  return 0
+}
+
+# ── Rendering the intake artifacts ──────────────────────────────────────────
+# adopt_render_intake_doc — PROJECT_INTAKE.md from the answers ledger.
+#
+# §8.6's provenance header is WP7's deliverable and is NOT emitted here. A
+# half-shaped header would be worse than none: WP7 ships a lint for the real
+# one, and a near-miss is what a lint cannot tell from the genuine article.
+# adopt_stub_provenance_headers says so out loud at run time.
+adopt_render_intake_doc() {
+  local root="$1" scenario="$2" landed="$3"
+  local field title kind value prov last_title=""
+  {
+    printf '# Project Intake\n\n'
+    printf 'Recorded during adoption on %s.\n\n' "$(date -u +%Y-%m-%d)"
+    printf 'Scenario: %s. Landed at phase %s.\n\n' "$scenario" "$landed"
+    printf 'Each answer below says where it came from. An answer marked as coming from\n'
+    printf 'the scan was derived from the code and confirmed by a person; an answer with\n'
+    printf 'no provenance was given by a person outright.\n'
+    while IFS="$(printf '\t')" read -r field title kind value prov; do
+      [ -n "${field:-}" ] || continue
+      if [ "$title" != "$last_title" ]; then
+        printf '\n## %s\n' "$title"
+        last_title="$title"
+      fi
+      printf '\n- **%s** (%s): %s\n' "$field" "$kind" "$value"
+      [ -n "$prov" ] && printf '  - Source: %s\n' "$prov"
+    done < "$ADOPT_ANSWERS"
+    printf '\n'
+  } | adopt_write_file "$root" "PROJECT_INTAKE.md"
+}
+
+# adopt_render_intake_progress — .claude/intake-progress.json, in the shape
+# scripts/intake-wizard.sh's own progress file uses, so --resume and
+# reconfigure-project.sh can read an adopted project's answers.
+adopt_render_intake_progress() {
+  local root="$1" scenario="$2"
+  local answers_json field title kind value prov
+  answers_json="{}"
+  while IFS="$(printf '\t')" read -r field title kind value prov; do
+    [ -n "${field:-}" ] || continue
+    answers_json="$(printf '%s' "$answers_json" | jq --arg k "$field" --arg v "$value" '. + {($k): $v}' 2>/dev/null)" || return 1
+  done < "$ADOPT_ANSWERS"
+  jq -n --arg at "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg s "$scenario" --argjson a "$answers_json" \
+    '{version: 1, started_at: $at, last_section: 13, completed_sections: [],
+      source: "adopt-project.sh", adoption_scenario: $s, answers: $a}' \
+    | adopt_write_file "$root" ".claude/intake-progress.json"
+}
+
+# adopt_persist_phase1_artifacts — the canonical home the Phase 1->2 ZDR gate
+# reads. Reuse-by-extraction of intake-wizard.sh's persist_phase1_artifacts():
+# the same jq merge onto .phase1_artifacts, with the file CREATED when the
+# adoptee has none (the wizard warns and returns, because in a greenfield
+# project init.sh has already made it; in an adoptee nothing has).
+adopt_persist_phase1_artifacts() {
+  local root="$1"
+  local pstate=".claude/process-state.json"
+  if [ ! -f "$root/$pstate" ]; then
+    printf '%s\n' '{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},"uat_session":{},"phase2_init":{"steps_completed":[],"attestations":{}},"phase3_validation":{},"phase4_release":{}}' \
+      | adopt_write_file "$root" "$pstate" || return 1
+  fi
+  local attested_json="false"
+  case "$ADOPT_ZDR_ATTESTED" in true|True|TRUE) attested_json="true" ;; esac
+  adopt_jq_edit "$root" "$pstate" \
+    '.phase1_artifacts = ((.phase1_artifacts // {}) + {data_classification: $c, zdr_attested: $a, zdr_attestation_reason: $r})' \
+    --arg c "$ADOPT_DATA_CLASSIFICATION" --argjson a "$attested_json" --arg r "$ADOPT_ZDR_REASON"
+}

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -321,6 +321,7 @@ adopt_install_hooks() {
     adopt_stub_collision_archive 1
   fi
   adopt_stub_hooks
+  adopt_stub_project_docs
   return 0
 }
 

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -252,6 +252,66 @@ STAGE_SET
   return 0
 }
 
+# ── The hooks (§4.5: no forward exemption) ──────────────────────────────────
+# adopt_install_hooks ROOT — put the framework's git hooks in place.
+#
+# WHY AFTER THE ADOPTION COMMIT, AND NOT BEFORE. The adoption commit belongs to
+# the adoptee's world: whatever hooks THEY already had should judge it, and the
+# framework's should not. Everything AFTER it belongs to the framework's world,
+# which is exactly §4.5's rule that no arm anywhere exempts a commit written
+# after adoption day. Installing here draws that line at the commit itself, and
+# it removes any temptation to reach for `--no-verify` to get past a gate the
+# driver had just installed on itself.
+#
+# Nothing here is staged, and nothing needs to be: `.git/hooks/` is not tracked.
+#
+# ONLY THE COMMIT-MSG HOOK IS INSTALLED, AND THE OMISSION IS MEASURED.
+#
+# The commit-msg hook carries the two MESSAGE-SCOPED gates — the BL-072
+# TDD-ordering gate, whose pre-adoption exemption this WP's stamp bounds, and
+# the BL-006 Build-Loop check. It COMPOSES: the shared emitter appends a MARKED
+# block, so an adoptee's existing commit-msg hook keeps working and gains the
+# framework's gates, and a second run finds the marker and stops.
+#
+# The FALLBACK PRE-COMMIT HOOK IS NOT INSTALLED, and this is a measurement
+# rather than a preference. Installed on an adoptee at this point in the build
+# it BRICKS the repository: with it in place a fixture here could not land an
+# ordinary `docs:` commit (rc 1) because the hook expects framework artifacts
+# — the Adoption Record among them — that WP7 has not landed yet. Shipping a
+# gate that refuses every commit is not enforcement, it is a broken project,
+# and the operator's only way out would be the `--no-verify` this framework
+# forbids. §10 names no owner for that hook on the adoption path, so it is
+# recorded as an open decision rather than quietly assumed; adopt_stub_hooks
+# says which checks are consequently NOT running.
+#
+# The shared writer also writes the WHOLE pre-commit file, so an adoptee's own
+# pre-commit hook is §7's own archive-and-replace example, belongs to WP6, and
+# is left untouched either way.
+adopt_install_hooks() {
+  local root="$1"
+  local hooks="$root/.git/hooks"
+  adopt_head "Turning the gates on"
+  mkdir -p "$hooks" 2>/dev/null || { adopt_refuse "could not create $hooks"; return 1; }
+
+  if [ ! -f "$hooks/commit-msg" ]; then
+    printf '%s\n' '#!/usr/bin/env bash' > "$hooks/commit-msg" || { adopt_refuse "could not create the commit-msg hook"; return 1; }
+  fi
+  if grep -qF "$SOIF_TDD_OPEN" "$hooks/commit-msg" 2>/dev/null; then
+    adopt_note "The commit-msg gate was already present — left as it was."
+  else
+    soif_emit_tdd_commitmsg_block >> "$hooks/commit-msg" || { adopt_refuse "could not extend the commit-msg hook"; return 1; }
+    adopt_note "Commit-msg gate installed (it composes with whatever was already in that hook)."
+  fi
+  chmod +x "$hooks/commit-msg" 2>/dev/null
+
+  if [ -e "$hooks/pre-commit" ]; then
+    adopt_note "You already have a pre-commit hook. It has been LEFT ALONE."
+    adopt_stub_collision_archive 1
+  fi
+  adopt_stub_hooks
+  return 0
+}
+
 # ── The run ─────────────────────────────────────────────────────────────────
 ADOPT_WORK=""
 
@@ -344,8 +404,15 @@ STATE_ORDER
   adopt_stub_adoption_record "$ADOPT_SCENARIO" "$ADOPT_LANDED_PHASE"
   adopt_stage_and_commit "$root" || return 1
 
+  # AFTER the commit, and that ordering is the point — see adopt_install_hooks.
+  adopt_install_hooks "$root" || return 1
+
   adopt_head "Adopted"
   adopt_note "Scenario: $ADOPT_SCENARIO. Landed at phase $ADOPT_LANDED_PHASE."
-  adopt_note "The framework's gates are live in this project from the next commit onward."
+  # Say exactly WHICH gates, and no more. "The gates are live" would be a claim
+  # the run has not earned: the message-scoped ones are on from the next commit,
+  # and adopt_stub_hooks has just listed the ones that are not.
+  adopt_note "From your next commit onward the framework's two message gates are live in"
+  adopt_note "this project: test-before-code ordering, and the Build-Loop commit check."
   return $rc
 }

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -97,8 +97,12 @@ adopt_install_framework() {
       continue
     fi
     mkdir -p "$(dirname "$dst")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$rel")"; return 1; }
-    cp "$src" "$dst" 2>/dev/null || { adopt_refuse "could not install $rel"; return 1; }
-    chmod +x "$dst" 2>/dev/null
+    # `cp -p`, and NOT `cp` followed by `chmod +x`. The framework's own modes
+    # are already right — entry scripts are 0755 and libs are 0644 — and a
+    # blanket +x would land every sourced lib in the adoptee at 0755, a
+    # difference from a scaffolded project that nothing downstream would ever
+    # explain. Preserving the source mode keeps the two births identical.
+    cp -p "$src" "$dst" 2>/dev/null || { adopt_refuse "could not install $rel"; return 1; }
     adopt_record_write "$rel"
     n_copied=$((n_copied + 1))
   done <<INSTALL_SET
@@ -167,10 +171,18 @@ adopt_write_intake() {
 # a birth stamp that acquires a second caller has become a backfill. WP3 made
 # that structural — a second stamp is REFUSED — but the budget here is one call
 # either way.
+# The `cmd … | awk … || fallback` spelling does NOT work here and is worth
+# naming: the `||` binds to the whole PIPELINE, whose status is awk's, and awk
+# succeeds happily on empty input — so a host without `shasum` would silently
+# record an empty hash instead of trying `sha256sum`. Probe for the tool.
 adopt_sha256() {
-  shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' \
-    || sha256sum "$1" 2>/dev/null | awk '{print $1}' \
-    || printf ''
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" 2>/dev/null | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" 2>/dev/null | awk '{print $1}'
+  else
+    printf ''
+  fi
 }
 
 adopt_write_manifest() {

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -79,12 +79,18 @@ _adopt_halt_requested() {
 # and collisions belong to §7/WP6; this driver records them and refuses to
 # overwrite. §1.2's measured problem with init.sh is unguarded overwrites, and
 # a driver that reproduced them would have earned nothing by being separate.
-ADOPT_COLLISIONS=""
+#
+# The collision LIST is kept in memory and PRINTED by the stub, not staged into
+# the run's temp directory. An earlier cut wrote it to a file under $ADOPT_WORK,
+# which the EXIT trap deletes — so the list evaporated unread and only the count
+# was ever used (R-WP4-4). A seam that disappears before anything can consume it
+# is not a seam; WP6 owns the durable archive and its MANIFEST, and until then
+# the operator gets the paths on screen.
+ADOPT_COLLISION_LIST=""
 adopt_install_framework() {
   local root="$1"
   local rel src dst n_copied=0 n_collided=0
-  ADOPT_COLLISIONS="$ADOPT_WORK/collisions"
-  : > "$ADOPT_COLLISIONS"
+  ADOPT_COLLISION_LIST=""
   adopt_head "Installing the framework's own scripts"
   while IFS= read -r rel; do
     [ -n "$rel" ] || continue
@@ -92,7 +98,8 @@ adopt_install_framework() {
     dst="$root/$rel"
     [ -f "$src" ] || continue
     if [ -e "$dst" ]; then
-      printf '%s\n' "$rel" >> "$ADOPT_COLLISIONS"
+      ADOPT_COLLISION_LIST="$ADOPT_COLLISION_LIST$rel
+"
       n_collided=$((n_collided + 1))
       continue
     fi
@@ -109,8 +116,31 @@ adopt_install_framework() {
 $(soif_parse_shipped_scripts "$ADOPT_FRAMEWORK_ROOT/init.sh" "$ADOPT_FRAMEWORK_ROOT/scripts")
 INSTALL_SET
   adopt_note "Installed $n_copied framework script(s); left $n_collided of your own file(s) untouched."
-  [ "$n_copied" -gt 0 ] || { adopt_refuse "no framework scripts could be installed — is this a complete clone?"; return 1; }
-  adopt_stub_collision_archive "$n_collided"
+  if [ "$n_copied" -eq 0 ]; then
+    # TWO CAUSES, AND THEY NEED DIFFERENT SENTENCES (R-WP4-2). The first cut
+    # blamed the clone for both, which is a misdiagnosis in the commonest case:
+    # a run that halted at the commit stage leaves every framework file already
+    # present, so the operator's obvious next move — fix the problem, re-run —
+    # met "is this a complete clone?" about the one thing that was fine. Name
+    # the real state, and say plainly that resuming is not built yet rather
+    # than implying a retry will work.
+    if [ "$n_collided" -gt 0 ]; then
+      adopt_refuse "every framework script is already present, so nothing was installed."
+      {
+        echo "          This project looks partly or fully adopted already — most likely an earlier"
+        echo "          adoption ran and stopped before it finished."
+        echo "          RESUMING AN INTERRUPTED ADOPTION IS NOT BUILT YET: collisions belong to WP6"
+        echo "          and the adoption record to WP7, so re-running cannot pick up where it left"
+        echo "          off, and the stamp refuses to be written twice by design."
+        echo "          Meanwhile the project is in the SAFE state: the gates are live at the"
+        echo "          strictest tier, so nothing slips through while this is unresolved."
+      } >&2
+      return 1
+    fi
+    adopt_refuse "no framework scripts could be installed and none were already there — is this a complete clone?"
+    return 1
+  fi
+  adopt_stub_collision_archive "$n_collided" "$ADOPT_COLLISION_LIST"
   return 0
 }
 
@@ -200,6 +230,17 @@ adopt_write_manifest() {
   fi
 
   sha="$(adopt_sha256 "$root/.claude/adoption/scout-report.json")"
+  # REFUSE ON AN EMPTY HASH (R-WP4-3), and refuse HERE rather than hoping the
+  # stamp will. `soif_adoption_stamp` takes `scanner_sha="${8:-}"` and writes
+  # whatever it is given, so an empty string would land in the durable record
+  # as a hash that ties the adoption decision to nothing — the same
+  # silent-empty shape as adopt_sha256's old unreachable fallback, one layer
+  # further out. There is no scenario in which "we could not hash the evidence"
+  # should still produce a record claiming to have hashed it.
+  if [ -z "$sha" ]; then                                                       # BF-ADOPT-SHA-REQUIRED
+    adopt_refuse "cannot hash the kept scan report — neither shasum nor sha256sum is available, and the adoption record must not claim an evidence hash it does not have"
+    return 1
+  fi
 
   # THE ONE CALL SITE. adoptedAtCommit is not passed — the stamp takes it from
   # `git rev-parse HEAD` at stamp time, i.e. the PRE-ADOPTION TIP, the parent
@@ -318,7 +359,7 @@ adopt_install_hooks() {
 
   if [ -e "$hooks/pre-commit" ]; then
     adopt_note "You already have a pre-commit hook. It has been LEFT ALONE."
-    adopt_stub_collision_archive 1
+    adopt_stub_collision_archive 1 ".git/hooks/pre-commit"
   fi
   adopt_stub_hooks
   adopt_stub_project_docs

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-state.sh — the framework install, the FAIL-SAFE
+# state-creation order (§8.4), the adoption stamp's ONE call site (§8.5),
+# explicit staging, and the run itself.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §8.4, §8.5, §5.5,
+# §8.1, §4.3/§4.4.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# §8.4 — WHY phase-state FIRST, AND WHY THE ORDER IS DATA
+#
+# The two failure directions are not symmetric, and that asymmetry is the whole
+# reason there is an order at all. Verified by execution, per surface:
+#
+#   phase-state present, manifest absent
+#     check-phase-gate.sh runs and exits 1; read_enforcement_level returns
+#     `strict` (missing file => strict). Gates live at the strictest tier —
+#     BLOCKED, which is the SAFE direction.
+#
+#   manifest present, phase-state absent
+#     check-phase-gate.sh prints "No .claude/phase-state.json found — skipping
+#     phase gate check." and exits 0. An adopted-LOOKING project with NO gate
+#     enforcement at all. That row must never be reachable.
+#
+# Writing phase-state FIRST means every interruption lands in the top row. §5.5
+# names the state this protects: "adoption does not complete" is a real state
+# and it must be a SAFE one — an operator who abandons an adoption mid-way ends
+# up with a blocked repository, not a silently degraded one.
+#
+# The honest qualification (§8.4's C4 correction, not restated as a flat
+# claim): "missing manifest fails strict" is true of scripts/lib/enforcement-level.sh
+# and FALSE inside check-phase-gate.sh, where the missing-manifest arm of the
+# Phase 1->2 protection backstop is a `[WARN]` with NO `issues` increment. The
+# ordering decision is unaffected — the tier ladder governs the commit-time
+# gates and it fails closed — but the flat claim would be wrong.
+#
+# init.sh's create_project() uses the OPPOSITE order (manifest, intake,
+# phase-state). That is not a counter-example: creation is one uninterrupted
+# run ending in a commit, so no partial state is ever left behind. Adoption can
+# legitimately halt at a blocker.
+
+# _adopt_state_order — §8.4's order, spelled ONCE, as data, so that reversing
+# it is a ONE-LINE edit and a mutation proof has a single site to hit.
+_adopt_state_order() {
+  printf '%s\n' phase_state intake manifest   # BF-ADOPT-STATE-ORDER
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# THE HALT HOOK IS A FAULT INJECTOR AND IT IS DELIBERATE.
+#
+# SOIF_ADOPT_HALT_AFTER=<stage> stops the run immediately after the named
+# stage. It exists so the §8.4 table can be asserted at every interruption
+# point by EXECUTION rather than by reasoning about one — the same kind of
+# affordance as the bare `:` above the prefill read: not dead code, but the
+# thing that makes the proof possible.
+#
+# It cannot weaken enforcement. Every value it accepts makes the run stop
+# EARLIER, and stopping earlier is by construction the safe direction (§5.5) —
+# there is no ordering of the stages under which halting produces the unsafe
+# row unless the ORDER ITSELF is wrong, which is exactly what it is here to
+# detect.
+_adopt_halt_requested() {
+  [ "${SOIF_ADOPT_HALT_AFTER:-}" = "$1" ]
+}
+
+# ── The framework install ───────────────────────────────────────────────────
+# adopt_install_framework ROOT — put the framework's own scripts into the
+# adoptee.
+#
+# The set is DERIVED from init.sh's `cp` lines through the shared parser
+# (soif_parse_shipped_scripts), never duplicated here: a hand-kept second copy
+# of that list is precisely the drift BL-088's source-closure check exists to
+# catch, and a duplicate would drift the moment either list changed. It is also
+# how scripts/lib/adoption-stamp.sh reaches the adoptee — WP3's own header
+# warns that without it every enabling arm silently no-ops on exactly the
+# projects they were built for.
+#
+# NON-DESTRUCTIVE, ALWAYS. An existing file at a framework path is a COLLISION
+# and collisions belong to §7/WP6; this driver records them and refuses to
+# overwrite. §1.2's measured problem with init.sh is unguarded overwrites, and
+# a driver that reproduced them would have earned nothing by being separate.
+ADOPT_COLLISIONS=""
+adopt_install_framework() {
+  local root="$1"
+  local rel src dst n_copied=0 n_collided=0
+  ADOPT_COLLISIONS="$ADOPT_WORK/collisions"
+  : > "$ADOPT_COLLISIONS"
+  adopt_head "Installing the framework's own scripts"
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    src="$ADOPT_FRAMEWORK_ROOT/$rel"
+    dst="$root/$rel"
+    [ -f "$src" ] || continue
+    if [ -e "$dst" ]; then
+      printf '%s\n' "$rel" >> "$ADOPT_COLLISIONS"
+      n_collided=$((n_collided + 1))
+      continue
+    fi
+    mkdir -p "$(dirname "$dst")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$rel")"; return 1; }
+    cp "$src" "$dst" 2>/dev/null || { adopt_refuse "could not install $rel"; return 1; }
+    chmod +x "$dst" 2>/dev/null
+    adopt_record_write "$rel"
+    n_copied=$((n_copied + 1))
+  done <<INSTALL_SET
+$(soif_parse_shipped_scripts "$ADOPT_FRAMEWORK_ROOT/init.sh" "$ADOPT_FRAMEWORK_ROOT/scripts")
+INSTALL_SET
+  adopt_note "Installed $n_copied framework script(s); left $n_collided of your own file(s) untouched."
+  [ "$n_copied" -gt 0 ] || { adopt_refuse "no framework scripts could be installed — is this a complete clone?"; return 1; }
+  adopt_stub_collision_archive "$n_collided"
+  return 0
+}
+
+# ── Stage 1 — phase-state ───────────────────────────────────────────────────
+# adopt_write_phase_state ROOT — the FIRST write of the run, on purpose.
+#
+# `deployment` and `poc_mode` are the tier key (# BL-084-TIER-KEY names the
+# sibling predicates that must agree). They are ASKED, never defaulted: an
+# empty `deployment` makes the commit-time gate BYPASSABLE by the mothership
+# safety rule, so silently omitting them would ship the adoptee a weaker gate
+# than the operator chose — the exact direction §8.4 exists to prevent.
+ADOPT_DEPLOYMENT=""
+ADOPT_POC_MODE="production"
+ADOPT_PROJECT_NAME=""
+
+ADOPT_AUDIENCE_Q="Who is this project for?"
+ADOPT_AUDIENCE_PERSONAL="Just me, or me and a few people I know"
+ADOPT_AUDIENCE_ORG="A company, a client, or people who are paying for it"
+
+adopt_ask_audience() {
+  adopt_ask_choice "who the project is for" "$ADOPT_AUDIENCE_Q" \
+    "$ADOPT_AUDIENCE_PERSONAL" "$ADOPT_AUDIENCE_ORG" || return 1
+  case "$ADOPT_ANSWER" in
+    "$ADOPT_AUDIENCE_ORG") ADOPT_DEPLOYMENT="organizational" ;;
+    *)                     ADOPT_DEPLOYMENT="personal" ;;
+  esac
+  return 0
+}
+
+adopt_write_phase_state() {
+  local root="$1"
+  jq -n --arg p "$ADOPT_PROJECT_NAME" --arg d "$ADOPT_DEPLOYMENT" --arg m "$ADOPT_POC_MODE" \
+        --argjson phase "$ADOPT_LANDED_PHASE" \
+    '{project: $p, framework_version: "1.0", current_phase: $phase, track: "full",
+      deployment: $d, poc_mode: $m, compliance_ready: false, review_gate_enforced: true,
+      gates: {phase_0_to_1: null, phase_1_to_2: null, phase_2_to_3: null, phase_3_to_4: null}}' \
+    | adopt_write_file "$root" ".claude/phase-state.json"
+}
+
+# ── Stage 2 — intake ────────────────────────────────────────────────────────
+adopt_write_intake() {
+  local root="$1" report="$2"
+  adopt_render_intake_doc "$root" "$ADOPT_SCENARIO" "$ADOPT_LANDED_PHASE" || return 1
+  adopt_render_intake_progress "$root" "$ADOPT_SCENARIO" || return 1
+  adopt_persist_phase1_artifacts "$root" || return 1
+  # The survey that justified every scanned answer travels with the project;
+  # the stamp's scannerReportSha256 is the hash of exactly this file, so the
+  # record and its evidence cannot drift apart.
+  cat "$report" | adopt_write_file "$root" ".claude/adoption/scout-report.json" || return 1
+  adopt_stub_provenance_headers
+  return 0
+}
+
+# ── Stage 3 — manifest, and THE STAMP ───────────────────────────────────────
+# §8.5: the stamp's home is `.claude/manifest.json`'s top-level `adoption`
+# block, and this is its ONE product call site. `soif_currency_stamp` has
+# exactly one too, and the operating-model design's F1 correction records why:
+# a birth stamp that acquires a second caller has become a backfill. WP3 made
+# that structural — a second stamp is REFUSED — but the budget here is one call
+# either way.
+adopt_sha256() {
+  shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' \
+    || sha256sum "$1" 2>/dev/null | awk '{print $1}' \
+    || printf ''
+}
+
+adopt_write_manifest() {
+  local root="$1" report="$2"
+  local host mode sha
+  host="$(adopt_report_read "$report" '.stack.ciHost // ""')"
+  case "$host" in ''|null) host="other" ;; esac
+  mode="$ADOPT_DEPLOYMENT"
+
+  if [ -f "$root/.claude/manifest.json" ]; then
+    adopt_jq_edit "$root" ".claude/manifest.json" '.host = $h | .mode = $m' --arg h "$host" --arg m "$mode" || return 1
+  else
+    jq -n --arg h "$host" --arg m "$mode" '{host: $h, mode: $m, remote_url: ""}' \
+      | adopt_write_file "$root" ".claude/manifest.json" || return 1
+  fi
+
+  sha="$(adopt_sha256 "$root/.claude/adoption/scout-report.json")"
+
+  # THE ONE CALL SITE. adoptedAtCommit is not passed — the stamp takes it from
+  # `git rev-parse HEAD` at stamp time, i.e. the PRE-ADOPTION TIP, the parent
+  # the adoption commit is about to land on. That anchor is what bounds the TDD
+  # exemption, so the stamp must be written BEFORE the adoption commit and the
+  # adoption commit must be the very next one. Both hold here: this is the last
+  # write of the last stage, and adopt_stage_and_commit follows immediately.
+  #
+  # Certification is EMPTY and that is honest, not an oversight: the
+  # certification pass is WP5 and has not run. adopt_stub_certification says so
+  # out loud rather than letting an empty array read as "measured, nothing
+  # found".
+  ( cd "$root" && soif_adoption_stamp ".claude/manifest.json" "$ADOPT_SCENARIO" "$ADOPT_LANDED_PHASE" \
+      '[]' '[]' '[]' '[]' "$sha" ) || { adopt_refuse "the adoption stamp was refused"; return 1; }   # BF-ADOPT-STAMP-CALL
+  adopt_record_write ".claude/manifest.json"
+
+  # The stamp no-ops silently (rc 0) when jq is missing or the manifest is not
+  # there, so rc 0 alone is not proof it landed. Read it back.
+  if ! ( cd "$root" && soif_adoption_adopted ".claude/manifest.json" ); then
+    adopt_refuse "the adoption stamp did not land in .claude/manifest.json"
+    return 1
+  fi
+  return 0
+}
+
+# ── Explicit staging and the commit (§8.5) ──────────────────────────────────
+# NEVER `git add -A`. The counter-example is create_project()'s blanket add
+# followed by `git commit --no-verify`, which on an adoptee would sweep their
+# uncommitted work into a framework commit with verification bypassed. The
+# precedent is upgrade-project.sh's `git add "${FILES_TO_STAGE[@]}"`.
+#
+# The array is built from the ledger every write recorded as it happened, so
+# "anything not in it is never staged" is a property of the code. There is also
+# no `--no-verify` here: whatever hook the adoptee already had still runs, and
+# it is their gate, not ours, to bypass.
+adopt_stage_and_commit() {
+  local root="$1"
+  local FILES_TO_STAGE=() rel n=0
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    [ -e "$root/$rel" ] || continue
+    FILES_TO_STAGE[$n]="$rel"
+    n=$((n + 1))
+  done <<STAGE_SET
+$(adopt_written_paths)
+STAGE_SET
+  if [ "$n" -eq 0 ]; then
+    adopt_refuse "there is nothing to commit — no file was recorded as written"
+    return 1
+  fi
+  adopt_head "Committing exactly what was written"
+  adopt_note "$n file(s), named one by one. Anything else you had in progress stays"
+  adopt_note "exactly as you left it — unstaged, uncommitted, untouched."
+  ( cd "$root" && git add -- "${FILES_TO_STAGE[@]}" ) || {   # BF-ADOPT-STAGE-EXPLICIT
+    adopt_refuse "could not stage the adoption files (are any of them ignored by .gitignore?)"
+    return 1
+  }
+  ( cd "$root" && git commit -q -m "chore: adopt ${ADOPT_PROJECT_NAME:-this project} into the Solo Orchestrator framework" ) || {
+    adopt_refuse "the adoption commit did not succeed — your own hooks or git identity may have refused it"
+    return 1
+  }
+  return 0
+}
+
+# ── The run ─────────────────────────────────────────────────────────────────
+ADOPT_WORK=""
+
+adopt_obtain_report() {
+  local root="$1" given="$2"
+  if [ -n "$given" ]; then
+    if [ ! -f "$given" ]; then
+      adopt_refuse "the scan report '$given' does not exist"
+      return 1
+    fi
+    printf '%s' "$given"
+    return 0
+  fi
+  local scout="$ADOPT_FRAMEWORK_ROOT/scripts/scout.sh"
+  if [ ! -f "$scout" ]; then
+    adopt_refuse "no scan report was given and Scout is not beside this driver"
+    return 1
+  fi
+  bash "$scout" --root "$root" --out "$ADOPT_WORK/scan" >/dev/null 2>&1 || {
+    adopt_refuse "the scan did not complete"
+    return 1
+  }
+  printf '%s' "$ADOPT_WORK/scan/scout-report.json"
+  return 0
+}
+
+adopt_main() {
+  local root="$1" given_report="$2"
+  local report stage rc=0
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "adopt-project: jq is required." >&2
+    return 2
+  fi
+  if ! ( cd "$root" && git rev-parse --verify --quiet HEAD >/dev/null 2>&1 ); then
+    echo "adopt-project: '$root' is not a git repository with at least one commit." >&2
+    echo "  Adoption records the commit it landed on, so there has to be one." >&2
+    return 2
+  fi
+
+  ADOPT_WORK="$(mktemp -d "${TMPDIR:-/tmp}/adopt-work.XXXXXXXX" 2>/dev/null)" || {
+    echo "adopt-project: could not create a temporary working directory." >&2
+    return 2
+  }
+  trap 'rm -rf "$ADOPT_WORK"' EXIT INT TERM
+
+  adopt_stdin_init
+  adopt_ledger_init "$ADOPT_WORK/written" || return 2
+  adopt_answers_init "$ADOPT_WORK/answers" || return 2
+  ADOPT_PROJECT_NAME="${root##*/}"
+
+  adopt_head "Adopting $ADOPT_PROJECT_NAME"
+  adopt_note "Nothing is written until the questions are answered. If you stop partway,"
+  adopt_note "this project ends up more strictly gated than it started, never less."
+
+  report="$(adopt_obtain_report "$root" "$given_report")" || return 1
+
+  adopt_present_evidence "$root" "$report"
+  adopt_ask_scenario || return 1
+  adopt_decide_placement "$report" || return 1
+  adopt_ask_audience || return 1
+  adopt_run_reverse_intake "$report" "$ADOPT_SCENARIO" || return 1
+
+  adopt_stub_secrets_disposition "$report"
+  adopt_stub_certification "$ADOPT_SCENARIO" "$ADOPT_LANDED_PHASE"
+  adopt_stub_test_debt_ledger
+
+  adopt_install_framework "$root" || return 1
+  if _adopt_halt_requested install; then
+    adopt_refuse "halted after the framework install, before any state was written (SOIF_ADOPT_HALT_AFTER)"
+    return 1
+  fi
+
+  while IFS= read -r stage; do
+    [ -n "$stage" ] || continue
+    case "$stage" in
+      phase_state) adopt_write_phase_state "$root" || return 1 ;;
+      intake)      adopt_write_intake "$root" "$report" || return 1 ;;
+      manifest)    adopt_write_manifest "$root" "$report" || return 1 ;;
+      *)           adopt_refuse "unknown state stage '$stage'"; return 1 ;;
+    esac
+    if _adopt_halt_requested "$stage"; then
+      adopt_refuse "halted after the '$stage' stage (SOIF_ADOPT_HALT_AFTER)"
+      return 1
+    fi
+  done <<STATE_ORDER
+$(_adopt_state_order)
+STATE_ORDER
+
+  adopt_stub_adoption_record "$ADOPT_SCENARIO" "$ADOPT_LANDED_PHASE"
+  adopt_stage_and_commit "$root" || return 1
+
+  adopt_head "Adopted"
+  adopt_note "Scenario: $ADOPT_SCENARIO. Landed at phase $ADOPT_LANDED_PHASE."
+  adopt_note "The framework's gates are live in this project from the next commit onward."
+  return $rc
+}

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -56,13 +56,28 @@ adopt_stub_test_debt_ledger() {
 
 # WP6 — the collision archive, its MANIFEST, the disclosure and the re-add
 # warning (§7.2/§7.3). WP4 refuses to overwrite; it does not archive.
+# adopt_stub_collision_archive N [LIST] — LIST is passed explicitly rather than
+# read from a global, because there are two call sites with two different sets
+# (the framework scripts, and the adoptee's own pre-commit hook) and a shared
+# global would print the first site's paths under the second site's heading.
 adopt_stub_collision_archive() {
-  local n="${1:-0}"
+  local n="${1:-0}" list="${2:-}" p
   [ "$n" -gt 0 ] || return 0
   adopt_stub_notice "the collision archive" "WP6" \
     "$n of your files sit where a framework file would go. They were LEFT ALONE — not archived,"
   adopt_note "not replaced, not listed in a restorable manifest. The framework's version of each"
   adopt_note "of those files is therefore NOT installed, so anything that depends on it is inert."
+  # The PATHS, not just the count. Until WP6 writes a durable MANIFEST this
+  # transcript is the only place they are ever named, and "3 collisions" tells
+  # an operator nothing they can act on. Bounded, because a heavily-occupied
+  # tree could otherwise bury the rest of the run.
+  if [ -n "$list" ]; then
+    printf '%s\n' "$list" | head -20 | while IFS= read -r p; do
+      [ -n "$p" ] && adopt_note "  yours, kept: $p"
+    done
+    [ "$n" -gt 20 ] && adopt_note "  ...and $((n - 20)) more."
+  fi
+  return 0
 }
 
 # §6.3 — per-finding secrets disposition. Scout already reported the findings

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-stubs.sh — the parts of adoption WP4 does NOT build,
+# said out loud at the point in the run where they belong.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §10 — WP5 (the
+# certification pass), WP5b (the test-debt ledger), WP6 (the collision archive,
+# the disclosure and the re-add warning), WP7 (the CI carve-out, the provenance
+# headers and the Adoption Record), §6.3 (per-finding secrets disposition).
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHY STUBS EXIST AT ALL, AND WHAT MAKES ONE HONEST.
+#
+# A driver that quietly skipped the certification pass would produce a project
+# that LOOKS certified: an `adoption` block with three empty certification
+# arrays reads, to anyone who finds it later, exactly like "we measured and
+# there was nothing to record". §5.1's indictment of bare grandfathering is
+# that "nothing is measured; nothing is recorded; the exemption is the ABSENCE
+# of a field" — an unannounced stub reproduces all three properties.
+#
+# So each stub below prints, at the moment the real thing would have run, what
+# did not happen and which work package owns it. None of them returns a result,
+# none of them writes a record, and none of them can be mistaken for a pass.
+# They are load-bearing honesty, and they are the whole of WP4's answer to the
+# parts of adoption it does not implement.
+
+adopt_stub_notice() {
+  local what="$1" owner="$2" consequence="$3"
+  adopt_blank
+  adopt_say "NOT DONE — $what"
+  adopt_note "Owner: $owner. This build does not do it, and does not pretend to."
+  adopt_note "$consequence"
+}
+
+# WP5 — the certification pass (§5). The empty certification arrays in the
+# stamp are the visible consequence and the notice names them, because an empty
+# array is exactly what a completed pass with no findings would also produce.
+adopt_stub_certification() {
+  local scenario="$1" landed="$2"
+  local scope
+  if [ "$scenario" = "completed" ]; then
+    scope="every gate from 0 to 4, because landing at 4 means all four have notionally been crossed"
+  else
+    scope="the gates below phase $landed; the ones above it get crossed the ordinary way, later"
+  fi
+  adopt_stub_notice "the certification pass" "WP5" \
+    "It would have run $scope, and a blocker-grade finding would have stopped this adoption."
+  adopt_note "Because it did not run, the adoption record's certification lists are EMPTY."
+  adopt_note "An empty list here means 'not measured', not 'measured and clean'."
+}
+
+# WP5b — the test-debt ledger and its ratchet (§5.4).
+adopt_stub_test_debt_ledger() {
+  adopt_stub_notice "the test-debt ledger" "WP5b" \
+    "Existing untested files are not recorded, so nothing yet stops that set from growing."
+}
+
+# WP6 — the collision archive, its MANIFEST, the disclosure and the re-add
+# warning (§7.2/§7.3). WP4 refuses to overwrite; it does not archive.
+adopt_stub_collision_archive() {
+  local n="${1:-0}"
+  [ "$n" -gt 0 ] || return 0
+  adopt_stub_notice "the collision archive" "WP6" \
+    "$n of your files sit where a framework file would go. They were LEFT ALONE — not archived,"
+  adopt_note "not replaced, not listed in a restorable manifest. The framework's version of each"
+  adopt_note "of those files is therefore NOT installed, so anything that depends on it is inert."
+}
+
+# §6.3 — per-finding secrets disposition. Scout already reported the findings
+# (redacted); deciding what to do about each one is not WP4's.
+adopt_stub_secrets_disposition() {
+  local report="$1"
+  local n
+  n="$(adopt_int "$(adopt_report_read "$report" '.secrets.findingCount // 0')")"
+  local status
+  status="$(adopt_report_read "$report" '.secrets.status // ""')"
+  if [ "$status" != "scanned" ]; then
+    adopt_stub_notice "the secrets disposition" "WP6" \
+      "The scan did not run a secrets tool, so this adoption knows nothing about credentials in your history."
+    return 0
+  fi
+  [ "$n" -gt 0 ] || return 0
+  adopt_stub_notice "the secrets disposition" "WP6" \
+    "The scan found $n secret-shaped finding(s) in this repository's history. Each one needs a"
+  adopt_note "recorded decision and this build does not collect one. Read"
+  adopt_note ".claude/adoption/scout-report.json's secrets section before you trust this repo."
+}
+
+# WP7 — the Adoption Record in APPROVAL_LOG.md, the audit rows, and the CI
+# carve-out. Named here because its absence has an immediate, visible effect:
+# check-phase-gate.sh exits 1 on a project with phase-state and no
+# APPROVAL_LOG.md, which is the SAFE direction but is not a finished adoption.
+adopt_stub_adoption_record() {
+  local scenario="$1" landed="$2"
+  adopt_stub_notice "the Adoption Record, the audit rows and the CI carve-out" "WP7" \
+    "APPROVAL_LOG.md is not written, so the phase gate will report it missing until WP7 lands."
+  adopt_note "That is the safe direction — a blocked project, not a silently-approved one — but it"
+  adopt_note "means this adoption ($scenario, phase $landed) is recorded in the manifest and"
+  adopt_note "nowhere else yet."
+}
+
+# WP7 — §8.6's provenance headers on reconstructed documents.
+adopt_stub_provenance_headers() {
+  adopt_stub_notice "the provenance headers on reconstructed documents" "WP7" \
+    "PROJECT_INTAKE.md records where each answer came from, but it carries no machine-readable"
+  adopt_note "provenance header. A near-miss header is worse than none: WP7 ships a lint for the"
+  adopt_note "real one, and a lint cannot tell a near-miss from the genuine article."
+}

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -98,6 +98,20 @@ adopt_stub_adoption_record() {
   adopt_note "nowhere else yet."
 }
 
+# The fallback PRE-COMMIT hook. Not attributed to a work package, because §10
+# names no owner for it on the adoption path — that is the honest statement and
+# the WP4 report records it as an open decision. Measured, not assumed: with
+# that hook installed at this point in the build an adopted fixture could not
+# land an ordinary `docs:` commit, because the hook expects framework artifacts
+# a WP4 adoption has not produced.
+adopt_stub_hooks() {
+  adopt_stub_notice "the commit-time scanners (the fallback pre-commit hook)" "nobody yet — §10 names no owner" \
+    "The message gates ARE on. The secret scan, the static-analysis pass and the schema-migration"
+  adopt_note "checks that normally run on every commit are NOT — installing that hook today refuses"
+  adopt_note "every commit, because it expects artifacts an adoption does not yet produce. Run them"
+  adopt_note "by hand until it lands: bash scripts/pre-commit-gate.sh --terminal-mode"
+}
+
 # WP7 — §8.6's provenance headers on reconstructed documents.
 adopt_stub_provenance_headers() {
   adopt_stub_notice "the provenance headers on reconstructed documents" "WP7" \

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -112,6 +112,20 @@ adopt_stub_hooks() {
   adopt_note "by hand until it lands: bash scripts/pre-commit-gate.sh --terminal-mode"
 }
 
+# The adoptee's own framework DOCUMENTS — CLAUDE.md, the generated templates,
+# docs/reference/, the .gitignore additions. Every one of them is a path an
+# adoptee may already occupy (a CLAUDE.md especially), which makes writing them
+# §7's collision question and therefore WP6's, not this package's. Named here
+# because the absence is not cosmetic: CLAUDE.md is what a downstream agent
+# reads at kickoff, so an adopted project without it starts every session
+# without its orientation.
+adopt_stub_project_docs() {
+  adopt_stub_notice "your project's framework documents" "WP6 (they are collision decisions before they are writes)" \
+    "CLAUDE.md, the document templates and the reference docs are NOT written. The scripts and the"
+  adopt_note "state are here, so the gates work; the reading material an agent picks up at the start"
+  adopt_note "of a session is not, and a CLAUDE.md you already have would be a collision, not a gap."
+}
+
 # WP7 — §8.6's provenance headers on reconstructed documents.
 adopt_stub_provenance_headers() {
   adopt_stub_notice "the provenance headers on reconstructed documents" "WP7" \

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -690,6 +690,39 @@ run_child_suite "tests/test-brownfield-wp3-regenerate-path.sh" \
   "Adoption stamp regenerate path (loud detection of an unpreventable loss)" \
   "Adoption WP3 regenerate-path tests FAILED (run tests/test-brownfield-wp3-regenerate-path.sh for details)"
 
+# Brownfield adoption WP4: tests/test-brownfield-wp4-driver.sh — the DRIVER
+# (scripts/adopt-project.sh), the scenario chooser, scenario placement and
+# reverse intake.
+# THREE PROPERTIES CARRY THE WEIGHT AND EACH IS PINNED TWICE.
+# (1) The chooser is Karl's sentence VERBATIM and is a DECISION, not a
+#     phrasing: pinned by STRING EQUALITY against a literal spelled
+#     independently in the suite, again as a whole line of the real
+#     transcript, and — because §4.2 explicitly rejects presenting a guess as
+#     a default for the most consequential answer in the flow — by withholding
+#     the answer and requiring the run to STOP rather than choose.
+# (2) The floor rule is ONE-DIRECTIONAL: both directions are asserted (an
+#     interview that lowers the placement does, one that raises it does not)
+#     and the mutation neuters the floor so the SAME interview raises S2 from
+#     2 to 4.
+# (3) The state-creation order is phase-state -> intake -> manifest because
+#     the failure directions are ASYMMETRIC. Every interruption point is
+#     executed, and the safe row is asserted through BOTH of §8.4's surfaces —
+#     the gate's exit code AND read_enforcement_level — never a label.
+#     Reversing the order makes the unsafe row reachable: a manifest, no
+#     phase-state, and a gate that skips entirely at rc 0.
+# Data classification's non-skippability is asserted THROUGH THE GATE that
+# makes it mechanical: the mutant completes a run without it and the resulting
+# project then FAILS its own Phase 1->2 ZDR backstop, with a positive control
+# so that failure cannot be vacuous. The TDD bound WP3 shipped is proved END TO
+# END on the adopted project, running the project's OWN installed gate, and the
+# blocked direction asserts exit 3 — the BL-072 TDD arm specifically — rather
+# than merely non-zero. Mutants run against a scratch framework MIRROR, so a
+# failure here can never leave this repository mutated. Never invokes the
+# scaffolder (it copies init.sh into the mirror; it does not run it) -> both lanes.
+run_child_suite "tests/test-brownfield-wp4-driver.sh" \
+  "Adoption driver (chooser verbatim, floor rule, reverse intake, fail-safe write order)" \
+  "Adoption WP4 driver tests FAILED (run tests/test-brownfield-wp4-driver.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -745,11 +745,17 @@ else
   t1_blocks=$(jq -r '[.. | objects | select(has("adopted"))] | length' "$T1D/p/.claude/manifest.json" 2>/dev/null)
   t1_scen=$(jq -r '.adoption.scenario // "MISSING"' "$T1D/p/.claude/manifest.json" 2>/dev/null)
   t1_landed=$(jq -r '.adoption.landedPhase // "MISSING"' "$T1D/p/.claude/manifest.json" 2>/dev/null)
+  # scannerReportSha256 must be the hash of the report the project actually
+  # KEEPS, not merely non-empty: the field exists so a later reader can tell
+  # whether the evidence beside it is the evidence the decision was made on.
+  t1_sha=$(jq -r '.adoption.scannerReportSha256 // ""' "$T1D/p/.claude/manifest.json" 2>/dev/null)
+  t1_real=$(shasum -a 256 "$T1D/p/.claude/adoption/scout-report.json" 2>/dev/null | awk '{print $1}')
   if [ "$t1_rc" -eq 0 ] && [ -n "$t1_parent" ] && [ "$t1_anchor" = "$t1_parent" ] \
-     && [ "$(_num "$t1_blocks")" -eq 1 ] && [ "$t1_scen" = "in-flight" ] && [ "$t1_landed" = "1" ]; then
-    pass "T1: the stamp lands ONCE and adoptedAtCommit is the PRE-adoption tip — the parent the adoption commit landed on"
+     && [ "$(_num "$t1_blocks")" -eq 1 ] && [ "$t1_scen" = "in-flight" ] && [ "$t1_landed" = "1" ] \
+     && [ -n "$t1_real" ] && [ "$t1_sha" = "$t1_real" ]; then
+    pass "T1: the stamp lands ONCE, adoptedAtCommit is the PRE-adoption tip, and scannerReportSha256 hashes the report the project kept"
   else
-    fail_ "T1" "rc=$t1_rc anchor=$t1_anchor parent=$t1_parent adoption_blocks=$t1_blocks (want 1) scenario=$t1_scen landed=$t1_landed"
+    fail_ "T1" "rc=$t1_rc anchor=$t1_anchor parent=$t1_parent adoption_blocks=$t1_blocks (want 1) scenario=$t1_scen landed=$t1_landed report_sha=$t1_sha kept_report_sha=$t1_real"
   fi
 
   # T4 — a POST-adoption commit blocks, and blocks for the RIGHT REASON.
@@ -963,6 +969,31 @@ else
     pass "H3: the run claims only the gates it installed — it names the commit-time scanners as NOT running and gives the command to run them by hand"
   else
     fail_ "H3" "rc=$h3_rc scanners_named_absent=$h3_named remedy_given=$h3_remedy claim_is_narrow=$h3_nooverclaim pre_commit_hook_written=$h3_precommit (want 0)"
+  fi
+fi
+
+# H4 — an adopted project's framework files are born the same way a scaffolded
+# one's are. Modes included: a blanket `chmod +x` over the installed set would
+# leave every sourced lib at 0755 downstream, a difference from a scaffolded
+# project that nothing there would ever explain.
+H4D="$(newtmp)"
+if ! mk_adoptee "$H4D/p"; then
+  fail_ "H4" "fixture setup failed"
+else
+  report_with_phase 2 "$H4D/report.json"
+  _ans_s2 3 > "$H4D/answers"
+  run_adopt "$H4D/p" "$H4D/answers" "$H4D/report.json"; h4_rc=$RUN_RC
+  h4_lib_src=$(_mode_of "$REPO_ROOT/scripts/lib/helpers-core.sh")
+  h4_lib_dst=$(_mode_of "$H4D/p/scripts/lib/helpers-core.sh")
+  h4_gate_src=$(_mode_of "$REPO_ROOT/scripts/pre-commit-gate.sh")
+  h4_gate_dst=$(_mode_of "$H4D/p/scripts/pre-commit-gate.sh")
+  h4_stamp=0
+  [ -f "$H4D/p/scripts/lib/adoption-stamp.sh" ] && h4_stamp=1
+  if [ "$h4_rc" -eq 0 ] && [ "$h4_lib_src" = "$h4_lib_dst" ] && [ "$h4_gate_src" = "$h4_gate_dst" ] \
+     && [ "$h4_lib_src" != "$h4_gate_src" ] && [ "$h4_stamp" -eq 1 ]; then
+    pass "H4: the installed framework files keep their own modes (lib $h4_lib_dst, entry script $h4_gate_dst — genuinely different, so the comparison is not vacuous) and adoption-stamp.sh reaches the adoptee"
+  else
+    fail_ "H4" "rc=$h4_rc lib_mode $h4_lib_src->$h4_lib_dst entry_mode $h4_gate_src->$h4_gate_dst (the two source modes must differ, else this proves nothing) adoption_stamp_installed=$h4_stamp"
   fi
 fi
 

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -1007,15 +1007,24 @@ else
   report_with_phase 2 "$W1D/report.json"
   _ans_s2 3 > "$W1D/answers"
   run_adopt "$W1D/p" "$W1D/answers" "$W1D/report.json"; w1_rc=$RUN_RC
-  w1_cert=0; w1_record=0; w1_empty_named=0
+  w1_cert=0; w1_record=0; w1_empty_named=0; w1_docs=0; w1_debt=0
   grep -q 'NOT DONE — the certification pass' "$RUN_OUT" && w1_cert=1
   grep -q 'NOT DONE — the Adoption Record' "$RUN_OUT" && w1_record=1
+  grep -q 'NOT DONE — the test-debt ledger' "$RUN_OUT" && w1_debt=1
+  grep -q "NOT DONE — your project's framework documents" "$RUN_OUT" && w1_docs=1
   grep -q "means 'not measured', not 'measured and clean'" "$RUN_OUT" && w1_empty_named=1
   w1_kinds=$(jq -r '[.adoption.certification.kindA, .adoption.certification.kindB, .adoption.certification.kindC] | map(length) | add' "$W1D/p/.claude/manifest.json" 2>/dev/null)
-  if [ "$w1_rc" -eq 0 ] && [ "$w1_cert" -eq 1 ] && [ "$w1_record" -eq 1 ] && [ "$w1_empty_named" -eq 1 ] && [ "$(_num "$w1_kinds")" -eq 0 ]; then
-    pass "W1: the unbuilt packages announce themselves — the certification lists in the stamp are empty AND the run says an empty list means 'not measured', not 'measured and clean'"
+  # The CLAUDE.md half is asserted as an ABSENCE, so it carries a structural
+  # discriminator: the file is not there AND the run said so. Either alone is
+  # satisfied by a driver that simply forgot.
+  w1_no_claude=1
+  [ -e "$W1D/p/CLAUDE.md" ] && w1_no_claude=0
+  if [ "$w1_rc" -eq 0 ] && [ "$w1_cert" -eq 1 ] && [ "$w1_record" -eq 1 ] && [ "$w1_debt" -eq 1 ] \
+     && [ "$w1_docs" -eq 1 ] && [ "$w1_no_claude" -eq 1 ] \
+     && [ "$w1_empty_named" -eq 1 ] && [ "$(_num "$w1_kinds")" -eq 0 ]; then
+    pass "W1: every unbuilt package announces itself — certification, the test-debt ledger, the Adoption Record and the project documents — and the run says an empty certification list means 'not measured', not 'measured and clean'"
   else
-    fail_ "W1" "rc=$w1_rc certification_stub=$w1_cert adoption_record_stub=$w1_record empty_means_unmeasured_stated=$w1_empty_named certification_entries=$w1_kinds (want 0)"
+    fail_ "W1" "rc=$w1_rc certification_stub=$w1_cert test_debt_stub=$w1_debt adoption_record_stub=$w1_record project_docs_stub=$w1_docs claude_md_absent=$w1_no_claude empty_means_unmeasured_stated=$w1_empty_named certification_entries=$w1_kinds (want 0)"
   fi
 fi
 

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -1,0 +1,909 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp4-driver.sh
+#
+# Brownfield adoption WP4 — THE DRIVER: its skeleton, the scenario chooser,
+# scenario placement, and reverse intake. Design:
+# docs/designs/2026-08-02-brownfield-adoption-v1.md §8.1 (the driver, and why
+# it is not a mode of init), §4.1 (the chooser, in Karl's exact words), §4.2
+# (the scanner OFFERS evidence and does not decide), §4.3/§4.4 (S1 and S2
+# landing, and THE FLOOR RULE), §4.5 (what both scenarios share), §8.3 (reverse
+# intake), §8.4 (the fail-safe state-creation ORDER), §8.5 (explicit staging
+# and the adoption stamp), §5.5 (a run that does not complete must be SAFE),
+# §10-WP4.
+#
+# ── WHAT THIS FILE ASSERTS ON ───────────────────────────────────────────────
+# EXIT CODES, never printed labels. In check-phase-gate.sh the `[WARN]`/`[FAIL]`
+# text is cosmetic — the exit predicate is `if [ $issues -eq 0 ]`, so an
+# exemption is the ABSENCE of an `issues` increment and a block is its
+# presence. Printed strings appear here only as PATH DISCRIMINATORS: they prove
+# WHICH path produced a code, never that a verdict was reached.
+#
+# ── BLOCKED FOR THE RIGHT REASON ────────────────────────────────────────────
+# `pre-commit-gate.sh --emit-blocked-gate` distinguishes its two message gates
+# by exit code: 3 is the BL-072 TDD-ordering block and 4 is the BL-006
+# Build-Loop message check. T4 asserts 3, not "non-zero" — a post-adoption
+# commit that blocked because of the Build-Loop gate would prove nothing about
+# the adoption bound this WP's stamp feeds.
+#
+# ── MUTATION HARNESS STANDARD (all mandatory, all learned in this wave) ─────
+#   • anchored end-of-line markers, excised with `s|^.*MARKER$|…|`;
+#   • the anchor asserted at sites==1 in its OWN shipped source;
+#   • exactly one line changed (a substitution is 2 diff lines);
+#   • EVERY mutant additionally asserts `bash -n` — a mutation that lands
+#     mid-continuation produces a mangled parse that reads as "caught";
+#   • a MODE-PRESERVING in-place edit (a scratch `chmod` silently changed a
+#     tracked file's mode twice this wave);
+#   • a FRESH fixture per scenario, from `mktemp -d` and never a counter inside
+#     a command substitution (a counter never survives the subshell, so every
+#     scenario lands in the same directory — that is how one proof came to pass
+#     against a NEIGHBOURING suite's fixture);
+#   • a STRUCTURAL DISCRIMINATOR wherever the expected mutant result is an
+#     ABSENCE, because "the arm did not fire" and "the mutant died" share one
+#     downstream silence.
+#
+# ── WHY THE MUTANTS RUN AGAINST A FRAMEWORK MIRROR ──────────────────────────
+# The driver is invoked from a framework clone, so a mutation cannot be made in
+# a fixture-local copy the way WP3 mutated a gate script it had installed. Each
+# mutation therefore copies `scripts/` and the installer into a scratch MIRROR,
+# mutates the mirror, and runs the mirror's driver. The tree under test is
+# never edited: a failure here cannot leave this repository mutated.
+#
+# Hermetic: temp dirs only, no network, no remote creation. The one thing that
+# executes outside the fixture is scripts/scout.sh, which is read-only by
+# construction (its own suite hashes a whole tree before and after).
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
+LIB_DIR="$REPO_ROOT/scripts/lib/adopt"
+L_CHOOSER="$LIB_DIR/adopt-chooser.sh"
+L_INTAKE="$LIB_DIR/adopt-intake.sh"
+L_STATE="$LIB_DIR/adopt-state.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+
+# _sites FILE MARKER — occurrences of an END-OF-LINE-anchored marker.
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+if [ ! -f "$DRIVER" ]; then
+  echo "  [FAIL] setup — $DRIVER not found (WP4 deliverable 1 missing)"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── The fixture ─────────────────────────────────────────────────────────────
+# An adoptee that is a real git repository with real history and enough written
+# down that Scout's ladder reaches rung 2 — the shape the floor rule needs, one
+# rung of headroom in each direction.
+mk_adoptee() {
+  local p="$1"
+  mkdir -p "$p/src" "$p/docs" || return 1
+  ( cd "$p" \
+      && git init -q . \
+      && git config user.email "wp4@test.invalid" \
+      && git config user.name  "WP4 Test" ) >/dev/null 2>&1 || return 1
+  printf '{"name":"acme-api","scripts":{"test":"npm test"}}\n' > "$p/package.json"
+  printf '# acme-api\n' > "$p/README.md"
+  printf '# What this is for\n\nInvoice reconciliation for small firms.\n' > "$p/docs/product.md"
+  printf '# Architecture\n\nA node service and a postgres database.\n' > "$p/docs/architecture.md"
+  ( cd "$p" && git add -A && git commit -q -m "chore: their own history" ) >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# ── The scan report ─────────────────────────────────────────────────────────
+# Produced ONCE by the real scripts/scout.sh against a template adoptee, so the
+# driver is exercised against the genuine §8.2 schema and the genuine WP2
+# prefill table rather than a hand-written stand-in of either. The placement
+# scenarios then override `phaseMap.suggestedPhase` with jq so the floor rule
+# is asserted against a KNOWN scanned rung instead of whatever the host's
+# toolchain happens to make the ladder report today.
+TEMPLATE="$(newtmp)/template"
+REPORT=""
+REPORT_OK=0
+if mk_adoptee "$TEMPLATE"; then
+  if bash "$REPO_ROOT/scripts/scout.sh" --root "$TEMPLATE" --out "$TOPTMP/scan" >/dev/null 2>&1; then
+    REPORT="$TOPTMP/scan/scout-report.json"
+    [ -s "$REPORT" ] && REPORT_OK=1
+  fi
+fi
+if [ "$REPORT_OK" -ne 1 ]; then
+  echo "  [FAIL] setup — scripts/scout.sh produced no report; WP4 consumes it and cannot be tested without one"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# report_with_phase N — the same report with a chosen scanned rung.
+report_with_phase() {
+  local n="$1" out="$2"
+  jq --argjson n "$n" '.phaseMap.suggestedPhase = $n' "$REPORT" > "$out" 2>/dev/null
+}
+
+# ── Answer scripts ──────────────────────────────────────────────────────────
+# Every line is one answer, in the order the driver asks. A BLANK line is an
+# unanswered question, which is exactly what an operator who walked away
+# produces; running OUT of lines is an EOF, which the driver treats the same
+# way. Both are supposed to reach a mandatory guard, never a default.
+_ans_s1() {
+  cat <<'ANS'
+1
+2
+1
+1
+we reconcile vendor invoices by hand
+six weeks and no budget
+it invoices people and chases the late ones
+internal
+yes
+typescript and postgres are settled
+subscription billing
+just me approves things
+anyone with a login, including screen readers
+aws, for our own staff
+it pages me on my phone
+my colleague dana
+github actions on a tag
+losing the database
+1
+1
+ANS
+}
+
+# _ans_s2 LADDER-CHOICE [DATA-CLASSIFICATION] [ZDR-ANSWER]
+#
+# `${2-public}` and not `${2:-public}`: an explicitly EMPTY classification is a
+# case under test (an operator who skipped the question), and `:-` would
+# silently answer it.
+#
+# ZDR-ANSWER is the answer to the attestation question, which is asked for any
+# classification ABOVE public. It is supplied for the SKIPPED-classification
+# cases too, and deliberately: the control refuses at the classification and
+# never reads it, while the mutant — which accepts the empty answer — does. One
+# answer file, two code paths, two outcomes; the inputs are provably identical
+# because they are literally the same bytes.
+_ans_s2() {
+  local ladder="$1" dc="${2-public}" zdr="${3-}"
+  cat <<ANS
+2
+$ladder
+2
+1
+1
+we reconcile vendor invoices by hand
+six weeks and no budget
+invoices only; no reporting in the first version
+$dc
+ANS
+  [ -n "$zdr" ] && printf '%s\n' "$zdr"
+  cat <<'ANS'
+typescript and postgres are settled
+subscription billing
+just me approves things
+anyone with a login
+aws
+losing the database
+1
+1
+ANS
+}
+
+# run_adopt DIR ANSWERFILE REPORT [HALT] [FRAMEWORK]
+#
+# Sets RUN_RC, RUN_OUT and RUN_ERR, and is therefore CALLED DIRECTLY, never
+# inside `$( … )`. A command substitution is a subshell, so a helper that
+# "returns" its transcript paths through globals loses them on the way out and
+# every later grep runs against an empty variable — which greps the wrong file,
+# fails, and reads as a genuine assertion failure. Measured here: fourteen
+# cases failed that way on the first run.
+RUN_RC=0; RUN_OUT=""; RUN_ERR=""
+run_adopt() {
+  local dir="$1" answers="$2" report="$3" halt="${4:-}" fw="${5:-$REPO_ROOT}"
+  RUN_RC=0
+  # The transcripts live BESIDE the fixture, never inside it: a scratch file in
+  # the adoptee would appear in the very `git status` the staging cases read.
+  RUN_OUT="$(dirname "$answers")/run-out"
+  RUN_ERR="$(dirname "$answers")/run-err"
+  ( cd "$dir" && SOIF_ADOPT_HALT_AFTER="$halt" bash "$fw/scripts/adopt-project.sh" \
+      --scan-report "$report" ) < "$answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+  return 0
+}
+
+# mk_mirror — a scratch framework the driver can be run from and mutated in.
+# The installer is copied because the driver DERIVES the set of framework
+# scripts an adoptee receives from init.sh's own copy list rather than
+# duplicating it.
+#
+# LANE NOTE. The line below NAMES init.sh, which is the exemption predicate
+# `# BL-181-UNIT-LANE-PREDICATE` reads — but this suite only READS that file,
+# it never runs it, so it belongs in the fast unit lane and is registered
+# there. The lint says so itself: "an exempted file that is in the unit list
+# anyway decided nothing and is not rendered". Spelling the name plainly and
+# registering the suite is the honest combination; dodging the predicate with
+# a glob would hide the decision instead of making it.
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
+  return 0
+}
+
+# gate_in DIR ARGS... — run the ADOPTEE'S OWN copy of the phase gate, from
+# inside the adoptee. Sets GATE_RC and GATE_OUT; called directly, never in a
+# command substitution, for the reason spelled out above run_adopt.
+GATE_RC=0; GATE_OUT=""
+gate_in() {
+  local dir="$1"; shift
+  GATE_RC=0
+  # OUTSIDE the adoptee: a scratch file inside it would show up in the very
+  # `git status` a staging assertion reads.
+  GATE_OUT="$TOPTMP/gate-out"
+  if [ ! -f "$dir/scripts/check-phase-gate.sh" ]; then
+    ( cd "$dir" && bash "$REPO_ROOT/scripts/check-phase-gate.sh" "$@" ) > "$GATE_OUT" 2>&1 || GATE_RC=$?
+  else
+    ( cd "$dir" && bash scripts/check-phase-gate.sh "$@" ) > "$GATE_OUT" 2>&1 || GATE_RC=$?
+  fi
+  return 0
+}
+
+echo "=== Q — the chooser's wording (§4.1: a decision, not a phrasing) ==="
+
+# The sentence, spelled here ONCE and independently of the source, so the pin
+# is a genuine STRING EQUALITY against Karl's words and not a tautology.
+CHOOSER_LITERAL="Is the project built out and needs to be able to be supported (i.e. bug fixes, maintenance, new features add), or are you still in the process of building your project?"
+
+q1_sites=$(grep -cF -- "$CHOOSER_LITERAL" "$L_CHOOSER" 2>/dev/null); q1_sites=$(_num "$q1_sites")
+q1_var=""
+# shellcheck source=/dev/null
+q1_var="$( . "$L_CHOOSER" >/dev/null 2>&1; printf '%s' "$ADOPT_CHOOSER_QUESTION" )"
+if [ "$q1_sites" -eq 1 ] && [ "$q1_var" = "$CHOOSER_LITERAL" ]; then
+  pass "Q1: the chooser is Karl's sentence VERBATIM — one site in adopt-chooser.sh, and the variable is string-equal to it"
+else
+  fail_ "Q1" "sites=$q1_sites (want 1); variable=[$q1_var]"
+fi
+
+# Non-developer register: no phase numbers, no framework vocabulary.
+q3_bad="$(printf '%s' "$CHOOSER_LITERAL" | grep -oiE 'phase|mvp|gate|scaffold|framework|intake|poc|repo|commit|artifact' | tr '\n' ' ')"
+if [ -z "$q3_bad" ]; then
+  pass "Q3: the question is in a non-developer register — no phase number and no framework vocabulary"
+else
+  fail_ "Q3" "the question names framework vocabulary: $q3_bad"
+fi
+
+# It asks about the project's SITUATION, not its artifacts.
+q4_bad="$(printf '%s' "$CHOOSER_LITERAL" | grep -oiE 'readme|changelog|test|ci|pipeline|tag|branch|file' | tr '\n' ' ')"
+if [ -z "$q4_bad" ] && printf '%s' "$CHOOSER_LITERAL" | grep -q 'the project'; then
+  pass "Q4: the question asks about the project's situation and names no artifact"
+else
+  fail_ "Q4" "artifact words present: [$q4_bad]"
+fi
+
+Q2D="$(newtmp)"
+if ! mk_adoptee "$Q2D/p"; then
+  fail_ "Q2" "fixture setup failed"
+  fail_ "Q5" "fixture setup failed"
+else
+  report_with_phase 2 "$Q2D/report.json"
+  _ans_s2 4 > "$Q2D/answers"
+  run_adopt "$Q2D/p" "$Q2D/answers" "$Q2D/report.json"; q2_rc=$RUN_RC
+  if grep -qxF -- "$CHOOSER_LITERAL" "$RUN_OUT"; then
+    pass "Q2: the driver asks it VERBATIM — the transcript carries the sentence as a whole line (run rc $q2_rc)"
+  else
+    fail_ "Q2" "the verbatim sentence is not a line of the transcript"
+  fi
+
+  # ── Q5 — NOT PREFILLED (§4.2's rejected alternative) ──────────────────────
+  # Two halves. Behaviourally: with the answer withheld the driver STOPS rather
+  # than choosing. Structurally: nothing around the question offers a default,
+  # so there is no guess for a tired operator to accept without reading.
+  Q5D="$(newtmp)"
+  if mk_adoptee "$Q5D/p"; then
+    report_with_phase 2 "$Q5D/report.json"
+    : > "$Q5D/answers"      # the operator walked away before answering
+    run_adopt "$Q5D/p" "$Q5D/answers" "$Q5D/report.json"; q5_rc=$RUN_RC
+    q5_refused=0
+    grep -q "This question has no default and no skip" "$RUN_ERR" && q5_refused=1
+    q5_untouched=1
+    [ -e "$Q5D/p/.claude/phase-state.json" ] && q5_untouched=0
+    [ -e "$Q5D/p/.claude/manifest.json" ] && q5_untouched=0
+    q5_nodefault=1
+    grep -qiE 'suggested|recommended|\[default|press enter to accept' "$RUN_OUT" && q5_nodefault=0
+    if [ "$q5_rc" -ne 0 ] && [ "$q5_refused" -eq 1 ] && [ "$q5_untouched" -eq 1 ] && [ "$q5_nodefault" -eq 1 ]; then
+      pass "Q5: the chooser is NOT prefilled — withheld, it stops the run (rc $q5_rc) with nothing written, and no default is offered anywhere in the transcript"
+    else
+      fail_ "Q5" "rc=$q5_rc (want non-zero) refused=$q5_refused untouched=$q5_untouched no_default_offered=$q5_nodefault"
+    fi
+  else
+    fail_ "Q5" "fixture setup failed"
+  fi
+fi
+
+# ── E — the evidence the scanner offers (§4.2) ──────────────────────────────
+E1D="$(newtmp)"
+if ! mk_adoptee "$E1D/p"; then
+  fail_ "E1" "fixture setup failed"
+else
+  report_with_phase 2 "$E1D/report.json"
+  _ans_s2 3 > "$E1D/answers"
+  run_adopt "$E1D/p" "$E1D/answers" "$E1D/report.json"
+  e1_conf=$(grep -c 'Confidence: ' "$RUN_OUT"); e1_conf=$(_num "$e1_conf")
+  e1_override=0
+  grep -q 'overrides all of it' "$RUN_OUT" && e1_override=1
+  e1_users=0
+  grep -q 'the scan cannot measure' "$RUN_OUT" && e1_users=1
+  if [ "$e1_conf" -ge 4 ] && [ "$e1_override" -eq 1 ] && [ "$e1_users" -eq 1 ]; then
+    pass "E1: the scan OFFERS evidence — $e1_conf signals each with a confidence tier, an explicit 'your answer overrides all of it', and 'users' declared unmeasurable"
+  else
+    fail_ "E1" "confidence_lines=$e1_conf (want >=4) override_stated=$e1_override users_declared_unmeasurable=$e1_users"
+  fi
+fi
+
+echo ""
+echo "=== P — scenario placement and THE FLOOR RULE (§4.3, §4.4) ==="
+
+P1D="$(newtmp)"
+if ! mk_adoptee "$P1D/p"; then
+  fail_ "P1" "fixture setup failed"
+else
+  report_with_phase 2 "$P1D/report.json"
+  _ans_s1 > "$P1D/answers"
+  run_adopt "$P1D/p" "$P1D/answers" "$P1D/report.json"; p1_rc=$RUN_RC
+  p1_phase=$(jq -r '.current_phase // "MISSING"' "$P1D/p/.claude/phase-state.json" 2>/dev/null)
+  p1_adopted=$(jq -r '.adoption.adopted // "MISSING"' "$P1D/p/.claude/manifest.json" 2>/dev/null)
+  p1_scen=$(jq -r '.adoption.scenario // "MISSING"' "$P1D/p/.claude/manifest.json" 2>/dev/null)
+  if [ "$p1_rc" -eq 0 ] && [ "$p1_phase" = "4" ] && [ "$p1_adopted" = "true" ] && [ "$p1_scen" = "completed" ]; then
+    pass "P1: S1 (\"built out\") lands at phase 4, adopted — regardless of what the artifacts scored"
+  else
+    fail_ "P1" "rc=$p1_rc phase=$p1_phase (want 4) adopted=$p1_adopted scenario=$p1_scen"
+  fi
+fi
+
+P2D="$(newtmp)"
+if ! mk_adoptee "$P2D/p"; then
+  fail_ "P2" "fixture setup failed"
+else
+  report_with_phase 2 "$P2D/report.json"
+  _ans_s2 3 > "$P2D/answers"        # option 3 == rung 2 == what the scan found
+  run_adopt "$P2D/p" "$P2D/answers" "$P2D/report.json"; p2_rc=$RUN_RC
+  p2_phase=$(jq -r '.current_phase // "MISSING"' "$P2D/p/.claude/phase-state.json" 2>/dev/null)
+  p2_scen=$(jq -r '.adoption.scenario // "MISSING"' "$P2D/p/.claude/manifest.json" 2>/dev/null)
+  if [ "$p2_rc" -eq 0 ] && [ "$p2_phase" = "2" ] && [ "$p2_scen" = "in-flight" ]; then
+    pass "P2: S2 lands at Scout's REACHED rung (2) when the interview agrees"
+  else
+    fail_ "P2" "rc=$p2_rc phase=$p2_phase (want 2) scenario=$p2_scen"
+  fi
+fi
+
+P3D="$(newtmp)"
+if ! mk_adoptee "$P3D/p"; then
+  fail_ "P3" "fixture setup failed"
+else
+  report_with_phase 2 "$P3D/report.json"
+  _ans_s2 5 > "$P3D/answers"        # option 5 == rung 4 — HIGHER than the scan
+  run_adopt "$P3D/p" "$P3D/answers" "$P3D/report.json"; p3_rc=$RUN_RC
+  p3_phase=$(jq -r '.current_phase // "MISSING"' "$P3D/p/.claude/phase-state.json" 2>/dev/null)
+  if [ "$p3_rc" -eq 0 ] && [ "$p3_phase" = "2" ]; then
+    pass "P3 (floor, direction 1): the interview claimed rung 4 and the placement STAYED at the scanned 2 — the interview cannot raise it"
+  else
+    fail_ "P3" "rc=$p3_rc phase=$p3_phase (want 2 — the interview must not raise the placement)"
+  fi
+fi
+
+P4D="$(newtmp)"
+if ! mk_adoptee "$P4D/p"; then
+  fail_ "P4" "fixture setup failed"
+else
+  report_with_phase 2 "$P4D/report.json"
+  _ans_s2 2 > "$P4D/answers"        # option 2 == rung 1 — LOWER than the scan
+  run_adopt "$P4D/p" "$P4D/answers" "$P4D/report.json"; p4_rc=$RUN_RC
+  p4_phase=$(jq -r '.current_phase // "MISSING"' "$P4D/p/.claude/phase-state.json" 2>/dev/null)
+  if [ "$p4_rc" -eq 0 ] && [ "$p4_phase" = "1" ]; then
+    pass "P4 (floor, direction 2): the interview claimed rung 1 and the placement LOWERED to 1 — the safer number wins"
+  else
+    fail_ "P4" "rc=$p4_rc phase=$p4_phase (want 1)"
+  fi
+fi
+
+# ── P5 — MUTATION: neuter the floor rule ────────────────────────────────────
+P5R="$(newtmp)"
+if ! mk_adoptee "$P5R/p" || ! mk_mirror "$P5R/fw"; then
+  fail_ "P5" "fixture setup failed"
+else
+  report_with_phase 2 "$P5R/report.json"
+  _ans_s2 5 > "$P5R/answers"
+  MUT5="$P5R/fw/scripts/lib/adopt/adopt-chooser.sh"
+  floor_sites=$(_sites "$L_CHOOSER" 'BF-ADOPT-FLOOR')
+  cp "$L_CHOOSER" "$P5R/orig.ref"
+  _sed_inplace "$MUT5" 's|^.*BF-ADOPT-FLOOR$|  printf '"'"'%s'"'"' "$claimed"   # BF-ADOPT-FLOOR|'
+  chg5=$(_changed_lines "$P5R/orig.ref" "$MUT5")
+  p5_parses=$(_parses "$MUT5")
+  run_adopt "$P5R/p" "$P5R/answers" "$P5R/report.json" "" "$P5R/fw"; p5_rc=$RUN_RC
+  p5_phase=$(jq -r '.current_phase // "MISSING"' "$P5R/p/.claude/phase-state.json" 2>/dev/null)
+  if [ "$p5_phase" = "4" ] && [ "$chg5" -eq 2 ] && [ "$floor_sites" -eq 1 ] && [ "$p5_parses" -eq 1 ]; then
+    pass "P5 (MUTATION): with the floor neutered (1 line, mutant still parses), the SAME interview raises the placement from 2 to 4 — the floor is load-bearing"
+  else
+    fail_ "P5" "landed=$p5_phase (want 4 under the mutant) run_rc=$p5_rc changed_lines=$chg5 (want 2) floor_sites=$floor_sites (want 1) parses=$p5_parses (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== I — reverse intake (§8.3) ==="
+
+I1D="$(newtmp)"
+if ! mk_adoptee "$I1D/p"; then
+  fail_ "I1" "fixture setup failed"
+else
+  report_with_phase 2 "$I1D/report.json"
+  _ans_s2 3 > "$I1D/answers"
+  run_adopt "$I1D/p" "$I1D/answers" "$I1D/report.json"; i1_rc=$RUN_RC
+  i1_value=0; i1_prov=0; i1_keep=0; i1_recorded=0
+  grep -q 'The scan found: acme-api' "$RUN_OUT" && i1_value=1
+  grep -q 'Where that came from: package.json name' "$RUN_OUT" && i1_prov=1
+  grep -q "Keep 'acme-api' as the answer?" "$RUN_OUT" && i1_keep=1
+  grep -q 'acme-api' "$I1D/p/PROJECT_INTAKE.md" 2>/dev/null && i1_recorded=1
+  if [ "$i1_rc" -eq 0 ] && [ "$i1_value" -eq 1 ] && [ "$i1_prov" -eq 1 ] && [ "$i1_keep" -eq 1 ] && [ "$i1_recorded" -eq 1 ]; then
+    pass "I1: a scan-derived answer is disclosed on TWO lines — the value AND its provenance — then offered keep-it / change-it, and 'keep it' records it"
+  else
+    fail_ "I1" "rc=$i1_rc value_line=$i1_value provenance_line=$i1_prov keep_change=$i1_keep recorded=$i1_recorded"
+  fi
+fi
+
+I2D="$(newtmp)"
+if ! mk_adoptee "$I2D/p"; then
+  fail_ "I2" "fixture setup failed"
+else
+  report_with_phase 2 "$I2D/report.json"
+  # Same script as _ans_s2 3, but section 1 answers "change it" and then gives
+  # the real answer — one extra line, at exactly that point.
+  {
+    printf '2\n3\n2\n'
+    printf '2\nledger-service\n'
+    printf '1\n'
+    printf 'we reconcile vendor invoices by hand\nsix weeks and no budget\ninvoices only\npublic\n'
+    printf 'typescript is settled\nsubscription billing\njust me\nanyone with a login\naws\nlosing the database\n'
+    printf '1\n1\n'
+  } > "$I2D/answers"
+  run_adopt "$I2D/p" "$I2D/answers" "$I2D/report.json"; i2_rc=$RUN_RC
+  i2_fallthrough=0; i2_new=0; i2_old=0
+  grep -q 'what is the right answer?' "$RUN_OUT" && i2_fallthrough=1
+  grep -q 'ledger-service' "$I2D/p/PROJECT_INTAKE.md" 2>/dev/null && i2_new=1
+  grep -q 'the scan had offered' "$I2D/p/PROJECT_INTAKE.md" 2>/dev/null && i2_old=1
+  if [ "$i2_rc" -eq 0 ] && [ "$i2_fallthrough" -eq 1 ] && [ "$i2_new" -eq 1 ] && [ "$i2_old" -eq 1 ]; then
+    pass "I2: 'change it' falls through to the ORDINARY question, records the new answer, and keeps a note of what the scan had offered"
+  else
+    fail_ "I2" "rc=$i2_rc fell_through=$i2_fallthrough new_value_recorded=$i2_new provenance_of_change=$i2_old"
+  fi
+fi
+
+I3D="$(newtmp)"
+if ! mk_adoptee "$I3D/p"; then
+  fail_ "I3" "fixture setup failed"
+else
+  report_with_phase 2 "$I3D/report.json"
+  # Answers run out exactly at the first JUDGMENT question (section 2).
+  printf '2\n3\n2\n1\n1\n' > "$I3D/answers"
+  run_adopt "$I3D/p" "$I3D/answers" "$I3D/report.json"; i3_rc=$RUN_RC
+  i3_refused=0; i3_asked=0; i3_untouched=1
+  grep -q "This question has no default and no skip" "$RUN_ERR" && i3_refused=1
+  grep -q 'What problem does this project solve' "$RUN_OUT" && i3_asked=1
+  [ -e "$I3D/p/.claude/phase-state.json" ] && i3_untouched=0
+  [ -e "$I3D/p/PROJECT_INTAKE.md" ] && i3_untouched=0
+  if [ "$i3_rc" -ne 0 ] && [ "$i3_refused" -eq 1 ] && [ "$i3_asked" -eq 1 ] && [ "$i3_untouched" -eq 1 ]; then
+    pass "I3: a judgment section REFUSES to proceed unattended — the question was asked (rc $i3_rc), no answer was invented, and nothing was written"
+  else
+    fail_ "I3" "rc=$i3_rc (want non-zero) refusal_printed=$i3_refused question_was_asked=$i3_asked project_untouched=$i3_untouched"
+  fi
+fi
+
+# ── I4 — the prefill read keeps the shape §8.3 warns about ──────────────────
+i4_sites=$(_sites "$L_INTAKE" 'BF-ADOPT-PREFILL-READ')
+i4_guard=0
+grep -B1 'BF-ADOPT-PREFILL-READ$' "$L_INTAKE" 2>/dev/null | grep -qE '^[[:space:]]*:([[:space:]]|$|#)' && i4_guard=1
+I4D="$(newtmp)"
+cp "$L_INTAKE" "$I4D/excised.sh"
+_sed_inplace "$I4D/excised.sh" 's|^.*BF-ADOPT-PREFILL-READ$||'
+i4_parses=$(_parses "$I4D/excised.sh")
+if [ "$i4_sites" -eq 1 ] && [ "$i4_guard" -eq 1 ] && [ "$i4_parses" -eq 1 ]; then
+  pass "I4: the prefill read keeps §8.3's shape — one end-of-line-anchored marker, a bare ':' above it, and the block still parses once the marked line is excised"
+else
+  fail_ "I4" "marker_sites=$i4_sites (want 1) bare_colon_above=$i4_guard (want 1) parses_when_excised=$i4_parses (want 1)"
+fi
+
+# ── I5/I6/I7 — data classification cannot be skipped, IN EITHER SCENARIO ────
+# The assertion is made through the gate that makes it a mechanical necessity:
+# check-phase-gate.sh's Phase 1->2 ZDR backstop. APPROVAL_LOG.md is created by
+# the TEST because the Adoption Record is WP7's and the gate exits at its
+# absence BEFORE the ZDR arm is reached — without it these three cases would be
+# asserting the wrong refusal.
+seed_approval_log() {
+  printf '# Approval Log\n\n## Phase Gate: Phase 0 to Phase 1\n\n  Date: 2026-01-01\n  Approved by: test\n' > "$1/APPROVAL_LOG.md"
+}
+
+I5D="$(newtmp)"
+if ! mk_adoptee "$I5D/p"; then
+  fail_ "I5" "fixture setup failed"
+else
+  report_with_phase 2 "$I5D/report.json"
+  # The classification question is left BLANK, and the attestation answer that
+  # only a run which ACCEPTED the blank would ever reach is supplied anyway —
+  # I6 reuses this identical file against the mutated driver.
+  _ans_s2 3 "" yes > "$I5D/answers"
+  run_adopt "$I5D/p" "$I5D/answers" "$I5D/report.json"; i5_rc=$RUN_RC
+  i5_refused=0; i5_untouched=1
+  grep -q 'no default, no guess and no skip' "$RUN_ERR" && i5_refused=1
+  [ -e "$I5D/p/.claude/phase-state.json" ] && i5_untouched=0
+  if [ "$i5_rc" -ne 0 ] && [ "$i5_refused" -eq 1 ] && [ "$i5_untouched" -eq 1 ]; then
+    pass "I5 (control): an unanswered data classification STOPS the adoption (rc $i5_rc) — no default, no inference, nothing written"
+  else
+    fail_ "I5" "rc=$i5_rc (want non-zero) refusal_named_the_question=$i5_refused untouched=$i5_untouched"
+  fi
+fi
+
+I7D="$(newtmp)"
+if ! mk_adoptee "$I7D/p"; then
+  fail_ "I7" "fixture setup failed"
+else
+  report_with_phase 2 "$I7D/report.json"
+  # `internal` is above `public`, so the attestation arm is exercised too.
+  _ans_s2 3 internal yes > "$I7D/answers"
+  run_adopt "$I7D/p" "$I7D/answers" "$I7D/report.json"; i7_rc=$RUN_RC
+  i7_class=$(jq -r '.phase1_artifacts.data_classification // "MISSING"' "$I7D/p/.claude/process-state.json" 2>/dev/null)
+  seed_approval_log "$I7D/p"
+  gate_in "$I7D/p" --gate phase_1_to_2; i7_gate=$GATE_RC
+  i7_zdr_ok=0; i7_zdr_fail=0
+  grep -q "ZDR gate: data_classification=" "$GATE_OUT" && i7_zdr_ok=1
+  grep -q "data_classification not set" "$GATE_OUT" && i7_zdr_fail=1
+  if [ "$i7_rc" -eq 0 ] && [ "$i7_class" = "internal" ] && [ "$i7_zdr_ok" -eq 1 ] && [ "$i7_zdr_fail" -eq 0 ]; then
+    pass "I7 (positive control): an ANSWERED classification lands in process-state.json and the Phase 1->2 ZDR arm reports OK — so I6's failure cannot be vacuous"
+  else
+    fail_ "I7" "rc=$i7_rc classification=$i7_class gate_rc=$i7_gate zdr_ok_line=$i7_zdr_ok zdr_notset_line=$i7_zdr_fail (want 0)"
+  fi
+fi
+
+# ── I6 — MUTATION: neuter data classification's non-skippability ────────────
+I6R="$(newtmp)"
+if ! mk_adoptee "$I6R/p" || ! mk_mirror "$I6R/fw"; then
+  fail_ "I6" "fixture setup failed"
+else
+  report_with_phase 2 "$I6R/report.json"
+  _ans_s2 3 "" yes > "$I6R/answers"   # byte-identical to I5's file
+  MUT6="$I6R/fw/scripts/lib/adopt/adopt-intake.sh"
+  dc_sites=$(_sites "$L_INTAKE" 'BF-ADOPT-DC-MANDATORY')
+  cp "$L_INTAKE" "$I6R/orig.ref"
+  _sed_inplace "$MUT6" 's|^.*BF-ADOPT-DC-MANDATORY$|    dc="$dc"   # BF-ADOPT-DC-MANDATORY|'
+  chg6=$(_changed_lines "$I6R/orig.ref" "$MUT6")
+  i6_parses=$(_parses "$MUT6")
+  run_adopt "$I6R/p" "$I6R/answers" "$I6R/report.json" "" "$I6R/fw"; i6_rc=$RUN_RC
+  i6_completed=0
+  [ -f "$I6R/p/.claude/manifest.json" ] && i6_completed=1
+  seed_approval_log "$I6R/p"
+  gate_in "$I6R/p" --gate phase_1_to_2; i6_gate=$GATE_RC
+  i6_zdr_fail=0
+  grep -q "data_classification not set" "$GATE_OUT" && i6_zdr_fail=1
+  if [ "$i6_rc" -eq 0 ] && [ "$i6_completed" -eq 1 ] && [ "$i6_gate" -ne 0 ] && [ "$i6_zdr_fail" -eq 1 ] \
+     && [ "$chg6" -eq 2 ] && [ "$dc_sites" -eq 1 ] && [ "$i6_parses" -eq 1 ]; then
+    pass "I6 (MUTATION): with non-skippability neutered (1 line, mutant still parses) the run COMPLETES without a classification — and the resulting project FAILS its own Phase 1->2 ZDR gate (rc $i6_gate) for exactly that reason"
+  else
+    fail_ "I6" "run_rc=$i6_rc (want 0) adoption_completed=$i6_completed gate_rc=$i6_gate (want non-zero) zdr_notset_line=$i6_zdr_fail (want 1) changed_lines=$chg6 (want 2) dc_sites=$dc_sites (want 1) parses=$i6_parses (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== S — the fail-safe state-creation order (§8.4, §5.5) ==="
+
+s1_order="$( . "$L_STATE" >/dev/null 2>&1; _adopt_state_order | tr '\n' ' ' )"
+s1_sites=$(_sites "$L_STATE" 'BF-ADOPT-STATE-ORDER')
+if [ "$s1_order" = "phase_state intake manifest " ] && [ "$s1_sites" -eq 1 ]; then
+  pass "S1: the order is §8.4's, spelled once as data — phase_state, intake, manifest"
+else
+  fail_ "S1" "order=[$s1_order] (want 'phase_state intake manifest ') sites=$s1_sites (want 1)"
+fi
+
+# _assert_safe_row LABEL DIR — §8.4's TOP row: phase-state present, manifest
+# absent => the gate BLOCKS and the tier ladder reads `strict`. Both halves,
+# because C4's correction says the single flat claim is not true of both.
+_assert_safe_row() {
+  local label="$1" dir="$2"
+  local rc has_ps has_mf lvl why=0
+  gate_in "$dir"; rc=$GATE_RC
+  has_ps=0; [ -f "$dir/.claude/phase-state.json" ] && has_ps=1
+  has_mf=0; [ -f "$dir/.claude/manifest.json" ] && has_mf=1
+  grep -q 'APPROVAL_LOG.md not found but' "$GATE_OUT" && why=1
+  lvl="$( . "$REPO_ROOT/scripts/lib/enforcement-level.sh" >/dev/null 2>&1; read_enforcement_level "$dir" )"
+  if [ "$rc" -ne 0 ] && [ "$has_ps" -eq 1 ] && [ "$has_mf" -eq 0 ] && [ "$why" -eq 1 ] && [ "$lvl" = "strict" ]; then
+    pass "$label: the safe row — phase-state present, manifest absent; the gate BLOCKS (rc $rc) for that reason and the tier ladder reads strict"
+  else
+    fail_ "$label" "gate_rc=$rc (want non-zero) phase_state=$has_ps (want 1) manifest=$has_mf (want 0) blocked_for_that_reason=$why enforcement_level=$lvl (want strict)"
+  fi
+}
+
+S2D="$(newtmp)"
+if ! mk_adoptee "$S2D/p"; then
+  fail_ "S2" "fixture setup failed"
+else
+  report_with_phase 2 "$S2D/report.json"
+  _ans_s2 3 > "$S2D/answers"
+  run_adopt "$S2D/p" "$S2D/answers" "$S2D/report.json" install; s2_rc=$RUN_RC
+  s2_ps=0; [ -e "$S2D/p/.claude/phase-state.json" ] && s2_ps=1
+  s2_mf=0; [ -e "$S2D/p/.claude/manifest.json" ] && s2_mf=1
+  gate_in "$S2D/p"; s2_gate=$GATE_RC
+  if [ "$s2_rc" -ne 0 ] && [ "$s2_ps" -eq 0 ] && [ "$s2_mf" -eq 0 ] && [ "$s2_gate" -eq 0 ]; then
+    pass "S2 (interruption before any state): neither state file exists, so the project is exactly as enforced as it was before adoption began — the UNSAFE row needs a manifest and there is none"
+  else
+    fail_ "S2" "run_rc=$s2_rc phase_state=$s2_ps (want 0) manifest=$s2_mf (want 0) gate_rc=$s2_gate"
+  fi
+fi
+
+S3D="$(newtmp)"
+if ! mk_adoptee "$S3D/p"; then
+  fail_ "S3" "fixture setup failed"
+else
+  report_with_phase 2 "$S3D/report.json"
+  _ans_s2 3 > "$S3D/answers"
+  run_adopt "$S3D/p" "$S3D/answers" "$S3D/report.json" phase_state
+  _assert_safe_row "S3 (interruption after phase-state)" "$S3D/p"
+fi
+
+S4D="$(newtmp)"
+if ! mk_adoptee "$S4D/p"; then
+  fail_ "S4" "fixture setup failed"
+else
+  report_with_phase 2 "$S4D/report.json"
+  _ans_s2 3 > "$S4D/answers"
+  run_adopt "$S4D/p" "$S4D/answers" "$S4D/report.json" intake
+  _assert_safe_row "S4 (interruption after intake)" "$S4D/p"
+fi
+
+# ── S5 — MUTATION: reverse the order, and the unsafe row becomes reachable ──
+S5R="$(newtmp)"
+if ! mk_adoptee "$S5R/p" || ! mk_mirror "$S5R/fw"; then
+  fail_ "S5" "fixture setup failed"
+else
+  report_with_phase 2 "$S5R/report.json"
+  _ans_s2 3 > "$S5R/answers"
+  MUT_S="$S5R/fw/scripts/lib/adopt/adopt-state.sh"
+  order_sites=$(_sites "$L_STATE" 'BF-ADOPT-STATE-ORDER')
+  cp "$L_STATE" "$S5R/orig.ref"
+  _sed_inplace "$MUT_S" 's|^.*BF-ADOPT-STATE-ORDER$|  printf '"'"'%s\\n'"'"' manifest intake phase_state   # BF-ADOPT-STATE-ORDER|'
+  chgS=$(_changed_lines "$S5R/orig.ref" "$MUT_S")
+  s5_parses=$(_parses "$MUT_S")
+  # Halt after the FIRST stage of the reversed order.
+  run_adopt "$S5R/p" "$S5R/answers" "$S5R/report.json" manifest "$S5R/fw"; s5_rc=$RUN_RC
+  s5_ps=0; [ -e "$S5R/p/.claude/phase-state.json" ] && s5_ps=1
+  s5_mf=0; [ -e "$S5R/p/.claude/manifest.json" ] && s5_mf=1
+  gate_in "$S5R/p"; s5_gate=$GATE_RC
+  s5_why=0
+  grep -q 'skipping phase gate check' "$GATE_OUT" && s5_why=1
+  if [ "$s5_gate" -eq 0 ] && [ "$s5_mf" -eq 1 ] && [ "$s5_ps" -eq 0 ] && [ "$s5_why" -eq 1 ] \
+     && [ "$chgS" -eq 2 ] && [ "$order_sites" -eq 1 ] && [ "$s5_parses" -eq 1 ]; then
+    pass "S5 (MUTATION): with the order reversed (1 line, mutant still parses) an interrupted run leaves a manifest and NO phase-state — the gate skips entirely (rc 0) and the UNSAFE row is reachable"
+  else
+    fail_ "S5" "gate_rc=$s5_gate (want 0) manifest=$s5_mf (want 1) phase_state=$s5_ps (want 0) gate_skipped_for_that_reason=$s5_why run_rc=$s5_rc changed_lines=$chgS (want 2) order_sites=$order_sites (want 1) parses=$s5_parses (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== T — the stamp, and the WP3 bound it feeds, end to end (§8.5) ==="
+
+# T2 — one call site in the WHOLE driver, per §8.5. A second stamp is a
+# backfill wearing a birth stamp's name, and WP3 refuses one; the budget here
+# is still one.
+t2_sites=0
+for f in "$DRIVER" "$LIB_DIR"/*.sh; do
+  n=$(grep -c '^[^#]*soif_adoption_stamp ' "$f" 2>/dev/null); n=$(_num "$n")
+  t2_sites=$((t2_sites + n))
+done
+t2_marked=$(_sites "$L_STATE" 'BF-ADOPT-STAMP-CALL')
+if [ "$t2_sites" -eq 1 ] && [ "$t2_marked" -eq 1 ]; then
+  pass "T2: soif_adoption_stamp has exactly ONE call site in the driver, and it is marked"
+else
+  fail_ "T2" "call_sites=$t2_sites (want 1) marked=$t2_marked (want 1)"
+fi
+
+T1D="$(newtmp)"
+if ! mk_adoptee "$T1D/p"; then
+  fail_ "T1" "fixture setup failed"
+  fail_ "T4" "fixture setup failed"
+else
+  report_with_phase 2 "$T1D/report.json"
+  _ans_s2 2 > "$T1D/answers"        # lands at 1, which keeps the BL-006
+                                    # message gate short-circuited so the TDD
+                                    # arm alone decides T4's verdict
+  run_adopt "$T1D/p" "$T1D/answers" "$T1D/report.json"; t1_rc=$RUN_RC
+  t1_anchor=$(jq -r '.adoption.adoptedAtCommit // "MISSING"' "$T1D/p/.claude/manifest.json" 2>/dev/null)
+  t1_parent=$( cd "$T1D/p" && git rev-parse HEAD^ 2>/dev/null )
+  t1_blocks=$(jq -r '[.. | objects | select(has("adopted"))] | length' "$T1D/p/.claude/manifest.json" 2>/dev/null)
+  t1_scen=$(jq -r '.adoption.scenario // "MISSING"' "$T1D/p/.claude/manifest.json" 2>/dev/null)
+  t1_landed=$(jq -r '.adoption.landedPhase // "MISSING"' "$T1D/p/.claude/manifest.json" 2>/dev/null)
+  if [ "$t1_rc" -eq 0 ] && [ -n "$t1_parent" ] && [ "$t1_anchor" = "$t1_parent" ] \
+     && [ "$(_num "$t1_blocks")" -eq 1 ] && [ "$t1_scen" = "in-flight" ] && [ "$t1_landed" = "1" ]; then
+    pass "T1: the stamp lands ONCE and adoptedAtCommit is the PRE-adoption tip — the parent the adoption commit landed on"
+  else
+    fail_ "T1" "rc=$t1_rc anchor=$t1_anchor parent=$t1_parent adoption_blocks=$t1_blocks (want 1) scenario=$t1_scen landed=$t1_landed"
+  fi
+
+  # T4 — a POST-adoption commit blocks, and blocks for the RIGHT REASON.
+  mkdir -p "$T1D/p/src"
+  printf 'export function add(a,b){return a+b;}\n' > "$T1D/p/src/add.js"
+  ( cd "$T1D/p" && git add src/add.js ) >/dev/null 2>&1
+  printf 'feat: work written after adoption day\n' > "$T1D/p/.git/COMMIT_EDITMSG"
+  t4_rc=0
+  t4_out=$( cd "$T1D/p" && bash scripts/pre-commit-gate.sh --terminal-mode --tdd-only --emit-blocked-gate 2>&1 ) || t4_rc=$?
+  t4_own_copy=0; [ -f "$T1D/p/scripts/pre-commit-gate.sh" ] && [ -f "$T1D/p/scripts/lib/adoption-stamp.sh" ] && t4_own_copy=1
+  if [ "$t4_rc" -eq 3 ] && [ "$t4_own_copy" -eq 1 ]; then
+    pass "T4 (end to end): on the ADOPTED project, running its OWN installed gate, a post-adoption commit with no test is blocked by the BL-072 TDD arm specifically (exit 3, not merely non-zero)"
+  else
+    fail_ "T4" "rc=$t4_rc (want 3 = BL-072 TDD block) adoptee_has_its_own_gate_and_stamp_lib=$t4_own_copy. Output: $(printf '%s' "$t4_out" | tail -3 | tr '\n' ' ')"
+  fi
+fi
+
+# T3 — the other direction: inside the adoption window, exempt.
+T3D="$(newtmp)"
+if ! mk_adoptee "$T3D/p"; then
+  fail_ "T3" "fixture setup failed"
+else
+  report_with_phase 2 "$T3D/report.json"
+  _ans_s2 2 > "$T3D/answers"
+  run_adopt "$T3D/p" "$T3D/answers" "$T3D/report.json" manifest
+  mkdir -p "$T3D/p/src"
+  printf 'export function add(a,b){return a+b;}\n' > "$T3D/p/src/add.js"
+  ( cd "$T3D/p" && git add src/add.js ) >/dev/null 2>&1
+  printf 'feat: their pre-adoption work\n' > "$T3D/p/.git/COMMIT_EDITMSG"
+  t3_rc=0
+  t3_out=$( cd "$T3D/p" && bash scripts/pre-commit-gate.sh --terminal-mode --tdd-only --emit-blocked-gate 2>&1 ) || t3_rc=$?
+  t3_announced=0
+  printf '%s' "$t3_out" | grep -q 'PRE-ADOPTION commit' && t3_announced=1
+  t3_stamped=$(jq -r '.adoption.adopted // "MISSING"' "$T3D/p/.claude/manifest.json" 2>/dev/null)
+  if [ "$t3_rc" -eq 0 ] && [ "$t3_announced" -eq 1 ] && [ "$t3_stamped" = "true" ]; then
+    pass "T3 (end to end): inside the adoption window the stamp WP4 wrote exempts the commit, and the exemption path announces itself — rc 0"
+  else
+    fail_ "T3" "rc=$t3_rc (want 0) exemption_path_announced=$t3_announced stamped=$t3_stamped"
+  fi
+fi
+
+echo ""
+echo "=== G — explicit staging (§8.5: never git add -A) ==="
+
+# _dirty_adoptee DIR — one UNTRACKED file and one MODIFIED tracked file, both
+# outside anything the driver writes. A blanket add sweeps both.
+_dirty_adoptee() {
+  local d="$1"
+  mkdir -p "$d/src"
+  printf 'half-finished work nobody asked to commit\n' > "$d/src/wip.js"
+  printf '\nlocal edit in progress\n' >> "$d/README.md"
+}
+
+G1D="$(newtmp)"
+if ! mk_adoptee "$G1D/p"; then
+  fail_ "G1" "fixture setup failed"
+else
+  report_with_phase 2 "$G1D/report.json"
+  _ans_s2 3 > "$G1D/answers"
+  _dirty_adoptee "$G1D/p"
+  run_adopt "$G1D/p" "$G1D/answers" "$G1D/report.json"; g1_rc=$RUN_RC
+  g1_committed=$( cd "$G1D/p" && git show --name-only --format= HEAD 2>/dev/null )
+  g1_wip_committed=$(printf '%s\n' "$g1_committed" | grep -c '^src/wip.js$'); g1_wip_committed=$(_num "$g1_wip_committed")
+  g1_readme_committed=$(printf '%s\n' "$g1_committed" | grep -c '^README.md$'); g1_readme_committed=$(_num "$g1_readme_committed")
+  # `-uall` and not the default: with `src/` entirely untracked git collapses
+  # the whole directory to one `?? src/` row, and an assertion looking for the
+  # FILE would read that as "the file is gone" — the wrong conclusion from the
+  # right state.
+  g1_still_dirty=$( cd "$G1D/p" && git status --porcelain -uall 2>/dev/null )
+  g1_wip_untracked=0; printf '%s\n' "$g1_still_dirty" | grep -q '^?? src/wip.js' && g1_wip_untracked=1
+  g1_readme_modified=0; printf '%s\n' "$g1_still_dirty" | grep -q '^ M README.md' && g1_readme_modified=1
+  g1_state_committed=$(printf '%s\n' "$g1_committed" | grep -c '^.claude/phase-state.json$'); g1_state_committed=$(_num "$g1_state_committed")
+  if [ "$g1_rc" -eq 0 ] && [ "$g1_wip_committed" -eq 0 ] && [ "$g1_readme_committed" -eq 0 ] \
+     && [ "$g1_wip_untracked" -eq 1 ] && [ "$g1_readme_modified" -eq 1 ] && [ "$g1_state_committed" -eq 1 ]; then
+    pass "G1: staging is explicit — the adoption commit carries the driver's own files and NOT the operator's dirty ones, which are still untracked and still modified afterwards"
+  else
+    fail_ "G1" "rc=$g1_rc wip_committed=$g1_wip_committed (want 0) readme_committed=$g1_readme_committed (want 0) wip_still_untracked=$g1_wip_untracked (want 1) readme_still_modified=$g1_readme_modified (want 1) adoption_state_committed=$g1_state_committed (want 1)"
+  fi
+fi
+
+G2R="$(newtmp)"
+if ! mk_adoptee "$G2R/p" || ! mk_mirror "$G2R/fw"; then
+  fail_ "G2" "fixture setup failed"
+else
+  report_with_phase 2 "$G2R/report.json"
+  _ans_s2 3 > "$G2R/answers"
+  _dirty_adoptee "$G2R/p"
+  MUT_G="$G2R/fw/scripts/lib/adopt/adopt-state.sh"
+  stage_sites=$(_sites "$L_STATE" 'BF-ADOPT-STAGE-EXPLICIT')
+  cp "$L_STATE" "$G2R/orig.ref"
+  _sed_inplace "$MUT_G" 's|^.*BF-ADOPT-STAGE-EXPLICIT$|  ( cd "$root" \&\& git add -A ) \|\| {   # BF-ADOPT-STAGE-EXPLICIT|'
+  chgG=$(_changed_lines "$G2R/orig.ref" "$MUT_G")
+  g2_parses=$(_parses "$MUT_G")
+  run_adopt "$G2R/p" "$G2R/answers" "$G2R/report.json" "" "$G2R/fw"; g2_rc=$RUN_RC
+  g2_committed=$( cd "$G2R/p" && git show --name-only --format= HEAD 2>/dev/null )
+  g2_wip=$(printf '%s\n' "$g2_committed" | grep -c '^src/wip.js$'); g2_wip=$(_num "$g2_wip")
+  g2_state=$(printf '%s\n' "$g2_committed" | grep -c '^.claude/phase-state.json$'); g2_state=$(_num "$g2_state")
+  if [ "$g2_rc" -eq 0 ] && [ "$g2_wip" -eq 1 ] && [ "$g2_state" -eq 1 ] \
+     && [ "$chgG" -eq 2 ] && [ "$stage_sites" -eq 1 ] && [ "$g2_parses" -eq 1 ]; then
+    pass "G2 (MUTATION): swapped for a blanket add (1 line, mutant still parses), the SAME run sweeps the operator's half-finished file into the adoption commit — G1's assertion is load-bearing"
+  else
+    fail_ "G2" "run_rc=$g2_rc wip_committed=$g2_wip (want 1 under the mutant) adoption_state_committed=$g2_state (want 1) changed_lines=$chgG (want 2) stage_sites=$stage_sites (want 1) parses=$g2_parses (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== X — guard_not_in_framework (§8.1) ==="
+
+# BOTH streams are read: the guard's refusal headline comes out of print_fail,
+# which writes to stdout, while its remediation lines go to stderr. Reading one
+# of them would pass or fail on a detail of the printer, not on the guard.
+x1_rc=0
+( cd "$REPO_ROOT" && bash scripts/adopt-project.sh --help ) >"$TOPTMP/x1.out" 2>&1 || x1_rc=$?
+x1_named=0
+grep -q 'Refusing to operate inside the Solo Orchestrator framework repo' "$TOPTMP/x1.out" && x1_named=1
+if [ "$x1_rc" -ne 0 ] && [ "$x1_named" -eq 1 ]; then
+  pass "X1: the guard fires BEFORE argument parsing — even --help exits non-zero ($x1_rc) inside the framework repo, naming the signature it matched"
+else
+  fail_ "X1" "rc=$x1_rc (want non-zero) refusal_named=$x1_named"
+fi
+
+X2D="$(newtmp)"
+x2_rc=0
+( cd "$X2D" && bash "$DRIVER" --root "$REPO_ROOT" ) >"$TOPTMP/x2.out" 2>&1 || x2_rc=$?
+x2_named=0
+grep -q 'Refusing to operate inside the Solo Orchestrator framework repo' "$TOPTMP/x2.out" && x2_named=1
+if [ "$x2_rc" -ne 0 ] && [ "$x2_named" -eq 1 ]; then
+  pass "X2: the TARGET arm fires too — --root pointing at a framework clone is refused from a benign cwd (rc $x2_rc)"
+else
+  fail_ "X2" "rc=$x2_rc (want non-zero) refusal_named=$x2_named"
+fi
+
+echo ""
+echo "=== W — the honest stubs (§10: WP5/WP5b/WP6/WP7 are NOT built here) ==="
+
+W1D="$(newtmp)"
+if ! mk_adoptee "$W1D/p"; then
+  fail_ "W1" "fixture setup failed"
+else
+  report_with_phase 2 "$W1D/report.json"
+  _ans_s2 3 > "$W1D/answers"
+  run_adopt "$W1D/p" "$W1D/answers" "$W1D/report.json"; w1_rc=$RUN_RC
+  w1_cert=0; w1_record=0; w1_empty_named=0
+  grep -q 'NOT DONE — the certification pass' "$RUN_OUT" && w1_cert=1
+  grep -q 'NOT DONE — the Adoption Record' "$RUN_OUT" && w1_record=1
+  grep -q "means 'not measured', not 'measured and clean'" "$RUN_OUT" && w1_empty_named=1
+  w1_kinds=$(jq -r '[.adoption.certification.kindA, .adoption.certification.kindB, .adoption.certification.kindC] | map(length) | add' "$W1D/p/.claude/manifest.json" 2>/dev/null)
+  if [ "$w1_rc" -eq 0 ] && [ "$w1_cert" -eq 1 ] && [ "$w1_record" -eq 1 ] && [ "$w1_empty_named" -eq 1 ] && [ "$(_num "$w1_kinds")" -eq 0 ]; then
+    pass "W1: the unbuilt packages announce themselves — the certification lists in the stamp are empty AND the run says an empty list means 'not measured', not 'measured and clean'"
+  else
+    fail_ "W1" "rc=$w1_rc certification_stub=$w1_cert adoption_record_stub=$w1_record empty_means_unmeasured_stated=$w1_empty_named certification_entries=$w1_kinds (want 0)"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -883,6 +883,90 @@ else
 fi
 
 echo ""
+echo "=== H — the gates are actually ON afterwards (§4.5: no forward exemption) ==="
+
+# The run's closing line names two gates as live from the next commit onward.
+# H1 makes git ITSELF prove that claim: in the adopted project, through its own
+# installed hook, a test-less feature commit is refused. The pair matters — a
+# hook that refused EVERYTHING would satisfy the blocking half on its own, and
+# that is not a hypothetical: installing the framework's FALLBACK PRE-COMMIT
+# hook here did exactly that, refusing an ordinary `docs:` commit, which is why
+# the driver does not install it and says so instead.
+H1D="$(newtmp)"
+if ! mk_adoptee "$H1D/p"; then
+  fail_ "H1" "fixture setup failed"
+  fail_ "H2" "fixture setup failed"
+else
+  report_with_phase 2 "$H1D/report.json"
+  _ans_s2 2 > "$H1D/answers"
+  run_adopt "$H1D/p" "$H1D/answers" "$H1D/report.json"; h1_rc=$RUN_RC
+  h1_hook=0
+  [ -x "$H1D/p/.git/hooks/commit-msg" ] && h1_hook=1
+  mkdir -p "$H1D/p/src"
+  printf 'export function add(a,b){return a+b;}\n' > "$H1D/p/src/add.js"
+  ( cd "$H1D/p" && git add src/add.js ) >/dev/null 2>&1
+  h1_feat=0
+  ( cd "$H1D/p" && git commit -q -m "feat: add without a test" ) >/dev/null 2>&1 || h1_feat=$?
+  printf 'a note\n' > "$H1D/p/NOTES.md"
+  ( cd "$H1D/p" && git add NOTES.md ) >/dev/null 2>&1
+  h1_chore=0
+  ( cd "$H1D/p" && git commit -q -m "docs: a note" ) >/dev/null 2>&1 || h1_chore=$?
+  if [ "$h1_rc" -eq 0 ] && [ "$h1_hook" -eq 1 ] && [ "$h1_feat" -ne 0 ] && [ "$h1_chore" -eq 0 ]; then
+    pass "H1: after adoption the project's OWN hooks are live — git itself refuses a test-less feature commit (rc $h1_feat) while an ordinary commit still lands"
+  else
+    fail_ "H1" "run_rc=$h1_rc commit_msg_hook_executable=$h1_hook feat_commit_rc=$h1_feat (want non-zero) ordinary_commit_rc=$h1_chore (want 0)"
+  fi
+fi
+
+# H2 — an adoptee's own pre-commit hook is a §7 collision, not something to
+# overwrite. The whole-file writer would destroy it, so it is not run.
+H2D="$(newtmp)"
+if ! mk_adoptee "$H2D/p"; then
+  fail_ "H2" "fixture setup failed"
+else
+  report_with_phase 2 "$H2D/report.json"
+  _ans_s2 3 > "$H2D/answers"
+  mkdir -p "$H2D/p/.git/hooks"
+  printf '#!/usr/bin/env bash\n# their own hook\nexit 0\n' > "$H2D/p/.git/hooks/pre-commit"
+  chmod +x "$H2D/p/.git/hooks/pre-commit"
+  h2_before=$(shasum -a 256 "$H2D/p/.git/hooks/pre-commit" 2>/dev/null | awk '{print $1}')
+  run_adopt "$H2D/p" "$H2D/answers" "$H2D/report.json"; h2_rc=$RUN_RC
+  h2_after=$(shasum -a 256 "$H2D/p/.git/hooks/pre-commit" 2>/dev/null | awk '{print $1}')
+  h2_said=0
+  grep -q 'LEFT ALONE' "$RUN_OUT" && h2_said=1
+  h2_stub=0
+  grep -q 'NOT DONE — the collision archive' "$RUN_OUT" && h2_stub=1
+  if [ "$h2_rc" -eq 0 ] && [ -n "$h2_before" ] && [ "$h2_before" = "$h2_after" ] && [ "$h2_said" -eq 1 ] && [ "$h2_stub" -eq 1 ]; then
+    pass "H2: an adoptee's existing pre-commit hook is byte-for-byte untouched, said out loud, and handed to WP6's collision stub rather than overwritten"
+  else
+    fail_ "H2" "rc=$h2_rc sha_before=$h2_before sha_after=$h2_after said_left_alone=$h2_said collision_stub_fired=$h2_stub"
+  fi
+fi
+
+# H3 — the omission is DISCLOSED, not silent. An adopted project without the
+# commit-time scanners is a defensible state; one whose operator does not know
+# it is not. The run must name what is not running and what to do instead.
+H3D="$(newtmp)"
+if ! mk_adoptee "$H3D/p"; then
+  fail_ "H3" "fixture setup failed"
+else
+  report_with_phase 2 "$H3D/report.json"
+  _ans_s2 3 > "$H3D/answers"
+  run_adopt "$H3D/p" "$H3D/answers" "$H3D/report.json"; h3_rc=$RUN_RC
+  h3_named=0; h3_remedy=0; h3_nooverclaim=0; h3_precommit=0
+  grep -q 'NOT DONE — the commit-time scanners' "$RUN_OUT" && h3_named=1
+  grep -q 'scripts/pre-commit-gate.sh --terminal-mode' "$RUN_OUT" && h3_remedy=1
+  grep -q "the framework's two message gates are live" "$RUN_OUT" && h3_nooverclaim=1
+  [ -e "$H3D/p/.git/hooks/pre-commit" ] && h3_precommit=1
+  if [ "$h3_rc" -eq 0 ] && [ "$h3_named" -eq 1 ] && [ "$h3_remedy" -eq 1 ] \
+     && [ "$h3_nooverclaim" -eq 1 ] && [ "$h3_precommit" -eq 0 ]; then
+    pass "H3: the run claims only the gates it installed — it names the commit-time scanners as NOT running and gives the command to run them by hand"
+  else
+    fail_ "H3" "rc=$h3_rc scanners_named_absent=$h3_named remedy_given=$h3_remedy claim_is_narrow=$h3_nooverclaim pre_commit_hook_written=$h3_precommit (want 0)"
+  fi
+fi
+
+echo ""
 echo "=== W — the honest stubs (§10: WP5/WP5b/WP6/WP7 are NOT built here) ==="
 
 W1D="$(newtmp)"

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -323,25 +323,44 @@ else
   fi
 
   # ── Q5 — NOT PREFILLED (§4.2's rejected alternative) ──────────────────────
-  # Two halves. Behaviourally: with the answer withheld the driver STOPS rather
-  # than choosing. Structurally: nothing around the question offers a default,
-  # so there is no guess for a tired operator to accept without reading.
+  # Behaviourally the driver must STOP rather than choose; structurally nothing
+  # around the question may offer a default.
+  #
+  # THE REFUSAL IS MATCHED BY ITS LABEL, NOT BY THE GENERIC PREFIX, AND THAT IS
+  # THE WHOLE PIN (R-WP4-1). This case first shipped grepping
+  # "This question has no default and no skip", which every mandatory question
+  # in the driver prints. A one-line default-on-empty in the SHARED choice
+  # reader — `raw="${ADOPT_ANSWER:-1}"` in adopt_ask_choice — silently answers
+  # the chooser "built out" and lets the run continue to the first free-text
+  # judgment question, whose refusal carries that same prefix. All four of this
+  # case's arms stayed green under it and the mutant survived the entire
+  # PR-blocking set: 36/0 and 15/15 lints. A default here is exactly the change
+  # someone makes for convenience, on the one property §4.2 is most emphatic
+  # about, so the pin now names the question:
+  #   * the refusal must name THE CHOOSER'S OWN LABEL; and
+  #   * neither landing note may appear — a run that reached a placement
+  #     answered the chooser, whatever it printed. That is the structural
+  #     discriminator for an expected ABSENCE.
   Q5D="$(newtmp)"
   if mk_adoptee "$Q5D/p"; then
     report_with_phase 2 "$Q5D/report.json"
     : > "$Q5D/answers"      # the operator walked away before answering
     run_adopt "$Q5D/p" "$Q5D/answers" "$Q5D/report.json"; q5_rc=$RUN_RC
     q5_refused=0
-    grep -q "This question has no default and no skip" "$RUN_ERR" && q5_refused=1
+    grep -q "no answer was given: the project's situation" "$RUN_ERR" && q5_refused=1
+    q5_noplacement=1
+    grep -q 'This project lands where a finished project lands' "$RUN_OUT" && q5_noplacement=0
+    grep -q 'the scan placed this project at rung' "$RUN_OUT" && q5_noplacement=0
     q5_untouched=1
     [ -e "$Q5D/p/.claude/phase-state.json" ] && q5_untouched=0
     [ -e "$Q5D/p/.claude/manifest.json" ] && q5_untouched=0
     q5_nodefault=1
     grep -qiE 'suggested|recommended|\[default|press enter to accept' "$RUN_OUT" && q5_nodefault=0
-    if [ "$q5_rc" -ne 0 ] && [ "$q5_refused" -eq 1 ] && [ "$q5_untouched" -eq 1 ] && [ "$q5_nodefault" -eq 1 ]; then
-      pass "Q5: the chooser is NOT prefilled — withheld, it stops the run (rc $q5_rc) with nothing written, and no default is offered anywhere in the transcript"
+    if [ "$q5_rc" -ne 0 ] && [ "$q5_refused" -eq 1 ] && [ "$q5_noplacement" -eq 1 ] \
+       && [ "$q5_untouched" -eq 1 ] && [ "$q5_nodefault" -eq 1 ]; then
+      pass "Q5: the chooser is NOT prefilled — withheld, the run stops AT THE CHOOSER (the refusal names it), no placement is ever reached, nothing is written, and no default is offered anywhere in the transcript"
     else
-      fail_ "Q5" "rc=$q5_rc (want non-zero) refused=$q5_refused untouched=$q5_untouched no_default_offered=$q5_nodefault"
+      fail_ "Q5" "rc=$q5_rc (want non-zero) refused_AT_THE_CHOOSER=$q5_refused no_placement_reached=$q5_noplacement untouched=$q5_untouched no_default_offered=$q5_nodefault"
     fi
   else
     fail_ "Q5" "fixture setup failed"
@@ -513,15 +532,23 @@ else
   # Answers run out exactly at the first JUDGMENT question (section 2).
   printf '2\n3\n2\n1\n1\n' > "$I3D/answers"
   run_adopt "$I3D/p" "$I3D/answers" "$I3D/report.json"; i3_rc=$RUN_RC
-  i3_refused=0; i3_asked=0; i3_untouched=1
-  grep -q "This question has no default and no skip" "$RUN_ERR" && i3_refused=1
+  i3_refused=0; i3_asked=0; i3_untouched=1; i3_gotpast=0
+  # By LABEL, for R-WP4-1's reason: every mandatory question prints the same
+  # prefix, so matching it would accept a refusal from any of the five
+  # questions before this one — including the chooser, which is a different
+  # property with its own case.
+  grep -q "no answer was given: Business Context" "$RUN_ERR" && i3_refused=1
   grep -q 'What problem does this project solve' "$RUN_OUT" && i3_asked=1
+  # …and the run genuinely REACHED the interview: the placement note is printed
+  # only after the chooser and the ladder were both answered.
+  grep -q 'the scan placed this project at rung' "$RUN_OUT" && i3_gotpast=1
   [ -e "$I3D/p/.claude/phase-state.json" ] && i3_untouched=0
   [ -e "$I3D/p/PROJECT_INTAKE.md" ] && i3_untouched=0
-  if [ "$i3_rc" -ne 0 ] && [ "$i3_refused" -eq 1 ] && [ "$i3_asked" -eq 1 ] && [ "$i3_untouched" -eq 1 ]; then
-    pass "I3: a judgment section REFUSES to proceed unattended — the question was asked (rc $i3_rc), no answer was invented, and nothing was written"
+  if [ "$i3_rc" -ne 0 ] && [ "$i3_refused" -eq 1 ] && [ "$i3_asked" -eq 1 ] \
+     && [ "$i3_gotpast" -eq 1 ] && [ "$i3_untouched" -eq 1 ]; then
+    pass "I3: a judgment section REFUSES to proceed unattended — the run reached the interview, asked the question, and stopped AT IT by name (rc $i3_rc) with nothing written"
   else
-    fail_ "I3" "rc=$i3_rc (want non-zero) refusal_printed=$i3_refused question_was_asked=$i3_asked project_untouched=$i3_untouched"
+    fail_ "I3" "rc=$i3_rc (want non-zero) refused_AT_BUSINESS_CONTEXT=$i3_refused question_was_asked=$i3_asked reached_the_interview=$i3_gotpast project_untouched=$i3_untouched"
   fi
 fi
 
@@ -559,13 +586,18 @@ else
   # I6 reuses this identical file against the mutated driver.
   _ans_s2 3 "" yes > "$I5D/answers"
   run_adopt "$I5D/p" "$I5D/answers" "$I5D/report.json"; i5_rc=$RUN_RC
-  i5_refused=0; i5_untouched=1
+  i5_refused=0; i5_untouched=1; i5_asked=0
+  # This refusal is ALREADY question-specific — ADOPT_DC_REFUSAL is its own
+  # sentence with one call site, not the shared prefix R-WP4-1 was about — so
+  # matching it cannot accept a refusal from another question. The "was it even
+  # asked" arm is here so the row reads the same way as Q5 and I3.
   grep -q 'no default, no guess and no skip' "$RUN_ERR" && i5_refused=1
+  grep -q 'The highest classification of any data this system handles' "$RUN_OUT" && i5_asked=1
   [ -e "$I5D/p/.claude/phase-state.json" ] && i5_untouched=0
-  if [ "$i5_rc" -ne 0 ] && [ "$i5_refused" -eq 1 ] && [ "$i5_untouched" -eq 1 ]; then
-    pass "I5 (control): an unanswered data classification STOPS the adoption (rc $i5_rc) — no default, no inference, nothing written"
+  if [ "$i5_rc" -ne 0 ] && [ "$i5_refused" -eq 1 ] && [ "$i5_asked" -eq 1 ] && [ "$i5_untouched" -eq 1 ]; then
+    pass "I5 (control): an unanswered data classification STOPS the adoption (rc $i5_rc) with its OWN refusal — no default, no inference, nothing written"
   else
-    fail_ "I5" "rc=$i5_rc (want non-zero) refusal_named_the_question=$i5_refused untouched=$i5_untouched"
+    fail_ "I5" "rc=$i5_rc (want non-zero) refusal_is_the_DC_one=$i5_refused question_was_asked=$i5_asked untouched=$i5_untouched"
   fi
 fi
 
@@ -994,6 +1026,109 @@ else
     pass "H4: the installed framework files keep their own modes (lib $h4_lib_dst, entry script $h4_gate_dst — genuinely different, so the comparison is not vacuous) and adoption-stamp.sh reaches the adoptee"
   else
     fail_ "H4" "rc=$h4_rc lib_mode $h4_lib_src->$h4_lib_dst entry_mode $h4_gate_src->$h4_gate_dst (the two source modes must differ, else this proves nothing) adoption_stamp_installed=$h4_stamp"
+  fi
+fi
+
+echo ""
+echo "=== R — the halted-run exits, and the record's evidence hash ==="
+
+# R1 — a re-run of an adoption that already installed everything must NAME the
+# real cause. This is the operator's most likely second move (something went
+# wrong at the commit, fix it, run again) and the first cut answered it by
+# blaming the clone — the one thing that was fine.
+R1D="$(newtmp)"
+if ! mk_adoptee "$R1D/p"; then
+  fail_ "R1" "fixture setup failed"
+else
+  report_with_phase 2 "$R1D/report.json"
+  _ans_s2 3 > "$R1D/answers"
+  run_adopt "$R1D/p" "$R1D/answers" "$R1D/report.json"; r1_first=$RUN_RC
+  run_adopt "$R1D/p" "$R1D/answers" "$R1D/report.json"; r1_second=$RUN_RC
+  r1_true=0; r1_false=0; r1_resume=0
+  grep -q 'every framework script is already present' "$RUN_ERR" && r1_true=1
+  grep -q 'is this a complete clone' "$RUN_ERR" && r1_false=1
+  grep -q 'RESUMING AN INTERRUPTED ADOPTION IS NOT BUILT YET' "$RUN_ERR" && r1_resume=1
+  # …and the safe row still holds after the refused re-run.
+  gate_in "$R1D/p"; r1_gate=$GATE_RC
+  if [ "$r1_first" -eq 0 ] && [ "$r1_second" -ne 0 ] && [ "$r1_true" -eq 1 ] \
+     && [ "$r1_false" -eq 0 ] && [ "$r1_resume" -eq 1 ] && [ "$r1_gate" -ne 0 ]; then
+    pass "R1: a second run on an already-installed project refuses with the TRUE cause, never the clone misdiagnosis, says resuming is not built yet, and leaves the gate still blocking"
+  else
+    fail_ "R1" "first_rc=$r1_first second_rc=$r1_second (want non-zero) named_true_cause=$r1_true blamed_the_clone=$r1_false (want 0) said_resume_unbuilt=$r1_resume gate_rc=$r1_gate (want non-zero)"
+  fi
+fi
+
+# R2/R3 — the stamp must never record an evidence hash it does not have.
+#
+# Driven at the FUNCTION level, with adopt_sha256 stubbed, because the real
+# trigger is a host with neither `shasum` nor `sha256sum` and there is no
+# honest way to manufacture that from a test without either shipping a
+# test-only backdoor in the driver or rebuilding PATH around a guess at every
+# tool the driver uses. The guard is what is under test; the tool probe itself
+# is one `command -v` pair. Dual direction, so a guard that refused everything
+# would fail R3.
+_stamp_fixture() {
+  local d="$1"
+  mkdir -p "$d/.claude/adoption" || return 1
+  ( cd "$d" && git init -q . && git config user.email r@t.invalid && git config user.name R \
+      && echo x > f.txt && git add f.txt && git commit -q -m "chore: base" ) >/dev/null 2>&1 || return 1
+  printf '%s\n' '{"stack":{"ciHost":"github"}}' > "$d/.claude/adoption/scout-report.json"
+  return 0
+}
+
+# _run_write_manifest DIR STUB_EMPTY — source the module, set the globals
+# adopt_write_manifest reads, optionally stub the hash, and call it. Echoes rc.
+_run_write_manifest() {
+  local d="$1" stub="$2"
+  (
+    # shellcheck source=/dev/null
+    . "$REPO_ROOT/scripts/lib/adoption-stamp.sh"
+    # shellcheck source=/dev/null
+    . "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh"
+    # shellcheck source=/dev/null
+    . "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh"
+    # shellcheck source=/dev/null
+    . "$REPO_ROOT/scripts/lib/adopt/adopt-stubs.sh"
+    adopt_ledger_init "$d/.ledger" >/dev/null 2>&1
+    ADOPT_SCENARIO="in-flight"; ADOPT_LANDED_PHASE=1; ADOPT_DEPLOYMENT="personal"
+    [ "$stub" = "empty" ] && adopt_sha256() { printf ''; }
+    cd "$d" || exit 9
+    adopt_write_manifest "$d" "$d/.claude/adoption/scout-report.json"
+  ) >/dev/null 2>&1
+  printf '%s\n' "$?"
+}
+
+R2D="$(newtmp)/p"
+if ! _stamp_fixture "$R2D"; then
+  fail_ "R2" "fixture setup failed"
+  fail_ "R3" "fixture setup failed"
+else
+  r2_rc=$(_run_write_manifest "$R2D" empty)
+  # Structural discriminator for an expected ABSENCE: the manifest exists (the
+  # function ran and got past its first write) but carries NO adoption block,
+  # so this is a refusal at the guard and not a crash before it.
+  r2_manifest=0; [ -f "$R2D/.claude/manifest.json" ] && r2_manifest=1
+  r2_block=1
+  jq -e '.adoption' "$R2D/.claude/manifest.json" >/dev/null 2>&1 || r2_block=0
+  r2_sites=$(_sites "$L_STATE" 'BF-ADOPT-SHA-REQUIRED')
+  if [ "$r2_rc" -ne 0 ] && [ "$r2_manifest" -eq 1 ] && [ "$r2_block" -eq 0 ] && [ "$r2_sites" -eq 1 ]; then
+    pass "R2: an unhashable scan report REFUSES the stamp (rc $r2_rc) — the manifest exists but carries no adoption block, so the record never claims an evidence hash it does not have"
+  else
+    fail_ "R2" "rc=$r2_rc (want non-zero) manifest_written=$r2_manifest (want 1) adoption_block_present=$r2_block (want 0) guard_sites=$r2_sites (want 1)"
+  fi
+
+  R3D="$(newtmp)/p"
+  if ! _stamp_fixture "$R3D"; then
+    fail_ "R3" "fixture setup failed"
+  else
+    r3_rc=$(_run_write_manifest "$R3D" real)
+    r3_sha=$(jq -r '.adoption.scannerReportSha256 // ""' "$R3D/.claude/manifest.json" 2>/dev/null)
+    r3_real=$(shasum -a 256 "$R3D/.claude/adoption/scout-report.json" 2>/dev/null | awk '{print $1}')
+    if [ "$r3_rc" -eq 0 ] && [ -n "$r3_real" ] && [ "$r3_sha" = "$r3_real" ]; then
+      pass "R3 (control): with a working hash the same call succeeds and records the real one — R2's guard refuses the empty case, not every case"
+    else
+      fail_ "R3" "rc=$r3_rc (want 0) recorded=$r3_sha real=$r3_real"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## What

Brownfield Adoption **WP4** — the adoption driver: `scripts/adopt-project.sh` plus `scripts/lib/adopt/*`. This is the entry point a real, already-started project uses to come under the framework.

- **`scripts/adopt-project.sh`, not a mode of `init.sh`** (§8.1): init's interactive path has no existence check and twelve unguarded overwrite sites, so a flag would mean auditing every one of them for a mode that must never reach them. `guard_not_in_framework` fires before argument parsing.
- **The scenario chooser, verbatim** (§4.1) — Karl's sentence byte-for-byte, including "new features add". Pinned four ways, and **never prefilled**: §4.2 explicitly rejects inferring the scenario and asking for confirmation, because a guess presented as a default makes the most consequential answer the easiest to skim past. Scout's evidence is offered with a per-signal confidence tier and the operator's answer overrides all of it.
- **Placement with the one-directional floor rule** (§4.4): S1 lands at phase 4 adopted; S2 lands at Scout's *reached* rung (matching the v1.2 amendment), and the interview may only move it **down**.
- **Reverse intake** (§8.3) consuming Scout's prefill table — scan-derived answers confirmed with their provenance, judgment sections human-mandatory, **data classification non-skippable in both scenarios** (a mechanical necessity: the Phase 1→2 ZDR backstop is a hard `[FAIL]` at `current_phase >= 2`).
- **The fail-safe write order** (§8.4) — phase-state → intake → manifest, because the failure directions are asymmetric. Every interruption point is *executed* via a documented fault injector and the safe row asserted through **both** §8.4 surfaces (the gate's exit code *and* `read_enforcement_level`), never a label.
- **The adoption stamp's one call site** — WP3 shipped it with no product caller; this is that caller. `adoptedAtCommit` feeds WP3's TDD bound, so the branch proves that security property **end to end through the adopted project's own installed gate**: a pre-adoption commit exempt, a post-adoption commit blocked at exit 3, the BL-072 arm specifically.
- **Explicit-path staging, never `git add -A`** — a dirty untracked file and a modified tracked file are neither staged nor committed and remain dirty; the mutant that swaps in `git add -A` sweeps them in.

## The shipping question, reversed against my own brief — and verified

My brief hedged toward shipping the driver via `init.sh`. The implementer concluded the opposite: `init.sh` is **core**, the driver is a **module**, so a `cp` line there is precisely the `core → module` edge M3 forbids. **The reviewer planted that line itself** and got `lint-module-dependencies.sh` rc 1 on T1 naming the M3 edge, with `CORE_ALLOWLIST` empty by design. The adoptee instead receives the ordinary shipped script set installed *by the driver* via `soif_parse_shipped_scripts` — derived from `init.sh`'s own copy list rather than duplicated — which is also how `adoption-stamp.sh` reaches the adoptee, as WP3's header requires. `init.sh` is untouched by this branch.

## Verification trail (fable pr-reviewer, xhigh, two rounds)

**Round 1 — `major_concerns`.** The product survived every attack: the chooser verbatim, the floor un-raisable under crafted-report / garbage-rung / `highestSatisfiedRung` attacks, the write order safe at every interruption the reviewer could invent (including a truncated-phase-state kill window and a failed commit), the stamp anchor correct including a merge-commit parent with empty history refused, and the TDD bound end-to-end. **Zero refuted claims.**

The blocker was a hole in the *test*, not the code: **Q5's no-prefill pin was label-blind.** The reviewer added the exact convenience change a future contributor would make — a default-on-empty in the shared choice reader — and the mutant survived **the whole suite and all 15 lints**, because Q5 matched a generic refusal prefix rather than the specific one. An empty stdin silently answered the chooser.

**Fix round.** Q5 now matches the refusal's own label *and* requires that no placement was ever reached — a structural discriminator, since any run printing a landing note necessarily answered the chooser. The audit found **one more** row of the same class (I3), confirmed I5 was genuinely not blind rather than "fixing" it for symmetry, and left a header on the shared refusal variable explaining why a bare-prefix grep cannot see the difference. Plus: an empty `scannerReportSha256` is now refused rather than silently recorded, a misdiagnosing re-run message corrected, and two pieces of dead state removed.

**Re-review — `approve`.** The mutant re-applied reds Q5 alone (three arms firing); a variant of it also caught; defeat attempts failed structurally. The reviewer swept every refusal-asserting row itself and confirmed the audit complete.

Suite **39/0**; WP3 arms 33/0; source-closure 6/0; run-lints 15/15; both-lane registration, not exempt.

## Six defects found and fixed during the build

Including one worth naming: `exec 3<&0 2>/dev/null` — `exec` with no command applies redirections *permanently*, so stderr went to `/dev/null` for the rest of the run and three refusal cases looked correct while printing nothing. Also a heredoc-fed `while read` loop consuming the operator's answers, a closing line that overclaimed which gates were live, a blanket `chmod +x` that would have landed installed libs at 0755, an `adopt_sha256` fallback that could record an empty hash, and a test harness losing globals through `$( … )`.

## Recorded, not built

The adopted project does not yet receive the fallback pre-commit hook: installing it today blocks **every** commit, because the hook expects framework artifacts an adoption does not produce, leaving `--no-verify` as the only exit. **Karl's decision (2026-08-09): WP7 installs it**, ordered after the Adoption Record exists, with §10-WP7 amended to record that ownership. Until then the run names the checks that are not running and prints the manual command. Also owed: a `chooserEvidence` section in Scout (the driver derives three of four §4.2 signals itself — reviewer-endorsed as a design amendment plus a Scout follow-up), a WP5 schema field so empty certification arrays mean "not measured" durably rather than by convention, and a WP8 doc line for `poc_mode: production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
