### PR TITLE
feat(brownfield): WP5b — the test-debt ledger and its tier ratchet

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -514,6 +514,7 @@ jobs:
             tests/test-brownfield-wp2-scout-sections.sh
             tests/test-brownfield-wp3-adoption-arms.sh
             tests/test-brownfield-wp4-driver.sh
+            tests/test-brownfield-wp5b-test-debt.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,18 @@ here.
 - **bash is 3.2** (`/bin/bash`, GNU bash 3.2.57). In product code: no `${var,,}`
   lowercasing, no associative arrays (`declare -A`), no `nullglob`. Use temp
   files / indexed arrays instead.
+- **`sed` with a `|` delimiter and a shell-code replacement bites, and it bites
+  SILENTLY.** Shell replacements are `|`-dense (`||`), so `s|old|new|` where
+  `new` contains `||` either errors (`bad flag in substitute command`) or —
+  worse — terminates the expression early and **leaves the file unchanged while
+  sed reports success**. It has bitten three times (twice inside a mutation
+  harness, once ad-hoc), and 25 files carry `s|`-delimited `sed`. Two rules:
+  pick a delimiter absent from the replacement, and **assert the edit actually
+  applied** (a changed-line count), because "sed ran" is not "sed edited".
+  A related one-liner: `&` in a `sed` replacement means *the whole match* —
+  an unescaped `&&` splices the original line back in, and that mutant passes
+  `bash -n`. See `## BL-224:` for the sibling case where a lint's own regex
+  over-matched for the same reason.
 - **Two repos required.** Tests and `init.sh` need the Claude Dev Framework
   cloned at `~/.claude-dev-framework` (the path is hard-required). Per
   CONTRIBUTING.md:

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,7 @@ five-phase build: after v1.0 ships, and before a project that already exists com
 | [step5-dogfood-walker-rubric.md](step5-dogfood-walker-rubric.md) | The pass/partial/fail rubric the Step-5 dogfood walker uses to disposition scenario outcomes. |
 | [delta-track.md](delta-track.md) | **After v1.0** — the post-release lifecycle `init.sh` installs into every project: the phase-4 activation gate, the four change classes and their confirm-not-quiz open, the brief whose Done-observable checklist *is* the close review, the close-time attribute ratchet, the hotfix lane and its release-blocking retro, the cadence clock's current/overdue/**unmeasurable** contract, `cut-release.sh`'s three refusals and tool-decided semver, and `.claude/delta-policy.json`. Worked transcripts throughout, all executed. |
 | [scout.md](scout.md) | **Scout** — the read-only survey (`scripts/scout.sh`). All seven report sections, the read-only proof, the opt-in `--run-tests`, full-history secret scanning with the value never printed, and the limits Scout states about itself (the untested-file count is a name-match heuristic; branch protection is `unknown`, not `no`). |
-| [adoption.md](adoption.md) | **Brownfield adoption** — `scripts/adopt-project.sh`: the chooser question verbatim, the floor rule, the reverse intake, the fail-safe write order, the adoption stamp and its loud loss detection, and the TDD exemption's bound. **Carries the prominent "what is not built yet" section** — the certification pass, test-debt ledger, collision archive, CI carve-out and Adoption Record are designed and not implemented. |
+| [adoption.md](adoption.md) | **Brownfield adoption** — `scripts/adopt-project.sh`: the chooser question verbatim, the floor rule, the reverse intake, the fail-safe write order, the adoption stamp and its loud loss detection, the TDD exemption's bound, and the test-debt ledger with its tier ratchet that is the exemption's forward equivalent. **Carries the prominent "what is not built yet" section** — the certification pass, collision archive, CI carve-out and Adoption Record are designed and not implemented. |
 
 ## Handoffs (`docs/handoffs/`)
 
@@ -82,10 +82,10 @@ amendment folded. **Built and shipping** — the user-facing page is [delta-trac
 (**Brownfield adoption** — the second entry path, for a codebase that already exists: a standalone
 read-only scanner, the completed-vs-in-flight scenario chooser, the certification pass that replaces
 grandfathering, full-history secret scanning with redacted findings, and the archive-and-disclose
-collision policy. v1.2, build-evidence amendment folded. **Half built** — Scout and the adoption
-driver ship; the certification pass, test-debt ledger, collision archive, CI carve-out and Adoption
-Record do not. User-facing pages: [scout.md](scout.md) and [adoption.md](adoption.md), which name
-every gap).
+collision policy. v1.2, build-evidence amendment folded. **Half built** — Scout, the adoption
+driver and the test-debt ledger with its ratchet ship; the certification pass, collision archive, CI
+carve-out and Adoption Record do not. User-facing pages: [scout.md](scout.md) and
+[adoption.md](adoption.md), which name every gap).
 
 ## Module contract (`docs/module-contract.md`)
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -12,9 +12,10 @@ bash /path/to/solo-orchestrator/scripts/adopt-project.sh
 > ## ⚠ Read this before you plan around adoption
 >
 > **Adoption is half built.** The driver, the scenario chooser, the reverse
-> intake, the state writes, the adoption stamp and the commit-time enabling arms
-> all ship and all work. **The certification pass, the test-debt ledger, the
-> collision archive, the CI carve-out and the Adoption Record do not exist.**
+> intake, the state writes, the adoption stamp, the commit-time enabling arms
+> and the test-debt ledger with its ratchet all ship and all work. **The
+> certification pass, the collision archive, the CI carve-out and the Adoption
+> Record do not exist.**
 >
 > The driver does not paper over that. It prints a labelled `NOT DONE` block for
 > every one of them, in the run, naming the work package that owns it. The full
