### PR TITLE
feat(delta): WP8 — intake paths, brief template, module shipping, BUGS.md row

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -565,6 +565,13 @@ jobs:
             tests/test-pre-commit-gate-lints.sh        # 122s — runs 4 lint copies inside fixture projects
             tests/test-upgrade-sync-framework.sh       #  37s
             tests/test-plan-staging.sh                 #  34s
+            # ── Re-pinned 2026-08-09, measured from runs 31332638444 (main @
+            #    faffd7a, complement leg 626s/720s) and 31332771622 (WP8 branch,
+            #    complement leg CANCELED at 736s). Nothing failed on that run —
+            #    the cap fired. Per the doctrine above, that is the RE-PIN
+            #    signal, not a reason to raise the cap.
+            tests/test-delta-wp5-hotfix-retro.sh       # 181s — THE long pole of the whole wave, and 3x the next one. It opens and closes deltas dozens of times, and each open now also renders a brief and seeds a ledger row, so it got slower as the feature landed rather than as the test grew
+            tests/test-brownfield-wp1-scout.sh         #  55s — the second pole. Moved WITH the first deliberately: the first alone left the complement leg at ~77% of the cap, which is the same "approaching" state the sast note below was written about, and the complement has taken a new suite in nearly every work package this wave
           )
 
           # The ONLY thing that maps a roster name to a pin array. Both the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -437,6 +437,7 @@ jobs:
             tests/test-delta-wp5-hotfix-retro.sh
             tests/test-delta-wp6-cadence.sh
             tests/test-delta-wp7-cut-release.sh
+            tests/test-delta-wp8-intake.sh
             tests/test-delta-severability.sh
             tests/test-docs-cluster-six-pack.sh
             tests/test-enforcement-level-lib.sh

