### PR TITLE
fix(lints): BL-215 — both boundary lints' CORE set gains scripts/host-drivers

### DIFF
--- a/docs/designs/2026-08-02-brownfield-adoption-v1.md
+++ b/docs/designs/2026-08-02-brownfield-adoption-v1.md
@@ -156,9 +156,9 @@ forced. No settled decision, decision table, or WP boundary changes. Amendment r
   `source …/delta-state.sh` to `scripts/host-drivers/github.sh`, and **both lints passed at rc=0**,
   while the identical lines in four-glob-covered core files red at rc=1. Karl approved extending
   coverage; the CORE set is now **five globs** here, in the delta design's §3.3, and in
-  `docs/module-contract.md`. **The lint edit is a separate follow-up, tracked as `## BL-215:`** —
-  as of 2026-08-09 both `CORE_GLOBS` arrays still list four entries, and this document is ahead of
-  the code by that one glob, deliberately and in writing.
+  `docs/module-contract.md`. **The lint edit shipped separately and has now landed
+  (`## BL-215:`)** — both `CORE_GLOBS` arrays carry the fifth glob under the sync-sibling marker
+  `# BL-215-CORE-GLOB-SYNC`, so this document is no longer ahead of the code by that one glob.
 
 - **A-BF-4 (FRONT MATTER) → Document Control, "Status of the thing described"** — that row read
   **"Nothing is built."** through v1.1. True when written; false by 2026-08-09, because WP0–WP3 have
@@ -427,12 +427,19 @@ sibling passes its own equivalent plant identically. The **identical** line appe
 predicate is sound; the population was short. Host drivers are core by every other measure
 (`init.sh`, `scripts/lib/host.sh` and `scripts/intake-wizard.sh` source them by path), so a
 convenience call added to one severs nothing and fuses everything, which is precisely the Tuesday-
-afternoon failure M3 exists to make red. **Not yet implemented:** the `CORE_GLOBS` arrays in both
-lints still list four entries as of 2026-08-09; widening them is tracked as **`## BL-215:`**, which
-carries the measurement table above and the both-lints-in-sync fix shape, and until it lands this
-contract is stated here and under-enforced there. The same correction lands on the delta design's
-§3.3 and on `docs/module-contract.md` M3, which is the standing normative transcription of this
-section.
+afternoon failure M3 exists to make red. **Implemented (`## BL-215:`).** Both `CORE_GLOBS` arrays
+now carry the fifth glob, under the sync-sibling marker `# BL-215-CORE-GLOB-SYNC` — grep it to find
+the pair, and change them together. This contract is no longer stated here and under-enforced
+there. On the real tree the widening raised this lint's scanned CORE population from **76 to 79**
+files with no new violation, so the three host drivers carried no pre-existing `core → module`
+edge. The enforcement half is pinned three ways in `tests/test-lint-module-dependencies.sh`, and
+the third pin is the load-bearing one: **S5** plants the line above in a host driver and requires
+tier **T2**; **S6** requires a *clean* host driver to raise the reported CORE population by exactly
+one, because `rc=0` cannot distinguish "scanned and clean" from "never scanned" and that ambiguity
+is the whole reason this gap survived from WP0; and **S7** deletes the glob from a copy of the lint
+and requires the plant to pass again, so the pin cannot stay green under the very edit it forbids.
+The same correction lands on the delta design's §3.3 and on `docs/module-contract.md` M3, which is
+the standing normative transcription of this section.
 
 **M5 is the load-bearing one and it has a cost worth stating.** Zero dependency means the scanner
 cannot reuse `scripts/lib/helpers-core.sh`'s printers, its `soif_read_*` state readers, or its host

--- a/docs/designs/2026-08-02-delta-track-v1.md
+++ b/docs/designs/2026-08-02-delta-track-v1.md
@@ -136,9 +136,10 @@ rows are prefixed `A-` to distinguish them from the review findings below, which
   it at rc=0**, while the identical line in `scripts/validate.sh` reds at rc=1 on T1 — re-executed in
   both directions for this amendment. The predicate is sound; the population was short. Karl approved extending coverage, so the CORE set is now
   **five globs** here, in the brownfield design's §3.3, and in `docs/module-contract.md` M3 — the