@@ -35,6 +36,7 @@ Everything on this page is output that was observed, pasted as it printed.
 - [What gets written, and in what order](#what-gets-written-and-in-what-order)
 - [The adoption stamp, and what happens when it is lost](#the-adoption-stamp-and-what-happens-when-it-is-lost)
 - [The TDD exemption and its bound](#the-tdd-exemption-and-its-bound)
+- [The test-debt ledger and its ratchet](#the-test-debt-ledger-and-its-ratchet)
 - [What is not built yet](#what-is-not-built-yet)
 - [Exit codes](#exit-codes)
 
@@ -480,6 +482,114 @@ in a scaffolded project.
 
 ---
 
+## The test-debt ledger and its ratchet
+
+The exemption above is the one thing adoption genuinely cannot re-run, so it
+does not stand alone: it comes with a **forward equivalent** that is fully
+enforced from adoption day. The adoption measures your test debt once, writes it
+down, and from then on holds you to two rules about the future.
+
+`.claude/test-debt.json`, written during the run and committed with the rest of
+the adoption:
+
+```json
+{
+  "schema": "test-debt/v1",
+  "writtenAt": "2026-08-10T23:08:35Z",
+  "atCommit": "0d1effdce6abcb4dbb78253374e0c12357ee3b76",
+  "method": "A source file counts as untested when no test file's NAME contains its basename stem and it carries no inline test attribute. This is a name-match heuristic, not coverage: ...",
+  "count": 1,
+  "files": [
+    "src/ledger.js"
+  ],
+  "audit": [
+    {
+      "at": "2026-08-10T23:08:35Z",
+      "action": "created",
+      "atCommit": "0d1effdce6abcb4dbb78253374e0c12357ee3b76",
+      "previousCount": null,
+      "count": 1
+    }
+  ]
+}
+```
+
+### The two arms, and the tier they sit on
+
+| Arm | Rule | `no` | `light` | `strict` |
+|---|---|---|---|---|
+| **Non-growth** | The untested set may not gain a member | silent | warn | **block** |
+| **Touch-repays** | A file in the set that is modified must leave it in the same commit | silent | warn | **block** |
+
+Run it against a staged commit:
+
+```text
+bash <framework>/scripts/lib/adopt/adopt-test-debt.sh --check --root .
+```
+
+At `strict`, adding a file with no test:
+
+```text
+[BLOCKED] test-debt (non-growth): 1 file(s) would ENTER the untested set.
+          + src/billing.js
+          A test whose NAME carries the file's stem clears it; for Rust, inline #[cfg(test)] counts.
+          This project's enforcement tier is strict, so this is a refusal, not a note.
+rc=3
+```
+
+At `strict`, editing a file that is already in the ledger:
+
+```text
+[BLOCKED] test-debt (touch-repays): 1 ledgered file(s) were modified without gaining a test.
+          ~ src/ledger.js
+          A test whose NAME carries the file's stem clears it; for Rust, inline #[cfg(test)] counts.
+rc=4
+```
+
+The **same** staged change at `light` — a note, not a refusal:
+
+```text
+[WARN] test-debt (touch-repays): 1 ledgered file(s) were modified without gaining a test.
+          ~ src/ledger.js
+          A test whose NAME carries the file's stem clears it; for Rust, inline #[cfg(test)] counts.
+rc=0
+```
+
+And at `no`, nothing at all — no output, `rc=0`. That is deliberate and it is
+tested in both directions: **a gate that fires at the lenient tier is as wrong
+as one that never fires.** A ratchet that blocks a POC project is not a stricter
+ratchet, it is the thing that makes people turn the framework off.
+
+| Code | Meaning |
+|---|---|
+| 0 | Clean, or a tier that does not block |
+| 2 | Unusable — no ledger to ratchet against, not a git repository, no `jq` |
+| 3 | **Blocked by non-growth** |
+| 4 | **Blocked by touch-repays** |
+
+### Three things it does not claim
+
+1. **"Has a test" is not "is tested."** The ledger answers a filename question
+   (plus, for Rust, an inline `#[cfg(test)]` probe), not a coverage question. A
+   file with an empty test file beside it satisfies it. The framework has no
+   coverage instrumentation in any language, and the `method` field in the file
+   says so where the number is actually read.
+2. **The ledger is a committed file and you can edit it.** Same property as
+   `enforcement_level`: you can route around the block, not around the record.
+   Every write appends an `audit` row carrying the count it replaced. Deleting
+   the file outright is not a quiet route around the block — at `strict` the
+   ratchet then refuses with `rc=2` rather than passing.
+3. **Non-growth is weaker than shrinkage.** There is no burn-down schedule. A
+   rate is a business decision, and a rate you cannot meet teaches you to
+   disable the gate.
+
+**What is still missing, plainly:** nothing yet runs this on every commit. The
+commit-time hook belongs to WP7, so today the ratchet is a command you run — by
+hand, or from a CI step — not an automatic gate. The tier ladder, both arms and
+the ledger are real; the *automatic* part is not.
+
+---
+
 ## What is not built yet
 
 This is the honest half of the page. Everything below is **designed and not
@@ -507,19 +617,16 @@ fixed or explicitly accepted with a recorded signer.
 **Today, none of that runs.** An adopted project lands at its phase with its
 certification lists empty. Do not read an adopted project as a certified one.
 
-### The test-debt ledger — WP5b
+### The test-debt ledger — WP5b — **shipped**
 
-```text
-NOT DONE — the test-debt ledger
-   Owner: WP5b. This build does not do it, and does not pretend to.
-   Existing untested files are not recorded, so nothing yet stops that set from growing.
-```
+This one used to be on this list and is not any more. The driver no longer
+prints a `NOT DONE` block for it: it writes `.claude/test-debt.json` during the
+run and both tier-floored arms exist. See
+[The test-debt ledger and its ratchet](#the-test-debt-ledger-and-its-ratchet).
 
-The forward equivalent of the TDD exemption: `.claude/test-debt.json`, recording
-the set of source files with no test, with two tier-floored arms — the untested
-set may not **grow**, and a file in the set that gets **modified** must leave it
-in the same commit. Neither exists. Scout's untested-file count is a starting
-figure for a ledger that has nowhere to go yet.
+The residue is named there rather than hidden here: **nothing invokes the arms
+automatically yet**, because the commit-time hook is WP7's. Today it is a
+command you run.
 
 ### The collision archive, disclosure and re-adds — WP6
 
@@ -609,6 +716,17 @@ would refuse every commit, so until WP7 the two **message** gates are live —
 test-before-code ordering, and the Build-Loop commit check, both demonstrated
 above — and the scanner arms are not. Run them by hand.
 
+**The test-debt ratchet is in the same position, for the same reason and one
+more.** Its two arms exist and are enforced on the tier ladder, but nothing
+calls them on commit yet, so it is `adopt-test-debt.sh --check` by hand or from
+CI until WP7 lands. The extra reason is structural rather than schedule:
+`scripts/pre-commit-gate.sh` is **core** and the ratchet is **module** code, so
+a call from the gate to the ratchet is exactly the `core → module` edge
+[the module contract](module-contract.md)'s M3 forbids and
+`scripts/lint-module-dependencies.sh` reds on. Whatever WP7 does about the hook
+has to reach the ratchet without spending the module's severability on one
+convenience call.
+
 ### And one more, from this page rather than the driver
 
 **This page is not shipped into adopted or generated projects.** `init.sh` copies
@@ -626,7 +744,7 @@ not among them. Read them here, in the framework clone you run the driver from.
 | Test-first ordering enforced from adoption day forward | ✅ Ships and works |
 | Gates that were skipped actually run and recorded | ❌ Certification pass — **not built** |
 | Adoption that can *fail* on a serious finding | ❌ Certification pass — **not built** |
-| A recorded, non-growing set of untested files | ❌ Test-debt ledger — **not built** |
+| A recorded, non-growing set of untested files | ✅ [Test-debt ledger + ratchet](#the-test-debt-ledger-and-its-ratchet) — ships and works, **but you run it; nothing calls it on commit yet (WP7)** |
 | Your colliding hooks/settings archived with a restore path | ❌ Collision archive — **not built** |
 | Framework CI installed beside yours, with a recorded keep-or-retire | ❌ CI carve-out — **not built** |
 | A readable record of how this project entered the framework | ❌ Adoption Record — **not built** |

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -567,6 +567,24 @@ ratchet, it is the thing that makes people turn the framework off.
 | 3 | **Blocked by non-growth** |
 | 4 | **Blocked by touch-repays** |
 
+### Renames
+
+A **pure** rename of a ledgered file passes. Neither rule is met — the set
+gained no member, and nothing was modified — so blocking it would be a
+false-FAIL, and an earlier cut that did block it had no way out: re-baselining
+put the new path in the ledger and the same rename blocked again from the other
+arm. What you get instead is a note, and the run still succeeds:
+
+```text
+[NOTE] test-debt: 1 ledgered file(s) were renamed. The ledger still names the old path(s):
+          src/ledger.js -> src/ledger-v2.js
+          Re-baseline so the debt follows the file:  --write --root .
+```
+
+A rename that **also changes the file** is a modification, and the obligation
+follows the file to its new path — otherwise `git mv` plus an edit would be a
+one-commit way to shed it.
+
 ### Three things it does not claim
 
 1. **"Has a test" is not "is tested."** The ledger answers a filename question

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -567,7 +567,36 @@ ratchet, it is the thing that makes people turn the framework off.
 | 3 | **Blocked by non-growth** |
 | 4 | **Blocked by touch-repays** |
 
-### Renames
+### It is about your code, not the framework's
+
+Adoption installs about sixty of the framework's own scripts into your project.
+None of them is ever in your ledger: the census subtracts the framework's
+installed inventory, derived from `init.sh`'s own copy list rather than a
+hand-kept second copy of it. That holds on **every** write, not just the one the
+adoption performs — including the re-baseline this page tells you to run. If the
+tool cannot derive that inventory it refuses rather than guessing, because the
+alternative is a ledger that demands tests for `check-phase-gate.sh`.
+
+The cost, stated: if you already own a file at a framework path, it is excluded
+from your debt too. That path is a collision — the driver refuses to overwrite
+it — and the trade is a small under-count instead of a large false refusal.
+
+### Your `.gitconfig` cannot switch the arms off
+
+Every git read the ratchet makes is pinned with `-c core.quotePath=false -c
+diff.renames=true`, and both pins are there because their absence was measured:
+
+- without the first, a path like `src/café.js` is rendered quoted and escaped,
+  has no recognised source extension, and drops out of the census in silence;
+- without the second, `diff.renames=copies` lets a **copied** untested file
+  enter the working set at `strict` with no output at all, and
+  `diff.renames=false` turns a pure rename back into a delete-plus-add that
+  blocks — and keeps blocking after you re-baseline.
+
+Command-line `-c` outranks your repo, global and system config, so these are not
+suggestions.
+
+### Renames, and other changes that are not modifications
 
 A **pure** rename of a ledgered file passes. Neither rule is met — the set
 gained no member, and nothing was modified — so blocking it would be a
@@ -584,6 +613,12 @@ arm. What you get instead is a note, and the run still succeeds:
 A rename that **also changes the file** is a modification, and the obligation
 follows the file to its new path — otherwise `git mv` plus an edit would be a
 one-commit way to shed it.
+
+A **mode-only** change — `chmod +x` on a ledgered file — passes for the same
+reason: git reports the identical blob on both sides, which is the exact fact
+the pure-rename carve-out rests on. Treating one as a modification and not the
+other would be two postures for one fact, and the strict one was in the
+false-refusal direction.
 
 ### Three things it does not claim
 

--- a/scripts/adopt-project.sh
+++ b/scripts/adopt-project.sh
@@ -52,6 +52,16 @@
 #                                        framework sync use, so an adopted
 #                                        project's hooks are byte-identical to
 #                                        a scaffolded one's
+#   scripts/lib/enforcement-level.sh     read_enforcement_level and
+#                                        assert_choosable, which WP5b's ratchet
+#                                        CONSUMES rather than re-deriving. The
+#                                        `# BL-084-TIER-KEY` predicate already
+#                                        has four spellings and a fifth would
+#                                        be a defect the moment it landed
+#   scripts/lib/tdd-classify.sh          the BL-072 file classifier the TDD
+#                                        gate itself uses, so the test-debt
+#                                        ledger and the gate cannot disagree
+#                                        about what an implementation file is
 #
 # Direction (M3) holds in one direction only: this module sources core, and no
 # core file names this module. That is why `init.sh` does NOT ship
@@ -93,7 +103,7 @@ ADOPT_LIB_DIR="$ADOPT_SELF_DIR/lib/adopt"
 ADOPT_CORE_LIB_DIR="$ADOPT_SELF_DIR/lib"
 
 # ── Core libs (M2's declared set) ───────────────────────────────────────────
-for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh hook-templates.sh; do
+for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh hook-templates.sh enforcement-level.sh tdd-classify.sh; do
   if [ ! -f "$ADOPT_CORE_LIB_DIR/$_core" ]; then
     echo "adopt-project: missing $ADOPT_CORE_LIB_DIR/$_core — run this from a complete framework clone." >&2
     exit 2
@@ -105,7 +115,7 @@ done
 # THE GUARD, BEFORE ARGUMENT PARSING — see the header. Sibling posture, kept.
 guard_not_in_framework || exit 1
 
-for _part in adopt-core adopt-chooser adopt-intake adopt-state adopt-stubs; do
+for _part in adopt-core adopt-chooser adopt-intake adopt-state adopt-stubs adopt-test-debt; do
   if [ ! -f "$ADOPT_LIB_DIR/$_part.sh" ]; then
     echo "adopt-project: missing $ADOPT_LIB_DIR/$_part.sh — the driver needs its own lib directory." >&2
     exit 2

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -431,7 +431,19 @@ adopt_main() {
 
   adopt_stub_secrets_disposition "$report"
   adopt_stub_certification "$ADOPT_SCENARIO" "$ADOPT_LANDED_PHASE"
-  adopt_stub_test_debt_ledger
+
+  # WP5b. Was adopt_stub_test_debt_ledger; it is a real measurement now.
+  # BEFORE adopt_install_framework, and that ordering is stated rather than
+  # inherited: the census reads `git ls-files`, so the ~60 framework scripts
+  # the install is about to copy in could not enter the ledger even if this ran
+  # after it — they are untracked until adopt_stage_and_commit. Running it here
+  # keeps the two facts independent instead of resting the property on the
+  # index's timing.
+  #
+  # A REFUSAL HERE ABORTS THE ADOPTION, and that is the safe direction: this is
+  # before any state write, so a run that cannot measure the debt leaves the
+  # project exactly as it found it rather than adopting it with no baseline.
+  adopt_test_debt_record "$root" || return 1
 
   adopt_install_framework "$root" || return 1
   if _adopt_halt_requested install; then

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -48,11 +48,14 @@ adopt_stub_certification() {
   adopt_note "An empty list here means 'not measured', not 'measured and clean'."
 }
 
-# WP5b — the test-debt ledger and its ratchet (§5.4).
-adopt_stub_test_debt_ledger() {
-  adopt_stub_notice "the test-debt ledger" "WP5b" \
-    "Existing untested files are not recorded, so nothing yet stops that set from growing."
-}
+# WP5b — the test-debt ledger and its ratchet (§5.4) — RETIRED, NOT DELETED IN
+# SPIRIT. The stub that used to live here said "existing untested files are not
+# recorded, so nothing yet stops that set from growing". They are recorded now:
+# scripts/lib/adopt/adopt-test-debt.sh writes .claude/test-debt.json during the
+# run and adopt_test_debt_record announces what it measured. The one thing WP5b
+# does NOT ship is an automatic commit-time invocation — §10 gives WP7 the
+# commit-time hook — and adopt_stub_hooks below already carries that sentence,
+# so a second stub here would be a duplicate notice, not an extra honesty.
 
 # WP6 — the collision archive, its MANIFEST, the disclosure and the re-add
 # warning (§7.2/§7.3). WP4 refuses to overwrite; it does not archive.

--- a/scripts/lib/adopt/adopt-test-debt.sh
+++ b/scripts/lib/adopt/adopt-test-debt.sh
@@ -256,12 +256,21 @@ _td_is_source_ext() {
 # overwrite it. The trade is a small under-count against a large false-FAIL, and
 # it is taken in the direction that does not teach an operator to switch the
 # gate off.
+# EACH OF THE THREE GUARDS BELOW IS A REFUSAL, AND EACH HAS ITS OWN FIXTURE.
+# A reviewer flipped `|| return 1` to `|| return 0` on the init.sh guard — one
+# character — and the whole suite stayed at 50/0, because no fixture ever ran
+# this module from an incomplete clone. The mutant WROTE a ledger with the
+# exclusion silently inert, which is precisely the guessing the fix that
+# introduced these lines advertised as foreclosed. The lesson is the one this
+# file already states twice about matcher atoms, turned on the refusal itself:
+# a branch no fixture can reach is pinned by nothing. Section R's rows reach all
+# three, and no repo lint executes this module, so a test is the only backstop.
 _td_shipped_init() {
   : > "$TD_TMP/shipped"
-  command -v soif_parse_shipped_scripts >/dev/null 2>&1 || return 1
-  [ -f "$TD_FRAMEWORK_ROOT/init.sh" ] || return 1
+  command -v soif_parse_shipped_scripts >/dev/null 2>&1 || return 1   # BF-TD-SHIPPED-PARSER
+  [ -f "$TD_FRAMEWORK_ROOT/init.sh" ] || return 1                     # BF-TD-SHIPPED-REQUIRED
   soif_parse_shipped_scripts "$TD_FRAMEWORK_ROOT/init.sh" "$TD_FRAMEWORK_ROOT/scripts" > "$TD_TMP/shipped" 2>/dev/null
-  [ -s "$TD_TMP/shipped" ] || return 1
+  [ -s "$TD_TMP/shipped" ] || return 1                                # BF-TD-SHIPPED-NONEMPTY
   return 0
 }
 

--- a/scripts/lib/adopt/adopt-test-debt.sh
+++ b/scripts/lib/adopt/adopt-test-debt.sh
@@ -150,10 +150,11 @@
 
 TD_SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TD_CORE_LIB_DIR="$(cd "$TD_SELF_DIR/.." && pwd)"
+TD_FRAMEWORK_ROOT="$(cd "$TD_CORE_LIB_DIR/../.." && pwd)"
 
 # M3 direction: module -> core, which is permitted. Sourced defensively so the
-# file works both ways — the driver declares both libs in its own M2 header and
-# sources them first, and a direct invocation from a framework clone has to
+# file works both ways — the driver declares all three libs in its own M2 header
+# and sources them first, and a direct invocation from a framework clone has to
 # bring them in itself.
 if ! command -v read_enforcement_level >/dev/null 2>&1; then
   # shellcheck disable=SC1090
@@ -163,9 +164,37 @@ if ! command -v _bl072_is_impl_file >/dev/null 2>&1; then
   # shellcheck disable=SC1090
   [ -f "$TD_CORE_LIB_DIR/tdd-classify.sh" ] && . "$TD_CORE_LIB_DIR/tdd-classify.sh"
 fi
+if ! command -v soif_parse_shipped_scripts >/dev/null 2>&1; then
+  # shellcheck disable=SC1090
+  [ -f "$TD_CORE_LIB_DIR/scaffold-shipped-set.sh" ] && . "$TD_CORE_LIB_DIR/scaffold-shipped-set.sh"
+fi
 
 TD_LEDGER_REL=".claude/test-debt.json"
 TD_TMP=""
+
+# TD_GIT — EVERY git read in this file goes through these two `-c` settings, and
+# both of them are load-bearing rather than tidy. A user's own `.gitconfig` is
+# input to this tool, and a fix a user's config can silently disable is not a
+# fix.
+#
+#   core.quotePath=false   without it git renders a non-ASCII path as
+#                          `"src/caf\303\251.js"` — quotes included — which has
+#                          no recognised source extension, so the file drops out
+#                          of the census in silence.
+#   diff.renames=true      `diff.renames=copies` made a COPIED untested file
+#                          arrive as `C100` and enter the working set at rc 0
+#                          with zero output (the silent-bypass class);
+#                          `diff.renames=false` made a pure rename arrive as
+#                          `D`+`A` and resurrected the rename loop verbatim
+#                          (rc 3, re-baseline, rc 4). Both measured. Pinning to
+#                          `true` forces rename detection ON and copy detection
+#                          OFF, which is why nothing below matches a `C` status:
+#                          under this pin git cannot emit one, and a branch no
+#                          fixture can reach is pinned by nothing.
+#
+# `-c` on the command line outranks repo, global and system config, so this
+# cannot be overridden from the adoptee's side.
+TD_GIT_CONF="-c core.quotePath=false -c diff.renames=true"
 
 # ── The membership predicate ────────────────────────────────────────────────
 
@@ -199,15 +228,71 @@ _td_is_source_ext() {
   return 1
 }
 
+# ── The framework's own installed inventory ─────────────────────────────────
+# _td_shipped_init — write the set of paths the adoption INSTALLS into an
+# adoptee, DERIVED from init.sh's own `cp` lines through the shared parser
+# (soif_parse_shipped_scripts) rather than duplicated here. Returns non-zero if
+# it cannot be derived.
+#
+# WHY THIS EXISTS AND WHAT IT REPLACED. The first cut of this module kept the
+# framework's ~60 scripts out of the ledger by TIMING: the census reads
+# `git ls-files`, and at adoption time those files were copied but not yet
+# tracked. That is not a defence, it is a coincidence with a schedule — and
+# every write AFTER the adoption commit was exposed. Worse, this tool actively
+# instructs the operator to perform one (the rename [NOTE] and the rc-2 refusal
+# both print `--write --root .`). Measured on a real driver run: the ledger held
+# 1 entry and 0 framework scripts at adoption, and 58 entries with 57 of the
+# framework's own scripts after running the advertised command — after which
+# touch-repays demanded tests for check-gate.sh and check-phase-gate.sh on any
+# framework sync. The tool told the user to break themselves.
+#
+# The exclusion is applied in _td_is_candidate, so it binds the CENSUS and BOTH
+# ARMS from one place. A later framework sync that adds a script is therefore
+# not growth either.
+#
+# HONEST COST: an adoptee that legitimately owns a file at a framework path
+# (their own `scripts/validate.sh`, say) has it excluded from their debt. That
+# path is a COLLISION and belongs to WP6; the driver already refuses to
+# overwrite it. The trade is a small under-count against a large false-FAIL, and
+# it is taken in the direction that does not teach an operator to switch the
+# gate off.
+_td_shipped_init() {
+  : > "$TD_TMP/shipped"
+  command -v soif_parse_shipped_scripts >/dev/null 2>&1 || return 1
+  [ -f "$TD_FRAMEWORK_ROOT/init.sh" ] || return 1
+  soif_parse_shipped_scripts "$TD_FRAMEWORK_ROOT/init.sh" "$TD_FRAMEWORK_ROOT/scripts" > "$TD_TMP/shipped" 2>/dev/null
+  [ -s "$TD_TMP/shipped" ] || return 1
+  return 0
+}
+
+# _td_is_framework_path PATH — is this one of the files the adoption installs?
+_td_is_framework_path() {
+  [ -s "$TD_TMP/shipped" ] || return 1
+  grep -qxF -- "$1" "$TD_TMP/shipped" 2>/dev/null
+}
+
 # _td_is_candidate PATH — a file the ledger and both arms can be about.
 _td_is_candidate() {
   _bl072_is_impl_file "$1" || return 1
   _td_is_source_ext "$1"  || return 1
+  _td_is_framework_path "$1" && return 1   # BF-TD-FRAMEWORK-EXCLUDE
   return 0
 }
 
 # _td_has_inline_tests FILE — `# BL-107-RUST-INLINE-TESTS`, re-aimed from a
 # staged diff to file content.
+#
+# SYNC SIBLINGS — the attribute family below is now spelled in THREE places and
+# they must change together, the same hazard `# BL-084-TIER-KEY` names:
+#   scripts/pre-commit-gate.sh          `_bl107_attr_re` — the original, over a
+#                                       staged .rs diff's ADDED lines
+#   scripts/lib/scout/scout-testsbaseline.sh  `_scout_has_inline_tests` — over
+#                                       file content, M5 forbids sourcing
+#   this file                           `_td_has_inline_tests` — over file
+#                                       content, because a census has no diff
+# Grep `BL-107-RUST-INLINE-TESTS` to find all three. A family that gains a macro
+# in one copy and not the others reports a correctly-tested file as untested,
+# and the touch-repays arm then blocks every edit to it.
 #
 # CARRIED, NOT SOURCED, and the copy is disclosed rather than hidden: the
 # gate's version lives in scripts/pre-commit-gate.sh (not in the classifier
@@ -236,7 +321,7 @@ _td_has_inline_tests() {
 # differently-spelled lookup over the staged diff.
 _td_test_names() {
   local p
-  ( cd "$1" 2>/dev/null && git -c core.quotePath=false ls-files 2>/dev/null ) | while IFS= read -r p; do
+  ( cd "$1" 2>/dev/null && git $TD_GIT_CONF ls-files 2>/dev/null ) | while IFS= read -r p; do
     [ -n "$p" ] || continue
     _bl072_is_test_file "$p" && printf '%s\n' "${p##*/}"
   done
@@ -279,7 +364,7 @@ _td_in_ledger() {
 # would then demand tests for them.
 _td_census() {
   local root="$1" names="$2" p
-  ( cd "$root" 2>/dev/null && git -c core.quotePath=false ls-files 2>/dev/null ) > "$TD_TMP/all"
+  ( cd "$root" 2>/dev/null && git $TD_GIT_CONF ls-files 2>/dev/null ) > "$TD_TMP/all"
   : > "$TD_TMP/untested"
   while IFS= read -r p; do
     [ -n "$p" ] || continue
@@ -365,6 +450,18 @@ _td_write_body() {
     return 2
   }
 
+  # FAIL CLOSED AND LOUD. If the framework's own inventory cannot be derived,
+  # the census cannot tell the adoptee's code from the framework's — and the
+  # failure mode it prevents is a ledger full of the framework's gate scripts,
+  # which then demands tests for them. Refusing is the only honest answer; the
+  # previous version had no answer at all because it relied on timing.
+  if ! _td_shipped_init; then
+    echo "test-debt: could not derive the framework's installed inventory from $TD_FRAMEWORK_ROOT/init.sh." >&2
+    echo "  Without it the census cannot tell your source from the framework's, and a ledger that" >&2
+    echo "  names the framework's own scripts would demand tests for them. Run this from a complete clone." >&2
+    return 2
+  fi
+
   names="$TD_TMP/names"
   _td_test_names "$root" > "$names"
   _td_census "$root" "$names" > "$TD_TMP/ledgered"
@@ -437,25 +534,63 @@ adopt_test_debt_write() {
 
 # ── The ratchet ─────────────────────────────────────────────────────────────
 
+# _td_unchanged_blobs ROOT — every staged path whose CONTENT did not change.
+#
+# git's raw format carries the pre- and post-image blob names, so an entry whose
+# two SHAs are equal changed something OTHER than content — in practice a file
+# mode. `chmod +x` on a ledgered file arrives as a plain `M` and used to owe a
+# test, while `R100` — which rests on exactly the same fact, git saying the
+# content is identical — did not. Two postures for one fact, and the `M` one was
+# in the false-FAIL direction, so they are reconciled here rather than argued
+# about in a comment.
+#
+# `--abbrev=40` because the default raw output abbreviates, and comparing two
+# abbreviations is comparing prefixes.
+_td_unchanged_blobs() {
+  local root="$1" line meta path oldsha newsha st
+  ( cd "$root" 2>/dev/null && git $TD_GIT_CONF diff --cached --raw --abbrev=40 2>/dev/null ) \
+  | while IFS= read -r line; do
+      case "$line" in :*) ;; *) continue ;; esac
+      meta="${line%%	*}"
+      path="${line#*	}"
+      set -- $meta
+      [ "$#" -ge 5 ] || continue
+      oldsha="$3"; newsha="$4"; st="$5"
+      # Renames carry TWO paths after the tab and are the other carve-out's
+      # business; only same-path entries are read here.
+      case "$st" in M|M[0-9]*|T|T[0-9]*) ;; *) continue ;; esac
+      [ "$oldsha" = "$newsha" ] && printf '%s\n' "$path"
+    done
+  return 0
+}
+
 # _td_owes_repayment STATUS OLDPATH EFFPATH — is this staged entry a TOUCH of a
 # ledgered file?
 #
-# `R100` / `C100` is git's own statement that the content is byte-identical, so
-# it is a MOVE and not a modification: the design's arm is "a file in the set
-# that is MODIFIED must leave it", and a move modifies nothing. Below 100 the
-# content did change, and then the obligation follows the file to its new path
-# — otherwise `git mv` plus an edit would be a one-commit way to shed the
+# `R100` is git's own statement that the content is byte-identical, so it is a
+# MOVE and not a modification: the design's arm is "a file in the set that is
+# MODIFIED must leave it", and a move modifies nothing. Below 100 the content
+# did change, and then the obligation follows the file to its new path —
+# otherwise `git mv` plus an edit would be a one-commit way to shed the
 # obligation entirely, which is a worse hole than the one this closes.
+#
+# There is no `C` branch, and its ABSENCE is the pin: every git read in this
+# file goes through `-c diff.renames=true`, which forces copy detection off, so
+# git cannot emit a `C` status here. A branch no fixture can reach is pinned by
+# nothing, and the config pin is what makes the reachable set small enough to
+# pin completely.
 _td_owes_repayment() {
   local status="$1" old="$2" eff="$3"
   case "$status" in
-    R100|C100) return 1 ;;
-    R*|C*)
+    R100) return 1 ;;
+    R*)
       _td_in_ledger "$old" "$TD_TMP/ledgered" && return 0
       _td_in_ledger "$eff" "$TD_TMP/ledgered" && return 0
       return 1
       ;;
   esac
+  # A mode-only change is not a modification — same fact as R100, same answer.
+  _td_in_ledger "$eff" "$TD_TMP/unchanged" && return 1   # BF-TD-MODE-ONLY
   _td_in_ledger "$eff" "$TD_TMP/ledgered"
 }
 
@@ -488,10 +623,21 @@ _td_check_body() {
     return 0
   fi
 
+  if ! _td_shipped_init; then
+    if [ "$sev" = "block" ]; then
+      echo "[BLOCKED] test-debt: the framework's own installed inventory could not be derived from init.sh,"
+      echo "          so the census cannot tell your code from the framework's. Run this from a complete clone."
+      return 2
+    fi
+    echo "[WARN] test-debt: the framework's installed inventory could not be derived — the arms did not run."
+    return 0
+  fi
+
   jq -r '.files[]? // empty' "$ledger" 2>/dev/null > "$TD_TMP/ledgered"
   names="$TD_TMP/names"
   _td_test_names "$root" > "$names"
-  staged="$( cd "$root" 2>/dev/null && git -c core.quotePath=false diff --cached --name-status 2>/dev/null )"
+  _td_unchanged_blobs "$root" > "$TD_TMP/unchanged"
+  staged="$( cd "$root" 2>/dev/null && git $TD_GIT_CONF diff --cached --name-status 2>/dev/null )"   # BF-TD-STAGED-READ
 
   : > "$TD_TMP/grow"
   : > "$TD_TMP/touch"
@@ -506,14 +652,23 @@ _td_check_body() {
   # stem no longer matched its test's name. A pure deletion is carved out
   # upstream by _bl072_status_effective_path.
   #
-  # `C` (copy) genuinely would create a member, and is deliberately not
-  # matched: git emits it only under `-C`, which nothing here passes, so a
-  # branch for it would be unreachable code pretending to be coverage.
+  # `C` (copy) genuinely WOULD create a member — and the reason it is not
+  # matched is the config pin, not an assumption. An earlier version of this
+  # comment claimed git emits `C` only under `-C`; that is refuted:
+  # `diff.renames=copies` in the adoptee's own .gitconfig makes porcelain emit
+  # `C100`, and `git diff --cached` is porcelain. Measured — a copied untested
+  # file entered the working set at rc 0 with zero output. Every read here is
+  # now pinned to `-c diff.renames=true`, which forces copy detection OFF, so a
+  # copy arrives as `A` and this arm catches it.
+  #
+  # `A[0-9]*` is NOT matched: git scores only `R` and `C`, so an `A` with a
+  # score cannot occur and the branch would be unreachable — which is the very
+  # shape a reviewer's `A|M` mutation exploited to survive a green suite.
   while IFS="$(printf '\t')" read -r status path extra; do
     [ -n "$status" ] || continue
     eff="$(_bl072_status_effective_path "$status" "$path" "$extra")"
     [ -z "$eff" ] && continue
-    case "$status" in A|A[0-9]*) ;; *) continue ;; esac
+    case "$status" in A) ;; *) continue ;; esac   # BF-TD-NONGROWTH-ADDITIONS-ONLY
     _td_is_candidate "$eff" || continue
     _td_in_ledger "$eff" "$TD_TMP/ledgered" && continue
     _td_has_test "$root" "$eff" "$names" && continue
@@ -532,7 +687,7 @@ TD_STAGED_ADDS
     eff="$(_bl072_status_effective_path "$status" "$path" "$extra")"
     [ -z "$eff" ] && continue
     case "$status" in
-      R*|C*) _td_in_ledger "$path" "$TD_TMP/ledgered" && printf '%s -> %s\n' "$path" "$eff" >> "$TD_TMP/moved" ;;
+      R*) _td_in_ledger "$path" "$TD_TMP/ledgered" && printf '%s -> %s\n' "$path" "$eff" >> "$TD_TMP/moved" ;;
     esac
     _td_owes_repayment "$status" "$path" "$eff" || continue
     _td_has_test "$root" "$eff" "$names" && continue
@@ -647,6 +802,24 @@ if [ "${BASH_SOURCE[0]}" = "$0" ]; then
   [ -n "$TD_MODE" ] || { echo "$TD_USAGE" >&2; exit 2; }
   TD_ROOT_ABS="$(cd "$TD_ROOT" 2>/dev/null && pwd)"
   [ -n "$TD_ROOT_ABS" ] || { echo "adopt-test-debt: '$TD_ROOT' is not a directory this can read." >&2; exit 2; }
+  # THE TARGET GUARD, ON `--write` ONLY, and the asymmetry is deliberate.
+  # `--write` creates a file in the target, and `--root .` run from a framework
+  # clone would drop a ledger into the framework itself. `--check` writes
+  # nothing, and running it from the mothership is legitimate, so it is not
+  # guarded — the sibling entry scripts guard the CWD because they all write.
+  # guard_target_not_in_framework (`# BL-199-TARGET-GUARD`) is the accessor that
+  # checks the TARGET and ignores the cwd, which is exactly this shape; running
+  # the tool FROM the clone against someone else's project is the documented
+  # usage and must keep working.
+  if [ "$TD_MODE" = "write" ]; then
+    if [ -f "$TD_CORE_LIB_DIR/helpers-core.sh" ] && ! command -v guard_target_not_in_framework >/dev/null 2>&1; then
+      # shellcheck disable=SC1090
+      . "$TD_CORE_LIB_DIR/helpers-core.sh"
+    fi
+    if command -v guard_target_not_in_framework >/dev/null 2>&1; then
+      guard_target_not_in_framework "$TD_ROOT_ABS" "$TD_FRAMEWORK_ROOT" || exit 1
+    fi
+  fi
   if [ "$TD_MODE" = "write" ]; then
     adopt_test_debt_write "$TD_ROOT_ABS"
     exit $?

--- a/scripts/lib/adopt/adopt-test-debt.sh
+++ b/scripts/lib/adopt/adopt-test-debt.sh
@@ -109,6 +109,41 @@
 # nothing. grep, sed, tr and shell only; the failure mode is removed rather
 # than defended against, and the suite pins the property.
 #
+# ─────────────────────────────────────────────────────────────────────────────
+# THREE BEHAVIOURS THAT ARE DECISIONS, NOT ACCIDENTS. Each is pinned by a test,
+# because an undocumented edge in a blocking gate becomes a bug report about
+# the framework rather than about the edge.
+#
+# 1. `git -c core.quotePath=false` ON EVERY GIT READ. Without it git renders a
+#    non-ASCII path as `"src/caf\303\251.js"` — quotes included — and that
+#    string has no recognised source extension, so the file drops out of the
+#    census silently and neither arm can ever see it. Measured on a fixture
+#    before the flag was added: `src/café.js` was untested and absent from the
+#    ledger. Paths containing a literal TAB or NEWLINE are still beyond this
+#    (the name-status reader splits on tabs), the same bound the BL-072 gate
+#    has.
+#
+# 2. A PURE RENAME (`R100`) OF A LEDGERED FILE PASSES, WITH A `[NOTE]`. Neither
+#    arm's rule is met — the set gained no member and nothing was modified — and
+#    an earlier cut that blocked it produced a trap worth recording: the block
+#    fired as non-growth on the new path, re-baselining then put the new path in
+#    the ledger, and the SAME staged rename immediately blocked again as
+#    touch-repays. There was no way out of that loop except writing a test for a
+#    file the operator had only moved, which is exactly the false-FAIL that
+#    teaches people to switch a gate off. It also blocked renames of TESTED
+#    files, because the new stem stopped matching the test's name. So the rename
+#    passes — and, because a rename is the one way debt can leave the ledger
+#    without being paid, the run says so and tells you to re-baseline. A rename
+#    that ALSO changes content (`R090`) is a modification and does owe a test,
+#    at the new path.
+#
+# 3. THE INLINE-TEST PROBE READS THE WORKING TREE, not the staged blob. For the
+#    census that is the only file there is. For the arms it means a `.rs` file
+#    staged WITH its `#[cfg(test)]` block and then stripped in the worktree
+#    reads as tested. The gate's own copy of the probe reads the staged diff;
+#    this one cannot, because the same function serves a census that has no
+#    diff to read.
+#
 # bash-3.2 safe: no ${var,,}, no associative arrays, no mapfile, no nullglob,
 # no ((x++)) (this file may be sourced into a caller running under errexit).
 # shellcheck shell=bash
@@ -201,7 +236,7 @@ _td_has_inline_tests() {
 # differently-spelled lookup over the staged diff.
 _td_test_names() {
   local p
-  ( cd "$1" 2>/dev/null && git ls-files 2>/dev/null ) | while IFS= read -r p; do
+  ( cd "$1" 2>/dev/null && git -c core.quotePath=false ls-files 2>/dev/null ) | while IFS= read -r p; do
     [ -n "$p" ] || continue
     _bl072_is_test_file "$p" && printf '%s\n' "${p##*/}"
   done
@@ -244,7 +279,7 @@ _td_in_ledger() {
 # would then demand tests for them.
 _td_census() {
   local root="$1" names="$2" p
-  ( cd "$root" 2>/dev/null && git ls-files 2>/dev/null ) > "$TD_TMP/all"
+  ( cd "$root" 2>/dev/null && git -c core.quotePath=false ls-files 2>/dev/null ) > "$TD_TMP/all"
   : > "$TD_TMP/untested"
   while IFS= read -r p; do
     [ -n "$p" ] || continue
@@ -402,10 +437,32 @@ adopt_test_debt_write() {
 
 # ── The ratchet ─────────────────────────────────────────────────────────────
 
+# _td_owes_repayment STATUS OLDPATH EFFPATH — is this staged entry a TOUCH of a
+# ledgered file?
+#
+# `R100` / `C100` is git's own statement that the content is byte-identical, so
+# it is a MOVE and not a modification: the design's arm is "a file in the set
+# that is MODIFIED must leave it", and a move modifies nothing. Below 100 the
+# content did change, and then the obligation follows the file to its new path
+# — otherwise `git mv` plus an edit would be a one-commit way to shed the
+# obligation entirely, which is a worse hole than the one this closes.
+_td_owes_repayment() {
+  local status="$1" old="$2" eff="$3"
+  case "$status" in
+    R100|C100) return 1 ;;
+    R*|C*)
+      _td_in_ledger "$old" "$TD_TMP/ledgered" && return 0
+      _td_in_ledger "$eff" "$TD_TMP/ledgered" && return 0
+      return 1
+      ;;
+  esac
+  _td_in_ledger "$eff" "$TD_TMP/ledgered"
+}
+
 _td_check_body() {
   local root="$1"
   local ledger="$root/$TD_LEDGER_REL"
-  local tier sev staged names status path extra eff n_grow n_touch
+  local tier sev staged names status path extra eff n_grow n_touch n_moved moved_row
 
   tier="$(adopt_test_debt_tier "$root")"
   sev="$(_td_severity "$tier")"
@@ -434,20 +491,29 @@ _td_check_body() {
   jq -r '.files[]? // empty' "$ledger" 2>/dev/null > "$TD_TMP/ledgered"
   names="$TD_TMP/names"
   _td_test_names "$root" > "$names"
-  staged="$( cd "$root" 2>/dev/null && git diff --cached --name-status 2>/dev/null )"
+  staged="$( cd "$root" 2>/dev/null && git -c core.quotePath=false diff --cached --name-status 2>/dev/null )"
 
   : > "$TD_TMP/grow"
   : > "$TD_TMP/touch"
+  : > "$TD_TMP/moved"
 
-  # ── Arm 1: NON-GROWTH — the untested set may not gain a member ────────────
-  # ADDITIONS only. A pure deletion is carved out upstream by
-  # _bl072_status_effective_path (removing a source file is not shipping
-  # implementation); a modification belongs to the other arm.
+  # ── Arm 1: NON-GROWTH — the untested set may not GAIN a member ────────────
+  # ADDITIONS ONLY, and the word is the design's. A rename does not create a
+  # member — the file was already in the repository under another name — so
+  # R/C statuses are the other arm's business, and were measured producing two
+  # false blocks here before this narrowing: renaming an untested file read as
+  # growth, and renaming a TESTED file read as growth too, because the new
+  # stem no longer matched its test's name. A pure deletion is carved out
+  # upstream by _bl072_status_effective_path.
+  #
+  # `C` (copy) genuinely would create a member, and is deliberately not
+  # matched: git emits it only under `-C`, which nothing here passes, so a
+  # branch for it would be unreachable code pretending to be coverage.
   while IFS="$(printf '\t')" read -r status path extra; do
     [ -n "$status" ] || continue
     eff="$(_bl072_status_effective_path "$status" "$path" "$extra")"
     [ -z "$eff" ] && continue
-    case "$status" in A|A[0-9]*|R*|C*) ;; *) continue ;; esac
+    case "$status" in A|A[0-9]*) ;; *) continue ;; esac
     _td_is_candidate "$eff" || continue
     _td_in_ledger "$eff" "$TD_TMP/ledgered" && continue
     _td_has_test "$root" "$eff" "$names" && continue
@@ -465,7 +531,10 @@ TD_STAGED_ADDS
     [ -n "$status" ] || continue
     eff="$(_bl072_status_effective_path "$status" "$path" "$extra")"
     [ -z "$eff" ] && continue
-    _td_in_ledger "$eff" "$TD_TMP/ledgered" || continue
+    case "$status" in
+      R*|C*) _td_in_ledger "$path" "$TD_TMP/ledgered" && printf '%s -> %s\n' "$path" "$eff" >> "$TD_TMP/moved" ;;
+    esac
+    _td_owes_repayment "$status" "$path" "$eff" || continue
     _td_has_test "$root" "$eff" "$names" && continue
     printf '%s\n' "$eff" >> "$TD_TMP/touch"   # BF-TD-TOUCH-ARM
   done <<TD_STAGED_TOUCHES
@@ -474,6 +543,21 @@ TD_STAGED_TOUCHES
 
   n_grow="$(grep -c . "$TD_TMP/grow" 2>/dev/null)";  case "$n_grow"  in ''|*[!0-9]*) n_grow=0 ;;  esac
   n_touch="$(grep -c . "$TD_TMP/touch" 2>/dev/null)"; case "$n_touch" in ''|*[!0-9]*) n_touch=0 ;; esac
+  n_moved="$(grep -c . "$TD_TMP/moved" 2>/dev/null)"; case "$n_moved" in ''|*[!0-9]*) n_moved=0 ;; esac
+
+  # The stale-ledger NOTE, and why it is not a block. A pure rename of a
+  # ledgered file is the one way debt can leave the ledger without being paid:
+  # the recorded path stops existing and the new one was never recorded, so
+  # touch-repays will never see that file again. Blocking would be wrong — the
+  # design says the set may not GAIN a member and that a MODIFIED member must
+  # leave, and a move is neither. Staying silent would be worse: it is a
+  # laundering route with no trace. So it is said, and the run still passes.
+  if [ "$n_moved" -gt 0 ]; then
+    echo "[NOTE] test-debt: $n_moved ledgered file(s) were renamed. The ledger still names the old path(s):"
+    while IFS= read -r moved_row; do [ -n "$moved_row" ] && echo "          $moved_row"; done < "$TD_TMP/moved"
+    echo "          Re-baseline so the debt follows the file:  --write --root ."
+  fi
+
   [ "$n_grow" -eq 0 ] && [ "$n_touch" -eq 0 ] && return 0
 
   _td_report "$sev" "$n_grow" "$n_touch"

