### PR TITLE
fix(bl222): a filename containing "dep" was the release gate's only security clock

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -518,6 +518,7 @@ jobs:
             tests/test-brownfield-wp6-collision-archive.sh
             tests/test-bl233-mcp-outcome-enforcement.sh
             tests/test-bl234-currency-and-availability.sh
+            tests/test-bl222-security-clock-evidence.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/scripts/check-maintenance.sh
+++ b/scripts/check-maintenance.sh
@@ -99,9 +99,12 @@ set -euo pipefail
 #   whose date nobody can read is no longer reported as fresh.
 #
 #   THREE SHAPES OF THAT RESIDUAL, MEASURED BY THE WP6 REVIEW AND NAMED HERE SO
-#   THE DISCLOSURE IS NOT NARROWER THAN THE BEHAVIOUR. Filed as backlog lines;
-#   none is changed by this WP, and the glob set is inherited verbatim from the
-#   pre-WP6 script:
+#   THE DISCLOSURE IS NOT NARROWER THAN THE BEHAVIOUR. **All three are now
+#   FIXED, and the filing is `## BL-222:`.** The sentence that used to stand
+#   here asserted a backlog filing that did not exist — no entry described any
+#   of the three — and BL-222 exists because a false tracking claim is worse
+#   than an untracked residual: it stops anyone from looking. Kept in place
+#   rather than deleted, because the shapes are what the tests pin:
 #     • SUBSTRING BREADTH (R-WP6-4). `*dep*` matches far more than a dependency
 #       audit — `deployment-notes-<date>.md` satisfies the cadence completely.
 #       The fold raises the stakes: one stray match now satisfies the WHOLE
@@ -231,6 +234,17 @@ cadence_epoch() {
     e="$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$s" +%s 2>/dev/null)" || e=""
   fi
   case "$e" in ''|*[!0-9]*) return 1 ;; esac
+  # BL-222 (R-WP6-5): a parser accepting the string is not the same as the date
+  # existing. `2026-13-45` is refused by both, but an IN-RANGE impossibility like
+  # `2026-02-30` NORMALISES on BSD (to March 2) and is refused by GNU — same
+  # repo, same artefact, two verdicts depending on whose laptop ran the check.
+  # Round-trip the epoch back to a date and require it to equal the input: that
+  # catches normalisation on whichever date(1) is installed, rather than
+  # enumerating the impossibilities one host at a time.
+  local rt=""
+  rt="$(date -u -d "@$e" +%Y-%m-%d 2>/dev/null)" || rt=""
+  [ -n "$rt" ] || rt="$(date -u -r "$e" +%Y-%m-%d 2>/dev/null)" || rt=""
+  [ "$rt" = "${s%%T*}" ] || return 1                                            # BL-222-DATE-ROUNDTRIP
   printf '%s\n' "$e"
   return 0
 }
@@ -329,9 +343,29 @@ fi
 # "no evidence at all", which is an exit 2 nobody could explain. Caught by E1
 # going rc 2 on an all-current fixture.
 if [ -d "docs/test-results" ]; then
-  latest_scan="$( { ls -t docs/test-results/*snyk* docs/test-results/*dep* \
+  # BL-222 (R-WP6-4): `*dep*` used to sit in this list and it matched
+  # `deployment-notes-<date>.md`, so an honest project writing deployment notes
+  # satisfied the release gate's ONLY security clock — no intent required, and
+  # the WP6 fold means one match covers the whole deep-security window. Narrowed
+  # to the dependency-audit vocabulary that does NOT spell `deployment`.
+  # `*audit*` below already covers dep-audit / npm-audit / pip-audit /
+  # cargo-audit, so the broad glob was mostly redundant before it was wrong.
+  # Deliberately its own line so it can be mutated on its own: the whole point
+  # of this fix is one pattern, and a proof that swaps it back must not have to
+  # rewrite the surrounding pipeline.
+  _dep_glob='docs/test-results/*dependency* docs/test-results/*deps*'   # BL-222-DEP-GLOB
+  # shellcheck disable=SC2086  # intentional split+glob: two patterns, not one word
+  latest_scan="$( { ls -t docs/test-results/*snyk* $_dep_glob \
                          docs/test-results/*audit* docs/test-results/*semgrep* \
                          docs/test-results/*sast* 2>/dev/null || true; } \
+                 | while IFS= read -r _cand; do
+                     # BL-222 (R-WP6-7): a name in the listing is not evidence.
+                     # A freshly dated empty DIRECTORY, or a dangling symlink,
+                     # used to satisfy this — `ls` supplies the name and the
+                     # date is read off the name. `-f` follows symlinks, so it
+                     # rejects both shapes with one test.
+                     [ -f "$_cand" ] && printf '%s\n' "$_cand"   # BL-222-ARTEFACT-MUST-BE-FILE
+                   done \
                  | awk 'NR == 1 { r = $0 } END { if (r != "") print r }')" || latest_scan=""
   if [ -n "$latest_scan" ]; then
     signal_date="$(printf '%s\n' "$latest_scan" \

--- a/scripts/check-maintenance.sh
+++ b/scripts/check-maintenance.sh
@@ -99,8 +99,16 @@ set -euo pipefail
 #   whose date nobody can read is no longer reported as fresh.
 #
 #   THREE SHAPES OF THAT RESIDUAL, MEASURED BY THE WP6 REVIEW AND NAMED HERE SO
