### PR TITLE
fix(f015): convert the tamper-pins from blacklist to allowlist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -399,6 +399,7 @@ jobs:
             tests/test-bl165-dast-hardened-serve.sh
             tests/test-bl169-gitignore-anchor.sh
             tests/test-bl147-ci-template-integrity.sh
+            tests/test-f015-tamper-pin-allowlist.sh
             tests/test-bl089-doc-foundations.sh
             tests/test-bl137-ci-tools-scope.sh
             tests/test-walk006-ci-protection-scope.sh

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -618,7 +618,7 @@ EOM
     *) print_fail "--token-env: '$token_env' is not a valid environment variable name"; return 1 ;;
   esac
   case "$token_env" in
-    *[!A-Za-z0-9_]*) print_fail "--token-env: '$token_env' is not a valid environment variable name"; return 1 ;;
+    *[!A-Za-z0-9_]*) print_fail "--token-env: '$token_env' is not a valid environment variable name"; return 1 ;;   # F-015-TOKEN-ENV-CHARSET
   esac
   eval "token=\${$token_env:-}"
   if [ -n "$token" ]; then
@@ -687,13 +687,34 @@ EOM
   #       (the script was found; its verdict failed). Under that shape a
   #       correctly-scoped token changes NOTHING, so saying "the next push
   #       enforces" would be false.
+  #
+  # F-015 (Karl, 2026-08-09 — "Harden it"): this test is an ALLOWLIST. It used
+  # to enumerate FORBIDDEN shapes — `\|\|[[:space:]]*(echo|true|:)` — and the
+  # sibling pin in bl147 was proven by mutation to let `|| exit 0` through for
+  # exactly that reason (BUG-009 confirm review, R-C1). A pipe, a trailing `&`,
+  # an `if !` wrapper, an interpreter swap and a command appended after the
+  # invocation all walked through it too, each earning the "the next push
+  # enforces the check" claim while the verdict went in the bin. Blacklists lose
+  # to creativity.
+  #
+  # So: an executable line naming the gate script may be the bare invocation or
+  # the existence guard the emitted templates wrap it in, and NOTHING else.
+  # Normalization is limited to what cannot change what bash runs — indentation,
+  # a YAML sequence dash, the `run:` key of an inline scalar, trailing blanks —
+  # which is why an older project whose step is `run: bash scripts/…` on one
+  # line still reads as honest. Whole-line comments are dropped because they are
+  # inert; a `#` on the invocation line is not, and makes the line deviate.
   local wf=".github/workflows/ci.yml"
   local wf_maps=0 wf_swallows=0
   if [ -f "$wf" ]; then
     grep -q "secrets.$secret_name" "$wf" && wf_maps=1
-    if grep -E '^[^#]*bash scripts/check-phase-gate\.sh' "$wf" \
-         | grep -Eq '\|\|[[:space:]]*(echo|true|:)'; then
-      wf_swallows=1
+    if grep -v '^[[:space:]]*#' "$wf" \
+         | grep -F 'scripts/check-phase-gate.sh' \
+         | sed -e 's/^[[:space:]]*//' -e 's/^-[[:space:]]*//' \
+               -e 's/^run:[[:space:]]*//' -e 's/[[:space:]]*$//' \
+         | grep -qvxF -e 'bash scripts/check-phase-gate.sh' \
+                      -e 'if [ ! -f scripts/check-phase-gate.sh ]; then'; then
+      wf_swallows=1   # F-015-PROJECT-ALLOWLIST-VERDICT
     fi
   fi
   if [ "$wf_maps" -eq 1 ] && [ "$wf_swallows" -eq 0 ]; then

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -699,11 +699,35 @@ EOM
   #
   # So: an executable line naming the gate script may be the bare invocation or
   # the existence guard the emitted templates wrap it in, and NOTHING else.
-  # Normalization is limited to what cannot change what bash runs — indentation,
-  # a YAML sequence dash, the `run:` key of an inline scalar, trailing blanks —
-  # which is why an older project whose step is `run: bash scripts/…` on one
-  # line still reads as honest. Whole-line comments are dropped because they are
-  # inert; a `#` on the invocation line is not, and makes the line deviate.
+  #
+  # WHAT THE NORMALIZATION DOES AND DOES NOT CLAIM. It strips indentation, a
+  # YAML sequence dash, the `run:` key of an inline scalar, and trailing blanks
+  # — which is why an older project whose step is `run: bash scripts/…` on one
+  # line still reads as honest. Whole-LINE comments are dropped before the
+  # comparison. It does NOT follow that everything surviving the comparison is
+  # execution-relevant: a TRAILING comment (`bash scripts/… # keep`) is
+  # perfectly inert to bash, and this predicate rejects it anyway, because what
+  # is compared is the line's exact TEXT. That is deliberate and it is the safe
+  # direction — an unexpected byte on the gate line is a thing to look at, not a
+  # thing to wave through — but it is a byte comparison, not an execution
+  # analysis, and the comment must not pretend otherwise.
+  #
+  # NOTE THE ASYMMETRY with the bl147 sibling (Cw6-strict). That pin freezes the
+  # phase-gate step's whole run: body byte-for-byte and therefore rejects the
+  # inline `run: bash scripts/…` form outright. This one accepts it, because it
+  # runs against a REAL user's ci.yml of unknown vintage rather than against the
+  # ten templates the framework itself emits. Same doctrine, deliberately
+  # different tolerance; do not "align" one to the other without re-reading why.
+  #
+  # HOST TRAP for anyone replicating this predicate by hand: `grep -qvxF` over
+  # EMPTY input must exit non-zero (no lines, so no non-matching line). That is
+  # what /usr/bin/grep does, and it is what runs here — this script is executed
+  # by a child bash with no interactive aliases. But at least one dev box in
+  # this project aliases interactive `grep` to ugrep, which INVERTS the
+  # empty-input result and will make the pipeline below look like it reports a
+  # swallow on a workflow that has no gate line at all. Shipped behaviour is
+  # unaffected; a hand-run reproduction in an interactive shell is not. Use
+  # `/usr/bin/grep` explicitly when checking this by hand.
   local wf=".github/workflows/ci.yml"
   local wf_maps=0 wf_swallows=0
   if [ -f "$wf" ]; then

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1107,6 +1107,17 @@ run_child_suite "tests/test-bl144-selfapproval-silent-arms.sh" \
 run_child_suite "tests/test-bl147-ci-template-integrity.sh" \
   "tests/test-bl147-ci-template-integrity.sh"
 
+# F-015 (Karl, 2026-08-09 — "Harden it"): the detector-of-the-detector for the
+# bl147 Cw6-strict tamper-pin, which BUG-009's confirm review (R-C1) proved was
+# a blacklist that `|| exit 0` walked straight through. The pin is now an
+# ALLOWLIST over the phase-gate step's whole run: body; this suite drives the
+# REAL bl147 suite against tampered mirrors of the REAL templates and proves six
+# unenumerated swallow shapes go red, the ten shipped templates stay green, an
+# inert comment is still tolerated, and — dual direction — a neutered pin lets
+# the tamper through. No init.sh -> both lanes.
+run_child_suite "tests/test-f015-tamper-pin-allowlist.sh" \
+  "tests/test-f015-tamper-pin-allowlist.sh"
+
 # BL-139 (Dogfood-3 F-DF3-004): a subject-less --check-commit-ready no
 # longer presumes feat — framework-gate's pre-commit call cannot know the
 # subject (BL-119 doctrine), and the commit-msg surface owns the feat rule

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1110,11 +1110,12 @@ run_child_suite "tests/test-bl147-ci-template-integrity.sh" \
 # F-015 (Karl, 2026-08-09 — "Harden it"): the detector-of-the-detector for the
 # bl147 Cw6-strict tamper-pin, which BUG-009's confirm review (R-C1) proved was
 # a blacklist that `|| exit 0` walked straight through. The pin is now an
-# ALLOWLIST over the phase-gate step's whole run: body; this suite drives the
-# REAL bl147 suite against tampered mirrors of the REAL templates and proves six
-# unenumerated swallow shapes go red, the ten shipped templates stay green, an
-# inert comment is still tolerated, and — dual direction — a neutered pin lets
-# the tamper through. No init.sh -> both lanes.
+# ALLOWLIST over the phase-gate step's whole run: body, its step keys and its
+# if: condition; this suite drives the REAL bl147 suite against tampered mirrors
+# of the REAL templates and proves SEVEN unenumerated swallow shapes go red, the
+# ten shipped templates stay green, an inert comment is still tolerated, and —
+# dual direction, twice — a neutered pin lets the tamper through.
+# No init.sh -> both lanes.
 run_child_suite "tests/test-f015-tamper-pin-allowlist.sh" \
   "tests/test-f015-tamper-pin-allowlist.sh"
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1110,12 +1110,15 @@ run_child_suite "tests/test-bl147-ci-template-integrity.sh" \
 # F-015 (Karl, 2026-08-09 — "Harden it"): the detector-of-the-detector for the
 # bl147 Cw6-strict tamper-pin, which BUG-009's confirm review (R-C1) proved was
 # a blacklist that `|| exit 0` walked straight through. The pin is now an
-# ALLOWLIST over the phase-gate step's whole run: body, its step keys and its
-# if: condition; this suite drives the REAL bl147 suite against tampered mirrors
-# of the REAL templates and proves SEVEN unenumerated swallow shapes go red, the
-# ten shipped templates stay green, an inert comment is still tolerated, and —
-# dual direction, twice — a neutered pin lets the tamper through.
-# No init.sh -> both lanes.
+# ALLOWLIST at three levels — the phase-gate step (body, keys, if:), the JOB
+# that holds it, and the workflow's on: trigger. This suite drives the REAL
+# bl147 suite against tampered mirrors of the REAL templates and proves SEVEN
+# unenumerated step-level swallow shapes go red, plus review R-F015-1's three
+# level-up cases (job `if: false`, job `if: ${{ …always-false }}`, `on:` gutted
+# to workflow_dispatch — each of which passed all 82 checks at rc=0 before the
+# pins existed); that the ten shipped templates stay green; that an inert
+# comment is still tolerated; and — dual direction, four times — that a neutered
+# verdict lets the tamper through. No init.sh -> both lanes.
 run_child_suite "tests/test-f015-tamper-pin-allowlist.sh" \
   "tests/test-f015-tamper-pin-allowlist.sh"
 

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1438,38 +1438,100 @@ fi
 # is the strict shape python/typescript/other already used.
 #
 # Scoped to the STEP, not the file: the phase-gate step is extracted by name and