--- a/init.sh
+++ b/init.sh
@@ -1456,10 +1456,13 @@ create_project() {
   #
   # These lines are INSTALLATION, not a dependency edge — init.sh copies bytes,
   # it never sources or calls the module. scripts/lint-delta-boundary.sh knows
-  # that through its DELTA-BOUNDARY-INSTALLER fence, which exempts exactly the
-  # lines between these two markers and nothing else in this file; a `source`
-  # smuggled in here is still a violation, and cases SH7-SH9 in
-  # tests/test-delta-wp8-intake.sh are the fixtures that prove it.
+  # that through its DELTA-BOUNDARY-INSTALLER fence, which exempts only lines
+  # matching its installation GRAMMAR, only between these two markers, and only
+  # in this one file — and which bounds the number of fences here at two. A
+  # `source` smuggled in is still a violation whether it stands alone or rides
+  # on a `cp` after a `;`. Cases SH7 (eleven smuggling attempts), SH8 and SH9 in
+  # tests/test-delta-wp8-intake.sh are the fixtures that prove it; the
+  # leading-token version of that check did NOT, and shipped a laundering hole.
   cp "$SCRIPT_DIR/scripts/lib/delta-state.sh"       scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/delta-policy.sh"      scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/delta-classify.sh"    scripts/lib/

--- a/init.sh
+++ b/init.sh
@@ -1434,6 +1434,40 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/lib/phase2-state.sh"      scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/cdf-refresh.sh"       scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/adoption-stamp.sh"    scripts/lib/
+  # ── DELTA-INSTALL-BEGIN ────────────────────────────────────────────────────
+  # THE POST-1.0 DELTA MODULE (design 2026-08-02-delta-track-v1 §3.1, §11-WP8).
+  # Karl's decision of 2026-08-09: until this block existed the scaffolder
+  # carried the string zero times, so the entire post-release track reached no
+  # generated project — every script, every gate and every refusal in it was
+  # framework-only code that nothing downstream could run.
+  #
+  # THE SPLIT MATCHES THE NEIGHBOURS EXACTLY. The four libs are SOURCED, so
+  # they get a plain cp and no chmod, like adoption-stamp.sh and every lib
+  # above them. The two entry scripts are RUN by the operator, so they get the
+  # +x — given locally rather than appended to the long chmod line below, which
+  # is the same shape the BL-029 and host-drivers blocks use.
+  #
+  # scripts/lint-delta-boundary.sh is deliberately NOT here. It is a FRAMEWORK
+  # lint: it scans init.sh and scripts/lib/*.sh for a module boundary that only
+  # exists in the framework repo, so downstream it would either scan nothing or
+  # scan the wrong thing. `## BUG-008:` records what a shipped lint that
+  # misbehaves on a generated tree costs, and the other unshipped lint-*.sh are
+  # treated the same way.
+  #
+  # These lines are INSTALLATION, not a dependency edge — init.sh copies bytes,
+  # it never sources or calls the module. scripts/lint-delta-boundary.sh knows
+  # that through its DELTA-BOUNDARY-INSTALLER fence, which exempts exactly the
+  # lines between these two markers and nothing else in this file; a `source`
+  # smuggled in here is still a violation, and cases SH7-SH9 in
+  # tests/test-delta-wp8-intake.sh are the fixtures that prove it.
+  cp "$SCRIPT_DIR/scripts/lib/delta-state.sh"       scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/delta-policy.sh"      scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/delta-classify.sh"    scripts/lib/
+  cp "$SCRIPT_DIR/scripts/lib/delta-cadence.sh"     scripts/lib/
+  cp "$SCRIPT_DIR/scripts/delta.sh"                 scripts/
+  cp "$SCRIPT_DIR/scripts/cut-release.sh"           scripts/
+  chmod +x scripts/delta.sh scripts/cut-release.sh
+  # ── DELTA-INSTALL-END ──────────────────────────────────────────────────────
   cp "$SCRIPT_DIR/scripts/install-filesystem-gates.sh" scripts/
   cp "$SCRIPT_DIR/scripts/detect-out-of-band-commits.sh" scripts/
   cp "$SCRIPT_DIR/scripts/hooks/record-claude-commit.sh" scripts/hooks/
@@ -1553,6 +1587,14 @@ create_project() {
   cp "$SCRIPT_DIR/templates/generated/changelog.tmpl" templates/generated/
   cp "$SCRIPT_DIR/templates/generated/bugs.tmpl" templates/generated/
   cp "$SCRIPT_DIR/templates/generated/release-notes.tmpl" templates/generated/
+  # ── DELTA-INSTALL-BEGIN ────────────────────────────────────────────────────
+  # The post-1.0 delta brief (§6.2). Class T — shipped VERBATIM, so the
+  # currency inventory tracks its drift like every other template here. It has
+  # to be in the PROJECT because §6.1's manual path is "copy this file to
+  # docs/deltas/ yourself", and because scripts/delta.sh renders the project's
+  # own copy first so an edited template is the one that gets used.
+  cp "$SCRIPT_DIR/templates/generated/delta-brief.tmpl" templates/generated/
+  # ── DELTA-INSTALL-END ──────────────────────────────────────────────────────
   # Verifier nit-2 follow-up (PR #92 review): copy the canonical
   # claude-md.tmpl into the project so verify-install.sh's self-
   # bootstrap fallback in fix_claude_md (scripts/verify-install.sh:645

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -781,6 +781,20 @@ _features_next_num() {
 #   when there is no ledger to write into. rc is always 0: a project that has
 #   deleted its ledger should not be unable to open a delta, it should be told.
 #
+#   THE CONTRACT IS "ECHO NOTHING UNLESS THE ROW LANDED", AND BOTH BRANCHES MUST
+#   HONOUR IT. The caller distinguishes "no ledger here" from "the write did not
+#   complete" by asking whether the file exists — and that discrimination only
+#   works if a failed write actually produces the empty result it is looking for.
+#   The BUGS branch got `|| return 0` when that discrimination was added; the
+#   FEATURE branch did not, and its unguarded `} >> "$ledger"` fell straight
+#   through to the `printf` below, returning the FILENAME on failure. So a
+#   read-only FEATURES.md produced: rc 0, "A row for DELTA-001 is on
+#   FEATURES.md", `grep -c DELTA-001` = 0, and `ledger: "FEATURES.md"` recorded
+#   in the state document — the lie reaching the audit record, not just the
+#   transcript. Measured, then fixed; L5 pins it by forcing the write to fail.
+#   Any third ledger branch added here needs the same guard, for the same
+#   reason: silence is the signal, so silence has to be reachable.
+#
 #   THE ROW IS SEEDED, NOT ATTESTED. `ledger_row` stays an operator-attested
 #   gate (WP5: "the operator's own BUGS.md row … stays attested like every
 #   other class's"). The framework writes what it knows — the id, the class's
@@ -815,7 +829,7 @@ _ledger_write() {
       printf '**Related ADRs:** [to be filled in at close]\n'
       printf '**Test Coverage:** [to be filled in at close]\n'
       printf '**Known Limitations:** [to be filled in at close]\n\n---\n'
-    } >> "$ledger"
+    } >> "$ledger" || return 0
   fi
   printf '%s' "$ledger"
   return 0

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -345,6 +345,7 @@ DELTA_RETRO_ROW_STATE_JQ='
 
 USAGE="Usage:
   scripts/delta.sh --open [--describe TEXT] [--slug SLUG] [--confirm]
+                   [--via guided|conversational|manual]
                    [--class feature|fix|hotfix|security-patch]
                    [--risk core|feature-local] [--level small|significant|evolution]
                    [--severity SEV-1|SEV-2|SEV-3|SEV-4] [--reason TEXT]
@@ -595,6 +596,249 @@ _slugify() {
   [ -n "$s" ] && printf '%s' "$s" || printf '%s' "delta"
 }
 
+# _slug_path_safe <raw> — rc 0 when the operator's `--slug` may be sanitised,
+# rc 2 when it is PATH-SHAPED and must be refused outright.
+#
+# WP8 IS WHERE A USER STRING BECOMES A FILESYSTEM PATH, and that is why the
+# refusal lives here rather than anywhere earlier. WP3's adversarial review
+# recorded `--slug ../../../etc/cron.d/evil` stored VERBATIM: harmless at the
+# time, because WP3 only ever wrote it into JSON. This work package composes
+# `docs/deltas/<id>-<slug>.md` out of it, so the same string is now a write
+# target.
+#
+# WHY REFUSE AND NOT JUST SANITISE. `_slugify` would in fact flatten every one
+# of these to something harmless — but silently, and the operator would find
+# their delta under a name they did not choose with no idea why. Worse, a
+# future edit that composed the path before slugifying (or slugified with a
+# looser expression) would re-open the hole with nothing failing. A refusal is
+# a fact the operator can see and a line a mutation can kill; sanitisation
+# alone is a property that has to keep being true. So it is BOTH: refuse the
+# path-shaped spellings loudly, sanitise everything else.
+#
+# The four spellings are one class and are matched as one, because a guard that
+# catches `../` and misses `..\` or a leading `.` is not a guard:
+#   */*      any separator, which covers `/etc/passwd` and `a/../b`
+#   *\\*     a Windows separator
+#   *..*     a traversal segment anywhere, even without a separator
+#   .*       a leading dot: `.hidden`, `.` and `..` all land here
+# An EMPTY slug is accepted — it means the operator did not pass `--slug` at
+# all, and the description is slugified instead.
+_slug_path_safe() {
+  local raw="${1:-}"
+  [ -n "$raw" ] || return 0
+  case "$raw" in
+    */*|*\\*|*..*|.*) return 2 ;;
+  esac
+  return 0
+}
+
+# ── The brief (§6.2/§6.3) ───────────────────────────────────────────────────
+# _brief_template — the template to render, project copy first.
+#
+# The PROJECT's own templates/generated/delta-brief.tmpl wins, because a
+# project may edit it and the manual path (§6.1) tells the operator to copy
+# THAT file. The framework-side sibling is the fallback for a scaffold that
+# predates the template shipping.
+_brief_template() {
+  if [ -f "templates/generated/delta-brief.tmpl" ]; then
+    printf '%s' "templates/generated/delta-brief.tmpl"; return 0
+  fi
+  if [ -f "$SCRIPT_DIR/../templates/generated/delta-brief.tmpl" ]; then
+    printf '%s' "$SCRIPT_DIR/../templates/generated/delta-brief.tmpl"; return 0
+  fi
+  return 1
+}
+
+# _brief_render <template> <dest> <id> <slug> <class> <at> <risk> <level> <sev>
+#   Substitute the {{…}} tokens and write the file. Every value spliced here is
+#   already constrained — the id matches DELTA-[0-9]+, the slug has been through
+#   `_slugify` so it is [a-z0-9-] only, the class and the attributes come from
+#   fixed vocabularies, and the timestamp is this script's own `date -u`. None
+#   of them can carry a `#`, a `&` or a newline into the sed replacement.
+#
+# THERE IS A BUILT-IN FALLBACK AND IT IS NOT A CONVENIENCE. A project whose
+# template file is missing — deleted, or scaffolded before the template
+# shipped — must still be able to open a feature delta. Refusing would make a
+# missing DOCUMENT stop the WORK, and it would do it at the worst moment: the
+# operator has just described what they need and confirmed four lines about it.
+# The fallback carries the same five sections and the same parse contract, so
+# the close gate behaves identically; only the prose guidance is thinner.
+_brief_builtin() {
+  local dest="$1" id="$2" slug="$3" class="$4" at="$5" risk="$6" level="$7" sev="$8"
+  [ -n "$sev" ] || sev="not applicable"
+  {
+    printf '# %s — %s\n\n' "$id" "$slug"
+    printf '**Class:** %s\n' "$class"
+    printf '**Opened:** %s\n' "$at"
+    printf '**Risk:** %s · **Level:** %s · **Severity:** %s\n\n' "$risk" "$level" "$sev"
+    printf '## What\n\n[One paragraph, in your own words.]\n\n'
+    printf '## Why\n\n[The user signal — what someone did, said, or failed to do.]\n\n'
+    printf '## Done-observable\n\n'
+    printf '<!-- One line per thing you will be able to SEE working. Tick a box\n'
+    printf '     only when you have watched that thing happen. This list is the\n'
+    printf '     whole review at close, and the close refuses while any box here\n'
+    printf '     is unticked. -->\n\n'
+    printf -- '- [ ] [the first thing you will be able to see working]\n'
+    printf -- '- [ ] [the second thing you will be able to see working]\n\n'
+    printf '## Must-not-change\n\n- [what must still work exactly as it does today]\n\n'
+    printf '## Touched surfaces\n\n- [file or area]\n'
+  } > "$dest"
+}
+
+_brief_render() {
+  local tmpl="$1" dest="$2" id="$3" slug="$4" class="$5" at="$6" risk="$7" level="$8" sev="$9"
+  [ -n "$sev" ] || sev="not applicable"
+  sed -e "s#{{DELTA_ID}}#$id#g" \
+      -e "s#{{SLUG}}#$slug#g" \
+      -e "s#{{CLASS}}#$class#g" \
+      -e "s#{{OPENED_AT}}#$at#g" \
+      -e "s#{{RISK}}#$risk#g" \
+      -e "s#{{LEVEL}}#$level#g" \
+      -e "s#{{SEVERITY}}#$sev#g" \
+      "$tmpl" > "$dest"
+}
+
+# ── The ledger row (§6.3) ───────────────────────────────────────────────────
+# THE HARD CONSTRAINT, restated at the code because it is the one thing here
+# that cannot be undone by an edit that looks tidy: `BUGS.md`'s table format is
+# PARSED BY SCRIPTS. Its own header says "Do NOT change the table format", and
+# scripts/test-gate.sh greps `SEV-1.*Open`, `SEV-2.*Open`, `SEV-2.*Deferred`
+# and `SEV-3.*Open` across it. So the delta link goes in the EXISTING
+# `Fix Reference` column — which already takes "PR #12"-shaped values — and
+# never in a new one. A new column shifts nothing today and is exactly the
+# edit that silently breaks a `grep -c` months later.
+
+# _ledger_for <class> — which ledger this class's row belongs in (§5.2).
+_ledger_for() {
+  case "${1:-}" in
+    feature) printf 'FEATURES.md' ;;
+    *)       printf 'BUGS.md' ;;
+  esac
+}
+
+# _cell <text> — a value safe to put in a markdown table cell: pipes would add
+# columns, newlines would add rows.
+_cell() {
+  printf '%s' "${1:-}" | tr '\n\r|' '   ' | sed -e 's/[[:space:]]\{1,\}/ /g' -e 's/^ //' -e 's/ $//'
+}
+
+# _bugs_next_num <file> — max of the `#` column + 1. Only the FIRST table's rows
+# carry a bare integer there, so the Status and Severity guide tables below it
+# cannot contribute.
+_bugs_next_num() {
+  local f="$1" n
+  n="$(grep -oE '^\|[[:space:]]*[0-9]+[[:space:]]*\|' "$f" 2>/dev/null \
+        | grep -oE '[0-9]+' | sort -n | tail -1)"
+  case "$n" in ''|*[!0-9]*) printf '1' ;; *) printf '%s' "$((n + 1))" ;; esac
+}
+
+# _bugs_append_row <file> <row> — append to the FIRST table only.
+#   The insertion point is the last line of the run of `|`-rows that begins at
+#   the separator, so the row lands at the bottom of the bug table and never
+#   inside the Status Guide or Severity Guide tables further down the file.
+_bugs_append_row() {
+  local f="$1" row="$2" tmp
+  tmp="$(mktemp)" || return 1
+  awk -v row="$row" '
+    { lines[NR] = $0 }
+    sep == 0 && /^\|---/ { sep = NR; last = NR; next }
+    sep > 0 && last == NR - 1 && /^\|/ { last = NR }
+    END {
+      if (last == 0) { for (i = 1; i <= NR; i++) print lines[i]; print row; exit }
+      for (i = 1; i <= NR; i++) { print lines[i]; if (i == last) print row }
+    }
+  ' "$f" > "$tmp" && mv "$tmp" "$f"
+}
+
+# _features_next_num <file>
+_features_next_num() {
+  local f="$1" n
+  n="$(grep -oE '^##[[:space:]]+Feature[[:space:]]+[0-9]+' "$f" 2>/dev/null \
+        | grep -oE '[0-9]+' | sort -n | tail -1)"
+  case "$n" in ''|*[!0-9]*) printf '1' ;; *) printf '%s' "$((n + 1))" ;; esac
+}
+
+# _ledger_write <class> <id> <slug> <describe> <severity> <brief-or-empty>
+#   Writes the delta's row and echoes the ledger's filename, or echoes nothing
+#   when there is no ledger to write into. rc is always 0: a project that has
+#   deleted its ledger should not be unable to open a delta, it should be told.
+#
+#   THE ROW IS SEEDED, NOT ATTESTED. `ledger_row` stays an operator-attested
+#   gate (WP5: "the operator's own BUGS.md row … stays attested like every
+#   other class's"). The framework writes what it knows — the id, the class's
+#   severity, the link — and the operator fills in the description and ticks
+#   the gate. For a HOTFIX this same row is Karl's decision-3 audit trace: a
+#   visible ledger row written the moment the fast lane opens, which survives
+#   an abandoned hotfix and a lost state file, neither of which the state
+#   document's own `audit_row_at_open` stamp does.
+_ledger_write() {
+  local class="$1" id="$2" slug="$3" desc="$4" sev="$5" brief="$6"
+  local ledger num row link feat
+  ledger="$(_ledger_for "$class")"
+  [ -f "$ledger" ] || return 0
+  if [ -n "$brief" ]; then link="$id ($brief)"; else link="$id"; fi
+  if [ "$ledger" = "BUGS.md" ]; then
+    num="$(_bugs_next_num "$ledger")"
+    [ -n "$sev" ] || sev="SEV-3"
+    # THE NINE SHIPPED COLUMNS, IN ORDER, AND NOT A TENTH:
+    # # | Severity | Status | Feature | Description | Session | Disposition |
+    # Fix Reference | Verified In
+    row="| $num | $sev | Open | $(_cell "$slug") | $(_cell "$desc") | - | Fix Now | $link | - |"   # DELTA-OPEN-LEDGER-COLUMN
+    _bugs_append_row "$ledger" "$row" || return 0
+  else
+    feat="$(_features_next_num "$ledger")"
+    {
+      printf '\n## Feature %s: %s\n\n' "$feat" "$(_cell "$slug")"
+      printf '**Phase Built:** 4 (post-1.0 %s)\n' "$id"
+      printf '**Status:** In Progress\n'
+      printf '**Summary:** %s\n' "$(_cell "$desc")"
+      if [ -n "$brief" ]; then printf '**Brief:** %s\n' "$brief"; fi
+      printf '**Key Interfaces:** [to be filled in at close]\n'
+      printf '**Related ADRs:** [to be filled in at close]\n'
+      printf '**Test Coverage:** [to be filled in at close]\n'
+      printf '**Known Limitations:** [to be filled in at close]\n\n---\n'
+    } >> "$ledger"
+  fi
+  printf '%s' "$ledger"
+  return 0
+}
+
+# ── The bridge (§10.4): the manifesto's § 6 read as CANDIDATES ──────────────
+# D7's bridge at v1.0, and the whole of it is a READ. § 6 Post-MVP Backlog
+# items become candidates listed by `--status`; nothing is auto-opened, nothing
+# is deleted from the manifesto, and the § 5 MVP-cutline governance is
+# untouched — because § 6's own text says these are candidates prioritised
+# "after launch based on real usage data", and auto-promoting them into a queue
+# would contradict the document being read.
+#
+# The awk program is a VARIABLE and the invocation is ONE self-contained line,
+# on purpose: `# DELTA-BRIDGE-READ-ONLY` is a mutation address, and a marker on
+# the last line of a multi-line quoted program would let a mutant delete the
+# closing quote and produce a parse error that reads as "the guard caught it".
+_MANIFESTO_S6_AWK='/^##[ \t]*6[. ]/ { insec = 1; next }
+/^##.*Post-MVP Backlog/ { insec = 1; next }
+insec && /^##/ { insec = 0 }
+insec && /^[-*+][ \t]+/ { print }'
+
+_manifesto_candidates() {
+  local mf="PRODUCT_MANIFESTO.md"
+  [ -f "$mf" ] || return 1
+  awk "$_MANIFESTO_S6_AWK" "$mf" 2>/dev/null || true                  # DELTA-BRIDGE-READ-ONLY
+  return 0
+}
+
+_render_candidates() {
+  local cands n
+  cands="$(_manifesto_candidates)" || return 0
+  [ -n "$cands" ] || return 0
+  n="$(printf '%s\n' "$cands" | grep -c '' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  echo ""
+  print_info "From your Post-MVP Backlog — $n candidate(s). Nothing here is scheduled and nothing has been opened; this is a read of PRODUCT_MANIFESTO.md section 6, which stays the place they live:"
+  printf '%s\n' "$cands" | sed -e 's/^[-*+][[:space:]]*/  - /'
+  return 0
+}
+
 # ═════════════════════════════════════════════════════════════════════════════
 # --status
 # ═════════════════════════════════════════════════════════════════════════════
@@ -698,6 +942,7 @@ cmd_status() {
   if [ "$(printf '%s\n' "$doc" | jq -r '.active_delta == null')" = "true" ]; then
     print_info "No delta is open. Start one with: scripts/delta.sh --open"
     _render_retros
+    _render_candidates
     echo ""
     return 0
   fi
@@ -723,6 +968,7 @@ cmd_status() {
 cmd_open() {
   local phase doc active_id pair touched lines gates obj now id slug reasons rc
   local retro_days retro_due retro_row audit_at gates_done filter
+  local brief_rel brief_created brief_json ledger_json ledger_file tmpl existing
 
   command -v jq >/dev/null 2>&1 || { print_fail "jq is required to open a delta."; return 1; }
 
@@ -760,6 +1006,35 @@ cmd_open() {
     echo ""
     return 4
   fi
+
+  # ── REFUSAL 3 — THE SLUG IS A WRITE TARGET (§6.3, WP8) ───────────────────
+  # It sits HERE — after the two refusals that describe the project's state,
+  # before anything at all is written — because it is an invocation error, not
+  # a state error: the operator typed something this flow cannot turn into a
+  # file name. Ordering it after the era guard keeps the load-bearing refusal
+  # first; ordering it before every write is what makes "nothing was opened"
+  # true of the whole tree.
+  if ! _slug_path_safe "$SLUG"; then                                  # DELTA-OPEN-SLUG-GUARD
+    echo ""
+    print_fail "That short name cannot be used: it looks like a file path, not a name."
+    print_info "The short name becomes part of a file name, so it can only contain letters, numbers and hyphens — no slashes, no dots at the start, and no \"..\"."
+    print_info "Try something like: --slug csv-export-unicode"
+    print_info "Nothing was opened."
+    echo ""
+    return 2
+  fi
+
+  # The recorded path is the one the operator asked for and the one they will
+  # be shown, so it is validated here too. Neither is a substitute for the
+  # other: `--via` is a vocabulary check, the slug guard above is a path check.
+  case "$VIA" in
+    guided|conversational|manual) : ;;
+    *)
+      print_fail "'$VIA' is not one of the three ways a piece of work gets started."
+      print_info "Use --via guided (you ran this script), --via conversational (an agent walked you through it) or --via manual (you wrote the plan by hand first)."
+      print_info "Nothing was opened."
+      return 2 ;;
+  esac
 
   if [ -z "$DESCRIBE" ]; then
     if [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${SOIF_NONINTERACTIVE:-}" ]; then
@@ -838,8 +1113,11 @@ cmd_open() {
   fi
 
   id="$(_next_id "$doc")"
-  slug="$SLUG"
-  [ -n "$slug" ] || slug="$(_slugify "$DESCRIBE")"
+  # BOTH sources go through `_slugify`, and the operator's is no exception.
+  # The guard above already refused the path-shaped spellings; this is the
+  # second half of the same defence — whatever survives is reduced to
+  # [a-z0-9-], so the composed file name cannot be anything else.
+  if [ -n "$SLUG" ]; then slug="$(_slugify "$SLUG")"; else slug="$(_slugify "$DESCRIBE")"; fi
   now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
   reasons="$(jq -c -n --arg r "$REASON_RISK" --arg l "$REASON_LEVEL" --arg s "$REASON_SEVERITY" '
@@ -883,17 +1161,80 @@ cmd_open() {
     fi
   fi
 
-  # `brief` and `ledger` stay null on purpose: §11-WP8 owns the brief template
-  # and the guided intake's ledger-row write. Materialising them here would
-  # invent a path to a file nothing creates yet.
+  # ── §6.1's OTHER TWO WRITES (WP8) ────────────────────────────────────────
+  # All three creation paths converge on the same three writes — the brief
+  # file, the ledger row and the state activation — and this is where the first
+  # two happen. The third has exactly one writer (the seam) and it is the call
+  # below.
+  #
+  # THE ORDER IS THE DESIGN. The brief and the ledger row are written FIRST and
+  # rolled back if the state write is refused, so the refusal's "nothing was
+  # opened" stays true of the whole tree. The reverse order would be worse in
+  # the way that matters: a state document pointing at a brief that does not
+  # exist closes on `_brief_path`'s "there isn't one to check against", which
+  # reads like the operator's fault.
+  brief_rel=""
+  brief_created=""
+  brief_json="null"
+  ledger_json="null"
+
+  # THE BRIEF IS WRITTEN ONLY WHEN THE CLASS OWES ONE (§5.2). A hotfix ships on
+  # the floor plus an audit row and nothing heavier; rendering it a brief would
+  # be exactly the ceremony the fast lane exists to skip.
+  if printf '%s\n' "$gates" | jq -e 'index("brief") != null' >/dev/null 2>&1; then
+    rc=0; existing="$(_brief_path "$id" "")" || rc=$?
+    if [ "$rc" -eq 2 ]; then
+      echo ""
+      print_fail "More than one written-up plan already claims to be $id's, so it is not clear which one this work would be reviewed against."
+      printf '%s\n' "$existing" | sed -e 's/^/  /'
+      print_info "Keep one and rename or remove the other. Nothing was opened."
+      echo ""
+      return 2
+    fi
+    if [ "$rc" -eq 0 ] && [ -n "$existing" ] && [ -f "$existing" ]; then
+      # THE MANUAL PATH (§6.1). The operator wrote their own plan before
+      # running anything; it is ADOPTED, never overwritten. A template render
+      # on top of it would destroy the very thing they came here with.
+      brief_rel="$existing"
+      print_info "Using the plan you already wrote at $existing."
+    else
+      brief_rel="docs/deltas/$id-$slug.md"
+      mkdir -p "docs/deltas" 2>/dev/null || true
+      rc=0
+      if tmpl="$(_brief_template)"; then
+        _brief_render "$tmpl" "$brief_rel" "$id" "$slug" "$CLASS" "$now" \
+          "$RISK" "$LEVEL" "$SEV" || rc=$?
+      else
+        _brief_builtin "$brief_rel" "$id" "$slug" "$CLASS" "$now" \
+          "$RISK" "$LEVEL" "$SEV" || rc=$?
+        print_info "There is no brief template in this project, so a plain one was written for you. If you want the fuller version back, restore templates/generated/delta-brief.tmpl."
+      fi
+      if [ "$rc" -ne 0 ]; then
+        rm -f "$brief_rel" 2>/dev/null || true
+        print_fail "Could not write the plan file, so nothing was opened."
+        return 1
+      fi
+      brief_created="$brief_rel"
+    fi
+    brief_json="$(_json_str "$brief_rel")"
+  fi
+
+  ledger_file="$(_ledger_write "$CLASS" "$id" "$slug" "$DESCRIBE" "$SEV" "$brief_rel")"   # DELTA-OPEN-LEDGER-ROW
+  if [ -n "$ledger_file" ]; then
+    ledger_json="$(_json_str "$ledger_file")"
+  else
+    print_info "There is no ledger file here to add a row to, so this delta is recorded only in its own record."
+  fi
+
   obj="$(jq -c -n \
     --arg id "$id" --arg slug "$slug" --arg class "$CLASS" \
-    --arg at "$now" --arg via "guided" \
+    --arg at "$now" --arg via "$VIA" \
+    --argjson brief "$brief_json" --argjson ledger "$ledger_json" \
     --arg risk "$RISK" --arg level "$LEVEL" --arg sev "$SEV" \
     --argjson gates "$gates" --argjson reasons "$reasons" \
     --argjson audit "$audit_at" --argjson done "$gates_done" '
     { id: $id, slug: $slug, class: $class,
-      brief: null, ledger: null,
+      brief: $brief, ledger: $ledger,
       opened_at: $at, opened_via: $via,
       attributes: { risk: $risk, level: $level,
                     severity: (if $sev == "" then null else $sev end) },
@@ -914,12 +1255,25 @@ cmd_open() {
     filter="$filter | .hotfix_retros += [$retro_row]"                 # DELTA-OPEN-RETRO-APPEND
   fi
   if ! _seam --delta-state-update "$filter"; then
+    # THE ROLLBACK. Only a brief THIS run created is removed — an adopted one
+    # is the operator's own file and was here before we were. Spelled as an
+    # `if` and not `[ -n … ] && rm`: this arm only runs when the seam has
+    # already refused, so it is the least-exercised path in the flow, and an
+    # AND-list whose left side is false is exactly the shape that trips `set -e`
+    # readings nobody has tested.
+    if [ -n "$brief_created" ]; then rm -f "$brief_created" 2>/dev/null || true; fi
     print_fail "The delta record refused the change, so nothing was opened."
     return 1
   fi
 
   echo ""
   print_ok "Opened $id — $slug ($CLASS)."
+  if [ -n "$brief_rel" ]; then
+    print_info "Write down what has to be TRUE when this is finished, in $brief_rel under 'Done-observable'. That list is the whole review at the end — you are writing it now, before you are invested in how you built it."
+  fi
+  if [ -n "$ledger_file" ]; then
+    print_info "A row for $id is on $ledger_file. Fill in what it says before you mark that check done."
+  fi
   printf '%s\n' "$gates" | jq -r '"  Before this can ship: " + join(", ")'
   if [ -n "$retro_row" ]; then
     # §4.3's plain register, and it is read at 3am: say what was borrowed, when
@@ -981,19 +1335,35 @@ _close_measure() {
 #   Ambiguity is a refusal rather than a first-match: picking one of two briefs
 #   silently means the close review ran against a document the operator may not
 #   have been looking at.
+#   WP8 AMENDMENT — THE AMBIGUITY CHECK NOW RUNS FIRST, AND UNCONDITIONALLY.
+#   The recorded path still wins, but it no longer SKIPS the glob. Once WP8's
+#   guided intake started filling `active_delta.brief`, an early return on the
+#   recorded value made the two-files-claim-one-id refusal unreachable through
+#   the front door: the close would review the framework's own render while the
+#   operator had been editing the other file all week, and if that other file
+#   happened to be complete, nothing anywhere would say so. Order matters here
+#   and it is the only thing that changed — a delta that names its own brief is
+#   still not second-guessed about WHICH file to read, it is only refused when
+#   there is genuinely more than one candidate to be confused by.
 _brief_path() {
-  local id="$1" recorded="${2:-}" hits n
+  local id="$1" recorded="${2:-}" hits="" n
+  if [ -d "docs/deltas" ]; then
+    hits="$(find docs/deltas -maxdepth 1 -type f \( -name "$id-*.md" -o -name "$id.md" \) 2>/dev/null | LC_ALL=C sort)"
+    if [ -n "$hits" ]; then
+      n="$(printf '%s\n' "$hits" | grep -c '' || true)"
+      case "$n" in ''|*[!0-9]*) n=0 ;; esac
+      if [ "$n" -gt 1 ]; then
+        printf '%s' "$hits"
+        return 2
+      fi
+    fi
+  fi
   if [ -n "$recorded" ] && [ "$recorded" != "null" ]; then
     printf '%s' "$recorded"
     return 0
   fi
-  [ -d "docs/deltas" ] || return 1
-  hits="$(find docs/deltas -maxdepth 1 -type f \( -name "$id-*.md" -o -name "$id.md" \) 2>/dev/null | LC_ALL=C sort)"
   [ -n "$hits" ] || return 1
-  n="$(printf '%s\n' "$hits" | grep -c '' || true)"
-  case "$n" in ''|*[!0-9]*) n=0 ;; esac
   printf '%s' "$hits"
-  [ "$n" -eq 1 ] || return 2
   return 0
 }
 
@@ -1580,6 +1950,11 @@ cmd_retro() {
 ACTION=""
 DESCRIBE=""
 SLUG=""
+# §6.1's three creation paths. They differ ONLY in who authored the brief; all
+# three end in this script performing the same three writes, which is what
+# keeps the state single-writer rule intact no matter how the operator got
+# here. `guided` is the default because that is what running this script IS.
+VIA="guided"
 CONFIRMED=0
 WANT_CLASS=""
 WANT_RISK=""
@@ -1622,6 +1997,7 @@ while [ $# -gt 0 ]; do
     --status)   ACTION="status"; shift ;;
     --describe) _need "$1" $#; DESCRIBE="$2"; shift 2 ;;
     --slug)     _need "$1" $#; SLUG="$2"; shift 2 ;;
+    --via)      _need "$1" $#; VIA="$2"; shift 2 ;;
     --class)    _need "$1" $#; WANT_CLASS="$2"; shift 2 ;;
     --risk)     _need "$1" $#; WANT_RISK="$2"; shift 2 ;;
     --level)    _need "$1" $#; WANT_LEVEL="$2"; shift 2 ;;

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -1237,9 +1237,23 @@ cmd_open() {
     brief_json="$(_json_str "$brief_rel")"
   fi
 
+  # THE EMPTY RESULT HAS TWO CAUSES AND THEY MUST NOT SHARE A MESSAGE.
+  # `_ledger_write` runs in a command substitution, so anything that kills it
+  # kills only the SUBSHELL — the parent carries on with an empty string and a
+  # zero exit code. So "" means either "this project has no such ledger" (fine,
+  # and common) or "the write did not complete" (not fine at all). Reporting
+  # both as the first is the reassuring version of a silent failure, and it is
+  # the shape this repo keeps finding. Ask the filesystem which one it was.
+  #
+  # Found by the CI-only failure of tests/test-delta-wp8-intake.sh::m3, where a
+  # mutant died inside this very substitution: the delta opened, rc was 0, and
+  # the only trace was a ledger row that silently never appeared.
   ledger_file="$(_ledger_write "$CLASS" "$id" "$slug" "$DESCRIBE" "$SEV" "$brief_rel")"   # DELTA-OPEN-LEDGER-ROW
   if [ -n "$ledger_file" ]; then
     ledger_json="$(_json_str "$ledger_file")"
+  elif [ -f "$(_ledger_for "$CLASS")" ]; then
+    print_warn "$(_ledger_for "$CLASS") is here, but the row for $id could not be added to it."
+    print_info "Everything else about $id was recorded. Add a row for it by hand before you mark the ledger check done."
   else
     print_info "There is no ledger file here to add a row to, so this delta is recorded only in its own record."
   fi

--- a/scripts/delta.sh
+++ b/scripts/delta.sh
@@ -623,12 +623,30 @@ _slugify() {
 #   .*       a leading dot: `.hidden`, `.` and `..` all land here
 # An EMPTY slug is accepted — it means the operator did not pass `--slug` at
 # all, and the description is slugified instead.
+#
+# THE FIFTH SPELLING IS NOT A SEPARATOR AT ALL (review R-WP8-3). A NEWLINE
+# passes every pattern above — it is not `/`, not `\`, not `..`, not a leading
+# dot — and `_slugify` PRESERVES it, because sed is line-oriented and processes
+# each half independently. The composed name `docs/deltas/$id-$slug.md` then
+# carries an embedded newline. No traversal and no injection is reachable
+# through it (each half is still reduced to [a-z0-9-], the ledger cell strips
+# `\n\r|`, and the state value goes through `jq --arg`), so this is robustness
+# rather than security — but a file whose name contains a line break is a file
+# the operator cannot type, and the guard is the honest place to say no.
+#
+# `tr -d '[:cntrl:]'` and not a pattern: it covers tab and carriage return by
+# the same stroke, and it leaves accented UTF-8 bytes alone — those are not
+# control characters, and `_slugify` already folds them to a hyphen, so a slug
+# like "Café Export" should be SANITISED rather than refused. Note the command
+# substitution strips trailing newlines from its own output, which is why a
+# slug that merely ENDS in a newline also compares unequal and is refused.
 _slug_path_safe() {
   local raw="${1:-}"
   [ -n "$raw" ] || return 0
   case "$raw" in
     */*|*\\*|*..*|.*) return 2 ;;
   esac
+  [ "$(printf '%s' "$raw" | tr -d '[:cntrl:]')" = "$raw" ] || return 2
   return 0
 }
 

--- a/scripts/lint-delta-boundary.sh
+++ b/scripts/lint-delta-boundary.sh
@@ -34,6 +34,13 @@
 #      trivially, and a passing lint that proves nothing is worse than no lint
 #      — this repo has the scar (see the BL-104 scoring inversions in
 #      CLAUDE.md, where an empty manifest scored better than no manifest).
+#   5. THE INSTALLER FENCE (WP8, added after §3.3 was written). The scaffolder
+#      must NAME every module file it copies, so it gets a second, narrower
+#      exemption than the seam's: only inside a `# DELTA-INSTALL` fence, only
+#      for lines matching an installation GRAMMAR, only in one file, and only
+#      up to a bounded number of fences. See the DELTA-BOUNDARY-INSTALLER
+#      block for why each of those four bounds exists and which one was
+#      missing when it first landed.
 #
 # THE SETS — one manifest, so they can never disagree
 #   DELTA = the §3.1 inventory, spelled once in the DELTA-BOUNDARY-MANIFEST
@@ -236,14 +243,48 @@ DELTA_MANIFEST=(
 #   2. Only lines INSIDE a `# DELTA-INSTALL-BEGIN` / `# DELTA-INSTALL-END`
 #      fence are exempt. A module path anywhere else in init.sh is still a
 #      violation, in both tiers.
-#   3. Only INSTALLATION STATEMENTS may live inside the fence — `cp`, `chmod`,
-#      `mkdir`. A `source scripts/lib/delta-state.sh` smuggled in there is a
-#      real fusion wearing an installer's coat, and it FAILS (tier I1). An
-#      unbalanced or nested fence fails too, because an unterminated BEGIN
-#      would exempt the rest of the file.
+#   3. Only INSTALLATION STATEMENTS may live inside the fence, and "installation
+#      statement" is defined by a POSITIVE GRAMMAR (`_install_stmt_ok`), not by
+#      a leading token. A `source scripts/lib/delta-state.sh` smuggled in there
+#      is a real fusion wearing an installer's coat and it FAILS (tier I1) —
+#      whether it stands alone OR rides on a `cp` line after a `;`, `&&`, `|`,
+#      a subshell or a backslash continuation. An unbalanced or nested fence
+#      fails too, because an unterminated BEGIN would exempt the rest of the
+#      file.
+#   4. The NUMBER OF FENCES inside that one file is bounded and asserted, so
+#      the exempt surface cannot grow by adding a fence somewhere else in the
+#      scaffolder.
+#
+#   CLAUSE 3 WAS FALSE WHEN THIS FENCE FIRST LANDED, and the correction is the
+#   reason clauses 3 and 4 read the way they do. The original check tested only
+#   whether a line's FIRST TOKEN was cp/chmod/mkdir and then exempted the WHOLE
+#   line, so `cp X ; source "$SCRIPT_DIR/lib/delta-state.sh"` passed this lint
+#   at rc 0 and rode through the PR-blocking `delta-boundary-lint` job. The
+#   severability suite could not see it either, because the revert drops the
+#   fence wholesale. An adversarial review found it by execution (R-WP8-1,
+#   cases A/C/E/F for the compound form and K for the extra-fence form); the
+#   tightness guarantee is the entire argument for accepting this exemption at
+#   all, so it now has to be TRUE, not merely written down.
 INSTALLER_ALLOWLIST=(
-  "init.sh|WP8 ships the §3.1 module to generated projects; the copy list must name each file LITERALLY because scripts/lib/scaffold-shipped-set.sh parses these cp lines to derive the shipped set. Copying bytes is installation, not a dependency edge — and only cp/chmod/mkdir statements inside the DELTA-INSTALL fence are exempt"
+  "init.sh|WP8 ships the §3.1 module to generated projects; the copy list must name each file LITERALLY because scripts/lib/scaffold-shipped-set.sh parses these cp lines to derive the shipped set. Copying bytes is installation, not a dependency edge — and only lines matching the installation GRAMMAR inside a DELTA-INSTALL fence are exempt"
 )
+# The fenced surface inside that one file, bounded (R-WP8-2). Two: the
+# scripts-copy block and the templates-copy block. They cannot be merged —
+# templates/generated/ is not created until well after the scripts block runs.
+#
+# A CEILING, NOT AN EQUALITY, and the difference is not laziness. The hazard is
+# an EXTRA fence — more exempt surface. FEWER is not a hazard in any direction:
+# a tree that ships no module at all has zero, and this lint runs under `--root`
+# against hermetic fixtures whose stub scaffolder has no fence. An equality
+# assertion reds all of those for being SAFER than the shipped tree, which is
+# the wrong direction for a boundary check to fail in.
+#
+# NAMED RESIDUAL: this bounds the COUNT, not the LOCATION. Merging the two real
+# fences and adding one elsewhere keeps the count at two. That is deliberate and
+# it is cheap to accept, because a third fence still cannot hold anything but
+# `cp`/`chmod`/`mkdir` — the grammar applies to every fence wherever it sits, so
+# the worst an unnoticed one can do is exempt a copy, never a `source`.
+INSTALLER_FENCE_MAX=2
 # ── DELTA-BOUNDARY-INSTALLER-END ────────────────────────────────────────
 
 # ── DELTA-BOUNDARY-SEAM-BEGIN ───────────────────────────────────────────
@@ -444,46 +485,79 @@ parse_allow() {
 }
 
 # ── DELTA-BOUNDARY-INSTALL-FENCE ────────────────────────────────────────
-# _install_fence <file> — one record per line, on stdout:
-#     EXEMPT <n>              this line is inside a fence and is installation
-#     BAD <n> <what>          a fence problem, or a non-installation statement
-#                             inside a fence
-# The fence markers themselves are comments, so the stripper has already
-# blanked them by the time the tiers run; they are read off the RAW file here.
+# _install_fence <file> — the fence GEOMETRY only, one record per line:
+#     IN <n>                  line n is inside a fence (classified by the
+#                             caller, against the STRIPPED line)
+#     BAD <n> <what>          a geometry problem
+#     FENCES <k>              how many BEGIN markers the file carries
+#
+# GEOMETRY HERE, CLASSIFICATION IN THE CALLER, and the split is deliberate.
+# Geometry needs the RAW file, because the markers are comments and the
+# stripper has already blanked them. Classification needs the STRIPPED file, so
+# that a trailing `# note` on a cp line cannot fail the grammar below. The two
+# files have identical line numbering — E1 BLANKS whole-line comments rather
+# than deleting them, precisely so `grep -n` and `sed -n Np` agree across both.
 #
 # EVERY FAILURE MODE FAILS CLOSED. An unterminated BEGIN would exempt the whole
-# rest of the scaffolder, so it is an error rather than a tolerated sloppiness;
-# a nested BEGIN is the same hazard wearing a second coat; and a statement that
-# is not `cp`, `chmod` or `mkdir` is the fusion this whole lint exists to catch,
-# so it is reported at the line rather than waived by its neighbours.
+# rest of the scaffolder, so it is an error rather than tolerated sloppiness; a
+# nested BEGIN is the same hazard wearing a second coat.
 _install_fence() {
   awk '
     /^[[:space:]]*#.*DELTA-INSTALL-BEGIN/ {
       if (open == 1) printf "BAD %d nested-DELTA-INSTALL-BEGIN\n", NR
-      open = 1; next
+      open = 1; fences++; next
     }
     /^[[:space:]]*#.*DELTA-INSTALL-END/ {
       if (open == 0) printf "BAD %d DELTA-INSTALL-END-with-no-BEGIN\n", NR
       open = 0; next
     }
-    open == 1 {
-      printf "EXEMPT %d\n", NR
-      s = $0
-      sub(/^[[:space:]]*/, "", s)
-      if (s == "") next
-      if (s ~ /^#/) next
-      if (s !~ /^(cp|chmod|mkdir)[[:space:]]/)
-        printf "BAD %d non-installation-statement-inside-the-fence\n", NR
+    open == 1 { printf "IN %d\n", NR }
+    END {
+      if (open == 1) printf "BAD %d unterminated-DELTA-INSTALL-fence\n", NR
+      printf "FENCES %d\n", fences + 0
     }
-    END { if (open == 1) printf "BAD %d unterminated-DELTA-INSTALL-fence\n", NR }
   ' "$1" 2>/dev/null
   return 0
+}
+
+# _install_stmt_ok <stripped-trimmed-line> — STAGE 2, the POSITIVE GRAMMAR.
+#
+# THIS IS A WHITELIST, NOT A BLACKLIST, AND THAT IS THE WHOLE POINT. The first
+# version of this check asked "does the line START with cp/chmod/mkdir?" and
+# then exempted the WHOLE line — so `cp X ; source "$SCRIPT_DIR/lib/delta-state.sh"`
+# was installation as far as the lint was concerned, and laundered a genuine
+# core->module `source` past a PR-blocking check (review R-WP8-1, cases A/C/E/F).
+# A leading-token test cannot see what follows the token; only a whole-line
+# grammar can.
+#
+# Three shapes, spelled out, and nothing else is installation:
+#   cp "$SCRIPT_DIR/<path>" <dest>
+#   chmod +x <path>...
+#   mkdir -p <path>...
+# The argument character class is `[A-Za-z0-9_./-]` — no `$`, no quotes beyond
+# the one `$SCRIPT_DIR` source form, no spaces in paths, and NO shell
+# metacharacter can appear anywhere in a matching line. That is what makes the
+# whole-line exemption sound again: a line that matches one of these is
+# provably a single simple command whose only arguments are paths, so exempting
+# the line exempts exactly the module paths that command copies — which is the
+# "exempt only the matched token" property, obtained structurally rather than
+# by trying to enumerate every way a second command can be smuggled on.
+#
+# It is deliberately BRITTLE in the fail-closed direction: a new installer
+# spelling reds until somebody adds it here, on purpose. This exemption is a
+# hole in a boundary; widening it should cost a reviewed edit.
+_install_stmt_ok() {
+  grep -qE \
+    -e '^cp[[:space:]]+"\$SCRIPT_DIR/[A-Za-z0-9_./-]+"[[:space:]]+[A-Za-z0-9_./-]+$' \
+    -e '^chmod[[:space:]]+\+x([[:space:]]+[A-Za-z0-9_./-]+)+$' \
+    -e '^mkdir[[:space:]]+-p([[:space:]]+[A-Za-z0-9_./-]+)+$' \
+    <<< "$1"
 }
 
 scan_core_file() {
   local rel="$1"
   local file="$ROOT/$rel"
-  local hits line n raw tok parsed has reason rec kind
+  local hits line n raw tok parsed has reason rec kind stmt stmt_nobs fences
   local t1_lines="|"
   local exempt_lines="|"
 
@@ -515,22 +589,83 @@ scan_core_file() {
   # DELTA-INSTALL fence in any other core file exempts nothing, which is the
   # fail-closed direction.
   if [ "$rel" = "$INSTALLER_PATH" ]; then
+    fences=0
     while IFS= read -r rec; do
       [ -n "$rec" ] || continue
       kind="${rec%% *}"
       rec="${rec#* }"
       n="${rec%% *}"
       case "$kind" in
-        EXEMPT) exempt_lines="${exempt_lines}${n}|" ;;
+        FENCES) fences="$n" ;;
         BAD)
-          echo "${rel}:${n}: lint-delta-boundary: I1 — ${rec#* } in the DELTA-INSTALL fence. Only cp / chmod / mkdir may live between the fence markers, and the fence must be balanced: an unterminated BEGIN would exempt the rest of this file. Move the statement out of the fence, or fix the markers." >&2
+          echo "${rel}:${n}: lint-delta-boundary: I1 — ${rec#* } in the DELTA-INSTALL fence. The fence must be balanced: an unterminated BEGIN would exempt the rest of this file." >&2
           VIOLATIONS=$((VIOLATIONS + 1))
           LIST_ROWS="${LIST_ROWS}FAIL\tI1\t${rel}:${n}\t${rec#* }\n"
+          ;;
+        IN)
+          # Classified against the STRIPPED line, so a trailing comment on an
+          # otherwise-clean cp cannot fail the grammar.
+          stmt="$(sed -n "${n}p" "$STRIPPED")"
+          stmt="${stmt#"${stmt%%[![:space:]]*}"}"
+          stmt="${stmt%"${stmt##*[![:space:]]}"}"
+          # A blank line (or one the stripper blanked because it was a comment)
+          # carries nothing to exempt and nothing to check.
+          [ -n "$stmt" ] || continue
+          # ── STAGE 1 — COMMAND CHAINING ──────────────────────────────────
+          # Ordered FIRST so the diagnostic names what actually happened, and
+          # kept even though STAGE 2's grammar already excludes every one of
+          # these characters. That redundancy is the point: this repo's scar
+          # tissue (`# BL-181-UNIT-LANE-PREDICATE`, three re-openings) is that
+          # a ONE-CHARACTER widening of a character class goes unnoticed. If
+          # somebody ever loosens the grammar's argument class, this stage is
+          # what still stops `cp X ; source Y`. Both stages are reachable on
+          # distinct inputs and each has its own fixture.
+          # The trailing `\` is tested with a suffix EXPANSION, not as a case
+          # pattern. `case … in *"\\")` looks like it works and does not: a
+          # backslash surviving quote removal into a pattern quotes the NEXT
+          # character, and there is no next character, so the arm never fires.
+          # Case G caught that — a `cp X \` continuation was reported by its
+          # SECOND line rather than its first, leaving this arm dead. A dead
+          # arm in a guard is the thing this file's own header warns about.
+          stmt_nobs="${stmt%\\}"
+          if [ "$stmt_nobs" != "$stmt" ]; then
+            echo "${rel}:${n}: lint-delta-boundary: I1 — command-chaining-inside-the-fence. A '\\' continuation carries the next line into this statement while the exemption stops at this one. One plain command per fenced line." >&2
+            VIOLATIONS=$((VIOLATIONS + 1))
+            LIST_ROWS="${LIST_ROWS}FAIL\tI1\t${rel}:${n}\tcommand-chaining-inside-the-fence\n"
+            continue
+          fi
+          case "$stmt" in
+            *";"*|*"&"*|*"|"*|*'`'*|*"("*|*")"*)
+              echo "${rel}:${n}: lint-delta-boundary: I1 — command-chaining-inside-the-fence. A second command riding on an installation line (';', '&&', '||', '|', a subshell, a backtick, or a '\\' continuation) is exempted along with the first, which is how a core -> module 'source' gets laundered. One plain command per fenced line." >&2
+              VIOLATIONS=$((VIOLATIONS + 1))
+              LIST_ROWS="${LIST_ROWS}FAIL\tI1\t${rel}:${n}\tcommand-chaining-inside-the-fence\n"
+              continue ;;
+          esac
+          # ── STAGE 2 — THE POSITIVE GRAMMAR ──────────────────────────────
+          if _install_stmt_ok "$stmt"; then
+            exempt_lines="${exempt_lines}${n}|"
+          else
+            echo "${rel}:${n}: lint-delta-boundary: I1 — not-a-plain-installation-statement. Only 'cp \"\$SCRIPT_DIR/<path>\" <dest>', 'chmod +x <path>...' and 'mkdir -p <path>...' may live between the fence markers. Move this line out of the fence." >&2
+            VIOLATIONS=$((VIOLATIONS + 1))
+            LIST_ROWS="${LIST_ROWS}FAIL\tI1\t${rel}:${n}\tnot-a-plain-installation-statement\n"
+          fi
           ;;
       esac
     done <<EOF
 $(_install_fence "$file")
 EOF
+    # ── DELTA-BOUNDARY-INSTALLER-FENCE-COUNT (review R-WP8-2) ────────────
+    # Cardinality bounds installer FILES to one; on its own that left the
+    # exempt SURFACE inside that one file unbounded, so an extra fence
+    # anywhere in the scaffolder was a fresh place to smuggle from.
+    if [ "$fences" -gt "$INSTALLER_FENCE_MAX" ]; then
+      echo "${rel}: lint-delta-boundary: I2 — DELTA-INSTALL-fence-count: the scaffolder carries $fences fence(s), at most $INSTALLER_FENCE_MAX are allowed." >&2
+      echo "The two sanctioned ones are the scripts-copy block and the templates-copy block, which sit in different regions of the file because templates/generated/ does not exist yet at the first one. A third fence is a third place the boundary is exempt — argue it in docs/designs/2026-08-02-delta-track-v1.md §3.1 and raise INSTALLER_FENCE_MAX, do not just add it." >&2
+      VIOLATIONS=$((VIOLATIONS + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\tI2\t${rel}\tDELTA-INSTALL-fence-count-${fences}-over-max-${INSTALLER_FENCE_MAX}\n"
+    else
+      LIST_ROWS="${LIST_ROWS}INFO\tI2\t${rel}\tDELTA-INSTALL fences: ${fences}/${INSTALLER_FENCE_MAX}\n"
+    fi
   fi
 
   # T1 — literal manifest tokens. Fixed-string matching: the tokens contain

--- a/scripts/lint-delta-boundary.sh
+++ b/scripts/lint-delta-boundary.sh
@@ -207,11 +207,44 @@ DELTA_MANIFEST=(
   "scripts/delta.sh"
   "scripts/cut-release.sh"
   "scripts/lint-delta-boundary.sh"
+  "templates/generated/delta-brief.tmpl"
   "docs/deltas/"
   ".claude/delta-state.json"
   ".claude/delta-policy.json"
 )
 # ── DELTA-BOUNDARY-MANIFEST-END ─────────────────────────────────────────
+
+# ── DELTA-BOUNDARY-INSTALLER-BEGIN ──────────────────────────────────────
+# THE INSTALLER, AND WHY IT IS NOT A SECOND SEAM.
+#
+# WP8 ships the module to generated projects, which means the scaffolder has to
+# NAME every module file it copies — and it has to name them LITERALLY, because
+# scripts/lib/scaffold-shipped-set.sh derives the shipped set by parsing those
+# very `cp` lines. A derived or composed spelling would satisfy this lint and
+# break the source-closure gate, which is the worse of the two failures.
+#
+# A `cp` is not a dependency edge. init.sh copies BYTES; it never sources a
+# module lib, never calls delta.sh, and would not notice if the module's
+# behaviour changed. Sever the module and these lines have nothing to copy —
+# which is why the severability revert removes the block outright, and why
+# tests/test-delta-severability.sh's V1 sweep reads the scaffolder.
+#
+# SO THE EXEMPTION IS BOUNDED THREE WAYS, and it is deliberately TIGHTER than
+# the seam's (which exempts a whole file):
+#   1. ONE installer file, cardinality asserted exactly as the seam's is. A
+#      second installer is a design change, not an appended row.
+#   2. Only lines INSIDE a `# DELTA-INSTALL-BEGIN` / `# DELTA-INSTALL-END`
+#      fence are exempt. A module path anywhere else in init.sh is still a
+#      violation, in both tiers.
+#   3. Only INSTALLATION STATEMENTS may live inside the fence — `cp`, `chmod`,
+#      `mkdir`. A `source scripts/lib/delta-state.sh` smuggled in there is a
+#      real fusion wearing an installer's coat, and it FAILS (tier I1). An
+#      unbalanced or nested fence fails too, because an unterminated BEGIN
+#      would exempt the rest of the file.
+INSTALLER_ALLOWLIST=(
+  "init.sh|WP8 ships the §3.1 module to generated projects; the copy list must name each file LITERALLY because scripts/lib/scaffold-shipped-set.sh parses these cp lines to derive the shipped set. Copying bytes is installation, not a dependency edge — and only cp/chmod/mkdir statements inside the DELTA-INSTALL fence are exempt"
+)
+# ── DELTA-BOUNDARY-INSTALLER-END ────────────────────────────────────────
 
 # ── DELTA-BOUNDARY-SEAM-BEGIN ───────────────────────────────────────────
 # The ONE seam (§3.1). Rows are `path|reason`; the reason is REQUIRED and is
@@ -264,6 +297,34 @@ if [ -z "$SEAM_REASON" ] || [ "$SEAM_REASON" = "${SEAM_ALLOWLIST[0]}" ]; then
   exit 1
 fi
 LIST_ROWS="${LIST_ROWS}INFO\tseam\t${SEAM_PATH}\tallowlisted (cardinality 1/1): ${SEAM_REASON}\n"
+
+# ── DELTA-BOUNDARY-INSTALLER-CARDINALITY ────────────────────────────────
+# The same assertion as the seam's, for the same reason and with the same
+# answer: one, or argue it in the design.
+INSTALLER_COUNT=0
+[ "${#INSTALLER_ALLOWLIST[@]}" -gt 0 ] && INSTALLER_COUNT=${#INSTALLER_ALLOWLIST[@]}
+if [ "$INSTALLER_COUNT" -ne 1 ]; then
+  echo "lint-delta-boundary: installer allowlist cardinality is $INSTALLER_COUNT, must be exactly 1." >&2
+  echo "The scaffolder is the ONE file allowed to name module paths inside a DELTA-INSTALL fence. A second installer is a design change — amend docs/designs/2026-08-02-delta-track-v1.md §3.1 and argue it, do not append a row." >&2
+  LIST_ROWS="${LIST_ROWS}FAIL\tinstaller\t${SELF_REL}\tcardinality ${INSTALLER_COUNT}, must be exactly 1\n"
+  emit_list
+  exit 1
+fi
+
+INSTALLER_PATH="${INSTALLER_ALLOWLIST[0]%%|*}"
+INSTALLER_REASON="${INSTALLER_ALLOWLIST[0]#*|}"
+if [ -z "$INSTALLER_REASON" ] || [ "$INSTALLER_REASON" = "${INSTALLER_ALLOWLIST[0]}" ]; then
+  echo "lint-delta-boundary: installer allowlist row '$INSTALLER_PATH' carries no reason. Every allowlist row requires a reason string (see this script's ALLOWLIST section)." >&2
+  LIST_ROWS="${LIST_ROWS}FAIL\tinstaller\t${INSTALLER_PATH}\tallowlist row has an empty reason\n"
+  emit_list
+  exit 1
+fi
+# THE WORDING IS DELIBERATELY NOT "cardinality 1/1". That exact string is the
+# SEAM's, and tests/test-delta-wp2-state-policy.sh::S6 counts its occurrences to
+# assert the seam allowlist is still one. A second row spelling it the same way
+# would make that count read 2 and break a WP2 assertion for a cosmetic reason —
+# so the installer says "1 of 1" and the two remain separately countable.
+LIST_ROWS="${LIST_ROWS}INFO\tinstaller\t${INSTALLER_PATH}\tDELTA-INSTALL fence exempt (installer allowlist 1 of 1): ${INSTALLER_REASON}\n"
 
 # ── Set derivation ──────────────────────────────────────────────────────
 
@@ -382,11 +443,49 @@ parse_allow() {
   printf '%d\t%s\n' "$has" "$reason"
 }
 
+# ── DELTA-BOUNDARY-INSTALL-FENCE ────────────────────────────────────────
+# _install_fence <file> — one record per line, on stdout:
+#     EXEMPT <n>              this line is inside a fence and is installation
+#     BAD <n> <what>          a fence problem, or a non-installation statement
+#                             inside a fence
+# The fence markers themselves are comments, so the stripper has already
+# blanked them by the time the tiers run; they are read off the RAW file here.
+#
+# EVERY FAILURE MODE FAILS CLOSED. An unterminated BEGIN would exempt the whole
+# rest of the scaffolder, so it is an error rather than a tolerated sloppiness;
+# a nested BEGIN is the same hazard wearing a second coat; and a statement that
+# is not `cp`, `chmod` or `mkdir` is the fusion this whole lint exists to catch,
+# so it is reported at the line rather than waived by its neighbours.
+_install_fence() {
+  awk '
+    /^[[:space:]]*#.*DELTA-INSTALL-BEGIN/ {
+      if (open == 1) printf "BAD %d nested-DELTA-INSTALL-BEGIN\n", NR
+      open = 1; next
+    }
+    /^[[:space:]]*#.*DELTA-INSTALL-END/ {
+      if (open == 0) printf "BAD %d DELTA-INSTALL-END-with-no-BEGIN\n", NR
+      open = 0; next
+    }
+    open == 1 {
+      printf "EXEMPT %d\n", NR
+      s = $0
+      sub(/^[[:space:]]*/, "", s)
+      if (s == "") next
+      if (s ~ /^#/) next
+      if (s !~ /^(cp|chmod|mkdir)[[:space:]]/)
+        printf "BAD %d non-installation-statement-inside-the-fence\n", NR
+    }
+    END { if (open == 1) printf "BAD %d unterminated-DELTA-INSTALL-fence\n", NR }
+  ' "$1" 2>/dev/null
+  return 0
+}
+
 scan_core_file() {
   local rel="$1"
   local file="$ROOT/$rel"
-  local hits line n raw tok parsed has reason
+  local hits line n raw tok parsed has reason rec kind
   local t1_lines="|"
+  local exempt_lines="|"
 
   # The one seam is exempt from BOTH tiers. §3.3 clause 3 names it "the sole
   # allowlisted core file" without qualifying by tier, and that is the honest
@@ -411,6 +510,29 @@ scan_core_file() {
     return 2
   fi
 
+  # THE INSTALLER'S FENCE, read before either tier so the exempt set exists by
+  # the time they need it. Only the ONE allowlisted installer gets it: a
+  # DELTA-INSTALL fence in any other core file exempts nothing, which is the
+  # fail-closed direction.
+  if [ "$rel" = "$INSTALLER_PATH" ]; then
+    while IFS= read -r rec; do
+      [ -n "$rec" ] || continue
+      kind="${rec%% *}"
+      rec="${rec#* }"
+      n="${rec%% *}"
+      case "$kind" in
+        EXEMPT) exempt_lines="${exempt_lines}${n}|" ;;
+        BAD)
+          echo "${rel}:${n}: lint-delta-boundary: I1 — ${rec#* } in the DELTA-INSTALL fence. Only cp / chmod / mkdir may live between the fence markers, and the fence must be balanced: an unterminated BEGIN would exempt the rest of this file. Move the statement out of the fence, or fix the markers." >&2
+          VIOLATIONS=$((VIOLATIONS + 1))
+          LIST_ROWS="${LIST_ROWS}FAIL\tI1\t${rel}:${n}\t${rec#* }\n"
+          ;;
+      esac
+    done <<EOF
+$(_install_fence "$file")
+EOF
+  fi
+
   # T1 — literal manifest tokens. Fixed-string matching: the tokens contain
   # `.` and `-`, and a BRE would let `delta.sh` match `deltaXsh`.
   if [ -s "$T1_TOKENS" ]; then
@@ -420,6 +542,10 @@ scan_core_file() {
         [ -n "$line" ] || continue
         n="${line%%:*}"
         t1_lines="${t1_lines}${n}|"
+        case "$exempt_lines" in *"|${n}|"*)
+          LIST_ROWS="${LIST_ROWS}PASS\tT1\t${rel}:${n}\tinstaller fence: installation, not a dependency edge\n"
+          continue ;;
+        esac
         # `sed -n '1p'` and not `head -1`: head exits on its first line, the
         # upstream grep dies of SIGPIPE, and `pipefail` (set at the top of this
         # script) promotes rc=141 into the substitution. `sed -n 1p` consumes
@@ -442,6 +568,10 @@ scan_core_file() {
       [ -n "$line" ] || continue
       n="${line%%:*}"
       case "$t1_lines" in *"|${n}|"*) continue ;; esac
+      case "$exempt_lines" in *"|${n}|"*)
+        LIST_ROWS="${LIST_ROWS}PASS\tT2\t${rel}:${n}\tinstaller fence: installation, not a dependency edge\n"
+        continue ;;
+      esac
       # The allowlist marker lives in the COMMENT the stripper just removed, so
       # it is read off the RAW line — after the tiers have matched against the
       # stripped one.

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -65,6 +65,134 @@ if [ -f "PROJECT_INTAKE.md" ] && [ "$PHASE" != "unknown" ] && [ "${PHASE:-1}" -e
   fi
 fi
 
+# ── DELTA-RESUME-BEGIN ──────────────────────────────────────────────────────
+# THE FOURTH BRANCH (design 2026-08-02-delta-track-v1 §10.5), ahead of the
+# classic one.
+#
+# D8's point, and the reason this is the branch that matters: today's post-1.0
+# workflow instructions are RETRIEVAL surfaces — the guide and the ledger
+# headers — correct, and unread at the moment of need. A greeting changes WHEN
+# the operator learns the rule, from after they act to before. §10.5 marks its
+# tier honestly: ADVISORY. A greeting cannot make anyone do anything.
+#
+# Two sub-cases, and no others:
+#   current_phase == 4 and something open  -> resume THAT piece of work: its
+#     id, class, confirmed attributes, and what is still outstanding.
+#   current_phase == 4 and nothing open    -> the post-1.0 greeting: how to
+#     state a need in plain words, any overdue maintenance, any write-up still
+#     owed, and how many candidates the manifesto's § 6 is holding.
+#
+# WHY IT GOES THROUGH THE SEAM AND NAMES NO MODULE FILE. This is a CORE script,
+# and the post-1.0 module is severable: core may never reference it
+# (scripts/lint-delta-boundary.sh, §3.3 clause 2). So this block reads the
+# record by delegating to scripts/process-checklist.sh — a core file, and the
+# ONE declared seam — exactly as scripts/validate.sh, scripts/upgrade-project.sh
+# and scripts/check-maintenance.sh already do. It names the seam's action FLAG
+# and never a module path, so tier T1 stays clean and the seam allowlist stays
+# at cardinality one.
+#
+# AND IT FAILS SOFT, which is what keeps the module severable rather than
+# merely separate. With the module absent the seam answers non-zero, the
+# document is empty, and control falls through to the classic prompt below —
+# no crash, no half-greeting. That is the same fail-soft contract the other
+# four core consumers carry, measured by the severability suite's V0.
+#
+# The whole block is contiguous between these two markers so the sever is a
+# single-block revert, like the seam's own fence.
+if [ "$PHASE" = "4" ] && command -v jq >/dev/null 2>&1; then          # DELTA-RESUME-PHASE4
+  pmv_seam="$SCRIPT_DIR/process-checklist.sh"
+  pmv_doc=""
+  if [ -f "$pmv_seam" ]; then
+    pmv_doc="$( bash "$pmv_seam" --delta-state-read </dev/null 2>/dev/null )" || pmv_doc=""   # lint-delta-boundary: allow core->core delegation to the ONE declared seam — this names the seam's action FLAG, never a module path (T1 is clean) and the seam allowlist stays at cardinality 1 (§3.1/§3.3)
+  fi
+  if [ -n "$pmv_doc" ] && printf '%s\n' "$pmv_doc" | jq -e . >/dev/null 2>&1; then
+    # Outstanding write-ups, and the candidate count, are the two things both
+    # sub-cases want.
+    pmv_owed=$(printf '%s\n' "$pmv_doc" | jq -r '
+      [ .hotfix_retros[]? | select(type == "object") | select(.closed_at == null) ]
+      | map("  " + (.id // "unknown") + " — due " + (.due_by // "an unrecorded date"))
+      | join("\n")' 2>/dev/null || echo "")
+    # The § 6 read is the SAME predicate the post-1.0 status surface uses, and
+    # the two are pinned to agree by test-delta-wp8-intake.sh's BR1/R3 pair
+    # (three items listed there, "3" reported here, from one manifesto). It is
+    # spelled out again rather than shared because a core script may not source
+    # a module lib — that is the cost of the boundary, named rather than hidden.
+    pmv_cands=0
+    if [ -f "PRODUCT_MANIFESTO.md" ]; then
+      pmv_cands=$(awk '/^##[ \t]*6[. ]/ { insec = 1; next }
+/^##.*Post-MVP Backlog/ { insec = 1; next }
+insec && /^##/ { insec = 0 }
+insec && /^[-*+][ \t]+/ { print }' PRODUCT_MANIFESTO.md 2>/dev/null | grep -c '' || true)
+      case "$pmv_cands" in ''|*[!0-9]*) pmv_cands=0 ;; esac
+    fi
+    pmv_maint=""
+    if [ -f "$SCRIPT_DIR/check-maintenance.sh" ]; then
+      pmv_mrc=0
+      bash "$SCRIPT_DIR/check-maintenance.sh" </dev/null >/dev/null 2>&1 || pmv_mrc=$?
+      case "$pmv_mrc" in
+        1) pmv_maint="Routine maintenance is OVERDUE — run scripts/check-maintenance.sh to see which window." ;;
+        2) pmv_maint="A maintenance window could not be measured — run scripts/check-maintenance.sh; it will say which signal it could not read." ;;
+      esac
+    fi
+
+    pmv_open=$(printf '%s\n' "$pmv_doc" | jq -r '.active_delta.id // ""' 2>/dev/null || echo "")
+    if [ -n "$pmv_open" ]; then
+      echo -e "${CYAN}--- Copy everything below this line into Claude Code ---${NC}"
+      echo ""
+      printf '%s\n' "$pmv_doc" | jq -r '
+        .active_delta as $d
+        | "We are resuming a piece of post-release work on this product.",
+          "",
+          "**In progress:** \($d.id) — \($d.slug // "no description recorded")",
+          "**Kind of change:** \($d.class // "unknown")",
+          "**Agreed at the start:** risk \($d.attributes.risk // "unknown"), size \($d.attributes.level // "unknown")"
+            + (if ($d.attributes.severity // null) == null then "" else ", severity \($d.attributes.severity)" end),
+          "**Written-up plan:** " + ($d.brief // "none — this kind of change does not need one"),
+          "**Still to do before it can ship:** "
+            + ((( ($d.gates_required // []) - ($d.gates_completed // []) ) | join(", "))
+               | if . == "" then "nothing — it is ready to close" else . end),
+          "**Already done:** "
+            + ((($d.gates_completed // []) | join(", ")) | if . == "" then "nothing yet" else . end)'
+      if [ -n "$pmv_owed" ]; then
+        echo ""
+        echo "**Write-ups still owed (nothing can be released until these are filed):**"
+        printf '%s\n' "$pmv_owed"
+      fi
+      if [ -n "$pmv_maint" ]; then echo ""; echo "**Maintenance:** $pmv_maint"; fi
+      echo ""
+      echo "Read CLAUDE.md for full product context, then pick this up where we left off. The plan file above is the review at the end — if what we build stops matching it, say so rather than quietly changing the plan."
+      echo ""
+      echo -e "${CYAN}--- End (a blank Claude Code screen means it is ready and waiting, not stuck) ---${NC}"
+      exit 0
+    fi
+
+    echo -e "${CYAN}--- Copy everything below this line into Claude Code ---${NC}"
+    echo ""
+    echo "This product has shipped. Nothing is in progress right now."
+    echo ""
+    echo "Everything from here on is one piece of work at a time — a new feature, a fix, an urgent fix, or a security patch. I do not need to know which; I will tell you in plain words what I need and you work out the rest with me."
+    echo ""
+    if [ -n "$pmv_owed" ]; then
+      echo "**Write-ups still owed (nothing can be released until these are filed):**"
+      printf '%s\n' "$pmv_owed"
+      echo ""
+    fi
+    if [ -n "$pmv_maint" ]; then
+      echo "**Maintenance:** $pmv_maint"
+      echo ""
+    fi
+    if [ "$pmv_cands" -gt 0 ]; then
+      echo "**Post-MVP Backlog:** PRODUCT_MANIFESTO.md section 6 is holding $pmv_cands candidate(s). They are candidates, not commitments — nothing there is scheduled, and nothing moves out of that document without me saying so."
+      echo ""
+    fi
+    echo "Read CLAUDE.md for full product context and for how post-release work is run here. Then ask me what I need."
+    echo ""
+    echo -e "${CYAN}--- End (a blank Claude Code screen means it is ready and waiting, not stuck) ---${NC}"
+    exit 0
+  fi
+fi
+# ── DELTA-RESUME-END ────────────────────────────────────────────────────────
+
 # Last 3 git log entries
 RECENT_COMMITS="(no commits)"
 if command -v git &>/dev/null && [ -d ".git" ]; then

--- a/scripts/resume.sh
+++ b/scripts/resume.sh
@@ -125,6 +125,14 @@ insec && /^##/ { insec = 0 }
 insec && /^[-*+][ \t]+/ { print }' PRODUCT_MANIFESTO.md 2>/dev/null | grep -c '' || true)
       case "$pmv_cands" in ''|*[!0-9]*) pmv_cands=0 ;; esac
     fi
+    # THE ONE PIECE OF THE CLASSIC PROMPT THAT IS CARRIED OVER. This branch
+    # REPLACES the classic prompt (§10.5: it sits ahead of it), and for a
+    # shipped product that is now the first message of every session forever.
+    # Dropping "what happened last" entirely would be an information regression
+    # nobody asked for, so the cheapest and most useful line of it comes along.
+    # The tool-version check deliberately does NOT: it can reach the network,
+    # and a greeting that stalls is worse than a greeting that is shorter.
+    pmv_commits="$(git log --oneline -3 2>/dev/null || true)"
     pmv_maint=""
     if [ -f "$SCRIPT_DIR/check-maintenance.sh" ]; then
       pmv_mrc=0
@@ -159,6 +167,11 @@ insec && /^[-*+][ \t]+/ { print }' PRODUCT_MANIFESTO.md 2>/dev/null | grep -c ''
         printf '%s\n' "$pmv_owed"
       fi
       if [ -n "$pmv_maint" ]; then echo ""; echo "**Maintenance:** $pmv_maint"; fi
+      if [ -n "$pmv_commits" ]; then
+        echo ""
+        echo "**Recent commits:**"
+        printf '%s\n' "$pmv_commits"
+      fi
       echo ""
       echo "Read CLAUDE.md for full product context, then pick this up where we left off. The plan file above is the review at the end — if what we build stops matching it, say so rather than quietly changing the plan."
       echo ""
@@ -183,6 +196,11 @@ insec && /^[-*+][ \t]+/ { print }' PRODUCT_MANIFESTO.md 2>/dev/null | grep -c ''
     fi
     if [ "$pmv_cands" -gt 0 ]; then
       echo "**Post-MVP Backlog:** PRODUCT_MANIFESTO.md section 6 is holding $pmv_cands candidate(s). They are candidates, not commitments — nothing there is scheduled, and nothing moves out of that document without me saying so."
+      echo ""
+    fi
+    if [ -n "$pmv_commits" ]; then
+      echo "**Recent commits:**"
+      printf '%s\n' "$pmv_commits"
       echo ""
     fi
     echo "Read CLAUDE.md for full product context and for how post-release work is run here. Then ask me what I need."

--- a/templates/generated/delta-brief.tmpl
+++ b/templates/generated/delta-brief.tmpl
@@ -1,0 +1,94 @@
+# {{DELTA_ID}} — {{SLUG}}
+
+<!--
+  THE POST-1.0 DELTA BRIEF — one page, five sections.
+
+  SPEC: docs/designs/2026-08-02-delta-track-v1.md §6.2 (the five sections and
+  why each one is here), §6.3 (this file lives at
+  docs/deltas/DELTA-NNN-<slug>.md), §5.3 (the done-observable list IS the close
+  review's rubric), §11-WP8.
+
+  THREE WAYS THIS FILE GETS HERE, and they all end in the same place:
+    • guided        scripts/delta.sh --open renders this template for you
+    • conversational  you say what you need in plain words and the agent fills
+                      these sections in with you, then opens the delta
+    • manual        copy this file to docs/deltas/DELTA-NNN-<slug>.md yourself,
+                    fill it in, then run scripts/delta.sh --open --slug <slug>;
+                    an existing brief for that id is ADOPTED, never overwritten
+
+  ─────────────────────────────────────────────────────────────────────────────
+  THE ONE SECTION A PROGRAM READS — "## Done-observable"
+
+  Everything else on this page is for humans. The Done-observable section is
+  parsed by scripts/delta.sh at close, and the close REFUSES while any box is
+  unticked. The contract, spelled out so this template and that parser can
+  never drift apart:
+
+    • The section is opened by ANY heading whose text begins "Done-observable",
+      case-insensitively, at ANY heading depth. A trailing parenthetical is
+      fine.
+    • It ENDS at the next heading of the SAME depth or SHALLOWER. A "###"
+      sub-heading nested inside it is still part of the rubric.
+    • A brief carrying TWO Done-observable headings has BOTH read, and the
+      criteria are POOLED. There is no "first one wins".
+    • A criterion is a list item whose marker is "-", "*" or "+", at any
+      indent, followed by a bracketed single character. "- [x]" and "- [X]"
+      are DONE; "- [ ]" is not. Anything else between the brackets counts as
+      NOT done and is named in the refusal — an undefined marker is a
+      criterion nobody has decided about.
+    • It FAILS CLOSED: no file, two files claiming the same id, no
+      Done-observable heading, or a heading with no checkboxes under it are
+      each a refusal to close. An empty rubric would let the work close on
+      nothing at all.
+
+  So: write the boxes BEFORE you start building. That is the whole point — you
+  are writing the review criteria while you are still able to be honest about
+  them.
+-->
+
+**Class:** {{CLASS}}
+**Opened:** {{OPENED_AT}}
+**Risk:** {{RISK}} · **Level:** {{LEVEL}} · **Severity:** {{SEVERITY}}
+
+## What
+
+[One paragraph, in your own words. What is being changed? Write it the way you
+would say it out loud to someone who has not seen the code.]
+
+## Why
+
+[The user signal. What did someone actually do, say, or fail to do that makes
+this worth building now? If this came off the Post-MVP Backlog in
+PRODUCT_MANIFESTO.md § 6, that entry already answers this — paste it.]
+
+## Done-observable
+
+<!--
+  One line per thing you will be able to SEE working when this is finished.
+  Observable, not aspirational: "the export downloads a file with the unicode
+  name intact", not "unicode handling is improved". Tick a box only when you
+  have actually seen that thing happen.
+-->
+
+- [ ] [the first thing you will be able to see working]
+- [ ] [the second thing you will be able to see working]
+
+## Must-not-change
+
+<!--
+  The regression contract. What would you be upset to discover had broken while
+  this was being built? Name it here and it becomes part of the close review.
+-->
+
+- [what must still work exactly as it does today]
+
+## Touched surfaces
+
+<!--
+  Your forecast of the files and areas this will touch. It feeds the risk
+  derivation when the delta opens, and it is compared against the REAL diff
+  when it closes — so a forecast that turns out wrong is information, not a
+  failure. Guess honestly.
+-->
+
+- [file or area]

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1876,6 +1876,20 @@ run_child_suite "tests/test-delta-wp7-cut-release.sh" \
 # Never executes the init script -> both lanes.
 run_child_suite "tests/test-delta-severability.sh" \
   "tests/test-delta-severability.sh"
+
+# Delta Track WP8 — the three intake paths (§6.1), the brief template (§6.2),
+# identity and the SLUG REFUSAL (§6.3), the manifesto bridge as a read (§10.4),
+# resume.sh's fourth branch (§10.5) — plus Karl's two decisions of 2026-08-09:
+# SHIPPING the module to generated projects (the scaffolder carried the string
+# zero times, so the whole track reached nobody) and writing the hotfix audit
+# trace as a REAL BUGS.md row rather than only a state-document stamp. Because
+# the copy list moves the derived shipped set, this suite also re-runs the
+# source-closure gate and the boundary lint and builds a mutant that drops a cp
+# line to prove that gate is load-bearing. Reads the init script STATICALLY and
+# never executes it (its basename is spelled split for the unit-lane predicate,
+# as tests/test-delta-severability.sh does) -> both lanes.
+run_child_suite "tests/test-delta-wp8-intake.sh" \
+  "tests/test-delta-wp8-intake.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-delta-severability.sh
+++ b/tests/test-delta-severability.sh
@@ -22,12 +22,35 @@
 #   3. scripts/validate.sh            _postmvp_era_assertion + its call site
 #                                     (WP3's §10.1 report-only assertion)
 #   4. scripts/check-maintenance.sh   the cadence policy read (WP6)
+#   5. scripts/resume.sh              the §10.5 fourth branch (WP8) — the
+#                                     `# DELTA-RESUME-BEGIN`/`-END` fence,
+#                                     another core->core seam delegation
+#   6. init.sh                        the WP8 copy list — the
+#                                     `# DELTA-INSTALL-BEGIN`/`-END` fences
+#                                     (TWO of them: the scripts block and the
+#                                     template block) that ship the module to
+#                                     generated projects
+#
+# CONSUMERS 5 AND 6 ARRIVED IN WP8 AND WERE FOUND BY THIS FILE, not by anyone
+# remembering. V1 named both by path the first time the suite ran against the
+# WP8 tree — which is the completeness sweep doing exactly the job the rest of
+# this header claims for it, and is the reason the revert list is allowed to be
+# a list at all.
+#
+# CONSUMER 6 IS A DIFFERENT SHAPE FROM 1-5 AND IS WORTH THE SENTENCE. The
+# scaffolder does not CALL the module; it copies its bytes. It has to name each
+# file literally, because scripts/lib/scaffold-shipped-set.sh derives the
+# shipped set by parsing those cp lines. Post-sever there is nothing to copy, so
+# the fence goes as a whole block — and scripts/lint-delta-boundary.sh accepts
+# it in the intact tree only inside that fence and only for cp/chmod/mkdir
+# statements (its DELTA-BOUNDARY-INSTALLER fence, cardinality one, asserted the
+# same way the seam's is).
 #
 # ...and TWO more that are not scripts at all:
 #
-#   5. .github/workflows/lint.yml    the `delta-boundary-lint` job, which runs
+#   7. .github/workflows/lint.yml    the `delta-boundary-lint` job, which runs
 #                                    scripts/lint-delta-boundary.sh (WP1)
-#   6. tests/full-project-test-suite.sh
+#   8. tests/full-project-test-suite.sh
 #                                    `run_child_suite "scripts/lint-delta-boundary.sh"`
 #                                    — the aggregator invoking the module's
 #                                    lint DIRECTLY, not through a tests/ path
@@ -306,7 +329,26 @@ _drop_fn() {
   return 0
 }
 
-# sever_seam <tree> — STEP 2: THE REVERT. Four core files, enumerated in this
+# _drop_fenced_block <file> <NAME> — remove every `# <NAME>-BEGIN` … `#
+#   <NAME>-END` block, markers included. EVERY pair, not the first: init.sh
+#   carries two DELTA-INSTALL fences (the scripts block and the template
+#   block), and a first-pair-only drop would leave the second one behind for
+#   V1 to find — which is the same "a multi-line construct is dropped as a
+#   construct or not at all" lesson the YAML job and the aggregator call each
+#   taught from their own direction.
+_drop_fenced_block() {
+  local f="$1" name="$2" tmp
+  [ -f "$f" ] || return 0
+  tmp="$(mktemp)"
+  awk -v name="$name" '
+    $0 ~ "^[[:space:]]*#.*" name "-BEGIN" { skip = 1; next }
+    skip == 1 { if ($0 ~ "^[[:space:]]*#.*" name "-END") skip = 0; next }
+    { print }
+  ' "$f" > "$tmp" && mv "$tmp" "$f"
+  return 0
+}
+
+# sever_seam <tree> — STEP 2: THE REVERT. Six core files, enumerated in this
 #   file's header and kept honest by V1's completeness sweep.
 sever_seam() {
   local d="$1" tmp
@@ -328,6 +370,17 @@ sever_seam() {
   tmp="$(mktemp)"
   sed -e 's|^.*# CADENCE-POLICY-READ.*$|    v=""|' "$d/scripts/check-maintenance.sh" > "$tmp" \
     && mv "$tmp" "$d/scripts/check-maintenance.sh"
+  # (5) resume.sh — WP8's §10.5 fourth branch. A whole-block drop like the
+  #     seam's, and for the same reason: the branch is contiguous between its
+  #     markers precisely so that the sever is one operation. Dropping the
+  #     single seam-delegation LINE would leave an `if` whose body reads a
+  #     document nothing produces, which is not a severed greeting — it is a
+  #     branch that always falls through while still claiming to be there.
+  _drop_fenced_block "$d/scripts/resume.sh" "DELTA-RESUME"
+  # (6) the scaffolder — WP8's copy list, BOTH fences. Post-sever there is
+  #     nothing to copy: the module files were deleted in step 1, so a
+  #     surviving cp line is a scaffolder that fails on every run.
+  _drop_fenced_block "$d/$INIT_FILE" "DELTA-INSTALL"
   return 0
 }
 

--- a/tests/test-delta-wp5-hotfix-retro.sh
+++ b/tests/test-delta-wp5-hotfix-retro.sh
@@ -58,8 +58,17 @@
 #   H — THE HOTFIX FAST LANE AT OPEN (§5.2)
 #     H1  a hotfix materialises EXACTLY the §5.2 row and NOTHING heavier — the
 #         set is asserted whole, not as a subset; no brief is demanded anywhere;
-#         and the open writes no file outside the two `.claude/` documents, so
-#         the floor (§5.1) is inherited rather than re-implemented
+#         and the open CREATES no file outside the two `.claude/` documents, so
+#         the floor (§5.1) is inherited rather than re-implemented.
+#         AMENDED BY WP8 / Karl's decision of 2026-08-09: the open now also
+#         APPENDS one row to the existing BUGS.md. That is the hotfix audit
+#         trace made visible — the reviewer's evidence was that the state
+#         document's `audit_row_at_open` stamp survives neither an abandoned
+#         hotfix nor a lost state file, so the audit trail it promises does not
+#         persist. H1 therefore no longer demands that BUGS.md be byte-identical;
+#         it demands that BUGS.md be the ONLY thing that moved, and that it moved
+#         by exactly one added line naming the delta. That is a stronger
+#         assertion than the one it replaced, not a relaxation of it.
 #     H2  the AUDIT ROW IS WRITTEN AT OPEN, not at close: the stamp is on the
 #         record and the gate is already complete the moment the delta opens —
 #         it is the one gate in the system nobody attests, because the framework
@@ -195,9 +204,10 @@ mk_proj() {
 }
 
 # A project carrying DECOYS: a generated pre-commit hook and the two ledgers a
-# real post-1.0 project has. H1 asserts the fast lane touches none of them —
-# §5.1's floor is INHERITED, and the delta track adds no floor arm. A fixture
-# with nothing to disturb could not tell "added no arm" from "found nothing".
+# real post-1.0 project has. H1 asserts the fast lane touches none of them
+# EXCEPT the one row WP8 appends to BUGS.md — §5.1's floor is INHERITED, and the
+# delta track adds no floor arm. A fixture with nothing to disturb could not
+# tell "added no arm" from "found nothing".
 mk_decoy_proj() {
   local d="$1" phase="$2"
   mk_proj "$d" "$phase"
@@ -400,6 +410,9 @@ echo "=== H — the hotfix fast lane at open (§5.2) ==="
 # added exactly the two `.claude/` documents and disturbed nothing else.
 T=$(mktemp -d); P="$T/proj"; mk_decoy_proj "$P" 4
 before="$(tree_manifest "$P")"
+# The one permitted move is measured line-by-line, so the ledger is snapshotted
+# HERE — before the open — alongside the whole-tree manifest.
+cp "$P/BUGS.md" "$T/bugs.before" 2>/dev/null || : > "$T/bugs.before"
 out=$(delta_run "$REPO_ROOT/scripts" "$P" --open --describe "checkout is down in production right now" --class hotfix --slug checkout --confirm); rc=$?
 after_files="$(tree_files "$P" | tr '\n' ' ')"
 gates="$(active_json "$P" -c '.active_delta.gates_required')"
@@ -409,22 +422,41 @@ klass="$(active_json "$P" -r '.active_delta.class')"
 heavy=n
 printf '%s' "$gates" | grep -qE 'brief|build_loop' && heavy=y
 had_deltas=n; [ -d "$P/docs/deltas" ] && had_deltas=y
-# Everything that existed before is byte-identical afterwards.
+# Everything that existed before is byte-identical afterwards — EXCEPT BUGS.md,
+# which gains exactly one row (Karl's decision of 2026-08-09: the hotfix audit
+# trace is a visible ledger row, not only a state-document stamp). The
+# exemption is spelled as "BUGS.md is the ONLY file that moved" plus "it moved
+# by one added line naming the delta", so a fast lane that started rewriting
+# the pre-commit hook, the changelog or the feature list would still be caught.
 undisturbed=y
+ledger_delta=""
 printf '%s\n' "$before" | while IFS= read -r row; do
   [ -n "$row" ] || continue
   f="${row#*  }"
   printf '%s  %s\n' "$(_md5file "$P/$f")" "$f"
 done > "$T/recheck"
 printf '%s\n' "$before" | grep -v '^$' > "$T/before"
-diff -q "$T/before" "$T/recheck" >/dev/null 2>&1 || undisturbed=n
+moved="$(diff "$T/before" "$T/recheck" 2>/dev/null | grep '^[<>]' || true)"
+if [ -n "$moved" ]; then
+  printf '%s\n' "$moved" | grep -qv 'BUGS\.md' && undisturbed=n
+fi
+# ...and the shape of the one permitted move. The diff goes to a FILE and the
+# assertions read the file: `diff` exits 1 when the files differ, and under
+# `set -o pipefail` that 1 propagates out of any `diff | grep -q …` pipeline
+# and turns a successful match into a failed test.
+diff "$T/bugs.before" "$P/BUGS.md" > "$T/bugs.diff" 2>/dev/null || true
+ledger_delta="$(grep -c '^[<>]' "$T/bugs.diff" || true)"
+case "$ledger_delta" in ''|*[!0-9]*) ledger_delta=0 ;; esac
+ledger_names=n
+if [ "$ledger_delta" -eq 1 ] && grep -q '^>.*DELTA-001' "$T/bugs.diff"; then ledger_names=y; fi
+[ "$ledger_names" = y ] || undisturbed=n
 if [ "$rc" -eq 0 ] && [ "$klass" = "hotfix" ] \
    && [ "$gates" = '["ledger_row","audit_row_at_open","retro_review","changelog"]' ] \
    && [ "$heavy" = n ] && [ "$had_deltas" = n ] && [ "$undisturbed" = y ] \
    && [ "$after_files" = "./.claude/delta-policy.json ./.claude/delta-state.json ./.claude/phase-state.json ./BUGS.md ./CHANGELOG.md ./FEATURES.md " ]; then
-  pass "H1: a hotfix materialises EXACTLY the §5.2 row ($gates) and nothing heavier (no brief, no brief_review, no build_loop: heavy=$heavy, docs/deltas created=$had_deltas); the open adds only the two .claude documents and leaves the pre-commit hook and all three ledgers byte-identical (undisturbed=$undisturbed) — the floor is inherited, not re-implemented"
+  pass "H1: a hotfix materialises EXACTLY the §5.2 row ($gates) and nothing heavier (no brief, no brief_review, no build_loop: heavy=$heavy, docs/deltas created=$had_deltas); the open CREATES only the two .claude documents, leaves the pre-commit hook, CHANGELOG.md and FEATURES.md byte-identical, and moves BUGS.md by exactly $ledger_delta added line naming the delta (undisturbed=$undisturbed) — the floor is inherited, not re-implemented, and the one write is the audit row Karl's decision of 2026-08-09 requires to be VISIBLE"
 else
-  fail_ "H1" "rc=$rc (expect 0); class=$klass; gates=$gates (expect the §5.2 hotfix row EXACTLY); heavy token present=$heavy (expect n); docs/deltas created=$had_deltas (expect n); pre-existing files undisturbed=$undisturbed (expect y); files after='$after_files'; output:\n$out"
+  fail_ "H1" "rc=$rc (expect 0); class=$klass; gates=$gates (expect the §5.2 hotfix row EXACTLY); heavy token present=$heavy (expect n); docs/deltas created=$had_deltas (expect n); everything but BUGS.md undisturbed AND BUGS.md moved by exactly one delta-naming line=$undisturbed (expect y; BUGS.md diff lines=$ledger_delta, names the delta=$ledger_names); files after='$after_files'; output:\n$out"
 fi
 rm -rf "$T"
 

--- a/tests/test-delta-wp8-intake.sh
+++ b/tests/test-delta-wp8-intake.sh
@@ -1,0 +1,1060 @@
+#!/usr/bin/env bash
+# tests/test-delta-wp8-intake.sh — Delta Track WP8.
+#
+# SPEC: docs/designs/2026-08-02-delta-track-v1.md §6.1 (the three creation
+# paths, all converging on the SAME three writes — brief file, ledger row,
+# state activation — with exactly one writer for the third), §6.2 (the brief's
+# five sections, and "the done-observable section IS the close review's
+# rubric"), §6.3 (identity `docs/deltas/DELTA-NNN-slug.md`, `max(existing)+1`,
+# and the HARD constraint that the BUGS.md table format is parsed by scripts so
+# the delta link rides the EXISTING `Fix Reference` column), §10.4 (the bridge:
+# the manifesto's § 6 Post-MVP Backlog is READ as candidates, never moved),
+# §10.5 (the ambient branch: resume.sh's fourth branch, ahead of the classic
+# one), §5.2 (`audit_row_at_open`), §11-WP8.
+#
+# Plus Karl's two decisions of 2026-08-09 that landed in this work package:
+#   D1  SHIP THE DELTA MODULE. init.sh carried the string `delta` zero times,
+#       so the entire track reached no generated project. The copy list, the
+#       chmod split (libs get none, entry scripts do) and the Class-T template
+#       are asserted here, and the source-closure invariant is re-run because a
+#       copy-list change MOVES the derived shipped set.
+#   D3  `audit_row_at_open` WRITES A REAL BUGS.md ROW, in addition to WP5's
+#       state-document stamp. The reviewer's evidence: the stamp survives
+#       neither an abandoned hotfix nor a lost state file, so the audit trace it
+#       promises does not persist. WP5's record is NOT removed and its tests are
+#       NOT disturbed — this suite asserts BOTH are written.
+#
+# (No `# BL-NNN-…` marker anywhere in the delta track on purpose: no backlog
+# entry exists for this build and minting one would red
+# scripts/lint-bl-markers.sh. The design-doc path above is the citation, per
+# the WP1–WP7 precedent.)
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# EXIT CODES, NEVER LABELS
+#
+# CLAUDE.md's `[WARN]` trap: the printed label and the exit predicate can
+# disagree. Every refusal below is asserted on the process EXIT CODE, on JSON
+# read back off disk, or on a byte-level md5 — never on a banner. The codes this
+# suite depends on are delta.sh's published set:
+#     2   invocation error (a bad `--slug`, a bad `--via`, two briefs claiming
+#         one id)
+#     8   the brief's rubric has an unchecked criterion
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# THE SLUG IS WHERE A USER STRING BECOMES A FILESYSTEM PATH
+#
+# WP3's adversarial review recorded `--slug ../../../etc/cron.d/evil` stored
+# VERBATIM in the state document. WP3 only ever wrote it to JSON; WP8 is the
+# work package that turns it into `docs/deltas/<slug>.md`, so the refusal lands
+# here and is pinned here — in BOTH directions. S1 proves the traversal is
+# refused and that NOTHING was written anywhere in the tree (a refusal that
+# leaves a file behind is not a refusal). S3 proves the sanitiser is not merely
+# a blanket "reject anything unusual": an ordinary messy human slug still opens,
+# and lands on a basename made only of [a-z0-9-].
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# MUTATIONS — the standard this wave settled on, all of it, every mutant
+#
+#   • the marker is ANCHORED to end-of-line (`…$`), so a sed cannot land in the
+#     middle of a continuation;
+#   • `sites == 1` is asserted — a marker that matches twice mutates two places
+#     and proves nothing about either;
+#   • EXACTLY ONE LINE CHANGED is asserted (`diff | grep -c '^[<>]'` == 2);
+#   • EVERY mutant additionally asserts `bash -n`. This is not ceremony: a
+#     mutation that landed mid-continuation earlier in this wave produced a
+#     MANGLED PARSE whose crash read as "the guard caught it". A mutant that
+#     does not parse has not tested anything;
+#   • the harness is MODE-PRESERVING (`stat -c || stat -f`, the house GNU-first
+#     pattern) — a mutant that silently drops the exec bit fails for the wrong
+#     reason;
+#   • FRESH-FIXTURE ISOLATION: every mutant gets its own scripts tree AND its
+#     own project, built from scratch;
+#   • STRUCTURAL DISCRIMINATORS where the expected result is an ABSENCE. m1's
+#     "the manifesto was not modified" is an absence, so the killed/survived
+#     decision reads an md5, not a message;
+#   • no fixture temp dir derives its uniqueness from a counter inside a command
+#     substitution — that produced cross-suite fixture collisions earlier in
+#     this wave. Every directory here is either `mktemp -d` or a NAMED
+#     subdirectory of one.
+#
+# ═════════════════════════════════════════════════════════════════════════════
+# LANE: BOTH. This suite reads the scaffolder statically (it never runs it), so
+# it is fast and belongs in the fast lane. The scaffolder's basename is spelled
+# SPLIT below for exactly the reason tests/test-delta-severability.sh spells it
+# split — `# BL-181-UNIT-LANE-PREDICATE` exempts any test whose executed lines
+# NAME init.sh, and an exempt fast test quietly stops running in PR CI. The
+# split is documented rather than hidden, and the file is registered in
+# tests/full-project-test-suite.sh AND in the tests.yml `unit-shard` list.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for tests/test-delta-wp8-intake.sh" >&2
+  exit 2
+fi
+if ! command -v git >/dev/null 2>&1; then
+  echo "git is required for tests/test-delta-wp8-intake.sh" >&2
+  exit 2
+fi
+
+# The scaffolder's basename, split so no EXECUTED line in this file names it.
+# See the LANE note in the header.
+INIT_FILE="init"".sh"
+INIT_PATH="$REPO_ROOT/$INIT_FILE"
+
+TMPROOT="$(mktemp -d)"
+trap 'rm -rf "$TMPROOT"' EXIT
+
+_md5file() {
+  if command -v md5 >/dev/null 2>&1; then md5 -q "$1"
+  else md5sum "$1" | awk '{print $1}'; fi
+}
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || echo "?"; }
+
+# tree_manifest <dir> — every path plus its md5, sorted. The instrument for
+# "the refusal wrote NOTHING": a diff of two manifests names the file that
+# appeared, rather than merely reporting that a count moved.
+tree_manifest() {
+  local d="$1" f
+  ( cd "$d" && find . -type f 2>/dev/null | LC_ALL=C sort ) | while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    printf '%s  %s\n' "$f" "$(_md5file "$d/$f")"
+  done
+}
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+
+mk_scripts_tree() {
+  mkdir -p "$1"
+  cp -R "$REPO_ROOT/scripts" "$1/scripts"
+}
+
+# mk_proj <dir> <phase> — a phase-N project with the shipped ledgers and the
+# shipped brief template, i.e. what init.sh actually lays down.
+mk_proj() {
+  local d="$1" phase="$2"
+  mkdir -p "$d/.claude" "$d/templates/generated"
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":%s,"phases":{}}\n' \
+    "$phase" > "$d/.claude/phase-state.json"
+  cp "$REPO_ROOT/templates/generated/bugs.tmpl"        "$d/BUGS.md"
+  cp "$REPO_ROOT/templates/generated/features.tmpl"    "$d/FEATURES.md"
+  cp "$REPO_ROOT/templates/generated/delta-brief.tmpl" "$d/templates/generated/delta-brief.tmpl" 2>/dev/null || true
+  mkdir -p "$d/src"
+  printf 'base\n' > "$d/src/app.ts"
+  ( cd "$d" && git init -q \
+      && git config user.email t@t.local && git config user.name T \
+      && unset GITHUB_BASE_REF && git add -A && git commit -q -m init ) >/dev/null 2>&1
+}
+
+# A BUGS.md that already carries rows the phase gate greps for, so "the table
+# still parses after we append" is measured against real rows and not an empty
+# table. SEV-2/Deferred is deliberately one of them: it is the row
+# tests/test-delta-wp0-inherited-predicates.sh pins the gate on.
+seed_bugs_rows() {
+  local f="$1" tmp
+  tmp="$(mktemp)"
+  awk '
+    { print }
+    /^\|---\|/ && !done {
+      print "| 1 | SEV-1 | Open | login | crashes on unicode | Session 2 | Fix Now | | |"
+      print "| 2 | SEV-2 | Deferred | export | wrong column order | Session 3 | Defer | | |"
+      print "| 3 | SEV-3 | Fixed | ui | tooltip truncated | Session 3 | Fix Now | PR #12 | Session 4 |"
+      done = 1
+    }
+  ' "$f" > "$tmp" && mv "$tmp" "$f"
+}
+
+# write_manifesto <project> — a PRODUCT_MANIFESTO.md whose § 6 Post-MVP Backlog
+# carries three real candidates, in the shape the shipped template asks for
+# ("Each item: what it is, and what user signal would justify building it").
+write_manifesto() {
+  local p="$1"
+  cat > "$p/PRODUCT_MANIFESTO.md" <<'MANIFESTO'
+# Product Manifesto
+
+## 5. MVP Cutline
+
+Everything above this line ships first.
+
+## 6. Post-MVP Backlog
+
+<!--
+  Items here are candidates, not commitments.
+-->
+
+- Bulk CSV import — a user signal would be three support tickets asking for it
+- Dark mode — a user signal would be a request from more than one paying customer
+- Saved filters — a user signal would be the same filter typed twice in one session
+
+## 7. Will-Not-Have List
+
+- Anything with a blockchain in it
+MANIFESTO
+}
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+DRC=0
+DOUT=""
+delta_run() {   # <scripts-dir> <project-dir> [args…]
+  local sd="$1" p="$2"; shift 2
+  DRC=0
+  DOUT="$( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/delta.sh" "$@" </dev/null 2>&1 )" || DRC=$?
+  return 0
+}
+
+RRC=0
+ROUT=""
+resume_run() {  # <scripts-dir> <project-dir>
+  local sd="$1" p="$2"
+  RRC=0
+  ROUT="$( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/resume.sh" </dev/null 2>&1 )" || RRC=$?
+  return 0
+}
+
+active_json() {
+  local p="$1"; shift
+  jq "$@" "$p/.claude/delta-state.json" 2>/dev/null || printf 'READ-FAILED'
+}
+
+# open_feature <scripts-dir> <project> <slug> [extra args…] — the guided path,
+# non-interactive, with every derivation pinned by an explicit override so the
+# three-path comparison is measuring the PATH and not the ambient git diff.
+open_feature() {
+  local sd="$1" p="$2" slug="$3"; shift 3
+  delta_run "$sd" "$p" --open --describe "add a bulk CSV import screen" \
+    --class feature --risk feature-local --level significant \
+    --slug "$slug" --lines 40 --confirm "$@"
+}
+
+# normalise_state <project> — the state document with the three fields that
+# CANNOT be equal across paths removed: the wall-clock stamps, and `opened_via`
+# (which exists precisely to record which path was taken). Everything else must
+# match byte-for-byte, which is what §6.1's "all three converge on the same
+# three writes" means operationally.
+normalise_state() {
+  local p="$1"
+  jq -S 'del(.active_delta.opened_at, .active_delta.attributes_confirmed_at,
+             .active_delta.opened_via, .active_delta.audit_row_at_open)' \
+     "$p/.claude/delta-state.json" 2>/dev/null || printf 'READ-FAILED'
+}
+
+echo "== tests/test-delta-wp8-intake.sh =="
+echo ""
+
+# ════════════════════════════════════════════════════════════════════════════
+echo "=== B — the brief template (§6.2), and the parse contract it must match ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+TMPL="$REPO_ROOT/templates/generated/delta-brief.tmpl"
+
+if [ -f "$TMPL" ]; then
+  pass "B0: templates/generated/delta-brief.tmpl exists — WP8's deliverable 1"
+else
+  fail_ "B0" "templates/generated/delta-brief.tmpl is missing; every case below depends on it"
+fi
+
+# B1 — the five sections, as HEADINGS, in §6.2's order.
+b1_missing=""
+for s in "What" "Why" "Done-observable" "Must-not-change" "Touched surfaces"; do
+  grep -qE "^## $s\$" "$TMPL" 2>/dev/null || b1_missing="$b1_missing [$s]"
+done
+b1_order="$(grep -nE '^## (What|Why|Done-observable|Must-not-change|Touched surfaces)$' "$TMPL" 2>/dev/null \
+            | sed -e 's/^[0-9]*:## //' | tr '\n' '|')"
+if [ -z "$b1_missing" ] && [ "$b1_order" = "What|Why|Done-observable|Must-not-change|Touched surfaces|" ]; then
+  pass "B1: the brief renders all five §6.2 sections as headings, in the design's order ($b1_order)"
+else
+  fail_ "B1" "missing section(s):$b1_missing; heading order was '$b1_order'"
+fi
+
+# B2 — the Done-observable section carries `- [ ]` rows, so a brief straight
+# off the template is a rubric with UNTICKED criteria (which is what makes the
+# close refuse until somebody has actually looked).
+b2_boxes="$(awk '/^## Done-observable$/{f=1;next} f && /^## /{f=0} f' "$TMPL" 2>/dev/null | grep -cE '^- \[ \]' || true)"
+case "$b2_boxes" in ''|*[!0-9]*) b2_boxes=0 ;; esac
+if [ "$b2_boxes" -ge 2 ]; then
+  pass "B2: the template's Done-observable section ships $b2_boxes '- [ ]' criteria — the rubric arrives unticked, so a brief nobody filled in cannot close"
+else
+  fail_ "B2" "the Done-observable section carries $b2_boxes '- [ ]' rows (want >= 2)"
+fi
+
+# B3 — THE CONTRACT SENTENCE. WP4's header records that this sentence used to
+# say "the FIRST heading" and the CODE disagreed; the sentence moved, not the
+# code, and WP4 states in as many words that "WP8's template codifies THIS
+# wording". So the template must teach POOLING, not first-wins.
+b3_pool=n; b3_first=n
+grep -qiE 'both[ ,].*(read|pooled)|pooled' "$TMPL" 2>/dev/null && b3_pool=y
+grep -qiE 'the first (such )?heading (wins|is)' "$TMPL" 2>/dev/null && b3_first=y
+if [ "$b3_pool" = y ] && [ "$b3_first" = n ]; then
+  pass "B3: the template documents WP4's CORRECTED contract — two Done-observable headings are POOLED, and it does not repeat the refuted 'first heading wins' wording"
+else
+  fail_ "B3" "template pooling wording present=$b3_pool, refuted first-wins wording present=$b3_first"
+fi
+
+# B4 — the same template, parsed by the PRODUCTION parser, end to end: two
+# Done-observable headings in one brief must POOL. Driven through --close, so
+# this is the shipped predicate and not a re-implementation of it.
+P="$TMPROOT/b4"; mk_proj "$P" 4
+open_feature "$REPO_ROOT/scripts" "$P" "pooling-check" >/dev/null 2>&1
+b4_brief="$(active_json "$P" -r '.active_delta.brief // "NONE"')"
+b4_ok=n
+if [ "$b4_brief" != "NONE" ] && [ -f "$P/$b4_brief" ]; then
+  # Tick every box the template shipped, then append a SECOND Done-observable
+  # heading carrying one UNTICKED box. A first-heading-only reader closes here.
+  sed -e 's/^- \[ \]/- [x]/' "$P/$b4_brief" > "$P/.b4tmp" && mv "$P/.b4tmp" "$P/$b4_brief"
+  printf '\n## Done-observable (follow-up)\n\n- [ ] the second pool is read too\n' >> "$P/$b4_brief"
+  while IFS= read -r g; do
+    [ -n "$g" ] || continue
+    delta_run "$REPO_ROOT/scripts" "$P" --complete-gate "$g" >/dev/null 2>&1
+  done <<EOF
+$(active_json "$P" -r '.active_delta.gates_required[]? // empty')
+EOF
+  delta_run "$REPO_ROOT/scripts" "$P" --close
+  [ "$DRC" -eq 8 ] && b4_ok=y
+fi
+if [ "$b4_ok" = y ]; then
+  pass "B4: a brief rendered from the template and then given a SECOND Done-observable heading is refused at close (rc $DRC) — the criteria pool, end to end through the shipped parser"
+else
+  fail_ "B4" "close answered rc $DRC (want 8) with brief '$b4_brief' — the second Done-observable heading was not pooled"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== P — the three creation paths (§6.1) converge on ONE state ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# GUIDED: delta.sh --open renders the brief itself.
+PG="$TMPROOT/p-guided"; mk_proj "$PG" 4
+open_feature "$REPO_ROOT/scripts" "$PG" "csv-import" --via guided
+pg_rc=$DRC
+
+# CONVERSATIONAL: the agent has interviewed the operator and filled the five
+# sections in already; it then opens the delta. Same command, `--via` records
+# which path it was.
+PC="$TMPROOT/p-conversational"; mk_proj "$PC" 4
+open_feature "$REPO_ROOT/scripts" "$PC" "csv-import" --via conversational
+pc_rc=$DRC
+
+# MANUAL: the operator copied the template to docs/deltas/ BY HAND before
+# running anything. The brief must be ADOPTED, never overwritten.
+PM="$TMPROOT/p-manual"; mk_proj "$PM" 4
+mkdir -p "$PM/docs/deltas"
+cp "$TMPL" "$PM/docs/deltas/DELTA-001-csv-import.md"
+printf '\n<!-- hand-written by the operator -->\n' >> "$PM/docs/deltas/DELTA-001-csv-import.md"
+pm_pre_md5="$(_md5file "$PM/docs/deltas/DELTA-001-csv-import.md")"
+open_feature "$REPO_ROOT/scripts" "$PM" "csv-import" --via manual
+pm_rc=$DRC
+pm_post_md5="$(_md5file "$PM/docs/deltas/DELTA-001-csv-import.md" 2>/dev/null || echo MISSING)"
+
+sg="$(normalise_state "$PG")"; sc="$(normalise_state "$PC")"; sm="$(normalise_state "$PM")"
+if [ "$pg_rc" -eq 0 ] && [ "$pc_rc" -eq 0 ] && [ "$pm_rc" -eq 0 ] \
+   && [ "$sg" = "$sc" ] && [ "$sc" = "$sm" ] && [ "$sg" != "READ-FAILED" ]; then
+  pass "P1: guided, conversational and manual all open (rc 0/0/0) and land BYTE-IDENTICAL state once the wall clock and 'opened_via' are removed — §6.1's 'all three converge on the same three writes'"
+else
+  fail_ "P1" "rcs $pg_rc/$pc_rc/$pm_rc; guided==conversational=$([ "$sg" = "$sc" ] && echo y || echo n); conversational==manual=$([ "$sc" = "$sm" ] && echo y || echo n)"
+fi
+
+# P2 — the three writes actually happened, on every path.
+p2_bad=""
+for pair in "guided:$PG" "conversational:$PC" "manual:$PM"; do
+  nm="${pair%%:*}"; d="${pair#*:}"
+  b="$(active_json "$d" -r '.active_delta.brief // "NONE"')"
+  l="$(active_json "$d" -r '.active_delta.ledger // "NONE"')"
+  [ "$b" != "NONE" ] && [ -f "$d/$b" ] || p2_bad="$p2_bad [$nm:brief=$b]"
+  [ "$l" != "NONE" ] || p2_bad="$p2_bad [$nm:ledger=$l]"
+  grep -q 'DELTA-001' "$d/FEATURES.md" 2>/dev/null || p2_bad="$p2_bad [$nm:no-ledger-row]"
+done
+if [ -z "$p2_bad" ]; then
+  pass "P2: every path wrote all THREE artefacts — the brief file on disk, a ledger row naming DELTA-001, and the state activation (the state write is the seam's, and it is the only writer)"
+else
+  fail_ "P2" "missing writes:$p2_bad"
+fi
+
+# P3 — the manual path ADOPTS. An operator who wrote their own brief must not
+# find it silently replaced by a template render.
+if [ "$pm_pre_md5" = "$pm_post_md5" ]; then
+  pass "P3: the manual path ADOPTED the operator's own brief byte-for-byte (md5 unchanged) rather than overwriting it with a fresh template render"
+else
+  fail_ "P3" "the hand-written brief changed: $pm_pre_md5 -> $pm_post_md5"
+fi
+
+# P4 — `opened_via` is recorded, and an unknown value is an invocation error.
+p4_via="$(active_json "$PC" -r '.active_delta.opened_via // "NONE"')"
+PV="$TMPROOT/p-badvia"; mk_proj "$PV" 4
+open_feature "$REPO_ROOT/scripts" "$PV" "whatever" --via telepathy
+p4_rc=$DRC
+p4_state="$([ -f "$PV/.claude/delta-state.json" ] && echo present || echo absent)"
+if [ "$p4_via" = "conversational" ] && [ "$p4_rc" -eq 2 ] && [ "$p4_state" = absent ]; then
+  pass "P4: the path is recorded (opened_via=$p4_via) and an unknown one is an invocation error (rc $p4_rc) that activates nothing (state file $p4_state)"
+else
+  fail_ "P4" "opened_via='$p4_via' (want conversational); bad --via rc=$p4_rc (want 2); state file $p4_state (want absent)"
+fi
+
+# P5 — TWO briefs claiming one id is AMBIGUOUS and must refuse, not first-match.
+PA="$TMPROOT/p-ambiguous"; mk_proj "$PA" 4
+mkdir -p "$PA/docs/deltas"
+cp "$TMPL" "$PA/docs/deltas/DELTA-001-one.md"
+cp "$TMPL" "$PA/docs/deltas/DELTA-001-two.md"
+open_feature "$REPO_ROOT/scripts" "$PA" "one"
+p5_rc=$DRC
+p5_state="$([ -f "$PA/.claude/delta-state.json" ] && echo present || echo absent)"
+if [ "$p5_rc" -eq 2 ] && [ "$p5_state" = absent ]; then
+  pass "P5: two briefs claiming DELTA-001 refuse the open (rc $p5_rc) and activate nothing — picking one silently would review against a document the operator may not be looking at"
+else
+  fail_ "P5" "rc=$p5_rc (want 2); state file $p5_state (want absent)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== E — the rubric bind, END TO END (open -> brief -> refuse -> tick -> close) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+PE="$TMPROOT/e2e"; mk_proj "$PE" 4
+open_feature "$REPO_ROOT/scripts" "$PE" "unicode-export"
+e_open_rc=$DRC
+e_brief="$(active_json "$PE" -r '.active_delta.brief // "NONE"')"
+while IFS= read -r g; do
+  [ -n "$g" ] || continue
+  delta_run "$REPO_ROOT/scripts" "$PE" --complete-gate "$g" >/dev/null 2>&1
+done <<EOF
+$(active_json "$PE" -r '.active_delta.gates_required[]? // empty')
+EOF
+delta_run "$REPO_ROOT/scripts" "$PE" --close
+e_refused_rc=$DRC
+e_still_open="$(active_json "$PE" -r '.active_delta.id // "NONE"')"
+# Tick every box the template shipped and close again.
+if [ "$e_brief" != "NONE" ] && [ -f "$PE/$e_brief" ]; then
+  sed -e 's/^- \[ \]/- [x]/' "$PE/$e_brief" > "$PE/.etmp" && mv "$PE/.etmp" "$PE/$e_brief"
+fi
+delta_run "$REPO_ROOT/scripts" "$PE" --close
+e_close_rc=$DRC
+e_closed="$(active_json "$PE" -r '(.closed | length)')"
+e_slot="$(active_json "$PE" -r '.active_delta == null')"
+if [ "$e_open_rc" -eq 0 ] && [ "$e_refused_rc" -eq 8 ] && [ "$e_still_open" = "DELTA-001" ] \
+   && [ "$e_close_rc" -eq 0 ] && [ "$e_closed" = "1" ] && [ "$e_slot" = "true" ]; then
+  pass "E1: the template's OWN output satisfies WP4's close gate end to end — open (rc $e_open_rc), close REFUSED on the untouched boxes (rc $e_refused_rc, delta still open), boxes ticked, close SUCCEEDS (rc $e_close_rc, 1 row on the closed tail, slot empty). The rendered brief is a working rubric, not a document that merely looks like one"
+else
+  fail_ "E1" "open=$e_open_rc refuse=$e_refused_rc (want 8) still-open=$e_still_open close=$e_close_rc closed-rows=$e_closed slot-null=$e_slot"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== I — identity and location (§6.3): max(existing)+1, zero-padded ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# A GAP IN THE SEQUENCE is the case worth pinning: `count + 1` and
+# `max + 1` agree on a dense sequence and disagree the moment anything is
+# deleted, and the one that reuses an id puts two pieces of work on one
+# identifier in the audit tail.
+PI="$TMPROOT/ident"; mk_proj "$PI" 4
+mkdir -p "$PI/docs/deltas"
+( cd "$PI" && unset GITHUB_BASE_REF; bash "$REPO_ROOT/scripts/process-checklist.sh" \
+    --delta-state-update '.closed = [{"id":"DELTA-001"},{"id":"DELTA-004"}]' ) >/dev/null 2>&1
+open_feature "$REPO_ROOT/scripts" "$PI" "after-the-gap"
+i1_id="$(active_json "$PI" -r '.active_delta.id // "NONE"')"
+i1_brief="$(active_json "$PI" -r '.active_delta.brief // "NONE"')"
+if [ "$i1_id" = "DELTA-005" ] && [ "$i1_brief" = "docs/deltas/DELTA-005-after-the-gap.md" ] \
+   && [ -f "$PI/$i1_brief" ]; then
+  pass "I1: with DELTA-001 and DELTA-004 on the record and 002/003 absent, the next id is max+1 = $i1_id (not count+1 = DELTA-003), and the brief lands at $i1_brief"
+else
+  fail_ "I1" "id=$i1_id (want DELTA-005); brief=$i1_brief (want docs/deltas/DELTA-005-after-the-gap.md); file present=$([ -f "$PI/$i1_brief" ] && echo y || echo n)"
+fi
+
+# I2 — zero padding to three, on a first delta.
+PZ="$TMPROOT/ident-pad"; mk_proj "$PZ" 4
+open_feature "$REPO_ROOT/scripts" "$PZ" "first-one"
+i2_id="$(active_json "$PZ" -r '.active_delta.id // "NONE"')"
+if [ "$i2_id" = "DELTA-001" ]; then
+  pass "I2: the first delta is zero-padded to three ($i2_id), matching the repo's own BL-NNN habit"
+else
+  fail_ "I2" "first id was '$i2_id' (want DELTA-001)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S — the slug is where a user string becomes a path ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+PS="$TMPROOT/slug-traversal"; mk_proj "$PS" 4
+s1_before="$(tree_manifest "$PS")"
+open_feature "$REPO_ROOT/scripts" "$PS" "../../../etc/cron.d/evil"
+s1_rc=$DRC
+s1_after="$(tree_manifest "$PS")"
+s1_diff="$(diff <(printf '%s\n' "$s1_before") <(printf '%s\n' "$s1_after") 2>/dev/null | grep -c '^[<>]' || true)"
+case "$s1_diff" in ''|*[!0-9]*) s1_diff=0 ;; esac
+s1_escaped=n
+[ -e "$TMPROOT/etc/cron.d/evil" ] && s1_escaped=y
+[ -e "$PS/../../../etc" ] && [ -e "$PS/../../../etc/cron.d" ] && s1_escaped=y
+if [ "$s1_rc" -eq 2 ] && [ "$s1_diff" -eq 0 ] && [ "$s1_escaped" = n ]; then
+  pass "S1: --slug '../../../etc/cron.d/evil' is REFUSED (rc $s1_rc) and the whole project tree is byte-identical afterwards ($s1_diff files changed) — the traversal never became a path"
+else
+  fail_ "S1" "rc=$s1_rc (want 2); tree changed on $s1_diff line(s) (want 0); escaped-write detected=$s1_escaped"
+fi
+
+# S2 — the neighbouring shapes, each on its OWN fresh fixture. An absolute
+# path, a bare `..`, a backslash and a leading dot are all the same class of
+# input and a guard that catches one spelling is not a guard.
+s2_bad=""
+s2_i=0
+for bad in "/etc/passwd" ".." "a/../../b" 'win\\path' ".hidden"; do
+  s2_i=$((s2_i + 1))
+  d="$TMPROOT/slug-shape-$s2_i"
+  mk_proj "$d" 4
+  open_feature "$REPO_ROOT/scripts" "$d" "$bad"
+  [ "$DRC" -eq 2 ] || s2_bad="$s2_bad [$bad=rc$DRC]"
+  [ -f "$d/.claude/delta-state.json" ] && s2_bad="$s2_bad [$bad=activated]"
+done
+if [ -z "$s2_bad" ]; then
+  pass "S2: every path-shaped slug spelling is refused with rc 2 and activates nothing — absolute, bare '..', an embedded '..', a backslash, and a leading dot"
+else
+  fail_ "S2" "these spellings were not refused cleanly:$s2_bad"
+fi
+
+# S3 — AND THE GUARD IS NOT A BLANKET REFUSAL. An ordinary messy human slug
+# still opens, and the basename it produces contains only [a-z0-9-].
+PS3="$TMPROOT/slug-sanitise"; mk_proj "$PS3" 4
+open_feature "$REPO_ROOT/scripts" "$PS3" "CSV Export -- Unicode!! (v2)"
+s3_rc=$DRC
+s3_slug="$(active_json "$PS3" -r '.active_delta.slug // "NONE"')"
+s3_brief="$(active_json "$PS3" -r '.active_delta.brief // "NONE"')"
+s3_clean=n
+case "$s3_slug" in
+  ''|*[!a-z0-9-]*) : ;;
+  *) s3_clean=y ;;
+esac
+if [ "$s3_rc" -eq 0 ] && [ "$s3_clean" = y ] && [ "$s3_brief" = "docs/deltas/DELTA-001-$s3_slug.md" ] \
+   && [ -f "$PS3/$s3_brief" ]; then
+  pass "S3: a messy human slug is SANITISED rather than refused — 'CSV Export -- Unicode!! (v2)' opens (rc $s3_rc) as '$s3_slug', all [a-z0-9-], at $s3_brief"
+else
+  fail_ "S3" "rc=$s3_rc; slug='$s3_slug' clean=$s3_clean; brief=$s3_brief"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== L — the ledger row (§6.3's HARD constraint) and Karl's decision 3 ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+PL="$TMPROOT/ledger-hotfix"; mk_proj "$PL" 4
+seed_bugs_rows "$PL/BUGS.md"
+l_cols_before="$(grep -c '^| [0-9]' "$PL/BUGS.md" || true)"
+l_sep_before="$(grep -n '^|---' "$PL/BUGS.md" | head -1 | cut -d: -f1)"
+l_width_before="$(grep '^|---' "$PL/BUGS.md" | head -1 | awk -F'|' '{print NF}')"
+delta_run "$REPO_ROOT/scripts" "$PL" --open --describe "checkout is down for everyone right now" \
+  --class hotfix --risk core --level small --slug "checkout-down" --lines 5 --confirm
+l_rc=$DRC
+l_id="$(active_json "$PL" -r '.active_delta.id // "NONE"')"
+l_ledger="$(active_json "$PL" -r '.active_delta.ledger // "NONE"')"
+l_audit="$(active_json "$PL" -r '.active_delta.audit_row_at_open // "NONE"')"
+l_row="$(grep -n "$l_id" "$PL/BUGS.md" | head -1)"
+l_rowtext="${l_row#*:}"
+
+# The delta link must sit in the EXISTING `Fix Reference` column — column 8 of
+# the shipped nine, counted the way `awk -F'|'` counts a leading-pipe row.
+l_fixref="$(printf '%s\n' "$l_rowtext" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $9); print $9}')"
+l_width_row="$(printf '%s\n' "$l_rowtext" | awk -F'|' '{print NF}')"
+if [ "$l_rc" -eq 0 ] && [ -n "$l_row" ] && [ "$l_width_row" = "$l_width_before" ] \
+   && printf '%s' "$l_fixref" | grep -q "$l_id"; then
+  pass "L1: the hotfix's BUGS.md row rides the EXISTING Fix Reference column ('$l_fixref') and the row has exactly the shipped column count ($l_width_row fields, same as the separator) — §6.3's hard constraint, because a new column is what silently breaks a grep -c 'SEV-2.*Deferred'"
+else
+  fail_ "L1" "rc=$l_rc; row='$l_rowtext'; Fix Reference cell='$l_fixref'; row width=$l_width_row vs separator $l_width_before"
+fi
+
+# L2 — the table STILL PARSES the way the gate parses it. These are the exact
+# greps scripts/test-gate.sh runs (`# BUGS.md format:` block), so this is the
+# gate's own instrument, not a lookalike.
+l2_sev1="$(grep -c 'SEV-1.*Open' "$PL/BUGS.md" 2>/dev/null || true)"
+l2_sev2o="$(grep -c 'SEV-2.*Open' "$PL/BUGS.md" 2>/dev/null || true)"
+l2_sev2d="$(grep -c 'SEV-2.*Deferred' "$PL/BUGS.md" 2>/dev/null || true)"
+l2_sev3="$(grep -c 'SEV-3.*Open' "$PL/BUGS.md" 2>/dev/null || true)"
+for v in l2_sev1 l2_sev2o l2_sev2d l2_sev3; do
+  eval "case \"\$$v\" in ''|*[!0-9]*) $v=0 ;; esac"
+done
+if [ "$l2_sev2d" -ge 1 ] && [ "$l2_sev1" -ge 1 ] && [ "$l2_sev3" = "0" ] && [ "$l2_sev2o" = "0" ]; then
+  pass "L2: after the append, the gate's OWN greps still find their rows — SEV-1.*Open=$l2_sev1, SEV-2.*Deferred=$l2_sev2d, and the rows that were never open still do not match (SEV-2.*Open=$l2_sev2o, SEV-3.*Open=$l2_sev3)"
+else
+  fail_ "L2" "gate greps after append: SEV-1.*Open=$l2_sev1 SEV-2.*Open=$l2_sev2o SEV-2.*Deferred=$l2_sev2d SEV-3.*Open=$l2_sev3"
+fi
+
+# L3 — KARL'S DECISION 3, BOTH HALVES. The visible ledger row AND WP5's state
+# stamp. WP5's record is not removed, and its test is not disturbed.
+if [ "$l_audit" != "NONE" ] && [ "$l_audit" != "null" ] && [ -n "$l_row" ] \
+   && [ "$l_ledger" = "BUGS.md" ]; then
+  pass "L3: the hotfix audit trace is written in BOTH places — a real BUGS.md row (Karl's decision 3: the state stamp survives neither an abandoned hotfix nor a lost state file) AND WP5's 'audit_row_at_open' stamp ($l_audit), which is left exactly as WP5 wrote it"
+else
+  fail_ "L3" "audit_row_at_open='$l_audit'; ledger='$l_ledger' (want BUGS.md); BUGS.md row present=$([ -n "$l_row" ] && echo y || echo n)"
+fi
+
+# L4 — `ledger_row` STAYS ATTESTED. WP5's header says the operator's own
+# BUGS.md row "stays attested like every other class's"; seeding a row must not
+# quietly tick that gate, or the operator never fills in what the row says.
+l4_done="$(active_json "$PL" -c '.active_delta.gates_completed')"
+l4_has_ledger=n
+printf '%s' "$l4_done" | grep -q 'ledger_row' && l4_has_ledger=y
+l4_has_audit=n
+printf '%s' "$l4_done" | grep -q 'audit_row_at_open' && l4_has_audit=y
+if [ "$l4_has_ledger" = n ] && [ "$l4_has_audit" = y ]; then
+  pass "L4: seeding the row did NOT tick 'ledger_row' (gates_completed=$l4_done) — the framework wrote the trace, the operator still owes the content. 'audit_row_at_open' stays complete-at-open, exactly as WP5 left it"
+else
+  fail_ "L4" "gates_completed=$l4_done — ledger_row ticked=$l4_has_ledger (want n), audit_row_at_open ticked=$l4_has_audit (want y)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== BR — the bridge (§10.4): a READ, never a move ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+PB="$TMPROOT/bridge"; mk_proj "$PB" 4
+write_manifesto "$PB"
+br_md5_before="$(_md5file "$PB/PRODUCT_MANIFESTO.md")"
+delta_run "$REPO_ROOT/scripts" "$PB" --status
+br_rc=$DRC
+br_out="$DOUT"
+br_md5_after="$(_md5file "$PB/PRODUCT_MANIFESTO.md")"
+br_named=0
+for item in "Bulk CSV import" "Dark mode" "Saved filters"; do
+  printf '%s\n' "$br_out" | grep -qF "$item" && br_named=$((br_named + 1))
+done
+if [ "$br_rc" -eq 0 ] && [ "$br_named" -eq 3 ] && [ "$br_md5_before" = "$br_md5_after" ]; then
+  pass "BR1: --status lists all 3 § 6 Post-MVP items as CANDIDATES (rc $br_rc) and PRODUCT_MANIFESTO.md is byte-identical afterwards (md5 $br_md5_before) — the seeding is a read, the cutline governance is untouched"
+else
+  fail_ "BR1" "rc=$br_rc; items named=$br_named of 3; md5 $br_md5_before -> $br_md5_after"
+fi
+
+# BR2 — nothing auto-opens. Reading candidates must not activate one.
+br2_state="$([ -f "$PB/.claude/delta-state.json" ] && echo present || echo absent)"
+if [ "$br2_state" = present ]; then
+  br2_active="$(active_json "$PB" -r '.active_delta')"
+else
+  br2_active="no-state-file"
+fi
+if [ "$br2_active" = "null" ] || [ "$br2_active" = "no-state-file" ]; then
+  pass "BR2: listing candidates opened nothing (active_delta=$br2_active, state file $br2_state) — §10.4's 'nothing is auto-opened, nothing is deleted'"
+else
+  fail_ "BR2" "active_delta after a --status read was '$br2_active'"
+fi
+
+# BR3 — the bridge is silent when there is nothing to bridge. A project with no
+# manifesto must not have --status invent a section.
+PB3="$TMPROOT/bridge-none"; mk_proj "$PB3" 4
+delta_run "$REPO_ROOT/scripts" "$PB3" --status
+br3_rc=$DRC
+br3_quiet=y
+printf '%s\n' "$DOUT" | grep -qi 'candidate' && br3_quiet=n
+if [ "$br3_rc" -eq 0 ] && [ "$br3_quiet" = y ]; then
+  pass "BR3: with no PRODUCT_MANIFESTO.md, --status still succeeds (rc $br3_rc) and says nothing about candidates — the bridge is a read of a document that may not be there"
+else
+  fail_ "BR3" "rc=$br3_rc; candidate wording present when no manifesto exists=$([ "$br3_quiet" = y ] && echo n || echo y)"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== R — resume.sh's FOURTH branch (§10.5) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# R1 — it does NOT fire below phase 4. The era invariant is the load-bearing
+# one; a greeting that talked about post-1.0 work at phase 2 would be teaching
+# the operator that the delta track is available before it is.
+PR3="$TMPROOT/resume-phase3"; mk_proj "$PR3" 3
+write_manifesto "$PR3"
+resume_run "$REPO_ROOT/scripts" "$PR3"
+r1_rc=$RRC
+r1_delta=n
+printf '%s\n' "$ROUT" | grep -qi 'shipped\|post-release\|post-1\.0' && r1_delta=y
+r1_classic=n
+printf '%s\n' "$ROUT" | grep -q 'We are resuming work on this project' && r1_classic=y
+if [ "$r1_rc" -eq 0 ] && [ "$r1_delta" = n ] && [ "$r1_classic" = y ]; then
+  pass "R1: at phase 3 the fourth branch does not fire — resume.sh emits the CLASSIC prompt (rc $r1_rc), and says nothing about post-release work"
+else
+  fail_ "R1" "rc=$r1_rc; delta wording present=$r1_delta (want n); classic prompt present=$r1_classic (want y)"
+fi
+
+# R2 — §10.5 sub-case ONE: phase 4 with a delta open.
+PR4="$TMPROOT/resume-open"; mk_proj "$PR4" 4
+write_manifesto "$PR4"
+open_feature "$REPO_ROOT/scripts" "$PR4" "csv-import"
+# Leave at least one gate outstanding so "the outstanding entries" has content.
+resume_run "$REPO_ROOT/scripts" "$PR4"
+r2_rc=$RRC
+r2_id=n; r2_class=n; r2_attrs=n; r2_gates=n; r2_classic=n
+printf '%s\n' "$ROUT" | grep -q 'DELTA-001' && r2_id=y
+printf '%s\n' "$ROUT" | grep -q 'feature' && r2_class=y
+printf '%s\n' "$ROUT" | grep -q 'feature-local' && r2_attrs=y
+printf '%s\n' "$ROUT" | grep -q 'brief' && r2_gates=y
+printf '%s\n' "$ROUT" | grep -q 'We are resuming work on this project' && r2_classic=y
+if [ "$r2_rc" -eq 0 ] && [ "$r2_id" = y ] && [ "$r2_class" = y ] && [ "$r2_attrs" = y ] \
+   && [ "$r2_gates" = y ] && [ "$r2_classic" = n ]; then
+  pass "R2: phase 4 + an open delta produces the RESUME-THAT-DELTA first message — id, class, confirmed attributes and the outstanding gates — and it replaces the classic prompt rather than being appended to it"
+else
+  fail_ "R2" "rc=$r2_rc id=$r2_id class=$r2_class attrs=$r2_attrs gates=$r2_gates classic-also-present=$r2_classic"
+fi
+
+# R3 — §10.5 sub-case TWO: phase 4 with nothing open. The post-1.0 greeting's
+# four content items: how to state a need, overdue cadence, open hotfix retro,
+# and the § 6 candidate count.
+PR5="$TMPROOT/resume-greeting"; mk_proj "$PR5" 4
+write_manifesto "$PR5"
+( cd "$PR5" && unset GITHUB_BASE_REF; bash "$REPO_ROOT/scripts/process-checklist.sh" \
+    --delta-state-update '.hotfix_retros = [{"id":"DELTA-002","shipped_at":"2026-01-01T00:00:00Z","due_by":"2026-01-04","closed_at":null,"record":null}]' ) >/dev/null 2>&1
+resume_run "$REPO_ROOT/scripts" "$PR5"
+r3_rc=$RRC
+r3_plain=n; r3_retro=n; r3_cand=n; r3_classic=n
+printf '%s\n' "$ROUT" | grep -qi 'plain words\|own words' && r3_plain=y
+printf '%s\n' "$ROUT" | grep -q 'DELTA-002' && r3_retro=y
+printf '%s\n' "$ROUT" | grep -qi 'candidate' && r3_cand=y
+printf '%s\n' "$ROUT" | grep -q 'We are resuming work on this project' && r3_classic=y
+r3_count=n
+printf '%s\n' "$ROUT" | grep -qE '\b3\b' && r3_count=y
+if [ "$r3_rc" -eq 0 ] && [ "$r3_plain" = y ] && [ "$r3_retro" = y ] && [ "$r3_cand" = y ] \
+   && [ "$r3_count" = y ] && [ "$r3_classic" = n ]; then
+  pass "R3: phase 4 + nothing open produces the POST-1.0 greeting — how to state a need in plain words, the outstanding write-up (DELTA-002), and the § 6 candidate count (3) — and it replaces the classic prompt"
+else
+  fail_ "R3" "rc=$r3_rc plain=$r3_plain retro=$r3_retro candidates=$r3_cand count=$r3_count classic-also=$r3_classic"
+fi
+
+# R4 — FAIL SOFT. A phase-4 project WITHOUT the delta module installed (an old
+# scaffold, or a severed tree) must fall through to the classic prompt, not
+# crash and not print a half-greeting.
+PR6="$TMPROOT/resume-nomodule"; mk_proj "$PR6" 4
+SEVSD="$TMPROOT/resume-nomodule-scripts"
+mk_scripts_tree "$SEVSD"
+rm -f "$SEVSD/scripts/lib/delta-state.sh" "$SEVSD/scripts/lib/delta-policy.sh" \
+      "$SEVSD/scripts/lib/delta-classify.sh" "$SEVSD/scripts/lib/delta-cadence.sh" \
+      "$SEVSD/scripts/delta.sh" "$SEVSD/scripts/cut-release.sh"
+resume_run "$SEVSD/scripts" "$PR6"
+r4_rc=$RRC
+r4_classic=n
+printf '%s\n' "$ROUT" | grep -q 'We are resuming work on this project' && r4_classic=y
+if [ "$r4_rc" -eq 0 ] && [ "$r4_classic" = y ]; then
+  pass "R4: at phase 4 with the delta module ABSENT, resume.sh falls through to the classic prompt (rc $r4_rc) — the branch fails soft exactly like the other four core consumers do, which is what keeps the module severable"
+else
+  fail_ "R4" "rc=$r4_rc; classic prompt present=$r4_classic (want y). Output was:
+$ROUT"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== SH — SHIPPING the module (Karl's decision 1), and the HARD GATE ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+# SH1 — every §3.1 module file that belongs in a project is in the copy list,
+# derived MECHANICALLY through the same parser the closure check and the
+# framework sync use. A hand grep would be a second source of truth.
+# shellcheck source=/dev/null
+. "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh"
+SHIPPED="$TMPROOT/shipped.txt"
+soif_parse_shipped_scripts "$INIT_PATH" "$REPO_ROOT/scripts" > "$SHIPPED"
+sh1_missing=""
+for w in scripts/delta.sh scripts/cut-release.sh scripts/lib/delta-state.sh \
+         scripts/lib/delta-policy.sh scripts/lib/delta-classify.sh scripts/lib/delta-cadence.sh; do
+  grep -qxF "$w" "$SHIPPED" || sh1_missing="$sh1_missing [$w]"
+done
+if [ -z "$sh1_missing" ]; then
+  pass "SH1: all six shippable delta-module scripts are in the derived shipped set — the module now reaches generated projects, which it did not before (the scaffolder carried the string zero times)"
+else
+  fail_ "SH1" "not shipped:$sh1_missing"
+fi
+
+# SH2 — THE LINT IS FRAMEWORK-ONLY AND MUST NOT SHIP. It scans init.sh and
+# scripts/lib/*.sh for a boundary that only exists in the framework repo, and
+# `## BUG-008:` records what a shipped lint that misbehaves on a generated tree
+# costs.
+if grep -qxF "scripts/lint-delta-boundary.sh" "$SHIPPED"; then
+  fail_ "SH2" "scripts/lint-delta-boundary.sh is in the shipped set — it is a FRAMEWORK lint (see BUG-008: shipped lints must behave on a generated tree with no backlog and no tests/)"
+else
+  pass "SH2: scripts/lint-delta-boundary.sh is NOT shipped — it is a framework lint, and it is treated exactly like the other unshipped lint-*.sh"
+fi
+
+# SH3 — the chmod split, matching the neighbours: entry scripts get +x, sourced
+# libs get a plain cp and none. `scripts/lib/adoption-stamp.sh` says so in as
+# many words two lines above the delta block.
+sh3_chmod="$(grep -E '^[[:space:]]*chmod \+x .*delta\.sh' "$INIT_PATH" || true)"
+sh3_lib_chmod="$(grep -E 'chmod \+x[^#]*scripts/lib/delta-' "$INIT_PATH" || true)"
+if [ -n "$sh3_chmod" ] && [ -z "$sh3_lib_chmod" ]; then
+  pass "SH3: the two entry scripts get chmod +x and the four sourced libs get none — the neighbours' split, followed exactly"
+else
+  fail_ "SH3" "entry chmod line found=$([ -n "$sh3_chmod" ] && echo y || echo n); a lib was wrongly chmod'd: '$sh3_lib_chmod'"
+fi
+
+# SH4 — the Class-T template ships, through the template parser (so the
+# currency inventory tracks its drift like every other verbatim template).
+SHIPT="$TMPROOT/shipped-templates.txt"
+soif_parse_shipped_templates "$INIT_PATH" > "$SHIPT"
+if grep -qxF "templates/generated/delta-brief.tmpl" "$SHIPT"; then
+  pass "SH4: templates/generated/delta-brief.tmpl is a shipped Class-T template — the manual path has a template to copy, and the currency inventory tracks it"
+else
+  fail_ "SH4" "delta-brief.tmpl is not in the derived shipped-template set:
+$(cat "$SHIPT")"
+fi
+
+# SH5 — THE HARD GATE ITSELF. A shipped script may not source a sibling that
+# is not shipped, and a copy-list change MOVES the derived shipped set. The
+# previous work package failed CI on exactly this.
+sh5_rc=0
+( bash "$REPO_ROOT/tests/test-scaffold-source-closure.sh" >"$TMPROOT/closure.out" 2>&1 ) || sh5_rc=$?
+if [ "$sh5_rc" -eq 0 ]; then
+  pass "SH5: tests/test-scaffold-source-closure.sh is GREEN against the new copy list — every \$SCRIPT_DIR sibling the six new shipped scripts source is itself shipped"
+else
+  fail_ "SH5" "the source-closure gate failed (rc $sh5_rc):
+$(tail -25 "$TMPROOT/closure.out")"
+fi
+
+# SH6 — the boundary lint still passes, and the seam is still cardinality ONE.
+# The shipped-file list is the scaffolder's business, not a delta reference,
+# and this row is where that claim is checked rather than asserted.
+sh6_rc=0
+( bash "$REPO_ROOT/scripts/lint-delta-boundary.sh" --list >"$TMPROOT/boundary.out" 2>&1 ) || sh6_rc=$?
+sh6_seam="$(grep -c '^INFO.seam.*cardinality 1/1' "$TMPROOT/boundary.out" || true)"
+case "$sh6_seam" in ''|*[!0-9]*) sh6_seam=0 ;; esac
+if [ "$sh6_rc" -eq 0 ] && [ "$sh6_seam" -eq 1 ]; then
+  pass "SH6: scripts/lint-delta-boundary.sh exits 0 with the seam allowlist still at cardinality 1/1 — shipping the module added no core -> delta dependency edge"
+else
+  fail_ "SH6" "lint rc=$sh6_rc; 'cardinality 1/1' rows=$sh6_seam (want 1):
+$(tail -20 "$TMPROOT/boundary.out")"
+fi
+
+# ── The installer exemption is FENCE-BOUNDED, and these three rows are why ──
+# The seam's exemption covers a whole file. The installer's deliberately does
+# not, because the scaffolder is 4000 lines of core code and a whole-file
+# exemption would retire the boundary for all of it. Three ways to get it
+# wrong, each measured on the lint's own exit code against a fixture tree.
+mk_lint_root() {   # <dest> — a tree the boundary lint can scan for real
+  local d="$1"
+  mkdir -p "$d"
+  cp -R "$REPO_ROOT/scripts" "$d/scripts"
+  cp "$INIT_PATH" "$d/$INIT_FILE"
+  mkdir -p "$d/docs/deltas"
+}
+LINT_RC=0
+LINT_FILE=""
+# lint_root <root> — sets LINT_RC and LINT_FILE. TWO traps are designed out
+# here, and both bit the first draft of these rows:
+#   * it is NOT called in a command substitution, because a subshell would
+#     swallow the globals it sets;
+#   * the output goes to a FILE and every assertion greps the FILE, never
+#     `printf "$VAR" | grep -q`. SH8's fixture makes the lint emit ~860 KB;
+#     `grep -q` exits on its first match, the upstream printf takes SIGPIPE,
+#     and `set -o pipefail` promotes rc 141 into the pipeline — so the `&&`
+#     never fires and a diagnostic that WAS printed reads as absent. That is
+#     the same trap scripts/lint-delta-boundary.sh records against `head -1`.
+lint_root() {
+  local root="$1" tag
+  tag="$(basename "$root")"
+  LINT_FILE="$TMPROOT/lint-$tag.out"
+  LINT_RC=0
+  bash "$REPO_ROOT/scripts/lint-delta-boundary.sh" --root "$root" --list >"$LINT_FILE" 2>&1 || LINT_RC=$?
+  return 0
+}
+
+# SH6b — THE BASELINE. Rows SH7-SH9 all assert a NON-ZERO lint, and a fixture
+# tree that reds for some unrelated reason would satisfy all three while
+# measuring nothing. So the unmodified fixture is linted first and must be
+# clean.
+LRB="$TMPROOT/lint-baseline"; mk_lint_root "$LRB"
+lint_root "$LRB"
+if [ "$LINT_RC" -eq 0 ]; then
+  pass "SH6b: the unmodified fixture tree lints CLEAN (rc $LINT_RC) — so the three non-zero results below are caused by the edits, not by the fixture"
+else
+  fail_ "SH6b" "the baseline fixture tree already reds (rc $LINT_RC):
+$(tail -20 "$LINT_FILE")"
+fi
+
+# SH7 — a REAL fusion smuggled inside the fence. A `source` of a module lib is
+# the exact defect the whole lint exists to catch, and an installer coat must
+# not launder it.
+LR7="$TMPROOT/lint-fence-source"; mk_lint_root "$LR7"
+awk '{ print; if ($0 ~ /DELTA-INSTALL-BEGIN/ && !d) { print "  source \"$SCRIPT_DIR/scripts/lib/delta-state.sh\""; d = 1 } }' \
+  "$LR7/$INIT_FILE" > "$LR7/tmp.$INIT_FILE" && mv "$LR7/tmp.$INIT_FILE" "$LR7/$INIT_FILE"
+lint_root "$LR7"; sh7_rc="$LINT_RC"
+sh7_i1=n
+grep -q 'non-installation-statement-inside-the-fence' "$LINT_FILE" && sh7_i1=y
+if [ "$sh7_rc" != "0" ] && [ "$sh7_i1" = y ]; then
+  pass "SH7: a 'source' of a module lib INSIDE the DELTA-INSTALL fence still fails (rc $sh7_rc, tier I1) — only cp/chmod/mkdir are installation, so the fence cannot launder a real dependency edge"
+else
+  fail_ "SH7" "lint rc=$sh7_rc (want non-zero); I1 diagnostic present=$sh7_i1"
+fi
+
+# SH8 — an UNTERMINATED fence. Left tolerated, one stray BEGIN near the top of
+# the scaffolder would exempt everything after it.
+LR8="$TMPROOT/lint-fence-open"; mk_lint_root "$LR8"
+grep -v 'DELTA-INSTALL-END' "$LR8/$INIT_FILE" > "$LR8/tmp.$INIT_FILE" && mv "$LR8/tmp.$INIT_FILE" "$LR8/$INIT_FILE"
+lint_root "$LR8"; sh8_rc="$LINT_RC"
+sh8_msg=n
+grep -q 'unterminated-DELTA-INSTALL-fence' "$LINT_FILE" && sh8_msg=y
+if [ "$sh8_rc" != "0" ] && [ "$sh8_msg" = y ]; then
+  pass "SH8: an unterminated fence fails closed (rc $sh8_rc) and says so — a stray BEGIN would otherwise exempt every line after it"
+else
+  fail_ "SH8" "lint rc=$sh8_rc (want non-zero); unterminated diagnostic present=$sh8_msg"
+fi
+
+# SH9 — a module path OUTSIDE the fence, in the same file. The exemption is
+# bounded to the fence, not granted to the scaffolder.
+LR9="$TMPROOT/lint-outside-fence"; mk_lint_root "$LR9"
+printf '\ncp "$SCRIPT_DIR/scripts/delta.sh" /tmp/somewhere\n' >> "$LR9/$INIT_FILE"
+lint_root "$LR9"; sh9_rc="$LINT_RC"
+sh9_t1=n
+grep -qE '^FAIL.T1' "$LINT_FILE" && sh9_t1=y
+if [ "$sh9_rc" != "0" ] && [ "$sh9_t1" = y ]; then
+  pass "SH9: the very same cp line OUTSIDE the fence is still a T1 violation (rc $sh9_rc) — the exemption is fence-bounded, and the scaffolder did not buy itself a blanket waiver"
+else
+  fail_ "SH9" "lint rc=$sh9_rc (want non-zero); T1 failure row present=$sh9_t1"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== M — mutation proofs (each mutant is BUILT, PARSE-CHECKED and RUN) ==="
+# ════════════════════════════════════════════════════════════════════════════
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(stat -c '%a' "$file" 2>/dev/null || stat -f '%Lp' "$file" 2>/dev/null || echo "")"
+  tmp="$(mktemp)"
+  sed -e "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ -n "$mode" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_mutation_report() {
+  local orig="$1" mut="$2" marker="$3" sites changed n
+  sites="$(grep -c "$marker" "$orig" || true)"
+  case "$sites" in ''|*[!0-9]*) sites=0 ;; esac
+  if diff "$orig" "$mut" >/dev/null 2>&1; then changed=n; else changed=y; fi
+  n="$(diff "$orig" "$mut" | grep -c '^[<>]' || true)"
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s|%s|%s' "$sites" "$changed" "$n"
+}
+
+MT="$TMPROOT/mutants"
+mkdir -p "$MT"
+MUT_REPORT=""
+MUT_SD=""
+
+# _mutate <name> <target-rel> <marker> <sed-expr> <check-fn>
+#   FRESH TREE per mutant. Anchored marker, sites==1, exactly one line changed,
+#   mode preserved, and `bash -n` on the mutated file — that last one is not
+#   ceremony: a mutation that lands mid-continuation yields a mangled parse
+#   whose crash reads as "the guard caught it", and this wave has one of those
+#   on the record.
+_mutate() {
+  local name="$1" rel="$2" marker="$3" expr="$4" check="$5"
+  local SD rep sites changed lines mode_before mode_after nrc
+  SD="$MT/$name"
+  mk_scripts_tree "$SD"
+  mode_before="$(_mode_of "$SD/$rel")"
+  cp "$SD/$rel" "$MT/$name.orig"
+  _sed_inplace "$SD/$rel" "$expr"
+  mode_after="$(_mode_of "$SD/$rel")"
+  rep="$(_mutation_report "$MT/$name.orig" "$SD/$rel" "$marker")"
+  sites="${rep%%|*}"; rep="${rep#*|}"; changed="${rep%%|*}"; lines="${rep##*|}"
+  nrc=0; bash -n "$SD/$rel" 2>/dev/null || nrc=$?
+  MUT_REPORT="marker '$marker' sites=$sites, changed=$changed, diff-lines=$lines, mode $mode_before -> $mode_after, bash -n rc=$nrc"
+  MUT_SD="$SD/scripts"
+  if [ "$sites" -ne 1 ] || [ "$changed" != y ] || [ "$lines" -ne 2 ] \
+     || [ "$mode_before" != "$mode_after" ] || [ "$nrc" -ne 0 ]; then
+    fail_ "$name (harness)" "the mutation is not anchored/single-line/mode-preserving/parseable: $MUT_REPORT"
+    return 0
+  fi
+  "$check" "$name"
+  return 0
+}
+
+# ── m1: the bridge WRITES to the manifesto ──────────────────────────────────
+# §10.4's whole point is that the seeding is a read. The discriminator is
+# STRUCTURAL — an md5 of the manifesto — because the expected result is an
+# ABSENCE, and no printed message can testify to a write that did not happen.
+_m1_check() {
+  local name="$1" P before after rc
+  P="$MT/$name-proj"; mk_proj "$P" 4; write_manifesto "$P"
+  before="$(_md5file "$P/PRODUCT_MANIFESTO.md")"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/delta.sh" --status </dev/null >/dev/null 2>&1 ) || rc=$?
+  after="$(_md5file "$P/PRODUCT_MANIFESTO.md" 2>/dev/null || echo MISSING)"
+  if [ "$before" != "$after" ]; then
+    pass "m1: with the read-only bridge turned into a write, --status MODIFIES PRODUCT_MANIFESTO.md (md5 $before -> $after) — BR1's md5 discriminator sees it. $MUT_REPORT"
+  else
+    fail_ "m1" "the mutant left the manifesto byte-identical ($before), so BR1 cannot see this line. $MUT_REPORT"
+  fi
+}
+
+# ── m2: the slug sanitiser, neutered ────────────────────────────────────────
+_m2_check() {
+  local name="$1" P rc slug
+  P="$MT/$name-proj"; mk_proj "$P" 4
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/delta.sh" --open \
+      --describe "add a bulk CSV import screen" --class feature --risk feature-local \
+      --level significant --lines 40 --slug "../../../etc/cron.d/evil" --confirm \
+      </dev/null >/dev/null 2>&1 ) || rc=$?
+  slug="$(jq -r '.active_delta.slug // "NONE"' "$P/.claude/delta-state.json" 2>/dev/null || echo NONE)"
+  if [ "$rc" -eq 0 ] && [ "$slug" != "NONE" ]; then
+    pass "m2: with the traversal guard neutered the mutant ACCEPTS '../../../etc/cron.d/evil' (rc $rc) instead of refusing it, and records it as '$slug' — S1 and S2 see the exit code move. Note what the mutant does NOT do: _slugify still flattens the string, so the guard is the LOUD half of a two-layer defence, and this row measures exactly that half"
+  else
+    fail_ "m2" "the mutant still refused (rc $rc, slug '$slug') — S1/S2 cannot see this line. $MUT_REPORT"
+  fi
+}
+
+# ── m3: the BUGS.md row written to a NEW column ─────────────────────────────
+# §6.3's hard constraint, and the failure it names is silent: a new column
+# shifts nothing today and breaks a `grep -c 'SEV-2.*Deferred'` later.
+_m3_check() {
+  local name="$1" P rc row width sep
+  P="$MT/$name-proj"; mk_proj "$P" 4; seed_bugs_rows "$P/BUGS.md"
+  sep="$(grep '^|---' "$P/BUGS.md" | head -1 | awk -F'|' '{print NF}')"
+  rc=0
+  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/delta.sh" --open \
+      --describe "checkout is down for everyone right now" --class hotfix --risk core \
+      --level small --lines 5 --slug "checkout-down" --confirm \
+      </dev/null >/dev/null 2>&1 ) || rc=$?
+  row="$(grep -n 'DELTA-001' "$P/BUGS.md" | head -1)"
+  row="${row#*:}"
+  width="$(printf '%s\n' "$row" | awk -F'|' '{print NF}')"
+  if [ -n "$row" ] && [ "$width" != "$sep" ]; then
+    pass "m3: with the row written to a NEW column the appended row has $width fields against the table's $sep — L1's column-count discriminator sees it. $MUT_REPORT"
+  else
+    fail_ "m3" "the mutant's row width was $width against $sep (row='$row') — L1 cannot see this line. $MUT_REPORT"
+  fi
+}
+
+_mutate m1 scripts/delta.sh '# DELTA-BRIDGE-READ-ONLY$' \
+  's|^\(.*\)# DELTA-BRIDGE-READ-ONLY$|  printf "candidate read\\n" >> "$mf"   # DELTA-BRIDGE-READ-ONLY|' \
+  _m1_check
+
+_mutate m2 scripts/delta.sh '# DELTA-OPEN-SLUG-GUARD$' \
+  's|^\(.*\)# DELTA-OPEN-SLUG-GUARD$|  if false; then   # DELTA-OPEN-SLUG-GUARD|' \
+  _m2_check
+
+_mutate m3 scripts/delta.sh '# DELTA-OPEN-LEDGER-COLUMN$' \
+  's@^\(.*\)# DELTA-OPEN-LEDGER-COLUMN$@    row="$row | $link |"   # DELTA-OPEN-LEDGER-COLUMN@' \
+  _m3_check
+
+# ── m4: drop a shipped file from the copy list -> the CLOSURE suite goes RED ─
+# The hard gate, driven through the real suite in a real tree rather than
+# re-implemented here. scripts/delta.sh sources "$SCRIPT_DIR/lib/delta-policy.sh",
+# so dropping that one cp line is a dangling source in a shipped script.
+M4="$MT/m4"
+mkdir -p "$M4/tests"
+cp -R "$REPO_ROOT/scripts" "$M4/scripts"
+cp "$REPO_ROOT/tests/test-scaffold-source-closure.sh" "$M4/tests/"
+grep -v 'cp "\$SCRIPT_DIR/scripts/lib/delta-policy.sh"' "$INIT_PATH" > "$M4/$INIT_FILE"
+m4_dropped=$(( $(grep -c '' "$INIT_PATH") - $(grep -c '' "$M4/$INIT_FILE") ))
+m4_nrc=0; bash -n "$M4/$INIT_FILE" 2>/dev/null || m4_nrc=$?
+m4_rc=0
+( bash "$M4/tests/test-scaffold-source-closure.sh" >"$M4/out" 2>&1 ) || m4_rc=$?
+if [ "$m4_dropped" -eq 1 ] && [ "$m4_nrc" -eq 0 ] && [ "$m4_rc" -ne 0 ] \
+   && grep -q 'delta-policy.sh' "$M4/out"; then
+  pass "m4: dropping the delta-policy.sh cp line (exactly 1 line, mutant still parses: bash -n rc $m4_nrc) makes the source-closure gate go RED (rc $m4_rc) and NAME the gap — SH5 is load-bearing, not decorative"
+else
+  fail_ "m4" "lines dropped=$m4_dropped (want 1); bash -n rc=$m4_nrc; closure rc=$m4_rc (want non-zero); gap named=$(grep -c 'delta-policy.sh' "$M4/out" || true)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-delta-wp8-intake.sh
+++ b/tests/test-delta-wp8-intake.sh
@@ -661,6 +661,59 @@ else
   fail_ "L4" "gates_completed=$l4_done — ledger_row ticked=$l4_has_ledger (want n), audit_row_at_open ticked=$l4_has_audit (want y)"
 fi
 
+# ── L5: A LEDGER WRITE THAT FAILS MUST SAY SO ───────────────────────────────
+# The silent-success class, pinned on the branch that had it live.
+#
+# `_ledger_write` echoes the ledger's filename on success and NOTHING when there
+# is nothing to write into, and the caller tells "no ledger here" apart from
+# "the write did not complete" by asking whether the file exists. That
+# discrimination only works if a failed write actually produces the empty
+# result it is looking for. The BUGS branch returned empty; the FEATURE branch's
+# unguarded `} >> "$ledger"` fell through and returned the FILENAME, so a
+# read-only FEATURES.md yielded rc 0, "A row for DELTA-001 is on FEATURES.md",
+# no row, and `ledger: "FEATURES.md"` in the state document — the lie reaching
+# the AUDIT RECORD, not just the transcript. Both branches are asserted here so
+# the two can never drift apart again.
+PLF="$TMPROOT/ledger-write-fails"; mk_proj "$PLF" 4
+chmod 444 "$PLF/FEATURES.md" 2>/dev/null || true
+# THE PRECONDITION, and it is the m3 lesson applied one row over: if the forced
+# failure does not take effect — a root runner, an exotic filesystem — then
+# every assertion below is vacuous, and a vacuous row must say so rather than
+# pass quietly.
+l5_forced=y
+if ( printf 'x\n' >> "$PLF/FEATURES.md" ) 2>/dev/null; then l5_forced=n; fi
+open_feature "$REPO_ROOT/scripts" "$PLF" "csv-import"
+l5_rc=$DRC
+l5_told=n
+printf '%s\n' "$DOUT" | grep -q 'could not be added' && l5_told=y
+l5_claimed=n
+printf '%s\n' "$DOUT" | grep -q 'A row for .* is on' && l5_claimed=y
+l5_rows="$(grep -c 'DELTA-001' "$PLF/FEATURES.md" 2>/dev/null || true)"
+case "$l5_rows" in ''|*[!0-9]*) l5_rows=0 ;; esac
+l5_ledger="$(active_json "$PLF" -r '.active_delta.ledger // "null"')"
+chmod 644 "$PLF/FEATURES.md" 2>/dev/null || true
+
+# THE BENIGN CONTROL. A guard that also breaks the working path is not a fix.
+PLG="$TMPROOT/ledger-write-ok"; mk_proj "$PLG" 4
+open_feature "$REPO_ROOT/scripts" "$PLG" "csv-import"
+l5g_rc=$DRC
+l5g_rows="$(grep -c 'DELTA-001' "$PLG/FEATURES.md" 2>/dev/null || true)"
+case "$l5g_rows" in ''|*[!0-9]*) l5g_rows=0 ;; esac
+l5g_ledger="$(active_json "$PLG" -r '.active_delta.ledger // "null"')"
+l5g_told=n
+printf '%s\n' "$DOUT" | grep -q 'could not be added' && l5g_told=y
+
+if [ "$l5_forced" = n ]; then
+  fail_ "L5 (vacuous)" "the forced failure did not take effect — FEATURES.md stayed writable, so nothing below was actually exercised. Running as root, or on a filesystem that ignores the mode bit"
+elif [ "$l5_rc" -eq 0 ] && [ "$l5_told" = y ] && [ "$l5_claimed" = n ] \
+     && [ "$l5_rows" -eq 0 ] && [ "$l5_ledger" = "null" ] \
+     && [ "$l5g_rc" -eq 0 ] && [ "$l5g_rows" -gt 0 ] && [ "$l5g_ledger" = "FEATURES.md" ] \
+     && [ "$l5g_told" = n ]; then
+  pass "L5: when the FEATURES.md write FAILS the operator is TOLD (rc $l5_rc, 'could not be added'), the framework does not also claim the row exists ($l5_claimed), the file really has no row ($l5_rows) and the state records ledger=$l5_ledger rather than naming a file it never wrote — so the audit record does not carry the lie either. The benign path is untouched: row written ($l5g_rows), ledger=$l5g_ledger, no warning ($l5g_told)"
+else
+  fail_ "L5" "forced-failure arm: rc=$l5_rc (want 0) told=$l5_told (want y) also-claimed-success=$l5_claimed (want n) rows=$l5_rows (want 0) ledger=$l5_ledger (want null); benign arm: rc=$l5g_rc (want 0) rows=$l5g_rows (want >0) ledger=$l5g_ledger (want FEATURES.md) warned=$l5g_told (want n)"
+fi
+
 # ════════════════════════════════════════════════════════════════════════════
 echo ""
 echo "=== BR — the bridge (§10.4): a READ, never a move ==="

--- a/tests/test-delta-wp8-intake.sh
+++ b/tests/test-delta-wp8-intake.sh
@@ -519,6 +519,26 @@ else
   fail_ "S2" "these spellings were not refused cleanly:$s2_bad"
 fi
 
+# S2b — THE SPELLING THAT IS NOT A SEPARATOR (review R-WP8-3). A newline passes
+# every pattern S2 covers — it is not `/`, not `\`, not `..`, not a leading dot
+# — and `_slugify`'s sed is LINE-oriented, so it survives into the composed file
+# name. Measured, not assumed: the assertion below reads the recorded slug back
+# and requires the tree to be untouched.
+PSN="$TMPROOT/slug-newline"; mk_proj "$PSN" 4
+s2b_before="$(tree_manifest "$PSN")"
+open_feature "$REPO_ROOT/scripts" "$PSN" "$(printf 'csv\nexport')"
+s2b_rc=$DRC
+s2b_after="$(tree_manifest "$PSN")"
+s2b_diff="$(diff <(printf '%s\n' "$s2b_before") <(printf '%s\n' "$s2b_after") 2>/dev/null | grep -c '^[<>]' || true)"
+case "$s2b_diff" in ''|*[!0-9]*) s2b_diff=0 ;; esac
+s2b_files="$(find "$PSN/docs/deltas" -type f 2>/dev/null | grep -c '' || true)"
+case "$s2b_files" in ''|*[!0-9]*) s2b_files=0 ;; esac
+if [ "$s2b_rc" -eq 2 ] && [ "$s2b_diff" -eq 0 ] && [ "$s2b_files" -eq 0 ]; then
+  pass "S2b: a --slug containing a NEWLINE is refused (rc $s2b_rc), the tree is byte-identical ($s2b_diff files changed) and no brief was written ($s2b_files files under docs/deltas) — no file name gains a line break the operator could never type"
+else
+  fail_ "S2b" "rc=$s2b_rc (want 2); tree changed on $s2b_diff line(s) (want 0); brief files written=$s2b_files (want 0)"
+fi
+
 # S3 — AND THE GUARD IS NOT A BLANKET REFUSAL. An ordinary messy human slug
 # still opens, and the basename it produces contains only [a-z0-9-].
 PS3="$TMPROOT/slug-sanitise"; mk_proj "$PS3" 4
@@ -854,32 +874,115 @@ lint_root() {
   return 0
 }
 
-# SH6b — THE BASELINE. Rows SH7-SH9 all assert a NON-ZERO lint, and a fixture
-# tree that reds for some unrelated reason would satisfy all three while
-# measuring nothing. So the unmodified fixture is linted first and must be
+# SH6b — THE BASELINE. Every row from SH7 on asserts a NON-ZERO lint, and a
+# fixture tree that reds for some unrelated reason would satisfy all of them
+# while measuring nothing. So the unmodified fixture is linted first and must be
 # clean.
 LRB="$TMPROOT/lint-baseline"; mk_lint_root "$LRB"
 lint_root "$LRB"
 if [ "$LINT_RC" -eq 0 ]; then
-  pass "SH6b: the unmodified fixture tree lints CLEAN (rc $LINT_RC) — so the three non-zero results below are caused by the edits, not by the fixture"
+  pass "SH6b: the unmodified fixture tree lints CLEAN (rc $LINT_RC) — so every non-zero result below is caused by the edit under test, not by the fixture"
 else
   fail_ "SH6b" "the baseline fixture tree already reds (rc $LINT_RC):
 $(tail -20 "$LINT_FILE")"
 fi
 
-# SH7 — a REAL fusion smuggled inside the fence. A `source` of a module lib is
-# the exact defect the whole lint exists to catch, and an installer coat must
-# not launder it.
-LR7="$TMPROOT/lint-fence-source"; mk_lint_root "$LR7"
-awk '{ print; if ($0 ~ /DELTA-INSTALL-BEGIN/ && !d) { print "  source \"$SCRIPT_DIR/scripts/lib/delta-state.sh\""; d = 1 } }' \
-  "$LR7/$INIT_FILE" > "$LR7/tmp.$INIT_FILE" && mv "$LR7/tmp.$INIT_FILE" "$LR7/$INIT_FILE"
-lint_root "$LR7"; sh7_rc="$LINT_RC"
-sh7_i1=n
-grep -q 'non-installation-statement-inside-the-fence' "$LINT_FILE" && sh7_i1=y
-if [ "$sh7_rc" != "0" ] && [ "$sh7_i1" = y ]; then
-  pass "SH7: a 'source' of a module lib INSIDE the DELTA-INSTALL fence still fails (rc $sh7_rc, tier I1) — only cp/chmod/mkdir are installation, so the fence cannot launder a real dependency edge"
+# ── SH7 — THE SMUGGLING BATTERY (review R-WP8-1 / R-WP8-2) ─────────────────
+#
+# THE FIRST VERSION OF THIS ROW TESTED ONE CASE AND GAVE FALSE CONFIDENCE. It
+# injected a STANDALONE `source` (case B below), watched it fail, and concluded
+# "the fence cannot launder a real dependency edge". The fence could: the check
+# read only a line's LEADING TOKEN, so
+#     cp "$SCRIPT_DIR/scripts/lib/delta-cadence.sh" scripts/lib/ ; source "$SCRIPT_DIR/scripts/lib/delta-state.sh"
+# was "installation" and the WHOLE line — the `source` with it — was exempted.
+# That passed the lint at rc 0 and rode straight through the PR-blocking
+# `delta-boundary-lint` job; the severability suite could not see it either,
+# because the revert drops the fence wholesale. An adversarial review found it
+# by execution.
+#
+# So this is a BATTERY, and every row asserts the RIGHT REASON, not merely a
+# non-zero exit — a fixture that reds for an unrelated reason is a row that
+# measures nothing. The two families are deliberately separated:
+#   chaining      a second command riding on an installation line
+#   grammar       a line that is not an installation statement at all
+# and case L is the one that matters most for R-WP8-2: a PERFECTLY CLEAN cp in
+# an extra fence, which no I1 arm can see and which only the fence-count bound
+# catches. Without L that bound could rot untested behind the chaining check.
+#
+# The payload is injected through a FILE, never `awk -v`: -v performs escape
+# processing and silently eats a trailing backslash, which would have made case
+# G test something other than what it says.
+_inject_in_fence() {   # <tree> <payload…>
+  local d="$1"; shift
+  printf '%s\n' "$@" > "$d/inject"
+  awk -v f="$d/inject" '
+    { print }
+    /DELTA-INSTALL-BEGIN/ && !d { while ((getline l < f) > 0) print l; d = 1 }
+  ' "$d/$INIT_FILE" > "$d/tmp.$INIT_FILE" && mv "$d/tmp.$INIT_FILE" "$d/$INIT_FILE"
+}
+_append_extra_fence() {   # <tree> <payload…>
+  local d="$1"; shift
+  {
+    printf '\n  # -- DELTA-INSTALL-BEGIN --\n'
+    printf '%s\n' "$@"
+    printf '  # -- DELTA-INSTALL-END --\n'
+  } >> "$d/$INIT_FILE"
+}
+
+SH7_SRC='  source "$SCRIPT_DIR/scripts/lib/delta-state.sh"'
+SH7_CP='  cp "$SCRIPT_DIR/scripts/lib/delta-cadence.sh" scripts/lib/'
+sh7_detail=""
+sh7_ok=y
+
+# _sh7 <tag> <expect-token> <where> <payload…>
+_sh7() {
+  local tag="$1" want="$2" where="$3"; shift 3
+  local d="$TMPROOT/lint-case-$tag"
+  mk_lint_root "$d"
+  case "$where" in
+    in)    _inject_in_fence "$d" "$@" ;;
+    extra) _append_extra_fence "$d" "$@" ;;
+  esac
+  lint_root "$d"
+  local got=n
+  grep -q "$want" "$LINT_FILE" && got=y
+  sh7_detail="$sh7_detail [$tag=rc$LINT_RC/$got]"
+  if [ "$LINT_RC" -eq 0 ] || [ "$got" = n ]; then sh7_ok=n; fi
+}
+
+CHAIN='command-chaining-inside-the-fence'
+GRAM='not-a-plain-installation-statement'
+COUNT='DELTA-INSTALL-fence-count'
+
+_sh7 A "$CHAIN" in    "$SH7_CP ; ${SH7_SRC# }"
+_sh7 B "$GRAM"  in    "$SH7_SRC"
+_sh7 C "$CHAIN" in    '  chmod +x scripts/delta.sh && source "$SCRIPT_DIR/scripts/lib/delta-state.sh"'
+_sh7 D "$GRAM"  in    '  ln -s scripts/lib/delta-state.sh /tmp/x'
+_sh7 E "$CHAIN" in    "$SH7_CP && ( ${SH7_SRC# } )"
+_sh7 F "$CHAIN" in    '  mkdir -p docs/deltas ; . "$SCRIPT_DIR/scripts/lib/delta-state.sh"'
+_sh7 G "$CHAIN" in    "$SH7_CP \\" "$SH7_SRC"
+_sh7 H "$CHAIN" in    '  cp "$SCRIPT_DIR/scripts/lib/delta-state.sh" $(dirname scripts/lib)/'
+_sh7 J "$COUNT" extra "$SH7_SRC"
+_sh7 K "$CHAIN" extra "$SH7_CP ; ${SH7_SRC# }"
+_sh7 L "$COUNT" extra "$SH7_CP"
+
+# L's STRUCTURAL DISCRIMINATOR. L is a clean cp — if it reds because some I1 arm
+# fired, the fence-count bound is not what caught it and R-WP8-2 is unpinned.
+sh7_l_clean=y
+grep -qE "$CHAIN|$GRAM" "$TMPROOT/lint-lint-case-L.out" 2>/dev/null && sh7_l_clean=n
+
+# And the SMUGGLED REFERENCE ITSELF must now be visible to tier T1 — the point
+# is not that the line was flagged, it is that the module path stopped being
+# exempt.
+sh7_t1=y
+for t in A B C D E F G H; do
+  grep -qE '^FAIL.T1' "$TMPROOT/lint-lint-case-$t.out" 2>/dev/null || sh7_t1=n
+done
+
+if [ "$sh7_ok" = y ] && [ "$sh7_l_clean" = y ] && [ "$sh7_t1" = y ]; then
+  pass "SH7: all eleven smuggling attempts fail, each for the RIGHT reason —$sh7_detail (tag=rc/expected-diagnostic-found). A-H are in-fence: the four chaining spellings (';', '&&', a subshell, a '\\' continuation), a command substitution, a standalone 'source', a bare 'ln', and in every one of them the module path is now visible to tier T1 again. J/K/L are extra fences, and L is a PERFECTLY CLEAN cp caught by the fence-count bound alone (no I1 row: $sh7_l_clean) — which is the only thing that pins R-WP8-2 independently"
 else
