### PR TITLE
docs(ledger): close BL-234 on #351, and fix three documents that had quietly become false

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,7 +33,8 @@ Session handoff documents. **One live state-of-record at the top level; finished
 handoffs move to `archive/` and leave a pointer stub at the old path** so every
 citation still resolves. Convention: [handoffs/archive/README.md](handoffs/archive/README.md).
 
-- **Live:** [handoffs/2026-07-31-bl201-bl200-close.md](handoffs/2026-07-31-bl201-bl200-close.md) — the current state-of-record (`main` at `1be4264`; BL-201 #292 and BL-200 #293 shipped and merged; next is the § 4 pick-list). Its § 8 is a paste-ready resume prompt.
+- **Live:** [handoffs/2026-08-15-currency-and-enforcement-wave.md](handoffs/2026-08-15-currency-and-enforcement-wave.md) — the current state-of-record (`main` at `a49ceaf`; #341–#351 shipped and merged; `## BL-234:` Closed; next is `## BL-222:` + `## BL-229:`, the Phase 3→4 release gate). Its § 10 is a paste-ready resume prompt, and its § 4.0 carries a ⚠ CORRECTION — read that before acting on the section.
+- **Superseded but still full-length:** [handoffs/2026-07-31-bl201-bl200-close.md](handoffs/2026-07-31-bl201-bl200-close.md) — the previous state-of-record, kept at top level rather than archived. **So the "everything else at top level is a stub" rule below has exactly one exception today**; CLAUDE.md's "trust the non-stub" tie-break does not resolve between two, so use the newer date.
 - **Archived:** [handoffs/archive/](handoffs/archive/) — eleven finished handoffs, 2026-07-08 through 2026-07-31, each with a pointer stub left at its old top-level path. See [handoffs/archive/README.md](handoffs/archive/README.md) for the per-file status (superseded vs fully executed). Everything at the top level of `docs/handoffs/` other than the live doc above is a stub.
 
 ## Superpowers (`docs/superpowers/`)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -29,13 +29,26 @@ five-phase build: after v1.0 ships, and before a project that already exists com
 
 ## Handoffs (`docs/handoffs/`)
 
-Session handoff documents. **One live state-of-record at the top level; finished
-handoffs move to `archive/` and leave a pointer stub at the old path** so every
-citation still resolves. Convention: [handoffs/archive/README.md](handoffs/archive/README.md).
+Session handoff documents. **Finished handoffs move to `archive/` and leave a
+pointer stub at the old path** so every citation still resolves. Convention:
+[handoffs/archive/README.md](handoffs/archive/README.md).
+
+**A stub is a pointer — a title and a blockquote, no `## ` sections — so derive
+the full handoffs rather than counting them here:**
+
+```
+grep -l '^## ' docs/handoffs/*.md     # full state-of-record docs
+grep -L '^## ' docs/handoffs/*.md     # pointer stubs
+```
+
+Usually that returns one file. It returns two whenever a superseded
+state-of-record is kept at top level rather than archived — as now — and in that
+case CLAUDE.md's "trust the non-stub" tie-break cannot resolve it: **use the
+newer date.**
 
 - **Live:** [handoffs/2026-08-15-currency-and-enforcement-wave.md](handoffs/2026-08-15-currency-and-enforcement-wave.md) — the current state-of-record (`main` at `a49ceaf`; #341–#351 shipped and merged; `## BL-234:` Closed; next is `## BL-222:` + `## BL-229:`, the Phase 3→4 release gate). Its § 10 is a paste-ready resume prompt, and its § 4.0 carries a ⚠ CORRECTION — read that before acting on the section.
-- **Superseded but still full-length:** [handoffs/2026-07-31-bl201-bl200-close.md](handoffs/2026-07-31-bl201-bl200-close.md) — the previous state-of-record, kept at top level rather than archived. **So the "everything else at top level is a stub" rule below has exactly one exception today**; CLAUDE.md's "trust the non-stub" tie-break does not resolve between two, so use the newer date.
-- **Archived:** [handoffs/archive/](handoffs/archive/) — eleven finished handoffs, 2026-07-08 through 2026-07-31, each with a pointer stub left at its old top-level path. See [handoffs/archive/README.md](handoffs/archive/README.md) for the per-file status (superseded vs fully executed). Everything at the top level of `docs/handoffs/` other than the live doc above is a stub.
+- **Superseded but still full-length:** [handoffs/2026-07-31-bl201-bl200-close.md](handoffs/2026-07-31-bl201-bl200-close.md) — the previous state-of-record, kept at top level rather than archived. This is the second file the `grep -l` above returns.
+- **Archived:** [handoffs/archive/](handoffs/archive/) — finished handoffs, 2026-07-08 through 2026-07-31, each with a pointer stub left at its old top-level path. See [handoffs/archive/README.md](handoffs/archive/README.md) for the per-file status (superseded vs fully executed).
 
 ## Superpowers (`docs/superpowers/`)
 

--- a/docs/handoffs/2026-08-15-currency-and-enforcement-wave.md
+++ b/docs/handoffs/2026-08-15-currency-and-enforcement-wave.md
@@ -1,0 +1,324 @@
+# Handoff — the currency-and-enforcement wave: delta track closed, brownfield half-built, four "declaration ≠ capability" defects fixed (2026-08-15)
+
+> Supersedes [`2026-07-31-bl201-bl200-close.md`](2026-07-31-bl201-bl200-close.md).
+> See [`archive/README.md`](archive/README.md) for the archive convention.
+
+## 1. Read this first — the environment is not what it was
+
+**The MCP enforcement gate is LIVE in this repo.** A new session will be
+**refused on its first `Write`/`Edit`** until it has made a **successful**
+`qdrant-find` **and** a **successful** `context7 query-docs`. This is not a
+malfunction; it shipped in #350 by the owner's explicit decision. The refusal
+text names its own remedies. **Do not route around it with `Bash`** — that is the
+dishonesty the gate exists to prevent, and it will be treated as a finding.
+
+Practical notes a new session needs:
+
+- **Qdrant is running** — container `qdrant`, `localhost:6333`, collections
+  `meshscope` and `solo-orchestrator`. If it is down: `docker start qdrant`.
+- **Colima was wedged and was repaired** on 2026-08-14 (it reported `Running`
+  with a socket dead since 18 July; `colima stop && colima start` fixed it,
+  nothing destroyed). If Docker is unresponsive, that is the first thing to try.
+- **A worktree is a different working directory** and needs its own satisfied
+  gate. The documented remedy is to run `scripts/session-test-gate-check.sh`
+  there, then make the two calls succeed.
+- The escape is `SOLO_MCP_ATTESTED=1 SOLO_MCP_REASON='<why>' claude` and it is
+  **session-launch-scoped** — it cannot be attached mid-session. That limitation
+  is real and recorded; it was hit on the gate's first live firing.
+
+## 2. Where we are
+
+`main` at **`a49ceaf`** — the merge of **#351**. This wave ran #341 → #351.
+
+> **§ 4.0 IS RESOLVED (2026-08-16).** #351 was red, is now **merged**. The root
+> cause was not the one this document guessed at — see the ⚠ block in § 4.0
+> before relying on anything written there. `## BL-234:` carries the measured
+> account; `CLAUDE.md` § ENVIRONMENT TRAPS carries the reusable trap.
+> **Next up, per the owner: `## BL-222:` + `## BL-229:` together** — both are
+> the Phase 3→4 release gate failing silently, in the same script.
+
+**Complete and shipping:**
+- **The Delta Track** — WP0–WP8 plus D-A and D-B. Post-1.0 lifecycle: classify,
+  brief, gates, ratchet, hotfix retro, cadence, release cut, ledger close.
+- **`workflow.html`** — verified claim-by-claim against the gate scripts, with
+  brownfield and delta chapters added. It had been stale since 2026-07-01.
+- **BL-233 WP-A** — the MCP gate now records outcomes rather than declarations.
+
+**Written, reviewed, NOT merged:**
+- **BL-234** — currency and availability measured rather than declared. Branch
+  `fix/solo-currency-and-availability`, **PR #351, CI red**. § 4.0.
+
+**Half built, and the docs say so:**
+- **Brownfield adoption** — WP0–WP4, **WP5b** (test-debt ledger) and **WP6**
+  (collision archive) are in. **WP5** (certification), **WP7** (CI carve-out +
+  Adoption Record) and the **joint E2E** are not.
+
+## 3. What this wave learned — read before writing any proof
+
+One sentence covers nearly every defect found: **a check asked whether something
+was DECLARED rather than whether it WORKED.** The named instances, because the
+next one will wear a different costume:
+
+| shape | instance |
+|---|---|
+| an exit code is not a receipt | `jq` exits 0 having read no document (`## BL-227:`); `sed` reports success having edited nothing; `PostToolUse` fires only on success, so a failed MCP call was **invisible** |
+| a name is not a capability | a server *named* qdrant in settings ⇒ "installed"; a *filename* containing `dep` satisfies the security clock (`## BL-222:`) |
+| a proxy is not the thing | `resolve-library-id` satisfies a gate whose purpose is reading documentation (`## BL-232:`) |
+| a reference can rot | Solo's currency compared against a **never-fetched local clone** — 161 commits stale, reported current |
+| an absence is not a negative | a probe returning nothing is **"cannot tell"**, not "nothing there" — see the ⚠ correction on `## BL-231:` |
+| a fallback arm that cannot fire | `cmd 2>/dev/null \| head \|\| echo "failed"` — a pipeline's status is the **last** command's, so the `\|\| echo` never runs |
+| the harness has the same bug | mutants that never applied scored as kills; a two-outcome fixture cannot see a leaked credential (a leak is a *wrong* key, logged like an honest unkeyed one) |
+
+**Proof rules this wave paid for, in blood:**
+
+- **A test that passes because a tool was CALLED is the bug, restated.** Assert
+  on state, bytes, exit codes, or the *server's* log — never on a label.
+- **If you write a fallback arm, prove it can fire.**
+- **Pin an atom's WIDTH and SPELLING, not its presence.** One-character mutants
+  survived full estates repeatedly this wave (`-eq 0`→`-lt 0` survived all 172
+  lane suites while making the tool lie permanently).
+- **Fresh fixture per DIRECTION, not per mutant** — a control run that writes to
+  the fixture poisons the mutant run.
+- **`bash -n` proves nothing about awk, and accepts files bash rejects at
+  runtime.** Drive awk mutants against a control that must still behave.
+- **Count what ran, not what failed.** "0 failed" is producible by a runner that
+  executed almost nothing.
+- **Enumerations go stale the moment they are written.** Four counts in this
+  backlog were wrong (six-that-were-eight, three-that-were-nine,
+  six-that-were-seven, fourteen-that-were-fifteen). **Print the derivation
+  command, not the number.**
+
+## 4. High-priority open work — ranked, with reasons
+
+### 4.0 ~~BLOCKING~~ — RESOLVED. PR #351 merged as `a49ceaf` (2026-08-16).
+
+> ⚠ **CORRECTION — the diagnosis below was wrong, and wrong in an instructive
+> way.** This section reasoned that "cloning an EMPTY repository succeeds". The
+> bare was **not** empty: it held `refs/heads/main`. Its **HEAD** was a dangling
+> symref pointing at `refs/heads/master`, because `build_fw` created the working
+> repo with `git init -q -b main` but the bare with a plain `git init -q --bare`,
+> so the bare followed **the host's** `init.defaultBranch`. This Mac gets `main`
+> free from the gitconfig Xcode ships; a runner gets `master`. Cloning a repo
+> whose HEAD dangles warns, **exits 0**, and leaves only `.git` — which is why
+> `|| return 1` could not see it. Right shape, wrong mechanism.
+>
+> The section's *method* advice held and is worth keeping: the swallowed rc was
+> the reason the diagnosis was invisible, and fixing the swallowing first is what
+> surfaced git's own warning. The section's instruction to reproduce on CI was
+> **unnecessary** — `GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null` runs the
+> runner's git configuration on this host and reproduced 44/4 exactly, locally.
+>
+> Three adversarial-review rounds followed a clean product change, and each found
+> this document's own defect class **inside the fix for it** — including a
+> receipt built on `git rev-parse HEAD`, which exits 0 on a dangling HEAD. Full
+> account on `## BL-234:`.
+>
+> Everything from here to the end of § 4.0 is preserved as written, for the audit
+> trail. **Do not act on it.**
+
+**`fix(bl234): measure currency and availability instead of reading a
+declaration`** — <https://github.com/kraulerson/solo-orchestrator/pull/351>,
+branch `fix/solo-currency-and-availability`, head `1eeebde`, worktree
+`.claude/worktrees/currency-avail`. `MERGEABLE` by git, **red by CI.** House rule:
+no merge on red, no `--admin`.
+
+**Measured, not inferred:**
+
+| fact | value |
+|---|---|
+| failing check | `unit-shard (rest)` (and therefore the required aggregator `unit`) |
+| suite | `tests/test-bl234-currency-and-availability.sh` |
+| CI | **44 passed, 4 failed** |
+| local | **48 passed, 0 failed** |
+| failing cases | **A1, E1, E3, M1** |
+
+The four symptoms, verbatim: A1 `fixture: could not advance the local bare
+origin`; E1 got `up_to_date|up to date`, wanted `behind`; E3 `local=… true_origin=…`
+identical when they must differ; M1 `control=no (want yes)`. All four repeat one
+error:
+
+```
+tests/test-bl234-currency-and-availability.sh: line 169: \
+  /tmp/tmp.XXXX/caseXXXX/adv/scripts/validate.sh: No such file or directory
+```
+
+**What that error is, structurally.** Line 169 is inside `advance_origin`, which
+does `_git clone -q "$bare" "$work" || return 1` and then writes
+`"$work/scripts/validate.sh"`. **Cloning an EMPTY repository succeeds** — git
+warns and exits 0 — so a clone that produced no working tree passes the `||
+return 1` guard and fails 1 line later on a redirect into a directory that was
+never created. The four failures are therefore **one upstream fixture failure
+wearing four costumes**: the bare origin is empty on CI and populated locally.
+
+**Why it is invisible.** `build_fw` runs `init`, `add`, `commit`, `init --bare`,
+`remote add`, `push -u` and `fetch` — **every one of them `>/dev/null 2>&1`, none
+of them rc-checked.** Whichever step fails on CI, its message was discarded and
+its failure not noticed. That is **this wave's own defect class, living inside
+the harness that exists to catch it** — an exit code thrown away is an exit code
+that cannot testify. Fix the swallowing *first*: it is the diagnostic.
+
+**Ruled out — do not re-litigate.** Git identity *is* configured (`_git()` at the
+fixture header passes `-c user.email` / `-c user.name` / `-c commit.gpgsign=false`
+on every call), so the classic "CI has no committer identity" cause is **not**
+it. **Root cause is NOT yet established** — no hypothesis in this document has
+been reproduced on CI, and none should be written into a fix as though it were.
+
+**Recipe:** rc-check each step in `build_fw` and `advance_origin`, print the git
+error on failure (the suite's own `Never echoes` comment is why they were muted —
+route diagnostics to stderr or a log file, not stdout, or the captures corrupt),
+push, read the CI log, *then* fix the real cause. Re-derive state before
+trusting any of the above:
+
+```
+gh pr checks 351 | grep -v pass
+gh run view --log-failed --job <job-id> | grep -n "not ok\|No such file"
+```
+
+Everything else on the branch reproduced under adversarial review (watched RED
+4/23, GREEN 29/0, neighbours 26/0 · 51/0 · 6/0, 172/172 lane suites locally,
+lints 15/15). **The failure is in the fixture, not the product change** — which
+is a claim to verify, not inherit.
+
+### 4.1 Live holes in shipped code
+1. **`## BL-229:`** — the Phase 3→4 release check hardcodes
+   `.github/workflows/release.yml`, so on **GitLab and Bitbucket it is skipped
+   and prints nothing**. A pipeline full of TODOs passes the gate. Not a wrong
+   answer — a *missing* one that reads as clean.
+2. **`## BL-222:`** — the release gate's **only** security clock is satisfied by
+   any dated file matching `*dep*`. Reproduced end-to-end: a
+   `deployment-notes-<date>.md` cuts a release with no scan ever run. **Needs no
+   intent** to trip.
+3. **`## BL-221:`** — `assert_choosable` fails **open** on a manifest with no
+   `deployment` key, so an adopted organizational project can lower enforcement
+   to `no` where a scaffolded one refuses. Owner's steer: **write the tier keys
+   at adoption** rather than defaulting the shared predicate closed.
+4. **`## BL-235:`** — the tool-matrix `check_command` tests for an MCP config
+   entry, never a running database. This is why a project reported Qdrant
+   "installed" for months with no database.
+
+### 4.2 Finish what is started
+5. **BL-233 WP-B** — the owner decided **warn at commit, block at the phase
+   gate** for the *storing* half. WP-A (retrieval) shipped; **WP-B has not
+   started.** Until it does, the ratchet has nothing behind it. Also pick up:
+   `session-end-qdrant-reminder.sh` still counts declarations and now disagrees
+   with the gate.
+6. **Brownfield WP7 → WP5 → WP8 residual → joint E2E**, in that order. **WP7
+   before WP5** — WP5's acceptance requires the Adoption Record, which WP7
+   builds. WP7 also owns the adopted project's pre-commit hook (owner's
+   decision) and the commit-time caller for WP5b's ratchet.
+
+### 4.3 Protective
+7. **`## BL-230:`** — `workflow.html` cites 18 markers and 7 doc paths and sits
+   **outside every lint surface**; proved by mutation (a corrupted link *and* a
+   corrupted marker both left the lints green). The accuracy just bought has no
+   mechanism to survive. Two traps are recorded in the entry.
+
+### 4.4 Larger, needs design first
+8. **`## BL-228:`** — multi-language projects and an architecture question the
+   intake never asks. Half the data model is **already plural** (tool-matrix
+   rows carry a `languages` list); the *selection* is scalar. The hard part is
+   CI: ten templates, one per language, one chosen.
+9. **`## BL-218:`** — the ci.yml detector enumerates ways a file can be wrong.
+   Three adversarial rounds each found new spellings; the fork is
+   canonical-shape-or-refuse. Owner deferred it deliberately as a design item.
+
+## 5. Decisions the owner still holds
+
+- **`run_with_timeout`'s poll floor** — session start costs **+1.03s**, of which
+  only ~300–390ms is the fetch; the rest is a `sleep 1` before the first check.
+  **11 call sites across 6 product files**, including `check-phase-gate.sh`.
+  Measured and deliberately not changed — speeding up a shared enforcement
+  primitive is the owner's call. A costed fix is in the BL-234 report.
+- **Agent-run updates** — the framework's standing doctrine is *"detection is
+  loud and automatic; remediation is consented, never auto-applied"*
+  (`## BL-099:`). The owner has asked whether the agent should run the update on
+  approval. Note for whoever picks this up: **the framework already
+  auto-installs 20+ tools**, including Docker, Colima and Context7 MCP — so this
+  is a narrower change than it first appears.
+- **`## BL-226:`** — adoption tells the operator files were "moved" when for most
+  nothing moved. Three options laid out, **none taken**: re-wording a
+  design-mandated string is the owner's call.
+- **Housekeeping** — `rm -rf /Users/karl/Code/demo-delta` (a review fixture,
+  single scaffold commit, no remote), and this repo's `.git/hooks/pre-commit` is
+  a stale snapshot versus the shipped gate.
+
+## 6. `powerpoint-voice` — a live example, investigated but not fixed
+
+A real generated project on this machine, and a useful test subject:
+
+- pinned to Solo `6417a255` — **161 commits behind**, and nothing told the
+  operator, because the freshness check compared against a **never-fetched**
+  local clone. BL-234 fixes the detection; **the project itself is untouched.**
+- its `.claude/tool-usage.json` is **tracked**. `## BL-236:` ships the ignore
+  rule for new projects; existing ones need
+  `git rm --cached .claude/tool-usage.json` — **recommended, deliberately not
+  performed on anyone's repo.**
+- Qdrant: the MCP client config is correct and per-project
+  (collection `powerpoint-voice`), but **no such collection exists** — nothing
+  was ever stored. The database was never provisioned for it.
+
+## 7. Standing gates — non-negotiable, all held this wave
+
+- **No merge on red.** No `gh pr merge --admin`.
+- **Adversarial review on the branch tip BEFORE opening any PR**, docs-only
+  included. Fix rounds until it clears, then PR.
+- **Verify the PR head SHA matches local** before merging; a watch can report on
+  a stale run.
+- **Use `--body-file`** for PR bodies — zsh globbed `[x]` out of one.
+- **TDD with dual-direction mutation proofs** for every enforcement change.
+- **Hermetic tests**: local bare repos as origins, `env -i` private HOMEs, no
+  live remotes, nothing touching the developer's real config.
+- **Cite by grep-able marker or function name, never bare `file:line`** — two
+  stale line-cites were found in `workflow.html` this wave.
+- **Never `--no-verify`.**
+
+## 8. Traps specific to this repo, learned the hard way this wave
+
+- **Do not create a branch in the main checkout if an agent will work it from a
+  worktree.** The branch ref advances, the main checkout's tree does not, and
+  git reports the whole diff as staged deletions — one `git commit -a` would
+  have wiped a day's work. It happened; it was caught by a reviewer.
+- **Put agent briefs on disk, not only in a message.** Two agents died to API
+  errors mid-task and their instructions died with them.
+- **Tell agents to commit each fix as it lands.** A commit survives an API
+  error; a working tree does not.
+- **`sed` with a `|` delimiter and shell-code replacement fails SILENTLY** — see
+  `CLAUDE.md` § ENVIRONMENT TRAPS, added this wave.
+- **`run_with_timeout` gives its child `/dev/null` on stdin** (bash nulls an
+  async command's stdin before any explicit redirection). Piping a secret into a
+  bounded child sends nothing, silently.
+
+## 9. References
+
+- Backlog: `## BL-216:` … `## BL-236:` are this wave's filings.
+- Designs: `docs/designs/2026-08-02-delta-track-v1.md`,
+  `docs/designs/2026-08-02-brownfield-adoption-v1.md`.
+- User-facing: `docs/delta-track.md`, `docs/scout.md`, `docs/adoption.md`,
+  `workflow.html`.
+- PRs this wave: #341 (D-B), #342 (D-A), #343 (docs capstone), #344 (WP5b),
+  #345 (WP6), #346 (shard pin), #347 (BL-228), #348 (workflow.html),
+  #350 (BL-233 WP-A). **#351 (BL-234) is open and red — § 4.0.**
+
+## 10. Resume prompt
+
+> Read `CLAUDE.md` first, then this handoff
+> (`docs/handoffs/2026-08-15-currency-and-enforcement-wave.md`), then
+> `solo-orchestrator-backlog.md` for the entries it names.
+>
+> **The MCP gate is live** — expect your first `Write`/`Edit` to be refused until
+> a `qdrant-find` and a `context7 query-docs` both succeed. Qdrant should be
+> running on `localhost:6333`; if not, `docker start qdrant`. Do not route around
+> the gate.
+>
+> **Start with § 4.0 — PR #351 is red and blocking.** Fix the fixture, get it
+> green, merge it; only then move on. After that, § 4.1 — the four live holes in
+> shipped code — unless the owner
+> redirects. Each is filed with measured evidence and a fix shape; **re-derive
+> every count before relying on it.** Then § 4.2, finishing BL-233 WP-B and the
+> brownfield remainder in the stated order (WP7 before WP5).
+>
+> House pattern: opus implementers in isolated worktrees, model mix stated,
+> adversarial review on every branch tip **before** any PR, fix rounds until
+> clear, explicit CI verification with a head-SHA check, sequential merges,
+> ledger closes citing PR numbers. Surface every judgment call to the owner
+> before building it, and end every message with a plain-English TL;DR.

--- a/docs/handoffs/2026-08-15-currency-and-enforcement-wave.md
+++ b/docs/handoffs/2026-08-15-currency-and-enforcement-wave.md
@@ -90,7 +90,7 @@ next one will wear a different costume:
 
 ## 4. High-priority open work — ranked, with reasons
 
-### 4.0 ~~BLOCKING~~ — RESOLVED. PR #351 merged as `a49ceaf` (2026-08-16).
+### 4.0 ~~BLOCKING~~ — RESOLVED. PR #351 merged as `a49ceaf` (2026-08-15).
 
 > ⚠ **CORRECTION — the diagnosis below was wrong, and wrong in an instructive
 > way.** This section reasoned that "cloning an EMPTY repository succeeds". The
@@ -104,9 +104,12 @@ next one will wear a different costume:
 >
 > The section's *method* advice held and is worth keeping: the swallowed rc was
 > the reason the diagnosis was invisible, and fixing the swallowing first is what
-> surfaced git's own warning. The section's instruction to reproduce on CI was
-> **unnecessary** — `GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null` runs the
-> runner's git configuration on this host and reproduced 44/4 exactly, locally.
+> surfaced git's own warning. Its instruction to reproduce on CI was **correct
+> given what was then known, and was superseded only once the cause was known to
+> be a config divergence** — an empty-bare theory gives no reason to suspect host
+> git *configuration*, so the local reproduction was not reachable from it.
+> `GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null` runs the runner's git
+> configuration on this host and reproduced 44/4 exactly, locally.
 >
 > Three adversarial-review rounds followed a clean product change, and each found
 > this document's own defect class **inside the fix for it** — including a

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10895,22 +10895,35 @@ and it is what leaves the residual permanently undone.
    valid-JSON and exists arms). A tracked ledger is one predicate away:
    `git ls-files --error-unmatch .claude/tool-usage.json` → `warn` naming the
    `git rm --cached` step.
-2. **`scripts/upgrade-project.sh` prints `[OK]` for a case it did not handle.**
-   The backfill gates solely on the `.gitignore` TEXT
-   (`grep -qxF '.claude/tool-usage.json' .gitignore`), never on the index, then
-   reports `print_ok "gitignore sidecar ignore-lines backfilled (BL-174)"`. For
-   an already-tracking project that `[OK]` is true about the file it wrote and
-   misleading about the operator's actual state.
+2. **`scripts/upgrade-project.sh` reports success for an operation that is
+   INAPPLICABLE to the affected projects.** The backfill gates solely on the
+   `.gitignore` TEXT (`grep -qxF '.claude/tool-usage.json' .gitignore`), never
+   on the index, then reports
+   `print_ok "gitignore sidecar ignore-lines backfilled (BL-174)"`. For an
+   already-tracking project the rule it adds is a **complete no-op** — measured
+   below — so the `[OK]` is true about the file it wrote and describes no change
+   whatsoever to the condition this entry exists for, for exactly the population
+   this entry's residual concerns.
 
 **One thing this is NOT, measured rather than assumed.** The backfilled rule
 does **not** hide the still-tracked file: `.gitignore` has no effect on paths
-already in the index, so a project whose ledger is tracked keeps seeing
-` M .claude/tool-usage.json` in `git status` after every session. Verified on a
-throwaway repo — tracked file, rewrite, `git status` shows it; add the ignore
-rule, rewrite again, `git status` still shows it. A review draft claimed the
-rule "removes the last symptom that would have prompted the operator"; it does
-not, and that matters for triage: the churn stays visible, so this is an
-inadequate-disclosure defect, not a symptom-suppressing one.
+already in the index. A review draft claimed the rule *"removes the last symptom
+that would have prompted the operator"*; it does not. Measured on throwaway
+repos, twice and independently — every operator-visible symptom is **byte-
+identical before and after** the rule is added:
+
+| probe | before rule | after rule | after `git rm --cached` |
+|---|---|---|---|
+| `git status --short` | ` M .claude/tool-usage.json` | ` M .claude/tool-usage.json` | *(empty)* |
+| `git ls-files` | present | present | absent |
+| does `git add -A` stage it | yes | yes | no |
+| does a fresh clone inherit it | yes, tracked | yes, tracked | no |
+
+So the rule is not merely non-suppressing, it is a **no-op** for an
+already-tracked ledger, and only the documented manual step clears any of it.
+Two consequences for triage: the session-by-session churn stays fully visible
+(this is an **inadequate-disclosure** defect, not a symptom-suppressing one),
+and item 2 above is reporting success for an operation that cannot apply.
 
 **Status stays Open for those two items** — not as a standing recommendation
 that can never close, which is how a backlog rots.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10286,9 +10286,18 @@ guard:
 
 Shard note: the merge also re-pinned two poles out of the `unit-shard (rest)`
 leg, which was CANCELLED at its 12-minute cap on this PR having printed
-`ran 156 unit test file(s); 0 failed`. Measured after: `rest` 725s → **530s**
-(74% of cap), no leg above 75%. Per the cap's own doctrine, approaching it is
-the re-pin signal, never a raise.
+`ran 156 unit test file(s); 0 failed`. `rest` went from **cancelled at 725s**
+— a truncation point, not a duration; its true cost was some unknown value
+above 720s — to **530s (74% of cap)**.
+
+**Do not read that as comfortable.** The longest leg is now `slow-misc` at
+540s, which is **exactly 75.0% of the cap**, and it drifted **468s → 540s
+between those two runs with nothing pinned into it** (`sast` likewise 467s →
+526s). Unchanged legs therefore move 12–15% run to run, which is the same
+order as the remaining margin — so by the doctrine this entry quotes,
+`slow-misc` is the **next re-pin candidate**, not a spare. Re-measure before
+adding anything to it. Per that doctrine, approaching the cap is the re-pin
+signal, never a raise.
 
 ### The one root cause
 
@@ -10871,13 +10880,40 @@ now ignored too (verified on `main` after the merge: `.claude/tool-usage.json`
 no longer appears in `git status`). **Existing projects need one manual step
 that this framework must NOT take for them** (below).
 
-**What would close this:** nothing the framework can do. The residual is an
-operator action on repositories this project does not own
-(`git rm --cached .claude/tool-usage.json`), so the entry stays Open as a
-standing recommendation rather than as outstanding work. Karl's call whether
-that warrants Closed with the recommendation preserved — the vocabulary has no
-"shipped, residual is someone else's to run" state, and this is the second
-entry to want one.
+**What would close this — and a first answer to it that was wrong.** A draft of
+this paragraph said *"nothing the framework can do."* That is false, and it is
+the kind of false claim that forecloses its own correction, so it is recorded
+rather than quietly replaced. Refusing to **mutate** a repository this project
+does not own is correct restraint. Refusing to **tell the operator something
+true about the repository they just pointed the tool at** is not the same thing,
+and it is what leaves the residual permanently undone.
+
+**Two concrete items remain, both on surfaces the framework unambiguously owns:**
+
+1. **`scripts/validate.sh` has no detection.** It already inspects this exact
+   file and already has a `warn` arm for it (grep `tool-usage.json` there — the
+   valid-JSON and exists arms). A tracked ledger is one predicate away:
+   `git ls-files --error-unmatch .claude/tool-usage.json` → `warn` naming the
+   `git rm --cached` step.
+2. **`scripts/upgrade-project.sh` prints `[OK]` for a case it did not handle.**
+   The backfill gates solely on the `.gitignore` TEXT
+   (`grep -qxF '.claude/tool-usage.json' .gitignore`), never on the index, then
+   reports `print_ok "gitignore sidecar ignore-lines backfilled (BL-174)"`. For
+   an already-tracking project that `[OK]` is true about the file it wrote and
+   misleading about the operator's actual state.
+
+**One thing this is NOT, measured rather than assumed.** The backfilled rule
+does **not** hide the still-tracked file: `.gitignore` has no effect on paths
+already in the index, so a project whose ledger is tracked keeps seeing
+` M .claude/tool-usage.json` in `git status` after every session. Verified on a
+throwaway repo — tracked file, rewrite, `git status` shows it; add the ignore
+rule, rewrite again, `git status` still shows it. A review draft claimed the
+rule "removes the last symptom that would have prompted the operator"; it does
+not, and that matters for triage: the churn stays visible, so this is an
+inadequate-disclosure defect, not a symptom-suppressing one.
+
+**Status stays Open for those two items** — not as a standing recommendation
+that can never close, which is how a backlog rots.
 
 ### The file
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10267,8 +10267,28 @@ and the empty detector. Filed as one entry because fixing them separately would
 produce four patches and leave the pattern intact.)
 **Category:** Silent-success — the same substitution `## BL-231:` and
 `## BL-233:` are about, on four new surfaces.
-**Status:** Open — fix implemented on branch `fix/solo-currency-and-availability`
-(test/fix commits below); close on merge with the PR number.
+**Status:** Closed — merged in **PR #351** (`a49ceaf`). All four surfaces
+measured rather than declared; the fifth, `## BL-235:`, was filed and
+deliberately not fixed.
+
+The PR took three adversarial-review rounds after the product change was
+already clean, and every round found the same defect class **inside the fix
+for it** — worth reading the two subsections below before writing any similar
+guard:
+1. the fixture's bare origin had no branch, so CI cloned nothing and reported
+   success (a Mac-only pass, from a gitconfig Xcode ships);
+2. the audit of neighbouring suites was transcribed rather than derived, and
+   was run against `main` instead of the branch, so it missed a file the same
+   PR had just broken;
+3. the receipt added to catch (1) used `git rev-parse HEAD`, which **exits 0 on
+   a dangling HEAD** — a guard with no discriminating power, which read as
+   coverage.
+
+Shard note: the merge also re-pinned two poles out of the `unit-shard (rest)`
+leg, which was CANCELLED at its 12-minute cap on this PR having printed
+`ran 156 unit test file(s); 0 failed`. Measured after: `rest` 725s → **530s**
+(74% of cap), no leg above 75%. Per the cap's own doctrine, approaching it is
+the re-pin signal, never a raise.
 
 ### The one root cause
 
@@ -10844,10 +10864,20 @@ project — `git ls-files` matches it, and it is absent from `.gitignore` while
 its three siblings ARE ignored there)
 **Category:** Operational state tracked as project content — the `## BL-174:`
 family, with a security-adjacent twist the sidecars did not have