-# both discard vectors are checked inside it — the shell one (`|| echo/true/:`
-# on the invocation) and the Actions-native one (`continue-on-error: true` on
-# the step, which grades a red step GREEN just as effectively). Other steps may
-# legitimately use either (java/kotlin's Lint step does); this one may not.
-w6_swallow=""; w6_coe=""
-if [ "$CPG_COUNT" -gt 0 ]; then
-  for f in "${CPG_FILES[@]}"; do
-    case "$f" in */ci/github/*) ;; *) continue ;; esac
-    grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{' "$f" || continue
+# both discard vectors are checked inside it — the shell one (on the invocation)
+# and the Actions-native one (`continue-on-error: true` on the step, which
+# grades a red step GREEN just as effectively). Other steps may legitimately use
+# either (java/kotlin's Lint step does); this one may not.
+#
+# F-015 (Karl, 2026-08-09 — "Harden it"): this pin used to enumerate FORBIDDEN
+# swallow shapes, `(\|\||;)[[:space:]]*(echo|true|:)`. BUG-009's confirm review
+# (R-C1) proved by mutation that `bash scripts/check-phase-gate.sh || exit 0`
+# walked through the entire suite — `exit` was simply not in the alternation —
+# and a pipe, a trailing `&`, an `if !` wrapper, an interpreter swap and a
+# command appended AFTER the invocation all walked through it too. Blacklists
+# lose to creativity. So the pin now states what is PERMITTED: the step's `run:`
+# body must be the known-good script VERBATIM. Everything else fails, including
+# the shapes nobody has imagined yet.
+#
+# Normalization is limited to the three edits that cannot change what bash
+# executes — leading/trailing whitespace, blank lines, whole-line comments — so
+# the pin is strict without being superstitious (tests/test-f015-tamper-pin-
+# allowlist.sh pins that tolerance, and pins each of the six shapes above going
+# red).
+#
+# The KEY allowlist is the same idea on the Actions side: only `if`, `env` and
+# `run` may appear on this step. `continue-on-error` keeps its own named case
+# because it deserves a specific diagnostic, but the key allowlist is what
+# catches its unimagined siblings.
+#
+# CHANGING THE STEP IS A DELIBERATE ACT. If the templates' phase-gate body
+# legitimately changes, this literal changes with it, in the same commit.
+W6_EXPECTED_BODY='if [ ! -f scripts/check-phase-gate.sh ]; then
+echo "::error::Phase gate check script missing. Framework integrity compromised."
+exit 1
+fi
+bash scripts/check-phase-gate.sh'
+#
+# The candidate set is every github template that MAPS the secret — NOT
+# CPG_FILES, which is itself derived by grepping for a `bash …` invocation. A
+# template that swapped the interpreter would have dropped out of CPG_FILES and
+# so out of this pin's reach; scoping on the mapping instead keeps it in, which
+# is the same allowlist discipline applied to the candidate set.
+w6_swallow=""; w6_coe=""; w6_keys=""; w6_examined=0
+if [ "$GH_COUNT" -gt 0 ]; then
+  for f in "${GH_FILES[@]}"; do
+    grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{' "$f" || continue   # F-015-STRICT-SCOPE-FILTER
+    w6_examined=$((w6_examined + 1))
     _w6_step=$(awk '
       /^      - name: Governance - Phase gate check$/ { inside = 1; next }
       inside && /^      - name: / { exit }
       inside { print }
     ' "$f")
-    if printf '%s\n' "$_w6_step" | grep -E '^[^#]*bash scripts/check-phase-gate\.sh' \
-         | grep -Eq '(\|\||;)[[:space:]]*(echo|true|:)'; then
-      w6_swallow="$w6_swallow ${f#*/ci/}"
+    _w6_body=$(printf '%s\n' "$_w6_step" \
+      | awk '/^[[:space:]]*run:[[:space:]]*\|[-+]?[[:space:]]*$/ { body = 1; next } body { print }' \
+      | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' \
+      | grep -v '^$' | grep -v '^#')
+    if [ "$_w6_body" != "$W6_EXPECTED_BODY" ]; then   # F-015-BODY-ALLOWLIST-VERDICT
+      # Report the offending line, not just the file: "it deviates" is not a
+      # diagnosis. An empty deviation set means a permitted line went missing.
+      _w6_dev=$(printf '%s\n' "$_w6_body" | grep -vxF "$W6_EXPECTED_BODY" | head -2 | tr '\n' '|')
+      [ -n "$_w6_dev" ] || _w6_dev='a permitted line is missing, reordered, or the run: block did not parse'
+      w6_swallow="$w6_swallow ${f#*/ci/}[$_w6_dev]"
     fi
     if printf '%s\n' "$_w6_step" | grep -Eq '^[[:space:]]*continue-on-error:[[:space:]]*true'; then
       w6_coe="$w6_coe ${f#*/ci/}"
     fi
+    # The step's own keys sit at exactly 8 spaces; the env: mapping and the
+    # run: body are deeper, so they are not candidates.
+    for _w6_k in $(printf '%s\n' "$_w6_step" | grep -E '^        [a-zA-Z][a-zA-Z0-9_-]*:' | sed 's/^ *//;s/:.*//'); do
+      case "$_w6_k" in
+        if|env|run) ;;
+        *) w6_keys="$w6_keys ${f#*/ci/}:$_w6_k" ;;
+      esac
+    done
   done
 fi
-if [ -z "$w6_swallow" ]; then
-  pass "Cw6-strict (every secret-mapping github template lets the gate's EXIT CODE decide the step)"
+# Cw6-strict's green is an ABSENCE, and an empty candidate set produces the same
+# absence. This floor is what tells clean apart from vacuous.
+if [ "$w6_examined" -ge 10 ]; then
+  pass "Cw6-strict-scope ($w6_examined secret-mapping github templates examined by the allowlist, floor 10)"
 else
-  fail_ "Cw6-strict" "the gate's exit code is discarded (\`|| echo/true/:\`) — a mapped secret cannot enforce anything — in:$w6_swallow"
+  fail_ "Cw6-strict-scope" "the allowlist examined only $w6_examined secret-mapping github templates (floor 10) — the Cw6-strict verdicts below are vacuous"
+fi
+if [ -z "$w6_swallow" ]; then
+  pass "Cw6-strict (all $w6_examined secret-mapping github templates run the ALLOWLISTED phase-gate body verbatim — the gate's exit code decides the step)"
+else
+  fail_ "Cw6-strict" "the phase-gate run: body is not the allowlisted script, so the gate's verdict may never reach the step — in:$w6_swallow"
 fi
 if [ -z "$w6_coe" ]; then
   pass "Cw6-strict-no-coe (no continue-on-error on the phase-gate step — the Actions-native swallow)"
 else
   fail_ "Cw6-strict-no-coe" "continue-on-error grades the phase-gate step GREEN regardless of the verdict, in:$w6_coe"
+fi
+if [ -z "$w6_keys" ]; then
+  pass "Cw6-strict-keys (the phase-gate step carries only the allowlisted keys: if, env, run)"
+else
+  fail_ "Cw6-strict-keys" "a non-allowlisted key on the phase-gate step can change how its verdict is graded — in:$w6_keys"
 fi
 
 # ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1464,6 +1464,11 @@ fi
 # because it deserves a specific diagnostic, but the key allowlist is what
 # catches its unimagined siblings.
 #
+# And the `if:` VALUE is allowlisted, not just the key. A key allowlist alone
+# leaves `if: false` — a step that never runs discards the verdict more
+# completely than `|| true` ever could, and it would have sailed through a pin
+# that only inspected the body.
+#
 # CHANGING THE STEP IS A DELIBERATE ACT. If the templates' phase-gate body
 # legitimately changes, this literal changes with it, in the same commit.
 W6_EXPECTED_BODY='if [ ! -f scripts/check-phase-gate.sh ]; then
@@ -1477,7 +1482,8 @@ bash scripts/check-phase-gate.sh'
 # template that swapped the interpreter would have dropped out of CPG_FILES and
 # so out of this pin's reach; scoping on the mapping instead keeps it in, which
 # is the same allowlist discipline applied to the candidate set.
-w6_swallow=""; w6_coe=""; w6_keys=""; w6_examined=0
+W6_EXPECTED_IF="if: hashFiles('.claude/phase-state.json') != ''"
+w6_swallow=""; w6_coe=""; w6_keys=""; w6_gating=""; w6_examined=0
 if [ "$GH_COUNT" -gt 0 ]; then
   for f in "${GH_FILES[@]}"; do
     grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{' "$f" || continue   # F-015-STRICT-SCOPE-FILTER
@@ -1509,6 +1515,8 @@ if [ "$GH_COUNT" -gt 0 ]; then
         *) w6_keys="$w6_keys ${f#*/ci/}:$_w6_k" ;;
       esac
     done