-  fail_ "SH7" "lint rc=$sh7_rc (want non-zero); I1 diagnostic present=$sh7_i1"
+  fail_ "SH7" "cases:$sh7_detail (want every rc non-zero and every expected diagnostic found); L caught by count alone=$sh7_l_clean; T1 visible on all of A-H=$sh7_t1"
 fi
 
 # SH8 — an UNTERMINATED fence. Left tolerated, one stray BEGIN near the top of

--- a/tests/test-delta-wp8-intake.sh
+++ b/tests/test-delta-wp8-intake.sh
@@ -484,20 +484,54 @@ echo ""
 echo "=== S — the slug is where a user string becomes a path ==="
 # ════════════════════════════════════════════════════════════════════════════
 
-PS="$TMPROOT/slug-traversal"; mk_proj "$PS" 4
-s1_before="$(tree_manifest "$PS")"
+# THE FIRST VERSION OF THIS ROW READ THE HOST'S FILESYSTEM, NOT THE PRODUCT,
+# and it took a Linux CI runner to show it. The probe was
+#     [ -e "$PS/../../../etc" ] && [ -e "$PS/../../../etc/cron.d" ]
+# with $PS one level under `mktemp -d`. On this laptop `mktemp -d` yields
+# /var/folders/<hash>/<hash>/T/tmp.XXXX, so `../../..` lands deep inside
+# /var/folders and the probe was ALWAYS false. On a GitHub runner `mktemp -d`
+# yields /tmp/tmp.XXXX, so `../../..` IS `/` — and Ubuntu ships /etc/cron.d. The
+# probe therefore went TRUE on CI with the product having written nothing at
+# all, and it was unfalsifiable in BOTH directions: it could fire with no write,
+# and on macOS it could not fire even if a real write had happened. A check that
+# reads the host is not a check.
+#
+# THE FIX IS TO MAKE THE TRAVERSAL LAND SOMEWHERE MEASURABLE. The project sits
+# three levels below a private sandbox root, so `../../../etc` resolves to
+# $S1_SB/etc on EVERY host, and the manifest covers the WHOLE sandbox rather
+# than just the project — so a write anywhere the traversal could reach shows up
+# as a changed line instead of as an existence test nobody can trust.
+S1_SB="$TMPROOT/s1-sandbox"
+PS="$S1_SB/a/b/proj"; mk_proj "$PS" 4
+s1_before="$(tree_manifest "$S1_SB")"
 open_feature "$REPO_ROOT/scripts" "$PS" "../../../etc/cron.d/evil"
 s1_rc=$DRC
