### PR TITLE
feat(bl233): the MCP gate records outcomes, not declarations

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,55 @@
+{
+  "$comment": "BL-233 deliverable 8 — the MCP enforcement mechanism now fires in the framework repo itself, not only in the projects init.sh generates. Before this file existed, solo-orchestrator had no .claude/settings.json at all, so scripts/session-test-gate-check.sh, scripts/track-tool-usage.sh and scripts/session-mcp-gate.sh were wired into generated projects ONLY and none of it ran where the framework is actually built. The same gap still hides the version-check hook. The tracker is registered on BOTH post-tool events because a failed MCP call fires PostToolUseFailure and NOT PostToolUse (measured 2026-08-13); each registration passes its own --event so the tracker scores the outcome from the registration rather than guessing. BLAST RADIUS, stated rather than discovered: the PreToolUse entry BLOCKS Write and Edit until the required MCP tools have SUCCEEDED, and Qdrant is currently down (see BL-231), so this will block writes in this repo until the server is up. That is the intended posture — configured-but-unreachable blocks — and the honest way through is SOLO_MCP_ATTESTED=1 SOLO_MCP_REASON='<why>', which is recorded to .claude/process-state.json::mcp_attestations[] and refused if it cannot be written.",
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-test-gate-check.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh --event PostToolUse"
+          }
+        ]
+      }
+    ],
+    "PostToolUseFailure": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh --event PostToolUseFailure"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-mcp-gate.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/session-mcp-gate.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -516,6 +516,7 @@ jobs:
             tests/test-brownfield-wp4-driver.sh
             tests/test-brownfield-wp5b-test-debt.sh
             tests/test-brownfield-wp6-collision-archive.sh
+            tests/test-bl233-mcp-outcome-enforcement.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/init.sh
+++ b/init.sh
@@ -2036,15 +2036,38 @@ PERMEOF
           fi
         done
 
-        # Add tool usage tracking to PostToolUse hook
+        # Add tool usage tracking to PostToolUse hook.
+        #
+        # BL-233: registered on PostToolUse ALONE, this tracker never saw a
+        # failure. A failed MCP call fires PostToolUseFailure and NOT
+        # PostToolUse (measured 2026-08-13 with a probe on both events), so
+        # failures were not miscounted by the framework — they were INVISIBLE
+        # to it, and a call that reached nothing left the same trace as no call
+        # at all. Both events are registered, each passing its own --event
+        # argument so the tracker can score the outcome without depending on a
+        # payload field, and can refuse to guess when the two disagree.
         if jq -e '.hooks.PostToolUse' .claude/settings.json >/dev/null 2>&1; then
           if ! jq -e '.hooks.PostToolUse[0].hooks[] | select(.command | contains("track-tool-usage.sh"))' .claude/settings.json >/dev/null 2>&1; then
-            jq '.hooks.PostToolUse[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh"}]' .claude/settings.json > .claude/settings.json.tmp \
+            jq '.hooks.PostToolUse[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh --event PostToolUse"}]' .claude/settings.json > .claude/settings.json.tmp \
               && mv .claude/settings.json.tmp .claude/settings.json
             hooks_added=true
           fi
         else
-          jq '.hooks.PostToolUse = [{"hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh"}]}]' .claude/settings.json > .claude/settings.json.tmp \
+          jq '.hooks.PostToolUse = [{"hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh --event PostToolUse"}]}]' .claude/settings.json > .claude/settings.json.tmp \
+            && mv .claude/settings.json.tmp .claude/settings.json
+          hooks_added=true
+        fi
+
+        # Add the SAME tracker to PostToolUseFailure — the event a failing MCP
+        # call actually fires.
+        if jq -e '.hooks.PostToolUseFailure' .claude/settings.json >/dev/null 2>&1; then
+          if ! jq -e '.hooks.PostToolUseFailure[0].hooks[] | select(.command | contains("track-tool-usage.sh"))' .claude/settings.json >/dev/null 2>&1; then
+            jq '.hooks.PostToolUseFailure[0].hooks += [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh --event PostToolUseFailure"}]' .claude/settings.json > .claude/settings.json.tmp \
+              && mv .claude/settings.json.tmp .claude/settings.json
+            hooks_added=true
+          fi
+        else
+          jq '.hooks.PostToolUseFailure = [{"hooks": [{"type": "command", "command": "bash \"$CLAUDE_PROJECT_DIR\"/scripts/track-tool-usage.sh --event PostToolUseFailure"}]}]' .claude/settings.json > .claude/settings.json.tmp \
             && mv .claude/settings.json.tmp .claude/settings.json
           hooks_added=true
         fi
@@ -2196,13 +2219,40 @@ BPEOF
 PSEOF
 
   # Generate tool usage tracking file
+  # BL-233: this seed used to carry NO `mcp_requirements` object at all, so
+  # `.mcp_requirements.qdrant_required // false` resolved to FALSE in every
+  # generated project and every MCP requirement defaulted to OFF — a missing
+  # key defaulting to the permissive answer, which is `## BL-221:`'s shape one
+  # subsystem over. The requirements are seeded fail-CLOSED (true); the
+  # SessionStart hook (scripts/session-test-gate-check.sh) re-derives them from
+  # the MCP servers actually configured on the very first session, before an
+  # agent can write anything, so a project with no MCP servers is not blocked —
+  # it is asked the question honestly instead of being silently exempted.
+  #
+  # The outcome fields are seeded too, so a generated ledger has the same schema
+  # session-mcp-gate.sh derives from. `*_called` are observability only; the
+  # gate reads `*_succeeded`.
   cat > .claude/tool-usage.json << 'TUEOF'
 {
   "session_id": null,
   "calls": [],
   "commits_since_last_context7": 0,
   "qdrant_find_called": false,
-  "qdrant_store_called": false
+  "qdrant_find_succeeded": false,
+  "qdrant_find_failed": 0,
+  "qdrant_find_empty": false,
+  "qdrant_find_empty_count": 0,
+  "qdrant_store_called": false,
+  "qdrant_store_succeeded": false,
+  "context7_called": false,
+  "context7_query_docs_succeeded": false,
+  "context7_resolve_only_count": 0,
+  "mcp_gate_satisfied": false,
+  "mcp_requirements": {
+    "qdrant_required": true,
+    "context7_required": true,
+    "additional_required": []
+  }
 }
 TUEOF
 

--- a/scripts/session-mcp-gate.sh
+++ b/scripts/session-mcp-gate.sh
@@ -67,19 +67,62 @@ TOOL_USAGE=".claude/tool-usage.json"
 PROCESS_STATE=".claude/process-state.json"
 ATTEST_JSONL=".claude/mcp-attestations.jsonl"
 
