### PR TITLE
feat(brownfield): WP6 — the collision archive, its MANIFEST and disclosure, recorded re-adds, and the archive-secrets refusal

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -515,6 +515,7 @@ jobs:
             tests/test-brownfield-wp3-adoption-arms.sh
             tests/test-brownfield-wp4-driver.sh
             tests/test-brownfield-wp5b-test-debt.sh
+            tests/test-brownfield-wp6-collision-archive.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/README.md
+++ b/README.md
@@ -174,8 +174,9 @@ still being built — and lands it accordingly, writing state in a fail-safe ord
 and committing exactly the files it wrote.
 
 > **⚠ Adoption is half built.** The driver, chooser, reverse intake, state
-> writes and adoption stamp ship and work. **The certification pass, the
-> test-debt ledger, the collision archive, the CI carve-out and the Adoption
+> writes, adoption stamp and the collision archive (with its disclosure,
+> recorded re-adds and pre-staging secret scan) ship and work. **The
+> certification pass, the test-debt ledger, the CI carve-out and the Adoption
 > Record do not exist yet.** The driver prints a labelled `NOT DONE` block for
 > each during the run rather than papering over it. Do not read an adopted
 > project as a certified one.
@@ -199,7 +200,7 @@ not among them. Read them here.
 - **One command setup** — `./init.sh` handles everything: tool installation, project scaffolding, CI/CD generation, security tooling, Git initialization, and health check.
 - **A lifecycle after v1.0** — the [delta track](docs/delta-track.md) ships into every project: one classified unit of post-release change at a time, a brief whose acceptance checklist is the close review, a hotfix lane whose deferred retro blocks the next release, a maintenance cadence that refuses a release when a window is overdue *or unmeasurable*, and `scripts/cut-release.sh`, which decides the semver from what actually shipped, promotes the changelog, closes the `BUGS.md`/`FEATURES.md` rows, and tags.
 - **Look before you install** — [Scout](docs/scout.md) (`scripts/scout.sh`) is a read-only survey of any codebase: stack, phase evidence, reality probes, **full-history secret scanning with the value never printed**, an inventory of what the framework would otherwise overwrite, a tests baseline, and an intake prefill. It writes nothing and needs nothing installed.
-- **A second way in for existing code** — [brownfield adoption](docs/adoption.md) (`scripts/adopt-project.sh`) brings a codebase that already exists under the framework, asking one plain-English question and landing it at the phase its own evidence supports. **Half built today** — the certification pass, test-debt ledger, collision archive, CI carve-out and Adoption Record are designed and not yet implemented; the driver says so, per capability, during the run.
+- **A second way in for existing code** — [brownfield adoption](docs/adoption.md) (`scripts/adopt-project.sh`) brings a codebase that already exists under the framework, asking one plain-English question and landing it at the phase its own evidence supports. **Half built today** — the certification pass, test-debt ledger, CI carve-out and Adoption Record are designed and not yet implemented; the driver says so, per capability, during the run. The collision archive ships: it copies the files the framework would land on into a timestamped, manifested, restorable directory, discloses every one of them by name, permits recorded re-adds, and refuses to commit an archived file a secret scanner matched.
 
 ---
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -25,7 +25,7 @@ five-phase build: after v1.0 ships, and before a project that already exists com
 | [step5-dogfood-walker-rubric.md](step5-dogfood-walker-rubric.md) | The pass/partial/fail rubric the Step-5 dogfood walker uses to disposition scenario outcomes. |
 | [delta-track.md](delta-track.md) | **After v1.0** — the post-release lifecycle `init.sh` installs into every project: the phase-4 activation gate, the four change classes and their confirm-not-quiz open, the brief whose Done-observable checklist *is* the close review, the close-time attribute ratchet, the hotfix lane and its release-blocking retro, the cadence clock's current/overdue/**unmeasurable** contract, `cut-release.sh`'s three refusals and tool-decided semver, and `.claude/delta-policy.json`. Worked transcripts throughout, all executed. |
 | [scout.md](scout.md) | **Scout** — the read-only survey (`scripts/scout.sh`). All seven report sections, the read-only proof, the opt-in `--run-tests`, full-history secret scanning with the value never printed, and the limits Scout states about itself (the untested-file count is a name-match heuristic; branch protection is `unknown`, not `no`). |
-| [adoption.md](adoption.md) | **Brownfield adoption** — `scripts/adopt-project.sh`: the chooser question verbatim, the floor rule, the reverse intake, the fail-safe write order, the adoption stamp and its loud loss detection, the TDD exemption's bound, and the test-debt ledger with its tier ratchet that is the exemption's forward equivalent. **Carries the prominent "what is not built yet" section** — the certification pass, collision archive, CI carve-out and Adoption Record are designed and not implemented. |
+| [adoption.md](adoption.md) | **Brownfield adoption** — `scripts/adopt-project.sh`: the chooser question verbatim, the floor rule, the reverse intake, the fail-safe write order, the adoption stamp and its loud loss detection, and the TDD exemption's bound. Plus the **test-debt ledger** and its tier ratchet, the exemption's forward equivalent; and the **collision archive** — layout and MANIFEST, the disclosure, `--re-add`, and the pre-staging secret scan that refuses to commit a matched archive entry. **Carries the prominent "what is not built yet" section** — the certification pass, CI carve-out and Adoption Record are designed and not implemented. |
 
 ## Handoffs (`docs/handoffs/`)
 
@@ -83,8 +83,8 @@ amendment folded. **Built and shipping** — the user-facing page is [delta-trac
 read-only scanner, the completed-vs-in-flight scenario chooser, the certification pass that replaces
 grandfathering, full-history secret scanning with redacted findings, and the archive-and-disclose
 collision policy. v1.2, build-evidence amendment folded. **Half built** — Scout, the adoption
-driver and the test-debt ledger with its ratchet ship; the certification pass, collision archive, CI
-carve-out and Adoption Record do not. User-facing pages: [scout.md](scout.md) and
+driver, the test-debt ledger with its ratchet, and the collision archive ship; the certification
+pass, CI carve-out and Adoption Record do not. User-facing pages: [scout.md](scout.md) and
 [adoption.md](adoption.md), which name every gap).
 
 ## Module contract (`docs/module-contract.md`)

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -13,9 +13,10 @@ bash /path/to/solo-orchestrator/scripts/adopt-project.sh
 >
 > **Adoption is half built.** The driver, the scenario chooser, the reverse
 > intake, the state writes, the adoption stamp, the commit-time enabling arms
-> and the test-debt ledger with its ratchet all ship and all work. **The
-> certification pass, the collision archive, the CI carve-out and the Adoption
-> Record do not exist.**
+> the test-debt ledger with its ratchet, and — as of WP6 — **the collision
+> archive, its disclosure and its recorded re-adds** all ship and all work.
+> **The certification pass, the CI carve-out and the Adoption Record do not
+> exist.**
 >
 > The driver does not paper over that. It prints a labelled `NOT DONE` block for
 > every one of them, in the run, naming the work package that owns it. The full
@@ -681,27 +682,96 @@ The residue is named there rather than hidden here: **nothing invokes the arms
 automatically yet**, because the commit-time hook is WP7's. Today it is a
 command you run.
 
-### The collision archive, disclosure and re-adds — WP6
+### The collision archive, disclosure and re-adds — SHIPS (WP6)
 
-Scout **reports** collisions (see [scout.md](scout.md#collisions--what-the-framework-would-otherwise-trample));
-nothing archives them. The designed behaviour — inventory, then archive your
-version into a timestamped directory **with a written MANIFEST and restore
-instructions**, then install the framework's clean set, then disclose plainly
-what moved — does not exist. Nor do the `adoption_event` audit rows.
+**This section used to say the archive did not exist. It does now.**
 
-Related, and printed by the driver:
+Before any framework writer runs, adoption copies the files it would otherwise
+land on into `.claude/adoption-archive/<UTC-timestamp>-<pid>/`, mirroring your
+paths, and writes a `MANIFEST.json` and a `MANIFEST.md` beside them. The
+population is the archive-and-replace bucket: `.claude/settings.json`,
+`.claude/settings.local.json`, `.mcp.json`, your `.claude/skills/*/SKILL.md`,
+and every non-`.sample` file in `.git/hooks/`. **Only files that exist are
+archived** — an absent surface produces no file and no manifest row.
+
+Nothing is deleted. Every entry carries a `restore` line you can paste, and
+every git-hook entry carries a short **advisory** description of what it
+invoked, assembled from a fixed list of tool names so that no byte of your hook
+can reach the manifest.
+
+The run then discloses it in full — the sentence, **the list** (every path, not
+a count), and the restore instructions:
+
+```text
+══ Your own configuration has been archived
+   The files below were moved to ensure the framework operates properly.
+   Nothing was deleted. Every one of them is in .claude/adoption-archive/… and can be put back.
+
+   yours: .git/hooks/pre-commit
+      archived as: .claude/adoption-archive/…/git-hooks/pre-commit
+      what it did: Ran `lint-staged`, `npx`, and other commands.
+      put it back: cp .claude/adoption-archive/…/git-hooks/pre-commit .git/hooks/pre-commit
+```
+
+#### Your files are yours — `--re-add`
+
+```bash
+bash /path/to/solo-orchestrator/scripts/adopt-project.sh --re-add .git/hooks/pre-commit
+```
+
+It prints the warning, asks you to confirm (there is no default and no skip),
+restores the file byte-for-byte at its recorded mode, and writes the choice
+into `.claude/bypass-audit.json` as an `adoption_event` row. The framework's
+premise is opinionated enforcement, not confiscation; it asks only that the
+override be findable by whoever reads the ledger next. See
+[audit-log-lifecycle.md](audit-log-lifecycle.md#adoption_event).
+
+#### The archive is scanned before anything is committed
+
+`.git/hooks/` is **not** tracked by git; `.claude/` is. So copying a hook into
+the archive and committing it would take a credential git had never seen and
+put it in your history — **adoption would create the leak.** So the archive is
+scanned with `gitleaks` *before* staging, and any entry that matches is written
+to disk and **kept out of the commit**, with the reason recorded:
+
+```text
+   1 of those copies were NOT added to the commit.
+   NOT COMMITTED — secret-match
+   A credential in a file git had never seen would have become a credential in
+   your history. Rotate it at the source; deleting the file does not un-leak it.
+```
+
+Two more refusals share that path. If gitleaks is **not installed**, the scan
+reports `tool-unavailable` and **the whole archive is withheld** — "nobody
+looked" is not "clean", and an unexamined tree does not enter version control.
+And if your own `.gitignore` excludes an archived path, that entry is withheld
+too (`gitignored`), because `git add` on an ignored path fails and would
+otherwise abort the entire adoption commit.
+
+This is a mitigation, not a proof: a hook can contain something a secret
+scanner does not recognise. Read `MANIFEST.md` before you push.
+
+#### Still not built by this package
 
 ```text
 NOT DONE — your project's framework documents
-   Owner: WP6 (they are collision decisions before they are writes). This build does not do it, and does not pretend to.
+   Owner: unassigned — §10 names no owner. This build does not do it, and does not pretend to.
    CLAUDE.md, the document templates and the reference docs are NOT written. The scripts and the
    state are here, so the gates work; the reading material an agent picks up at the start
    of a session is not, and a CLAUDE.md you already have would be a collision, not a gap.
+   WP6's archive covers your AI-layer settings and your git hooks; documents are neither.
 ```
 
 So an adopted project has working gates and **no `CLAUDE.md`** — the file an
 agent reads at the start of every session. Write one by hand, or copy
 `templates/generated/claude-md.tmpl` from the framework clone and fill it in.
+
+The other gap is the **replacement** half for framework-script collisions: a
+file of yours sitting where a framework *script* would go is still left alone
+and still not replaced, so the framework's version of it is not installed. That
+class is deliberately outside the archive — swapping out a `scripts/validate.sh`
+your own build may call is a decision nobody has made yet — and the run names
+it with its own `NOT DONE` block.
 
 ### The CI carve-out, provenance headers and the Adoption Record — WP7
 
@@ -739,7 +809,9 @@ how this project entered the framework, carrying the scenario, the landed phase,
 the certification inventory, the blocker acceptances, the secrets dispositions,
 the collision archive path and the CI keep-or-retire decisions — does not exist.
 Neither does the eight-clause lint that keeps it structurally unparseable as a
-gate approval.
+gate approval. (The archive path it would carry is real now — it is in
+`.claude/adoption-archive/*/MANIFEST.json` and in an `adoption_event` audit
+row. What is missing is the Record that gathers it with everything else.)
 
 The **CI carve-out** does not exist either. Nothing installs framework CI as its
 own files, and nothing records a keep-or-retire decision about your pipelines.
@@ -798,11 +870,15 @@ not among them. Read them here, in the framework clone you run the driver from.
 | Gates that were skipped actually run and recorded | ❌ Certification pass — **not built** |
 | Adoption that can *fail* on a serious finding | ❌ Certification pass — **not built** |
 | A recorded, non-growing set of untested files | ✅ [Test-debt ledger + ratchet](#the-test-debt-ledger-and-its-ratchet) — ships and works, **but you run it; nothing calls it on commit yet (WP7)** |
-| Your colliding hooks/settings archived with a restore path | ❌ Collision archive — **not built** |
+| Your colliding hooks/settings archived with a restore path | ✅ Collision archive — ships |
+| Plain disclosure of what was archived, path by path | ✅ Ships |
+| Putting one of your own files back, warned and recorded | ✅ `--re-add`, ships |
+| A guarantee adoption will not commit a secret out of your hooks | ✅ Ships — the archive is scanned before staging, and a match is withheld |
 | Framework CI installed beside yours, with a recorded keep-or-retire | ❌ CI carve-out — **not built** |
 | A readable record of how this project entered the framework | ❌ Adoption Record — **not built** |
 | Secret scanning, SAST and migration checks on every commit | ❌ Deferred to WP7, by decision |
-| A `CLAUDE.md` in the adopted project | ❌ Deferred to WP6 |
+| The framework's version of a colliding `scripts/*.sh` installed | ❌ Replacement half — **not built**, and unassigned |
+| A `CLAUDE.md` in the adopted project | ❌ **Not built** — unassigned; §10 names no owner |
 | The manifest's tier keys, so enforcement cannot be downgraded | ❌ **Not written — `## BL-221:`.** Set them by hand on an organizational adoptee |
 
 ---

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -762,9 +762,19 @@ proxy setting, an internal endpoint or a personal token, and standardly
 gitignored. The ordinary ignore rule for it is *anchored*
 (`.claude/settings.local.json`), so it matches the original and **cannot** match
 `.claude/adoption-archive/…/.claude/settings.local.json`. Asking git about the
-copy's path would answer a question you never asked. Your git hooks are
-unaffected: git excludes `.git/` by construction rather than by your
-instruction, so hooks are still archived and still committed.
+copy's path would answer a question you never asked.
+
+**Your git hooks are exempt from this rule, and the reason is worth stating
+because an earlier version of this page got it wrong.** It claimed hooks were
+safe because "git excludes `.git/` by construction" — they are not:
+`git check-ignore` applies your patterns to any path it is given, `.git/`
+included, so a `.gitignore` containing `*`, `hooks/` or even the cargo-cult
+line `.git/` reports `.git/hooks/pre-commit` as ignored. The exemption is
+deliberate instead: a `.gitignore` line about a `.git/` path is not an
+instruction git can act on — git never tracks `.git/`, so the rule changes
+nothing and expresses no decision about whether that content may be preserved.
+Without the exemption a single inert `.git/` line would silently withhold your
+hooks, which are the most important thing the archive holds.
 
 #### Still not built by this package
 

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -741,15 +741,30 @@ to disk and **kept out of the commit**, with the reason recorded:
    your history. Rotate it at the source; deleting the file does not un-leak it.
 ```
 
-Two more refusals share that path. If gitleaks is **not installed**, the scan
-reports `tool-unavailable` and **the whole archive is withheld** — "nobody
-looked" is not "clean", and an unexamined tree does not enter version control.
-And if your own `.gitignore` excludes an archived path, that entry is withheld
-too (`gitignored`), because `git add` on an ignored path fails and would
-otherwise abort the entire adoption commit.
+**A pattern scanner is a mitigation, not a proof, and this page will not call
+it a guarantee.** It recognises credential *shapes*. An internal hostname, a
+proxy URL, a customer name or a username matches nothing, and a hook can hold
+any of them. Read `MANIFEST.md` before you push.
 
-This is a mitigation, not a proof: a hook can contain something a secret
-scanner does not recognise. Read `MANIFEST.md` before you push.
+Which is why the scan is not the only gate. Three more reasons withhold an
+entry, and the MANIFEST names whichever applies:
+
+| `withheldReason` | What happened |
+|---|---|
+| `secret-match` | The scanner matched something in that file. |
+| `not-scanned` | gitleaks was **not installed** or the scan failed, so **the whole archive is withheld**. "Nobody looked" is not "clean", and an unexamined tree does not enter version control. |
+| `original-gitignored` | **Your `.gitignore` excludes the original.** A gitignore entry is your explicit statement that this *content* must never enter history, so the archive keeps a copy you can restore and never commits that copy under a different name. |
+| `gitignored` | Your `.gitignore` excludes the archived path itself. Withheld because `git add` on an ignored path fails and would otherwise abort the entire adoption commit. |
+
+`original-gitignored` is the one that will fire most often, and the file it
+usually fires on is `.claude/settings.local.json` — the standard place for a
+proxy setting, an internal endpoint or a personal token, and standardly
+gitignored. The ordinary ignore rule for it is *anchored*
+(`.claude/settings.local.json`), so it matches the original and **cannot** match
+`.claude/adoption-archive/…/.claude/settings.local.json`. Asking git about the
+copy's path would answer a question you never asked. Your git hooks are
+unaffected: git excludes `.git/` by construction rather than by your
+instruction, so hooks are still archived and still committed.
 
 #### Still not built by this package
 
@@ -873,7 +888,8 @@ not among them. Read them here, in the framework clone you run the driver from.
 | Your colliding hooks/settings archived with a restore path | ✅ Collision archive — ships |
 | Plain disclosure of what was archived, path by path | ✅ Ships |
 | Putting one of your own files back, warned and recorded | ✅ `--re-add`, ships |
-| A guarantee adoption will not commit a secret out of your hooks | ✅ Ships — the archive is scanned before staging, and a match is withheld |
+| Adoption refusing to commit a *recognised* secret out of your hooks | ✅ Ships — the archive is scanned before staging and a match is withheld. **A mitigation, not a guarantee** — see below |
+| Adoption never committing a file your `.gitignore` excludes | ✅ Ships — the **original's** ignore status decides, not the archive copy's |
 | Framework CI installed beside yours, with a recorded keep-or-retire | ❌ CI carve-out — **not built** |
 | A readable record of how this project entered the framework | ❌ Adoption Record — **not built** |
 | Secret scanning, SAST and migration checks on every commit | ❌ Deferred to WP7, by decision |

--- a/docs/audit-log-lifecycle.md
+++ b/docs/audit-log-lifecycle.md
@@ -101,6 +101,28 @@ The SessionStart detector or the bypass-audit library hit an unrecoverable error
 - **`actor`:** `framework`.
 - **`details`:** `{reason}`.
 
+### `adoption_event`
+
+A **brownfield adoption** did something to the operator's project that they are entitled to find again later. One type covers all of them, discriminated by `details.event` — [the brownfield design](designs/2026-08-02-brownfield-adoption-v1.md) §8.9 chose one member with a discriminator over five members, because adding a row type touches five surfaces and five types would be five times that work for no extra fidelity.
+
+- **Writer:** the adoption driver (`--re-add`, and the collision archive during an adoption run).
+- **Lifecycle:** terminal on write. `user_response: "n/a"`, `final_outcome: "recorded_only"`.
+- **`actor`:** `framework`.
+- **`enforcement_level_at_event`:** always `"n/a"`, deliberately. These are disclosure events, not gate outcomes; reading a tier for them would fork the `# BL-084-TIER-KEY` predicate into a sixth site that must be changed in sync with the other five.
+- **`details`:** `{event, …}`, where `event` is one of:
+
+| `details.event` | Recorded when | Extra `details` |
+| - | - | - |
+| `collision_archive` | The collision archive is written during an adoption | `archiveDir`, `entryCount`, `secretsScanStatus` |
+| `collision_re_add` | The operator puts one of their archived files back | `path`, `archivedPath`, `warningShown` |
+| `adoption` | The adoption itself completes | *no emitter yet* |
+| `blocker_acceptance` | A certification blocker is accepted | *no emitter yet* |
+| `secrets_disposition` | A finding is dispositioned `accepted risk` | *no emitter yet* |
+
+The three "no emitter yet" rows are named because the vocabulary is closed and a reader of a ledger should be able to tell "this never happened" from "this happens and is not recorded". Today only the two collision events are written.
+
+**A `collision_re_add` row is the operator overriding the framework, on purpose.** §7.3 permits re-adds — *"the framework's premise is opinionated enforcement, not confiscation"* — and asks only that the choice be legible to whoever reads the ledger next. A project with re-add rows is not a misconfigured project; it is one whose owner made a decision you can now go and read.
+
 ## Lifecycle per enforcement level
 
 The user-guide table gives you the high-level matrix. The audit log's *content* is what concretely differs across levels:
@@ -132,6 +154,9 @@ jq '[.[] | select(.type == "escalation")] | .[] | {ts: .timestamp, response: .us
 
 # 5. Detector errors (gaps in coverage that should be investigated).
 jq '[.[] | select(.type == "detector_error")] | .[] | {ts: .timestamp, level: .enforcement_level_at_event, reason: .details.reason}' .claude/bypass-audit.json
+
+# 7. Brownfield adoption: what the archive took, and what the operator took back.
+jq '[.[] | select(.type == "adoption_event")] | sort_by(.timestamp) | .[] | {ts: .timestamp, event: .details.event, path: (.details.path // .details.archiveDir // "n/a"), details: .details}' .claude/bypass-audit.json
 
 # 6. Quick health summary — counts by type, by actor.
 jq 'group_by(.type) | map({type: .[0].type, count: length})' .claude/bypass-audit.json

--- a/docs/audit-log-lifecycle.md
+++ b/docs/audit-log-lifecycle.md
@@ -155,10 +155,10 @@ jq '[.[] | select(.type == "escalation")] | .[] | {ts: .timestamp, response: .us
 # 5. Detector errors (gaps in coverage that should be investigated).
 jq '[.[] | select(.type == "detector_error")] | .[] | {ts: .timestamp, level: .enforcement_level_at_event, reason: .details.reason}' .claude/bypass-audit.json
 
-# 7. Brownfield adoption: what the archive took, and what the operator took back.
+# 6. Brownfield adoption: what the archive took, and what the operator took back.
 jq '[.[] | select(.type == "adoption_event")] | sort_by(.timestamp) | .[] | {ts: .timestamp, event: .details.event, path: (.details.path // .details.archiveDir // "n/a"), details: .details}' .claude/bypass-audit.json
 
-# 6. Quick health summary — counts by type, by actor.
+# 7. Quick health summary — counts by type, by actor.
 jq 'group_by(.type) | map({type: .[0].type, count: length})' .claude/bypass-audit.json
 jq 'group_by(.actor) | map({actor: .[0].actor, count: length})' .claude/bypass-audit.json
 ```

--- a/docs/audit-log-lifecycle.md
+++ b/docs/audit-log-lifecycle.md
@@ -12,7 +12,7 @@ The W7 use case (successor handoff under the Solo Orchestrator governance framew
 
 - **Path:** `.claude/bypass-audit.json` (tracked in git — must survive `git clone`).
 - **Schema:** JSON array of rows. Each row has a fixed seven-field shape (see [Row schema](#row-schema)).
-- **Writer:** every writer goes through `scripts/lib/bypass-audit.sh::bypass_audit_append`. Direct edits are not part of the contract.
+- **Writer:** the *contract* writer is `scripts/lib/bypass-audit.sh::bypass_audit_append`, and it is the only writer that validates the ledger's shape before appending (refusing empty / `null` / multi-document / non-array loudly, with the file untouched). **Seven inline `jq '. + [$r]'` sites in five files still bypass it** — see `## BL-227:`, which carries the derivation command; an earlier version of this line claimed every writer went through the library, and a grep refutes it. Direct edits are not part of the contract.
 - **Atomic append:** `bypass_audit_append` holds a portable `mkdir`-based advisory lock for the read-modify-write window, then writes via an adjacent `mktemp` so the final `mv` is a same-filesystem atomic rename. A SIGKILL during the write window leaves the previous valid ledger untouched.
 - **Pending-row resolution:** `bypass_audit_close_pending` flips PENDING rows whose `type == "claude_bypass_proposal"` to `accepted/bypassed` or `declined/abandoned`. It is intentionally scoped to that row type — escalations are not collapsed into the same lifecycle.
 

--- a/scripts/adopt-project.sh
+++ b/scripts/adopt-project.sh
@@ -62,6 +62,18 @@
 #                                        gate itself uses, so the test-debt
 #                                        ledger and the gate cannot disagree
 #                                        about what an implementation file is
+#   scripts/lib/bypass-audit.sh          bypass_audit_append, the contract
+#                                        writer of .claude/bypass-audit.json.
+#                                        §8.9's `adoption_event` rows go through
+#                                        it rather than through a second
+#                                        appender, because the ledger's
+#                                        flock-equivalent lock and its atomic
+#                                        adjacent-mktemp rename are the reason
+#                                        concurrent writers do not truncate it —
+#                                        and because it is the only writer that
+#                                        VALIDATES the ledger's shape before
+#                                        appending (`## BL-227:` records the
+#                                        seven inline sites that still do not)
 #
 # Direction (M3) holds in one direction only: this module sources core, and no
 # core file names this module. That is why `init.sh` does NOT ship
@@ -103,7 +115,7 @@ ADOPT_LIB_DIR="$ADOPT_SELF_DIR/lib/adopt"
 ADOPT_CORE_LIB_DIR="$ADOPT_SELF_DIR/lib"
 
 # ── Core libs (M2's declared set) ───────────────────────────────────────────
-for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh hook-templates.sh enforcement-level.sh tdd-classify.sh; do
+for _core in helpers-core.sh adoption-stamp.sh scaffold-shipped-set.sh hook-templates.sh enforcement-level.sh tdd-classify.sh bypass-audit.sh; do
   if [ ! -f "$ADOPT_CORE_LIB_DIR/$_core" ]; then
     echo "adopt-project: missing $ADOPT_CORE_LIB_DIR/$_core — run this from a complete framework clone." >&2
     exit 2
@@ -115,7 +127,7 @@ done
 # THE GUARD, BEFORE ARGUMENT PARSING — see the header. Sibling posture, kept.
 guard_not_in_framework || exit 1
 
-for _part in adopt-core adopt-chooser adopt-intake adopt-state adopt-stubs adopt-test-debt; do
+for _part in adopt-core adopt-chooser adopt-intake adopt-state adopt-archive adopt-stubs adopt-test-debt; do
   if [ ! -f "$ADOPT_LIB_DIR/$_part.sh" ]; then
     echo "adopt-project: missing $ADOPT_LIB_DIR/$_part.sh — the driver needs its own lib directory." >&2
     exit 2
@@ -133,8 +145,16 @@ adopt-project — bring an existing project under the framework.
 
   --root DIR          the project to adopt (default: the current directory)
   --scan-report FILE  consume this Scout report instead of running a new scan
+  --re-add PATH       put one of YOUR archived files back, warned and recorded
   --version           print the driver's version and exit
   --help              print this and exit
+
+--re-add is the other half of the collision archive and it does NOT run an
+adoption. Point it at one of your own files as the archive MANIFEST names it
+(for example .git/hooks/pre-commit); it shows you what the framework thinks
+that trade costs, asks you to confirm, puts the file back exactly as it was,
+and records the choice in the audit trail. The framework's premise is
+opinionated enforcement, not confiscation — your files are yours.
 
 What it does, in order: reads the survey, offers what the survey found as
 EVIDENCE, asks you the one question the survey cannot answer, confirms the
@@ -152,6 +172,7 @@ USAGE
 
 ADOPT_ROOT="."
 ADOPT_REPORT=""
+ADOPT_READD=""
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -159,6 +180,8 @@ while [ "$#" -gt 0 ]; do
     --root=*)        ADOPT_ROOT="${1#--root=}"; shift ;;
     --scan-report)   [ "$#" -ge 2 ] || { echo "adopt-project: --scan-report needs a file" >&2; exit 2; }; ADOPT_REPORT="$2"; shift 2 ;;
     --scan-report=*) ADOPT_REPORT="${1#--scan-report=}"; shift ;;
+    --re-add)        [ "$#" -ge 2 ] || { echo "adopt-project: --re-add needs a path" >&2; exit 2; }; ADOPT_READD="$2"; shift 2 ;;
+    --re-add=*)      ADOPT_READD="${1#--re-add=}"; shift ;;
     --version)       adopt_module_version; exit 0 ;;
     -h|--help)       usage; exit 0 ;;
     *)               echo "adopt-project: unrecognised option '$1'" >&2; echo "" >&2; usage >&2; exit 2 ;;
@@ -173,6 +196,15 @@ fi
 # The target arm of the same guard: --root must not point at a framework clone
 # either (the security-audits-1 vector that the cwd-only check missed).
 guard_not_in_framework "$ADOPT_ROOT_ABS" || exit 1