+    _w6_if=$(printf '%s\n' "$_w6_step" | grep -E '^        if:' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    [ "$_w6_if" = "$W6_EXPECTED_IF" ] || w6_gating="$w6_gating ${f#*/ci/}[${_w6_if:-<no if: on the step>}]"   # F-015-IF-ALLOWLIST-VERDICT
   done
 fi
 # Cw6-strict's green is an ABSENCE, and an empty candidate set produces the same
@@ -1532,6 +1540,11 @@ if [ -z "$w6_keys" ]; then
   pass "Cw6-strict-keys (the phase-gate step carries only the allowlisted keys: if, env, run)"
 else
   fail_ "Cw6-strict-keys" "a non-allowlisted key on the phase-gate step can change how its verdict is graded — in:$w6_keys"
+fi
+if [ -z "$w6_gating" ]; then
+  pass "Cw6-strict-gating (the step's if: is the allowlisted phase-state condition — a step that never runs cannot enforce)"
+else
+  fail_ "Cw6-strict-gating" "the phase-gate step's if: is not the allowlisted condition, so the step may be skipped rather than obeyed — in:$w6_gating"
 fi
 
 # ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────

--- a/tests/test-bl147-ci-template-integrity.sh
+++ b/tests/test-bl147-ci-template-integrity.sh
@@ -1469,6 +1469,32 @@ fi
 # completely than `|| true` ever could, and it would have sailed through a pin
 # that only inspected the body.
 #
+# R-F015-1 (review, 2026-08-09): the same argument runs one level up, twice, and
+# a step-scoped pin is blind to both. Measured before these two cases existed:
+# job-level `if: false` passed all 82 checks at rc=0, and `on:` reduced to
+# `workflow_dispatch:` passed all 82 at rc=0. A job that never starts and a
+# workflow that never triggers discard the verdict exactly as completely as the
+# step-level shapes above, so:
+#   Cw6-strict-job      the job CONTAINING the phase-gate step carries only the
+#                       allowlisted keys (`runs-on`, `steps`). That refuses
+#                       job-level `if:` and job-level `continue-on-error:` by
+#                       construction, along with every sibling nobody has named
+#                       — which is the point of allowlisting the key SET rather
+#                       than blacklisting the two keys we happen to know about.
+#                       The job is located by CONTAINMENT, not by name, so
+#                       renaming it is not a false red.
+#   Cw6-strict-trigger  the workflow's `on:` block is the known-good push +
+#                       pull_request stanza VERBATIM. An exact block match, not
+#                       a "contains push:" test, because `paths-ignore: ['**']`
+#                       or `branches: [never]` under a present `push:` key
+#                       neuters the trigger just as thoroughly as deleting it.
+#
+# HOST TRAP for anyone reproducing these predicates by hand: at least one dev
+# box in this project aliases interactive `grep` to ugrep, which inverts the
+# empty-input result. The suite runs /usr/bin/grep (no interactive aliases in a
+# script), so shipped behaviour is unaffected — but a hand-run reproduction in
+# an interactive shell can read backwards. Use `/usr/bin/grep` explicitly.
+#
 # CHANGING THE STEP IS A DELIBERATE ACT. If the templates' phase-gate body
 # legitimately changes, this literal changes with it, in the same commit.
 W6_EXPECTED_BODY='if [ ! -f scripts/check-phase-gate.sh ]; then
@@ -1483,7 +1509,14 @@ bash scripts/check-phase-gate.sh'
 # so out of this pin's reach; scoping on the mapping instead keeps it in, which
 # is the same allowlist discipline applied to the candidate set.
 W6_EXPECTED_IF="if: hashFiles('.claude/phase-state.json') != ''"
-w6_swallow=""; w6_coe=""; w6_keys=""; w6_gating=""; w6_examined=0
+W6_EXPECTED_JOBKEYS='runs-on
+steps'
+W6_EXPECTED_ON='on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]'
+w6_swallow=""; w6_coe=""; w6_keys=""; w6_gating=""; w6_job=""; w6_on=""; w6_examined=0
 if [ "$GH_COUNT" -gt 0 ]; then
   for f in "${GH_FILES[@]}"; do
     grep -Eq '^[[:space:]]*GH_TOKEN:[[:space:]]*\$\{\{' "$f" || continue   # F-015-STRICT-SCOPE-FILTER
@@ -1517,6 +1550,29 @@ if [ "$GH_COUNT" -gt 0 ]; then
     done
     _w6_if=$(printf '%s\n' "$_w6_step" | grep -E '^        if:' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
     [ "$_w6_if" = "$W6_EXPECTED_IF" ] || w6_gating="$w6_gating ${f#*/ci/}[${_w6_if:-<no if: on the step>}]"   # F-015-IF-ALLOWLIST-VERDICT
+
+    # ── R-F015-1, level 2: the JOB that contains the step ────────────────────
+    # Located by CONTAINMENT (walk down, remember the current job id, stop at
+    # the step) so a job rename is not a false red. An unfound job yields an
+    # empty key set, which is not the expected set — fail-closed.
+    _w6_jobid=$(awk '
+      /^  [a-zA-Z_][a-zA-Z0-9_-]*:[[:space:]]*$/ { cur = $0; sub(/^[[:space:]]+/, "", cur); sub(/:.*/, "", cur) }
+      $0 == "      - name: Governance - Phase gate check" { print cur; exit }
+    ' "$f")
+    _w6_jobkeys=$(awk -v J="$_w6_jobid" '
+      J != "" && $0 ~ "^  " J ":[[:space:]]*$" { inj = 1; next }
+      inj && /^[^[:space:]]/ { exit }
+      inj && /^  [a-zA-Z_]/ { exit }
+      inj && /^    [a-zA-Z_][a-zA-Z0-9_-]*:/ { k = $0; sub(/^[[:space:]]+/, "", k); sub(/:.*/, "", k); print k }
+    ' "$f" | sort)
+    _w6_jk1=$(printf '%s' "$_w6_jobkeys" | tr '\n' ',')
+    [ "$_w6_jobkeys" = "$W6_EXPECTED_JOBKEYS" ] || w6_job="$w6_job ${f#*/ci/}:${_w6_jobid:-<job not found>}[$_w6_jk1]"   # F-015-JOB-ALLOWLIST-VERDICT
+
+    # ── R-F015-1, level 3: the WORKFLOW's trigger ────────────────────────────
+    _w6_on=$(awk '/^on:[[:space:]]*$/ { o = 1; print; next } o && /^[^[:space:]#]/ { exit } o { print }' "$f" \
+      | sed 's/[[:space:]]*$//' | grep -v '^[[:space:]]*#' | grep -v '^$')
+    _w6_on1=$(printf '%s' "$_w6_on" | tr '\n' '|')
+    [ "$_w6_on" = "$W6_EXPECTED_ON" ] || w6_on="$w6_on ${f#*/ci/}[$_w6_on1]"   # F-015-TRIGGER-ALLOWLIST-VERDICT
   done
 fi
 # Cw6-strict's green is an ABSENCE, and an empty candidate set produces the same
@@ -1545,6 +1601,16 @@ if [ -z "$w6_gating" ]; then
   pass "Cw6-strict-gating (the step's if: is the allowlisted phase-state condition — a step that never runs cannot enforce)"
 else
   fail_ "Cw6-strict-gating" "the phase-gate step's if: is not the allowlisted condition, so the step may be skipped rather than obeyed — in:$w6_gating"
+fi
+if [ -z "$w6_job" ]; then
+  pass "Cw6-strict-job (the job holding the phase-gate step carries only the allowlisted keys: runs-on, steps — no job-level if:, no job-level continue-on-error:)"
+else
+  fail_ "Cw6-strict-job" "a non-allowlisted key on the job that HOLDS the phase-gate step can stop that job running or stop its failure counting — in:$w6_job"
+fi
+if [ -z "$w6_on" ]; then
+  pass "Cw6-strict-trigger (the workflow's on: block is the allowlisted push + pull_request stanza — a workflow that never triggers never runs the gate)"
+else
+  fail_ "Cw6-strict-trigger" "the workflow's on: block is not the allowlisted push + pull_request stanza, so the gate may never run on a change — in:$w6_on"
 fi
 
 # ── Cw16 (walk 2026-08-02 ISSUE-016): the tag-deploy environment trap ───────

--- a/tests/test-f015-tamper-pin-allowlist.sh
+++ b/tests/test-f015-tamper-pin-allowlist.sh
@@ -40,12 +40,19 @@
 #         never even selected for inspection.
 #     M7  `continue-on-error: true` — the Actions-native swallow, plus the new
 #         step-KEY allowlist that catches its unimagined siblings.
+#    M10  `if: false` — the swallow that leaves the run: body byte-identical and
+#         the key set untouched. A step that never runs discards the verdict
+#         more completely than `|| true` ever could, so the if: VALUE is
+#         allowlisted too, and this is the only case that can see it.
 #     M8  DUAL DIRECTION: neuter the allowlist verdict in the pin itself and the
 #         M1 tamper sails through — the pin, not something else, is what caught
 #         it.
 #     M9  the vacuity discriminator earns its place: neuter the scope filter so
 #         zero templates are examined, and Cw6-strict-scope goes red while
 #         Cw6-strict would otherwise pass over an empty set.
+#    M11  DUAL DIRECTION for M10: with the if: verdict neutered, `if: false`
+#         passes the ENTIRE suite — body allowlist, key allowlist, floor and
+#         all. That is M10's watched-RED, made permanent.
 #
 # MUTATION-HARNESS STANDARD (all asserted, none assumed): anchored end-of-line
 #   target patterns; sites==1; exactly-N-lines-changed; every mutant is checked
@@ -90,6 +97,7 @@ PASS_SCOPE='^[[:space:]]*\[PASS\] Cw6-strict-scope[[:space:]]'
 FAIL_COE='^[[:space:]]*\[FAIL\] Cw6-strict-no-coe[[:space:]]'
 FAIL_KEYS='^[[:space:]]*\[FAIL\] Cw6-strict-keys[[:space:]]'
 PASS_KEYS='^[[:space:]]*\[PASS\] Cw6-strict-keys[[:space:]]'
+PASS_GATING='^[[:space:]]*\[PASS\] Cw6-strict-gating[[:space:]]'
 
 # ── The fixture mirror ──────────────────────────────────────────────────────
 # bl147 derives every path from REPO_ROOT = the parent of its own directory, so
@@ -200,7 +208,8 @@ g1_out=$(bash "$BL147" 2>&1); g1_rc=$?
 if [ "$g1_rc" -eq 0 ] \
    && printf '%s\n' "$g1_out" | grep -Eq "$PASS_STRICT" \
    && printf '%s\n' "$g1_out" | grep -Eq "$PASS_SCOPE" \
-   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_KEYS"; then
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_KEYS" \
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_GATING"; then
   pass "G1-shipped-templates-still-pass (the real bl147 suite is green on the tracked templates; the allowlist passes all ten)"
 else
   fail_ "G1-shipped-templates-still-pass" "rc=$g1_rc — the hardened pin reds the SHIPPED templates, which is worse than the blacklist it replaced: $(printf '%s\n' "$g1_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
@@ -333,6 +342,27 @@ else
   fail_ "M7-actions-native-swallow" "$MUT_WHY"
 fi
 
+# ── M10: the swallow that leaves the body untouched ─────────────────────────
+# A key allowlist alone would have missed this: `if:` is a PERMITTED key, and
+# the run: body is byte-identical to the allowlisted script. A step that never
+# runs discards the verdict more completely than `|| true` ever could, so the
+# if: VALUE is allowlisted too.
+t_m10() { sed "s#^        if: hashFiles('\.claude/phase-state\.json') != ''\$#        if: false#"; }
+echo "=== M10-unenumerated-step-never-runs ==="
+if prep_mutant m10 templates/pipelines/ci/github/kotlin.yml \
+     "^        if: hashFiles\('\.claude/phase-state\.json'\) != ''\$" t_m10 1 1; then
+  m10_out=$(run_pin "$MK_FIX"); m10_rc=$?
+  if [ "$m10_rc" -ne 0 ] \
+     && printf '%s\n' "$m10_out" | grep -E '^[[:space:]]*\[FAIL\] Cw6-strict-gating[[:space:]]' | grep -Fq github/kotlin.yml \
+     && printf '%s\n' "$m10_out" | grep -Eq "$PASS_STRICT"; then
+    pass "M10-unenumerated-step-never-runs (\`if: false\` leaves the allowlisted body intact and is still caught — by the if: allowlist, which is the only case that can see it)"
+  else
+    fail_ "M10-unenumerated-step-never-runs" "rc=$m10_rc gating=[$(printf '%s\n' "$m10_out" | grep -E 'Cw6-strict-gating' | tr '\n' ' ')] — a step that never runs was graded as enforcing"
+  fi
+else
+  fail_ "M10-unenumerated-step-never-runs" "$MUT_WHY"
+fi
+
 # ── M8: DUAL DIRECTION — neuter the pin, the tamper sails through ───────────
 # Everything above shows tampers going red. This shows WHY: remove the
 # allowlist's verdict line from the pin and M1's tamper stops being detected.
@@ -359,6 +389,32 @@ if prep_mutant m8 "$BL147_REL" \
   fi
 else
   fail_ "M8-neutered-pin-lets-the-tamper-through" "$MUT_WHY"
+fi
+
+# ── M11: DUAL DIRECTION for the if: allowlist ───────────────────────────────
+# The other half of M10, and its watched-RED made permanent: with the if:
+# verdict neutered, `if: false` passes the whole suite — body allowlist, key
+# allowlist, count floor and all. Nothing else in bl147 can see it.
+t_m11() { sed 's@^\([[:space:]]*\)\[ "\$_w6_if" = "\$W6_EXPECTED_IF" \].*# F-015-IF-ALLOWLIST-VERDICT$@\1:@'; }
+echo "=== M11-neutered-if-allowlist-lets-a-dead-step-through ==="
+if prep_mutant m11 "$BL147_REL" \
+     '^[[:space:]]*\[ "\$_w6_if" = "\$W6_EXPECTED_IF" \].*# F-015-IF-ALLOWLIST-VERDICT$' \
+     t_m11 1 1; then
+  m11_tmpl="$MK_FIX/templates/pipelines/ci/github/kotlin.yml"
+  m11_sites=$(grep -Ec "^        if: hashFiles\('\.claude/phase-state\.json'\) != ''\$" "$m11_tmpl")
+  t_m10 < "$m11_tmpl" > "$TOPTMP/m11-tampered"
+  cat "$TOPTMP/m11-tampered" > "$m11_tmpl"
+  m11_out=$(run_pin "$MK_FIX"); m11_rc=$?
+  if [ "$m11_sites" -eq 1 ] \
+     && grep -Fq '        if: false' "$m11_tmpl" \
+     && [ "$m11_rc" -eq 0 ] \
+     && printf '%s\n' "$m11_out" | grep -Eq "$PASS_SCOPE"; then
+    pass "M11-neutered-if-allowlist-lets-a-dead-step-through (with the if: verdict gone, a step that never runs passes the ENTIRE suite — the if: allowlist is the only thing standing between the tree and that swallow)"
+  else
+    fail_ "M11-neutered-if-allowlist-lets-a-dead-step-through" "sites=$m11_sites rc=$m11_rc — the neutered pin did not go quiet, so M10 may be measuring another case: $(printf '%s\n' "$m11_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
+  fi
+else
+  fail_ "M11-neutered-if-allowlist-lets-a-dead-step-through" "$MUT_WHY"
 fi
 
 # ── M9: the absence-discriminator earns its place ───────────────────────────

--- a/tests/test-f015-tamper-pin-allowlist.sh
+++ b/tests/test-f015-tamper-pin-allowlist.sh
@@ -54,6 +54,20 @@
 #         passes the ENTIRE suite — body allowlist, key allowlist, floor and
 #         all. That is M10's watched-RED, made permanent.
 #
+# R-F015-1 (review, 2026-08-09) — THE SAME DEFECT ONE LEVEL UP. A step-scoped
+#   pin cannot see a JOB that never runs or a WORKFLOW that never triggers, and
+#   those discard the verdict exactly as completely as `if: false` on the step
+#   did. Measured before the fix: job-level `if: false` passed all 82 checks at
+#   rc=0, and `on:` gutted to `workflow_dispatch` only passed all 82 at rc=0.
+#     A/RA  job-level `if: false`
+#     C/RC  job-level `if: ${{ github.event_name == 'never' }}` — before the fix
+#           this was caught only INCIDENTALLY, by an unrelated pin that objects
+#           to `${{ }}` (Cg8-env-indirection). RC therefore asserts the
+#           Cw6-strict-job verdict BY NAME: an incidental catch is not a pin.
+#     B/RB  `on:` reduced to `workflow_dispatch:` — the workflow stops running
+#           on push and pull_request, so the gate never executes on any change.
+#     RA2/RB2  dual direction for each new verdict line.
+#
 # MUTATION-HARNESS STANDARD (all asserted, none assumed): anchored end-of-line
 #   target patterns; sites==1; exactly-N-lines-changed; every mutant is checked
 #   with `bash -n` (for a YAML template, the extracted run: body is what gets
@@ -98,6 +112,10 @@ FAIL_COE='^[[:space:]]*\[FAIL\] Cw6-strict-no-coe[[:space:]]'
 FAIL_KEYS='^[[:space:]]*\[FAIL\] Cw6-strict-keys[[:space:]]'
 PASS_KEYS='^[[:space:]]*\[PASS\] Cw6-strict-keys[[:space:]]'
 PASS_GATING='^[[:space:]]*\[PASS\] Cw6-strict-gating[[:space:]]'
+FAIL_JOB='^[[:space:]]*\[FAIL\] Cw6-strict-job[[:space:]]'
+PASS_JOB='^[[:space:]]*\[PASS\] Cw6-strict-job[[:space:]]'
+FAIL_TRIGGER='^[[:space:]]*\[FAIL\] Cw6-strict-trigger[[:space:]]'
+PASS_TRIGGER='^[[:space:]]*\[PASS\] Cw6-strict-trigger[[:space:]]'
 
 # ── The fixture mirror ──────────────────────────────────────────────────────
 # bl147 derives every path from REPO_ROOT = the parent of its own directory, so
@@ -209,7 +227,9 @@ if [ "$g1_rc" -eq 0 ] \
    && printf '%s\n' "$g1_out" | grep -Eq "$PASS_STRICT" \
    && printf '%s\n' "$g1_out" | grep -Eq "$PASS_SCOPE" \
    && printf '%s\n' "$g1_out" | grep -Eq "$PASS_KEYS" \
-   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_GATING"; then
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_GATING" \
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_JOB" \
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_TRIGGER"; then
   pass "G1-shipped-templates-still-pass (the real bl147 suite is green on the tracked templates; the allowlist passes all ten)"
 else
   fail_ "G1-shipped-templates-still-pass" "rc=$g1_rc — the hardened pin reds the SHIPPED templates, which is worse than the blacklist it replaced: $(printf '%s\n' "$g1_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
@@ -361,6 +381,121 @@ if prep_mutant m10 templates/pipelines/ci/github/kotlin.yml \
   fi
 else
   fail_ "M10-unenumerated-step-never-runs" "$MUT_WHY"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# R-F015-1 — the class one level up: the JOB and the WORKFLOW
+# ════════════════════════════════════════════════════════════════════════════
+# The step allowlist is necessary and not sufficient. A step that runs perfectly
+# inside a job that never starts, or a workflow that never triggers on a change,
+# discards the verdict as completely as `|| true` ever did — and by exactly the
+# argument that earned Cw6-strict-gating its place at the step level.
+#
+# assert_caught_by <case> <fixture> <FAIL-ere> <case-label> <template> <why>
+# Same "right reason" discipline as assert_caught, parameterised on which of the
+# new verdicts must be the one that fires.
+assert_caught_by() {
+  local case_name="$1" fx="$2" fail_ere="$3" label="$4" tmpl="$5" why="$6"
+  local out rc line
+  out=$(run_pin "$fx"); rc=$?
+  line=$(printf '%s\n' "$out" | grep -E "$fail_ere")
+  if [ "$rc" -ne 0 ] \
+     && [ -n "$line" ] \
+     && printf '%s\n' "$line" | grep -Fq "$tmpl" \
+     && printf '%s\n' "$out" | grep -Eq "$PASS_SCOPE"; then
+    pass "$case_name ($why — $label names $tmpl)"
+  else
+    fail_ "$case_name" "rc=$rc; $label FAIL line=[${line:-<none>}]; scope=[$(printf '%s\n' "$out" | grep -E 'Cw6-strict-scope' | tr '\n' ' ')] — not caught by $label for the right reason"
+  fi
+}
+
+# The job header the tamper attaches to. Anchored, and `test:` is the job that
+# holds the phase-gate step in all ten templates (RA0 proves that rather than
+# assuming it).
+JOB_ERE='^  test:$'
+
+t_ra() { awk '{ print } /^  test:$/ { print "    if: false" }'; }
+echo "=== RA-job-level-if-false ==="
+if prep_mutant ra templates/pipelines/ci/github/python.yml "$JOB_ERE" t_ra 0 1; then
+  assert_caught_by RA-job-level-if-false "$MK_FIX" "$FAIL_JOB" Cw6-strict-job github/python.yml \
+    'reviewer case A: the JOB never runs, so a perfectly-allowlisted step never executes'
+else
+  fail_ "RA-job-level-if-false" "$MUT_WHY"
+fi
+
+# Reviewer case C. Before the fix this was caught only incidentally, by a pin
+# that objects to `${{ }}` appearing where it does not belong — so the assertion
+# here is deliberately on Cw6-strict-job BY NAME. An incidental catch is not a
+# pin: it moves the moment the incidental pin changes.
+t_rc() { awk '{ print } /^  test:$/ { print "    if: ${{ github.event_name == '\''never'\'' }}" }'; }
+echo "=== RC-job-level-if-expression ==="
+if prep_mutant rc templates/pipelines/ci/github/csharp.yml "$JOB_ERE" t_rc 0 1; then
+  assert_caught_by RC-job-level-if-expression "$MK_FIX" "$FAIL_JOB" Cw6-strict-job github/csharp.yml \
+    'reviewer case C: an always-false job condition, caught on the job allowlist rather than incidentally on a ${{ }} pin'
+else
+  fail_ "RC-job-level-if-expression" "$MUT_WHY"
+fi
+
+# Reviewer case B. The `on:` block is replaced wholesale, so the site count is
+# taken on the block opener and the delta is the whole stanza — declared
+# explicitly rather than waved at.
+t_rb() { awk '
+  /^on:$/ { print; print "  workflow_dispatch:"; skip = 1; next }
+  skip && (/^[^[:space:]]/ || $0 == "") { skip = 0 }
+  skip { next }
+  { print }
+'; }
+echo "=== RB-workflow-never-triggers ==="
+if prep_mutant rb templates/pipelines/ci/github/go.yml '^on:$' t_rb 4 1; then
+  assert_caught_by RB-workflow-never-triggers "$MK_FIX" "$FAIL_TRIGGER" Cw6-strict-trigger github/go.yml \
+    'reviewer case B: the WORKFLOW no longer runs on push or pull_request, so the gate never executes on any change'
+else
+  fail_ "RB-workflow-never-triggers" "$MUT_WHY"
+fi
+
+# ── RA2 / RB2: DUAL DIRECTION for each new verdict ──────────────────────────
+t_ra2() { sed 's@^\([[:space:]]*\)\[ "\$_w6_jobkeys" = "\$W6_EXPECTED_JOBKEYS" \].*# F-015-JOB-ALLOWLIST-VERDICT$@\1:@'; }
+echo "=== RA2-neutered-job-allowlist-lets-a-dead-job-through ==="
+if prep_mutant ra2 "$BL147_REL" \
+     '^[[:space:]]*\[ "\$_w6_jobkeys" = "\$W6_EXPECTED_JOBKEYS" \].*# F-015-JOB-ALLOWLIST-VERDICT$' \
+     t_ra2 1 1; then
+  ra2_tmpl="$MK_FIX/templates/pipelines/ci/github/python.yml"
+  ra2_sites=$(grep -Ec "$JOB_ERE" "$ra2_tmpl")
+  t_ra < "$ra2_tmpl" > "$TOPTMP/ra2-tampered"
+  cat "$TOPTMP/ra2-tampered" > "$ra2_tmpl"
+  ra2_out=$(run_pin "$MK_FIX"); ra2_rc=$?
+  if [ "$ra2_sites" -eq 1 ] \
+     && grep -Fq '    if: false' "$ra2_tmpl" \
+     && [ "$ra2_rc" -eq 0 ] \
+     && printf '%s\n' "$ra2_out" | grep -Eq "$PASS_SCOPE"; then
+    pass "RA2-neutered-job-allowlist-lets-a-dead-job-through (with the job verdict gone, a job that never runs passes the ENTIRE suite — reproducing the pre-fix measurement exactly)"
+  else
+    fail_ "RA2-neutered-job-allowlist-lets-a-dead-job-through" "sites=$ra2_sites rc=$ra2_rc — the neutered pin did not go quiet: $(printf '%s\n' "$ra2_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
+  fi
+else
+  fail_ "RA2-neutered-job-allowlist-lets-a-dead-job-through" "$MUT_WHY"
+fi
+
+t_rb2() { sed 's@^\([[:space:]]*\)\[ "\$_w6_on" = "\$W6_EXPECTED_ON" \].*# F-015-TRIGGER-ALLOWLIST-VERDICT$@\1:@'; }
+echo "=== RB2-neutered-trigger-allowlist-lets-a-dead-workflow-through ==="
+if prep_mutant rb2 "$BL147_REL" \
+     '^[[:space:]]*\[ "\$_w6_on" = "\$W6_EXPECTED_ON" \].*# F-015-TRIGGER-ALLOWLIST-VERDICT$' \
+     t_rb2 1 1; then
+  rb2_tmpl="$MK_FIX/templates/pipelines/ci/github/go.yml"
+  rb2_sites=$(grep -Ec '^on:$' "$rb2_tmpl")
+  t_rb < "$rb2_tmpl" > "$TOPTMP/rb2-tampered"
+  cat "$TOPTMP/rb2-tampered" > "$rb2_tmpl"
+  rb2_out=$(run_pin "$MK_FIX"); rb2_rc=$?
+  if [ "$rb2_sites" -eq 1 ] \
+     && ! grep -q '^  push:$' "$rb2_tmpl" \
+     && [ "$rb2_rc" -eq 0 ] \
+     && printf '%s\n' "$rb2_out" | grep -Eq "$PASS_SCOPE"; then
+    pass "RB2-neutered-trigger-allowlist-lets-a-dead-workflow-through (with the trigger verdict gone, a workflow that never runs on push passes the ENTIRE suite — reproducing the pre-fix measurement exactly)"
+  else
+    fail_ "RB2-neutered-trigger-allowlist-lets-a-dead-workflow-through" "sites=$rb2_sites rc=$rb2_rc — the neutered pin did not go quiet: $(printf '%s\n' "$rb2_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
+  fi
+else
+  fail_ "RB2-neutered-trigger-allowlist-lets-a-dead-workflow-through" "$MUT_WHY"
 fi
 
 # ── M8: DUAL DIRECTION — neuter the pin, the tamper sails through ───────────

--- a/tests/test-f015-tamper-pin-allowlist.sh
+++ b/tests/test-f015-tamper-pin-allowlist.sh
@@ -1,0 +1,388 @@
+#!/usr/bin/env bash
+# tests/test-f015-tamper-pin-allowlist.sh — the detector-of-the-detector for
+# F-015 (Karl, 2026-08-09: "Harden it" — option (a)).
+#
+# WHY THIS EXISTS
+#   BUG-009 shipped ten correct, execution-verified CI templates: each runs the
+#   phase gate with a BARE invocation, so the gate's exit code decides the step.
+#   The regression detector meant to keep it that way — Cw6-strict in
+#   tests/test-bl147-ci-template-integrity.sh — matched swallow shapes with a
+#   BLACKLIST, `(\|\||;)\s*(echo|true|:)`. BUG-009's confirm review (finding
+#   R-C1) proved by mutation that
+#       bash scripts/check-phase-gate.sh || exit 0
+#   walks straight through the entire bl147 suite: `exit` is simply not in the
+#   alternation. Blacklists lose to creativity.
+#
+#   Cw6-strict is now an ALLOWLIST: the phase-gate step's `run:` body must be
+#   the known-good script VERBATIM (indentation, blank lines and whole-line
+#   comments normalized away — the only three edits that cannot change what
+#   bash executes). Anything else fails, including shapes nobody enumerated.
+#
+# WHAT THIS SUITE PROVES — and the reason it is a separate file: the claim is
+#   about the DETECTOR's behaviour under tampering, which can only be measured
+#   by running the real bl147 suite against tampered copies of the real
+#   templates. Asserting it inside bl147 would be the pin grading itself.
+#     G1  the ten SHIPPED templates still pass — the real suite, the real tree.
+#         A hardened pin that reds correct templates is worse than the
+#         blacklist it replaced, so this case comes first.
+#     G2  the fixture mirror is faithful (baseline copy passes identically).
+#     G3  the allowlist tolerates edits that cannot change execution (a comment
+#         inside the run body) — it is strict, not superstitious.
+#     M1  `|| exit 0`            — the shape R-C1 proved the blacklist missed.
+#     M2  `| cat`                — pipe; the pipeline's status is cat's.
+#     M3  `&`                    — background; the step exits 0 immediately.
+#     M4  `if ! …; then …; fi`   — wrapper; the compound returns 0.
+#     M5  a trailing command AFTER the invocation — last command wins. This one
+#         is invisible to ANY pin scoped to the invocation LINE, which is why
+#         the allowlist is over the whole body.
+#     M6  `sh …; exit 0`         — a different interpreter. The old pin's
+#         pre-filter was `bash scripts/check-phase-gate\.sh`, so this shape was
+#         never even selected for inspection.
+#     M7  `continue-on-error: true` — the Actions-native swallow, plus the new
+#         step-KEY allowlist that catches its unimagined siblings.
+#     M8  DUAL DIRECTION: neuter the allowlist verdict in the pin itself and the
+#         M1 tamper sails through — the pin, not something else, is what caught
+#         it.
+#     M9  the vacuity discriminator earns its place: neuter the scope filter so
+#         zero templates are examined, and Cw6-strict-scope goes red while
+#         Cw6-strict would otherwise pass over an empty set.
+#
+# MUTATION-HARNESS STANDARD (all asserted, none assumed): anchored end-of-line
+#   target patterns; sites==1; exactly-N-lines-changed; every mutant is checked
+#   with `bash -n` (for a YAML template, the extracted run: body is what gets
+#   parsed — a mutant that merely breaks the shell proves nothing); a FRESH
+#   fixture per mutant, named after the mutant and never after a counter; and
+#   the harness never chmods, never writes, and never copies over anything in
+#   the tracked tree — the mirror is symlinks plus one copy of templates/.
+#
+# REGISTRATION: no init.sh, not an aggregator -> BOTH the aggregator
+# (tests/full-project-test-suite.sh) and the tests.yml unit list.
+# Hermetic: reads tracked files, writes only under mktemp -d. bash-3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BL147_REL="tests/test-bl147-ci-template-integrity.sh"
+BL147="$REPO_ROOT/$BL147_REL"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 - $2"; FAILED=$((FAILED + 1)); }
+
+if [ ! -f "$BL147" ]; then
+  echo "  [FAIL] F0-target-present - $BL147_REL is missing; every case below would be vacuous"
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT
+
+# The exact case-line greps. `Cw6-strict-scope` contains `Cw6-strict` as a
+# prefix, so every predicate below matches the case name plus the SPACE that
+# separates it from fail_()'s em dash.
+FAIL_STRICT='^[[:space:]]*\[FAIL\] Cw6-strict[[:space:]]'
+PASS_STRICT='^[[:space:]]*\[PASS\] Cw6-strict[[:space:]]'
+FAIL_SCOPE='^[[:space:]]*\[FAIL\] Cw6-strict-scope[[:space:]]'
+PASS_SCOPE='^[[:space:]]*\[PASS\] Cw6-strict-scope[[:space:]]'
+FAIL_COE='^[[:space:]]*\[FAIL\] Cw6-strict-no-coe[[:space:]]'
+FAIL_KEYS='^[[:space:]]*\[FAIL\] Cw6-strict-keys[[:space:]]'
+PASS_KEYS='^[[:space:]]*\[PASS\] Cw6-strict-keys[[:space:]]'
+
+# ── The fixture mirror ──────────────────────────────────────────────────────
+# bl147 derives every path from REPO_ROOT = the parent of its own directory, so
+# a mirror is just a directory whose children look like the repo's. Everything
+# except templates/ and tests/ is SYMLINKED: no copy means no mode to get wrong
+# and no tracked byte at risk (a scratch script's hard chmod silently changed a
+# tracked file's mode twice this wave). templates/ is a real copy because the
+# mutants edit it; tests/ holds a copy of the pin suite because M8 and M9 edit
+# the SUITE.
+mk_fix() {  # mk_fix <name> -> sets MK_FIX to the fixture root
+  local name="$1"
+  MK_FIX="$TOPTMP/fx-$name"
+  rm -rf "$MK_FIX"
+  mkdir -p "$MK_FIX/tests" || return 1
+  local e base
+  for e in "$REPO_ROOT"/* "$REPO_ROOT"/.github; do
+    base="${e##*/}"
+    case "$base" in templates|tests) continue ;; esac
+    [ -e "$e" ] || continue
+    ln -s "$e" "$MK_FIX/$base" || return 1
+  done
+  cp -R "$REPO_ROOT/templates" "$MK_FIX/templates" || return 1
+  cp "$BL147" "$MK_FIX/$BL147_REL" || return 1
+  return 0
+}
+
+run_pin() {  # run_pin <fixture-root> -> stdout is the suite's output; rc is its exit code
+  bash "$1/$BL147_REL" 2>&1
+}
+
+# ── The mutation applier ────────────────────────────────────────────────────
+# prep_mutant <name> <relpath> <target-ERE> <transform-fn> <exp-removed> <exp-added>
+# On success sets MK_FIX to a fresh, mutated fixture and returns 0. On failure
+# sets MUT_WHY and returns 1 — the caller reports it as a FAILED case, never as
+# a skip: an unapplied mutant proves nothing, and silence would look like a pass.
+MUT_WHY=""
+prep_mutant() {
+  local name="$1" rel="$2" ere="$3" fn="$4" exp_rm="$5" exp_add="$6"
+  MUT_WHY=""
+  mk_fix "$name" || { MUT_WHY="could not build the fixture mirror"; return 1; }
+  local tgt="$MK_FIX/$rel"
+  local orig="$TOPTMP/orig-$name"
+  [ -f "$tgt" ] || { MUT_WHY="$rel is not in the fixture"; return 1; }
+  cp "$tgt" "$orig" || { MUT_WHY="could not snapshot $rel"; return 1; }
+
+  # sites==1: an anchored pattern that matches twice would mutate two places,
+  # and one that matches zero times would mutate nothing while the case still
+  # ran.
+  local sites
+  sites=$(grep -Ec "$ere" "$orig")
+  if [ "$sites" -ne 1 ]; then
+    MUT_WHY="sites==$sites for /$ere/ in $rel (expected exactly 1) — the mutant is ambiguous or vacuous"
+    return 1
+  fi
+
+  # Write THROUGH the existing inode (cat >) rather than replacing it, so the
+  # fixture file keeps its mode.
+  "$fn" < "$orig" > "$TOPTMP/new-$name" || { MUT_WHY="the transform failed"; return 1; }
+  cat "$TOPTMP/new-$name" > "$tgt" || { MUT_WHY="could not write the mutant"; return 1; }
+
+  local n_rm n_add
+  n_rm=$(diff "$orig" "$tgt" | grep -c '^<')
+  n_add=$(diff "$orig" "$tgt" | grep -c '^>')
+  if [ "$n_rm" -ne "$exp_rm" ] || [ "$n_add" -ne "$exp_add" ]; then
+    MUT_WHY="the edit changed $n_rm removed / $n_add added lines (expected $exp_rm / $exp_add) — not the single-line mutation this case describes"
+    return 1
+  fi
+
+  # `bash -n` on every mutant. For a .sh that is the file; for a CI template it
+  # is the phase-gate step's run: body, dedented — the actual shell the runner
+  # would execute. A mutant that is not valid shell proves nothing.
+  local bn="$TOPTMP/bn-$name"
+  case "$rel" in
+    *.sh)
+      if ! bash -n "$tgt" 2>"$bn"; then
+        MUT_WHY="the mutated $rel is not valid bash: $(tr '\n' ' ' < "$bn")"
+        return 1
+      fi
+      ;;
+    *.yml)
+      awk '
+        /^      - name: Governance - Phase gate check$/ { inside = 1; next }
+        inside && /^      - name: / { exit }
+        inside && /^[[:space:]]*run:[[:space:]]*\|/ { body = 1; next }
+        body { print }
+      ' "$tgt" | sed 's/^[[:space:]]*//' > "$TOPTMP/body-$name.sh"
+      if [ ! -s "$TOPTMP/body-$name.sh" ]; then
+        MUT_WHY="the mutant left no extractable run: body — the case would measure the extraction, not the pin"
+        return 1
+      fi
+      if ! bash -n "$TOPTMP/body-$name.sh" 2>"$bn"; then
+        MUT_WHY="the mutated run: body is not valid bash, so the tamper is a typo rather than a swallow: $(tr '\n' ' ' < "$bn")"
+        return 1
+      fi
+      ;;
+  esac
+  return 0
+}
+
+# The one line every template shares, anchored at both ends.
+INV_ERE='^          bash scripts/check-phase-gate\.sh$'
+
+# ── G1: the SHIPPED templates, the REAL suite, the REAL tree ────────────────
+# First, because the whole risk of hardening a pin is that it reds the correct
+# thing. This is not a fixture: it is the tracked tree as it will be merged.
+echo "=== G1-shipped-templates-still-pass ==="
+g1_out=$(bash "$BL147" 2>&1); g1_rc=$?
+if [ "$g1_rc" -eq 0 ] \
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_STRICT" \
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_SCOPE" \
+   && printf '%s\n' "$g1_out" | grep -Eq "$PASS_KEYS"; then
+  pass "G1-shipped-templates-still-pass (the real bl147 suite is green on the tracked templates; the allowlist passes all ten)"
+else
+  fail_ "G1-shipped-templates-still-pass" "rc=$g1_rc — the hardened pin reds the SHIPPED templates, which is worse than the blacklist it replaced: $(printf '%s\n' "$g1_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
+fi
+
+# ── G2: the mirror is faithful ──────────────────────────────────────────────
+echo "=== G2-fixture-mirror-is-faithful ==="
+if mk_fix baseline; then
+  g2_out=$(run_pin "$MK_FIX"); g2_rc=$?
+  if [ "$g2_rc" -eq 0 ] && printf '%s\n' "$g2_out" | grep -Eq "$PASS_STRICT"; then
+    pass "G2-fixture-mirror-is-faithful (an untampered mirror reproduces the real green run — every M-case's signal is the tamper)"
+  else
+    fail_ "G2-fixture-mirror-is-faithful" "rc=$g2_rc — the mirror is not green before tampering, so no mutant below is attributable: $(printf '%s\n' "$g2_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
+  fi
+else
+  fail_ "G2-fixture-mirror-is-faithful" "could not build the mirror"
+fi
+
+# ── G3: strict, not superstitious ───────────────────────────────────────────
+# A comment line inside the run: body cannot change what bash executes, so the
+# allowlist must accept it. Without this case, "the pin is an allowlist" and
+# "the pin forbids all edits" are indistinguishable.
+t_g3() { awk '/^          bash scripts\/check-phase-gate\.sh$/ { print "          # a note for the next reader" } { print }'; }
+echo "=== G3-inert-comment-tolerated ==="
+if prep_mutant g3 templates/pipelines/ci/github/other.yml "$INV_ERE" t_g3 0 1; then
+  g3_out=$(run_pin "$MK_FIX"); g3_rc=$?
+  if [ "$g3_rc" -eq 0 ] && printf '%s\n' "$g3_out" | grep -Eq "$PASS_STRICT"; then
+    pass "G3-inert-comment-tolerated (a comment in the run: body is not a deviation — the allowlist normalizes exactly what cannot execute)"
+  else
+    fail_ "G3-inert-comment-tolerated" "rc=$g3_rc — the pin reds on an inert comment; it is a freeze, not an allowlist: $(printf '%s\n' "$g3_out" | grep -E '\[FAIL\]' | tr '\n' ' ')"
+  fi
+else
+  fail_ "G3-inert-comment-tolerated" "$MUT_WHY"
+fi
+
+# ── The tamper cases ────────────────────────────────────────────────────────
+# assert_caught <case> <fixture-root> <template-suffix> <human-why>
+# Caught for the RIGHT REASON: rc non-zero is not enough (the suite has ~40
+# other cases). The Cw6-strict FAIL line itself must name the tampered
+# template, and Cw6-strict-scope must still be green — a red scope case would
+# mean the pin examined nothing and the FAIL came from the vacuity guard.
+assert_caught() {
+  local case_name="$1" fx="$2" tmpl="$3" why="$4"
+  local out rc
+  out=$(run_pin "$fx"); rc=$?
+  local line
+  line=$(printf '%s\n' "$out" | grep -E "$FAIL_STRICT")
+  if [ "$rc" -ne 0 ] \
+     && [ -n "$line" ] \
+     && printf '%s\n' "$line" | grep -Fq "$tmpl" \
+     && printf '%s\n' "$out" | grep -Eq "$PASS_SCOPE"; then
+    pass "$case_name ($why — Cw6-strict names $tmpl)"
+  else
+    fail_ "$case_name" "rc=$rc; Cw6-strict FAIL line=[${line:-<none>}]; scope-case=[$(printf '%s\n' "$out" | grep -E 'Cw6-strict-scope' | tr '\n' ' ')] — the tamper was not caught by the allowlist for the right reason"
+  fi
+}
+
+t_m1() { sed 's#^          bash scripts/check-phase-gate\.sh$#          bash scripts/check-phase-gate.sh || exit 0#'; }
+echo "=== M1-unenumerated-or-exit ==="
+if prep_mutant m1 templates/pipelines/ci/github/swift.yml "$INV_ERE" t_m1 1 1; then
+  assert_caught M1-unenumerated-or-exit "$MK_FIX" github/swift.yml \
+    "\`|| exit 0\` — the exact shape R-C1 proved the blacklist let through"
+else
+  fail_ "M1-unenumerated-or-exit" "$MUT_WHY"
+fi
+
+t_m2() { sed 's#^          bash scripts/check-phase-gate\.sh$#          bash scripts/check-phase-gate.sh | cat#'; }
+echo "=== M2-unenumerated-pipe ==="
+if prep_mutant m2 templates/pipelines/ci/github/python.yml "$INV_ERE" t_m2 1 1; then
+  assert_caught M2-unenumerated-pipe "$MK_FIX" github/python.yml \
+    "a pipe — the pipeline reports cat's status, never the gate's"
+else
+  fail_ "M2-unenumerated-pipe" "$MUT_WHY"
+fi
+
+# `&` is the whole match in a sed replacement, hence the backslash.
+t_m3() { sed 's#^          bash scripts/check-phase-gate\.sh$#          bash scripts/check-phase-gate.sh \&#'; }
+echo "=== M3-unenumerated-background ==="
+if prep_mutant m3 templates/pipelines/ci/github/go.yml "$INV_ERE" t_m3 1 1; then
+  assert_caught M3-unenumerated-background "$MK_FIX" github/go.yml \
+    "a trailing \`&\` — the gate is backgrounded and the step exits 0 before it decides anything"
+else
+  fail_ "M3-unenumerated-background" "$MUT_WHY"
+fi
+
+t_m4() { sed 's#^          bash scripts/check-phase-gate\.sh$#          if ! bash scripts/check-phase-gate.sh; then echo "::warning::phase gate soft-failed"; fi#'; }
+echo "=== M4-unenumerated-wrapper ==="
+if prep_mutant m4 templates/pipelines/ci/github/rust.yml "$INV_ERE" t_m4 1 1; then
+  assert_caught M4-unenumerated-wrapper "$MK_FIX" github/rust.yml \
+    "an \`if !\` wrapper — the compound command succeeds however the gate votes"
+else
+  fail_ "M4-unenumerated-wrapper" "$MUT_WHY"
+fi
+
+t_m5() { awk '{ print } /^          bash scripts\/check-phase-gate\.sh$/ { print "          echo \"phase gate step complete\"" }'; }
+echo "=== M5-unenumerated-trailing-command ==="
+if prep_mutant m5 templates/pipelines/ci/github/typescript.yml "$INV_ERE" t_m5 0 1; then
+  assert_caught M5-unenumerated-trailing-command "$MK_FIX" github/typescript.yml \
+    "a command AFTER the invocation — the script's status is the LAST command's, and no pin scoped to the invocation line can see this"
+else
+  fail_ "M5-unenumerated-trailing-command" "$MUT_WHY"
+fi
+
+t_m6() { sed 's#^          bash scripts/check-phase-gate\.sh$#          sh scripts/check-phase-gate.sh; exit 0#'; }
+echo "=== M6-unenumerated-interpreter-swap ==="
+if prep_mutant m6 templates/pipelines/ci/github/dart.yml "$INV_ERE" t_m6 1 1; then
+  assert_caught M6-unenumerated-interpreter-swap "$MK_FIX" github/dart.yml \
+    "a different interpreter plus \`exit 0\` — the old pin's pre-filter required the literal \`bash \`, so it never even inspected this line"
+else
+  fail_ "M6-unenumerated-interpreter-swap" "$MUT_WHY"
+fi
+
+# ── M7: the Actions-native swallow and the step-KEY allowlist ───────────────
+# `continue-on-error: true` grades a red step GREEN without touching the shell
+# at all. The named pin catches that one key; the key allowlist catches the
+# ones nobody has thought of, because only `if`, `env` and `run` are permitted.
+t_m7() { awk '{ print } /^      - name: Governance - Phase gate check$/ { print "        continue-on-error: true" }'; }
+echo "=== M7-actions-native-swallow ==="
+if prep_mutant m7 templates/pipelines/ci/github/java.yml \
+     '^      - name: Governance - Phase gate check$' t_m7 0 1; then
+  m7_out=$(run_pin "$MK_FIX"); m7_rc=$?
+  if [ "$m7_rc" -ne 0 ] \
+     && printf '%s\n' "$m7_out" | grep -E "$FAIL_COE" | grep -Fq github/java.yml \
+     && printf '%s\n' "$m7_out" | grep -E "$FAIL_KEYS" | grep -Fq 'continue-on-error'; then
+    pass "M7-actions-native-swallow (the named pin AND the step-key allowlist both red — an unimagined step key would be caught by the second even if the first never learns its name)"
+  else
+    fail_ "M7-actions-native-swallow" "rc=$m7_rc coe=[$(printf '%s\n' "$m7_out" | grep -E 'Cw6-strict-no-coe' | tr '\n' ' ')] keys=[$(printf '%s\n' "$m7_out" | grep -E 'Cw6-strict-keys' | tr '\n' ' ')]"
+  fi
+else
+  fail_ "M7-actions-native-swallow" "$MUT_WHY"
+fi
+
+# ── M8: DUAL DIRECTION — neuter the pin, the tamper sails through ───────────
+# Everything above shows tampers going red. This shows WHY: remove the
+# allowlist's verdict line from the pin and M1's tamper stops being detected.
+# Without this leg, "the tamper is caught" and "something else in the suite is
+# red" are the same observation.
+t_m8() { sed 's@^\([[:space:]]*\)if \[ "\$_w6_body" != "\$W6_EXPECTED_BODY" \]; then.*# F-015-BODY-ALLOWLIST-VERDICT$@\1if false; then@'; }
+echo "=== M8-neutered-pin-lets-the-tamper-through ==="
+if prep_mutant m8 "$BL147_REL" \
+     '^[[:space:]]*if \[ "\$_w6_body" != "\$W6_EXPECTED_BODY" \]; then.*# F-015-BODY-ALLOWLIST-VERDICT$' \
+     t_m8 1 1; then
+  # Apply M1's tamper on top of the neutered pin, in the SAME fixture.
+  m8_tmpl="$MK_FIX/templates/pipelines/ci/github/swift.yml"
+  m8_sites=$(grep -Ec "$INV_ERE" "$m8_tmpl")
+  t_m1 < "$m8_tmpl" > "$TOPTMP/m8-tampered"
+  cat "$TOPTMP/m8-tampered" > "$m8_tmpl"
+  m8_out=$(run_pin "$MK_FIX"); m8_rc=$?
+  if [ "$m8_sites" -eq 1 ] \
+     && grep -Fq 'bash scripts/check-phase-gate.sh || exit 0' "$m8_tmpl" \
+     && printf '%s\n' "$m8_out" | grep -Eq "$PASS_STRICT" \
+     && printf '%s\n' "$m8_out" | grep -Eq "$PASS_SCOPE"; then
+    pass "M8-neutered-pin-lets-the-tamper-through (with the verdict line gone the \`|| exit 0\` tamper passes — the allowlist is load-bearing, exactly as the blacklist was not)"
+  else
+    fail_ "M8-neutered-pin-lets-the-tamper-through" "sites=$m8_sites rc=$m8_rc strict=[$(printf '%s\n' "$m8_out" | grep -E 'Cw6-strict[[:space:]]' | tr '\n' ' ')] — the neutered pin did not go quiet, so the M-cases above may be measuring something else"
+  fi
+else
+  fail_ "M8-neutered-pin-lets-the-tamper-through" "$MUT_WHY"
+fi
+
+# ── M9: the absence-discriminator earns its place ───────────────────────────
+# Cw6-strict's green is an ABSENCE (no template deviated), and an absence is
+# also what an empty candidate set produces. Neuter the scope filter so every
+# template is skipped: Cw6-strict still passes over nothing, and only
+# Cw6-strict-scope tells the truth.
+t_m9() { sed 's@^\([[:space:]]*\)grep -Eq .*# F-015-STRICT-SCOPE-FILTER$@\1continue@'; }
+echo "=== M9-scope-floor-catches-the-empty-set ==="
+if prep_mutant m9 "$BL147_REL" \
+     '^[[:space:]]*grep -Eq .*# F-015-STRICT-SCOPE-FILTER$' t_m9 1 1; then
+  m9_out=$(run_pin "$MK_FIX"); m9_rc=$?
+  if [ "$m9_rc" -ne 0 ] \
+     && printf '%s\n' "$m9_out" | grep -Eq "$FAIL_SCOPE" \
+     && printf '%s\n' "$m9_out" | grep -Eq "$PASS_STRICT"; then
+    pass "M9-scope-floor-catches-the-empty-set (examining nothing makes Cw6-strict pass vacuously and Cw6-strict-scope red — the floor is what distinguishes clean from empty)"
+  else
+    fail_ "M9-scope-floor-catches-the-empty-set" "rc=$m9_rc scope=[$(printf '%s\n' "$m9_out" | grep -E 'Cw6-strict-scope' | tr '\n' ' ')] strict=[$(printf '%s\n' "$m9_out" | grep -E 'Cw6-strict[[:space:]]' | tr '\n' ' ')]"
+  fi
+else
+  fail_ "M9-scope-floor-catches-the-empty-set" "$MUT_WHY"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] || exit 1
+exit 0

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -694,9 +694,12 @@ fi
 # the full "the next push enforces the check" claim — the exact false statement
 # F-015 exists to prevent.
 echo "=== S6m-neutered-allowlist-claims-false-enforcement ==="