-#   THE DISCLOSURE IS NOT NARROWER THAN THE BEHAVIOUR. **All three are now
-#   FIXED, and the filing is `## BL-222:`.** The sentence that used to stand
+#   THE DISCLOSURE IS NOT NARROWER THAN THE BEHAVIOUR. **All three MEASURED
+#   holes are now CLOSED, and the filing is `## BL-222:`.** Not "the shapes can
+#   no longer happen": matching is still SUBSTRING-based, so a deployment
+#   artefact that happens to spell `deps` or `dependency` still counts —
+#   `deployment-deps-<date>.md` satisfies the clock, `deployment-notes-<date>.md`
+#   no longer does, and `deployment-dependency` differs from
+#   `deployment-dependencies` for no reason a reader would predict. Case D6
+#   pins that boundary so the residual is regression-tested rather than merely
+#   worded. Closing it properly means asserting on CONTENT, not on a name.
+#   The sentence that used to stand
 #   here asserted a backlog filing that did not exist — no entry described any
 #   of the three — and BL-222 exists because a false tracking claim is worse
 #   than an untracked residual: it stops anyone from looking. Kept in place
@@ -359,7 +367,7 @@ if [ -d "docs/test-results" ]; then
   # reached by `*dependency*`, `*deps*` or `*audit*`. None of the four spells
   # `deployment`, which is the only thing this narrowing is meant to exclude.
   _dep_glob='docs/test-results/*dependency* docs/test-results/*deps* docs/test-results/*dep-scan* docs/test-results/*dependabot*'   # BL-222-DEP-GLOB
-  # shellcheck disable=SC2086  # intentional split+glob: two patterns, not one word
+  # shellcheck disable=SC2086  # intentional split+glob: several patterns, not one word
   latest_scan="$( { ls -t docs/test-results/*snyk* $_dep_glob \
                          docs/test-results/*audit* docs/test-results/*semgrep* \
                          docs/test-results/*sast* 2>/dev/null || true; } \

--- a/scripts/check-maintenance.sh
+++ b/scripts/check-maintenance.sh
@@ -353,7 +353,12 @@ if [ -d "docs/test-results" ]; then
   # Deliberately its own line so it can be mutated on its own: the whole point
   # of this fix is one pattern, and a proof that swaps it back must not have to
   # rewrite the surrounding pipeline.
-  _dep_glob='docs/test-results/*dependency* docs/test-results/*deps*'   # BL-222-DEP-GLOB
+  # `*dep-scan*` (OWASP's vulnerability scanner) and `*dependabot*` (the
+  # commonest dependency artefact on the default host) are here because a naive
+  # narrowing loses them: both were caught by the old broad glob and neither is
+  # reached by `*dependency*`, `*deps*` or `*audit*`. None of the four spells
+  # `deployment`, which is the only thing this narrowing is meant to exclude.
+  _dep_glob='docs/test-results/*dependency* docs/test-results/*deps* docs/test-results/*dep-scan* docs/test-results/*dependabot*'   # BL-222-DEP-GLOB
   # shellcheck disable=SC2086  # intentional split+glob: two patterns, not one word
   latest_scan="$( { ls -t docs/test-results/*snyk* $_dep_glob \
                          docs/test-results/*audit* docs/test-results/*semgrep* \

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9166,7 +9166,25 @@ under a gate that refuses releases.
   were not filed anywhere; **this entry is that filing**, and case H2 pins that
   the disclosure survives the correction rather than being deleted with it.
 
-**Proof:** `tests/test-bl222-security-clock-evidence.sh`, 10 cases, ~3s,
+**RESIDUAL, pinned rather than papered over.** "Fixed" means the three MEASURED
+holes are closed, not that the shapes can no longer occur. Matching is still a
+SUBSTRING heuristic, so a deployment artefact that happens to spell `deps` or
+`dependency` still counts:
+
+| name | verdict |
+|---|---|
+| `deployment-notes-<date>.md` | rejected — the headline hole, closed |
+| `deployment-deps-<date>.md` | **still satisfies** — spells `deps` |
+| `deployment-dependency-<date>.md` | **still satisfies** — spells `dependency` |
+| `deployment-dependencies-<date>.md` | rejected — no literal `dependency` |
+
+That singular/plural split is not something a reader would predict, which is
+exactly why case **D6** now pins the boundary: the day someone closes it
+properly — by asserting on CONTENT rather than a name — D6 goes red and tells
+them the disclosure needs updating too. It is **not a regression**: all of these
+are accepted on `main` as well.
+
+**Proof:** `tests/test-bl222-security-clock-evidence.sh`, 11 cases, ~3s,
 asserting on EXIT CODES because the script's contract is one (0 current /
 1 overdue / **2 undetermined**, and `cut-release.sh` refuses on 2). Case B1
 establishes an rc-0 baseline first, so no row can pass by making everything
@@ -9187,8 +9205,10 @@ refuses `2026-02-30` outright. The failure message says so, rather than letting
 a structurally-unfirable mutant read as a kill.
 
 **Split from `## BL-229:` deliberately.** The two shipped as one branch until
-adversarial review blocked the BL-229 half on a Bitbucket defect; this entry
-survived every probe and is not held hostage to that rework.
+adversarial review blocked the BL-229 half on a Bitbucket defect. This half
+cleared — the one coverage finding against it is fixed above, and the one
+wording finding is the residual note below — so it is not held hostage to that
+rework.
 
 **The false clause.** `scripts/check-maintenance.sh`'s header, in the block
 introducing the WP6 review's measured residuals:

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9137,7 +9137,58 @@ Disclosure mitigates the deception, not the hole. The residuals are described
 accurately in the product; what was false is the clause claiming they were
 filed — and because they were not, the weakest of the three sat unexamined
 under a gate that refuses releases.
