### PR TITLE
fix(ci-token): stop claiming enforcement the walkthrough cannot verify

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -575,6 +575,19 @@ jobs:
             #    signal, not a reason to raise the cap.
             tests/test-delta-wp5-hotfix-retro.sh       # 181s — THE long pole of the whole wave, and 3x the next one. It opens and closes deltas dozens of times, and each open now also renders a brief and seeds a ledger row, so it got slower as the feature landed rather than as the test grew
             tests/test-brownfield-wp1-scout.sh         #  55s — the second pole. Moved WITH the first deliberately: the first alone left the complement leg at ~77% of the cap, which is the same "approaching" state the sast note below was written about, and the complement has taken a new suite in nearly every work package this wave
+            # ── Re-pinned 2026-08-10. Not a long pole in itself — it is the
+            #    GROWTH that moved it. Measured locally: 87s at 125 rows before
+            #    the D-A round-3 work, 118s at 158 rows after (~0.75s/row), and
+            #    the file gained rows in all three adversarial rounds. The
+            #    complement leg was already at 598s/720s on PR #341, so leaving
+            #    it there put the leg at roughly 10.5m against a 12m cap. Per
+            #    the doctrine above, approaching the cap is the RE-PIN signal.
+            #    The specific cost of not acting: on this stack a complement
+            #    cancellation ALREADY hid two real CI-only failures once (a
+            #    host-reading probe and a mutant that did not mutate), so a
+            #    timeout here does not merely delay the answer — it replaces a
+            #    red with a cancellation and the failures go unread.
+            tests/test-walk006-ci-protection-scope.sh  # 118s at 158 rows — see note above
           )
 
           # The ONLY thing that maps a roster name to a pin array. Both the

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -579,9 +579,16 @@ jobs:
             #    GROWTH that moved it. Measured locally: 87s at 125 rows before
             #    the D-A round-3 work, 118s at 158 rows after (~0.75s/row), and
             #    the file gained rows in all three adversarial rounds. The
-            #    complement leg was already at 598s/720s on PR #341, so leaving
-            #    it there put the leg at roughly 10.5m against a 12m cap. Per
-            #    the doctrine above, approaching the cap is the RE-PIN signal.
+            #    complement leg was already at 598s/720s on PR #341. A first
+            #    draft of this note called the unpinned landing point "roughly
+            #    10.5m" by adding only the GROWTH to 598s; review corrected it —
+            #    that 598s was measured on MAIN's tree, which carries the 785-line
+            #    pre-branch copy of this file, not the branch's 3379-line one. The
+            #    real landing point is 598 - t(main's copy) + 118, i.e. ~11.2-11.9m
+            #    against the 720s cap. The error ran in the safe direction, but it
+            #    understated the case: this pin is closer to necessary than
+            #    optional. Per the doctrine above, approaching the cap is the
+            #    RE-PIN signal.
             #    The specific cost of not acting: on this stack a complement
             #    cancellation ALREADY hid two real CI-only failures once (a
             #    host-reading probe and a mutant that did not mutate), so a

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -494,6 +494,117 @@ cmd_repair() {
   print_ok "Repair complete"
 }
 
+# D-A-GATE-SCOPE-BEGIN
+# _wf_gate_scope <workflow-file> — the STEP that runs the phase gate, and the
+# JOB that holds it, reduced to a tiny tagged report:
+#
+#   GATE none                no executable line names the gate script
+#   STEP none                a gate line exists but no enclosing `- ` step
+#   JOB none                 a step exists but no enclosing job
+#   STEPKEY <k> / JOBKEY <k> a key at that level's own key column
+#   STEPIF <v> / JOBIF <v>   the value of an `if:` at that level
+#   STEPCOE <v> / JOBCOE <v> the value of a `continue-on-error:` at that level
+#
+# WHY THIS EXISTS (D-A, Karl 2026-08-09). The project-side detector in
+# cmd_setup_ci_token used to read the workflow as a flat list of lines, so it
+# could not see the two Actions-native ways a gate stops mattering while its
+# `run:` body stays byte-perfect: `continue-on-error: true` (which grades a
+# FAILED step as success) and a step-level `if: false` (a step that never runs
+# cannot enforce). Both earned "The next push enforces the check". The bl147
+# sibling has been step- and job-scoped since F-015 (`Cw6-strict-keys`,
+# `Cw6-strict-gating`, `Cw6-strict-job`); this brings the user-facing surface up
+# to the same doctrine.
+#
+# LOCATED BY CONTAINMENT, NOT BY NAME. bl147 can anchor on
+# `- name: Governance - Phase gate check` because it is reading the ten
+# templates the framework itself wrote. This faces a REAL user's ci.yml of
+# unknown vintage, where the step may have been renamed or re-indented, so it
+# walks up from the gate line to the enclosing sequence item, up again to the
+# enclosing `steps:`, and up once more to the job id. Same reasoning
+# `Cw6-strict-job` gives for locating the JOB by containment: a rename must not
+# be a false red.
+#
+# The key column is DERIVED from the step's own first key rather than assumed to
+# be eight spaces, because a four-space `steps:` sequence (YAML permits the dash
+# at the same column as its key) is ordinary hand-written style and reading it
+# as "no keys at all" would fail OPEN — the direction that produced this defect.
+# Tabs are not handled because YAML forbids tab indentation outright.
+_wf_gate_scope() {
+  awk '
+    function ind(s,   t) { t = s; sub(/[^ ].*$/, "", t); return length(t) }
+    function emit(pfx, c,   k, v) {
+      if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*:/) return
+      k = c; sub(/:.*$/, "", k)
+      v = c; sub(/^[A-Za-z_][A-Za-z0-9_-]*:[ ]*/, "", v); sub(/[ ]+$/, "", v)
+      print pfx "KEY " k
+      if (k == "if")                print pfx "IF " v
+      if (k == "continue-on-error") print pfx "COE " v
+    }
+    { L[NR] = $0; n = NR }
+    END {
+      hit = 0
+      for (i = 1; i <= n; i++) {
+        c = L[i]; sub(/^ +/, "", c)
+        if (substr(c, 1, 1) == "#") continue
+        if (index(L[i], "scripts/check-phase-gate.sh") > 0) { hit = i; break }
+      }
+      if (hit == 0) { print "GATE none"; exit }
+      st = 0
+      for (i = hit; i >= 1; i--) if (L[i] ~ /^ *- /) { st = i; break }
+      if (st == 0) { print "STEP none"; exit }
+      si = ind(L[st])
+      c = L[st]; sub(/^ *- */, "", c)
+      kl = length(L[st]) - length(c)
+      emit("STEP", c)
+      for (i = st + 1; i <= n; i++) {
+        if (L[i] ~ /^ *$/) continue
+        if (ind(L[i]) <= si) break
+        if (ind(L[i]) != kl) continue
+        c = L[i]; sub(/^ +/, "", c)
+        if (substr(c, 1, 1) == "#") continue
+        emit("STEP", c)
+      }
+      sp = 0
+      for (i = st; i >= 1; i--) if (L[i] ~ /^ +steps: *$/ && ind(L[i]) <= si) { sp = i; break }
+      if (sp == 0) { print "JOB none"; exit }
+      spi = ind(L[sp])
+      jb = 0
+      for (i = sp; i >= 1; i--) if (L[i] ~ /^ +[A-Za-z_][A-Za-z0-9_-]*: *$/ && ind(L[i]) < spi) { jb = i; break }
+      if (jb == 0) { print "JOB none"; exit }
+      ji = ind(L[jb])
+      for (i = jb + 1; i <= n; i++) {
+        if (L[i] ~ /^ *$/) continue
+        if (ind(L[i]) <= ji) break
+        if (ind(L[i]) != spi) continue
+        c = L[i]; sub(/^ +/, "", c)
+        if (substr(c, 1, 1) == "#") continue
+        emit("JOB", c)
+      }
+    }
+  ' "$1"
+}
+
+# The step shape the framework emits, printed verbatim wherever the walkthrough
+# has to tell someone what to add. One writer, so the advice cannot drift from
+# templates/pipelines/ci/github/*.yml the way a second hand-kept copy would.
+_wf_print_gate_step() {
+  echo "      - name: Governance - Phase gate check"
+  echo "        if: hashFiles('.claude/phase-state.json') != ''"
+  echo "        env:"
+  echo "          GH_TOKEN: \${{ secrets.${1:-SOIF_PROTECTION_TOKEN} }}"
+  _wf_print_gate_run
+}
+
+_wf_print_gate_run() {
+  echo "        run: |"
+  echo "          if [ ! -f scripts/check-phase-gate.sh ]; then"
+  echo "            echo \"::error::Phase gate check script missing. Framework integrity compromised.\""
+  echo "            exit 1"
+  echo "          fi"
+  echo "          bash scripts/check-phase-gate.sh"
+}
+# D-A-GATE-SCOPE-END
+
 # WALK-ISSUE-006-SETUP-CI-TOKEN-BEGIN
 # Walk 2026-08-02, ISSUE-006 remediation, part 3 of 3. Part 1 stops the gate's
 # branch-protection backstop from blocking a runner that structurally cannot
@@ -675,10 +786,18 @@ EOM
     print_warn "Secret write reported success but '$secret_name' is not listed — check Settings > Secrets and variables > Actions."
   fi
 
-  # The last links in the chain, and BOTH are required before this command may
-  # claim the check now enforces (adversarial review R-1):
+  # The last links in the chain, and ALL THREE are required before this command
+  # may claim the check now enforces (adversarial review R-1; third condition
+  # added by D-A, Karl 2026-08-09):
   #   (a) the workflow READS the secret — a secret nothing reads is a silent
   #       no-op wearing a success message;
+  #   (a2) something actually INVOKES the gate. Two independent reviewers
+  #       reproduced the vacuous case: the old predicate asked only whether any
+  #       line naming the gate DEVIATED from the allowlist, and a workflow with
+  #       no gate line at all has no deviating line — so a ci.yml that maps the
+  #       secret and runs nothing earned "The next push enforces the check".
+  #       Nothing ran, so nothing enforced. The floor is now positive: at least
+  #       one executable line must BE the allowlisted invocation.
   #   (b) the gate's EXIT CODE still decides the step. Generated projects
   #       scaffolded before this shipped ran the gate as
   #         bash scripts/check-phase-gate.sh 2>/dev/null || echo "…skipping"
@@ -712,49 +831,193 @@ EOM
   # thing to wave through — but it is a byte comparison, not an execution
   # analysis, and the comment must not pretend otherwise.
   #
-  # NOTE THE ASYMMETRY with the bl147 sibling (Cw6-strict). That pin freezes the
-  # phase-gate step's whole run: body byte-for-byte and therefore rejects the
-  # inline `run: bash scripts/…` form outright. This one accepts it, because it
-  # runs against a REAL user's ci.yml of unknown vintage rather than against the
-  # ten templates the framework itself emits. Same doctrine, deliberately
-  # different tolerance; do not "align" one to the other without re-reading why.
+  # THE FOUR RECORDED ASYMMETRIES with the bl147 sibling (Cw6-strict). That pin
+  # reads the ten templates the framework itself wrote; this one reads a REAL
+  # user's ci.yml of unknown vintage, so it is deliberately more tolerant in
+  # four named places. Each is a decision, not an oversight — do not "align"
+  # either side without re-reading why, and
+  # tests/test-walk006-ci-protection-scope.sh pins all four so that "aligning"
+  # them goes red rather than quiet.
+  #   # D-A-PARITY-1-INLINE-RUN     bl147 freezes the step's whole `run:` body
+  #     byte-for-byte and so rejects the inline `run: bash scripts/…` form.
+  #     This accepts it: a project scaffolded before the block scalar shipped
+  #     is honest, and telling its owner otherwise would be a false red.
+  #   # D-A-PARITY-2-ABSENT-IF      bl147 requires the step's `if:` to BE the
+  #     allowlisted phase-state condition; an absent `if:` is a red there.
+  #     Here an absent `if:` is ACCEPTED — a step with no condition always
+  #     runs, which is the safest shape there is, and pre-`if:` vintages are
+  #     exactly what this surface faces. Any OTHER `if:` is still refused.
+  #   # D-A-PARITY-3-STEP-KEYSET    bl147 allowlists {if, env, run} on the step.
+  #     Here the allowlist is the documented run-step key set, so a user's
+  #     `id:`/`shell:`/`working-directory:`/`timeout-minutes:` is not a false
+  #     red — none of them can change how the verdict is graded. It is still an
+  #     ALLOWLIST (a closed set refuses the sibling nobody has imagined);
+  #     `continue-on-error` is inside it only so that it produces ONE specific
+  #     diagnostic instead of two vague ones.
+  #   # D-A-PARITY-4-NO-TRIGGER-PIN bl147 freezes the workflow's `on:` block
+  #     (`Cw6-strict-trigger`). This does NOT inspect the trigger: a real user
+  #     legitimately adds `workflow_dispatch`, extra branches or a merge queue,
+  #     and redding those would be worse than the gap. KNOWN RESIDUAL: a
+  #     workflow with no `push:` trigger at all still earns the claim, and
+  #     "the next push enforces" is false for it. Recorded deliberately —
+  #     D-A's decided scope is maps && invokes && !swallows.
   #
-  # HOST TRAP for anyone replicating this predicate by hand: `grep -qvxF` over
-  # EMPTY input must exit non-zero (no lines, so no non-matching line). That is
-  # what /usr/bin/grep does, and it is what runs here — this script is executed
-  # by a child bash with no interactive aliases. But at least one dev box in
-  # this project aliases interactive `grep` to ugrep, which INVERTS the
-  # empty-input result and will make the pipeline below look like it reports a
-  # swallow on a workflow that has no gate line at all. Shipped behaviour is
-  # unaffected; a hand-run reproduction in an interactive shell is not. Use
-  # `/usr/bin/grep` explicitly when checking this by hand.
+  # JOB SCOPE IS PART OF !swallows, NOT A FOURTH CONDITION. A job-level `if:`
+  # stops the step running and a job-level `continue-on-error:` stops its
+  # failure counting; both discard the verdict exactly as a step-level swallow
+  # does (`Cw6-strict-job` makes the same argument one level up). At job level
+  # the two keys are named explicitly rather than allowlisted as a set, because
+  # a real user's job legitimately carries `needs`, `strategy`, `permissions`,
+  # `container`, `outputs` and more — a job key allowlist would red almost
+  # every customised workflow.
+  #
+  # HOST TRAP, now defused: this predicate used to depend on `grep -qvxF` over
+  # EMPTY input exiting non-zero (no lines, so no non-matching line). That is
+  # what /usr/bin/grep does and what runs here, but at least one dev box in this
+  # project aliases interactive `grep` to ugrep, which INVERTS the empty-input
+  # result — so a hand-run reproduction read backwards. The empty case is now
+  # handled by an explicit `[ -n "$wf_gate" ]` guard instead of by grep's
+  # empty-input convention, so the reproduction and the shipped behaviour agree.
   local wf=".github/workflows/ci.yml"
-  local wf_maps=0 wf_swallows=0
+  # The permitted spellings, named ONCE and consumed by both halves of the
+  # verdict — the `invokes` floor and the deviation scan — so a future edit
+  # cannot teach one half a spelling the other has never heard of.
+  local wf_allow_invoke='bash scripts/check-phase-gate.sh'
+  local wf_allow_guard='if [ ! -f scripts/check-phase-gate.sh ]; then'
+  local wf_allow_if="if: hashFiles('.claude/phase-state.json') != ''"
+  local wf_maps=0 wf_invokes=0 wf_swallows=0 wf_enforces=1
+  local wf_exec="" wf_gate="" wf_dev="" wf_scope="" wf_n_inv=0
+  local wf_step_coe="" wf_step_if="" wf_job_coe="" wf_job_if=""
+  local wf_has_step_coe=0 wf_has_step_if=0 wf_bad_key="" wf_unlocated="" wf_k=""
   if [ -f "$wf" ]; then
-    grep -q "secrets.$secret_name" "$wf" && wf_maps=1
-    if grep -v '^[[:space:]]*#' "$wf" \
-         | grep -F 'scripts/check-phase-gate.sh' \
-         | sed -e 's/^[[:space:]]*//' -e 's/^-[[:space:]]*//' \
-               -e 's/^run:[[:space:]]*//' -e 's/[[:space:]]*$//' \
-         | grep -qvxF -e 'bash scripts/check-phase-gate.sh' \
-                      -e 'if [ ! -f scripts/check-phase-gate.sh ]; then'; then
-      wf_swallows=1   # F-015-PROJECT-ALLOWLIST-VERDICT
+    # Whole-line comments are dropped up front: everything below reasons about
+    # what the runner EXECUTES, and the emitted step carries a 25-line comment
+    # block that would otherwise be read as workflow content.
+    wf_exec=$(grep -v '^[[:space:]]*#' "$wf" || true)
+
+    # (a) maps. A literal match, not a regex — `$secret_name` is
+    # operator-supplied via --secret-name and its `.`/`*` would otherwise be
+    # metacharacters, and a mapping that only exists inside a comment is not a
+    # mapping at all.
+    case "$wf_exec" in
+      *"secrets.$secret_name"*) wf_maps=1 ;;   # D-A-MAPS-VERDICT
+    esac
+
+    wf_gate=$(printf '%s\n' "$wf_exec" \
+      | grep -F 'scripts/check-phase-gate.sh' \
+      | sed -e 's/^[[:space:]]*//' -e 's/^-[[:space:]]*//' \
+            -e 's/^run:[[:space:]]*//' -e 's/[[:space:]]*$//' || true)
+    if [ -n "$wf_gate" ]; then
+      # (a2) invokes — a POSITIVE floor. `grep -c` (not `-q`) because it reads
+      # its whole input: a `-q` that exits early can SIGPIPE the upstream stage
+      # and, under `pipefail`, turn a found match into a non-zero pipeline.
+      wf_n_inv=$(printf '%s\n' "$wf_gate" | grep -cxF -- "$wf_allow_invoke" || true)
+      case "$wf_n_inv" in ''|*[!0-9]*) wf_n_inv=0 ;; esac
+      if [ "$wf_n_inv" -ge 1 ]; then
+        wf_invokes=1   # D-A-INVOKES-VERDICT
+      fi
+      wf_dev=$(printf '%s\n' "$wf_gate" \
+        | grep -vxF -e "$wf_allow_invoke" -e "$wf_allow_guard" || true)
+      if [ -n "$wf_dev" ]; then
+        wf_swallows=1   # F-015-PROJECT-ALLOWLIST-VERDICT
+      fi
+    fi
+
+    # (b2) the Actions-native swallows, which live in the step's KEYS rather
+    # than in its `run:` body and are therefore invisible to any line scan.
+    wf_scope=$(_wf_gate_scope "$wf" || true)
+    wf_step_coe=$(printf '%s\n' "$wf_scope" | sed -n 's/^STEPCOE //p' | head -1 || true)
+    wf_step_if=$(printf  '%s\n' "$wf_scope" | sed -n 's/^STEPIF //p'  | head -1 || true)
+    wf_job_coe=$(printf  '%s\n' "$wf_scope" | sed -n 's/^JOBCOE //p'  | head -1 || true)
+    wf_job_if=$(printf   '%s\n' "$wf_scope" | sed -n 's/^JOBIF //p'   | head -1 || true)
+    # Presence is read from the KEY list, not from the value: `if:` with an
+    # empty value is present and unverifiable, and an absent key and an empty
+    # one must not collapse into the same answer.
+    wf_has_step_coe=$(printf '%s\n' "$wf_scope" | grep -cx 'STEPKEY continue-on-error' || true)
+    case "$wf_has_step_coe" in ''|*[!0-9]*) wf_has_step_coe=0 ;; esac
+    wf_has_step_if=$(printf  '%s\n' "$wf_scope" | grep -cx 'STEPKEY if' || true)
+    case "$wf_has_step_if" in ''|*[!0-9]*) wf_has_step_if=0 ;; esac
+    for wf_k in $(printf '%s\n' "$wf_scope" | sed -n 's/^STEPKEY //p'); do
+      case "$wf_k" in
+        # The documented run-step key set (# D-A-PARITY-3-STEP-KEYSET).
+        name|id|if|env|run|shell|working-directory|timeout-minutes|continue-on-error) ;;
+        *) wf_bad_key="$wf_bad_key $wf_k" ;;
+      esac
+    done
+    if printf '%s\n' "$wf_scope" | grep -qx 'STEP none'; then wf_unlocated="step"; fi
+    if printf '%s\n' "$wf_scope" | grep -qx 'JOB none';  then wf_unlocated="job";  fi
+
+    if [ "$wf_has_step_coe" -ge 1 ] && [ "$wf_step_coe" != "false" ]; then
+      wf_swallows=1   # D-A-STEP-COE-VERDICT
+    fi
+    if [ "$wf_has_step_if" -ge 1 ] && [ "$wf_step_if" != "${wf_allow_if#if: }" ]; then
+      wf_swallows=1   # D-A-STEP-IF-VERDICT
+    fi
+    if [ -n "$wf_bad_key" ]; then
+      wf_swallows=1   # D-A-STEP-KEY-VERDICT
+    fi
+    if [ -n "$wf_job_if" ] || { [ -n "$wf_job_coe" ] && [ "$wf_job_coe" != "false" ]; }; then
+      wf_swallows=1   # D-A-JOB-VERDICT
+    fi
+    if [ -n "$wf_unlocated" ]; then
+      wf_swallows=1   # D-A-UNLOCATED-VERDICT
     fi
   fi
-  if [ "$wf_maps" -eq 1 ] && [ "$wf_swallows" -eq 0 ]; then
+
+  # ONE TERM PER LINE. The three conditions gate the claim independently, and
+  # writing them as three lines is what lets each be neutered on its own in the
+  # mutation proofs — a single `&&` chain can only be broken all at once, which
+  # is how you end up with a "proof" that never separated the conditions.
+  [ "$wf_maps" -eq 1 ]     || wf_enforces=0   # D-A-MAPS-GATE
+  [ "$wf_invokes" -eq 1 ]  || wf_enforces=0   # D-A-INVOKES-GATE
+  [ "$wf_swallows" -eq 0 ] || wf_enforces=0   # D-A-SWALLOWS-GATE
+
+  if [ "$wf_enforces" -eq 1 ]; then
     print_ok "$wf maps $secret_name into the phase-gate step AND lets the gate's exit code decide it. The next push enforces the check."
-  elif [ "$wf_maps" -eq 1 ] && [ "$wf_swallows" -eq 1 ]; then
-    print_warn "$wf maps $secret_name, but its phase-gate step DISCARDS the gate's exit code, so the token cannot enforce anything. Replace the swallowing 'run:' line with:"
-    echo "        run: |"
-    echo "          if [ ! -f scripts/check-phase-gate.sh ]; then"
-    echo "            echo \"::error::Phase gate check script missing. Framework integrity compromised.\""
-    echo "            exit 1"
-    echo "          fi"
-    echo "          bash scripts/check-phase-gate.sh"
   else