-**Status:** Open — **new projects fixed** by `# BL-236-LEDGER-IGNORE` (the
-ignore rule ships in `templates/generated/gitignore-base.tmpl` and is backfilled
-by `scripts/upgrade-project.sh`). **Existing projects need one manual step that
-this framework must NOT take for them** (below).
+**Status:** Open — **the framework half shipped** in **PR #351** (`a49ceaf`):
+`# BL-236-LEDGER-IGNORE` in `templates/generated/gitignore-base.tmpl`,
+backfilled by `scripts/upgrade-project.sh`, and the framework repo's own copy
+now ignored too (verified on `main` after the merge: `.claude/tool-usage.json`
+no longer appears in `git status`). **Existing projects need one manual step
+that this framework must NOT take for them** (below).
+
+**What would close this:** nothing the framework can do. The residual is an
+operator action on repositories this project does not own
+(`git rm --cached .claude/tool-usage.json`), so the entry stays Open as a
+standing recommendation rather than as outstanding work. Karl's call whether
+that warrants Closed with the recommendation preserved — the vocabulary has no
+"shipped, residual is someone else's to run" state, and this is the second
+entry to want one.
 
 ### The file
 


### PR DESCRIPTION
Docs-only. Closes the ledger for the wave that ended with #351, and fixes three documents that had quietly become false.