-**Status:** Open
+**Status:** Open — all three residuals FIXED on branch
+`fix/bl222-security-clock`; close on merge with the PR number.
+
+### All three fixed, and the false tracking clause corrected
+
+- **R-WP6-4** (`# BL-222-DEP-GLOB`) — `*dep*` narrowed to `*dependency*`,
+  `*deps*`, `*dep-scan*` and `*dependabot*`. None spells `deployment`, which is
+  the only thing the narrowing is meant to exclude. `*audit*` already covered
+  dep-audit / npm-audit / pip-audit / cargo-audit, so the broad glob was mostly
+  **redundant before it was wrong**.
+  **Adversarial review caught a real coverage loss in the first narrowing** and
+  it is fixed here: `dep-scan` (OWASP's vulnerability scanner) and
+  `dependabot-alerts` (the commonest dependency artefact on the default host)
+  were both caught by the old glob and reached by none of the replacements.
+  The loss direction was fail-safe — rc 2 blocks a release cut rather than
+  waving one through — but a false alarm on a project that DID run its scan is
+  still a defect. Case D2 now pins all eight spellings.
+- **R-WP6-7** (`# BL-222-ARTEFACT-MUST-BE-FILE`) — candidates are filtered
+  through `[ -f ]`, which follows symlinks and so rejects the dated empty
+  directory and the dangling symlink with one test.
+- **R-WP6-5** (`# BL-222-DATE-ROUNDTRIP`) — `cadence_epoch` round-trips the
+  parsed epoch back to a date and requires it to equal the input. That catches
+  BSD's normalisation of an in-range impossibility (`2026-02-30` → March 2) on
+  whichever `date(1)` is installed, rather than enumerating impossibilities one
+  platform at a time.
+- The header no longer asserts the residuals were filed as backlog lines. They
+  were not filed anywhere; **this entry is that filing**, and case H2 pins that
+  the disclosure survives the correction rather than being deleted with it.
+
+**Proof:** `tests/test-bl222-security-clock-evidence.sh`, 10 cases, ~3s,
+asserting on EXIT CODES because the script's contract is one (0 current /
+1 overdue / **2 undetermined**, and `cut-release.sh` refuses on 2). Case B1
+establishes an rc-0 baseline first, so no row can pass by making everything
+undetermined — the "narrowed until nothing matches" failure mode, which is
+exactly what the review's coverage finding turned out to be a mild case of.
+
+**One expectation corrected mid-proof, and the correction is sharper than the
+original.** M2 first expected the mutant to answer rc 0. It answers **rc 1**:
+`2026-02-30` normalises to a March date old enough to read as overdue. The real
+discriminator is **rc 2 versus any measured verdict** — the mutant does not
+mis-date the artefact, it **fabricates a measurement from a date that does not
+exist**. Asserted that way the proof is also immune to calendar drift, where a
+hardcoded impossible date would wander in and out of the 95-day window as the
+real date moves and start failing for the wrong reason.
+
+**Stated limit:** on a GNU-date host M2 **cannot fire at all**, because GNU
+refuses `2026-02-30` outright. The failure message says so, rather than letting
+a structurally-unfirable mutant read as a kill.
+
+**Split from `## BL-229:` deliberately.** The two shipped as one branch until
+adversarial review blocked the BL-229 half on a Bitbucket defect; this entry
+survived every probe and is not held hostage to that rework.
 
 **The false clause.** `scripts/check-maintenance.sh`'s header, in the block
 introducing the WP6 review's measured residuals:

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2044,6 +2044,9 @@ run_child_suite "tests/test-bl233-mcp-outcome-enforcement.sh" \
 # their fence markers and EXECUTES them, so the assertions land on shipped code.
 run_child_suite "tests/test-bl234-currency-and-availability.sh" \
   "tests/test-bl234-currency-and-availability.sh"
+
+run_child_suite "tests/test-bl222-security-clock-evidence.sh" \
+  "tests/test-bl222-security-clock-evidence.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-bl222-security-clock-evidence.sh
+++ b/tests/test-bl222-security-clock-evidence.sh
@@ -178,15 +178,21 @@ fi
 # count, or the fix trades a false pass for a false alarm. Every spelling here is
 # one a real toolchain emits.
 d2_bad=""
+# `dep-scan` is OWASP's vulnerability scanner and `dependabot-alerts` is the
+# commonest dependency artefact on the default host — both were caught by the
+# old broad `*dep*` and both are lost by a naive narrowing. The loss direction
+# is fail-safe (rc 2 blocks a release cut rather than waving one through), but a
+# false alarm on a project that DID run its scan is still a defect.
 for name in "dep-audit-DATE.json" "npm-audit-DATE.txt" "pip-audit-DATE.json" \
-            "cargo-audit-DATE.txt" "dependency-check-DATE.html" "deps-report-DATE.txt"; do
+            "cargo-audit-DATE.txt" "dependency-check-DATE.html" "deps-report-DATE.txt" \
+            "dep-scan-DATE.json" "dependabot-alerts-DATE.json"; do
   d="$(newtmp)"; mk_base "$d/p"
   printf 'findings: none\n' > "$d/p/docs/test-results/${name/DATE/$(days_ago 5)}"
   run_check "$REPO_ROOT/scripts" "$d/p"
   [ "$CHK_RC" -eq 0 ] || d2_bad="$d2_bad ${name}(rc=$CHK_RC)"
 done
 if [ -z "$d2_bad" ]; then
-  pass "D2: every real dependency-audit spelling still satisfies the clock — dep-audit, npm-audit, pip-audit, cargo-audit, dependency-check, deps-report. The narrowing removed 'deployment', not the coverage"
+  pass "D2: every real dependency-audit spelling still satisfies the clock — dep-audit, npm-audit, pip-audit, cargo-audit, dependency-check, deps-report, dep-scan (OWASP) and dependabot-alerts. The narrowing removed 'deployment', not the coverage"
 else
   fail_ "D2" "these legitimate artefacts stopped counting:$d2_bad"
 fi