--- a/scripts/lib/adopt/adopt-test-debt.sh
+++ b/scripts/lib/adopt/adopt-test-debt.sh
@@ -1,0 +1,572 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-test-debt.sh — the TEST-DEBT LEDGER and its TIER
+# RATCHET: kind (c)'s forward equivalent.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §5.4 (the ledger, the
+# two arms, the three honest limits), §5 (the per-gate mapping: TDD ordering on
+# pre-adoption commits is kind (c) — impossible to re-run — so what is enforced
+# instead is this), §10-WP5b. The standing module rules are
+# docs/module-contract.md.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT THIS IS FOR, IN ONE PARAGRAPH.
+#
+# An adopted project's history was written before the framework existed, so the
+# TDD-ordering gate cannot judge it: there is no re-runnable fact about whether
+# a 2023 commit put its test first. Bare grandfathering would stop there and
+# exempt the code forever. Instead the adoption measures the debt ONCE — the
+# set of source files that have no test — writes it down, and from that day
+# enforces two things that ARE about the future: the set may not GROW, and a
+# file in the set that you TOUCH must leave it.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# M1/M3 — THIS IS MODULE CODE AND IT ADDS NO ENTRY SCRIPT.
+#
+# The adopt module's one entry script is still scripts/adopt-project.sh, which
+# sources this file. No path outside scripts/lib/adopt/ names it, so M3's
+# `core -> module` prohibition holds by construction and
+# scripts/lint-module-dependencies.sh stays rc 0 — the ratchet is therefore NOT
+# reachable from scripts/pre-commit-gate.sh, and that is deliberate rather than
+# incidental. It runs FROM the framework clone against an adoptee, the same way
+# Scout and the driver do:
+#
+#   bash /path/to/solo-orchestrator/scripts/lib/adopt/adopt-test-debt.sh \
+#        --check --root /path/to/their-project
+#
+# WHAT THAT LEAVES UNDONE, SAID PLAINLY: nothing yet CALLS this on every
+# commit. §10 gives WP7 the commit-time hook and names no owner for the
+# fallback pre-commit hook on the adoption path (see adopt_stub_hooks), so
+# until that lands the arms are a command an operator or a CI step runs, not an
+# automatic gate. The alternative — reaching into scripts/pre-commit-gate.sh —
+# is the exact edge M3 exists to make red, and severability is not worth
+# trading for one convenience call.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE TIER READ FAILS CLOSED, AND `## BL-221:` IS THE REASON IT IS SPELLED THIS
+# WAY.
+#
+# The tier is READ, never re-derived: `# BL-084-TIER-KEY` is a sync-sibling
+# predicate already spelled four times (pre-commit-gate.sh, check-phase-gate.sh,
+# init.sh, scripts/lib/enforcement-level.sh) and a fifth spelling would be a
+# defect the moment it landed. So this consumes the two existing accessors:
+#
+#   read_enforcement_level  — fails CLOSED: a missing manifest, an unparseable
+#                             one, a missing key or a value off the ladder all
+#                             return `strict`.
+#   assert_choosable        — fails OPEN, and that is the live bug `## BL-221:`
+#                             filed: `jq -r '.deployment // "personal"'` makes
+#                             an ABSENT key resolve to the CHOOSABLE tier, and
+#                             an adopted manifest has no `deployment` key at
+#                             all.
+#
+# The composition is RAISE-ONLY: assert_choosable can push the tier UP to
+# strict and can never pull it down. A false "choosable" therefore buys
+# nothing, because the tier it would have permitted is whatever
+# read_enforcement_level already returned — and that reader fails closed. On
+# top of that, a `choosable` verdict is only allowed to stand when the key it
+# is derived from is actually PRESENT (`# BF-TD-TIER-KEY-PRESENT`); an absent
+# or null `deployment` is treated as a tier we cannot trust, which is strict.
+# This is a guard on absent data, not a re-implementation of the predicate: the
+# deployment/poc_mode question is still answered entirely by assert_choosable.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE TIER FLOOR IS CONSULTED FIRST, AND THAT ORDER IS LOAD-BEARING.
+#
+# A gate that fires at the lenient tier is as wrong as one that never fires. A
+# ratchet that blocks a `poc_mode` project is not a stricter ratchet, it is a
+# broken one, and it is the shape that teaches an operator to disable the whole
+# framework (the false-FAIL doctrine this repo already paid for in
+# BL-122/BL-149). So `no` returns before anything can refuse — before the git
+# check, before the missing-ledger refusal, before either arm.
+#
+# The `[WARN]` label is cosmetic in this framework: check-phase-gate.sh's exit
+# predicate is `if [ $issues -eq 0 ]`, so a "WARN" arm that increments `issues`
+# blocks. The `light` tier here prints WARN lines and returns 0, and the tests
+# assert the CODE, never the label.
+#
+# EXIT CODES — the two arms are distinguishable, the way
+# pre-commit-gate.sh --emit-blocked-gate distinguishes its two message gates:
+#
+#   0  clean, or a tier that does not block
+#   2  unusable — no ledger to ratchet against, no git repository, no jq
+#   3  BLOCKED by NON-GROWTH   (the untested set gained a member)
+#   4  BLOCKED by TOUCH-REPAYS (a ledgered file was modified without a test)
+#
+# When both arms fire the code is 3 and BOTH lists are printed: the code names
+# the first arm, the transcript names everything.
+#
+# A MISSING LEDGER AT `strict` IS rc 2, NOT A PASS. §5.4 limit 2 concedes that
+# the ledger is a committed file and can be edited — "you can route around the
+# block, not around the record". Deleting it outright is not a quiet route
+# around the block; it is a loud one, and it gets the same posture WP3 gave the
+# adoption stamp's loss detection. At `light` the same absence warns; at `no`
+# it is silent, because the floor was consulted first.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# NO awk ANYWHERE IN THIS FILE, DELIBERATELY. `bash -n` does not syntax-check
+# an embedded program, so a dead one emits an empty result and empty reads as
+# "nothing wrong" — a mutant can then pass every harness check while doing
+# nothing. grep, sed, tr and shell only; the failure mode is removed rather
+# than defended against, and the suite pins the property.
+#
+# bash-3.2 safe: no ${var,,}, no associative arrays, no mapfile, no nullglob,
+# no ((x++)) (this file may be sourced into a caller running under errexit).
+# shellcheck shell=bash
+
+TD_SELF_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TD_CORE_LIB_DIR="$(cd "$TD_SELF_DIR/.." && pwd)"
+
+# M3 direction: module -> core, which is permitted. Sourced defensively so the
+# file works both ways — the driver declares both libs in its own M2 header and
+# sources them first, and a direct invocation from a framework clone has to
+# bring them in itself.
+if ! command -v read_enforcement_level >/dev/null 2>&1; then
+  # shellcheck disable=SC1090
+  [ -f "$TD_CORE_LIB_DIR/enforcement-level.sh" ] && . "$TD_CORE_LIB_DIR/enforcement-level.sh"
+fi
+if ! command -v _bl072_is_impl_file >/dev/null 2>&1; then
+  # shellcheck disable=SC1090
+  [ -f "$TD_CORE_LIB_DIR/tdd-classify.sh" ] && . "$TD_CORE_LIB_DIR/tdd-classify.sh"
+fi
+
+TD_LEDGER_REL=".claude/test-debt.json"
+TD_TMP=""
+
+# ── The membership predicate ────────────────────────────────────────────────
+
+# _td_is_source_ext PATH — THE ONE NARROWING over the BL-072 classifier, and
+# the same one Scout's census makes for the same reason.
+#
+# `_bl072_is_impl_file` classifies a DIFF, where a changed package.json or a
+# regenerated lockfile is legitimately implementation that shipped. This is a
+# census of a TREE, and in a census a manifest is not source: counting it would
+# make the untested figure a number about manifests, and then the non-growth
+# arm would refuse `npm init`. The extension set is carried from the language
+# table Scout's stack section counts languages with, so the ledger and the scan
+# report cannot disagree about what a source file is.
+#
+# THE ARMS USE THIS TOO, not only the census. If the two disagreed about
+# membership, adding a lockfile would block a strict project against a set the
+# ledger never had it in.
+_td_is_source_ext() {
+  local base ext
+  base="${1##*/}"
+  case "$base" in *.*) ;; *) return 1 ;; esac
+  ext="$(printf '%s' "${base##*.}" | tr 'A-Z' 'a-z')"
+  case "$ext" in
+    ts|tsx|mts|cts|js|jsx|mjs|cjs)      return 0 ;;
+    py|rb|go|rs|java|kt|kts|swift)      return 0 ;;
+    c|h|cc|cpp|cxx|hpp|hh|cs|php|scala) return 0 ;;
+    sh|bash|zsh|lua|dart)               return 0 ;;
+    ex|exs|erl|hs|clj|cljs)             return 0 ;;
+    m|mm|r|pl|pm|sql|vue|svelte|tf)     return 0 ;;
+  esac
+  return 1
+}
+
+# _td_is_candidate PATH — a file the ledger and both arms can be about.
+_td_is_candidate() {
+  _bl072_is_impl_file "$1" || return 1
+  _td_is_source_ext "$1"  || return 1
+  return 0
+}
+
+# _td_has_inline_tests FILE — `# BL-107-RUST-INLINE-TESTS`, re-aimed from a
+# staged diff to file content.
+#
+# CARRIED, NOT SOURCED, and the copy is disclosed rather than hidden: the
+# gate's version lives in scripts/pre-commit-gate.sh (not in the classifier
+# lib, which is contractually a pure function of the path set) and greps the
+# ADDED lines of a staged .rs diff. There is no diff to read when taking a
+# census, so this asks the same question of the file itself — the same shape
+# Scout's scanner arrived at independently. The attribute family is carried
+# unchanged: std #[test] / #[cfg(test)] / #![cfg(test)] / cfg(all(test,…)) /
+# cfg(any(test,…)), the runtime family (anything ::test] — tokio, async_std,
+# actix_rt, googletest) and the popular harness macros.
+#
+# Dropping it would report every inline-tested Rust file as untested — a large,
+# confident, wrong number — and the touch-repays arm would then block every
+# edit to a correctly-tested file.
+_td_has_inline_tests() {
+  case "$1" in *.rs) ;; *) return 1 ;; esac
+  grep -qE '#!?\[(test|cfg\((all\(|any\()?test|([A-Za-z_][A-Za-z0-9_]*::)+test\]|rstest|wasm_bindgen_test|quickcheck|proptest)' \
+    "$1" 2>/dev/null
+}
+
+# _td_test_names ROOT — the basename of every test file in the INDEX.
+#
+# `git ls-files` reads the index, not the working tree, so a test file STAGED
+# in the commit under review is already in this set. That is what lets the arms
+# accept "the file arrived with its test in the same commit" without a second,
+# differently-spelled lookup over the staged diff.
+_td_test_names() {
+  local p
+  ( cd "$1" 2>/dev/null && git ls-files 2>/dev/null ) | while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    _bl072_is_test_file "$p" && printf '%s\n' "${p##*/}"
+  done
+  return 0
+}
+
+# _td_has_test ROOT PATH NAMESFILE — the name-match heuristic, stated as such.
+#
+# §5.4 limit 1: "has a test" is not "is tested". This answers a filename /
+# inline-marker question, not a coverage question, and a file with an empty
+# test file satisfies it. That is deliberate — the framework has no coverage
+# instrumentation in any language — and the ledger carries the sentence saying
+# so, in the artefact, where the number is read.
+_td_has_test() {
+  local root="$1" p="$2" names="$3" base stem
+  _td_has_inline_tests "$root/$p" && return 0
+  base="${p##*/}"
+  stem="${base%.*}"
+  [ -n "$stem" ] || return 1
+  [ -s "$names" ] || return 1
+  grep -qF -- "$stem" "$names" 2>/dev/null && return 0
+  return 1
+}
+
+# _td_in_ledger PATH FILE — exact whole-line membership, never a substring.
+_td_in_ledger() {
+  [ -s "$2" ] || return 1
+  grep -qxF -- "$1" "$2" 2>/dev/null
+}
+
+# ── The census ──────────────────────────────────────────────────────────────
+# _td_census ROOT NAMESFILE — every untested candidate in the INDEX, sorted.
+#
+# The population is `git ls-files`, i.e. TRACKED files, not the working tree.
+# Two reasons, both measured rather than assumed: a working-tree walk would
+# sweep node_modules and build output into the adoptee's "debt", and the
+# adoption driver copies ~60 framework scripts into the project before it
+# commits — a tree census taken after that install would file the framework's
+# own gate scripts as the adoptee's untested code, and the touch-repays arm
+# would then demand tests for them.
+_td_census() {
+  local root="$1" names="$2" p
+  ( cd "$root" 2>/dev/null && git ls-files 2>/dev/null ) > "$TD_TMP/all"
+  : > "$TD_TMP/untested"
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    _td_is_candidate "$p" || continue    # BF-TD-CENSUS-CANDIDATE
+    _td_has_test "$root" "$p" "$names" && continue
+    printf '%s\n' "$p" >> "$TD_TMP/untested"
+  done < "$TD_TMP/all"
+  sort "$TD_TMP/untested"
+  return 0
+}
+
+# adopt_test_debt_method — the sentence that keeps the number honest, written
+# INTO the artefact rather than into a design document nobody opens at 2am.
+adopt_test_debt_method() {
+  printf '%s' "A source file counts as untested when no test file's NAME contains its basename stem and it carries no inline test attribute. This is a name-match heuristic, not coverage: it cannot see a test that exercises a file without naming it, and it will call a file tested on a coincidental name match. An empty test file satisfies it. The framework has no coverage instrumentation in any language, and this ledger does not pretend otherwise."
+}
+
+# ── The tier ────────────────────────────────────────────────────────────────
+
+# _td_severity TIER — the ladder, spelled ONCE, as data.
+#
+# Spelled once ON PURPOSE. Two copies of a tier ladder is the
+# `# BL-084-TIER-KEY` sync-sibling trap in miniature, so the second mutation
+# direction for the second arm is proved by a second FIXTURE, not by a second
+# line. The `*` row is the fail-closed default and is reachable: an unknown
+# tier is strict.
+_td_severity() {
+  case "$1" in
+    no)     echo silent ;;   # BF-TD-FLOOR-NO
+    light)  echo warn ;;     # BF-TD-FLOOR-LIGHT
+    strict) echo block ;;    # BF-TD-FLOOR-STRICT
+    *)      echo block ;;    # BF-TD-FLOOR-CLOSED
+  esac
+}
+
+# _td_tier_trusted ROOT — may a `choosable` verdict stand?
+#
+# Only when the key it is derived from is PRESENT. assert_choosable resolves an
+# absent `deployment` to "personal" (`## BL-221:`), and an adopted manifest has
+# no `deployment` key, so without this the whole ladder would be decided by a
+# default. The deployment/poc_mode question itself is still answered entirely
+# by assert_choosable — this adds a presence check, not a fifth spelling.
+_td_tier_trusted() {
+  local root="$1" manifest="$root/.claude/manifest.json" deployment
+  command -v jq >/dev/null 2>&1 || return 1
+  command -v assert_choosable >/dev/null 2>&1 || return 1
+  deployment="$(jq -r '.deployment // ""' "$manifest" 2>/dev/null)"
+  case "$deployment" in ''|null) return 1 ;; esac
+  assert_choosable "$root" >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# adopt_test_debt_tier ROOT — the effective tier: no | light | strict.
+adopt_test_debt_tier() {
+  local root="$1" tier
+  if ! command -v read_enforcement_level >/dev/null 2>&1; then
+    echo strict
+    return 0
+  fi
+  tier="$(read_enforcement_level "$root")"
+  if [ ! -f "$root/.claude/manifest.json" ]; then
+    echo strict
+    return 0
+  fi
+  # RAISE-ONLY: this branch can only make the tier stricter.
+  if ! _td_tier_trusted "$root"; then   # BF-TD-TIER-KEY-PRESENT
+    tier="strict"
+  fi
+  echo "$tier"
+  return 0
+}
+
+# ── The ledger ──────────────────────────────────────────────────────────────
+
+_td_write_body() {
+  local root="$1"
+  local ledger="$root/$TD_LEDGER_REL"
+  local names count files_json prev audit action now sha json
+
+  command -v jq >/dev/null 2>&1 || { echo "test-debt: jq is required to write the ledger." >&2; return 2; }
+  ( cd "$root" 2>/dev/null && git rev-parse --verify --quiet HEAD >/dev/null 2>&1 ) || {
+    echo "test-debt: '$root' is not a git repository with at least one commit." >&2
+    return 2
+  }
+
+  names="$TD_TMP/names"
+  _td_test_names "$root" > "$names"
+  _td_census "$root" "$names" > "$TD_TMP/ledgered"
+
+  count="$(grep -c . "$TD_TMP/ledgered" 2>/dev/null)"
+  case "$count" in ''|*[!0-9]*) count=0 ;; esac
+  files_json="$(jq -R . < "$TD_TMP/ledgered" 2>/dev/null | jq -s . 2>/dev/null)"
+  [ -n "$files_json" ] || files_json='[]'
+
+  # §5.4 limit 2: the ledger is a committed file and can be edited — the same
+  # property enforcement_level has. You can route around the block, not around
+  # the record, so every write leaves a row carrying the count it replaced.
+  prev="null"; audit="[]"; action="created"
+  if [ -f "$ledger" ]; then
+    prev="$(jq -r '.count // "null"' "$ledger" 2>/dev/null)"
+    case "$prev" in ''|*[!0-9]*) prev="null" ;; esac
+    audit="$(jq -c '.audit // []' "$ledger" 2>/dev/null)"
+    [ -n "$audit" ] || audit="[]"
+    action="rewritten"
+  fi
+
+  now="$(date -u '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)"
+  sha="$( cd "$root" 2>/dev/null && git rev-parse HEAD 2>/dev/null )"
+
+  json="$(jq -n \
+    --argjson files "$files_json" \
+    --argjson audit "$audit" \
+    --argjson prev  "$prev" \
+    --argjson count "$count" \
+    --arg now "$now" --arg sha "$sha" --arg action "$action" \
+    --arg method "$(adopt_test_debt_method)" \
+    '{schema: "test-debt/v1",
+      writtenAt: $now,
+      atCommit: $sha,
+      method: $method,
+      count: $count,
+      files: $files,
+      audit: ($audit + [{at: $now, action: $action, atCommit: $sha, previousCount: $prev, count: $count}])}' \
+    2>/dev/null)"
+  [ -n "$json" ] || { echo "test-debt: could not build the ledger." >&2; return 2; }
+
+  # adopt_write_file records the path in the driver's write ledger, which is
+  # what gets staged — explicitly, one file at a time, never `git add -A`. When
+  # this runs standalone that function does not exist and the write is plain.
+  if command -v adopt_write_file >/dev/null 2>&1; then
+    printf '%s\n' "$json" | adopt_write_file "$root" "$TD_LEDGER_REL" || return 1
+  else
+    mkdir -p "$root/.claude" 2>/dev/null || { echo "test-debt: could not create $root/.claude" >&2; return 2; }
+    printf '%s\n' "$json" > "$ledger" || { echo "test-debt: could not write $ledger" >&2; return 2; }
+  fi
+  TD_LAST_COUNT="$count"
+  return 0
+}
+
+# adopt_test_debt_write ROOT — measure the debt and write .claude/test-debt.json.
+#
+# The temp directory is created and removed HERE rather than by a trap: this
+# file is sourced into a driver that already owns an EXIT trap for its own work
+# directory, and a second `trap … EXIT` would replace it and leak that
+# directory.
+TD_LAST_COUNT=0
+adopt_test_debt_write() {
+  local rc=0
+  TD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/td-write.XXXXXXXX" 2>/dev/null)" || return 2
+  _td_write_body "$@" || rc=$?
+  rm -rf "$TD_TMP"
+  TD_TMP=""
+  return $rc
+}
+
+# ── The ratchet ─────────────────────────────────────────────────────────────
+
+_td_check_body() {
+  local root="$1"
+  local ledger="$root/$TD_LEDGER_REL"
+  local tier sev staged names status path extra eff n_grow n_touch
+
+  tier="$(adopt_test_debt_tier "$root")"
+  sev="$(_td_severity "$tier")"
+  # THE FLOOR, FIRST. Everything below can refuse; at `no` nothing may.
+  [ "$sev" = "silent" ] && return 0
+
+  ( cd "$root" 2>/dev/null && git rev-parse --verify --quiet HEAD >/dev/null 2>&1 ) || {
+    if [ "$sev" = "block" ]; then
+      echo "[BLOCKED] test-debt: '$root' is not a git repository with a commit, so there is no staged set to judge."
+      return 2
+    fi
+    echo "[WARN] test-debt: '$root' is not a git repository with a commit — the ratchet did not run."
+    return 0
+  }
+
+  if [ ! -f "$ledger" ]; then
+    if [ "$sev" = "block" ]; then
+      echo "[BLOCKED] test-debt: $TD_LEDGER_REL is missing. A ratchet with no baseline is not a ratchet."
+      echo "          Write one:  bash <framework>/scripts/lib/adopt/adopt-test-debt.sh --write --root ."
+      return 2
+    fi
+    echo "[WARN] test-debt: $TD_LEDGER_REL is missing, so neither arm could run."
+    return 0
+  fi
+
+  jq -r '.files[]? // empty' "$ledger" 2>/dev/null > "$TD_TMP/ledgered"
+  names="$TD_TMP/names"
+  _td_test_names "$root" > "$names"
+  staged="$( cd "$root" 2>/dev/null && git diff --cached --name-status 2>/dev/null )"
+
+  : > "$TD_TMP/grow"
+  : > "$TD_TMP/touch"
+
+  # ── Arm 1: NON-GROWTH — the untested set may not gain a member ────────────
+  # ADDITIONS only. A pure deletion is carved out upstream by
+  # _bl072_status_effective_path (removing a source file is not shipping
+  # implementation); a modification belongs to the other arm.
+  while IFS="$(printf '\t')" read -r status path extra; do
+    [ -n "$status" ] || continue
+    eff="$(_bl072_status_effective_path "$status" "$path" "$extra")"
+    [ -z "$eff" ] && continue
+    case "$status" in A|A[0-9]*|R*|C*) ;; *) continue ;; esac
+    _td_is_candidate "$eff" || continue
+    _td_in_ledger "$eff" "$TD_TMP/ledgered" && continue
+    _td_has_test "$root" "$eff" "$names" && continue
+    printf '%s\n' "$eff" >> "$TD_TMP/grow"    # BF-TD-NONGROWTH-ARM
+  done <<TD_STAGED_ADDS
+$staged
+TD_STAGED_ADDS
+
+  # ── Arm 2: TOUCH-REPAYS — a ledgered file that is modified must leave ─────
+  # LEDGER-SCOPED, deliberately. Firing on every edit would be a coverage
+  # mandate, and §5.4 limit 3 declines to write one: a burn-down rate is a
+  # business decision, and a rate the operator cannot meet teaches them to
+  # disable the gate.
+  while IFS="$(printf '\t')" read -r status path extra; do
+    [ -n "$status" ] || continue
+    eff="$(_bl072_status_effective_path "$status" "$path" "$extra")"
+    [ -z "$eff" ] && continue
+    _td_in_ledger "$eff" "$TD_TMP/ledgered" || continue
+    _td_has_test "$root" "$eff" "$names" && continue
+    printf '%s\n' "$eff" >> "$TD_TMP/touch"   # BF-TD-TOUCH-ARM
+  done <<TD_STAGED_TOUCHES
+$staged
+TD_STAGED_TOUCHES
+
+  n_grow="$(grep -c . "$TD_TMP/grow" 2>/dev/null)";  case "$n_grow"  in ''|*[!0-9]*) n_grow=0 ;;  esac
+  n_touch="$(grep -c . "$TD_TMP/touch" 2>/dev/null)"; case "$n_touch" in ''|*[!0-9]*) n_touch=0 ;; esac
+  [ "$n_grow" -eq 0 ] && [ "$n_touch" -eq 0 ] && return 0
+
+  _td_report "$sev" "$n_grow" "$n_touch"
+  [ "$sev" = "block" ] || return 0
+  [ "$n_grow" -gt 0 ] && return 3
+  return 4
+}
+
+# _td_report SEVERITY N_GROW N_TOUCH — say what was found, once, in the tier's
+# own voice. The label is presentation; the caller's exit code is the verdict.
+_td_report() {
+  local sev="$1" n_grow="$2" n_touch="$3" tag p
+  if [ "$sev" = "block" ]; then tag="[BLOCKED]"; else tag="[WARN]"; fi
+  if [ "$n_grow" -gt 0 ]; then
+    echo "$tag test-debt (non-growth): $n_grow file(s) would ENTER the untested set."
+    while IFS= read -r p; do [ -n "$p" ] && echo "          + $p"; done < "$TD_TMP/grow"
+  fi
+  if [ "$n_touch" -gt 0 ]; then
+    echo "$tag test-debt (touch-repays): $n_touch ledgered file(s) were modified without gaining a test."
+    while IFS= read -r p; do [ -n "$p" ] && echo "          ~ $p"; done < "$TD_TMP/touch"
+  fi
+  echo "          A test whose NAME carries the file's stem clears it; for Rust, inline #[cfg(test)] counts."
+  if [ "$sev" = "block" ]; then
+    echo "          This project's enforcement tier is strict, so this is a refusal, not a note."
+  fi
+  return 0
+}
+
+# adopt_test_debt_check ROOT — run both arms against the staged set.
+adopt_test_debt_check() {
+  local rc=0
+  TD_TMP="$(mktemp -d "${TMPDIR:-/tmp}/td-check.XXXXXXXX" 2>/dev/null)" || return 2
+  _td_check_body "$@" || rc=$?
+  rm -rf "$TD_TMP"
+  TD_TMP=""
+  return $rc
+}
+
+# ── The driver's call site ──────────────────────────────────────────────────
+# adopt_test_debt_record ROOT — write the ledger during an adoption and say
+# what it recorded.
+#
+# It replaces a `NOT DONE` stub, so it is held to the standard that stub set:
+# it states what was measured and what the number does NOT mean. An operator
+# who reads "0 untested files" and hears "this project is covered" has been
+# misled by the artefact, not by the heuristic.
+adopt_test_debt_record() {
+  local root="$1" rc=0
+  if ! command -v adopt_head >/dev/null 2>&1; then
+    adopt_test_debt_write "$root"
+    return $?
+  fi
+  adopt_head "Measuring the test debt"
+  adopt_test_debt_write "$root" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    adopt_note "The test-debt ledger could not be written; nothing has been recorded."
+    return "$rc"
+  fi
+  adopt_note "$TD_LEDGER_REL records $TD_LAST_COUNT source file(s) with no test today."
+  adopt_note "That set is the baseline: from here it may not grow, and a file in it that you"
+  adopt_note "change has to leave it. It is a name-match count, not coverage — read the"
+  adopt_note "'method' field in the file before you quote the number."
+  return 0
+}
+
+# ── Direct invocation ───────────────────────────────────────────────────────
+# The module's ENTRY SCRIPT is still scripts/adopt-project.sh; this block adds
+# a command, not an entry point, and nothing in core reaches it. Until WP7's
+# commit-time hook lands it is how the arms are actually run — the same posture
+# adopt_stub_hooks takes for the checks that hook would carry ("run them by
+# hand until it lands").
+if [ "${BASH_SOURCE[0]}" = "$0" ]; then
+  set -uo pipefail
+  TD_MODE=""
+  TD_ROOT="."
+  TD_USAGE="Usage: adopt-test-debt.sh (--check | --write) [--root DIR]"
+  while [ "$#" -gt 0 ]; do
+    case "$1" in
+      --check)   TD_MODE="check"; shift ;;
+      --write)   TD_MODE="write"; shift ;;
+      --root)    [ "$#" -ge 2 ] || { echo "$TD_USAGE" >&2; exit 2; }; TD_ROOT="$2"; shift 2 ;;
+      --root=*)  TD_ROOT="${1#--root=}"; shift ;;
+      -h|--help) echo "$TD_USAGE"; exit 0 ;;
+      *)         echo "$TD_USAGE" >&2; exit 2 ;;
+    esac
+  done
+  [ -n "$TD_MODE" ] || { echo "$TD_USAGE" >&2; exit 2; }
+  TD_ROOT_ABS="$(cd "$TD_ROOT" 2>/dev/null && pwd)"
+  [ -n "$TD_ROOT_ABS" ] || { echo "adopt-test-debt: '$TD_ROOT' is not a directory this can read." >&2; exit 2; }
+  if [ "$TD_MODE" = "write" ]; then
+    adopt_test_debt_write "$TD_ROOT_ABS"
+    exit $?
+  fi
+  adopt_test_debt_check "$TD_ROOT_ABS"
+  exit $?
+fi

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -351,9 +351,14 @@ tdd_terminal_enforce() {
   # about history, not a severity.
   #
   # HONEST LIMIT, stated rather than implied: kind (c)'s forward equivalent is
-  # the test-debt ledger and its ratchet (§5.4). It is NAMED here and it is NOT
-  # IMPLEMENTED — WP5b owns it. Until it lands, this exemption's forward
-  # counterpart does not exist, and the arm claims only what it does: it
+  # the test-debt ledger and its ratchet (§5.4). WP5b SHIPPED it — the ledger is
+  # written at adoption and both arms exist — but NOTHING CALLS IT FROM HERE and
+  # nothing will: the ratchet is module code under scripts/lib/adopt/ and this
+  # file is core, so a call from here is the `core -> module` edge M3 forbids
+  # and scripts/lint-module-dependencies.sh reds on. The commit-time caller is
+  # WP7's, in the ADOPTED project. Until it lands the arms are a command an
+  # operator or a CI step runs, and this exemption's forward counterpart is
+  # therefore real but not automatic. The arm here claims only what it does: it
   # exempts pre-adoption commits and nothing else.
   #
   # The decision is computed FIRST and the guard is a single line, so the

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9197,3 +9197,120 @@ is the evidence half of a question already on the record.
 `scripts/cut-release.sh`, found first; this entry is what generalising that
 finding produced), BL-104 (a check whose printed result outran what it measured),
 BL-196 (a passing check that proves nothing is worse than no check).