+
+# --re-add is a DIFFERENT OPERATION, not a mode of the adoption run: it touches
+# no state, writes no commit, and is the only thing this driver does that is
+# meant to be run long after adoption day. Dispatching before adopt_main keeps
+# the adoption path exactly as WP4 shipped it.
+if [ -n "$ADOPT_READD" ]; then
+  adopt_readd_main "$ADOPT_ROOT_ABS" "$ADOPT_READD"
+  exit $?
+fi
 
 adopt_main "$ADOPT_ROOT_ABS" "$ADOPT_REPORT"
 exit $?

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -1,0 +1,781 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-archive.sh — §7's COLLISION ARCHIVE: the inventory,
+# the archive tree and its MANIFEST, the plain disclosure, the recorded re-add,
+# and §7.3's archive-secrets refusal.
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §7.1 (the four
+# buckets, and the vocabulary is reused rather than reinvented), §7.2 (the
+# layout, the MANIFEST, and the five properties inherited from
+# `_upgrade_snapshot_pre_mutation` in scripts/upgrade-project.sh), §7.3
+# (disclosure, re-adds, the warning, and THE NEW EXPOSURE this design creates),
+# §6.2 (redaction is a PROJECTION, not a flag), §8.9 (the `adoption_event` row
+# and the five surfaces a new row type touches), §12-5, §10-WP6.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE ONE SENTENCE THIS FILE EXISTS TO IMPLEMENT
+#
+# The operator's own configuration is copied somewhere they can get it back
+# from, every copy is named out loud with a restore line, and NOTHING is
+# committed until a secret scanner has looked at it.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# §7.3'S EXPOSURE, IN THE PLAINEST TERMS, BECAUSE IT IS THE REASON THIS FILE IS
+# WRITTEN THE WAY IT IS
+#
+# `.git/hooks/` is NOT tracked by git. `.claude/` IS. So copying a hook into
+# the archive and staging the archive takes a file git has never seen — a file
+# that may hold a token the operator put there precisely because it would never
+# be committed — and COMMITS IT. Adoption would create the leak. The same is
+# true of any `.claude/settings.local.json` the operator gitignored.
+#
+# So: the archive is written, then SCANNED, and only then staged, and an entry
+# the scanner matched is never handed to `git add`. The refusal is per ENTRY,
+# not per run — a secret in one hook must not cost the operator the record of
+# everything else.
+#
+# AND WHEN NOBODY LOOKED, NOTHING IS STAGED. If gitleaks is absent or the scan
+# fails, every entry is withheld. "We could not check" and "we checked and it
+# is clean" are different claims and only one of them may result in a commit.
+# The archive is still written to disk and still disclosed — the operator keeps
+# their copy — it simply does not enter version control on an unexamined tree.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE PROJECTION (§6.2's doctrine, applied to a surface §6.2 does not mention)
+#
+# gitleaks emits EIGHTEEN fields per finding and `--redact` covers exactly two
+# of them, `Secret` and `Match`. It does NOT touch `Message` — the full commit
+# message — which WP2 demonstrated carries a planted key straight through a
+# "redacted" report. Nothing here passes the tool's report through: the one
+# read of it NAMES the three fields it wants and can express no other. A field
+# gitleaks adds in a future release is dropped because it was never named.
+#
+# THE ARCHIVE SCAN IS A `gitleaks dir` OVER THE ARCHIVE DIRECTORY ALONE, and
+# that has a second, deliberate property: the adoptee's own `.gitleaks.toml`
+# lives at their project root, not inside the archive, so a repo-local config
+# that allowlists `AKIA[A-Z2-7]{16}` cannot suppress this scan. A clean bill of
+# health issued under rules written by the thing being audited is a different
+# claim, and this is the one place the framework refuses to accept it.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# M2/M3: this file is MODULE code. It sources nothing itself — the driver
+# sources its libs in order — and it uses `bypass_audit_append` from
+# scripts/lib/bypass-audit.sh, which scripts/adopt-project.sh declares in its
+# M2 header. No core file names this file; that is M3 and the boundary lint
+# proves it.
+#
+# bash-3.2 safe: no associative arrays, no `${var,,}`, no `((x++))`.
+
+# ── The archive-and-replace population (§7.1's first row), spelled ONCE ─────
+#
+# Their AI-layer surfaces — Claude settings, skills, MCP connections — and
+# their git hooks. NOT their pipelines (§7.4's carve-out: audited, never
+# touched) and NOT their project files (§7.5: keep theirs).
+#
+# `.git/hooks/*.sample` IS EXCLUDED, and the exclusion is not cosmetic: git
+# ships thirteen of them in every repository, none is ever active, and
+# archiving them would bury the two or three hooks the operator actually wrote
+# in a list nobody reads. The disclosure's value is that a person can read it.
+_adopt_archive_ai_surfaces() {
+  cat <<'SURFACES'
+.claude/settings.json
+.claude/settings.local.json
+.mcp.json
+SURFACES
+}
+
+# adopt_archive_inventory ROOT — one `<originalPath>\t<class>\t<archivedPath>`
+# row per archive-and-replace surface THAT EXISTS.
+#
+# "ONLY FILES THAT EXIST ARE ARCHIVED" is §7.2's inherited property and it is
+# expressed here, at the inventory, rather than by a later `[ -f ]` before each
+# copy: a surface that is absent produces NO ROW, so it cannot reach the
+# MANIFEST, the disclosure or the staging list by any path. A phantom entry for
+# a file the operator never had is worse than a missing one — it teaches them
+# the record is fiction.
+adopt_archive_inventory() {
+  local root="$1"
+  local rel h base
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    [ -f "$root/$rel" ] || continue
+    printf '%s\t%s\t%s\n' "$rel" "ai-settings" "$rel"
+  done <<AI
+$(_adopt_archive_ai_surfaces)
+AI
+
+  # Skills are a directory shape, not a fixed path, so they are globbed. `find`
+  # rather than a glob because bash 3.2 has no `nullglob` and an unmatched glob
+  # would be passed through as a literal path.
+  if [ -d "$root/.claude/skills" ]; then
+    while IFS= read -r rel; do
+      [ -n "$rel" ] || continue
+      printf '%s\t%s\t%s\n' "$rel" "skill" "$rel"
+    done <<SKILLS
+$( cd "$root" 2>/dev/null && find .claude/skills -type f -name 'SKILL.md' 2>/dev/null | LC_ALL=C sort )
+SKILLS
+  fi
+
+  # Git hooks. Archived under `git-hooks/` and not `.git/hooks/`, exactly as
+  # §7.2's tree shows: an archive directory containing a literal `.git`
+  # subdirectory is a trap for every tool that walks a tree looking for one.
+  if [ -d "$root/.git/hooks" ]; then
+    while IFS= read -r h; do
+      [ -n "$h" ] || continue
+      base="${h##*/}"
+      case "$base" in *.sample) continue ;; esac
+      printf '%s\t%s\t%s\n' ".git/hooks/$base" "git-hook" "git-hooks/$base"
+    done <<HOOKS
+$( cd "$root" 2>/dev/null && find .git/hooks -maxdepth 1 -type f 2>/dev/null | LC_ALL=C sort )
+HOOKS
+  fi
+  return 0
+}
+
+# ── The archive directory (§7.2's inherited naming) ─────────────────────────
+# adopt_archive_dir_new ROOT — a fresh `<UTC-timestamp>-<pid>` directory name,
+# relative to ROOT, with the precedent's `-1`, `-2`, … collision loop.
+#
+# The loop is not decoration. Two adoptions inside the same wall-clock second
+# from the same shell would otherwise collide, and the SECOND one would write
+# its MANIFEST over the first — destroying the only copy of a set of files
+# whose whole purpose is to be recoverable. It is asserted by CALLING this
+# function twice, because `-1` in the source proves nothing about what runs.
+#
+# RETENTION IS UNLIMITED, and that is §7.2's second declared divergence from
+# the precedent, which prunes to keep-3. An adoption archive is written once
+# per project and is the operator's only copy of their own configuration.
+# Nothing in this file deletes one, on any path, including the failure paths.
+adopt_archive_dir_new() {
+  local root="$1" ts dir n
+  ts="$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+  dir=".claude/adoption-archive/$ts-$$"
+  n=0
+  while [ -e "$root/$dir" ]; do
+    n=$((n + 1))
+    dir=".claude/adoption-archive/$ts-$$-$n"
+  done
+  printf '%s\n' "$dir"
+}
+
+# ── The hook description (§7.2), and why it is a CLOSED vocabulary ──────────
+#
+# §7.2 requires a what-it-did description for every archived git hook and calls
+# it explicitly ADVISORY. §7.3 names the hazard in the same breath: a
+# hand-rolled hook can contain a token. So the description is ASSEMBLED FROM A
+# FIXED LIST — the generator emits names it recognises and nothing else. A hook
+# line reading `export AWS_ACCESS_KEY_ID=AKIA…` contributes exactly nothing,
+# because no allowlisted token matches it.
+#
+# This is the same shape as the §6.2 field allowlist and the same shape as
+# Scout's own hook vocabulary, and it is DUPLICATED here rather than sourced:
+# Scout is a separate severable module under M1/M3, and reaching into
+# scripts/lib/scout/ from here would fuse two modules that are meant to be
+# liftable independently. §3.3 calls this reuse-by-extraction — copy the
+# PREDICATE, not the DEPENDENCY — and this is exactly that case.
+_adopt_archive_hook_vocabulary() {
+  cat <<'VOCAB'
+husky
+lefthook
+pre-commit
+lint-staged
+commitlint
+gitleaks
+semgrep
+trufflehog
+shellcheck
+shfmt
+npx
+npm
+pnpm
+yarn
+bun
+node
+deno
+tsc
+eslint
+prettier
+jest
+vitest
+mocha
+python
+python3
+pytest
+pip
+poetry
+uv
+black
+ruff
+mypy
+flake8
+isort
+cargo
+clippy
+rustfmt
+go
+gofmt
+golangci-lint
+make
+gradle
+mvn
+dotnet
+php
+composer
+bundle
+rspec
+rubocop
+swiftlint
+ktlint
+detekt
+clang-format
+terraform
+tflint
+docker
+VOCAB
+}
+
+# adopt_archive_hook_description FILE — a one-sentence advisory summary.
+#
+# Shallow and static by design: it reads word-shaped tokens, keeps the ones on
+# the list, and says "and other commands" when it dropped something. It never
+# quotes a byte of the file, so it cannot leak one.
+#
+# THE LOOKUP IS A `case`, NOT A PIPE INTO `grep -q`, AND THAT IS A CORRECTNESS
+# FIX RATHER THAN A TIDY-UP. The driver runs under `set -o pipefail`. The
+# obvious spelling —
+#
+#     printf '%s\n' "$(_adopt_archive_hook_vocabulary)" | grep -qx -- "$tok"
+#
+# — makes `grep -q` exit the moment it matches, which closes the pipe under
+# `printf` and kills it with SIGPIPE (141). Under `pipefail` the PIPELINE's
+# status is that 141, so a SUCCESSFUL match reports failure and the token is
+# discarded as unrecognised. Whether printf has finished writing before grep
+# leaves is a RACE, so the same hook described the same file three different
+# ways across three runs of the same suite — and the two words nearest the top
+# of the vocabulary lost most often, because grep reaches them soonest. A6's
+# positive control caught it only because it looks for a specific tool name; a
+# "the description is non-empty" assertion would have passed every time.
+adopt_archive_hook_description() {
+  local f="$1" tok seen="" pretty="" others=0 vocab
+  [ -f "$f" ] || { printf 'An empty or unreadable hook.'; return 0; }
+  vocab=" $(_adopt_archive_hook_vocabulary | tr '\n' ' ') "
+  # Split on anything that is not a word character, so `npx lint-staged` and
+  # `npm run test` both surrender their tool names, and a quoted secret
+  # surrenders nothing that is on the list.
+  #
+  # THE RENDERED SENTENCE IS BUILT IN THIS LOOP AND NEVER RE-SPLIT. The obvious
+  # spelling collects the kept tokens into a space-joined string and then walks
+  # it with `for t in $kept`, which depends on IFS still holding a space —
+  # and it does not: measured here, after a `while IFS= read` loop the
+  # subsequent unquoted expansion did not split at all, so every hook was
+  # described as one token named "lint-staged npx". Nothing downstream would
+  # have caught that; A6's positive control did, because it looks for a tool
+  # name rather than for a non-empty string. `seen` stays space-joined because
+  # `case` PATTERN-MATCHES it and never splits it.
+  while IFS= read -r tok; do
+    [ -n "$tok" ] || continue
+    case "$vocab" in
+      *" $tok "*)
+        case " $seen " in
+          *" $tok "*) : ;;
+          *) seen="$seen $tok"; pretty="$pretty \`$tok\`," ;;
+        esac
+        ;;
+      *) others=1 ;;
+    esac
+  done <<TOKENS
+$(tr -c 'A-Za-z0-9_-' '\n' < "$f" 2>/dev/null | grep -v '^$' | LC_ALL=C sort -u)
+TOKENS
+  if [ -z "$pretty" ]; then
+    printf 'Ran commands this summary does not recognise. Read the archived copy.'
+    return 0
+  fi
+  printf 'Ran%s' "$pretty"
+  if [ "$others" -eq 1 ]; then
+    printf ' and other commands.'
+  else
+    printf ' and nothing else this summary recognises.'
+  fi
+  return 0
+}
+
+# ── §7.3's scan (§6.2's projection) ─────────────────────────────────────────
+# adopt_archive_scan ARCHIVE_ABS WORK — look at the archive BEFORE it is
+# staged. Writes into WORK:
+#
+#   arcstatus  scanned | tool-unavailable | scan-failed
+#   arccount   the finding count, or empty when nothing was scanned
+#   archits    one archived-relative path per matched file, deduplicated
+#   arcnote    an honest one-line explanation of whichever status it is
+#
+# THE STATUS VOCABULARY IS THREE WORDS BECAUSE THE CLAIMS ARE DIFFERENT, and
+# collapsing any two of them into "no findings" is the silent-success class
+# aimed at the one surface in this package where being wrong means a committed
+# credential. `scanned` with zero findings is a positive result;
+# `tool-unavailable` is nobody looked; `scan-failed` is we looked and something
+# broke. Only the first may result in a commit.
+adopt_archive_scan() {
+  local arc="$1" work="$2"
+  local _bin _rc _count
+
+  : > "$work/archits"
+  : > "$work/arccount"
+
+  # SOIF_ADOPT_GITLEAKS_BIN exists so the suite can point this at a name that
+  # is not installed and prove the tool-unavailable arm without uninstalling
+  # anything on the host running the tests.
+  _bin="${SOIF_ADOPT_GITLEAKS_BIN:-gitleaks}"
+
+  if ! command -v "$_bin" >/dev/null 2>&1; then
+    printf 'tool-unavailable\n' > "$work/arcstatus"
+    printf '%s\n' "gitleaks is not installed, so NOTHING WAS SCANNED. That is not a clean result — it is the absence of one, and the archive is therefore NOT committed. Install it (macOS: brew install gitleaks) and re-run, or commit the archive yourself once you have checked it." > "$work/arcnote"
+    return 0
+  fi
+
+  # `--exit-code 0` makes "leaks were found" an rc of 0, so a NON-zero rc means
+  # the scan itself failed and can be reported as such. Without it, findings
+  # and failures share an exit code and the three honest statuses collapse into
+  # two. `--redact` is defence in depth and is NOT what makes this safe — the
+  # three-field read below is.
+  ( cd "$arc" 2>/dev/null || exit 2
+    "$_bin" dir --no-banner --redact --exit-code 0 -f json -r "$work/arc-gl.json" . ) \
+    >"$work/arc-gl.out" 2>"$work/arc-gl.err"
+  _rc=$?
+
+  if [ "$_rc" -ne 0 ] || [ ! -f "$work/arc-gl.json" ]; then
+    printf 'scan-failed\n' > "$work/arcstatus"
+    printf '%s\n' "The archive's secret scan did not complete (gitleaks exited $_rc). NOTHING here was checked, so the archive is NOT committed — treat it as unknown, not as clean." > "$work/arcnote"
+    return 0
+  fi
+
+  # THE PROJECTION. Three fields are NAMED and nothing else can be read: `File`
+  # to know which entry to withhold, `RuleID` and `StartLine` so the operator
+  # can be told where to look. `Secret`, `Match` and above all `Message` are
+  # not named, so no code path exists from them to any byte written here. This
+  # is one line on purpose — it is the mutation target, and replacing it with
+  # the tool's own field list is what a passthrough would look like.
+  if ! jq -r '.[] | [.File, .RuleID, .StartLine] | @tsv' "$work/arc-gl.json" > "$work/arc-fields" 2>/dev/null; then   # BF-ADOPT-ARCHIVE-PROJECT
+    printf 'scan-failed\n' > "$work/arcstatus"
+    printf '%s\n' "The scanner exited cleanly but its report did not parse, so nothing here can be trusted — the archive is NOT committed. A truncated report is usually a full disk or a killed process; re-run." > "$work/arcnote"
+    return 0
+  fi
+
+  # gitleaks reports paths relative to the directory it scanned, sometimes with
+  # a leading `./`. Normalise so the join against the MANIFEST's archivedPath
+  # is exact rather than nearly.
+  sed -e 's|^\./||' < "$work/arc-fields" | cut -f1 | grep -v '^$' | LC_ALL=C sort -u > "$work/archits"
+  _count=$(grep -c '' < "$work/arc-fields" 2>/dev/null)
+  case "$_count" in ''|*[!0-9]*) _count=0 ;; esac
+  printf '%s\n' "$_count" > "$work/arccount"
+  printf 'scanned\n' > "$work/arcstatus"
+  printf '%s\n' "Every file in this archive was scanned for credentials before anything was committed. Findings are located by rule, file and line — the value itself is never recorded here." > "$work/arcnote"
+  return 0
+}
+
+# ── The audit row (§8.9) ────────────────────────────────────────────────────
+# adopt_audit_event ROOT EVENT DETAILS_JSON — one `adoption_event` row.
+#
+# §8.9 chooses ONE type with a `details.event` discriminator over five types,
+# because one enum member is one five-surface change and five members is five.
+# The five events the design names are:
+#
+#   adoption               the adoption itself                    (WP7 owns it)
+#   blocker_acceptance     every accepted blocker                 (WP5 owns it)
+#   secrets_disposition    every `accepted risk` disposition      (unowned)
+#   collision_archive      every collision archive                THIS PACKAGE
+#   collision_re_add       every re-add                           THIS PACKAGE
+#
+# The two this package owns are emitted; the other three have no emitter yet
+# and this comment says so rather than leaving a reader to infer that adoption
+# records everything already.
+#
+# `enforcement_level_at_event` IS "n/a" AND THAT IS A DECISION. The documented
+# enum admits it, and the alternative is worse: reading the tier here would
+# fork the `# BL-084-TIER-KEY` predicate into a sixth site, and CLAUDE.md's own
+# gotcha list says that predicate lives in scripts that must be changed IN
+# SYNC. These rows record a disclosure event, not a gate outcome; there is no
+# tier for them to have been decided at.
+adopt_audit_event() {
+  local root="$1" event="$2" details="${3:-\{\}}"
+  local _ae_type _ts row
+  _ae_type="adoption_event"   # BF-ADOPT-AUDIT-ROW
+  command -v jq >/dev/null 2>&1 || return 0
+  _ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  row="$(jq -n --arg t "$_ae_type" --arg ts "$_ts" --arg e "$event" --argjson d "$details" \
+    '{timestamp: $ts, session_id: null, type: $t, actor: "framework",
+      enforcement_level_at_event: "n/a",
+      details: ($d + {event: $e}),
+      user_response: "n/a", final_outcome: "recorded_only"}' 2>/dev/null)"
+  [ -n "$row" ] || return 0
+  bypass_audit_append "$root" "$row" >/dev/null 2>&1
+  return 0
+}
+
+# ── Writing the archive ─────────────────────────────────────────────────────
+# adopt_archive_write ROOT WORK — inventory, copy, scan, MANIFEST, disclose,
+# and record only the entries that may be committed.
+#
+# ORDER IS THE WHOLE DESIGN: copy, then SCAN, then decide what is staged. The
+# scan cannot precede the copy — there is nothing to scan — and the staging
+# decision cannot precede the scan, which is §7.3's entire sentence.
+#
+# RETURNS 0 EVEN WHEN IT WITHHOLDS EVERYTHING. A withheld archive is not a
+# failed adoption: the operator's files are on disk, disclosed, and restorable.
+# Refusing the whole run because a hook had a token in it would punish them for
+# the thing the framework is trying to tell them about.
+ADOPT_ARCHIVE_DIR=""
+ADOPT_ARCHIVE_ENTRIES=0
+
+adopt_archive_write() {
+  local root="$1" work="$2"
+  local rel class arel n=0 mode sha desc dispo staged reason
+  local arc_rel arc_abs status count note first
+
+  ADOPT_ARCHIVE_DIR=""
+  ADOPT_ARCHIVE_ENTRIES=0
+
+  adopt_archive_inventory "$root" > "$work/arcinv" || return 0
+  n=$(grep -c '' < "$work/arcinv" 2>/dev/null)
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  if [ "$n" -eq 0 ]; then
+    adopt_head "Your own configuration"
+    adopt_note "You had none of the files the framework would otherwise land on, so nothing"
+    adopt_note "was archived and nothing of yours was touched."
+    return 0
+  fi
+
+  arc_rel="$(adopt_archive_dir_new "$root")"
+  arc_abs="$root/$arc_rel"
+  mkdir -p "$arc_abs" 2>/dev/null || { adopt_refuse "could not create the collision archive at $arc_rel"; return 1; }
+
+  while IFS="$(printf '\t')" read -r rel class arel; do
+    [ -n "$rel" ] || continue
+    mkdir -p "$(dirname "$arc_abs/$arel")" 2>/dev/null || { adopt_refuse "could not create the archive path for $rel"; return 1; }
+    # `cp -p` preserves the mode, which matters more here than anywhere else in
+    # the driver: a git hook that comes back at 0644 does not run, and an
+    # operator restoring one would get silence rather than an error.
+    cp -p "$root/$rel" "$arc_abs/$arel" 2>/dev/null || { adopt_refuse "could not archive $rel"; return 1; }
+  done < "$work/arcinv"
+
+  # ── §7.3: LOOK BEFORE ANYTHING IS STAGED ─────────────────────────────────
+  adopt_archive_scan "$arc_abs" "$work"   # BF-ADOPT-ARCHIVE-SCAN
+  status="$(cat "$work/arcstatus" 2>/dev/null)"
+  count="$(cat "$work/arccount" 2>/dev/null)"
+  note="$(cat "$work/arcnote" 2>/dev/null)"
+
+  # ── The MANIFEST ─────────────────────────────────────────────────────────
+  : > "$work/arcentries"
+  while IFS="$(printf '\t')" read -r rel class arel; do
+    [ -n "$rel" ] || continue
+    mode="$(stat -c '%a' "$arc_abs/$arel" 2>/dev/null || stat -f '%Lp' "$arc_abs/$arel" 2>/dev/null || printf '644')"
+    sha="$(adopt_sha256 "$arc_abs/$arel")"
+    desc=""
+    [ "$class" = "git-hook" ] && desc="$(adopt_archive_hook_description "$arc_abs/$arel")"
+
+    # WHAT HAPPENED TO THEIR ORIGINAL, said per entry rather than in one
+    # sentence for the whole archive, because it differs per entry and a
+    # blanket claim would be wrong for most of them. `composed` is §7.1's
+    # marker-composed bucket: the framework appends a MARKED block to their
+    # commit-msg hook, so their file keeps working and the archive is the
+    # pre-composition copy the restore line puts back.
+    case "$rel" in
+      .git/hooks/commit-msg) dispo="composed" ;;
+      *)                     dispo="kept" ;;
+    esac
+
+    staged="true"; reason=""
+    if [ "$status" != "scanned" ]; then
+      staged="false"; reason="not-scanned"
+    elif grep -qxF -- "$arel" "$work/archits" 2>/dev/null; then
+      staged="false"; reason="secret-match"
+    elif ( cd "$root" && git check-ignore -q -- "$arc_rel/$arel" ) 2>/dev/null; then
+      # THEIR .gitignore WINS, AND NOT ONLY OUT OF POLITENESS. `git add` on an
+      # ignored path FAILS, and the driver stages every recorded path in one
+      # command — so a single ignored archive entry would abort the whole
+      # adoption commit. Withholding it keeps the operator's ignore rules
+      # intact AND keeps the run alive, and the MANIFEST says which entry and
+      # why instead of leaving them a git error to decode.
+      staged="false"; reason="gitignored"
+    fi
+
+    jq -n --arg op "$rel" --arg ap "$arel" --arg cl "$class" --arg sh "$sha" \
+          --arg mo "$mode" --arg de "$desc" --arg di "$dispo" \
+          --argjson st "$staged" --arg re "$reason" --arg ad "$arc_rel" \
+      '{originalPath: $op, archivedPath: $ap, class: $cl, sha256: $sh, mode: $mo,
+        disposition: $di, description: $de,
+        stagedForCommit: $st, withheldReason: $re,
+        restore: ("cp " + $ad + "/" + $ap + " " + $op + " && chmod " + $mo + " " + $op)}' \
+      >> "$work/arcentries" 2>/dev/null
+  done < "$work/arcinv"
+
+  jq -s --arg at "$(date -u +"%Y-%m-%dT%H:%M:%SZ")" --arg ad "$arc_rel" \
+        --arg st "$status" --arg no "$note" --arg ct "$count" \
+    '{schemaVersion: 1, adoptedAt: $at, archiveDir: $ad,
+      advisory: "Every `description` below is a SHALLOW STATIC SUMMARY assembled from a fixed list of tool names — it is advisory, not a specification. A hook can do anything; read the archived copy before you trust the sentence.",
+      secretsScan: {tool: "gitleaks", status: $st,
+                    findingCount: (if $ct == "" then null else ($ct | tonumber) end),
+                    note: $no},
+      entries: .}' "$work/arcentries" > "$arc_abs/MANIFEST.json" 2>/dev/null \
+    || { adopt_refuse "could not write the archive MANIFEST"; return 1; }
+
+  _adopt_archive_manifest_md "$arc_abs/MANIFEST.json" > "$arc_abs/MANIFEST.md" 2>/dev/null \
+    || { adopt_refuse "could not write the archive MANIFEST.md"; return 1; }
+
+  ADOPT_ARCHIVE_DIR="$arc_rel"
+  ADOPT_ARCHIVE_ENTRIES=$(jq -r '.entries | length' "$arc_abs/MANIFEST.json" 2>/dev/null)
+  case "$ADOPT_ARCHIVE_ENTRIES" in ''|*[!0-9]*) ADOPT_ARCHIVE_ENTRIES=0 ;; esac
+
+  # THE MANIFEST ITSELF IS ALWAYS STAGED, and it carries no file bytes — only
+  # paths, hashes, modes and rule names. It is the record of what was withheld
+  # as much as of what was kept, and withholding the record along with the
+  # files would leave the operator with an unexplained directory.
+  adopt_record_write "$arc_rel/MANIFEST.json"
+  adopt_record_write "$arc_rel/MANIFEST.md"
+  while IFS= read -r arel; do
+    [ -n "$arel" ] || continue
+    adopt_record_write "$arc_rel/$arel"
+  done <<STAGEABLE
+$(jq -r '.entries[] | select(.stagedForCommit == true) | .archivedPath' "$arc_abs/MANIFEST.json" 2>/dev/null)
+STAGEABLE
+
+  _adopt_archive_disclose "$root" "$arc_rel" "$arc_abs/MANIFEST.json"
+
+  # §8.9: "every collision archive" is one of the five events.
+  adopt_audit_event "$root" "collision_archive" \
+    "$(jq -n --arg d "$arc_rel" --argjson n "$ADOPT_ARCHIVE_ENTRIES" --arg s "$status" \
+        '{archiveDir: $d, entryCount: $n, secretsScanStatus: $s}' 2>/dev/null)"
+
+  # AND THE LEDGER ITSELF IS COMMITTED, because this is the first row an
+  # adopted project ever has. docs/audit-log-lifecycle.md draws a deliberate
+  # line between the TRACKED ledger and the non-tracked
+  # `.claude/last-gate-pass.txt` receipt, and a scaffolded project gets the
+  # tracked side by way of init's blanket add. An adopted project stages only
+  # what the driver wrote, so without this line its governance record would sit
+  # untracked — the archive row would exist and no clone would carry it.
+  _adopt_record_if_stageable "$root" ".claude/bypass-audit.json"
+  return 0
+}
+
+# _adopt_record_if_stageable ROOT REL — record REL for staging unless the
+# operator's own .gitignore excludes it.
+#
+# `git add` on an ignored path FAILS, and the driver stages every recorded path
+# in ONE command, so a single ignored entry aborts the whole adoption commit.
+# Their ignore rules are theirs; the run says what it skipped rather than
+# forcing the add or dying on it.
+_adopt_record_if_stageable() {
+  local root="$1" rel="$2"
+  [ -e "$root/$rel" ] || return 0
+  if ( cd "$root" && git check-ignore -q -- "$rel" ) 2>/dev/null; then
+    adopt_note "Your .gitignore excludes $rel, so it stays out of the commit — it is on disk."
+    return 0
+  fi
+  adopt_record_write "$rel"
+  return 0
+}
+
+# _adopt_archive_manifest_md MANIFEST.json — the same content, for a person.
+# §7.2 asks for both and they are generated from ONE source so they cannot
+# disagree; a human-readable disclosure that has drifted from the machine
+# record is worse than not having one.
+_adopt_archive_manifest_md() {
+  local mj="$1"
+  printf '# What was archived, and how to get it back\n\n'
+  printf 'These are copies of files you already had. They were **moved to ensure the\n'
+  printf 'framework operates properly** — nothing here was deleted, and every file\n'
+  printf 'below can be put back with the single command beside it.\n\n'
+  printf 'Archive: `%s`\n\n' "$(jq -r '.archiveDir' "$mj" 2>/dev/null)"
+  printf 'Secret scan before anything was committed: **%s**' "$(jq -r '.secretsScan.status' "$mj" 2>/dev/null)"
+  printf ' (%s finding(s))\n\n' "$(jq -r '.secretsScan.findingCount // "not counted"' "$mj" 2>/dev/null)"
+  printf '%s\n\n' "$(jq -r '.secretsScan.note' "$mj" 2>/dev/null)"
+  printf '%s\n\n' "$(jq -r '.advisory' "$mj" 2>/dev/null)"
+  printf '| Your file | Archived as | What it did | Committed? | Put it back with |\n'
+  printf '|---|---|---|---|---|\n'
+  jq -r '.entries[] | [.originalPath, .archivedPath,
+                       (if (.description // "") == "" then "-" else .description end),
+                       (if .stagedForCommit then "yes" else ("no — " + .withheldReason) end),
+                       .restore]
+                    | @tsv' "$mj" 2>/dev/null \
+    | while IFS="$(printf '\t')" read -r op ap de st re; do
+        printf '| `%s` | `%s` | %s | %s | `%s` |\n' "$op" "$ap" "$de" "$st" "$re"
+      done
+  printf '\n## Adding one back\n\n'
+  printf 'Run the command in the last column, or let the driver record it for you:\n\n'
+  printf '```\nbash /path/to/solo-orchestrator/scripts/adopt-project.sh --re-add <your file>\n```\n\n'
+  printf 'The second form prints the warning and writes an audit row. Either way the\n'
+  printf 'file is yours; the framework only insists that the choice is written down.\n'
+  return 0
+}
+
+# _adopt_archive_disclose ROOT ARCHIVE_REL MANIFEST — §7.3's disclosure.
+#
+# THE SENTENCE, THE LIST, AND THE RESTORE INSTRUCTIONS. Not a summary count —
+# §7.3 says "the list" in as many words, and it is right: "4 files archived"
+# tells an operator nothing they can act on, and the one thing they need at
+# this moment is to see their own filenames go past so they can object.
+_adopt_archive_disclose() {
+  local root="$1" arc="$2" mj="$3"
+  local op ap st re de withheld
+
+  adopt_head "Your own configuration has been archived"
+  adopt_say "   The files below were moved to ensure the framework operates properly."
+  adopt_note "Nothing was deleted. Every one of them is in $arc and can be put back."
+  adopt_blank
+  jq -r '.entries[] | [.originalPath, .archivedPath, (if .stagedForCommit then "committed" else ("withheld:" + .withheldReason) end), (.description // "")] | @tsv' "$mj" 2>/dev/null \
+    | while IFS="$(printf '\t')" read -r op ap st de; do
+        adopt_note "yours: $op"
+        adopt_note "   archived as: $arc/$ap"
+        [ -n "$de" ] && adopt_note "   what it did: $de"
+        case "$st" in
+          withheld:*) adopt_note "   NOT COMMITTED — $(printf '%s' "$st" | sed 's/^withheld://')" ;;
+        esac
+        adopt_note "   put it back: cp $arc/$ap $op"
+      done
+  adopt_blank
+
+  withheld="$(jq -r '[.entries[] | select(.stagedForCommit == false)] | length' "$mj" 2>/dev/null)"
+  case "$withheld" in ''|*[!0-9]*) withheld=0 ;; esac
+  if [ "$withheld" -gt 0 ]; then
+    adopt_say "   $withheld of those copies were NOT added to the commit."
+    adopt_note "$(jq -r '.secretsScan.note' "$mj" 2>/dev/null)"
+    adopt_note "They are still on disk in $arc — they are simply not in version control."
+    if jq -e '.secretsScan.status == "scanned" and (.secretsScan.findingCount > 0)' "$mj" >/dev/null 2>&1; then
+      adopt_note "A credential in a file git had never seen would have become a credential in"
+      adopt_note "your history. Rotate it at the source; deleting the file does not un-leak it."
+      jq -r '.entries[] | select(.withheldReason == "secret-match") | "   look at: " + .originalPath' "$mj" 2>/dev/null
+    fi
+    if jq -e '.secretsScan.status != "scanned"' "$mj" >/dev/null 2>&1; then
+      adopt_note "NOTHING WAS SCANNED, so this is not a clean result — it is the absence of one."
+    fi
+    adopt_blank
+  fi
+  adopt_note "The full record, including a restore line for every file, is in"
+  adopt_note "$arc/MANIFEST.md (and MANIFEST.json beside it)."
+  return 0
+}
+
+# ── The re-add (§7.3) ───────────────────────────────────────────────────────
+# THE WARNING, NEAR-VERBATIM PER THE DESIGN. Spelled ONCE, as a constant, so
+# there is a single site for a test to pin and a single site to change if Karl
+# ever rewords it.
+ADOPT_READD_WARNING="Personal systems may conflict with the framework — accuracy, documentation, and capabilities may be compromised."
+
+# adopt_archive_latest ROOT — the newest archive directory, relative to ROOT.
+# Newest by NAME, which is safe because the name begins with a UTC timestamp in
+# a lexicographically sortable format; sorting by mtime would be defeated by a
+# restore that touched the directory.
+adopt_archive_latest() {
+  local root="$1"
+  ( cd "$root" 2>/dev/null || return 1
+    find .claude/adoption-archive -mindepth 1 -maxdepth 1 -type d 2>/dev/null \
+      | LC_ALL=C sort | tail -1 )
+}
+
+# adopt_archive_readd ROOT ORIGINALPATH — put one archived file back.
+#
+# §7.3: "Re-adds are permitted — this is Karl's decision and it matters: the
+# framework's premise is opinionated enforcement, not confiscation." So this
+# never argues. It warns, it requires the operator to say yes, it restores the
+# file exactly as it was, and it WRITES THE ROW.
+adopt_archive_readd() {
+  local root="$1" want="$2"
+  local arc mj entry ap mode restored_from _readd_details
+
+  arc="$(adopt_archive_latest "$root")"
+  if [ -z "$arc" ] || [ ! -f "$root/$arc/MANIFEST.json" ]; then
+    adopt_refuse "there is no collision archive in this project — nothing to add back"
+    return 1
+  fi
+  mj="$root/$arc/MANIFEST.json"
+
+  # READ THE TWO FIELDS DIRECTLY. The first cut selected the whole entry with
+  # `@json` and then re-parsed it with `fromjson`, which fails silently — jq's
+  # `-r` had already unwrapped it, so `fromjson` was handed an object rather
+  # than a string, `ap` and `mode` came back empty, and every re-add refused
+  # with "listed in the MANIFEST but is not on disk". Two reads of the file is
+  # cheaper than a round trip through a string.
+  entry="$(jq -r --arg p "$want" '[.entries[] | select(.originalPath == $p)] | length' "$mj" 2>/dev/null)"
+  case "$entry" in ''|*[!0-9]*) entry=0 ;; esac
+  if [ "$entry" -eq 0 ]; then
+    adopt_refuse "'$want' is not in $arc/MANIFEST.json"
+    {
+      echo "          What is in there:"
+      jq -r '.entries[] | "            " + .originalPath' "$mj" 2>/dev/null
+    } >&2
+    return 1
+  fi
+  ap="$(jq -r --arg p "$want" 'first(.entries[] | select(.originalPath == $p) | .archivedPath) // ""' "$mj" 2>/dev/null)"
+  mode="$(jq -r --arg p "$want" 'first(.entries[] | select(.originalPath == $p) | .mode) // ""' "$mj" 2>/dev/null)"
+  restored_from="$root/$arc/$ap"
+  if [ ! -f "$restored_from" ]; then
+    adopt_refuse "$arc/$ap is listed in the MANIFEST but is not on disk"
+    return 1
+  fi
+
+  adopt_head "Adding back $want"
+  adopt_blank
+  adopt_say "   $ADOPT_READD_WARNING"
+  adopt_blank
+  adopt_note "This file is yours and you may have it back. The framework's own version of"
+  adopt_note "whatever it governs will not be in charge while yours is in place, and this"
+  adopt_note "choice is written into the audit trail either way."
+  adopt_blank
+
+  adopt_stdin_init
+  adopt_ask_choice "whether to add $want back" \
+    "Do you want to put your own $want back?" \
+    "Yes — put it back, and record that I chose to" \
+    "No — leave it archived" || return 1
+  case "$ADOPT_ANSWER" in
+    Yes*) : ;;
+    *)
+      adopt_note "Left archived. Nothing was changed."
+      return 0
+      ;;
+  esac
+
+  mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want")"; return 1; }
+  cp -p "$restored_from" "$root/$want" || { adopt_refuse "could not restore $want"; return 1; }
+  case "$mode" in ''|*[!0-7]*) : ;; *) chmod "$mode" "$root/$want" 2>/dev/null ;; esac
+
+  # §7.3: "every re-add is recorded in the audit trail". THE ROW IS THE POINT.
+  # A re-add nobody can find later is exactly the silent confiscation-in-
+  # reverse this design refuses: the framework permits the operator to override
+  # it, and asks only that the override be legible to whoever reads the ledger
+  # next. Suppress the marked line and the re-add still happens — silently.
+  #
+  # THE DETAILS ARE BUILT ON THEIR OWN LINE so that the emit is a COMPLETE
+  # ONE-LINE STATEMENT. A marker on the last line of a multi-line continuation
+  # cannot be neutered by a one-line substitution without leaving a dangling
+  # `\` behind it, and a mutant that does not parse proves nothing about the
+  # code — it only proves sed can break a file.
+  _readd_details="$(jq -n --arg p "$want" --arg a "$arc/$ap" --arg w "$ADOPT_READD_WARNING" \
+      '{path: $p, archivedPath: $a, warningShown: $w}' 2>/dev/null)"
+  adopt_audit_event "$root" "collision_re_add" "$_readd_details"   # BF-ADOPT-READD-AUDIT
+
+  adopt_blank
+  adopt_note "$want is back, exactly as it was, at mode $mode."
+  adopt_note "The choice is recorded in .claude/bypass-audit.json as an adoption_event."
+  return 0
+}
+
+# adopt_readd_main ROOT PATH — the `--re-add` entry point.
+#
+# A SEPARATE ENTRY POINT AND NOT A STAGE OF `adopt_main`, because a re-add
+# happens LATER — days or months after adoption, when the operator has lived
+# with the framework's version and decided they want theirs back. Folding it
+# into the adoption run would mean the only moment they could exercise Karl's
+# "re-adds are permitted" decision was the moment they had not yet formed an
+# opinion.
+adopt_readd_main() {
+  local root="$1" want="$2"
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "adopt-project: jq is required." >&2
+    return 2
+  fi
+  if [ -z "$want" ]; then
+    echo "adopt-project: --re-add needs the path of one of YOUR files, as it is named in" >&2
+    echo "  the archive MANIFEST (for example .git/hooks/pre-commit)." >&2
+    return 2
+  fi
+  adopt_archive_readd "$root" "$want"
+}

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -672,10 +672,27 @@ STAGEABLE
     # what the driver wrote, so without this the governance record would sit
     # untracked — the archive row would exist and no clone would carry it.
     #