## What this does

**1. Commits the wave handoff, which had never been tracked in git.**
`docs/handoffs/2026-08-15-currency-and-enforcement-wave.md` existed only in `main`'s working tree — one `git clean` from gone, and it is the sole narrative record of #341–#351. Verified: `git log --all -- <path>` returns only this branch's commit.

**2. Corrects that handoff's § 4.0 rather than committing it as written.**
It said *"#351 is OPEN and RED — do not merge it"* and diagnosed *"cloning an EMPTY repository succeeds"*. Both false. The bare held `refs/heads/main`; it was **HEAD** that dangled at `refs/heads/master`, because `build_fw` named a branch for the working repo and not for the bare, so the bare followed the **host's** `init.defaultBranch`. Right shape, wrong mechanism.

Corrected in a ⚠ block with the original reasoning **preserved, not rewritten** — its method advice (fix the swallowed rc first; it is the diagnostic) is what actually surfaced git's own warning, and its "reproduce on CI" instruction was correct given what was then known.

**3. Closes `## BL-234:`** citing #351 / `a49ceaf`, and updates `## BL-236:` to cite the PR for the framework half while staying **Open** for two concrete items.

**4. Repoints `docs/INDEX.md`** — it named the superseded 2026-07-31 handoff as **Live** with a stale `main` SHA, and asserted a stub-invariant that this branch's own first commit falsified.