+# The verdict is REPLACED by a no-op rather than deleted: it is the only
+# statement in its `if`, and an empty then-block is a syntax error — a mutant
+# that fails to parse would prove nothing about the allowlist.
 if mk_cg_mutant projverdict \
      '^[[:space:]]*wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$' \
-     '/# F-015-PROJECT-ALLOWLIST-VERDICT$/d' 1 0; then
+     's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$@\1:@' 1 1; then
   P="$TOPTMP/s6m"; mk_tok "$P" github ok custom 'bash scripts/check-phase-gate.sh || exit 0'
   out=$(run_tok_with "$CG_MUT" "$P" "$GOOD_TOKEN"); rc=$?
   if [ "$rc" -eq 0 ] \

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -353,9 +353,13 @@ CHECK_GATE="$REPO_ROOT/scripts/check-gate.sh"
 GOOD_TOKEN="ghp_walk006_good"
 BAD_TOKEN="ghp_walk006_bad"
 
-# mk_tok <dir> <host> <auth: ok|unauth> [ci.yml shape: yes|no|swallow]
+# mk_tok <dir> <host> <auth: ok|unauth> [ci.yml shape: yes|no|swallow|emitted|custom] [run-line]
+# `custom` writes an arbitrary phase-gate `run:` line, which is how the F-015
+# allowlist gets driven against swallow shapes nobody enumerated. `emitted` is
+# the byte-shape the templates actually ship (guard + bare invocation, block
+# scalar) — the false-positive guard.
 mk_tok() {
-  local d="$1" host="$2" auth="$3" wired="${4:-yes}"
+  local d="$1" host="$2" auth="$3" wired="${4:-yes}" run_line="${5:-}"
   rm -rf "$d"
   mkdir -p "$d/.claude" "$d/scripts/lib" "$d/scripts/host-drivers" "$d/bin" "$d/stub" \
            "$d/.github/workflows"
@@ -377,6 +381,16 @@ mk_tok() {
       # The pre-R-1 shape a project scaffolded before this fix still carries:
       # the secret IS mapped, but the gate's exit code is thrown away.
       printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "Phase gate check script not found"\n' \
+        > "$d/.github/workflows/ci.yml" ;;
+    emitted)
+      # Byte-for-byte the shape templates/pipelines/ci/github/*.yml ships: the
+      # existence guard AND the bare invocation, in a block scalar. The
+      # allowlist must accept BOTH lines — a detector that warns about the
+      # emitted workflow is worse than one that misses a swallow.
+      printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n        run: |\n          if [ ! -f scripts/check-phase-gate.sh ]; then\n            echo "::error::Phase gate check script missing. Framework integrity compromised."\n            exit 1\n          fi\n          bash scripts/check-phase-gate.sh\n' \
+        > "$d/.github/workflows/ci.yml" ;;
+    custom)
+      printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n        run: %s\n' "$run_line" \
         > "$d/.github/workflows/ci.yml" ;;
     *)
       printf 'jobs:\n  test:\n    steps:\n      - name: Governance - Phase gate check\n' \