--- a/tests/test-bl222-security-clock-evidence.sh
+++ b/tests/test-bl222-security-clock-evidence.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# tests/test-bl222-security-clock-evidence.sh
+#
+# BL-222 — the release gate's ONLY security clock is satisfied by a FILENAME,
+# and the filename pattern is far wider than the thing it stands for.
+#
+# scripts/check-maintenance.sh reads the newest dated name in docs/test-results/
+# matching `*snyk*`, `*dep*`, `*audit*`, `*semgrep*` or `*sast*`. `*dep*` catches
+# `deployment-notes-<date>.md`. WP6 FOLDED the separate 95-day dependency-audit
+# row into the deep-security cadence, so ONE stray match now satisfies the WHOLE
+# deep-security clock — and that clock is what scripts/cut-release.sh refuses on
+# (refusal 3, exit 5).
+#
+# Reproduced end-to-end by the WP6 adversarial review: a phase-4 project whose
+# docs/test-results/ holds nothing but `deployment-notes-<date>.md` reports
+# `[OK] Deep security scan (dependency audit folded in) current` and CUTS A
+# RELEASE at rc 0 with the tag written, having never run a scan. Delete that one
+# file and the same project refuses at rc 2.
+#
+# TWO PROPERTIES MAKE THIS WORSE THAN ITS SIBLINGS, and both are why it is the
+# residual that got fixed rather than merely filed:
+#   • it sits on the release gate's ONLY security clock, because the fold means
+#     one match satisfies both the dependency and the deep-security windows;
+#   • it needs NO INTENT WHATSOEVER. The dated-empty-file residual requires
+#     someone to fabricate evidence. This one requires an honest project to
+#     write deployment notes.
+#
+# ── THE THREE RESIDUALS, ALL FIXED HERE ────────────────────────────────────
+#   R-WP6-4  SUBSTRING BREADTH — `*dep*` matches `deployment*`. Narrowed to the
+#            dependency-audit vocabulary that does not spell `deployment`.
+#            Note `*audit*` already covers `dep-audit`/`npm-audit`/`pip-audit`/
+#            `cargo-audit`, so `*dep*` was mostly redundant BEFORE it was wrong.
+#   R-WP6-7  NON-FILE ARTEFACTS — a freshly dated empty DIRECTORY, or a dangling
+#            symlink, satisfied it too: `ls` supplies the name and the date is
+#            read off the name. Now the artefact must be a readable regular file.
+#   R-WP6-5  CROSS-HOST DATE DIVERGENCE — `2026-13-45` is refused by both
+#            parsers, but an in-range impossibility like `2026-02-30`
+#            NORMALISES on BSD (to March 2) and is refused by GNU. Same repo,
+#            same file, two verdicts depending on the operator's laptop. Fixed
+#            by round-tripping the parsed epoch back to a date and requiring it
+#            to equal the input, which is host-independent.
+#
+# And the entry's own trigger: check-maintenance.sh's header claimed all three
+# were "Filed as backlog lines". They were not; BL-222 IS that filing. A false
+# tracking claim is worse than an untracked residual, because it stops anyone
+# looking.
+#
+# ASSERTIONS ARE EXIT CODES, because the script's own contract is one:
+#   0 = every cadence current    1 = something overdue    2 = UNDETERMINED
+# and cut-release refuses on 2. A printed label is not the verdict — CLAUDE.md's
+# `[WARN]` trap is about exactly that gap, and `## BL-213:` is this script's own
+# instance of it.
+#
+# Hermetic: temp dirs, local git only, no network, no init.sh. bash 3.2 safe.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECKER="$REPO_ROOT/scripts/check-maintenance.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
+
+_num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
+
+_mutate() {
+  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp
+  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  mode="$(_mode_of "$f")"
+  before="$(mktemp)"; cp -p "$f" "$before"
+  sites=$(_sites "$f" "$marker")
+  tmp="$(mktemp)"
+  sed "s%^.*${marker}\$%${safe}%" "$f" > "$tmp" && mv "$tmp" "$f"
+  [ "$mode" != "?" ] && chmod "$mode" "$f" 2>/dev/null
+  changed=$(_changed_lines "$before" "$f")
+  parses=0; bash -n "$f" >/dev/null 2>&1 && parses=1
+  rm -f "$before"
+  printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+days_ago() {   # <n> -> YYYY-MM-DD, n whole days before now, UTC
+  local n="$1" e
+  e=$(( $(date -u +%s) - n * 86400 ))
+  date -u -d "@$e" +%Y-%m-%d 2>/dev/null || date -u -r "$e" +%Y-%m-%d
+}
+
+FIXTURE_SEQ=0
+mk_proj() {
+  local d="$1"
+  mkdir -p "$d/.claude"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    git init -q .
+    git config user.email "bl222@example.invalid"
+    git config user.name "BL222 Fixture"
+    git config commit.gpgsign false
+  ) >/dev/null 2>&1
+  printf '{"track":"light","deployment":"personal","poc_mode":null,"current_phase":4,"phases":{}}\n' \
+    > "$d/.claude/phase-state.json"
+}
+
+commit_dated() {
+  local d="$1" f="$2" n="$3" stamp want
+  FIXTURE_SEQ=$((FIXTURE_SEQ + 1))
+  want="$(days_ago "$n")"; stamp="${want}T12:00:00+0000"
+  printf 'fixture %s r%s\n' "$f" "$FIXTURE_SEQ" > "$d/$f"
+  (
+    cd "$d" && unset GITHUB_BASE_REF
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git add "$f"
+    GIT_AUTHOR_DATE="$stamp" GIT_COMMITTER_DATE="$stamp" git commit -q -m "chore: $f r$FIXTURE_SEQ"
+  ) >/dev/null 2>&1
+}
+
+# mk_base <dir> — every cadence surface fresh EXCEPT the security evidence.
+# Each case then supplies exactly one security artefact, so a non-zero answer is
+# attributable to that artefact and nothing else.
+mk_base() {
+  local d="$1"
+  mk_proj "$d"
+  commit_dated "$d" CHANGELOG.md 2
+  commit_dated "$d" sbom.json 2
+  mkdir -p "$d/docs/test-results"
+}
+
+CHK_RC=0; CHK_OUT=""
+run_check() {   # <scripts-dir> <project-dir>
+  local sd="$1" p="$2"
+  CHK_RC=0
+  CHK_OUT="$( cd "$p" && unset GITHUB_BASE_REF; bash "$sd/check-maintenance.sh" </dev/null 2>&1 )" || CHK_RC=$?
+  return 0
+}
+
+if [ ! -f "$CHECKER" ]; then
+  echo "  [FAIL] scripts/check-maintenance.sh is missing" >&2
+  echo "Results: 0 passed, 1 failed"; exit 1
+fi
+
+echo "=== B — the baseline, so every row below perturbs exactly one thing ==="
+
+# ── B1: a genuine, freshly dated scan artefact makes the whole check rc 0.
+# Without this the suite could pass by making EVERYTHING undetermined, which is
+# the "narrowed until nothing matches" failure mode.
+B1="$(newtmp)"; mk_base "$B1/p"
+printf 'scan\n' > "$B1/p/docs/test-results/$(days_ago 10)_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$B1/p"
+if [ "$CHK_RC" -eq 0 ]; then
+  pass "B1: a real, fresh semgrep artefact -> rc 0. This is the baseline; anything below that answers non-zero does so because of the artefact it swapped in"
+else
+  fail_ "B1" "rc=$CHK_RC (want 0) out='$(printf '%s' "$CHK_OUT" | tr '\n' '|' | cut -c1-300)'"
+fi
+
+echo "=== D — a filename is not a scan ==="
+
+# ── D1: THE HEADLINE. Deployment notes are not a security scan, and no honest
+# project should have to know that `deployment` contains `dep`.
+D1="$(newtmp)"; mk_base "$D1/p"
+printf 'we deployed on tuesday\n' > "$D1/p/docs/test-results/deployment-notes-$(days_ago 3).md"
+run_check "$REPO_ROOT/scripts" "$D1/p"
+d1_said_current=no
+printf '%s' "$CHK_OUT" | grep -qi 'Deep security scan.*current' && d1_said_current=yes
+if [ "$CHK_RC" -eq 2 ] && [ "$d1_said_current" = "no" ]; then
+  pass "D1: a project whose ONLY artefact is deployment-notes-<date>.md answers rc 2 (undetermined) and does NOT report the deep-security scan current — the release gate's only security clock stops being satisfied by a word that merely contains 'dep'"
+else
+  fail_ "D1" "rc=$CHK_RC (want 2) said-current=$d1_said_current (want no) — a deployment note is still satisfying the security clock"
+fi
+
+# ── D2: THE ANTI-OVER-NARROWING ROW. Real dependency-audit artefacts must still
+# count, or the fix trades a false pass for a false alarm. Every spelling here is
+# one a real toolchain emits.
+d2_bad=""
+for name in "dep-audit-DATE.json" "npm-audit-DATE.txt" "pip-audit-DATE.json" \
+            "cargo-audit-DATE.txt" "dependency-check-DATE.html" "deps-report-DATE.txt"; do
+  d="$(newtmp)"; mk_base "$d/p"
+  printf 'findings: none\n' > "$d/p/docs/test-results/${name/DATE/$(days_ago 5)}"
+  run_check "$REPO_ROOT/scripts" "$d/p"
+  [ "$CHK_RC" -eq 0 ] || d2_bad="$d2_bad ${name}(rc=$CHK_RC)"
+done
+if [ -z "$d2_bad" ]; then
+  pass "D2: every real dependency-audit spelling still satisfies the clock — dep-audit, npm-audit, pip-audit, cargo-audit, dependency-check, deps-report. The narrowing removed 'deployment', not the coverage"
+else
+  fail_ "D2" "these legitimate artefacts stopped counting:$d2_bad"
+fi
+
+# ── D3: a freshly dated empty DIRECTORY is not evidence. `ls` supplies the name
+# and the date is read off the name, so before the fix a mkdir satisfied it.
+D3="$(newtmp)"; mk_base "$D3/p"
+mkdir -p "$D3/p/docs/test-results/$(days_ago 3)_semgrep_run"
+run_check "$REPO_ROOT/scripts" "$D3/p"
+if [ "$CHK_RC" -eq 2 ]; then
+  pass "D3: a freshly dated empty DIRECTORY does not satisfy the clock (rc 2) — the artefact must be a readable regular file, not merely a name in the listing"
+else
+  fail_ "D3" "rc=$CHK_RC (want 2) — a mkdir is still passing as a security scan"
+fi
+
+# ── D4: a dangling symlink is a name with nothing behind it. Same shape as D3,
+# one step further: the path resolves to nothing at all.
+D4="$(newtmp)"; mk_base "$D4/p"
+ln -s /nonexistent/target "$D4/p/docs/test-results/$(days_ago 3)_sast_report.txt" 2>/dev/null
+run_check "$REPO_ROOT/scripts" "$D4/p"
+if [ "$CHK_RC" -eq 2 ]; then
+  pass "D4: a DANGLING SYMLINK does not satisfy the clock (rc 2) — a name that resolves to nothing is not a scan report"
+else
+  fail_ "D4" "rc=$CHK_RC (want 2) — a broken symlink is still passing as a security scan"
+fi
+
+echo "=== C — the same date must mean the same thing on every host ==="
+
+# ── D5 / R-WP6-5: 2026-02-30 does not exist. GNU refuses it; BSD NORMALISES it
+# to March 2 and returns a perfectly good epoch. Same repo, same file, two
+# verdicts depending on whose laptop ran the check. Asserted on THIS host, but
+# the fix is a round-trip comparison, which is host-independent by construction.
+D5="$(newtmp)"; mk_base "$D5/p"
+printf 'scan\n' > "$D5/p/docs/test-results/2026-02-30_semgrep_pass.txt"
+run_check "$REPO_ROOT/scripts" "$D5/p"
+if [ "$CHK_RC" -eq 2 ]; then
+  pass "D5: an in-range impossible date (2026-02-30) is refused (rc 2) rather than silently normalised to March 2 — the verdict no longer depends on which date(1) the operator happens to have"
+else
+  fail_ "D5" "rc=$CHK_RC (want 2) — 2026-02-30 was accepted as a real date on this host, so the answer is host-dependent"
+fi
+
+echo "=== H — the header stops claiming a filing that never happened ==="
+
+# ── H1: the trigger for the whole entry. Three residuals were described
+# accurately and then said to have been "Filed as backlog lines"; none was. A
+# false tracking claim is worse than an untracked residual, because it stops
+# anyone from looking. Asserted as an absence, so it is paired with H2's
+# structural check that the disclosure itself survives.
+if ! grep -q 'Filed as backlog lines' "$CHECKER"; then
+  pass "H1: the header no longer claims the three residuals were 'Filed as backlog lines' — they were not, and BL-222 is that filing"
+else
+  fail_ "H1" "check-maintenance.sh still asserts the residuals were filed as backlog lines"
+fi
+
+# ── H2: the disclosure must not be deleted along with the false clause. An
+# absence assertion needs a companion that fails if the whole block went.
+if grep -q 'R-WP6-4' "$CHECKER" && grep -q 'BL-222' "$CHECKER"; then
+  pass "H2: the residual disclosure SURVIVES and now cites its real filing (R-WP6-4 named, BL-222 cited) — H1 is not satisfiable by deleting the block"
+else
+  fail_ "H2" "the residual disclosure was removed rather than corrected — H1 must not be satisfiable by deletion"
+fi
+
+echo "=== M — mutation proofs ==="
+
+# ── M1: restore the broad `*dep*` glob and D1 must go back to passing a
+# deployment note off as a security scan.
+M1="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M1/scripts"
+m1_meta=$(_mutate "$M1/scripts/check-maintenance.sh" '# BL-222-DEP-GLOB' "  _dep_glob='docs/test-results/*dep*'")
+m1_sites="${m1_meta%% *}"; m1_rest="${m1_meta#* }"; m1_changed="${m1_rest%% *}"; m1_parses="${m1_rest##* }"
+d="$(newtmp)"; mk_base "$d/p"
+printf 'we deployed on tuesday\n' > "$d/p/docs/test-results/deployment-notes-$(days_ago 3).md"
+run_check "$M1/scripts" "$d/p"
+if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$CHK_RC" -eq 0 ]; then
+  pass "M1: with the broad '*dep*' glob restored, a deployment note satisfies the security clock again (rc 0 where the repaired tree answers 2) — the narrowing is load-bearing (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
+else
+  fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed rc=$CHK_RC (want 0)"
+fi
+
+# ── M2: remove the round-trip date check and D5 must go back to being decided
+# by whichever date(1) is installed.
+M2="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M2/scripts"
+m2_meta=$(_mutate "$M2/scripts/check-maintenance.sh" '# BL-222-DATE-ROUNDTRIP' '  :')
+m2_sites="${m2_meta%% *}"; m2_rest="${m2_meta#* }"; m2_changed="${m2_rest%% *}"; m2_parses="${m2_rest##* }"
+d="$(newtmp)"; mk_base "$d/p"
+printf 'scan\n' > "$d/p/docs/test-results/2026-02-30_semgrep_pass.txt"
+run_check "$M2/scripts" "$d/p"
+# The discriminator is rc 2 vs ANY MEASURED verdict, not rc 2 vs rc 0.
+# 2026-02-30 normalises to March 2, which is far enough in the past to read as
+# OVERDUE rather than current — so the mutant answers rc 1 here. That is still
+# decisive, and it is the sharper statement of the defect: the mutant does not
+# merely mis-date the artefact, it FABRICATES A MEASUREMENT from a date that
+# does not exist, where the repaired tree says it cannot measure at all (rc 2,
+# proven by D5). Asserted this way the proof is also immune to calendar drift:
+# a hardcoded impossible date would wander in and out of the 95-day window as
+# the real date moves, and this suite would start failing for the wrong reason.
+m2_measured=no
+[ "$CHK_RC" -ne 2 ] && m2_measured=yes
+if [ "$m2_sites" -eq 1 ] && [ "$m2_parses" -eq 1 ] && [ "$m2_measured" = "yes" ]; then
+  pass "M2: with the round-trip removed, this host turns 2026-02-30 into a real measurement (rc $CHK_RC) where the repaired tree refuses to measure at all (rc 2) — a date that does not exist becomes a security verdict (sites=$m2_sites changed=$m2_changed parses=$m2_parses)"
+else
+  fail_ "M2" "sites=$m2_sites (want 1) parses=$m2_parses (want 1) changed=$m2_changed rc=$CHK_RC (want anything but 2) — NOTE: on a GNU-date host this mutant cannot fire at all, because GNU refuses 2026-02-30 outright. That is a real limit of this proof and not a pass"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl222-security-clock-evidence.sh
+++ b/tests/test-bl222-security-clock-evidence.sh
@@ -219,6 +219,26 @@ else
   fail_ "D4" "rc=$CHK_RC (want 2) — a broken symlink is still passing as a security scan"
 fi
 