-  three surfaces are kept at parity by design. **The lint edit is a separate follow-up, tracked as
-  `## BL-215:`:** as of 2026-08-09 both `CORE_GLOBS` arrays still list four entries, and §3.3 says
-  so rather than reading as a description of shipped behaviour.
+  three surfaces are kept at parity by design. **The lint edit shipped separately and has now
+  landed (`## BL-215:`):** both `CORE_GLOBS` arrays carry the fifth glob under the sync-sibling
+  marker `# BL-215-CORE-GLOB-SYNC`, so §3.3 is a description of shipped behaviour again rather
+  than a contract running ahead of it.
 - **A-DT-3 (FRONT MATTER) → Document Control, "Status of the thing described"** — that row read
   **"Nothing is built."** through v1.1, verified at the time against §14-V11. True at that commit;
   false by 2026-08-09, because **WP0–WP7 have shipped** (PRs #323, #324, #327, #328, #330, #332,
@@ -420,10 +421,18 @@ module exactly as thoroughly as the same line in `check-phase-gate.sh`, and the 
 property is gone with no check failing. **The sibling brownfield lint has the same hole for the same
 reason and takes the same correction** (`docs/designs/2026-08-02-brownfield-adoption-v1.md` §3.3 and
 `docs/module-contract.md` M3), because the two lints are kept at exact parity by design.
-**Not yet implemented:** the `CORE_GLOBS` arrays in both lints still list four entries as of
-2026-08-09. Widening them is tracked as **`## BL-215:`**, which carries the measurement table above
-and the both-lints-in-sync fix shape; until it lands, this section states the contract and the lints
-under-enforce it.
+**Implemented (`## BL-215:`).** Both `CORE_GLOBS` arrays now carry the fifth glob, under the
+sync-sibling marker `# BL-215-CORE-GLOB-SYNC` — grep it to find the pair, and change them together.
+This section describes shipped behaviour again; it is no longer a contract stated here and
+under-enforced there. On the real tree the widening raised this lint's scanned CORE population from
+**73 to 76** files with no new violation, so the three host drivers carried no pre-existing
+`core → delta` edge. The enforcement half is pinned three ways in
+`tests/test-lint-delta-boundary.sh`, and the third pin is the load-bearing one: **S4** plants the
+line above in a host driver and requires tier **T1**; **S5** requires a *clean* host driver to raise
+the reported CORE population by exactly one, because `rc=0` cannot distinguish "scanned and clean"
+from "never scanned" and that ambiguity is the whole reason this gap survived several work packages;
+and **S6** deletes the glob from a copy of the lint and requires the plant to pass again, so the pin
+cannot stay green under the very edit it forbids.
 
 **Two match tiers, because literal paths are evadable (R-DT-6).** Clause 2 as written matches
 *literal* delta paths, and bash lets a reference be composed at runtime:

--- a/docs/module-contract.md
+++ b/docs/module-contract.md
@@ -71,7 +71,7 @@ and review is the check until a module actually accrues a listed dependency.
 that makes severance a `git mv`, not a refactor.
 
 **The set "outside" means — five globs. Corrected 2026-08-09 (Karl's approval);
-evidence-led, and not yet implemented.** Both lints render M3's universal as a
+evidence-led, and now implemented in both lints.** Both lints render M3's universal as a
 literal CORE glob set: `init.sh` + `scripts/*.sh` + `scripts/lib/*.sh` +
 `scripts/hooks/*.sh` + **`scripts/host-drivers/*.sh`**, minus the module
 inventory, minus the lint itself, minus sibling boundary lints. The fifth glob
@@ -86,12 +86,23 @@ rc=0 — while the same lines in `scripts/validate.sh` and
 `scripts/check-maintenance.sh` red at rc=1 on T1 and T2 respectively. Host
 drivers are core by every other measure (`init.sh`, `scripts/lib/host.sh` and
 `scripts/intake-wizard.sh` source them by path), so a convenience call added to
-one fuses a module with nothing going red. **As of 2026-08-09 the `CORE_GLOBS`
-arrays in both lints still list four entries** — widening them is tracked as
-`## BL-215:` in `solo-orchestrator-backlog.md`, which carries the full
-measurement table and the both-lints-in-sync fix shape, so this page is ahead of
-the code by exactly that one glob. Amended in both designs' §3.3 in the same
-pass.
+one fuses a module with nothing going red. **Both `CORE_GLOBS` arrays now carry
+the fifth glob** (`## BL-215:`), under the sync-sibling marker
+`# BL-215-CORE-GLOB-SYNC` — grep it to find the pair, and change them together;
+a one-sided edit silently re-opens the hole on the other module. This page is no
+longer ahead of the code. Widening the population found **no** pre-existing
+violation in `scripts/host-drivers/`: the delta lint went from 73 to 76 scanned
+core files and the module lint from 76 to 79, both still at rc=0. Amended in
+both designs' §3.3 in the same pass.
+
+**Each lint pins the new glob three ways, and the third is the load-bearing
+one** (`tests/test-lint-delta-boundary.sh` S4-S6,
+`tests/test-lint-module-dependencies.sh` S5-S7): the plant reds at the right
+tier; a *clean* host driver must raise the reported CORE population by exactly
+one, because `rc=0` cannot distinguish "scanned and clean" from "never scanned"
+and that ambiguity is what let this gap survive; and deleting the glob from a
+copy of the lint must let the plant through again, so neither pin can stay green
+under the very edit it forbids.
 
 *Enforced by:* both lints, in two match tiers. T1 is the literal manifest path
 and is **not** waivable. T2 is a path-shaped token that catches runtime

--- a/scripts/lint-delta-boundary.sh
+++ b/scripts/lint-delta-boundary.sh
@@ -7,10 +7,14 @@
 # D1 requires this lint FROM THE FIRST COMMIT, which is why it lands alongside
 # the first module file rather than at the end of the track.
 #
-# (Deliberately NO `# BL-NNN-…` marker: no backlog entry exists for the delta
-# build, and CLAUDE.md's citation rule is satisfied by the design-doc path
-# above plus the grep-able `DELTA-BOUNDARY-*` fences below. Do not mint a BL
-# marker here — scripts/lint-bl-markers.sh would red on an id nobody filed.)
+# (Deliberately NO `# BL-NNN-…` marker for the lint AS A WHOLE: no backlog
+# entry exists for the delta build, and CLAUDE.md's citation rule is satisfied
+# by the design-doc path above plus the grep-able `DELTA-BOUNDARY-*` fences
+# below. Do not mint one for the build — scripts/lint-bl-markers.sh would red
+# on an id nobody filed. ONE LINE IS THE EXCEPTION and it is filed: the fifth
+# CORE glob carries `# BL-215-CORE-GLOB-SYNC`, because BL-215 is a real entry
+# and because that line has a SYNC SIBLING in another file — which is exactly
+# the case the marker primitive exists for, cf. `# BL-084-TIER-KEY`.)
 #
 # THE DEFECT CLASS
 #   A severable module stops being severable one convenience call at a time.
@@ -45,13 +49,33 @@
 # THE SETS — one manifest, so they can never disagree
 #   DELTA = the §3.1 inventory, spelled once in the DELTA-BOUNDARY-MANIFEST
 #           fence below. Adding a module file is a one-line edit there.
-#   CORE  = init.sh + scripts/*.sh + scripts/lib/*.sh + scripts/hooks/*.sh,
-#           MINUS the delta inventory and MINUS this script (which names every
-#           delta path by construction). The self-exclusion is by BOTH manifest
-#           membership and the explicit SELF_REL path, per §3.3.
-#           scripts/host-drivers/*.sh is NOT in the CORE set: §3.3 names four
-#           globs and this is the fourth-glob-faithful reading. Widen it only
-#           by amending the design.
+#   CORE  = init.sh + scripts/*.sh + scripts/lib/*.sh + scripts/hooks/*.sh +
+#           scripts/host-drivers/*.sh, MINUS the delta inventory and MINUS this
+#           script (which names every delta path by construction). The
+#           self-exclusion is by BOTH manifest membership and the explicit
+#           SELF_REL path, per §3.3.
+#
+#           THE FIFTH GLOB IS A CORRECTION, NOT A GROWTH SPURT (BL-215, §3.3
+#           v1.2, Karl's approval 2026-08-09). v1.0/v1.1 named FOUR globs, this
+#           lint was built faithful to that number, and this header used to say
+#           the exclusion of scripts/host-drivers/*.sh was the faithful reading
+#           and should be widened "only by amending the design". The design was
+#           amended, and what it was amended ON is worth keeping: the gap was
+#           measured, not argued. A planted
+#           `source "$SCRIPT_DIR/lib/delta-state.sh"` in
+#           scripts/host-drivers/github.sh left this lint at rc=0, while the
+#           IDENTICAL line in scripts/validate.sh red at rc=1 on T1. The
+#           positive control is the whole argument: the predicate was sound and
+#           the POPULATION was short, so nothing below this line changed. Host
+#           drivers are core by every other measure — init.sh,
+#           scripts/lib/host.sh and scripts/intake-wizard.sh source them by
+#           path, and init.sh ships them downstream — so a convenience call
+#           added to one fuses the module exactly as thoroughly as the same
+#           call in check-phase-gate.sh.
+#           Pinned by tests/test-lint-delta-boundary.sh S4 (the plant reds at
+#           T1), S5 (a clean host driver is IN the population — structural,
+#           because rc=0 cannot tell that from "not scanned") and S6 (drop the
+#           glob and the plant passes again).
 #
 #   A RENAMED COPY of this script inside scripts/ is NOT self-excluded, and
 #   that is deliberate. Unlike scripts/lint-bl-markers.sh — where a copy could
@@ -420,11 +444,18 @@ fi
 # a literal and is filtered by the `[ -f ]` test.
 CORE_FILES="$TMPD/core-files"
 : > "$CORE_FILES"
+# BL-215-CORE-GLOB-SYNC — SYNC SIBLINGS. The host-drivers glob below is
+# duplicated verbatim in scripts/lint-module-dependencies.sh's CORE_GLOBS and
+# the two must be changed TOGETHER: the designs keep the two CORE sets at exact
+# parity by construction (delta §3.3, brownfield §3.3, docs/module-contract.md
+# M3 all state the same five globs), so a one-sided edit silently re-opens the
+# hole on the other module. Grep the marker to find the sibling.
 CORE_GLOBS=(
   "$ROOT/init.sh"
   "$ROOT/scripts"/*.sh
   "$ROOT/scripts/lib"/*.sh
   "$ROOT/scripts/hooks"/*.sh
+  "$ROOT/scripts/host-drivers"/*.sh
 )
 for entry in "${CORE_GLOBS[@]}"; do
   [ -f "$entry" ] || continue

--- a/scripts/lint-module-dependencies.sh
+++ b/scripts/lint-module-dependencies.sh
@@ -7,11 +7,14 @@
 # §10-WP0. The rules are transcribed as a standing contract in
 # docs/module-contract.md; this script is M2/M3/M5's enforcement half.
 #
-# (Deliberately NO `# BL-NNN-…` marker: no backlog entry exists for the
-# brownfield build, and CLAUDE.md's citation rule is satisfied by the
-# design-doc path above plus the grep-able `MODULE-DEPS-*` fences below. Do not
-# mint a BL marker here — scripts/lint-bl-markers.sh would red on an id nobody
-# filed.)
+# (Deliberately NO `# BL-NNN-…` marker for the lint AS A WHOLE: no backlog
+# entry exists for the brownfield build, and CLAUDE.md's citation rule is
+# satisfied by the design-doc path above plus the grep-able `MODULE-DEPS-*`
+# fences below. Do not mint one for the build — scripts/lint-bl-markers.sh
+# would red on an id nobody filed. ONE LINE IS THE EXCEPTION and it is filed:
+# the fifth CORE glob carries `# BL-215-CORE-GLOB-SYNC`, because BL-215 is a
+# real entry and because that line has a SYNC SIBLING in another file — which
+# is exactly the case the marker primitive exists for, cf. `# BL-084-TIER-KEY`.)
 #
 # WHY A SIBLING AND NOT A GENERALISATION
 #   The post-MVP delta track ships its own boundary lint, whose architecture
@@ -66,13 +69,37 @@
 #            fence below as `<module>|<path>` rows. The module column is what
 #            makes M5's scout-only bound derivable from the same list instead
 #            of from a second one that could drift out of step with it.
-#   CORE   = init.sh + scripts/*.sh + scripts/lib/*.sh + scripts/hooks/*.sh,
-#            MINUS the module inventory, MINUS this script, and MINUS sibling
-#            boundary lints. scripts/host-drivers/*.sh is NOT in the CORE set:
-#            §3.3's co-owned contract names four globs and this is the
-#            fourth-glob-faithful reading, kept at exact parity with the delta
-#            lint. The gap is a known, pending design question for BOTH lints —
-#            widen it only by amending the design, and then in both places.
+#   CORE   = init.sh + scripts/*.sh + scripts/lib/*.sh + scripts/hooks/*.sh +
+#            scripts/host-drivers/*.sh, MINUS the module inventory, MINUS this
+#            script, and MINUS sibling boundary lints.
+#
+#            THE FIFTH GLOB IS A CORRECTION, NOT A GROWTH SPURT (BL-215, §3.3
+#            v1.2 + docs/module-contract.md M3, Karl's approval 2026-08-09).
+#            The co-owned contract named FOUR globs, both lints were built
+#            faithful to that number at exact parity, and this header used to
+#            call the exclusion a pending design question to be widened "only
+#            by amending the design, and then in both places". The design was
+#            amended and both places moved in the same commit. What it was
+#            amended ON is worth keeping: the gap was measured, not argued. A
+#            planted `source "$SCRIPT_DIR/lib/scout/scout-phasemap.sh"` in
+#            scripts/host-drivers/gitlab.sh left this lint at rc=0, while the
+#            IDENTICAL line in scripts/check-maintenance.sh red at rc=1 on T2.
+#            The positive control is the whole argument: the predicate was
+#            sound and the POPULATION was short, so nothing below this line
+#            changed. Host drivers are core by every other measure — init.sh,
+#            scripts/lib/host.sh and scripts/intake-wizard.sh source them by
+#            path — so a convenience call added to one fuses a module exactly
+#            as thoroughly as the same call in check-phase-gate.sh.
+#            Pinned by tests/test-lint-module-dependencies.sh S5 (the plant
+#            reds at T2), S6 (a clean host driver is IN the population —
+#            structural, because rc=0 cannot tell that from "not scanned") and
+#            S7 (drop the glob and the plant passes again).
+#
+#            NOTE ON THE SIBLING EXCLUSION, which the fifth glob does NOT
+#            disturb: `scripts/lint-*-boundary.sh` requires the literal
+#            `scripts/lint-` prefix, so no host driver can ever match it and
+#            neither lint starts scanning the other as a result of this
+#            widening. That exclusion is load-bearing — see below.
 #
 #   SELF-EXCLUSION IS BY EXACT PATH, and that is deliberate: a RENAMED COPY of
 #   this script inside scripts/ is NOT self-excluded. A copy is a core file
@@ -514,11 +541,18 @@ case "$ZERODEP_COUNT" in ''|*[!0-9]*) ZERODEP_COUNT=0 ;; esac
 # literal and is filtered by the `[ -f ]` test.
 CORE_FILES="$TMPD/core-files"
 : > "$CORE_FILES"
+# BL-215-CORE-GLOB-SYNC — SYNC SIBLINGS. The host-drivers glob below is
+# duplicated verbatim in scripts/lint-delta-boundary.sh's CORE_GLOBS and the
+# two must be changed TOGETHER: the designs keep the two CORE sets at exact
+# parity by construction (brownfield §3.3, delta §3.3, docs/module-contract.md
+# M3 all state the same five globs), so a one-sided edit silently re-opens the
+# hole on the other module. Grep the marker to find the sibling.
 CORE_GLOBS=(
   "$ROOT/init.sh"
   "$ROOT/scripts"/*.sh
   "$ROOT/scripts/lib"/*.sh
   "$ROOT/scripts/hooks"/*.sh
+  "$ROOT/scripts/host-drivers"/*.sh
 )
 for entry in "${CORE_GLOBS[@]}"; do
   [ -f "$entry" ] || continue

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -1909,15 +1909,19 @@ run_child_suite "tests/test-delta-wp7-cut-release.sh" \
   "tests/test-delta-wp7-cut-release.sh"
 
 # Delta Track §3.1's SEVERABILITY test (WP7). Builds a real severed tree —
-# every §3.1 module file deleted, the seam reverted in all FOUR core consumers
+# every §3.1 module file deleted and every core consumer of the module reverted
 # — and proves the framework still parses, still behaves, and carries not one
 # dangling reference. The module inventory is READ OUT OF
 # scripts/lint-delta-boundary.sh's own manifest rather than retyped, so the two
-# can never disagree about what "the module" is. §3.1 says the revert is "the
-# seam block in process-checklist.sh", singular; running this test enumerates
-# the real set (process-checklist.sh, upgrade-project.sh, validate.sh,
-# check-maintenance.sh) and V1's completeness sweep is what keeps that list
-# honest when a fifth consumer arrives. The §11-WP7 mutation — delete a module
+# can never disagree about what "the module" is. §3.1 SAID the revert was "the
+# seam block in process-checklist.sh", singular, and by WP7 the real set was
+# four core files (process-checklist.sh, upgrade-project.sh, validate.sh,
+# check-maintenance.sh) — that quote is kept in the past tense because it is
+# WHY this suite delegates the enumeration instead of restating it. Running the
+# test is what produced the real set, and consumers beyond those four were
+# found by V1's completeness sweep rather than by anyone remembering, so the
+# live list is the banner in tests/test-delta-severability.sh and no count is
+# repeated here to go stale. The §11-WP7 mutation — delete a module
 # file but NOT the seam revert — is killed by V1 and ONLY by V1, and m1
 # measures why: every consumer fails soft by design, so the probes stay
 # identical to the intact tree and no functional arm could ever see it.

--- a/tests/test-delta-severability.sh
+++ b/tests/test-delta-severability.sh
@@ -2,18 +2,32 @@
 # tests/test-delta-severability.sh — Delta Track §3.1's severability test.
 #
 # SPEC: docs/designs/2026-08-02-delta-track-v1.md §3.1 ("delete every
-# delta-module file and revert the seam block in process-checklist.sh, and the
+# delta-module file and revert EVERY CORE CONSUMER OF THE MODULE, and the
 # full suite must pass — that is the property 'severable' means operationally;
 # §11-WP7 makes it a test"), §3.3 (the dependency-direction lint this protects),
 # §0.3-C10 (the seam and the single writer are the same file, which is what
 # makes the edge cardinality ONE), §11-WP7.
 #
+# THAT IS THE v1.2 WORDING. Through v1.1 the same sentence SAID "revert the seam
+# block in process-checklist.sh", SINGULAR, and this header quoted it in the
+# present tense for as long as that was true. The old spelling is kept below in
+# the PAST tense rather than deleted, because it is not a stale detail — it is
+# the reason this file has the shape it has. A design that named one consumer is
+# what made enumerating by RUNNING the only trustworthy method; delete the quote
+# and the next reader has no explanation for the banner that follows.
+#
 # ═════════════════════════════════════════════════════════════════════════════
 # THE ENUMERATION IS THE POINT — AND IT IS DONE BY RUNNING, NOT BY REMEMBERING
 #
-# §3.1 says "the seam block in process-checklist.sh", singular. By the time WP7
-# arrived the revert was FOUR core files, and each one arrived in a different
-# work package with its own good reason:
+# §3.1 SAID "the seam block in process-checklist.sh", singular — the v1.0/v1.1
+# wording, and running this test is what refuted it. §3.1 v1.2 now says "revert
+# every core consumer of the module" and carries a consumer table, so the
+# singular is history; it is quoted here in the past tense, and kept, because it
+# is the premise of everything below. A design sentence that named ONE consumer
+# is precisely why this test enumerates by RUNNING rather than by remembering,
+# and the enumeration outran the design twice after that sentence was corrected.
+# By the time WP7 arrived the revert was FOUR core files, and each one arrived
+# in a different work package with its own good reason:
 #
 #   1. scripts/process-checklist.sh   the DELTA-SEAM fence (WP2) — the seam
 #                                     itself, and the only allowlisted edge

--- a/tests/test-lint-delta-boundary.sh
+++ b/tests/test-lint-delta-boundary.sh
@@ -23,8 +23,19 @@
 #     S1  init.sh is scanned
 #     S2  scripts/hooks/*.sh is scanned
 #     S3  scripts/lib/*.sh (non-delta members) is scanned
-#     A narrowed surface would pass D1-D5 while seeing nothing; these three are
-#     the anti-vacuity pins for the CORE half specifically.
+#     S4  scripts/host-drivers/*.sh is scanned         (BL-215, the fifth glob)
+#     S5  a CLEAN host driver joins the CORE POPULATION — a structural pin,
+#         because rc=0 cannot tell "scanned and clean" from "never scanned"
+#     S6  mutant M-HD: revert the fifth glob and the S4 plant passes again
+#     A narrowed surface would pass D1-D5 while seeing nothing; these six are
+#     the anti-vacuity pins for the CORE half specifically. S4-S6 exist because
+#     that failure mode was not hypothetical: for two work packages the CORE
+#     set was FOUR globs, `scripts/host-drivers/*.sh` sat outside all of them,
+#     and a planted `source .../delta-state.sh` in a host driver passed this
+#     lint at rc=0 while the IDENTICAL line in scripts/validate.sh red at rc=1
+#     (`## BL-215:`, measured with positive controls in both directions). Every
+#     other case in this file was green throughout. A population defect is
+#     invisible to a suite that only ever pins the predicate.
 #
 #   THE EXECUTED-LINES STRIPPER (§3.3 "Executed lines only")
 #     This predicate has repo scar tissue. CLAUDE.md records that a
@@ -194,6 +205,55 @@ run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
 # diagnostics carry the same file:line text and would double every row count.
 run_fixture_list() { bash "$LINTER" --root "$TMP" --list 2>/dev/null; return $?; }
 
+# core_in_scope LIST-OUTPUT — the CORE population count off the --list INFO row.
+# The count is the only thing that can distinguish "scanned and clean" from
+# "never in the population", and those two are the same exit code.
+core_in_scope() {
+  printf '%s\n' "$1" | sed -n 's/.*, \([0-9][0-9]*\) core file(s) in scope.*/\1/p'
+}
+
+# ── Mutation harness ────────────────────────────────────────────────────
+# A mutation proof is only a proof if the mutant is the edit it claims to be,
+# so the harness MEASURES the edit and hands the numbers back for the case to
+# assert on rather than assuming any of them:
+#   sites     the ANCHORED pattern must match exactly ONE line of the lint.
+#             An unanchored or over-broad pattern that hit two lines would
+#             mutate more than the case describes; one that hit zero would
+#             produce a pristine "mutant" and a green run that proves nothing.
+#   removed   exactly one line fewer than the original.
+#   changed   diff shows exactly one changed line — `removed` alone cannot see
+#             a deletion silently paired with an insertion.
+#   syntax_ok `bash -n` on the mutant. A mutant that does not PARSE exits
+#             non-zero for a reason that has nothing to do with the predicate,
+#             which would read as a kill and prove nothing.
+#   mode_ok   the copy carries the original's mode. Mode-preserving so the
+#             mutant differs from the shipped lint in exactly one dimension.
+# Callers keep the copy inside their own mktemp fixture — never in the repo —
+# and pair it with a positive control (the pristine lint on the same fixture).
+_file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+mutate_drop_line() {
+  local src="$1" dst="$2" pat="$3"
+  local sites before after removed changed syntax_ok mode mode_ok
+  sites=$(grep -c "$pat" "$src")
+  grep -v "$pat" "$src" > "$dst"
+  before=$(grep -c '' "$src")
+  after=$(grep -c '' "$dst")
+  removed=$((before - after))
+  changed=$(diff "$src" "$dst" | grep -c '^[<>]')
+  if bash -n "$dst" 2>/dev/null; then syntax_ok=1; else syntax_ok=0; fi
+  mode=$(_file_mode "$src")
+  [ -n "$mode" ] && chmod "$mode" "$dst"
+  mode_ok=0
+  if [ -n "$mode" ] && [ "$(_file_mode "$dst")" = "$mode" ]; then mode_ok=1; fi
+  printf '%s|%s|%s|%s|%s\n' "$sites" "$removed" "$changed" "$syntax_ok" "$mode_ok"
+}
+
+# The ANCHORED end-of-line pattern for the fifth CORE glob (`# BL-215-CORE-GLOB-SYNC`).
+# Anchored at both ends and spelled with the literal two-space indent, so it
+# cannot drift onto the prose that also names this path.
+HD_GLOB_PAT='^  "\$ROOT/scripts/host-drivers"/\*\.sh$'
+
 # ════════════════════════════════════════════════════════════════════
 echo "=== D1: a clean tree -> exit 0 ==="
 # ════════════════════════════════════════════════════════════════════
@@ -342,6 +402,122 @@ if [ "$rc" -eq 1 ] && echo "$out" | grep -q 'scripts/lib/helpers-core\.sh:2'; th
   pass "S3: a non-delta scripts/lib member is scanned"
 else
   fail_ "S3" "expected rc=1 naming helpers-core.sh:2; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S4 (BL-215): scripts/host-drivers/*.sh is inside the CORE surface"
+echo "    -> the reviewer's plant reds at tier T1 ==="
+# ════════════════════════════════════════════════════════════════════
+# THE FIFTH GLOB. §3.3 named FOUR globs through v1.1 and this lint was built
+# faithful to that number, disclosing the exclusion in its own header as a
+# pending design question. `## BL-215:` measured what the exclusion cost, with
+# positive controls in both directions: the plant below left this lint at rc=0
+# in `scripts/host-drivers/github.sh`, while the IDENTICAL line in
+# `scripts/validate.sh` red at rc=1 on T1. That pairing is what makes it a
+# POPULATION defect and not a PREDICATE defect — the tiers were right, they
+# were simply not looking there — and it is why no other case in this file
+# could ever have caught it. §3.3 v1.2 widened the contract to five globs and
+# this case is the enforcement half.
+#
+# The fixture line is the reviewer's exact plant. It lands on T1 because
+# `delta-state.sh` is a manifest-DERIVED literal token, and the tier is
+# asserted (not just the exit code) because T1 is non-waivable while T2 takes
+# an inline allowlist — a silent demotion between them would be a real loss
+# that rc alone cannot see.
+setup_fixture
+mkdir -p "$TMP/scripts/host-drivers"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"\n'
+  printf 'source "$SCRIPT_DIR/lib/delta-state.sh"\n'
+} > "$TMP/scripts/host-drivers/github.sh"
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^FAIL.*T1.*scripts/host-drivers/github\.sh:3'; then
+  pass "S4: a core -> delta source line in a host driver reds at tier T1"
+else
+  fail_ "S4" "expected rc=1 with a T1 row for scripts/host-drivers/github.sh:3; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S5 (BL-215): a CLEAN host driver is IN the CORE population — pinned"
+echo "    structurally, because 'scanned and clean' and 'never scanned' share"
+echo "    an exit code ==="
+# ════════════════════════════════════════════════════════════════════
+# THE ABSENCE HALF OF S4, AND IT NEEDS A STRUCTURAL DISCRIMINATOR. `rc=0` is
+# exactly what a four-glob lint returned on the S4 plant, so an exit-0
+# assertion here would have been green before BL-215 and green after it, and
+# would have pinned nothing at all. The pin is therefore the POPULATION COUNT
+# off the --list INFO row: adding the host driver must raise `core file(s) in
+# scope` by exactly one and removing it must lower it by exactly one, with
+# rc=0 on both sides. That distinguishes the two readings the exit code
+# cannot, and it also pins the bash-3.2 no-nullglob behaviour in the other
+# direction — the unmatched `scripts/host-drivers/*.sh` glob must survive as a
+# literal and be filtered by `[ -f ]`, not counted.
+setup_fixture
+mkdir -p "$TMP/scripts/host-drivers"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'host_create_repo() { echo "create"; }\n'
+} > "$TMP/scripts/host-drivers/github.sh"
+out_with=$(run_fixture_list); rc_with=$?
+n_with=$(core_in_scope "$out_with")
+rm -f "$TMP/scripts/host-drivers/github.sh"
+out_without=$(run_fixture_list); rc_without=$?
+n_without=$(core_in_scope "$out_without")
+if [ "$rc_with" -eq 0 ] && [ "$rc_without" -eq 0 ] \
+   && [ -n "$n_with" ] && [ -n "$n_without" ] \
+   && [ "$n_with" -eq $((n_without + 1)) ]; then
+  pass "S5: a clean host driver joins the CORE population ($n_without -> $n_with) and passes"
+else
+  fail_ "S5" "expected rc=0 both sides and the core count to rise by exactly 1; rc=$rc_with/$rc_without counts=$n_without/$n_with; output:\n$out_with"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S6 (mutant M-HD, BL-215): REVERTING the fifth glob makes the S4"
+echo "    plant pass again -> the glob is what catches it ==="
+# ════════════════════════════════════════════════════════════════════
+# THE DIRECTION THAT MATTERS MORE. S4 proves the plant reds TODAY; it does not
+# prove WHICH line does the work, and a surface pin that would stay green
+# under the very edit it exists to forbid is the BL-181 scar exactly (a
+# one-character narrowing re-opened that hole three times while passing every
+# PR-blocking check). So this case deletes the fifth glob from a COPY of the
+# lint and asserts the plant goes QUIET again.
+#
+# Everything here is measured rather than assumed — see the mutate_drop_line
+# header for why each of sites/removed/changed/syntax_ok/mode_ok is asserted.
+# The copy lives inside this case's own mktemp fixture and is pointed at that
+# same fixture with --root, so the probe never reads the host tree; the
+# pristine lint on the SAME fixture is the positive control, which is what
+# makes `rc=0` here a kill and not an artefact of a broken mutant.
+setup_fixture
+mkdir -p "$TMP/scripts/host-drivers"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"\n'
+  printf 'source "$SCRIPT_DIR/lib/delta-state.sh"\n'
+} > "$TMP/scripts/host-drivers/github.sh"
+COPY="$TMP/lint-copy-hostdrivers.sh"
+probe=$(mutate_drop_line "$LINTER" "$COPY" "$HD_GLOB_PAT")
+m_sites=$(printf '%s' "$probe" | cut -d'|' -f1)
+m_removed=$(printf '%s' "$probe" | cut -d'|' -f2)
+m_changed=$(printf '%s' "$probe" | cut -d'|' -f3)
+m_syntax=$(printf '%s' "$probe" | cut -d'|' -f4)
+m_mode=$(printf '%s' "$probe" | cut -d'|' -f5)
+out=$(bash "$COPY" --root "$TMP" 2>&1); rc=$?
+out_ctl=$(run_fixture); rc_ctl=$?
+if [ "$m_sites" -eq 1 ] && [ "$m_removed" -eq 1 ] && [ "$m_changed" -eq 1 ] \
+   && [ "$m_syntax" -eq 1 ] && [ "$m_mode" -eq 1 ] \
+   && [ "$rc" -eq 0 ] && [ "$rc_ctl" -eq 1 ]; then
+  pass "S6: dropping the host-drivers glob lets the plant through (mutant rc=0, control rc=1)"
+else
+  fail_ "S6" "expected sites/removed/changed/syntax/mode = 1/1/1/1/1, mutant rc=0, control rc=1; got $m_sites/$m_removed/$m_changed/$m_syntax/$m_mode rc=$rc rc_ctl=$rc_ctl; output:\n$out"
 fi
 teardown_fixture
 