+
+---
+
+## BL-223: `soif_parse_shipped_scripts` re-parses `init.sh` once per caller invocation — a single-pass rewrite is worth ~125ms a call, and it is a core lib with three consumers
+
+**Logged:** 2026-08-10 (measured during the WP5b brownfield fix round; filed
+because the follow-up otherwise existed only in a commit-body sentence)
+**Category:** Performance / core-lib hygiene — a hot loop in a shared parser
+**Severity:** Low. Nothing is wrong; it is slower than it needs to be, and the
+cost only became visible when a third consumer started calling it on every
+invocation rather than once per test run.
+**Status:** Open — DEFERRED
+
+**What it is.** `soif_parse_shipped_scripts` in
+`scripts/lib/scaffold-shipped-set.sh` greps `init.sh` for its `cp` lines and
+then spawns **one `sed` subshell per matched line** to extract the path:
+
+```
+grep -E 'cp[[:space:]]+"\$SCRIPT_DIR/scripts/' "$init_file" | while IFS= read -r line; do
+  rel="$(printf '%s\n' "$line" | sed -n 's#...#\1#p')"
+```
+
+With ~60 matched lines that is ~120 process spawns per call.
+
+**Measured, 2026-08-10:** **125 ms per call.** WP5b's
+`scripts/lib/adopt/adopt-test-debt.sh` calls it once per `--check` and once per
+`--write` — **67 invocation sites** across
+`tests/test-brownfield-wp5b-test-debt.sh` — which is the bulk of that suite's
+jump from ~11.4s to ~28.8s. A single-pass `sed -n 's#...#\1p'` over the file
+(no `grep`, no per-line subshell) does the same work in one process.
+
+**Why it was NOT done as a drive-by, and this is the load-bearing half of the
+entry.** It is a **core lib with three consumers**, each with its own
+correctness story:
+
+| Consumer | What breaks if the parse changes |
+|---|---|
+| `tests/test-scaffold-source-closure.sh` | the BL-088 source-closure check — its whole claim is that the derived set is byte-identical to init.sh's real copy list |
+| `scripts/upgrade-project.sh --sync-framework` | BL-099 SLICE-A copies exactly this set framework→project |
+| `scripts/lib/adopt/adopt-test-debt.sh` | the test-debt census's framework exclusion; a set that shrinks silently re-opens the ledger poisoning the WP5b fix round closed |
+
+The parser's own header says its full-line matching "mirrors the original inline
+parser in `tests/test-scaffold-source-closure.sh` **byte-for-byte** so both
+consumers observe an identical set". A rewrite has to preserve the glob-expansion
+branch (`host-drivers/`) and the sort/dedup, and it needs its own mutation proof
+that the emitted set is unchanged on the real `init.sh` — not a passing suite,
+which a *smaller* set also produces.
+
+**Acceptance:** the rewritten parser emits a byte-identical set to the current
+one on the real `init.sh` (diff of both outputs, asserted, not eyeballed); all
+three consumers' suites stay green; a mutation that drops the glob-expansion
+branch reds. Re-measure and record the per-call cost.
+
+**Related:** `## BL-088:` (source closure, consumer 1), `## BL-099:` (framework
+sync, consumer 2). The WP5b consumer arrived 2026-08-10 with the brownfield
+test-debt ledger.
+
+---
+
+## BL-224: `lint-no-live-remote-in-tests.sh` reds any test that WRITES an `init.sh` carrying a `#!/usr/bin/env` shebang — the shebang string satisfies its own `env …` alternation
+
+**Logged:** 2026-08-10 (hit while building the WP5b brownfield fix round's
+incomplete-clone fixtures; reproduced and reduced to one line before filing)
+**Category:** Lint false positive — a hermetic-tests check firing on a file that
+is written, never executed
+**Severity:** Low, with one aggravating property: the workaround a contributor
+reaches for first is to SPELL AROUND the lint, which is the dodging pathology
+this repo already has scar tissue for on the unit-lane predicate.
+**Status:** Open — DEFERRED
+
+**The reproduction, one line.** In any `tests/test-*.sh`:
+
+```
+printf '#!/usr/bin/env bash\n# no copy lines\n' > "$m/init.sh"
+```
+
+reds as:
+
+```
+lint-no-live-remote: init.sh run can reach LIVE remote creation — add --no-remote-creation …
+```
+
+Delete the shebang from the printf and the same line passes. Nothing is
+executed either way.
+
+**Why.** `line_is_init_exec`'s rule B is
+
+```
+(^|[(;&|]|&&|env[[:space:]][^;&|]*)[[:space:]]*"?<init-token>"?[[:space:]]
+```
+
+The `env[[:space:]][^;&|]*` alternative exists to catch `env FOO=bar "$INIT" …`.
+The literal text `/usr/bin/env bash\n# no copy lines\n' > ` also satisfies it —
+`env`, a space, then a run with no `;`/`&`/`|` — after which `"$m/init.sh"`
+matches the init token in apparent command position. The lint cannot tell a
+redirect TARGET from a command word here, and a shebang inside a single-quoted
+string is not code at all.
+
+**Scope, measured on the tree of 2026-08-10:** one occurrence, in
+`tests/test-brownfield-wp5b-test-debt.sh`'s `mk_mirror`, worked around by
+omitting the shebang from a stub that is only ever parsed. The stub's header
+says why in as many words, so the next reader does not "fix" it back.
+
+**Candidate fixes, none taken here.** (a) Require the init token to be preceded
+by a command terminator that is not inside a quoted string — a real shell-aware
+parse, and a large change to a lint with its own suite. (b) Exclude logical
+lines whose init token is immediately preceded by a redirect operator (`>`,
+`>>`) — narrow, cheap, and covers this class exactly. (c) Anchor the `env`
+alternative so it must be at command position too. **(b) is the smallest
+honest fix**; it needs its own mutation proof that a genuine
+`env FOO=bar "$INIT"` still reds, because the risk of narrowing a hermeticity
+lint is a live `gh repo create` — which this repo has already leaked once
+(2026-07-06).
+
+**Related:** `## BL-076:` (the lint itself). Sibling shape:
+`## BL-181:`, where narrowing a predicate by one character re-opened a hole
+three times.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9229,14 +9229,23 @@ jump from ~11.4s to ~28.8s. A single-pass `sed -n 's#...#\1p'` over the file
 (no `grep`, no per-line subshell) does the same work in one process.
 
 **Why it was NOT done as a drive-by, and this is the load-bearing half of the
-entry.** It is a **core lib with three consumers**, each with its own
-correctness story:
+entry.** It is a **core lib with NINE calling files**, each with its own
+correctness story. *A first draft of this entry said three, naming only the ones
+this work package had touched; adversarial review counted the rest. Derive the
+list, do not remember it —* `git grep -ln soif_parse_shipped_scripts -- 'scripts/*' 'tests/*'`
+*minus the lib itself:*
 
 | Consumer | What breaks if the parse changes |
 |---|---|
 | `tests/test-scaffold-source-closure.sh` | the BL-088 source-closure check — its whole claim is that the derived set is byte-identical to init.sh's real copy list |
 | `scripts/upgrade-project.sh --sync-framework` | BL-099 SLICE-A copies exactly this set framework→project |
 | `scripts/lib/adopt/adopt-test-debt.sh` | the test-debt census's framework exclusion; a set that shrinks silently re-opens the ledger poisoning the WP5b fix round closed |
+| `scripts/lib/adopt/adopt-state.sh` | the adoption **install** set — the same derivation the exclusion above subtracts, which is *why* they cannot diverge |
+| `scripts/adopt-project.sh` | the driver's own set reference |
+| `scripts/lib/currency-manifest.sh` | the currency manifest's shipped-file inventory |
+| `scripts/lib/plan-staging.sh` | plan staging iterates the set |
+| `tests/test-currency-birth-stamp.sh` | asserts against the derived set |
+| `tests/test-delta-wp8-intake.sh` | asserts against the derived set |
 
 The parser's own header says its full-line matching "mirrors the original inline
 parser in `tests/test-scaffold-source-closure.sh` **byte-for-byte** so both
@@ -9246,13 +9255,20 @@ that the emitted set is unchanged on the real `init.sh` — not a passing suite,
 which a *smaller* set also produces.
 
 **Acceptance:** the rewritten parser emits a byte-identical set to the current
-one on the real `init.sh` (diff of both outputs, asserted, not eyeballed); all
-three consumers' suites stay green; a mutation that drops the glob-expansion
-branch reds. Re-measure and record the per-call cost.
+one on the real `init.sh` (diff of both outputs, asserted, not eyeballed); **every
+calling file's suite stays green — re-derive the list at the time, do not trust
+the table above**; a mutation that drops the glob-expansion branch reds.
+Re-measure and record the per-call cost.
 
-**Related:** `## BL-088:` (source closure, consumer 1), `## BL-099:` (framework
-sync, consumer 2). The WP5b consumer arrived 2026-08-10 with the brownfield
-test-debt ledger.
+The byte-identical criterion is what makes the under-count survivable: it
+protects every caller regardless of whether the table names them. That is the
+reason to keep it even if a future rewrite looks obviously safe.
+
+**Related:** `## BL-088:` (source closure), `## BL-099:` (framework sync). The
+WP5b consumer arrived 2026-08-10 with the brownfield test-debt ledger.
+Measured cost: 125 ms/call on the implementer's run, 144 ms on the reviewer's —
+same magnitude, and the spread is why the entry says re-measure rather than
+quoting one number.
 
 ---
 
@@ -9270,8 +9286,15 @@ this repo already has scar tissue for on the unit-lane predicate.
 **The reproduction, one line.** In any `tests/test-*.sh`:
 
 ```
-printf '#!/usr/bin/env bash\n# no copy lines\n' > "$m/init.sh"
+printf '#!/usr/bin/env bash\n# no copy lines\n' > "$m/init.sh" || true
 ```
+
+**The trailing `|| true` is load-bearing and was missing from the first draft of
+this entry** — rule B requires `[[:space:]]` *after* the init token, so the bare
+redirect does not red (measured: rc 0, zero hits) and a future fixer running the
+recipe verbatim would conclude the bug was already gone. The real `mk_mirror`
+shape that first fired it ends `|| return 1 ;;`. Reproduce, then fix; the entry
+that sends you looking is only as good as its recipe.
 
 reds as:
 
@@ -9304,12 +9327,29 @@ says why in as many words, so the next reader does not "fix" it back.
 by a command terminator that is not inside a quoted string — a real shell-aware
 parse, and a large change to a lint with its own suite. (b) Exclude logical
 lines whose init token is immediately preceded by a redirect operator (`>`,
-`>>`) — narrow, cheap, and covers this class exactly. (c) Anchor the `env`
-alternative so it must be at command position too. **(b) is the smallest
-honest fix**; it needs its own mutation proof that a genuine
+`>>`) — narrow, cheap, and covers *the redirect class* exactly. (c) Anchor the
+`env` alternative so it must be at command position too.
+
+**Whichever is taken needs its own mutation proof** that a genuine
 `env FOO=bar "$INIT"` still reds, because the risk of narrowing a hermeticity
 lint is a live `gh repo create` — which this repo has already leaked once
 (2026-07-06).
+
+**(b) is NOT sufficient — two more over-broad shapes, measured by adversarial
+review 2026-08-10.** The first draft of this entry called (b) "the smallest
+honest fix"; that was written from one instance rather than from a survey.
+Rule B also reds:
+- a **heredoc body** line — `uses env FOO=bar "$m/init.sh" here` inside a
+  `<<'DOC'` block reds at rc 1, though nothing there is a command at all;
+- a **mid-word `env`** — `run_getenv "$m/init.sh" now` fires, because the
+  `env[[:space:]]` alternative has no left word-boundary.
+
+**(b) covers neither. (c) covers all three**, which makes command-position
+anchoring the fix to price rather than the redirect exclusion. Negative controls
+behaved correctly and should be kept as the preservation half of the proof:
+comments are stripped, an `scripts/env-setup.sh`-style path passes (`env`
+followed by `-`), and the genuine `env SOIF_FAKE=1 "$m/init.sh" --whatever`
+still reds.
 
 **Related:** `## BL-076:` (the lint itself). Sibling shape:
 `## BL-181:`, where narrowing a predicate by one character re-opened a hole

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -723,6 +723,30 @@ run_child_suite "tests/test-brownfield-wp4-driver.sh" \
   "Adoption driver (chooser verbatim, floor rule, reverse intake, fail-safe write order)" \
   "Adoption WP4 driver tests FAILED (run tests/test-brownfield-wp4-driver.sh for details)"
 
+# Brownfield adoption WP5b: tests/test-brownfield-wp5b-test-debt.sh — the
+# TEST-DEBT LEDGER (.claude/test-debt.json) and its tier ratchet, which is
+# kind (c)'s forward equivalent: the ordering of pre-adoption commits is not a
+# re-runnable fact, so what is enforced instead is that the untested set may
+# not GROW and that a ledgered file which is TOUCHED must leave the set.
+# THE SECOND MUTATION DIRECTION IS THE POINT. Neutering an arm and watching
+# the untested set grow silently is the obvious half. The other half — neuter
+# the TIER FLOOR and watch the arm refuse a `no`-tier project — is the one
+# that usually gets skipped, and a ratchet that blocks a poc_mode project is
+# not a stricter ratchet, it is the shape that makes an operator disable the
+# framework (the false-FAIL doctrine of BL-122/BL-149). Both directions are
+# proved for BOTH arms: M1/M2 neuter the arms, M3/M4 neuter the floor and
+# observe it through each arm's own fixture, M5 promotes the `light` row so
+# the identical WARN becomes a block (the `[WARN]` trap, asserted as an exit
+# code and never as a label).
+# The tier read consumes read_enforcement_level and assert_choosable and
+# RAISES ONLY, so `## BL-221:`'s live fail-open — `.deployment // "personal"`
+# resolving an ABSENT key to the choosable tier — cannot lower anything; M6
+# deletes the key-presence guard and the same manifest buys silence.
+# Never invokes the scaffolder -> both lanes.
+run_child_suite "tests/test-brownfield-wp5b-test-debt.sh" \
+  "Adoption test-debt ledger + tier ratchet (non-growth, touch-repays, both mutation directions)" \
+  "Adoption WP5b test-debt tests FAILED (run tests/test-brownfield-wp5b-test-debt.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -1145,8 +1145,18 @@ else
   w1_cert=0; w1_record=0; w1_empty_named=0; w1_docs=0; w1_debt=0
   grep -q 'NOT DONE — the certification pass' "$RUN_OUT" && w1_cert=1
   grep -q 'NOT DONE — the Adoption Record' "$RUN_OUT" && w1_record=1
-  grep -q 'NOT DONE — the test-debt ledger' "$RUN_OUT" && w1_debt=1
   grep -q "NOT DONE — your project's framework documents" "$RUN_OUT" && w1_docs=1
+  # WP5b RETIRED ITS STUB, so this row flipped: the test-debt notice must be
+  # GONE and the thing it apologised for must be PRESENT. The absence alone
+  # would also be satisfied by a driver that simply stopped printing it, so it
+  # is asserted together with the artefact — the ledger has to exist on disk.
+  # Its contents, its tier ratchet and both mutation directions belong to
+  # tests/test-brownfield-wp5b-test-debt.sh; what W1 owns is the honesty
+  # accounting, and a package that has shipped must not still announce itself
+  # as NOT DONE.
+  w1_debt=1
+  grep -q 'NOT DONE — the test-debt ledger' "$RUN_OUT" && w1_debt=0
+  [ -s "$W1D/p/.claude/test-debt.json" ] || w1_debt=0
   grep -q "means 'not measured', not 'measured and clean'" "$RUN_OUT" && w1_empty_named=1
   w1_kinds=$(jq -r '[.adoption.certification.kindA, .adoption.certification.kindB, .adoption.certification.kindC] | map(length) | add' "$W1D/p/.claude/manifest.json" 2>/dev/null)
   # The CLAUDE.md half is asserted as an ABSENCE, so it carries a structural
@@ -1157,9 +1167,9 @@ else
   if [ "$w1_rc" -eq 0 ] && [ "$w1_cert" -eq 1 ] && [ "$w1_record" -eq 1 ] && [ "$w1_debt" -eq 1 ] \
      && [ "$w1_docs" -eq 1 ] && [ "$w1_no_claude" -eq 1 ] \
      && [ "$w1_empty_named" -eq 1 ] && [ "$(_num "$w1_kinds")" -eq 0 ]; then
-    pass "W1: every unbuilt package announces itself — certification, the test-debt ledger, the Adoption Record and the project documents — and the run says an empty certification list means 'not measured', not 'measured and clean'"
+    pass "W1: every STILL-unbuilt package announces itself — certification, the Adoption Record and the project documents — the run says an empty certification list means 'not measured', not 'measured and clean', and the one package that HAS shipped (WP5b's test-debt ledger) no longer announces itself as NOT DONE and left its artefact behind"
   else
-    fail_ "W1" "rc=$w1_rc certification_stub=$w1_cert test_debt_stub=$w1_debt adoption_record_stub=$w1_record project_docs_stub=$w1_docs claude_md_absent=$w1_no_claude empty_means_unmeasured_stated=$w1_empty_named certification_entries=$w1_kinds (want 0)"
+    fail_ "W1" "rc=$w1_rc certification_stub=$w1_cert test_debt_retired_and_written=$w1_debt (want 1) adoption_record_stub=$w1_record project_docs_stub=$w1_docs claude_md_absent=$w1_no_claude empty_means_unmeasured_stated=$w1_empty_named certification_entries=$w1_kinds (want 0)"
   fi
 fi
 

--- a/tests/test-brownfield-wp5b-test-debt.sh
+++ b/tests/test-brownfield-wp5b-test-debt.sh
@@ -76,6 +76,7 @@ LIB="$REPO_ROOT/scripts/lib/adopt/adopt-test-debt.sh"
 DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
 CORE_ENF="$REPO_ROOT/scripts/lib/enforcement-level.sh"
 CORE_TDD="$REPO_ROOT/scripts/lib/tdd-classify.sh"
+CORE_SHIPPED="$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh"
 
 PASSED=0
 FAILED=0
@@ -808,11 +809,160 @@ ANS
     # untested debt, and the touch-repays arm would then demand tests for the
     # framework's own gate scripts.
     g2_fw=$(jq -r '[.files[] | select(startswith("scripts/"))] | length' "$g_file" 2>/dev/null)
+    g2_count=$(jq -r '.count // -1' "$g_file" 2>/dev/null)
     if [ "$(_num "$g2_fw")" -eq 0 ]; then
       pass "G2: the ledger contains NONE of the framework scripts the adoption installed — the census is of the adoptee's own tracked source, not of the tree the driver leaves behind"
     else
       fail_ "G2" "framework scripts ledgered: $g2_fw (want 0)"
     fi
+
+    # G3 — THE SECOND WRITE, and the reason this row exists at all.
+    #
+    # G2 above passes for a reason that is NOT a defence: at adoption time the
+    # framework's scripts are copied but not yet TRACKED, and the census reads
+    # `git ls-files`. That is timing, not exclusion — and a defence that works
+    # by timing is a coincidence with a schedule. Every write after the
+    # adoption commit is exposed, and this tool ACTIVELY INSTRUCTS the operator
+    # to perform one: the rename [NOTE] and the rc-2 refusal both print
+    # `--write --root .`.
+    #
+    # Measured before the fix, on exactly this fixture: count 1 / 0 framework
+    # entries at adoption, then count 58 / 57 framework entries after running
+    # the advertised command — after which touch-repays demanded tests for
+    # check-gate.sh and check-phase-gate.sh on any framework sync. The tool
+    # told the user to break themselves.
+    #
+    # A THIRD assertion is here on purpose: the audit row count. "Unchanged" and
+    # "the write never ran" are the same bytes on disk, and only the audit row
+    # tells them apart.
+    write_ledger "$GD/p"
+    g3_fw=$(jq -r '[.files[] | select(startswith("scripts/"))] | length' "$g_file" 2>/dev/null)
+    g3_count=$(jq -r '.count // -1' "$g_file" 2>/dev/null)
+    g3_rows=$(jq -r '.audit | length' "$g_file" 2>/dev/null)
+    if [ "$(_num "$g3_fw")" -eq 0 ] && [ "$(_num "$g3_count")" = "$(_num "$g2_count")" ] \
+       && [ "$(_num "$g3_rows")" -eq 2 ]; then
+      pass "G3: running the re-baseline command the tool itself advertises, AFTER the adoption commit, still ledgers zero framework scripts and the same count ($g3_count) — and the second audit row proves the write actually ran"
+    else
+      fail_ "G3" "framework scripts after re-baseline: $g3_fw (want 0) count=$g3_count (want $g2_count) audit_rows=$g3_rows (want 2 — 1 means the write never happened and this row proves nothing)"
+    fi
+  fi
+fi
+
+echo ""
+echo "=== P — the adoptee's own git config must not be able to switch the arms off ==="
+
+# A fix a user's .gitconfig can silently disable is not a fix. Both rows below
+# were REPRODUCED before being fixed, and both carry a structural discriminator
+# proving the fixture really is running under the hostile config — without it a
+# green row would only mean "the config had no effect here".
+
+# P1 — `diff.renames=copies`. Staging a copy of a TESTED file plus a touch of
+# its source made git report `C100 src/paid.js src/clone.js`, and src/clone.js —
+# an untested source file — ENTERED the working set at rc 0 with zero bytes of
+# output. That is the silent-bypass class: no refusal, no warning, no trace.
+P1D="$(newtmp)/p"
+if ! mk_repo "$P1D"; then fail_ "P1" "fixture setup failed"; else
+  write_ledger "$P1D"
+  set_tier "$P1D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  gitq "$P1D" config diff.renames copies
+  cp "$P1D/src/paid.js" "$P1D/src/clone.js"
+  printf 'export function paid() { return 2; }\n' > "$P1D/src/paid.js"
+  gitq "$P1D" add -A
+  # The discriminator: git's OWN reading of this index, with nothing pinned.
+  p1_raw=$( unset GITHUB_BASE_REF; cd "$P1D" && git diff --cached --name-status 2>/dev/null | grep -c '^C' )
+  p1_raw=$(_num "$p1_raw")
+  check_in "$P1D"
+  p1_named=0; grep -q 'src/clone\.js' "$CHK_OUT" && p1_named=1
+  if [ "$CHK_RC" -eq 3 ] && [ "$p1_named" -eq 1 ] && [ "$p1_raw" -ge 1 ]; then
+    pass "P1: under the adoptee's own diff.renames=copies the copied untested file still BLOCKS at strict (rc 3, named) — the read pins diff.renames=true, so a config that makes git say C100 cannot make the arm say nothing"
+  else
+    fail_ "P1" "rc=$CHK_RC (want 3) clone_named=$p1_named (want 1) unpinned_git_reports_C_rows=$p1_raw (want >=1; 0 means the fixture is not exercising the hostile config and this row proves nothing)"
+  fi
+fi
+
+# P2 — `diff.renames=false`. The rename loop the previous commit is named after
+# comes back VERBATIM: git reports D+A instead of R100, non-growth blocks at
+# rc 3, re-baselining puts the new path in the ledger, and the same staged
+# rename blocks again at rc 4. Reproduced before the fix.
+P2D="$(newtmp)/p"
+if ! mk_repo "$P2D"; then fail_ "P2" "fixture setup failed"; else
+  write_ledger "$P2D"
+  set_tier "$P2D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  gitq "$P2D" config diff.renames false
+  gitq "$P2D" mv src/debt.js src/debt2.js
+  p2_raw=$( unset GITHUB_BASE_REF; cd "$P2D" && git diff --cached --name-status 2>/dev/null | grep -c '^D' )
+  p2_raw=$(_num "$p2_raw")
+  check_in "$P2D"
+  p2_noted=0; grep -q 'src/debt\.js -> src/debt2\.js' "$CHK_OUT" && p2_noted=1
+  if [ "$CHK_RC" -eq 0 ] && [ "$p2_noted" -eq 1 ] && [ "$p2_raw" -ge 1 ]; then
+    pass "P2: under the adoptee's own diff.renames=false the pure rename is still seen as a rename — rc 0 with the stale-ledger note, not the rc 3 -> re-baseline -> rc 4 loop the config resurrected"
+  else
+    fail_ "P2" "rc=$CHK_RC (want 0) rename_noted=$p2_noted (want 1) unpinned_git_reports_D_rows=$p2_raw (want >=1; 0 means the fixture is not exercising the hostile config)"
+  fi
+fi
+
+echo ""
+echo "=== Q — status atoms every fixture can actually reach ==="
+
+# Q1 — a staged MODIFICATION of a file that is NEITHER ledgered NOR tested.
+#
+# This row exists because a reviewer's mutation survived a 42/0 suite: widening
+# the non-growth match from `A` to `A|M` — which REVERSES the documented
+# "additions only" decision and turns the arm into the coverage mandate §5.4
+# limit 3 declines to write — changed nothing, because every other fixture's
+# staged `M` row is either ledgered (skipped by the ledger check) or tested
+# (skipped by the test check). The `M` branch was unreachable, so it was pinned
+# by nothing.
+#
+# The fixture reaches it by deleting the test AFTER baselining: src/paid.js is
+# then unledgered (it had a test when the ledger was written) and untested (the
+# test is gone), which is the one combination that lands in the `M` branch.
+Q1D="$(newtmp)/p"
+if ! mk_repo "$Q1D"; then fail_ "Q1" "fixture setup failed"; else
+  write_ledger "$Q1D"
+  set_tier "$Q1D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  gitq "$Q1D" rm -q tests/paid.test.js
+  gitq "$Q1D" commit -q -m "chore: the test goes away"
+  printf 'export function paid() { return 3; }\n' > "$Q1D/src/paid.js"
+  gitq "$Q1D" add src/paid.js
+  # Three discriminators, because a green row here must not be reachable by a
+  # fixture that drifted into some other shape.
+  q1_status=$( unset GITHUB_BASE_REF; cd "$Q1D" && git diff --cached --name-status 2>/dev/null | cut -f1 | tr -d '\n' )
+  q1_ledgered=$(jq -r '[.files[] | select(. == "src/paid.js")] | length' "$Q1D/.claude/test-debt.json" 2>/dev/null)
+  q1_tested=0; [ -e "$Q1D/tests/paid.test.js" ] && q1_tested=1
+  check_in "$Q1D"
+  if [ "$CHK_RC" -eq 0 ] && [ "$q1_status" = "M" ] \
+     && [ "$(_num "$q1_ledgered")" -eq 0 ] && [ "$q1_tested" -eq 0 ]; then
+    pass "Q1: a staged M of an UNLEDGERED, UNTESTED file passes at strict (rc 0) — non-growth is additions-only, and this is the only fixture shape that can reach the branch which says so"
+  else
+    fail_ "Q1" "rc=$CHK_RC (want 0) staged_status='$q1_status' (want M) ledgered=$q1_ledgered (want 0) test_file_still_present=$q1_tested (want 0)"
+  fi
+fi
+
+# Q2 — a MODE-ONLY change. `chmod +x` on a ledgered file reads as `M` and used
+# to block at rc 4, although git's own raw output shows the SAME blob SHA on
+# both sides. That is the identical fact the R100 carve-out rests on, so the
+# two postures were inconsistent, and inconsistent in the false-FAIL direction.
+# The control is the same file with its CONTENT changed: that must still block,
+# or this row would be pinning "touch-repays never fires".
+Q2D="$(newtmp)/p"
+if ! mk_repo "$Q2D"; then fail_ "Q2" "fixture setup failed"; else
+  write_ledger "$Q2D"
+  set_tier "$Q2D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  chmod +x "$Q2D/src/debt.js"
+  gitq "$Q2D" add src/debt.js
+  q2_same=$( unset GITHUB_BASE_REF; cd "$Q2D" && git diff --cached --raw --abbrev=40 2>/dev/null \
+             | sed -n 's/^:[0-7]* [0-7]* \([0-9a-f]*\) \([0-9a-f]*\) .*/\1 \2/p' \
+             | while read -r a b; do [ "$a" = "$b" ] && echo same; done | grep -c 'same' )
+  q2_same=$(_num "$q2_same")
+  check_in "$Q2D"; q2_mode_rc=$CHK_RC
+  printf 'export function debt() { return 77; }\n' > "$Q2D/src/debt.js"
+  gitq "$Q2D" add src/debt.js
+  check_in "$Q2D"; q2_content_rc=$CHK_RC
+  if [ "$q2_mode_rc" -eq 0 ] && [ "$q2_content_rc" -eq 4 ] && [ "$q2_same" -ge 1 ]; then
+    pass "Q2: a mode-only chmod +x on a ledgered file passes (rc 0) because git reports identical blob SHAs — the same fact R100 rests on — while a real content change on the SAME file still blocks at rc 4"
+  else
+    fail_ "Q2" "mode_only_rc=$q2_mode_rc (want 0) content_change_rc=$q2_content_rc (want 4) git_reports_identical_blobs=$q2_same (want >=1; 0 means the fixture never made a mode-only change)"
   fi
 fi
 