-    print_warn "$wf does not map $secret_name yet — the secret would be stored but unread. Add these lines to the 'Governance - Phase gate check' step:"
-    echo "        env:"
-    echo "          GH_TOKEN: \${{ secrets.$secret_name }}"
+    # A refusal that does not name its cause is the 3am-lane defect this wave
+    # already fixed once, so EVERY failing condition is reported, each with the
+    # edit that clears it. Withholding the claim is the point of D-A: a setup
+    # that used to read "you're all set" is now told, specifically, that it is
+    # not protected.
+    print_warn "$wf will NOT enforce the check on the next push. The secret is stored, but this project does not yet turn it into enforcement. Cause(s) and fix(es):"
+    if [ ! -f "$wf" ]; then
+      echo "  - There is no $wf in this project, so nothing reads the secret. Add a phase-gate step to your workflow:"
+      _wf_print_gate_step "$secret_name"
+    fi
+    if [ -f "$wf" ] && [ "$wf_maps" -eq 0 ]; then
+      echo "  - $wf does not map $secret_name yet — the secret would be stored but unread. Add these lines to the 'Governance - Phase gate check' step:"
+      echo "        env:"
+      echo "          GH_TOKEN: \${{ secrets.$secret_name }}"
+    fi
+    if [ -f "$wf" ] && [ "$wf_invokes" -eq 0 ]; then
+      echo "  - No step in $wf INVOKES the phase gate: not one executable line is 'bash scripts/check-phase-gate.sh', so there is no check for the token to arm. Add (or restore) the step:"
+      _wf_print_gate_step "$secret_name"
+    fi
+    if [ -n "$wf_dev" ]; then
+      echo "  - The phase-gate step DISCARDS the gate's exit code, so the token cannot enforce anything. This line is neither the bare invocation nor the framework's existence guard: $(printf '%s' "$wf_dev" | head -1)"
+      echo "    Replace the swallowing 'run:' line with:"
+      _wf_print_gate_run
+    fi
+    if [ "$wf_has_step_coe" -ge 1 ] && [ "$wf_step_coe" != "false" ]; then
+      echo "  - The phase-gate step carries 'continue-on-error: $wf_step_coe', which grades a FAILED step as success — the gate's verdict is thrown away before it can block. Delete that key from the step."
+    fi
+    if [ "$wf_has_step_if" -ge 1 ] && [ "$wf_step_if" != "${wf_allow_if#if: }" ]; then
+      echo "  - The phase-gate step's condition is 'if: $wf_step_if', which is not the one this framework ships, so the step may be SKIPPED rather than obeyed — and a step that never runs cannot enforce. Use \"$wf_allow_if\", or drop the 'if:' line entirely (a step with no condition always runs)."
+    fi
+    if [ -n "$wf_bad_key" ]; then
+      echo "  - The phase-gate step carries a key this check does not recognise:$wf_bad_key. An unrecognised key can change how the step's verdict is graded, so enforcement cannot be claimed. Remove it, or move the gate into a step without it."
+    fi
+    if [ -n "$wf_job_if" ]; then
+      echo "  - The job that HOLDS the phase-gate step carries 'if: $wf_job_if'. A job that never starts discards the gate's verdict as completely as any step-level swallow. Remove that key from the job."
+    fi
+    if [ -n "$wf_job_coe" ] && [ "$wf_job_coe" != "false" ]; then
+      echo "  - The job that HOLDS the phase-gate step carries 'continue-on-error: $wf_job_coe', so that job's failure does not count against the run. Remove that key from the job."
+    fi
+    if [ -n "$wf_unlocated" ]; then
+      echo "  - Could not locate the $wf_unlocated that runs the gate in $wf, so how its verdict is graded cannot be verified. Check the file by hand against this shape:"
+      _wf_print_gate_step "$secret_name"
+    fi
   fi
   echo ""
   print_info "Verify locally any time with: scripts/check-gate.sh --preflight"

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -550,7 +550,7 @@ _wf_gate_scope() {
     # quote arms visibly parallel for review instead of one being a special
     # case. Dynamic regexes ("^" DQ ...) are POSIX awk and behave identically on
     # BSD awk, gawk and mawk.
-    BEGIN { CR = sprintf("%c", 13); DQ = sprintf("%c", 34); SQ = sprintf("%c", 39); TB = sprintf("%c", 9) }
+    BEGIN { CR = sprintf("%c", 13); DQ = sprintf("%c", 34); SQ = sprintf("%c", 39) }
     function ind(s,   t) { t = s; sub(/[^ ].*$/, "", t); return length(t) }
     # A QUOTED key is the same key (R-dA-2). YAML permits both quote styles for
     # an implicit key and generated / round-tripped workflows emit them, so a
@@ -577,24 +577,34 @@ _wf_gate_scope() {
     # reach. (No apostrophe appears anywhere in this program — see the note on
     # CR/DQ/SQ above; the whole thing is one single-quoted shell string.)
     #
-    # QUOTE-TRACKED, because a `#` INSIDE a quoted scalar is content, and a
-    # naive tail-strip eats it — `contains(msg, " #skip")` is an ordinary
-    # condition. That direction cannot produce a false OK (a strip only turns a
-    # refusal into an acceptance if what remains is byte-exact an allowlisted
-    # value, and both of those start UNQUOTED, so a quote opened after the first
-    # character leaves the naive remainder holding an unbalanced quote that can
-    # never equal them) — but it does make the refusal quote a MANGLED condition
-    # back at the user, which is the same self-refuting message the CRLF fix
-    # removed. Single quotes: YAML escapes one by doubling it, and a doubled
-    # quote reads here as "close, then reopen", which lands on the same state.
-    function decomment(s,   i, ch, pv, q, out) {
-      q = ""; out = ""
+    # A `#` inside a QUOTED scalar is content, and eating it makes the refusal
+    # quote a MANGLED condition back — the same self-refuting message the CRLF
+    # fix removed. But a YAML scalar is quoted only when it OPENS with a quote:
+    # inside a PLAIN scalar an apostrophe is ordinary content and the value
+    # really does end at the ` #`. That is measured, not reasoned — PyYAML loads
+    # `if: contains(m, SQ #skip SQ)` as the plain scalar `contains(m, SQ`. So
+    # the quote state is armed at the first NON-BLANK character and nowhere
+    # else; a scan that armed it anywhere read plain scalars whole, which
+    # under-strips (a false RED, never a false OK, because a strip can only turn
+    # a refusal into an acceptance when what remains is byte-exact an
+    # allowlisted value) but is still the wrong reading.
+    #
+    # TABS ARE CONTENT HERE, NEVER SEPARATION — `# D-A-RESIDUAL-TAB-SEPARATOR`.
+    # YAML permits a tab inside a quoted scalar (`run: "echo a<TAB>b"` loads
+    # fine, so redding it would be a false red) but PyYAML rejects every
+    # tab-as-SEPARATOR spelling outright: a tab before a `#`, between a key and
+    # its colon, or after the colon. Reading a tab as content keeps all of those
+    # refused, which is the safe direction on files no parser here accepts. The
+    # one that would matter if some parser did accept it is a tab-spaced colon
+    # hiding `continue-on-error` — recorded, because the only blanket defence
+    # (fail closed on any tab in the block) reds the legitimate quoted case.
+    function decomment(s,   i, ch, q, st, out) {
+      q = ""; st = 0; out = ""
       for (i = 1; i <= length(s); i++) {
         ch = substr(s, i, 1)
         if (q != "") { out = out ch; if (ch == q) q = ""; continue }
-        if (ch == DQ || ch == SQ) { q = ch; out = out ch; continue }                                          # D-A-COMMENT-INSIDE-QUOTES
-        pv = (i > 1) ? substr(s, i - 1, 1) : ""
-        if (ch == "#" && (pv == " " || pv == TB)) break                                                       # D-A-COMMENT-STRIP
+        if (ch == "#" && i > 1 && substr(s, i - 1, 1) == " ") break                                           # D-A-COMMENT-STRIP
+        if (st == 0 && ch != " ") { st = 1; if (ch == DQ || ch == SQ) q = ch }                                # D-A-COMMENT-INSIDE-QUOTES
         out = out ch
       }
       sub(/[ ]+$/, "", out)
@@ -1321,7 +1331,7 @@ EOM
       _wf_print_gate_run
     fi
     if [ -n "$wf_dupkey" ]; then
-      echo "  - The same key is declared TWICE where the gate runs:$wf_dupkey. Only one of them takes effect and this check cannot tell you which — and GitHub's own parser rejects duplicate mapping keys, so this workflow does not run at all. Delete the duplicate."
+      echo "  - The same key is declared TWICE where the gate runs:$wf_dupkey. Parsers disagree about which one wins — some take the LAST, and GitHub is documented to reject duplicate mapping keys outright — so neither the effective value nor whether this workflow runs at all can be determined from the file. Delete the duplicate."
     fi
   fi
   echo ""

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -838,12 +838,20 @@ _wf_gate_scope() {
       # GitHub documents, so the gate runs with a token the tests in this repo
       # say cannot read branch protection, while "maps <name> into the phase-gate
       # step" is still earned. Pre-existing: the file-wide match this replaced
-      # had the identical blind spot. UNFIXED because the fix is not free — it
-      # means resolving the effective value of one named variable across three
-      # env scopes, and the variable is not knowable here: `--token-env` is
-      # operator-supplied, and a `${{ secrets.X }}` written straight into the
-      # `run:` body (which this scope deliberately accepts as a real mapping)
-      # carries no variable name at all. A narrowing that guessed wrong would
+      # had the identical blind spot. UNFIXED because the fix is not free, and
+      # the reason is SCOPE COLLAPSE, not an unknown variable name — an earlier
+      # draft of this comment blamed `--token-env`, which is wrong and adversarial
+      # review caught it: that flag names the local shell variable the SETUP
+      # command reads the token value from, and the workflow-side name is
+      # hard-coded (`_wf_print_gate_step` emits `GH_TOKEN:`), so for the
+      # same-name shadow the name is right there on the outer mapping line.
+      # What actually costs: this emitter deliberately UNIONS the three env
+      # scopes into one stream, so nothing downstream can tell an outer binding
+      # from an inner one — seeing a shadow means emitting scope-tagged lines and
+      # teaching every consumer to read them. It also needs an exemption for a
+      # `${{ secrets.X }}` written straight into the `run:` body, which this
+      # scope deliberately accepts as a real mapping and which carries no
+      # variable name to compare. A narrowing that guessed wrong would
       # red a legitimately-wired file, which is the direction this branch treats
       # as the worse one. Karl owns behaviour changes; this is recorded, and
       # pinned in tests/test-walk006-ci-protection-scope.sh, so closing it is a

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -539,17 +539,23 @@ _wf_gate_scope() {
     # BSD awk, gawk and mawk.
     BEGIN { CR = sprintf("%c", 13); DQ = sprintf("%c", 34); SQ = sprintf("%c", 39) }
     function ind(s,   t) { t = s; sub(/[^ ].*$/, "", t); return length(t) }
-    function emit(pfx, c,   k, v) {
-      # A QUOTED key is the same key (R-dA-2). YAML permits both quote styles
-      # for an implicit key and generated / round-tripped workflows emit them,
-      # so a double-quoted continue-on-error and a single-quoted if are ordinary
-      # spellings of the two swallows this scan exists to find. Reading only the
-      # bare spelling let them through UNSEEN and the claim was earned while the
-      # step was inert — the unsafe direction. The key is unquoted for
-      # COMPARISON only; the value keeps its existing handling, so a quoted key
-      # with a deviating value is still refused on the value.
+    # A QUOTED key is the same key (R-dA-2). YAML permits both quote styles for
+    # an implicit key and generated / round-tripped workflows emit them, so a
+    # double-quoted continue-on-error and a single-quoted if are ordinary
+    # spellings of the two swallows this scan exists to find. Reading only the
+    # bare spelling let them through UNSEEN and the claim was earned while the
+    # step was inert — the unsafe direction. The key is unquoted for COMPARISON
+    # only; the value keeps its existing handling, so a quoted key with a
+    # deviating value is still refused on the value. ONE writer, because the job
+    # LOCATOR has to read the same spellings the key scan does — a quoted job id
+    # it could not read is what let the locator wander (see D-A-JOB-ID-CLOSED).
+    function unq(c) {
       if (c ~ ("^" DQ "[A-Za-z_][A-Za-z0-9_-]*" DQ "[ ]*:")) { sub("^" DQ, "", c); sub(DQ "[ ]*:", ":", c) }  # D-A-QUOTED-KEY-DQ
       if (c ~ ("^" SQ "[A-Za-z_][A-Za-z0-9_-]*" SQ "[ ]*:")) { sub("^" SQ, "", c); sub(SQ "[ ]*:", ":", c) }  # D-A-QUOTED-KEY-SQ
+      return c
+    }
+    function emit(pfx, c,   k, v) {
+      c = unq(c)
       # A merge key pulls the effective configuration in from an anchor
       # ELSEWHERE in the file, so the block being read does not settle the
       # question and the swallow may be in the anchor. Anchors are deliberately
@@ -602,9 +608,31 @@ _wf_gate_scope() {
       for (i = st; i >= 1; i--) if (L[i] ~ /^ +steps: *$/ && ind(L[i]) <= si) { sp = i; break }
       if (sp == 0) { print "JOB none"; exit }
       spi = ind(L[sp])
+      # THE JOB IS THE NEAREST ENCLOSING LINE, not the nearest one that happens
+      # to look like a job id. This search used to climb until something matched
+      # /^ +[A-Za-z_][A-Za-z0-9_-]*: *$/ and SKIP whatever it could not read — so
+      # a job id it could not read (a quoted one, or one carrying an anchor) sent
+      # it climbing straight out of `jobs:` and it bound "the job" to `push:`
+      # inside the `on:` block. It then scanned the TRIGGER for job-level
+      # swallows, found none, and the claim was EARNED while a real
+      # `continue-on-error: true` on the actual job was never read — fail OPEN,
+      # the worst direction, and the same defect class as the quoted step key.
+      # So: stop at the enclosing line, then judge it. Blank lines and comments
+      # are skipped because neither encloses anything.
       jb = 0
-      for (i = sp; i >= 1; i--) if (L[i] ~ /^ +[A-Za-z_][A-Za-z0-9_-]*: *$/ && ind(L[i]) < spi) { jb = i; break }
-      if (jb == 0) { print "JOB none"; exit }
+      for (i = sp - 1; i >= 1; i--) {
+        if (L[i] ~ /^ *$/) continue
+        c = L[i]; sub(/^ +/, "", c)
+        if (substr(c, 1, 1) == "#") continue
+        if (ind(L[i]) >= spi) continue
+        jb = i; break
+      }
+      # ind == 0 is not a job: a job id is always indented under `jobs:`, and
+      # this is what keeps a composite action (`runs:` at column 0) unlocatable
+      # rather than scanned as if `runs` were a job.
+      if (jb == 0 || ind(L[jb]) == 0) { print "JOB none"; exit }
+      c = L[jb]; sub(/^ +/, "", c); c = unq(c)
+      if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*[ ]*: *$/) { print "JOB none"; exit }                                  # D-A-JOB-ID-CLOSED
       ji = ind(L[jb])
       for (i = jb + 1; i <= n; i++) {
         if (L[i] ~ /^ *$/) continue

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -504,6 +504,10 @@ cmd_repair() {
 #   STEPKEY <k> / JOBKEY <k> a key at that level's own key column
 #   STEPIF <v> / JOBIF <v>   the value of an `if:` at that level
 #   STEPCOE <v> / JOBCOE <v> the value of a `continue-on-error:` at that level
+#   STEPFOLD <v>             the step's `run:` is a FOLDED block scalar
+#   MAPSCOPE <line>          a line a secret mapping must live on to reach the
+#                            gate step: the step's own block, or the gate job's
+#                            or the workflow's `env:`
 #
 # WHY THIS EXISTS (D-A, Karl 2026-08-09). The project-side detector in
 # cmd_setup_ci_token used to read the workflow as a flat list of lines, so it
@@ -529,6 +533,15 @@ cmd_repair() {
 # at the same column as its key) is ordinary hand-written style and reading it
 # as "no keys at all" would fail OPEN — the direction that produced this defect.
 # Tabs are not handled because YAML forbids tab indentation outright.
+#
+# WHAT THIS IS NOT. It is a structural reader, not a YAML parser: it answers
+# "which lines belong to the gate step and its job" and leaves every judgement
+# to the caller. Everything it cannot answer that way is reported as such —
+# `STEP none` / `JOB none` for structure it cannot locate, `MERGE` for keys that
+# live in an anchor, `FOLD` for a command that is assembled by the emitter
+# rather than written down — and the caller fails CLOSED on all of them. That
+# is the whole design: the alternative is guessing, and every defect this
+# function has had was a guess that went the permissive way.
 _wf_gate_scope() {
   awk '
     # CR, DQ and SQ are built with sprintf rather than written literally. This
@@ -537,7 +550,7 @@ _wf_gate_scope() {
     # quote arms visibly parallel for review instead of one being a special
     # case. Dynamic regexes ("^" DQ ...) are POSIX awk and behave identically on
     # BSD awk, gawk and mawk.
-    BEGIN { CR = sprintf("%c", 13); DQ = sprintf("%c", 34); SQ = sprintf("%c", 39) }
+    BEGIN { CR = sprintf("%c", 13); DQ = sprintf("%c", 34); SQ = sprintf("%c", 39); TB = sprintf("%c", 9) }
     function ind(s,   t) { t = s; sub(/[^ ].*$/, "", t); return length(t) }
     # A QUOTED key is the same key (R-dA-2). YAML permits both quote styles for
     # an implicit key and generated / round-tripped workflows emit them, so a
@@ -554,6 +567,39 @@ _wf_gate_scope() {
       if (c ~ ("^" SQ "[A-Za-z_][A-Za-z0-9_-]*" SQ "[ ]*:")) { sub("^" SQ, "", c); sub(SQ "[ ]*:", ":", c) }  # D-A-QUOTED-KEY-SQ
       return c
     }
+    # A TRAILING COMMENT IS NOT PART OF THE VALUE (R-CTE-5). The shipped phase
+    # gate condition, and that same condition with ` # phase gate` after it, are
+    # the same configuration — YAML ends a scalar at a `#` that follows white
+    # space — and refusing the second one told a correctly-wired project that
+    # its own condition was not its own condition: the CRLF regression one notch
+    # subtler. The same applies to the STRUCTURAL anchors, not just to values:
+    # one comment on `steps:` or on the job id used to put the whole job out of
+    # reach. (No apostrophe appears anywhere in this program — see the note on
+    # CR/DQ/SQ above; the whole thing is one single-quoted shell string.)
+    #
+    # QUOTE-TRACKED, because a `#` INSIDE a quoted scalar is content, and a
+    # naive tail-strip eats it — `contains(msg, " #skip")` is an ordinary
+    # condition. That direction cannot produce a false OK (a strip only turns a
+    # refusal into an acceptance if what remains is byte-exact an allowlisted
+    # value, and both of those start UNQUOTED, so a quote opened after the first
+    # character leaves the naive remainder holding an unbalanced quote that can
+    # never equal them) — but it does make the refusal quote a MANGLED condition
+    # back at the user, which is the same self-refuting message the CRLF fix
+    # removed. Single quotes: YAML escapes one by doubling it, and a doubled
+    # quote reads here as "close, then reopen", which lands on the same state.
+    function decomment(s,   i, ch, pv, q, out) {
+      q = ""; out = ""
+      for (i = 1; i <= length(s); i++) {
+        ch = substr(s, i, 1)
+        if (q != "") { out = out ch; if (ch == q) q = ""; continue }
+        if (ch == DQ || ch == SQ) { q = ch; out = out ch; continue }                                          # D-A-COMMENT-INSIDE-QUOTES
+        pv = (i > 1) ? substr(s, i - 1, 1) : ""
+        if (ch == "#" && (pv == " " || pv == TB)) break                                                       # D-A-COMMENT-STRIP
+        out = out ch
+      }
+      sub(/[ ]+$/, "", out)
+      return out
+    }
     function emit(pfx, c,   k, v) {
       c = unq(c)
       # A merge key pulls the effective configuration in from an anchor
@@ -567,10 +613,27 @@ _wf_gate_scope() {
       # `[ ]*:` and not `:`. Same evasion class as the quoted key, same fix.
       if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*[ ]*:/) return                                                        # D-A-SPACED-KEY
       k = c; sub(/[ ]*:.*$/, "", k)
-      v = c; sub(/^[A-Za-z_][A-Za-z0-9_-]*[ ]*:[ ]*/, "", v); sub(/[ ]+$/, "", v)
+      # The blanks after the colon are kept until decomment() has run, so that a
+      # value which is NOTHING BUT a comment (`if: # later`) is read as the null
+      # value it is rather than as the literal text of the comment.
+      v = c; sub(/^[A-Za-z_][A-Za-z0-9_-]*[ ]*:/, "", v); v = decomment(v); sub(/^[ ]+/, "", v)
       print pfx "KEY " k
       if (k == "if")                print pfx "IF " v
       if (k == "continue-on-error") print pfx "COE " v
+      # A FOLDED block scalar (`run: >`, with any chomping or indentation
+      # indicator) joins its source lines together with SPACES before bash ever
+      # sees them, so the command the runner executes is not any line in this
+      # file: `bash scripts/check-phase-gate.sh` on one line and `|| true` on the
+      # next fold into the canonical swallow while every line-wise check passes
+      # — the visible gate line is byte-exact the allowlisted invocation and the
+      # `|| true` line names nothing. The `run: |` equivalents all deviate
+      # line-wise and are already caught; only FOLDING evades, because the join
+      # happens in YAML rather than in bash. Same doctrine as the merge key: the
+      # effective command is not in the lines being read, so report it and let
+      # the caller fail closed. A plain scalar cannot begin with `>` (it is an
+      # indicator character), so the first byte settles it and no indicator
+      # spelling can slip past by being enumerated wrong.
+      if (k == "run" && substr(v, 1, 1) == ">") print pfx "FOLD " v                                           # D-A-FOLDED-RUN
     }
     { L[NR] = $0; n = NR }
     # CRLF is a line ENDING, not a configuration difference: GitHub Actions
@@ -589,23 +652,64 @@ _wf_gate_scope() {
         if (index(L[i], "scripts/check-phase-gate.sh") > 0) { hit = i; break }
       }
       if (hit == 0) { print "GATE none"; exit }
+      # A LONE `-` on its own line, with the keys below it, is an ordinary
+      # sequence item — hand-written and emitter-produced (R-CTE-1). The climb
+      # used to require a space after the dash, so it walked PAST that line and
+      # bound the gate to the previous step, reading the wrong keys
+      # entirely: `continue-on-error: true` on the real step was never seen and
+      # the claim was earned. The space is still REQUIRED — a dash with no space
+      # after it is an option (`-w packages/app` continued onto its own line in
+      # a run body), not a sequence item, and accepting those would bind the step
+      # to a line inside its own command. So the line is read with a space
+      # APPENDED: one regex, still anchored on "dash then a space", and the only
+      # thing that changes is that end-of-line now supplies the space.
       st = 0
-      for (i = hit; i >= 1; i--) if (L[i] ~ /^ *- /) { st = i; break }
+      for (i = hit; i >= 1; i--) if ((L[i] " ") ~ /^ *- /) { st = i; break }                                   # D-A-LONE-DASH-CLIMB
       if (st == 0) { print "STEP none"; exit }
       si = ind(L[st])
       c = L[st]; sub(/^ *- */, "", c)
       kl = length(L[st]) - length(c)
+      # …and FINDING that step is only half of it. The key column is normally
+      # derived from the dash line itself, which has no keys on it when the dash
+      # stands alone — that arithmetic put the column one past the dash, so no
+      # key ever matched it. Worse with trailing blanks after the dash: the
+      # column landed four deeper and an `env:` entry (`GH_TOKEN`) was read AS A
+      # STEP KEY, refusing the file for a key that is not a step key while the
+      # real swallow went unread. Both spellings are the same case — the dash
+      # line carries no inline content — so the column comes from the first line
+      # below it instead, and a step with no readable key line at all is
+      # unlocatable rather than silently keyless.
+      if (c == "") {                                                                                          # D-A-LONE-DASH-KEYCOL
+        kl = 0
+        for (i = st + 1; i <= n; i++) {
+          if (L[i] ~ /^ *$/) continue
+          if (ind(L[i]) <= si) break
+          d = L[i]; sub(/^ +/, "", d)
+          if (substr(d, 1, 1) == "#") continue
+          kl = ind(L[i]); break
+        }
+        if (kl == 0) { print "STEP none"; exit }
+      }
       emit("STEP", c)
+      # `se` is the step block end, captured by the SAME walk that reads the
+      # keys so the two cannot disagree about where the step stops. The maps
+      # scope below depends on it: a step boundary read one step too far is how
+      # a secret in a sibling step would count as one in this step.
+      se = n
       for (i = st + 1; i <= n; i++) {
         if (L[i] ~ /^ *$/) continue
-        if (ind(L[i]) <= si) break
+        if (ind(L[i]) <= si) { se = i - 1; break }
         if (ind(L[i]) != kl) continue
         c = L[i]; sub(/^ +/, "", c)
         if (substr(c, 1, 1) == "#") continue
         emit("STEP", c)
       }
+      # The anchors get the same comment handling the values do, for the same
+      # reason: `steps: # the governance job` is `steps:`, and a `$`-anchored
+      # regex that misses it puts the entire job out of reach and fails closed on
+      # a correctly-wired file.
       sp = 0
-      for (i = st; i >= 1; i--) if (L[i] ~ /^ +steps: *$/ && ind(L[i]) <= si) { sp = i; break }
+      for (i = st; i >= 1; i--) if (decomment(L[i]) ~ /^ +steps: *$/ && ind(L[i]) <= si) { sp = i; break }     # D-A-ANCHOR-COMMENT
       if (sp == 0) { print "JOB none"; exit }
       spi = ind(L[sp])
       # THE JOB IS THE NEAREST ENCLOSING LINE, not the nearest one that happens
@@ -631,7 +735,7 @@ _wf_gate_scope() {
       # this is what keeps a composite action (`runs:` at column 0) unlocatable
       # rather than scanned as if `runs` were a job.
       if (jb == 0 || ind(L[jb]) == 0) { print "JOB none"; exit }
-      c = L[jb]; sub(/^ +/, "", c); c = unq(c)
+      c = L[jb]; sub(/^ +/, "", c); c = decomment(unq(c))
       if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*[ ]*: *$/) { print "JOB none"; exit }                                  # D-A-JOB-ID-CLOSED
       ji = ind(L[jb])
       for (i = jb + 1; i <= n; i++) {
@@ -641,6 +745,48 @@ _wf_gate_scope() {
         c = L[i]; sub(/^ +/, "", c)
         if (substr(c, 1, 1) == "#") continue
         emit("JOB", c)
+      }
+      # WHERE A SECRET HAS TO BE FOR THE GATE STEP TO READ IT (R-CTE-6). Three
+      # places, and only three: the whole block of the gate STEP — its `env:`
+      # and also its `run:` body, because `${{ secrets.X }}` written straight
+      # into a command is a real mapping too — plus the `env:` of the gate JOB,
+      # plus the `env:` of the WORKFLOW. Both of the outer two are inherited by
+      # every step of the job, so narrowing to the step block alone would red
+      # them; the `env:` of a SIBLING step, or of ANOTHER job, is inherited by
+      # nothing here, which is exactly what the old file-wide substring match
+      # could not tell apart.
+      for (i = st; i <= se; i++) {
+        if (L[i] ~ /^ *$/) continue
+        c = L[i]; sub(/^ +/, "", c)
+        if (substr(c, 1, 1) == "#") continue
+        print "MAPSCOPE " L[i]
+      }
+      for (i = jb + 1; i <= n; i++) {
+        if (L[i] ~ /^ *$/) continue
+        if (ind(L[i]) <= ji) break
+        if (ind(L[i]) != spi) continue
+        c = L[i]; sub(/^ +/, "", c)
+        if (substr(c, 1, 1) == "#" || unq(c) !~ /^env[ ]*:/) continue
+        print "MAPSCOPE " L[i]
+        for (j = i + 1; j <= n; j++) {
+          if (L[j] ~ /^ *$/) continue
+          if (ind(L[j]) <= spi) break
+          c = L[j]; sub(/^ +/, "", c)
+          if (substr(c, 1, 1) == "#") continue
+          print "MAPSCOPE " L[j]
+        }
+      }
+      for (i = 1; i <= n; i++) {
+        if (L[i] ~ /^ *$/ || ind(L[i]) != 0) continue
+        if (substr(L[i], 1, 1) == "#" || unq(L[i]) !~ /^env[ ]*:/) continue
+        print "MAPSCOPE " L[i]
+        for (j = i + 1; j <= n; j++) {
+          if (L[j] ~ /^ *$/) continue
+          if (ind(L[j]) == 0) break
+          c = L[j]; sub(/^ +/, "", c)
+          if (substr(c, 1, 1) == "#") continue
+          print "MAPSCOPE " L[j]
+        }
       }
     }
   ' "$1"
@@ -924,6 +1070,31 @@ EOM
   #     "the next push enforces" is false for it. Recorded deliberately —
   #     D-A's decided scope is maps && invokes && !swallows.
   #
+  # RECORDED RESIDUALS — known, unfixed, and deliberate. Named here rather than
+  # in a report so the next reader of this code meets them, and pinned in
+  # tests/test-walk006-ci-protection-scope.sh so closing one is a change with a
+  # proof rather than a surprise.
+  #   # D-A-RESIDUAL-HEREDOC-DATA  The `invokes` floor asks whether an
+  #     executable LINE is the allowlisted invocation. A byte-exact gate line
+  #     inside a heredoc (`cat > helper.sh <<'DONE' … DONE`) is DATA — written
+  #     to a file, never run — and it counts, so a workflow that only WRITES the
+  #     invocation earns the claim. This is the same "names on executed lines is
+  #     not the same as invokes" gap CLAUDE.md records for BL-181, so it is not
+  #     academic. It is unfixed because telling code from data inside a `run:`
+  #     body needs a bash lexer (quoted and unquoted delimiters, `<<-`, nesting,
+  #     command substitution, `#` in strings) and BL-181 is this repo's own
+  #     record of a lexical approximation of "executed" being narrowed one
+  #     character at a time and re-opening three times. The direction matters
+  #     too: `wf_gate` feeds BOTH the floor and the deviation scan, so a heredoc
+  #     skip that is one delimiter form too greedy would hide a real swallowing
+  #     line — fail OPEN, the worse half. A correct fix is a lexer, and a lexer
+  #     is its own change.
+  #   # D-A-RESIDUAL-QUOTED-STEPS-KEY  A quoted `"steps":` is not read as the
+  #     sequence anchor, so the job goes unlocatable and the file fails CLOSED.
+  #     Left alone because the direction is safe (a false red, not a false OK)
+  #     and `steps:` is structure rather than one of the keys this scan judges.
+  #     Same for a flow-style step mapping (`- {name: …, run: …}`).
+  #
   # JOB SCOPE IS PART OF !swallows, NOT A FOURTH CONDITION. A job-level `if:`
   # stops the step running and a job-level `continue-on-error:` stops its
   # failure counting; both discard the verdict exactly as a step-level swallow
@@ -952,17 +1123,34 @@ EOM
   local wf_step_coe="" wf_step_if="" wf_job_coe="" wf_job_if=""
   local wf_has_step_coe=0 wf_has_step_if=0 wf_bad_key="" wf_unlocated="" wf_k=""
   local wf_merge="" wf_merge_txt=""
+  local wf_folded="" wf_dupkey="" wf_mapscope="" wf_maps_src=""
   if [ -f "$wf" ]; then
     # Whole-line comments are dropped up front: everything below reasons about
     # what the runner EXECUTES, and the emitted step carries a 25-line comment
     # block that would otherwise be read as workflow content.
     wf_exec=$(grep -v '^[[:space:]]*#' "$wf" || true)
 
-    # (a) maps. A literal match, not a regex — `$secret_name` is
+    # The structural read comes FIRST now, because `maps` depends on it.
+    wf_scope=$(_wf_gate_scope "$wf" || true)
+
+    # (a) maps — a literal match (not a regex: `$secret_name` is
     # operator-supplied via --secret-name and its `.`/`*` would otherwise be
-    # metacharacters, and a mapping that only exists inside a comment is not a
-    # mapping at all.
-    case "$wf_exec" in
+    # metacharacters), over the lines a mapping has to live on to reach the gate
+    # step. It used to run over the WHOLE FILE, so a secret mapped into a
+    # different step — or a different job — earned the sentence "maps
+    # $secret_name into the phase-gate step" while the gate step got no token at
+    # all. Claiming a scope nobody checked is this branch's whole subject, so
+    # the check now covers what the sentence says: the step's own block, the
+    # gate job's `env:`, the workflow's `env:`.
+    #
+    # MAPSCOPE is empty ONLY when _wf_gate_scope could not read the structure at
+    # all, and every one of those exits is already refused below by the
+    # fail-closed arms. Falling back to the file-wide text there is therefore
+    # not a hole — the claim is withheld either way — it just stops the refusal
+    # printing a "does not map" cause it has no standing to assert.
+    wf_mapscope=$(printf '%s\n' "$wf_scope" | sed -n 's/^MAPSCOPE //p' || true)
+    if [ -n "$wf_mapscope" ]; then wf_maps_src="$wf_mapscope"; else wf_maps_src="$wf_exec"; fi   # D-A-MAPS-SCOPE
+    case "$wf_maps_src" in
       *"secrets.$secret_name"*) wf_maps=1 ;;   # D-A-MAPS-VERDICT
     esac
 
@@ -974,9 +1162,19 @@ EOM
       # (a2) invokes — a POSITIVE floor. `grep -c` (not `-q`) because it reads
       # its whole input: a `-q` that exits early can SIGPIPE the upstream stage
       # and, under `pipefail`, turn a found match into a non-zero pipeline.
-      wf_n_inv=$(printf '%s\n' "$wf_gate" | grep -cxF -- "$wf_allow_invoke" || true)
+      # `-x` is whole-LINE on purpose: a line that merely CONTAINS the
+      # invocation (`bash scripts/check-phase-gate.sh || true`) is not an
+      # invocation, and while the deviation scan below refuses that file anyway,
+      # the user needs BOTH edits named — restore the invocation, and drop the
+      # swallow — not one of them.
+      wf_n_inv=$(printf '%s\n' "$wf_gate" | grep -cxF -- "$wf_allow_invoke" || true)   # D-A-INVOKES-WHOLE-LINE
       case "$wf_n_inv" in ''|*[!0-9]*) wf_n_inv=0 ;; esac
-      if [ "$wf_n_inv" -ge 1 ]; then
+      # A THRESHOLD, and the threshold is the point: `-ge 1`, not `-ge 0`. The
+      # shape that reaches it is a workflow carrying the framework's existence
+      # GUARD with the invocation deleted — `wf_gate` is non-empty (the guard
+      # names the script) and the count is zero. `-ge 0` is satisfied by nothing
+      # at all and hands that file the claim.
+      if [ "$wf_n_inv" -ge 1 ]; then   # D-A-INVOKES-FLOOR
         wf_invokes=1   # D-A-INVOKES-VERDICT
       fi
       wf_dev=$(printf '%s\n' "$wf_gate" \
@@ -988,7 +1186,7 @@ EOM
 
     # (b2) the Actions-native swallows, which live in the step's KEYS rather
     # than in its `run:` body and are therefore invisible to any line scan.
-    wf_scope=$(_wf_gate_scope "$wf" || true)
+    # ($wf_scope was read above — `maps` needs it too.)
     wf_step_coe=$(printf '%s\n' "$wf_scope" | sed -n 's/^STEPCOE //p' | head -1 || true)
     wf_step_if=$(printf  '%s\n' "$wf_scope" | sed -n 's/^STEPIF //p'  | head -1 || true)
     wf_job_coe=$(printf  '%s\n' "$wf_scope" | sed -n 's/^JOBCOE //p'  | head -1 || true)
@@ -1016,6 +1214,24 @@ EOM
     if printf '%s\n' "$wf_scope" | grep -q '^STEPMERGE '; then wf_merge="step"; fi
     if printf '%s\n' "$wf_scope" | grep -q '^JOBMERGE ';  then wf_merge="${wf_merge:+$wf_merge and }job"; fi
     wf_merge_txt=$(printf '%s\n' "$wf_scope" | sed -n -e 's/^STEPMERGE //p' -e 's/^JOBMERGE //p' | head -1 || true)
+    # A folded `run:` is the same kind of unreadable as a merge key, one level
+    # down: the block IS found, but the command it runs is assembled by the YAML
+    # emitter out of lines that individually say nothing wrong.
+    wf_folded=$(printf '%s\n' "$wf_scope" | sed -n 's/^STEPFOLD //p' | head -1 || true)
+    # DUPLICATE KEYS. Every value above is read with `head -1`, which picks the
+    # FIRST of a repeated key — so `continue-on-error: false` followed by
+    # `continue-on-error: true` looked hard while the effective value was true.
+    # There is no correct choice to make here: GitHub's own parser REJECTS
+    # duplicate mapping keys, so a workflow carrying one does not run at all and
+    # "the next push enforces the check" is false for it twice over. Failing
+    # closed is the answer, and it deletes the ambiguity rather than pinning an
+    # arbitrary resolution of it.
+    for wf_k in $(printf '%s\n' "$wf_scope" | sed -n 's/^STEPKEY //p' | sort | uniq -d); do
+      wf_dupkey="$wf_dupkey step:$wf_k"
+    done
+    for wf_k in $(printf '%s\n' "$wf_scope" | sed -n 's/^JOBKEY //p' | sort | uniq -d); do
+      wf_dupkey="$wf_dupkey job:$wf_k"
+    done
 
     if [ "$wf_has_step_coe" -ge 1 ] && [ "$wf_step_coe" != "false" ]; then
       wf_swallows=1   # D-A-STEP-COE-VERDICT
@@ -1034,6 +1250,12 @@ EOM
     fi
     if [ -n "$wf_merge" ]; then
       wf_swallows=1   # D-A-MERGE-VERDICT
+    fi
+    if [ -n "$wf_folded" ]; then
+      wf_swallows=1   # D-A-FOLDED-RUN-VERDICT
+    fi
+    if [ -n "$wf_dupkey" ]; then
+      wf_swallows=1   # D-A-DUP-KEY-VERDICT
     fi
   fi
 
@@ -1059,7 +1281,7 @@ EOM
       _wf_print_gate_step "$secret_name"
     fi
     if [ -f "$wf" ] && [ "$wf_maps" -eq 0 ]; then
-      echo "  - $wf does not map $secret_name yet — the secret would be stored but unread. Add these lines to the 'Governance - Phase gate check' step:"
+      echo "  - $wf does not map $secret_name into the phase-gate step — the secret would be stored but unread. A mapping on a DIFFERENT step, or in a different job, does not reach it. Add these lines to the 'Governance - Phase gate check' step (its job's 'env:' or the workflow's 'env:' work too, since a step inherits both):"
       echo "        env:"
       echo "          GH_TOKEN: \${{ secrets.$secret_name }}"
     fi
@@ -1093,6 +1315,13 @@ EOM
     fi
     if [ -n "$wf_merge" ]; then
       echo "  - A YAML merge key on the gate's $wf_merge pulls in keys from ELSEWHERE in the file: $wf_merge_txt. The effective 'continue-on-error:' and 'if:' are therefore not in the block this check reads, so a swallow could be sitting in the anchor. Anchors are not resolved here — write the keys out on the $wf_merge itself and re-run this command."
+    fi
+    if [ -n "$wf_folded" ]; then
+      echo "  - The phase-gate step's 'run:' is a FOLDED block scalar ('run: $wf_folded'), which joins its lines together with spaces before bash sees them — so the command that actually runs is not any line in this file, and something as invisible as '|| true' on a line of its own becomes part of the invocation. Rewrite it as a literal block scalar:"
+      _wf_print_gate_run
+    fi
+    if [ -n "$wf_dupkey" ]; then
+      echo "  - The same key is declared TWICE where the gate runs:$wf_dupkey. Only one of them takes effect and this check cannot tell you which — and GitHub's own parser rejects duplicate mapping keys, so this workflow does not run at all. Delete the duplicate."
     fi
   fi
   echo ""

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -531,16 +531,50 @@ cmd_repair() {
 # Tabs are not handled because YAML forbids tab indentation outright.
 _wf_gate_scope() {
   awk '
+    # CR, DQ and SQ are built with sprintf rather than written literally. This
+    # whole program lives inside a single-quoted shell string, so an apostrophe
+    # cannot appear in it at all; building all three the same way keeps the two
+    # quote arms visibly parallel for review instead of one being a special
+    # case. Dynamic regexes ("^" DQ ...) are POSIX awk and behave identically on
+    # BSD awk, gawk and mawk.
+    BEGIN { CR = sprintf("%c", 13); DQ = sprintf("%c", 34); SQ = sprintf("%c", 39) }
     function ind(s,   t) { t = s; sub(/[^ ].*$/, "", t); return length(t) }
     function emit(pfx, c,   k, v) {
-      if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*:/) return
-      k = c; sub(/:.*$/, "", k)
-      v = c; sub(/^[A-Za-z_][A-Za-z0-9_-]*:[ ]*/, "", v); sub(/[ ]+$/, "", v)
+      # A QUOTED key is the same key (R-dA-2). YAML permits both quote styles
+      # for an implicit key and generated / round-tripped workflows emit them,
+      # so a double-quoted continue-on-error and a single-quoted if are ordinary
+      # spellings of the two swallows this scan exists to find. Reading only the
+      # bare spelling let them through UNSEEN and the claim was earned while the
+      # step was inert — the unsafe direction. The key is unquoted for
+      # COMPARISON only; the value keeps its existing handling, so a quoted key
+      # with a deviating value is still refused on the value.
+      if (c ~ ("^" DQ "[A-Za-z_][A-Za-z0-9_-]*" DQ "[ ]*:")) { sub("^" DQ, "", c); sub(DQ "[ ]*:", ":", c) }  # D-A-QUOTED-KEY-DQ
+      if (c ~ ("^" SQ "[A-Za-z_][A-Za-z0-9_-]*" SQ "[ ]*:")) { sub("^" SQ, "", c); sub(SQ "[ ]*:", ":", c) }  # D-A-QUOTED-KEY-SQ
+      # A merge key pulls the effective configuration in from an anchor
+      # ELSEWHERE in the file, so the block being read does not settle the
+      # question and the swallow may be in the anchor. Anchors are deliberately
+      # NOT resolved — this reports the merge and lets the caller fail closed,
+      # the same doctrine the unlocatable structure already gets.
+      if (substr(c, 1, 3) == "<<:") { print pfx "MERGE " c; return }                                          # D-A-MERGE-KEY
+      # …and YAML allows whitespace between an implicit key and its colon
+      # (`s-separate-in-line?`), which is why the guard and both extractors read
+      # `[ ]*:` and not `:`. Same evasion class as the quoted key, same fix.
+      if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*[ ]*:/) return                                                        # D-A-SPACED-KEY
+      k = c; sub(/[ ]*:.*$/, "", k)
+      v = c; sub(/^[A-Za-z_][A-Za-z0-9_-]*[ ]*:[ ]*/, "", v); sub(/[ ]+$/, "", v)
       print pfx "KEY " k
       if (k == "if")                print pfx "IF " v
       if (k == "continue-on-error") print pfx "COE " v
     }
     { L[NR] = $0; n = NR }
+    # CRLF is a line ENDING, not a configuration difference: GitHub Actions
+    # parses a CRLF workflow identically to its LF twin, and before this strip
+    # the trailing \r rode along on every key value and on the `steps:` / job-id
+    # anchors, so a correctly-wired CRLF ci.yml was told its own `if:` was not
+    # its own `if:` and its job could not be located. ANCHORED at end of line on
+    # purpose: a CR *inside* a value is content, and eating it would repair a
+    # genuinely different condition into the shipped one — a false OK.
+    { sub(CR "$", "", L[NR]) }                                                                                # D-A-CRLF-STRIP
     END {
       hit = 0
       for (i = 1; i <= n; i++) {
@@ -889,6 +923,7 @@ EOM
   local wf_exec="" wf_gate="" wf_dev="" wf_scope="" wf_n_inv=0
   local wf_step_coe="" wf_step_if="" wf_job_coe="" wf_job_if=""
   local wf_has_step_coe=0 wf_has_step_if=0 wf_bad_key="" wf_unlocated="" wf_k=""
+  local wf_merge="" wf_merge_txt=""
   if [ -f "$wf" ]; then
     # Whole-line comments are dropped up front: everything below reasons about
     # what the runner EXECUTES, and the emitted step carries a 25-line comment
@@ -946,6 +981,13 @@ EOM
     done
     if printf '%s\n' "$wf_scope" | grep -qx 'STEP none'; then wf_unlocated="step"; fi
     if printf '%s\n' "$wf_scope" | grep -qx 'JOB none';  then wf_unlocated="job";  fi
+    # A merge key is unlocatable structure of a subtler kind: the step and the
+    # job ARE found, but their effective keys are not all in the block that was
+    # read. Named separately from $wf_unlocated so the two stay independently
+    # neuterable and the user gets the edit that actually applies to them.
+    if printf '%s\n' "$wf_scope" | grep -q '^STEPMERGE '; then wf_merge="step"; fi
+    if printf '%s\n' "$wf_scope" | grep -q '^JOBMERGE ';  then wf_merge="${wf_merge:+$wf_merge and }job"; fi
+    wf_merge_txt=$(printf '%s\n' "$wf_scope" | sed -n -e 's/^STEPMERGE //p' -e 's/^JOBMERGE //p' | head -1 || true)
 
     if [ "$wf_has_step_coe" -ge 1 ] && [ "$wf_step_coe" != "false" ]; then
       wf_swallows=1   # D-A-STEP-COE-VERDICT
@@ -961,6 +1003,9 @@ EOM
     fi
     if [ -n "$wf_unlocated" ]; then
       wf_swallows=1   # D-A-UNLOCATED-VERDICT
+    fi
+    if [ -n "$wf_merge" ]; then
+      wf_swallows=1   # D-A-MERGE-VERDICT
     fi
   fi
 
@@ -1017,6 +1062,9 @@ EOM
     if [ -n "$wf_unlocated" ]; then
       echo "  - Could not locate the $wf_unlocated that runs the gate in $wf, so how its verdict is graded cannot be verified. Check the file by hand against this shape:"
       _wf_print_gate_step "$secret_name"
+    fi
+    if [ -n "$wf_merge" ]; then
+      echo "  - A YAML merge key on the gate's $wf_merge pulls in keys from ELSEWHERE in the file: $wf_merge_txt. The effective 'continue-on-error:' and 'if:' are therefore not in the block this check reads, so a swallow could be sitting in the anchor. Anchors are not resolved here — write the keys out on the $wf_merge itself and re-run this command."
     fi
   fi
   echo ""

--- a/scripts/check-gate.sh
+++ b/scripts/check-gate.sh
@@ -504,6 +504,12 @@ cmd_repair() {
 #   STEPKEY <k> / JOBKEY <k> a key at that level's own key column
 #   STEPIF <v> / JOBIF <v>   the value of an `if:` at that level
 #   STEPCOE <v> / JOBCOE <v> the value of a `continue-on-error:` at that level
+#   STEPSHELL <v>            the value of the step's `shell:`
+#   JOBDEFSHELL <v> /        the `shell:` inside a `defaults:` block, at job and
+#   WFDEFSHELL <v>           at workflow level
+#   STEPOPAQUE <l> /         a key line written with a YAML node tag or in
+#   JOBOPAQUE <l>            explicit-key form — a real key this reader cannot
+#                            read as one
 #   STEPFOLD <v>             the step's `run:` is a FOLDED block scalar
 #   MAPSCOPE <line>          a line a secret mapping must live on to reach the
 #                            gate step: the step's own block, or the gate job's
@@ -618,6 +624,28 @@ _wf_gate_scope() {
       # NOT resolved — this reports the merge and lets the caller fail closed,
       # the same doctrine the unlocatable structure already gets.
       if (substr(c, 1, 3) == "<<:") { print pfx "MERGE " c; return }                                          # D-A-MERGE-KEY
+      # A NODE TAG or an EXPLICIT KEY is still a key, and the guard below reads
+      # neither. `!!str continue-on-error: true` and the explicit-key form
+      # (`? continue-on-error` on one line, `: true` on the next) both load as a
+      # REAL continue-on-error: true — measured with PyYAML 6.0.3, at step level
+      # and at job level — so before this arm the guard returned early, no key
+      # was reported, and the soft step earned the claim. Same fail-open class as
+      # the quoted key, one indicator character further out.
+      #
+      # SETTLED WITHOUT NEEDING GITHUB TO ARBITRATE, which is why it is decided
+      # here rather than recorded: the public actions/runner reader
+      # (src/Sdk/DTPipelines/Pipelines/ObjectTemplating/YamlObjectReader.cs)
+      # HONOURS the five standard scalar tags, tag:yaml.org,2002:str among them,
+      # so a tagged key is a real key to Actions as well; an explicit key reaches
+      # no handler there at all and errors the file out. Honoured means a real
+      # swallow. Rejected means the workflow does not run and "the next push
+      # enforces the check" is false twice over. The verdict is the same under
+      # both readings, so the reading does not have to be settled to decide it.
+      # NARROW on purpose — the two indicator characters that begin a key, not
+      # every line this reader cannot parse — because a blanket "anything I
+      # cannot read is a refusal" would red a flow-style block terminator sitting
+      # at the key column, and that is a working file.
+      if (substr(c, 1, 1) == "!" || substr(c, 1, 1) == "?") { print pfx "OPAQUE " c; return }                 # D-A-OPAQUE-KEY
       # …and YAML allows whitespace between an implicit key and its colon
       # (`s-separate-in-line?`), which is why the guard and both extractors read
       # `[ ]*:` and not `:`. Same evasion class as the quoted key, same fix.
@@ -630,6 +658,11 @@ _wf_gate_scope() {
       print pfx "KEY " k
       if (k == "if")                print pfx "IF " v
       if (k == "continue-on-error") print pfx "COE " v
+      # THE STEP INTERPRETER decides whether a failing command inside `run:`
+      # ends the step — see the fourth condition in cmd_setup_ci_token. Reported
+      # like any other value and judged by the caller; this function does not
+      # know which shells fail fast and should not.
+      if (k == "shell")             print pfx "SHELL " v                                                      # D-A-SHELL-VALUE
       # A FOLDED block scalar (`run: >`, with any chomping or indentation
       # indicator) joins its source lines together with SPACES before bash ever
       # sees them, so the command the runner executes is not any line in this
@@ -644,6 +677,28 @@ _wf_gate_scope() {
       # indicator character), so the first byte settles it and no indicator
       # spelling can slip past by being enumerated wrong.
       if (k == "run" && substr(v, 1, 1) == ">") print pfx "FOLD " v                                           # D-A-FOLDED-RUN
+    }
+    # defshell(<first line INSIDE the defaults: block>, <indent that ends it>,
+    #          <report prefix>) — `defaults.run.shell`, which sets the
+    # interpreter for every run step below it with NO `shell:` key on the step at
+    # all. A condition that read only the step key would have been steppable
+    # around by moving one line up one level, so both levels are reported and the
+    # caller resolves precedence. `defaults` has exactly one documented sub-key
+    # (`run`, itself carrying `shell` and `working-directory`), so the FIRST
+    # `shell:` anywhere inside the block is the one, and reading it that way
+    # needs no second indentation model to keep in step with this one.
+    function defshell(start, base, pfx,   j, d) {
+      for (j = start; j <= n; j++) {
+        if (L[j] ~ /^ *$/) continue
+        if (ind(L[j]) <= base) return
+        d = L[j]; sub(/^ +/, "", d)
+        if (substr(d, 1, 1) == "#") continue
+        d = decomment(unq(d))
+        if (d !~ /^shell[ ]*:/) continue
+        sub(/^shell[ ]*:/, "", d); sub(/^[ ]+/, "", d)
+        print pfx "DEFSHELL " d
+        return
+      }
     }
     { L[NR] = $0; n = NR }
     # CRLF is a line ENDING, not a configuration difference: GitHub Actions
@@ -755,6 +810,15 @@ _wf_gate_scope() {
         c = L[i]; sub(/^ +/, "", c)
         if (substr(c, 1, 1) == "#") continue
         emit("JOB", c)
+        if (decomment(unq(c)) ~ /^defaults[ ]*:/) defshell(i + 1, spi, "JOB")                                 # D-A-DEFAULTS-JOB
+      }
+      # …and the workflow-level block, which is not inside the job at all, so no
+      # job-scoped walk would ever reach it.
+      for (i = 1; i <= n; i++) {
+        if (L[i] ~ /^ *$/ || ind(L[i]) != 0) continue
+        if (substr(L[i], 1, 1) == "#") continue
+        if (decomment(unq(L[i])) !~ /^defaults[ ]*:/) continue
+        defshell(i + 1, 0, "WF")                                                                              # D-A-DEFAULTS-WF
       }
       # WHERE A SECRET HAS TO BE FOR THE GATE STEP TO READ IT (R-CTE-6). Three
       # places, and only three: the whole block of the gate STEP — its `env:`
@@ -765,6 +829,25 @@ _wf_gate_scope() {
       # them; the `env:` of a SIBLING step, or of ANOTHER job, is inherited by
       # nothing here, which is exactly what the old file-wide substring match
       # could not tell apart.
+      #
+      # RECORDED RESIDUAL — `# D-A-RESIDUAL-ENV-SHADOW`. What the caller does
+      # with these lines is a PRESENCE test (does `secrets.<name>` appear
+      # anywhere in scope), and a presence test cannot see a SHADOW. Map the
+      # secret at workflow `env:` while the gate step overrides the same variable
+      # — `GH_TOKEN: ${{ github.token }}` — and step env wins by the precedence
+      # GitHub documents, so the gate runs with a token the tests in this repo
+      # say cannot read branch protection, while "maps <name> into the phase-gate
+      # step" is still earned. Pre-existing: the file-wide match this replaced
+      # had the identical blind spot. UNFIXED because the fix is not free — it
+      # means resolving the effective value of one named variable across three
+      # env scopes, and the variable is not knowable here: `--token-env` is
+      # operator-supplied, and a `${{ secrets.X }}` written straight into the
+      # `run:` body (which this scope deliberately accepts as a real mapping)
+      # carries no variable name at all. A narrowing that guessed wrong would
+      # red a legitimately-wired file, which is the direction this branch treats
+      # as the worse one. Karl owns behaviour changes; this is recorded, and
+      # pinned in tests/test-walk006-ci-protection-scope.sh, so closing it is a
+      # deliberate change with its own proof.
       for (i = st; i <= se; i++) {
         if (L[i] ~ /^ *$/) continue
         c = L[i]; sub(/^ +/, "", c)
@@ -1068,10 +1151,17 @@ EOM
   #   # D-A-PARITY-3-STEP-KEYSET    bl147 allowlists {if, env, run} on the step.
   #     Here the allowlist is the documented run-step key set, so a user's
   #     `id:`/`shell:`/`working-directory:`/`timeout-minutes:` is not a false
-  #     red — none of them can change how the verdict is graded. It is still an
-  #     ALLOWLIST (a closed set refuses the sibling nobody has imagined);
-  #     `continue-on-error` is inside it only so that it produces ONE specific
-  #     diagnostic instead of two vague ones.
+  #     red. It is still an ALLOWLIST (a closed set refuses the sibling nobody
+  #     has imagined); membership means only that the key is a DOCUMENTED
+  #     run-step key rather than an unknown one, and it decides nothing about
+  #     the key's VALUE. Two of them are then judged on their value by name:
+  #     `continue-on-error` (which is inside the set only so that it produces
+  #     ONE specific diagnostic instead of two vague ones) and `shell`.
+  #     An earlier draft of this note claimed none of these keys "can change how
+  #     the step's verdict is graded". That was false, and it is corrected here
+  #     rather than deleted, because it is the sentence that let R-CTE-8 sit
+  #     unnoticed: `shell` decides EXACTLY that (see the fourth condition
+  #     below), and a note that reassures the next author is worse than none.
   #   # D-A-PARITY-4-NO-TRIGGER-PIN bl147 freezes the workflow's `on:` block
   #     (`Cw6-strict-trigger`). This does NOT inspect the trigger: a real user
   #     legitimately adds `workflow_dispatch`, extra branches or a merge queue,
@@ -1099,13 +1189,61 @@ EOM
   #     skip that is one delimiter form too greedy would hide a real swallowing
   #     line — fail OPEN, the worse half. A correct fix is a lexer, and a lexer
   #     is its own change.
+  #   # D-A-RESIDUAL-RUN-BODY-DISARM  The fourth condition below establishes
+  #     that the step's SHELL fails fast. It does not — and this shape of
+  #     scanner cannot — establish that the `run:` BODY leaves it that way. A
+  #     body that reads `set +e` … `bash scripts/check-phase-gate.sh` … `exit 0`
+  #     runs under the fail-fast default, carries a byte-exact invocation, and
+  #     still grades a failed gate green. Every line the deviation scan reads is
+  #     a line NAMING the script; arbitrary bash control flow on any other line
+  #     is structurally invisible to it, and closing that needs a bash lexer —
+  #     the same difficulty as # D-A-RESIDUAL-HEREDOC-DATA, for the same reason.
+  #     Recorded rather than half-fixed so the OK sentence is not read as
+  #     promising more than it checks. `## BL-218:` is the design-level decision
+  #     that would subsume it (canonical-shape-or-refuse), and it is Karl's.
   #   # D-A-RESIDUAL-QUOTED-STEPS-KEY  A quoted `"steps":` is not read as the
   #     sequence anchor, so the job goes unlocatable and the file fails CLOSED.
   #     Left alone because the direction is safe (a false red, not a false OK)
   #     and `steps:` is structure rather than one of the keys this scan judges.
   #     Same for a flow-style step mapping (`- {name: …, run: …}`).
   #
-  # JOB SCOPE IS PART OF !swallows, NOT A FOURTH CONDITION. A job-level `if:`
+  # THE FOURTH CONDITION — THE STEP'S SHELL HAS TO FAIL FAST (R-CTE-8, Karl
+  # 2026-08-10). `maps && invokes && !swallows` all hold for a step whose `run:`
+  # body is byte-perfect and whose keys are clean, and the gate can STILL be
+  # graded green, because the interpreter decides what a failing command does.
+  # Per GitHub's workflow syntax reference, "Exit codes and error action
+  # preference": for the BUILT-IN `bash` and `sh` keywords GitHub enforces
+  # fail-fast with `set -e` (bash also `-o pipefail`), and "you can override
+  # these defaults by providing a custom shell template string". Under
+  # `shell: bash {0}` the script runs bare — a failing
+  # `bash scripts/check-phase-gate.sh` no longer ends the step, and any line
+  # after it sets the exit code to 0. That is the same swallow
+  # `continue-on-error: true` performs, spelled in a key that was previously
+  # allowlisted and never read.
+  #
+  # AN ALLOWLIST, NOT A BLACKLIST — the doctrine this file already uses for the
+  # step key set and F-015 uses for the invocation. The allowed set is the
+  # documented keywords whose documented semantics make a failing gate fail the
+  # step AND that can execute the POSIX-shell body this framework emits:
+  # `bash` and `sh`. `pwsh`/`powershell` are documented fail-fast too, but for
+  # PowerShell bodies — a step running this framework's `if [ ! -f … ]` body
+  # under them does not run the gate at all, so it cannot be claimed as
+  # enforcement either. `cmd` and `python` are neither. An ABSENT `shell:` is
+  # ALLOWED and must stay allowed: it is the documented default and the shape
+  # all ten shipped templates use.
+  #
+  # AND IT IS READ AT ALL THREE LEVELS, BY PRECEDENCE. `defaults.run.shell` at
+  # job level or workflow level sets the same interpreter with no `shell:` key
+  # on the step, so a step-scoped read would have shipped a condition anyone
+  # could step around by moving one line up one level. Step > job defaults >
+  # workflow defaults, resolved by writing the arms in that order and letting
+  # the last one win, so a step key that overrides a bad default is not a false
+  # red. The VALUE is compared as written, the same way `if:` and
+  # `continue-on-error:` are — `shell: "bash"` is refused on its quotes. That is
+  # the byte comparison this file already documents above, and the safe
+  # direction; the refusal names the exact edit.
+  #
+  # JOB SCOPE IS PART OF !swallows, NOT A CONDITION OF ITS OWN. A job-level `if:`
   # stops the step running and a job-level `continue-on-error:` stops its
   # failure counting; both discard the verdict exactly as a step-level swallow
   # does (`Cw6-strict-job` makes the same argument one level up). At job level
@@ -1128,12 +1266,15 @@ EOM
   local wf_allow_invoke='bash scripts/check-phase-gate.sh'
   local wf_allow_guard='if [ ! -f scripts/check-phase-gate.sh ]; then'
   local wf_allow_if="if: hashFiles('.claude/phase-state.json') != ''"
-  local wf_maps=0 wf_invokes=0 wf_swallows=0 wf_enforces=1
+  local wf_maps=0 wf_invokes=0 wf_swallows=0 wf_failfast=1 wf_enforces=1
   local wf_exec="" wf_gate="" wf_dev="" wf_scope="" wf_n_inv=0
   local wf_step_coe="" wf_step_if="" wf_job_coe="" wf_job_if=""
   local wf_has_step_coe=0 wf_has_step_if=0 wf_bad_key="" wf_unlocated="" wf_k=""
   local wf_merge="" wf_merge_txt=""
   local wf_folded="" wf_dupkey="" wf_mapscope="" wf_maps_src=""
+  local wf_opaque="" wf_opaque_txt=""
+  local wf_shell="" wf_has_shell=0 wf_jobdefshell="" wf_has_jobdefshell=0
+  local wf_wfdefshell="" wf_has_wfdefshell=0 wf_eff_shell="" wf_eff_src=""
   if [ -f "$wf" ]; then
     # Whole-line comments are dropped up front: everything below reasons about
     # what the runner EXECUTES, and the emitted step carries a 25-line comment
@@ -1204,10 +1345,24 @@ EOM
     # Presence is read from the KEY list, not from the value: `if:` with an
     # empty value is present and unverifiable, and an absent key and an empty
     # one must not collapse into the same answer.
-    wf_has_step_coe=$(printf '%s\n' "$wf_scope" | grep -cx 'STEPKEY continue-on-error' || true)
+    #
+    # EVERY GREP BELOW READS A GRAMMAR THIS FILE PRINTS, AND ITS ANCHOR IS
+    # LOAD-BEARING — the `-x` on the whole-line matches and the `^` on the
+    # prefix matches alike. `MAPSCOPE` re-emits RAW lines of the gate step's own
+    # block, its `run:` body included, into this same stream, so a command that
+    # merely echoes a sentinel token (`echo "STEP none"`) matches an unanchored
+    # grep and a correctly-wired workflow is refused for a cause it does not
+    # have. Round 2 argued these atoms could not change a verdict, on the
+    # grounds that `STEP none` is terminal and a `STEPKEY continue-on-error…`
+    # superstring would be refused as an unknown key anyway; both arguments read
+    # the wrong stream. All of them are pinned now, one mutant per anchor
+    # (DM27-DM35). An argument is not a measurement.
+    wf_has_step_coe=$(printf '%s\n' "$wf_scope" | grep -cx 'STEPKEY continue-on-error' || true)   # D-A-SCOPE-GRAMMAR-STEPKEY-COE
     case "$wf_has_step_coe" in ''|*[!0-9]*) wf_has_step_coe=0 ;; esac
-    wf_has_step_if=$(printf  '%s\n' "$wf_scope" | grep -cx 'STEPKEY if' || true)
+    wf_has_step_if=$(printf  '%s\n' "$wf_scope" | grep -cx 'STEPKEY if' || true)   # D-A-SCOPE-GRAMMAR-STEPKEY-IF
     case "$wf_has_step_if" in ''|*[!0-9]*) wf_has_step_if=0 ;; esac
+    wf_has_shell=$(printf    '%s\n' "$wf_scope" | grep -cx 'STEPKEY shell' || true)   # D-A-SCOPE-GRAMMAR-STEPKEY-SHELL
+    case "$wf_has_shell" in ''|*[!0-9]*) wf_has_shell=0 ;; esac
     for wf_k in $(printf '%s\n' "$wf_scope" | sed -n 's/^STEPKEY //p'); do
       case "$wf_k" in
         # The documented run-step key set (# D-A-PARITY-3-STEP-KEYSET).
@@ -1215,15 +1370,22 @@ EOM
         *) wf_bad_key="$wf_bad_key $wf_k" ;;
       esac
     done
-    if printf '%s\n' "$wf_scope" | grep -qx 'STEP none'; then wf_unlocated="step"; fi
-    if printf '%s\n' "$wf_scope" | grep -qx 'JOB none';  then wf_unlocated="job";  fi
+    if printf '%s\n' "$wf_scope" | grep -qx 'STEP none'; then wf_unlocated="step"; fi   # D-A-SCOPE-GRAMMAR-STEP-NONE
+    if printf '%s\n' "$wf_scope" | grep -qx 'JOB none';  then wf_unlocated="job";  fi   # D-A-SCOPE-GRAMMAR-JOB-NONE
     # A merge key is unlocatable structure of a subtler kind: the step and the
     # job ARE found, but their effective keys are not all in the block that was
     # read. Named separately from $wf_unlocated so the two stay independently
     # neuterable and the user gets the edit that actually applies to them.
-    if printf '%s\n' "$wf_scope" | grep -q '^STEPMERGE '; then wf_merge="step"; fi
-    if printf '%s\n' "$wf_scope" | grep -q '^JOBMERGE ';  then wf_merge="${wf_merge:+$wf_merge and }job"; fi
+    if printf '%s\n' "$wf_scope" | grep -q '^STEPMERGE '; then wf_merge="step"; fi   # D-A-SCOPE-GRAMMAR-STEPMERGE
+    if printf '%s\n' "$wf_scope" | grep -q '^JOBMERGE ';  then wf_merge="${wf_merge:+$wf_merge and }job"; fi   # D-A-SCOPE-GRAMMAR-JOBMERGE
     wf_merge_txt=$(printf '%s\n' "$wf_scope" | sed -n -e 's/^STEPMERGE //p' -e 's/^JOBMERGE //p' | head -1 || true)
+    # A NODE-TAGGED or EXPLICIT key is unreadable in the same way a merge key
+    # is: the block IS found, but one of its entries is not in a shape this
+    # reader can compare. Its own name and its own bullet, so the two stay
+    # independently neuterable and the user gets the edit that applies to them.
+    if printf '%s\n' "$wf_scope" | grep -q '^STEPOPAQUE '; then wf_opaque="step"; fi   # D-A-SCOPE-GRAMMAR-STEPOPAQUE
+    if printf '%s\n' "$wf_scope" | grep -q '^JOBOPAQUE ';  then wf_opaque="${wf_opaque:+$wf_opaque and }job"; fi   # D-A-SCOPE-GRAMMAR-JOBOPAQUE
+    wf_opaque_txt=$(printf '%s\n' "$wf_scope" | sed -n -e 's/^STEPOPAQUE //p' -e 's/^JOBOPAQUE //p' | head -1 || true)
     # A folded `run:` is the same kind of unreadable as a merge key, one level
     # down: the block IS found, but the command it runs is assembled by the YAML
     # emitter out of lines that individually say nothing wrong.
@@ -1243,6 +1405,31 @@ EOM
       wf_dupkey="$wf_dupkey job:$wf_k"
     done
 
+    # (b4) the step's SHELL, at all three levels it can be set from. Presence is
+    # read separately from value for the same reason it is for `if:` — an empty
+    # `shell:` is present and unverifiable, and it must not read as absent.
+    wf_shell=$(printf '%s\n' "$wf_scope" | sed -n 's/^STEPSHELL //p' | head -1 || true)
+    wf_has_jobdefshell=$(printf '%s\n' "$wf_scope" | grep -c '^JOBDEFSHELL ' || true)
+    case "$wf_has_jobdefshell" in ''|*[!0-9]*) wf_has_jobdefshell=0 ;; esac
+    wf_jobdefshell=$(printf '%s\n' "$wf_scope" | sed -n 's/^JOBDEFSHELL //p' | head -1 || true)
+    wf_has_wfdefshell=$(printf '%s\n' "$wf_scope" | grep -c '^WFDEFSHELL ' || true)
+    case "$wf_has_wfdefshell" in ''|*[!0-9]*) wf_has_wfdefshell=0 ;; esac
+    wf_wfdefshell=$(printf '%s\n' "$wf_scope" | sed -n 's/^WFDEFSHELL //p' | head -1 || true)
+    # PRECEDENCE, WRITTEN AS LAST-WINS. GitHub resolves a step's shell as
+    # step > job defaults > workflow defaults, so the three arms are in that
+    # order and the last one that fires is the effective one. Three lines
+    # instead of an if/elif chain for the same reason the three gate terms are
+    # three lines: each can be neutered ALONE, and DM43 does exactly that.
+    if [ "$wf_has_wfdefshell"  -ge 1 ]; then wf_eff_shell="$wf_wfdefshell";  wf_eff_src="the workflow's 'defaults.run.shell'"; fi   # D-A-SHELL-PRECEDENCE-WF
+    if [ "$wf_has_jobdefshell" -ge 1 ]; then wf_eff_shell="$wf_jobdefshell"; wf_eff_src="the job's 'defaults.run.shell'";      fi   # D-A-SHELL-PRECEDENCE-JOB
+    if [ "$wf_has_shell"       -ge 1 ]; then wf_eff_shell="$wf_shell";       wf_eff_src="the step's own 'shell:'";             fi   # D-A-SHELL-PRECEDENCE-STEP
+    if [ -n "$wf_eff_src" ]; then
+      case "$wf_eff_shell" in
+        bash|sh) ;;   # D-A-SHELL-ALLOWLIST
+        *) wf_failfast=0 ;;   # D-A-FAILFAST-VERDICT
+      esac
+    fi
+
     if [ "$wf_has_step_coe" -ge 1 ] && [ "$wf_step_coe" != "false" ]; then
       wf_swallows=1   # D-A-STEP-COE-VERDICT
     fi
@@ -1261,6 +1448,9 @@ EOM
     if [ -n "$wf_merge" ]; then
       wf_swallows=1   # D-A-MERGE-VERDICT
     fi
+    if [ -n "$wf_opaque" ]; then
+      wf_swallows=1   # D-A-OPAQUE-VERDICT
+    fi
     if [ -n "$wf_folded" ]; then
       wf_swallows=1   # D-A-FOLDED-RUN-VERDICT
     fi
@@ -1269,13 +1459,14 @@ EOM
     fi
   fi
 
-  # ONE TERM PER LINE. The three conditions gate the claim independently, and
-  # writing them as three lines is what lets each be neutered on its own in the
+  # ONE TERM PER LINE. The four conditions gate the claim independently, and
+  # writing them as four lines is what lets each be neutered on its own in the
   # mutation proofs — a single `&&` chain can only be broken all at once, which
   # is how you end up with a "proof" that never separated the conditions.
   [ "$wf_maps" -eq 1 ]     || wf_enforces=0   # D-A-MAPS-GATE
   [ "$wf_invokes" -eq 1 ]  || wf_enforces=0   # D-A-INVOKES-GATE
   [ "$wf_swallows" -eq 0 ] || wf_enforces=0   # D-A-SWALLOWS-GATE
+  [ "$wf_failfast" -eq 1 ] || wf_enforces=0   # D-A-FAILFAST-GATE
 
   if [ "$wf_enforces" -eq 1 ]; then
     print_ok "$wf maps $secret_name into the phase-gate step AND lets the gate's exit code decide it. The next push enforces the check."
@@ -1325,6 +1516,12 @@ EOM
     fi
     if [ -n "$wf_merge" ]; then
       echo "  - A YAML merge key on the gate's $wf_merge pulls in keys from ELSEWHERE in the file: $wf_merge_txt. The effective 'continue-on-error:' and 'if:' are therefore not in the block this check reads, so a swallow could be sitting in the anchor. Anchors are not resolved here — write the keys out on the $wf_merge itself and re-run this command."
+    fi
+    if [ -n "$wf_opaque" ]; then
+      echo "  - The gate's $wf_opaque carries a key this check cannot read as a key: $wf_opaque_txt. A YAML node tag ('!!str continue-on-error: true') and the explicit-key form ('? continue-on-error' / ': true') both load as a REAL 'continue-on-error: true', so a swallow can sit in one — and GitHub's own reader rejects some of these outright, in which case the workflow does not run at all. Either way the next push does not enforce the check. Write the key out in plain 'key: value' form and re-run this command."
+    fi
+    if [ "$wf_failfast" -eq 0 ]; then
+      echo "  - $wf_eff_src is '$wf_eff_shell', which GitHub does not run with 'set -e'. Only the built-in 'bash' and 'sh' keywords are documented to fail fast (bash also gets '-o pipefail'); a custom template such as 'bash {0}' runs the script bare. Without it a FAILING 'bash scripts/check-phase-gate.sh' does not end the step, and any line after it sets the step's exit code to 0 — the gate's verdict is discarded before it can block. Use 'shell: bash', or delete the key and take the default."
     fi
     if [ -n "$wf_folded" ]; then
       echo "  - The phase-gate step's 'run:' is a FOLDED block scalar ('run: $wf_folded'), which joins its lines together with spaces before bash sees them — so the command that actually runs is not any line in this file, and something as invisible as '|| true' on a line of its own becomes part of the invocation. Rewrite it as a literal block scalar:"

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -8775,3 +8775,92 @@ a real loss.
 
 **Related:** BL-213 (a closing sentence that disagreed with the work — the same
 family, one severity up), BL-104 (silent success).
+
+---
+
+## BL-218: The ci.yml enforcement detector enumerates ways a file can be wrong; three adversarial rounds say the fork is canonical-shape-or-refuse
+
+**Logged:** 2026-08-10 (found by the third adversarial round on
+`fix/ci-token-enforcement-claim`; every count below was measured on that branch,
+not estimated)
+**Category:** Design fork / detector shape — an enumerating checker on a surface
+whose input space is not enumerable
+**Severity:** Medium. Nothing shipped is wrong today: the three rounds closed
+every hole they found, the four conditions are pinned by 158 rows with a mutant
+per atom, and every remaining gap is recorded in the product with its own
+marker. What is unresolved is whether the SHAPE of the detector can converge.
+**Status:** Open
+
+**The fork.** `cmd_setup_ci_token` in `scripts/check-gate.sh` decides whether a
+project's `.github/workflows/ci.yml` turns a stored secret into enforcement, and
+prints "The next push enforces the check" when it does. It decides that by
+enumeration: read the gate step and its job, and refuse each way the file can
+discard the gate's verdict. Three adversarial rounds each found new spellings
+the enumeration had not reached.
+
+- **Rounds 1-2 found YAML spellings** — CRLF line endings, quoted keys in both
+  quote styles, a space before the colon, merge keys, a lone-dash sequence item,
+  a folded block scalar, duplicate keys, a quoted job id that sent the job
+  locator climbing out of `jobs:` and binding "the job" to `push:` inside `on:`.
+  Every one earned the claim on a file whose effective configuration was a
+  swallow. These are *reachable* by enumeration — each closed for good, each
+  pinned by a marker and a mutant (`# D-A-CRLF-STRIP`, `# D-A-QUOTED-KEY-DQ`,
+  `# D-A-SPACED-KEY`, `# D-A-MERGE-KEY`, `# D-A-LONE-DASH-CLIMB`,
+  `# D-A-FOLDED-RUN`, `# D-A-DUP-KEY-VERDICT`, `# D-A-JOB-ID-CLOSED`).
+- **Round 3 found something different in kind: bash semantics inside the `run:`
+  body.** No amount of YAML parsing reaches it. The scanner inspects lines that
+  NAME the gate script plus a small set of keys; arbitrary shell control flow on
+  any other line is structurally invisible to a detector of this shape. A body
+  reading `set +e` / `bash scripts/check-phase-gate.sh` / `exit 0` runs under the
+  fail-fast default, carries a byte-exact invocation, passes every one of the
+  four conditions, and grades a failed gate green. Measured, not argued —
+  recorded in the product as `# D-A-RESIDUAL-RUN-BODY-DISARM`.
+
+**The decided direction (Karl, 2026-08-10): canonical-shape-or-refuse.** Require
+the gate step to match one shipped shape and tell anyone who deviates *"I cannot
+verify this file — here is the shape I need"*, instead of enumerating the ways a
+file can be wrong. This is the repo's own allowlist-over-blacklist doctrine —
+F-015's invocation allowlist, the `DELTA-INSTALL` fence grammar, and on this very
+branch `# D-A-PARITY-3-STEP-KEYSET` and `# D-A-SHELL-ALLOWLIST` — applied to the
+one part of this surface still doing the opposite. The bl147 sibling already
+works this way (`Cw6-strict-keys` / `-gating` / `-job` / `-trigger` freeze the
+ten templates byte-for-byte), which is why that pin has needed no rounds.
+
+**Why it is not being improvised into a fix round.** It is a product decision
+about how much customisation the framework tolerates, and the risk it carries
+runs the other way: **false reds for users who legitimately customised** — added
+a `working-directory:`, renamed the step, put the gate in a job with a
+`strategy:`. That is the direction that makes people ignore the tool, and it is
+worse than the gap. The four recorded parity asymmetries
+(`# D-A-PARITY-1-INLINE-RUN` … `# D-A-PARITY-4-NO-TRIGGER-PIN`) exist precisely
+because this surface faces a real user's file of unknown vintage rather than the
+ten the framework wrote. Deciding how far that tolerance goes needs a design
+doc, an inventory of the shapes real projects actually carry, and a migration
+story for the ones that would newly red. It does not need a patch.
+
+**What it would subsume, and what survives it.**
+
+| Recorded residual | Subsumed by canonical-shape-or-refuse? |
+|---|---|
+| `# D-A-RESIDUAL-HEREDOC-DATA` — a byte-exact gate line inside a heredoc is DATA and still satisfies the invokes floor | **Yes.** A canonical body has no heredoc; anything else is refused unverified. |
+| `# D-A-RESIDUAL-RUN-BODY-DISARM` — `set +e` … `exit 0` in the body | **Yes**, and this is the residual that motivates the whole entry. |
+| `# D-A-RESIDUAL-ENV-SHADOW` — `maps` is a PRESENCE test, so a step-level `GH_TOKEN` that shadows a workflow-level mapping is invisible (R-CTE-9) | **Partly.** A canonical STEP pins the step's own `env:`, so the shadowing spelling is refused. A secret mapped at job or workflow `env:` is still legitimate and outside any step-shaped canon, so the resolution question survives unless the canon reaches upward too. |
+| `# D-A-RESIDUAL-TAB-SEPARATOR` — a tab-spaced colon hiding `continue-on-error` | **Yes**, trivially: a canonical shape is byte-compared. |
+| `# D-A-RESIDUAL-QUOTED-STEPS-KEY` — a quoted `"steps":` or a flow-style step mapping | Already fails CLOSED; a canon changes the message, not the verdict. |
+| `!!str continue-on-error: true` and the explicit-key form (`? continue-on-error` / `: true`) | **Not a survivor — SETTLED and CLOSED in round 3**, `# D-A-OPAQUE-KEY`. Listed here only so the record shows it was answered rather than deferred. |
+| `# D-A-PARITY-4-NO-TRIGGER-PIN` — a workflow with no `push:` trigger still earns "the next push enforces" | **Yes** — the bl147 sibling freezes the `on:` block for exactly this reason. Still Karl's separate open call today. |
+
+**Fix shape (for the design doc, not for a patch).** Decide the canon; decide
+whether it is one shape or a small set (the ten templates are not identical);
+decide whether a non-matching file gets a REFUSAL or an "unverified" third
+verdict distinct from both the OK and the ten cause bullets; measure the false-red
+population before shipping it, because that is the risk. Whatever lands must keep
+the property this branch has: one term per line, one marker per atom, a mutant
+per marker, and no claim that outruns what was measured.
+
+**Related:** BL-181 (a one-character narrowing re-opening the same hole three
+times while passing every PR-blocking check — the reason "enumerate the wrong
+spellings" is treated here as a shape problem rather than a diligence problem),
+BL-104 (label and predicate disagreeing, so the printed word was not the
+verdict), BL-196 (a passing check that proves nothing is worse than no check —
+why every atom on this branch is pinned by a mutant rather than asserted).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -8850,6 +8850,23 @@ story for the ones that would newly red. It does not need a patch.
 | `!!str continue-on-error: true` and the explicit-key form (`? continue-on-error` / `: true`) | **Not a survivor — SETTLED and CLOSED in round 3**, `# D-A-OPAQUE-KEY`. Listed here only so the record shows it was answered rather than deferred. |
 | `# D-A-PARITY-4-NO-TRIGGER-PIN` — a workflow with no `push:` trigger still earns "the next push enforces" | **Yes** — the bl147 sibling freezes the `on:` block for exactly this reason. Still Karl's separate open call today. |
 
+**An input to the false-red measurement, recorded 2026-08-10 (R-CTE-12).**
+GitHub's current documentation **actively recommends YAML anchors and aliases**
+— the reusing-workflow-configurations page carries worked examples anchoring
+whole jobs and `env:` blocks — while `actions/runner` still throws
+`Anchors are not currently supported` from **two** files
+(`src/Sdk/WorkflowParser/Conversion/YamlObjectReader.cs` and its DTPipelines
+sibling). Both halves independently verified by adversarial review.
+
+No verdict changes today: `# D-A-MERGE-VERDICT` fails CLOSED on a merge key
+either way, which is correct under both readings. **The population does.** If
+anchors work in the service, GitHub's own docs are steering users toward exactly
+the shapes this detector refuses — and a plain alias on the gate job or step
+surfaces as a less precise "does not map" or unlocatable refusal rather than the
+merge-key cause bullet. That is the false-red population C must be measured
+against, so it belongs in the inventory below rather than in a session note.
+Round 1 assumed anchors were rare; that assumption is now the thing to check.
+
 **Fix shape (for the design doc, not for a patch).** Decide the canon; decide
 whether it is one shape or a small set (the ten templates are not identical);
 decide whether a non-matching file gets a REFUSAL or an "unverified" third

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -534,6 +534,19 @@ mk_tok_wf() {
   mk_wf "$d/.github/workflows/ci.yml" "$@"
 }
 
+# mk_raw_wf <dir> — a fixture PROJECT whose ci.yml is read VERBATIM from stdin.
+# mk_wf writes one canonical shape with splice points, which is right when the
+# thing under test is a step key. The round-2 findings are about the SHAPE of the
+# file itself — a lone `-` sequence item, a folded scalar, a comment on the
+# `steps:` anchor, a secret in a different step — so those fixtures have to be
+# written out whole. Quoted heredocs throughout: `${{ secrets.… }}` must reach
+# the file as those bytes, and an unquoted heredoc would not survive `${{`.
+mk_raw_wf() {
+  local d="$1"
+  mk_tok "$d" github ok yes || return 1
+  cat > "$d/.github/workflows/ci.yml"
+}
+
 # ── CRLF fixture mechanics (R-dA-1) ─────────────────────────────────────────
 # The bytes are WRITTEN, never described. `awk … %c,13` rather than
 # `sed 's/$/\r/'` because BSD sed inserts a literal `r` for that escape, which
@@ -675,6 +688,36 @@ assert_mutant_refuses() {
   fi
 }
 
+# assert_mutant_drops_cause <case> <mut> <ere> <sed> <rm> <add> <dir> <sig>
+#                           <why>
+#   The THIRD mutation direction, for a line that decides WHICH CAUSE is named
+#   rather than whether the claim is withheld. Both of round 2's cases are real:
+#   `grep -cxF` vs `grep -cF` on the invokes floor cannot change the verdict (a
+#   line that is a strict superstring of the invocation is always caught by the
+#   deviation scan as well), and a naive comment strip cannot change the verdict
+#   either (proved below at D40). What they DO change is what the user is told,
+#   and "a refusal that does not name its cause" is the defect this whole wave
+#   exists to fix — so the bullet set is contract, and it is pinned as one. The
+#   mutant must therefore still WITHHOLD (proving it did not simply break the
+#   detector) while the named cause is GONE.
+assert_mutant_drops_cause() {
+  local case_name="$1" mut="$2" ere="$3" expr="$4" n_rm="$5" n_add="$6" d="$7" sig="$8" why="$9"
+  if ! mk_cg_mutant "$mut" "$ere" "$expr" "$n_rm" "$n_add"; then
+    fail_ "$case_name" "$CG_WHY"
+    return
+  fi
+  local out rc
+  out=$(run_tok_with "$CG_MUT" "$d" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && ! printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && printf '%s' "$out" | grep -qF "will NOT enforce the check on the next push" \
+     && ! printf '%s' "$out" | grep -qF -- "$sig"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — expected the claim still WITHHELD but the cause [$sig] no longer named; got: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+  fi
+}
+
 # ── S1: non-github host → NOT APPLICABLE + the manual per-host steps ───────
 echo "=== S1-non-github-not-applicable ==="
 P="$TOPTMP/s1"; mk_tok "$P" gitlab ok
@@ -758,7 +801,7 @@ echo "=== S6-unwired-workflow-warned ==="
 P="$TOPTMP/s6"; mk_tok "$P" github ok no
 out=$(run_tok "$P" "$GOOD_TOKEN"); rc=$?
 if [ "$rc" -eq 0 ] \
-   && printf '%s' "$out" | grep -q "does not map SOIF_PROTECTION_TOKEN yet" \
+   && printf '%s' "$out" | grep -q "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
    && printf '%s' "$out" | grep -q 'GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}'; then
   pass "S6-unwired-workflow-warned (names the gap and prints the exact lines to add)"
 else
@@ -1012,7 +1055,7 @@ assert_withheld D1-no-invocation-withheld "$P" \
 echo "=== D2-unmapped-withheld ==="
 P="$TOPTMP/d2"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" no emitted
 assert_withheld D2-unmapped-withheld "$P" \
-  "does not map SOIF_PROTECTION_TOKEN yet" \
+  "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
   'the gate runs and honours its exit code, but nothing reads the secret'
 
 # ── D2b: a mapping that exists only in a COMMENT is not a mapping ──────────
@@ -1025,7 +1068,7 @@ echo "=== D2b-commented-out-mapping-is-not-mapped ==="
 P="$TOPTMP/d2b"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" no emitted
 printf '        # GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n' >> "$P/.github/workflows/ci.yml"
 assert_withheld D2b-commented-out-mapping-is-not-mapped "$P" \
-  "does not map SOIF_PROTECTION_TOKEN yet" \
+  "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
   'a commented-out mapping injects nothing into the step environment'
 
 # ── D3: `!swallows` violated ALONE — the Actions-native swallow ────────────
@@ -1394,6 +1437,622 @@ assert_earns_ok D30-quoted-job-id-clean-job-still-earns "$P" \
   'the locator must read the quoted id, not merely refuse it — failing every quoted job closed would be a false red'
 
 # ════════════════════════════════════════════════════════════════════════════
+# D31-D53 — FIX ROUND 2 (reviewer findings R-CTE-1…R-CTE-7, plus the atoms the
+# sweep those findings forced turned up). Every case here is ORDINARY,
+# parser-valid GitHub Actions YAML: none of it is exotic, all of it is emitted
+# by some hand or some tool, and each one either earned the enforcement claim
+# while the gate was inert or was refused while it was perfectly wired.
+#
+#   R-CTE-1  a LONE `-` sequence item. The step-climb required a space after
+#            the dash, so the gate bound to the PREVIOUS step and never read the
+#            real step's `continue-on-error:` (D31); the same style with the
+#            gate step first in the job failed closed instead (D32); and a dash
+#            with trailing blanks matched the climb but derived the wrong key
+#            column, so it read a line out of the env block as a step key (D34).
+#   R-CTE-2  a FOLDED scalar (`run: >`) joins its lines with spaces before bash
+#            sees them, so `|| true` on a line of its own is part of the
+#            invocation while every line-wise check passes (D35/D36).
+#   R-CTE-4  the invokes floor's THRESHOLD, reachable only from a guard-only
+#            workflow (D37) — the one shape that gets past `wf_gate` empty.
+#   R-CTE-5  a trailing YAML comment is not part of a value (D38/D39) nor of the
+#            `steps:` anchor (D41) nor of a job id (D42) — and a `#` INSIDE a
+#            quoted value is not a comment at all (D40).
+#   R-CTE-6  `maps` was file-wide while the OK sentence says step-scoped: a
+#            secret in a DIFFERENT step's env (D43) or a DIFFERENT job's env
+#            (D46) earned "maps … into the phase-gate step". Job- and
+#            workflow-level env DO reach the step and must still earn (D44/D45).
+#   R-CTE-7  duplicate mapping keys — `head -1` read the benign first one (D47).
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── D31-D34: R-CTE-1, the lone-dash sequence item, in BOTH directions ──────
+echo "=== D31-lone-dash-step-hides-swallow ==="
+P="$TOPTMP/d31"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: echo hi
+      -
+        name: Governance - Phase gate check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D31-lone-dash-step-hides-swallow "$P" \
+  "carries 'continue-on-error: true'" \
+  'a bare dash on its own line is an ordinary sequence item — binding the gate to the PREVIOUS step read the wrong keys entirely'
+
+echo "=== D32-lone-dash-first-step-still-earns ==="
+P="$TOPTMP/d32"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D32-lone-dash-first-step-still-earns "$P" \
+  'the mirror direction: the same style with nothing above it used to fail closed as "could not locate the step" — a false red on a correctly-wired file'
+
+echo "=== D33-lone-dash-first-step-swallow-still-caught ==="
+P="$TOPTMP/d33"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Governance - Phase gate check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D33-lone-dash-first-step-swallow-still-caught "$P" \
+  "carries 'continue-on-error: true'" \
+  'reading the lone-dash step is not enough — its KEY COLUMN has to come from the first line below it, or the keys are still never read'
+
+# NOT IN THE BRIEF. A dash followed by trailing blanks DID match the old climb
+# (there is a space after the dash), but `sub(/^ *- */, …)` then consumed the
+# blanks too and the key column came out four columns too deep — so the scan
+# read `GH_TOKEN` out of the env block AS A STEP KEY and refused for that,
+# while the real `continue-on-error: true` was never seen. Observed directly:
+# the scope report for such a file reads `STEPKEY GH_TOKEN`. Third spelling of
+# the same defect; one fix covers all three because the test is now "the dash
+# line carries no inline content", not "how many blanks follow the dash".
+echo "=== D34-lone-dash-trailing-blanks-swallow-caught ==="
+# The blanks after the dash are WRITTEN, never described: a heredoc in this file
+# would carry them invisibly and the next editor to trim whitespace would make
+# this case silently vacuous — the same reason to_crlf() exists above. n_trail
+# asserts the premise before anything else is asserted.
+P="$TOPTMP/d34"; mk_tok "$P" github ok yes
+{
+  printf 'name: CI\non:\n  push:\n    branches: [main]\n\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n'
+  printf '      -%s\n' "   "
+  printf '        name: Governance - Phase gate check\n        continue-on-error: true\n        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n        run: |\n          bash scripts/check-phase-gate.sh\n'
+} > "$P/.github/workflows/ci.yml"
+d34_trail=$(grep -c '^ *-  *$' "$P/.github/workflows/ci.yml")
+if [ "$d34_trail" -eq 1 ]; then
+  pass "D34-premise (the fixture really carries a dash followed by trailing blanks)"
+else
+  fail_ "D34-premise" "the dash-plus-blanks line was not written ($d34_trail matches) — D34 would be vacuous"
+fi
+assert_withheld D34-lone-dash-trailing-blanks-swallow-caught "$P" \
+  "carries 'continue-on-error: true'" \
+  'trailing blanks after the dash used to shift the key column and turn an env entry into a bogus step key'
+
+# ── D35/D36: R-CTE-2, the folded scalar ────────────────────────────────────
+# `run: >` folds its source lines together with SPACES, so the command the
+# runner executes is `bash scripts/check-phase-gate.sh || true` — the canonical
+# swallow, verbatim — while the visible gate line is byte-exact the allowlisted
+# invocation and `|| true` sits on a line naming nothing. Every line-wise check
+# passes. The `run: |` equivalents are all caught already (a trailing `\` or a
+# trailing `||` deviates line-wise); only FOLDING evades, because the join
+# happens in YAML rather than in bash. Same doctrine as the merge key: the
+# effective command is not in the lines being read, so fail CLOSED.
+echo "=== D35-folded-run-fails-closed ==="
+P="$TOPTMP/d35"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: >
+          bash scripts/check-phase-gate.sh
+          || true
+YML
+assert_withheld D35-folded-run-fails-closed "$P" \
+  "FOLDED block scalar" \
+  'the effective command is not any line in the file, so no line-wise check can settle the question'
+
+echo "=== D36-folded-run-chomping-indicator-fails-closed ==="
+P="$TOPTMP/d36"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: >-
+          bash scripts/check-phase-gate.sh
+          || true
+YML
+assert_withheld D36-folded-run-chomping-indicator-fails-closed "$P" \
+  "FOLDED block scalar" \
+  'the chomping and indentation indicators are part of the same folded form — reading only a bare > would leave three spellings open'
+
+# ── D37: R-CTE-4 — the invokes floor's THRESHOLD, not its presence ─────────
+# A PR-blocking-check survivor before this case existed: `-ge 1` → `-ge 0` left
+# the suite at 79/0, because every invokes-path fixture leaves `wf_gate` empty
+# and the threshold is never reached. The one shape that reaches it is a
+# GUARD-ONLY workflow — the framework's existence guard present, the invocation
+# deleted — which is exactly what a half-finished edit leaves behind.
+# CLAUDE.md's BL-181 lesson, verbatim: pin each atom's WIDTH, not its presence.
+echo "=== D37-guard-only-workflow-withheld ==="
+P="$TOPTMP/d37"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+YML
+assert_withheld D37-guard-only-workflow-withheld "$P" \
+  "INVOKES the phase gate" \
+  'the guard NAMES the gate script but never runs it — the floor has to count invocations, not mentions'
+
+# ── D38-D42: R-CTE-5 — a YAML comment is not part of the value ─────────────
+echo "=== D38-trailing-comment-on-step-if-still-earns ==="
+P="$TOPTMP/d38"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: hashFiles('.claude/phase-state.json') != '' # phase gate
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D38-trailing-comment-on-step-if-still-earns "$P" \
+  'semantically identical config: a comment is not part of the value, and refusing it is the CRLF regression one notch subtler'
+
+echo "=== D39-trailing-comment-on-step-coe-still-earns ==="
+P="$TOPTMP/d39"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        continue-on-error: false # deliberately hard
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D39-trailing-comment-on-step-coe-still-earns "$P" \
+  'the same for the one continue-on-error value that is SAFE — an explicit false with a note is still an explicit false'
+
+# The strip's other direction, which is the one that could go wrong. A `#`
+# inside a quoted scalar is CONTENT, not a comment, and a naive tail-strip eats
+# it. The reviewer's safety argument — a strip can only turn a refusal into an
+# acceptance when the remainder is byte-exact the shipped value, so it cannot
+# create a false OK — was VERIFIED rather than accepted, and it holds for a
+# reason worth writing down: both allowlisted values start unquoted, and a
+# quote opened after the first character can only close before a content `#` by
+# ending the quoted region, so a naive remainder always keeps an unbalanced
+# opening quote and can never equal the shipped bytes. What a naive strip DOES
+# break is the message: the refusal quotes a MANGLED condition back at the user,
+# which is the self-refuting-message defect this branch already fixed once for
+# CRLF. So both directions are pinned — refused, AND quoted back intact.
+echo "=== D40-hash-inside-quoted-value-is-not-a-comment ==="
+P="$TOPTMP/d40"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: contains(github.event.head_commit.message, ' #skip')
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D40-hash-inside-quoted-value-is-not-a-comment "$P" \
+  "condition is 'if: contains(github.event.head_commit.message, ' #skip')'" \
+  'a # inside a quoted scalar is content — the condition is refused AND quoted back whole, not truncated at the hash'
+
+echo "=== D41-trailing-comment-on-steps-anchor-still-earns ==="
+P="$TOPTMP/d41"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: # the governance job's steps
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D41-trailing-comment-on-steps-anchor-still-earns "$P" \
+  'NOT IN THE BRIEF: the same comment defect on the STRUCTURAL anchor — the $-anchored steps: regex missed it and the whole job went unlocatable'
+
+echo "=== D42-trailing-comment-on-job-id-still-earns ==="
+P="$TOPTMP/d42"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test: # the governance job
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D42-trailing-comment-on-job-id-still-earns "$P" \
+  'NOT IN THE BRIEF: and on the job id, where the same regex is what D-A-JOB-ID-CLOSED reads'
+
+# ── D43-D46: R-CTE-6 — `maps` has to be SCOPED to what reaches the step ────
+# The OK sentence says "maps SOIF_PROTECTION_TOKEN into the phase-gate step".
+# The test behind it was a file-wide substring match, so a secret mapped into a
+# DIFFERENT step's env earned that sentence while the gate step got no token at
+# all — the sentence claimed a scope nobody had checked, which is this branch's
+# whole subject. The correct scope is the gate step's own block (its env: AND
+# its run: body, because `${{ secrets.X }}` used directly in a command is a real
+# mapping too) plus the gate job's env: and the workflow's env:, both of which
+# DO reach the step. D44/D45/D46 are the false-red guards that keep the fix from
+# over-narrowing — the failure mode a scoping change invites.
+echo "=== D43-secret-mapped-into-another-step-withheld ==="
+P="$TOPTMP/d43"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Other step
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: echo hi
+      - name: Governance - Phase gate check
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D43-secret-mapped-into-another-step-withheld "$P" \
+  "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
+  'a secret in a sibling step never enters the gate step environment — the OK sentence said step scope and nothing checked it'
+
+echo "=== D44-workflow-level-env-still-earns ==="
+P="$TOPTMP/d44"; mk_raw_wf "$P" <<'YML'
+name: CI
+env:
+  GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D44-workflow-level-env-still-earns "$P" \
+  'workflow-level env IS inherited by every step, so narrowing to the step block alone would have redded it'
+
+echo "=== D45-job-level-env-still-earns ==="
+P="$TOPTMP/d45"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+    steps:
+      - name: Governance - Phase gate check
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D45-job-level-env-still-earns "$P" \
+  'and so is the gate job own env — the third of the three routes into the step environment'
+
+echo "=== D46-secret-mapped-into-another-job-withheld ==="
+P="$TOPTMP/d46"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        run: |
+          bash scripts/check-phase-gate.sh
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+    steps:
+      - name: Ship
+        run: echo ship
+YML
+assert_withheld D46-secret-mapped-into-another-job-withheld "$P" \
+  "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
+  'the same argument one level up: another job env is a different runner and a different environment'
+
+# ── D47: R-CTE-7 — duplicate keys, where head -1 read the benign one ───────
+# `head -1` picked `false` and the gate looked hard while the effective value
+# was `true`. Mitigating and decisive at once: GitHub own parser REJECTS
+# duplicate mapping keys, so this workflow does not run at all — which means
+# "the next push enforces the check" is false for it twice over. Failing closed
+# on the duplicate is therefore the correct answer AND it removes the ambiguity
+# `head -1` was resolving arbitrarily, which is why the sweep found that
+# selector unpinned: the right fix is to delete the choice, not to pin it.
+echo "=== D47-duplicate-step-key-fails-closed ==="
+P="$TOPTMP/d47"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        continue-on-error: false
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D47-duplicate-step-key-fails-closed "$P" \
+  "declared TWICE" \
+  'only one of the two takes effect and this check cannot tell you which — and GitHub rejects the file outright'
+
+# ════════════════════════════════════════════════════════════════════════════
+# D48-D53 — THE ATOM SWEEP. R-CTE-4 was a threshold that survived the whole
+# suite, so per the brief every other numeric and quantifier atom in this
+# surface was mutated the same way and the survivors triaged. These six pin the
+# survivors that are behaviourally REAL. The rest are recorded in the report
+# with the argument for why they cannot change a verdict.
+# ════════════════════════════════════════════════════════════════════════════
+
+# The product comment promises this shape works ("a four-space `steps:` sequence
+# — YAML permits the dash at the same column as its key — is ordinary
+# hand-written style and reading it as no keys at all would fail OPEN"). It was
+# never driven. Mutating the anchor search from `<= si` to `< si` left the suite
+# at 79/0, which is what an unexercised promise looks like.
+echo "=== D48-dash-at-steps-column-swallow-caught ==="
+P="$TOPTMP/d48"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Governance - Phase gate check
+      continue-on-error: true
+      env:
+        GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+      run: |
+        bash scripts/check-phase-gate.sh
+YML
+assert_withheld D48-dash-at-steps-column-swallow-caught "$P" \
+  "carries 'continue-on-error: true'" \
+  'the dash at the same column as steps: is ordinary YAML, and the anchor search has to accept an equal indent or the whole job goes unread'
+
+echo "=== D49-single-character-step-key-withheld ==="
+P="$TOPTMP/d49"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        x: true" yes emitted
+assert_withheld D49-single-character-step-key-withheld "$P" \
+  "does not recognise: x" \
+  'the key guard quantifier: narrowing [A-Za-z0-9_-]* to + makes a one-character key invisible, and an invisible key is not an allowlisted one'
+
+echo "=== D50-spaced-colon-job-id-still-reads-the-job ==="
+P="$TOPTMP/d50"; mk_jobid_wf "$P" '  test :' "    continue-on-error: true"
+assert_withheld D50-spaced-colon-job-id-still-reads-the-job "$P" \
+  "so that job's failure does not count" \
+  'YAML allows a space before the colon on a job id too — D24 doctrine, one level up, and dropping the [ ]* there loses the whole job'
+
+# A `run:` body line that starts with a dash but is NOT a sequence item — a
+# continued command-line option is the everyday case. The climb REQUIRES the
+# space after the dash for exactly this reason; widen it to /^ *-/ and the step
+# binds to a line inside its own run body, the key column comes out nonsense,
+# and the swallow above goes unread. The suite did not notice that widening.
+echo "=== D51-dash-option-in-run-body-does-not-open-a-step ==="
+P="$TOPTMP/d51"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          npm run lint \
+            -w packages/app
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D51-dash-option-in-run-body-does-not-open-a-step "$P" \
+  "carries 'continue-on-error: true'" \
+  'a dash with no space after it is an option, not a sequence item — the climb must not bind the step to it'
+
+# A COMMENTED-OUT gate line in an earlier, clean step. The gate-line search
+# skips comments; stop skipping them and the scan binds to that comment step
+# instead — a step with nothing wrong with it — while the real gate step
+# carries the swallow. Verified as a false OK, not merely a wrong report.
+echo "=== D52-commented-gate-line-does-not-steal-the-step ==="
+P="$TOPTMP/d52"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: echo hi
+        # bash scripts/check-phase-gate.sh
+      - name: Governance - Phase gate check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D52-commented-gate-line-does-not-steal-the-step "$P" \
+  "carries 'continue-on-error: true'" \
+  'a commented gate line is not the gate — binding to it moves the whole scan onto an innocent step'
+
+# The bullet SET is contract, not decoration. A workflow whose only gate line is
+# the swallowed inline form fails TWO conditions — no line IS the invocation,
+# and that line is not in the allowlist — and both have to be said, because the
+# fix for one is not the fix for the other.
+echo "=== D53-swallowed-inline-invocation-names-both-causes ==="
+P="$TOPTMP/d53"; mk_tok "$P" github ok custom 'bash scripts/check-phase-gate.sh || true'
+assert_withheld D53a-swallowed-inline-names-invokes "$P" \
+  "INVOKES the phase gate" \
+  'the whole-line match on the floor: a line that merely CONTAINS the invocation is not the invocation'
+assert_withheld D53b-swallowed-inline-names-deviation "$P" \
+  "DISCARDS the gate's exit code" \
+  'and the deviation scan names the line itself — two causes, two edits'
+
+# ── D54: R-CTE-3 recorded, not fixed, and recorded EXECUTABLY ──────────────
+# The `invokes` floor counts a byte-exact gate line inside a heredoc — data
+# written to a file and never executed. That is the same "names on executed
+# lines ≠ invokes" gap CLAUDE.md documents for BL-181, so it is not academic.
+# It is recorded rather than fixed because telling data from code inside a
+# `run:` body needs a bash lexer (quoted and unquoted delimiters, `<<-`, nesting,
+# command substitution), and BL-181 is this repo's own record of a lexical
+# approximation of "executed" being narrowed one character at a time and
+# re-opening three times. Worse, `wf_gate` feeds BOTH the floor and the
+# deviation scan, so a heredoc skip that is one delimiter form too greedy hides
+# a real swallowing line — the fail-OPEN direction. The residual is pinned in
+# BOTH halves: the marker is in the product, and the behaviour it describes is
+# asserted, so changing it goes RED rather than quiet.
+echo "=== D54-heredoc-residual-is-recorded ==="
+grep -qF '# D-A-RESIDUAL-HEREDOC-DATA' "$CHECK_GATE" \
+  && pass "D54-heredoc-residual-is-recorded (the residual is named in the product, beside the parity notes)" \
+  || fail_ "D54-heredoc-residual-is-recorded" "the recorded-residual marker is gone — an unfixed known defect is now an undocumented one"
+P="$TOPTMP/d54"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate helper
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          cat > helper.sh <<'DONE'
+          bash scripts/check-phase-gate.sh
+          DONE
+YML
+assert_earns_ok D54b-heredoc-residual-behaves-as-recorded "$P" \
+  'RECORDED RESIDUAL, not an endorsement: the floor still counts a gate line that is heredoc DATA. Pinned so that closing it is a deliberate change with its own proof'
+
+# ════════════════════════════════════════════════════════════════════════════
 # DM1-DM8 — the other direction. Each mutant neuters ONE line and the false
 # claim comes back. mk_cg_mutant asserts the harness standard for every one of
 # them: sites==1 for the anchored end-of-line marker, exactly-N-lines-changed,
@@ -1405,7 +2064,7 @@ echo "=== DM1-maps-gate-carries-D2 ==="
 P="$TOPTMP/dm1"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" no emitted
 assert_mutant_false_ok DM1-maps-gate-carries-D2 mapsgate \
   '# D-A-MAPS-GATE$' '/# D-A-MAPS-GATE$/d' 1 0 \
-  "$P" "does not map SOIF_PROTECTION_TOKEN yet" \
+  "$P" "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
   'without the maps term an unmapped workflow is told the next push enforces'
 
 echo "=== DM2-invokes-gate-carries-D1 ==="
@@ -1544,6 +2203,274 @@ assert_mutant_false_ok_ctl DM15-job-id-closed-carries-D29 jobidclosed \
   "$P" "Could not locate the job that runs the gate" \
   "$DMCTL" "$DMCTL_SIG" \
   'without the fail-closed job-id guard an unreadable enclosing line is scanned as if it were the job'
+
+# ════════════════════════════════════════════════════════════════════════════
+# DM16-DM26 — fix round 2. Eight of the eleven edit the awk program inside
+# _wf_gate_scope, so they carry the liveness control: `bash -n` only parses the
+# SHELL, and a dead awk prints an empty scope report which reads downstream as
+# "no swallowing key found". Two of them use assert_mutant_refuses instead,
+# because the line they neuter exists to prevent a false RED — and that assert
+# is itself dead-awk-proof, since a dead awk earns the claim rather than
+# refusing. One uses assert_mutant_drops_cause, for a line that decides which
+# cause is named rather than whether the claim is withheld.
+# ════════════════════════════════════════════════════════════════════════════
+
+echo "=== DM16-invokes-floor-threshold-carries-D37 ==="
+P="$TOPTMP/dm16"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo "::error::Phase gate check script missing. Framework integrity compromised."
+            exit 1
+          fi
+YML
+assert_mutant_false_ok DM16-invokes-floor-threshold-carries-D37 invfloor \
+  '# D-A-INVOKES-FLOOR$' \
+  's@^\([[:space:]]*\)if \[ "\$wf_n_inv" -ge 1 \]; then.*# D-A-INVOKES-FLOOR$@\1if [ "$wf_n_inv" -ge 0 ]; then@' 1 1 \
+  "$P" "INVOKES the phase gate" \
+  'the THRESHOLD, not the marker: -ge 0 is satisfied by zero invocations and a guard-only workflow is told the next push enforces'
+
+echo "=== DM17-lone-dash-climb-carries-D31 ==="
+P="$TOPTMP/dm17"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup
+        run: echo hi
+      -
+        name: Governance - Phase gate check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok_ctl DM17-lone-dash-climb-carries-D31 lonedashclimb \
+  '# D-A-LONE-DASH-CLIMB$' \
+  's@^\([[:space:]]*\)for (i = hit; i >= 1; i--) if ((L\[i\] " ") ~ /\^ \*- /) { st = i; break }.*# D-A-LONE-DASH-CLIMB$@\1for (i = hit; i >= 1; i--) if (L[i] ~ /^ *- /) { st = i; break }@' 1 1 \
+  "$P" "$DMCTL_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'take the appended space away and the climb needs a space after the dash again, binds to the PREVIOUS step and reads its keys — R-CTE-1, reproduced'
+
+echo "=== DM18-lone-dash-keycol-carries-D33 ==="
+P="$TOPTMP/dm18"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Governance - Phase gate check
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok_ctl DM18-lone-dash-keycol-carries-D33 lonedashkeycol \
+  '# D-A-LONE-DASH-KEYCOL$' \
+  's@^\([[:space:]]*\)if (c == "") {.*# D-A-LONE-DASH-KEYCOL$@\1if (0) {@' 1 1 \
+  "$P" "$DMCTL_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'finding the lone-dash step is only half of it — without the derived key column the column is one past the dash and NO key is ever read'
+
+echo "=== DM19-folded-run-emit-carries-D35 ==="
+P="$TOPTMP/dm19"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: hashFiles('.claude/phase-state.json') != ''
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: >
+          bash scripts/check-phase-gate.sh
+          || true
+YML
+assert_mutant_false_ok_ctl DM19-folded-run-emit-carries-D35 foldedemit \
+  '# D-A-FOLDED-RUN$' '/# D-A-FOLDED-RUN$/d' 1 0 \
+  "$P" "FOLDED block scalar" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'without the folded-scalar report every line-wise check passes on a step whose effective command is the canonical swallow — R-CTE-2, reproduced'
+
+echo "=== DM20-folded-run-verdict-carries-D35 ==="
+P="$TOPTMP/dm20"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: >
+          bash scripts/check-phase-gate.sh
+          || true
+YML
+assert_mutant_false_ok DM20-folded-run-verdict-carries-D35 foldedverdict \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-FOLDED-RUN-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-FOLDED-RUN-VERDICT$@\1:@' 1 1 \
+  "$P" "FOLDED block scalar" \
+  'and the fail-closed arm is a term of its own — reporting the fold without acting on it would claim enforcement anyway'
+
+echo "=== DM21-comment-strip-carries-D38 ==="
+P="$TOPTMP/dm21"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: hashFiles('.claude/phase-state.json') != '' # phase gate
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_refuses DM21-comment-strip-carries-D38 commentstrip \
+  '# D-A-COMMENT-STRIP$' '/# D-A-COMMENT-STRIP$/d' 1 0 \
+  "$P" "which is not the one this framework ships" \
+  'without the strip the comment rides on the value and a correctly-wired project is told its own condition is not its own condition — R-CTE-5, reproduced'
+
+echo "=== DM22-comment-strip-is-quote-aware-carries-D40 ==="
+P="$TOPTMP/dm22"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: contains(github.event.head_commit.message, ' #skip')
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_drops_cause DM22-comment-strip-is-quote-aware-carries-D40 naivestrip \
+  '# D-A-COMMENT-INSIDE-QUOTES$' '/# D-A-COMMENT-INSIDE-QUOTES$/d' 1 0 \
+  "$P" "condition is 'if: contains(github.event.head_commit.message, ' #skip')'" \
+  'stop tracking quotes and the strip eats content: still refused, but the condition quoted back at the user is truncated at the hash'
+
+echo "=== DM23-anchor-comment-carries-D41 ==="
+P="$TOPTMP/dm23"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps: # the governance job's steps
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_refuses DM23-anchor-comment-carries-D41 anchorcomment \
+  '# D-A-ANCHOR-COMMENT$' \
+  's@^\([[:space:]]*\)for (i = st; i >= 1; i--) if (decomment(L\[i\]) ~ @\1for (i = st; i >= 1; i--) if (L[i] ~ @' 1 1 \
+  "$P" "Could not locate the job that runs the gate" \
+  'the anchors need the same comment handling the values do, or one comment on steps: takes the whole job out of reach'
+
+echo "=== DM24-maps-scope-carries-D43 ==="
+P="$TOPTMP/dm24"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Other step
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: echo hi
+      - name: Governance - Phase gate check
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok_ctl DM24-maps-scope-carries-D43 mapsscope \
+  '# D-A-MAPS-SCOPE$' \
+  's@^\([[:space:]]*\)if \[ -n "\$wf_mapscope" \].*# D-A-MAPS-SCOPE$@\1wf_maps_src="$wf_exec"@' 1 1 \
+  "$P" "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'read the whole file again and a secret in a sibling step earns "maps it into the phase-gate step" — R-CTE-6, reproduced'
+
+echo "=== DM25-dup-key-verdict-carries-D47 ==="
+P="$TOPTMP/dm25"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        continue-on-error: false
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok DM25-dup-key-verdict-carries-D47 dupkey \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-DUP-KEY-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-DUP-KEY-VERDICT$@\1:@' 1 1 \
+  "$P" "declared TWICE" \
+  'without the duplicate arm the first value wins by accident of head -1 and a step whose effective continue-on-error is true is told the next push enforces — R-CTE-7, reproduced'
+
+echo "=== DM26-invokes-whole-line-carries-D53 ==="
+P="$TOPTMP/dm26"; mk_tok "$P" github ok custom 'bash scripts/check-phase-gate.sh || true'
+assert_mutant_drops_cause DM26-invokes-whole-line-carries-D53 invwholeline \
+  '# D-A-INVOKES-WHOLE-LINE$' \
+  's@grep -cxF -- "\$wf_allow_invoke" || true)   # D-A-INVOKES-WHOLE-LINE$@grep -cF -- "$wf_allow_invoke" || true)@' 1 1 \
+  "$P" "INVOKES the phase gate" \
+  'drop the whole-line anchor and a swallowed line COUNTS as an invocation: the verdict survives on the deviation scan alone, but the user loses one of the two edits they need'
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -1697,20 +1697,51 @@ YML
 assert_earns_ok D39-trailing-comment-on-step-coe-still-earns "$P" \
   'the same for the one continue-on-error value that is SAFE — an explicit false with a note is still an explicit false'
 
-# The strip's other direction, which is the one that could go wrong. A `#`
-# inside a quoted scalar is CONTENT, not a comment, and a naive tail-strip eats
-# it. The reviewer's safety argument — a strip can only turn a refusal into an
+# The strip's other direction, which is the one that could go wrong — and where
+# the obvious implementation is WRONG in a way only a real parser catches.
+#
+# The reviewer's safety argument (a strip can only turn a refusal into an
 # acceptance when the remainder is byte-exact the shipped value, so it cannot
-# create a false OK — was VERIFIED rather than accepted, and it holds for a
-# reason worth writing down: both allowlisted values start unquoted, and a
-# quote opened after the first character can only close before a content `#` by
-# ending the quoted region, so a naive remainder always keeps an unbalanced
-# opening quote and can never equal the shipped bytes. What a naive strip DOES
-# break is the message: the refusal quotes a MANGLED condition back at the user,
-# which is the self-refuting-message defect this branch already fixed once for
-# CRLF. So both directions are pinned — refused, AND quoted back intact.
-echo "=== D40-hash-inside-quoted-value-is-not-a-comment ==="
+# create a false OK) was VERIFIED, not accepted, and it holds: both allowlisted
+# values start unquoted, so a naive remainder always keeps an unbalanced opening
+# quote and can never equal the shipped bytes. What a naive strip DOES break is
+# the message — it quotes a MANGLED condition back at the user, the same
+# self-refuting message the CRLF fix removed.
+#
+# But "do not strip inside quotes" is only right for a QUOTED scalar, and a YAML
+# scalar is quoted only when it OPENS with a quote. Inside a PLAIN scalar an
+# apostrophe is ordinary content and YAML really does end the value at the
+# ` #`. Measured, not reasoned — PyYAML loads
+#   if: contains(m, ' #skip')
+# as the plain scalar `contains(m, '`. A scan that tracks quotes from anywhere
+# gets that case wrong (conservatively: it under-strips, so it can only produce
+# a false RED, never a false OK — but it is still the wrong reading and it is
+# still a mangled message). D40 pins the genuinely quoted form; D40b pins the
+# plain one, against what the parser actually says.
+echo "=== D40-hash-inside-quoted-scalar-is-content ==="
 P="$TOPTMP/d40"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: "hashFiles('.claude/phase-state.json') != '' # not really"
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D40-hash-inside-quoted-scalar-is-content "$P" \
+  "condition is 'if: \"hashFiles('.claude/phase-state.json') != '' # not really\"'" \
+  'the value OPENS with a quote, so it is a quoted scalar and the # is content — refused, and quoted back whole rather than truncated at the hash'
+
+echo "=== D40b-hash-in-plain-scalar-ends-the-value ==="
+P="$TOPTMP/d40b"; mk_raw_wf "$P" <<'YML'
 name: CI
 on:
   push:
@@ -1727,9 +1758,9 @@ jobs:
         run: |
           bash scripts/check-phase-gate.sh
 YML
-assert_withheld D40-hash-inside-quoted-value-is-not-a-comment "$P" \
-  "condition is 'if: contains(github.event.head_commit.message, ' #skip')'" \
-  'a # inside a quoted scalar is content — the condition is refused AND quoted back whole, not truncated at the hash'
+assert_withheld D40b-hash-in-plain-scalar-ends-the-value "$P" \
+  "condition is 'if: contains(github.event.head_commit.message, ''" \
+  'and the mirror: this value does NOT open with a quote, so the apostrophes are content and YAML ends it at the space-hash — which is what the message must say'
 
 echo "=== D41-trailing-comment-on-steps-anchor-still-earns ==="
 P="$TOPTMP/d41"; mk_raw_wf "$P" <<'YML'
@@ -1899,7 +1930,7 @@ jobs:
 YML
 assert_withheld D47-duplicate-step-key-fails-closed "$P" \
   "declared TWICE" \
-  'only one of the two takes effect and this check cannot tell you which — and GitHub rejects the file outright'
+  'parsers disagree about which one wins — PyYAML takes the LAST (so the effective value here is the swallow), GitHub is documented to reject duplicate keys — and an answer nobody can predict is not one to claim enforcement on'
 
 # ════════════════════════════════════════════════════════════════════════════
 # D48-D53 — THE ATOM SWEEP. R-CTE-4 was a threshold that survived the whole
@@ -1914,7 +1945,12 @@ assert_withheld D47-duplicate-step-key-fails-closed "$P" \
 # hand-written style and reading it as no keys at all would fail OPEN"). It was
 # never driven. Mutating the anchor search from `<= si` to `< si` left the suite
 # at 79/0, which is what an unexercised promise looks like.
-echo "=== D48-dash-at-steps-column-swallow-caught ==="
+# The step keys are emitted BEFORE the job is located, so a step-level swallow
+# is reported either way and asserting one here would NOT have exercised the
+# anchor at all — which is exactly why the mutation survived. The decisive pair
+# is a clean file that must EARN (a job it cannot locate fails closed) and a
+# JOB-level swallow that must be caught (which needs the job located first).
+echo "=== D48-dash-at-steps-column-still-earns ==="
 P="$TOPTMP/d48"; mk_raw_wf "$P" <<'YML'
 name: CI
 on:
@@ -1926,15 +1962,35 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Governance - Phase gate check
-      continue-on-error: true
       env:
         GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
       run: |
         bash scripts/check-phase-gate.sh
 YML
-assert_withheld D48-dash-at-steps-column-swallow-caught "$P" \
-  "carries 'continue-on-error: true'" \
-  'the dash at the same column as steps: is ordinary YAML, and the anchor search has to accept an equal indent or the whole job goes unread'
+assert_earns_ok D48-dash-at-steps-column-still-earns "$P" \
+  'the dash at the same column as steps: is ordinary YAML, and the anchor search has to accept an EQUAL indent or a correctly-wired job goes unlocatable'
+
+echo "=== D48b-dash-at-steps-column-job-swallow-caught ==="
+P="$TOPTMP/d48b"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+    - name: Governance - Phase gate check
+      env:
+        GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+      run: |
+        bash scripts/check-phase-gate.sh
+YML
+assert_withheld D48b-dash-at-steps-column-job-swallow-caught "$P" \
+  "so that job's failure does not count" \
+  'and the job-level scan has to reach it there too — that half is unreachable unless the anchor matched'
 
 echo "=== D49-single-character-step-key-withheld ==="
 P="$TOPTMP/d49"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
@@ -2019,6 +2075,79 @@ assert_withheld D53a-swallowed-inline-names-invokes "$P" \
 assert_withheld D53b-swallowed-inline-names-deviation "$P" \
   "DISCARDS the gate's exit code" \
   'and the deviation scan names the line itself — two causes, two edits'
+
+# ── D55-D57: three more atoms the POST-fix sweep found still unpinned ──────
+# The sweep was re-run against the fixed code, not just the old one, because a
+# fix moves which atoms are load-bearing: the maps scoping made two indentation
+# comparisons decisive that were inert before, and left three others open.
+
+# An `if:` whose value is NOTHING BUT a comment is the NULL condition, and the
+# refusal has to say so rather than read the comment text back as if it were a
+# condition — the self-refuting message again, in its smallest form.
+echo "=== D55-comment-only-value-is-the-null-value ==="
+P="$TOPTMP/d55"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: # decide later
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D55-comment-only-value-is-the-null-value "$P" \
+  "condition is 'if: '" \
+  'PyYAML loads this as if: None — a present key with no value, which is neither absent nor the shipped condition'
+
+# The workflow-level `env:` block has to END at the next column-0 key. Let it run
+# to end of file and every secret anywhere below it counts as workflow env,
+# which puts the file-wide match back through the side door.
+echo "=== D56-workflow-env-block-ends-at-column-zero ==="
+P="$TOPTMP/d56"; mk_raw_wf "$P" <<'YML'
+name: CI
+env:
+  NODE_ENV: test
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Other step
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: echo hi
+      - name: Governance - Phase gate check
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D56-workflow-env-block-ends-at-column-zero "$P" \
+  "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
+  'a workflow env that does NOT carry the secret must not drag the rest of the file into scope with it'
+
+# TABS. Recorded, not handled: YAML permits a tab inside a quoted scalar
+# (`run: "echo a<TAB>b"` loads fine) but NOT as separation, and PyYAML rejects
+# every tab-as-separator spelling outright — a tab before a `#`, a tab between a
+# key and its colon, a tab after the colon. So this program treats a tab as
+# CONTENT everywhere and never as white space, which keeps every one of those
+# files refused (the safe direction) and keeps a legitimate tab in a quoted
+# command from being a false red. The one that would matter if a parser ever
+# accepted it — a tab-spaced colon hiding continue-on-error — is recorded rather
+# than fixed, because a blanket "tab in the block ⇒ fail closed" WOULD red
+# `run: "echo a<TAB>b"`, which is valid.
+echo "=== D57-tab-separator-residual-is-recorded ==="
+grep -qF '# D-A-RESIDUAL-TAB-SEPARATOR' "$CHECK_GATE" \
+  && pass "D57-tab-separator-residual-is-recorded (the tab reading is stated in the product, with what the parser says)" \
+  || fail_ "D57-tab-separator-residual-is-recorded" "the tab residual is no longer recorded — the reading becomes accidental"
 
 # ── D54: R-CTE-3 recorded, not fixed, and recorded EXECUTABLY ──────────────
 # The `invokes` floor counts a byte-exact gate line inside a heredoc — data
@@ -2385,7 +2514,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Governance - Phase gate check
-        if: contains(github.event.head_commit.message, ' #skip')
+        if: "hashFiles('.claude/phase-state.json') != '' # not really"
         env:
           GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: |
@@ -2393,8 +2522,32 @@ jobs:
 YML
 assert_mutant_drops_cause DM22-comment-strip-is-quote-aware-carries-D40 naivestrip \
   '# D-A-COMMENT-INSIDE-QUOTES$' '/# D-A-COMMENT-INSIDE-QUOTES$/d' 1 0 \
-  "$P" "condition is 'if: contains(github.event.head_commit.message, ' #skip')'" \
-  'stop tracking quotes and the strip eats content: still refused, but the condition quoted back at the user is truncated at the hash'
+  "$P" "condition is 'if: \"hashFiles('.claude/phase-state.json') != '' # not really\"'" \
+  'stop opening the quote and the strip eats content out of a genuinely quoted scalar: still refused, but the condition quoted back at the user is truncated at the hash'
+
+echo "=== DM22b-quotes-only-open-a-scalar-carries-D40b ==="
+P="$TOPTMP/dm22b"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        if: contains(github.event.head_commit.message, ' #skip')
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_drops_cause DM22b-quotes-only-open-a-scalar-carries-D40b scalarstart \
+  '# D-A-COMMENT-INSIDE-QUOTES$' \
+  's@^\([[:space:]]*\)if (st == 0 \&\& ch != " ") @\1if (ch != " ") @' 1 1 \
+  "$P" "condition is 'if: contains(github.event.head_commit.message, ''" \
+  'drop the opens-the-scalar test and a quote ANYWHERE starts quoting, which is the reading PyYAML contradicts: the plain scalar is no longer ended at the space-hash'
 
 echo "=== DM23-anchor-comment-carries-D41 ==="
 P="$TOPTMP/dm23"; mk_raw_wf "$P" <<'YML'

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -534,6 +534,26 @@ mk_tok_wf() {
   mk_wf "$d/.github/workflows/ci.yml" "$@"
 }
 
+# ── CRLF fixture mechanics (R-dA-1) ─────────────────────────────────────────
+# The bytes are WRITTEN, never described. `awk … %c,13` rather than
+# `sed 's/$/\r/'` because BSD sed inserts a literal `r` for that escape, which
+# would produce a fixture that merely LOOKS like CRLF in the source of this file
+# — the exact vacuity these proofs exist to prevent. n_cr() counts the actual CR
+# bytes so every CRLF case can assert its own premise before asserting anything
+# else.
+to_crlf() { awk '{ printf "%s%c\n", $0, 13 }' "$1" > "$2"; }
+n_cr()    { tr -dc '\r' < "$1" | wc -c | tr -d ' '; }
+
+# mk_tok_wf_crlf <dir> <mk_wf args…> — mk_tok_wf, then rewrite ci.yml with CRLF
+# line terminators. Nothing else about the fixture differs, so a difference in
+# verdict is attributable to the line endings and to nothing else.
+mk_tok_wf_crlf() {
+  local d="$1"; shift
+  mk_tok_wf "$d" "$@" || return 1
+  local w="$d/.github/workflows/ci.yml"
+  to_crlf "$w" "$w.crlf" && mv "$w.crlf" "$w"
+}
+
 # The legacy leftover: the emitted step, plus the pre-R-1 soft step a project
 # upgraded from an older vintage still carries. The ONLY thing wrong with it is
 # the deviating gate line — it maps, and it does carry a real invocation — which
@@ -595,6 +615,63 @@ assert_mutant_false_ok() {
     pass "$case_name ($why)"
   else
     fail_ "$case_name" "rc=$rc — the neutered detector did not produce the false OK, so the positive case may be measuring something else: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+  fi
+}
+
+# assert_mutant_false_ok_ctl <case> <mut> <ere> <sed> <rm> <add> <dir> <sig>
+#                            <ctl-dir> <ctl-sig> <why>
+#   assert_mutant_false_ok PLUS a liveness discriminator, required for every
+#   mutant that edits the awk program inside _wf_gate_scope. `bash -n` only
+#   parses the SHELL: an awk program mangled into a syntax error still passes it,
+#   and a dead awk prints nothing, which reads downstream as "no swallowing key
+#   found" — i.e. the false OK, for entirely the wrong reason. So the same mutant
+#   is also driven against a control fixture whose swallow is spelled the ORDINARY
+#   way, and that one must STILL be refused with its own cause named. Only then
+#   is the false OK attributable to the removed line.
+assert_mutant_false_ok_ctl() {
+  local case_name="$1" mut="$2" ere="$3" expr="$4" n_rm="$5" n_add="$6" d="$7" sig="$8"
+  local ctl="${9}" ctl_sig="${10}" why="${11}"
+  if ! mk_cg_mutant "$mut" "$ere" "$expr" "$n_rm" "$n_add"; then
+    fail_ "$case_name" "$CG_WHY"
+    return
+  fi
+  local out rc cout crc
+  out=$(run_tok_with "$CG_MUT" "$d" "$GOOD_TOKEN"); rc=$?
+  cout=$(run_tok_with "$CG_MUT" "$ctl" "$GOOD_TOKEN"); crc=$?
+  if [ "$crc" -ne 0 ] \
+     || printf '%s' "$cout" | grep -q "The next push enforces the check" \
+     || ! printf '%s' "$cout" | grep -qF -- "$ctl_sig"; then
+    fail_ "$case_name" "the mutant stopped detecting the ORDINARY spelling too (crc=$crc), so it did not isolate one line — most likely the awk program no longer runs: $(printf '%s' "$cout" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+    return
+  fi
+  if [ "$rc" -eq 0 ] \
+     && printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && ! printf '%s' "$out" | grep -qF -- "$sig"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — the neutered detector did not produce the false OK, so the positive case may be measuring something else: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+  fi
+}
+
+# assert_mutant_refuses <case> <mut> <ere> <sed> <rm> <add> <dir> <sig> <why>
+#   The INVERTED mutation direction, for a line whose job is to prevent a false
+#   RED rather than a false OK. Neuter it and a LEGITIMATE setup is refused —
+#   and refused with a named cause, so a mutant that broke something unrelated
+#   cannot pass. (R-dA-1: the CRLF strip is that kind of line.)
+assert_mutant_refuses() {
+  local case_name="$1" mut="$2" ere="$3" expr="$4" n_rm="$5" n_add="$6" d="$7" sig="$8" why="$9"
+  if ! mk_cg_mutant "$mut" "$ere" "$expr" "$n_rm" "$n_add"; then
+    fail_ "$case_name" "$CG_WHY"
+    return
+  fi
+  local out rc
+  out=$(run_tok_with "$CG_MUT" "$d" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && ! printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && printf '%s' "$out" | grep -qF -- "$sig"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — with that line neutered the legitimate fixture was NOT falsely refused for the named reason [$sig], so the positive case is not measuring the line it claims to: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
   fi
 }
 
@@ -1110,6 +1187,155 @@ else
 fi
 
 # ════════════════════════════════════════════════════════════════════════════
+# D15-D27 — FIX ROUND (reviewer findings R-dA-1 and R-dA-2). Two false verdicts
+# in OPPOSITE directions, both produced by reading a workflow as bytes rather
+# than as YAML:
+#
+#   R-dA-1  CRLF. A ci.yml with CRLF terminators earned the claim before the
+#           step/job scope existed and was REFUSED after it, because the
+#           trailing \r rides on every key and value the scan reads. The
+#           refusal was self-refuting on its face — it quoted back an `if:`
+#           and told the user to replace it with the same bytes.
+#   R-dA-2  QUOTED KEYS. The scope report only emitted keys matching
+#           /^[A-Za-z_]/, so `"continue-on-error": true` and `'if': false`
+#           were never emitted and never reached the swallow scan: the claim
+#           was EARNED while the step was inert. Confirmed against a real YAML
+#           parser — all of these load to the identical effective config.
+#           A YAML merge key (`<<: *anchor`) is the third case: the effective
+#           configuration is not in the block being read at all, so it is
+#           treated the way every other unreadable structure is — fail CLOSED.
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── D15: the CRLF fixtures are really CRLF ─────────────────────────────────
+# The premise before any conclusion. A "CRLF test" whose fixture is quietly LF
+# asserts nothing at all, and `sed 's/$/\r/'` — the obvious way to write one —
+# produces exactly that on BSD sed. So the bytes are counted.
+echo "=== D15-crlf-fixture-is-really-crlf ==="
+P="$TOPTMP/d15"; mk_tok_wf_crlf "$P" "" "$STEP_KEYS_GOOD" yes emitted
+d15_wf="$P/.github/workflows/ci.yml"
+d15_cr=$(n_cr "$d15_wf"); d15_ln=$(wc -l < "$d15_wf" | tr -d ' ')
+if [ "$d15_cr" -gt 0 ] && [ "$d15_cr" -eq "$d15_ln" ]; then
+  pass "D15-crlf-fixture-is-really-crlf ($d15_cr CR bytes over $d15_ln lines — every line terminator is CRLF)"
+else
+  fail_ "D15-crlf-fixture-is-really-crlf" "the fixture is not CRLF ($d15_cr CR bytes over $d15_ln lines) — every CRLF case below would be vacuous"
+fi
+
+# ── D16: R-dA-1 — a CRLF workflow that IS wired earns the claim ────────────
+# Same fixture as D15. This is one assertion over all three conditions at once:
+# `maps`, the `invokes` floor and every arm of `!swallows` must each survive
+# CRLF for the claim to appear.
+echo "=== D16-crlf-good-earns-the-claim ==="
+assert_earns_ok D16-crlf-good-earns-the-claim "$P" \
+  'R-dA-1: CRLF is a line ENDING, not a configuration difference — GitHub Actions parses this file identically to its LF twin'
+
+# ── D17: …and the fix did not neuter the condition ─────────────────────────
+echo "=== D17-crlf-swallow-still-refused ==="
+P="$TOPTMP/d17"; mk_tok_wf_crlf "$P" "" "$STEP_KEYS_GOOD
+        continue-on-error: true" yes emitted
+assert_withheld D17-crlf-swallow-still-refused "$P" \
+  "carries 'continue-on-error: true'" \
+  'stripping the line endings must not make CRLF workflows unjudgeable — a real swallow is still caught'
+
+# ── D18: the strip is ANCHORED — a CR inside a value is not eaten ──────────
+# The paired direction of the same fix. `gsub(/\r/,"")` would silently repair a
+# value that does NOT equal the shipped condition into one that does, turning a
+# genuinely different `if:` into a claim of enforcement. Only a TRAILING CR is a
+# line ending.
+echo "=== D18-crlf-mid-value-not-eaten ==="
+CRB=$(printf '\r')
+P="$TOPTMP/d18"; mk_tok_wf_crlf "$P" "" "        if: hashFiles('.claude/phase-state.json')${CRB} != ''" yes emitted
+assert_withheld D18-crlf-mid-value-not-eaten "$P" \
+  "which is not the one this framework ships" \
+  'a CR in the MIDDLE of a value is content, not a terminator — the strip must not widen into it'
+
+# ── D19-D22: R-dA-2 — the quoted-key evasion, all four spellings ───────────
+# YAML permits both quote styles for a key and generated / round-tripped
+# workflows emit them. Each of these was confirmed to EARN the claim on the
+# pre-fix code while the step or job was inert.
+echo "=== D19-double-quoted-step-coe-withheld ==="
+P="$TOPTMP/d19"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        \"continue-on-error\": true" yes emitted
+assert_withheld D19-double-quoted-step-coe-withheld "$P" \
+  "carries 'continue-on-error: true'" \
+  'a double-quoted key is the same key — the step is still graded green however the gate votes'
+
+echo "=== D20-single-quoted-step-if-withheld ==="
+P="$TOPTMP/d20"; mk_tok_wf "$P" "" "        'if': false" yes emitted
+assert_withheld D20-single-quoted-step-if-withheld "$P" \
+  "condition is 'if: false'" \
+  'a single-quoted key is the same key — the step never runs'
+
+echo "=== D21-double-quoted-job-coe-withheld ==="
+P="$TOPTMP/d21"; mk_tok_wf "$P" "    \"continue-on-error\": true" "$STEP_KEYS_GOOD" yes emitted
+assert_withheld D21-double-quoted-job-coe-withheld "$P" \
+  "so that job's failure does not count" \
+  'the evasion works one level up too, and the job arm must read quoted keys as well'
+
+echo "=== D22-single-quoted-job-if-withheld ==="
+P="$TOPTMP/d22"; mk_tok_wf "$P" "    'if': false" "$STEP_KEYS_GOOD" yes emitted
+assert_withheld D22-single-quoted-job-if-withheld "$P" \
+  "The job that HOLDS the phase-gate step carries 'if: false'" \
+  'a quoted job-level if: false starts no job at all'
+
+# ── D23: the false-positive direction of the same fix ──────────────────────
+# Unquoting the key must make it COMPARABLE, not automatically suspect. A step
+# whose keys are quoted but whose values are the shipped ones is a legitimate
+# setup and must still earn the claim, or the fix has traded one false verdict
+# for another.
+echo "=== D23-quoted-good-keys-still-earn ==="
+P="$TOPTMP/d23"; mk_tok_wf "$P" "" "        \"if\": hashFiles('.claude/phase-state.json') != ''
+        'continue-on-error': false" yes emitted
+assert_earns_ok D23-quoted-good-keys-still-earn "$P" \
+  'the key is unquoted for COMPARISON only — a quoted spelling of the shipped configuration is the shipped configuration'
+
+# ── D24: a sibling evasion the review did not name ─────────────────────────
+# NOT IN THE BRIEF. The same emit() guard rejected `continue-on-error : true`
+# (a space before the colon) for the same reason it rejected the quoted form,
+# and YAML permits it — `s-separate-in-line?` sits between an implicit key and
+# its `:`. Verified against a real parser: it loads to {continue-on-error: true},
+# byte-identically to the ordinary spelling, and it earned the claim pre-fix.
+# Reported rather than papered over; carried here so it cannot come back.
+echo "=== D24-spaced-colon-step-coe-withheld ==="
+P="$TOPTMP/d24"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        continue-on-error : true" yes emitted
+assert_withheld D24-spaced-colon-step-coe-withheld "$P" \
+  "carries 'continue-on-error: true'" \
+  'YAML allows whitespace between an implicit key and its colon — the key is the same key'
+
+# ── D25/D26: the THIRD case — configuration that is not in the block ───────
+# A merge key pulls the effective `continue-on-error:` / `if:` in from an anchor
+# elsewhere in the file. Resolving anchors is not attempted; unverifiable must
+# not read as verified, which is the same doctrine as D8.
+merge_sig() { printf "A YAML merge key on the gate's %s pulls in keys from ELSEWHERE in the file" "$1"; }
+echo "=== D25-step-merge-key-fails-closed ==="
+P="$TOPTMP/d25"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        <<: *soft" yes emitted
+printf 'x-soft: &soft\n  continue-on-error: true\n' >> "$P/.github/workflows/ci.yml"
+assert_withheld D25-step-merge-key-fails-closed "$P" \
+  "$(merge_sig step)" \
+  'the swallow can live in the anchor, so the block being read does not settle the question'
+
+echo "=== D26-job-merge-key-fails-closed ==="
+P="$TOPTMP/d26"; mk_tok_wf "$P" "    <<: *soft" "$STEP_KEYS_GOOD" yes emitted
+printf 'x-soft: &soft\n  continue-on-error: true\n' >> "$P/.github/workflows/ci.yml"
+assert_withheld D26-job-merge-key-fails-closed "$P" \
+  "$(merge_sig job)" \
+  'the same argument one level up — a merged job-level continue-on-error is invisible here'
+
+# ── D27: a step REPLACED by an alias already fails closed ──────────────────
+# The remaining anchor shape, pinned rather than assumed: when the step itself is
+# `- *gate_step`, the gate line lives in the anchor definition, which has no
+# enclosing sequence item — so the EXISTING unlocatable arm catches it and no
+# new code is needed. Asserting it here is what keeps that true.
+echo "=== D27-alias-step-fails-closed ==="
+P="$TOPTMP/d27"; mk_tok "$P" github ok yes
+printf 'name: CI\non:\n  push:\n    branches: [main]\nx-gate: &gate_step\n  name: Governance - Phase gate check\n  continue-on-error: true\n  env:\n    GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n  run: |\n    bash scripts/check-phase-gate.sh\n\njobs:\n  test:\n    runs-on: ubuntu-latest\n    steps:\n      - *gate_step\n' \
+  > "$P/.github/workflows/ci.yml"
+assert_withheld D27-alias-step-fails-closed "$P" \
+  "Could not locate the step that runs the gate" \
+  'an aliased step keeps its configuration outside the block, and the existing fail-closed arm already refuses it'
+
+# ════════════════════════════════════════════════════════════════════════════
 # DM1-DM8 — the other direction. Each mutant neuters ONE line and the false
 # claim comes back. mk_cg_mutant asserts the harness standard for every one of
 # them: sites==1 for the anchored end-of-line marker, exactly-N-lines-changed,
@@ -1182,6 +1408,76 @@ assert_mutant_false_ok DM8-unlocated-verdict-carries-D8 unlocated \
   's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-UNLOCATED-VERDICT$@\1:@' 1 1 \
   "$P" "Could not locate the job that runs the gate" \
   'without the fail-closed arm an unreadable structure is told the next push enforces'
+
+# ════════════════════════════════════════════════════════════════════════════
+# DM9-DM14 — the fix round's mutants. Four of the six edit the awk program
+# inside _wf_gate_scope, where `bash -n` proves nothing: a mangled awk program
+# is still valid SHELL, and a dead awk prints an empty scope report, which reads
+# downstream as "no swallowing key found" — the false OK, for the wrong reason.
+# Those four therefore use assert_mutant_false_ok_ctl, which also drives the
+# same mutant against a fixture whose swallow is spelled the ORDINARY way and
+# requires it to STILL be refused.
+# ════════════════════════════════════════════════════════════════════════════
+
+# The liveness control, shared: the plainest swallow there is.
+DMCTL="$TOPTMP/dmctl"; mk_tok_wf "$DMCTL" "" "$STEP_KEYS_GOOD
+        continue-on-error: true" yes emitted
+DMCTL_SIG="carries 'continue-on-error: true'"
+
+echo "=== DM9-crlf-strip-carries-D16 ==="
+P="$TOPTMP/dm9"; mk_tok_wf_crlf "$P" "" "$STEP_KEYS_GOOD" yes emitted
+assert_mutant_refuses DM9-crlf-strip-carries-D16 crlfstrip \
+  '# D-A-CRLF-STRIP$' '/# D-A-CRLF-STRIP$/d' 1 0 \
+  "$P" "which is not the one this framework ships" \
+  'without the strip a correctly-wired CRLF workflow is falsely refused — R-dA-1, reproduced'
+
+echo "=== DM10-crlf-strip-is-anchored-carries-D18 ==="
+P="$TOPTMP/dm10"; mk_tok_wf_crlf "$P" "" "        if: hashFiles('.claude/phase-state.json')${CRB} != ''" yes emitted
+DMCTL_CRLF="$TOPTMP/dmctlcrlf"; mk_tok_wf_crlf "$DMCTL_CRLF" "" "$STEP_KEYS_GOOD
+        continue-on-error: true" yes emitted
+assert_mutant_false_ok_ctl DM10-crlf-strip-is-anchored-carries-D18 crlfgsub \
+  '# D-A-CRLF-STRIP$' \
+  's@^\([[:space:]]*\){ sub(CR .*# D-A-CRLF-STRIP$@\1{ gsub(CR, "", L[NR]) }@' 1 1 \
+  "$P" "which is not the one this framework ships" \
+  "$DMCTL_CRLF" "$DMCTL_SIG" \
+  'widened from sub(…$) to gsub, a CR inside the value is eaten and a DIFFERENT if: is repaired into the shipped one'
+
+echo "=== DM11-quoted-key-dq-carries-D19 ==="
+P="$TOPTMP/dm11"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        \"continue-on-error\": true" yes emitted
+assert_mutant_false_ok_ctl DM11-quoted-key-dq-carries-D19 quotedq \
+  '# D-A-QUOTED-KEY-DQ$' '/# D-A-QUOTED-KEY-DQ$/d' 1 0 \
+  "$P" "$DMCTL_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'without the double-quote arm an inert step is told the next push enforces — R-dA-2, reproduced'
+
+echo "=== DM12-quoted-key-sq-carries-D20 ==="
+P="$TOPTMP/dm12"; mk_tok_wf "$P" "" "        'if': false" yes emitted
+assert_mutant_false_ok_ctl DM12-quoted-key-sq-carries-D20 quotesq \
+  '# D-A-QUOTED-KEY-SQ$' '/# D-A-QUOTED-KEY-SQ$/d' 1 0 \
+  "$P" "condition is 'if: false'" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'the single-quote arm is a SEPARATE arm — the double-quote one does not cover it'
+
+echo "=== DM13-spaced-key-carries-D24 ==="
+P="$TOPTMP/dm13"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        continue-on-error : true" yes emitted
+assert_mutant_false_ok_ctl DM13-spaced-key-carries-D24 spacedkey \
+  '# D-A-SPACED-KEY$' \
+  's@^\([[:space:]]*\)if (c !~ .*# D-A-SPACED-KEY$@\1if (c !~ /^[A-Za-z_][A-Za-z0-9_-]*:/) return@' 1 1 \
+  "$P" "$DMCTL_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'narrow the key guard by the one [ ]* and the spaced spelling goes invisible again'
+
+echo "=== DM14-merge-verdict-carries-D25 ==="
+P="$TOPTMP/dm14"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        <<: *soft" yes emitted
+printf 'x-soft: &soft\n  continue-on-error: true\n' >> "$P/.github/workflows/ci.yml"
+assert_mutant_false_ok "DM14-merge-verdict-carries-D25" mergeverdict \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-MERGE-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-MERGE-VERDICT$@\1:@' 1 1 \
+  "$P" "$(merge_sig step)" \
+  'without the fail-closed merge arm a step whose real configuration is in an anchor is told the next push enforces'
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -2134,6 +2134,35 @@ assert_withheld D56-workflow-env-block-ends-at-column-zero "$P" \
   "does not map SOIF_PROTECTION_TOKEN into the phase-gate step" \
   'a workflow env that does NOT carry the secret must not drag the rest of the file into scope with it'
 
+# A `#` that is NOT preceded by white space does not start a comment — it is an
+# ordinary character in the value. Measured: PyYAML loads
+# `continue-on-error: false#note` as the STRING 'false#note', which GitHub
+# evaluates as truthy, so that step IS soft and refusing it is the correct
+# answer. Drop the white-space requirement from the strip and the value becomes
+# `false`, which is the one continue-on-error value that earns the claim — a
+# false OK, from one relaxed condition in a comment scanner.
+echo "=== D58-hash-without-preceding-space-is-not-a-comment ==="
+P="$TOPTMP/d58"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        continue-on-error: false#note
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D58-hash-without-preceding-space-is-not-a-comment "$P" \
+  "carries 'continue-on-error: false#note'" \
+  'the value is the string false#note, not the boolean false — truthy, so the step is soft, and the strip must not manufacture a false out of it'
+
 # TABS. Recorded, not handled: YAML permits a tab inside a quoted scalar
 # (`run: "echo a<TAB>b"` loads fine) but NOT as separation, and PyYAML rejects
 # every tab-as-separator spelling outright — a tab before a `#`, a tab between a
@@ -2548,6 +2577,31 @@ assert_mutant_drops_cause DM22b-quotes-only-open-a-scalar-carries-D40b scalarsta
   's@^\([[:space:]]*\)if (st == 0 \&\& ch != " ") @\1if (ch != " ") @' 1 1 \
   "$P" "condition is 'if: contains(github.event.head_commit.message, ''" \
   'drop the opens-the-scalar test and a quote ANYWHERE starts quoting, which is the reading PyYAML contradicts: the plain scalar is no longer ended at the space-hash'
+
+echo "=== DM22c-comment-needs-preceding-space-carries-D58 ==="
+P="$TOPTMP/dm22c"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        continue-on-error: false#note
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok_ctl DM22c-comment-needs-preceding-space-carries-D58 hashnospace \
+  '# D-A-COMMENT-STRIP$' \
+  's@^\([[:space:]]*\)if (ch == "#" \&\& i > 1 \&\& substr(s, i - 1, 1) == " ") break.*# D-A-COMMENT-STRIP$@\1if (ch == "#" \&\& i > 1) break@' 1 1 \
+  "$P" "carries 'continue-on-error: false#note'" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'relax the strip to any # and a value that is really the string false#note is truncated into the boolean false — the one value that earns the claim'
 
 echo "=== DM23-anchor-comment-carries-D41 ==="
 P="$TOPTMP/dm23"; mk_raw_wf "$P" <<'YML'

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -481,6 +481,123 @@ mk_cg_mutant() {
   return 0
 }
 
+# ── D-A fixture writer (Karl 2026-08-09) ────────────────────────────────────
+# mk_wf <out> <job-extra-keys> <step-keys> <mapped:yes|no> <body:emitted|nogate>
+#       [extra-steps]
+# Writes a COMPLETE, structurally-valid github workflow whose phase-gate step is
+# the shape templates/pipelines/ci/github/*.yml ships, differing from it only by
+# what the caller splices in. One writer for every structural case below, so a
+# refusal is attributable to exactly one cause and "withheld alone" means what
+# it says.
+#
+# <step-keys> is the WHOLE step key block, not an addition to a fixed one: an
+# `if:` case must REPLACE the shipped condition rather than sit beside it as a
+# duplicate YAML key, which would be a malformed fixture testing nothing.
+STEP_KEYS_GOOD="        if: hashFiles('.claude/phase-state.json') != ''"
+mk_wf() {
+  local out="$1" jobkeys="$2" stepkeys="$3" mapped="$4" body="$5" extra="${6:-}"
+  {
+    printf 'name: CI\n'
+    printf 'on:\n  push:\n    branches: [main]\n  pull_request:\n    branches: [main]\n\n'
+    printf 'jobs:\n  test:\n    runs-on: ubuntu-latest\n'
+    [ -n "$jobkeys" ] && printf '%s\n' "$jobkeys"
+    printf '    steps:\n'
+    printf '      - name: Governance - Phase gate check\n'
+    [ -n "$stepkeys" ] && printf '%s\n' "$stepkeys"
+    if [ "$mapped" = yes ]; then
+      printf '        env:\n          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n'
+    fi
+    printf '        run: |\n'
+    if [ "$body" = emitted ]; then
+      printf '          if [ ! -f scripts/check-phase-gate.sh ]; then\n'
+      printf '            echo "::error::Phase gate check script missing. Framework integrity compromised."\n'
+      printf '            exit 1\n'
+      printf '          fi\n'
+      printf '          bash scripts/check-phase-gate.sh\n'
+    else
+      printf '          npm test\n'
+    fi
+    [ -n "$extra" ] && printf '%s\n' "$extra"
+  } > "$out"
+  return 0
+}
+
+# mk_tok_wf <dir> <mk_wf args…> — a fixture PROJECT (manifest, git, gh stub)
+# whose ci.yml is written by mk_wf. Every fixture lives under $TOPTMP; nothing
+# here reads or writes the host filesystem, and no probe resolves a path
+# relative to the fixture's parent (the `../../..` trap: from a mktemp dir that
+# is /var/folders on macOS and / on Ubuntu, so a probe there is unfalsifiable in
+# both directions).
+mk_tok_wf() {
+  local d="$1"; shift
+  mk_tok "$d" github ok yes || return 1
+  mk_wf "$d/.github/workflows/ci.yml" "$@"
+}
+
+# The legacy leftover: the emitted step, plus the pre-R-1 soft step a project
+# upgraded from an older vintage still carries. The ONLY thing wrong with it is
+# the deviating gate line — it maps, and it does carry a real invocation — which
+# is what makes it the right fixture for the allowlist's dual-direction proof.
+WF_LEGACY_STEP='      - name: Governance - Phase gate check (legacy)
+        run: bash scripts/check-phase-gate.sh 2>/dev/null || echo "skipping"'
+
+# assert_withheld <case> <dir> <cause-signature> <why>
+#   Three assertions, not one: the claim is withheld, the refusal SAYS it is
+#   withholding, and it NAMES the cause. A refusal that does not name its cause
+#   is the 3am-lane defect this wave already fixed once, so "it printed
+#   something" is not the bar.
+assert_withheld() {
+  local case_name="$1" d="$2" sig="$3" why="$4"
+  local out rc
+  out=$(run_tok "$d" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && ! printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && printf '%s' "$out" | grep -qF "will NOT enforce the check on the next push" \
+     && printf '%s' "$out" | grep -qF -- "$sig"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — expected the claim WITHHELD and the cause named [$sig], got: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+  fi
+}
+
+# assert_earns_ok <case> <dir> <why> — the false-positive direction. A hardened
+# detector that reds correct setups is worse than the weak one it replaced.
+assert_earns_ok() {
+  local case_name="$1" d="$2" why="$3"
+  local out rc
+  out=$(run_tok "$d" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && ! printf '%s' "$out" | grep -q "will NOT enforce"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — a LEGITIMATE setup was refused: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+  fi
+}
+
+# assert_mutant_false_ok <case> <mut> <ere> <sed> <rm> <add> <dir> <sig> <why>
+#   Dual direction: with this one line neutered, the fixture that was just
+#   refused earns the full enforcement claim — the exact false statement the
+#   line exists to prevent. The verdict is CONDITIONAL on observing the thing it
+#   judges: the claim must appear AND the cause signature must be gone, so a
+#   mutant that merely broke something else cannot pass.
+assert_mutant_false_ok() {
+  local case_name="$1" mut="$2" ere="$3" expr="$4" n_rm="$5" n_add="$6" d="$7" sig="$8" why="$9"
+  if ! mk_cg_mutant "$mut" "$ere" "$expr" "$n_rm" "$n_add"; then
+    fail_ "$case_name" "$CG_WHY"
+    return
+  fi
+  local out rc
+  out=$(run_tok_with "$CG_MUT" "$d" "$GOOD_TOKEN"); rc=$?
+  if [ "$rc" -eq 0 ] \
+     && printf '%s' "$out" | grep -q "The next push enforces the check" \
+     && ! printf '%s' "$out" | grep -qF -- "$sig"; then
+    pass "$case_name ($why)"
+  else
+    fail_ "$case_name" "rc=$rc — the neutered detector did not produce the false OK, so the positive case may be measuring something else: $(printf '%s' "$out" | grep -E 'next push|WILL NOT|^  - ' | tr '\n' ' ')"
+  fi
+}
+
 # ── S1: non-github host → NOT APPLICABLE + the manual per-host steps ───────
 echo "=== S1-non-github-not-applicable ==="
 P="$TOPTMP/s1"; mk_tok "$P" gitlab ok
@@ -688,30 +805,36 @@ else
   fail_ "S6k-allowlist-accepts-the-emitted-shape" "rc=$rc — the hardened detector warns about the framework's OWN emitted workflow: $(printf '%s' "$out" | grep -E 'phase-gate step|next push' | tr '\n' ' ')"
 fi
 
-# ── S6m: DUAL DIRECTION — neuter the verdict and the escape claims success ──
-# Everything above shows shapes being refused. This shows that the allowlist is
-# what refuses them: delete its verdict line and the `|| exit 0` workflow gets
-# the full "the next push enforces the check" claim — the exact false statement
-# F-015 exists to prevent.
+# ── S6L / S6m: DUAL DIRECTION — neuter the verdict and the deviation is waved
+# through. Everything above shows shapes being refused. This shows that the
+# ALLOWLIST is what refuses them: delete its verdict line and a workflow whose
+# only defect is a deviating gate line gets the full "the next push enforces the
+# check" claim — the exact false statement F-015 exists to prevent.
+#
+# WHY THE FIXTURE CHANGED (D-A, 2026-08-09). S6m used to drive the mutant with a
+# bare `|| exit 0` run line. That workflow now fails the NEW `invokes` floor as
+# well (no line is the allowlisted invocation), so neutering the allowlist alone
+# no longer produces the false OK and the mutant would have gone vacuous —
+# passing on a fixture it no longer isolates. The fixture is now the realistic
+# shape whose ONLY defect is the deviation: the emitted step, kept intact, plus
+# the pre-R-1 soft step an upgraded project still carries. S6L is its positive
+# control — without it, S6m's "the claim came back" would not be attributable.
+echo "=== S6L-legacy-leftover-step-withheld ==="
+P="$TOPTMP/s6L"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" yes emitted "$WF_LEGACY_STEP"
+assert_withheld S6L-legacy-leftover-step-withheld "$P" \
+  "DISCARDS the gate's exit code" \
+  'a leftover soft gate step: the emitted step is intact, so ONLY the deviating line is wrong'
+
 echo "=== S6m-neutered-allowlist-claims-false-enforcement ==="
 # The verdict is REPLACED by a no-op rather than deleted: it is the only
 # statement in its `if`, and an empty then-block is a syntax error — a mutant
 # that fails to parse would prove nothing about the allowlist.
-if mk_cg_mutant projverdict \
-     '^[[:space:]]*wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$' \
-     's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$@\1:@' 1 1; then
-  P="$TOPTMP/s6m"; mk_tok "$P" github ok custom 'bash scripts/check-phase-gate.sh || exit 0'
-  out=$(run_tok_with "$CG_MUT" "$P" "$GOOD_TOKEN"); rc=$?
-  if [ "$rc" -eq 0 ] \
-     && printf '%s' "$out" | grep -q "The next push enforces the check" \
-     && ! printf '%s' "$out" | grep -q "DISCARDS the gate's exit code"; then
-    pass "S6m-neutered-allowlist-claims-false-enforcement (without the verdict line the escape is told the next push enforces — the allowlist carries S6e-S6j)"
-  else
-    fail_ "S6m-neutered-allowlist-claims-false-enforcement" "rc=$rc — the neutered detector did not produce the false claim, so S6e-S6j may be measuring something else: $(printf '%s' "$out" | grep -E 'phase-gate step|next push' | tr '\n' ' ')"
-  fi
-else
-  fail_ "S6m-neutered-allowlist-claims-false-enforcement" "$CG_WHY"
-fi
+P="$TOPTMP/s6m"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" yes emitted "$WF_LEGACY_STEP"
+assert_mutant_false_ok S6m-neutered-allowlist-claims-false-enforcement projverdict \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# F-015-PROJECT-ALLOWLIST-VERDICT$@\1:@' 1 1 \
+  "$P" "DISCARDS the gate's exit code" \
+  'without the verdict line the deviating gate line is told the next push enforces — the allowlist carries S6e-S6j and S6L'
 
 # ── S6b: --token-env rejects a non-identifier (the eval IS an injection sink) ─
 # The indirect read is `eval "token=\${$token_env:-}"`. Without a name check, a
@@ -778,6 +901,287 @@ if [ "$chain_ok" -eq 1 ]; then
 else
   fail_ "S7-chain-secret-name-agrees" "the walkthrough's secret name, the template's mapping and the gate's probe variable do not line up — the walkthrough would store a secret nothing reads"
 fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# PART 3 — D-A (Karl, 2026-08-09): the enforcement claim is gated on
+#     maps && invokes && !swallows
+#
+# Two independent reviewers reproduced two situations where this command told a
+# REAL user "The next push enforces the check" and it was false:
+#   1. NO GATE AT ALL. The old predicate asked only whether a line naming the
+#      gate DEVIATED from the allowlist. A ci.yml that maps the secret and
+#      invokes nothing has no deviating line, so it satisfied the predicate
+#      VACUOUSLY. Nothing ran; nothing enforced.
+#   2. A GATE THAT CANNOT FAIL. The detector was not step-scoped, so it could
+#      not see `continue-on-error: true` (which grades a FAILED step as success)
+#      or a step-level `if: false`. Both kept the enforcement claim while the
+#      verdict went in the bin.
+#
+# Every case below states which of the three conditions it violates, and asserts
+# the refusal NAMES that condition — "it refused" is not the bar, because a
+# refusal that does not name its cause is the defect this wave already fixed
+# once. The mutants are the other direction: neuter the one line that carries a
+# condition and the false claim comes back.
+# ════════════════════════════════════════════════════════════════════════════
+
+# ── D1: `invokes` violated ALONE — the vacuous case, reproduced ────────────
+echo "=== D1-no-invocation-withheld ==="
+P="$TOPTMP/d1"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" yes nogate
+assert_withheld D1-no-invocation-withheld "$P" \
+  "INVOKES the phase gate" \
+  'the secret is mapped and NOTHING runs the gate — the case the old predicate satisfied vacuously'
+
+# ── D2: `maps` violated ALONE ──────────────────────────────────────────────
+echo "=== D2-unmapped-withheld ==="
+P="$TOPTMP/d2"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" no emitted
+assert_withheld D2-unmapped-withheld "$P" \
+  "does not map SOIF_PROTECTION_TOKEN yet" \
+  'the gate runs and honours its exit code, but nothing reads the secret'
+
+# ── D2b: a mapping that exists only in a COMMENT is not a mapping ──────────
+# Behaviour change shipped with D-A and pinned here so it is deliberate: the
+# maps test used to be an unanchored regex over the whole file, so a
+# commented-out example mapping — the shape a half-finished edit leaves behind —
+# earned the enforcement claim while the runner read no secret at all. Same
+# defect class as the two the reviewers found, on the same line of reasoning.
+echo "=== D2b-commented-out-mapping-is-not-mapped ==="
+P="$TOPTMP/d2b"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" no emitted
+printf '        # GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n' >> "$P/.github/workflows/ci.yml"
+assert_withheld D2b-commented-out-mapping-is-not-mapped "$P" \
+  "does not map SOIF_PROTECTION_TOKEN yet" \
+  'a commented-out mapping injects nothing into the step environment'
+
+# ── D3: `!swallows` violated ALONE — the Actions-native swallow ────────────
+# continue-on-error grades a FAILED step as success (confirmed against the
+# GitHub docs), so the run: body can be byte-perfect and still enforce nothing.
+echo "=== D3-continue-on-error-withheld ==="
+P="$TOPTMP/d3"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        continue-on-error: true" yes emitted
+assert_withheld D3-continue-on-error-withheld "$P" \
+  "carries 'continue-on-error: true'" \
+  'the emitted body, graded as success however the gate votes'
+
+# ── D4: `!swallows` violated ALONE — a step that never runs ────────────────
+echo "=== D4-step-if-false-withheld ==="
+P="$TOPTMP/d4"; mk_tok_wf "$P" "" "        if: false" yes emitted
+assert_withheld D4-step-if-false-withheld "$P" \
+  "condition is 'if: false'" \
+  'a step-level if: false discards the verdict more completely than || true ever could'
+
+# ── D5: `!swallows` violated ALONE — the sibling nobody has named ──────────
+# The step key set is an ALLOWLIST, so a key outside the documented run-step
+# schema is refused without anyone having to imagine it first.
+echo "=== D5-unknown-step-key-withheld ==="
+P="$TOPTMP/d5"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        on-failure: continue" yes emitted
+assert_withheld D5-unknown-step-key-withheld "$P" \
+  "does not recognise: on-failure" \
+  'an unrecognised step key could change how the verdict is graded'
+
+# ── D6/D7: the same argument one level up (Cw6-strict-job's reasoning) ─────
+echo "=== D6-job-if-withheld ==="
+P="$TOPTMP/d6"; mk_tok_wf "$P" "    if: false" "$STEP_KEYS_GOOD" yes emitted
+assert_withheld D6-job-if-withheld "$P" \
+  "The job that HOLDS the phase-gate step carries 'if: false'" \
+  'a job that never starts runs no step, however perfect the step is'
+
+echo "=== D7-job-continue-on-error-withheld ==="
+P="$TOPTMP/d7"; mk_tok_wf "$P" "    continue-on-error: true" "$STEP_KEYS_GOOD" yes emitted
+assert_withheld D7-job-continue-on-error-withheld "$P" \
+  "so that job's failure does not count" \
+  "a job whose failure does not count cannot enforce"
+
+# ── D8: fail CLOSED when the structure cannot be read ──────────────────────
+# A composite-action file: the gate step is real and the body is the emitted
+# one, but there is no job above it, so how its verdict is graded cannot be
+# determined. Unverifiable must not read as verified.
+echo "=== D8-unlocatable-job-withheld ==="
+P="$TOPTMP/d8"; mk_tok "$P" github ok yes
+printf 'runs:\n  using: composite\n  steps:\n    - name: Governance - Phase gate check\n      env:\n        GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n      run: |\n        if [ ! -f scripts/check-phase-gate.sh ]; then\n          echo "::error::Phase gate check script missing. Framework integrity compromised."\n          exit 1\n        fi\n        bash scripts/check-phase-gate.sh\n' \
+  > "$P/.github/workflows/ci.yml"
+assert_withheld D8-unlocatable-job-withheld "$P" \
+  "Could not locate the job that runs the gate" \
+  'fail-closed: an unreadable structure is not a verified one'
+
+# ── D9: THE FALSE-POSITIVE GUARD — every shipped template still earns it ───
+# Run against the REAL emitted workflows, not fixtures: init.sh lays these down
+# with a verbatim `cp` (grep `cp "$template_path" "$target_path"` in init.sh),
+# so the file a user's detector reads IS this file. A hardened detector that
+# reds correct setups is worse than the weak one it replaced.
+echo "=== D9-emitted-templates-earn-the-claim ==="
+GH_CI_DIR="$REPO_ROOT/templates/pipelines/ci/github"
+d9_examined=0; d9_bad=""
+for tpl in "$GH_CI_DIR"/*.yml; do
+  [ -f "$tpl" ] || continue
+  d9_examined=$((d9_examined + 1))
+  P="$TOPTMP/d9-$(basename "$tpl" .yml)"
+  mk_tok "$P" github ok yes
+  cp "$tpl" "$P/.github/workflows/ci.yml"
+  out=$(run_tok "$P" "$GOOD_TOKEN")
+  printf '%s' "$out" | grep -q "The next push enforces the check" \
+    || d9_bad="$d9_bad $(basename "$tpl")[$(printf '%s' "$out" | grep -E '^  - ' | head -1 | cut -c1-90)]"
+done
+# A green that is really an empty loop is the vacuity this repo keeps catching:
+# the floor is what tells "all clean" apart from "nothing examined".
+if [ "$d9_examined" -ge 10 ]; then
+  pass "D9-scope ($d9_examined shipped github CI templates driven through the detector, floor 10)"
+else
+  fail_ "D9-scope" "only $d9_examined github CI templates were examined (floor 10) — D9's verdict is vacuous"
+fi
+if [ -z "$d9_bad" ]; then
+  pass "D9-emitted-templates-earn-the-claim (all $d9_examined shipped templates still earn the enforcement claim)"
+else
+  fail_ "D9-emitted-templates-earn-the-claim" "the hardened detector REFUSES the framework's own emitted workflows — in:$d9_bad"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# D10-D14 — PARITY with the bl147 pin (tests/test-bl147-ci-template-integrity.sh
+# `Cw6-strict*`). The two detectors judge the same property on two different
+# populations: bl147 reads the ten templates the framework wrote, this one reads
+# a real user's ci.yml of unknown vintage. Where they agree, they must keep
+# agreeing on the SPELLING (D14). Where they deliberately differ, the difference
+# is pinned behaviourally (D10-D12) and named in the product comment (D13), so
+# "aligning" them goes red rather than quiet.
+# ════════════════════════════════════════════════════════════════════════════
+BL147="$REPO_ROOT/tests/test-bl147-ci-template-integrity.sh"
+
+# ── D10: parity difference 1 — the inline `run:` form is accepted here ─────
+echo "=== D10-parity-inline-run-accepted ==="
+P="$TOPTMP/d10"; mk_tok "$P" github ok custom 'bash scripts/check-phase-gate.sh'
+assert_earns_ok D10-parity-inline-run-accepted "$P" \
+  '# D-A-PARITY-1-INLINE-RUN: bl147 freezes the block scalar byte-for-byte; a pre-block-scalar vintage is honest and must not be redded'
+
+# ── D11: parity difference 2 — an ABSENT step if: is accepted here ─────────
+echo "=== D11-parity-absent-step-if-accepted ==="
+P="$TOPTMP/d11"; mk_tok_wf "$P" "" "" yes emitted
+assert_earns_ok D11-parity-absent-step-if-accepted "$P" \
+  '# D-A-PARITY-2-ABSENT-IF: a step with no condition ALWAYS runs — the safest shape there is, and a red there would be backwards'
+
+# ── D12: parity difference 3 — the wider step key set is accepted here ─────
+echo "=== D12-parity-wider-step-keyset-accepted ==="
+P="$TOPTMP/d12"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        id: phase-gate
+        shell: bash
+        working-directory: .
+        timeout-minutes: 10" yes emitted
+assert_earns_ok D12-parity-wider-step-keyset-accepted "$P" \
+  '# D-A-PARITY-3-STEP-KEYSET: none of id/shell/working-directory/timeout-minutes can change how the verdict is graded'
+
+# ── D13: every recorded parity difference is still recorded, both sides ────
+echo "=== D13-parity-differences-are-recorded ==="
+d13_missing=""
+for mk in D-A-PARITY-1-INLINE-RUN D-A-PARITY-2-ABSENT-IF D-A-PARITY-3-STEP-KEYSET D-A-PARITY-4-NO-TRIGGER-PIN; do
+  grep -qF "# $mk" "$CHECK_GATE" || d13_missing="$d13_missing check-gate.sh:$mk"
+done
+# …and the bl147 counterparts each difference is a difference FROM. If one of
+# these disappears the asymmetry note is describing a pin that no longer exists,
+# which is how a "deliberate difference" quietly becomes an accident.
+for pin in Cw6-strict-keys Cw6-strict-gating Cw6-strict-job Cw6-strict-trigger; do
+  grep -qF "$pin" "$BL147" || d13_missing="$d13_missing bl147:$pin"
+done
+if [ -z "$d13_missing" ]; then
+  pass "D13-parity-differences-are-recorded (all four asymmetries named in the product, all four bl147 counterparts still present)"
+else
+  fail_ "D13-parity-differences-are-recorded" "a recorded parity difference or its bl147 counterpart is gone — the asymmetry is now accidental:$d13_missing"
+fi
+
+# ── D14: the SHARED vocabulary is one vocabulary ───────────────────────────
+# Both sides are extracted from their own file at runtime and compared, rather
+# than re-typed here as a third copy that could agree with neither.
+echo "=== D14-parity-shared-vocabulary-agrees ==="
+cg_inv=$(sed -n "s/^  local wf_allow_invoke='\(.*\)'\$/\1/p" "$CHECK_GATE" | head -1)
+cg_guard=$(sed -n "s/^  local wf_allow_guard='\(.*\)'\$/\1/p" "$CHECK_GATE" | head -1)
+cg_if=$(sed -n 's/^  local wf_allow_if="\(.*\)"$/\1/p' "$CHECK_GATE" | head -1)
+b7_guard=$(sed -n "s/^W6_EXPECTED_BODY='\(.*\)\$/\1/p" "$BL147" | head -1)
+b7_inv=$(sed -n "/^W6_EXPECTED_BODY=/,/'\$/p" "$BL147" | tail -1 | sed "s/'\$//")
+b7_if=$(sed -n 's/^W6_EXPECTED_IF="\(.*\)"$/\1/p' "$BL147" | head -1)
+d14_why=""
+[ -n "$cg_inv" ] && [ -n "$cg_guard" ] && [ -n "$cg_if" ] \
+  || d14_why="$d14_why; a check-gate.sh literal did not extract (inv=[$cg_inv] guard=[$cg_guard] if=[$cg_if])"
+[ -n "$b7_inv" ] && [ -n "$b7_guard" ] && [ -n "$b7_if" ] \
+  || d14_why="$d14_why; a bl147 literal did not extract (inv=[$b7_inv] guard=[$b7_guard] if=[$b7_if])"
+[ "$cg_inv" = "$b7_inv" ]     || d14_why="$d14_why; invocation differs ([$cg_inv] vs [$b7_inv])"
+[ "$cg_guard" = "$b7_guard" ] || d14_why="$d14_why; existence guard differs ([$cg_guard] vs [$b7_guard])"
+[ "$cg_if" = "$b7_if" ]       || d14_why="$d14_why; allowlisted if: differs ([$cg_if] vs [$b7_if])"
+if [ -z "$d14_why" ]; then
+  pass "D14-parity-shared-vocabulary-agrees (invocation, existence guard and allowlisted if: are byte-identical across both detectors)"
+else
+  fail_ "D14-parity-shared-vocabulary-agrees" "the two detectors no longer speak one vocabulary$d14_why"
+fi
+
+# ════════════════════════════════════════════════════════════════════════════
+# DM1-DM8 — the other direction. Each mutant neuters ONE line and the false
+# claim comes back. mk_cg_mutant asserts the harness standard for every one of
+# them: sites==1 for the anchored end-of-line marker, exactly-N-lines-changed,
+# a lib-complete copy, and `bash -n` on the result — a mutant that merely fails
+# to parse proves nothing. Each gets a FRESH fixture.
+# ════════════════════════════════════════════════════════════════════════════
+
+echo "=== DM1-maps-gate-carries-D2 ==="
+P="$TOPTMP/dm1"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" no emitted
+assert_mutant_false_ok DM1-maps-gate-carries-D2 mapsgate \
+  '# D-A-MAPS-GATE$' '/# D-A-MAPS-GATE$/d' 1 0 \
+  "$P" "does not map SOIF_PROTECTION_TOKEN yet" \
+  'without the maps term an unmapped workflow is told the next push enforces'
+
+echo "=== DM2-invokes-gate-carries-D1 ==="
+P="$TOPTMP/dm2"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD" yes nogate
+assert_mutant_false_ok DM2-invokes-gate-carries-D1 invokesgate \
+  '# D-A-INVOKES-GATE$' '/# D-A-INVOKES-GATE$/d' 1 0 \
+  "$P" "INVOKES the phase gate" \
+  'without the invokes term a workflow that runs NO gate is told the next push enforces — defect 1, reproduced'
+
+echo "=== DM3-swallows-gate-carries-D3 ==="
+P="$TOPTMP/dm3"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        continue-on-error: true" yes emitted
+assert_mutant_false_ok DM3-swallows-gate-carries-D3 swallowsgate \
+  '# D-A-SWALLOWS-GATE$' '/# D-A-SWALLOWS-GATE$/d' 1 0 \
+  "$P" "carries 'continue-on-error: true'" \
+  'without the swallows term a step graded green regardless of the verdict is told the next push enforces — defect 2, reproduced'
+
+echo "=== DM4-step-coe-verdict-carries-D3 ==="
+P="$TOPTMP/dm4"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        continue-on-error: true" yes emitted
+assert_mutant_false_ok DM4-step-coe-verdict-carries-D3 stepcoe \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-STEP-COE-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-STEP-COE-VERDICT$@\1:@' 1 1 \
+  "$P" "carries 'continue-on-error: true'" \
+  'the continue-on-error arm, not something else, is what refuses D3'
+
+echo "=== DM5-step-if-verdict-carries-D4 ==="
+P="$TOPTMP/dm5"; mk_tok_wf "$P" "" "        if: false" yes emitted
+assert_mutant_false_ok DM5-step-if-verdict-carries-D4 stepif \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-STEP-IF-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-STEP-IF-VERDICT$@\1:@' 1 1 \
+  "$P" "condition is 'if: false'" \
+  'the if: allowlist, not the key allowlist, is what refuses D4'
+
+echo "=== DM6-step-key-verdict-carries-D5 ==="
+P="$TOPTMP/dm6"; mk_tok_wf "$P" "" "$STEP_KEYS_GOOD
+        on-failure: continue" yes emitted
+assert_mutant_false_ok DM6-step-key-verdict-carries-D5 stepkey \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-STEP-KEY-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-STEP-KEY-VERDICT$@\1:@' 1 1 \
+  "$P" "does not recognise: on-failure" \
+  'the step key allowlist is what refuses the unimagined sibling'
+
+echo "=== DM7-job-verdict-carries-D6 ==="
+P="$TOPTMP/dm7"; mk_tok_wf "$P" "    if: false" "$STEP_KEYS_GOOD" yes emitted
+assert_mutant_false_ok DM7-job-verdict-carries-D6 jobverdict \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-JOB-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-JOB-VERDICT$@\1:@' 1 1 \
+  "$P" "The job that HOLDS the phase-gate step carries 'if: false'" \
+  'the job-level arm is what refuses D6 — a step-scoped detector alone is blind to it'
+
+echo "=== DM8-unlocated-verdict-carries-D8 ==="
+P="$TOPTMP/dm8"; mk_tok "$P" github ok yes
+printf 'runs:\n  using: composite\n  steps:\n    - name: Governance - Phase gate check\n      env:\n        GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}\n      run: |\n        if [ ! -f scripts/check-phase-gate.sh ]; then\n          echo "::error::Phase gate check script missing. Framework integrity compromised."\n          exit 1\n        fi\n        bash scripts/check-phase-gate.sh\n' \
+  > "$P/.github/workflows/ci.yml"
+assert_mutant_false_ok DM8-unlocated-verdict-carries-D8 unlocated \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-UNLOCATED-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-UNLOCATED-VERDICT$@\1:@' 1 1 \
+  "$P" "Could not locate the job that runs the gate" \
+  'without the fail-closed arm an unreadable structure is told the next push enforces'
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -1466,6 +1466,12 @@ assert_earns_ok D30-quoted-job-id-clean-job-still-earns "$P" \
 
 # ── D31-D34: R-CTE-1, the lone-dash sequence item, in BOTH directions ──────
 echo "=== D31-lone-dash-step-hides-swallow ==="
+# The secret is mapped at JOB level here, not on the step. That is deliberate
+# and it is what makes DM17 isolate one line: with the climb narrowed back, the
+# scan binds to `Setup`, and a step-level mapping would then make it fail on
+# `maps` — refusing for a second reason and proving nothing about the climb.
+# Mapped at job level, every step inherits it, so the ONLY thing the mutant
+# changes is which step's keys are read.
 P="$TOPTMP/d31"; mk_raw_wf "$P" <<'YML'
 name: CI
 on:
@@ -1475,14 +1481,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
     steps:
       - name: Setup
         run: echo hi
       -
         name: Governance - Phase gate check
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: |
           bash scripts/check-phase-gate.sh
 YML
@@ -2251,14 +2257,14 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
     steps:
       - name: Setup
         run: echo hi
       -
         name: Governance - Phase gate check
         continue-on-error: true
-        env:
-          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
         run: |
           bash scripts/check-phase-gate.sh
 YML

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -2217,6 +2217,400 @@ assert_earns_ok D54b-heredoc-residual-behaves-as-recorded "$P" \
   'RECORDED RESIDUAL, not an endorsement: the floor still counts a gate line that is heredoc DATA. Pinned so that closing it is a deliberate change with its own proof'
 
 # ════════════════════════════════════════════════════════════════════════════
+# ROUND 3 — the scope report is a GRAMMAR, and MAPSCOPE re-emits raw run-body
+# lines into the very stream the verdict greps read.
+#
+# The round-2 report argued that the `-x` flags on the greps that read
+# _wf_gate_scope's report "cannot change a verdict", on the structural grounds
+# that `STEP none` / `JOB none` are terminal and that a proper superstring of
+# `STEPKEY continue-on-error` would be refused as an unrecognised key anyway.
+# That argument overlooked `MAPSCOPE`, which prints RAW LINES of the gate step's
+# own block — its `run:` body included — into the same stream. A gate step whose
+# command echoes any sentinel token then matches a NON-anchored grep, and every
+# one of those greps turns a correctly-wired workflow into a refusal. The atoms
+# are anchors against this function's OWN output, not merely against structure.
+#
+# ONE fixture carries every sentinel in the grammar, which is the stronger
+# statement: a legitimate workflow that names the whole report vocabulary in its
+# command still earns the claim, and each mutant below removes exactly one
+# anchor and gets exactly one named refusal back. An argument is not a
+# measurement — this is the measurement.
+mk_sentinel_wf() {
+  mk_raw_wf "$1" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          echo "scope grammar: STEP none"
+          echo "scope grammar: JOB none"
+          echo "scope grammar: STEPKEY continue-on-error"
+          echo "scope grammar: STEPKEY if"
+          echo "scope grammar: STEPKEY shell"
+          echo "scope grammar: STEPMERGE <<: *soft"
+          echo "scope grammar: JOBMERGE <<: *soft"
+          echo "scope grammar: STEPOPAQUE !!str continue-on-error: true"
+          echo "scope grammar: JOBOPAQUE ? continue-on-error"
+          bash scripts/check-phase-gate.sh
+YML
+}
+# The step deliberately carries NEITHER `if:` NOR `shell:`. Both are permitted
+# absent (# D-A-PARITY-2-ABSENT-IF, and an absent shell is the documented
+# default), and only their ABSENCE makes the two `STEPKEY` sentinels decisive:
+# with a real `if:` present the count is already 1 and the mutant proves nothing.
+echo "=== D59-report-grammar-in-a-run-body-still-earns ==="
+P="$TOPTMP/d59"; mk_sentinel_wf "$P"
+assert_earns_ok D59-report-grammar-in-a-run-body-still-earns "$P" \
+  'a correctly-wired gate step may echo every sentinel token of the scope-report grammar; the anchors are what keep MAPSCOPE re-emission from being read as structure'
+
+# ── D60-D63: node tags and explicit keys — the fail-open the key guard left ──
+# `emit()` skips any line that is not a plain `key:`, so a key written with a
+# YAML node tag (`!!str continue-on-error: true`) or in explicit-key form
+# (`? continue-on-error` / `: true`) was never reported at all and the swallow
+# was invisible. SETTLED, not assumed, and it settles the same way under both
+# readings of GitHub's parser:
+#   • PyYAML 6.0.3 loads all four spellings below as a REAL
+#     `continue-on-error: true` at the level written (measured, not argued);
+#   • the public `actions/runner` YAML reader
+#     (src/Sdk/DTPipelines/Pipelines/ObjectTemplating/YamlObjectReader.cs)
+#     HONOURS the five standard scalar tags — `tag:yaml.org,2002:str` among them
+#     — so a tagged key is a real key to Actions too, while an explicit key
+#     reaches no handler at all and errors out.
+# Honoured ⇒ a real swallow. Rejected ⇒ the workflow does not run, so "the next
+# push enforces the check" is false twice over. The verdict does not depend on
+# which, so it is decided rather than guessed: fail CLOSED with its own cause.
+OPAQUE_SIG="cannot read as a key"
+echo "=== D60-tagged-step-key-withheld ==="
+P="$TOPTMP/d60"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        !!str continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D60-tagged-step-key-withheld "$P" "$OPAQUE_SIG" \
+  'a node tag on the key is the same key to a YAML parser, so the step is soft and the claim was earned'
+
+echo "=== D61-explicit-step-key-withheld ==="
+P="$TOPTMP/d61"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        ? continue-on-error
+        : true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D61-explicit-step-key-withheld "$P" "$OPAQUE_SIG" \
+  'the explicit-key form is the same mapping entry, and Actions own reader errors on it — unearned either way'
+
+echo "=== D62-tagged-job-key-withheld ==="
+P="$TOPTMP/d62"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    !!str continue-on-error: true
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D62-tagged-job-key-withheld "$P" "$OPAQUE_SIG" \
+  'the same evasion one level up — the JOB is soft and the step below it cannot enforce'
+
+echo "=== D63-explicit-job-key-withheld ==="
+P="$TOPTMP/d63"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    ? continue-on-error
+    : true
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D63-explicit-job-key-withheld "$P" "$OPAQUE_SIG" \
+  'explicit key at job level, same disposition'
+
+# ── D64-D70: the FOURTH condition — the step's shell must fail fast ──────────
+# R-CTE-8, Karl 2026-08-10. `shell:` was allowlisted as a documented run-step
+# key on the false ground that it "cannot change how the step's verdict is
+# graded". It is the one key on that list that decides exactly that. Per
+# GitHub's own workflow syntax reference ("Exit codes and error action
+# preference"): for the BUILT-IN `bash` and `sh` keywords GitHub enforces
+# fail-fast with `set -e` (bash also `-o pipefail`), and "you can override these
+# defaults by providing a custom shell template string". Under a custom template
+# such as `shell: bash {0}` the script runs bare, so a FAILING
+# `bash scripts/check-phase-gate.sh` no longer aborts and any line after it sets
+# the step's exit code to 0 — the gate's verdict is discarded exactly as
+# `continue-on-error: true` discards it, and the file was told the next push
+# enforces the check.
+SHELL_SIG="which GitHub does not run with 'set -e'"
+echo "=== D64-custom-shell-template-withheld ==="
+P="$TOPTMP/d64"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: bash {0}
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+          echo "gate done"
+YML
+assert_withheld D64-custom-shell-template-withheld "$P" "$SHELL_SIG" \
+  'a custom template runs the script with no -e, so the trailing echo grades a FAILED gate as success'
+
+echo "=== D65-non-fail-fast-keyword-withheld ==="
+P="$TOPTMP/d65"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: python
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_withheld D65-non-fail-fast-keyword-withheld "$P" "$SHELL_SIG" \
+  'an ALLOWLIST, not a blacklist: python is a documented keyword and it is still refused, because it is not documented fail-fast for this body'
+
+echo "=== D66-shell-bash-still-earns ==="
+P="$TOPTMP/d66"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D66-shell-bash-still-earns "$P" \
+  'the built-in bash keyword is documented with set -e -o pipefail — writing it out explicitly must not be a red'
+
+echo "=== D67-shell-sh-still-earns ==="
+P="$TOPTMP/d67"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: sh
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D67-shell-sh-still-earns "$P" \
+  'sh is documented with set -e as well, and the allowlist is the documented fail-fast set rather than one favoured spelling'
+
+# The same vector one LEVEL UP. `defaults.run.shell` sets the interpreter for
+# every run step of a job (or of the whole workflow) with no `shell:` key on the
+# step at all, so a detector that reads only the step key would have shipped a
+# condition anyone could step around by moving one line. Handled by precedence
+# rather than by a blanket refusal: step > job defaults > workflow defaults.
+echo "=== D68-job-defaults-shell-withheld ==="
+P="$TOPTMP/d68"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash {0}
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+          echo "gate done"
+YML
+assert_withheld D68-job-defaults-shell-withheld "$P" "the job's 'defaults.run.shell' is 'bash {0}'" \
+  'the job default reaches the gate step with no shell: key on the step, and it is the same swallow'
+
+echo "=== D69-workflow-defaults-shell-withheld ==="
+P="$TOPTMP/d69"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash {0}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+          echo "gate done"
+YML
+assert_withheld D69-workflow-defaults-shell-withheld "$P" "the workflow's 'defaults.run.shell' is 'bash {0}'" \
+  'and again at workflow level, which no step-scoped read would ever see'
+
+echo "=== D70-step-shell-overrides-a-bad-job-default ==="
+P="$TOPTMP/d70"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash {0}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash {0}
+    steps:
+      - name: Governance - Phase gate check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D70-step-shell-overrides-a-bad-job-default "$P" \
+  'PRECEDENCE, not a blanket refusal: the step key wins over both defaults blocks, so a file that is actually fail-fast is not a false red'
+
+# ── D71 / D72: two more recorded residuals, in the product and pinned ────────
+# Same treatment as # D-A-RESIDUAL-HEREDOC-DATA: the marker lives in the code so
+# the next reader meets it, and the behaviour it describes is ASSERTED, so
+# closing one is a deliberate change with its own proof rather than a surprise.
+echo "=== D71-env-shadow-residual-is-recorded ==="
+grep -qF '# D-A-RESIDUAL-ENV-SHADOW' "$CHECK_GATE" \
+  && pass "D71-env-shadow-residual-is-recorded (the presence-test blind spot is named where MAPSCOPE is built)" \
+  || fail_ "D71-env-shadow-residual-is-recorded" "the env-shadow residual is no longer recorded — a known fail-open becomes an undocumented one"
+P="$TOPTMP/d71"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+env:
+  GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_earns_ok D71b-env-shadow-behaves-as-recorded "$P" \
+  'RECORDED RESIDUAL, not an endorsement: maps is a PRESENCE test over the union of the three scopes, so a step-level GH_TOKEN that SHADOWS the workflow-level mapping is invisible to it'
+
+echo "=== D72-run-body-disarm-residual-is-recorded ==="
+grep -qF '# D-A-RESIDUAL-RUN-BODY-DISARM' "$CHECK_GATE" \
+  && pass "D72-run-body-disarm-residual-is-recorded (the OK sentence does not silently overclaim for bash control flow)" \
+  || fail_ "D72-run-body-disarm-residual-is-recorded" "the run-body residual is gone — the shell condition would read as more than it is"
+P="$TOPTMP/d72"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          set +e
+          bash scripts/check-phase-gate.sh
+          exit 0
+YML
+assert_earns_ok D72b-run-body-disarm-behaves-as-recorded "$P" \
+  'RECORDED RESIDUAL: `set +e` … `exit 0` inside the run body disarms the gate with a fail-fast shell and a byte-exact invocation. Telling code from data in a run body needs a bash lexer — same difficulty as # D-A-RESIDUAL-HEREDOC-DATA, and the reason BL-218 exists'
+
+# ════════════════════════════════════════════════════════════════════════════
 # DM1-DM8 — the other direction. Each mutant neuters ONE line and the false
 # claim comes back. mk_cg_mutant asserts the harness standard for every one of
 # them: sites==1 for the anchored end-of-line marker, exactly-N-lines-changed,
@@ -2684,6 +3078,300 @@ assert_mutant_drops_cause DM26-invokes-whole-line-carries-D53 invwholeline \
   's@grep -cxF -- "\$wf_allow_invoke" || true)   # D-A-INVOKES-WHOLE-LINE$@grep -cF -- "$wf_allow_invoke" || true)@' 1 1 \
   "$P" "INVOKES the phase gate" \
   'drop the whole-line anchor and a swallowed line COUNTS as an invocation: the verdict survives on the deviation scan alone, but the user loses one of the two edits they need'
+
+# ════════════════════════════════════════════════════════════════════════════
+# DM27-DM35 — the scope-report anchors. ONE fixture (mk_sentinel_wf, D59), nine
+# mutants, each removing exactly ONE anchor character and each getting exactly
+# ONE named refusal back on a workflow that is correctly wired. These are the
+# INVERTED direction — the atoms prevent a false RED — so assert_mutant_refuses
+# is the right assertion and the named cause is what proves the mutant did not
+# simply break something else. The round-2 report claimed these atoms "cannot
+# change a verdict"; every one of them can, and this is the measurement.
+# ════════════════════════════════════════════════════════════════════════════
+
+echo "=== DM27-scope-anchor-step-none-carries-D59 ==="
+P="$TOPTMP/dm27"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM27-scope-anchor-step-none-carries-D59 anchstepnone \
+  '# D-A-SCOPE-GRAMMAR-STEP-NONE$' \
+  's@grep -qx \(.\)STEP none\(.\)\(.*\)# D-A-SCOPE-GRAMMAR-STEP-NONE$@grep -q \1STEP none\2\3# D-A-SCOPE-GRAMMAR-STEP-NONE@' 1 1 \
+  "$P" "Could not locate the step that runs the gate" \
+  'drop -x and a run body that echoes the sentinel is re-read as MAPSCOPE structure: the step is reported unlocatable and a correct file is refused'
+
+echo "=== DM28-scope-anchor-job-none-carries-D59 ==="
+P="$TOPTMP/dm28"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM28-scope-anchor-job-none-carries-D59 anchjobnone \
+  '# D-A-SCOPE-GRAMMAR-JOB-NONE$' \
+  's@grep -qx \(.\)JOB none\(.\)\(.*\)# D-A-SCOPE-GRAMMAR-JOB-NONE$@grep -q \1JOB none\2\3# D-A-SCOPE-GRAMMAR-JOB-NONE@' 1 1 \
+  "$P" "Could not locate the job that runs the gate" \
+  'same one level up — terminality does not save it, because MAPSCOPE lines are printed by a DIFFERENT exit path than the one that prints JOB none'
+
+echo "=== DM29-scope-anchor-stepkey-coe-carries-D59 ==="
+P="$TOPTMP/dm29"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM29-scope-anchor-stepkey-coe-carries-D59 anchstepcoe \
+  '# D-A-SCOPE-GRAMMAR-STEPKEY-COE$' \
+  's@grep -cx \(.\)STEPKEY continue-on-error\(.\)\(.*\)# D-A-SCOPE-GRAMMAR-STEPKEY-COE$@grep -c \1STEPKEY continue-on-error\2\3# D-A-SCOPE-GRAMMAR-STEPKEY-COE@' 1 1 \
+  "$P" "which grades a FAILED step as success" \
+  'the superstring argument was answered with the wrong stream: a MAPSCOPE line CONTAINS the token without being a step key at all'
+
+echo "=== DM30-scope-anchor-stepkey-if-carries-D59 ==="
+P="$TOPTMP/dm30"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM30-scope-anchor-stepkey-if-carries-D59 anchstepif \
+  '# D-A-SCOPE-GRAMMAR-STEPKEY-IF$' \
+  's@grep -cx \(.\)STEPKEY if\(.\)\(.*\)# D-A-SCOPE-GRAMMAR-STEPKEY-IF$@grep -c \1STEPKEY if\2\3# D-A-SCOPE-GRAMMAR-STEPKEY-IF@' 1 1 \
+  "$P" "which is not the one this framework ships" \
+  'and the file is then told its own ABSENT condition is the wrong condition — the self-refuting refusal the CRLF fix removed once already'
+
+echo "=== DM31-scope-anchor-stepkey-shell-carries-D59 ==="
+P="$TOPTMP/dm31"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM31-scope-anchor-stepkey-shell-carries-D59 anchstepshell \
+  '# D-A-SCOPE-GRAMMAR-STEPKEY-SHELL$' \
+  's@grep -cx \(.\)STEPKEY shell\(.\)\(.*\)# D-A-SCOPE-GRAMMAR-STEPKEY-SHELL$@grep -c \1STEPKEY shell\2\3# D-A-SCOPE-GRAMMAR-STEPKEY-SHELL@' 1 1 \
+  "$P" "$SHELL_SIG" \
+  'the FOURTH condition reads the same grammar and inherits the same trap — pinned when it was written, not three rounds later'
+
+echo "=== DM32-scope-anchor-stepmerge-carries-D59 ==="
+P="$TOPTMP/dm32"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM32-scope-anchor-stepmerge-carries-D59 anchstepmerge \
+  '# D-A-SCOPE-GRAMMAR-STEPMERGE$' \
+  's@grep -q \(.\)\(.\)STEPMERGE \(.\)\(.*\)# D-A-SCOPE-GRAMMAR-STEPMERGE$@grep -q \1STEPMERGE \3\4# D-A-SCOPE-GRAMMAR-STEPMERGE@' 1 1 \
+  "$P" "A YAML merge key on the gate's step" \
+  'the ^ anchors are the same class as the -x flags, and nobody named these two: measured, then pinned'
+
+echo "=== DM33-scope-anchor-jobmerge-carries-D59 ==="
+P="$TOPTMP/dm33"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM33-scope-anchor-jobmerge-carries-D59 anchjobmerge \
+  '# D-A-SCOPE-GRAMMAR-JOBMERGE$' \
+  's@grep -q \(.\)\(.\)JOBMERGE \(.\)\(.*\)# D-A-SCOPE-GRAMMAR-JOBMERGE$@grep -q \1JOBMERGE \3\4# D-A-SCOPE-GRAMMAR-JOBMERGE@' 1 1 \
+  "$P" "A YAML merge key on the gate's job" \
+  'and its sibling'
+
+echo "=== DM34-scope-anchor-stepopaque-carries-D59 ==="
+P="$TOPTMP/dm34"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM34-scope-anchor-stepopaque-carries-D59 anchstepopaque \
+  '# D-A-SCOPE-GRAMMAR-STEPOPAQUE$' \
+  's@grep -q \(.\)\(.\)STEPOPAQUE \(.\)\(.*\)# D-A-SCOPE-GRAMMAR-STEPOPAQUE$@grep -q \1STEPOPAQUE \3\4# D-A-SCOPE-GRAMMAR-STEPOPAQUE@' 1 1 \
+  "$P" "$OPAQUE_SIG" \
+  'the new arm ships with its anchor pinned, so the grammar cannot grow another hole quietly'
+
+echo "=== DM35-scope-anchor-jobopaque-carries-D59 ==="
+P="$TOPTMP/dm35"; mk_sentinel_wf "$P"
+assert_mutant_refuses DM35-scope-anchor-jobopaque-carries-D59 anchjobopaque \
+  '# D-A-SCOPE-GRAMMAR-JOBOPAQUE$' \
+  's@grep -q \(.\)\(.\)JOBOPAQUE \(.\)\(.*\)# D-A-SCOPE-GRAMMAR-JOBOPAQUE$@grep -q \1JOBOPAQUE \3\4# D-A-SCOPE-GRAMMAR-JOBOPAQUE@' 1 1 \
+  "$P" "$OPAQUE_SIG" \
+  'and its sibling'
+
+# ════════════════════════════════════════════════════════════════════════════
+# DM36-DM43 — the two new arms: the opaque key shapes and the FOURTH condition.
+# Every mutant that edits the awk program inside _wf_gate_scope is driven
+# against the ordinary-spelling control as well, because `bash -n` cannot tell a
+# live awk program from a dead one and a dead one prints the false OK.
+# ════════════════════════════════════════════════════════════════════════════
+
+echo "=== DM36-opaque-key-carries-D60 ==="
+P="$TOPTMP/dm36"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        !!str continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok_ctl DM36-opaque-key-carries-D60 opaquekey \
+  '# D-A-OPAQUE-KEY$' '/# D-A-OPAQUE-KEY$/d' 1 0 \
+  "$P" "$OPAQUE_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'without the report the tagged key is not a key at all, the swallow is unseen and the claim comes back'
+
+echo "=== DM37-opaque-verdict-carries-D60 ==="
+P="$TOPTMP/dm37"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        ? continue-on-error
+        : true
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_false_ok DM37-opaque-verdict-carries-D60 opaqueverdict \
+  '^[[:space:]]*wf_swallows=1[[:space:]]*# D-A-OPAQUE-VERDICT$' \
+  's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-OPAQUE-VERDICT$@\1:@' 1 1 \
+  "$P" "$OPAQUE_SIG" \
+  'reporting the shape without failing closed on it is the silent-ignore this whole surface keeps re-learning'
+
+echo "=== DM38-failfast-gate-carries-D64 ==="
+P="$TOPTMP/dm38"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: bash {0}
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+          echo "gate done"
+YML
+assert_mutant_false_ok DM38-failfast-gate-carries-D64 failfastgate \
+  '# D-A-FAILFAST-GATE$' '/# D-A-FAILFAST-GATE$/d' 1 0 \
+  "$P" "$SHELL_SIG" \
+  'ONE TERM PER LINE: neuter the fourth term alone and the custom-template file is told the next push enforces the check — R-CTE-8, reproduced'
+
+echo "=== DM39-shell-value-carries-D66 ==="
+P="$TOPTMP/dm39"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_refuses DM39-shell-value-carries-D66 shellvalue \
+  '# D-A-SHELL-VALUE$' '/# D-A-SHELL-VALUE$/d' 1 0 \
+  "$P" "$SHELL_SIG" \
+  'stop emitting the value and presence alone survives, so an explicitly CORRECT shell: bash is refused — the arm fails closed on its own blindness, which is right, and that is exactly why the emission has to be pinned separately'
+
+echo "=== DM40-defaults-job-carries-D68 ==="
+P="$TOPTMP/dm40"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash {0}
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+          echo "gate done"
+YML
+assert_mutant_false_ok_ctl DM40-defaults-job-carries-D68 defaultsjob \
+  '# D-A-DEFAULTS-JOB$' '/# D-A-DEFAULTS-JOB$/d' 1 0 \
+  "$P" "$SHELL_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'without the job defaults walk the condition is bypassable by moving one line up one level — the shape a step-scoped read can never see'
+
+echo "=== DM41-defaults-wf-carries-D69 ==="
+P="$TOPTMP/dm41"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash {0}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+          echo "gate done"
+YML
+assert_mutant_false_ok_ctl DM41-defaults-wf-carries-D69 defaultswf \
+  '# D-A-DEFAULTS-WF$' '/# D-A-DEFAULTS-WF$/d' 1 0 \
+  "$P" "$SHELL_SIG" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'and the workflow-level block, which is not even inside the job the scan reads'
+
+echo "=== DM42-shell-allowlist-carries-D67 ==="
+P="$TOPTMP/dm42"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Governance - Phase gate check
+        shell: sh
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_refuses DM42-shell-allowlist-carries-D67 shellallow \
+  '# D-A-SHELL-ALLOWLIST$' \
+  's@bash|sh) ;;\(.*\)# D-A-SHELL-ALLOWLIST$@bash) ;;\1# D-A-SHELL-ALLOWLIST@' 1 1 \
+  "$P" "$SHELL_SIG" \
+  'narrow the allowlist by one documented fail-fast keyword and a legitimate sh step is refused — the WIDTH of the set is contract, not just its existence'
+
+echo "=== DM43-shell-precedence-step-carries-D70 ==="
+P="$TOPTMP/dm43"; mk_raw_wf "$P" <<'YML'
+name: CI
+on:
+  push:
+    branches: [main]
+
+defaults:
+  run:
+    shell: bash {0}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash {0}
+    steps:
+      - name: Governance - Phase gate check
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          bash scripts/check-phase-gate.sh
+YML
+assert_mutant_refuses DM43-shell-precedence-step-carries-D70 shellprec \
+  '# D-A-SHELL-PRECEDENCE-STEP$' '/# D-A-SHELL-PRECEDENCE-STEP$/d' 1 0 \
+  "$P" "$SHELL_SIG" \
+  'the arms are written LAST-WINS in GitHub precedence order, so deleting the step arm lets a job default outrank the key that actually governs and a fail-fast file is falsely refused'
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"

--- a/tests/test-walk006-ci-protection-scope.sh
+++ b/tests/test-walk006-ci-protection-scope.sh
@@ -1335,6 +1335,64 @@ assert_withheld D27-alias-step-fails-closed "$P" \
   "Could not locate the step that runs the gate" \
   'an aliased step keeps its configuration outside the block, and the existing fail-closed arm already refuses it'
 
+# ── D28-D30: the same evasion ONE LEVEL UP, in the job LOCATOR ─────────────
+# Found while probing the residual surface of R-dA-2, and the worst of the set
+# because it fails OPEN. Locating the job was a climb for the nearest line
+# matching /^ +[A-Za-z_][A-Za-z0-9_-]*: *$/, and a line it could not read was
+# SKIPPED rather than stopped at — so a quoted job id sent it climbing out of
+# `jobs:` entirely and it bound "the job" to `push:` inside the `on:` block.
+# Observed directly: the scope report for such a file reads `JOBKEY branches`.
+# It then scanned the TRIGGER for job-level swallows, found none, and awarded
+# the claim while a real `continue-on-error: true` on the actual job was never
+# read. The fix is to stop at the nearest ENCLOSING line and fail closed when it
+# is not a readable job id — guessing further is what produced this.
+JOB_ID_FIXTURE_HEAD='name: CI
+on:
+  push:
+    branches: [main]
+
+jobs:'
+JOB_ID_FIXTURE_TAIL="    steps:
+      - name: Governance - Phase gate check
+$STEP_KEYS_GOOD
+        env:
+          GH_TOKEN: \${{ secrets.SOIF_PROTECTION_TOKEN }}
+        run: |
+          if [ ! -f scripts/check-phase-gate.sh ]; then
+            echo \"::error::Phase gate check script missing. Framework integrity compromised.\"
+            exit 1
+          fi
+          bash scripts/check-phase-gate.sh"
+# mk_jobid_wf <dir> <job-id-line> <job-keys-or-empty>
+mk_jobid_wf() {
+  local d="$1" idline="$2" jobkeys="${3:-}"
+  mk_tok "$d" github ok yes || return 1
+  {
+    printf '%s\n' "$JOB_ID_FIXTURE_HEAD"
+    printf '%s\n' "$idline"
+    [ -n "$jobkeys" ] && printf '%s\n' "$jobkeys"
+    printf '    runs-on: ubuntu-latest\n'
+    printf '%s\n' "$JOB_ID_FIXTURE_TAIL"
+  } > "$d/.github/workflows/ci.yml"
+}
+
+echo "=== D28-quoted-job-id-still-reads-the-job ==="
+P="$TOPTMP/d28"; mk_jobid_wf "$P" '  "test":' "    continue-on-error: true"
+assert_withheld D28-quoted-job-id-still-reads-the-job "$P" \
+  "so that job's failure does not count" \
+  'a quoted job id must not make the job unreadable — the swallow on it is a real swallow'
+
+echo "=== D29-unreadable-job-id-fails-closed ==="
+P="$TOPTMP/d29"; mk_jobid_wf "$P" '  test: &jobdefaults' ""
+assert_withheld D29-unreadable-job-id-fails-closed "$P" \
+  "Could not locate the job that runs the gate" \
+  'an id line that is not a plain job id must STOP the search, not send it climbing into the on: block'
+
+echo "=== D30-quoted-job-id-clean-job-still-earns ==="
+P="$TOPTMP/d30"; mk_jobid_wf "$P" '  "test":' ""
+assert_earns_ok D30-quoted-job-id-clean-job-still-earns "$P" \
+  'the locator must read the quoted id, not merely refuse it — failing every quoted job closed would be a false red'
+
 # ════════════════════════════════════════════════════════════════════════════
 # DM1-DM8 — the other direction. Each mutant neuters ONE line and the false
 # claim comes back. mk_cg_mutant asserts the harness standard for every one of
@@ -1478,6 +1536,14 @@ assert_mutant_false_ok "DM14-merge-verdict-carries-D25" mergeverdict \
   's@^\([[:space:]]*\)wf_swallows=1[[:space:]]*# D-A-MERGE-VERDICT$@\1:@' 1 1 \
   "$P" "$(merge_sig step)" \
   'without the fail-closed merge arm a step whose real configuration is in an anchor is told the next push enforces'
+
+echo "=== DM15-job-id-closed-carries-D29 ==="
+P="$TOPTMP/dm15"; mk_jobid_wf "$P" '  test: &jobdefaults' ""
+assert_mutant_false_ok_ctl DM15-job-id-closed-carries-D29 jobidclosed \
+  '# D-A-JOB-ID-CLOSED$' '/# D-A-JOB-ID-CLOSED$/d' 1 0 \
+  "$P" "Could not locate the job that runs the gate" \
+  "$DMCTL" "$DMCTL_SIG" \
+  'without the fail-closed job-id guard an unreadable enclosing line is scanned as if it were the job'
 
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"


### PR DESCRIPTION
## What this does

`check-gate.sh --setup-ci-token` printed one sentence after storing the secret:

> maps `SOIF_PROTECTION_TOKEN` into the phase-gate step AND lets the gate's exit
> code decide it. **The next push enforces the check.**

It printed that sentence without checking whether any of it was true. This branch
gates it on four conditions, **one term per line so each can be neutered alone** —
a single `&&` chain can only be broken all at once, which is how you get a proof
that never separated the conditions.

| condition | marker |
|---|---|
| the secret is actually mapped, over comment-stripped lines | `# D-A-MAPS-VERDICT` |
| at least one **executable** line IS the allowlisted invocation | `# D-A-INVOKES-VERDICT` |
| nothing swallows the step or the job | `# D-A-GATE-SCOPE-BEGIN` |
| the shell fails fast | `# D-A-FAILFAST-GATE` |

When a condition fails the claim is **withheld** and every failing condition gets
its own bullet naming the exact edit that clears it — not just the first one.
**The OK string is byte-identical** (`cmp`-verified against the base, 137 bytes),
so a correctly-wired project sees exactly what it saw before.

## Why this took three adversarial rounds

Every round found false OKs the previous one missed. That is the story of the
branch and it is worth reading before the diff.

**Round 1** — the brief named two; the implementer found a third (`maps` was an
unanchored regex over the whole file, so a *commented-out* example mapping earned
the claim) and, after review, a fourth: the job locator **failed open**. A quoted
job id sent it out of `jobs:` entirely, it bound "the job" to `push:` inside
`on:`, scanned the **trigger** for job-level swallows, found none, and awarded the
claim while a real `continue-on-error: true` on the actual job went unread.

**Round 2** — review found two more parser-valid spellings: a step written as a
bare `-` on its own line (the climb regex required a space after the dash, so it
read the *previous* step's keys), and `run: >`, where YAML folding joins `|| true`
onto the invocation so every line-wise check passes on lines that are each clean.

**Round 3** — review found something different in kind: **bash semantics inside
the `run:` body**. `shell: bash {0}` is a *custom template*, and GitHub's built-in
`bash` adds `set -e -o pipefail` while a custom template does not — so a failing
gate followed by any trailing command grades as success. Same defect as
`continue-on-error: true`, written in shell instead of in an Actions key. The code
comment justifying why `shell` was safe to allowlist was **provably false**, and
review confirmed it against current GitHub docs.

That is why the fourth condition exists, and why **BL-218** is filed: no amount of
YAML parsing reaches a `run:` body. The owner decided to close the `shell` vector
now and take canonical-shape-or-refuse as a designed follow-up rather than
improvise it here — the risk it carries is **false reds for users who
legitimately customised**, which is the direction that makes a tool get ignored.

## The verification was the weak part, not the code

Review found one unpinned atom — the invocation threshold, where `-ge 1` → `-ge 0`
survived the whole suite. Sweeping for siblings found **twelve more**. Then review
found four `grep -x` anchors the sweep's own write-up had argued "cannot change a
verdict"; the implementer reproduced all four independently and found **two more**
nobody had named. Their diagnosis of their own error is exact: the argument
reasoned about step *keys*, while the match that lands is a `MAPSCOPE` line that
is not a key at all.

Two harness invariants came out of it, both measured rather than assumed:

- **`bash -n` does not syntax-check awk.** A deliberately-broken awk mutant passes
  `bash -n` *and* produces the false OK, because a dead awk emits an empty scope
  report and empty reads as "nothing wrong". Every awk mutant is now driven
  against a control fixture that must still be refused. Four earlier proofs were
  passable by breaking awk rather than by breaking the thing under test.
- **An argument is not a measurement.** Applied three times on this stack this
  week, twice to this branch's own author.

## Verification

- `tests/test-walk006-ci-protection-scope.sh` — **158 passed, 0 failed**. Watched
  RED reproduced by review to the digit (131/27), including that all six
  pre-fix-green rows are genuine guards with their own mutants, not vacuous.
- Review planted **three mutations of its own** — a consumer-token typo, a widened
  allowlist, and a reordering of the shell-precedence arms. All three died in the
  PR-blocking lane.
- **D9**: all ten shipped templates still earn the claim. **0 hits** for `shell:`
  or `defaults:` across all ten.
- bl147 84/0 · check-gate 5/0 · f015-tamper-pin 19/0 · walk016 15/0 ·
  lint-tests-registered 24/0 · `run-lints` 15/15.
- Allowlist and precedence checked against current GitHub docs: `bash`/`sh`
  fail-fast, `cmd` documented as not supporting automatic fail-fast,
  `pwsh`/`powershell` fail-fast for PowerShell bodies (this framework emits a
  POSIX body). Precedence is most-specific-wins, step > job > workflow, and the
  **arm order itself** is pinned by test.

`defaults.run.shell` is **handled at all three levels, not recorded as a
residual** — a deliberate deviation from the brief. Recording it would have
shipped a condition bypassable by moving one line up one level.

## Recorded, not fixed

- `# D-A-RESIDUAL-RUN-BODY-DISARM` — `set +e` … `exit 0` in the body. Needs a bash
  lexer; BL-218 owns it.
- `# D-A-RESIDUAL-ENV-SHADOW` — `maps` is a presence test, so a step-level
  `GH_TOKEN` shadowing a workflow-level mapping is invisible. Pre-existing; the
  file-wide match this replaced had the identical blind spot.
- `# D-A-RESIDUAL-HEREDOC-DATA` — a byte-exact gate line inside a heredoc is data,
  and still satisfies the invokes floor.
- `# D-A-PARITY-4-NO-TRIGGER-PIN` — untouched, still the owner's separate open
  call.

**The OK sentence is falsified by the first two shapes.** That is stated plainly
rather than papered over: both are pinned in both halves (marker presence *and*
behaviour), both are named in the product where the next reader meets them, and
BL-218 explicitly owns the sentence's future including a possible third
"unverified" verdict.

## Also in this PR

- **BL-218** — the design fork, with a subsumption table that marks the
  env-shadow residual "Partly" rather than claiming it, and names C's false-red
  risk as the reason not to improvise it. Carries the anchors finding: GitHub's
  docs now recommend YAML anchors while `actions/runner` still throws "Anchors are
  not currently supported" — no verdict changes, but the false-red population C
  must be measured against does.
- **A CI shard pin.** This suite grew 87s → 118s across the three rounds and the
  complement leg was at 598s against a 720s cap. Per the doctrine in that file,
  approaching the cap is the re-pin signal. Membership is unchanged — the file
  stays in the canonical `tests=(` array; the pin array only decides which shard
  claims it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