@@ -421,6 +435,50 @@ run_tok() {
     ( cd "$d" && PATH="$d/bin:$PATH" GH_STUB_DIR="$d/stub" \
         env SOIF_PROTECTION_TOKEN="$tok" bash "$CHECK_GATE" --setup-ci-token "$@" </dev/null 2>&1 )
   fi
+}
+
+# run_tok_with <script> <dir> <token> [args...] — run_tok against a MUTANT copy
+# of check-gate.sh. The copy is lib-complete (check-gate sources
+# scripts/lib/helpers-core.sh relative to its own path) and the host driver is
+# read from the fixture project, exactly as in the real run.
+run_tok_with() {
+  local s="$1" d="$2" tok="$3"; shift 3
+  ( cd "$d" && PATH="$d/bin:$PATH" GH_STUB_DIR="$d/stub" \
+      env SOIF_PROTECTION_TOKEN="$tok" bash "$s" --setup-ci-token "$@" </dev/null 2>&1 )
+}
+
+# mk_cg_mutant <name> <anchored-marker-ERE> <sed-expr> <exp-removed> <exp-added>
+# Sets CG_MUT to the mutant path on success; sets CG_WHY and returns 1 on
+# failure. Asserts the mutation-harness invariants the same way the rest of this
+# wave does: sites==1, exactly-N-lines-changed, and `bash -n` on the result — a
+# mutant that merely fails to parse proves nothing.
+CG_MUT=""; CG_WHY=""
+mk_cg_mutant() {
+  local name="$1" ere="$2" expr="$3" exp_rm="$4" exp_add="$5"
+  CG_MUT=""; CG_WHY=""
+  local m="$TOPTMP/cgmut-$name"
+  rm -rf "$m"; mkdir -p "$m/scripts/lib" || { CG_WHY="mkdir failed"; return 1; }
+  local sites
+  sites=$(grep -Ec "$ere" "$CHECK_GATE")
+  if [ "$sites" -ne 1 ]; then
+    CG_WHY="sites==$sites for /$ere/ in scripts/check-gate.sh (expected exactly 1) — the mutant is ambiguous or vacuous"
+    return 1
+  fi
+  sed "$expr" "$CHECK_GATE" > "$m/scripts/check-gate.sh" || { CG_WHY="sed failed"; return 1; }
+  cp "$REPO_ROOT/scripts/lib/"*.sh "$m/scripts/lib/" || { CG_WHY="lib copy failed"; return 1; }
+  local n_rm n_add
+  n_rm=$(diff "$CHECK_GATE" "$m/scripts/check-gate.sh" | grep -c '^<')
+  n_add=$(diff "$CHECK_GATE" "$m/scripts/check-gate.sh" | grep -c '^>')
+  if [ "$n_rm" -ne "$exp_rm" ] || [ "$n_add" -ne "$exp_add" ]; then
+    CG_WHY="the edit changed $n_rm removed / $n_add added lines (expected $exp_rm / $exp_add)"
+    return 1
+  fi
+  if ! bash -n "$m/scripts/check-gate.sh" 2>"$m/bn.txt"; then
+    CG_WHY="the mutant is not valid bash: $(tr '\n' ' ' < "$m/bn.txt")"
+    return 1
+  fi
+  CG_MUT="$m/scripts/check-gate.sh"
+  return 0
 }
 
 # ── S1: non-github host → NOT APPLICABLE + the manual per-host steps ───────