@@ -822,11 +972,26 @@ echo "=== M — mutations (both arms, both directions) ==="
 # Every mutant runs against a MIRROR of the module plus the two core libs it
 # sources. The tree under test is never edited: a failure here cannot leave
 # this repository mutated.
+#
+# LANE NOTE. The line below NAMES init.sh, which is the exemption predicate
+# `# BL-181-UNIT-LANE-PREDICATE` reads — but this suite only COPIES that file so
+# the shipped-set parser has something to parse; it never runs it. The suite
+# belongs in the fast unit lane and is registered there. The lint says so
+# itself: "an exempted file that is in the unit list anyway decided nothing and
+# is not rendered". Spelling the name plainly and registering the suite is the
+# honest combination; dodging the predicate with a glob would hide the decision.
+#
+# init.sh and scaffold-shipped-set.sh are in the mirror because the module now
+# REFUSES when it cannot derive the framework's own installed inventory. A
+# mirror without them is an incomplete clone, and the module is supposed to say
+# so rather than fall back to a census that ledgers the framework.
 mk_mirror() {
   local m="$1"
   mkdir -p "$m/scripts/lib/adopt" || return 1
   cp -p "$CORE_ENF" "$m/scripts/lib/" || return 1
   cp -p "$CORE_TDD" "$m/scripts/lib/" || return 1
+  cp -p "$CORE_SHIPPED" "$m/scripts/lib/" || return 1
+  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
   cp -p "$LIB" "$m/scripts/lib/adopt/" || return 1
   return 0
 }
@@ -988,6 +1153,91 @@ else
     pass "M7 (the census): control ledgers 1 untested file; with the candidate predicate neutered the writer still emits VALID JSON with count 0 — an empty ledger is a real, reachable state and it is not the same fact as a clean tree"
   else
     fail_ "M7" "control_count=$m7_ctl (want 1) mutant_ledger_valid=$m7_valid (want 1) mutant_count=$m7_mut (want 0) sites=$m7_sites (want 1) changed_lines=$m7_changed (want 2) parses=$m7_parses (want 1)"
+  fi
+fi
+
+# ── M9: the additions-only decision, pinned against the `M` widening ───────
+# The mutation a reviewer landed on a 42/0 suite. Widening the non-growth
+# status match to include `M` reverses the documented decision and turns the
+# arm into a coverage mandate; Q1's fixture is the only shape that reaches the
+# branch, so it is the only thing that can kill this.
+M9D="$(newtmp)"
+if ! mk_repo "$M9D/p" || ! mk_mirror "$M9D/m"; then
+  fail_ "M9" "fixture setup failed"
+else
+  write_ledger "$M9D/p"
+  set_tier "$M9D/p" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  gitq "$M9D/p" rm -q tests/paid.test.js
+  gitq "$M9D/p" commit -q -m "chore: the test goes away"
+  printf 'export function paid() { return 3; }\n' > "$M9D/p/src/paid.js"
+  gitq "$M9D/p" add src/paid.js
+  check_in "$M9D/p" "$(_mlib "$M9D/m")"; m9_ctl=$CHK_RC
+  m9_ctl_bytes=$(_bytes "$CHK_OUT")
+  m9_meta=$(_mutate "$M9D/m" '# BF-TD-NONGROWTH-ADDITIONS-ONLY' '    case "$status" in A|M) ;; *) continue ;; esac')
+  set -- $m9_meta; m9_sites=$1; m9_changed=$2; m9_parses=$3
+  check_in "$M9D/p" "$(_mlib "$M9D/m")"; m9_mut=$CHK_RC
+  if [ "$m9_ctl" -eq 0 ] && [ "$m9_ctl_bytes" -eq 0 ] && [ "$m9_mut" -eq 3 ] \
+     && [ "$m9_sites" -eq 1 ] && [ "$m9_changed" -eq 2 ] && [ "$m9_parses" -eq 1 ]; then
+    pass "M9 (additions-only): control passes a staged M of an unledgered untested file silently; widening the status match to A|M refuses it with rc 3 — the coverage mandate §5.4 limit 3 declines to write"
+  else
+    fail_ "M9" "control_rc=$m9_ctl (want 0) control_bytes=$m9_ctl_bytes (want 0) mutant_rc=$m9_mut (want 3) sites=$m9_sites (want 1) changed_lines=$m9_changed (want 2) parses=$m9_parses (want 1)"
+  fi
+fi
+
+# ── M10: the framework-path exclusion, killed on the SECOND write ──────────
+# The exclusion replaced a defence that worked by TIMING (the framework's
+# scripts were merely untracked at adoption time). So the mutant is observed
+# where the timing defence used to hold and no longer does: a repository that
+# already TRACKS a framework path.
+M10D="$(newtmp)"
+if ! mk_repo "$M10D/p" || ! mk_mirror "$M10D/m"; then
+  fail_ "M10" "fixture setup failed"
+else
+  mkdir -p "$M10D/p/scripts"
+  printf '#!/usr/bin/env bash\necho gate\n' > "$M10D/p/scripts/check-gate.sh"
+  gitq "$M10D/p" add scripts/check-gate.sh
+  gitq "$M10D/p" commit -q -m "chore: the framework's own script, tracked"
+  write_ledger "$M10D/p" "$(_mlib "$M10D/m")"
+  m10_ctl=$(jq -r '[.files[] | select(. == "scripts/check-gate.sh")] | length' "$M10D/p/.claude/test-debt.json" 2>/dev/null)
+  m10_meta=$(_mutate "$M10D/m" '# BF-TD-FRAMEWORK-EXCLUDE' '  :')
+  set -- $m10_meta; m10_sites=$1; m10_changed=$2; m10_parses=$3
+  write_ledger "$M10D/p" "$(_mlib "$M10D/m")"
+  m10_valid=0; jq -e . "$M10D/p/.claude/test-debt.json" >/dev/null 2>&1 && m10_valid=1
+  m10_mut=$(jq -r '[.files[] | select(. == "scripts/check-gate.sh")] | length' "$M10D/p/.claude/test-debt.json" 2>/dev/null)
+  if [ "$(_num "$m10_ctl")" -eq 0 ] && [ "$m10_valid" -eq 1 ] && [ "$(_num "$m10_mut")" -eq 1 ] \
+     && [ "$m10_sites" -eq 1 ] && [ "$m10_changed" -eq 2 ] && [ "$m10_parses" -eq 1 ]; then
+    pass "M10 (the census exclusion): control keeps a TRACKED scripts/check-gate.sh out of the ledger; with the exclusion neutered the framework's own gate script becomes the adoptee's untested debt — asserted on ledger BYTES, because an absent entry and an absent write look the same"
+  else
+    fail_ "M10" "control_entry=$m10_ctl (want 0) mutant_ledger_valid=$m10_valid (want 1) mutant_entry=$m10_mut (want 1) sites=$m10_sites (want 1) changed_lines=$m10_changed (want 2) parses=$m10_parses (want 1)"
+  fi
+fi
+
+# ── M11: the git-config pin on the staged read ────────────────────────────
+# Deleting `-c diff.renames=true` restores the measured silent bypass: under
+# the adoptee's own `diff.renames=copies` the copied untested file enters the
+# working set at rc 0 with zero bytes. A fix a user's .gitconfig can disable is
+# not a fix, and this is what proves the pin is load-bearing rather than
+# decorative.
+M11D="$(newtmp)"
+if ! mk_repo "$M11D/p" || ! mk_mirror "$M11D/m"; then
+  fail_ "M11" "fixture setup failed"
+else
+  write_ledger "$M11D/p" "$(_mlib "$M11D/m")"
+  set_tier "$M11D/p" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  gitq "$M11D/p" config diff.renames copies
+  cp "$M11D/p/src/paid.js" "$M11D/p/src/clone.js"
+  printf 'export function paid() { return 2; }\n' > "$M11D/p/src/paid.js"
+  gitq "$M11D/p" add -A
+  check_in "$M11D/p" "$(_mlib "$M11D/m")"; m11_ctl=$CHK_RC
+  m11_meta=$(_mutate "$M11D/m" '# BF-TD-STAGED-READ' '  staged="$( cd "$root" 2>/dev/null && git -c core.quotePath=false diff --cached --name-status 2>/dev/null )"')
+  set -- $m11_meta; m11_sites=$1; m11_changed=$2; m11_parses=$3
+  check_in "$M11D/p" "$(_mlib "$M11D/m")"; m11_mut=$CHK_RC
+  m11_bytes=$(_bytes "$CHK_OUT")
+  if [ "$m11_ctl" -eq 3 ] && [ "$m11_mut" -eq 0 ] && [ "$m11_bytes" -eq 0 ] \
+     && [ "$m11_sites" -eq 1 ] && [ "$m11_changed" -eq 2 ] && [ "$m11_parses" -eq 1 ]; then
+    pass "M11 (the config pin): control blocks the copied untested file with rc 3; dropping -c diff.renames=true from the staged read makes the SAME commit pass with zero bytes — the silent-bypass class, reproduced on demand"
+  else
+    fail_ "M11" "control_rc=$m11_ctl (want 3) mutant_rc=$m11_mut (want 0) mutant_bytes=$m11_bytes (want 0) sites=$m11_sites (want 1) changed_lines=$m11_changed (want 2) parses=$m11_parses (want 1)"
   fi
 fi
 

--- a/tests/test-brownfield-wp5b-test-debt.sh
+++ b/tests/test-brownfield-wp5b-test-debt.sh
@@ -985,16 +985,50 @@ echo "=== M — mutations (both arms, both directions) ==="
 # REFUSES when it cannot derive the framework's own installed inventory. A
 # mirror without them is an incomplete clone, and the module is supposed to say
 # so rather than fall back to a census that ledgers the framework.
+#
+# The optional VARIANT makes a mirror INCOMPLETE in exactly one way, so each of
+# the three guards in _td_shipped_init has a fixture that reaches it:
+#   (default)  a complete clone
+#   noinit     no init.sh                    -> the BF-TD-SHIPPED-REQUIRED guard
+#   emptyinit  an init.sh with no copy lines -> the BF-TD-SHIPPED-NONEMPTY guard
+#   noparser   no scaffold-shipped-set.sh    -> the BF-TD-SHIPPED-PARSER guard
 mk_mirror() {
-  local m="$1"
+  local m="$1" variant="${2:-full}"
   mkdir -p "$m/scripts/lib/adopt" || return 1
   cp -p "$CORE_ENF" "$m/scripts/lib/" || return 1
   cp -p "$CORE_TDD" "$m/scripts/lib/" || return 1
-  cp -p "$CORE_SHIPPED" "$m/scripts/lib/" || return 1
-  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
+  [ "$variant" = "noparser" ] || cp -p "$CORE_SHIPPED" "$m/scripts/lib/" || return 1
+  case "$variant" in
+    noinit)    ;;
+    # NO SHEBANG IN THIS STUB, and the omission is load-bearing rather than
+    # tidy: with `#!/usr/bin/env bash` in it, lint-no-live-remote-in-tests.sh
+    # reds this very line as "init.sh run can reach LIVE remote creation". Its
+    # rule-B alternation carries `env[[:space:]][^;&|]*`, which the SHEBANG
+    # STRING satisfies, and the redirect target then reads as a command word.
+    # The stub is never executed — it exists only to be parsed for copy lines,
+    # of which it has none — so dropping the shebang removes a false positive
+    # without spelling around a real check. Filed as `## BL-224:`.
+    emptyinit) printf '# a clone whose copy list is empty\n' > "$m/init.sh" || return 1 ;;
+    *)         cp -p "$REPO_ROOT/init.sh" "$m/" || return 1 ;;
+  esac
   cp -p "$LIB" "$m/scripts/lib/adopt/" || return 1
   return 0
 }
+
+# mk_repo_fw DIR — mk_repo plus a TRACKED file at a framework path, so that a
+# ledger written by a module whose exclusion has gone inert is visibly wrong
+# rather than merely one entry larger.
+mk_repo_fw() {
+  mk_repo "$1" || return 1
+  mkdir -p "$1/scripts" || return 1
+  printf '#!/usr/bin/env bash\necho gate\n' > "$1/scripts/check-gate.sh" || return 1
+  gitq "$1" add scripts/check-gate.sh
+  gitq "$1" commit -q -m "chore: a framework path, tracked"
+  return 0
+}
+
+# write_via MIRROR DIR — run the mirror's writer; sets LEDGER_RC.
+write_via() { write_ledger "$2" "$(_mlib "$1")"; }
 
 # _mutate MIRROR MARKER REPLACEMENT — one anchored, end-of-line-marked line,
 # excised and replaced. Echoes "sites changed parses" for the caller to assert.