## The one thing that blocked review

A draft of `## BL-236:` said **"nothing the framework can do"** would close it. That is false, and it is the kind of false claim that forecloses its own correction — an entry saying "nothing to do here" never gets revisited.

Refusing to **mutate** a repository this project does not own is correct restraint. Refusing to **tell the operator something true about the repository they just pointed the tool at** is not the same thing. Two concrete items now stand in its place, both on surfaces this framework owns:

- `scripts/validate.sh` has **no detection at all**, while already inspecting that exact file and already having a `warn` arm available — one predicate away.
- `scripts/upgrade-project.sh` gates the backfill on the `.gitignore` **text**, never the index, then prints `[OK] backfilled`.

## Half of that finding is refuted, by measurement

Review claimed the backfilled ignore rule *"removes the last symptom that would have prompted the operator"* by hiding the tracked file from `git status`. It does not — `.gitignore` has no effect on paths already in the index. Measured on throwaway repos, twice and independently:

| probe | before rule | after rule | after `git rm --cached` |
|---|---|---|---|
| `git status --short` | ` M .claude/tool-usage.json` | ` M .claude/tool-usage.json` | *(empty)* |
| `git ls-files` | present | present | absent |
| `git add -A` stages it | yes | yes | no |
| fresh clone inherits it | yes, tracked | yes, tracked | no |