-    # ONLY ON SUCCESS. A successful append proves the ledger parsed, since the
-    # appender's own jq had to read it. Staging it on the failure path would
-    # commit whatever unparseable bytes are there — turning a corrupt file into
-    # the permanent first entry of the project's audit history.
+    # ONLY ON SUCCESS. Staging on the failure path would commit whatever
+    # unparseable bytes are there — turning a corrupt file into the permanent
+    # first entry of the project's audit history.
+    #
+    # ⚠ THE REASON THIS IS SAFE IS NOT THE ONE ORIGINALLY WRITTEN HERE
+    # (R-WP6-14). That comment said "a successful append proves the ledger
+    # parsed, since the appender's own jq had to read it". REFUTED by
+    # measurement: `jq FILTER file` over a ZERO-BYTE file runs across zero
+    # documents, emits nothing and EXITS 0 — the append succeeded, read no
+    # document, and wrote no row. Measured end to end at that commit: adopt
+    # rc 0, zero "could not be recorded" in the transcript, the row lost, and
+    # the zero-byte ledger COMMITTED into HEAD. Same hole via `[]\n[]`, which
+    # exits 0 and duplicates the row into each document.
+    #
+    # An exit code is not a receipt. "jq exited 0" and "jq read a document" are
+    # different facts. What makes this safe now is an explicit predicate in
+    # `bypass_audit_append` — `jq -es 'length == 1 and (.[0] | type ==
+    # "array")'` — which rejects empty, null, multi-document and non-array
+    # ledgers before the append and routes them all into the failure arm below.
+    # The guard lives in the appender because six files call it and two of them
+    # already announce its rc; a guard here would have fixed one caller.
     _adopt_record_if_stageable "$root" ".claude/bypass-audit.json"
   else
     adopt_blank

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -51,10 +51,16 @@
 #
 # THE ARCHIVE SCAN IS A `gitleaks dir` OVER THE ARCHIVE DIRECTORY ALONE, and
 # that has a second, deliberate property: the adoptee's own `.gitleaks.toml`
-# lives at their project root, not inside the archive, so a repo-local config
+# lives at their project root, not inside the archive, so a REPO-LOCAL config
 # that allowlists `AKIA[A-Z2-7]{16}` cannot suppress this scan. A clean bill of
 # health issued under rules written by the thing being audited is a different
 # claim, and this is the one place the framework refuses to accept it.
+#
+# THAT ARGUMENT COVERS THE FILE AND NOT THE ENVIRONMENT, and saying so is the
+# difference between a property and a slogan: `GITLEAKS_CONFIG` and
+# `GITLEAKS_CONFIG_TOML` outrank the scanned path entirely and are inherited
+# from whatever launched the driver. They are unset inside the scan subshell
+# for exactly that reason — see the scrub in `adopt_archive_scan`.
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # M2/M3: this file is MODULE code. It sources nothing itself — the driver
@@ -254,6 +260,20 @@ VOCAB
 # of the vocabulary lost most often, because grep reaches them soonest. A6's
 # positive control caught it only because it looks for a specific tool name; a
 # "the description is non-empty" assertion would have passed every time.
+#
+# THE EXACT BOUNDARY, MEASURED, BECAUSE IT DECIDES WHAT A FUTURE EDITOR MAY DO.
+# The race needs a producer that writes MORE THAN ONCE. With a SINGLE `write(2)`
+# — one `printf` of a whole table — it is impossible rather than merely
+# unlikely: grep cannot match, and therefore cannot exit, before the producer's
+# only write has completed, and after it there is nothing left to SIGPIPE.
+# 3000 iterations of the single-write form: zero failures. A per-LINE writer
+# under the identical pipeline: 300 failures in 300. So the hazard is not the
+# `| grep -q` idiom by itself — it is the idiom plus a multi-write producer,
+# which a table grown past the single-write chunk (~4KiB stdio worst case) also
+# becomes. **The guard this note exists for: do not "tidy" a producer here into
+# per-line emission, and do not let the vocabulary grow past a single write
+# while a pipeline consumes it.** The `case` form below has neither exposure,
+# which is why it is the form that ships.
 adopt_archive_hook_description() {
   local f="$1" tok seen="" pretty="" others=0 vocab
   [ -f "$f" ] || { printf 'An empty or unreadable hook.'; return 0; }
@@ -336,7 +356,18 @@ adopt_archive_scan() {
   # and failures share an exit code and the three honest statuses collapse into
   # two. `--redact` is defence in depth and is NOT what makes this safe — the
   # three-field read below is.
+  # THE SCAN'S ENVIRONMENT IS SCRUBBED, AND THIS IS A SUPPRESSION VECTOR RATHER
+  # THAN A TIDY-UP (R-WP6-9). `GITLEAKS_CONFIG` and `GITLEAKS_CONFIG_TOML`
+  # OUTRANK the scanned path, so the "the archive directory structurally cannot
+  # contain a .gitleaks.toml" argument — which is true, and is why a repo-local
+  # config cannot reach this scan — does not cover them. Measured on 8.30.1:
+  # exporting either one at a config whose rules match nothing takes the same
+  # planted key from 1 finding to 0, while the MANIFEST still says
+  # `status: scanned`. A shell profile, a CI job env or a direnv file in the
+  # adoptee would therefore have switched §7.3's refusal off silently. Unset
+  # inside the subshell so the driver's own environment is untouched.
   ( cd "$arc" 2>/dev/null || exit 2
+    unset GITLEAKS_CONFIG GITLEAKS_CONFIG_TOML
     "$_bin" dir --no-banner --redact --exit-code 0 -f json -r "$work/arc-gl.json" . ) \
     >"$work/arc-gl.out" 2>"$work/arc-gl.err"
   _rc=$?
@@ -398,15 +429,22 @@ adopt_audit_event() {
   local root="$1" event="$2" details="${3:-\{\}}"
   local _ae_type _ts row
   _ae_type="adoption_event"   # BF-ADOPT-AUDIT-ROW
-  command -v jq >/dev/null 2>&1 || return 0
+  command -v jq >/dev/null 2>&1 || return 1
   _ts="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
   row="$(jq -n --arg t "$_ae_type" --arg ts "$_ts" --arg e "$event" --argjson d "$details" \
     '{timestamp: $ts, session_id: null, type: $t, actor: "framework",
       enforcement_level_at_event: "n/a",
       details: ($d + {event: $e}),
       user_response: "n/a", final_outcome: "recorded_only"}' 2>/dev/null)"
-  [ -n "$row" ] || return 0
-  bypass_audit_append "$root" "$row" >/dev/null 2>&1
+  [ -n "$row" ] || return 1
+  # EVERY FAILURE PATH RETURNS NON-ZERO (R-WP6-4). This function used to answer
+  # 0 unconditionally — missing jq, an unrenderable row, and a REFUSED APPEND
+  # all reported success. `bypass_audit_append` genuinely returns 1: its jq
+  # filter fails on a corrupt ledger, and it gives up after a 10s lock timeout.
+  # A caller that treats "recorded" as a precondition cannot do so against a
+  # function that never says no, and the re-add path below is exactly such a
+  # caller — so this rc is load-bearing, not tidiness.
+  bypass_audit_append "$root" "$row" >/dev/null 2>&1 || return 1
   return 0
 }
 
@@ -482,18 +520,44 @@ adopt_archive_write() {
       *)                     dispo="kept" ;;
     esac
 
+    # ── THE WITHHOLD CHAIN, IN PRECEDENCE ORDER ────────────────────────────
+    #
+    # Ordered by how strong the statement is, so the MANIFEST names the most
+    # important reason when more than one applies: nothing was checked, then a
+    # scanner match, then the operator's own instruction, then the mechanical
+    # `git add` guard.
     staged="true"; reason=""
     if [ "$status" != "scanned" ]; then
       staged="false"; reason="not-scanned"
     elif grep -qxF -- "$arel" "$work/archits" 2>/dev/null; then
       staged="false"; reason="secret-match"
-    elif ( cd "$root" && git check-ignore -q -- "$arc_rel/$arel" ) 2>/dev/null; then
-      # THEIR .gitignore WINS, AND NOT ONLY OUT OF POLITENESS. `git add` on an
-      # ignored path FAILS, and the driver stages every recorded path in one
-      # command — so a single ignored archive entry would abort the whole
-      # adoption commit. Withholding it keeps the operator's ignore rules
-      # intact AND keeps the run alive, and the MANIFEST says which entry and
-      # why instead of leaving them a git error to decode.
+    elif ( cd "$root" && git check-ignore -q -- "$rel" ) 2>/dev/null; then   # BF-ADOPT-IGNORE-ORIGINAL
+      # A GITIGNORE ENTRY IS THE OPERATOR'S EXPLICIT STATEMENT THAT THIS
+      # CONTENT MUST NEVER ENTER HISTORY (R-WP6-1). Copying it to a new path
+      # and re-asking the question about the NEW path answers a question
+      # nobody asked — and answers it wrongly, because the ecosystem-standard
+      # rule is ANCHORED: `.claude/settings.local.json` matches the original
+      # and cannot match `.claude/adoption-archive/<dir>/.claude/settings.local.json`.
+      # Measured hermetically: original -> ignored, archive copy -> NOT
+      # ignored. Before this arm the archive committed a copy of a gitignored
+      # `settings.local.json` — the MODAL adoptee shape, and the one file most
+      # likely to hold an internal hostname, a proxy URL or a username. None
+      # of those is secret-SHAPED, so the scanner is no defence: G1 asserts
+      # findingCount == 0 precisely to prove the ignore rule is what saved it.
+      #
+      # SCOPE, and it is narrower than it looks: `.git/hooks/*` is NOT
+      # reported as ignored (verified, rc 1) because git excludes `.git/` by
+      # construction rather than by the operator's instruction. So the hooks —
+      # the archive's whole point and §7.3's carrier — are untouched by this
+      # arm, and G1b pins that bound in the same run.
+      staged="false"; reason="original-gitignored"
+    elif ( cd "$root" && git check-ignore -q -- "$arc_rel/$arel" ) 2>/dev/null; then   # BF-ADOPT-IGNORE-ARCHIVE
+      # The MECHANICAL guard, and a different question from the one above:
+      # `git add` on an ignored path FAILS, and the driver stages every
+      # recorded path in ONE command — so a single ignored archive entry would
+      # abort the whole adoption commit. Withholding keeps the operator's
+      # rules intact AND keeps the run alive, and the MANIFEST says which
+      # entry and why instead of leaving them a git error to decode.
       staged="false"; reason="gitignored"
     fi
 
@@ -524,12 +588,18 @@ adopt_archive_write() {
   ADOPT_ARCHIVE_ENTRIES=$(jq -r '.entries | length' "$arc_abs/MANIFEST.json" 2>/dev/null)
   case "$ADOPT_ARCHIVE_ENTRIES" in ''|*[!0-9]*) ADOPT_ARCHIVE_ENTRIES=0 ;; esac
 
-  # THE MANIFEST ITSELF IS ALWAYS STAGED, and it carries no file bytes — only
-  # paths, hashes, modes and rule names. It is the record of what was withheld
-  # as much as of what was kept, and withholding the record along with the
-  # files would leave the operator with an unexplained directory.
-  adopt_record_write "$arc_rel/MANIFEST.json"
-  adopt_record_write "$arc_rel/MANIFEST.md"
+  # THE MANIFEST CARRIES NO FILE BYTES — only paths, hashes, modes and rule
+  # names — so it is committed wherever it can be. It is the record of what was
+  # withheld as much as of what was kept.
+  #
+  # BUT IT GOES THROUGH THE IGNORE GUARD LIKE EVERYTHING ELSE. An earlier cut
+  # recorded both MANIFESTs unconditionally, and an operator who gitignores
+  # `.claude/adoption-archive/` — an entirely reasonable thing to do to a local
+  # backup directory — then hit `git add` refusing an ignored path, which took
+  # THE WHOLE ADOPTION down (measured: rc 1, no adoption commit). Two arms
+  # guarding the entries and one unconditional pair beside them is not a guard.
+  _adopt_record_if_stageable "$root" "$arc_rel/MANIFEST.json"
+  _adopt_record_if_stageable "$root" "$arc_rel/MANIFEST.md"
   while IFS= read -r arel; do
     [ -n "$arel" ] || continue
     adopt_record_write "$arc_rel/$arel"
@@ -646,6 +716,14 @@ _adopt_archive_disclose() {
     if jq -e '.secretsScan.status != "scanned"' "$mj" >/dev/null 2>&1; then
       adopt_note "NOTHING WAS SCANNED, so this is not a clean result — it is the absence of one."
     fi
+    # THE OPERATOR'S OWN RULE, EXPLAINED IN THEIR TERMS. "original-gitignored"
+    # is a manifest token; a person reading a transcript needs the sentence.
+    if jq -e '[.entries[] | select(.withheldReason == "original-gitignored")] | length > 0' "$mj" >/dev/null 2>&1; then
+      adopt_note "Some of those are files your own .gitignore says never to commit. The archive"
+      adopt_note "keeps a copy so you can restore them, and does NOT commit that copy under a"
+      adopt_note "different name — your rule is about the contents, not about the path."
+      jq -r '.entries[] | select(.withheldReason == "original-gitignored") | "   your .gitignore covers: " + .originalPath' "$mj" 2>/dev/null
+    fi
     adopt_blank
   fi
   adopt_note "The full record, including a restore line for every file, is in"
@@ -678,7 +756,7 @@ adopt_archive_latest() {
 # file exactly as it was, and it WRITES THE ROW.
 adopt_archive_readd() {
   local root="$1" want="$2"
-  local arc mj entry ap mode restored_from _readd_details
+  local arc mj entry ap mode restored_from _readd_details _readd_recorded=1
 
   arc="$(adopt_archive_latest "$root")"
   if [ -z "$arc" ] || [ ! -f "$root/$arc/MANIFEST.json" ]; then
@@ -733,15 +811,26 @@ adopt_archive_readd() {
       ;;
   esac
 
-  mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want")"; return 1; }
-  cp -p "$restored_from" "$root/$want" || { adopt_refuse "could not restore $want"; return 1; }
-  case "$mode" in ''|*[!0-7]*) : ;; *) chmod "$mode" "$root/$want" 2>/dev/null ;; esac
-
   # §7.3: "every re-add is recorded in the audit trail". THE ROW IS THE POINT.
   # A re-add nobody can find later is exactly the silent confiscation-in-
   # reverse this design refuses: the framework permits the operator to override
   # it, and asks only that the override be legible to whoever reads the ledger
   # next. Suppress the marked line and the re-add still happens — silently.
+  #
+  # THE RECORD IS WRITTEN BEFORE THE RESTORE, AND THAT ORDER IS THE FIX
+  # (R-WP6-4). Recording afterwards made "recorded" unenforceable: on a corrupt
+  # ledger or a lock timeout `bypass_audit_append` returns 1, the file had
+  # already been restored, and the driver went on to print "The choice is
+  # recorded in .claude/bypass-audit.json" — a false claim about the only
+  # artifact the re-add's legitimacy rests on. That is the R2 mutation's
+  # failure mode reachable at RUNTIME rather than by sed. Recording first makes
+  # the row a PRECONDITION: no row, no re-add.
+  #
+  # The residual is stated rather than hidden: if the `cp` below fails, a row
+  # exists for a re-add that did not happen. Over-recording is the safe
+  # direction — an operator investigating a row that describes nothing loses an
+  # afternoon; an override with no row is the thing §7.3 forbids — and the
+  # refusal that follows a failed `cp` is loud.
   #
   # THE DETAILS ARE BUILT ON THEIR OWN LINE so that the emit is a COMPLETE
   # ONE-LINE STATEMENT. A marker on the last line of a multi-line continuation
@@ -750,7 +839,22 @@ adopt_archive_readd() {
   # code — it only proves sed can break a file.
   _readd_details="$(jq -n --arg p "$want" --arg a "$arc/$ap" --arg w "$ADOPT_READD_WARNING" \
       '{path: $p, archivedPath: $a, warningShown: $w}' 2>/dev/null)"
-  adopt_audit_event "$root" "collision_re_add" "$_readd_details"   # BF-ADOPT-READD-AUDIT
+  adopt_audit_event "$root" "collision_re_add" "$_readd_details" || _readd_recorded=0   # BF-ADOPT-READD-AUDIT
+  if [ "$_readd_recorded" -eq 0 ]; then
+    adopt_refuse "the re-add could not be recorded in .claude/bypass-audit.json, so it was NOT made"
+    {
+      echo "          Every re-add is written into the audit trail — that is the whole basis on"
+      echo "          which the framework lets you override it. The ledger would not accept the"
+      echo "          row (it may be corrupt, or another process may be holding it), so $want"
+      echo "          has been LEFT AS IT IS rather than changed with no record of who chose it."
+      echo "          Check .claude/bypass-audit.json is valid JSON, then run this again."
+    } >&2
+    return 1
+  fi
+
+  mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want")"; return 1; }
+  cp -p "$restored_from" "$root/$want" || { adopt_refuse "could not restore $want — the audit row was already written, so the ledger records an intent that did not complete"; return 1; }
+  case "$mode" in ''|*[!0-7]*) : ;; *) chmod "$mode" "$root/$want" 2>/dev/null ;; esac
 
   adopt_blank
   adopt_note "$want is back, exactly as it was, at mode $mode."

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -448,6 +448,48 @@ adopt_audit_event() {
   return 0
 }
 