@@ -1002,15 +1036,37 @@ mk_mirror() {
 # TWO SED METACHARACTERS IN THE REPLACEMENT, BOTH LEARNED THE HARD WAY IN THIS
 # FILE. `|` was the delimiter, so a replacement containing one — `case $status
 # in A|M)`, the exact widening a reviewer used to survive a green suite —
-# terminated the expression, sed errored, and the mutant was NOT APPLIED: the
-# harness reported `changed_lines=0` rather than a passing mutant, which is the
-# lucky direction but only by accident. `&` in a replacement means THE WHOLE
-# MATCH, so `cmd_a && cmd_b` spliced the original line back in twice and
-# produced a mutant nobody had designed. The delimiter is now `%` (no marker or
-# replacement in this file contains one) and `&` is escaped.
+# terminated the expression, sed errored, and the mutant was NOT APPLIED. `&` in
+# a replacement means THE WHOLE MATCH, so `cmd_a && cmd_b` spliced the original
+# line back in twice and produced a mutant nobody had designed. The delimiter is
+# now `%` (no marker or replacement in this file contains one) and `&` is
+# escaped.
 #
-# The exactly-N-lines-changed assertion is what caught both. A harness that only
-# checked the mutant's exit code would have called each of them a kill.
+# WHICH CHECK CAUGHT WHICH — corrected, because the first version of this
+# comment credited the wrong layer and a future author would then trust the
+# wrong thing:
+#
+#   • the DELIMITER defect was caught by the exactly-N-lines-changed assertion.
+#     sed exits 1, the file is untouched, `changed_lines=0`. Meta-assertion,
+#     working exactly as intended.
+#   • the `&`-SPLICE defect was NOT. Measured under the old semantics: the
+#     splice yields `changed_lines=2` AND `bash -n` PASSES, so every
+#     meta-assertion here stays green. What caught it was M11's FUNCTIONAL
+#     assertion — the spliced module dies at runtime (`bad substitution: no
+#     closing ')'`), rc 1 and 564 bytes against a wanted rc 0 / 0 bytes.
+#
+# So the meta-assertions are NOT the defence against `&`-class accidents; the
+# CONTROL plus the functional assertion is. Note the generalisation, because it
+# is this wave's "bash -n does not syntax-check awk" one step further in:
+# **`bash -n` accepts a file bash rejects at runtime.** A parse check is not an
+# execution check, and only a mutant that RUNS proves anything.
+#
+# RESIDUAL, stated rather than left to be discovered: backslash sequences in a
+# replacement are the remaining unhandled metacharacter class. `\n` fails LOUD
+# (`changed=3`, since GNU sed turns it into a newline), but a `\.`-style escape
+# would substitute silently wrong. Nothing enforces their absence — it is header
+# convention only. `%` is verified safe today (no call site carries one) and a
+# `%`-bearing replacement would fail loud for the same reason `|` did.
 _mutate() {
   local m="$1" marker="$2" repl="$3"
   local f="$m/scripts/lib/adopt/adopt-test-debt.sh"
@@ -1274,6 +1330,147 @@ if [ "$m8_awk" -eq 0 ]; then
   pass "M8: the module drives no awk — the 'a dead awk emits empty and empty reads as fine' failure mode is removed rather than defended against"
 else
   fail_ "M8" "awk occurrences in $LIB: $m8_awk (want 0)"
+fi
+
+echo ""
+echo "=== R — the refusal branches, which were the least-pinned code on this branch ==="
+
+# WHY THIS SECTION EXISTS. The framework-exclusion fix introduced three
+# refusals — refuse to write, block a check at strict, warn at light — and
+# pinned NONE of them, because every mirror in this file was a complete clone.
+# A reviewer flipped ONE character on the init.sh guard (`|| return 1` ->
+# `|| return 0`) and the suite stayed at 50 passed, 0 failed: the mutant WROTE a
+# ledger with the exclusion silently inert, which is exactly the guessing the
+# fix advertised as foreclosed. The doctrine this file states twice about
+# matcher atoms — a branch no fixture can reach is pinned by nothing — was not
+# applied to the branch the fix was proudest of. No repo lint executes this
+# module, so nothing else would have caught it either.
+
+# R1 — --write from an incomplete clone: refuse, AND leave no file behind.
+# Both halves, because "refused" and "wrote nothing" are separate facts and a
+# writer that refuses after writing is the failure being prevented. The CONTROL
+# is the same fixture against a COMPLETE mirror: without it this row is
+# satisfied by any mirror too broken to run at all.
+R1D="$(newtmp)"
+if ! mk_repo_fw "$R1D/p" || ! mk_mirror "$R1D/m" noinit || ! mk_mirror "$R1D/full"; then
+  fail_ "R1" "fixture setup failed"
+else
+  write_via "$R1D/m" "$R1D/p"; r1_rc=$LEDGER_RC
+  r1_file=0; [ -e "$R1D/p/.claude/test-debt.json" ] && r1_file=1
+  write_via "$R1D/full" "$R1D/p"; r1_ctl_rc=$LEDGER_RC
+  r1_ctl_file=0; [ -s "$R1D/p/.claude/test-debt.json" ] && r1_ctl_file=1
+  r1_ctl_fw=$(jq -r '[.files[] | select(. == "scripts/check-gate.sh")] | length' "$R1D/p/.claude/test-debt.json" 2>/dev/null)
+  if [ "$r1_rc" -eq 2 ] && [ "$r1_file" -eq 0 ] \
+     && [ "$r1_ctl_rc" -eq 0 ] && [ "$r1_ctl_file" -eq 1 ] && [ "$(_num "$r1_ctl_fw")" -eq 0 ]; then
+    pass "R1: --write from a clone with no init.sh REFUSES at rc 2 and writes NO ledger; the same fixture against a complete mirror writes one (rc 0) that excludes the tracked framework path — refusal and silence are asserted separately"
+  else
+    fail_ "R1" "incomplete_clone_rc=$r1_rc (want 2) ledger_written_anyway=$r1_file (want 0) complete_clone_rc=$r1_ctl_rc (want 0) complete_clone_wrote=$r1_ctl_file (want 1) framework_path_in_control_ledger=$r1_ctl_fw (want 0)"
+  fi
+fi
+
+# R2/R3 — the CHECK side of the same refusal, on both tiers that can speak.
+# The ledger is written by the REAL module first, so the only thing the
+# incomplete mirror changes is whether the arms can run at all.
+R2D="$(newtmp)"
+if ! mk_repo_fw "$R2D/p" || ! mk_mirror "$R2D/m" noinit; then
+  fail_ "R2" "fixture setup failed"
+else
+  write_ledger "$R2D/p"
+  set_tier "$R2D/p" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  printf 'export function fresh() { return 9; }\n' > "$R2D/p/src/fresh.js"
+  gitq "$R2D/p" add src/fresh.js
+  check_in "$R2D/p" "$(_mlib "$R2D/m")"; r2_rc=$CHK_RC
+  r2_said=0; grep -q 'inventory could not be derived' "$CHK_OUT" && r2_said=1
+  if [ "$r2_rc" -eq 2 ] && [ "$r2_said" -eq 1 ]; then
+    pass "R2: --check at strict from a clone with no init.sh is rc 2 (unusable), NOT rc 3 — it refuses to judge rather than judging with a census that cannot tell your code from the framework's"
+  else
+    fail_ "R2" "rc=$r2_rc (want 2, and specifically not 3) reason_stated=$r2_said (want 1)"
+  fi
+
+  set_tier "$R2D/p" '{"deployment":"personal","poc_mode":"production","enforcement_level":"light"}'
+  check_in "$R2D/p" "$(_mlib "$R2D/m")"; r3_rc=$CHK_RC
+  r3_warn=0; grep -q '^\[WARN\]' "$CHK_OUT" && r3_warn=1
+  r3_block=0; grep -q 'BLOCKED' "$CHK_OUT" && r3_block=1
+  if [ "$r3_rc" -eq 0 ] && [ "$r3_warn" -eq 1 ] && [ "$r3_block" -eq 0 ]; then
+    pass "R3: the SAME incomplete clone at light WARNS and exits 0 — the refusal is tier-floored like everything else here, so an unusable clone cannot block a project that never asked for blocking"
+  else
+    fail_ "R3" "rc=$r3_rc (want 0) warned=$r3_warn (want 1) said_BLOCKED=$r3_block (want 0)"
+  fi
+fi
+
+# R4 — an init.sh that exists but names no copy list at all. Reaches the
+# NONEMPTY guard, which the noinit fixture short-circuits past.
+R4D="$(newtmp)"
+if ! mk_repo_fw "$R4D/p" || ! mk_mirror "$R4D/m" emptyinit; then
+  fail_ "R4" "fixture setup failed"
+else
+  write_via "$R4D/m" "$R4D/p"; r4_rc=$LEDGER_RC
+  r4_file=0; [ -e "$R4D/p/.claude/test-debt.json" ] && r4_file=1
+  if [ "$r4_rc" -eq 2 ] && [ "$r4_file" -eq 0 ]; then
+    pass "R4: an init.sh that parses to an EMPTY copy list is refused too (rc 2, no ledger) — an empty exclusion set is indistinguishable from no exclusion at all, and this is the guard that says so"
+  else
+    fail_ "R4" "rc=$r4_rc (want 2) ledger_written_anyway=$r4_file (want 0)"
+  fi
+fi
+
+# R5 — the parser itself missing. Reaches the third guard.
+R5D="$(newtmp)"
+if ! mk_repo_fw "$R5D/p" || ! mk_mirror "$R5D/m" noparser; then
+  fail_ "R5" "fixture setup failed"
+else
+  write_via "$R5D/m" "$R5D/p"; r5_rc=$LEDGER_RC
+  r5_file=0; [ -e "$R5D/p/.claude/test-debt.json" ] && r5_file=1
+  if [ "$r5_rc" -eq 2 ] && [ "$r5_file" -eq 0 ]; then
+    pass "R5: a clone missing scaffold-shipped-set.sh is refused (rc 2, no ledger) — the third of three guards now has a fixture, so none of them is load-bearing on faith"
+  else
+    fail_ "R5" "rc=$r5_rc (want 2) ledger_written_anyway=$r5_file (want 0)"
+  fi
+fi
+
+# ── M12: the reviewer's one-character mutant ──────────────────────────────
+# `|| return 1` -> `|| return 0` on the init.sh guard. Verified to survive the
+# 50/0 suite before R1-R5 existed. The mutant's expected result is a WRITE, so
+# it is asserted on ledger BYTES: the file exists, it is valid JSON, and it
+# names the framework path the exclusion should have removed.
+M12D="$(newtmp)"
+if ! mk_repo_fw "$M12D/p" || ! mk_mirror "$M12D/m" noinit; then
+  fail_ "M12" "fixture setup failed"
+else
+  write_via "$M12D/m" "$M12D/p"; m12_ctl=$LEDGER_RC
+  m12_ctl_file=0; [ -e "$M12D/p/.claude/test-debt.json" ] && m12_ctl_file=1
+  m12_meta=$(_mutate "$M12D/m" '# BF-TD-SHIPPED-REQUIRED' '  [ -f "$TD_FRAMEWORK_ROOT/init.sh" ] || return 0')
+  set -- $m12_meta; m12_sites=$1; m12_changed=$2; m12_parses=$3
+  write_via "$M12D/m" "$M12D/p"; m12_mut=$LEDGER_RC
+  m12_valid=0; jq -e . "$M12D/p/.claude/test-debt.json" >/dev/null 2>&1 && m12_valid=1
+  m12_fw=$(jq -r '[.files[] | select(. == "scripts/check-gate.sh")] | length' "$M12D/p/.claude/test-debt.json" 2>/dev/null)
+  if [ "$m12_ctl" -eq 2 ] && [ "$m12_ctl_file" -eq 0 ] && [ "$m12_mut" -eq 0 ] \
+     && [ "$m12_valid" -eq 1 ] && [ "$(_num "$m12_fw")" -eq 1 ] \
+     && [ "$m12_sites" -eq 1 ] && [ "$m12_changed" -eq 2 ] && [ "$m12_parses" -eq 1 ]; then
+    pass "M12: control refuses an incomplete clone (rc 2, no file); flipping ONE character on the init.sh guard makes the module WRITE a ledger that names scripts/check-gate.sh — the exclusion silently inert, which is the guessing this guard exists to forbid"
+  else
+    fail_ "M12" "control_rc=$m12_ctl (want 2) control_wrote=$m12_ctl_file (want 0) mutant_rc=$m12_mut (want 0) mutant_ledger_valid=$m12_valid (want 1) framework_path_in_mutant_ledger=$m12_fw (want 1) sites=$m12_sites (want 1) changed_lines=$m12_changed (want 2) parses=$m12_parses (want 1)"
+  fi
+fi
+
+# ── M13: the same flip on the NONEMPTY guard ──────────────────────────────
+# The other reachable spelling of the same mistake, and the reason R4 exists:
+# without an emptyinit fixture this guard would be exactly as unpinned as the
+# init.sh one was.
+M13D="$(newtmp)"
+if ! mk_repo_fw "$M13D/p" || ! mk_mirror "$M13D/m" emptyinit; then
+  fail_ "M13" "fixture setup failed"
+else
+  write_via "$M13D/m" "$M13D/p"; m13_ctl=$LEDGER_RC
+  m13_meta=$(_mutate "$M13D/m" '# BF-TD-SHIPPED-NONEMPTY' '  [ -s "$TD_TMP/shipped" ] || return 0')
+  set -- $m13_meta; m13_sites=$1; m13_changed=$2; m13_parses=$3
+  write_via "$M13D/m" "$M13D/p"; m13_mut=$LEDGER_RC
+  m13_fw=$(jq -r '[.files[] | select(. == "scripts/check-gate.sh")] | length' "$M13D/p/.claude/test-debt.json" 2>/dev/null)
+  if [ "$m13_ctl" -eq 2 ] && [ "$m13_mut" -eq 0 ] && [ "$(_num "$m13_fw")" -eq 1 ] \
+     && [ "$m13_sites" -eq 1 ] && [ "$m13_changed" -eq 2 ] && [ "$m13_parses" -eq 1 ]; then
+    pass "M13: the same flip on the empty-inventory guard produces the same silent guess — asserted on the ledger's bytes, not on an exit code, because a written ledger is what makes it dangerous"
+  else
+    fail_ "M13" "control_rc=$m13_ctl (want 2) mutant_rc=$m13_mut (want 0) framework_path_in_mutant_ledger=$m13_fw (want 1) sites=$m13_sites (want 1) changed_lines=$m13_changed (want 2) parses=$m13_parses (want 1)"
+  fi
 fi
 
 echo ""

--- a/tests/test-brownfield-wp5b-test-debt.sh
+++ b/tests/test-brownfield-wp5b-test-debt.sh
@@ -1,0 +1,896 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp5b-test-debt.sh
+#
+# Brownfield adoption WP5b — THE TEST-DEBT LEDGER AND ITS TIER RATCHET.
+# Design: docs/designs/2026-08-02-brownfield-adoption-v1.md §5.4 (the ledger,
+# the two arms, the three honest limits), §5 (kind (c)'s forward equivalent),
+# §10-WP5b (the acceptance rows), §3.3 / docs/module-contract.md (this is
+# MODULE code: no core file may name it and the boundary lint must stay rc 0).
+#
+# ── WHAT THIS FILE ASSERTS ON ───────────────────────────────────────────────
+# EXIT CODES, never printed labels. The `[WARN]`/`[FAIL]` text in this
+# framework's gate scripts is cosmetic — check-phase-gate.sh's exit predicate
+# is `if [ $issues -eq 0 ]`, so a "WARN" arm that increments `issues` BLOCKS
+# and two arms printing identical text can have opposite outcomes. That
+# mismatch hid two real scoring inversions in this repo, so printed strings
+# appear here only as PATH DISCRIMINATORS: they prove WHICH path produced a
+# code, never that a verdict was reached.
+#
+# ── BLOCKED FOR THE RIGHT REASON ────────────────────────────────────────────
+# The ratchet distinguishes its two arms by exit code, the way
+# `pre-commit-gate.sh --emit-blocked-gate` distinguishes its two message gates
+# (3 = TDD ordering, 4 = Build Loop):
+#
+#   0  clean, or a tier that does not block
+#   2  unusable: no ledger to ratchet against, or not a git repository
+#   3  BLOCKED by NON-GROWTH   (the untested set gained a member)
+#   4  BLOCKED by TOUCH-REPAYS (a ledgered file was modified without a test)
+#
+# Every blocking case below asserts 3 or 4, never "non-zero". A touch-repays
+# fixture that blocked because the non-growth arm also fired would prove
+# nothing about the arm under test.
+#
+# ── THE TWO NON-BLOCKING OUTCOMES ARE NOT THE SAME OUTCOME ──────────────────
+# `light` warns and `no` is silent, and BOTH exit 0. Exit code alone therefore
+# cannot tell them apart — nor can it tell either of them from an arm that
+# never ran. So every non-blocking case carries a STRUCTURAL DISCRIMINATOR:
+# `no` asserts ZERO BYTES on stdout and stderr combined, `light` asserts a
+# WARN line that NAMES the offending path. "Silent" and "warned" are then
+# distinguishable by bytes, not by hope.
+#
+# ── MUTATION HARNESS STANDARD (all mandatory, all learned in this wave) ─────
+#   • anchored end-of-line markers, excised with `s|^.*MARKER$|…|`;
+#   • the anchor asserted at sites==1 in its OWN shipped source;
+#   • exactly-N-lines-changed asserted (a substitution is 2 diff lines);
+#   • EVERY mutant additionally asserts `bash -n` — a mutation that lands
+#     mid-continuation produces a mangled parse that reads as "caught";
+#   • a MODE-PRESERVING in-place edit;
+#   • a FRESH fixture per mutant, from `mktemp -d`, never a counter inside a
+#     command substitution (a counter never survives the subshell, so every
+#     scenario lands in the same directory — that is how one proof in this
+#     wave came to pass against a NEIGHBOURING suite's fixture);
+#   • a CONTROL beside every mutant: the same fixture against the UNMUTATED
+#     mirror, asserted GREEN in the same run. A mutant killed with no control
+#     cannot distinguish "the mutation broke the arm" from "the fixture never
+#     worked".
+#
+# ── NO awk IN THE CODE UNDER TEST, DELIBERATELY ─────────────────────────────
+# `bash -n` does not syntax-check awk: a dead awk program emits an empty
+# result and empty reads as "nothing wrong", so an awk mutant can pass every
+# harness check while doing nothing. scripts/lib/adopt/adopt-test-debt.sh
+# drives no awk at all — grep, sed and shell only — which removes the failure
+# mode rather than defending against it. M8 pins that property, so a later
+# edit that introduces an awk pipeline has to argue with a test.
+#
+# Hermetic: temp dirs only, no network, no remote creation, no `--no-verify`.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LIB="$REPO_ROOT/scripts/lib/adopt/adopt-test-debt.sh"
+DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
+CORE_ENF="$REPO_ROOT/scripts/lib/enforcement-level.sh"
+CORE_TDD="$REPO_ROOT/scripts/lib/tdd-classify.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+
+# _sites FILE MARKER — occurrences of an END-OF-LINE-anchored marker.
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+if [ ! -f "$LIB" ]; then
+  echo "  [FAIL] setup — $LIB not found (WP5b deliverable 1 missing)"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── The adoptee fixture ─────────────────────────────────────────────────────
+# A real git repository with real history. `src/paid.js` HAS a test (the test
+# file's name carries its stem) and `src/debt.js` does NOT, so a census has one
+# of each and a proof that finds "everything untested" or "nothing untested" is
+# distinguishable from a correct one.
+#
+# git identity is configured and GITHUB_BASE_REF is unset in every fixture git
+# op: a CI environment that exports it changes what `git diff` resolves.
+mk_repo() {
+  local p="$1"
+  mkdir -p "$p/src" "$p/tests" || return 1
+  (
+    unset GITHUB_BASE_REF
+    cd "$p" \
+      && git init -q . \
+      && git config user.email "wp5b@test.invalid" \
+      && git config user.name  "WP5b Test" \
+      && git config commit.gpgsign false
+  ) >/dev/null 2>&1 || return 1
+  printf 'export function paid() { return 1; }\n' > "$p/src/paid.js"
+  printf 'export function debt() { return 2; }\n' > "$p/src/debt.js"
+  printf 'test("paid", () => {});\n'              > "$p/tests/paid.test.js"
+  printf '{"name":"fixture"}\n'                   > "$p/package.json"
+  printf '# fixture\n'                            > "$p/README.md"
+  ( unset GITHUB_BASE_REF; cd "$p" && git add -A && git commit -q -m "chore: their own history" ) >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# gitq DIR ARGS… — a fixture git op with the environment neutralised.
+gitq() { local d="$1"; shift; ( unset GITHUB_BASE_REF; cd "$d" && git "$@" ) >/dev/null 2>&1; }
+
+# set_tier DIR JSON — write .claude/manifest.json verbatim.
+set_tier() {
+  local d="$1" json="$2"
+  mkdir -p "$d/.claude" || return 1
+  printf '%s\n' "$json" > "$d/.claude/manifest.json"
+}
+
+# ledger_of DIR — write the ledger by running the shipped writer.
+LEDGER_RC=0
+write_ledger() { local d="$1" lib="${2:-$LIB}"; LEDGER_RC=0; ( unset GITHUB_BASE_REF; cd "$d" && bash "$lib" --write --root "$d" ) >/dev/null 2>&1 || LEDGER_RC=$?; return 0; }
+
+# check_in DIR [LIB] — run the ratchet. Sets CHK_RC and CHK_OUT (a FILE path,
+# beside the fixture and never inside it: a scratch file in the repository
+# would appear in the very `git status` the staged-set arms read).
+#
+# Called DIRECTLY, never inside `$( … )`: a command substitution is a subshell,
+# so a helper that returns its transcript path through a global loses it on the
+# way out and every later grep runs against an empty variable — which greps the
+# wrong file, fails, and reads as a genuine assertion failure.
+CHK_RC=0; CHK_OUT=""
+check_in() {
+  local d="$1" lib="${2:-$LIB}"
+  CHK_RC=0
+  CHK_OUT="$TOPTMP/chk-$$-$RANDOM"
+  ( unset GITHUB_BASE_REF; cd "$d" && bash "$lib" --check --root "$d" ) > "$CHK_OUT" 2>&1 || CHK_RC=$?
+  return 0
+}
+
+_bytes() { local n; n=$(wc -c < "$1" 2>/dev/null | tr -d ' '); _num "$n"; }
+
+echo "=== A — the ledger (§5.4: the set of source files with no test) ==="
+
+# A1/A2/A3/A4 share one census so the fixture is built once and read four ways.
+A1D="$(newtmp)/p"
+if ! mk_repo "$A1D"; then
+  fail_ "A" "fixture setup failed"
+else
+  write_ledger "$A1D"
+  a_rc=$LEDGER_RC
+  a_file="$A1D/.claude/test-debt.json"
+  a_json=0; [ -s "$a_file" ] && jq -e . "$a_file" >/dev/null 2>&1 && a_json=1
+  a_debt=$(jq -r '[.files[] | select(. == "src/debt.js")] | length' "$a_file" 2>/dev/null)
+  a_paid=$(jq -r '[.files[] | select(. == "src/paid.js")] | length' "$a_file" 2>/dev/null)
+  a_pkg=$(jq -r '[.files[] | select(. == "package.json")] | length' "$a_file" 2>/dev/null)
+  a_readme=$(jq -r '[.files[] | select(. == "README.md")] | length' "$a_file" 2>/dev/null)
+  a_count=$(jq -r '.count // -1' "$a_file" 2>/dev/null)
+  a_len=$(jq -r '.files | length' "$a_file" 2>/dev/null)
+  if [ "$a_rc" -eq 0 ] && [ "$a_json" -eq 1 ] \
+     && [ "$(_num "$a_debt")" -eq 1 ] && [ "$(_num "$a_paid")" -eq 0 ] \
+     && [ "$(_num "$a_count")" = "$(_num "$a_len")" ]; then
+    pass "A1: the ledger is written, is valid JSON, and records the untested file WITHOUT recording the tested one (count agrees with the array's length)"
+  else
+    fail_ "A1" "rc=$a_rc valid_json=$a_json debt_listed=$a_debt (want 1) paid_listed=$a_paid (want 0) count=$a_count files_len=$a_len"
+  fi
+
+  # A2 — the SOURCE-EXTENSION gate. `_bl072_is_impl_file` classifies a DIFF,
+  # where a changed package.json is legitimately implementation that shipped.
+  # This is a CENSUS OF A TREE, and in a census a manifest is not source: a
+  # ledger that counted it would make the untested figure a number about
+  # manifests, and the non-growth arm would then block on `npm init`.
+  if [ "$(_num "$a_pkg")" -eq 0 ] && [ "$(_num "$a_readme")" -eq 0 ]; then
+    pass "A2: the census gates on a SOURCE EXTENSION — package.json and README.md are not ledgered, so the ratchet cannot block a manifest edit"
+  else
+    fail_ "A2" "package.json_listed=$a_pkg (want 0) README.md_listed=$a_readme (want 0)"
+  fi
+
+  # A3 — the honest-limit sentence is IN THE ARTEFACT, not only in a design
+  # document nobody opens at 2am. §5.4 limit 1: "has a test" is not "is tested".
+  a_method=$(jq -r '.method // ""' "$a_file" 2>/dev/null)
+  a_says=0
+  case "$a_method" in *"not coverage"*|*"not a coverage"*) a_says=1 ;; esac
+  if [ -n "$a_method" ] && [ "$a_says" -eq 1 ]; then
+    pass "A3: the ledger carries its own method sentence and that sentence says it is not coverage (§5.4 limit 1, stated where the number is read)"
+  else
+    fail_ "A3" "method='$a_method' disclaims_coverage=$a_says (want 1)"
+  fi
+
+  # A4 — §5.4 limit 2: a ledger mutation writes an audit row. Re-running the
+  # writer after the debt changes must leave a trail, not a silent overwrite.
+  printf 'export function extra() { return 3; }\n' > "$A1D/src/extra.js"
+  gitq "$A1D" add src/extra.js
+  gitq "$A1D" commit -q -m "chore: one more untested file"
+  write_ledger "$A1D"
+  a4_rows=$(jq -r '.audit | length' "$a_file" 2>/dev/null)
+  a4_prev=$(jq -r '.audit[-1].previousCount // -1' "$a_file" 2>/dev/null)
+  a4_now=$(jq -r '.audit[-1].count // -1' "$a_file" 2>/dev/null)
+  a4_count=$(jq -r '.count // -1' "$a_file" 2>/dev/null)
+  if [ "$(_num "$a4_rows")" -eq 2 ] && [ "$(_num "$a4_prev")" -eq 1 ] \
+     && [ "$(_num "$a4_now")" -eq 2 ] && [ "$(_num "$a4_count")" -eq 2 ]; then
+    pass "A4: re-writing the ledger APPENDS an audit row carrying the count it replaced (§5.4 limit 2 — you can route around the block, not around the record)"
+  else
+    fail_ "A4" "audit_rows=$a4_rows (want 2) previousCount=$a4_prev (want 1) row_count=$a4_now (want 2) ledger_count=$a4_count (want 2)"
+  fi
+fi
+
+# A5 — `# BL-107-RUST-INLINE-TESTS` parity. Idiomatic Rust unit tests live
+# INSIDE the implementation file and are invisible to any path-only
+# classifier. Dropping the probe here would report every inline-tested Rust
+# file as untested — a large, confident, wrong number — and then the
+# touch-repays arm would block every edit to a correctly-tested file.
+A5D="$(newtmp)/p"
+if ! mk_repo "$A5D"; then
+  fail_ "A5" "fixture setup failed"
+else
+  mkdir -p "$A5D/rs"
+  printf 'pub fn a() -> u8 { 1 }\n\n#[cfg(test)]\nmod t { #[test] fn works() { assert!(true); } }\n' > "$A5D/rs/inline.rs"
+  printf 'pub fn b() -> u8 { 2 }\n' > "$A5D/rs/bare.rs"
+  gitq "$A5D" add rs
+  gitq "$A5D" commit -q -m "chore: rust"
+  write_ledger "$A5D"
+  a5_inline=$(jq -r '[.files[] | select(. == "rs/inline.rs")] | length' "$A5D/.claude/test-debt.json" 2>/dev/null)
+  a5_bare=$(jq -r '[.files[] | select(. == "rs/bare.rs")] | length' "$A5D/.claude/test-debt.json" 2>/dev/null)
+  if [ "$(_num "$a5_inline")" -eq 0 ] && [ "$(_num "$a5_bare")" -eq 1 ]; then
+    pass "A5: the # BL-107-RUST-INLINE-TESTS content probe is carried — a file whose only tests are #[cfg(test)] is NOT ledgered, and its bare sibling is"
+  else
+    fail_ "A5" "inline_tested_listed=$a5_inline (want 0) bare_listed=$a5_bare (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== B — the tier read (## BL-221: this must not fail OPEN) ==="
+
+# The whole of section B is one fixture read many ways: the ratchet's verdict
+# on an IDENTICAL staged change under different manifests. Everything that
+# varies is the manifest, so a difference in outcome can only be the tier.
+_b_fixture() {
+  local p="$1"
+  mk_repo "$p" || return 1
+  write_ledger "$p"
+  printf 'export function fresh() { return 9; }\n' > "$p/src/fresh.js"
+  gitq "$p" add src/fresh.js
+  return 0
+}
+
+# B1 — no manifest at all.
+B1D="$(newtmp)/p"
+if ! _b_fixture "$B1D"; then fail_ "B1" "fixture setup failed"; else
+  check_in "$B1D"
+  if [ "$CHK_RC" -eq 3 ]; then
+    pass "B1: with NO manifest the tier is unreadable and the arm BLOCKS (rc 3) — absent data reads as strict, the direction the rest of this framework fails in"
+  else
+    fail_ "B1" "rc=$CHK_RC (want 3) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# B2 — a manifest with no enforcement_level key. This is EXACTLY the shape
+# `scripts/adopt-project.sh` writes today: `## BL-221:` measured `deployment`,
+# `poc_mode` and `enforcement_level` all absent from an adopted manifest.
+B2D="$(newtmp)/p"
+if ! _b_fixture "$B2D"; then fail_ "B2" "fixture setup failed"; else
+  set_tier "$B2D" '{"host":"github","mode":"personal","remote_url":""}'
+  check_in "$B2D"
+  if [ "$CHK_RC" -eq 3 ]; then
+    pass "B2: an ADOPTED manifest (no enforcement_level, no deployment — the shape ## BL-221: measured) blocks at rc 3 rather than defaulting permissive"
+  else
+    fail_ "B2" "rc=$CHK_RC (want 3) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# B3 — a manifest that is not JSON at all.
+B3D="$(newtmp)/p"
+if ! _b_fixture "$B3D"; then fail_ "B3" "fixture setup failed"; else
+  set_tier "$B3D" 'this is not json {{{'
+  check_in "$B3D"
+  if [ "$CHK_RC" -eq 3 ]; then
+    pass "B3: an UNPARSEABLE manifest blocks at rc 3 — an unreadable tier is strict, not silent"
+  else
+    fail_ "B3" "rc=$CHK_RC (want 3) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# B4 — a manifest whose enforcement_level is a value the ladder does not know.
+B4D="$(newtmp)/p"
+if ! _b_fixture "$B4D"; then fail_ "B4" "fixture setup failed"; else
+  set_tier "$B4D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"relaxed"}'
+  check_in "$B4D"
+  if [ "$CHK_RC" -eq 3 ]; then
+    pass "B4: an enforcement_level OFF the ladder ('relaxed') blocks at rc 3 — an unrecognised tier is strict"
+  else
+    fail_ "B4" "rc=$CHK_RC (want 3) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# B5 — the BL-221 SHAPE ITSELF, and the reason this suite exists. The manifest
+# names a lenient tier but carries NO `deployment` key. `assert_choosable`
+# resolves an absent key to "personal" — the CHOOSABLE tier — which is the
+# live fail-open. This ratchet must not inherit it: a choosable verdict is
+# only allowed to stand when the key it is derived from is actually present.
+B5D="$(newtmp)/p"
+if ! _b_fixture "$B5D"; then fail_ "B5" "fixture setup failed"; else
+  set_tier "$B5D" '{"host":"github","enforcement_level":"no"}'
+  check_in "$B5D"
+  if [ "$CHK_RC" -eq 3 ]; then
+    pass "B5 (## BL-221: NOT INHERITED): a lenient enforcement_level with an ABSENT deployment key does NOT buy silence — rc 3, because a tier derived from a missing key is not a tier"
+  else
+    fail_ "B5" "rc=$CHK_RC (want 3) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# B6 — organizational. `assert_choosable` returns 1, so the tier is forced to
+# strict no matter what the file says. The accessor is consumed, never
+# re-derived: a fifth spelling of the # BL-084-TIER-KEY predicate is a defect
+# the moment it lands.
+B6D="$(newtmp)/p"
+if ! _b_fixture "$B6D"; then fail_ "B6" "fixture setup failed"; else
+  set_tier "$B6D" '{"deployment":"organizational","poc_mode":"production","enforcement_level":"no"}'
+  check_in "$B6D"
+  if [ "$CHK_RC" -eq 3 ]; then
+    pass "B6: an ORGANIZATIONAL project cannot buy silence with enforcement_level:no — assert_choosable refuses and the tier is raised to strict (rc 3)"
+  else
+    fail_ "B6" "rc=$CHK_RC (want 3) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# B7 — the CONTROL for all of B, and the one that stops this section from
+# being a test that cannot fail. A COMPLETE personal manifest at `no` must be
+# SILENT. Without this row every B case above would also pass on a ratchet
+# that blocks unconditionally.
+B7D="$(newtmp)/p"
+if ! _b_fixture "$B7D"; then fail_ "B7" "fixture setup failed"; else
+  set_tier "$B7D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"no"}'
+  check_in "$B7D"
+  b7_bytes=$(_bytes "$CHK_OUT")
+  if [ "$CHK_RC" -eq 0 ] && [ "$b7_bytes" -eq 0 ]; then
+    pass "B7 (control): a COMPLETE personal manifest at 'no' is silent and rc 0 — B1-B6 refuse a tier they cannot trust, they do not refuse everything"
+  else
+    fail_ "B7" "rc=$CHK_RC (want 0) output_bytes=$b7_bytes (want 0) out=$(head -3 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+echo ""
+echo "=== C — the NON-GROWTH arm (§10-WP5b: block at strict, warn at light, silent at no) ==="
+
+_c_fixture() {
+  local p="$1" level="$2"
+  mk_repo "$p" || return 1
+  write_ledger "$p"
+  set_tier "$p" "{\"deployment\":\"personal\",\"poc_mode\":\"production\",\"enforcement_level\":\"$level\"}"
+  printf 'export function fresh() { return 9; }\n' > "$p/src/fresh.js"
+  gitq "$p" add src/fresh.js
+  return 0
+}
+
+C1D="$(newtmp)/p"
+if ! _c_fixture "$C1D" strict; then fail_ "C1" "fixture setup failed"; else
+  check_in "$C1D"
+  c1_named=0; grep -q 'src/fresh\.js' "$CHK_OUT" && c1_named=1
+  if [ "$CHK_RC" -eq 3 ] && [ "$c1_named" -eq 1 ]; then
+    pass "C1: adding an untested file BLOCKS at strict — rc 3 (the non-growth arm, not some other refusal) and the offending path is named"
+  else
+    fail_ "C1" "rc=$CHK_RC (want 3) path_named=$c1_named (want 1) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+C2D="$(newtmp)/p"
+if ! _c_fixture "$C2D" light; then fail_ "C2" "fixture setup failed"; else
+  check_in "$C2D"
+  c2_warn=0; grep -qi 'warn' "$CHK_OUT" && c2_warn=1
+  c2_named=0; grep -q 'src/fresh\.js' "$CHK_OUT" && c2_named=1
+  if [ "$CHK_RC" -eq 0 ] && [ "$c2_warn" -eq 1 ] && [ "$c2_named" -eq 1 ]; then
+    pass "C2: the same commit WARNS at light and exits 0 — the warn arm does not increment anything that blocks, and it still names the file (the [WARN] trap, asserted as a code and a byte string, never as a label)"
+  else
+    fail_ "C2" "rc=$CHK_RC (want 0) warned=$c2_warn (want 1) path_named=$c2_named (want 1) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+C3D="$(newtmp)/p"
+if ! _c_fixture "$C3D" no; then fail_ "C3" "fixture setup failed"; else
+  check_in "$C3D"
+  c3_bytes=$(_bytes "$CHK_OUT")
+  if [ "$CHK_RC" -eq 0 ] && [ "$c3_bytes" -eq 0 ]; then
+    pass "C3: the same commit is SILENT at no — rc 0 AND zero bytes of output, which is what distinguishes 'silent' from 'warned' (both exit 0)"
+  else
+    fail_ "C3" "rc=$CHK_RC (want 0) output_bytes=$c3_bytes (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# C4 — the arm's CONTROL: an added file that DOES arrive with a test must
+# pass at strict. Without this the arm could be "block on any addition" and
+# every case above would still be green.
+C4D="$(newtmp)/p"
+if ! _c_fixture "$C4D" strict; then fail_ "C4" "fixture setup failed"; else
+  printf 'test("fresh", () => {});\n' > "$C4D/tests/fresh.test.js"
+  gitq "$C4D" add tests/fresh.test.js
+  check_in "$C4D"
+  if [ "$CHK_RC" -eq 0 ]; then
+    pass "C4 (control): the SAME added file with its test in the SAME commit passes at strict (rc 0) — the arm blocks untested growth, not growth"
+  else
+    fail_ "C4" "rc=$CHK_RC (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# C5 — a NON-SOURCE addition. The census gates on a source extension (A2), and
+# the arm must gate identically or the two disagree about what the untested
+# set is: adding a lockfile would then block a strict project forever.
+C5D="$(newtmp)/p"
+if ! _c_fixture "$C5D" strict; then fail_ "C5" "fixture setup failed"; else
+  gitq "$C5D" reset -q
+  printf '{"lockfileVersion":3}\n' > "$C5D/package-lock.json"
+  printf 'FROM scratch\n' > "$C5D/Dockerfile"
+  gitq "$C5D" add package-lock.json Dockerfile
+  check_in "$C5D"
+  if [ "$CHK_RC" -eq 0 ]; then
+    pass "C5: adding a lockfile and a Dockerfile does NOT block at strict — the arm's membership predicate is the census's, so the two cannot disagree about the untested set"
+  else
+    fail_ "C5" "rc=$CHK_RC (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# C6 — a DELETION is not growth. `_bl072_status_effective_path` already
+# carves pure deletions out of the TDD gate for the same reason: removing a
+# source file is not shipping implementation.
+C6D="$(newtmp)/p"
+if ! _c_fixture "$C6D" strict; then fail_ "C6" "fixture setup failed"; else
+  gitq "$C6D" reset -q
+  gitq "$C6D" rm -q src/debt.js
+  check_in "$C6D"
+  if [ "$CHK_RC" -eq 0 ]; then
+    pass "C6: DELETING the ledgered untested file passes at strict (rc 0) — paying debt down by removal is not growth, and not a touch that owes a test"
+  else
+    fail_ "C6" "rc=$CHK_RC (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+echo ""
+echo "=== D — the TOUCH-REPAYS arm (§5.4: a modified ledgered file must leave the set) ==="
+
+_d_fixture() {
+  local p="$1" level="$2"
+  mk_repo "$p" || return 1
+  write_ledger "$p"
+  set_tier "$p" "{\"deployment\":\"personal\",\"poc_mode\":\"production\",\"enforcement_level\":\"$level\"}"
+  printf 'export function debt() { return 22; }\n' > "$p/src/debt.js"
+  gitq "$p" add src/debt.js
+  return 0
+}
+
+D1D="$(newtmp)/p"
+if ! _d_fixture "$D1D" strict; then fail_ "D1" "fixture setup failed"; else
+  check_in "$D1D"
+  d1_named=0; grep -q 'src/debt\.js' "$CHK_OUT" && d1_named=1
+  if [ "$CHK_RC" -eq 4 ] && [ "$d1_named" -eq 1 ]; then
+    pass "D1: modifying a ledgered file with no test BLOCKS at strict with rc 4 — the TOUCH-REPAYS code, not the non-growth code, so the block is attributable to the arm under test"
+  else
+    fail_ "D1" "rc=$CHK_RC (want 4, NOT 3) path_named=$d1_named (want 1) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+D2D="$(newtmp)/p"
+if ! _d_fixture "$D2D" light; then fail_ "D2" "fixture setup failed"; else
+  check_in "$D2D"
+  d2_warn=0; grep -qi 'warn' "$CHK_OUT" && d2_warn=1
+  d2_named=0; grep -q 'src/debt\.js' "$CHK_OUT" && d2_named=1
+  if [ "$CHK_RC" -eq 0 ] && [ "$d2_warn" -eq 1 ] && [ "$d2_named" -eq 1 ]; then
+    pass "D2: the same touch WARNS at light and exits 0, naming the file"
+  else
+    fail_ "D2" "rc=$CHK_RC (want 0) warned=$d2_warn (want 1) path_named=$d2_named (want 1) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+D3D="$(newtmp)/p"
+if ! _d_fixture "$D3D" no; then fail_ "D3" "fixture setup failed"; else
+  check_in "$D3D"
+  d3_bytes=$(_bytes "$CHK_OUT")
+  if [ "$CHK_RC" -eq 0 ] && [ "$d3_bytes" -eq 0 ]; then
+    pass "D3: the same touch is SILENT at no — rc 0 and zero bytes"
+  else
+    fail_ "D3" "rc=$CHK_RC (want 0) output_bytes=$d3_bytes (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+D4D="$(newtmp)/p"
+if ! _d_fixture "$D4D" strict; then fail_ "D4" "fixture setup failed"; else
+  printf 'test("debt", () => {});\n' > "$D4D/tests/debt.test.js"
+  gitq "$D4D" add tests/debt.test.js
+  check_in "$D4D"
+  if [ "$CHK_RC" -eq 0 ]; then
+    pass "D4 (control): the same touch WITH a test added in the same commit passes at strict (rc 0) — the debt is repaid and the arm says so"
+  else
+    fail_ "D4" "rc=$CHK_RC (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# D5 — the arm is LEDGER-SCOPED. Touching a file that already had a test is
+# not a repayment obligation, and an arm that fired here would be a coverage
+# mandate the design explicitly did not write (§5.4 limit 3).
+D5D="$(newtmp)/p"
+if ! _d_fixture "$D5D" strict; then fail_ "D5" "fixture setup failed"; else
+  gitq "$D5D" reset -q
+  printf 'export function paid() { return 11; }\n' > "$D5D/src/paid.js"
+  gitq "$D5D" add src/paid.js
+  check_in "$D5D"
+  if [ "$CHK_RC" -eq 0 ]; then
+    pass "D5: touching an ALREADY-TESTED file passes at strict (rc 0) — touch-repays is scoped to the ledger, not to every edit"
+  else
+    fail_ "D5" "rc=$CHK_RC (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+echo ""
+echo "=== E — no ledger, and the order the tier is consulted in ==="
+
+# E1 — a strict project with no ledger. A ratchet with no baseline is not a
+# ratchet, and passing silently would be the fail-open shape this whole WP is
+# the forward equivalent of.
+E1D="$(newtmp)/p"
+if ! mk_repo "$E1D"; then fail_ "E1" "fixture setup failed"; else
+  set_tier "$E1D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  printf 'export function fresh() { return 9; }\n' > "$E1D/src/fresh.js"
+  gitq "$E1D" add src/fresh.js
+  check_in "$E1D"
+  if [ "$CHK_RC" -eq 2 ]; then
+    pass "E1: at strict with NO ledger the ratchet refuses with rc 2 — it does not pass silently, and it does not claim an arm fired"
+  else
+    fail_ "E1" "rc=$CHK_RC (want 2) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# E2 — THE ORDER. The same missing ledger at `no` must be silent, because the
+# tier floor is consulted BEFORE anything can refuse. A gate that fires at the
+# lenient tier is as wrong as one that never fires, and "your project is
+# missing a file you never asked for" is exactly the false-FAIL that teaches
+# an operator to disable the framework (BL-122 / BL-149).
+E2D="$(newtmp)/p"
+if ! mk_repo "$E2D"; then fail_ "E2" "fixture setup failed"; else
+  set_tier "$E2D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"no"}'
+  printf 'export function fresh() { return 9; }\n' > "$E2D/src/fresh.js"
+  gitq "$E2D" add src/fresh.js
+  check_in "$E2D"
+  e2_bytes=$(_bytes "$CHK_OUT")
+  if [ "$CHK_RC" -eq 0 ] && [ "$e2_bytes" -eq 0 ]; then
+    pass "E2: the SAME missing ledger at 'no' is silent (rc 0, zero bytes) — the tier floor is read before the refusal, so a poc project is never blocked by a ratchet it did not opt into"
+  else
+    fail_ "E2" "rc=$CHK_RC (want 0) output_bytes=$e2_bytes (want 0) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+  fi
+fi
+
+# E3 — not a git repository at all.
+E3D="$(newtmp)/p"
+mkdir -p "$E3D"
+set_tier "$E3D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+check_in "$E3D"
+if [ "$CHK_RC" -eq 2 ]; then
+  pass "E3: a target that is not a git repository is rc 2 (unusable), never a silent pass"
+else
+  fail_ "E3" "rc=$CHK_RC (want 2) out=$(head -5 "$CHK_OUT" | tr '\n' '|')"
+fi
+
+echo ""
+echo "=== F — the module contract (docs/module-contract.md M1/M3) ==="
+
+f1_rc=0
+bash "$REPO_ROOT/scripts/lint-module-dependencies.sh" >/dev/null 2>&1 || f1_rc=$?
+if [ "$f1_rc" -eq 0 ]; then
+  pass "F1: scripts/lint-module-dependencies.sh is rc 0 with the new module file present"
+else
+  fail_ "F1" "rc=$f1_rc (want 0)"
+fi
+
+# F2 — M3 from the other direction, asserted directly rather than trusted to
+# the lint: the lint's CORE set is a glob list, and a file it does not scan
+# cannot red. This greps the whole tree for the new module file's basename
+# outside the module's own directory and its own test.
+f2_hits=$(grep -rl 'adopt-test-debt' "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" 2>/dev/null \
+  | grep -v '^'"$REPO_ROOT"'/scripts/lib/adopt/' | wc -l | tr -d ' ')
+f2_hits=$(_num "$f2_hits")
+if [ "$f2_hits" -eq 0 ]; then
+  pass "F2 (M3): no file outside scripts/lib/adopt/ names the new module file — core -> module stays unreachable by grep as well as by lint"
+else
+  fail_ "F2" "core files naming adopt-test-debt: $f2_hits (want 0): $(grep -rl 'adopt-test-debt' "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" 2>/dev/null | grep -v '^'"$REPO_ROOT"'/scripts/lib/adopt/' | tr '\n' ' ')"
+fi
+
+# F3 — M2: the entry script's declared core-lib list must actually name the
+# two libs this module now sources. M2 is enforced by review, and a review
+# needs the list to be true.
+f3_enf=0; f3_tdd=0
+grep -q 'enforcement-level\.sh' "$DRIVER" && f3_enf=1
+grep -q 'tdd-classify\.sh' "$DRIVER" && f3_tdd=1
+if [ "$f3_enf" -eq 1 ] && [ "$f3_tdd" -eq 1 ]; then
+  pass "F3 (M2): the driver's declared core-lib set names enforcement-level.sh and tdd-classify.sh — the two core libs the ledger consumes"
+else
+  fail_ "F3" "enforcement-level_declared=$f3_enf tdd-classify_declared=$f3_tdd (want 1 1)"
+fi
+
+echo ""
+echo "=== G — the driver writes the ledger (the stub is retired) ==="
+
+# One scout run and one driver run for the whole section: the driver consumes
+# the genuine §8.2 schema rather than a hand-written stand-in of it, and this
+# suite runs in the fast unit lane, so it buys that fidelity exactly once.
+G_OK=0
+GTEMPLATE="$(newtmp)/template"
+if mk_repo "$GTEMPLATE"; then
+  printf '# What this is for\n\nInvoice reconciliation.\n' > "$GTEMPLATE/PRODUCT.md"
+  gitq "$GTEMPLATE" add PRODUCT.md
+  gitq "$GTEMPLATE" commit -q -m "docs: product"
+  if bash "$REPO_ROOT/scripts/scout.sh" --root "$GTEMPLATE" --out "$TOPTMP/scan" >/dev/null 2>&1; then
+    [ -s "$TOPTMP/scan/scout-report.json" ] && G_OK=1
+  fi
+fi
+
+if [ "$G_OK" -ne 1 ]; then
+  fail_ "G" "scripts/scout.sh produced no report; the driver consumes one and cannot be exercised without it"
+else
+  GD="$(newtmp)"
+  if ! mk_repo "$GD/p"; then
+    fail_ "G1" "fixture setup failed"
+  else
+    jq '.phaseMap.suggestedPhase = 2' "$TOPTMP/scan/scout-report.json" > "$GD/report.json" 2>/dev/null
+    cat > "$GD/answers" <<'ANS'
+2
+3
+2
+1
+1
+we reconcile vendor invoices by hand
+six weeks and no budget
+invoices only; no reporting in the first version
+public
+typescript and postgres are settled
+subscription billing
+just me approves things
+anyone with a login
+aws
+losing the database
+1
+1
+ANS
+    g_rc=0
+    ( unset GITHUB_BASE_REF; cd "$GD/p" && bash "$DRIVER" --scan-report "$GD/report.json" ) \
+      < "$GD/answers" > "$GD/out" 2> "$GD/err" || g_rc=$?
+    g_file="$GD/p/.claude/test-debt.json"
+    g_exists=0; [ -s "$g_file" ] && g_exists=1
+    g_committed=$( unset GITHUB_BASE_REF; cd "$GD/p" && git show --name-only --format= HEAD 2>/dev/null )
+    g_staged=$(printf '%s\n' "$g_committed" | grep -c '^\.claude/test-debt\.json$'); g_staged=$(_num "$g_staged")
+    g_debt=$(jq -r '[.files[] | select(. == "src/debt.js")] | length' "$g_file" 2>/dev/null)
+    # The STUB must be gone — and gone is an ABSENCE, so it is asserted
+    # alongside a positive: the run must also SAY what it recorded.
+    g_stub=0; grep -q 'NOT DONE — the test-debt ledger' "$GD/out" && g_stub=1
+    g_said=0; grep -qi 'test-debt' "$GD/out" && g_said=1
+    if [ "$g_rc" -eq 0 ] && [ "$g_exists" -eq 1 ] && [ "$g_staged" -eq 1 ] \
+       && [ "$(_num "$g_debt")" -eq 1 ] && [ "$g_stub" -eq 0 ] && [ "$g_said" -eq 1 ]; then
+      pass "G1: a real adoption WRITES .claude/test-debt.json, COMMITS it, records the untested file, and no longer prints the WP5b 'NOT DONE' stub — it reports what it recorded instead"
+    else
+      fail_ "G1" "rc=$g_rc ledger_exists=$g_exists ledger_committed=$g_staged (want 1) debt_listed=$g_debt (want 1) stub_still_printed=$g_stub (want 0) run_mentions_ledger=$g_said (want 1) err=$(head -3 "$GD/err" | tr '\n' '|')"
+    fi
+
+    # G2 — the ledger must be about THEIR code. The driver installs ~60
+    # framework scripts into the adoptee; a census taken over the working tree
+    # after that install would file every one of them as the adoptee's
+    # untested debt, and the touch-repays arm would then demand tests for the
+    # framework's own gate scripts.
+    g2_fw=$(jq -r '[.files[] | select(startswith("scripts/"))] | length' "$g_file" 2>/dev/null)
+    if [ "$(_num "$g2_fw")" -eq 0 ]; then
+      pass "G2: the ledger contains NONE of the framework scripts the adoption installed — the census is of the adoptee's own tracked source, not of the tree the driver leaves behind"
+    else
+      fail_ "G2" "framework scripts ledgered: $g2_fw (want 0)"
+    fi
+  fi
+fi
+
+echo ""
+echo "=== M — mutations (both arms, both directions) ==="
+
+# Every mutant runs against a MIRROR of the module plus the two core libs it
+# sources. The tree under test is never edited: a failure here cannot leave
+# this repository mutated.
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m/scripts/lib/adopt" || return 1
+  cp -p "$CORE_ENF" "$m/scripts/lib/" || return 1
+  cp -p "$CORE_TDD" "$m/scripts/lib/" || return 1
+  cp -p "$LIB" "$m/scripts/lib/adopt/" || return 1
+  return 0
+}
+
+# _mutate MIRROR MARKER REPLACEMENT — one anchored, end-of-line-marked line,
+# excised and replaced. Echoes "sites changed parses" for the caller to assert.
+_mutate() {
+  local m="$1" marker="$2" repl="$3"
+  local f="$m/scripts/lib/adopt/adopt-test-debt.sh"
+  local before sites changed parses
+  before="$(mktemp)"
+  cp -p "$f" "$before"
+  sites=$(_sites "$f" "$marker")
+  _sed_inplace "$f" "s|^.*${marker}\$|${repl}|"
+  changed=$(_changed_lines "$before" "$f")
+  parses=$(_parses "$f")
+  rm -f "$before"
+  printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+_mlib() { printf '%s/scripts/lib/adopt/adopt-test-debt.sh\n' "$1"; }
+
+# ── M1: neuter the NON-GROWTH arm → the untested set grows silently ─────────
+M1D="$(newtmp)"
+if ! _c_fixture "$M1D/p" strict || ! mk_mirror "$M1D/m"; then
+  fail_ "M1" "fixture setup failed"
+else
+  check_in "$M1D/p" "$(_mlib "$M1D/m")"; m1_ctl=$CHK_RC
+  m1_meta=$(_mutate "$M1D/m" '# BF-TD-NONGROWTH-ARM' '    continue')
+  set -- $m1_meta; m1_sites=$1; m1_changed=$2; m1_parses=$3
+  check_in "$M1D/p" "$(_mlib "$M1D/m")"; m1_mut=$CHK_RC
+  m1_bytes=$(_bytes "$CHK_OUT")
+  if [ "$m1_ctl" -eq 3 ] && [ "$m1_mut" -ne 3 ] && [ "$m1_bytes" -eq 0 ] \
+     && [ "$m1_sites" -eq 1 ] && [ "$m1_changed" -eq 2 ] && [ "$m1_parses" -eq 1 ]; then
+    pass "M1 (direction 1, non-growth): control blocks with rc 3; with the arm neutered the SAME added untested file passes with NO output — the set grew silently, which is the failure this arm exists to prevent"
+  else
+    fail_ "M1" "control_rc=$m1_ctl (want 3) mutant_rc=$m1_mut (want != 3) mutant_output_bytes=$m1_bytes (want 0) sites=$m1_sites (want 1) changed_lines=$m1_changed (want 2) parses=$m1_parses (want 1)"
+  fi
+fi
+
+# ── M2: neuter the TOUCH-REPAYS arm ────────────────────────────────────────
+M2D="$(newtmp)"
+if ! _d_fixture "$M2D/p" strict || ! mk_mirror "$M2D/m"; then
+  fail_ "M2" "fixture setup failed"
+else
+  check_in "$M2D/p" "$(_mlib "$M2D/m")"; m2_ctl=$CHK_RC
+  m2_meta=$(_mutate "$M2D/m" '# BF-TD-TOUCH-ARM' '    continue')
+  set -- $m2_meta; m2_sites=$1; m2_changed=$2; m2_parses=$3
+  check_in "$M2D/p" "$(_mlib "$M2D/m")"; m2_mut=$CHK_RC
+  m2_bytes=$(_bytes "$CHK_OUT")
+  if [ "$m2_ctl" -eq 4 ] && [ "$m2_mut" -ne 4 ] && [ "$m2_bytes" -eq 0 ] \
+     && [ "$m2_sites" -eq 1 ] && [ "$m2_changed" -eq 2 ] && [ "$m2_parses" -eq 1 ]; then
+    pass "M2 (direction 1, touch-repays): control blocks with rc 4; with the arm neutered the SAME modification of a ledgered file passes with no output"
+  else
+    fail_ "M2" "control_rc=$m2_ctl (want 4) mutant_rc=$m2_mut (want != 4) mutant_output_bytes=$m2_bytes (want 0) sites=$m2_sites (want 1) changed_lines=$m2_changed (want 2) parses=$m2_parses (want 1)"
+  fi
+fi
+
+# ── M3: neuter the TIER FLOOR → the non-growth arm blocks at `no` ──────────
+# THE SECOND DIRECTION, and the one that usually gets skipped. A gate that
+# fires at the lenient tier is as wrong as one that never fires: a ratchet
+# that blocks a poc_mode project is not a stricter ratchet, it is a broken
+# one, and it is the shape that makes people disable the whole framework.
+M3D="$(newtmp)"
+if ! _c_fixture "$M3D/p" no || ! mk_mirror "$M3D/m"; then
+  fail_ "M3" "fixture setup failed"
+else
+  check_in "$M3D/p" "$(_mlib "$M3D/m")"; m3_ctl=$CHK_RC
+  m3_ctl_bytes=$(_bytes "$CHK_OUT")
+  m3_meta=$(_mutate "$M3D/m" '# BF-TD-FLOOR-NO' "    no)     printf 'block\\n' ;;")
+  set -- $m3_meta; m3_sites=$1; m3_changed=$2; m3_parses=$3
+  check_in "$M3D/p" "$(_mlib "$M3D/m")"; m3_mut=$CHK_RC
+  if [ "$m3_ctl" -eq 0 ] && [ "$m3_ctl_bytes" -eq 0 ] && [ "$m3_mut" -eq 3 ] \
+     && [ "$m3_sites" -eq 1 ] && [ "$m3_changed" -eq 2 ] && [ "$m3_parses" -eq 1 ]; then
+    pass "M3 (direction 2, non-growth): control is silent at 'no'; with the floor's 'no' row raised to block the SAME commit is refused with rc 3 — the tier floor is load-bearing, not decorative"
+  else
+    fail_ "M3" "control_rc=$m3_ctl (want 0) control_bytes=$m3_ctl_bytes (want 0) mutant_rc=$m3_mut (want 3) sites=$m3_sites (want 1) changed_lines=$m3_changed (want 2) parses=$m3_parses (want 1)"
+  fi
+fi
+
+# ── M4: the same floor mutation, observed through the OTHER arm ────────────
+# One site, two independent observations. A floor spelled once is the correct
+# architecture (a second spelling is the # BL-084-TIER-KEY sync-sibling trap),
+# so the second direction for the second arm is proved by a second FIXTURE,
+# not by a second line.
+M4D="$(newtmp)"
+if ! _d_fixture "$M4D/p" no || ! mk_mirror "$M4D/m"; then
+  fail_ "M4" "fixture setup failed"
+else
+  check_in "$M4D/p" "$(_mlib "$M4D/m")"; m4_ctl=$CHK_RC
+  m4_ctl_bytes=$(_bytes "$CHK_OUT")
+  m4_meta=$(_mutate "$M4D/m" '# BF-TD-FLOOR-NO' "    no)     printf 'block\\n' ;;")
+  set -- $m4_meta; m4_sites=$1; m4_changed=$2; m4_parses=$3
+  check_in "$M4D/p" "$(_mlib "$M4D/m")"; m4_mut=$CHK_RC
+  if [ "$m4_ctl" -eq 0 ] && [ "$m4_ctl_bytes" -eq 0 ] && [ "$m4_mut" -eq 4 ] \
+     && [ "$m4_sites" -eq 1 ] && [ "$m4_changed" -eq 2 ] && [ "$m4_parses" -eq 1 ]; then
+    pass "M4 (direction 2, touch-repays): control is silent at 'no'; the same one-line floor mutation makes the touch-repays arm refuse a poc project with rc 4"
+  else
+    fail_ "M4" "control_rc=$m4_ctl (want 0) control_bytes=$m4_ctl_bytes (want 0) mutant_rc=$m4_mut (want 4) sites=$m4_sites (want 1) changed_lines=$m4_changed (want 2) parses=$m4_parses (want 1)"
+  fi
+fi
+
+# ── M5: the `light` row of the floor — the [WARN] trap, mutated ────────────
+M5D="$(newtmp)"
+if ! _c_fixture "$M5D/p" light || ! mk_mirror "$M5D/m"; then
+  fail_ "M5" "fixture setup failed"
+else
+  check_in "$M5D/p" "$(_mlib "$M5D/m")"; m5_ctl=$CHK_RC
+  m5_ctl_warn=0; grep -qi 'warn' "$CHK_OUT" && m5_ctl_warn=1
+  m5_meta=$(_mutate "$M5D/m" '# BF-TD-FLOOR-LIGHT' "    light)  printf 'block\\n' ;;")
+  set -- $m5_meta; m5_sites=$1; m5_changed=$2; m5_parses=$3
+  check_in "$M5D/p" "$(_mlib "$M5D/m")"; m5_mut=$CHK_RC
+  if [ "$m5_ctl" -eq 0 ] && [ "$m5_ctl_warn" -eq 1 ] && [ "$m5_mut" -eq 3 ] \
+     && [ "$m5_sites" -eq 1 ] && [ "$m5_changed" -eq 2 ] && [ "$m5_parses" -eq 1 ]; then
+    pass "M5 (the [WARN] trap): control WARNS and exits 0; promoting the floor's 'light' row to block turns the identical warning into rc 3 — proof the warn arm's exit code is decided by the floor and not by the label it prints"
+  else
+    fail_ "M5" "control_rc=$m5_ctl (want 0) control_warned=$m5_ctl_warn (want 1) mutant_rc=$m5_mut (want 3) sites=$m5_sites (want 1) changed_lines=$m5_changed (want 2) parses=$m5_parses (want 1)"
+  fi
+fi
+
+# ── M6: the ## BL-221: guard — the tier must not be trusted to a missing key ─
+M6D="$(newtmp)"
+if ! _c_fixture "$M6D/p" no || ! mk_mirror "$M6D/m"; then
+  fail_ "M6" "fixture setup failed"
+else
+  set_tier "$M6D/p" '{"host":"github","enforcement_level":"no"}'
+  check_in "$M6D/p" "$(_mlib "$M6D/m")"; m6_ctl=$CHK_RC
+  m6_meta=$(_mutate "$M6D/m" '# BF-TD-TIER-KEY-PRESENT' '  if false; then')
+  set -- $m6_meta; m6_sites=$1; m6_changed=$2; m6_parses=$3
+  check_in "$M6D/p" "$(_mlib "$M6D/m")"; m6_mut=$CHK_RC
+  m6_bytes=$(_bytes "$CHK_OUT")
+  if [ "$m6_ctl" -eq 3 ] && [ "$m6_mut" -eq 0 ] && [ "$m6_bytes" -eq 0 ] \
+     && [ "$m6_sites" -eq 1 ] && [ "$m6_changed" -eq 2 ] && [ "$m6_parses" -eq 1 ]; then
+    pass "M6 (## BL-221:): control refuses a tier whose deployment key is absent (rc 3); removing the presence guard makes the SAME manifest buy silence — which is the live fail-open, reproduced here on purpose so it cannot come back unnoticed"
+  else
+    fail_ "M6" "control_rc=$m6_ctl (want 3) mutant_rc=$m6_mut (want 0) mutant_bytes=$m6_bytes (want 0) sites=$m6_sites (want 1) changed_lines=$m6_changed (want 2) parses=$m6_parses (want 1)"
+  fi
+fi
+
+# ── M7: the census predicate — an empty ledger must not read as no debt ────
+# The expected mutant result is an ABSENCE (nothing in the ledger), and "the
+# census found nothing" and "the census never ran" share one downstream
+# silence. So this asserts the ledger's BYTES: the file must still be valid
+# JSON with count 0, and the CONTROL must have found the debt.
+M7D="$(newtmp)"
+if ! mk_repo "$M7D/p" || ! mk_mirror "$M7D/m"; then
+  fail_ "M7" "fixture setup failed"
+else
+  write_ledger "$M7D/p" "$(_mlib "$M7D/m")"
+  m7_ctl=$(jq -r '.count // -1' "$M7D/p/.claude/test-debt.json" 2>/dev/null)
+  m7_meta=$(_mutate "$M7D/m" '# BF-TD-CENSUS-CANDIDATE' '    continue')
+  set -- $m7_meta; m7_sites=$1; m7_changed=$2; m7_parses=$3
+  rm -f "$M7D/p/.claude/test-debt.json"
+  write_ledger "$M7D/p" "$(_mlib "$M7D/m")"
+  m7_valid=0; jq -e . "$M7D/p/.claude/test-debt.json" >/dev/null 2>&1 && m7_valid=1
+  m7_mut=$(jq -r '.count // -1' "$M7D/p/.claude/test-debt.json" 2>/dev/null)
+  if [ "$(_num "$m7_ctl")" -eq 1 ] && [ "$m7_valid" -eq 1 ] && [ "$(_num "$m7_mut")" -eq 0 ] \
+     && [ "$m7_sites" -eq 1 ] && [ "$m7_changed" -eq 2 ] && [ "$m7_parses" -eq 1 ]; then
+    pass "M7 (the census): control ledgers 1 untested file; with the candidate predicate neutered the writer still emits VALID JSON with count 0 — an empty ledger is a real, reachable state and it is not the same fact as a clean tree"
+  else
+    fail_ "M7" "control_count=$m7_ctl (want 1) mutant_ledger_valid=$m7_valid (want 1) mutant_count=$m7_mut (want 0) sites=$m7_sites (want 1) changed_lines=$m7_changed (want 2) parses=$m7_parses (want 1)"
+  fi
+fi
+
+# ── M8: no awk under this module ──────────────────────────────────────────
+# `bash -n` does not syntax-check awk, so every mutant above would pass its
+# parse check while a dead awk emitted an empty result that reads as "nothing
+# wrong". The defence is structural: this module drives no awk. Pinned here so
+# that introducing one has to argue with a test rather than slip in.
+m8_awk=$(grep -c '\bawk\b' "$LIB" 2>/dev/null); m8_awk=$(_num "$m8_awk")
+if [ "$m8_awk" -eq 0 ]; then
+  pass "M8: the module drives no awk — the 'a dead awk emits empty and empty reads as fine' failure mode is removed rather than defended against"
+else
+  fail_ "M8" "awk occurrences in $LIB: $m8_awk (want 0)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-brownfield-wp5b-test-debt.sh
+++ b/tests/test-brownfield-wp5b-test-debt.sh
@@ -998,14 +998,28 @@ mk_mirror() {
 
 # _mutate MIRROR MARKER REPLACEMENT — one anchored, end-of-line-marked line,
 # excised and replaced. Echoes "sites changed parses" for the caller to assert.
+#
+# TWO SED METACHARACTERS IN THE REPLACEMENT, BOTH LEARNED THE HARD WAY IN THIS
+# FILE. `|` was the delimiter, so a replacement containing one — `case $status
+# in A|M)`, the exact widening a reviewer used to survive a green suite —
+# terminated the expression, sed errored, and the mutant was NOT APPLIED: the
+# harness reported `changed_lines=0` rather than a passing mutant, which is the
+# lucky direction but only by accident. `&` in a replacement means THE WHOLE
+# MATCH, so `cmd_a && cmd_b` spliced the original line back in twice and
+# produced a mutant nobody had designed. The delimiter is now `%` (no marker or
+# replacement in this file contains one) and `&` is escaped.
+#
+# The exactly-N-lines-changed assertion is what caught both. A harness that only
+# checked the mutant's exit code would have called each of them a kill.
 _mutate() {
   local m="$1" marker="$2" repl="$3"
   local f="$m/scripts/lib/adopt/adopt-test-debt.sh"
-  local before sites changed parses
+  local before sites changed parses safe
+  safe="${repl//&/\\&}"
   before="$(mktemp)"
   cp -p "$f" "$before"
   sites=$(_sites "$f" "$marker")
-  _sed_inplace "$f" "s|^.*${marker}\$|${repl}|"
+  _sed_inplace "$f" "s%^.*${marker}\$%${safe}%"
   changed=$(_changed_lines "$before" "$f")
   parses=$(_parses "$f")
   rm -f "$before"
@@ -1229,6 +1243,8 @@ else
   printf 'export function paid() { return 2; }\n' > "$M11D/p/src/paid.js"
   gitq "$M11D/p" add -A
   check_in "$M11D/p" "$(_mlib "$M11D/m")"; m11_ctl=$CHK_RC
+  # The real line MINUS the diff.renames pin and nothing else — the `&&` is
+  # carried verbatim, which is what proves _mutate's `&` escaping works.
   m11_meta=$(_mutate "$M11D/m" '# BF-TD-STAGED-READ' '  staged="$( cd "$root" 2>/dev/null && git -c core.quotePath=false diff --cached --name-status 2>/dev/null )"')
   set -- $m11_meta; m11_sites=$1; m11_changed=$2; m11_parses=$3
   check_in "$M11D/p" "$(_mlib "$M11D/m")"; m11_mut=$CHK_RC

--- a/tests/test-brownfield-wp5b-test-debt.sh
+++ b/tests/test-brownfield-wp5b-test-debt.sh
@@ -472,6 +472,85 @@ if ! _c_fixture "$C6D" strict; then fail_ "C6" "fixture setup failed"; else
   fi
 fi
 
+# C7 — a PURE RENAME (git reports R100) of a ledgered untested file. Neither
+# arm's rule is met: the set gained no member and nothing was modified. An
+# earlier cut of this module blocked it as non-growth on the new path, and the
+# result was a TRAP worth pinning against: re-baselining put the new path in
+# the ledger, and the same staged rename immediately blocked again as
+# touch-repays — no way out but writing a test for a file that had only moved.
+#
+# So the rename passes, and because a rename is the one way debt can leave the
+# ledger unpaid, the run must SAY the ledger is now stale. The pin asserts all
+# three: rc 0, the note naming both paths, and — after re-baselining — that the
+# debt FOLLOWED the file instead of evaporating.
+C7D="$(newtmp)/p"
+if ! _c_fixture "$C7D" strict; then fail_ "C7" "fixture setup failed"; else
+  gitq "$C7D" reset -q
+  gitq "$C7D" mv src/debt.js src/renamed-debt.js
+  check_in "$C7D"; c7_rc=$CHK_RC
+  c7_noted=0; grep -q 'src/debt\.js -> src/renamed-debt\.js' "$CHK_OUT" && c7_noted=1
+  write_ledger "$C7D"
+  c7_carried=$(jq -r '[.files[] | select(. == "src/renamed-debt.js")] | length' "$C7D/.claude/test-debt.json" 2>/dev/null)
+  c7_rows=$(jq -r '.audit | length' "$C7D/.claude/test-debt.json" 2>/dev/null)
+  if [ "$c7_rc" -eq 0 ] && [ "$c7_noted" -eq 1 ] \
+     && [ "$(_num "$c7_carried")" -eq 1 ] && [ "$(_num "$c7_rows")" -eq 2 ]; then
+    pass "C7: a PURE rename of a ledgered untested file passes (rc 0) and is NOTED with both paths; re-baselining carries the debt to the new path and leaves a second audit row — the move is not growth, not a modification, and not a silent way out"
+  else
+    fail_ "C7" "rc=$c7_rc (want 0) stale_ledger_noted=$c7_noted (want 1) debt_carried_to_new_path=$c7_carried (want 1) audit_rows=$c7_rows (want 2)"
+  fi
+fi
+
+# C9 — the same rename WITH a content change (git reports R090 here). Now it IS
+# a modification, so the obligation follows the file to its new path. Without
+# this row, `git mv` plus an edit would be a one-commit way to shed the
+# obligation entirely — a bigger hole than the false block C7 removed. The
+# control is C7 itself: identical fixture, identical rename, no edit, rc 0.
+C9D="$(newtmp)/p"
+if ! mk_repo "$C9D"; then fail_ "C9" "fixture setup failed"; else
+  # A file big enough for git to score the rename instead of reporting A+D.
+  : > "$C9D/src/wide.js"
+  for c9_i in 1 2 3 4 5 6 7 8 9 10; do
+    printf 'export function f%s() { return %s; }\n' "$c9_i" "$c9_i" >> "$C9D/src/wide.js"
+  done
+  gitq "$C9D" add src/wide.js
+  gitq "$C9D" commit -q -m "chore: a wide untested file"
+  write_ledger "$C9D"
+  set_tier "$C9D" '{"deployment":"personal","poc_mode":"production","enforcement_level":"strict"}'
+  gitq "$C9D" mv src/wide.js src/wider.js
+  printf 'export function added() { return 99; }\n' >> "$C9D/src/wider.js"
+  gitq "$C9D" add src/wider.js
+  c9_status=$( unset GITHUB_BASE_REF; cd "$C9D" && git -c core.quotePath=false diff --cached --name-status 2>/dev/null | cut -f1 )
+  check_in "$C9D"
+  c9_named=0; grep -q 'src/wider\.js' "$CHK_OUT" && c9_named=1
+  case "$c9_status" in R100|A) c9_shape=0 ;; R*) c9_shape=1 ;; *) c9_shape=0 ;; esac
+  if [ "$CHK_RC" -eq 4 ] && [ "$c9_named" -eq 1 ] && [ "$c9_shape" -eq 1 ]; then
+    pass "C9: a rename that ALSO changes content ($c9_status) owes a test at the NEW path — rc 4, touch-repays, so `git mv` plus an edit is not a way to shed the obligation"
+  else
+    fail_ "C9" "rc=$CHK_RC (want 4) new_path_named=$c9_named (want 1) git_status='$c9_status' partial_rename_shape=$c9_shape (want 1; a plain A or R100 would mean the fixture stopped testing what it names)"
+  fi
+fi
+
+# C8 — a NON-ASCII path must not vanish. git renders it as "src/caf\303\251.js"
+# — quotes included — unless core.quotePath is off, and that string has no
+# recognised source extension, so the file drops out of the census in silence
+# and neither arm can ever see it. Measured on a fixture before the flag was
+# added: absent from the ledger. A silent exclusion from a blocking gate is
+# worse than a noisy one, so it gets its own row.
+C8D="$(newtmp)/p"
+if ! mk_repo "$C8D"; then fail_ "C8" "fixture setup failed"; else
+  printf 'export function cafe() { return 1; }\n' > "$C8D/src/café.js"
+  gitq "$C8D" add "src/café.js"
+  gitq "$C8D" commit -q -m "chore: a non-ascii path"
+  write_ledger "$C8D"
+  c8_listed=$(jq -r '[.files[] | select(. == "src/café.js")] | length' "$C8D/.claude/test-debt.json" 2>/dev/null)
+  c8_quoted=$(jq -r '[.files[] | select(startswith("\""))] | length' "$C8D/.claude/test-debt.json" 2>/dev/null)
+  if [ "$(_num "$c8_listed")" -eq 1 ] && [ "$(_num "$c8_quoted")" -eq 0 ]; then
+    pass "C8: a non-ASCII source path is ledgered under its REAL name — core.quotePath is off on every git read, so the file cannot drop out of the census as an unrecognised extension"
+  else
+    fail_ "C8" "unicode_path_listed=$c8_listed (want 1) quoted_paths_in_ledger=$c8_quoted (want 0) files=$(jq -c '.files' "$C8D/.claude/test-debt.json" 2>/dev/null)"
+  fi
+fi
+
 echo ""
 echo "=== D — the TOUCH-REPAYS arm (§5.4: a modified ledgered file must leave the set) ==="
 

--- a/tests/test-brownfield-wp5b-test-debt.sh
+++ b/tests/test-brownfield-wp5b-test-debt.sh
@@ -52,7 +52,12 @@
 #   • a CONTROL beside every mutant: the same fixture against the UNMUTATED
 #     mirror, asserted GREEN in the same run. A mutant killed with no control
 #     cannot distinguish "the mutation broke the arm" from "the fixture never
-#     worked".
+#     worked";
+#   • NO BACKSLASH ESCAPES IN A REPLACEMENT STRING. `\n` in the RHS of `s///`
+#     is a newline to GNU sed and a literal `n` to BSD sed, so the same mutant
+#     would change one line on macOS and two on Linux — and the
+#     exactly-N-lines-changed assertion would then be a platform test. Every
+#     replacement below is plain text.
 #
 # ── NO awk IN THE CODE UNDER TEST, DELIBERATELY ─────────────────────────────
 # `bash -n` does not syntax-check awk: a dead awk program emits an empty
@@ -604,15 +609,43 @@ fi
 
 # F2 — M3 from the other direction, asserted directly rather than trusted to
 # the lint: the lint's CORE set is a glob list, and a file it does not scan
-# cannot red. This greps the whole tree for the new module file's basename
-# outside the module's own directory and its own test.
-f2_hits=$(grep -rl 'adopt-test-debt' "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" 2>/dev/null \
-  | grep -v '^'"$REPO_ROOT"'/scripts/lib/adopt/' | wc -l | tr -d ' ')
-f2_hits=$(_num "$f2_hits")
-if [ "$f2_hits" -eq 0 ]; then
-  pass "F2 (M3): no file outside scripts/lib/adopt/ names the new module file — core -> module stays unreachable by grep as well as by lint"
+# cannot red, which is exactly how `## BL-215:`'s missing fifth glob survived
+# from WP0. This greps the whole tree for the new file's basename and then
+# subtracts the module's own inventory.
+#
+# The inventory is READ FROM THE LINT'S OWN MANIFEST FENCE, not spelled again
+# here. Hardcoding it would mean an edit that moved a module path could widen
+# this exclusion silently — and `scripts/adopt-project.sh` is precisely such a
+# path: it is the module's ENTRY SCRIPT, so it is module code by the manifest's
+# own definition even though it lives beside core scripts.
+f2_hits="$TOPTMP/f2-hits"
+f2_mods="$TOPTMP/f2-modules"
+grep -rl 'adopt-test-debt' "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" 2>/dev/null > "$f2_hits"
+sed -n '/MODULE-DEPS-MANIFEST-BEGIN/,/MODULE-DEPS-MANIFEST-END/p' "$REPO_ROOT/scripts/lint-module-dependencies.sh" \
+  | grep -o '"adopt|[^"]*"' | sed 's/^"adopt|//; s/"$//' > "$f2_mods"
+f2_total=$(grep -c . "$f2_hits"); f2_total=$(_num "$f2_total")
+f2_modrows=$(grep -c . "$f2_mods"); f2_modrows=$(_num "$f2_modrows")
+f2_core=0
+f2_names=""
+while IFS= read -r f2_hit; do
+  [ -n "$f2_hit" ] || continue
+  f2_rel="${f2_hit#"$REPO_ROOT"/}"
+  f2_is_module=0
+  while IFS= read -r f2_mp; do
+    [ -n "$f2_mp" ] || continue
+    case "$f2_rel" in "$f2_mp"|"$f2_mp"*) f2_is_module=1 ;; esac
+  done < "$f2_mods"
+  if [ "$f2_is_module" -eq 0 ]; then
+    f2_core=$((f2_core + 1))
+    f2_names="$f2_names $f2_rel"
+  fi
+done < "$f2_hits"
+# The vacuity floor: "no core file names it" must not be reachable by scanning
+# nothing. The module's own files DO name it, so a zero total is a broken probe.
+if [ "$f2_core" -eq 0 ] && [ "$f2_total" -gt 0 ] && [ "$f2_modrows" -gt 0 ]; then
+  pass "F2 (M3): every file that names adopt-test-debt is in the adopt module's own manifest inventory ($f2_total naming files, $f2_modrows manifest rows) — core -> module stays unreachable by grep as well as by lint"
 else