--- a/tests/test-lint-module-dependencies.sh
+++ b/tests/test-lint-module-dependencies.sh
@@ -27,13 +27,25 @@
 #     D7  `module -> core` is permitted for the DRIVER        -> 0
 #     D8  T1 and T2 do not double-report the same line        -> exactly one row
 #
-#   SURFACE — the four CORE globs, minus module files and BOTH boundary lints
+#   SURFACE — the five CORE globs, minus module files and BOTH boundary lints
 #     S1  init.sh is scanned
 #     S2  scripts/hooks/*.sh is scanned
 #     S3  scripts/lib/*.sh (non-module members) is scanned
 #     S4  the two boundary lints are NOT scanned (self + sibling exclusion)
-#     A narrowed surface would pass D1-D8 while seeing nothing; S1-S3 are the
-#     anti-vacuity pins for the CORE half specifically.
+#     S5  scripts/host-drivers/*.sh is scanned         (BL-215, the fifth glob)
+#     S6  a CLEAN host driver joins the CORE POPULATION — a structural pin,
+#         because rc=0 cannot tell "scanned and clean" from "never scanned"
+#     S7  mutant M-HD: revert the fifth glob and the S5 plant passes again
+#     A narrowed surface would pass D1-D8 while seeing nothing; S1-S3 and S5-S7
+#     are the anti-vacuity pins for the CORE half specifically. S5-S7 exist
+#     because that failure mode was not hypothetical: this lint shipped with a
+#     FOUR-glob CORE set, `scripts/host-drivers/*.sh` sat outside all of them,
+#     and a planted `source .../scout-phasemap.sh` in a host driver passed at
+#     rc=0 while the IDENTICAL line in scripts/check-maintenance.sh red at rc=1
+#     on T2 (`## BL-215:`, measured with positive controls in both directions,
+#     and reproduced on the delta sibling with its own plant). Every other case
+#     in this file was green throughout. A population defect is invisible to a
+#     suite that only ever pins the predicate.
 #
 #   M5 — the scanner depends on NOTHING
 #     M1  a scout module file sourcing a core lib             -> 1   kills M-M5