Byte-identical before and after: the rule is a **no-op** for an already-tracked ledger. That downgrades the defect from symptom-suppressing to **inadequate-disclosure**, and upgrades the `[OK]` charge to *reports success for an operation that cannot apply*. Both recorded in the entry with the measurement, including that a review draft got it wrong.

## Other corrections, all re-derived

- **The shard note read as reassurance.** `rest` 725s was a **cancellation** — a truncation point, not a duration; true cost unknown and above 720s. And the longest leg is now `slow-misc` at **exactly 75.0%** of the cap, having drifted 468s → 540s with **nothing pinned into it** (`sast` 467s → 526s likewise). Unchanged legs move 12–15% run to run — the same order as the remaining margin — so `slow-misc` is the **next re-pin candidate**, not a spare.
- **`docs/INDEX.md` now derives rather than counts.** A stub is a pointer with no `## ` sections, so `grep -l '^## ' docs/handoffs/*.md` returns the full ones (2 today, 11 stubs). My first fix said "exactly one exception today" — a hand-maintained count, which is the category that bit twice on the parent PR.
- § 4.0's heading dated the merge `2026-08-16`; it is `Sat Aug 15 18:21:44 2026 -0600`, and this repo dates locally.

## Verification

- `bash scripts/run-lints.sh` → **15 lints, 15 passed, 0 failed**, `lint-backlog-references.sh` and `lint-doc-anchors.sh` included
- Docs-only: `git diff --stat main..HEAD` touches no source
- Adversarial review across three rounds, final verdict **approve**

## Deliberately not done

- **Not archiving** `2026-07-31-bl201-bl200-close.md`. Scope discipline; review agreed.
- **Not fixing** the two `BL-236` items here — they are code changes, and this is the ledger PR.

## Process note

`de29330` (the shard re-pin) landed on #351 after the review's approve and merged unreviewed. I asked for the decision, got it, then did not route the resulting commit back through review. It has since been reviewed retroactively — the workflow's own partition logic re-executed against both trees, 172 paths / 172 distinct / zero duplicates / zero orphans, placements exactly as claimed — and **no findings**. The habit still needs keeping: CI config is exactly where a silently dropped test would hide.