-  fail_ "F2" "core files naming adopt-test-debt: $f2_hits (want 0): $(grep -rl 'adopt-test-debt' "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" 2>/dev/null | grep -v '^'"$REPO_ROOT"'/scripts/lib/adopt/' | tr '\n' ' ')"
+  fail_ "F2" "core files naming adopt-test-debt: $f2_core (want 0):$f2_names | total_naming_files=$f2_total (want >0) manifest_rows=$f2_modrows (want >0)"
 fi
 
 # F3 — M2: the entry script's declared core-lib list must actually name the
@@ -784,7 +817,7 @@ if ! _c_fixture "$M3D/p" no || ! mk_mirror "$M3D/m"; then
 else
   check_in "$M3D/p" "$(_mlib "$M3D/m")"; m3_ctl=$CHK_RC
   m3_ctl_bytes=$(_bytes "$CHK_OUT")
-  m3_meta=$(_mutate "$M3D/m" '# BF-TD-FLOOR-NO' "    no)     printf 'block\\n' ;;")
+  m3_meta=$(_mutate "$M3D/m" '# BF-TD-FLOOR-NO' "    no)     echo block ;;")
   set -- $m3_meta; m3_sites=$1; m3_changed=$2; m3_parses=$3
   check_in "$M3D/p" "$(_mlib "$M3D/m")"; m3_mut=$CHK_RC
   if [ "$m3_ctl" -eq 0 ] && [ "$m3_ctl_bytes" -eq 0 ] && [ "$m3_mut" -eq 3 ] \