@@ -217,6 +229,58 @@ run_fixture() { bash "$LINTER" --root "$TMP" 2>&1; return $?; }
 # --list asserts on the TABLE, so stderr is dropped: the per-violation
 # diagnostics carry the same file:line text and would double every row count.
 run_fixture_list() { bash "$LINTER" --root "$TMP" --list 2>/dev/null; return $?; }
+
+# core_in_scope LIST-OUTPUT — the CORE population count off the --list INFO row.
+# The count is the only thing that can distinguish "scanned and clean" from
+# "never in the population", and those two are the same exit code.
+core_in_scope() {
+  printf '%s\n' "$1" | sed -n 's/.*, \([0-9][0-9]*\) core file(s) in scope.*/\1/p'
+}
+
+# ── Mutation harness ────────────────────────────────────────────────────
+# A mutation proof is only a proof if the mutant is the edit it claims to be,
+# so the harness MEASURES the edit and hands the numbers back for the case to
+# assert on rather than assuming any of them:
+#   sites     the ANCHORED pattern must match exactly ONE line of the lint.
+#             An unanchored or over-broad pattern that hit two lines would
+#             mutate more than the case describes; one that hit zero would
+#             produce a pristine "mutant" and a green run that proves nothing.
+#             That second failure is not hypothetical — L3's first version was
+#             a no-op edit reported as a proof, which is why every mutation in
+#             this file now asserts that it really mutated something.
+#   removed   exactly one line fewer than the original.
+#   changed   diff shows exactly one changed line — `removed` alone cannot see
+#             a deletion silently paired with an insertion.
+#   syntax_ok `bash -n` on the mutant. A mutant that does not PARSE exits
+#             non-zero for a reason that has nothing to do with the predicate,
+#             which would read as a kill and prove nothing.
+#   mode_ok   the copy carries the original's mode. Mode-preserving so the
+#             mutant differs from the shipped lint in exactly one dimension.
+# Callers keep the copy inside their own mktemp fixture — never in the repo —
+# and pair it with a positive control (the pristine lint on the same fixture).
+_file_mode() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null; }
+
+mutate_drop_line() {
+  local src="$1" dst="$2" pat="$3"
+  local sites before after removed changed syntax_ok mode mode_ok
+  sites=$(grep -c "$pat" "$src")
+  grep -v "$pat" "$src" > "$dst"
+  before=$(grep -c '' "$src")
+  after=$(grep -c '' "$dst")
+  removed=$((before - after))
+  changed=$(diff "$src" "$dst" | grep -c '^[<>]')
+  if bash -n "$dst" 2>/dev/null; then syntax_ok=1; else syntax_ok=0; fi
+  mode=$(_file_mode "$src")
+  [ -n "$mode" ] && chmod "$mode" "$dst"
+  mode_ok=0
+  if [ -n "$mode" ] && [ "$(_file_mode "$dst")" = "$mode" ]; then mode_ok=1; fi
+  printf '%s|%s|%s|%s|%s\n' "$sites" "$removed" "$changed" "$syntax_ok" "$mode_ok"
+}
+
+# The ANCHORED end-of-line pattern for the fifth CORE glob (`# BL-215-CORE-GLOB-SYNC`).
+# Anchored at both ends and spelled with the literal two-space indent, so it
+# cannot drift onto the prose that also names this path.
+HD_GLOB_PAT='^  "\$ROOT/scripts/host-drivers"/\*\.sh$'
 
 # ════════════════════════════════════════════════════════════════════
 echo "=== D1: a clean tree -> exit 0 ==="