-s1_after="$(tree_manifest "$PS")"
+s1_after="$(tree_manifest "$S1_SB")"
 s1_diff="$(diff <(printf '%s\n' "$s1_before") <(printf '%s\n' "$s1_after") 2>/dev/null | grep -c '^[<>]' || true)"
 case "$s1_diff" in ''|*[!0-9]*) s1_diff=0 ;; esac
 s1_escaped=n
-[ -e "$TMPROOT/etc/cron.d/evil" ] && s1_escaped=y
-[ -e "$PS/../../../etc" ] && [ -e "$PS/../../../etc/cron.d" ] && s1_escaped=y
-if [ "$s1_rc" -eq 2 ] && [ "$s1_diff" -eq 0 ] && [ "$s1_escaped" = n ]; then
-  pass "S1: --slug '../../../etc/cron.d/evil' is REFUSED (rc $s1_rc) and the whole project tree is byte-identical afterwards ($s1_diff files changed) — the traversal never became a path"
+[ -e "$S1_SB/etc" ] && s1_escaped=y
+
+# THE POSITIVE CONTROL, and it is the whole lesson of the CI failure. A probe
+# that cannot be made to fire is the same no-op the old one was, so the
+# IDENTICAL predicate runs against a sandbox where the escape is planted BY
+# HAND and must report it. Without this the row could rot back into a check
+# that passes because nothing can ever trip it.
+S1_CTL="$TMPROOT/s1-control"
+mkdir -p "$S1_CTL/a/b/proj"
+s1_ctl_before="$(tree_manifest "$S1_CTL")"
+mkdir -p "$S1_CTL/etc/cron.d" && : > "$S1_CTL/etc/cron.d/evil"
+s1_ctl_after="$(tree_manifest "$S1_CTL")"
+s1_ctl_diff="$(diff <(printf '%s\n' "$s1_ctl_before") <(printf '%s\n' "$s1_ctl_after") 2>/dev/null | grep -c '^[<>]' || true)"
+case "$s1_ctl_diff" in ''|*[!0-9]*) s1_ctl_diff=0 ;; esac
+s1_ctl_seen=n
+[ -e "$S1_CTL/etc" ] && s1_ctl_seen=y
+
+if [ "$s1_rc" -eq 2 ] && [ "$s1_diff" -eq 0 ] && [ "$s1_escaped" = n ] \
+   && [ "$s1_ctl_seen" = y ] && [ "$s1_ctl_diff" -gt 0 ]; then
+  pass "S1: --slug '../../../etc/cron.d/evil' is REFUSED (rc $s1_rc) and the whole SANDBOX — not just the project — is byte-identical afterwards ($s1_diff files changed), with nothing at the traversal's landing site. The same predicate DOES fire on a hand-planted escape ($s1_ctl_diff file(s), detected=$s1_ctl_seen), so this measures a write rather than the host's own /etc"
 else