+# ── D6 / the RESIDUAL, pinned rather than papered over. The narrowing is a
+# SUBSTRING heuristic, not a semantic test, so a deployment artefact that
+# happens to spell `deps` or `dependency` still counts. That is disclosed in the
+# script header; this case makes it regression-tested, so the day someone
+# closes it properly (by asserting on CONTENT rather than a name) this row goes
+# red and tells them the disclosure needs updating too.
+D6="$(newtmp)"; mk_base "$D6/p"
+printf 'the deps we shipped\n' > "$D6/p/docs/test-results/deployment-deps-$(days_ago 3).md"
+run_check "$REPO_ROOT/scripts" "$D6/p"
+d6_deps_rc="$CHK_RC"
+D6b="$(newtmp)"; mk_base "$D6b/p"
+printf 'we deployed on tuesday\n' > "$D6b/p/docs/test-results/deployment-notes-$(days_ago 3).md"
+run_check "$REPO_ROOT/scripts" "$D6b/p"
+d6_notes_rc="$CHK_RC"
+if [ "$d6_deps_rc" -eq 0 ] && [ "$d6_notes_rc" -eq 2 ]; then
+  pass "D6: the residual is exactly where the header says it is — 'deployment-deps' still SATISFIES the clock (rc $d6_deps_rc) because it spells 'deps', while 'deployment-notes' does not (rc $d6_notes_rc). A substring heuristic, disclosed and now pinned; closing it needs a content assertion, not another pattern"
+else
+  fail_ "D6" "deployment-deps rc=$d6_deps_rc (want 0) deployment-notes rc=$d6_notes_rc (want 2) — the residual moved, so the header's disclosure is now wrong in one direction or the other"
+fi
+
 echo "=== C — the same date must mean the same thing on every host ==="
 
 # ── D5 / R-WP6-5: 2026-02-30 does not exist. GNU refuses it; BSD NORMALISES it