+# _adopt_original_is_ignored ROOT REL — does the operator's own .gitignore
+# cover the ORIGINAL file, in a way git would actually act on?
+#
+# ⚠ THE `.git/` EXEMPTION, AND THE CLAIM IT REPLACES (R-WP6-10). An earlier cut
+# of this file asserted, and `docs/adoption.md` repeated, that "`.git/hooks/*`
+# is NOT reported as ignored because git excludes `.git/` by construction".
+# THAT IS FALSE, and it was verified false by measurement:
+#
+#     .gitignore = '*'        -> check-ignore .git/hooks/pre-commit  rc 0
+#     .gitignore = 'hooks/'   -> rc 0   (.gitignore:1:hooks/)
+#     .gitignore = '.git/'    -> rc 0   (.gitignore:1:.git/)
+#     .gitignore = '.claude/settings.local.json' -> rc 1
+#
+# `git check-ignore` applies patterns to ANY pathname it is handed, `.git/`
+# paths included; there is no check-ignore exemption for them, only a
+# tracked-file one. The rc 1 originally observed was a property of the ANCHORED
+# PATTERN in the fixture, not of git — and the test that "pinned the bound"
+# used only that pattern, so it could not have seen the difference. A bound
+# claim, a comment and a manual page were all wrong together.
+#
+# WHY THE EXEMPTION IS STILL RIGHT, on the corrected reasoning: the arm above
+# exists to honour an operator INSTRUCTION about content. A gitignore statement
+# about a `.git/` path is not an instruction git can honour — git never tracks
+# `.git/`, so the rule changes nothing about git's own behaviour and expresses
+# no decision about whether that content may be preserved. The "content, not
+# path" doctrine has nothing to anchor to there. Without this guard a single
+# cargo-cult `.git/` line — inert against every framework-written path, and
+# common in real repositories — silently withholds the hooks, which are §7.3's
+# carrier and the archive's entire purpose, while adoption reports success and
+# the disclosure attributes to the operator an instruction git would never act
+# on. Measured end to end before the fix: rc 0, hooks `original-gitignored`,
+# zero hook copies in HEAD, every suite row green.
+#
+# G1b pins it against a rule that genuinely reaches (asserting the probe reaches
+# first, so the case cannot silently revert to testing the anchored rule), and
+# G1c mutates the guard away and watches the hooks disappear.
+_adopt_original_is_ignored() {
+  local root="$1" rel="$2"
+  case "$rel" in .git/*) return 1 ;; esac   # BF-ADOPT-GITDIR-EXEMPT
+  ( cd "$root" && git check-ignore -q -- "$rel" ) 2>/dev/null
+}
+
 # ── Writing the archive ─────────────────────────────────────────────────────
 # adopt_archive_write ROOT WORK — inventory, copy, scan, MANIFEST, disclose,
 # and record only the entries that may be committed.
@@ -531,7 +573,7 @@ adopt_archive_write() {
       staged="false"; reason="not-scanned"
     elif grep -qxF -- "$arel" "$work/archits" 2>/dev/null; then
       staged="false"; reason="secret-match"
-    elif ( cd "$root" && git check-ignore -q -- "$rel" ) 2>/dev/null; then   # BF-ADOPT-IGNORE-ORIGINAL
+    elif _adopt_original_is_ignored "$root" "$rel"; then   # BF-ADOPT-IGNORE-ORIGINAL
       # A GITIGNORE ENTRY IS THE OPERATOR'S EXPLICIT STATEMENT THAT THIS
       # CONTENT MUST NEVER ENTER HISTORY (R-WP6-1). Copying it to a new path
       # and re-asking the question about the NEW path answers a question
@@ -545,11 +587,8 @@ adopt_archive_write() {
       # of those is secret-SHAPED, so the scanner is no defence: G1 asserts
       # findingCount == 0 precisely to prove the ignore rule is what saved it.
       #
-      # SCOPE, and it is narrower than it looks: `.git/hooks/*` is NOT
-      # reported as ignored (verified, rc 1) because git excludes `.git/` by
-      # construction rather than by the operator's instruction. So the hooks —
-      # the archive's whole point and §7.3's carrier — are untouched by this
-      # arm, and G1b pins that bound in the same run.
+      # The `.git/` bound lives in the helper, with the measurement that
+      # corrected it.
       staged="false"; reason="original-gitignored"
     elif ( cd "$root" && git check-ignore -q -- "$arc_rel/$arel" ) 2>/dev/null; then   # BF-ADOPT-IGNORE-ARCHIVE
       # The MECHANICAL guard, and a different question from the one above:
@@ -610,18 +649,44 @@ STAGEABLE
   _adopt_archive_disclose "$root" "$arc_rel" "$arc_abs/MANIFEST.json"
 
   # §8.9: "every collision archive" is one of the five events.
-  adopt_audit_event "$root" "collision_archive" \
-    "$(jq -n --arg d "$arc_rel" --argjson n "$ADOPT_ARCHIVE_ENTRIES" --arg s "$status" \
-        '{archiveDir: $d, entryCount: $n, secretsScanStatus: $s}' 2>/dev/null)"
-
-  # AND THE LEDGER ITSELF IS COMMITTED, because this is the first row an
-  # adopted project ever has. docs/audit-log-lifecycle.md draws a deliberate
-  # line between the TRACKED ledger and the non-tracked
-  # `.claude/last-gate-pass.txt` receipt, and a scaffolded project gets the
-  # tracked side by way of init's blanket add. An adopted project stages only
-  # what the driver wrote, so without this line its governance record would sit
-  # untracked — the archive row would exist and no clone would carry it.
-  _adopt_record_if_stageable "$root" ".claude/bypass-audit.json"
+  #
+  # THE rc IS CHECKED HERE TOO (R-WP6-11), and the asymmetry with the re-add is
+  # deliberate rather than an oversight — which is why it is written down on
+  # BOTH sides now instead of only on the re-add's. The re-add REFUSES when the
+  # row cannot be written, because the row is the re-add's ONLY record and an
+  # unrecorded override is the thing §7.3 forbids. The archive does NOT refuse,
+  # because it has a primary committed record — the MANIFEST — so a failed row
+  # degrades the trail rather than invalidating the act. What it must never do
+  # is degrade QUIETLY. Measured before this fix, with a ledger that was already
+  # corrupt when adoption started: rc 0, the row silently dropped, no mention
+  # anywhere in the transcript, and THE STILL-CORRUPT LEDGER COMMITTED INTO HEAD
+  # as the project's first governance record.
+  if adopt_audit_event "$root" "collision_archive" \
+       "$(jq -n --arg d "$arc_rel" --argjson n "$ADOPT_ARCHIVE_ENTRIES" --arg s "$status" \
+           '{archiveDir: $d, entryCount: $n, secretsScanStatus: $s}' 2>/dev/null)"; then
+    # AND THE LEDGER ITSELF IS COMMITTED, because this is the first row an
+    # adopted project ever has. docs/audit-log-lifecycle.md draws a deliberate
+    # line between the TRACKED ledger and the non-tracked
+    # `.claude/last-gate-pass.txt` receipt, and a scaffolded project gets the
+    # tracked side by way of init's blanket add. An adopted project stages only
+    # what the driver wrote, so without this the governance record would sit
+    # untracked — the archive row would exist and no clone would carry it.
+    #
+    # ONLY ON SUCCESS. A successful append proves the ledger parsed, since the
+    # appender's own jq had to read it. Staging it on the failure path would
+    # commit whatever unparseable bytes are there — turning a corrupt file into
+    # the permanent first entry of the project's audit history.
+    _adopt_record_if_stageable "$root" ".claude/bypass-audit.json"
+  else
+    adopt_blank
+    adopt_say "   THE ARCHIVE HAPPENED. THE AUDIT ROW FOR IT could not be recorded."
+    adopt_note "$arc_rel is written, disclosed above, and listed in its own MANIFEST — none of"
+    adopt_note "that is in doubt. What is missing is the line in .claude/bypass-audit.json that"
+    adopt_note "would let someone find it later without being told. The ledger would not accept"
+    adopt_note "the row; it is most likely not valid JSON. It has been LEFT OUT of the commit"
+    adopt_note "rather than committed in that state — check it by hand:"
+    adopt_note "  jq . .claude/bypass-audit.json"
+  fi
   return 0
 }
 
@@ -832,6 +897,15 @@ adopt_archive_readd() {
   # afternoon; an override with no row is the thing §7.3 forbids — and the
   # refusal that follows a failed `cp` is loud.
   #
+  # AND THE WINDOW IS EXACTLY ONE STATEMENT WIDE, WHICH IT WAS NOT (R-WP6-12).
+  # The `mkdir -p` used to sit inside it too, undisclosed, so a re-add that
+  # could not even create its parent directory still wrote a row claiming it
+  # happened. The mkdir mutates nothing the archive governs, so it belongs
+  # ABOVE the record and now runs there — which makes the residual documented
+  # above the WHOLE residual rather than most of it. R5 forces that failure
+  # with a regular file where a directory has to go and asserts zero rows.
+  mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want") — nothing has been changed and nothing recorded"; return 1; }
+  #
   # THE DETAILS ARE BUILT ON THEIR OWN LINE so that the emit is a COMPLETE
   # ONE-LINE STATEMENT. A marker on the last line of a multi-line continuation
   # cannot be neutered by a one-line substitution without leaving a dangling
@@ -852,7 +926,6 @@ adopt_archive_readd() {
     return 1
   fi
 
-  mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want")"; return 1; }
   cp -p "$restored_from" "$root/$want" || { adopt_refuse "could not restore $want — the audit row was already written, so the ledger records an intent that did not complete"; return 1; }
   case "$mode" in ''|*[!0-7]*) : ;; *) chmod "$mode" "$root/$want" 2>/dev/null ;; esac
 

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -33,11 +33,12 @@
 
 # adopt_module_version — the driver's own version marker. A literal, for the
 # same reason Scout's is: at adoption time there may be no framework state to
-# read a version out of. The `-wp4` suffix is information, not decoration —
-# this build carries the skeleton, the chooser, placement and reverse intake,
-# and HONEST STUBS where WP5/WP5b/WP6/WP7 will land.
+# read a version out of. The suffix is information, not decoration — this build
+# carries the skeleton, the chooser, placement, reverse intake AND WP6's
+# collision archive, disclosure, recorded re-adds and archive-secrets refusal,
+# with HONEST STUBS where WP5/WP5b/WP7 will land.
 adopt_module_version() {
-  printf '%s\n' "0.1.0-wp4"
+  printf '%s\n' "0.2.0-wp6"
 }
 
 # ── Output. One transcript, on stdout, so a test can pin it. ────────────────

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -140,7 +140,7 @@ INSTALL_SET
     adopt_refuse "no framework scripts could be installed and none were already there — is this a complete clone?"
     return 1
   fi
-  adopt_stub_collision_archive "$n_collided" "$ADOPT_COLLISION_LIST"
+  adopt_stub_framework_script_collisions "$n_collided" "$ADOPT_COLLISION_LIST"
   return 0
 }
 
@@ -358,8 +358,12 @@ adopt_install_hooks() {
   chmod +x "$hooks/commit-msg" 2>/dev/null
 
   if [ -e "$hooks/pre-commit" ]; then
-    adopt_note "You already have a pre-commit hook. It has been LEFT ALONE."
-    adopt_stub_collision_archive 1 ".git/hooks/pre-commit"
+    # LEFT ALONE, AND ARCHIVED. WP6's archive already took a copy before any of
+    # this ran, so the operator has a restorable record of the hook they wrote
+    # even though nothing here replaces it. The WP4 stub that used to fire here
+    # is gone: it announced the archive as missing, and it is not.
+    adopt_note "You already have a pre-commit hook. It has been LEFT ALONE, and a copy is in"
+    adopt_note "the archive with a restore line — see ${ADOPT_ARCHIVE_DIR:-the archive}/MANIFEST.md."
   fi
   adopt_stub_hooks
   adopt_stub_project_docs
@@ -444,6 +448,16 @@ adopt_main() {
   # before any state write, so a run that cannot measure the debt leaves the
   # project exactly as it found it rather than adopting it with no baseline.
   adopt_test_debt_record "$root" || return 1
+
+  # §7 — THE COLLISION ARCHIVE, BEFORE ANY FRAMEWORK WRITER RUNS.
+  #
+  # It has to precede adopt_install_framework and adopt_install_hooks for one
+  # reason: an archive taken AFTER a writer has run is a copy of the
+  # framework's file, not of theirs, and the restore line would put the
+  # framework's own output back under the operator's name. The commit-msg hook
+  # is the live case — adopt_install_hooks appends a marked block to it — so
+  # the archived copy is deliberately the PRE-composition one.
+  adopt_archive_write "$root" "$ADOPT_WORK" || return 1
 
   adopt_install_framework "$root" || return 1
   if _adopt_halt_requested install; then

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -1,11 +1,20 @@
 #!/usr/bin/env bash
-# scripts/lib/adopt/adopt-stubs.sh — the parts of adoption WP4 does NOT build,
+# scripts/lib/adopt/adopt-stubs.sh — the parts of adoption that are NOT built,
 # said out loud at the point in the run where they belong.
 #
 # SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md §10 — WP5 (the
-# certification pass), WP5b (the test-debt ledger), WP6 (the collision archive,
-# the disclosure and the re-add warning), WP7 (the CI carve-out, the provenance
-# headers and the Adoption Record), §6.3 (per-finding secrets disposition).
+# certification pass), WP5b (the test-debt ledger), WP7 (the CI carve-out, the
+# provenance headers and the Adoption Record), §6.3 (per-finding secrets
+# disposition, which §10 assigns to no package).
+#
+# WP6 IS NO LONGER IN THAT LIST, and the header is the first place that had to
+# change when it landed: §7's collision archive, its MANIFEST, the disclosure
+# and the recorded re-adds all ship (scripts/lib/adopt/adopt-archive.sh). What
+# remains unbuilt around it is named honestly by the two stubs below — the
+# adoptee's framework DOCUMENTS and the REPLACEMENT half for framework-script
+# collisions — and both are attributed to nobody, because nobody owns them.
+# A stub file whose own header still claims a delivered package is exactly the
+# "measured and clean" misreading these stubs exist to prevent, one level up.
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # WHY STUBS EXIST AT ALL, AND WHAT MAKES ONE HONEST.

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -57,23 +57,34 @@ adopt_stub_certification() {
 # commit-time hook — and adopt_stub_hooks below already carries that sentence,
 # so a second stub here would be a duplicate notice, not an extra honesty.
 
-# WP6 — the collision archive, its MANIFEST, the disclosure and the re-add
-# warning (§7.2/§7.3). WP4 refuses to overwrite; it does not archive.
-# adopt_stub_collision_archive N [LIST] — LIST is passed explicitly rather than
-# read from a global, because there are two call sites with two different sets
-# (the framework scripts, and the adoptee's own pre-commit hook) and a shared
-# global would print the first site's paths under the second site's heading.
-adopt_stub_collision_archive() {
+# THE FRAMEWORK-SCRIPT COLLISION CLASS — a file of theirs sitting at a path a
+# framework SCRIPT wants. WP6 landed the collision archive, so this notice no
+# longer says "not archived": it says what is genuinely still missing, which is
+# the REPLACEMENT half.
+#
+# WHY WP6'S ARCHIVE DOES NOT COVER THIS CLASS, stated rather than left as a
+# gap. §7.1's archive-and-replace population is their AI-LAYER surfaces and
+# their GIT HOOKS, and that boundary is deliberate: archiving-and-replacing an
+# adoptee's `scripts/validate.sh` with the framework's would swap out a file
+# their own CI may call, on day one, with no operator decision in between —
+# the same class of harm §7.4 refuses for their pipelines. Which package owns
+# that decision is not settled in §10, so it is named here and not assumed.
+#
+# adopt_stub_framework_script_collisions N [LIST] — LIST is passed explicitly
+# rather than read from a global, so the paths printed are the caller's own.
+adopt_stub_framework_script_collisions() {
   local n="${1:-0}" list="${2:-}" p
   [ "$n" -gt 0 ] || return 0
-  adopt_stub_notice "the collision archive" "WP6" \
-    "$n of your files sit where a framework file would go. They were LEFT ALONE — not archived,"
-  adopt_note "not replaced, not listed in a restorable manifest. The framework's version of each"
-  adopt_note "of those files is therefore NOT installed, so anything that depends on it is inert."
-  # The PATHS, not just the count. Until WP6 writes a durable MANIFEST this
-  # transcript is the only place they are ever named, and "3 collisions" tells
-  # an operator nothing they can act on. Bounded, because a heavily-occupied
-  # tree could otherwise bury the rest of the run.
+  adopt_stub_notice "installing the framework's version of $n colliding script(s)" \
+    "unassigned — §10 gives this class to no work package" \
+    "$n of your files sit where a framework SCRIPT would go. They were LEFT ALONE, which is"
+  adopt_note "the safe direction, and it has a cost: the framework's version of each of those"
+  adopt_note "files is NOT installed, so anything that depends on it is inert. The collision"
+  adopt_note "ARCHIVE (WP6) covers your AI-layer settings and your git hooks; these are neither,"
+  adopt_note "and replacing a script your own build may call is a decision nobody has made yet."
+  # The PATHS, not just the count — "3 collisions" tells an operator nothing
+  # they can act on. Bounded, because a heavily-occupied tree could otherwise
+  # bury the rest of the run.
   if [ -n "$list" ]; then
     printf '%s\n' "$list" | head -20 | while IFS= read -r p; do
       [ -n "$p" ] && adopt_note "  yours, kept: $p"
@@ -91,13 +102,17 @@ adopt_stub_secrets_disposition() {
   n="$(adopt_int "$(adopt_report_read "$report" '.secrets.findingCount // 0')")"
   local status
   status="$(adopt_report_read "$report" '.secrets.status // ""')"
+  # OWNER CORRECTED AT WP6. §6.3's per-finding disposition of the project's
+  # HISTORY is a different surface from §7.3's archive scan, which WP6 did
+  # build, and §10 assigns §6.3 to no work package at all. Naming WP6 here now
+  # that WP6 has landed would read as "already done".
   if [ "$status" != "scanned" ]; then
-    adopt_stub_notice "the secrets disposition" "WP6" \
+    adopt_stub_notice "the secrets disposition" "unassigned — §10 gives §6.3 to no work package" \
       "The scan did not run a secrets tool, so this adoption knows nothing about credentials in your history."
     return 0
   fi
   [ "$n" -gt 0 ] || return 0
-  adopt_stub_notice "the secrets disposition" "WP6" \
+  adopt_stub_notice "the secrets disposition" "unassigned — §10 gives §6.3 to no work package" \
     "The scan found $n secret-shaped finding(s) in this repository's history. Each one needs a"
   adopt_note "recorded decision and this build does not collect one. Read"
   adopt_note ".claude/adoption/scout-report.json's secrets section before you trust this repo."
@@ -137,11 +152,19 @@ adopt_stub_hooks() {
 # because the absence is not cosmetic: CLAUDE.md is what a downstream agent
 # reads at kickoff, so an adopted project without it starts every session
 # without its orientation.
+#
+# OWNER CORRECTED AT WP6, for the same reason as the secrets stub above. WP6
+# built §7's collision ARCHIVE — the AI-layer surfaces and the git hooks. It
+# does not write the adoptee's framework DOCUMENTS, and §10-WP6's scope row
+# does not ask it to. Leaving "WP6" here after WP6 landed would announce a
+# delivered owner for undelivered work, which is the one thing an honest stub
+# must not do.
 adopt_stub_project_docs() {
-  adopt_stub_notice "your project's framework documents" "WP6 (they are collision decisions before they are writes)" \
+  adopt_stub_notice "your project's framework documents" "unassigned — §10 names no owner" \
     "CLAUDE.md, the document templates and the reference docs are NOT written. The scripts and the"
   adopt_note "state are here, so the gates work; the reading material an agent picks up at the start"
   adopt_note "of a session is not, and a CLAUDE.md you already have would be a collision, not a gap."
+  adopt_note "WP6's archive covers your AI-layer settings and your git hooks; documents are neither."
 }
 
 # WP7 — §8.6's provenance headers on reconstructed documents.

--- a/scripts/lib/bypass-audit.sh
+++ b/scripts/lib/bypass-audit.sh
@@ -121,6 +121,42 @@ bypass_audit_append() {
     sleep 0.1
   done
 
+  # THE LEDGER MUST BE ONE JSON ARRAY, AND `jq` EXITING 0 DOES NOT PROVE IT.
+  #
+  # AN EXIT CODE IS NOT A RECEIPT. `jq FILTER file` over a ZERO-BYTE file runs
+  # the filter across zero input documents, emits nothing, and exits 0 — so the
+  # append below "succeeds", renames an empty temp over the empty ledger, and
+  # writes NOTHING. Every caller that trusts the rc then reports success for a
+  # row that does not exist. Measured, one row per corruption spelling:
+  #
+  #   ledger        append rc   docs out   rows written
+  #   empty (0 B)      0           0          none        <- SILENT LOSS
+  #   null             0           1          1           <- silently "repairs"
+  #   `[]\n[]`         0           2          2           <- silently DUPLICATES
+  #   {"x":1}          5           0          none
+  #   garbage          5           0          none
+  #   `[]`             0           1          1
+  #
+  # A zero-byte file is THE canonical truncation artifact — the D3 note below
+  # is itself about a SIGKILL truncating this very file mid-write — so the
+  # silent cases are the likely ones, not the exotic ones.
+  #
+  # THE GUARD BELONGS HERE AND NOT IN A CALLER. Six files call this function.
+  # The two loud-fail arms in scripts/lib/hook-templates.sh (`# BL-163`,
+  # `# BL-185`) already test this rc and print a `[note]` when it fails, so
+  # before this check they announced nothing on a truncated ledger and dropped
+  # the row in silence. Fixing one caller would have left five.
+  #
+  # `-s` slurps every document into an array, so `length == 1` rejects both the
+  # zero-document and the multi-document cases, and the `type == "array"` test
+  # rejects `null` and any other scalar or object. `-e` turns a `false` result
+  # into a non-zero exit. A parse error exits non-zero on its own.
+  if ! jq -es 'length == 1 and (.[0] | type == "array")' "$file" >/dev/null 2>&1; then
+    rmdir "$lock_dir" 2>/dev/null
+    echo "[FAIL] bypass_audit_append: $file is not a single JSON array (empty, truncated, multi-document or the wrong type) — refusing to append rather than silently losing the row. Inspect it with: jq . \"$file\"" >&2
+    return 1
+  fi
+
   # D3 fix (post-PR-A): create the temp file ADJACENT to the audit
   # file so the subsequent `mv` is a same-filesystem rename — atomic
   # on POSIX. With $TMPDIR mktemp (/var/folders on macOS), the audit

--- a/scripts/lib/bypass-audit.sh
+++ b/scripts/lib/bypass-audit.sh
@@ -11,7 +11,23 @@
 #     "type":                      "claude_bypass_proposal" | "terminal_commit_blocked" |
 #                                  "terminal_commit_passed" | "out_of_band_commit" |
 #                                  "enforcement_level_set" | "detector_error" | "escalation" |
-#                                  "sast_suppression",
+#                                  "sast_suppression" | "adoption_event",
+#                                  (Brownfield §8.9: "adoption_event" records a
+#                                  brownfield ADOPTION event, discriminated by
+#                                  details.event rather than by a type of its
+#                                  own — one enum member is one five-surface
+#                                  change and five members would be five. The
+#                                  event vocabulary is: adoption,
+#                                  blocker_acceptance, secrets_disposition,
+#                                  collision_archive, collision_re_add. Written
+#                                  by the adoption driver; actor is always
+#                                  "framework", final_outcome always
+#                                  "recorded_only", and
+#                                  enforcement_level_at_event always "n/a" —
+#                                  these are disclosure events, not gate
+#                                  outcomes, and reading a tier for them would
+#                                  fork the # BL-084-TIER-KEY predicate into a
+#                                  sixth site.)
 #                                  (BL-185: "sast_suppression" records a staged
 #                                  nosemgrep/nosem directive observed by the SAST arm;
 #                                  final_outcome is always "recorded_only" — the arm

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9477,3 +9477,72 @@ rather than quietly re-word a design-decided string.
 
 **Related:** BL-225 (the other WP6-adjacent residual), and
 docs/designs/2026-08-02-brownfield-adoption-v1.md §7.1/§7.3/§7.5.
+
+---
+
+## BL-227: seven inline `jq '. + [$r]'` appends bypass `bypass_audit_append` entirely — and a live doc sentence says none do
+
+**Logged:** 2026-08-10 (found by adversarial review while verifying WP6's
+appender-level fix; the count was then re-derived and came out one higher than
+the review's)
+**Category:** Chokepoint that is not one / silent-success class — the guard that
+makes ledger corruption loud is installed at a door six of the seven writers do
+not use
+**Severity:** Medium. Pre-existing and outside WP6's diff, so nothing shipped
+today regressed. But WP6 fixed a real silent-loss defect **at the library** on
+the stated rationale that "every caller that trusts the rc" is protected there —
+and that rationale is bounded by this entry.
+**Status:** Open
+
+**The claim that is refuted.** `docs/audit-log-lifecycle.md` § Ledger states:
+
+> **Writer:** every writer goes through
+> `scripts/lib/bypass-audit.sh::bypass_audit_append`. Direct edits are not part
+> of the contract.
+
+`git grep -c "jq --argjson r" -- 'scripts/*' 'init.sh'`, minus the library
+itself, returns **seven sites in five files**:
+
+| file | sites |
+|---|---|
+| `init.sh` | 1 |
+| `scripts/detect-out-of-band-commits.sh` | 1 |
+| `scripts/install-filesystem-gates.sh` | 1 |
+| `scripts/reconfigure-project.sh` | 2 |
+| `scripts/upgrade-project.sh` | 2 |
+
+**Derive this number, do not quote it.** The review that found the class named
+**six**, omitting `install-filesystem-gates.sh`; re-running the grep at filing
+time produced seven. The recipe is in this paragraph precisely so the next
+reader re-runs it rather than trusting either figure.
+
+**Why it matters, measured.** Each site is the identical
+`jq '. + [$r]' "$f" > tmp && mv` shape whose behaviour on a **zero-byte** ledger
+was measured during WP6 round 3: jq runs the filter over zero input documents,
+emits nothing, and **exits 0** — the append "succeeds", writes an empty file
+over an empty file, and drops the row. A `null` ledger is worse: `null + [$r]`
+evaluates to `[$r]`, so the corrupt state a reader would have investigated is
+silently **repaired away**. So, e.g., `detect-out-of-band-commits.sh` can print
+that it recorded a bypass to `.claude/bypass-audit.json` having written nothing.
+
+`bypass_audit_append` now refuses all of empty / `null` / multi-document /
+non-array with a loud failure and an untouched file
+(`jq -es 'length == 1 and (.[0] | type == "array")'`). **None of the seven
+inline sites inherits that.**
+
+**Fix shape.** Route all seven through `bypass_audit_append`. Two constraints
+worth knowing before starting: some sites run in contexts where the library is
+not sourced (`init.sh` scaffolds *into* a project rather than running inside
+one), so this is a real refactor rather than a sed; and the archived BL-029 /
+BL-030 plans already scheduled these rewrites and they did not happen, which is
+itself evidence that "route it through the library later" does not survive
+contact with a work package.
+
+**The weaker alternative, if the refactor is not taken:** correct the
+`audit-log-lifecycle.md` sentence to say what is true. A doc that overstates a
+chokepoint is worse than no doc, because the next author reads it and installs
+their guard at the door nobody uses — which is exactly what WP6 nearly did.
+
+**Related:** `## BL-225:` (the other WP6-adjacent residual), `## BL-029:` /
+`## BL-030:` (the archived plans that scheduled this), and BL-104's
+silent-success family.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9357,7 +9357,7 @@ three times.
 
 ---
 
-## BL-225: The adoption driver writes ~69 files into an adoptee before it discovers their `.gitignore` refuses one — no preflight, no rollback
+## BL-225: The adoption driver writes 64 files into an adoptee before it discovers their `.gitignore` refuses one — no preflight, no rollback, and a refusal that says "nothing has been committed"
 
 **Logged:** 2026-08-10 (found by adversarial review of the brownfield WP6
 branch; the WP6-local instances of the same class were fixed there, this is the
@@ -9380,11 +9380,31 @@ framework-owned paths recorded unconditionally in `adopt-state.sh` and
 files the adoption *is*; skipping one produces a broken install rather than a
 disclosed omission.
 
-So an adoptee whose `.gitignore` contains `.claude/` wholesale, or `hooks/`
-(which catches the framework's own `scripts/hooks/`), gets: ~69 files written
-into their tree, then a refusal at staging, then no adoption commit and no
-rollback. The gates are live at the strictest tier, which is the safe row, but
-the operator is left to clean up by hand and the driver does not tell them how.
+**Reproduced, hermetically, on an adoptee whose `.gitignore` is the single line
+`.claude/`** (framework clone at `feat/brownfield-wp6-collision-archive`, host
+git config neutralised):
+
+```
+run rc                   : 1
+adoption commit landed   : chore: their history   <- their own, not adoption's
+untracked files before   : 0
+untracked files after    : 64                     <- written into their tree
+framework scripts on disk: 63
+phase-state written      : yes
+```
+
+**64 files, no commit, no rollback.** The gates are live at the strictest tier,
+which is the safe row, but the operator is left to clean up by hand.
+
+**Two things make the refusal worse than the abort itself.**
+
+1. It says **"Adoption did not complete. Nothing has been committed."** That is
+   literally true and reads as "nothing happened" — while 64 files sit in their
+   working tree. The sentence should distinguish *committed* from *written*.
+2. Git names the culprit (`.claude`) in a hint on stderr, and the driver's own
+   line then **asks the question git just answered**: *"are any of them ignored
+   by .gitignore?"*. The information is present and the framework declines to
+   use it.
 
 **The right shape** is a preflight `git check-ignore` over the whole write-set
 BEFORE anything is written, with a legible refusal naming the offending

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9357,7 +9357,7 @@ three times.
 
 ---
 
-## BL-225: The adoption driver writes 64 files into an adoptee before it discovers their `.gitignore` refuses one — no preflight, no rollback, and a refusal that says "nothing has been committed"
+## BL-225: The adoption driver writes 78 files into an adoptee, STAGES 64 of them, then discovers their `.gitignore` refuses one — no preflight, no rollback, no `git reset`, and a refusal that says "nothing has been committed"
 
 **Logged:** 2026-08-10 (found by adversarial review of the brownfield WP6
 branch; the WP6-local instances of the same class were fixed there, this is the
@@ -9382,29 +9382,51 @@ disclosed omission.
 
 **Reproduced, hermetically, on an adoptee whose `.gitignore` is the single line
 `.claude/`** (framework clone at `feat/brownfield-wp6-collision-archive`, host
-git config neutralised):
+git config neutralised; the adoptee carries the ordinary AI-layer surfaces, so
+the collision archive has entries to write):
 
 ```
-run rc                   : 1
-adoption commit landed   : chore: their history   <- their own, not adoption's
-untracked files before   : 0
-untracked files after    : 64                     <- written into their tree
-framework scripts on disk: 63
-phase-state written      : yes
+adopt rc                 : 1
+HEAD subject             : chore: their history   <- their own, not adoption's
+files WRITTEN (delta)    : 78
+  of which under .claude : 14    <- hidden from `git status` by their own rule
+git status 'A ' (staged) : 64
+git status '??'          : 0
+paths in INDEX vs HEAD   : 64
 ```
 
-**64 files, no commit, no rollback.** The gates are live at the strictest tier,
-which is the safe row, but the operator is left to clean up by hand.
+⚠ **Amended: an earlier revision of this entry said "64 untracked". Both halves
+of that were wrong** — the number was the staged count, and nothing was
+untracked at all. The experiment was right and the *reading* of it was not; the
+correction is recorded rather than silently overwritten because misreading a
+measurement is the same defect class as not taking one. On a bare adoptee with
+no AI-layer surfaces the written total is **69** (5 under `.claude/`); the
+78/14 figures are the realistic shape, where the archive has files to write.
 
-**Two things make the refusal worse than the abort itself.**
+**The 64 are STAGED, not stray, and that is the hazard.** The partially-failed
+`git add` stages every non-ignored path *before* erroring on `.claude`, and the
+refusal path does no `git reset`. So the operator is left with 64 framework
+files pre-loaded in their index. Measured consequence — their next innocent
+commit:
 
-1. It says **"Adoption did not complete. Nothing has been committed."** That is
-   literally true and reads as "nothing happened" — while 64 files sit in their
-   working tree. The sentence should distinguish *committed* from *written*.
+```
+$ echo 'a routine edit' >> README.md && git add README.md && git commit -m "docs: a routine edit of my own"
+files in that commit     : 65
+  framework scripts in it: 63
+```
+
+**Three things make the aftermath worse than the abort itself.**
+
+1. The refusal says **"Adoption did not complete. Nothing has been committed."**
+   Literally true, and it reads as "nothing happened" — while 78 files sit in
+   the tree and 64 are staged. It should distinguish *committed* from *written*
+   from *staged*.
 2. Git names the culprit (`.claude`) in a hint on stderr, and the driver's own
    line then **asks the question git just answered**: *"are any of them ignored
    by .gitignore?"*. The information is present and the framework declines to
    use it.
+3. Cleanup guidance is absent, and `git reset` is the first step of it — without
+   it the residue is not merely untidy, it is armed.
 
 **The right shape** is a preflight `git check-ignore` over the whole write-set
 BEFORE anything is written, with a legible refusal naming the offending

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9354,3 +9354,84 @@ still reds.
 **Related:** `## BL-076:` (the lint itself). Sibling shape:
 `## BL-181:`, where narrowing a predicate by one character re-opened a hole
 three times.
+
+---
+
+## BL-225: The adoption driver writes ~69 files into an adoptee before it discovers their `.gitignore` refuses one — no preflight, no rollback
+
+**Logged:** 2026-08-10 (found by adversarial review of the brownfield WP6
+branch; the WP6-local instances of the same class were fixed there, this is the
+residual one level down)
+**Category:** Fail-loud-but-late — a refusal that arrives after the mutation it
+should have prevented
+**Severity:** Real, not cosmetic. The failure direction is safe (nothing leaks,
+git names the culprit) but the adoptee is left half-written with no way back
+except by hand.
+**Status:** Open
+
+**What happens.** `scripts/adopt-project.sh` stages every recorded path in ONE
+`git add`, and `git add` on a gitignored path FAILS. WP6 fixed this for the
+paths it owns — the collision archive's entries, both MANIFESTs and the audit
+ledger all route through `_adopt_record_if_stageable`, which withholds an
+ignored path and says so. **Withholding is not available for the rest.** The
+framework-owned paths recorded unconditionally in `adopt-state.sh` and
+`adopt-core.sh` — the shipped script set, `.claude/phase-state.json`,
+`.claude/manifest.json`, `PROJECT_INTAKE.md`, the kept scan report — are the
+files the adoption *is*; skipping one produces a broken install rather than a
+disclosed omission.
+
+So an adoptee whose `.gitignore` contains `.claude/` wholesale, or `hooks/`
+(which catches the framework's own `scripts/hooks/`), gets: ~69 files written
+into their tree, then a refusal at staging, then no adoption commit and no
+rollback. The gates are live at the strictest tier, which is the safe row, but
+the operator is left to clean up by hand and the driver does not tell them how.
+
+**The right shape** is a preflight `git check-ignore` over the whole write-set
+BEFORE anything is written, with a legible refusal naming the offending
+patterns and the paths they cover — the same information the post-hoc git error
+carries, delivered while it is still actionable. `adopt_written_paths` already
+knows the set for the withheld half; the preflight needs the framework-owned
+half enumerated before the run rather than accumulated during it.
+
+**Not in scope for WP6**, which owns §7's archive. Filing rather than fixing
+because the write-set enumeration is a driver-skeleton change (WP4's surface)
+and deserves its own TDD pass.
+
+**Related:** BL-221 (the other adoption-path fail-direction finding), and
+`# BF-ADOPT-STAGE-EXPLICIT` for the staging call this refuses at.
+
+---
+
+## BL-226: Adoption tells the operator their files were "moved" when for most of them nothing moved
+
+**Logged:** 2026-08-10 (found during the brownfield WP6 build; carried forward
+by review rather than resolved, because the wording is design-mandated)
+**Category:** Honest-output defect — spec-conformant text contradicted by the
+program's own per-entry data
+**Severity:** Cosmetic in mechanism, not in consequence: it is the sentence an
+operator reads while deciding whether to trust the tool with their repository.
+**Status:** Open
+
+**The contradiction.** §7.3 mandates the disclosure sentence *"moved to ensure
+the framework operates properly"*, and `MANIFEST.md` repeats it. Both ship. But
+§7.1's other half — install the framework's clean set over the archived
+original — **is not built for the AI-layer surfaces**, because `init.sh` writes
+`.claude/settings.json` inline inside `create_project()` with no extractable
+emitter, and §8.1 forbids the driver from reaching into that function. So the
+archive COPIES and leaves the originals in place and in charge.
+
+The program already knows this and records it correctly: every entry carries a
+`disposition`, and every value is `kept` except `.git/hooks/commit-msg`, which
+is `composed`. **Nothing is `replaced`.** The per-entry field and the headline
+sentence disagree, and the sentence is the one a person reads first.
+
+**Options, none taken here:** (a) build the replacement half for the AI layer,
+which needs an extractable settings emitter and is a real piece of work;
+(b) re-word the disclosure to match the dispositions, which contradicts a
+verbatim design mandate and so is Karl's call, not an implementer's; (c) print
+the mandated sentence scoped to the entries it is true of, and a different one
+for `kept`. The WP6 build chose to ship the mandate and file the contradiction
+rather than quietly re-word a design-decided string.
+
+**Related:** BL-225 (the other WP6-adjacent residual), and
+docs/designs/2026-08-02-brownfield-adoption-v1.md §7.1/§7.3/§7.5.

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -746,6 +746,29 @@ run_child_suite "tests/test-brownfield-wp4-driver.sh" \
 run_child_suite "tests/test-brownfield-wp5b-test-debt.sh" \
   "Adoption test-debt ledger + tier ratchet (non-growth, touch-repays, both mutation directions)" \
   "Adoption WP5b test-debt tests FAILED (run tests/test-brownfield-wp5b-test-debt.sh for details)"
+# Brownfield adoption WP6: tests/test-brownfield-wp6-collision-archive.sh — the
+# COLLISION ARCHIVE (§7.2's layout and MANIFEST), the disclosure, the re-add
+# warning and its audit row, and §7.3's archive-secrets refusal.
+# THE SECURITY HALF IS THE POINT. Archiving a `.git/hooks/` file promotes an
+# UNTRACKED file into version control, so adoption can commit a credential that
+# was never committed before. The suite plants a BASE32-valid AWS key in the
+# fixture's pre-commit hook and asserts, IN THIS ORDER: that the plant is live
+# and the scan found it (a dud plant makes every later assertion vacuous — the
+# §6.5 lesson applied to a different surface); that the matching entry refuses
+# to stage while its CLEAN SIBLING in the same archive still commits; and that
+# the plant reaches zero bytes of the committed tree, the MANIFEST, the
+# transcript and the ledger. Every absence has a positive control, including
+# the `git grep HEAD` probe, which must find a token that IS committed.
+# Three mutations: neuter the pre-staging scan (the secret is committed);
+# suppress the re-add audit row (the file is still restored and nothing is
+# recorded — a SILENT re-add); and drift the emitter's type literal by one
+# character, which the REAL T6 predicate — extracted from
+# tests/test-bl029-integration.sh rather than re-typed — must reject.
+# Never invokes the scaffolder (it copies init.sh into a mutation mirror; it
+# does not run it) -> both lanes.
+run_child_suite "tests/test-brownfield-wp6-collision-archive.sh" \
+  "Collision archive (layout, MANIFEST, disclosure, re-add audit, archive-secrets refusal)" \
+  "Adoption WP6 collision-archive tests FAILED (run tests/test-brownfield-wp6-collision-archive.sh for details)"
 
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS

--- a/tests/test-bl029-integration.sh
+++ b/tests/test-bl029-integration.sh
@@ -68,6 +68,32 @@ fi
 esc_rows=$(jq '[.[] | select(.type=="escalation")] | length' "$PROJ/.claude/bypass-audit.json")
 if [ "$esc_rows" = "1" ]; then pass "T4: escalation audit row"; else fail_ "T4" "rows=$esc_rows"; fi
 
+# T4b (brownfield §8.9): put a REAL adoption_event row in the ledger, written
+# by the REAL emitter, BEFORE the T5 and T6 enum invariants read it.
+#
+# THIS IS THE POINT OF THE CASE AND IT IS NOT DECORATION. §8.9's indictment of
+# the two most recent row-type additions is that their pins "pass today only
+# because they run over fixture ledgers that never contain those types — a test
+# that cannot fail is not a pin." `sast_suppression` is in the docblock and
+# absent from T6's whitelist; `freshness_enforcement_snooze` is in neither.
+# Both go unnoticed because no fixture ever carries them.
+#
+# So `adoption_event` arrives with a fixture. The row below is produced by
+# adopt_audit_event — the shipped emitter, not a hand-written stand-in — which
+# means the ledger T5 and T6 read now contains the real thing. Drift the
+# emitter's type literal by one character and T6 goes RED for real; drop
+# adoption_event from T6's whitelist and it goes RED for real. Neither is true
+# of a whitelist entry with no fixture behind it.
+( . "$REPO_ROOT/scripts/lib/bypass-audit.sh" >/dev/null 2>&1
+  . "$REPO_ROOT/scripts/lib/adopt/adopt-archive.sh" >/dev/null 2>&1
+  adopt_audit_event "$PROJ" "collision_re_add" '{"path":".git/hooks/pre-commit"}' ) >/dev/null 2>&1
+ae_rows=$(jq '[.[] | select(.type=="adoption_event")] | length' "$PROJ/.claude/bypass-audit.json" 2>/dev/null)
+if [ "$ae_rows" = "1" ]; then
+  pass "T4b: the real emitter wrote an adoption_event row — T5 and T6 below now run over a ledger that CONTAINS the type they whitelist"
+else
+  fail_ "T4b" "adoption_event rows=$ae_rows (want 1) — without it the T6 pin below cannot fail"
+fi
+
 # T5: actor enum invariant — every row's actor is one of the documented values.
 ACTORS=$(jq -r '[.[].actor] | unique | .[]' "$PROJ/.claude/bypass-audit.json")
 ALL_OK=1
@@ -82,7 +108,7 @@ TYPES=$(jq -r '[.[].type] | unique | .[]' "$PROJ/.claude/bypass-audit.json")
 TYPE_OK=1
 for t in $TYPES; do
   case "$t" in
-    claude_bypass_proposal|terminal_commit_blocked|terminal_commit_passed|out_of_band_commit|enforcement_level_set|detector_error|escalation) ;;
+    claude_bypass_proposal|terminal_commit_blocked|terminal_commit_passed|out_of_band_commit|enforcement_level_set|detector_error|escalation|adoption_event) ;;
     *) TYPE_OK=0 ;;
   esac
 done

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -972,12 +972,25 @@ else
   h2_after=$(shasum -a 256 "$H2D/p/.git/hooks/pre-commit" 2>/dev/null | awk '{print $1}')
   h2_said=0
   grep -q 'LEFT ALONE' "$RUN_OUT" && h2_said=1
-  h2_stub=0
-  grep -q 'NOT DONE — the collision archive' "$RUN_OUT" && h2_stub=1
-  if [ "$h2_rc" -eq 0 ] && [ -n "$h2_before" ] && [ "$h2_before" = "$h2_after" ] && [ "$h2_said" -eq 1 ] && [ "$h2_stub" -eq 1 ]; then
-    pass "H2: an adoptee's existing pre-commit hook is byte-for-byte untouched, said out loud, and handed to WP6's collision stub rather than overwritten"
+  # RE-AIMED WHEN WP6 LANDED. This case used to require the WP6 STUB to fire
+  # ("NOT DONE — the collision archive"), which was the right assertion while
+  # the archive did not exist and is the wrong one now: an honest stub for
+  # delivered work is a false claim, so WP6 removed it. The property H2 was
+  # always about — their hook is byte-for-byte untouched and the run says so —
+  # is unchanged and still asserted. What replaces the stub check is the
+  # STRONGER version of the same intent: the hook is now RECOVERABLE, so the
+  # archive must hold a copy of it with a restore line.
+  h2_arch=$( cd "$H2D/p" && find .claude/adoption-archive -mindepth 1 -maxdepth 1 -type d 2>/dev/null | LC_ALL=C sort | head -1 )
+  h2_copy=""
+  [ -n "$h2_arch" ] && h2_copy=$(shasum -a 256 "$H2D/p/$h2_arch/git-hooks/pre-commit" 2>/dev/null | awk '{print $1}')
+  h2_restore=0
+  [ -n "$h2_arch" ] && jq -e '[.entries[] | select(.originalPath == ".git/hooks/pre-commit") | select((.restore // "") != "")] | length == 1' \
+    "$H2D/p/$h2_arch/MANIFEST.json" >/dev/null 2>&1 && h2_restore=1
+  if [ "$h2_rc" -eq 0 ] && [ -n "$h2_before" ] && [ "$h2_before" = "$h2_after" ] && [ "$h2_said" -eq 1 ] \
+     && [ -n "$h2_copy" ] && [ "$h2_copy" = "$h2_before" ] && [ "$h2_restore" -eq 1 ]; then
+    pass "H2: an adoptee's existing pre-commit hook is byte-for-byte untouched, said out loud, AND archived byte-identically with a restore line (WP6) rather than overwritten"
   else
-    fail_ "H2" "rc=$h2_rc sha_before=$h2_before sha_after=$h2_after said_left_alone=$h2_said collision_stub_fired=$h2_stub"
+    fail_ "H2" "rc=$h2_rc sha_before=$h2_before sha_after=$h2_after said_left_alone=$h2_said archive=$h2_arch archived_copy_sha=$h2_copy restore_line_present=$h2_restore"
   fi
 fi
 

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -180,6 +180,14 @@ mkdir -p "$XDG_CONFIG_HOME"
 unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_TEMPLATE_DIR
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
 unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_COMMON_DIR
+# The pathspec-magic family (R-WP6-18). Not a silent decision like the config
+# channels above — it is a FATAL: with `sub/*.txt` ignored,
+# `GIT_NOGLOB_PATHSPECS=1 git check-ignore -q -- sub/a.txt` dies
+# "pathspec magic not supported by this command", which every probe here wraps
+# in 2>/dev/null and therefore scores as NOT ignored. A fixture verdict flips
+# on an environment variable no fixture set. Unset for the same reason as the
+# rest: "not set on this host" is a property of today.
+unset GIT_LITERAL_PATHSPECS GIT_NOGLOB_PATHSPECS GIT_GLOB_PATHSPECS GIT_ICASE_PATHSPECS
 
 # ── Portable primitives (house pattern, WP2/WP4 parity) ─────────────────────
 _mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -1036,10 +1036,18 @@ for spelling in empty null multidoc nonarray garbage valid; do
     [ "$g6c_rc" -ne 0 ] || g6c_fail="$g6c_fail $spelling:rc=0(want non-zero)"
   fi
 done
-if [ -z "$g6c_fail" ] && [ "$g6c_rows_valid" -eq 1 ]; then
-  pass "G6c (R-WP6-14, library contract): bypass_audit_append REFUSES every corrupt ledger spelling — empty, null, multi-document, non-array and garbage — and still appends exactly one row to a valid [] (rows=$g6c_rows_valid), so the guard is a predicate and not a blanket refusal"
+# THE GUARD RETURNS FROM INSIDE THE LOCK, so it has to release it. Asserted
+# rather than inferred: the loop above takes the failure path five times, and a
+# leaked `.lockdir` would make every later append spin for the full 10-second
+# timeout and then fail for the WRONG reason — which this case would still have
+# scored as a refusal. The valid append that follows the five failures is the
+# behavioural half of the same proof.
+g6c_lock=0
+[ -d "$G6C/proj/.claude/bypass-audit.json.lockdir" ] && g6c_lock=1
+if [ -z "$g6c_fail" ] && [ "$g6c_rows_valid" -eq 1 ] && [ "$g6c_lock" -eq 0 ]; then
+  pass "G6c (R-WP6-14, library contract): bypass_audit_append REFUSES every corrupt ledger spelling — empty, null, multi-document, non-array and garbage — releases its lock on each refusal, and still appends exactly one row to a valid [] (rows=$g6c_rows_valid), so the guard is a predicate and not a blanket refusal"
 else
-  fail_ "G6c" "spellings that did not refuse:$g6c_fail; rows appended to a VALID ledger=$g6c_rows_valid (want 1)"
+  fail_ "G6c" "spellings that did not refuse:$g6c_fail; rows appended to a VALID ledger=$g6c_rows_valid (want 1); lockdir leaked=$g6c_lock (want 0)"
 fi
 
 # ── R5 (R-WP6-12) — a re-add that fails BEFORE the copy leaves no row ───────

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -123,6 +123,31 @@ TOPTMP="$(mktemp -d)"
 trap 'rm -rf "$TOPTMP"' EXIT INT TERM
 newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
 
+# ── HOST GIT CONFIG IS NEUTRALIZED, AND IT HAD TO BE (R-WP6-3) ─────────────
+#
+# MEASURED ON THIS HOST, NOT ANTICIPATED. `~/.config/git/ignore` contains
+# `**/.claude/settings.local.json`. That is the ecosystem-standard line, it is
+# on a great many developer machines, and it is a GLOBAL EXCLUDES FILE — so
+# `git check-ignore` inside a fixture consulted it and reported the fixture's
+# ARCHIVE COPY as ignored. On this laptop the R-WP6-1 exposure was therefore
+# invisible; on a CI runner, which has no such file, it was live. A fixture
+# whose verdict is decided by whose machine it runs on is not a fixture.
+#
+# `GIT_CONFIG_GLOBAL` DOES NOT COVER THIS and that is the trap worth spelling
+# out: the excludes file is found at `$XDG_CONFIG_HOME/git/ignore` (falling
+# back to `$HOME/.config/git/ignore`), which is a PATH DEFAULT, not a config
+# key. Pointing GIT_CONFIG_GLOBAL at /dev/null neutralizes `core.excludesFile`
+# and nothing else. XDG_CONFIG_HOME is the knob that matters, and H0 below
+# proves it in both directions rather than asserting it.
+#
+# Same class as the house rules' `GITHUB_BASE_REF` provision: the fixture must
+# own every input git reads.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_SYSTEM=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+export XDG_CONFIG_HOME="$TOPTMP/xdg"
+mkdir -p "$XDG_CONFIG_HOME"
+
 # ── Portable primitives (house pattern, WP2/WP4 parity) ─────────────────────
 _mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
 _num()     { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
@@ -332,7 +357,44 @@ _adoption_commit_landed() {
   esac
 }
 
+# _add_local_settings DIR PAYLOAD — the modal adoptee shape: a gitignored
+# `.claude/settings.local.json` holding something private that IS NOT
+# SECRET-SHAPED. An internal hostname and a username match no scanner pattern,
+# which is the point — the only thing standing between them and the commit is
+# the operator's own ignore rule.
+_add_local_settings() {
+  local d="$1" payload="$2"
+  mkdir -p "$d/.claude" || return 1
+  printf '{"env":{"HTTPS_PROXY":"%s"},"user":"%s"}\n' "$payload" "$payload" > "$d/.claude/settings.local.json"
+  return 0
+}
+
 # ═══════════════════════════════════════════════════════════════════════════
+echo "=== H0 — the fixtures are isolated from host git config (R-WP6-3) ==="
+
+# TWO DIRECTIONS, because a neutralization nobody tested is a comment. The
+# probe writes the exact line this host really carries into a THROWAWAY
+# XDG_CONFIG_HOME, proves git honours it (so the knob is live and the hazard is
+# real), then proves the suite's own isolated XDG_CONFIG_HOME does not.
+H0="$(newtmp)"
+h0_ok=0
+if mk_adoptee "$H0/p"; then
+  mkdir -p "$H0/xdg-host/git"
+  printf '**/.claude/settings.local.json\n' > "$H0/xdg-host/git/ignore"
+  h0_probe=".claude/adoption-archive/T-1/.claude/settings.local.json"
+  h0_with=1
+  ( cd "$H0/p" && XDG_CONFIG_HOME="$H0/xdg-host" git check-ignore -q -- "$h0_probe" ) 2>/dev/null || h0_with=0
+  h0_without=1
+  ( cd "$H0/p" && git check-ignore -q -- "$h0_probe" ) 2>/dev/null || h0_without=0
+  h0_ok=1
+fi
+if [ "$h0_ok" -eq 1 ] && [ "$h0_with" -eq 1 ] && [ "$h0_without" -eq 0 ]; then
+  pass "H0: a global excludes file DOES decide an archive path (ignored=$h0_with with one in scope) and the suite's isolated XDG_CONFIG_HOME removes it (ignored=$h0_without) — the fixtures below are the suite's, not the host's"
+else
+  fail_ "H0" "setup=$h0_ok ignored-with-host-excludes=$h0_with (want 1 — the knob must be live, or this proves nothing) ignored-under-isolation=$h0_without (want 0)"
+fi
+
+echo ""
 echo "=== A — the archive layout and its MANIFEST (§7.2) ==="
 
 A_D="$(newtmp)"
@@ -642,8 +704,53 @@ if [ "$HAVE_GITLEAKS" -eq 1 ]; then
       fail_ "S4" "sites=$s4_sites (want 1) changed_lines=$s4_chg (want 2) parses=$s4_parses (want 1) adoption commit landed=$s4_landed (want 1) entry in HEAD=$s4_tracked (want 1) plant_in_tree=$s4_tree (want >=1)"
     fi
   fi
+  # ── S6 (R-WP6-9) — an inherited GITLEAKS_CONFIG must not switch the scan off
+  #
+  # This is a SUPPRESSION VECTOR, not a documentation nit. Measured on gitleaks
+  # 8.30.1: exporting GITLEAKS_CONFIG (or GITLEAKS_CONFIG_TOML) at a config
+  # whose rules match nothing takes the plant from 1 finding to 0 — and those
+  # variables OUTRANK the scanned path, so the "the archive dir cannot contain
+  # a .gitleaks.toml" argument does not cover them. Anything in the operator's
+  # environment — a shell profile, a CI job env, a direnv file in the adoptee —
+  # would have silently disabled §7.3's refusal while the MANIFEST still said
+  # `status: scanned`, which is the worst available combination.
+  #
+  # TWO DIRECTIONS. The vector is proved live against the real binary first
+  # (or the fix could be pinned against a threat that does not exist), then the
+  # driver is run with the same variables exported and must be unaffected.
+  S6="$(newtmp)"
+  if ! mk_adoptee "$S6/p" || ! _add_surfaces "$S6/p" "$HOOK_PLANT"; then
+    fail_ "S6 (R-WP6-9)" "fixture setup failed"
+  else
+    mkdir -p "$S6/probe"
+    cp "$S6/p/.git/hooks/pre-commit" "$S6/probe/hook.sh"
+    printf 'title = "suppress"\n[[rules]]\nid = "never-matches"\ndescription = "matches nothing"\nregex = %s\n' \
+      "'''NEVERMATCHESANYTHING12345'''" > "$S6/allow.toml"
+    ( cd "$S6/probe" && gitleaks dir --no-banner --redact --exit-code 0 -f json -r "$S6/base.json" . ) >/dev/null 2>&1
+    ( cd "$S6/probe" && GITLEAKS_CONFIG="$S6/allow.toml" gitleaks dir --no-banner --redact --exit-code 0 -f json -r "$S6/supp.json" . ) >/dev/null 2>&1
+    s6_base=$(jq 'length' "$S6/base.json" 2>/dev/null); s6_base=$(_num "$s6_base")
+    s6_supp=$(jq 'length' "$S6/supp.json" 2>/dev/null); s6_supp=$(_num "$s6_supp")
+    _ans > "$S6/answers"
+    RUN_RC=0
+    RUN_OUT="$S6/run-out"; RUN_ERR="$S6/run-err"
+    ( cd "$S6/p" && GITLEAKS_CONFIG="$S6/allow.toml" GITLEAKS_CONFIG_TOML="$(cat "$S6/allow.toml")" \
+        bash "$REPO_ROOT/scripts/adopt-project.sh" --scan-report "$TOPTMP/report.json" ) \
+      < "$S6/answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+    s6_arch="$(arch_dir_of "$S6/p")"
+    s6_mj="$S6/p/$s6_arch/MANIFEST.json"
+    s6_count=$(jq -r '.secretsScan.findingCount // "null"' "$s6_mj" 2>/dev/null); s6_count=$(_num "$s6_count")
+    s6_reason=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .withheldReason // ""' "$s6_mj" 2>/dev/null)
+    s6_head=$(_in_head "$S6/p" "$s6_arch/git-hooks/pre-commit")
+    if [ "$s6_base" -ge 1 ] && [ "$s6_supp" -eq 0 ] \
+       && [ "$s6_count" -ge 1 ] && [ "$s6_reason" = "secret-match" ] && [ "$s6_head" -eq 0 ]; then
+      pass "S6 (R-WP6-9): the vector is real — GITLEAKS_CONFIG takes the same file from $s6_base finding(s) to $s6_supp against the raw binary — and the driver is IMMUNE to it: findingCount=$s6_count, the entry is still withheld as secret-match and still absent from HEAD"
+    else
+      fail_ "S6" "raw binary baseline=$s6_base (want >=1) raw binary under GITLEAKS_CONFIG=$s6_supp (want 0 — else the vector is not real and this proves nothing); driver findingCount=$s6_count (want >=1) withheldReason='$s6_reason' (want secret-match) entry in HEAD=$s6_head (want 0)"
+    fi
+  fi
 else
   skip_ "S0-S4 (§7.3 archive-secrets proof and its mutation)" "gitleaks not installed — see the banner above"
+  skip_ "S6 (inherited GITLEAKS_CONFIG cannot suppress the scan)" "gitleaks not installed"
 fi
 
 # ── S5 — "nobody looked" is never "clean" ──────────────────────────────────
@@ -766,6 +873,242 @@ else
   fi
 fi
 
+# ── R4 (R-WP6-4) — a re-add that CANNOT be recorded must not happen ─────────
+#
+# The R2 mutation forbids a silent re-add by sed. This one forbids the same
+# thing AT RUNTIME, which is the version an operator can actually hit:
+# `bypass_audit_append` returns 1 on a corrupt ledger (its jq filter fails) or
+# on a lock timeout. Before this fix the driver ignored that rc and printed
+# "The choice is recorded in .claude/bypass-audit.json" regardless — a false
+# claim in the one artifact the re-add's legitimacy rests on.
+#
+# The ledger is corrupted rather than mocked, because the real failure is the
+# real jq refusing real garbage.
+R4="$(newtmp)"
+if ! mk_adoptee "$R4/p" || ! _add_surfaces "$R4/p"; then
+  fail_ "R4" "fixture setup failed"
+else
+  _ans > "$R4/answers"
+  run_adopt "$R4/p" "$R4/answers"
+  r4_arch="$(arch_dir_of "$R4/p")"
+  printf '#!/usr/bin/env bash\n# replaced\nexit 0\n' > "$R4/p/.git/hooks/pre-commit"
+  r4_before="$(_sha "$R4/p/.git/hooks/pre-commit")"
+  printf 'this is not json at all\n' > "$R4/p/.claude/bypass-audit.json"
+  printf '1\n' > "$R4/confirm"
+  run_readd "$R4/p" ".git/hooks/pre-commit" "$R4/confirm"
+  r4_rc=$READD_RC
+  r4_after="$(_sha "$R4/p/.git/hooks/pre-commit")"
+  # The false claim must be ABSENT, and the refusal must name the real cause.
+  r4_falseclaim=$(_count_in "$READD_OUT" "The choice is recorded")
+  r4_loud=$(_count_in "$READD_ERR" "could not be recorded")
+  if [ "$r4_rc" -ne 0 ] && [ -n "$r4_before" ] && [ "$r4_before" = "$r4_after" ] \
+     && [ "$r4_falseclaim" -eq 0 ] && [ "$r4_loud" -ge 1 ]; then
+    pass "R4 (R-WP6-4): with the ledger corrupt the re-add REFUSES (rc $r4_rc) and does NOT restore the file — no row, no re-add, and the 'choice is recorded' claim is never printed"
+  else
+    fail_ "R4" "rc=$r4_rc (want non-zero) sha before=$r4_before after=$r4_after (want equal — the file must NOT be restored) false 'recorded' claim printed=$r4_falseclaim (want 0) refusal names the cause=$r4_loud (want >=1)"
+  fi
+fi
+
+echo ""
+echo "=== G — the operator's .gitignore is an instruction, not a hint ==="
+
+# THE PRIVATE PAYLOAD IS DELIBERATELY NOT SECRET-SHAPED.
+# `internal-proxy.corp.example` matches no gitleaks rule — verified by G1's own
+# `findingCount == 0` assertion. That is what makes G1 a test of the IGNORE
+# rule rather than an accidental second test of the scanner: if the scanner
+# could catch this, the withhold would be attributable to the wrong arm and the
+# mutation could not isolate anything.
+PRIVATE_PAYLOAD="internal-proxy.corp.example-jdoe"
+
+# ── G1 (R-WP6-1) — a gitignored ORIGINAL is never committed under a new name ─
+#
+# The exposure this case exists for: the operator wrote
+# `.claude/settings.local.json` in their .gitignore — an explicit statement
+# that this CONTENT must never enter history — and the archive copied it to
+# `.claude/adoption-archive/<dir>/.claude/settings.local.json`, a path the
+# ANCHORED rule cannot match. Asking `git check-ignore` about the NEW path
+# answers a question nobody asked. Verified hermetically: anchored rule vs
+# original -> ignored; vs archive copy -> NOT ignored.
+G1="$(newtmp)"
+G1_OK=0
+if mk_adoptee "$G1/p" && _add_surfaces "$G1/p" && _add_local_settings "$G1/p" "$PRIVATE_PAYLOAD"; then
+  printf '.claude/settings.local.json\n' > "$G1/p/.gitignore"
+  ( cd "$G1/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  _ans > "$G1/answers"
+  run_adopt "$G1/p" "$G1/answers"
+  G1_OK=1
+fi
+if [ "$G1_OK" -ne 1 ]; then
+  fail_ "G1" "fixture setup failed"
+  fail_ "G1b" "fixture setup failed"
+else
+  g1_arch="$(arch_dir_of "$G1/p")"
+  g1_mj="$G1/p/$g1_arch/MANIFEST.json"
+  g1_staged=$(jq -r '.entries[] | select(.originalPath == ".claude/settings.local.json") | .stagedForCommit' "$g1_mj" 2>/dev/null)
+  g1_reason=$(jq -r '.entries[] | select(.originalPath == ".claude/settings.local.json") | .withheldReason // ""' "$g1_mj" 2>/dev/null)
+  g1_landed=$(_adoption_commit_landed "$G1/p")
+  g1_inhead=$(_in_head "$G1/p" "$g1_arch/.claude/settings.local.json")
+  # THE PROBE CONTROLS. The archive copy on disk MUST hold the payload (the
+  # copy really happened and the probe can see it), the committed-tree probe
+  # MUST be able to find something that IS committed, and the scanner MUST
+  # have found nothing — so the withhold is the ignore rule's doing.
+  g1_ondisk=$(_count_in "$G1/p/$g1_arch/.claude/settings.local.json" "$PRIVATE_PAYLOAD")
+  g1_ctrl=$( cd "$G1/p" && git grep -F -l -- "acme-api" HEAD 2>/dev/null | grep -c . ); g1_ctrl=$(_num "$g1_ctrl")
+  g1_tree=$( cd "$G1/p" && git grep -F -l -- "$PRIVATE_PAYLOAD" HEAD 2>/dev/null | grep -c . ); g1_tree=$(_num "$g1_tree")
+  g1_findings=$(jq -r '.secretsScan.findingCount // "null"' "$g1_mj" 2>/dev/null)
+  g1_sib=$(_in_head "$G1/p" "$g1_arch/.claude/settings.json")
+  if [ "$RUN_RC" -eq 0 ] && [ "$g1_landed" -eq 1 ] && [ "$g1_staged" = "false" ] \
+     && [ "$g1_reason" = "original-gitignored" ] && [ "$g1_inhead" -eq 0 ] \
+     && [ "$g1_ondisk" -ge 1 ] && [ "$g1_ctrl" -ge 1 ] && [ "$g1_tree" -eq 0 ] \
+     && [ "$g1_findings" = "0" ] && [ "$g1_sib" -eq 1 ]; then
+    pass "G1 (R-WP6-1): a file the operator gitignored is archived but NEVER committed under its new name — withheldReason=original-gitignored, absent from HEAD, and its payload is in 0 committed files while present in the archive copy. The scanner found $g1_findings, so the ignore rule is what saved it"
+  else
+    fail_ "G1" "rc=$RUN_RC landed=$g1_landed stagedForCommit='$g1_staged' (want false) withheldReason='$g1_reason' (want original-gitignored) in HEAD=$g1_inhead (want 0) payload in archive copy=$g1_ondisk (want >=1) tree probe control=$g1_ctrl (want >=1) payload in committed tree=$g1_tree (want 0) findingCount='$g1_findings' (want 0 — a non-zero count would mean the SCANNER caught it and this proves nothing about the ignore rule) clean sibling in HEAD=$g1_sib (want 1)"
+  fi
+
+  # G1b — the bound. `.git/hooks/*` is NOT an operator ignore statement: git
+  # simply never tracks `.git/`. Verified hermetically that `git check-ignore`
+  # reports rc 1 for it, so the new arm must not swallow the hooks — which are
+  # the whole point of the archive and §7.3's carrier.
+  g1b_hook_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$g1_mj" 2>/dev/null)
+  g1b_hook_head=$(_in_head "$G1/p" "$g1_arch/git-hooks/pre-commit")
+  if [ "$g1b_hook_staged" = "true" ] && [ "$g1b_hook_head" -eq 1 ]; then
+    pass "G1b (the bound): in the same run the git hooks are still archived AND committed — the original-ignore arm does not swallow .git/hooks, which git excludes by construction rather than by the operator's instruction"
+  else
+    fail_ "G1b" "hook stagedForCommit='$g1b_hook_staged' (want true) hook in HEAD=$g1b_hook_head (want 1) — the new arm is over-withholding"
+  fi
+fi
+
+# ── G2 (R-WP6-2) — the archive-path arm, which had NO test at all ───────────
+#
+# `git-hooks/` is chosen precisely because it reaches the ARCHIVE COPY and NOT
+# the original: the original is `.git/hooks/pre-commit`, whose directory is
+# `hooks`, not `git-hooks`. So this case exercises the archive-path arm ALONE
+# and cannot be satisfied by G1's original-path arm.
+G2="$(newtmp)"
+G2_OK=0
+if mk_adoptee "$G2/p" && _add_surfaces "$G2/p"; then
+  printf 'git-hooks/\n' > "$G2/p/.gitignore"
+  ( cd "$G2/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  _ans > "$G2/answers"
+  run_adopt "$G2/p" "$G2/answers"
+  G2_OK=1
+fi
+if [ "$G2_OK" -ne 1 ]; then
+  fail_ "G2" "fixture setup failed"
+else
+  g2_arch="$(arch_dir_of "$G2/p")"
+  g2_mj="$G2/p/$g2_arch/MANIFEST.json"
+  g2_reason=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .withheldReason // ""' "$g2_mj" 2>/dev/null)
+  g2_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$g2_mj" 2>/dev/null)
+  g2_landed=$(_adoption_commit_landed "$G2/p")
+  g2_head=$(_in_head "$G2/p" "$g2_arch/git-hooks/pre-commit")
+  g2_manifest=$(_in_head "$G2/p" "$g2_arch/MANIFEST.json")
+  g2_sib=$(_in_head "$G2/p" "$g2_arch/.claude/settings.json")
+  # The ORIGINAL must not be ignored, or this case would be indistinguishable
+  # from G1 and would pass on the wrong arm.
+  g2_orig_ign=1
+  ( cd "$G2/p" && git check-ignore -q -- ".git/hooks/pre-commit" ) 2>/dev/null || g2_orig_ign=0
+  if [ "$RUN_RC" -eq 0 ] && [ "$g2_landed" -eq 1 ] && [ "$g2_staged" = "false" ] \
+     && [ "$g2_reason" = "gitignored" ] && [ "$g2_head" -eq 0 ] \
+     && [ "$g2_orig_ign" -eq 0 ] && [ "$g2_manifest" -eq 1 ] && [ "$g2_sib" -eq 1 ]; then
+    pass "G2 (R-WP6-2): an ignore rule that reaches only the ARCHIVE COPY withholds that entry (withheldReason=gitignored) while the run completes rc 0 and the MANIFEST and clean sibling still commit — the original is NOT ignored, so this is the archive-path arm and no other"
+  else
+    fail_ "G2" "rc=$RUN_RC landed=$g2_landed stagedForCommit='$g2_staged' (want false) withheldReason='$g2_reason' (want gitignored) entry in HEAD=$g2_head (want 0) original ignored=$g2_orig_ign (want 0 — else this is G1's arm) MANIFEST in HEAD=$g2_manifest (want 1) sibling in HEAD=$g2_sib (want 1)"
+  fi
+fi
+
+# ── G3 — MUTATION for R-WP6-1: neuter the ORIGINAL-path check ───────────────
+G3="$(newtmp)"
+if ! mk_adoptee "$G3/p" || ! _add_surfaces "$G3/p" || ! _add_local_settings "$G3/p" "$PRIVATE_PAYLOAD" || ! mk_mirror "$G3/fw"; then
+  fail_ "G3 (MUTATION)" "fixture setup failed"
+else
+  printf '.claude/settings.local.json\n' > "$G3/p/.gitignore"
+  ( cd "$G3/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  MUTG="$G3/fw/scripts/lib/adopt/adopt-archive.sh"
+  g3_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-IGNORE-ORIGINAL')
+  cp "$L_ARCHIVE" "$G3/orig.ref"
+  _sed_inplace "$MUTG" 's|^.*BF-ADOPT-IGNORE-ORIGINAL$|    elif false; then   # BF-ADOPT-IGNORE-ORIGINAL|'
+  g3_chg=$(_changed_lines "$G3/orig.ref" "$MUTG")
+  g3_parses=$(_parses "$MUTG")
+  _ans > "$G3/answers"
+  run_adopt "$G3/p" "$G3/answers" "$G3/fw"
+  g3_arch="$(arch_dir_of "$G3/p")"
+  g3_head=$(_in_head "$G3/p" "$g3_arch/.claude/settings.local.json")
+  g3_tree=$( cd "$G3/p" && git grep -F -l -- "$PRIVATE_PAYLOAD" HEAD 2>/dev/null | grep -c . ); g3_tree=$(_num "$g3_tree")
+  if [ "$g3_sites" -eq 1 ] && [ "$g3_chg" -eq 2 ] && [ "$g3_parses" -eq 1 ] \
+     && [ "$g3_head" -eq 1 ] && [ "$g3_tree" -ge 1 ]; then
+    pass "G3 (MUTATION): with the original-path check neutered (1 site, 2 lines, mutant parses) the gitignored file's copy IS committed and its private payload appears in $g3_tree committed file(s) — RED"
+  else
+    fail_ "G3" "sites=$g3_sites (want 1) changed_lines=$g3_chg (want 2) parses=$g3_parses (want 1) copy in HEAD=$g3_head (want 1) payload in tree=$g3_tree (want >=1)"
+  fi
+fi
+
+# ── G4 — MUTATION for R-WP6-2: neuter the ARCHIVE-path check ────────────────
+#
+# Its observable is different from G3's and that difference is the arm's whole
+# purpose: `git add` on an ignored path FAILS, and the driver stages every
+# recorded path in ONE command, so removing this guard does not leak anything —
+# it takes the entire adoption down. Asserted as an exit code AND as the
+# absence of an adoption commit, with the archive on disk proving the run got
+# that far rather than falling over earlier.
+G4="$(newtmp)"
+if ! mk_adoptee "$G4/p" || ! _add_surfaces "$G4/p" || ! mk_mirror "$G4/fw"; then
+  fail_ "G4 (MUTATION)" "fixture setup failed"
+else
+  printf 'git-hooks/\n' > "$G4/p/.gitignore"
+  ( cd "$G4/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  MUTG4="$G4/fw/scripts/lib/adopt/adopt-archive.sh"
+  g4_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-IGNORE-ARCHIVE')
+  cp "$L_ARCHIVE" "$G4/orig.ref"
+  _sed_inplace "$MUTG4" 's|^.*BF-ADOPT-IGNORE-ARCHIVE$|    elif false; then   # BF-ADOPT-IGNORE-ARCHIVE|'
+  g4_chg=$(_changed_lines "$G4/orig.ref" "$MUTG4")
+  g4_parses=$(_parses "$MUTG4")
+  _ans > "$G4/answers"
+  run_adopt "$G4/p" "$G4/answers" "$G4/fw"
+  g4_rc=$RUN_RC
+  g4_landed=$(_adoption_commit_landed "$G4/p")
+  g4_arch="$(arch_dir_of "$G4/p")"
+  g4_ondisk=0; [ -n "$g4_arch" ] && [ -f "$G4/p/$g4_arch/MANIFEST.json" ] && g4_ondisk=1
+  if [ "$g4_sites" -eq 1 ] && [ "$g4_chg" -eq 2 ] && [ "$g4_parses" -eq 1 ] \
+     && [ "$g4_rc" -ne 0 ] && [ "$g4_landed" -eq 0 ] && [ "$g4_ondisk" -eq 1 ]; then
+    pass "G4 (MUTATION): with the archive-path check neutered (1 site, 2 lines, mutant parses) git add refuses the ignored path and the WHOLE adoption fails (rc $g4_rc, no adoption commit) — the archive is on disk, so the run reached staging — RED"
+  else
+    fail_ "G4" "sites=$g4_sites (want 1) changed_lines=$g4_chg (want 2) parses=$g4_parses (want 1) run rc=$g4_rc (want non-zero) adoption commit landed=$g4_landed (want 0) archive on disk=$g4_ondisk (want 1)"
+  fi
+fi
+
+# ── G5 — the operator may ignore the ARCHIVE ITSELF, and adoption survives ──
+# `.claude/adoption-archive/` is a plausible thing to gitignore: it is a local
+# backup directory. It reaches every entry AND both MANIFEST files, so the
+# MANIFEST's own staging has to go through the same guard — otherwise the one
+# unconditional `adopt_record_write` pair takes the adoption down.
+G5="$(newtmp)"
+if ! mk_adoptee "$G5/p" || ! _add_surfaces "$G5/p"; then
+  fail_ "G5" "fixture setup failed"
+else
+  printf '.claude/adoption-archive/\n' > "$G5/p/.gitignore"
+  ( cd "$G5/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  _ans > "$G5/answers"
+  run_adopt "$G5/p" "$G5/answers"
+  g5_rc=$RUN_RC
+  g5_landed=$(_adoption_commit_landed "$G5/p")
+  g5_arch="$(arch_dir_of "$G5/p")"
+  g5_mj=""; [ -n "$g5_arch" ] && g5_mj="$G5/p/$g5_arch/MANIFEST.json"
+  g5_ondisk=0; [ -n "$g5_mj" ] && [ -f "$g5_mj" ] && g5_ondisk=1
+  g5_staged=$(jq -r '[.entries[] | select(.stagedForCommit == true)] | length' "$g5_mj" 2>/dev/null); g5_staged=$(_num "$g5_staged")
+  g5_manifest=0
+  [ -n "$g5_arch" ] && g5_manifest=$(_in_head "$G5/p" "$g5_arch/MANIFEST.json")
+  g5_disclosed=0
+  [ -n "$g5_arch" ] && g5_disclosed=$(_count_in "$RUN_OUT" "$g5_arch")
+  if [ "$g5_rc" -eq 0 ] && [ "$g5_landed" -eq 1 ] && [ "$g5_ondisk" -eq 1 ] \
+     && [ "$g5_staged" -eq 0 ] && [ "$g5_manifest" -eq 0 ] && [ "$g5_disclosed" -ge 1 ]; then
+    pass "G5: an operator who gitignores the archive directory still gets a COMPLETED adoption (rc 0) — nothing archive-shaped is committed, including the MANIFEST, and the archive is still on disk and still disclosed on screen"
+  else
+    fail_ "G5" "rc=$g5_rc (want 0) landed=$g5_landed (want 1) MANIFEST on disk=$g5_ondisk (want 1) entries staged=$g5_staged (want 0) MANIFEST in HEAD=$g5_manifest (want 0) archive named in transcript=$g5_disclosed (want >=1)"
+  fi
+fi
+
 echo ""
 echo "=== E — adoption_event across §8.9's five surfaces ==="
 
@@ -777,18 +1120,27 @@ else
   fail_ "E1" "occurrences in the docblock=$e1 (want >=1)"
 fi
 
-# Surface 2 — the T6 whitelist AND a fixture ledger containing it.
-# §8.9's indictment of the two previous row types is that their pins run over
-# fixtures that never carry them, so BOTH halves are asserted here.
+# Surface 2 — §8.9's second surface is PRESENT in test-bl029-integration.sh.
+#
+# WHAT THIS CASE CLAIMS, NARROWED (R-WP6-8). It is a PRESENCE check: the type
+# is named in that file and that file writes a row with the real emitter. Its
+# earlier wording claimed the pin "can make it fail", which this case cannot
+# show — its whitelist half is a BRE whose second alternative
+# (`adoption_event.*)`) is satisfied by T4b's own fail-message text, so the
+# whitelist could be gone and this would stay green. The falsifiability claim
+# belongs to E6, which runs the REAL extracted predicate against a mutated
+# emitter, and to tests/test-bl029-integration.sh itself, which goes to
+# 7 passed / 1 failed when adoption_event is dropped from the whitelist.
+# Overlapping coverage is fine; an overstated claim is not.
 e2_case=$(grep -c 'adoption_event' "$BL029" 2>/dev/null); e2_case=$(_num "$e2_case")
 e2_white=0
-grep -q 'claude_bypass_proposal|.*adoption_event\|adoption_event.*)' "$BL029" 2>/dev/null && e2_white=1
+grep -q '|adoption_event)' "$BL029" 2>/dev/null && e2_white=1
 e2_fixture=0
 grep -q 'adopt_audit_event' "$BL029" 2>/dev/null && e2_fixture=1
 if [ "$e2_case" -ge 2 ] && [ "$e2_white" -eq 1 ] && [ "$e2_fixture" -eq 1 ]; then
-  pass "E2 (surface 2/5): T6's type-enum whitelist lists adoption_event AND the suite writes such a row into the ledger T6 reads — the pin has a fixture that can make it fail"
+  pass "E2 (surface 2/5, PRESENCE): adoption_event is a case-arm alternative in T6's whitelist and test-bl029-integration.sh writes such a row with the real emitter. Falsifiability is E6's and bl029's own, not this case's"
 else
-  fail_ "E2" "adoption_event mentions in test-bl029=$e2_case (want >=2) in the whitelist=$e2_white writes a row via the real emitter=$e2_fixture"
+  fail_ "E2" "adoption_event mentions in test-bl029=$e2_case (want >=2) present as a '|adoption_event)' case alternative=$e2_white writes a row via the real emitter=$e2_fixture"
 fi
 
 # Surface 3 — the emitter, marked, with exactly one site.

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -191,10 +191,25 @@ mk_adoptee() {
 # to be worth asserting, and a fixture that carries every surface can only
 # prove the positive half.
 #
-# The pre-commit hook invokes two tools from the description generator's closed
+# The pre-commit hook names two tools from the description generator's closed
 # vocabulary (`npx`, `lint-staged`) so the §7.2 description requirement has a
 # POSITIVE control, and — when a plant is passed — carries a BASE32-valid key
 # in an `export` line, which is the §7.3 hazard in its most ordinary form.
+#
+# THE HOOK MUST EXIT 0, AND FINDING OUT WHY COST A FAILING MUTATION. WP4
+# installs the framework's hooks AFTER the adoption commit on purpose: the
+# adoptee's OWN hooks judge that commit. A fixture hook that really ran
+# `npx lint-staged` therefore exited 127 on a host without npx, the adoption
+# commit was REJECTED, and two probes went quiet about it — S1's `git ls-files`
+# reads the INDEX, which is populated whether or not the commit lands, and S2's
+# "the plant is in no committed file" was trivially true because there was no
+# adoption commit at all. S4's mutation is what surfaced it: the mutant staged
+# the secret-bearing entry exactly as predicted and the plant still could not
+# be found in HEAD. The hook now names its tools in a comment and exits 0 —
+# §7.2's description is a SHALLOW STATIC READ of the whole file, so the
+# positive control is unaffected — every tracked-ness probe reads
+# `git ls-tree HEAD`, and every case that depends on a commit asserts the
+# commit landed.
 _add_surfaces() {
   local d="$1" plant="${2:-}"
   mkdir -p "$d/.claude/skills/invoice-helper" "$d/.git/hooks" || return 1
@@ -203,7 +218,8 @@ _add_surfaces() {
   {
     printf '#!/usr/bin/env bash\n'
     [ -n "$plant" ] && printf 'export AWS_ACCESS_KEY_ID=%s\n' "$plant"
-    printf 'npx lint-staged\n'
+    printf '# on a developer machine this hook runs: npx lint-staged\n'
+    printf 'exit 0\n'
   } > "$d/.git/hooks/pre-commit"
   chmod 755 "$d/.git/hooks/pre-commit"
   printf '#!/usr/bin/env bash\n# their own commit-msg hook\nexit 0\n' > "$d/.git/hooks/commit-msg"
@@ -289,6 +305,31 @@ run_readd() {
 arch_dir_of() {
   ( cd "$1" 2>/dev/null || return 1
     find .claude/adoption-archive -mindepth 1 -maxdepth 1 -type d 2>/dev/null | LC_ALL=C sort | head -1 )
+}
+
+# _in_head DIR PATH — 1 when PATH is in the COMMIT, 0 otherwise.
+#
+# `git ls-tree HEAD` and NOT `git ls-files`, and the difference is the whole
+# reason this helper exists rather than being written inline. `git ls-files`
+# reads the INDEX: a path that was `git add`ed reports as tracked even if the
+# commit that was supposed to carry it was refused by a hook. Every assertion
+# in this suite about what adoption COMMITTED must read the commit.
+_in_head() {
+  local n
+  n=$( cd "$1" 2>/dev/null && git ls-tree -r --name-only HEAD 2>/dev/null | grep -cxF -- "$2" )
+  _num "$n"
+}
+
+# _adoption_commit_landed DIR — 1 when HEAD is the adoption commit.
+# The control every committed-tree assertion needs: "the plant is in no
+# committed file" is satisfied just as well by there being no commit.
+_adoption_commit_landed() {
+  local s
+  s=$( cd "$1" 2>/dev/null && git log -1 --format=%s 2>/dev/null )
+  case "$s" in
+    "chore: adopt "*) printf '1\n' ;;
+    *)               printf '0\n' ;;
+  esac
 }
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -521,15 +562,18 @@ if [ "$HAVE_GITLEAKS" -eq 1 ]; then
   # ── S1 — the matching entry REFUSES TO STAGE ─────────────────────────────
   s1_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$S_MJ" 2>/dev/null)
   s1_reason=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .withheldReason // ""' "$S_MJ" 2>/dev/null)
-  s1_tracked=$( cd "$S_D/p" && git ls-files -- "$S_ARCH/git-hooks/pre-commit" 2>/dev/null | grep -c . ); s1_tracked=$(_num "$s1_tracked")
+  s1_tracked=$(_in_head "$S_D/p" "$S_ARCH/git-hooks/pre-commit")
   # The clean sibling in the SAME archive must still be committed, or "nothing
-  # was staged" would satisfy this assertion just as well as a targeted refusal.
-  s1_sib=$( cd "$S_D/p" && git ls-files -- "$S_ARCH/.claude/settings.json" 2>/dev/null | grep -c . ); s1_sib=$(_num "$s1_sib")
+  # was staged" would satisfy this assertion just as well as a targeted
+  # refusal — and the adoption commit itself must have LANDED, or "not in the
+  # commit" would be a statement about a commit that does not exist.
+  s1_sib=$(_in_head "$S_D/p" "$S_ARCH/.claude/settings.json")
+  s1_landed=$(_adoption_commit_landed "$S_D/p")
   if [ "$s1_staged" = "false" ] && [ "$s1_reason" = "secret-match" ] \
-     && [ "$s1_tracked" -eq 0 ] && [ "$s1_sib" -eq 1 ]; then
-    pass "S1: the matching entry REFUSES TO STAGE (stagedForCommit=false, withheldReason=secret-match, untracked) while its clean sibling in the same archive IS committed"
+     && [ "$s1_landed" -eq 1 ] && [ "$s1_tracked" -eq 0 ] && [ "$s1_sib" -eq 1 ]; then
+    pass "S1: the matching entry REFUSES TO STAGE (stagedForCommit=false, withheldReason=secret-match, absent from HEAD) while its clean sibling in the same archive IS in the adoption commit"
   else
-    fail_ "S1" "stagedForCommit='$s1_staged' (want false) withheldReason='$s1_reason' (want secret-match) tracked=$s1_tracked (want 0) clean-sibling-tracked=$s1_sib (want 1)"
+    fail_ "S1" "stagedForCommit='$s1_staged' (want false) withheldReason='$s1_reason' (want secret-match) adoption commit landed=$s1_landed (want 1) in HEAD=$s1_tracked (want 0) clean-sibling in HEAD=$s1_sib (want 1)"
   fi
 
   # ── S2 — the plant reaches NO artifact byte ──────────────────────────────
@@ -551,11 +595,12 @@ if [ "$HAVE_GITLEAKS" -eq 1 ]; then
   s2_err=$(_count_in "$RUN_ERR" "$HOOK_PLANT")
   s2_ledger=$(_count_in "$S_D/p/.claude/bypass-audit.json" "$HOOK_PLANT")
   if [ "$s0_copy" -eq 1 ] && [ "$s0_count" -ge 1 ] && [ -s "$S_MJ" ] && [ -s "$S_MD" ] \
+     && [ "$(_adoption_commit_landed "$S_D/p")" -eq 1 ] \
      && [ "$s2_ctrl" -ge 1 ] && [ "$s2_tree" -eq 0 ] && [ "$s2_mj" -eq 0 ] && [ "$s2_md" -eq 0 ] \
      && [ "$s2_out" -eq 0 ] && [ "$s2_err" -eq 0 ] && [ "$s2_ledger" -eq 0 ]; then
     pass "S2: the plant occurs in ZERO bytes of the committed tree, MANIFEST.json, MANIFEST.md, the transcript and the audit ledger — while provably present once in the archive copy, and with the tree probe proven able to see a committed token ($s2_ctrl file)"
   else
-    fail_ "S2" "precondition: plant-in-archive-copy=$s0_copy (want 1) findingCount=$s0_count (want >=1) MANIFEST.json non-empty=$([ -s "$S_MJ" ] && echo 1 || echo 0) MANIFEST.md non-empty=$([ -s "$S_MD" ] && echo 1 || echo 0); probe control=$s2_ctrl (want >=1); committed tree=$s2_tree MANIFEST.json=$s2_mj MANIFEST.md=$s2_md stdout=$s2_out stderr=$s2_err ledger=$s2_ledger (all want 0)"
+    fail_ "S2" "precondition: plant-in-archive-copy=$s0_copy (want 1) findingCount=$s0_count (want >=1) MANIFEST.json non-empty=$([ -s "$S_MJ" ] && echo 1 || echo 0) MANIFEST.md non-empty=$([ -s "$S_MD" ] && echo 1 || echo 0) adoption commit landed=$(_adoption_commit_landed "$S_D/p") (want 1); probe control=$s2_ctrl (want >=1); committed tree=$s2_tree MANIFEST.json=$s2_mj MANIFEST.md=$s2_md stdout=$s2_out stderr=$s2_err ledger=$s2_ledger (all want 0)"
   fi
 
   # ── S3 — POSITIVE CONTROL: a CLEAN archive IS staged ─────────────────────
@@ -564,11 +609,13 @@ if [ "$HAVE_GITLEAKS" -eq 1 ]; then
   s3_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$A_MJ" 2>/dev/null)
   s3_status=$(jq -r '.secretsScan.status // "MISSING"' "$A_MJ" 2>/dev/null)
   s3_count=$(jq -r '.secretsScan.findingCount // "null"' "$A_MJ" 2>/dev/null)
-  s3_tracked=$( cd "$A_D/p" && git ls-files -- "$A_ARCH/git-hooks/pre-commit" 2>/dev/null | grep -c . ); s3_tracked=$(_num "$s3_tracked")
-  if [ "$s3_staged" = "true" ] && [ "$s3_status" = "scanned" ] && [ "$s3_count" = "0" ] && [ "$s3_tracked" -eq 1 ]; then
-    pass "S3 POSITIVE CONTROL: with no plant the same entry IS staged and committed (status=scanned, findingCount=0) — the refusal is targeted, not a blanket"
+  s3_tracked=$(_in_head "$A_D/p" "$A_ARCH/git-hooks/pre-commit")
+  s3_landed=$(_adoption_commit_landed "$A_D/p")
+  if [ "$s3_staged" = "true" ] && [ "$s3_status" = "scanned" ] && [ "$s3_count" = "0" ] \
+     && [ "$s3_landed" -eq 1 ] && [ "$s3_tracked" -eq 1 ]; then
+    pass "S3 POSITIVE CONTROL: with no plant the same entry IS staged and lands in the adoption commit (status=scanned, findingCount=0) — the refusal is targeted, not a blanket"
   else
-    fail_ "S3" "stagedForCommit='$s3_staged' (want true) status='$s3_status' findingCount='$s3_count' (want 0) tracked=$s3_tracked (want 1)"
+    fail_ "S3" "stagedForCommit='$s3_staged' (want true) status='$s3_status' findingCount='$s3_count' (want 0) adoption commit landed=$s3_landed (want 1) in HEAD=$s3_tracked (want 1)"
   fi
 
   # ── S4 — MUTATION: remove the pre-staging scan ───────────────────────────
@@ -585,13 +632,14 @@ if [ "$HAVE_GITLEAKS" -eq 1 ]; then
     _ans > "$S4/answers"
     run_adopt "$S4/p" "$S4/answers" "$S4/fw"
     s4_arch="$(arch_dir_of "$S4/p")"
-    s4_tracked=$( cd "$S4/p" && git ls-files -- "$s4_arch/git-hooks/pre-commit" 2>/dev/null | grep -c . ); s4_tracked=$(_num "$s4_tracked")
+    s4_tracked=$(_in_head "$S4/p" "$s4_arch/git-hooks/pre-commit")
+    s4_landed=$(_adoption_commit_landed "$S4/p")
     s4_tree=$( cd "$S4/p" && git grep -F -l -- "$HOOK_PLANT" HEAD 2>/dev/null | grep -c . ); s4_tree=$(_num "$s4_tree")
     if [ "$s4_sites" -eq 1 ] && [ "$s4_chg" -eq 2 ] && [ "$s4_parses" -eq 1 ] \
-       && [ "$s4_tracked" -eq 1 ] && [ "$s4_tree" -ge 1 ]; then
+       && [ "$s4_landed" -eq 1 ] && [ "$s4_tracked" -eq 1 ] && [ "$s4_tree" -ge 1 ]; then
       pass "S4 (MUTATION): with the pre-staging scan neutered (1 site, 2 lines, mutant parses) the secret-bearing entry IS committed and the plant appears in $s4_tree committed file(s) — RED"
     else
-      fail_ "S4" "sites=$s4_sites (want 1) changed_lines=$s4_chg (want 2) parses=$s4_parses (want 1) entry_tracked=$s4_tracked (want 1) plant_in_tree=$s4_tree (want >=1)"
+      fail_ "S4" "sites=$s4_sites (want 1) changed_lines=$s4_chg (want 2) parses=$s4_parses (want 1) adoption commit landed=$s4_landed (want 1) entry in HEAD=$s4_tracked (want 1) plant_in_tree=$s4_tree (want >=1)"
     fi
   fi
 else
@@ -851,10 +899,43 @@ echo "=== C — the collision archive is recorded, and the module stays severabl
 c1_rows=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_archive")] | length' "$A_D/p/.claude/bypass-audit.json" 2>/dev/null); c1_rows=$(_num "$c1_rows")
 c1_dir=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_archive")] | .[0].details.archiveDir // ""' "$A_D/p/.claude/bypass-audit.json" 2>/dev/null)
 c1_count=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_archive")] | .[0].details.entryCount // -1' "$A_D/p/.claude/bypass-audit.json" 2>/dev/null); c1_count=$(_num "$c1_count")
-if [ "$c1_rows" -eq 1 ] && [ "$c1_dir" = "$A_ARCH" ] && [ "$c1_count" -ge 4 ]; then
-  pass "C1: the collision archive writes exactly one adoption_event/collision_archive row naming the directory and its $c1_count entries"
+# AND THE LEDGER IS IN THE COMMIT. A row that exists only in an untracked file
+# is a record no clone carries — docs/audit-log-lifecycle.md calls this the
+# TRACKED ledger, and an adopted project must get the same thing a scaffolded
+# one does.
+c1_ledger=$(_in_head "$A_D/p" ".claude/bypass-audit.json")
+if [ "$c1_rows" -eq 1 ] && [ "$c1_dir" = "$A_ARCH" ] && [ "$c1_count" -ge 4 ] && [ "$c1_ledger" -eq 1 ]; then
+  pass "C1: the collision archive writes exactly one adoption_event/collision_archive row naming the directory and its $c1_count entries — and the ledger carrying it is IN the adoption commit"
 else
-  fail_ "C1" "rows=$c1_rows (want 1) archiveDir='$c1_dir' (want $A_ARCH) entryCount=$c1_count (want >=4)"
+  fail_ "C1" "rows=$c1_rows (want 1) archiveDir='$c1_dir' (want $A_ARCH) entryCount=$c1_count (want >=4) ledger in HEAD=$c1_ledger (want 1)"
+fi
+
+# C1b — the same, with the operator's .gitignore excluding the ledger: the run
+# must NOT abort. `git add` on an ignored path fails, and the driver stages
+# every recorded path in one command, so an unguarded record here would take
+# the whole adoption down. Positive control built in: the adoption commit must
+# still land and the archive's own MANIFEST must still be in it.
+C1B="$(newtmp)"
+if ! mk_adoptee "$C1B/p" || ! _add_surfaces "$C1B/p"; then
+  fail_ "C1b" "fixture setup failed"
+else
+  printf '.claude/bypass-audit.json\n' > "$C1B/p/.gitignore"
+  ( cd "$C1B/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  _ans > "$C1B/answers"
+  run_adopt "$C1B/p" "$C1B/answers"
+  c1b_rc=$RUN_RC
+  c1b_landed=$(_adoption_commit_landed "$C1B/p")
+  c1b_arch="$(arch_dir_of "$C1B/p")"
+  c1b_ledger=$(_in_head "$C1B/p" ".claude/bypass-audit.json")
+  c1b_manifest=0
+  [ -n "$c1b_arch" ] && c1b_manifest=$(_in_head "$C1B/p" "$c1b_arch/MANIFEST.json")
+  c1b_ondisk=0; [ -f "$C1B/p/.claude/bypass-audit.json" ] && c1b_ondisk=1
+  if [ "$c1b_rc" -eq 0 ] && [ "$c1b_landed" -eq 1 ] && [ "$c1b_ledger" -eq 0 ] \
+     && [ "$c1b_manifest" -eq 1 ] && [ "$c1b_ondisk" -eq 1 ]; then
+    pass "C1b: when the operator's .gitignore excludes the ledger the adoption still COMPLETES (rc 0) — the ledger is on disk and out of the commit, and the archive MANIFEST still lands"
+  else
+    fail_ "C1b" "rc=$c1b_rc (want 0) adoption commit landed=$c1b_landed (want 1) ledger in HEAD=$c1b_ledger (want 0) ledger on disk=$c1b_ondisk (want 1) MANIFEST in HEAD=$c1b_manifest (want 1)"
+  fi
 fi
 
 # C2 — M3: no CORE file may name this module. Run the real lint.

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -148,6 +148,32 @@ export GIT_CONFIG_NOSYSTEM=1
 export XDG_CONFIG_HOME="$TOPTMP/xdg"
 mkdir -p "$XDG_CONFIG_HOME"
 
+# THE FILE SCOPES ARE NOT ALL THE SCOPES (R-WP6-13). Three more channels reach
+# git without touching any file the four exports above neutralise, and the
+# first of them OUTRANKS every one of them:
+#
+#   GIT_CONFIG_COUNT / GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n
+#       COMMAND scope, which is the highest precedence git has. Measured: with
+#       every file scope pointed at /dev/null, one of these pairs setting
+#       `core.excludesFile` still decides a fixture path. Unsetting COUNT is
+#       sufficient and is the whole gate — git reads it first and ignores the
+#       KEY_n/VALUE_n pairs entirely without it.
+#   GIT_TEMPLATE_DIR
+#       Seeds `info/exclude` into EVERY repository `git init` creates, so it
+#       reaches fixtures that are created after this line runs. Measured: a
+#       template `info/exclude` decides a fresh fixture's paths.
+#   GIT_DIR / GIT_WORK_TREE / GIT_INDEX_FILE / GIT_OBJECT_DIRECTORY / …
+#       Live whenever anything runs a suite from inside a git hook, which
+#       points fixture operations at the WRONG REPOSITORY.
+#
+# None is set on this host, so this is a completeness fix against the principle
+# the block above states — the fixture must own every input git reads — rather
+# than a live hazard. H0b measures the first two in both directions anyway,
+# because "not set today" is a property of today.
+unset GIT_CONFIG_COUNT GIT_TEMPLATE_DIR
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_COMMON_DIR
+
 # ── Portable primitives (house pattern, WP2/WP4 parity) ─────────────────────
 _mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
 _num()     { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
@@ -392,6 +418,34 @@ if [ "$h0_ok" -eq 1 ] && [ "$h0_with" -eq 1 ] && [ "$h0_without" -eq 0 ]; then
   pass "H0: a global excludes file DOES decide an archive path (ignored=$h0_with with one in scope) and the suite's isolated XDG_CONFIG_HOME removes it (ignored=$h0_without) — the fixtures below are the suite's, not the host's"
 else
   fail_ "H0" "setup=$h0_ok ignored-with-host-excludes=$h0_with (want 1 — the knob must be live, or this proves nothing) ignored-under-isolation=$h0_without (want 0)"
+fi
+
+# H0b — the other two channels, same two-direction shape as H0.
+H0B="$(newtmp)"
+h0b_ok=0
+if mk_adoptee "$H0B/p"; then
+  printf 'settings.local.json\n' > "$H0B/inject"
+  h0b_probe=".claude/adoption-archive/T-1/.claude/settings.local.json"
+  h0b_cfg_with=1
+  ( cd "$H0B/p" && GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=core.excludesFile GIT_CONFIG_VALUE_0="$H0B/inject" \
+      git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_cfg_with=0
+  h0b_cfg_without=1
+  ( cd "$H0B/p" && git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_cfg_without=0
+  # GIT_TEMPLATE_DIR reaches repositories created AFTER it is set, so the probe
+  # creates one each way rather than reusing the fixture above.
+  mkdir -p "$H0B/tpl/info"; printf 'settings.local.json\n' > "$H0B/tpl/info/exclude"
+  mkdir -p "$H0B/t1" "$H0B/t2"
+  h0b_tpl_with=1
+  ( cd "$H0B/t1" && GIT_TEMPLATE_DIR="$H0B/tpl" git init -q . && git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_tpl_with=0
+  h0b_tpl_without=1
+  ( cd "$H0B/t2" && git init -q . && git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_tpl_without=0
+  h0b_ok=1
+fi
+if [ "$h0b_ok" -eq 1 ] && [ "$h0b_cfg_with" -eq 1 ] && [ "$h0b_cfg_without" -eq 0 ] \
+   && [ "$h0b_tpl_with" -eq 1 ] && [ "$h0b_tpl_without" -eq 0 ]; then
+  pass "H0b (R-WP6-13): GIT_CONFIG_COUNT (command scope, outranking every file scope) and GIT_TEMPLATE_DIR both DO decide a fixture path when set, and neither does under the suite's unset preamble"
+else
+  fail_ "H0b" "setup=$h0b_ok GIT_CONFIG_COUNT decides when set=$h0b_cfg_with (want 1 — else the channel is not real) and when unset=$h0b_cfg_without (want 0); GIT_TEMPLATE_DIR when set=$h0b_tpl_with (want 1) and when unset=$h0b_tpl_without (want 0)"
 fi
 
 echo ""
@@ -909,6 +963,39 @@ else
   fi
 fi
 
+# ── R5 (R-WP6-12) — a re-add that fails BEFORE the copy leaves no row ───────
+#
+# The record-before-restore fix (R-WP6-4) buys "no re-add without a row" and
+# costs a documented over-record: a failure between the row and the copy leaves
+# a row describing something that did not happen. That window had TWO
+# statements in it, not one — the `mkdir -p` as well as the `cp` — and only the
+# `cp` was disclosed. The mkdir governs nothing the archive owns, so it belongs
+# ABOVE the record, which shrinks the window to the `cp` alone and makes the
+# documented residual the true one.
+#
+# Forced by making the parent path un-creatable: a regular FILE where the
+# restore needs a directory.
+R5="$(newtmp)"
+if ! mk_adoptee "$R5/p" || ! _add_surfaces "$R5/p"; then
+  fail_ "R5" "fixture setup failed"
+else
+  _ans > "$R5/answers"
+  run_adopt "$R5/p" "$R5/answers"
+  r5_rows_before=$(jq -r '[.[] | select(.details.event == "collision_re_add")] | length' "$R5/p/.claude/bypass-audit.json" 2>/dev/null); r5_rows_before=$(_num "$r5_rows_before")
+  rm -rf "$R5/p/.claude/skills"
+  printf 'a file where a directory needs to be\n' > "$R5/p/.claude/skills"
+  printf '1\n' > "$R5/confirm"
+  run_readd "$R5/p" ".claude/skills/invoice-helper/SKILL.md" "$R5/confirm"
+  r5_rc=$READD_RC
+  r5_rows_after=$(jq -r '[.[] | select(.details.event == "collision_re_add")] | length' "$R5/p/.claude/bypass-audit.json" 2>/dev/null); r5_rows_after=$(_num "$r5_rows_after")
+  r5_isfile=0; [ -f "$R5/p/.claude/skills" ] && r5_isfile=1
+  if [ "$r5_rc" -ne 0 ] && [ "$r5_isfile" -eq 1 ] && [ "$r5_rows_after" -eq "$r5_rows_before" ]; then
+    pass "R5 (R-WP6-12): a re-add that cannot create its parent directory refuses (rc $r5_rc) and writes NO row — the mkdir sits above the record, so the documented over-record window is the cp alone"
+  else
+    fail_ "R5" "rc=$r5_rc (want non-zero) blocking file still present=$r5_isfile (want 1) re-add rows before=$r5_rows_before after=$r5_rows_after (want equal — a row here would mean the record ran before a step that failed)"
+  fi
+fi
+
 echo ""
 echo "=== G — the operator's .gitignore is an instruction, not a hint ==="
 
@@ -932,7 +1019,20 @@ PRIVATE_PAYLOAD="internal-proxy.corp.example-jdoe"
 G1="$(newtmp)"
 G1_OK=0
 if mk_adoptee "$G1/p" && _add_surfaces "$G1/p" && _add_local_settings "$G1/p" "$PRIVATE_PAYLOAD"; then
-  printf '.claude/settings.local.json\n' > "$G1/p/.gitignore"
+  # TWO RULES, AND THE SECOND ONE IS THE ONE THAT BITES (R-WP6-10).
+  #
+  # `.git/` is a cargo-cult line real repositories commonly carry. It reaches
+  # NO framework-written path, so it looks inert — and it is not. Measured
+  # hermetically: `git check-ignore` applies patterns to any pathname it is
+  # handed, `.git/` paths INCLUDED. `*`, `hooks/` and `.git/` all report
+  # `.git/hooks/pre-commit` as IGNORED (rc 0). The earlier claim that
+  # "`.git/hooks/*` is not reported as ignored because git excludes `.git/` by
+  # construction" was a property of THE ANCHORED PATTERN in this fixture, not
+  # of git — and G1b, testing only that anchored rule, structurally could not
+  # see it. With this line present and no exemption, adoption completes at
+  # rc 0 while silently withholding the hooks: §7.3's carrier and the archive's
+  # whole point, withheld under an instruction git itself would never honour.
+  printf '.claude/settings.local.json\n.git/\n' > "$G1/p/.gitignore"
   ( cd "$G1/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
   _ans > "$G1/answers"
   run_adopt "$G1/p" "$G1/answers"
@@ -966,16 +1066,84 @@ else
     fail_ "G1" "rc=$RUN_RC landed=$g1_landed stagedForCommit='$g1_staged' (want false) withheldReason='$g1_reason' (want original-gitignored) in HEAD=$g1_inhead (want 0) payload in archive copy=$g1_ondisk (want >=1) tree probe control=$g1_ctrl (want >=1) payload in committed tree=$g1_tree (want 0) findingCount='$g1_findings' (want 0 — a non-zero count would mean the SCANNER caught it and this proves nothing about the ignore rule) clean sibling in HEAD=$g1_sib (want 1)"
   fi
 
-  # G1b — the bound. `.git/hooks/*` is NOT an operator ignore statement: git
-  # simply never tracks `.git/`. Verified hermetically that `git check-ignore`
-  # reports rc 1 for it, so the new arm must not swallow the hooks — which are
-  # the whole point of the archive and §7.3's carrier.
+  # G1b — THE BOUND, now tested against a pattern that actually reaches.
+  #
+  # THE PROBE CONTROL IS THE POINT OF THIS VERSION. The fixture's `.git/` rule
+  # must genuinely make `git check-ignore` report the hook as IGNORED —
+  # asserted below — or this case is back to testing the anchored rule, which
+  # cannot reach `.git/` paths and therefore proved nothing about the bound.
+  # That is precisely how the false claim survived a full review round.
+  g1b_reaches=1
+  ( cd "$G1/p" && git check-ignore -q -- ".git/hooks/pre-commit" ) 2>/dev/null || g1b_reaches=0
   g1b_hook_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$g1_mj" 2>/dev/null)
+  g1b_hook_reason=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .withheldReason // ""' "$g1_mj" 2>/dev/null)
   g1b_hook_head=$(_in_head "$G1/p" "$g1_arch/git-hooks/pre-commit")
-  if [ "$g1b_hook_staged" = "true" ] && [ "$g1b_hook_head" -eq 1 ]; then
-    pass "G1b (the bound): in the same run the git hooks are still archived AND committed — the original-ignore arm does not swallow .git/hooks, which git excludes by construction rather than by the operator's instruction"
+  if [ "$g1b_reaches" -eq 1 ] && [ "$g1b_hook_staged" = "true" ] \
+     && [ -z "$g1b_hook_reason" ] && [ "$g1b_hook_head" -eq 1 ]; then
+    pass "G1b (the bound, R-WP6-10): the fixture's '.git/' rule DOES make check-ignore report the hook ignored (probe=$g1b_reaches), and the hooks are still archived AND committed anyway — a gitignore statement about a .git/ path is not an instruction git can honour, so the arm must not act on it"
   else
-    fail_ "G1b" "hook stagedForCommit='$g1b_hook_staged' (want true) hook in HEAD=$g1b_hook_head (want 1) — the new arm is over-withholding"
+    fail_ "G1b" "fixture rule reaches .git/hooks/pre-commit=$g1b_reaches (want 1 — else this case tests nothing) hook stagedForCommit='$g1b_hook_staged' (want true) withheldReason='$g1b_hook_reason' (want empty) hook in HEAD=$g1b_hook_head (want 1)"
+  fi
+fi
+
+# ── G1c — MUTATION: neuter the .git/* exemption ─────────────────────────────
+G1C="$(newtmp)"
+if ! mk_adoptee "$G1C/p" || ! _add_surfaces "$G1C/p" || ! mk_mirror "$G1C/fw"; then
+  fail_ "G1c (MUTATION)" "fixture setup failed"
+else
+  printf '.git/\n' > "$G1C/p/.gitignore"
+  ( cd "$G1C/p" && git add .gitignore && git commit -q -m "chore: their ignore rules" ) >/dev/null 2>&1
+  MUTGC="$G1C/fw/scripts/lib/adopt/adopt-archive.sh"
+  g1c_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-GITDIR-EXEMPT')
+  cp "$L_ARCHIVE" "$G1C/orig.ref"
+  _sed_inplace "$MUTGC" 's|^.*BF-ADOPT-GITDIR-EXEMPT$|  case "$rel" in .git/*) : ;; esac   # BF-ADOPT-GITDIR-EXEMPT|'
+  g1c_chg=$(_changed_lines "$G1C/orig.ref" "$MUTGC")
+  g1c_parses=$(_parses "$MUTGC")
+  _ans > "$G1C/answers"
+  run_adopt "$G1C/p" "$G1C/answers" "$G1C/fw"
+  g1c_arch="$(arch_dir_of "$G1C/p")"
+  g1c_mj="$G1C/p/$g1c_arch/MANIFEST.json"
+  g1c_reason=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .withheldReason // ""' "$g1c_mj" 2>/dev/null)
+  g1c_head=$(_in_head "$G1C/p" "$g1c_arch/git-hooks/pre-commit")
+  g1c_landed=$(_adoption_commit_landed "$G1C/p")
+  if [ "$g1c_sites" -eq 1 ] && [ "$g1c_chg" -eq 2 ] && [ "$g1c_parses" -eq 1 ] \
+     && [ "$g1c_reason" = "original-gitignored" ] && [ "$g1c_head" -eq 0 ] && [ "$g1c_landed" -eq 1 ]; then
+    pass "G1c (MUTATION): with the .git/* exemption neutered (1 site, 2 lines, mutant parses) an inert '.git/' line silently withholds the hooks (reason=original-gitignored, absent from HEAD) while adoption still reports success — RED"
+  else
+    fail_ "G1c" "sites=$g1c_sites (want 1) changed_lines=$g1c_chg (want 2) parses=$g1c_parses (want 1) hook withheldReason='$g1c_reason' (want original-gitignored) hook in HEAD=$g1c_head (want 0) adoption landed=$g1c_landed (want 1)"
+  fi
+fi
+
+# ── G6 (R-WP6-11) — a corrupt ledger must not be committed in silence ───────
+#
+# The re-add treats "recorded" as a precondition; the archive's own row did not
+# check the rc at all. Measured before the fix: adoption completed rc 0, the
+# row was dropped without a word, and the STILL-CORRUPT ledger was committed
+# into HEAD as the project's first governance record.
+#
+# The asymmetry with the re-add is deliberate and is not silence: the archive
+# has a primary committed record (the MANIFEST), so a failed row degrades it
+# rather than invalidating it. What it must not do is degrade quietly.
+G6="$(newtmp)"
+if ! mk_adoptee "$G6/p" || ! _add_surfaces "$G6/p"; then
+  fail_ "G6" "fixture setup failed"
+else
+  mkdir -p "$G6/p/.claude"
+  printf 'this is not json at all\n' > "$G6/p/.claude/bypass-audit.json"
+  _ans > "$G6/answers"
+  run_adopt "$G6/p" "$G6/answers"
+  g6_rc=$RUN_RC
+  g6_landed=$(_adoption_commit_landed "$G6/p")
+  g6_arch="$(arch_dir_of "$G6/p")"
+  g6_manifest=0
+  [ -n "$g6_arch" ] && g6_manifest=$(_in_head "$G6/p" "$g6_arch/MANIFEST.json")
+  g6_ledger=$(_in_head "$G6/p" ".claude/bypass-audit.json")
+  g6_loud=$(_count_in "$RUN_OUT" "could not be recorded")
+  if [ "$g6_rc" -eq 0 ] && [ "$g6_landed" -eq 1 ] && [ "$g6_manifest" -eq 1 ] \
+     && [ "$g6_ledger" -eq 0 ] && [ "$g6_loud" -ge 1 ]; then
+    pass "G6 (R-WP6-11): with the ledger already corrupt the adoption still completes (rc 0) and the MANIFEST still commits, but the failed audit row is announced LOUDLY and the corrupt ledger is kept OUT of the commit"
+  else
+    fail_ "G6" "rc=$g6_rc (want 0) landed=$g6_landed (want 1) MANIFEST in HEAD=$g6_manifest (want 1) corrupt ledger in HEAD=$g6_ledger (want 0) failure announced=$g6_loud (want >=1)"
   fi
 fi
 

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -170,7 +170,14 @@ mkdir -p "$XDG_CONFIG_HOME"
 # the block above states — the fixture must own every input git reads — rather
 # than a live hazard. H0b measures the first two in both directions anyway,
 # because "not set today" is a property of today.
-unset GIT_CONFIG_COUNT GIT_TEMPLATE_DIR
+#   GIT_CONFIG_PARAMETERS (R-WP6-15)
+#       The fourth channel, and it arrives in EXACTLY the scenario the GIT_DIR
+#       line above names: `git -c foo.bar=baz` exports it to every child, so a
+#       suite run from inside a hook inherits it. Measured: with every file
+#       scope neutralised and GIT_CONFIG_COUNT unset,
+#       GIT_CONFIG_PARAMETERS="'core.excludesFile'='…'" still decides a fixture
+#       path. H0b's third direction pins it.
+unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_TEMPLATE_DIR
 unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
 unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_COMMON_DIR
 
@@ -439,13 +446,23 @@ if mk_adoptee "$H0B/p"; then
   ( cd "$H0B/t1" && GIT_TEMPLATE_DIR="$H0B/tpl" git init -q . && git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_tpl_with=0
   h0b_tpl_without=1
   ( cd "$H0B/t2" && git init -q . && git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_tpl_without=0
+  # Third direction (R-WP6-15): GIT_CONFIG_PARAMETERS, which is what
+  # `git -c foo.bar=baz` exports to every child process — so it is live in
+  # exactly the run-from-inside-a-hook scenario the preamble's GIT_DIR line
+  # already names.
+  h0b_par_with=1
+  ( cd "$H0B/p" && GIT_CONFIG_PARAMETERS="'core.excludesFile'='$H0B/inject'" \
+      git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_par_with=0
+  h0b_par_without=1
+  ( cd "$H0B/p" && git check-ignore -q -- "$h0b_probe" ) 2>/dev/null || h0b_par_without=0
   h0b_ok=1
 fi
 if [ "$h0b_ok" -eq 1 ] && [ "$h0b_cfg_with" -eq 1 ] && [ "$h0b_cfg_without" -eq 0 ] \
-   && [ "$h0b_tpl_with" -eq 1 ] && [ "$h0b_tpl_without" -eq 0 ]; then
-  pass "H0b (R-WP6-13): GIT_CONFIG_COUNT (command scope, outranking every file scope) and GIT_TEMPLATE_DIR both DO decide a fixture path when set, and neither does under the suite's unset preamble"
+   && [ "$h0b_tpl_with" -eq 1 ] && [ "$h0b_tpl_without" -eq 0 ] \
+   && [ "$h0b_par_with" -eq 1 ] && [ "$h0b_par_without" -eq 0 ]; then
+  pass "H0b (R-WP6-13/15): all three remaining channels — GIT_CONFIG_COUNT (command scope), GIT_TEMPLATE_DIR (seeds info/exclude) and GIT_CONFIG_PARAMETERS (what 'git -c' exports) — DO decide a fixture path when set, and none does under the suite's unset preamble"
 else
-  fail_ "H0b" "setup=$h0b_ok GIT_CONFIG_COUNT decides when set=$h0b_cfg_with (want 1 — else the channel is not real) and when unset=$h0b_cfg_without (want 0); GIT_TEMPLATE_DIR when set=$h0b_tpl_with (want 1) and when unset=$h0b_tpl_without (want 0)"
+  fail_ "H0b" "setup=$h0b_ok GIT_CONFIG_COUNT decides when set=$h0b_cfg_with (want 1 — else the channel is not real) and when unset=$h0b_cfg_without (want 0); GIT_TEMPLATE_DIR when set=$h0b_tpl_with (want 1) and when unset=$h0b_tpl_without (want 0); GIT_CONFIG_PARAMETERS when set=$h0b_par_with (want 1) and when unset=$h0b_par_without (want 0)"
 fi
 
 echo ""
@@ -963,6 +980,68 @@ else
   fi
 fi
 
+# ── G6b / G6c (R-WP6-14) — AN EXIT CODE IS NOT A RECEIPT ────────────────────
+#
+# G6 pinned "a corrupt ledger must not be committed in silence" using ONE
+# corruption spelling — a file of garbage — which `jq` refuses with rc 5. The
+# fix rested on the inference that a zero rc from `bypass_audit_append` proves
+# the ledger parsed, "since the appender's own jq had to read it". THAT IS
+# FALSE, and it is false for the most ordinary corruption there is. Measured:
+#
+#   ledger      append rc   docs out   rows written   proposed guard rc
+#   ----------------------------------------------------------------------
+#   empty         0            0          none              1     <- SILENT LOSS
+#   null          0            1          1                 1     <- silent repair
+#   multidoc      0            2          2                 1     <- silent DUPLICATE
+#   non-array     5            0          none              1
+#   garbage       5            0          none              5
+#   valid []      0            1          1                 0
+#
+# `jq FILTER file` over a ZERO-BYTE file runs the filter across zero input
+# documents, emits nothing and exits 0. The append "succeeds", `mv`s an empty
+# temp over the empty file, and appends nothing. A zero-byte file is THE
+# canonical truncation artifact — bypass-audit.sh's own D3 comment worries
+# about a SIGKILL truncating this very file — so this is not an exotic input.
+#
+# THE FIX BELONGS TO THE APPENDER, NOT TO THIS PACKAGE'S CALLER. Six files call
+# `bypass_audit_append`, and the two loud-fail arms in hook-templates.sh
+# (`# BL-163`, `# BL-185`) already test its rc and announce a `[note]` when it
+# fails — so today they announce nothing on a truncated ledger and lose the row.
+# Guarding here would have fixed one caller and left five.
+#
+# G6c pins the LIBRARY CONTRACT over every spelling, with the valid case as the
+# positive control so the guard cannot be "always refuse". G6b pins the
+# end-to-end consequence for the zero-byte spelling specifically, which is the
+# one G6 could not see.
+G6C="$(newtmp)"
+g6c_fail=""
+g6c_rows_valid=0
+mkdir -p "$G6C/proj/.claude"
+for spelling in empty null multidoc nonarray garbage valid; do
+  case "$spelling" in
+    empty)    : > "$G6C/proj/.claude/bypass-audit.json" ;;
+    null)     printf 'null\n'        > "$G6C/proj/.claude/bypass-audit.json" ;;
+    multidoc) printf '[]\n[]\n'      > "$G6C/proj/.claude/bypass-audit.json" ;;
+    nonarray) printf '{"x":1}\n'     > "$G6C/proj/.claude/bypass-audit.json" ;;
+    garbage)  printf 'not json\n'    > "$G6C/proj/.claude/bypass-audit.json" ;;
+    valid)    printf '[]\n'          > "$G6C/proj/.claude/bypass-audit.json" ;;
+  esac
+  g6c_rc=0
+  ( . "$BYPASS_LIB" >/dev/null 2>&1
+    bypass_audit_append "$G6C/proj" '{"type":"adoption_event","actor":"framework"}' ) >/dev/null 2>&1 || g6c_rc=$?
+  if [ "$spelling" = "valid" ]; then
+    [ "$g6c_rc" -eq 0 ] || g6c_fail="$g6c_fail valid:rc=$g6c_rc(want 0)"
+    g6c_rows_valid=$(jq -r 'length' "$G6C/proj/.claude/bypass-audit.json" 2>/dev/null); g6c_rows_valid=$(_num "$g6c_rows_valid")
+  else
+    [ "$g6c_rc" -ne 0 ] || g6c_fail="$g6c_fail $spelling:rc=0(want non-zero)"
+  fi
+done
+if [ -z "$g6c_fail" ] && [ "$g6c_rows_valid" -eq 1 ]; then
+  pass "G6c (R-WP6-14, library contract): bypass_audit_append REFUSES every corrupt ledger spelling — empty, null, multi-document, non-array and garbage — and still appends exactly one row to a valid [] (rows=$g6c_rows_valid), so the guard is a predicate and not a blanket refusal"
+else
+  fail_ "G6c" "spellings that did not refuse:$g6c_fail; rows appended to a VALID ledger=$g6c_rows_valid (want 1)"
+fi
+
 # ── R5 (R-WP6-12) — a re-add that fails BEFORE the copy leaves no row ───────
 #
 # The record-before-restore fix (R-WP6-4) buys "no re-add without a row" and
@@ -1144,6 +1223,36 @@ else
     pass "G6 (R-WP6-11): with the ledger already corrupt the adoption still completes (rc 0) and the MANIFEST still commits, but the failed audit row is announced LOUDLY and the corrupt ledger is kept OUT of the commit"
   else
     fail_ "G6" "rc=$g6_rc (want 0) landed=$g6_landed (want 1) MANIFEST in HEAD=$g6_manifest (want 1) corrupt ledger in HEAD=$g6_ledger (want 0) failure announced=$g6_loud (want >=1)"
+  fi
+fi
+
+# ── G6b (R-WP6-14) — the same, for the spelling G6 structurally could not see ─
+# A ZERO-BYTE ledger, which `jq` accepts at rc 0 while reading nothing. Before
+# the appender guard this reached: adopt rc 0, zero "could not be recorded" in
+# the transcript, the row silently dropped, and the zero-byte file COMMITTED
+# into HEAD as the project's first governance record — G6's exact forbidden
+# outcome, through a door G6's garbage fixture never opened.
+G6B="$(newtmp)"
+if ! mk_adoptee "$G6B/p" || ! _add_surfaces "$G6B/p"; then
+  fail_ "G6b" "fixture setup failed"
+else
+  mkdir -p "$G6B/p/.claude"
+  : > "$G6B/p/.claude/bypass-audit.json"
+  g6b_size_before=$(wc -c < "$G6B/p/.claude/bypass-audit.json" | tr -d ' ')
+  _ans > "$G6B/answers"
+  run_adopt "$G6B/p" "$G6B/answers"
+  g6b_rc=$RUN_RC
+  g6b_landed=$(_adoption_commit_landed "$G6B/p")
+  g6b_arch="$(arch_dir_of "$G6B/p")"
+  g6b_manifest=0
+  [ -n "$g6b_arch" ] && g6b_manifest=$(_in_head "$G6B/p" "$g6b_arch/MANIFEST.json")
+  g6b_ledger=$(_in_head "$G6B/p" ".claude/bypass-audit.json")
+  g6b_loud=$(_count_in "$RUN_OUT" "could not be recorded")
+  if [ "$g6b_size_before" -eq 0 ] && [ "$g6b_rc" -eq 0 ] && [ "$g6b_landed" -eq 1 ] \
+     && [ "$g6b_manifest" -eq 1 ] && [ "$g6b_ledger" -eq 0 ] && [ "$g6b_loud" -ge 1 ]; then
+    pass "G6b (R-WP6-14, end to end): a ZERO-BYTE ledger — the canonical truncation artifact, which jq accepts at rc 0 while reading nothing — is announced LOUDLY and kept out of the commit, exactly as the garbage spelling is"
+  else
+    fail_ "G6b" "ledger size before=$g6b_size_before (want 0) rc=$g6b_rc (want 0) landed=$g6b_landed (want 1) MANIFEST in HEAD=$g6b_manifest (want 1) zero-byte ledger in HEAD=$g6b_ledger (want 0) failure announced=$g6b_loud (want >=1)"
   fi
 fi
 

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -1,0 +1,889 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp6-collision-archive.sh — behaviour suite for the
+# collision archive, its MANIFEST, the disclosure, the re-add warning and its
+# audit row, and §7.3's archive-secrets refusal (WP6-brownfield).
+#
+# SPEC: docs/designs/2026-08-02-brownfield-adoption-v1.md — §7.1 (the four
+# buckets), §7.2 (archive layout and MANIFEST, and the five properties
+# inherited from `_upgrade_snapshot_pre_mutation`), §7.3 (disclosure, the
+# re-add warning, and THE NEW EXPOSURE: archiving a `.git/hooks/` file promotes
+# an UNTRACKED file into version control), §8.9 (the `adoption_event` row and
+# the five surfaces a new row type touches), §10-WP6, §12-5.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT THIS SUITE IS PROTECTING, IN ONE SENTENCE
+#
+# The archive collects files the operator wrote — hooks, AI settings, MCP
+# connections — and stages them into a commit, so a credential that was
+# UNTRACKED or GITIGNORED before adoption can be committed BY adoption. §7.3
+# says the driver must scan the archive before staging and refuse a matching
+# entry, and this suite proves the refusal with a real planted key.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE PLANT, AND WHY IT IS SHAPED THE WAY IT IS (§6.5's fixture preconditions,
+# applied to a different surface)
+#
+#   HOOK_PLANT  AKIA3XN7QW5ZTBMR2VKD  — in the fixture's .git/hooks/pre-commit.
+#
+# It matches `AKIA[A-Z2-7]{16}`. BASE32-VALIDITY IS LOAD-BEARING: the
+# `aws-access-token` rule requires the 16 characters after `AKIA` to be drawn
+# from [A-Z2-7], so a plant containing a `9` or a `1` yields ZERO findings and
+# every assertion below passes for the wrong reason. `AKIAIOSFODNN7EXAMPLE` is
+# separately allowlisted by gitleaks' own default config and also yields zero.
+# S0 therefore asserts a NON-ZERO finding count AND that the probe can see the
+# plant in the archive copy BEFORE any absence is asserted — a dud fixture
+# fails loudly instead of certifying nothing.
+#
+# `.git/hooks/pre-commit` is the right carrier and not an arbitrary one: git
+# never tracks `.git/`, so the plant is provably absent from the adoptee's
+# history before adoption runs. Any occurrence in the commit is one THIS
+# DESIGN created.
+#
+# EVERY ABSENCE ASSERTION HAS A POSITIVE CONTROL. The archive's copy of the
+# hook is the operator's own file and MUST contain the plant — that is what an
+# archive is. So the probe is proven able to see the plant (S0, exactly one
+# occurrence in the archive copy) before it is used to assert zero occurrences
+# in the MANIFEST, the transcript, the ledger and the committed tree. The
+# committed-tree probe gets its own control too: `git grep` over HEAD must find
+# a token that IS committed, or "found nothing" would mean "looked at nothing".
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE MUTATIONS
+#
+#   S4  neuter the pre-staging scan (ONE marked line)  -> the secret-bearing
+#                                                         archive entry is
+#                                                         COMMITTED and the
+#                                                         plant is in the
+#                                                         committed tree -> RED
+#   R2  neuter the re-add audit row (ONE marked line)  -> the file is still
+#                                                         restored and NO row
+#                                                         is written: a SILENT
+#                                                         re-add -> RED
+#   E6  neuter the emitter's type literal              -> the REAL T6 predicate,
+#                                                         extracted from
+#                                                         tests/test-bl029-integration.sh,
+#                                                         rejects the ledger -> RED
+#
+# R2 asserts the file bytes as well as the row count, because a mutant that
+# died before doing anything leaves the same "no row" state a correct refusal
+# does. E6 exists because §8.9's own indictment of the two previous row types
+# is that their pins run over fixture ledgers that never contain them — a
+# whitelist entry with no fixture exercising it is a pin that cannot go red.
+#
+# EXIT CODES AND VALUES, NEVER LABELS (CLAUDE.md's [WARN] trap).
+#
+# GITLEAKS IS DETECTED, NEVER ASSUMED, and a skip is LOUD — and FATAL in CI.
+# The posture is WP2's, for WP2's reason: a green required check credited with
+# a leak proof that never ran is the silent-success class sitting on the
+# highest-stakes property in this design. The workflows install a pinned,
+# checksum-verified gitleaks in every unit shard, so this arm fires only if
+# that install is removed or breaks.
+#
+# HERMETICITY: every fixture is a `mktemp -d` tree; no network, no real remote.
+# bash-3.2 safe: no associative arrays, no `${var,,}`, no `mapfile`, no
+# `((x++))`.
+#
+# LANE: registered in tests/full-project-test-suite.sh AND in the
+# .github/workflows/tests.yml `unit-shard` list. `mk_mirror` NAMES init.sh on
+# an executed line (the driver derives the shipped-script set from init.sh's
+# own copy list, so a mutation mirror must carry it), which makes this suite
+# unit-lane-EXEMPT by `# BL-181-UNIT-LANE-PREDICATE`. It is registered in the
+# unit list anyway — the suite never runs the scaffolder, and the lint says an
+# exempted file that is in the list anyway "decided nothing and is not
+# rendered". Spelling the name plainly and registering it is the honest
+# combination; dodging the predicate with a glob would hide the decision.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
+LIB_DIR="$REPO_ROOT/scripts/lib/adopt"
+L_ARCHIVE="$LIB_DIR/adopt-archive.sh"
+BYPASS_LIB="$REPO_ROOT/scripts/lib/bypass-audit.sh"
+BL029="$REPO_ROOT/tests/test-bl029-integration.sh"
+LIFECYCLE_DOC="$REPO_ROOT/docs/audit-log-lifecycle.md"
+
+PASSED=0
+FAILED=0
+SKIPPED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+skip_() { echo "  [SKIP] $1 — $2"; SKIPPED=$((SKIPPED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required for tests/test-brownfield-wp6-collision-archive.sh" >&2
+  exit 2
+fi
+
+HAVE_GITLEAKS=0
+command -v gitleaks >/dev/null 2>&1 && HAVE_GITLEAKS=1
+GITLEAKS_ABSENT_IS_FATAL=0
+[ -n "${CI:-}" ] && GITLEAKS_ABSENT_IS_FATAL=1
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+# ── Portable primitives (house pattern, WP2/WP4 parity) ─────────────────────
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_num()     { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses()  { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+_sites()   { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_sha()     { shasum -a 256 "$1" 2>/dev/null | awk '{print $1}' || sha256sum "$1" 2>/dev/null | awk '{print $1}'; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+# _count_in FILE STRING — fixed-string occurrences, 0 when the file is absent.
+_count_in() {
+  local n
+  [ -f "$1" ] || { printf '0\n'; return 0; }
+  n=$(grep -c -F -- "$2" "$1" 2>/dev/null)
+  _num "$n"
+}
+
+# ── The plant, assembled from halves ────────────────────────────────────────
+# So that this source file does not itself carry a 20-character AKIA-shaped
+# literal that a secret scanner pointed at THIS repository would report. The
+# halves are inert; the join is what matches.
+HOOK_PLANT="AKIA3XN7QW5Z""TBMR2VKD"
+
+if [ ! -f "$DRIVER" ]; then
+  echo "  [FAIL] setup — $DRIVER not found"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── The fixture ─────────────────────────────────────────────────────────────
+mk_adoptee() {
+  local p="$1"
+  mkdir -p "$p/src" "$p/docs" || return 1
+  ( cd "$p" \
+      && git init -q . \
+      && git config user.email "wp6@test.invalid" \
+      && git config user.name  "WP6 Test" ) >/dev/null 2>&1 || return 1
+  printf '{"name":"acme-api","scripts":{"test":"npm test"}}\n' > "$p/package.json"
+  printf '# acme-api\n' > "$p/README.md"
+  printf '# What this is for\n\nInvoice reconciliation for small firms.\n' > "$p/docs/product.md"
+  printf '# Architecture\n\nA node service and a postgres database.\n' > "$p/docs/architecture.md"
+  ( cd "$p" && git add -A && git commit -q -m "chore: their own history" ) >/dev/null 2>&1 || return 1
+  return 0
+}
+
+# _add_surfaces DIR [PLANT] — the archive-and-replace surfaces the adoptee
+# already occupies (§7.1's first row), and DELIBERATELY NOT ALL OF THEM.
+#
+# `.mcp.json` and `.claude/settings.local.json` are LEFT ABSENT on purpose:
+# §7.2's "only files that exist are archived" is a claim that needs a negative
+# to be worth asserting, and a fixture that carries every surface can only
+# prove the positive half.
+#
+# The pre-commit hook invokes two tools from the description generator's closed
+# vocabulary (`npx`, `lint-staged`) so the §7.2 description requirement has a
+# POSITIVE control, and — when a plant is passed — carries a BASE32-valid key
+# in an `export` line, which is the §7.3 hazard in its most ordinary form.
+_add_surfaces() {
+  local d="$1" plant="${2:-}"
+  mkdir -p "$d/.claude/skills/invoice-helper" "$d/.git/hooks" || return 1
+  printf '{"permissions":{"allow":["Bash(npm test:*)"]},"hooks":{}}\n' > "$d/.claude/settings.json"
+  printf '# invoice-helper\n\nTheir own skill.\n' > "$d/.claude/skills/invoice-helper/SKILL.md"
+  {
+    printf '#!/usr/bin/env bash\n'
+    [ -n "$plant" ] && printf 'export AWS_ACCESS_KEY_ID=%s\n' "$plant"
+    printf 'npx lint-staged\n'
+  } > "$d/.git/hooks/pre-commit"
+  chmod 755 "$d/.git/hooks/pre-commit"
+  printf '#!/usr/bin/env bash\n# their own commit-msg hook\nexit 0\n' > "$d/.git/hooks/commit-msg"
+  chmod 755 "$d/.git/hooks/commit-msg"
+  # A `.sample` hook must NEVER be archived: git ships them in every repo and
+  # archiving them would bury the operator's real hooks in noise.
+  printf '#!/bin/sh\nexit 0\n' > "$d/.git/hooks/pre-push.sample"
+  return 0
+}
+
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
+  return 0
+}
+
+# ── The scan report, produced ONCE by the real scanner ──────────────────────
+TEMPLATE="$(newtmp)/template"
+REPORT=""
+REPORT_OK=0
+if mk_adoptee "$TEMPLATE"; then
+  if bash "$REPO_ROOT/scripts/scout.sh" --root "$TEMPLATE" --out "$TOPTMP/scan" >/dev/null 2>&1; then
+    REPORT="$TOPTMP/scan/scout-report.json"
+    [ -s "$REPORT" ] && REPORT_OK=1
+  fi
+fi
+if [ "$REPORT_OK" -ne 1 ]; then
+  echo "  [FAIL] setup — scripts/scout.sh produced no report; the driver consumes it"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+jq '.phaseMap.suggestedPhase = 2' "$REPORT" > "$TOPTMP/report.json" 2>/dev/null
+
+# ── Answers ─────────────────────────────────────────────────────────────────
+_ans() {
+  cat <<'ANS'
+2
+3
+2
+1
+1
+we reconcile vendor invoices by hand
+six weeks and no budget
+invoices only; no reporting in the first version
+public
+typescript and postgres are settled
+subscription billing
+just me approves things
+anyone with a login
+aws
+losing the database
+1
+1
+ANS
+}
+
+RUN_RC=0; RUN_OUT=""; RUN_ERR=""
+run_adopt() {
+  local dir="$1" answers="$2" fw="${3:-$REPO_ROOT}" glbin="${4:-}"
+  RUN_RC=0
+  RUN_OUT="$(dirname "$answers")/run-out"
+  RUN_ERR="$(dirname "$answers")/run-err"
+  ( cd "$dir" && SOIF_ADOPT_GITLEAKS_BIN="$glbin" bash "$fw/scripts/adopt-project.sh" \
+      --scan-report "$TOPTMP/report.json" ) < "$answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+  return 0
+}
+
+READD_RC=0; READD_OUT=""; READD_ERR=""
+run_readd() {
+  local dir="$1" path="$2" answers="$3" fw="${4:-$REPO_ROOT}"
+  READD_RC=0
+  READD_OUT="$(dirname "$answers")/readd-out"
+  READD_ERR="$(dirname "$answers")/readd-err"
+  ( cd "$dir" && bash "$fw/scripts/adopt-project.sh" --re-add "$path" ) \
+    < "$answers" > "$READD_OUT" 2> "$READD_ERR" || READD_RC=$?
+  return 0
+}
+
+# arch_dir_of DIR — the one archive directory, relative to the adoptee root.
+arch_dir_of() {
+  ( cd "$1" 2>/dev/null || return 1
+    find .claude/adoption-archive -mindepth 1 -maxdepth 1 -type d 2>/dev/null | LC_ALL=C sort | head -1 )
+}
+
+# ═══════════════════════════════════════════════════════════════════════════
+echo "=== A — the archive layout and its MANIFEST (§7.2) ==="
+
+A_D="$(newtmp)"
+A_OK=0
+if mk_adoptee "$A_D/p" && _add_surfaces "$A_D/p"; then
+  _ans > "$A_D/answers"
+  run_adopt "$A_D/p" "$A_D/answers"
+  A_OK=1
+fi
+
+if [ "$A_OK" -ne 1 ]; then
+  fail_ "A (setup)" "fixture setup failed"
+  A_ARCH=""
+else
+  A_ARCH="$(arch_dir_of "$A_D/p")"
+fi
+A_MJ="$A_D/p/$A_ARCH/MANIFEST.json"
+A_MD="$A_D/p/$A_ARCH/MANIFEST.md"
+
+# A1 — the directory exists, under the designed root, with the designed name
+# shape. `<UTC-timestamp>-<pid>` inherited from _upgrade_snapshot_pre_mutation.
+if [ -n "$A_ARCH" ] \
+   && printf '%s' "$A_ARCH" | grep -Eq '^\.claude/adoption-archive/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}-[0-9]{2}-[0-9]{2}Z-[0-9]+(-[0-9]+)?$'; then
+  pass "A1: the archive is at .claude/adoption-archive/<UTC-timestamp>-<pid> — $A_ARCH"
+else
+  fail_ "A1" "archive dir='$A_ARCH' (want .claude/adoption-archive/<ts>-<pid>); run_rc=$RUN_RC"
+fi
+
+# A2 — relative paths MIRRORED, and git hooks under `git-hooks/` (§7.2's tree).
+#
+# EVERY PROBE IS GUARDED ON A NON-EMPTY `$A_ARCH`. With it empty the paths
+# below collapse onto the ADOPTEE'S OWN `.claude/settings.json`, and the probe
+# reports the archive mirrored a file it never touched — measured on this
+# suite's watched-RED run, where it also silently supplied A3's positive
+# control.
+a2_set=0; a2_skill=0; a2_hook=0; a2_cm=0
+if [ -n "$A_ARCH" ]; then
+  [ -f "$A_D/p/$A_ARCH/.claude/settings.json" ] && a2_set=1
+  [ -f "$A_D/p/$A_ARCH/.claude/skills/invoice-helper/SKILL.md" ] && a2_skill=1
+  [ -f "$A_D/p/$A_ARCH/git-hooks/pre-commit" ] && a2_hook=1
+  [ -f "$A_D/p/$A_ARCH/git-hooks/commit-msg" ] && a2_cm=1
+fi
+if [ "$a2_set" -eq 1 ] && [ "$a2_skill" -eq 1 ] && [ "$a2_hook" -eq 1 ] && [ "$a2_cm" -eq 1 ]; then
+  pass "A2: original paths are mirrored relative to the project root, and .git/hooks/* lands under git-hooks/"
+else
+  fail_ "A2" "settings=$a2_set skill=$a2_skill pre-commit=$a2_hook commit-msg=$a2_cm (all want 1)"
+fi
+
+# A3 — ONLY FILES THAT EXIST. The fixture has no .mcp.json and no
+# settings.local.json; a spurious empty file or a phantom entry is the defect.
+# The positive half (A2) and the negative half are asserted together, because
+# an archive that contains nothing at all would satisfy the negative alone.
+a3_files=0; a3_entries=0
+# `$A_ARCH` EMPTY MUST NOT DEGRADE INTO A SEARCH OF THE ADOPTEE ROOT. Without
+# the guard, an absent archive makes `find "$root/"` walk the whole fixture and
+# this case reports a "finding" from the operator's own tree — an assertion
+# that answers a question nobody asked.
+[ -n "$A_ARCH" ] && \
+a3_files=$(find "$A_D/p/$A_ARCH" \( -name '.mcp.json' -o -name 'settings.local.json' -o -name 'pre-push.sample' \) 2>/dev/null | grep -c .)
+a3_files=$(_num "$a3_files")
+a3_entries=$(jq -r '[.entries[] | select(.originalPath == ".mcp.json" or .originalPath == ".claude/settings.local.json" or (.originalPath | test("\\.sample$")))] | length' "$A_MJ" 2>/dev/null)
+a3_entries=$(_num "$a3_entries")
+if [ "$a3_files" -eq 0 ] && [ "$a3_entries" -eq 0 ] && [ "$a2_set" -eq 1 ]; then
+  pass "A3: only files that EXIST are archived — no .mcp.json, no settings.local.json, no .sample hook, and no phantom MANIFEST entry for any of them"
+else
+  fail_ "A3" "absent-surface files in archive=$a3_files (want 0) phantom entries=$a3_entries (want 0) control settings.json present=$a2_set (want 1)"
+fi
+
+# A4 — the MANIFEST lists EVERY entry, both directions.
+a4_files=$( cd "$A_D/p/$A_ARCH" 2>/dev/null && find . -type f 2>/dev/null | sed 's|^\./||' | grep -v '^MANIFEST\.' | LC_ALL=C sort )
+a4_listed=$(jq -r '.entries[].archivedPath' "$A_MJ" 2>/dev/null | LC_ALL=C sort)
+a4_n=$(printf '%s\n' "$a4_files" | grep -c .); a4_n=$(_num "$a4_n")
+a4_match=0
+[ "$a4_files" = "$a4_listed" ] && a4_match=1
+if [ "$a4_match" -eq 1 ] && [ "$a4_n" -ge 4 ]; then
+  pass "A4: the MANIFEST lists EVERY archived file and no others — $a4_n entries, bijective with the tree"
+else
+  fail_ "A4" "archived files=[$(printf '%s' "$a4_files" | tr '\n' ' ')] listed=[$(printf '%s' "$a4_listed" | tr '\n' ' ')] n=$a4_n (want >=4)"
+fi
+
+# A5 — every entry carries a RESTORE line, and one of them is EXECUTED.
+# A restore string nobody runs is documentation; running it is the assertion.
+a5_missing=$(jq -r '[.entries[] | select((.restore // "") == "")] | length' "$A_MJ" 2>/dev/null); a5_missing=$(_num "$a5_missing")
+a5_cmd=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .restore' "$A_MJ" 2>/dev/null)
+a5_before=""; a5_after=""; a5_mode=""; a5_ran=0
+if [ -n "$a5_cmd" ] && [ -f "$A_D/p/.git/hooks/pre-commit" ]; then
+  a5_before="$(_sha "$A_D/p/.git/hooks/pre-commit")"
+  rm -f "$A_D/p/.git/hooks/pre-commit"
+  ( cd "$A_D/p" && eval "$a5_cmd" ) >/dev/null 2>&1 && a5_ran=1
+  a5_after="$(_sha "$A_D/p/.git/hooks/pre-commit")"
+  a5_mode="$(_mode_of "$A_D/p/.git/hooks/pre-commit")"
+fi
+if [ "$a5_missing" -eq 0 ] && [ "$a5_ran" -eq 1 ] && [ -n "$a5_before" ] && [ "$a5_before" = "$a5_after" ] && [ "$a5_mode" = "755" ]; then
+  pass "A5: every entry carries a restore line, and the git-hook one RUNS — the file comes back byte-identical at mode 755"
+else
+  fail_ "A5" "entries with no restore=$a5_missing (want 0) restore_ran=$a5_ran before=$a5_before after=$a5_after mode=$a5_mode (want 755) cmd=[$a5_cmd]"
+fi
+
+# A6 — a `git-hook` entry carries a DESCRIPTION, it is derived from a closed
+# tool vocabulary, and it quotes NO byte of the hook (§7.2 + §7.3's hazard).
+a6_class=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .class' "$A_MJ" 2>/dev/null)
+a6_desc=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .description // ""' "$A_MJ" 2>/dev/null)
+a6_nondesc=$(jq -r '[.entries[] | select(.class == "git-hook") | select((.description // "") == "")] | length' "$A_MJ" 2>/dev/null); a6_nondesc=$(_num "$a6_nondesc")
+a6_names=0
+printf '%s' "$a6_desc" | grep -q 'lint-staged' && a6_names=1
+a6_advisory=0
+jq -e '(.advisory // "") | test("advisory"; "i")' "$A_MJ" >/dev/null 2>&1 && a6_advisory=1
+if [ "$a6_class" = "git-hook" ] && [ "$a6_nondesc" -eq 0 ] && [ "$a6_names" -eq 1 ] && [ "$a6_advisory" -eq 1 ]; then
+  pass "A6: every git-hook entry carries a description; it names the tool the hook invokes (lint-staged) and the MANIFEST says it is ADVISORY"
+else
+  fail_ "A6" "class=$a6_class git-hook entries with no description=$a6_nondesc (want 0) names_lint-staged=$a6_names advisory_header=$a6_advisory desc=[$a6_desc]"
+fi
+
+# A7 — the MANIFEST is machine-readable and self-locating.
+a7_ver=$(jq -r '.schemaVersion // "MISSING"' "$A_MJ" 2>/dev/null)
+a7_dir=$(jq -r '.archiveDir // "MISSING"' "$A_MJ" 2>/dev/null)
+a7_at=$(jq -r '.adoptedAt // ""' "$A_MJ" 2>/dev/null)
+a7_md=0; [ -s "$A_MD" ] && a7_md=1
+if [ "$a7_ver" = "1" ] && [ "$a7_dir" = "$A_ARCH" ] && [ -n "$a7_at" ] && [ "$a7_md" -eq 1 ]; then
+  pass "A7: MANIFEST.json parses with schemaVersion 1 and archiveDir equal to its own location, and MANIFEST.md exists beside it"
+else
+  fail_ "A7" "schemaVersion=$a7_ver archiveDir=$a7_dir (want $A_ARCH) adoptedAt=[$a7_at] MANIFEST.md=$a7_md"
+fi
+
+# A8 — the collision loop. Two archives inside the SAME wall-clock second must
+# not be the same directory. Asserted by CALLING the allocator twice, not by
+# reading the loop: `-1`/`-2` in the source proves nothing about what runs.
+A8="$(newtmp)"
+mkdir -p "$A8/p"
+a8_one=""; a8_two=""; a8_probe=0
+if [ -f "$L_ARCHIVE" ]; then
+  a8_pair="$( . "$L_ARCHIVE" >/dev/null 2>&1
+              one="$(adopt_archive_dir_new "$A8/p")"; mkdir -p "$A8/p/$one"
+              two="$(adopt_archive_dir_new "$A8/p")"
+              printf '%s\n%s\n' "$one" "$two" )"
+  a8_one="$(printf '%s\n' "$a8_pair" | sed -n '1p')"
+  a8_two="$(printf '%s\n' "$a8_pair" | sed -n '2p')"
+  [ -n "$a8_one" ] && a8_probe=1
+fi
+if [ "$a8_probe" -eq 1 ] && [ -n "$a8_two" ] && [ "$a8_one" != "$a8_two" ]; then
+  pass "A8: a second archive allocated in the same second gets a distinct directory ($a8_one vs $a8_two)"
+else
+  fail_ "A8" "probe_ran=$a8_probe first=[$a8_one] second=[$a8_two] (want two different non-empty names)"
+fi
+
+echo ""
+echo "=== D — the disclosure (§7.3: the sentence, the LIST, the restore) ==="
+
+# The design's own words, spelled here independently of the source so the pin
+# is a string equality against the design and not a tautology.
+DISCLOSURE_SENTENCE="moved to ensure the framework operates properly"
+
+d1=$(_count_in "$RUN_OUT" "$DISCLOSURE_SENTENCE")
+if [ "$d1" -ge 1 ]; then
+  pass "D1: the disclosure prints the design's sentence — 'moved to ensure the framework operates properly'"
+else
+  fail_ "D1" "occurrences in the transcript=$d1 (want >=1)"
+fi
+
+# D2 — THE LIST, NOT A COUNT. Every archived original path must be named.
+d2_missing=""
+if [ -f "$A_MJ" ]; then
+  while IFS= read -r op; do
+    [ -n "$op" ] || continue
+    if [ "$(_count_in "$RUN_OUT" "$op")" -eq 0 ]; then d2_missing="$d2_missing $op"; fi
+  done <<D2SET
+$(jq -r '.entries[].originalPath' "$A_MJ" 2>/dev/null)
+D2SET
+fi
+d2_n=$(jq -r '.entries | length' "$A_MJ" 2>/dev/null); d2_n=$(_num "$d2_n")
+if [ -z "$d2_missing" ] && [ "$d2_n" -ge 4 ]; then
+  pass "D2: the disclosure names EVERY archived path ($d2_n of them), not a summary count"
+else
+  fail_ "D2" "paths absent from the transcript:$d2_missing entries=$d2_n (want >=4)"
+fi
+
+# D3 — the restore INSTRUCTIONS, and they must name the real archive directory.
+# `$A_ARCH` empty would make the grep an EMPTY PATTERN, which matches every
+# line of the transcript and turns this into a line count. Guarded.
+d3_dir=0
+[ -n "$A_ARCH" ] && d3_dir=$(_count_in "$RUN_OUT" "$A_ARCH")
+d3_cp=$(_count_in "$RUN_OUT" "cp .claude/adoption-archive/")
+if [ -n "$A_ARCH" ] && [ "$d3_dir" -ge 1 ] && [ "$d3_cp" -ge 1 ]; then
+  pass "D3: the disclosure prints restore instructions naming the real archive directory"
+else
+  fail_ "D3" "archive dir named=$d3_dir (want >=1) restore command shown=$d3_cp (want >=1)"
+fi
+
+echo ""
+echo "=== S — §7.3's exposure: the archive is scanned BEFORE staging ==="
+
+if [ "$HAVE_GITLEAKS" -ne 1 ]; then
+  echo ""
+  echo "  ***********************************************************************"
+  echo "  *  gitleaks IS NOT INSTALLED ON THIS HOST.                            *"
+  echo "  *  The §7.3 archive-secrets proof and its mutation DID NOT RUN.       *"
+  echo "  *  Nobody looked. This is not a clean result.                         *"
+  echo "  *  Install it:  brew install gitleaks                                 *"
+  echo "  ***********************************************************************"
+  echo ""
+fi
+
+if [ "$HAVE_GITLEAKS" -eq 1 ]; then
+  S_D="$(newtmp)"
+  S_OK=0
+  if mk_adoptee "$S_D/p" && _add_surfaces "$S_D/p" "$HOOK_PLANT"; then
+    _ans > "$S_D/answers"
+    run_adopt "$S_D/p" "$S_D/answers"
+    S_OK=1
+  fi
+  S_ARCH="$(arch_dir_of "$S_D/p")"
+  S_MJ="$S_D/p/$S_ARCH/MANIFEST.json"
+  S_MD="$S_D/p/$S_ARCH/MANIFEST.md"
+
+  # ── S0 — THE PRECONDITION. Everything below is vacuous without it. ────────
+  s0_status=$(jq -r '.secretsScan.status // "MISSING"' "$S_MJ" 2>/dev/null)
+  s0_count=$(jq -r '.secretsScan.findingCount // "null"' "$S_MJ" 2>/dev/null); s0_count=$(_num "$s0_count")
+  s0_copy=$(_count_in "$S_D/p/$S_ARCH/git-hooks/pre-commit" "$HOOK_PLANT")
+  s0_pre=$(_count_in "$S_D/p/.git/hooks/pre-commit" "$HOOK_PLANT")
+  if [ "$S_OK" -eq 1 ] && [ "$s0_status" = "scanned" ] && [ "$s0_count" -ge 1 ] \
+     && [ "$s0_copy" -eq 1 ] && [ "$s0_pre" -eq 1 ]; then
+    pass "S0 PRECONDITION: the BASE32-valid plant is live in the hook, the archive copied it (probe sees it exactly $s0_copy time), and the scan reports status=scanned with findingCount=$s0_count (non-zero)"
+  else
+    fail_ "S0 PRECONDITION" "setup=$S_OK status='$s0_status' (want scanned) findingCount=$s0_count (want >=1) plant-in-archive-copy=$s0_copy (want 1) plant-in-hook=$s0_pre (want 1) — a dud plant makes every assertion below vacuous"
+  fi
+
+  # ── S1 — the matching entry REFUSES TO STAGE ─────────────────────────────
+  s1_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$S_MJ" 2>/dev/null)
+  s1_reason=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .withheldReason // ""' "$S_MJ" 2>/dev/null)
+  s1_tracked=$( cd "$S_D/p" && git ls-files -- "$S_ARCH/git-hooks/pre-commit" 2>/dev/null | grep -c . ); s1_tracked=$(_num "$s1_tracked")
+  # The clean sibling in the SAME archive must still be committed, or "nothing
+  # was staged" would satisfy this assertion just as well as a targeted refusal.
+  s1_sib=$( cd "$S_D/p" && git ls-files -- "$S_ARCH/.claude/settings.json" 2>/dev/null | grep -c . ); s1_sib=$(_num "$s1_sib")
+  if [ "$s1_staged" = "false" ] && [ "$s1_reason" = "secret-match" ] \
+     && [ "$s1_tracked" -eq 0 ] && [ "$s1_sib" -eq 1 ]; then
+    pass "S1: the matching entry REFUSES TO STAGE (stagedForCommit=false, withheldReason=secret-match, untracked) while its clean sibling in the same archive IS committed"
+  else
+    fail_ "S1" "stagedForCommit='$s1_staged' (want false) withheldReason='$s1_reason' (want secret-match) tracked=$s1_tracked (want 0) clean-sibling-tracked=$s1_sib (want 1)"
+  fi
+
+  # ── S2 — the plant reaches NO artifact byte ──────────────────────────────
+  # THIS CASE CARRIES S0'S PRECONDITION IN ITS OWN CONDITION, and that is not
+  # belt-and-braces. Measured during the watched-RED run of this suite, with
+  # the module absent: every artifact below was missing, the plant was
+  # therefore in zero of them, and S2 PASSED — a green assertion about files
+  # that did not exist. An absence proves nothing until the thing that could
+  # have leaked has been shown to exist and to contain the plant.
+  #
+  # The committed-tree probe gets its own positive control too: `git grep` over
+  # HEAD must find something that IS committed, or "found nothing" would be
+  # indistinguishable from "searched nothing".
+  s2_ctrl=$( cd "$S_D/p" && git grep -F -l -- "acme-api" HEAD 2>/dev/null | grep -c . ); s2_ctrl=$(_num "$s2_ctrl")
+  s2_tree=$( cd "$S_D/p" && git grep -F -l -- "$HOOK_PLANT" HEAD 2>/dev/null | grep -c . ); s2_tree=$(_num "$s2_tree")
+  s2_mj=$(_count_in "$S_MJ" "$HOOK_PLANT")
+  s2_md=$(_count_in "$S_MD" "$HOOK_PLANT")
+  s2_out=$(_count_in "$RUN_OUT" "$HOOK_PLANT")
+  s2_err=$(_count_in "$RUN_ERR" "$HOOK_PLANT")
+  s2_ledger=$(_count_in "$S_D/p/.claude/bypass-audit.json" "$HOOK_PLANT")
+  if [ "$s0_copy" -eq 1 ] && [ "$s0_count" -ge 1 ] && [ -s "$S_MJ" ] && [ -s "$S_MD" ] \
+     && [ "$s2_ctrl" -ge 1 ] && [ "$s2_tree" -eq 0 ] && [ "$s2_mj" -eq 0 ] && [ "$s2_md" -eq 0 ] \
+     && [ "$s2_out" -eq 0 ] && [ "$s2_err" -eq 0 ] && [ "$s2_ledger" -eq 0 ]; then
+    pass "S2: the plant occurs in ZERO bytes of the committed tree, MANIFEST.json, MANIFEST.md, the transcript and the audit ledger — while provably present once in the archive copy, and with the tree probe proven able to see a committed token ($s2_ctrl file)"
+  else
+    fail_ "S2" "precondition: plant-in-archive-copy=$s0_copy (want 1) findingCount=$s0_count (want >=1) MANIFEST.json non-empty=$([ -s "$S_MJ" ] && echo 1 || echo 0) MANIFEST.md non-empty=$([ -s "$S_MD" ] && echo 1 || echo 0); probe control=$s2_ctrl (want >=1); committed tree=$s2_tree MANIFEST.json=$s2_mj MANIFEST.md=$s2_md stdout=$s2_out stderr=$s2_err ledger=$s2_ledger (all want 0)"
+  fi
+
+  # ── S3 — POSITIVE CONTROL: a CLEAN archive IS staged ─────────────────────
+  # Without this, "refuses to stage" is satisfied by a driver that stages
+  # nothing, ever.
+  s3_staged=$(jq -r '.entries[] | select(.originalPath == ".git/hooks/pre-commit") | .stagedForCommit' "$A_MJ" 2>/dev/null)
+  s3_status=$(jq -r '.secretsScan.status // "MISSING"' "$A_MJ" 2>/dev/null)
+  s3_count=$(jq -r '.secretsScan.findingCount // "null"' "$A_MJ" 2>/dev/null)
+  s3_tracked=$( cd "$A_D/p" && git ls-files -- "$A_ARCH/git-hooks/pre-commit" 2>/dev/null | grep -c . ); s3_tracked=$(_num "$s3_tracked")
+  if [ "$s3_staged" = "true" ] && [ "$s3_status" = "scanned" ] && [ "$s3_count" = "0" ] && [ "$s3_tracked" -eq 1 ]; then
+    pass "S3 POSITIVE CONTROL: with no plant the same entry IS staged and committed (status=scanned, findingCount=0) — the refusal is targeted, not a blanket"
+  else
+    fail_ "S3" "stagedForCommit='$s3_staged' (want true) status='$s3_status' findingCount='$s3_count' (want 0) tracked=$s3_tracked (want 1)"
+  fi
+
+  # ── S4 — MUTATION: remove the pre-staging scan ───────────────────────────
+  S4="$(newtmp)"
+  if ! mk_adoptee "$S4/p" || ! _add_surfaces "$S4/p" "$HOOK_PLANT" || ! mk_mirror "$S4/fw"; then
+    fail_ "S4 (MUTATION)" "fixture setup failed"
+  else
+    MUT="$S4/fw/scripts/lib/adopt/adopt-archive.sh"
+    s4_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-ARCHIVE-SCAN')
+    cp "$L_ARCHIVE" "$S4/orig.ref"
+    _sed_inplace "$MUT" 's|^.*BF-ADOPT-ARCHIVE-SCAN$|  printf "scanned\\n" > "$work/arcstatus"   # BF-ADOPT-ARCHIVE-SCAN|'
+    s4_chg=$(_changed_lines "$S4/orig.ref" "$MUT")
+    s4_parses=$(_parses "$MUT")
+    _ans > "$S4/answers"
+    run_adopt "$S4/p" "$S4/answers" "$S4/fw"
+    s4_arch="$(arch_dir_of "$S4/p")"
+    s4_tracked=$( cd "$S4/p" && git ls-files -- "$s4_arch/git-hooks/pre-commit" 2>/dev/null | grep -c . ); s4_tracked=$(_num "$s4_tracked")
+    s4_tree=$( cd "$S4/p" && git grep -F -l -- "$HOOK_PLANT" HEAD 2>/dev/null | grep -c . ); s4_tree=$(_num "$s4_tree")
+    if [ "$s4_sites" -eq 1 ] && [ "$s4_chg" -eq 2 ] && [ "$s4_parses" -eq 1 ] \
+       && [ "$s4_tracked" -eq 1 ] && [ "$s4_tree" -ge 1 ]; then
+      pass "S4 (MUTATION): with the pre-staging scan neutered (1 site, 2 lines, mutant parses) the secret-bearing entry IS committed and the plant appears in $s4_tree committed file(s) — RED"
+    else
+      fail_ "S4" "sites=$s4_sites (want 1) changed_lines=$s4_chg (want 2) parses=$s4_parses (want 1) entry_tracked=$s4_tracked (want 1) plant_in_tree=$s4_tree (want >=1)"
+    fi
+  fi
+else
+  skip_ "S0-S4 (§7.3 archive-secrets proof and its mutation)" "gitleaks not installed — see the banner above"
+fi
+
+# ── S5 — "nobody looked" is never "clean" ──────────────────────────────────
+# Runs WITHOUT gitleaks by construction: it points the driver at a binary name
+# that does not exist, so it proves the tool-unavailable arm on any host.
+S5="$(newtmp)"
+if ! mk_adoptee "$S5/p" || ! _add_surfaces "$S5/p"; then
+  fail_ "S5" "fixture setup failed"
+else
+  _ans > "$S5/answers"
+  run_adopt "$S5/p" "$S5/answers" "$REPO_ROOT" "definitely-not-a-real-binary-name"
+  s5_arch="$(arch_dir_of "$S5/p")"
+  s5_mj="$S5/p/$s5_arch/MANIFEST.json"
+  s5_status=$(jq -r '.secretsScan.status // "MISSING"' "$s5_mj" 2>/dev/null)
+  s5_count=$(jq -r '.secretsScan.findingCount' "$s5_mj" 2>/dev/null)
+  s5_staged=$(jq -r '[.entries[] | select(.stagedForCommit == true)] | length' "$s5_mj" 2>/dev/null); s5_staged=$(_num "$s5_staged")
+  s5_reason=$(jq -r '[.entries[] | select(.withheldReason == "not-scanned")] | length' "$s5_mj" 2>/dev/null); s5_reason=$(_num "$s5_reason")
+  s5_n=$(jq -r '.entries | length' "$s5_mj" 2>/dev/null); s5_n=$(_num "$s5_n")
+  s5_loud=$(_count_in "$RUN_OUT" "NOTHING WAS SCANNED")
+  if [ "$s5_status" = "tool-unavailable" ] && [ "$s5_count" = "null" ] \
+     && [ "$s5_staged" -eq 0 ] && [ "$s5_n" -ge 4 ] && [ "$s5_reason" -eq "$s5_n" ] && [ "$s5_loud" -ge 1 ]; then
+    pass "S5: with the scanner unavailable the archive reports status=tool-unavailable and findingCount=null (NOT 0), every one of its $s5_n entries is withheld with reason 'not-scanned', and the run says so out loud"
+  else
+    fail_ "S5" "status='$s5_status' (want tool-unavailable) findingCount='$s5_count' (want null) staged=$s5_staged (want 0) entries=$s5_n withheld-as-not-scanned=$s5_reason (want $s5_n) loud=$s5_loud (want >=1)"
+  fi
+fi
+
+echo ""
+echo "=== R — re-adds: permitted, WARNED, and RECORDED (§7.3) ==="
+
+# The design's warning, spelled here independently of the source.
+READD_WARNING="Personal systems may conflict with the framework"
+READD_WARNING2="accuracy, documentation, and capabilities may be compromised"
+
+R1="$(newtmp)"
+R1_OK=0
+if mk_adoptee "$R1/p" && _add_surfaces "$R1/p"; then
+  _ans > "$R1/answers"
+  run_adopt "$R1/p" "$R1/answers"
+  R1_OK=1
+fi
+if [ "$R1_OK" -ne 1 ]; then
+  fail_ "R1" "fixture setup failed"
+  fail_ "R3" "fixture setup failed"
+else
+  r1_arch="$(arch_dir_of "$R1/p")"
+  # Overwrite the live hook so a restore is observable rather than a no-op.
+  printf '#!/usr/bin/env bash\n# replaced\nexit 0\n' > "$R1/p/.git/hooks/pre-commit"
+  chmod 700 "$R1/p/.git/hooks/pre-commit"
+  r1_want="$(_sha "$R1/p/$r1_arch/git-hooks/pre-commit")"
+  printf '1\n' > "$R1/confirm"
+  run_readd "$R1/p" ".git/hooks/pre-commit" "$R1/confirm"
+  r1_got="$(_sha "$R1/p/.git/hooks/pre-commit")"
+  r1_mode="$(_mode_of "$R1/p/.git/hooks/pre-commit")"
+  r1_w1=$(_count_in "$READD_OUT" "$READD_WARNING")
+  r1_w2=$(_count_in "$READD_OUT" "$READD_WARNING2")
+  r1_rows=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_re_add")] | length' "$R1/p/.claude/bypass-audit.json" 2>/dev/null); r1_rows=$(_num "$r1_rows")
+  r1_path=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_re_add")] | .[0].details.path // ""' "$R1/p/.claude/bypass-audit.json" 2>/dev/null)
+  if [ "$READD_RC" -eq 0 ] && [ -n "$r1_want" ] && [ "$r1_want" = "$r1_got" ] && [ "$r1_mode" = "755" ] \
+     && [ "$r1_w1" -ge 1 ] && [ "$r1_w2" -ge 1 ] && [ "$r1_rows" -eq 1 ] && [ "$r1_path" = ".git/hooks/pre-commit" ]; then
+    pass "R1: a re-add restores the archived file byte-identically at its recorded mode, prints the warning near-verbatim, and writes exactly one adoption_event/collision_re_add row naming the path"
+  else
+    fail_ "R1" "rc=$READD_RC want_sha=$r1_want got_sha=$r1_got mode=$r1_mode (want 755) warning_part1=$r1_w1 warning_part2=$r1_w2 rows=$r1_rows (want 1) path='$r1_path'"
+  fi
+
+  # R3 — the confirmation is MANDATORY. No answer means no re-add and no row.
+  #
+  # THE REFUSAL MUST BE THE RIGHT REFUSAL. Measured during this suite's
+  # watched-RED run, with `--re-add` not yet a flag: the driver exited 2 on
+  # "unrecognised option", the file was untouched, no row was written, and R3
+  # PASSED — a green assertion that a feature refuses correctly, produced by
+  # the feature not existing. So the transcript must carry the driver's own
+  # mandatory-question refusal, spelled here independently of the source.
+  R3="$(newtmp)"
+  R3_REFUSAL="This question has no default and no skip, and no answer was given:"
+  printf '#!/usr/bin/env bash\n# replaced again\nexit 0\n' > "$R1/p/.git/hooks/pre-commit"
+  r3_before="$(_sha "$R1/p/.git/hooks/pre-commit")"
+  r3_rows_before=$(jq -r '[.[] | select(.type == "adoption_event")] | length' "$R1/p/.claude/bypass-audit.json" 2>/dev/null); r3_rows_before=$(_num "$r3_rows_before")
+  : > "$R3/confirm"
+  run_readd "$R1/p" ".git/hooks/pre-commit" "$R3/confirm"
+  r3_after="$(_sha "$R1/p/.git/hooks/pre-commit")"
+  r3_rows_after=$(jq -r '[.[] | select(.type == "adoption_event")] | length' "$R1/p/.claude/bypass-audit.json" 2>/dev/null); r3_rows_after=$(_num "$r3_rows_after")
+  r3_why=$(_count_in "$READD_ERR" "$R3_REFUSAL")
+  if [ "$READD_RC" -ne 0 ] && [ "$r3_why" -ge 1 ] && [ "$r3_before" = "$r3_after" ] \
+     && [ "$r3_rows_after" -eq "$r3_rows_before" ] && [ "$r3_rows_before" -ge 1 ]; then
+    pass "R3: an unanswered confirmation refuses the re-add (rc $READD_RC) FOR THAT REASON — the file is untouched and no new audit row joins the $r3_rows_before already there"
+  else
+    fail_ "R3" "rc=$READD_RC (want non-zero) refused-for-the-mandatory-question=$r3_why (want >=1) sha before=$r3_before after=$r3_after rows before=$r3_rows_before (want >=1) after=$r3_rows_after"
+  fi
+fi
+
+# ── R2 — MUTATION: suppress the re-add audit row -> a SILENT re-add ─────────
+R2="$(newtmp)"
+if ! mk_adoptee "$R2/p" || ! _add_surfaces "$R2/p" || ! mk_mirror "$R2/fw"; then
+  fail_ "R2 (MUTATION)" "fixture setup failed"
+else
+  _ans > "$R2/answers"
+  run_adopt "$R2/p" "$R2/answers" "$R2/fw"
+  r2_arch="$(arch_dir_of "$R2/p")"
+  MUTR="$R2/fw/scripts/lib/adopt/adopt-archive.sh"
+  r2_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-READD-AUDIT')
+  cp "$L_ARCHIVE" "$R2/orig.ref"
+  _sed_inplace "$MUTR" 's|^.*BF-ADOPT-READD-AUDIT$|  :   # BF-ADOPT-READD-AUDIT|'
+  r2_chg=$(_changed_lines "$R2/orig.ref" "$MUTR")
+  r2_parses=$(_parses "$MUTR")
+  printf '#!/usr/bin/env bash\n# replaced\nexit 0\n' > "$R2/p/.git/hooks/pre-commit"
+  r2_want="$(_sha "$R2/p/$r2_arch/git-hooks/pre-commit")"
+  printf '1\n' > "$R2/confirm"
+  run_readd "$R2/p" ".git/hooks/pre-commit" "$R2/confirm" "$R2/fw"
+  r2_got="$(_sha "$R2/p/.git/hooks/pre-commit")"
+  r2_rows=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_re_add")] | length' "$R2/p/.claude/bypass-audit.json" 2>/dev/null); r2_rows=$(_num "$r2_rows")
+  # THE FILE MUST HAVE BEEN RESTORED. A mutant that died before doing anything
+  # leaves the same "no row" state a correct refusal does; asserting the bytes
+  # is what makes this a SILENT RE-ADD rather than an early exit.
+  if [ "$r2_sites" -eq 1 ] && [ "$r2_chg" -eq 2 ] && [ "$r2_parses" -eq 1 ] \
+     && [ -n "$r2_want" ] && [ "$r2_want" = "$r2_got" ] && [ "$r2_rows" -eq 0 ]; then
+    pass "R2 (MUTATION): with the audit row suppressed (1 site, 2 lines, mutant parses) the re-add STILL HAPPENS — the file is restored byte-identically and the ledger records nothing. A silent re-add — RED"
+  else
+    fail_ "R2" "sites=$r2_sites (want 1) changed_lines=$r2_chg (want 2) parses=$r2_parses (want 1) restored_sha=$r2_got want=$r2_want rows=$r2_rows (want 0)"
+  fi
+fi
+
+echo ""
+echo "=== E — adoption_event across §8.9's five surfaces ==="
+
+# Surface 1 — the type enum docblock in scripts/lib/bypass-audit.sh.
+e1=$(_count_in "$BYPASS_LIB" "adoption_event")
+if [ "$e1" -ge 1 ]; then
+  pass "E1 (surface 1/5): the type enum docblock in scripts/lib/bypass-audit.sh names adoption_event"
+else
+  fail_ "E1" "occurrences in the docblock=$e1 (want >=1)"
+fi
+
+# Surface 2 — the T6 whitelist AND a fixture ledger containing it.
+# §8.9's indictment of the two previous row types is that their pins run over
+# fixtures that never carry them, so BOTH halves are asserted here.
+e2_case=$(grep -c 'adoption_event' "$BL029" 2>/dev/null); e2_case=$(_num "$e2_case")
+e2_white=0
+grep -q 'claude_bypass_proposal|.*adoption_event\|adoption_event.*)' "$BL029" 2>/dev/null && e2_white=1
+e2_fixture=0
+grep -q 'adopt_audit_event' "$BL029" 2>/dev/null && e2_fixture=1
+if [ "$e2_case" -ge 2 ] && [ "$e2_white" -eq 1 ] && [ "$e2_fixture" -eq 1 ]; then
+  pass "E2 (surface 2/5): T6's type-enum whitelist lists adoption_event AND the suite writes such a row into the ledger T6 reads — the pin has a fixture that can make it fail"
+else
+  fail_ "E2" "adoption_event mentions in test-bl029=$e2_case (want >=2) in the whitelist=$e2_white writes a row via the real emitter=$e2_fixture"
+fi
+
+# Surface 3 — the emitter, marked, with exactly one site.
+e3_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-AUDIT-ROW')
+e3_fn=0
+grep -q '^adopt_audit_event()' "$L_ARCHIVE" 2>/dev/null && e3_fn=1
+if [ "$e3_sites" -eq 1 ] && [ "$e3_fn" -eq 1 ]; then
+  pass "E3 (surface 3/5): the emitter adopt_audit_event exists and its type literal is marked at exactly one site"
+else
+  fail_ "E3" "marked sites=$e3_sites (want 1) function present=$e3_fn"
+fi
+
+# Surface 4 — a consumer that puts the type in a ledger and ASSERTS on it.
+# R1 above is that consumer; E4 checks the row is schema-valid, because a row
+# that no reader can parse is not a record.
+E4="$(newtmp)"
+e4_ok=0
+if [ "$R1_OK" -eq 1 ]; then
+  e4_row=$(jq -r '[.[] | select(.type == "adoption_event")] | .[0]' "$R1/p/.claude/bypass-audit.json" 2>/dev/null)
+  printf '%s\n' "$e4_row" > "$E4/row.json"
+  jq -e '(.type == "adoption_event")
+         and (.actor == "framework")
+         and ((.timestamp // "") != "")
+         and ((.enforcement_level_at_event // "") | test("^(no|light|strict|n/a)$"))
+         and ((.user_response // "") | test("^(PENDING|accepted|declined|n/a)$"))
+         and ((.final_outcome // "") | test("^(committed|bypassed|escalated|abandoned|recorded_only|n/a)$"))
+         and ((.details.event // "") != "")' "$E4/row.json" >/dev/null 2>&1 && e4_ok=1
+fi
+if [ "$e4_ok" -eq 1 ]; then
+  pass "E4 (surface 4/5): the emitted row satisfies the documented BL-030 schema — actor, enforcement level, user_response and final_outcome are all inside their enums, and details.event discriminates"
+else
+  fail_ "E4" "row=[$(head -c 300 "$E4/row.json" 2>/dev/null | tr '\n' ' ')]"
+fi
+
+# Surface 5 — docs/audit-log-lifecycle.md's taxonomy AND a cold-pickup recipe
+# that is EXECUTED against a real ledger. A recipe nobody runs is prose.
+e5_tax=0
+grep -q '^### `adoption_event`' "$LIFECYCLE_DOC" 2>/dev/null && e5_tax=1
+e5_recipe="$(grep -F "select(.type == \"adoption_event\")" "$LIFECYCLE_DOC" 2>/dev/null | grep '^jq ' | head -1)"
+e5_ran=0; e5_hits=0
+if [ -n "$e5_recipe" ] && [ "$R1_OK" -eq 1 ]; then
+  e5_out="$( cd "$R1/p" && eval "$e5_recipe" 2>/dev/null )"
+  e5_ran=1
+  e5_hits=$(printf '%s' "$e5_out" | grep -c 'collision_re_add'); e5_hits=$(_num "$e5_hits")
+fi
+if [ "$e5_tax" -eq 1 ] && [ "$e5_ran" -eq 1 ] && [ "$e5_hits" -ge 1 ]; then
+  pass "E5 (surface 5/5): the lifecycle doc carries an adoption_event section, and its cold-pickup jq recipe RUNS against a real ledger and returns the re-add row"
+else
+  fail_ "E5" "taxonomy section=$e5_tax recipe found and run=$e5_ran rows returned=$e5_hits recipe=[$e5_recipe]"
+fi
+
+# ── E6 — MUTATION: the T6 pin can actually go RED ──────────────────────────
+# The whole point of §8.9's fourth surface. The REAL T6 predicate is EXTRACTED
+# from tests/test-bl029-integration.sh (never re-typed here, which would only
+# prove that a copy agrees with itself) and run over two ledgers built by the
+# emitter: the shipped one, and one whose type literal has been mutated.
+E6="$(newtmp)"
+e6_pred="$E6/t6.sh"
+sed -n '/^TYPES=/,/^done$/p' "$BL029" > "$E6/t6-body" 2>/dev/null
+e6_extract=0
+grep -q 'case "$t" in' "$E6/t6-body" 2>/dev/null && e6_extract=1
+{
+  printf 'PROJ="$1"\n'
+  cat "$E6/t6-body"
+  printf '[ "$TYPE_OK" = "1" ]\n'
+} > "$e6_pred"
+
+_e6_ledger() {
+  local libdir="$1" out="$2"
+  mkdir -p "$out/.claude"
+  printf '[]\n' > "$out/.claude/bypass-audit.json"
+  ( . "$REPO_ROOT/scripts/lib/bypass-audit.sh" >/dev/null 2>&1
+    . "$libdir/adopt-archive.sh" >/dev/null 2>&1
+    adopt_audit_event "$out" "collision_re_add" '{"path":".git/hooks/pre-commit"}' ) >/dev/null 2>&1
+}
+
+e6_good_rc=0; e6_bad_rc=0; e6_good_rows=0; e6_bad_rows=0
+if [ "$e6_extract" -eq 1 ] && mk_mirror "$E6/fw"; then
+  _e6_ledger "$LIB_DIR" "$E6/good"
+  e6_good_rows=$(jq -r 'length' "$E6/good/.claude/bypass-audit.json" 2>/dev/null); e6_good_rows=$(_num "$e6_good_rows")
+  bash "$e6_pred" "$E6/good" >/dev/null 2>&1 || e6_good_rc=$?
+
+  MUTE="$E6/fw/scripts/lib/adopt/adopt-archive.sh"
+  e6_sites=$(_sites "$L_ARCHIVE" 'BF-ADOPT-AUDIT-ROW')
+  cp "$L_ARCHIVE" "$E6/orig.ref"
+  _sed_inplace "$MUTE" 's|^.*BF-ADOPT-AUDIT-ROW$|  _ae_type="adoption_evnt"   # BF-ADOPT-AUDIT-ROW|'
+  e6_chg=$(_changed_lines "$E6/orig.ref" "$MUTE")
+  e6_parses=$(_parses "$MUTE")
+  _e6_ledger "$E6/fw/scripts/lib/adopt" "$E6/bad"
+  e6_bad_rows=$(jq -r 'length' "$E6/bad/.claude/bypass-audit.json" 2>/dev/null); e6_bad_rows=$(_num "$e6_bad_rows")
+  bash "$e6_pred" "$E6/bad" >/dev/null 2>&1 || e6_bad_rc=$?
+else
+  e6_sites=0; e6_chg=0; e6_parses=0
+fi
+if [ "$e6_extract" -eq 1 ] && [ "$e6_sites" -eq 1 ] && [ "$e6_chg" -eq 2 ] && [ "$e6_parses" -eq 1 ] \
+   && [ "$e6_good_rows" -eq 1 ] && [ "$e6_bad_rows" -eq 1 ] \
+   && [ "$e6_good_rc" -eq 0 ] && [ "$e6_bad_rc" -ne 0 ]; then
+  pass "E6 (MUTATION): the REAL T6 predicate, extracted from test-bl029-integration.sh, accepts the shipped emitter's row (rc 0) and REJECTS a one-character type drift (rc $e6_bad_rc) — the whitelist pin can go red"
+else
+  fail_ "E6" "extracted=$e6_extract sites=$e6_sites (want 1) changed_lines=$e6_chg (want 2) parses=$e6_parses rows good=$e6_good_rows bad=$e6_bad_rows (both want 1) predicate rc good=$e6_good_rc (want 0) bad=$e6_bad_rc (want non-zero)"
+fi
+
+echo ""
+echo "=== C — the collision archive is recorded, and the module stays severable ==="
+
+# C1 — the archive itself is an audit EVENT (§8.9's fourth row: "every
+# collision archive"), not only a printed disclosure.
+c1_rows=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_archive")] | length' "$A_D/p/.claude/bypass-audit.json" 2>/dev/null); c1_rows=$(_num "$c1_rows")
+c1_dir=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_archive")] | .[0].details.archiveDir // ""' "$A_D/p/.claude/bypass-audit.json" 2>/dev/null)
+c1_count=$(jq -r '[.[] | select(.type == "adoption_event") | select(.details.event == "collision_archive")] | .[0].details.entryCount // -1' "$A_D/p/.claude/bypass-audit.json" 2>/dev/null); c1_count=$(_num "$c1_count")
+if [ "$c1_rows" -eq 1 ] && [ "$c1_dir" = "$A_ARCH" ] && [ "$c1_count" -ge 4 ]; then
+  pass "C1: the collision archive writes exactly one adoption_event/collision_archive row naming the directory and its $c1_count entries"
+else
+  fail_ "C1" "rows=$c1_rows (want 1) archiveDir='$c1_dir' (want $A_ARCH) entryCount=$c1_count (want >=4)"
+fi
+
+# C2 — M3: no CORE file may name this module. Run the real lint.
+c2_rc=0
+( cd "$REPO_ROOT" && bash scripts/lint-module-dependencies.sh ) >"$TOPTMP/mod.out" 2>&1 || c2_rc=$?
+if [ "$c2_rc" -eq 0 ]; then
+  pass "C2: scripts/lint-module-dependencies.sh is rc 0 — no core file references the adoption module"
+else
+  fail_ "C2" "lint rc=$c2_rc: $(tail -5 "$TOPTMP/mod.out" | tr '\n' ' ')"
+fi
+
+# C3 — the driver's declared core-dependency header (M2) names bypass-audit.sh,
+# which WP6 adds. An undeclared source line is an M2 violation that no lint
+# catches today, so the declaration is asserted here.
+c3=0
+grep -q 'bypass-audit\.sh' "$DRIVER" 2>/dev/null && c3=1
+if [ "$c3" -eq 1 ]; then
+  pass "C3 (M2): the driver's declared core-dependency list names scripts/lib/bypass-audit.sh"
+else
+  fail_ "C3" "the M2 header does not declare the bypass-audit dependency this package adds"
+fi
+
+echo ""
+if [ "$SKIPPED" -gt 0 ] && [ "$GITLEAKS_ABSENT_IS_FATAL" -eq 1 ]; then
+  echo "  [FAIL] CI GUARD — $SKIPPED case(s) skipped for a missing gitleaks. In CI that is a"
+  echo "         proof that did not run, on the property whose failure mode is a committed"
+  echo "         credential. Install gitleaks in the workflow or fix the install step."
+  FAILED=$((FAILED + 1))
+fi
+
+echo "Results: $PASSED passed, $FAILED failed, $SKIPPED skipped"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
## What this builds

Brownfield WP6 — the **collision archive**. When the framework moves into an
existing project it has to displace files the operator already wrote: their
`.git/hooks/*`, their AI settings, their MCP config. This preserves them,
discloses them path by path (never a summary count), and gives each one a
one-line restore command.

- **§7.2** — archive layout mirroring relative paths, and a MANIFEST listing
  every entry with its restore line.
- **§7.3 — the security half.** Those files were often **untracked or
  gitignored specifically because they hold secrets**, and archiving stages them
  into a commit. The archive is scanned **before** staging; a matching entry is
  withheld; and if the scanner is absent the **whole batch is refused** rather
  than called clean.
- **`--re-add`** — warned, confirmed, restored byte-identically, and **recorded
  before it restores**, so "recorded" is a precondition rather than a hopeful
  afterthought.
- **§8.9** — `adoption_event` rows across all five surfaces.

## Four review rounds. What each one found.

**Round 1 — the archive committed a file you told git never to commit.** Proved
on a hermetic run: a `.claude/settings.local.json` holding an internal proxy URL
and a username, gitignored with the standard anchored pattern, landed in history.
The code *did* call `git check-ignore` — on the **archived** path, as a `git add`
liveness guard. The **original's** ignore status was never consulted, and an
anchored pattern cannot match a copy at a different path. The only remaining gate
was the secret scanner, and a hostname is not password-shaped.

Fully spec-conformant — §7.2 says archive it, §7.3 says scan it, both done —
which is exactly why reading the design would not have caught it. The chain now
asks about the **original**: *a gitignore entry is a statement about content, not
about a filename.*

**Round 1 also — the machine was hiding it.** `~/.config/git/ignore` on the
development host carries `**/.claude/settings.local.json`, which matches the
archive copy. The exposure was **invisible locally and live everywhere else**.
Every local run of this suite was being decided by one line of personal git
config no fixture controlled. The suite now neutralises global config, system
config, the XDG excludes path, `GIT_CONFIG_COUNT`, `GIT_CONFIG_PARAMETERS`,
`GIT_TEMPLATE_DIR`, the `GIT_DIR` family and the `GIT_*_PATHSPECS` family — and
proves the isolation **in both directions**, demonstrating the leak unsealed
before demonstrating it sealed.

**Round 2 — a shipped claim that was false.** The code comment and
`docs/adoption.md` both said a user's gitignore can never reach the project's
hooks, "because git excludes `.git/` by construction." It does not:
`git check-ignore` applies patterns to any path handed to it. What had been
verified was a property of one fixture's **anchored pattern**. Consequence: an
adoptee whose `.gitignore` is the common one-liner `.git/` gets a successful
adoption at rc 0 with **the hooks silently withheld** — the archive's whole
point — while the disclosure attributes it to an instruction git would never
honour. Every test stayed green, because the fixture guarding that boundary used
a rule that structurally could not reach.

**Round 3 — the fix worked for garbage and failed for emptiness.** The guard
meant to stop a corrupt audit ledger being committed silently rested on
*"a successful append proves the ledger parsed."* It does not. On a **zero-byte**
ledger, `jq '. + [$r]' file` processes zero documents, emits nothing and
**exits 0** — the append "succeeds", drops the row, announces nothing, and
commits invalid JSON as the project's first governance record. A `null` ledger is
worse: `null + [$r]` is `[$r]`, so the corrupt state a reader would have
investigated is silently **repaired away**.

Fixed at the **appender** (`jq -es 'length == 1 and (.[0] | type == "array")'`),
which closes empty / `null` / multi-document / non-array in one move — and
protects the **five other callers** that had the same blind spot. Guarding at the
call site would have fixed one and left five.

**Round 4 — clean.** Review could not break the predicate in either direction:
8 must-append shapes (including a 5000-row ledger, a real-emitter-written one,
and the bootstrap case of no file at all) and 7 must-refuse shapes beyond the
six tested. No caller relied on the permissive behaviour, because the permissive
path never actually wrote the row.

## Verification

- `tests/test-brownfield-wp6-collision-archive.sh` — **45 passed, 0 failed**.
- **After rebasing onto the WP5b sibling** (both packages now load into one
  driver): WP6 45/0, WP5b 57/0, WP4 driver 39/0, `run-lints` 15/15.
- All **14 ledger-touching suites** re-run for the library change:
  bypass-audit-lib 10/0, -integrity 8/0, -trap-isolation 13/0, -tmp-hardening
  7/0, bl163 7/0, bl171 8/0, bl161 7/0, bypass-detector 15/0, sentinel 5/0,
  escalate 4/0, pending-approval 21/0, bl030-replay 4/0, out-of-band 8/0,
  freshness 26/0.
- §7.3's plant is BASE32-valid `AKIA[A-Z2-7]{16}` and not the gitleaks-allowlisted
  example, carried in `.git/hooks/pre-commit` — git never tracks `.git/`, so any
  occurrence in the commit is one this design created. Every absence assertion has
  a positive control, and the finding count is asserted **non-zero first**.

## Filed here

- **BL-225** — adoption writes **78 files** before discovering the adoptee's
  `.gitignore` refuses one: **64 staged in their index**, 14 hidden under
  `.claude/` by their own rule, 0 untracked. No preflight, no rollback. The
  residue is *armed*, not untidy — the next ordinary commit sweeps 65 files, 63
  of them framework scripts. The refusal says *"Nothing has been committed"*,
  which is true and reads as *nothing happened*; and git names the culprit on
  stderr immediately before the driver asks the question git just answered.
  **Both figures carry their fixture conditions** (78/14 with AI-layer surfaces,
  69/5 on a bare adoptee) because the first draft quoted an estimate.
- **BL-226** — the design mandates a disclosure saying files were "moved", while
  every per-entry disposition is `kept`. Three options laid out, **none taken**:
  re-wording a design-mandated string is the owner's call.
- **BL-227** — **seven** inline `jq '. + [$r]'` sites in five files bypass
  `bypass_audit_append` entirely, and `docs/audit-log-lifecycle.md` asserted the
  opposite in as many words. The doc line is corrected. Review counted six; the
  grep at filing time returned seven, so the entry carries the **derivation
  command** rather than either number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