-ESCAPE_HINT="If this cannot be satisfied honestly — offline, a project with no prior memory, a change that involves no library — attest the exception: SOLO_MCP_ATTESTED=1 SOLO_MCP_REASON='<why>'. The reason is MANDATORY, the escape is RECORDED to .claude/process-state.json::mcp_attestations[], and it is REFUSED if that record cannot be written."
+# THE ESCAPE IS LAUNCH-TIME, and the hint must say so rather than implying a
+# retry. A PreToolUse hook inherits the environment Claude Code started with,
+# and unlike BL-072's TDD escape — which rides the `git commit` command line, so
+# an operator can set it per commit — there is no way to attach an env var to a
+# single Write. "Re-run with SOLO_MCP_REASON=…" is advice that cannot be
+# followed mid-session; a gate whose escape route does not exist is one people
+# route around (`## BL-149:`), so the honest paths are named explicitly and in
+# preference order.
+ESCAPE_HINT="MID-SESSION, the ways through are: (1) make the call succeed — start the server (Qdrant: docker start, port 6333) and call the tool again, which is the outcome this gate exists to produce; or (2) if it genuinely cannot be satisfied — offline, a project with no prior memory, a change that involves no library — EXIT and restart the session with the attestation exported: SOLO_MCP_ATTESTED=1 SOLO_MCP_REASON='<why>' claude. The variables are read from the session's environment, so they cannot be attached to a single Write after the session has started. The reason is MANDATORY, the escape is RECORDED to .claude/process-state.json::mcp_attestations[] (or .claude/mcp-attestations.jsonl if jq is unavailable), and it is REFUSED if neither record can be written."
+
+# _scrub_ctl STRING — sets SCRUBBED to STRING with every control byte
+# U+0001-U+001F replaced by a space.
+#
+# WHY THE WHOLE CLASS AND NOT A LIST. This function replaces an escaper that
+# handled `\\`, `"`, `\n` and `\t` — the characters that came to mind, not the
+# class. `\r` alone defeated it, and the text being escaped is NOT OURS: the
+# UNREACHABLE arm splices `last_mcp_error`, which is the remote server's own
+# message, and the attestation arms splice the operator's free text. `jq -r`
+# emits those bytes raw, so whatever the server says arrives intact.
+#
+# What an unescaped control byte costs is a FAIL-OPEN, and a durable one. The
+# hook exits 0, Claude Code parses stdout for a decision, and an unparseable
+# envelope means "no decision — normal permission flow applies": the block is
+# silently dropped. Because `last_mcp_error` persists in the ledger, the gate
+# then keeps failing open for the rest of the session. The strictest posture
+# and the weakest outcome, from the same input.
+#
+# `printf -v` and parameter expansion are BUILTINS, so this works with an empty
+# PATH — which it must, because the no-jq refusal is emitted through here and
+# cannot use jq to build its JSON the way the tracker does. U+0000 is not in
+# the loop: a bash string cannot hold a NUL (it would terminate the value), so
+# one can never reach the envelope through a shell variable.
+SCRUBBED=""
+_scrub_ctl() {
+  local s="$1" i ch
+  for i in 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f; do
+    printf -v ch "\\x$i"
+    s=${s//"$ch"/ }
+  done
+  SCRUBBED="$s"
+}
 
 # deny REASON — emit the PreToolUse deny envelope, then exit 0.
 #
 # printf and parameter expansion only, no cat/heredoc/sed: the no-jq arm must
 # be able to report a missing toolchain without depending on that toolchain,
 # and this function is what it reports through. It works with an EMPTY PATH.
+#
+# Order matters: scrub the control class FIRST, then escape `\` and `"`. The
+# scrub only ever introduces spaces, so it cannot manufacture an escape the
+# following two lines would then miss.
 deny() {
   local reason="$1"
+  _scrub_ctl "$reason"; reason="$SCRUBBED"  # BL-233-CTL-SCRUB
   reason=${reason//\\/\\\\}
   reason=${reason//\"/\\\"}
-  reason=${reason//$'\n'/ }
-  reason=${reason//$'\t'/ }
   printf '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "%s"}}\n' "$reason"
   exit 0
 }
@@ -158,10 +201,16 @@ mcp_record_attestation() {
     fi
   fi
 
-  # Fallback sink — builtins only, so it survives the no-jq state.
-  local r="$reason" b="$blocked"
-  r=${r//\\/\\\\}; r=${r//\"/\\\"}; r=${r//$'\n'/ }
-  b=${b//\\/\\\\}; b=${b//\"/\\\"}; b=${b//$'\n'/ }
+  # Fallback sink — builtins only, so it survives the no-jq state. Same
+  # control-class scrub as deny(): this line is hand-built JSON carrying the
+  # operator's free text, and a record nothing can parse is not a record. The
+  # sink counted the write as "recorded" whether or not the line was valid,
+  # so a stray CR in a reason produced an escape whose only trace was corrupt.
+  local r b
+  _scrub_ctl "$reason"; r="$SCRUBBED"
+  _scrub_ctl "$blocked"; b="$SCRUBBED"
+  r=${r//\\/\\\\}; r=${r//\"/\\\"}
+  b=${b//\\/\\\\}; b=${b//\"/\\\"}
   if ( printf '{"date": "%s", "reason": "%s", "blocked_on": "%s"}\n' "${now:-unknown}" "$r" "$b" >> "$ATTEST_JSONL" ) 2>/dev/null; then
     ok=0
   fi
@@ -232,7 +281,11 @@ fi
 # ── Allow ───────────────────────────────────────────────────────────────────
 if [ -z "$BLOCK_REASON" ]; then
   if command -v jq >/dev/null 2>&1 && [ -f "$TOOL_USAGE" ]; then
-    jq '.mcp_gate_satisfied = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    # The UPWARD half of the re-derivation. Nothing else in the framework reads
+    # this field, so deleting this line changes no decision and no other test —
+    # which is exactly why it needs its own assertion (D2) and its own mutant
+    # (M12) rather than three prose claims that it happens.
+    jq '.mcp_gate_satisfied = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null  # BL-233-LATCH-RECORD-UP
   fi
   exit 0
 fi

--- a/scripts/session-mcp-gate.sh
+++ b/scripts/session-mcp-gate.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail
-
 # Solo Orchestrator — PreToolUse hook for MCP session-start enforcement
-# Blocks Write and Edit tool calls until required MCP tools have been called.
+# Blocks Write and Edit tool calls until required MCP tools have SUCCEEDED.
 # Registered as a PreToolUse hook on Write and Edit tool calls.
 #
 # This closes the enforcement gap identified in the hook architecture:
@@ -10,71 +8,259 @@ set -euo pipefail
 # This hook makes them mechanical — the agent cannot produce output until
 # it has loaded prior context and verified library documentation.
 #
+# ── BL-233: every layer here asked whether something was DECLARED ───────────
+# The intent above was right; the enforcement was not. Four separate arms
+# exited 0 in silence — absent ledger, absent jq, a missing requirement key
+# defaulting to "not required", and a latch that made "satisfied once" mean
+# "satisfied forever" — and satisfaction itself was read from a flag set by
+# TOOL NAME, so a qdrant-find that returned "All connection attempts failed"
+# passed the gate (BL-231) and a Context7 ID lookup that fetched no
+# documentation passed a gate whose stated purpose is that documentation was
+# read (BL-232). Every one of those is the same substitution.
+#
+# Three rules now hold, and each one is mutation-proved in
+# tests/test-bl233-mcp-outcome-enforcement.sh:
+#
+#   1. SATISFACTION IS AN OUTCOME. The gate reads qdrant_find_succeeded /
+#      context7_query_docs_succeeded, which track-tool-usage.sh sets only from
+#      the hook EVENT (a failed MCP call fires PostToolUseFailure, never
+#      PostToolUse — measured 2026-08-13; there is no isError field anywhere,
+#      so the event is the only signal).
+#   2. "CANNOT TELL" IS NOT "SATISFIED". Every degraded state DENIES, and the
+#      refusal text says which state it is in. `# BL-112-SAST-NOTRUN`'s shipped
+#      doctrine, one subsystem over: "the scanner did not run" must never read
+#      as "the scanner found nothing."
+#   3. THREE STATES, NOT TWO. reachable / configured-but-unreachable /
+#      not-configured are separately reported. Not-configured is a determinate
+#      answer and ALLOWS; unreachable BLOCKS, and says so in those words.
+#
+# ── THE LATCH — decided deliberately (BL-233 item 5) ───────────────────────
+# `mcp_gate_satisfied` is written into .claude/tool-usage.json, a file the
+# agent itself can edit. A latch there is a self-signed permission slip, so
+# THIS HOOK NEVER TAKES A FAST PATH ON IT. The field is still written, as a
+# record of the last derivation, and it is RE-DERIVED on every invocation —
+# read for the transcript, never for the decision.
+#
+# What that costs: a few small jq reads per Write/Edit instead of one. What it
+# buys: the gate answers "is it satisfied NOW" rather than "was it satisfied
+# once". Session scope comes from the ledger's own lifecycle, which is left
+# exactly as `5b1a081` fixed it — SessionStart's `startup` path resets the
+# outcome flags, and resume/compact/clear MERGE so a satisfied requirement is
+# not re-armed mid-Build-Loop. Re-arming there was the destructive behaviour
+# 5b1a081 removed, and re-introducing it through the back door of a latch
+# reset would undo that fix.
+#
+# ── set -e is deliberately NOT set ─────────────────────────────────────────
+# Under `set -e` an unexpected non-zero anywhere exits non-zero, and a
+# PreToolUse hook exiting non-zero-but-not-2 is a NON-BLOCKING error — it
+# would fail OPEN, which is the whole bug class. Instead: no `set -e`, every
+# read routed through _flag/_count which sanitize to the BLOCKING default, and
+# every exit path explicit.
+#
 # Input: Claude Code passes tool input JSON on stdin
 # Output:
 #   - No output = allow
 #   - JSON with permissionDecision: "deny" = block
+set -uo pipefail
 
 TOOL_USAGE=".claude/tool-usage.json"
+PROCESS_STATE=".claude/process-state.json"
+ATTEST_JSONL=".claude/mcp-attestations.jsonl"
 
-# No tracking file = no enforcement (project not initialized with hooks)
-if [ ! -f "$TOOL_USAGE" ]; then
+ESCAPE_HINT="If this cannot be satisfied honestly — offline, a project with no prior memory, a change that involves no library — attest the exception: SOLO_MCP_ATTESTED=1 SOLO_MCP_REASON='<why>'. The reason is MANDATORY, the escape is RECORDED to .claude/process-state.json::mcp_attestations[], and it is REFUSED if that record cannot be written."
+
+# deny REASON — emit the PreToolUse deny envelope, then exit 0.
+#
+# printf and parameter expansion only, no cat/heredoc/sed: the no-jq arm must
+# be able to report a missing toolchain without depending on that toolchain,
+# and this function is what it reports through. It works with an EMPTY PATH.
+deny() {
+  local reason="$1"
+  reason=${reason//\\/\\\\}
+  reason=${reason//\"/\\\"}
+  reason=${reason//$'\n'/ }
+  reason=${reason//$'\t'/ }
+  printf '{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "%s"}}\n' "$reason"
   exit 0
-fi
+}
 
-command -v jq &>/dev/null || exit 0
+# _flag JQPATH DEFAULT — read a boolean from the ledger, FAIL CLOSED on
+# anything unexpected (missing key, null, malformed file, jq error). The
+# default is supplied by the caller precisely so that "required" and
+# "satisfied" can default in OPPOSITE directions: unknown requirement ⇒ true,
+# unknown satisfaction ⇒ false. Both of those block.
+#
+# NO `// default` INSIDE THE JQ FILTER, and this is not a style preference.
+# jq's alternative operator treats `false` exactly like `null`, so
+# `.qdrant_required // true` on an explicit `false` yields TRUE — the honest
+# "this server is not configured" answer would be silently upgraded to
+# "required", and a project with no MCP servers could never write a file. The
+# missing-key default has to be applied HERE, where `false` and `null` are
+# still distinguishable. (`jq -r` prints the literal `null` for a missing key
+# at rc 0, which is the same shape `## BL-203:` was filed for.)
+_flag() {
+  local v
+  v=$(jq -r "$1" "$TOOL_USAGE" 2>/dev/null)
+  case "$v" in
+    true)  printf 'true\n' ;;
+    false) printf 'false\n' ;;
+    *)     printf '%s\n' "$2" ;;
+  esac
+}
 
-# Fast path: if gate already satisfied, exit immediately.
-# This check runs on EVERY Write/Edit call — must be fast.
-GATE_SATISFIED=$(jq -r '.mcp_gate_satisfied // false' "$TOOL_USAGE" 2>/dev/null)
-if [ "$GATE_SATISFIED" = "true" ]; then
-  exit 0
-fi
+# _count JQPATH — a non-negative integer, 0 on anything unexpected.
+_count() {
+  local v
+  v=$(jq -r "$1 // 0" "$TOOL_USAGE" 2>/dev/null)
+  case "$v" in ''|*[!0-9]*) v=0 ;; esac
+  printf '%s\n' "$v"
+}
 
-# Check each required MCP tool
-MISSING=""
+# mcp_record_attestation REASON BLOCKED_ON — durably log an attested escape.
+# Returns 0 only on a write that actually landed, 1 on ANY failure; the caller
+# must be loud and REFUSE on 1. Modelled on `# BL-072-TDD-ENFORCE`'s
+# tdd_record_attestation, with one addition: a jq-free fallback sink.
+#
+# Why the fallback exists. The primary sink needs jq, and one of the states
+# this gate blocks on IS "jq is missing" — so a jq-only recorder would make the
+# no-jq refusal UNESCAPABLE, and `## BL-149:` says a gate people cannot satisfy
+# honestly is a gate they delete. The fallback appends one JSON object per line
+# with shell builtins alone. An escape is refused only when BOTH sinks fail.
+#
+# Every write is wrapped in a `( … ) 2>/dev/null` SUBSHELL, not given a
+# trailing `2>/dev/null`. A redirection onto an unwritable target fails in the
+# shell BEFORE the command's own stderr redirect is installed, so the error
+# text lands on the real stderr — and a hook that prints anything alongside its
+# JSON envelope has emitted a malformed decision. The subshell's stderr is
+# already redirected when the inner redirection is attempted.
+#
+# `mkdir` and `date` are EXTERNAL binaries and one of the states this gate
+# blocks on is an empty PATH, so neither may be load-bearing: a missing mkdir
+# is not itself a failure to record (the append below decides that), and a
+# missing date degrades the timestamp rather than the record.
+mcp_record_attestation() {
+  local reason="$1" blocked="$2" now="" tmp ok=1
+  [ -d .claude ] || ( mkdir -p .claude ) 2>/dev/null
 
-# Qdrant requirement: qdrant-find must be called at session start
-QDRANT_REQUIRED=$(jq -r '.mcp_requirements.qdrant_required // false' "$TOOL_USAGE" 2>/dev/null)
-if [ "$QDRANT_REQUIRED" = "true" ]; then
-  QDRANT_CALLED=$(jq -r '.qdrant_find_called // false' "$TOOL_USAGE" 2>/dev/null)
-  if [ "$QDRANT_CALLED" = "false" ]; then
-    MISSING="${MISSING}qdrant-find (retrieve prior session context before starting work). "
-  fi
-fi
-
-# Context7 requirement: at least one Context7 call must be made
-CONTEXT7_REQUIRED=$(jq -r '.mcp_requirements.context7_required // false' "$TOOL_USAGE" 2>/dev/null)
-if [ "$CONTEXT7_REQUIRED" = "true" ]; then
-  CONTEXT7_CALLED=$(jq -r '.context7_called // false' "$TOOL_USAGE" 2>/dev/null)
-  if [ "$CONTEXT7_CALLED" = "false" ]; then
-    MISSING="${MISSING}context7 resolve-library-id or query-docs (verify library documentation is current before writing). "
-  fi
-fi
-
-# Check any additional required MCP tools (user-configured)
-ADDITIONAL=$(jq -r '.mcp_requirements.additional_required // [] | .[]' "$TOOL_USAGE" 2>/dev/null)
-if [ -n "$ADDITIONAL" ]; then
-  while IFS= read -r tool_pattern; do
-    [ -z "$tool_pattern" ] && continue
-    TOOL_CALLED=$(jq --arg pat "$tool_pattern" '[.calls[] | select(.tool | test($pat))] | length > 0' "$TOOL_USAGE" 2>/dev/null)
-    if [ "$TOOL_CALLED" != "true" ]; then
-      MISSING="${MISSING}${tool_pattern} (required MCP tool not yet called this session). "
+  if command -v jq >/dev/null 2>&1; then
+    now=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)
+    if [ ! -f "$PROCESS_STATE" ]; then
+      ( printf '%s\n' '{}' > "$PROCESS_STATE" ) 2>/dev/null
     fi
-  done <<< "$ADDITIONAL"
+    if [ -f "$PROCESS_STATE" ]; then
+      tmp="$PROCESS_STATE.tmp.$$"
+      if ( jq --arg date "$now" --arg reason "$reason" --arg blocked "$blocked" \
+             '.mcp_attestations = ((.mcp_attestations // []) + [{date:$date, reason:$reason, blocked_on:$blocked}])' \
+             "$PROCESS_STATE" > "$tmp" && mv "$tmp" "$PROCESS_STATE" ) 2>/dev/null; then
+        ok=0
+      fi
+      ( rm -f "$tmp" ) 2>/dev/null
+    fi
+  fi
+
+  # Fallback sink — builtins only, so it survives the no-jq state.
+  local r="$reason" b="$blocked"
+  r=${r//\\/\\\\}; r=${r//\"/\\\"}; r=${r//$'\n'/ }
+  b=${b//\\/\\\\}; b=${b//\"/\\\"}; b=${b//$'\n'/ }
+  if ( printf '{"date": "%s", "reason": "%s", "blocked_on": "%s"}\n' "${now:-unknown}" "$r" "$b" >> "$ATTEST_JSONL" ) 2>/dev/null; then
+    ok=0
+  fi
+
+  return "$ok"
+}
+
+# ── Derive the block reason (empty string = allow) ──────────────────────────
+BLOCK_REASON=""
+GATE_PRIOR="unknown"
+
+if ! command -v jq >/dev/null 2>&1; then
+  BLOCK_REASON="MCP SESSION GATE — CANNOT VERIFY: jq is not installed, so this hook cannot read .claude/tool-usage.json and cannot tell whether the required MCP tools succeeded this session. That is 'cannot tell', which is NOT 'satisfied'. Install jq and retry."  # BL-233-FAILCLOSED-JQ
+elif [ ! -f "$TOOL_USAGE" ]; then
+  BLOCK_REASON="MCP SESSION GATE — CANNOT VERIFY: the tracking ledger .claude/tool-usage.json is ABSENT, so this hook cannot tell whether the required MCP tools succeeded this session. That is 'cannot tell', which is NOT 'satisfied'. Start a session so the SessionStart hook writes the ledger (scripts/session-test-gate-check.sh), or verify the hooks are installed with scripts/verify-install.sh."  # BL-233-FAILCLOSED-NOFILE
+else
+  # Read for the transcript ONLY. Turning this into a fast path is the latch
+  # this hook deliberately does not have — see the header.
+  GATE_PRIOR=$(_flag '.mcp_gate_satisfied' false)  # BL-233-NO-LATCH
+
+  # A MISSING requirement key defaults to REQUIRED. An absent key means the
+  # ledger cannot tell us, and `## BL-221:` is what the permissive reading of
+  # that costs: `// false` made every requirement silently OFF in every
+  # generated project, because the scaffolder seeded no mcp_requirements at all.
+  QDRANT_REQUIRED=$(_flag '.mcp_requirements.qdrant_required' true)  # BL-233-FAILCLOSED-REQ
+  CONTEXT7_REQUIRED=$(_flag '.mcp_requirements.context7_required' true)  # BL-233-FAILCLOSED-REQ-C7
+
+  QDRANT_OK=$(_flag '.qdrant_find_succeeded' false)  # BL-233-OUTCOME-QDRANT
+  CONTEXT7_OK=$(_flag '.context7_query_docs_succeeded' false)  # BL-233-OUTCOME-C7
+
+  QDRANT_FAILS=$(_count '.qdrant_find_failed')
+  C7_RESOLVE_ONLY=$(_count '.context7_resolve_only_count')
+  LAST_ERR=$(jq -r '.last_mcp_error // ""' "$TOOL_USAGE" 2>/dev/null)
+
+  # Qdrant — three states, distinguishable in the output.
+  if [ "$QDRANT_REQUIRED" = "true" ] && [ "$QDRANT_OK" = "false" ]; then
+    if [ "$QDRANT_FAILS" -gt 0 ]; then
+      BLOCK_REASON="${BLOCK_REASON}qdrant-find was CALLED $QDRANT_FAILS time(s) this session and EVERY call FAILED (last error: ${LAST_ERR:-unrecorded}). The server is CONFIGURED BUT UNREACHABLE — which is a different state from not-configured, and is not 'satisfied'. Nothing was retrieved, so there is no prior context loaded. Start the Qdrant server (docker ps / port 6333) and call qdrant-find again. "  # BL-233-UNREACHABLE
+    else
+      BLOCK_REASON="${BLOCK_REASON}qdrant-find has not returned successfully this session (retrieve prior session context before starting work). "
+    fi
+  fi
+
+  # Context7 — require the call that FETCHES DOCUMENTATION. resolve-library-id
+  # returns a list of library IDs and reads nothing; it is the argument step.
+  if [ "$CONTEXT7_REQUIRED" = "true" ] && [ "$CONTEXT7_OK" = "false" ]; then
+    if [ "$C7_RESOLVE_ONLY" -gt 0 ]; then
+      BLOCK_REASON="${BLOCK_REASON}context7 resolve-library-id succeeded $C7_RESOLVE_ONLY time(s), but it fetches NO documentation — it only returns library IDs. Call mcp__context7__query-docs with that ID to actually read the docs. "  # BL-233-C7-RESOLVE-ONLY
+    else
+      BLOCK_REASON="${BLOCK_REASON}context7 query-docs has not returned successfully this session (read current library documentation before writing). "
+    fi
+  fi
+
+  # Operator-configured additional requirements — same outcome footing: a call
+  # row only counts if its recorded outcome is success.
+  ADDITIONAL=$(jq -r '.mcp_requirements.additional_required // [] | .[]' "$TOOL_USAGE" 2>/dev/null)
+  if [ -n "$ADDITIONAL" ]; then
+    while IFS= read -r tool_pattern; do
+      [ -z "$tool_pattern" ] && continue
+      TOOL_OK=$(jq --arg pat "$tool_pattern" '[.calls[]? | select((.tool // "") | test($pat)) | select((.outcome // "") == "success")] | length > 0' "$TOOL_USAGE" 2>/dev/null)
+      if [ "$TOOL_OK" != "true" ]; then
+        BLOCK_REASON="${BLOCK_REASON}${tool_pattern} (required MCP tool has not returned successfully this session). "  # BL-233-ADDITIONAL-OUTCOME
+      fi
+    done <<< "$ADDITIONAL"
+  fi
 fi
 
-if [ -n "$MISSING" ]; then
-  # Strip trailing space
-  MISSING="${MISSING% }"
-  ESCAPED=$(echo "$MISSING" | sed 's/"/\\"/g')
-  cat << HOOKEOF
-{"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "deny", "permissionDecisionReason": "SESSION START REQUIREMENTS NOT MET. Before making any file changes, you must call the following MCP tools: $ESCAPED These tools are required at the start of every session to ensure you are working with current context and accurate documentation. Call them now, then retry your Write/Edit operation."}}
-HOOKEOF
+# ── Allow ───────────────────────────────────────────────────────────────────
+if [ -z "$BLOCK_REASON" ]; then
+  if command -v jq >/dev/null 2>&1 && [ -f "$TOOL_USAGE" ]; then
+    jq '.mcp_gate_satisfied = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+  fi
   exit 0
 fi
 
-# All requirements met — set gate satisfied for fast-path on future calls
-jq '.mcp_gate_satisfied = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+BLOCK_REASON="${BLOCK_REASON% }"
 
-exit 0
+# Re-derive the recorded flag DOWNWARD too, so a stale `true` left by an
+# earlier derivation (or written by hand) never survives a run that blocked.
+if command -v jq >/dev/null 2>&1 && [ -f "$TOOL_USAGE" ]; then
+  jq '.mcp_gate_satisfied = false' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+fi
+
+# ── The attested escape (BL-072's shape) ────────────────────────────────────
+if [ "${SOLO_MCP_ATTESTED:-0}" = "1" ]; then
+  ATTEST_REASON="${SOLO_MCP_REASON:-}"  # BL-233-ATTEST-REASON
+  if [ -z "$ATTEST_REASON" ]; then
+    deny "MCP SESSION GATE — ATTESTATION REFUSED: SOLO_MCP_ATTESTED=1 was set with no SOLO_MCP_REASON. The reason is MANDATORY — an unexplained escape is indistinguishable from the advisory posture this gate replaced, and it is the reason that makes the record worth keeping. Re-run with SOLO_MCP_REASON='<why this cannot be satisfied>'. Blocked on: $BLOCK_REASON"
+  fi
+  if mcp_record_attestation "$ATTEST_REASON" "$BLOCK_REASON"; then
+    exit 0
+  fi
+  # LOUD failure — an attested escape MUST be on the record; never a silent pass.
+  deny "MCP SESSION GATE — ATTESTATION REFUSED: SOLO_MCP_ATTESTED=1 with a reason, but the attestation could NOT be durably recorded to either .claude/process-state.json::mcp_attestations[] or .claude/mcp-attestations.jsonl (disk/permissions/jq). REFUSING the write — an attested escape must be durably logged, and an escape that leaves no trace is exactly the advisory posture this gate exists to replace. Fix the write error and retry. Blocked on: $BLOCK_REASON"  # BL-233-ATTEST-REFUSE
+fi
+
+STALE_NOTE=""
+if [ "$GATE_PRIOR" = "true" ]; then
+  STALE_NOTE=" NOTE: .claude/tool-usage.json carried mcp_gate_satisfied=true, but this gate re-derives on every call and the requirement is NOT satisfied now — the flag has been corrected."
+fi
+
+deny "MCP SESSION GATE — REQUIREMENTS NOT MET. Before making any file changes you must SUCCESSFULLY call: $BLOCK_REASON A tool that was called but errored does not count; the framework reads the hook event, not the tool name.$STALE_NOTE $ESCAPE_HINT"

--- a/scripts/track-tool-usage.sh
+++ b/scripts/track-tool-usage.sh
@@ -194,15 +194,29 @@ RESPONSE_TEXT=$(echo "$INPUT" | jq -r '
     elif ($r | type) == "object" then ($r | tostring)
     else "" end' 2>/dev/null)
 
+# Emptiness is decided by SHAPE first and by WORDING only as a fallback, and
+# the two halves are not equally trustworthy. A zero-length content array, an
+# absent tool_response, and text that is all whitespace are structural facts
+# about what came back. A phrase list is a guess about how a particular server
+# writes "nothing here" — it covers the ones we have seen and it will miss a
+# server that words it differently. That residual is stated rather than hidden:
+# a missed phrase records qdrant_find_empty=false and reports nothing, so an
+# empty memory would look like a healthy one. The shape checks are what keep
+# that from being the common case.
 IS_EMPTY=0
 if [ "$OUTCOME" = "success" ]; then
+  # Shape: no content blocks at all (`[]`), or tool_response absent entirely.
+  RESPONSE_BLOCKS=$(echo "$INPUT" | jq -r 'if (.tool_response // null | type) == "array" then (.tool_response | length) else -1 end' 2>/dev/null)
+  case "$RESPONSE_BLOCKS" in ''|*[!0-9-]*) RESPONSE_BLOCKS=-1 ;; esac
   _stripped=$(printf '%s' "$RESPONSE_TEXT" | tr -d '[:space:]')
-  if [ -z "$_stripped" ]; then
+  if [ "$RESPONSE_BLOCKS" = "0" ]; then
     IS_EMPTY=1
-  elif printf '%s' "$RESPONSE_TEXT" | grep -qiE 'no information found|no results found|no matching (documents|entries|results)' 2>/dev/null; then
-    # The qdrant MCP server's own zero-result phrasing. A gate that reads this
-    # as content is the "returned something" question answered by a sentence
-    # that says nothing was returned.
+  elif [ -z "$_stripped" ]; then
+    IS_EMPTY=1
+  elif printf '%s' "$RESPONSE_TEXT" | grep -qiE 'no (information|results?|matches|matching|entries|entry|documents?|data|content|context) (found|available|returned)?|nothing found|empty (result|collection)|0 results|found 0 ' 2>/dev/null; then
+    # Known zero-result phrasings, the qdrant MCP server's own included. A gate
+    # that reads these as content answers "did it return something?" with a
+    # sentence that says nothing was returned.
     IS_EMPTY=1
   fi
 fi
@@ -286,11 +300,19 @@ fi
 # field written above, and it is written whether or not this line is reached.
 # Only the two states worth interrupting for are reported: a retrieval that
 # returned nothing, and a call that failed.
+#
+# BUILT BY jq, NOT BY printf. The failure report splices $TOOL_ERROR — the
+# remote server's own message, which is not ours and can carry any byte. It
+# used to be hand-escaped for `\`, `"`, `\n`, `\r` and `\t`; that is a list, not
+# the control CLASS, and an unparseable hook envelope is worse than no envelope.
+# jq is guaranteed present here (the script exits above without it), so there is
+# no reason to hand-build JSON on this path — unlike session-mcp-gate.sh's
+# deny(), which must be able to report a MISSING jq and therefore scrubs the
+# class with builtins instead.
 if [ "$IS_EMPTY" = "1" ] && echo "$TOOL_NAME" | grep -q "qdrant" 2>/dev/null; then
-  printf '{"hookSpecificOutput": {"hookEventName": "%s", "additionalContext": "QDRANT EMPTY RESULT: %s returned no stored context. This does NOT block you — an empty semantic memory is expected on a new project. On an established one it means nothing was ever stored, so the retrieval half has nothing behind it. Report it to the Orchestrator and store what this session learns."}}\n' "$EVENT" "$TOOL_NAME"  # BL-233-EMPTY-REPORT
+  jq -nc --arg ev "$EVENT" --arg tool "$TOOL_NAME" '{hookSpecificOutput: {hookEventName: $ev, additionalContext: ("QDRANT EMPTY RESULT: " + $tool + " returned no stored context. This does NOT block you — an empty semantic memory is expected on a new project. On an established one it means nothing was ever stored, so the retrieval half has nothing behind it. Report it to the Orchestrator and store what this session learns.")}}'  # BL-233-EMPTY-REPORT
 elif [ "$OUTCOME" = "failure" ]; then
-  _err_escaped=$(printf '%s' "$TOOL_ERROR" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr -d '\n\r\t')
-  printf '{"hookSpecificOutput": {"hookEventName": "%s", "additionalContext": "MCP CALL FAILED: %s did not execute (%s). This is RECORDED and it does NOT satisfy any session requirement — the framework now distinguishes configured-but-unreachable from not-configured. Fix the server or attest the exception; do not retry silently and proceed."}}\n' "$EVENT" "$TOOL_NAME" "$_err_escaped"
+  jq -nc --arg ev "$EVENT" --arg tool "$TOOL_NAME" --arg err "$TOOL_ERROR" '{hookSpecificOutput: {hookEventName: $ev, additionalContext: ("MCP CALL FAILED: " + $tool + " did not execute (" + $err + "). This is RECORDED and it does NOT satisfy any session requirement — the framework now distinguishes configured-but-unreachable from not-configured. Fix the server or attest the exception; do not retry silently and proceed.")}}'
 fi
 
 exit 0

--- a/scripts/track-tool-usage.sh
+++ b/scripts/track-tool-usage.sh
@@ -99,6 +99,18 @@ case "$EVENT" in
   *)                  OUTCOME=unknown ;;
 esac  # BL-233-EVENT-OUTCOME
 
+# A call the OPERATOR cancelled also arrives on PostToolUseFailure, carrying
+# is_interrupt=true. It did not succeed, so it must not satisfy anything — that
+# does not soften. But "you pressed Esc" is not evidence that the server is
+# down, and the gate's unreachable arm makes a CLAIM ABOUT THE WORLD from the
+# failure count. Scoring an interrupt as a failure would have the gate announce
+# CONFIGURED BUT UNREACHABLE because someone cancelled a query, which is
+# `## BL-104:`'s lesson restated: the label is never the behaviour. Recorded
+# separately, counted separately, still unsatisfied.
+if [ "$OUTCOME" = "failure" ] && [ "$(echo "$INPUT" | jq -r '.is_interrupt // false' 2>/dev/null)" = "true" ]; then
+  OUTCOME=interrupted  # BL-233-INTERRUPT
+fi
+
 # The error text is present only on the failure event.
 TOOL_ERROR=$(echo "$INPUT" | jq -r '.error // ""' 2>/dev/null)
 
@@ -251,7 +263,12 @@ if echo "$TOOL_NAME" | grep -q "qdrant" 2>/dev/null; then
          | .qdrant_find_empty = ($empty == 1)
          | .qdrant_find_empty_count = ((.qdrant_find_empty_count // 0) + $empty)' \
         "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    elif [ "$OUTCOME" = "interrupted" ]; then
+      jq '.qdrant_find_interrupted = ((.qdrant_find_interrupted // 0) + 1)' \
+        "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
     else
+      # Only a real failed round trip counts toward the evidence the gate uses
+      # to call the server unreachable.
       jq '.qdrant_find_failed = ((.qdrant_find_failed // 0) + 1)' \
         "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
     fi

--- a/scripts/track-tool-usage.sh
+++ b/scripts/track-tool-usage.sh
@@ -1,18 +1,79 @@
 #!/usr/bin/env bash
-# Solo Orchestrator — PostToolUse hook for MCP tool usage tracking
+# Solo Orchestrator — post-tool hook for MCP tool usage tracking
 # Logs Context7, Qdrant, and any configured MCP tool calls to .claude/tool-usage.json.
 # Updates compliance state for the session-mcp-gate.sh PreToolUse enforcement hook.
 # Fires after every tool call — must be fast for non-MCP tools.
-
-# Don't use set -e — this is an advisory PostToolUse hook that must NEVER block
+#
+# ── BL-233: this hook records OUTCOMES, not DECLARATIONS ────────────────────
+# It used to set `qdrant_find_called = true` / `context7_called = true` from the
+# TOOL NAME alone. A qdrant-find that connected to nothing and returned
+# "All connection attempts failed" therefore satisfied the session gate exactly
+# as a working one did (BL-231), and a Context7 ID lookup that fetches no
+# documentation satisfied a gate whose stated purpose is that documentation was
+# read (BL-232). Both are the same substitution: was a matching tool CALLED,
+# rather than did the call WORK.
+#
+# ── GROUND TRUTH, measured 2026-08-13 (the docs carry no worked MCP example) ─
+# Captured by registering a probe on both events and firing one failing and one
+# succeeding MCP call:
+#
+#   A FAILED MCP CALL FIRES `PostToolUseFailure`. IT DOES NOT FIRE `PostToolUse`.
+#
+#   | field         | success (PostToolUse)                 | failure (PostToolUseFailure) |
+#   |---------------|---------------------------------------|------------------------------|
+#   | tool_response | PRESENT — array of MCP content blocks | ABSENT                       |
+#   | error         | absent                                | "Error calling tool '…': …"  |
+#   | is_interrupt  | —                                     | false                        |
+#   | isError       | NONE ANYWHERE — MCP's own isError is not preserved by either event     |
+#
+# So THE EVENT IS THE SIGNAL: there is no field to test for success, and this
+# hook must be registered on BOTH events or failures are not miscounted — they
+# are INVISIBLE. (BL-233's own text says "read .tool_response". That is wrong:
+# tool_response tells you what came BACK, not that the call worked. What it is
+# genuinely good for is the separate question of whether the result was EMPTY,
+# which is why the empty-retrieval arm below reads it and the outcome arm does
+# not. The entry is corrected as part of WP-A.)
+#
+# A THIRD STATE exists: a call rejected before execution (unknown tool, schema
+# validation) fires NEITHER event. It is scored `unknown` and satisfies nothing,
+# which under fail-closed is correct — but it must never look like success.
+#
+# Registration (init.sh, and this repo's .claude/settings.json):
+#   PostToolUse:        bash …/track-tool-usage.sh --event PostToolUse
+#   PostToolUseFailure: bash …/track-tool-usage.sh --event PostToolUseFailure
+# The --event argument is belt-and-braces: the payload's own hook_event_name is
+# used when the argument is absent, and a DISAGREEMENT between the two — the
+# shape a mis-registration pointing both events at PostToolUse produces — is
+# scored `unknown` rather than trusted.
+#
+# Don't use set -e — this is an advisory post-tool hook that must NEVER block
 # the agent's work. If tool-usage.json is corrupted or jq fails, the agent
 # continues working and tool tracking silently degrades. This is intentional:
 # a tracking failure should not interrupt a build loop or any other operation.
+# The enforcement half of the split lives in session-mcp-gate.sh, which fails
+# CLOSED for exactly the states this hook shrugs off. Tracker never blocks;
+# gate always fails closed.
 set +e
 
 TOOL_USAGE=".claude/tool-usage.json"
 
-# Read tool info from stdin (Claude Code passes PostToolUse JSON)
+# ── argv: --event <name> ────────────────────────────────────────────────────
+# Unknown arguments are ignored rather than fatal — an argv this hook does not
+# understand must not turn every tool call into a hook error.
+EVENT_ARG=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event)
+      if [ "$#" -ge 2 ]; then EVENT_ARG="$2"; shift 2; else shift; fi
+      ;;
+    --event=*)
+      EVENT_ARG="${1#--event=}"; shift
+      ;;
+    *) shift ;;
+  esac
+done
+
+# Read tool info from stdin (Claude Code passes the post-tool JSON)
 INPUT=$(cat)
 
 # Extract tool name
@@ -21,6 +82,25 @@ TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null)
 if [ -z "$TOOL_NAME" ]; then
   exit 0
 fi
+
+# ── Outcome, derived from the EVENT ─────────────────────────────────────────
+EVENT_PAYLOAD=$(echo "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null)
+EVENT="$EVENT_ARG"
+[ -z "$EVENT" ] && EVENT="$EVENT_PAYLOAD"
+if [ -n "$EVENT_ARG" ] && [ -n "$EVENT_PAYLOAD" ] && [ "$EVENT_ARG" != "$EVENT_PAYLOAD" ]; then
+  # The registration and the payload disagree about which event this is. That
+  # is a mis-registration, and guessing in the permissive direction is how a
+  # failure gets scored as a success. Refuse to guess.
+  EVENT="disagreement:${EVENT_ARG}!=${EVENT_PAYLOAD}"
+fi
+case "$EVENT" in
+  PostToolUse)        OUTCOME=success ;;
+  PostToolUseFailure) OUTCOME=failure ;;
+  *)                  OUTCOME=unknown ;;
+esac  # BL-233-EVENT-OUTCOME
+
+# The error text is present only on the failure event.
+TOOL_ERROR=$(echo "$INPUT" | jq -r '.error // ""' 2>/dev/null)
 
 # Fast exit for non-MCP, non-commit tools (vast majority of calls)
 case "$TOOL_NAME" in
@@ -31,6 +111,7 @@ case "$TOOL_NAME" in
     if echo "$BASH_CMD" | grep -qE '^\s*git\s+commit' 2>/dev/null; then
       if [ -f "$TOOL_USAGE" ] && command -v jq &>/dev/null; then
         CURRENT=$(jq -r '.commits_since_last_context7 // 0' "$TOOL_USAGE" 2>/dev/null)
+        case "$CURRENT" in ''|*[!0-9]*) CURRENT=0 ;; esac
         jq ".commits_since_last_context7 = $((CURRENT + 1))" "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
       fi
     fi
@@ -39,8 +120,18 @@ case "$TOOL_NAME" in
   *) exit 0 ;; # Not an MCP tool, not a commit — exit fast
 esac
 
-# Ensure tool-usage.json exists
+# Ensure tool-usage.json exists.
+#
+# BL-233: this recovery seed deliberately carries NO `mcp_requirements` object.
+# It used to write `"qdrant_required": false, "context7_required": false`, so a
+# ledger this hook re-created turned every requirement OFF — a hook whose own
+# recovery path disarmed the gate it feeds. Requirements are SessionStart's to
+# derive from the configured MCP servers; an ABSENT object makes
+# session-mcp-gate.sh fail CLOSED (its default is `true`, not `false`), which is
+# the correct reading of "this file cannot tell me".
+CREATED_LEDGER=0
 if [ ! -f "$TOOL_USAGE" ]; then
+  CREATED_LEDGER=1
   mkdir -p .claude
   cat > "$TOOL_USAGE" << 'EOF'
 {
@@ -48,50 +139,141 @@ if [ ! -f "$TOOL_USAGE" ]; then
   "calls": [],
   "commits_since_last_context7": 0,
   "qdrant_find_called": false,
+  "qdrant_find_succeeded": false,
+  "qdrant_find_failed": 0,
+  "qdrant_find_empty": false,
+  "qdrant_find_empty_count": 0,
   "qdrant_store_called": false,
+  "qdrant_store_succeeded": false,
   "context7_called": false,
-  "mcp_gate_satisfied": false,
-  "mcp_requirements": {
-    "qdrant_required": false,
-    "context7_required": false,
-    "additional_required": []
-  }
+  "context7_query_docs_succeeded": false,
+  "context7_resolve_only_count": 0,
+  "mcp_gate_satisfied": false
 }
 EOF
 fi
 
 command -v jq &>/dev/null || exit 0
 
+# Belt-and-braces on the absence above, scoped to a ledger THIS invocation just
+# created (never to one SessionStart or the scaffolder wrote — those carry
+# derived requirements this hook has no business deleting). If the heredoc ever
+# drifts back to shipping a permissive object, this strips it. Mutating this
+# line into a re-seed is BL-231's "tracker re-seed" row, verbatim.
+[ "$CREATED_LEDGER" = "1" ] && jq 'del(.mcp_requirements)' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null  # BL-233-NO-REQ-RESEED
+
 TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
-# Track Context7 calls
-if echo "$TOOL_NAME" | grep -q "context7" 2>/dev/null; then
-  jq --arg tool "$TOOL_NAME" --arg ts "$TIMESTAMP" \
-    '.calls += [{"tool": $tool, "timestamp": $ts}] | .commits_since_last_context7 = 0 | .context7_called = true' \
-    "$TOOL_USAGE" > "$TOOL_USAGE.tmp" && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE"
+# ── Was the returned payload EMPTY? ─────────────────────────────────────────
+# Only meaningful on the success event. `tool_response` is an ARRAY of MCP
+# content blocks on a real MCP call, a plain string for some built-in tools,
+# and ABSENT entirely on the failure event — all three are handled, because a
+# jq filter that assumes the array shape returns null on the others and null
+# would read as "empty" for a call that returned plenty.
+#
+# Karl's decision 1: an empty result does NOT block — it satisfies the
+# retrieval requirement — but it is recorded and reported prominently. Empty is
+# information on a new project and a symptom on an old one, and the two are
+# indistinguishable if nobody is told.
+RESPONSE_TEXT=$(echo "$INPUT" | jq -r '
+  (.tool_response // null) as $r
+  | if   ($r | type) == "array"  then ([$r[]? | if (type == "object") then (.text? // "") else (. | tostring) end] | join(" "))
+    elif ($r | type) == "string" then $r
+    elif ($r | type) == "object" then ($r | tostring)
+    else "" end' 2>/dev/null)
+
+IS_EMPTY=0
+if [ "$OUTCOME" = "success" ]; then
+  _stripped=$(printf '%s' "$RESPONSE_TEXT" | tr -d '[:space:]')
+  if [ -z "$_stripped" ]; then
+    IS_EMPTY=1
+  elif printf '%s' "$RESPONSE_TEXT" | grep -qiE 'no information found|no results found|no matching (documents|entries|results)' 2>/dev/null; then
+    # The qdrant MCP server's own zero-result phrasing. A gate that reads this
+    # as content is the "returned something" question answered by a sentence
+    # that says nothing was returned.
+    IS_EMPTY=1
+  fi
 fi
 
-# Track Qdrant calls
+# ── Which Context7 tool is this? ────────────────────────────────────────────
+# `resolve-library-id` returns a LIST OF LIBRARY IDS and fetches no
+# documentation — it is the argument step, whose entire purpose is to produce
+# an argument for the call that does the work. It is ALLOWED and LOGGED, and it
+# is NOT COUNTED. Both the shipped server (mcp__context7__*) and the plugin
+# spelling (mcp__plugin_context7_context7__*) are matched by tool SUFFIX.
+C7KIND=other
+case "$TOOL_NAME" in
+  *query-docs*)         C7KIND=query ;;
+  *resolve-library-id*) C7KIND=resolve ;;
+esac  # BL-233-C7-QUERYDOCS
+
+# ── Append the call row (every MCP call, every outcome) ─────────────────────
+# The row carries the event and the outcome so a failure is VISIBLE rather than
+# absent — before BL-233 this hook was registered on PostToolUse only, so a
+# failed call produced no row at all and the framework could not tell a broken
+# server from an idle one.
+jq --arg tool "$TOOL_NAME" --arg ts "$TIMESTAMP" --arg ev "$EVENT" --arg oc "$OUTCOME" --argjson empty "$IS_EMPTY" \
+  '.calls += [{"tool": $tool, "timestamp": $ts, "event": $ev, "outcome": $oc, "empty_result": ($empty == 1)}]' \
+  "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+
+if [ "$OUTCOME" = "failure" ] && [ -n "$TOOL_ERROR" ]; then
+  jq --arg err "$TOOL_ERROR" --arg tool "$TOOL_NAME" \
+    '.last_mcp_error = $err | .last_mcp_error_tool = $tool' \
+    "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+fi
+
+# ── Context7 ────────────────────────────────────────────────────────────────
+if echo "$TOOL_NAME" | grep -q "context7" 2>/dev/null; then
+  # context7_called stays name-derived on purpose: it is the OBSERVABILITY
+  # field ("a Context7 tool was invoked"), kept for the reminder/validate
+  # surfaces. It is no longer what the gate reads.
+  jq '.context7_called = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+
+  if [ "$C7KIND" = "query" ] && [ "$OUTCOME" = "success" ]; then
+    # A real documentation read. This is the only thing that satisfies the
+    # Context7 requirement, and the only thing that may reset the commit-time
+    # staleness counter — an ID lookup used to silence that nudge too.
+    jq '.context7_query_docs_succeeded = true | .commits_since_last_context7 = 0' \
+      "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+  elif [ "$C7KIND" = "resolve" ]; then
+    jq '.context7_resolve_only_count = ((.context7_resolve_only_count // 0) + 1)' \
+      "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+  fi
+fi
+
+# ── Qdrant ──────────────────────────────────────────────────────────────────
 if echo "$TOOL_NAME" | grep -q "qdrant" 2>/dev/null; then
   if echo "$TOOL_NAME" | grep -q "find" 2>/dev/null; then
-    jq --arg tool "$TOOL_NAME" --arg ts "$TIMESTAMP" \
-      '.calls += [{"tool": $tool, "timestamp": $ts}] | .qdrant_find_called = true' \
-      "$TOOL_USAGE" > "$TOOL_USAGE.tmp" && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE"
+    jq '.qdrant_find_called = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    if [ "$OUTCOME" = "success" ]; then  # BL-233-QDRANT-SUCCESS
+      jq --argjson empty "$IS_EMPTY" \
+        '.qdrant_find_succeeded = true
+         | .qdrant_find_empty = ($empty == 1)
+         | .qdrant_find_empty_count = ((.qdrant_find_empty_count // 0) + $empty)' \
+        "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    else
+      jq '.qdrant_find_failed = ((.qdrant_find_failed // 0) + 1)' \
+        "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    fi
   elif echo "$TOOL_NAME" | grep -q "store" 2>/dev/null; then
-    jq --arg tool "$TOOL_NAME" --arg ts "$TIMESTAMP" \
-      '.calls += [{"tool": $tool, "timestamp": $ts}] | .qdrant_store_called = true' \
-      "$TOOL_USAGE" > "$TOOL_USAGE.tmp" && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE"
+    jq '.qdrant_store_called = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    if [ "$OUTCOME" = "success" ]; then
+      jq '.qdrant_store_succeeded = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+    fi
   fi
 fi
 
-# Track any other MCP tool call (for additional_required enforcement)
-if echo "$TOOL_NAME" | grep -q "^mcp__" 2>/dev/null; then
-  # Only log if not already tracked above (avoid double-logging context7/qdrant)
-  if ! echo "$TOOL_NAME" | grep -qE "context7|qdrant" 2>/dev/null; then
-    jq --arg tool "$TOOL_NAME" --arg ts "$TIMESTAMP" \
-      '.calls += [{"tool": $tool, "timestamp": $ts}]' \
-      "$TOOL_USAGE" > "$TOOL_USAGE.tmp" && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE"
-  fi
+# ── Report, prominently ─────────────────────────────────────────────────────
+# additionalContext is the documented channel for a post-tool hook to tell the
+# AGENT something, which is who needs to know; the durable half is the ledger
+# field written above, and it is written whether or not this line is reached.
+# Only the two states worth interrupting for are reported: a retrieval that
+# returned nothing, and a call that failed.
+if [ "$IS_EMPTY" = "1" ] && echo "$TOOL_NAME" | grep -q "qdrant" 2>/dev/null; then
+  printf '{"hookSpecificOutput": {"hookEventName": "%s", "additionalContext": "QDRANT EMPTY RESULT: %s returned no stored context. This does NOT block you — an empty semantic memory is expected on a new project. On an established one it means nothing was ever stored, so the retrieval half has nothing behind it. Report it to the Orchestrator and store what this session learns."}}\n' "$EVENT" "$TOOL_NAME"  # BL-233-EMPTY-REPORT
+elif [ "$OUTCOME" = "failure" ]; then
+  _err_escaped=$(printf '%s' "$TOOL_ERROR" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' | tr -d '\n\r\t')
+  printf '{"hookSpecificOutput": {"hookEventName": "%s", "additionalContext": "MCP CALL FAILED: %s did not execute (%s). This is RECORDED and it does NOT satisfy any session requirement — the framework now distinguishes configured-but-unreachable from not-configured. Fix the server or attest the exception; do not retry silently and proceed."}}\n' "$EVENT" "$TOOL_NAME" "$_err_escaped"
 fi
 
 exit 0

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9886,7 +9886,10 @@ even before the database went down.
    not a running one. `# BL-112-SAST-NOTRUN`'s shipped doctrine is the precedent
    and it is already this repo's law: *"the scanner did not run" must never be
    silently equivalent to "the scanner found nothing."*
-2. **Verify the call succeeded, not that it was made.** Read `.tool_response`.
+2. **Verify the call succeeded, not that it was made.** ~~Read
+   `.tool_response`.~~ **Corrected 2026-08-13 — see `## BL-233:` item 2: a
+   failed MCP call fires `PostToolUseFailure`, not `PostToolUse`, so the EVENT
+   is the success signal and `.tool_response` is not.** The requirement stands.
    This session alone produced four siblings of this bug — `jq` exiting 0 without
    reading a document (`## BL-227:`), `sed` reporting success without editing,
    a mutant scored as killed that was never applied, a gate satisfied by a
@@ -10031,7 +10034,41 @@ something was *declared* rather than whether it *happened*
 document the two visible symptoms and should be read first for the evidence;
 neither should be fixed on its own, because a patch to either leaves the
 mechanism intact.
-**Status:** Open
+**Status:** Open — **WP-A landed** on `feat/bl233-mcp-enforcement`; **WP-B (the
+storing half: warn at commit, block at the phase gate) is still open**, and so
+is item 6's underlying question of whether accumulation is enforced at all.
+
+**WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
+done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is
+the first test that ever executed `scripts/session-mcp-gate.sh` (watched RED
+against the shipped code at 5 passed / 37 failed, 42/0 after, 11 mutants).
+Four decisions are recorded here because they are not recoverable from the diff:
+
+- **The latch (item 5) is not an authority.** `mcp_gate_satisfied` lives in a
+  file the agent can edit, so the gate re-derives on EVERY Write/Edit and never
+  fast-paths on it (`# BL-233-NO-LATCH`); the field is still written, as a
+  record of the last derivation, and a stale `true` is corrected downward on a
+  blocking run. Session scope comes from the ledger's own lifecycle, left
+  exactly as `5b1a081` fixed it — `startup` resets, resume/compact/clear merge —
+  because re-arming mid-Build-Loop is the destructive behaviour that commit
+  removed, and resetting the latch at a session boundary would have reintroduced
+  it through the back door.
+- **The attested escape** is `SOLO_MCP_ATTESTED=1` plus a **mandatory**
+  `SOLO_MCP_REASON`, recorded to `.claude/process-state.json::mcp_attestations[]`
+  and **refused if it cannot be written** (`# BL-233-ATTEST-REFUSE`) — BL-072's
+  shape, plus one addition: a jq-free `.claude/mcp-attestations.jsonl` fallback
+  sink, because "jq is missing" is itself one of the blocking states and a
+  jq-only recorder would have made that refusal unescapable (`## BL-149:`).
+- **Availability is probed by the agent's own round trip**, not by a synchronous
+  reachability check inside a PreToolUse hook that runs on every Write. A
+  recorded `PostToolUseFailure` IS the failed round trip, which satisfies item 1
+  without putting a network call on the write path.
+- **Item 7 (register the hooks in this repo) has a blast radius**, stated so it
+  is decided rather than discovered: `.claude/settings.json` now registers the
+  Write/Edit gate here, and with Qdrant down (`## BL-231:`) that blocks writes in
+  solo-orchestrator itself until the server is up or an operator attests. That is
+  the intended posture — configured-but-unreachable blocks — but it takes effect
+  the moment this merges.
 
 ### The mechanism
 
@@ -10071,8 +10108,27 @@ separately would produce two patches and no fix.
    states, distinguishable in output: reachable / configured-but-unreachable /
    not-configured. `# BL-112-SAST-NOTRUN` is the shipped precedent — *"did not
    run" must never read as "found nothing."*
-2. **Read `.tool_response`.** The PostToolUse payload carries the result; the
-   tracker currently reads only `.tool_name`. An error must not satisfy anything.
+2. ~~**Read `.tool_response`.** The PostToolUse payload carries the result; the
+   tracker currently reads only `.tool_name`. An error must not satisfy
+   anything.~~ **CORRECTED 2026-08-13 (WP-A) — the instruction was wrong, the
+   requirement was right.** The payload was measured, not read from the docs
+   (there is no worked MCP example in them): a probe registered on both events
+   fired one failing and one succeeding MCP call. **A failed MCP call fires
+   `PostToolUseFailure`; it does NOT fire `PostToolUse`.** On failure
+   `tool_response` is **absent** and an `error` string is present; on success
+   `tool_response` is an array of MCP content blocks. **There is no `isError`
+   key anywhere** — MCP's own `isError` is not preserved by either event.
+   So `.tool_response` cannot tell you the call succeeded, only what came
+   **back**: **the EVENT is the only success signal**, and the tracker has to be
+   registered on **both** events or failures are not miscounted — they are
+   **invisible**. A **third state** exists: a call rejected before execution
+   (unknown tool, schema validation) fires **neither** event, which under
+   fail-closed correctly leaves the requirement unsatisfied but must never look
+   like success. What `.tool_response` IS good for is the separate question
+   Karl's decision made load-bearing: **"succeeded" and "returned something" are
+   separable**, so a successful-but-empty retrieval satisfies the requirement and
+   is reported and recorded rather than blocking. Implemented at
+   `# BL-233-EVENT-OUTCOME` (tracker) and `# BL-233-OUTCOME-QDRANT` (gate).
 3. **Name the tool that does the work.** `resolve-library-id` is the argument
    step. Require `query-docs` (or require both, in order).
 4. **Seed `mcp_requirements` in `init.sh`.** A missing key must not be a silent

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10091,7 +10091,23 @@ None of these blocks the WP-A work; all three are real and none is fixed:
    tracker matches tool names by suffix and handles both spellings correctly;
    only the derivation is name-based. This is the `availability` row of the
    table above surviving in a narrower form.
-3. **`session-end-qdrant-reminder.sh` still counts DECLARATIONS.** It reads
+3. **Where the control-character fix STOPS, measured rather than assumed.** The
+   fix scrubs U+0001-U+001F because a raw control byte is a **hard syntax
+   error** in every conforming JSON parser — that is what turned a deny into an
+   allow. The adjacent case is **invalid UTF-8**, which can still reach both the
+   deny envelope and the jq-free jsonl sink (neither is scrubbed for it). It was
+   probed: parsers **substitute U+FFFD rather than erroring** (`jq` confirmed
+   accepting `{"a":"x\xffy"}` while rejecting `{"a":"x\ry"}`), and on the
+   tracker path jq sanitizes the bytes on the way *into* the ledger, so the gate
+   never reads them back. The residual is therefore a mangled character inside a
+   message, **not a lost decision** — a different severity class from the one
+   that was fixed, and the reason it is recorded here instead of patched.
+   Separately verified in the same sweep: a **malformed regex** in an
+   operator-supplied `additional_required` entry (`"[unclosed"`) makes jq error,
+   which falls through to **deny** with a parseable envelope and no stderr leak
+   — fail-closed, as intended, though the message does not tell the operator
+   their pattern is the problem.
+4. **`session-end-qdrant-reminder.sh` still counts DECLARATIONS.** It reads
    `.calls | length` and the `*_called` flags, so its end-of-session summary
    reports calls that FAILED as calls that happened — it now disagrees with the
    gate. It is a Stop-hook reminder and nothing enforces on it, so this is

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10041,7 +10041,7 @@ is item 6's underlying question of whether accumulation is enforced at all.
 **WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
 done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is
 the first test that ever executed `scripts/session-mcp-gate.sh` (watched RED
-against the shipped code at 5 passed / 37 failed, 42/0 after, 11 mutants).
+against the base tree at **6 passed / 45 failed**, 51/0 after, 13 mutants).
 Four decisions are recorded here because they are not recoverable from the diff:
 
 - **The latch (item 5) is not an authority.** `mcp_gate_satisfied` lives in a
@@ -10069,6 +10069,35 @@ Four decisions are recorded here because they are not recoverable from the diff:
   solo-orchestrator itself until the server is up or an operator attests. That is
   the intended posture — configured-but-unreachable blocks — but it takes effect
   the moment this merges.
+
+**WP-A residuals — carried here because they outlive any handoff document.**
+None of these blocks the WP-A work; all three are real and none is fixed:
+
+1. **The escape is LAUNCH-TIME ONLY.** A PreToolUse hook inherits the
+   environment the session started with. BL-072's TDD escape rides the
+   `git commit` command line, so it can be supplied per commit; there is no
+   equivalent for a single `Write`, so `SOLO_MCP_ATTESTED` must be exported
+   before `claude` starts. Decision 3's letter is met and the ergonomics are
+   not. The deny text now names the real mid-session paths (start the server,
+   or restart the session with the vars exported) instead of saying "re-run",
+   which was advice that could not be followed. A per-Write channel — a
+   sentinel file the operator can touch, say — is the obvious follow-up.
+2. **Requirement derivation misses PLUGIN-provided MCP servers.**
+   `session-test-gate-check.sh` classifies by NAME from `.mcpServers` across
+   four settings files. A server provided by a plugin (this host also exposes
+   `mcp__plugin_context7_context7__*`) does not appear there, so
+   `context7_required` derives **false** in a project where Context7 is
+   available only via a plugin — the requirement silently switches off. The
+   tracker matches tool names by suffix and handles both spellings correctly;
+   only the derivation is name-based. This is the `availability` row of the
+   table above surviving in a narrower form.
+3. **`session-end-qdrant-reminder.sh` still counts DECLARATIONS.** It reads
+   `.calls | length` and the `*_called` flags, so its end-of-session summary
+   reports calls that FAILED as calls that happened — it now disagrees with the
+   gate. It is a Stop-hook reminder and nothing enforces on it, so this is
+   cosmetic today, but the outcome fields it needs
+   (`qdrant_find_succeeded`, `qdrant_find_failed`, `qdrant_find_interrupted`)
+   are already in the ledger. **WP-B pickup.**
 
 ### The mechanism
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2014,6 +2014,23 @@ run_child_suite "tests/test-delta-wp8-intake.sh" \
 # Never executes the scaffolder -> both lanes.
 run_child_suite "tests/test-delta-db-ledger-close.sh" \
   "tests/test-delta-db-ledger-close.sh"
+
+# BL-233 WP-A — the first tests for the MCP enforcement mechanism.
+# scripts/session-mcp-gate.sh, the PreToolUse hook that blocks Write/Edit, was
+# executed by NO test before this suite; the one suite that touched the surface
+# asserted only that SessionStart WROTE the fields, never that the gate acted on
+# them. Watched RED against the shipped code at 5 passed / 37 failed, including
+# the headline: a qdrant-find that returned "All connection attempts failed"
+# satisfied the gate. 42/0 after. Eleven mutants, each sites==1, exactly-2-lines
+# changed, `bash -n`-checked, mode-preserving, fresh fixture PER DIRECTION (the
+# gate rewrites mcp_gate_satisfied on every call, so a shared fixture let the
+# latch mutant survive with every meta-assertion green). Two absences carry
+# structural discriminators: the gate takes no latch fast path, and the
+# tracker's recovery seed writes no mcp_requirements. Reads init.sh statically
+# for the seed and the PostToolUseFailure registration; never executes it, so it
+# runs in the unit lane too.
+run_child_suite "tests/test-bl233-mcp-outcome-enforcement.sh" \
+  "tests/test-bl233-mcp-outcome-enforcement.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-bl233-mcp-outcome-enforcement.sh
+++ b/tests/test-bl233-mcp-outcome-enforcement.sh
@@ -561,10 +561,17 @@ else
   run_tracker "$TRACKER" "$D2D" "$(ev_success 'mcp__qdrant__qdrant-find' '<entry>prior context</entry>')" --event PostToolUse
   run_gate "$GATE" "$D2D"
   d2_dec=$(decision_of "$GATE_OUT")
-  if [ "$d2_dec" = "allow" ]; then
-    pass "D2 (direction 2): the same fixture with a SUCCEEDING round trip allows — the two directions differ only in which hook event fired, which is the whole point: the event is the signal"
+  # The UPWARD half of the re-derivation. D3 pins the downward correction (a
+  # stale true is reset to false when a run blocks); without this line the
+  # opposite direction is unpinned, and replacing the allow-path write with `:`
+  # leaves the whole suite green — nothing else in scripts/, init.sh or
+  # templates/ reads the field. A property stated in the gate header, the
+  # backlog entry and the report deserves an assertion, not three prose claims.
+  d2_flag=$(jqf "$D2D" '.mcp_gate_satisfied // false')
+  if [ "$d2_dec" = "allow" ] && [ "$d2_flag" = "true" ]; then
+    pass "D2 (direction 2): the same fixture with a SUCCEEDING round trip allows — the two directions differ only in which hook event fired, which is the whole point: the event is the signal — AND the derivation is recorded upward (mcp_gate_satisfied=true), which is the half D3 does not cover"
   else
-    fail_ "D2" "decision=$d2_dec (want allow) transcript='$(cat "$GATE_OUT" 2>/dev/null)'"
+    fail_ "D2" "decision=$d2_dec (want allow) mcp_gate_satisfied_after_allow=$d2_flag (want true) transcript='$(cat "$GATE_OUT" 2>/dev/null)'"
   fi
 fi
 
@@ -834,6 +841,162 @@ if [ -z "$h4_missing" ]; then
   pass "H4: this repository's own .claude/settings.json registers the SessionStart check, the tracker on BOTH post-tool events, and the Write/Edit gate — the mechanism now fires where the framework is BUILT, not only in generated projects. The same gap hides the version-check hook"
 else
   fail_ "H4" "missing from $REPO_SETTINGS: $h4_missing"
+fi
+
+echo ""
+echo "=== R — control characters in text the framework does NOT control ==="
+
+# The deny envelope splices `last_mcp_error` — the REMOTE SERVER'S OWN MESSAGE —
+# into permissionDecisionReason, and SOLO_MCP_REASON — the operator's free text —
+# into the refusal paths. Neither is ours.
+#
+# A raw control byte in either one makes the emitted JSON unparseable, and the
+# hook contract turns that into a FAIL-OPEN: the hook exits 0, stdout is parsed
+# for a decision, and no parseable decision means "no decision — normal
+# permission flow applies". The block is silently dropped. Worse, last_mcp_error
+# PERSISTS in the ledger, so the gate keeps failing open for the rest of the
+# session. The strictest posture and the weakest outcome, from the same input.
+#
+# The original escaping handled `\\`, `"`, `\n` and `\t` — the characters that
+# came to mind, not the CLASS. `\r` alone defeated it, and `jq -r '.error'`
+# emits the raw byte, so the tracker writes exactly that. These rows assert the
+# property that actually matters: the envelope PARSES **and** the decision is
+# still deny. A parsing envelope that allows would be no better.
+
+# _parses_json FILE — 1 if the file is a single parseable JSON value.
+_parses_json() { jq -e . "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+
+# ctl_ledger DIR ERRTEXT — a blocked-on-unreachable ledger carrying ERRTEXT
+# verbatim in last_mcp_error. Built with jq so the control bytes are correctly
+# \u-escaped ON DISK; the gate then reads them back as RAW bytes via `jq -r`,
+# which is exactly the production path.
+ctl_ledger() {
+  local d="$1" err="$2"
+  mkdir -p "$d/.claude" || return 1
+  jq -n --arg e "$err" '{session_id:"s", calls:[], commits_since_last_context7:0,
+     qdrant_find_called:true, qdrant_find_succeeded:false, qdrant_find_failed:1,
+     context7_query_docs_succeeded:false, last_mcp_error:$e, mcp_gate_satisfied:false,
+     mcp_requirements:{qdrant_required:true, context7_required:false, additional_required:[]}}' \
+     > "$d/.claude/tool-usage.json" 2>/dev/null || return 1
+  return 0
+}
+
+# R1 — the reported blocker, with the exact byte that produced it.
+R1D="$(newtmp)/p"
+r1_err="Error calling tool 'qdrant-find': connection reset$(printf '\r')retrying"
+if ! ctl_ledger "$R1D" "$r1_err"; then
+  fail_ "R1" "fixture setup failed"
+else
+  run_gate "$GATE" "$R1D"
+  r1_parses=$(_parses_json "$GATE_OUT")
+  r1_dec=$(decision_of "$GATE_OUT")
+  if [ "$r1_parses" -eq 1 ] && [ "$r1_dec" = "deny" ]; then
+    pass "R1 (blocker): a CARRIAGE RETURN in the server's own error text still produces a PARSEABLE deny envelope. Unescaped, it made the envelope invalid JSON at exit 0 — which the hook contract reads as 'no decision', so the intended block became an allow, and kept doing so all session because last_mcp_error persists"
+  else
+    fail_ "R1" "envelope_parses=$r1_parses (want 1) decision=$r1_dec (want deny) raw='$(cat "$GATE_OUT" 2>/dev/null | head -c 200)'"
+  fi
+fi
+
+# R2 — the whole class, not the one byte that was reported. U+0000 is excluded
+# because a bash string cannot hold a NUL: it would terminate the value, so it
+# can never reach the envelope through a shell variable in the first place.
+R2D="$(newtmp)/p"
+r2_err="down:"
+for _i in 01 02 03 04 05 06 07 08 09 0a 0b 0c 0d 0e 0f 10 11 12 13 14 15 16 17 18 19 1a 1b 1c 1d 1e 1f; do
+  printf -v _ch "\\x$_i"
+  r2_err="${r2_err}${_ch}x"
+done
+if ! ctl_ledger "$R2D" "$r2_err"; then
+  fail_ "R2" "fixture setup failed"
+else
+  run_gate "$GATE" "$R2D"
+  r2_parses=$(_parses_json "$GATE_OUT")
+  r2_dec=$(decision_of "$GATE_OUT")
+  r2_len=$(jq -r '.hookSpecificOutput.permissionDecisionReason | length' "$GATE_OUT" 2>/dev/null)
+  if [ "$r2_parses" -eq 1 ] && [ "$r2_dec" = "deny" ] && [ "$(_num "$r2_len")" -gt 0 ]; then
+    pass "R2: EVERY control byte U+0001-U+001F in the error text is neutralised — the envelope parses, the decision is still deny, and the reason is non-empty. Escaping the characters someone thought of is what left the hole; this asserts the class"
+  else
+    fail_ "R2" "envelope_parses=$r2_parses (want 1) decision=$r2_dec (want deny) reason_len=$r2_len (want >0)"
+  fi
+fi
+
+# R3 — the same splice, through the OPERATOR's text instead of the server's,
+# on the refusal path where an attestation could not be recorded.
+R3D="$(newtmp)/p"
+if ! mk_proj "$R3D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "R3" "fixture setup failed"
+else
+  mkdir -p "$R3D/.claude/process-state.json" "$R3D/.claude/mcp-attestations.jsonl"
+  run_gate "$GATE" "$R3D" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=offline$(printf '\r')on a plane"
+  r3_parses=$(_parses_json "$GATE_OUT")
+  r3_dec=$(decision_of "$GATE_OUT")
+  if [ "$r3_parses" -eq 1 ] && [ "$r3_dec" = "deny" ]; then
+    pass "R3: a control byte in SOLO_MCP_REASON does not break the REFUSAL envelope either — an operator could otherwise turn a refused escape into a silent allow by pasting a reason with a stray CR in it"
+  else
+    fail_ "R3" "envelope_parses=$r3_parses (want 1) decision=$r3_dec (want deny)"
+  fi
+fi
+
+# R4 — an escape that leaves an UNPARSEABLE trace is not a trace. The jq-free
+# fallback sink hand-builds its JSON line, so it has the same exposure, and it
+# counted the write as "recorded" regardless of whether the line was valid.
+R4D="$(newtmp)/p"
+if ! mk_proj "$R4D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "R4" "fixture setup failed"
+else
+  run_gate "$GATE" "$R4D" "PATH=" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=no jq$(printf '\r')and a stray CR"
+  r4_dec=$(decision_of "$GATE_OUT")
+  r4_rows=0
+  r4_valid=0
+  if [ -f "$R4D/.claude/mcp-attestations.jsonl" ]; then
+    r4_rows=$(_num "$(wc -l < "$R4D/.claude/mcp-attestations.jsonl" | tr -d ' ')")
+    if [ "$r4_rows" -ge 1 ] && jq -e . < "$R4D/.claude/mcp-attestations.jsonl" >/dev/null 2>&1; then
+      r4_valid=1
+    fi
+  fi
+  if [ "$r4_dec" = "allow" ] && [ "$r4_rows" -eq 1 ] && [ "$r4_valid" -eq 1 ]; then
+    pass "R4: the jq-free fallback sink writes a line that actually PARSES when the reason carries a control byte. A record nothing can read is the advisory posture this sink exists to prevent, one level down"
+  else
+    fail_ "R4" "decision=$r4_dec (want allow) jsonl_rows=$r4_rows (want 1) jsonl_is_valid_json=$r4_valid (want 1) raw='$(cat "$R4D/.claude/mcp-attestations.jsonl" 2>/dev/null | head -c 200)'"
+  fi
+fi
+
+# R5 — the tracker emits JSON too, and its failure report splices the same
+# uncontrolled error text.
+R5D="$(newtmp)/p"
+if ! mk_proj "$R5D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "R5" "fixture setup failed"
+else
+  r5_env=$(_ev "$(jq -nc --arg e "connection reset$(printf '\r')retrying" \
+    '{session_id:"s1",cwd:"/tmp",hook_event_name:"PostToolUseFailure",tool_name:"mcp__qdrant__qdrant-find",tool_input:{query:"q"},error:$e,is_interrupt:false}')")
+  run_tracker "$TRACKER" "$R5D" "$r5_env" --event PostToolUseFailure
+  r5_parses=$(_parses_json "$TRK_OUT")
+  r5_recorded=$(_num "$(jqf "$R5D" '.qdrant_find_failed // 0')")
+  if [ "$r5_parses" -eq 1 ] && [ "$r5_recorded" -eq 1 ]; then
+    pass "R5: the tracker's own failure report stays valid JSON when the server's error carries a control byte, and the failure is still recorded. It hand-escaped four characters; it now delegates the whole job to jq, which is present on that path by construction"
+  else
+    fail_ "R5" "report_parses=$r5_parses (want 1) qdrant_find_failed=$r5_recorded (want 1) raw='$(cat "$TRK_OUT" 2>/dev/null | head -c 200)'"
+  fi
+fi
+
+# R6 — emptiness by SHAPE, not by wording. A zero-length tool_response array is
+# a call that returned no content blocks at all; no phrase list can be relied on
+# for that, and a server that phrases zero results in its own words must not
+# silently read as a healthy retrieval.
+R6D="$(newtmp)/p"
+if ! mk_proj "$R6D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "R6" "fixture setup failed"
+else
+  r6_env=$(_ev "$(printf '{"session_id":"s1","cwd":"/tmp","hook_event_name":"PostToolUse","tool_name":"mcp__qdrant__qdrant-find","tool_input":{"query":"q"},"tool_response":[]}')")
+  run_tracker "$TRACKER" "$R6D" "$r6_env" --event PostToolUse
+  r6_ok=$(jqf "$R6D" '.qdrant_find_succeeded // false')
+  r6_empty=$(jqf "$R6D" '.qdrant_find_empty // false')
+  r6_reported=$(_bytes "$TRK_OUT")
+  if [ "$r6_ok" = "true" ] && [ "$r6_empty" = "true" ] && [ "$r6_reported" -gt 0 ]; then
+    pass "R6: a zero-length tool_response ARRAY is recognised as empty by shape — no content blocks came back at all. The phrase list is the best-effort half of this detector; the shape checks are the half that does not depend on guessing a server's wording"
+  else
+    fail_ "R6" "succeeded=$r6_ok (want true) empty_flag=$r6_empty (want true) report_bytes=$r6_reported (want >0)"
+  fi
 fi
 
 echo ""
@@ -1112,6 +1275,49 @@ if [ "$z1_bad" -eq 0 ]; then
 else
   fail_ "Z1" "$z1_bad malformed envelope(s) were fed to a hook — every assertion using one is meaningless:
 $(cat "$BAD_ENVELOPES")"
+fi
+
+# ── M12: drop the upward latch record ───────────────────────────────────────
+# The mutant a reviewer wrote that survived every PR-blocking check.
+M12D="$(newtmp)"
+if ! mk_proj "$M12D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M12D/m"; then
+  fail_ "M12" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$M12D/p" "$(ev_success 'mcp__qdrant__qdrant-find' 'ctx')" --event PostToolUse
+  run_gate "$M12D/m/gate.sh" "$M12D/p"; m12_ctl_dec=$(decision_of "$GATE_OUT")
+  m12_ctl=$(jqf "$M12D/p" '.mcp_gate_satisfied // false')
+  m12_meta=$(_mutate "$M12D/m/gate.sh" '# BL-233-LATCH-RECORD-UP' '    :')
+  set -- $m12_meta; m12_sites=$1; m12_changed=$2; m12_parses=$3
+  mk_proj "$M12D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_tracker "$TRACKER" "$M12D/p2" "$(ev_success 'mcp__qdrant__qdrant-find' 'ctx')" --event PostToolUse
+  run_gate "$M12D/m/gate.sh" "$M12D/p2"; m12_mut_dec=$(decision_of "$GATE_OUT")
+  m12_mut=$(jqf "$M12D/p2" '.mcp_gate_satisfied // false')
+  if [ "$m12_ctl" = "true" ] && [ "$m12_mut" = "false" ] \
+     && [ "$m12_ctl_dec" = "allow" ] && [ "$m12_mut_dec" = "allow" ] \
+     && [ "$m12_sites" -eq 1 ] && [ "$m12_changed" -eq 2 ] && [ "$m12_parses" -eq 1 ]; then
+    pass "M12: control records the satisfied derivation; drop the write and the field stays false while the gate still allows — the ledger then says the requirement was never met by a session that was writing files. Both directions ALLOW, so only the state assertion separates them; a decision-only proof cannot see this at all"
+  else
+    fail_ "M12" "control_flag=$m12_ctl (want true) mutant_flag=$m12_mut (want false) control_decision=$m12_ctl_dec (want allow) mutant_decision=$m12_mut_dec (want allow) sites=$m12_sites (want 1) changed=$m12_changed (want 2) parses=$m12_parses (want 1)"
+  fi
+fi
+
+# ── M13: remove the control-character scrub ─────────────────────────────────
+M13D="$(newtmp)"
+if ! ctl_ledger "$M13D/p" "boom$(printf '\r')x" || ! mk_mirror "$M13D/m"; then
+  fail_ "M13" "fixture setup failed"
+else
+  run_gate "$M13D/m/gate.sh" "$M13D/p"; m13_ctl_parses=$(_parses_json "$GATE_OUT"); m13_ctl_dec=$(decision_of "$GATE_OUT")
+  m13_meta=$(_mutate "$M13D/m/gate.sh" '# BL-233-CTL-SCRUB' '  reason="$reason"')
+  set -- $m13_meta; m13_sites=$1; m13_changed=$2; m13_parses=$3
+  ctl_ledger "$M13D/p2" "boom$(printf '\r')x"
+  run_gate "$M13D/m/gate.sh" "$M13D/p2"; m13_mut_parses=$(_parses_json "$GATE_OUT"); m13_mut_dec=$(decision_of "$GATE_OUT")
+  if [ "$m13_ctl_parses" -eq 1 ] && [ "$m13_ctl_dec" = "deny" ] \
+     && [ "$m13_mut_parses" -eq 0 ] && [ "$m13_mut_dec" != "deny" ] \
+     && [ "$m13_sites" -eq 1 ] && [ "$m13_changed" -eq 2 ] && [ "$m13_parses" -eq 1 ]; then
+    pass "M13: control emits a parseable deny; remove the scrub and the SAME ledger yields an unparseable envelope at exit 0 — which the hook contract reads as no decision at all, so the block evaporates. The mutation changes nothing about the gate's logic and everything about whether its verdict is heard"
+  else
+    fail_ "M13" "control_parses=$m13_ctl_parses (want 1) control_decision=$m13_ctl_dec (want deny) mutant_parses=$m13_mut_parses (want 0) mutant_decision=$m13_mut_dec (want != deny) sites=$m13_sites (want 1) changed=$m13_changed (want 2) parses=$m13_parses (want 1)"
+  fi
 fi
 
 END_EPOCH=$(date +%s)

--- a/tests/test-bl233-mcp-outcome-enforcement.sh
+++ b/tests/test-bl233-mcp-outcome-enforcement.sh
@@ -58,7 +58,15 @@
 #   • EVERY mutant asserts `bash -n` — a mutation that lands as a syntax error
 #     kills every test for the wrong reason and would score as a pass;
 #   • mode-preserving (`stat -c || stat -f`, GNU-first);
-#   • a FRESH fixture per mutant, so no mutant inherits another's ledger;
+#   • a FRESH fixture per mutant — and per DIRECTION. Sharing one project
+#     directory between a control run and its mutant run is not merely untidy
+#     here, it is wrong: the gate REWRITES mcp_gate_satisfied on every
+#     invocation, so a control run that denied left the flag false and the
+#     latch mutant (M5) then had nothing to latch onto. It survived, and it
+#     survived silently — the meta-assertions were all green because the
+#     mutation applied perfectly. Only the direction assertion caught it;
+#   • every mutant that changes a project's ledger re-runs its own tracker
+#     calls against the fresh fixture rather than inheriting them;
 #   • structural discriminators for ABSENCES — an absence cannot be greped for,
 #     so the two absence properties (the gate takes NO latch fast path; the
 #     tracker re-seed carries NO mcp_requirements) are each pinned by a real
@@ -173,6 +181,21 @@ LEDGER_NONE_REQUIRED='{
   "mcp_gate_satisfied": false,
   "mcp_requirements": {
     "qdrant_required": false,
+    "context7_required": false,
+    "additional_required": []
+  }
+}'
+
+# One key present, the OTHER missing — the fixture M3 needs. With both keys
+# absent, flipping one default cannot change the verdict (the other still
+# blocks) and the mutant would survive for a reason that has nothing to do with
+# the line under test.
+LEDGER_MISSING_QDRANT_KEY='{
+  "session_id": "2026-08-13T00:00:00Z",
+  "calls": [],
+  "commits_since_last_context7": 0,
+  "mcp_gate_satisfied": false,
+  "mcp_requirements": {
     "context7_required": false,
     "additional_required": []
   }
@@ -703,12 +726,19 @@ else
   g2_created=0
   [ -f "$G2D/.claude/tool-usage.json" ] && g2_created=1
   g2_has_req=$(jq -r 'has("mcp_requirements")' "$G2D/.claude/tool-usage.json" 2>/dev/null)
+  # Both fail-closed requirements are live on a ledger with no requirements
+  # object, so BOTH have to be genuinely satisfied for the gate to allow —
+  # which is the point: the re-seed did not switch either of them off.
+  run_gate "$GATE" "$G2D"
+  g2_dec_partial=$(decision_of "$GATE_OUT")
+  run_tracker "$TRACKER" "$G2D" "$(ev_success 'mcp__context7__query-docs' 'the docs')" --event PostToolUse
   run_gate "$GATE" "$G2D"
   g2_dec=$(decision_of "$GATE_OUT")
-  if [ "$g2_rc" -eq 0 ] && [ "$g2_created" -eq 1 ] && [ "$g2_has_req" = "false" ] && [ "$g2_dec" = "allow" ]; then
-    pass "G2: when the tracker re-creates a missing ledger it writes NO mcp_requirements object, so a re-created file can never turn a requirement OFF. Requirements are SessionStart's to derive; an absent object makes the gate fail closed. (Here the qdrant call SUCCEEDED, so the fail-closed requirement is met and the gate allows — the requirement was not silently switched off, it was satisfied)"
+  if [ "$g2_rc" -eq 0 ] && [ "$g2_created" -eq 1 ] && [ "$g2_has_req" = "false" ] \
+     && [ "$g2_dec_partial" = "deny" ] && [ "$g2_dec" = "allow" ]; then
+    pass "G2: when the tracker re-creates a missing ledger it writes NO mcp_requirements object, so a re-created file can never turn a requirement OFF — it used to write qdrant_required=false and context7_required=false, disarming the gate it feeds. Both requirements stay live (one satisfied still denies) and only both satisfied allows"
   else
-    fail_ "G2" "tracker_rc=$g2_rc (want 0) ledger_created=$g2_created (want 1) reseed_has_mcp_requirements=$g2_has_req (want false) gate_decision=$g2_dec (want allow)"
+    fail_ "G2" "tracker_rc=$g2_rc (want 0) ledger_created=$g2_created (want 1) reseed_has_mcp_requirements=$g2_has_req (want false) decision_with_one_of_two_satisfied=$g2_dec_partial (want deny) decision_with_both_satisfied=$g2_dec (want allow)"
   fi
 fi
 
@@ -823,7 +853,8 @@ else
   run_gate "$M1D/m/gate.sh" "$M1D/p"; m1_ctl=$(decision_of "$GATE_OUT")
   m1_meta=$(_mutate "$M1D/m/gate.sh" '# BL-233-FAILCLOSED-NOFILE' '  BLOCK_REASON=""')
   set -- $m1_meta; m1_sites=$1; m1_changed=$2; m1_parses=$3
-  run_gate "$M1D/m/gate.sh" "$M1D/p"; m1_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M1D/p2" ""
+  run_gate "$M1D/m/gate.sh" "$M1D/p2"; m1_mut=$(decision_of "$GATE_OUT")
   if [ "$m1_ctl" = "deny" ] && [ "$m1_mut" = "allow" ] \
      && [ "$m1_sites" -eq 1 ] && [ "$m1_changed" -eq 2 ] && [ "$m1_parses" -eq 1 ]; then
     pass "M1: control denies with no ledger; with the fail-closed arm neutered the same absent ledger ALLOWS — the pre-BL-233 behaviour, restored on demand"
@@ -840,7 +871,8 @@ else
   run_gate "$M2D/m/gate.sh" "$M2D/p" "PATH="; m2_ctl=$(decision_of "$GATE_OUT")
   m2_meta=$(_mutate "$M2D/m/gate.sh" '# BL-233-FAILCLOSED-JQ' '  exit 0')
   set -- $m2_meta; m2_sites=$1; m2_changed=$2; m2_parses=$3
-  run_gate "$M2D/m/gate.sh" "$M2D/p" "PATH="; m2_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M2D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_gate "$M2D/m/gate.sh" "$M2D/p2" "PATH="; m2_mut=$(decision_of "$GATE_OUT")
   if [ "$m2_ctl" = "deny" ] && [ "$m2_mut" = "allow" ] \
      && [ "$m2_sites" -eq 1 ] && [ "$m2_changed" -eq 2 ] && [ "$m2_parses" -eq 1 ]; then
     pass "M2: control denies with jq unavailable; with the arm turned back into 'exit 0' the missing toolchain silently disables enforcement again"
@@ -851,13 +883,14 @@ fi
 
 # ── M3: flip the missing-key default back to permissive ─────────────────────
 M3D="$(newtmp)"
-if ! mk_proj "$M3D/p" "$LEDGER_NO_REQUIREMENTS" || ! mk_mirror "$M3D/m"; then
+if ! mk_proj "$M3D/p" "$LEDGER_MISSING_QDRANT_KEY" || ! mk_mirror "$M3D/m"; then
   fail_ "M3" "fixture setup failed"
 else
   run_gate "$M3D/m/gate.sh" "$M3D/p"; m3_ctl=$(decision_of "$GATE_OUT")
   m3_meta=$(_mutate "$M3D/m/gate.sh" '# BL-233-FAILCLOSED-REQ' 'QDRANT_REQUIRED=$(_flag ".mcp_requirements.qdrant_required" false)')
   set -- $m3_meta; m3_sites=$1; m3_changed=$2; m3_parses=$3
-  run_gate "$M3D/m/gate.sh" "$M3D/p"; m3_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M3D/p2" "$LEDGER_MISSING_QDRANT_KEY"
+  run_gate "$M3D/m/gate.sh" "$M3D/p2"; m3_mut=$(decision_of "$GATE_OUT")
   if [ "$m3_ctl" = "deny" ] && [ "$m3_mut" = "allow" ] \
      && [ "$m3_sites" -eq 1 ] && [ "$m3_changed" -eq 2 ] && [ "$m3_parses" -eq 1 ]; then
     pass "M3: control denies on a ledger with no mcp_requirements; with the default flipped from true to false the missing key is a silent opt-out again — one character, and BL-221's shape is back"
@@ -877,7 +910,9 @@ else
   run_gate "$M4D/m/gate.sh" "$M4D/p"; m4_ctl=$(decision_of "$GATE_OUT")
   m4_meta=$(_mutate "$M4D/m/gate.sh" '# BL-233-OUTCOME-QDRANT' 'QDRANT_OK=$(_flag ".qdrant_find_called" false)')
   set -- $m4_meta; m4_sites=$1; m4_changed=$2; m4_parses=$3
-  run_gate "$M4D/m/gate.sh" "$M4D/p"; m4_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M4D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_tracker "$TRACKER" "$M4D/p2" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  run_gate "$M4D/m/gate.sh" "$M4D/p2"; m4_mut=$(decision_of "$GATE_OUT")
   if [ "$m4_ctl" = "deny" ] && [ "$m4_mut" = "allow" ] \
      && [ "$m4_sites" -eq 1 ] && [ "$m4_changed" -eq 2 ] && [ "$m4_parses" -eq 1 ]; then
     pass "M4 (the root cause, mutated back in): reading .qdrant_find_called — 'a matching tool was called' — instead of .qdrant_find_succeeded makes a call that reached NOTHING satisfy the gate. Same ledger, same failing round trip, opposite verdict"
@@ -897,7 +932,8 @@ else
   run_gate "$M5D/m/gate.sh" "$M5D/p"; m5_ctl=$(decision_of "$GATE_OUT")
   m5_meta=$(_mutate "$M5D/m/gate.sh" '# BL-233-NO-LATCH' 'GATE_PRIOR=$(_flag ".mcp_gate_satisfied" false); [ "$GATE_PRIOR" = "true" ] && exit 0')
   set -- $m5_meta; m5_sites=$1; m5_changed=$2; m5_parses=$3
-  run_gate "$M5D/m/gate.sh" "$M5D/p"; m5_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M5D/p2" "$(printf '%s' "$LEDGER_BOTH_REQUIRED" | jq '.mcp_gate_satisfied = true')"
+  run_gate "$M5D/m/gate.sh" "$M5D/p2"; m5_mut=$(decision_of "$GATE_OUT")
   if [ "$m5_ctl" = "deny" ] && [ "$m5_mut" = "allow" ] \
      && [ "$m5_sites" -eq 1 ] && [ "$m5_changed" -eq 2 ] && [ "$m5_parses" -eq 1 ]; then
     pass "M5: control denies despite mcp_gate_satisfied=true; restore the fast path and a flag the agent itself can write ends the enforcement — 'was it satisfied once' replacing 'is it satisfied now'"
@@ -915,7 +951,9 @@ else
   run_gate "$M6D/m/gate.sh" "$M6D/p" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=hostile disk"; m6_ctl=$(decision_of "$GATE_OUT")
   m6_meta=$(_mutate "$M6D/m/gate.sh" '# BL-233-ATTEST-REFUSE' '  exit 0')
   set -- $m6_meta; m6_sites=$1; m6_changed=$2; m6_parses=$3
-  run_gate "$M6D/m/gate.sh" "$M6D/p" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=hostile disk"; m6_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M6D/p2" "$LEDGER_BOTH_REQUIRED"
+  mkdir -p "$M6D/p2/.claude/process-state.json" "$M6D/p2/.claude/mcp-attestations.jsonl"
+  run_gate "$M6D/m/gate.sh" "$M6D/p2" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=hostile disk"; m6_mut=$(decision_of "$GATE_OUT")
   if [ "$m6_ctl" = "deny" ] && [ "$m6_mut" = "allow" ] \
      && [ "$m6_sites" -eq 1 ] && [ "$m6_changed" -eq 2 ] && [ "$m6_parses" -eq 1 ]; then
     pass "M6: control refuses an escape it could not record; drop the refusal and the escape passes leaving NO trace anywhere — which is precisely the advisory posture BL-233 exists to replace"
@@ -932,7 +970,8 @@ else
   run_gate "$M7D/m/gate.sh" "$M7D/p" "SOLO_MCP_ATTESTED=1"; m7_ctl=$(decision_of "$GATE_OUT")
   m7_meta=$(_mutate "$M7D/m/gate.sh" '# BL-233-ATTEST-REASON' '  ATTEST_REASON="${SOLO_MCP_REASON:-unspecified}"')
   set -- $m7_meta; m7_sites=$1; m7_changed=$2; m7_parses=$3
-  run_gate "$M7D/m/gate.sh" "$M7D/p" "SOLO_MCP_ATTESTED=1"; m7_mut=$(decision_of "$GATE_OUT")
+  mk_proj "$M7D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_gate "$M7D/m/gate.sh" "$M7D/p2" "SOLO_MCP_ATTESTED=1"; m7_mut=$(decision_of "$GATE_OUT")
   if [ "$m7_ctl" = "deny" ] && [ "$m7_mut" = "allow" ] \
      && [ "$m7_sites" -eq 1 ] && [ "$m7_changed" -eq 2 ] && [ "$m7_parses" -eq 1 ]; then
     pass "M7: control refuses a reasonless attestation; default the reason instead and SOLO_MCP_ATTESTED=1 becomes a bare bypass flag with a placeholder in the ledger"
@@ -948,7 +987,12 @@ if ! mk_proj "$M8D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M8D/m"; then
 else
   run_tracker "$M8D/m/tracker.sh" "$M8D/p" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
   m8_ctl=$(jqf "$M8D/p" '.qdrant_find_succeeded // false')
-  m8_meta=$(_mutate "$M8D/m/tracker.sh" '# BL-233-EVENT-OUTCOME' 'OUTCOME=success')
+  # The marker sits on an `esac`, so the replacement must carry one: dropping
+  # it leaves the `case` unterminated and the mutant does not parse. The
+  # `bash -n` assertion is what said so — a mutation that lands as a syntax
+  # error kills every downstream test for the wrong reason and would otherwise
+  # have scored as a clean kill.
+  m8_meta=$(_mutate "$M8D/m/tracker.sh" '# BL-233-EVENT-OUTCOME' 'esac; OUTCOME=success')
   set -- $m8_meta; m8_sites=$1; m8_changed=$2; m8_parses=$3
   mk_proj "$M8D/p2" "$LEDGER_BOTH_REQUIRED"
   run_tracker "$M8D/m/tracker.sh" "$M8D/p2" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
@@ -968,7 +1012,7 @@ if ! mk_proj "$M9D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M9D/m"; then
 else
   run_tracker "$M9D/m/tracker.sh" "$M9D/p" "$(ev_success 'mcp__context7__resolve-library-id' '/qdrant/qdrant')" --event PostToolUse
   m9_ctl=$(jqf "$M9D/p" '.context7_query_docs_succeeded // false')
-  m9_meta=$(_mutate "$M9D/m/tracker.sh" '# BL-233-C7-QUERYDOCS' 'C7KIND=query')
+  m9_meta=$(_mutate "$M9D/m/tracker.sh" '# BL-233-C7-QUERYDOCS' 'esac; C7KIND=query')
   set -- $m9_meta; m9_sites=$1; m9_changed=$2; m9_parses=$3
   mk_proj "$M9D/p2" "$LEDGER_BOTH_REQUIRED"
   run_tracker "$M9D/m/tracker.sh" "$M9D/p2" "$(ev_success 'mcp__context7__resolve-library-id' '/qdrant/qdrant')" --event PostToolUse

--- a/tests/test-bl233-mcp-outcome-enforcement.sh
+++ b/tests/test-bl233-mcp-outcome-enforcement.sh
@@ -1,0 +1,1049 @@
+#!/usr/bin/env bash
+# tests/test-bl233-mcp-outcome-enforcement.sh
+#
+# BL-233 WP-A — the MCP enforcement mechanism must record OUTCOMES, not
+# DECLARATIONS. Three shipped files carry the mechanism and, before this suite,
+# `scripts/session-mcp-gate.sh` — the hook that actually blocks Write/Edit — was
+# executed by NO test in the repository. One suite
+# (tests/test-session-test-gate-check-merge.sh) reads `mcp_gate_satisfied` and
+# `mcp_requirements`, but it only asserts that the SessionStart hook WRITES those
+# fields; it never runs the gate. The test suite had the same defect as the code:
+# it verified the declaration was recorded, never that enforcement happened.
+#
+# ── GROUND TRUTH, measured 2026-08-13 (not from the docs) ───────────────────
+# The official Claude Code documentation carries no worked MCP hook example, so
+# the payload shape below was captured by registering a probe on both events and
+# firing one failing and one succeeding MCP call. Every fixture in this file
+# matches it exactly, because `scripts/lint-fixture-envelopes.sh` exists for the
+# lesson that a wrong-shaped fixture "silently falls through the hook's `// \"\"`
+# fallback and never exercises the detector".
+#
+#   A FAILED MCP CALL FIRES `PostToolUseFailure`. IT DOES NOT FIRE `PostToolUse`.
+#
+#   | field          | success (PostToolUse)                  | failure (PostToolUseFailure) |
+#   |----------------|----------------------------------------|------------------------------|
+#   | tool_response  | PRESENT — array of MCP content blocks  | ABSENT                       |
+#   | error          | absent                                 | "Error calling tool '…': …"  |
+#   | is_interrupt   | —                                      | false                        |
+#   | isError        | NONE ANYWHERE — MCP's own isError is not preserved by either event      |
+#
+# Three consequences this suite is built around:
+#   1. THE EVENT IS THE SIGNAL. There is no field to test for success. BL-233's
+#      own text says "read .tool_response" — that instruction is WRONG (a
+#      successful call's tool_response tells you what came BACK, not that the
+#      call worked), and the entry is corrected as part of this package.
+#   2. A third state exists: a call rejected BEFORE execution (unknown tool,
+#      schema validation) fires NEITHER event. Fail-closed leaves the
+#      requirement unsatisfied, which is correct — but it must never look like
+#      success. G-group pins that.
+#   3. Because tool_response carries the RETURNED TEXT, "succeeded" and
+#      "returned something" are separable. Karl's decision 1: a successful but
+#      EMPTY retrieval satisfies the requirement, and is reported loudly and
+#      recorded. E-group pins both halves.
+#
+# ── What every assertion here refuses to do ────────────────────────────────
+# "A test that passes because a tool was CALLED is this bug, restated in the
+# test suite." Not one assertion below greps for a label, a reason string alone,
+# or the presence of a call row as proof of satisfaction. Every one asserts on
+# the resulting STATE (a JSON field in the ledger) or the resulting DECISION
+# (the gate's permissionDecision / the process exit code).
+#
+# ── Mutation harness standard (all mandatory, per the WP-A brief) ──────────
+#   • anchored END-OF-LINE markers, asserted at sites==1 in the SHIPPED source;
+#   • exactly-N-lines-changed asserted for every mutant (this is the check that
+#     catches a sed that reported success and edited nothing — CLAUDE.md's sed
+#     trap; the delimiter here is `%`, absent from every marker and every
+#     replacement, and `&` is escaped because in a sed replacement `&` means THE
+#     WHOLE MATCH and an unescaped `&&` splices the original line back in);
+#   • EVERY mutant asserts `bash -n` — a mutation that lands as a syntax error
+#     kills every test for the wrong reason and would score as a pass;
+#   • mode-preserving (`stat -c || stat -f`, GNU-first);
+#   • a FRESH fixture per mutant, so no mutant inherits another's ledger;
+#   • structural discriminators for ABSENCES — an absence cannot be greped for,
+#     so the two absence properties (the gate takes NO latch fast path; the
+#     tracker re-seed carries NO mcp_requirements) are each pinned by a real
+#     line of code whose mutation REINTRODUCES the removed behaviour.
+#
+# Hermetic: temp dirs only, no network, no remote creation, no `--no-verify`,
+# no `timeout`/`gtimeout` (absent on the dev host — they yield a spurious 127).
+# bash 3.2 compatible: no ${var,,}, no declare -A, no nullglob.
+#
+# This suite names init.sh on executed lines (C-group reads the scaffolder's
+# tool-usage.json seed and hook registration STATICALLY — it never runs it), so
+# lint-tests-registered.sh marks it unit-lane-exempt. It is registered in the
+# tests.yml unit list anyway: the lint treats a listed test as "the exemption
+# decided nothing", and the suite is fast enough for the fast lane.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+GATE="$REPO_ROOT/scripts/session-mcp-gate.sh"
+TRACKER="$REPO_ROOT/scripts/track-tool-usage.sh"
+SESSION_CHECK="$REPO_ROOT/scripts/session-test-gate-check.sh"
+SCAFFOLDER="$REPO_ROOT/init.sh"
+REPO_SETTINGS="$REPO_ROOT/.claude/settings.json"
+
+BASH_BIN="$(command -v bash)"
+[ -n "$BASH_BIN" ] || BASH_BIN="/bin/bash"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+START_EPOCH=$(date +%s)
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+_bytes() { local n; n=$(wc -c < "$1" 2>/dev/null | tr -d ' '); _num "$n"; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  _num "$n"
+}
+
+# _sites FILE MARKER — occurrences of an END-OF-LINE-anchored marker.
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+if [ ! -f "$GATE" ] || [ ! -f "$TRACKER" ]; then
+  echo "  [FAIL] setup — gate or tracker not found under $REPO_ROOT/scripts"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq is not installed — this suite asserts on JSON ledger state."
+  echo ""
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+# ── Fixture builders ────────────────────────────────────────────────────────
+
+# mk_proj DIR LEDGER_JSON — a project directory with a tool-usage ledger.
+# Pass the empty string to create the project WITHOUT a ledger.
+mk_proj() {
+  local p="$1" ledger="$2"
+  mkdir -p "$p/.claude" || return 1
+  if [ -n "$ledger" ]; then
+    printf '%s\n' "$ledger" > "$p/.claude/tool-usage.json" || return 1
+  fi
+  return 0
+}
+
+# A ledger in the shape session-test-gate-check.sh writes at SessionStart, with
+# both servers CONFIGURED (required) and nothing yet called.
+LEDGER_BOTH_REQUIRED='{
+  "session_id": "2026-08-13T00:00:00Z",
+  "calls": [],
+  "commits_since_last_context7": 0,
+  "qdrant_find_called": false,
+  "qdrant_store_called": false,
+  "context7_called": false,
+  "mcp_gate_satisfied": false,
+  "mcp_requirements": {
+    "qdrant_required": true,
+    "context7_required": false,
+    "additional_required": []
+  }
+}'
+
+# The same, with NEITHER server configured — the honest "not-configured" state.
+LEDGER_NONE_REQUIRED='{
+  "session_id": "2026-08-13T00:00:00Z",
+  "calls": [],
+  "commits_since_last_context7": 0,
+  "mcp_gate_satisfied": false,
+  "mcp_requirements": {
+    "qdrant_required": false,
+    "context7_required": false,
+    "additional_required": []
+  }
+}'
+
+# The BL-221 shape: a ledger with NO mcp_requirements object at all. This is
+# exactly what init.sh seeds today and what track-tool-usage.sh re-creates.
+LEDGER_NO_REQUIREMENTS='{
+  "session_id": "2026-08-13T00:00:00Z",
+  "calls": [],
+  "commits_since_last_context7": 0,
+  "qdrant_find_called": false,
+  "qdrant_store_called": false,
+  "mcp_gate_satisfied": false
+}'
+
+# ── Real-wire-format envelope builders ──────────────────────────────────────
+# ev_success TOOL TEXT      — PostToolUse: tool_response present, NO error key.
+# ev_failure TOOL ERROR     — PostToolUseFailure: error present, NO tool_response.
+# Neither carries an `isError` key, because neither event does.
+#
+# These are hand-written printf templates rather than jq-assembled objects on
+# purpose: the literal wire shape is half of what this file documents. The cost
+# of that choice is that a builder ARGUMENT containing a `"` or a `\` silently
+# produces INVALID JSON, and an invalid envelope makes every hook take its
+# "no tool_name" fast exit — which reads as a real assertion failure while
+# actually testing nothing. That happened once while writing this suite (a
+# `'"'"'`-style quote dance inside a double-quoted assignment emitted `"` where
+# `'` was meant, and D1 went red for entirely the wrong reason). So EVERY
+# envelope routes through _ev, which records a breach to a file that Z1 asserts
+# is empty — the subshell of a $( … ) builder cannot increment a variable, but
+# it can append to a file.
+BAD_ENVELOPES="$TOPTMP/bad-envelopes"
+: > "$BAD_ENVELOPES"
+_ev() {
+  local json="$1"
+  printf '%s\n' "$json" | jq -e . >/dev/null 2>&1 || printf '%s\n' "$json" >> "$BAD_ENVELOPES"
+  printf '%s\n' "$json"
+}
+ev_success() {
+  _ev "$(printf '{"session_id":"s1","transcript_path":"/tmp/t.jsonl","cwd":"/tmp","permission_mode":"default","hook_event_name":"PostToolUse","tool_name":"%s","tool_input":{"query":"prior session context"},"tool_response":[{"type":"text","text":"%s"}]}' "$1" "$2")"
+}
+ev_success_no_response() {
+  _ev "$(printf '{"session_id":"s1","transcript_path":"/tmp/t.jsonl","cwd":"/tmp","permission_mode":"default","hook_event_name":"PostToolUse","tool_name":"%s","tool_input":{"query":"prior session context"}}' "$1")"
+}
+ev_failure() {
+  _ev "$(printf '{"session_id":"s1","transcript_path":"/tmp/t.jsonl","cwd":"/tmp","permission_mode":"default","hook_event_name":"PostToolUseFailure","tool_name":"%s","tool_input":{"query":"prior session context"},"error":"%s","is_interrupt":false}' "$1" "$2")"
+}
+# An envelope with NO hook_event_name at all — the shape a mis-registration or a
+# future rename produces. "Cannot tell which event" must not read as success.
+ev_eventless() {
+  _ev "$(printf '{"session_id":"s1","cwd":"/tmp","tool_name":"%s","tool_input":{"query":"q"},"tool_response":[{"type":"text","text":"%s"}]}' "$1" "$2")"
+}
+
+# Verbatim, from the live 2026-08-12 call against the dead database.
+QDRANT_DOWN="Error calling tool 'qdrant-find': All connection attempts failed"
+
+# ── Runners ─────────────────────────────────────────────────────────────────
+
+# run_tracker LIB DIR ENVELOPE [extra argv…] — sets TRK_RC / TRK_OUT (a file).
+TRK_RC=0; TRK_OUT=""
+run_tracker() {
+  local lib="$1" d="$2" envelope="$3"; shift 3
+  local infile
+  TRK_RC=0
+  TRK_OUT="$TOPTMP/trk-out-$$-$RANDOM"
+  infile="$TOPTMP/trk-in-$$-$RANDOM"
+  printf '%s\n' "$envelope" > "$infile"
+  ( cd "$d" && "$BASH_BIN" "$lib" "$@" < "$infile" ) > "$TRK_OUT" 2>&1 || TRK_RC=$?
+  rm -f "$infile"
+  return 0
+}
+
+# run_gate LIB DIR [VAR=VAL …] — sets GATE_RC / GATE_OUT (a file).
+# Called DIRECTLY, never inside $( … ): a command substitution is a subshell, so
+# a helper returning its transcript path through a global loses it on the way
+# out, and every later assertion then greps an empty path — which reads as a
+# genuine failure instead of a broken harness.
+GATE_RC=0; GATE_OUT=""
+GATE_ENVELOPE='{"session_id":"s1","transcript_path":"/tmp/t.jsonl","cwd":"/tmp","permission_mode":"default","hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"note.txt","content":"x"}}'
+run_gate() {
+  local lib="$1" d="$2"; shift 2
+  local infile
+  GATE_RC=0
+  GATE_OUT="$TOPTMP/gate-out-$$-$RANDOM"
+  infile="$TOPTMP/gate-in-$$-$RANDOM"
+  printf '%s\n' "$GATE_ENVELOPE" > "$infile"
+  if [ "$#" -gt 0 ]; then
+    ( cd "$d" && /usr/bin/env "$@" "$BASH_BIN" "$lib" < "$infile" ) > "$GATE_OUT" 2>&1 || GATE_RC=$?
+  else
+    ( cd "$d" && "$BASH_BIN" "$lib" < "$infile" ) > "$GATE_OUT" 2>&1 || GATE_RC=$?
+  fi
+  rm -f "$infile"
+  return 0
+}
+
+# decision_of FILE — "deny", "allow", or "malformed".
+# ALLOW is the ABSENCE of a decision envelope, so this reads the transcript
+# structurally rather than grepping for a word that could appear in prose.
+decision_of() {
+  local f="$1" d
+  if [ ! -s "$f" ]; then printf 'allow\n'; return 0; fi
+  d=$(jq -r '.hookSpecificOutput.permissionDecision // "malformed"' "$f" 2>/dev/null)
+  case "$d" in
+    deny|allow) printf '%s\n' "$d" ;;
+    *) printf 'malformed\n' ;;
+  esac
+}
+
+# reason_of FILE — the deny reason text, or the empty string.
+reason_of() { jq -r '.hookSpecificOutput.permissionDecisionReason // ""' "$1" 2>/dev/null; }
+
+# jqf DIR FILTER — read the ledger.
+jqf() { jq -r "$2" "$1/.claude/tool-usage.json" 2>/dev/null; }
+
+echo "=== A — the tracker records the EVENT as the outcome (track-tool-usage.sh) ==="
+
+# A1 is the assertion that would have caught today's behaviour: a call that
+# connected to nothing must not move the requirement toward satisfied.
+A1D="$(newtmp)/p"
+if ! mk_proj "$A1D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "A1" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$A1D" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  a1_ok=$(jqf "$A1D" '.qdrant_find_succeeded // false')
+  a1_fails=$(_num "$(jqf "$A1D" '.qdrant_find_failed // 0')")
+  if [ "$a1_ok" = "false" ] && [ "$a1_fails" -eq 1 ] && [ "$TRK_RC" -eq 0 ]; then
+    pass "A1: a PostToolUseFailure qdrant-find leaves qdrant_find_succeeded=false and records qdrant_find_failed=1 — a failed call moves the requirement AWAY from satisfied, not toward it"
+  else
+    fail_ "A1" "qdrant_find_succeeded=$a1_ok (want false) qdrant_find_failed=$a1_fails (want 1) tracker_rc=$TRK_RC (want 0)"
+  fi
+fi
+
+A2D="$(newtmp)/p"
+if ! mk_proj "$A2D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "A2" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$A2D" "$(ev_success 'mcp__qdrant__qdrant-find' '<entry>prior decision: use worktrees</entry>')" --event PostToolUse
+  a2_ok=$(jqf "$A2D" '.qdrant_find_succeeded // false')
+  a2_fails=$(_num "$(jqf "$A2D" '.qdrant_find_failed // 0')")
+  a2_empty=$(jqf "$A2D" '.qdrant_find_empty // false')
+  if [ "$a2_ok" = "true" ] && [ "$a2_fails" -eq 0 ] && [ "$a2_empty" = "false" ]; then
+    pass "A2 (direction 2): a PostToolUse qdrant-find carrying real content sets qdrant_find_succeeded=true, records no failure, and is not flagged empty"
+  else
+    fail_ "A2" "qdrant_find_succeeded=$a2_ok (want true) qdrant_find_failed=$a2_fails (want 0) qdrant_find_empty=$a2_empty (want false)"
+  fi
+fi
+
+A3D="$(newtmp)/p"
+if ! mk_proj "$A3D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "A3" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$A3D" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  a3_rows=$(_num "$(jqf "$A3D" '[.calls[] | select(.outcome == "failure")] | length')")
+  a3_err=$(jqf "$A3D" '.last_mcp_error // ""')
+  a3_event=$(jqf "$A3D" '[.calls[] | select(.outcome == "failure") | .event] | first // ""')
+  if [ "$a3_rows" -eq 1 ] && [ "$a3_event" = "PostToolUseFailure" ] \
+     && printf '%s' "$a3_err" | grep -q 'All connection attempts failed'; then
+    pass "A3: the failure is RECORDED DISTINCTLY — a calls[] row with outcome=failure and event=PostToolUseFailure, plus the server's own error text on last_mcp_error. Before this, failures were not miscounted, they were UNSEEN (the tracker was registered on PostToolUse only)"
+  else
+    fail_ "A3" "failure_rows=$a3_rows (want 1) recorded_event='$a3_event' (want PostToolUseFailure) last_mcp_error='$a3_err' (want the connection error)"
+  fi
+fi
+
+# A4 — the third state. An envelope that names no event cannot be scored as a
+# success, and the ARG-vs-payload disagreement case is scored the same way.
+A4D="$(newtmp)/p"
+if ! mk_proj "$A4D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "A4" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$A4D" "$(ev_eventless 'mcp__qdrant__qdrant-find' 'looks like a result')"
+  a4_ok=$(jqf "$A4D" '.qdrant_find_succeeded // false')
+  a4_unknown=$(_num "$(jqf "$A4D" '[.calls[] | select(.outcome == "unknown")] | length')")
+  run_tracker "$TRACKER" "$A4D" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUse
+  a4_mis=$(jqf "$A4D" '.qdrant_find_succeeded // false')
+  if [ "$a4_ok" = "false" ] && [ "$a4_unknown" -eq 1 ] && [ "$a4_mis" = "false" ]; then
+    pass "A4: an envelope with NO hook_event_name scores outcome=unknown and satisfies nothing; and when the --event ARG disagrees with the payload's hook_event_name (a mis-registration pointing both events at PostToolUse) the disagreement also scores unknown rather than success"
+  else
+    fail_ "A4" "eventless_succeeded=$a4_ok (want false) unknown_rows=$a4_unknown (want 1) arg_payload_disagreement_succeeded=$a4_mis (want false)"
+  fi
+fi
+
+echo ""
+echo "=== B — Context7: the gate must require the call that FETCHES DOCUMENTATION ==="
+
+B1D="$(newtmp)/p"
+if ! mk_proj "$B1D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "B1" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$B1D" "$(ev_success 'mcp__context7__resolve-library-id' '/qdrant/qdrant - 412 snippets')" --event PostToolUse
+  b1_q=$(jqf "$B1D" '.context7_query_docs_succeeded // false')
+  b1_r=$(_num "$(jqf "$B1D" '.context7_resolve_only_count // 0')")
+  b1_logged=$(_num "$(jqf "$B1D" '[.calls[] | select(.tool | test("resolve-library-id"))] | length')")
+  if [ "$b1_q" = "false" ] && [ "$b1_r" -eq 1 ] && [ "$b1_logged" -eq 1 ]; then
+    pass "B1: a SUCCESSFUL resolve-library-id leaves context7_query_docs_succeeded=false — it returns a list of library IDs and fetches no documentation. It is still ALLOWED and LOGGED (it is the argument step), just not COUNTED"
+  else
+    fail_ "B1" "query_docs_succeeded=$b1_q (want false) resolve_only_count=$b1_r (want 1) call_logged=$b1_logged (want 1)"
+  fi
+fi
+
+B2D="$(newtmp)/p"
+if ! mk_proj "$B2D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "B2" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$B2D" "$(ev_success 'mcp__context7__query-docs' 'Qdrant search API: client.query_points(...)')" --event PostToolUse
+  b2_q=$(jqf "$B2D" '.context7_query_docs_succeeded // false')
+  if [ "$b2_q" = "true" ]; then
+    pass "B2 (direction 2): a SUCCESSFUL query-docs sets context7_query_docs_succeeded=true — the call that actually reads documentation is the one that satisfies the gate whose stated purpose is 'verify library documentation is current before writing'"
+  else
+    fail_ "B2" "query_docs_succeeded=$b2_q (want true)"
+  fi
+fi
+
+# B3 — BL-232's second half: an ID lookup also silenced the commit-time
+# staleness nudge by resetting the counter. Only a real doc read may reset it.
+B3D="$(newtmp)/p"
+if ! mk_proj "$B3D" "$(printf '%s' "$LEDGER_BOTH_REQUIRED" | jq '.commits_since_last_context7 = 7')"; then
+  fail_ "B3" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$B3D" "$(ev_success 'mcp__context7__resolve-library-id' '/qdrant/qdrant')" --event PostToolUse
+  b3_after_resolve=$(_num "$(jqf "$B3D" '.commits_since_last_context7 // 0')")
+  run_tracker "$TRACKER" "$B3D" "$(ev_success 'mcp__context7__query-docs' 'the docs themselves')" --event PostToolUse
+  b3_after_query=$(_num "$(jqf "$B3D" '.commits_since_last_context7 // 0')")
+  if [ "$b3_after_resolve" -eq 7 ] && [ "$b3_after_query" -eq 0 ]; then
+    pass "B3: resolve-library-id does NOT reset commits_since_last_context7 (stays 7) while query-docs does (drops to 0) — the staleness nudge is no longer silenced by an ID lookup"
+  else
+    fail_ "B3" "counter_after_resolve=$b3_after_resolve (want 7, unchanged) counter_after_query_docs=$b3_after_query (want 0)"
+  fi
+fi
+
+# B4 — a FAILED query-docs must not satisfy Context7 either.
+B4D="$(newtmp)/p"
+if ! mk_proj "$B4D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "B4" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$B4D" "$(ev_failure 'mcp__context7__query-docs' "Error calling tool 'query-docs': upstream 503")" --event PostToolUseFailure
+  b4_q=$(jqf "$B4D" '.context7_query_docs_succeeded // false')
+  b4_reset=$(_num "$(jqf "$B4D" '.commits_since_last_context7 // 0')")
+  if [ "$b4_q" = "false" ] && [ "$b4_reset" -eq 0 ]; then
+    pass "B4: a FAILED query-docs leaves context7_query_docs_succeeded=false — the tool that does the work still has to have worked"
+  else
+    fail_ "B4" "query_docs_succeeded=$b4_q (want false) counter=$b4_reset"
+  fi
+fi
+
+echo ""
+echo "=== C — the gate FAILS CLOSED where it used to exit 0 in silence (session-mcp-gate.sh) ==="
+
+C1D="$(newtmp)/p"
+if ! mk_proj "$C1D" ""; then
+  fail_ "C1" "fixture setup failed"
+else
+  run_gate "$GATE" "$C1D"
+  c1_dec=$(decision_of "$GATE_OUT")
+  c1_reason=$(reason_of "$GATE_OUT")
+  c1_says_why=0
+  printf '%s' "$c1_reason" | grep -qi 'cannot' && c1_says_why=1
+  if [ "$c1_dec" = "deny" ] && [ "$c1_says_why" -eq 1 ] && [ "$GATE_RC" -eq 0 ]; then
+    pass "C1: an ABSENT .claude/tool-usage.json now DENIES, and the refusal text says which state it is in ('cannot verify'), not 'satisfied'. Before, no file meant no enforcement, silently"
+  else
+    fail_ "C1" "decision=$c1_dec (want deny) reason_distinguishes_cannot_tell=$c1_says_why (want 1) rc=$GATE_RC (want 0) reason='$c1_reason'"
+  fi
+fi
+
+C2D="$(newtmp)/p"
+if ! mk_proj "$C2D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "C2" "fixture setup failed"
+else
+  run_gate "$GATE" "$C2D" "PATH="
+  c2_dec=$(decision_of "$GATE_OUT")
+  c2_reason=$(reason_of "$GATE_OUT")
+  c2_names_jq=0
+  printf '%s' "$c2_reason" | grep -q 'jq' && c2_names_jq=1
+  if [ "$c2_dec" = "deny" ] && [ "$c2_names_jq" -eq 1 ] && [ "$GATE_RC" -eq 0 ]; then
+    pass "C2: with jq unavailable (empty PATH) the gate DENIES and names jq as the reason it cannot tell — and it emits that refusal using shell builtins only, so the no-jq arm does not depend on the very toolchain it is reporting missing"
+  else
+    fail_ "C2" "decision=$c2_dec (want deny) reason_names_jq=$c2_names_jq (want 1) rc=$GATE_RC (want 0) transcript='$(cat "$GATE_OUT" 2>/dev/null)'"
+  fi
+fi
+
+# C3 — BL-221's shape, one subsystem over: a MISSING key must not be a silent
+# opt-out. This is the ledger init.sh seeds today.
+C3D="$(newtmp)/p"
+if ! mk_proj "$C3D" "$LEDGER_NO_REQUIREMENTS"; then
+  fail_ "C3" "fixture setup failed"
+else
+  run_gate "$GATE" "$C3D"
+  c3_dec=$(decision_of "$GATE_OUT")
+  if [ "$c3_dec" = "deny" ]; then
+    pass "C3: a ledger with NO mcp_requirements object at all now DENIES — an absent key reads as 'required' (fail closed), not as the permissive default that made every requirement silently OFF"
+  else
+    fail_ "C3" "decision=$c3_dec (want deny) — the missing-key default is still permissive"
+  fi
+fi
+
+# C4 — the honest third state. not-configured is a REAL answer and must pass.
+C4D="$(newtmp)/p"
+if ! mk_proj "$C4D" "$LEDGER_NONE_REQUIRED"; then
+  fail_ "C4" "fixture setup failed"
+else
+  run_gate "$GATE" "$C4D"
+  c4_dec=$(decision_of "$GATE_OUT")
+  if [ "$c4_dec" = "allow" ]; then
+    pass "C4 (direction 2): an EXPLICIT not-configured ledger (qdrant_required=false, context7_required=false) allows — 'no server configured' is a determinate answer and must be distinguishable from 'cannot tell', or the gate becomes one people delete"
+  else
+    fail_ "C4" "decision=$c4_dec (want allow) transcript='$(cat "$GATE_OUT" 2>/dev/null)'"
+  fi
+fi
+
+echo ""
+echo "=== D — the gate reads OUTCOMES, and the latch is not an authority ==="
+
+D1D="$(newtmp)/p"
+if ! mk_proj "$D1D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "D1" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$D1D" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  run_gate "$GATE" "$D1D"
+  d1_dec=$(decision_of "$GATE_OUT")
+  d1_reason=$(reason_of "$GATE_OUT")
+  d1_distinct=0
+  printf '%s' "$d1_reason" | grep -qi 'unreachable' && d1_distinct=1
+  if [ "$d1_dec" = "deny" ] && [ "$d1_distinct" -eq 1 ]; then
+    pass "D1 (the headline): the tracker records a real failing round trip and the gate then DENIES, naming CONFIGURED-BUT-UNREACHABLE as a state distinct from not-configured. This is the end-to-end path where a call returning 'All connection attempts failed' used to satisfy the gate"
+  else
+    fail_ "D1" "decision=$d1_dec (want deny) reason_names_unreachable=$d1_distinct (want 1) reason='$d1_reason'"
+  fi
+fi
+
+D2D="$(newtmp)/p"
+if ! mk_proj "$D2D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "D2" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$D2D" "$(ev_success 'mcp__qdrant__qdrant-find' '<entry>prior context</entry>')" --event PostToolUse
+  run_gate "$GATE" "$D2D"
+  d2_dec=$(decision_of "$GATE_OUT")
+  if [ "$d2_dec" = "allow" ]; then
+    pass "D2 (direction 2): the same fixture with a SUCCEEDING round trip allows — the two directions differ only in which hook event fired, which is the whole point: the event is the signal"
+  else
+    fail_ "D2" "decision=$d2_dec (want allow) transcript='$(cat "$GATE_OUT" 2>/dev/null)'"
+  fi
+fi
+
+# D3 — the latch. mcp_gate_satisfied lives in a file the agent can edit.
+D3D="$(newtmp)/p"
+if ! mk_proj "$D3D" "$(printf '%s' "$LEDGER_BOTH_REQUIRED" | jq '.mcp_gate_satisfied = true')"; then
+  fail_ "D3" "fixture setup failed"
+else
+  run_gate "$GATE" "$D3D"
+  d3_dec=$(decision_of "$GATE_OUT")
+  d3_after=$(jqf "$D3D" '.mcp_gate_satisfied // false')
+  if [ "$d3_dec" = "deny" ] && [ "$d3_after" = "false" ]; then
+    pass "D3 (the latch): mcp_gate_satisfied=true with the requirement UNSATISFIED still denies, and the stale flag is re-derived to false. The gate asks 'is it satisfied NOW', never 'was it satisfied once' — a latch in an agent-editable file is a self-signed permission slip"
+  else
+    fail_ "D3" "decision=$d3_dec (want deny) mcp_gate_satisfied_after=$d3_after (want false — re-derived)"
+  fi
+fi
+
+# D4 — additional_required is on the same outcome footing.
+D4D="$(newtmp)/p"
+if ! mk_proj "$D4D" "$(printf '%s' "$LEDGER_NONE_REQUIRED" | jq '.mcp_requirements.additional_required = ["sentry"]')"; then
+  fail_ "D4" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$D4D" "$(ev_failure 'mcp__sentry__list-issues' "Error calling tool 'list-issues': 401")" --event PostToolUseFailure
+  run_gate "$GATE" "$D4D"
+  d4_fail_dec=$(decision_of "$GATE_OUT")
+  run_tracker "$TRACKER" "$D4D" "$(ev_success 'mcp__sentry__list-issues' 'issue 1')" --event PostToolUse
+  run_gate "$GATE" "$D4D"
+  d4_ok_dec=$(decision_of "$GATE_OUT")
+  if [ "$d4_fail_dec" = "deny" ] && [ "$d4_ok_dec" = "allow" ]; then
+    pass "D4: an operator-added additional_required tool obeys the same rule — a FAILED call denies, a SUCCEEDING one allows. The additional_required arm used to count any logged call row regardless of outcome"
+  else
+    fail_ "D4" "decision_after_failed_call=$d4_fail_dec (want deny) decision_after_successful_call=$d4_ok_dec (want allow)"
+  fi
+fi
+
+echo ""
+echo "=== E — a successful but EMPTY retrieval: allowed, reported loudly, recorded ==="
+
+E1D="$(newtmp)/p"
+if ! mk_proj "$E1D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "E1" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$E1D" "$(ev_success 'mcp__qdrant__qdrant-find' '')" --event PostToolUse
+  e1_ok=$(jqf "$E1D" '.qdrant_find_succeeded // false')
+  e1_empty=$(jqf "$E1D" '.qdrant_find_empty // false')
+  e1_count=$(_num "$(jqf "$E1D" '.qdrant_find_empty_count // 0')")
+  e1_reported=$(_bytes "$TRK_OUT")
+  run_gate "$GATE" "$E1D"
+  e1_dec=$(decision_of "$GATE_OUT")
+  if [ "$e1_ok" = "true" ] && [ "$e1_empty" = "true" ] && [ "$e1_count" -eq 1 ] \
+     && [ "$e1_reported" -gt 0 ] && [ "$e1_dec" = "allow" ]; then
+    pass "E1 (Karl's decision 1): a SUCCESSFUL find that returned nothing satisfies the requirement (allow) AND is recorded (qdrant_find_empty=true, count=1) AND is reported — 'succeeded' and 'returned something' are separable because tool_response carries the returned text. Empty is information on a new project and a symptom on an old one"
+  else
+    fail_ "E1" "succeeded=$e1_ok (want true) empty_flag=$e1_empty (want true) empty_count=$e1_count (want 1) report_bytes=$e1_reported (want >0) gate_decision=$e1_dec (want allow)"
+  fi
+fi
+
+# E2 — a success envelope with NO tool_response at all returned nothing either.
+E2D="$(newtmp)/p"
+if ! mk_proj "$E2D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "E2" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$E2D" "$(ev_success_no_response 'mcp__qdrant__qdrant-find')" --event PostToolUse
+  e2_ok=$(jqf "$E2D" '.qdrant_find_succeeded // false')
+  e2_empty=$(jqf "$E2D" '.qdrant_find_empty // false')
+  if [ "$e2_ok" = "true" ] && [ "$e2_empty" = "true" ]; then
+    pass "E2: a PostToolUse envelope with tool_response ABSENT is a success that returned nothing — flagged empty, still satisfying. The event decides success; the payload decides emptiness"
+  else
+    fail_ "E2" "succeeded=$e2_ok (want true) empty_flag=$e2_empty (want true)"
+  fi
+fi
+
+# E3 — the qdrant MCP server's literal zero-result phrase.
+E3D="$(newtmp)/p"
+if ! mk_proj "$E3D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "E3" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$E3D" "$(ev_success 'mcp__qdrant__qdrant-find' 'No information found')" --event PostToolUse
+  e3_empty=$(jqf "$E3D" '.qdrant_find_empty // false')
+  if [ "$e3_empty" = "true" ]; then
+    pass "E3: the qdrant MCP server's own zero-result phrase ('No information found') is recognised as empty rather than as content"
+  else
+    fail_ "E3" "empty_flag=$e3_empty (want true)"
+  fi
+fi
+
+echo ""
+echo "=== F — the attested escape: recorded, or refused (BL-072's shape) ==="
+
+F1D="$(newtmp)/p"
+if ! mk_proj "$F1D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "F1" "fixture setup failed"
+else
+  run_gate "$GATE" "$F1D" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=offline on a plane, qdrant unreachable by design"
+  f1_dec=$(decision_of "$GATE_OUT")
+  f1_rows=$(_num "$(jq -r '.mcp_attestations | length' "$F1D/.claude/process-state.json" 2>/dev/null)")
+  f1_reason=$(jq -r '.mcp_attestations[0].reason // ""' "$F1D/.claude/process-state.json" 2>/dev/null)
+  f1_blocked=$(jq -r '.mcp_attestations[0].blocked_on // ""' "$F1D/.claude/process-state.json" 2>/dev/null)
+  if [ "$f1_dec" = "allow" ] && [ "$f1_rows" -eq 1 ] \
+     && printf '%s' "$f1_reason" | grep -q 'on a plane' \
+     && printf '%s' "$f1_blocked" | grep -qi 'qdrant'; then
+    pass "F1: SOLO_MCP_ATTESTED=1 with a reason allows, and the escape is DURABLY RECORDED to .claude/process-state.json::mcp_attestations[] with the operator's reason AND what was being escaped. An escape that leaves no trace is the advisory posture this work exists to replace"
+  else
+    fail_ "F1" "decision=$f1_dec (want allow) attestation_rows=$f1_rows (want 1) recorded_reason='$f1_reason' blocked_on='$f1_blocked'"
+  fi
+fi
+
+F2D="$(newtmp)/p"
+if ! mk_proj "$F2D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "F2" "fixture setup failed"
+else
+  run_gate "$GATE" "$F2D" "SOLO_MCP_ATTESTED=1"
+  f2_dec=$(decision_of "$GATE_OUT")
+  f2_reason=$(reason_of "$GATE_OUT")
+  f2_rows=$(_num "$(jq -r '.mcp_attestations | length' "$F2D/.claude/process-state.json" 2>/dev/null)")
+  f2_names=0
+  printf '%s' "$f2_reason" | grep -q 'SOLO_MCP_REASON' && f2_names=1
+  if [ "$f2_dec" = "deny" ] && [ "$f2_rows" -eq 0 ] && [ "$f2_names" -eq 1 ]; then
+    pass "F2: SOLO_MCP_ATTESTED=1 with NO reason is REFUSED and records nothing — the reason is mandatory, because an unexplained escape is indistinguishable from the bypass it replaces"
+  else
+    fail_ "F2" "decision=$f2_dec (want deny) attestation_rows=$f2_rows (want 0) reason_names_the_variable=$f2_names (want 1)"
+  fi
+fi
+
+# F3 — the property that makes the escape honest: an escape that CANNOT be
+# recorded is a refusal, not a pass. Both record sinks are made unwritable by
+# being directories — deterministic, and unlike chmod it also holds under root.
+F3D="$(newtmp)/p"
+if ! mk_proj "$F3D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "F3" "fixture setup failed"
+else
+  mkdir -p "$F3D/.claude/process-state.json" "$F3D/.claude/mcp-attestations.jsonl"
+  run_gate "$GATE" "$F3D" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=offline, and the disk is hostile"
+  f3_dec=$(decision_of "$GATE_OUT")
+  f3_reason=$(reason_of "$GATE_OUT")
+  f3_loud=0
+  printf '%s' "$f3_reason" | grep -qi 'REFUS' && f3_loud=1
+  if [ "$f3_dec" = "deny" ] && [ "$f3_loud" -eq 1 ]; then
+    pass "F3 (the load-bearing half): with BOTH record sinks unwritable the attested escape is REFUSED, loudly. This is BL-072's rule copied exactly — 'an attested escape must be durably logged', and a silent pass on a write failure would re-open the whole class"
+  else
+    fail_ "F3" "decision=$f3_dec (want deny) refusal_is_loud=$f3_loud (want 1) reason='$f3_reason'"
+  fi
+fi
+
+# F4 — escapability under the very degradation the gate reports. A gate that
+# cannot be satisfied honestly is a gate people delete (BL-149), so the no-jq
+# refusal must still have a way through that leaves a trace.
+F4D="$(newtmp)/p"
+if ! mk_proj "$F4D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "F4" "fixture setup failed"
+else
+  run_gate "$GATE" "$F4D" "PATH=" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=no jq on this host yet"
+  f4_dec=$(decision_of "$GATE_OUT")
+  f4_lines=0
+  [ -f "$F4D/.claude/mcp-attestations.jsonl" ] && f4_lines=$(_num "$(grep -c 'no jq on this host' "$F4D/.claude/mcp-attestations.jsonl" 2>/dev/null)")
+  if [ "$f4_dec" = "allow" ] && [ "$f4_lines" -eq 1 ]; then
+    pass "F4: with jq absent the escape still works and still leaves a trace — the jq-free fallback sink .claude/mcp-attestations.jsonl is appended with shell builtins. Without this, the no-jq refusal would be unescapable and the whole hook would get deleted"
+  else
+    fail_ "F4" "decision=$f4_dec (want allow) jsonl_rows_matching_reason=$f4_lines (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== G — hooks must never wedge the session on their OWN failure ==="
+
+G1D="$(newtmp)/p"
+if ! mk_proj "$G1D" 'this is not json {'; then
+  fail_ "G1" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$G1D" "$(ev_success 'mcp__qdrant__qdrant-find' 'x')" --event PostToolUse
+  g1_trk_rc=$TRK_RC
+  run_gate "$GATE" "$G1D"
+  g1_dec=$(decision_of "$GATE_OUT")
+  if [ "$g1_trk_rc" -eq 0 ] && [ "$g1_dec" = "deny" ]; then
+    pass "G1 (the pinned split): a MALFORMED ledger leaves the tracker at rc 0 — a tracking failure must never interrupt a build loop — while the GATE, whose job is enforcement, denies because it cannot tell. The tracker never blocks; the gate always fails closed"
+  else
+    fail_ "G1" "tracker_rc=$g1_trk_rc (want 0) gate_decision=$g1_dec (want deny)"
+  fi
+fi
+
+G2D="$(newtmp)/p"
+if ! mk_proj "$G2D" ""; then
+  fail_ "G2" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$G2D" "$(ev_success 'mcp__qdrant__qdrant-find' 'x')" --event PostToolUse
+  g2_rc=$TRK_RC
+  g2_created=0
+  [ -f "$G2D/.claude/tool-usage.json" ] && g2_created=1
+  g2_has_req=$(jq -r 'has("mcp_requirements")' "$G2D/.claude/tool-usage.json" 2>/dev/null)
+  run_gate "$GATE" "$G2D"
+  g2_dec=$(decision_of "$GATE_OUT")
+  if [ "$g2_rc" -eq 0 ] && [ "$g2_created" -eq 1 ] && [ "$g2_has_req" = "false" ] && [ "$g2_dec" = "allow" ]; then
+    pass "G2: when the tracker re-creates a missing ledger it writes NO mcp_requirements object, so a re-created file can never turn a requirement OFF. Requirements are SessionStart's to derive; an absent object makes the gate fail closed. (Here the qdrant call SUCCEEDED, so the fail-closed requirement is met and the gate allows — the requirement was not silently switched off, it was satisfied)"
+  else
+    fail_ "G2" "tracker_rc=$g2_rc (want 0) ledger_created=$g2_created (want 1) reseed_has_mcp_requirements=$g2_has_req (want false) gate_decision=$g2_dec (want allow)"
+  fi
+fi
+
+G3D="$(newtmp)/p"
+if ! mk_proj "$G3D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "G3" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$G3D" "$(ev_success 'mcp__qdrant__qdrant-find' 'x')" --event PostToolUse "PATH="
+  g3_rc=$TRK_RC
+  run_tracker "$TRACKER" "$G3D" 'not json at all' --event PostToolUse
+  g3_rc2=$TRK_RC
+  if [ "$g3_rc" -eq 0 ] && [ "$g3_rc2" -eq 0 ]; then
+    pass "G3: the tracker exits 0 on a garbage stdin envelope and on an unexpected argv — pinned, because a PostToolUse hook that dies non-zero on its own bug would surface as a tool failure on every single call"
+  else
+    fail_ "G3" "rc_with_odd_argv=$g3_rc (want 0) rc_with_garbage_stdin=$g3_rc2 (want 0)"
+  fi
+fi
+
+echo ""
+echo "=== H — the seeds and registrations (static reads of init.sh and this repo) ==="
+
+# The scaffolder's tool-usage.json heredoc, extracted and parsed. Static read
+# only: this suite never executes the scaffolder.
+H_SEED="$TOPTMP/seed.json"
+awk "/cat > .claude\/tool-usage.json << 'TUEOF'/{f=1;next} f&&/^TUEOF\$/{f=0} f" "$SCAFFOLDER" > "$H_SEED" 2>/dev/null
+
+h1_valid=0
+jq -e . "$H_SEED" >/dev/null 2>&1 && h1_valid=1
+h1_q=$(jq -r '.mcp_requirements.qdrant_required // "ABSENT"' "$H_SEED" 2>/dev/null)
+h1_c=$(jq -r '.mcp_requirements.context7_required // "ABSENT"' "$H_SEED" 2>/dev/null)
+h1_add=$(jq -r '.mcp_requirements.additional_required | length' "$H_SEED" 2>/dev/null)
+if [ "$h1_valid" -eq 1 ] && [ "$h1_q" = "true" ] && [ "$h1_c" = "true" ] && [ "$(_num "$h1_add")" -eq 0 ]; then
+  pass "H1: the scaffolder's tool-usage.json seed now carries an mcp_requirements object, seeded fail-CLOSED (both required=true). It contained no such object at all, which is why '.mcp_requirements.X_required // false' made every requirement default to OFF in every generated project — BL-221's shape exactly. SessionStart re-derives the real values on the first session"
+else
+  fail_ "H1" "seed_parses=$h1_valid qdrant_required='$h1_q' (want true) context7_required='$h1_c' (want true) additional_required_len='$h1_add' (want 0)"
+fi
+
+h2_out=$(jq -r '.qdrant_find_succeeded, .context7_query_docs_succeeded, .qdrant_find_failed' "$H_SEED" 2>/dev/null | tr '\n' ' ')
+if printf '%s' "$h2_out" | grep -q 'false false 0'; then
+  pass "H2: the seed also carries the OUTCOME fields the gate reads (qdrant_find_succeeded, context7_query_docs_succeeded, qdrant_find_failed), so a generated project's ledger has the same schema the gate derives from"
+else
+  fail_ "H2" "outcome fields in seed = '$h2_out' (want 'false false 0')"
+fi
+
+h3_reg=$(grep -c 'PostToolUseFailure' "$SCAFFOLDER" 2>/dev/null)
+h3_ev=$(grep -c 'track-tool-usage.sh --event' "$SCAFFOLDER" 2>/dev/null)
+if [ "$(_num "$h3_reg")" -gt 0 ] && [ "$(_num "$h3_ev")" -ge 2 ]; then
+  pass "H3: the scaffolder registers the tracker on PostToolUseFailure as well as PostToolUse, each with its own --event argument. Registered on PostToolUse alone, failures were not miscounted by the framework — they were INVISIBLE to it"
+else
+  fail_ "H3" "PostToolUseFailure mentions in scaffolder=$h3_reg (want >0) '--event'-carrying registrations=$h3_ev (want >=2)"
+fi
+
+h4_missing=""
+if [ ! -f "$REPO_SETTINGS" ]; then
+  h4_missing="the file itself"
+else
+  for _h in session-test-gate-check.sh track-tool-usage.sh session-mcp-gate.sh; do
+    grep -q "$_h" "$REPO_SETTINGS" 2>/dev/null || h4_missing="${h4_missing}${_h} "
+  done
+  jq -e '.hooks.PostToolUseFailure' "$REPO_SETTINGS" >/dev/null 2>&1 || h4_missing="${h4_missing}PostToolUseFailure "
+  jq -e '.' "$REPO_SETTINGS" >/dev/null 2>&1 || h4_missing="${h4_missing}(invalid JSON) "
+fi
+if [ -z "$h4_missing" ]; then
+  pass "H4: this repository's own .claude/settings.json registers the SessionStart check, the tracker on BOTH post-tool events, and the Write/Edit gate — the mechanism now fires where the framework is BUILT, not only in generated projects. The same gap hides the version-check hook"
+else
+  fail_ "H4" "missing from $REPO_SETTINGS: $h4_missing"
+fi
+
+echo ""
+echo "=== M — mutation proofs (each mutant: sites==1, N lines changed, bash -n, fresh fixture) ==="
+
+# mk_mirror DIR — a private copy of the two shipped hooks, mode preserved, so a
+# mutant is applied to a throwaway file and never to the tree under test.
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -p "$GATE" "$m/gate.sh" || return 1
+  cp -p "$TRACKER" "$m/tracker.sh" || return 1
+  return 0
+}
+
+# _mutate FILE MARKER REPLACEMENT — excise the one END-OF-LINE-anchored marked
+# line and replace it. Echoes "sites changed parses".
+#
+# The delimiter is `%`: shell replacements are `|`-dense (`||`), and `s|old|new|`
+# with a `|` in the replacement either errors or — worse — terminates the
+# expression early and leaves the file UNCHANGED WHILE SED REPORTS SUCCESS.
+# `&` means THE WHOLE MATCH in a replacement, so it is escaped here; an
+# unescaped `&&` splices the original line back in and yields a mutant nobody
+# designed, one that still passes `bash -n`. No marker or replacement in this
+# file contains a `%`, and the changed-line assertion is what would catch it if
+# one ever did.
+_mutate() {
+  local f="$1" marker="$2" repl="$3"
+  local before sites changed parses safe
+  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  before="$(mktemp)"
+  cp -p "$f" "$before"
+  sites=$(_sites "$f" "$marker")
+  _sed_inplace "$f" "s%^.*${marker}\$%${safe}%"
+  changed=$(_changed_lines "$before" "$f")
+  parses=$(_parses "$f")
+  rm -f "$before"
+  printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+# ── M1: restore the silent no-file exit ─────────────────────────────────────
+M1D="$(newtmp)"
+if ! mk_proj "$M1D/p" "" || ! mk_mirror "$M1D/m"; then
+  fail_ "M1" "fixture setup failed"
+else
+  run_gate "$M1D/m/gate.sh" "$M1D/p"; m1_ctl=$(decision_of "$GATE_OUT")
+  m1_meta=$(_mutate "$M1D/m/gate.sh" '# BL-233-FAILCLOSED-NOFILE' '  BLOCK_REASON=""')
+  set -- $m1_meta; m1_sites=$1; m1_changed=$2; m1_parses=$3
+  run_gate "$M1D/m/gate.sh" "$M1D/p"; m1_mut=$(decision_of "$GATE_OUT")
+  if [ "$m1_ctl" = "deny" ] && [ "$m1_mut" = "allow" ] \
+     && [ "$m1_sites" -eq 1 ] && [ "$m1_changed" -eq 2 ] && [ "$m1_parses" -eq 1 ]; then
+    pass "M1: control denies with no ledger; with the fail-closed arm neutered the same absent ledger ALLOWS — the pre-BL-233 behaviour, restored on demand"
+  else
+    fail_ "M1" "control=$m1_ctl (want deny) mutant=$m1_mut (want allow) sites=$m1_sites (want 1) changed=$m1_changed (want 2) parses=$m1_parses (want 1)"
+  fi
+fi
+
+# ── M2: restore the silent no-jq exit ───────────────────────────────────────
+M2D="$(newtmp)"
+if ! mk_proj "$M2D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M2D/m"; then
+  fail_ "M2" "fixture setup failed"
+else
+  run_gate "$M2D/m/gate.sh" "$M2D/p" "PATH="; m2_ctl=$(decision_of "$GATE_OUT")
+  m2_meta=$(_mutate "$M2D/m/gate.sh" '# BL-233-FAILCLOSED-JQ' '  exit 0')
+  set -- $m2_meta; m2_sites=$1; m2_changed=$2; m2_parses=$3
+  run_gate "$M2D/m/gate.sh" "$M2D/p" "PATH="; m2_mut=$(decision_of "$GATE_OUT")
+  if [ "$m2_ctl" = "deny" ] && [ "$m2_mut" = "allow" ] \
+     && [ "$m2_sites" -eq 1 ] && [ "$m2_changed" -eq 2 ] && [ "$m2_parses" -eq 1 ]; then
+    pass "M2: control denies with jq unavailable; with the arm turned back into 'exit 0' the missing toolchain silently disables enforcement again"
+  else
+    fail_ "M2" "control=$m2_ctl (want deny) mutant=$m2_mut (want allow) sites=$m2_sites (want 1) changed=$m2_changed (want 2) parses=$m2_parses (want 1)"
+  fi
+fi
+
+# ── M3: flip the missing-key default back to permissive ─────────────────────
+M3D="$(newtmp)"
+if ! mk_proj "$M3D/p" "$LEDGER_NO_REQUIREMENTS" || ! mk_mirror "$M3D/m"; then
+  fail_ "M3" "fixture setup failed"
+else
+  run_gate "$M3D/m/gate.sh" "$M3D/p"; m3_ctl=$(decision_of "$GATE_OUT")
+  m3_meta=$(_mutate "$M3D/m/gate.sh" '# BL-233-FAILCLOSED-REQ' 'QDRANT_REQUIRED=$(_flag ".mcp_requirements.qdrant_required" false)')
+  set -- $m3_meta; m3_sites=$1; m3_changed=$2; m3_parses=$3
+  run_gate "$M3D/m/gate.sh" "$M3D/p"; m3_mut=$(decision_of "$GATE_OUT")
+  if [ "$m3_ctl" = "deny" ] && [ "$m3_mut" = "allow" ] \
+     && [ "$m3_sites" -eq 1 ] && [ "$m3_changed" -eq 2 ] && [ "$m3_parses" -eq 1 ]; then
+    pass "M3: control denies on a ledger with no mcp_requirements; with the default flipped from true to false the missing key is a silent opt-out again — one character, and BL-221's shape is back"
+  else
+    fail_ "M3" "control=$m3_ctl (want deny) mutant=$m3_mut (want allow) sites=$m3_sites (want 1) changed=$m3_changed (want 2) parses=$m3_parses (want 1)"
+  fi
+fi
+
+# ── M4: read the DECLARATION instead of the OUTCOME ─────────────────────────
+# This mutant is BL-231 itself: satisfaction from `qdrant_find_called`, the flag
+# that is true whether the call worked or not.
+M4D="$(newtmp)"
+if ! mk_proj "$M4D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M4D/m"; then
+  fail_ "M4" "fixture setup failed"
+else
+  run_tracker "$TRACKER" "$M4D/p" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  run_gate "$M4D/m/gate.sh" "$M4D/p"; m4_ctl=$(decision_of "$GATE_OUT")
+  m4_meta=$(_mutate "$M4D/m/gate.sh" '# BL-233-OUTCOME-QDRANT' 'QDRANT_OK=$(_flag ".qdrant_find_called" false)')
+  set -- $m4_meta; m4_sites=$1; m4_changed=$2; m4_parses=$3
+  run_gate "$M4D/m/gate.sh" "$M4D/p"; m4_mut=$(decision_of "$GATE_OUT")
+  if [ "$m4_ctl" = "deny" ] && [ "$m4_mut" = "allow" ] \
+     && [ "$m4_sites" -eq 1 ] && [ "$m4_changed" -eq 2 ] && [ "$m4_parses" -eq 1 ]; then
+    pass "M4 (the root cause, mutated back in): reading .qdrant_find_called — 'a matching tool was called' — instead of .qdrant_find_succeeded makes a call that reached NOTHING satisfy the gate. Same ledger, same failing round trip, opposite verdict"
+  else
+    fail_ "M4" "control=$m4_ctl (want deny) mutant=$m4_mut (want allow) sites=$m4_sites (want 1) changed=$m4_changed (want 2) parses=$m4_parses (want 1)"
+  fi
+fi
+
+# ── M5: reintroduce the latch fast path (structural discriminator) ──────────
+# The absence of a fast path cannot be greped for, so it is pinned by the line
+# that reads the flag FOR THE RECORD ONLY; the mutant turns that read back into
+# an authority.
+M5D="$(newtmp)"
+if ! mk_proj "$M5D/p" "$(printf '%s' "$LEDGER_BOTH_REQUIRED" | jq '.mcp_gate_satisfied = true')" || ! mk_mirror "$M5D/m"; then
+  fail_ "M5" "fixture setup failed"
+else
+  run_gate "$M5D/m/gate.sh" "$M5D/p"; m5_ctl=$(decision_of "$GATE_OUT")
+  m5_meta=$(_mutate "$M5D/m/gate.sh" '# BL-233-NO-LATCH' 'GATE_PRIOR=$(_flag ".mcp_gate_satisfied" false); [ "$GATE_PRIOR" = "true" ] && exit 0')
+  set -- $m5_meta; m5_sites=$1; m5_changed=$2; m5_parses=$3
+  run_gate "$M5D/m/gate.sh" "$M5D/p"; m5_mut=$(decision_of "$GATE_OUT")
+  if [ "$m5_ctl" = "deny" ] && [ "$m5_mut" = "allow" ] \
+     && [ "$m5_sites" -eq 1 ] && [ "$m5_changed" -eq 2 ] && [ "$m5_parses" -eq 1 ]; then
+    pass "M5: control denies despite mcp_gate_satisfied=true; restore the fast path and a flag the agent itself can write ends the enforcement — 'was it satisfied once' replacing 'is it satisfied now'"
+  else
+    fail_ "M5" "control=$m5_ctl (want deny) mutant=$m5_mut (want allow) sites=$m5_sites (want 1) changed=$m5_changed (want 2) parses=$m5_parses (want 1)"
+  fi
+fi
+
+# ── M6: let an UNRECORDABLE attestation pass ────────────────────────────────
+M6D="$(newtmp)"
+if ! mk_proj "$M6D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M6D/m"; then
+  fail_ "M6" "fixture setup failed"
+else
+  mkdir -p "$M6D/p/.claude/process-state.json" "$M6D/p/.claude/mcp-attestations.jsonl"
+  run_gate "$M6D/m/gate.sh" "$M6D/p" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=hostile disk"; m6_ctl=$(decision_of "$GATE_OUT")
+  m6_meta=$(_mutate "$M6D/m/gate.sh" '# BL-233-ATTEST-REFUSE' '  exit 0')
+  set -- $m6_meta; m6_sites=$1; m6_changed=$2; m6_parses=$3
+  run_gate "$M6D/m/gate.sh" "$M6D/p" "SOLO_MCP_ATTESTED=1" "SOLO_MCP_REASON=hostile disk"; m6_mut=$(decision_of "$GATE_OUT")
+  if [ "$m6_ctl" = "deny" ] && [ "$m6_mut" = "allow" ] \
+     && [ "$m6_sites" -eq 1 ] && [ "$m6_changed" -eq 2 ] && [ "$m6_parses" -eq 1 ]; then
+    pass "M6: control refuses an escape it could not record; drop the refusal and the escape passes leaving NO trace anywhere — which is precisely the advisory posture BL-233 exists to replace"
+  else
+    fail_ "M6" "control=$m6_ctl (want deny) mutant=$m6_mut (want allow) sites=$m6_sites (want 1) changed=$m6_changed (want 2) parses=$m6_parses (want 1)"
+  fi
+fi
+
+# ── M7: make the reason optional ────────────────────────────────────────────
+M7D="$(newtmp)"
+if ! mk_proj "$M7D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M7D/m"; then
+  fail_ "M7" "fixture setup failed"
+else
+  run_gate "$M7D/m/gate.sh" "$M7D/p" "SOLO_MCP_ATTESTED=1"; m7_ctl=$(decision_of "$GATE_OUT")
+  m7_meta=$(_mutate "$M7D/m/gate.sh" '# BL-233-ATTEST-REASON' '  ATTEST_REASON="${SOLO_MCP_REASON:-unspecified}"')
+  set -- $m7_meta; m7_sites=$1; m7_changed=$2; m7_parses=$3
+  run_gate "$M7D/m/gate.sh" "$M7D/p" "SOLO_MCP_ATTESTED=1"; m7_mut=$(decision_of "$GATE_OUT")
+  if [ "$m7_ctl" = "deny" ] && [ "$m7_mut" = "allow" ] \
+     && [ "$m7_sites" -eq 1 ] && [ "$m7_changed" -eq 2 ] && [ "$m7_parses" -eq 1 ]; then
+    pass "M7: control refuses a reasonless attestation; default the reason instead and SOLO_MCP_ATTESTED=1 becomes a bare bypass flag with a placeholder in the ledger"
+  else
+    fail_ "M7" "control=$m7_ctl (want deny) mutant=$m7_mut (want allow) sites=$m7_sites (want 1) changed=$m7_changed (want 2) parses=$m7_parses (want 1)"
+  fi
+fi
+
+# ── M8: score every event as a success (tracker) ────────────────────────────
+M8D="$(newtmp)"
+if ! mk_proj "$M8D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M8D/m"; then
+  fail_ "M8" "fixture setup failed"
+else
+  run_tracker "$M8D/m/tracker.sh" "$M8D/p" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  m8_ctl=$(jqf "$M8D/p" '.qdrant_find_succeeded // false')
+  m8_meta=$(_mutate "$M8D/m/tracker.sh" '# BL-233-EVENT-OUTCOME' 'OUTCOME=success')
+  set -- $m8_meta; m8_sites=$1; m8_changed=$2; m8_parses=$3
+  mk_proj "$M8D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_tracker "$M8D/m/tracker.sh" "$M8D/p2" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  m8_mut=$(jqf "$M8D/p2" '.qdrant_find_succeeded // false')
+  if [ "$m8_ctl" = "false" ] && [ "$m8_mut" = "true" ] \
+     && [ "$m8_sites" -eq 1 ] && [ "$m8_changed" -eq 2 ] && [ "$m8_parses" -eq 1 ]; then
+    pass "M8: control leaves the flag false on PostToolUseFailure; force the outcome to success and the identical failing envelope marks the requirement met. The event IS the signal — there is no field to fall back on"
+  else
+    fail_ "M8" "control_flag=$m8_ctl (want false) mutant_flag=$m8_mut (want true) sites=$m8_sites (want 1) changed=$m8_changed (want 2) parses=$m8_parses (want 1)"
+  fi
+fi
+
+# ── M9: let resolve-library-id count as a documentation read (tracker) ──────
+M9D="$(newtmp)"
+if ! mk_proj "$M9D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M9D/m"; then
+  fail_ "M9" "fixture setup failed"
+else
+  run_tracker "$M9D/m/tracker.sh" "$M9D/p" "$(ev_success 'mcp__context7__resolve-library-id' '/qdrant/qdrant')" --event PostToolUse
+  m9_ctl=$(jqf "$M9D/p" '.context7_query_docs_succeeded // false')
+  m9_meta=$(_mutate "$M9D/m/tracker.sh" '# BL-233-C7-QUERYDOCS' 'C7KIND=query')
+  set -- $m9_meta; m9_sites=$1; m9_changed=$2; m9_parses=$3
+  mk_proj "$M9D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_tracker "$M9D/m/tracker.sh" "$M9D/p2" "$(ev_success 'mcp__context7__resolve-library-id' '/qdrant/qdrant')" --event PostToolUse
+  m9_mut=$(jqf "$M9D/p2" '.context7_query_docs_succeeded // false')
+  if [ "$m9_ctl" = "false" ] && [ "$m9_mut" = "true" ] \
+     && [ "$m9_sites" -eq 1 ] && [ "$m9_changed" -eq 2 ] && [ "$m9_parses" -eq 1 ]; then
+    pass "M9: control does not credit an ID lookup; collapse the two Context7 tools back into one and the argument step satisfies a gate whose stated purpose is that documentation was read"
+  else
+    fail_ "M9" "control_flag=$m9_ctl (want false) mutant_flag=$m9_mut (want true) sites=$m9_sites (want 1) changed=$m9_changed (want 2) parses=$m9_parses (want 1)"
+  fi
+fi
+
+# ── M10: suppress the empty-result report (tracker) ─────────────────────────
+M10D="$(newtmp)"
+if ! mk_proj "$M10D/p" "$LEDGER_BOTH_REQUIRED" || ! mk_mirror "$M10D/m"; then
+  fail_ "M10" "fixture setup failed"
+else
+  run_tracker "$M10D/m/tracker.sh" "$M10D/p" "$(ev_success 'mcp__qdrant__qdrant-find' '')" --event PostToolUse
+  m10_ctl=$(_bytes "$TRK_OUT")
+  m10_meta=$(_mutate "$M10D/m/tracker.sh" '# BL-233-EMPTY-REPORT' '  :')
+  set -- $m10_meta; m10_sites=$1; m10_changed=$2; m10_parses=$3
+  mk_proj "$M10D/p2" "$LEDGER_BOTH_REQUIRED"
+  run_tracker "$M10D/m/tracker.sh" "$M10D/p2" "$(ev_success 'mcp__qdrant__qdrant-find' '')" --event PostToolUse
+  m10_mut=$(_bytes "$TRK_OUT")
+  m10_still_recorded=$(jqf "$M10D/p2" '.qdrant_find_empty // false')
+  if [ "$m10_ctl" -gt 0 ] && [ "$m10_mut" -eq 0 ] && [ "$m10_still_recorded" = "true" ] \
+     && [ "$m10_sites" -eq 1 ] && [ "$m10_changed" -eq 2 ] && [ "$m10_parses" -eq 1 ]; then
+    pass "M10: control reports the empty retrieval; suppress the report and the ledger still RECORDS it while nobody is told — an empty memory on an old project would then look exactly like a healthy one"
+  else
+    fail_ "M10" "control_report_bytes=$m10_ctl (want >0) mutant_report_bytes=$m10_mut (want 0) still_recorded=$m10_still_recorded (want true) sites=$m10_sites (want 1) changed=$m10_changed (want 2) parses=$m10_parses (want 1)"
+  fi
+fi
+
+# ── M11: re-seed requirements OFF on a re-created ledger (structural) ───────
+# The tracker's re-seed carrying NO mcp_requirements is an ABSENCE, pinned by
+# the guard line that enforces it; the mutant puts the old permissive object
+# back — BL-231's "tracker re-seed" row, verbatim.
+M11D="$(newtmp)"
+if ! mk_proj "$M11D/p" "" || ! mk_mirror "$M11D/m"; then
+  fail_ "M11" "fixture setup failed"
+else
+  run_tracker "$M11D/m/tracker.sh" "$M11D/p" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  run_gate "$GATE" "$M11D/p"; m11_ctl=$(decision_of "$GATE_OUT")
+  m11_meta=$(_mutate "$M11D/m/tracker.sh" '# BL-233-NO-REQ-RESEED' '  jq ".mcp_requirements = {\"qdrant_required\": false, \"context7_required\": false, \"additional_required\": []}" "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE"')
+  set -- $m11_meta; m11_sites=$1; m11_changed=$2; m11_parses=$3
+  mk_proj "$M11D/p2" ""
+  run_tracker "$M11D/m/tracker.sh" "$M11D/p2" "$(ev_failure 'mcp__qdrant__qdrant-find' "$QDRANT_DOWN")" --event PostToolUseFailure
+  run_gate "$GATE" "$M11D/p2"; m11_mut=$(decision_of "$GATE_OUT")
+  if [ "$m11_ctl" = "deny" ] && [ "$m11_mut" = "allow" ] \
+     && [ "$m11_sites" -eq 1 ] && [ "$m11_changed" -eq 2 ] && [ "$m11_parses" -eq 1 ]; then
+    pass "M11: control denies after a re-created ledger and a failed call; restore the permissive re-seed and the tracker itself switches the requirement OFF — a hook whose own recovery path disarms the gate it feeds"
+  else
+    fail_ "M11" "control=$m11_ctl (want deny) mutant=$m11_mut (want allow) sites=$m11_sites (want 1) changed=$m11_changed (want 2) parses=$m11_parses (want 1)"
+  fi
+fi
+
+echo ""
+echo "=== Z — harness meta-assertion ==="
+
+# Z1 is not a property of the code under test; it is a property of this file.
+# Without it, a malformed fixture makes every hook take its "no tool_name" fast
+# exit and the resulting red reads as a genuine defect. That is the exact
+# failure mode `scripts/lint-fixture-envelopes.sh` was written for, one layer
+# in: not the WRONG KEY, but no parseable JSON at all.
+z1_bad=$(_num "$(wc -l < "$BAD_ENVELOPES" 2>/dev/null | tr -d ' ')")
+if [ "$z1_bad" -eq 0 ]; then
+  pass "Z1: every hook payload this suite fed to a hook parsed as JSON — so each red above is a statement about the hook, not about the fixture"
+else
+  fail_ "Z1" "$z1_bad malformed envelope(s) were fed to a hook — every assertion using one is meaningless:
+$(cat "$BAD_ENVELOPES")"
+fi
+
+END_EPOCH=$(date +%s)
+echo ""
+echo "Wall clock: $((END_EPOCH - START_EPOCH))s"
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl233-mcp-outcome-enforcement.sh
+++ b/tests/test-bl233-mcp-outcome-enforcement.sh
@@ -378,6 +378,35 @@ else
   fi
 fi
 
+# A5 — the fourth state, and the reason the ground-truth table lists
+# `is_interrupt` at all. A call the OPERATOR cancelled also arrives on
+# PostToolUseFailure, but "you pressed Esc" and "the server is not there" are
+# different facts. Both leave the requirement unsatisfied — that part must not
+# soften — but only one of them is evidence about the server, and a gate that
+# announces CONFIGURED BUT UNREACHABLE because someone cancelled a query is
+# `## BL-104:`'s lesson restated: the label is never the behaviour.
+A5D="$(newtmp)/p"
+if ! mk_proj "$A5D" "$LEDGER_BOTH_REQUIRED"; then
+  fail_ "A5" "fixture setup failed"
+else
+  a5_env=$(_ev "$(printf '{"session_id":"s1","cwd":"/tmp","hook_event_name":"PostToolUseFailure","tool_name":"mcp__qdrant__qdrant-find","tool_input":{"query":"q"},"error":"The user doesn'"'"'t want to take this action right now.","is_interrupt":true}')")
+  run_tracker "$TRACKER" "$A5D" "$a5_env" --event PostToolUseFailure
+  a5_ok=$(jqf "$A5D" '.qdrant_find_succeeded // false')
+  a5_fails=$(_num "$(jqf "$A5D" '.qdrant_find_failed // 0')")
+  a5_int=$(_num "$(jqf "$A5D" '.qdrant_find_interrupted // 0')")
+  a5_outcome=$(jqf "$A5D" '[.calls[] | .outcome] | first // ""')
+  run_gate "$GATE" "$A5D"
+  a5_dec=$(decision_of "$GATE_OUT")
+  a5_claims_down=0
+  printf '%s' "$(reason_of "$GATE_OUT")" | grep -qi 'unreachable' && a5_claims_down=1
+  if [ "$a5_ok" = "false" ] && [ "$a5_dec" = "deny" ] && [ "$a5_claims_down" -eq 0 ] \
+     && [ "$a5_fails" -eq 0 ] && [ "$a5_int" -eq 1 ] && [ "$a5_outcome" = "interrupted" ]; then
+    pass "A5: an OPERATOR-CANCELLED call (is_interrupt=true on PostToolUseFailure) still leaves the requirement unsatisfied and still denies — but it is recorded as interrupted, not failed, and the gate does NOT diagnose the server as unreachable on the strength of it. Unsatisfied is a verdict; unreachable is a claim about the world, and only a real failed round trip earns it"
+  else
+    fail_ "A5" "succeeded=$a5_ok (want false) gate=$a5_dec (want deny) claims_unreachable=$a5_claims_down (want 0) qdrant_find_failed=$a5_fails (want 0) qdrant_find_interrupted=$a5_int (want 1) call_outcome='$a5_outcome' (want interrupted)"
+  fi
+fi
+
 echo ""
 echo "=== B — Context7: the gate must require the call that FETCHES DOCUMENTATION ==="
 


### PR DESCRIPTION
## What

**BL-233 WP-A** — rebuilds the MCP enforcement mechanism so it records **outcomes**
rather than **declarations**.

The old gate blocked `Write`/`Edit` until Qdrant and Context7 had been "called".
It never worked. The headline proof is reproducible: the tracker records a real
`PostToolUseFailure` carrying *"All connection attempts failed"* — and the gate
**allows the write**.

## Ground truth this is built on

The official docs carry **no worked MCP example**, so the payload contract was
measured by probing both hook events with one failing and one succeeding MCP call:

| | success (`PostToolUse`) | failure (`PostToolUseFailure`) |
|---|---|---|
| `tool_response` | present — array of `[{type:"text", text:…}]` | **absent** |
| `error` | absent | `Error calling tool 'qdrant-find': …` |
| any `isError` key | **none anywhere** | — |

**A failed MCP call fires `PostToolUseFailure`, not `PostToolUse`** — and the
tracker was registered only on the latter, so failures were **invisible**, not
miscounted. **The event is the only success signal.** BL-233's own instruction to
"read `.tool_response`" was wrong and is struck through in the entry.

## The owner's three decisions

1. **Retrieval** — satisfied by a *successful* call. An empty result does not
   block but is reported and recorded.
2. **Storing** — warn at commit, block at the phase gate. **WP-B**;
   `pre-commit-gate.sh` and `check-phase-gate.sh` are untouched here.
3. **Unreachable** — block, with an attested escape that must be durably
   recorded and **refuses if unrecordable**.

## What changed

Registers on **both** events. Fails closed at every layer that previously exited
0 silently (absent ledger, absent `jq`, missing `mcp_requirements`, malformed
ledger) — each naming *which* state it is in, because *"cannot tell" is not
"satisfied"*. Seeds `mcp_requirements` in `init.sh`, which previously omitted it
entirely so every requirement defaulted **off**. Requires Context7's
`query-docs`, not `resolve-library-id` — the latter returns a list of IDs and
fetched no documentation while satisfying a gate whose stated purpose is
verifying documentation. Escape via `SOLO_MCP_ATTESTED=1` + **mandatory**
`SOLO_MCP_REASON`, recorded to `process-state.json`, with a **jq-free JSONL
fallback** because "jq is missing" is itself a blocking state and a jq-only
recorder would make that refusal inescapable.

**The latch is deliberately not an authority** (`# BL-233-NO-LATCH`) — re-derived
every call, never fast-pathed, because the file is agent-editable and a latch
there is a self-signed permission slip. Measured cost: **~32ms/Write**.

## Review — two rounds, `major_concerns` → `approve`

**The blocker was a fail-open driven by text we do not control.** `deny()`
escaped `\`, `"`, `\n`, `\t` — not the control-character class — and spliced the
**MCP server's own error text** into the refusal. A `\r` produced malformed JSON;
per the platform contract, exit 0 with unparseable stdout means *"no decision;
normal permission flow applies"*. The deny became an allow, and **stayed** one,
because the error text persists in the ledger.

Root cause in one line: *the characters they thought of, not the class.* Fixed by
scrubbing **U+0001–U+001F** with builtins — builtins because `deny()` must be able
to report a **missing jq** and therefore cannot use jq to build its own JSON.
U+0000 is excluded with a stated proof (command substitution drops NUL).

Second blocker: the reviewer's own mutation of a new write survived 43/0. Now
pinned — their mutation yields 49/2.

Then the author extended the lesson to the *next* class — invalid UTF-8 — and
measured that the severity **differs**: a control byte is a hard syntax error
(lost decision), while invalid UTF-8 is substituted (mangled character). Recorded
rather than patched. **Review verified it is stronger still**: `jq -r` sanitises
on read-back, so invalid UTF-8 cannot reach the envelope raw by any path.

Final review: **approve, no findings**, having re-run every prior attack plus new
ones — including a class-narrowing mutation (dropping only `1f`) that the suite
correctly caught, proving it pins the **class**, not the exemplar.

## Verification

- New suite **51 passed, 0 failed**, 13 mutants, `/bin/bash` 3.2.57.
- **Watched RED 6/45** against the base tree — the evidence the mechanism never
  worked. (Corrected twice: an earlier 5/37 was measured on a smaller file, and a
  re-measure was contaminated by reverting only two scripts.)
- `run-lints` 15/15 · neighbours 9/0, 5/0, 8/0 · registered in both the aggregator
  and the `tests.yml` unit list.

## Known residuals, recorded in the entry

The escape is **session-launch-scoped** (a PreToolUse hook inherits the launch
env; unlike BL-072's, it cannot ride a command line). Plugin-provided MCP servers
still evade requirement *derivation*. `session-end-qdrant-reminder.sh` still
counts declarations and now disagrees with the gate — a WP-B pickup.

## Merge-time note, decided by the owner

This registers the mechanism in **this repo**, so the gate is live here. With
Qdrant down it will **deny `Write`/`Edit`** until the server is up or a session
exports `SOLO_MCP_ATTESTED=1` with a reason. That is decision 3 working as
intended, chosen knowingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