@@ -806,7 +839,7 @@ if ! _d_fixture "$M4D/p" no || ! mk_mirror "$M4D/m"; then
 else
   check_in "$M4D/p" "$(_mlib "$M4D/m")"; m4_ctl=$CHK_RC
   m4_ctl_bytes=$(_bytes "$CHK_OUT")
-  m4_meta=$(_mutate "$M4D/m" '# BF-TD-FLOOR-NO' "    no)     printf 'block\\n' ;;")
+  m4_meta=$(_mutate "$M4D/m" '# BF-TD-FLOOR-NO' "    no)     echo block ;;")
   set -- $m4_meta; m4_sites=$1; m4_changed=$2; m4_parses=$3
   check_in "$M4D/p" "$(_mlib "$M4D/m")"; m4_mut=$CHK_RC
   if [ "$m4_ctl" -eq 0 ] && [ "$m4_ctl_bytes" -eq 0 ] && [ "$m4_mut" -eq 4 ] \
@@ -824,7 +857,7 @@ if ! _c_fixture "$M5D/p" light || ! mk_mirror "$M5D/m"; then
 else
   check_in "$M5D/p" "$(_mlib "$M5D/m")"; m5_ctl=$CHK_RC
   m5_ctl_warn=0; grep -qi 'warn' "$CHK_OUT" && m5_ctl_warn=1
-  m5_meta=$(_mutate "$M5D/m" '# BF-TD-FLOOR-LIGHT' "    light)  printf 'block\\n' ;;")
+  m5_meta=$(_mutate "$M5D/m" '# BF-TD-FLOOR-LIGHT' "    light)  echo block ;;")
   set -- $m5_meta; m5_sites=$1; m5_changed=$2; m5_parses=$3
   check_in "$M5D/p" "$(_mlib "$M5D/m")"; m5_mut=$CHK_RC
   if [ "$m5_ctl" -eq 0 ] && [ "$m5_ctl_warn" -eq 1 ] && [ "$m5_mut" -eq 3 ] \
@@ -884,7 +917,14 @@ fi
 # parse check while a dead awk emitted an empty result that reads as "nothing
 # wrong". The defence is structural: this module drives no awk. Pinned here so
 # that introducing one has to argue with a test rather than slip in.
-m8_awk=$(grep -c '\bawk\b' "$LIB" 2>/dev/null); m8_awk=$(_num "$m8_awk")
+#
+# Whole-line comments are stripped before counting, and only those: the module
+# has to be able to EXPLAIN this rule in its own header, and a check that
+# forbade the word would forbid the explanation. A trailing comment mentioning
+# it would still count, which is the conservative direction — a false red on a
+# comment costs a sentence, a false green on a live pipeline costs the
+# property.
+m8_awk=$(grep -v '^[[:space:]]*#' "$LIB" | grep -c '\bawk\b'); m8_awk=$(_num "$m8_awk")
 if [ "$m8_awk" -eq 0 ]; then
   pass "M8: the module drives no awk — the 'a dead awk emits empty and empty reads as fine' failure mode is removed rather than defended against"
 else


### PR DESCRIPTION
## What this builds

Brownfield WP5b — the **test-debt ledger** and its ratchet. When a project is
adopted, it gets a one-time census of source files that have no test, written to
`.claude/test-debt.json`. Two arms then hold the line:

- **Non-growth** — adding an untested file **blocks at `strict`**, **warns at
  `light`**, is **silent at `no`**.
- **Touch-repays** — modifying a ledgered file without adding a test blocks at
  `strict`.

**Not wired to commit time yet, and the page says so in three places.** The
commit-time caller is WP7's, because `pre-commit-gate.sh` is core and this is
module — that call is the `core → module` edge M3 forbids. The hook WP7 installs
lands in the *adopted project*, where it is not that edge at all. Review accepted
shipping the ratchet un-called **because** the documentation states the residue
plainly.

## Three review rounds, and what each found

**Round 1 — the tool's own advice broke the user.** The census must only ever
contain *their* code. It was defended **by timing** — relying on the first write
happening before the framework's files landed — and the tool then printed a
re-baseline command and told the operator to run it. Measured: at adoption, 1
entry and 0 framework scripts; after running the advertised command, **58 entries
and 57 framework scripts**, after which `strict` demanded tests for
`check-gate.sh` on every framework sync.

Now the census subtracts the installed inventory via `soif_parse_shipped_scripts`
from `init.sh`'s **own copy list** — the same derivation `adopt_install_framework`
uses. Review confirmed this is closed **by construction, not by test**: the
install set and the exclusion set cannot diverge, and a framework file the copy
list does not name is one the driver never installs.

**Round 1 also — two silent bypasses from the adoptee's own `.gitconfig`.**
`diff.renames=copies` let a copied untested file enter the working set at rc 0
with **zero output**; `diff.renames=false` resurrected the rename loop this
branch is named after fixing. One line — `-c core.quotePath=false
-c diff.renames=true` on every read — closes both. Review then hunted a third
knob (`diff.renameLimit`, `status.renames`, a `.gitattributes -diff`, hostile
`GIT_CONFIG_PARAMETERS`) and found no bypass.

**Round 2 — a mutation survived 42/0.** Widening the status match to
`A|M|A[0-9]*` reverses the documented additions-only decision and passed
everything, because every fixture's staged `M` row was either ledgered or tested,
so the branch was never reached.

**Round 3 — the refusals were themselves unpinned.** The fix added three
"underivable ⇒ refuse, not guess" guards. Changing **one character**
(`return 1` → `return 0`) made the tool silently guess again with all 50 tests
green. Each guard now has a fixture that reaches it, and R2 asserts rc 2 **and
specifically not rc 3** — *refusing to judge is not judging*.

## BL-221 immunity, attacked and held

This branch consumes both existing tier accessors and composes them
**raise-only**, so BL-221's `jq -r '.deployment // "personal"'` fail-open cannot
lower anything, plus a guard requiring the `deployment` key to actually exist.
Review attacked it structurally and then with four adversarial manifests beyond
the suite's seven — `{"deployment":"personal","poc_mode":"production"}`, an
off-ladder `"enforcement_level":["no"]`, `"deployment":""`, and
`"deployment":null` with `"enforcement_level":"no"`. All blocked at rc 3. **No
manifest exists in which the fail-open lowers the tier.**

## Two bugs the author found in their own work

- A **rename loop**: `git mv` on a ledgered file blocked as new debt, and
  re-baselining then blocked it as unpaid debt — no exit except writing a test
  for a file that had only *moved*. It blocked renames of already-tested files
  too.
- A **non-ASCII path vanishing silently** from the census, because git quotes
  `"src/caf\303\251.js"` and the quoted form has no recognisable extension.

## The harness bug worth reading

The mutation harness had two `sed` defects: a `|` delimiter that made a
replacement **never apply**, and an unescaped `&` that spliced the original line
back in twice.

**The attribution was then corrected under review**, and the correction is the
useful part: the exactly-N-lines-changed assertion caught the delimiter defect.
The `&` splice yielded `changed_lines=2` **and passed `bash -n`** — every
structural assertion stayed green — and was caught only by the *functional*
assertion, when the mutant died at runtime. So `bash -n` accepts a file bash
rejects at runtime, and against that class the meta-assertions are blind.

`CLAUDE.md`'s ENVIRONMENT TRAPS gains the rule, because it has bitten three times
across 25 files carrying `s|`-delimited `sed`: **pick a delimiter absent from the
replacement, and assert the edit applied — "sed ran" is not "sed edited".**

## Verification

- `tests/test-brownfield-wp5b-test-debt.sh` — **57 passed, 0 failed** (~29s).
- Review re-ran its own mutation and three more of its own devising; all die.
- WP4 driver 39/0 · `run-lints` 15/15.
- Suite registered in both `tests/full-project-test-suite.sh` and the `tests.yml`
  unit list; lane reachability confirmed **by execution**, not by lint.

## Filed here

- **BL-223** — `soif_parse_shipped_scripts` re-parses `init.sh` per call
  (~125–144ms). Deferred deliberately: it is a core lib and the fix belongs with
  its consumers, not smuggled into a review-fix commit. The entry said *three*
  consumers; review counted **nine**, so it now carries the derivation command
  rather than a remembered list.
- **BL-224** — `lint-no-live-remote-in-tests.sh` reds any test that *writes* an
  `init.sh` carrying a `#!/usr/bin/env` shebang. The workaround here drops the
  shebang from a parse-only stub **and says why in place**, rather than spelling
  around the lint. The entry's own reproduction line was one token short and is
  corrected; and its preferred fix was priced from one instance — review found
  two more over-broad shapes it would not cover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