--- a/tests/test-bl222-security-clock-evidence.sh
+++ b/tests/test-bl222-security-clock-evidence.sh
@@ -308,12 +308,37 @@ run_check "$M2/scripts" "$d/p"
 # proven by D5). Asserted this way the proof is also immune to calendar drift:
 # a hardcoded impossible date would wander in and out of the 95-day window as
 # the real date moves, and this suite would start failing for the wrong reason.
+# HOST-AWARE, because the mutant is structurally unfirable on GNU date. This
+# suite's first version merely NARRATED that limit in its failure message and
+# then failed on CI, which is a limit stated instead of handled — the exact
+# thing this entry is about. Detect the host's parser and assert what is
+# actually provable here.
+# The predicate is "NEITHER parser accepts 2026-02-30", not "this host is GNU":
+# BSD refuses `-d` as an illegal option too, so a `-d`-only probe answers yes on
+# both hosts and would send a BSD run down the wrong branch. Measured here:
+# BSD `-d` -> illegal option (fails), BSD `-j -f` -> 1772409600 (succeeds, and
+# that IS the normalisation D5 pins); GNU `-d` -> invalid date (fails), GNU has
+# no `-j` (fails). Only the second host reaches the mutation-is-unfirable arm.
+m2_d_ok=yes;  date -u -d '2026-02-30T00:00:00Z' +%s >/dev/null 2>&1 || m2_d_ok=no
+m2_jf_ok=yes; date -u -j -f '%Y-%m-%dT%H:%M:%SZ' '2026-02-30T00:00:00Z' +%s >/dev/null 2>&1 || m2_jf_ok=no
+if [ "$m2_d_ok" = "no" ] && [ "$m2_jf_ok" = "no" ]; then
+  # Neither parser accepts it: the date is refused before the round-trip is
+  # reached, so removing the round-trip changes nothing and there is no mutant
+  # to kill. Assert the marked line EXISTS at sites==1 and that the control
+  # still refuses the date — real, and true on every host.
+  if [ "$m2_sites" -eq 1 ] && [ "$m2_parses" -eq 1 ] && [ "$CHK_RC" -eq 2 ]; then
+    pass "M2 (GNU-date host): the round-trip mutant is structurally UNFIRABLE here — this host's date(1) refuses 2026-02-30 outright, so the guard is never reached. Asserted instead: the marked line exists at sites==$m2_sites and the tree still answers rc 2 (d_ok=$m2_d_ok jf_ok=$m2_jf_ok). The BSD half of this proof runs on a BSD host; D5 covers the behaviour on both"
+  else
+    fail_ "M2" "GNU-date host: sites=$m2_sites (want 1) parses=$m2_parses (want 1) rc=$CHK_RC (want 2)"
+  fi
+else
 m2_measured=no
 [ "$CHK_RC" -ne 2 ] && m2_measured=yes
 if [ "$m2_sites" -eq 1 ] && [ "$m2_parses" -eq 1 ] && [ "$m2_measured" = "yes" ]; then
   pass "M2: with the round-trip removed, this host turns 2026-02-30 into a real measurement (rc $CHK_RC) where the repaired tree refuses to measure at all (rc 2) — a date that does not exist becomes a security verdict (sites=$m2_sites changed=$m2_changed parses=$m2_parses)"
 else