@@ -542,11 +600,126 @@ else
   fail_ "S6d-enforcement-claim-is-earned" "rc=$rc: $out"
 fi
 
+# ════════════════════════════════════════════════════════════════════════════
+# S6e-S6k (F-015, Karl 2026-08-09 — "Harden it"): the project-side detector is
+# an ALLOWLIST too.
+#
+# The check above used to ask whether the workflow's gate line matched a list of
+# FORBIDDEN shapes — `\|\|[[:space:]]*(echo|true|:)`. BUG-009's confirm review
+# (R-C1) proved the sibling pin in bl147 let `|| exit 0` through for exactly
+# that reason, and this one was narrower still (no `;` arm at all). So it now
+# states what is PERMITTED: an executable line naming the gate script may be the
+# bare invocation or the existence guard the emitted templates wrap it in, and
+# nothing else. Normalization is limited to what cannot change what bash runs —
+# indentation, a YAML sequence dash, the `run:` key of an inline scalar,
+# trailing blanks.
+#
+# Every case below is a shape nobody enumerated, and each is a REAL discard of
+# the gate's verdict, not a cosmetic difference. The assertion is that the
+# walkthrough refuses for the RIGHT REASON — it names the discarded exit code
+# and withholds the enforcement claim — never merely that it printed something.
+# ════════════════════════════════════════════════════════════════════════════
+
+# assert_swallow_warned <case> <fixture-tag> <run-line> <why>
+assert_swallow_warned() {
+  local case_name="$1" tag="$2" line="$3" why="$4"
+  # The tamper must be valid shell. A shape that cannot run is a typo, and a
+  # detector catching typos would prove nothing about swallows.
+  if ! printf '%s\n' "$line" | bash -n 2>"$TOPTMP/bn-$tag"; then
+    fail_ "$case_name" "the fixture's run: line is not valid bash, so it is a typo rather than a swallow: $(tr '\n' ' ' < "$TOPTMP/bn-$tag")"
+    return
+  fi
+  local P="$TOPTMP/$tag"
+  mk_tok "$P" github ok custom "$line"
+  local out rc
+  out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && printf '%s' "$out" | grep -q "DISCARDS the gate's exit code" \
+     && ! printf '%s' "$out" | grep -q "The next push enforces the check"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — the allowlist did not refuse '$line': $(printf '%s' "$out" | grep -E 'phase-gate step|next push|maps SOIF' | tr '\n' ' ')"
+  fi
+}
+
+echo "=== S6e-allowlist-refuses-or-exit ==="
+assert_swallow_warned S6e-allowlist-refuses-or-exit s6e \
+  'bash scripts/check-phase-gate.sh || exit 0' \
+  'the R-C1 escape: `exit` was never in the old alternation'
+
+echo "=== S6f-allowlist-refuses-pipe ==="
+assert_swallow_warned S6f-allowlist-refuses-pipe s6f \
+  'bash scripts/check-phase-gate.sh | cat' \
+  "a pipe: the status reported is cat's, never the gate's"
+
+echo "=== S6g-allowlist-refuses-background ==="
+assert_swallow_warned S6g-allowlist-refuses-background s6g \
+  'bash scripts/check-phase-gate.sh &' \
+  'a trailing `&`: the step exits 0 before the gate has decided anything'
+
+echo "=== S6h-allowlist-refuses-interpreter-swap ==="
+assert_swallow_warned S6h-allowlist-refuses-interpreter-swap s6h \
+  'sh scripts/check-phase-gate.sh; exit 0' \
+  'a different interpreter: the old pre-filter required the literal `bash `, so this line was never even inspected'
+
+echo "=== S6i-allowlist-refuses-wrapper ==="
+assert_swallow_warned S6i-allowlist-refuses-wrapper s6i \
+  'if ! bash scripts/check-phase-gate.sh; then echo "::warning::soft"; fi' \
+  'an `if !` wrapper: the compound command succeeds however the gate votes'
+
+echo "=== S6j-allowlist-refuses-trailing-command ==="
+assert_swallow_warned S6j-allowlist-refuses-trailing-command s6j \
+  'bash scripts/check-phase-gate.sh; echo "phase gate step complete"' \
+  'a command after the invocation: the last command owns the exit status'
+
+# ── S6k: the EMITTED shape is not a swallow ────────────────────────────────
+# The false-positive guard, and the reason the allowlist permits two spellings
+# rather than one: every shipped template wraps the bare invocation in an
+# existence guard that also names the script. A detector that warned about the
+# workflow the framework itself writes would be worse than the blacklist.
+echo "=== S6k-allowlist-accepts-the-emitted-shape ==="
+P="$TOPTMP/s6k"; mk_tok "$P" github ok emitted
+out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
+if [ "$rc" -eq 0 ] \
+   && printf '%s' "$out" | grep -q "The next push enforces the check" \
+   && ! printf '%s' "$out" | grep -q "DISCARDS the gate's exit code"; then
+  pass "S6k-allowlist-accepts-the-emitted-shape (guard + bare invocation, exactly as templates/pipelines/ci/github/*.yml ships it)"
+else
+  fail_ "S6k-allowlist-accepts-the-emitted-shape" "rc=$rc — the hardened detector warns about the framework's OWN emitted workflow: $(printf '%s' "$out" | grep -E 'phase-gate step|next push' | tr '\n' ' ')"
+fi
+
+# ── S6m: DUAL DIRECTION — neuter the verdict and the escape claims success ──
+# Everything above shows shapes being refused. This shows that the allowlist is
+# what refuses them: delete its verdict line and the `|| exit 0` workflow gets
+# the full "the next push enforces the check" claim — the exact false statement
+# F-015 exists to prevent.
+echo "=== S6m-neutered-allowlist-claims-false-enforcement ==="
+if mk_cg_mutant projverdict \
+     '^[[:space:]]*wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$' \
+     '/# F-015-PROJECT-ALLOWLIST-VERDICT$/d' 1 0; then
+  P="$TOPTMP/s6m"; mk_tok "$P" github ok custom 'bash scripts/check-phase-gate.sh || exit 0'
+  out=$(run_tok_with "$CG_MUT" "$P" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && ! printf '%s' "$out" | grep -q "DISCARDS the gate's exit code"; then
+    pass "S6m-neutered-allowlist-claims-false-enforcement (without the verdict line the escape is told the next push enforces — the allowlist carries S6e-S6j)"
+  else
+    fail_ "S6m-neutered-allowlist-claims-false-enforcement" "rc=$rc — the neutered detector did not produce the false claim, so S6e-S6j may be measuring something else: $(printf '%s' "$out" | grep -E 'phase-gate step|next push' | tr '\n' ' ')"
+  fi
+else
+  fail_ "S6m-neutered-allowlist-claims-false-enforcement" "$CG_WHY"
+fi
+
 # ── S6b: --token-env rejects a non-identifier (the eval IS an injection sink) ─
 # The indirect read is `eval "token=\${$token_env:-}"`. Without a name check, a
-# `--token-env` value carrying a command substitution EXECUTES — demonstrated,
-# not asserted: the mutation run below (validation arms deleted) creates the
-# canary file, and this run must not.
+# `--token-env` value carrying a command substitution EXECUTES. Demonstrated,
+# not asserted, in BOTH directions: this run must leave the canary file absent,
+# and S6b-mut below — which deletes the character-class arm of the validation,
+# the arm this payload actually trips — must create it.
+#
+# The canary is a STRUCTURAL discriminator, not decoration: "rejected" and
+# "rejected only after the eval already ran" produce the same message and the
+# same exit code, and only the canary's absence tells them apart.
 echo "=== S6b-token-env-name-validated ==="
 CANARY="$TOPTMP/s6b-canary"
 rm -f "$CANARY"
@@ -560,6 +733,31 @@ else
   fail_ "S6b-token-env-name-validated" "rc=$rc canary=$([ -e "$CANARY" ] && echo CREATED || echo absent): $out"
 fi
 rm -f "$CANARY"
+
+# ── S6b-mut: the other direction of S6b (R-C2) ─────────────────────────────
+# S6b's comment used to promise a mutation run that did not exist — the property
+# had been proven by hand during review. Here it is, executed: delete the
+# character-class arm (the one `X:-$(…)` trips; the identifier-start arm lets
+# that payload past) and the eval fires, creating the canary. That is the
+# injection S6b claims to prevent, so S6b is now a real two-sided proof.
+echo "=== S6b-mut-unvalidated-name-executes ==="
+if mk_cg_mutant tokencharset \
+     '^[[:space:]]*\*\[!A-Za-z0-9_\]\*\).*# F-015-TOKEN-ENV-CHARSET$' \
+     '/# F-015-TOKEN-ENV-CHARSET$/d' 1 0; then
+  CANARY="$TOPTMP/s6b-mut-canary"
+  rm -f "$CANARY"
+  P="$TOPTMP/s6bmut"; mk_tok "$P" github ok yes
+  out=$(run_tok_with "$CG_MUT" "$P" "$GOOD_TOKEN" --token-env "X:-\$(touch $CANARY)"); rc=$?
+  if [ -e "$CANARY" ] \
+     && ! printf '%s' "$out" | grep -q "not a valid environment variable name"; then
+    pass "S6b-mut-unvalidated-name-executes (without the charset arm the payload EXECUTES — the validation, not luck, is what keeps S6b's canary absent)"
+  else
+    fail_ "S6b-mut-unvalidated-name-executes" "rc=$rc canary=$([ -e "$CANARY" ] && echo CREATED || echo absent) — the mutant did not reproduce the injection, so S6b proves nothing: $(printf '%s' "$out" | tail -3 | tr '\n' ' ')"
+  fi
+  rm -f "$CANARY"
+else
+  fail_ "S6b-mut-unvalidated-name-executes" "$CG_WHY"
+fi
 
 # ── S7: THE CHAIN — the stored secret is the one the templates map ────────
 # The walkthrough's result only "genuinely flips the check to enforcing" if the


### PR DESCRIPTION
## What

**F-015**, decided by Karl on 2026-08-09 ("Harden it"): convert two tamper-pins from **blacklist** to **allowlist**.

The old pin enumerated forbidden swallow shapes — `(\|\||;)\s*(echo|true|:)` — and a prior review proved `bash scripts/check-phase-gate.sh || exit 0` walks straight through, because `exit` simply isn't in the alternation. Blacklists lose to creativity. These pins now assert the **exact known-good invocation**, so anything else fails, including shapes nobody has imagined.

Measured on the un-converted blacklist: five of the seven bypass shapes below made the **entire** bl147 suite exit 0. It was missing the class, not one spelling.

## Shapes now caught, each for the right reason (the FAIL line names the tampered template)

Implementer's seven: `|| exit 0` · `| cat` · trailing `&` · an `if ! …; then …; fi` wrapper · a command appended after the invocation · `sh …; exit 0` (interpreter swap) · `if: false` on the step.

Reviewer's four invented independently, all caught: a renamed step · a trailing `# keep` · `{ bash …; } || :` (brace-group) · `until bash …; do break; done` (a genuinely novel swallow that always exits 0).

## Two holes found and closed during review

**`if: false` on the step** — self-found. A key allowlist permits `if:`, and the body allowlist sees a byte-identical block, so a step that *never runs* passed every case. `Cw6-strict-gating` now pins the `if:` value.

**The same defect one level up** — reviewer-found, and closed here rather than deferred (it was graded an optional follow-up; the implementer's own rationale for the step-level verdict applies identically to a job that never runs). Verified pre-fix: **job-level `if: false` and an `on:` gutted to `workflow_dispatch` each passed all 82 checks at rc=0.** Now:

- `Cw6-strict-job` allowlists the containing job's **key set** (`runs-on`, `steps`) rather than blacklisting the two keys we happened to name — so job-level `if:`, `continue-on-error:` and every unnamed sibling are refused by construction. The reviewer's attacks on it — `strategy`/matrix, `needs: [ghost]`, `environment:`, a reusable-workflow `uses:` job — were all caught.
- `Cw6-strict-trigger` matches the `on:` block **verbatim** rather than testing "contains `push:`", because `paths-ignore: ['**']` under a still-present `push:` key neuters a workflow just as thoroughly. The reviewer confirmed a "contains" test would have missed exactly that.

Also: the candidate set moved from `CPG_FILES` to `GH_FILES` + a mapping filter, because `CPG_FILES` was derived by grepping for a `bash …` invocation — so an **interpreter swap dropped a template out of the pin's reach entirely**.

## No false reds

`G1` runs the **real** bl147 suite against the **tracked** tree: 84/0. No shipped CI template content is modified anywhere in the branch (0 files by diff). `G3` proves allowlist-not-freeze. Containment verified: a `test:`→`build:` job rename is not a false red, an unrelated second job is not a false red, an orphaned step fails **closed**.

## Dual-direction proofs

`RA2`/`RB2`: neuter either new verdict and the corresponding tamper passes the **entire** suite at rc=0 again — reproducing the pre-fix measurements exactly. Plus `M8`, `M11`, `M9` (scope filter → `Cw6-strict` passes over an *empty* set, only the floor tells the truth), `S6m`, and `S6b-mut`.

## Ride-along (R-C2)

walk006's `S6b` comment referenced a mutant that didn't exist — the property had been proven by hand at review time. The comment is corrected **and** the missing mutant added: delete the character-class arm and the `eval` fires, creating the canary. Now two-sided.

Also corrected: a comment claiming a trailing `#` "is not inert" — now stated accurately as a byte comparison rather than an execution analysis, with the deliberate asymmetry named (bl147 freezes the body; the project-side detector accepts the inline form, because it faces a real user's `ci.yml` of unknown vintage). And a host quirk recorded where a hand-reproducer would trip: an interactive `ugrep` alias inverts the empty-input result, while shipped code gets `/usr/bin/grep` via a child bash.

## Verification

Two adversarial rounds, both `minor_concerns` → **approve**. Suites: f015 **19/0**, bl147 **84/0**, walk006 31/0, check-gate 5/0, walk016 15/0, tests-registered 24/0, run-lints **15/15** — all by execution. Registered in both lanes, not exempt; bl147/walk006 lane assignments unchanged.

## Recorded, not fixed

- **Two `cmd_setup_ci_token` weaknesses, both CONFIRMED real and graded MEDIUM, both pre-existing and byte-identical before/after — escalated to Karl:** a `ci.yml` that maps the secret but invokes **no gate at all** still prints "the next push enforces the check"; and the project-side detector isn't step-scoped, so `continue-on-error: true` (which grades a failed step as *success*) still earns the enforcement claim. Recommended as one bundled fix: require ≥1 allowlisted invocation and gate the OK on `maps && invokes && !swallows`.
- The pin now **freezes** the phase-gate step (body, keys, `if:`, job key set, trigger) — a deliberate change must update the literals in the same commit. Graded acceptable friction; the failure messages say so.
- Runtime ~120s locally. Deliberately **left unpinned in `rest`**: the pin arrays document *measured CI* time, and pinning on a local number is the mistake the `pin_lint_scan` comment warns against. Reviewer concurred and prescribed measuring on the first CI run. `rest` currently has headroom.
- Non-blocking residuals: the job allowlist checks the key set but not the `runs-on` **value** (a nonexistent label yields a hung check, never a false green), and one cosmetic fail-closed diagnostic on a malformed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