@@ -473,6 +537,126 @@ if [ "$rc" -eq 0 ]; then
   pass "S4: neither boundary lint is scanned as a core file"
 else
   fail_ "S4" "expected rc=0; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S5 (BL-215): scripts/host-drivers/*.sh is inside the CORE surface"
+echo "    -> the reviewer's plant reds at tier T2 ==="
+# ════════════════════════════════════════════════════════════════════
+# THE FIFTH GLOB. The co-owned contract named FOUR globs and both boundary
+# lints were built faithful to that number at exact parity, each disclosing the
+# exclusion in its own header as a pending design question. `## BL-215:`
+# measured what the exclusion cost, with positive controls in both directions:
+# the plant below left this lint at rc=0 in `scripts/host-drivers/gitlab.sh`,
+# while the IDENTICAL line in `scripts/check-maintenance.sh` red at rc=1 on T2.
+# That pairing is what makes it a POPULATION defect and not a PREDICATE defect
+# — the tiers were right, they were simply not looking there — and it is why no
+# other case in this file could ever have caught it. §3.3 v1.2 and
+# docs/module-contract.md M3 widened the contract to five globs; this case is
+# the enforcement half, and its delta-track sibling (S4-S6 of
+# tests/test-lint-delta-boundary.sh) is the other one. The two lints are SYNC
+# SIBLINGS for this glob: change one and change the other.
+#
+# THE TIER IS T2, AND THE REASON IS STRUCTURAL rather than incidental. T1's
+# directory token is the FULL prefix `scripts/lib/scout/`; the plant spells the
+# house's dominant idiom `"$SCRIPT_DIR/lib/scout/…"`, which carries no
+# `scripts/` segment, so T1 is blind to it and the bare `scout/` segment token
+# is what catches it. Asserting the tier therefore pins the surface AND keeps
+# the S3 token decision honest on the new glob.
+setup_fixture
+mkdir -p "$TMP/scripts/host-drivers"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"\n'
+  printf 'source "$SCRIPT_DIR/lib/scout/scout-phasemap.sh"\n'
+} > "$TMP/scripts/host-drivers/gitlab.sh"
+out=$(run_fixture_list); rc=$?
+if [ "$rc" -eq 1 ] \
+   && echo "$out" | grep -q '^FAIL.*T2.*scripts/host-drivers/gitlab\.sh:3'; then
+  pass "S5: a core -> module source line in a host driver reds at tier T2"
+else
+  fail_ "S5" "expected rc=1 with a T2 row for scripts/host-drivers/gitlab.sh:3; rc=$rc; output:\n$out"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S6 (BL-215): a CLEAN host driver is IN the CORE population — pinned"
+echo "    structurally, because 'scanned and clean' and 'never scanned' share"
+echo "    an exit code ==="
+# ════════════════════════════════════════════════════════════════════
+# THE ABSENCE HALF OF S5, AND IT NEEDS A STRUCTURAL DISCRIMINATOR. `rc=0` is
+# exactly what a four-glob lint returned on the S5 plant, so an exit-0
+# assertion here would have been green before BL-215 and green after it, and
+# would have pinned nothing at all. The pin is therefore the POPULATION COUNT
+# off the --list INFO row: adding the host driver must raise `core file(s) in
+# scope` by exactly one and removing it must lower it by exactly one, with
+# rc=0 on both sides. That distinguishes the two readings the exit code
+# cannot, and it also pins the bash-3.2 no-nullglob behaviour in the other
+# direction — the unmatched `scripts/host-drivers/*.sh` glob must survive as a
+# literal and be filtered by `[ -f ]`, not counted.
+setup_fixture
+mkdir -p "$TMP/scripts/host-drivers"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'host_create_repo() { echo "create"; }\n'
+} > "$TMP/scripts/host-drivers/gitlab.sh"
+out_with=$(run_fixture_list); rc_with=$?
+n_with=$(core_in_scope "$out_with")
+rm -f "$TMP/scripts/host-drivers/gitlab.sh"
+out_without=$(run_fixture_list); rc_without=$?
+n_without=$(core_in_scope "$out_without")
+if [ "$rc_with" -eq 0 ] && [ "$rc_without" -eq 0 ] \
+   && [ -n "$n_with" ] && [ -n "$n_without" ] \
+   && [ "$n_with" -eq $((n_without + 1)) ]; then
+  pass "S6: a clean host driver joins the CORE population ($n_without -> $n_with) and passes"
+else
+  fail_ "S6" "expected rc=0 both sides and the core count to rise by exactly 1; rc=$rc_with/$rc_without counts=$n_without/$n_with; output:\n$out_with"
+fi
+teardown_fixture
+
+# ════════════════════════════════════════════════════════════════════
+echo ""
+echo "=== S7 (mutant M-HD, BL-215): REVERTING the fifth glob makes the S5"
+echo "    plant pass again -> the glob is what catches it ==="
+# ════════════════════════════════════════════════════════════════════
+# THE DIRECTION THAT MATTERS MORE. S5 proves the plant reds TODAY; it does not
+# prove WHICH line does the work, and a surface pin that would stay green
+# under the very edit it exists to forbid is the BL-181 scar exactly (a
+# one-character narrowing re-opened that hole three times while passing every
+# PR-blocking check). So this case deletes the fifth glob from a COPY of the
+# lint and asserts the plant goes QUIET again.
+#
+# Everything here is measured rather than assumed — see the mutate_drop_line
+# header for why each of sites/removed/changed/syntax_ok/mode_ok is asserted.
+# The copy lives inside this case's own mktemp fixture and is pointed at that
+# same fixture with --root, so the probe never reads the host tree; the
+# pristine lint on the SAME fixture is the positive control, which is what
+# makes `rc=0` here a kill and not an artefact of a broken mutant.
+setup_fixture
+mkdir -p "$TMP/scripts/host-drivers"
+{
+  printf '#!/usr/bin/env bash\n'
+  printf 'SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"\n'
+  printf 'source "$SCRIPT_DIR/lib/scout/scout-phasemap.sh"\n'
+} > "$TMP/scripts/host-drivers/gitlab.sh"
+COPY="$TMP/lint-copy-hostdrivers.sh"
+probe=$(mutate_drop_line "$LINTER" "$COPY" "$HD_GLOB_PAT")
+m_sites=$(printf '%s' "$probe" | cut -d'|' -f1)
+m_removed=$(printf '%s' "$probe" | cut -d'|' -f2)
+m_changed=$(printf '%s' "$probe" | cut -d'|' -f3)
+m_syntax=$(printf '%s' "$probe" | cut -d'|' -f4)
+m_mode=$(printf '%s' "$probe" | cut -d'|' -f5)
+out=$(bash "$COPY" --root "$TMP" 2>&1); rc=$?
+out_ctl=$(run_fixture); rc_ctl=$?
+if [ "$m_sites" -eq 1 ] && [ "$m_removed" -eq 1 ] && [ "$m_changed" -eq 1 ] \
+   && [ "$m_syntax" -eq 1 ] && [ "$m_mode" -eq 1 ] \
+   && [ "$rc" -eq 0 ] && [ "$rc_ctl" -eq 1 ]; then
+  pass "S7: dropping the host-drivers glob lets the plant through (mutant rc=0, control rc=1)"
+else
+  fail_ "S7" "expected sites/removed/changed/syntax/mode = 1/1/1/1/1, mutant rc=0, control rc=1; got $m_sites/$m_removed/$m_changed/$m_syntax/$m_mode rc=$rc rc_ctl=$rc_ctl; output:\n$out"
 fi
 teardown_fixture
 