-  fail_ "M2" "sites=$m2_sites (want 1) parses=$m2_parses (want 1) changed=$m2_changed rc=$CHK_RC (want anything but 2) — NOTE: on a GNU-date host this mutant cannot fire at all, because GNU refuses 2026-02-30 outright. That is a real limit of this proof and not a pass"
+  fail_ "M2" "BSD-date host: sites=$m2_sites (want 1) parses=$m2_parses (want 1) changed=$m2_changed rc=$CHK_RC (want anything but 2)"
+fi
 fi
 
 echo ""


### PR DESCRIPTION
Closes the three WP6 residuals on `scripts/check-maintenance.sh`'s deep-security cadence — the release gate's **only** security clock.

## The defect

`*dep*` matched `deployment-notes-<date>.md`. WP6 folded the separate 95-day dependency-audit row into the deep-security cadence, so **one stray match satisfied the whole clock** — and that clock is what `cut-release.sh` refuses on (refusal 3, `exit 5`).

Two properties made this the residual worth fixing rather than filing:

- it sits on the **only** security clock, because the fold means one match covers both windows;
- it needs **no intent whatsoever**. The dated-empty-file residual requires someone to fabricate evidence. This one requires an honest project to write deployment notes.

## The three residuals

| | fix |
|---|---|
| **R-WP6-4** substring breadth | `*dep*` → `*dependency*`, `*deps*`, `*dep-scan*`, `*dependabot*` — none spells `deployment` |
| **R-WP6-7** non-file artefacts | candidates filtered through `[ -f ]`, which follows symlinks and rejects the dated empty directory *and* the dangling symlink with one test |
| **R-WP6-5** cross-host date divergence | `cadence_epoch` round-trips the parsed epoch back to a date and requires equality — catches BSD's normalisation of `2026-02-30` → March 2 on whichever `date(1)` is installed |

