### PR TITLE
ci(shards): pin both brownfield suites to slow-misc — the complement is at 93% of the cap

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -597,6 +597,20 @@ jobs:
             #    timeout here does not merely delay the answer — it replaces a
             #    red with a cancellation and the failures go unread.
             tests/test-walk006-ci-protection-scope.sh  # 118s at 158 rows — see note above
+            # ── Re-pinned 2026-08-10, the second time today. The complement is
+            #    at 93% of the cap and the two brownfield suites are why.
+            #    Derived from the shard history rather than a local stopwatch,
+            #    because the pin doctrine is keyed to MEASURED CI TIME and this
+            #    host runs both suites in roughly half:
+            #      PR #343 (neither)          rest = 561s
+            #      PR #344 (+ wp5b)           rest = 606s   → wp5b ~45s
+            #      PR #345 (+ wp5b + wp6)     rest = 667s   → wp6  ~61s
+            #    Moving both: rest ~561s (78%), slow-misc ~584s (81%). Neither
+            #    leg is then the one to watch, which is the point — pinning only
+            #    the larger would have left the complement at 87% and bought one
+            #    work package of headroom.
+            tests/test-brownfield-wp5b-test-debt.sh          #  ~45s in CI (30s local)
+            tests/test-brownfield-wp6-collision-archive.sh   #  ~61s in CI (36s local)
           )
 
           # The ONLY thing that maps a roster name to a pin array. Both the


### PR DESCRIPTION
## Why

`unit-shard (rest)` reached **11m7s against a 12-minute cap** on PR #345 — 93%.
The workflow's own doctrine, written above the `timeout-minutes` line, says
approaching the cap is the **re-pin signal, not a reason to raise the cap**.

## The measurement

Derived from shard history rather than a local stopwatch, because the `pin_*`
arrays are keyed to **measured CI time** and this host runs both suites in
roughly half:

| PR | contents | `rest` |
|---|---|---|
| #343 | neither suite | 561s |
| #344 | + wp5b | 606s → **wp5b ≈ 45s** |
| #345 | + wp5b + wp6 | 667s → **wp6 ≈ 61s** |

Cap is 720s. `slow-misc` was at 478s.

**After:** `rest` ≈ 561s (78%), `slow-misc` ≈ 584s (81%).

## Why both, not just the larger one

Pinning only wp6 leaves the complement at ~87% — one work package of headroom,
and **four work packages remain in this design** (WP5 certification, WP7 CI
carve-out + Adoption Record, WP8 residual, and the joint E2E). Moving both means
neither leg is the one to watch.

## Membership is unchanged

Both files stay in the canonical `tests=( )` array, which is what
`lint-tests-registered.sh` actually checks; the pin array only decides which
shard claims them. Verified: lint rc 0, `tests.yml` parses, three jobs intact,
each file present exactly twice (canonical array + pin array), matching every
other pinned entry.

## What a timeout would cost

On record for this exact stack: a complement cancellation **already hid two real
CI-only failures once** — a probe reading the runner's filesystem, and a mutant
that did not mutate on the runner's bash. A timeout does not delay an answer; it
replaces a red with a cancellation, and the failures go unread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