### PR DESCRIPTION
## What

**BL-215**, approved by Karl on 2026-08-09 (his "extend coverage" call). The design amendments landed in PR #336; this is the code half.

Both boundary lints defined CORE as four globs — `init.sh` + `scripts/*.sh` + `scripts/lib/*.sh` + `scripts/hooks/*.sh` — which silently **excluded `scripts/host-drivers/*.sh`**. A module reference planted there passed both lints at rc=0, while the identical line in a covered file correctly red. That pairing is what made this a **population** defect rather than a predicate one: the logic was right, it just wasn't looking there.

Both lints now cover host-drivers. They are sync siblings for this change and moved together.

## No pre-existing violation — measured, not asserted

The widened lints walk **76/79** core files against the HEAD copies' **73/76**; the `+3` is exactly `github`, `gitlab`, `bitbucket`, and the counter is the per-file loop counter, so those files were genuinely scanned rather than merely counted. Both still rc=0: nothing in those three files was already breaking the rule.

## The proof shape, and why one direction isn't an exit-code assertion

Four mutations, all passing:

| Lint | Direction | Result |
|---|---|---|
| delta | plant → red at the right tier | rc=1, `FAIL/T1` at `host-drivers/github.sh:3` |
| delta | revert the glob → the plant passes again | mutant rc=0, pristine control rc=1, same fixture |
| module | plant → red at the right tier | rc=1, `FAIL/T2` at `host-drivers/gitlab.sh:3` |
| module | revert the glob → the plant passes again | mutant rc=0, pristine control rc=1, same fixture |