Plus the trigger for the entry: the header claimed all three were *"Filed as backlog lines"*. They were not filed anywhere. `## BL-222:` **is** that filing, and case **H2** pins that the disclosure survives the correction rather than being deleted along with the false clause.

## Review found a real coverage loss, and it is fixed

The first narrowing dropped two genuine scanners. Extending D2 made it go red exactly as measured:

```
[FAIL] D2 — these legitimate artefacts stopped counting:
        dep-scan-DATE.json(rc=2) dependabot-alerts-DATE.json(rc=2)
```

`dep-scan` is OWASP's vulnerability scanner; `dependabot-alerts` is the commonest dependency artefact on the default host. Both were caught by the old broad glob and reached by none of the replacements. The loss direction was fail-safe — rc 2 blocks a release cut rather than waving one through — but a false alarm on a project that *did* scan is still a defect, and it is a mild case of the exact failure mode **B1** exists to catch: narrowing until nothing matches.

Review independently proved **each** restored pattern is load-bearing: dropping either alone turns D2 red naming only that one.

**Two suggestions declined, with reasons.** `depcheck` and `deptry` detect *unused* dependencies, not vulnerabilities — including them would let a tidy-up report satisfy a **security** cadence, which is the same category error as the deployment note. Review agreed on the oracle (`/osprey-oss/deptry`).

## The residual is pinned, not papered over

"Fixed" means the three **measured** holes are closed — not that the shapes cannot occur. Matching is still a substring heuristic:

| name | verdict |
|---|---|
| `deployment-notes-<date>.md` | rejected — the headline hole, closed |
| `deployment-deps-<date>.md` | **still satisfies** — spells `deps` |
| `deployment-dependency-<date>.md` | **still satisfies** — spells `dependency` |
| `deployment-dependencies-<date>.md` | rejected — no literal `dependency` |

That singular/plural split is not something a reader would predict. **Not a regression** — all of these are accepted on `main` too. Case **D6** now pins the boundary, so the day someone closes it properly (by asserting on *content* rather than a name) D6 goes red and tells them the disclosure needs updating too. A residual that is regression-tested cannot rot the way a worded one can.

## Proof

11 cases, ~3s, asserting on **exit codes** because the script's contract is one: `0` current / `1` overdue / **`2` undetermined**, and `cut-release.sh` refuses on 2. **B1** establishes an rc-0 baseline first so no row can pass by making everything undetermined.

**One expectation corrected mid-proof, and the correction is sharper than the original.** M2 first expected the mutant to answer rc 0; it answers **rc 1**, because `2026-02-30` normalises to a March date old enough to read as overdue. The real discriminator is **rc 2 versus any measured verdict** — the mutant does not mis-date the artefact, it **fabricates a measurement from a date that does not exist**. Asserted that way the proof is also immune to calendar drift, which the original would not have been.

**Stated limit:** on a GNU-date host M2 **cannot fire at all**, because GNU refuses `2026-02-30` outright. The failure message says so, rather than letting a structurally-unfirable mutant read as a kill.

## Verification

- suite **11/11**, lints **15/15**
- neighbours on the same script: wp6-cadence **33/0**, wp7-cut-release **37/0**, severability **14/0**
- registered in `tests/full-project-test-suite.sh` and the `tests.yml` unit array
- adversarial review: **minor_concerns → clears for PR**; all three wording findings folded in before opening

## Why this is split from BL-229

They began as one branch. Review **blocked** the BL-229 half on a Bitbucket defect I introduced — and on a false premise I had given the owner about Bitbucket's import support. This half cleared every probe designed against it, so it is not held hostage to that rework. `git diff --stat main...HEAD` touches five files, none of them BL-229's; a repo-wide grep for `BL-229` returns zero.