-  fail_ "S1" "rc=$s1_rc (want 2); tree changed on $s1_diff line(s) (want 0); escaped-write detected=$s1_escaped"
+  fail_ "S1" "rc=$s1_rc (want 2); sandbox changed on $s1_diff line(s) (want 0); escaped-write detected=$s1_escaped (want n); POSITIVE CONTROL detected=$s1_ctl_seen on $s1_ctl_diff changed line(s) (want y and >0 — if this half fails the probe is a no-op again)"
 fi
 
 # S2 — the neighbouring shapes, each on its OWN fresh fixture. An absolute
@@ -1108,21 +1142,52 @@ _m2_check() {
 # §6.3's hard constraint, and the failure it names is silent: a new column
 # shifts nothing today and breaks a `grep -c 'SEV-2.*Deferred'` later.
 _m3_check() {
-  local name="$1" P rc row width sep
+  local name="$1" P rc row width sep out fixref
   P="$MT/$name-proj"; mk_proj "$P" 4; seed_bugs_rows "$P/BUGS.md"
   sep="$(grep '^|---' "$P/BUGS.md" | head -1 | awk -F'|' '{print NF}')"
   rc=0
-  ( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/delta.sh" --open \
+  out="$( cd "$P" && unset GITHUB_BASE_REF; bash "$MUT_SD/delta.sh" --open \
       --describe "checkout is down for everyone right now" --class hotfix --risk core \
       --level small --lines 5 --slug "checkout-down" --confirm \
-      </dev/null >/dev/null 2>&1 ) || rc=$?
+      </dev/null 2>&1 )" || rc=$?
   row="$(grep -n 'DELTA-001' "$P/BUGS.md" | head -1)"
   row="${row#*:}"
   width="$(printf '%s\n' "$row" | awk -F'|' '{print NF}')"
-  if [ -n "$row" ] && [ "$width" != "$sep" ]; then
-    pass "m3: with the row written to a NEW column the appended row has $width fields against the table's $sep — L1's column-count discriminator sees it. $MUT_REPORT"
+
+  # ── PRECONDITIONS, ASSERTED BEFORE ANY VERDICT IS BELIEVED ───────────────
+  # THIS IS THE VACUITY CLASS, FOUND IN THIS HARNESS BY CI. An absent row
+  # trivially "differs in width" from the table, so the old form could report a
+  # mutation KILLED on the strength of a row that never existed.
+  #
+  # WHAT ACTUALLY HAPPENED ON CI, and it is sharper than "the mutant crashed".
+  # The previous mutant read `$row` before assignment. bash 3.2 — this repo's
+  # local shell — treats a bare `local row` as empty and sails through, so it
+  # passed here. bash 5 aborts on it under `set -u`. But `_ledger_write` is
+  # called in a COMMAND SUBSTITUTION, so that abort killed only the subshell:
+  # `--open` carried on, recorded the delta, and returned **rc 0** with no
+  # ledger row anywhere. Measured, not assumed — the reproduction below prints
+  # `open rc=0`.
+  #
+  # THAT IS WHY BOTH HALVES OF THIS PRECONDITION EXIST, and why the exit code
+  # alone would have been useless: rc was fine. The row's PRESENCE is the
+  # load-bearing half. The failure says VACUOUS rather than quoting a width,
+  # because a mutation that proved nothing must never read as a measurement,
+  # and the mutant's own output is captured (not sent to /dev/null) so the next
+  # reader sees why instead of re-running CI to find out.
+  if [ "$rc" -ne 0 ] || [ -z "$row" ]; then
+    fail_ "$name (vacuous)" "the mutant produced NO row to judge — open rc=$rc, row='$row'. A missing row is not a killed mutation. $MUT_REPORT
+    last lines of the mutant's own output: $(printf '%s' "$out" | tail -3 | tr '\n' ' ')"
+    return 0
+  fi
+
+  # Two independent discriminators, because the mutation now writes a
+  # WELL-FORMED row with a TENTH column rather than a mangled fragment: the
+  # field count moves, AND the delta link is no longer in Fix Reference.
+  fixref="$(printf '%s\n' "$row" | awk -F'|' '{gsub(/^[ \t]+|[ \t]+$/, "", $9); print $9}')"
+  if [ "$width" != "$sep" ] && ! printf '%s' "$fixref" | grep -q 'DELTA-001'; then
+    pass "m3: with the link written to a NEW tenth column the appended row carries $width fields against the table's $sep AND its Fix Reference cell is now '$fixref' rather than the delta — L1 sees it twice over, on the column count and on the cell. $MUT_REPORT"
   else
-    fail_ "m3" "the mutant's row width was $width against $sep (row='$row') — L1 cannot see this line. $MUT_REPORT"
+    fail_ "m3" "the mutant's row width was $width against $sep and its Fix Reference cell was '$fixref' (row='$row') — L1 cannot see this line. $MUT_REPORT"
   fi
 }
 
@@ -1134,8 +1199,18 @@ _mutate m2 scripts/delta.sh '# DELTA-OPEN-SLUG-GUARD$' \
   's|^\(.*\)# DELTA-OPEN-SLUG-GUARD$|  if false; then   # DELTA-OPEN-SLUG-GUARD|' \
   _m2_check
 
+# THE MUTANT BUILDS A COMPLETE ROW AND READS NOTHING IT HAS NOT ASSIGNED.
+# Its first form was `row="$row | $link |"`, which had two faults. It depended
+# on `$row` before assignment — harmless on bash 3.2, fatal under `set -u` on
+# bash 5, so the mutant died on CI instead of mutating. And even when it ran it
+# produced a mangled three-field fragment, which L1 caught almost by accident.
+# This form writes a well-formed row with a TENTH column and the delta link
+# moved OUT of Fix Reference into it — which is literally §6.3's hazard ("the
+# delta link goes in an EXISTING column, never a new one") rather than a
+# lookalike, and it is shell-version independent because `$num`, `$sev` and
+# `$link` are all assigned above the marked line.
 _mutate m3 scripts/delta.sh '# DELTA-OPEN-LEDGER-COLUMN$' \
-  's@^\(.*\)# DELTA-OPEN-LEDGER-COLUMN$@    row="$row | $link |"   # DELTA-OPEN-LEDGER-COLUMN@' \
+  's@^\(.*\)# DELTA-OPEN-LEDGER-COLUMN$@    row="| $num | $sev | Open | m3 | m3 | - | Fix Now | | - | $link |"   # DELTA-OPEN-LEDGER-COLUMN@' \
   _m3_check
 
 # ── m4: drop a shipped file from the copy list -> the CLOSURE suite goes RED ─


### PR DESCRIPTION
## What

Delta Track **WP8** — the intake half of the delta track, plus **two decisions Karl made on 2026-08-09**.

- **`templates/generated/delta-brief.tmpl`** — §6.2's five sections, codifying WP4's *corrected* Done-observable pooling contract (verified against the shipped `_rubric_boxes` parser, not the prose).
- **Three creation paths** (§6.1) converging on the same three writes, with `--via guided|conversational|manual` recorded so a later review can tell which path produced which quality of brief.
- **`resume.sh`'s fourth branch** (§10.5) — phase-4-gated, fails soft to the classic prompt when the module is absent.
- **The §10.4 bridge** — manifesto § 6 items listed as *candidates* by `--status`. A read, never a move; the mutation that makes it write to `PRODUCT_MANIFESTO.md` goes RED.
- **The slug guard** — WP3's review recorded `--slug ../../../etc/cron.d/evil` stored verbatim; WP8 is where a slug becomes a path. Traversal refused, and control characters (newline/tab/CR) now refused too, while `café-export` is still sanitised rather than rejected.

### Karl's decision 1 — the delta module now ships

`init.sh` previously contained the string `delta` **zero times**: the entire track reached no generated project. It now ships `delta.sh`, `cut-release.sh` and all four delta libs plus the brief template. Verified by the reviewer in a **real scaffold** — files present with correct permissions, the framework-only lint correctly *not* shipped, and the module opens deltas downstream.

### Karl's decision 3 — the hotfix audit row is a real `BUGS.md` entry

Riding the **existing `Fix Reference` column** (§6.3's hard constraint — a new column silently breaks `grep -c 'SEV-2.*Deferred'`-shaped readers). Table still parses; `check_phase_gate`'s own grep still finds its rows.

## The primary review target: a new lint exemption, and the hole in it

My brief assumed a copy list in `init.sh` would be lint-clean. It wasn't — 8 T1 violations — and the implementer *couldn't* route around it, because `soif_parse_shipped_scripts` derives the shipped set by parsing those very `cp` lines, so a cleverer spelling would satisfy the lint and break the closure gate. Its answer was a new `DELTA-BOUNDARY-INSTALLER` fence.

**Round 1 found that fence laundering compound lines.** The `I1` check inspected only a line's *leading token*, so `cp X ; source delta-state.sh` inside the fence passed `lint-delta-boundary.sh` at **rc=0** — smuggling a core→module reference past both the PR-blocking lint job and the severability suite. The tightness guarantee was the entire justification for accepting the exemption, and it was false.

**The fix chose a whitelist over a blacklist**, and the reasoning is the wave's own lesson: a blacklist has to be *complete* to be correct, and CLAUDE.md records a sibling predicate reopened three times by one-character widenings. So: a positive whole-line **grammar** admitting exactly three shapes whose argument class is `[A-Za-z0-9_./-]` — which no shell metacharacter can satisfy, making a matching line provably one simple command over paths. The chaining check is **kept anyway, ordered first**, so both stages fire on distinct inputs and a future widening of the argument class still can't re-open `cp X ; source Y`.

Twelve cases red, each for the right reason — and critically, each asserts the smuggled path is **visible to T1 again**, since the point is that the reference stopped being *exempt*, not merely that a line got flagged. The reviewer added five more probes (pipe, backtick, `$(…)`, backslash-continuation, standalone) and graded the grammar **sound**: options (`cp -r`), non-grammar commands (`eval`, `ln`, `source`, `.`) and every composition attempt rejected.

Also fixed: the fence **count** is now bounded by a ceiling (case L — an extra fence containing a perfectly clean `cp` — reds on that count *alone*, pinning it independently), and a dead `case … *"\\")` arm that could never fire, replaced by a suffix expansion.

## Two amendments to earlier work packages, both forced

- `_brief_path`'s ambiguity check now runs first and unconditionally: populating `active_delta.brief` had made WP4's two-briefs refusal **unreachable**. Fixed in the product, not the test.
- WP5's `H1` no longer demands `BUGS.md` be byte-identical — Karl's decision 3 requires that write. It now demands `BUGS.md` be the *only* file that moved **and** that it moved by exactly one delta-naming line. Verified to bite on both a two-line move and a foreign-file move.

The severability revert set grew to **six** consumers, named by the sweep itself.

## Verification

Two adversarial rounds, `major_concerns` → **approve**. Suites: WP8 **42/0**, boundary-lint 29/0, severability 14/0, source-closure 6/0, WP0/2/3/4/5/6/7 = 13/31/29/29/34/33/37, run-lints 15/15, real-tree boundary lint rc 0 with the seam still at cardinality 1/1. `edge-cases-scripts.sh` — the one suite left unmeasured by the implementer — was run independently by the supervisor against the final tree: rc=0, 74 total, 0 fail, 0 skip.

## Escalated to Karl, not built

Post-1.0 `SEV-N | Open` rows **accumulate**: `--open` writes the row, `--close` writes state only, `cut-release.sh` writes `shipped_in` into the state document — nothing ever flips the row to `Fixed`. Inert at the gate (§10.2 forbids phase re-entrancy) but a real human-signal problem, since a healthy product grows a list of apparently-open SEV-1s. Rows *are* distinguishable by content (each carries `DELTA-NNN`) but not by the gate's position-independent grep. Four options were written up; the recommendation is the promotion step in `cut-release.sh` — the only moment when "this bug is fixed" becomes true — with a documentation fix as an immediate free mitigation. Marking it at *close* was explicitly rejected: close is not ship.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