The "remove the plant → GREEN" direction **cannot** be an exit-code assertion, because rc=0 is exactly what the un-widened lint returned *on the plant* — it would read green on both sides of the fix and prove nothing. It's pinned structurally instead: a clean host driver must raise the reported CORE population by exactly one. The reviewer confirmed that pin bites (reds at `counts=4/4` when the glob is dropped) and that its no-nullglob side-claim is real (reds at `counts=5/5` when the `[ -f ]` filter is dropped).

## Ride-alongs

The three surviving present-tense quotes of the superseded §3.1 sentence — "the seam block in `process-checklist.sh`", singular — are **past-tensed, not deleted**. That spelling is precisely why those tests enumerate by *running* rather than by remembering, so the quote carries the reason the test has its shape.

The three amended surfaces (both designs' §3.3 and `docs/module-contract.md` M3) drop the "stated and under-enforced" caveat, which stops being true with this commit. Docs-only, separate commit.

## Verification

Watched RED first (29/3 and 40/3). Tallies: `lint-delta-boundary` 32/0, `lint-module-dependencies` 43/0, severability 14/0, WP2 31/0, WP3 29/0, WP6 33/0, WP7 37/0, WP8 43/0, brownfield-WP1 35/0, `run-lints` 15/15.

Adversarial review: **approve**, zero refuted claims. The reviewer re-planted the original violations, planted new ones in every previously-skipped file, ran seven further probes of its own (all three drivers × both lints, composed-T2, literal-T1, adopt-module, comment-only, trailing-comment), and designed two novel mutants — count-without-scan, and dropping the `[ -f ]` no-nullglob filter — **both killed**. It also verified the review package's changed-line set was byte-identical to the real diff. Record: `.superpowers/sdd/2026-08-02-delta-track-v1/bl215-review.md` (session artifact).

## One defect filed, not fixed here

The reviewer overturned the implementer's read that the §3.1 consumer-table discrepancy was a documentation-parity question: **the design table is factually wrong.** The real consumer set is **eight**, not six — §3.1 omits `scripts/resume.sh`'s `DELTA-RESUME` fence and `init.sh`'s two `DELTA-INSTALL` fences, both measured live at this tip. The severability test's banner enumerates all eight. Following the normative table during a severance would leave two fences behind.

Pre-existing on main (it arrived with PR #336's amendment) and this branch deliberately repeats no count, so it does not block. It is the documentation capstone's to fix.

Also recorded, environmental only: this repo's `.git/hooks/pre-commit` is a stale 1317-line snapshot against the shipped 1458-line gate. Both commits here were gated by that snapshot, compensated by an explicit run of the current gate and by this review's full green re-run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
