### PR TITLE
fix(bl229): resolve pipeline paths from the host, and prove the release file can actually run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -518,6 +518,7 @@ jobs:
             tests/test-brownfield-wp6-collision-archive.sh
             tests/test-bl233-mcp-outcome-enforcement.sh
             tests/test-bl234-currency-and-availability.sh
+            tests/test-bl229-host-pipeline-paths.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/init.sh
+++ b/init.sh
@@ -3170,30 +3170,31 @@ generate_release() {
     return 0
   fi
 
-  # Host-specific output path: GitHub workflows live under .github/workflows,
-  # GitLab pipelines under .gitlab-ci/, Bitbucket under bitbucket-pipelines/
-  # (deploy phase is appended to bitbucket-pipelines.yml via include).
-  local target_dir target_file
-  case "$host" in
-    github)
-      target_dir=".github/workflows"
-      target_file="$target_dir/release.yml"
-      ;;
-    gitlab)
-      target_dir=".gitlab-ci"
-      target_file="$target_dir/release.yml"
-      ;;
-    bitbucket)
-      target_dir="bitbucket-pipelines"
-      target_file="$target_dir/release.yml"
-      ;;
-    *)
-      print_warn "Unknown host '$host'; defaulting release output to .github/workflows/release.yml"
-      target_dir=".github/workflows"
-      target_file="$target_dir/release.yml"
-      ;;
-  esac
-  mkdir -p "$target_dir"
+  # BL-229-INIT-RELEASE-PATH: ask the resolver. This `case` WAS the only copy of
+  # the host->path mapping, and five readers had each grown their own hardcoded
+  # GitHub spelling because of it. It is now a call, so writer and readers
+  # cannot drift — the sync-sibling failure `# BL-084-TIER-KEY` exists for.
+  #
+  # The comment this replaced claimed the Bitbucket "deploy phase is appended to
+  # bitbucket-pipelines.yml via include". No such include existed anywhere in
+  # the repo, and Bitbucket has no mechanism to create one: its sharing is
+  # CROSS-REPOSITORY (`definitions.imports.<name>: <repo-slug>:<ref>:<path>`,
+  # needing `export: true` in the other repo). So the file this function used to
+  # write at bitbucket-pipelines/release.yml could never execute. GitLab is the
+  # opposite case — `include: local` genuinely supports a subdirectory file, so
+  # its release file was legitimate and merely unwired.
+  # host.sh's only other source site in this file is conditional and runs much
+  # earlier, so do not assume the function exists here. Guarded, not repeated:
+  # sourcing twice is harmless, calling an undefined function is not.
+  if ! command -v host_pipeline_resolve >/dev/null 2>&1; then
+    # shellcheck disable=SC1090
+    source "$SCRIPT_DIR/scripts/lib/host.sh"
+  fi
+  if ! host_pipeline_resolve "$host" 2>/dev/null; then
+    print_warn "Unknown host '$host' — no release pipeline laid down. Record a supported host and re-run."
+    return 0
+  fi
+  local target_file="$HOST_RELEASE_PATH"
 
   # Get language-specific build variables
   get_release_vars
@@ -3205,6 +3206,8 @@ generate_release() {
   # shipped suppression would silence the mutable-action-tag rule on that line in
   # every downstream repo. Stripping is keyed on the marker token alone so no
   # suppression directive text exists in any shipped script either.
+  local _rendered
+  _rendered="$(mktemp)"
   sed -e 's|[[:space:]]*#.*__SOLO_TEMPLATE_ONLY__[[:space:]]*$||' \
       -e "s|__SETUP_ACTION__|$RELEASE_SETUP_ACTION|g" \
       -e "s|__SETUP_VERSION_KEY__|$RELEASE_SETUP_VERSION_KEY|g" \
@@ -3212,7 +3215,32 @@ generate_release() {
       -e "s|__INSTALL_COMMAND__|$RELEASE_INSTALL_COMMAND|g" \
       -e "s|__BUILD_COMMAND__|$RELEASE_BUILD_COMMAND|g" \
       -e "s|__PROJECT_NAME__|$PROJECT_NAME|g" \
-      "$release_template" > "$target_file"
+      "$release_template" > "$_rendered"
+
+  # How the rendered steps reach the runner differs per host, and getting this
+  # wrong is what left two of three hosts with a release pipeline on disk that
+  # nothing ever executed.
+  # How the rendered steps reach the runner differs per host, and getting this
+  # wrong is what left two of three hosts with a release pipeline on disk that
+  # nothing ever executed. The WIRING itself lives in one place —
+  # `host_wire_release` (# BL-229-WIRE-RELEASE) — because verify-install.sh
+  # auto-fixes the same thing and a second copy is the drift this entry is about.
+  mkdir -p "$(dirname "$target_file")"
+  mv "$_rendered" "$target_file"
+  if host_wire_release "$HOST_CI_PATH" "$target_file" "$HOST_RELEASE_EXECUTES"; then
+    case "$HOST_RELEASE_EXECUTES" in
+      file) : ;;   # GitHub needs no wiring; saying so would be noise
+      *)    print_info "Wired $target_file into $HOST_CI_PATH ($HOST_RELEASE_EXECUTES)" ;;
+    esac
+  else
+    # A WRITE THAT DID NOT HAPPEN MUST NOT REPORT SUCCESS. The previous attempt
+    # at the Bitbucket arm printed "folded" over a splice that never ran.
+    print_warn "Could NOT wire $target_file into $HOST_CI_PATH — the release pipeline will NOT run."
+    case "$HOST_RELEASE_EXECUTES" in
+      include) print_warn "  Add by hand: include: [{ local: /$target_file }]" ;;
+      import)  print_warn "  Add by hand: 'definitions: imports: release: $target_file' and 'import: release-pipeline@release' under a pipelines start-condition." ;;
+    esac
+  fi
 
   print_info "Release pipeline created at $target_file (host: $host, platform: $PLATFORM)"
   case "$TRACK" in

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -2011,7 +2011,12 @@ if [ "$current_phase" -ge 3 ] && [ "$skip_later_gate" -eq 0 ]; then   # BL-166-G
     if [ "$_wire_rc" -eq 2 ]; then
       echo -e "${YELLOW}[WARN]${NC} Phase 3→4: could NOT VERIFY that $_rel_path is wired into $_rel_ci"
       echo "  The pipeline file uses a shape this check cannot read (flow style, or multiple documents)."
-      echo "  Cannot-measure is not a pass — confirm the '$_rel_how' reference by hand."
+      echo "  Cannot-measure is not a pass. Confirm by hand that $_rel_ci contains:"
+      case "$_rel_how" in
+        include) echo "    include: [{ local: /$_rel_path }]" ;;
+        import)  echo "    definitions.imports.release: $_rel_path"
+                 echo "    and, under a pipelines start-condition: import: release-pipeline@release" ;;
+      esac
     else
       echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline $_rel_path is NOT WIRED into $_rel_ci — it will never run"
       echo "  This host reaches the release file by '$_rel_how'; without that reference the file is inert."

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1995,15 +1995,27 @@ if [ "$current_phase" -ge 3 ] && [ "$skip_later_gate" -eq 0 ]; then   # BL-166-G
     echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline not found at $_rel_path"
     echo "  A configured release pipeline is required before production release."
     issues=$((issues + 1))
-  elif [ "$_rel_how" != "file" ] && { [ ! -f "$_rel_ci" ] || ! grep -q "$_rel_path" "$_rel_ci" 2>/dev/null; }; then
+  elif [ "$_rel_how" != "file" ] && { _hwr_verify "$_rel_ci" "$_rel_path" "$_rel_how"; _wire_rc=$?; [ "$_wire_rc" -ne 0 ]; }; then
     # BL-229-GATE-RELEASE-WIRED: existence is not execution. On GitLab and
     # Bitbucket the release file is INERT until the root pipeline references it
     # — GitLab by `include:`, Bitbucket by `definitions.imports` plus an
     # `import:`. init.sh shipped unreferenced release files on both hosts for
     # months, so a gate that stops at `[ -f ]` would bless exactly the state
     # this entry exists to end.
-    echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline $_rel_path is NOT WIRED into $_rel_ci — it will never run"
-    echo "  This host reaches the release file by '$_rel_how'; without that reference the file is inert."
+    # ASK the shared predicate (# BL-229-WIRE-VERIFY) rather than re-deriving it.
+    # A private `grep -q "$path" "$ci"` here was satisfied by a mention in a
+    # comment, by a source declared and never invoked, and by a declaration
+    # YAML had already discarded — so the gate blessed three inert states the
+    # writer's own verifier rejected. Two predicates for one question, and they
+    # disagreed: a fresh sync sibling inside the entry about sync siblings.
+    if [ "$_wire_rc" -eq 2 ]; then
+      echo -e "${YELLOW}[WARN]${NC} Phase 3→4: could NOT VERIFY that $_rel_path is wired into $_rel_ci"
+      echo "  The pipeline file uses a shape this check cannot read (flow style, or multiple documents)."
+      echo "  Cannot-measure is not a pass — confirm the '$_rel_how' reference by hand."
+    else
+      echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline $_rel_path is NOT WIRED into $_rel_ci — it will never run"
+      echo "  This host reaches the release file by '$_rel_how'; without that reference the file is inert."
+    fi
     issues=$((issues + 1))
   else
     todo_count=$(grep -c "TODO" "$_rel_path" 2>/dev/null) || todo_count=0

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1988,13 +1988,39 @@ if [ "$current_phase" -ge 3 ] && [ "$skip_later_gate" -eq 0 ]; then   # BL-166-G
     fi
   fi
   if [ -z "$_rel_path" ]; then
-    echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline NOT CHECKED — could not resolve this project's host"
-    echo "  Record it with: bash scripts/check-gate.sh --backfill-host"
-    issues=$((issues + 1))
+    # Same tier rule as the absence arm below (# BL-229-RELEASE-ABSENT-TIER /
+    # BL-084-TIER-KEY). An unrecorded host is "cannot tell", and cannot-tell
+    # must never read as clean — so it is ALWAYS reported. But requiring a
+    # recorded host to clear 3→4 is a new gate condition BL-229 never asked
+    # for, and it blocked light-track personal fixtures that have no manifest
+    # at all. Block where the tier expects a release pipeline; inform otherwise.
+    if [ "$deployment" = "organizational" ] || [ "$poc_mode" = "sponsored_poc" ]; then
+      echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline NOT CHECKED — could not resolve this project's host"
+      echo "  This tier (deployment=$deployment) needs the check to run. Record the host with: bash scripts/check-gate.sh --backfill-host"
+      issues=$((issues + 1))
+    else
+      echo -e "${BLUE}  [INFO]${NC} Phase 3→4: release pipeline not checked — no host recorded (deployment=$deployment). Record one with: bash scripts/check-gate.sh --backfill-host"
+    fi
   elif [ ! -f "$_rel_path" ]; then
-    echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline not found at $_rel_path"
-    echo "  A configured release pipeline is required before production release."
-    issues=$((issues + 1))
+    # BL-229-RELEASE-ABSENT-TIER / BL-084-TIER-KEY (SYNC SIBLINGS — same
+    # predicate as the bypass-eligibility arm above, and as pre-commit-gate.sh,
+    # init.sh and scripts/lib/enforcement-level.sh).
+    #
+    # ABSENCE IS NOT THE SAME DEFECT AS SILENCE. BL-229 is about the check not
+    # RUNNING on two of three hosts; a light-track personal project with no
+    # release pipeline is a legitimate shape, not a finding. An earlier version
+    # of this block made absence BLOCK on every host, which imposed a new
+    # requirement the entry never asked for and broke 13 assertions across three
+    # suites whose fixtures encode exactly that shape. So: always REPORT — never
+    # silent, which was the real defect — and BLOCK only where the tier expects
+    # a release pipeline to exist.
+    if [ "$deployment" = "organizational" ] || [ "$poc_mode" = "sponsored_poc" ]; then
+      echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline not found at $_rel_path"
+      echo "  This tier (deployment=$deployment, poc_mode=${poc_mode:-none}) requires one before production release."
+      issues=$((issues + 1))
+    else
+      echo -e "${BLUE}  [INFO]${NC} Phase 3→4: no release pipeline at $_rel_path (deployment=$deployment) — not required at this tier, and not checked further"
+    fi
   elif [ "$_rel_how" != "file" ] && { _hwr_verify "$_rel_ci" "$_rel_path" "$_rel_how"; _wire_rc=$?; [ "$_wire_rc" -ne 0 ]; }; then
     # BL-229-GATE-RELEASE-WIRED: existence is not execution. On GitLab and
     # Bitbucket the release file is INERT until the root pipeline references it

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -1962,12 +1962,58 @@ fi
 
 # Release pipeline configuration check (Phase 3→4)
 if [ "$current_phase" -ge 3 ] && [ "$skip_later_gate" -eq 0 ]; then   # BL-166-GATE-SCOPE
-  if [ -f ".github/workflows/release.yml" ]; then
-    todo_count=$(grep -c "TODO" .github/workflows/release.yml 2>/dev/null) || todo_count=0
+  # BL-229-GATE-RELEASE-PATH: resolve the release pipeline from the RECORDED
+  # host rather than assuming the GitHub spelling. Before this the `-f` test was
+  # false on GitLab and Bitbucket, so the whole block was skipped and printed
+  # NOTHING — a release pipeline full of unconfigured TODOs passed the 3→4 gate
+  # on two of three hosts, and the silence read exactly like a clean result.
+  # That is the `# BL-112-SAST-NOTRUN` prohibition: "did not run" must never be
+  # spelled the same as "found nothing".
+  #
+  # All three failure arms below increment `issues`, i.e. they BLOCK. Read the
+  # increment, not the [WARN] label (CLAUDE.md's WARN trap) — and note the
+  # artifact loop immediately below has always failed closed this way for
+  # HANDOFF.md / sbom.json. This block is now consistent with its neighbour.
+  # Reuse SCRIPT_DIR_CPG when the phase>=2 block already derived it; the >=3
+  # guard above implies it ran, but derive as a fallback rather than assume.
+  _cpg_lib_dir="${SCRIPT_DIR_CPG:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+  _rel_path=""; _rel_how=""; _rel_ci=""
+  if [ -f "$_cpg_lib_dir/lib/host.sh" ]; then
+    # shellcheck disable=SC1090
+    . "$_cpg_lib_dir/lib/host.sh"
+    if host_pipeline_resolve >/dev/null 2>&1; then
+      _rel_path="$HOST_RELEASE_PATH"
+      _rel_how="$HOST_RELEASE_EXECUTES"
+      _rel_ci="$HOST_CI_PATH"
+    fi
+  fi
+  if [ -z "$_rel_path" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline NOT CHECKED — could not resolve this project's host"
+    echo "  Record it with: bash scripts/check-gate.sh --backfill-host"
+    issues=$((issues + 1))
+  elif [ ! -f "$_rel_path" ]; then
+    echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline not found at $_rel_path"
+    echo "  A configured release pipeline is required before production release."
+    issues=$((issues + 1))
+  elif [ "$_rel_how" != "file" ] && { [ ! -f "$_rel_ci" ] || ! grep -q "$_rel_path" "$_rel_ci" 2>/dev/null; }; then
+    # BL-229-GATE-RELEASE-WIRED: existence is not execution. On GitLab and
+    # Bitbucket the release file is INERT until the root pipeline references it
+    # — GitLab by `include:`, Bitbucket by `definitions.imports` plus an
+    # `import:`. init.sh shipped unreferenced release files on both hosts for
+    # months, so a gate that stops at `[ -f ]` would bless exactly the state
+    # this entry exists to end.
+    echo -e "${YELLOW}[WARN]${NC} Phase 3→4: release pipeline $_rel_path is NOT WIRED into $_rel_ci — it will never run"
+    echo "  This host reaches the release file by '$_rel_how'; without that reference the file is inert."
+    issues=$((issues + 1))
+  else
+    todo_count=$(grep -c "TODO" "$_rel_path" 2>/dev/null) || todo_count=0
+    case "$todo_count" in ''|*[!0-9]*) todo_count=0 ;; esac
     if [ "$todo_count" -gt 0 ]; then
-      echo -e "${YELLOW}[WARN]${NC} Release pipeline has $todo_count unconfigured TODO items in .github/workflows/release.yml"
+      echo -e "${YELLOW}[WARN]${NC} Release pipeline has $todo_count unconfigured TODO items in $_rel_path"
       echo "  Configure code signing, deployment secrets, and store credentials before production release."
       issues=$((issues + 1))
+    else
+      echo -e "${GREEN}  [OK]${NC} Release pipeline configured ($_rel_path; steps run: $_rel_how)"
     fi
   fi
 fi

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1218,7 +1218,24 @@ echo "  2. git commit -m \"chore(release): $TAG\""
 echo "  3. git tag -f $TAG          <-- the step above. Do not skip it."
 echo "  4. git push && git push origin $TAG"
 echo ""
-echo "  Your release pipeline fires on the tag push in step 4, and not before."
+# BL-229-CUTREL-TRIGGER: true on GitHub and GitLab, which really are
+# tag-triggered. NOT true on Bitbucket, where the release is a `custom:`
+# pipeline (Atlassian documents `import:` under `custom:`/`branches:` only, and
+# `branches:` would fire on every push). Saying "the tag fires it" to a
+# Bitbucket operator is the framework claiming something ran when it did not —
+# this entry's whole subject.
+_cr_how=""
+if [ -f "$SCRIPT_DIR/lib/host.sh" ]; then
+  # shellcheck disable=SC1090
+  . "$SCRIPT_DIR/lib/host.sh" 2>/dev/null
+  host_pipeline_resolve >/dev/null 2>&1 && _cr_how="$HOST_RELEASE_EXECUTES"
+fi
+if [ "$_cr_how" = "import" ]; then
+  echo "  On this host the release pipeline is a MANUAL pipeline: pushing the tag does"
+  echo "  NOT start it. Run it from Pipelines > Run pipeline > custom: release."
+else
+  echo "  Your release pipeline fires on the tag push in step 4, and not before."
+fi
 
 # THE LAST WORD IS NOT ALLOWED TO BE A CLEAN ONE WHEN THE CUT WAS NOT. The
 # release happened and the operator needs the four steps above regardless, so

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -71,8 +71,12 @@ host_read_from_manifest() {
 # HOST_RELEASE_PATH outright: init.sh's `case "$host"` was its only other copy
 # and is now a call. HOST_CI_PATH still has live siblings that this branch does
 # NOT convert — `scripts/verify-install.sh` (`_ci_dest`, and the fix_ci_pipeline
-# writer) and `scripts/reconfigure-project.sh`. Derive the current set rather
-# than trusting this sentence:
+# writer), `scripts/reconfigure-project.sh`, `scripts/validate.sh`'s
+# Competency-Matrix guard, `scripts/check-updates.sh` and `scripts/check-gate.sh`.
+# The first enumeration here named three and its own recipe found six; the
+# validate.sh one matters most, because it makes that whole check SILENTLY SKIP
+# on GitLab and Bitbucket — this entry's defect class, in the file this entry
+# fixes. Derive the current set rather than trusting this sentence:
 #
 #   grep -rn '\.gitlab-ci\|bitbucket-pipelines\|\.github/workflows' scripts/ init.sh
 #
@@ -134,20 +138,44 @@ host_pipeline_resolve() {
 #      key that YAML then discarded, taking the real declaration with it.
 # Hence: merge into an existing block rather than emitting a rival one, and
 # verify STRUCTURE — anchored keys, and the reference actually invoked.
+# _hwr_verify <ci> <rel> <how> — is the release file genuinely reachable?
+#
+#   0  wired
+#   1  NOT wired — a real defect
+#   2  CANNOT TELL — the file's shape is beyond these greps
+#
+# THE THIRD STATE IS NOT PEDANTRY. This is anchored-grep matching, not a YAML
+# parse, so flow style (`definitions: {imports: {...}}`) and multi-document
+# files are shapes it cannot read. Answering "not wired" there would tell a
+# CORRECTLY wired project that its release will never run — which is BL-229's
+# own false-failure symptom, relocated. Callers must fail closed on 2 (a gate
+# that cannot measure must not pass) while SAYING something different from 1.
+# Same distinction `## BL-213:` forced on the cadence checker.
 _hwr_verify() {                                                      # BL-229-WIRE-VERIFY
-  local ci="$1" rel="$2" how="$3"
+  local ci="$1" rel="$2" how="$3" norm
+  # CRLF is not a defect. A Windows contributor's checkout is a healthy project
+  # and must not be told its release pipeline is broken.
+  norm="$(tr -d '\r' < "$ci" 2>/dev/null)"
+  case "$norm" in
+    *"---"*)  ;;   # checked properly below; this arm only cheapens the common case
+  esac
+  # Shapes these greps cannot read -> "cannot tell", never "not wired".
+  if printf '%s\n' "$norm" | grep -qE '^(definitions|pipelines):[[:space:]]*[{[]' \
+     || printf '%s\n' "$norm" | grep -qE '^---[[:space:]]*$'; then
+    return 2
+  fi
   case "$how" in
     include)
-      # anchored, so a path named in a comment cannot satisfy it
-      grep -q "^  - local: /${rel}\$" "$ci" 2>/dev/null || return 1
+      printf '%s\n' "$norm" | grep -q "^  - local: /${rel}\$" || return 1
       ;;
     import)
       # exactly ONE imports: block — two means YAML keeps the last and silently
-      # drops the other, which is how this passed while being broken
-      [ "$(grep -c '^  imports:$' "$ci" 2>/dev/null)" -eq 1 ] || return 1
-      grep -q "^    release: ${rel}\$" "$ci" 2>/dev/null || return 1
-      # DECLARED IS NOT INVOKED: an import source nothing references never runs
-      grep -q 'import: release-pipeline@release' "$ci" 2>/dev/null || return 1
+      # discards the other, which is how an earlier version passed while broken
+      [ "$(printf '%s\n' "$norm" | grep -c '^  imports:$')" -eq 1 ] || return 1
+      printf '%s\n' "$norm" | grep -q "^    release: ${rel}\$" || return 1
+      # DECLARED IS NOT INVOKED, and the reference must be ANCHORED: unanchored,
+      # a commented-out line satisfied it.
+      printf '%s\n' "$norm" | grep -q "^      import: release-pipeline@release\$" || return 1
       ;;
   esac
   return 0

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -28,6 +28,182 @@ host_read_from_manifest() {
   echo "$host"
 }
 
+# ── Pipeline paths ─────────────────────────────────────────────────────────
+# host_pipeline_resolve [host] — the ONE place that knows where each host keeps
+# its CI and release pipelines. Sets three globals:
+#
+#   HOST_CI_PATH          the root pipeline file the host actually executes
+#   HOST_RELEASE_PATH     where the release steps live
+#   HOST_RELEASE_EXECUTES how those steps reach the runner:
+#                           file    — its own file, executed directly (GitHub)
+#                           include — its own file, pulled in by the root
+#                                     pipeline's `include:` (GitLab)
+#                           import  — its own file, pulled in by the root
+#                                     pipeline's `definitions.imports` plus an
+#                                     `import:` reference (Bitbucket)
+#
+# `file` needs no wiring. `include` and `import` DO, and a release file nothing
+# references never executes — which is the deepest form of this entry's defect
+# and what a reader must check beyond `[ -f ]`.
+#
+# THE THIRD FIELD IS NOT DECORATION. Without it every caller re-derives
+# "…but Bitbucket is different" locally, which is exactly the duplication that
+# produced BL-229: five scripts each hardcoded `.github/workflows/release.yml`,
+# so on GitLab and Bitbucket the readers either said nothing (check-phase-gate,
+# a skipped block indistinguishable from a clean one) or said something false
+# (validate.sh, `[FAIL] CI pipeline missing` on a healthy project).
+#
+# BITBUCKET DOES SUPPORT A SAME-REPO IMPORT, AND AN EARLIER VERSION OF THIS
+# COMMENT SAID IT DID NOT. That false premise shipped in four places and drove a
+# design decision; it is corrected here rather than quietly deleted. Atlassian
+# documents `definitions: imports: <name>: <path>` with a same-repo path, and
+# the imported file declares `export: true`. So Bitbucket gets a separate
+# release file like the other two — it simply needs two wiring points instead of
+# GitLab's one (the `imports` declaration, and an `import:` reference under the
+# start-condition).
+#
+# What is genuinely NOT available on Bitbucket is GitLab's transparent
+# `include:` — the imported pipeline must be referenced by name. That is the
+# real asymmetry, and it is smaller than the one previously claimed.
+#
+# SYNC SIBLINGS — STATED HONESTLY, because an earlier version of this comment
+# claimed there were none and that was not true. This function owns
+# HOST_RELEASE_PATH outright: init.sh's `case "$host"` was its only other copy
+# and is now a call. HOST_CI_PATH still has live siblings that this branch does
+# NOT convert — `scripts/verify-install.sh` (`_ci_dest`, and the fix_ci_pipeline
+# writer) and `scripts/reconfigure-project.sh`. Derive the current set rather
+# than trusting this sentence:
+#
+#   grep -rn '\.gitlab-ci\|bitbucket-pipelines\|\.github/workflows' scripts/ init.sh
+#
+# cf. `# BL-084-TIER-KEY`, which exists because a different predicate grew
+# copies. Callers ask for the RELEASE path; they do not re-derive it.
+HOST_CI_PATH=""
+HOST_RELEASE_PATH=""
+HOST_RELEASE_EXECUTES=""
+host_pipeline_resolve() {
+  local host="${1:-}"
+  if [ -z "$host" ]; then
+    host="$(host_read_from_manifest)" || return $?
+  fi
+  case "$host" in   # BL-229-HOST-PIPELINE-PATHS
+    github)
+      HOST_CI_PATH=".github/workflows/ci.yml"
+      HOST_RELEASE_PATH=".github/workflows/release.yml"
+      HOST_RELEASE_EXECUTES="file"
+      ;;
+    gitlab)
+      HOST_CI_PATH=".gitlab-ci.yml"
+      HOST_RELEASE_PATH=".gitlab-ci/release.yml"   # BL-229-HOST-PIPELINE-GITLAB
+      HOST_RELEASE_EXECUTES="include"
+      ;;
+    bitbucket)
+      HOST_CI_PATH="bitbucket-pipelines.yml"
+      HOST_RELEASE_PATH=".bitbucket/release-pipelines.yml"   # BL-229-BITBUCKET-EXPORT-NAME
+      HOST_RELEASE_EXECUTES="import"
+      ;;
+    *)
+      # FAIL CLOSED, and name the value. The arm this replaced defaulted an
+      # unknown host to the GitHub paths behind a warning, which is how a
+      # mis-recorded host silently produced a GitHub-shaped answer everywhere.
+      HOST_CI_PATH=""; HOST_RELEASE_PATH=""; HOST_RELEASE_EXECUTES=""
+      echo "host.sh: cannot resolve pipeline paths for host '$host'. Valid: github, gitlab, bitbucket" >&2
+      return 4
+      ;;
+  esac
+  return 0
+}
+
+# host_wire_release <ci_path> <release_path> <how> — make the release file
+# REACHABLE from the root pipeline, and return non-zero if that did not happen.
+#
+# One owner, because two callers need it (init.sh at scaffold time,
+# verify-install.sh as an auto-fix) and a second copy is the drift this entry is
+# about.
+#
+# Prints NOTHING: callers own their reporting vocabulary. The contract is the
+# exit code and the bytes on disk.
+#
+# THREE MECHANISMS HAVE FAILED HERE, EACH VERIFYING THE PREVIOUS ONE'S MISTAKE:
+#   1. `awk -v` with a multi-line body — BSD awk rejects the newline, the splice
+#      never ran, and the caller printed success.
+#   2. `[ -f ]` on the release file — existence is not execution; an
+#      unreferenced file reported as configured.
+#   3. `grep -q "$rel" "$ci"` — a SUBSTRING test, satisfied by a mention in a
+#      comment, and satisfied even when `sed` had inserted a SECOND `imports:`
+#      key that YAML then discarded, taking the real declaration with it.
+# Hence: merge into an existing block rather than emitting a rival one, and
+# verify STRUCTURE — anchored keys, and the reference actually invoked.
+_hwr_verify() {                                                      # BL-229-WIRE-VERIFY
+  local ci="$1" rel="$2" how="$3"
+  case "$how" in
+    include)
+      # anchored, so a path named in a comment cannot satisfy it
+      grep -q "^  - local: /${rel}\$" "$ci" 2>/dev/null || return 1
+      ;;
+    import)
+      # exactly ONE imports: block — two means YAML keeps the last and silently
+      # drops the other, which is how this passed while being broken
+      [ "$(grep -c '^  imports:$' "$ci" 2>/dev/null)" -eq 1 ] || return 1
+      grep -q "^    release: ${rel}\$" "$ci" 2>/dev/null || return 1
+      # DECLARED IS NOT INVOKED: an import source nothing references never runs
+      grep -q 'import: release-pipeline@release' "$ci" 2>/dev/null || return 1
+      ;;
+  esac
+  return 0
+}
+
+host_wire_release() {                                                # BL-229-WIRE-RELEASE
+  local ci="$1" rel="$2" how="$3"
+  [ "$how" = "file" ] && return 0            # GitHub: its own file, no wiring
+  [ -f "$ci" ] || return 1                   # nothing to wire it into
+  _hwr_verify "$ci" "$rel" "$how" && return 0    # already wired; idempotent
+
+  local frag tmp
+  frag="$(mktemp)"; tmp="$(mktemp)"
+  case "$how" in
+    include)
+      { printf '\n# Release pipeline (solo-orchestrator). Without this include the\n'
+        printf '# file below is never evaluated by GitLab.\n'
+        printf 'include:\n'
+        printf '  - local: %s\n' "/$rel"
+      } >> "$ci"
+      ;;
+    import)
+      # MERGE, never rival. If an `imports:` block exists, the declaration goes
+      # INSIDE it; emitting a second one is what silently discarded the wiring.
+      printf '    release: %s\n' "$rel" > "$frag"                   # BL-229-IMPORT-WIRE
+      if grep -q '^  imports:$' "$ci"; then
+        sed "/^  imports:\$/r $frag" "$ci" > "$tmp" && cat "$tmp" > "$ci"
+      elif grep -q '^definitions:' "$ci"; then
+        { printf '  imports:\n'; cat "$frag"; } > "$tmp"
+        sed "/^definitions:[[:space:]]*\$/r $tmp" "$ci" > "$frag" && cat "$frag" > "$ci"
+      else
+        { printf '\ndefinitions:\n  imports:\n'; cat "$frag"; } >> "$ci"
+      fi
+      # The reference. `custom:` is used rather than `tags:` because Atlassian
+      # documents `import:` under `custom:` and `branches:` and NOT under
+      # `tags:`; `branches:` would fire a release on every push, so `custom:` —
+      # an on-demand pipeline — is the documented shape that also matches what a
+      # release is. Recorded because it is an inference about the vendor's
+      # surface, not a preference.
+      printf '  custom:\n    release:\n      import: release-pipeline@release\n' > "$frag"
+      if grep -q '^  custom:$' "$ci"; then
+        printf '    release:\n      import: release-pipeline@release\n' > "$frag"
+        sed "/^  custom:\$/r $frag" "$ci" > "$tmp" && cat "$tmp" > "$ci"
+      elif grep -q '^pipelines:' "$ci"; then
+        sed "/^pipelines:[[:space:]]*\$/r $frag" "$ci" > "$tmp" && cat "$tmp" > "$ci"
+      else
+        { printf '\npipelines:\n'; cat "$frag"; } >> "$ci"
+      fi
+      ;;
+    *) rm -f "$frag" "$tmp"; return 1 ;;
+  esac
+  rm -f "$frag" "$tmp"
+  # VERIFY STRUCTURE, then let the caller claim.
+  _hwr_verify "$ci" "$rel" "$how"
+}
+
 host_load_driver() {
   local host
   host=$(host_read_from_manifest) || return $?

--- a/scripts/lib/host.sh
+++ b/scripts/lib/host.sh
@@ -153,12 +153,14 @@ host_pipeline_resolve() {
 # Same distinction `## BL-213:` forced on the cadence checker.
 _hwr_verify() {                                                      # BL-229-WIRE-VERIFY
   local ci="$1" rel="$2" how="$3" norm
+  # The readers gave up their own `[ -f ]` guard when they adopted this
+  # function, so the guard has to live here. Without it the redirection below
+  # fails BEFORE `2>/dev/null` applies and the operator sees a raw
+  # "host.sh: line N: <file>: No such file or directory" through the gate.
+  [ -f "$ci" ] || return 1
   # CRLF is not a defect. A Windows contributor's checkout is a healthy project
   # and must not be told its release pipeline is broken.
   norm="$(tr -d '\r' < "$ci" 2>/dev/null)"
-  case "$norm" in
-    *"---"*)  ;;   # checked properly below; this arm only cheapens the common case
-  esac
   # Shapes these greps cannot read -> "cannot tell", never "not wired".
   if printf '%s\n' "$norm" | grep -qE '^(definitions|pipelines):[[:space:]]*[{[]' \
      || printf '%s\n' "$norm" | grep -qE '^---[[:space:]]*$'; then

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -130,7 +130,12 @@ else
     # answering one question with two different greps is how the gate came to
     # bless states the writer's own verifier rejected.
     if [ "$_v_wire" -eq 2 ]; then
-      warn "Could NOT VERIFY that $_v_rel is wired into $_v_ci ($_v_how) — the pipeline file uses a shape this check cannot read; confirm by hand"
+      case "$_v_how" in
+        include) _v_expect="include: [{ local: /$_v_rel }]" ;;
+        import)  _v_expect="definitions.imports.release: $_v_rel plus 'import: release-pipeline@release'" ;;
+        *)       _v_expect="a reference to $_v_rel" ;;
+      esac
+      warn "Could NOT VERIFY that $_v_rel is wired into $_v_ci ($_v_how) — this check cannot read that file's shape. Confirm by hand that it contains: $_v_expect"
     else
       warn "Release pipeline $_v_rel is NOT WIRED into $_v_ci ($_v_how) — it will never run"
     fi

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -121,12 +121,19 @@ else
   [ -f "$_v_ci" ] && print_ok "CI pipeline ($_v_ci)" || fail "CI pipeline missing ($_v_ci)"
 
   if [ -f "$_v_rel" ] && [ "$_v_how" != "file" ] \
-     && { [ ! -f "$_v_ci" ] || ! grep -q "$_v_rel" "$_v_ci" 2>/dev/null; }; then
+     && { _hwr_verify "$_v_ci" "$_v_rel" "$_v_how"; _v_wire=$?; [ "$_v_wire" -ne 0 ]; }; then
     # BL-229-VALIDATE-RELEASE-WIRED: existence is not execution. On GitLab and
     # Bitbucket the release file is inert until the root pipeline references it,
     # and init.sh shipped unreferenced release files on both hosts for months.
     # Reporting "configured" here would bless exactly that state.
-    warn "Release pipeline $_v_rel is NOT WIRED into $_v_ci ($_v_how) — it will never run"
+    # Same shared predicate as the gate (# BL-229-WIRE-VERIFY). Two readers
+    # answering one question with two different greps is how the gate came to
+    # bless states the writer's own verifier rejected.
+    if [ "$_v_wire" -eq 2 ]; then
+      warn "Could NOT VERIFY that $_v_rel is wired into $_v_ci ($_v_how) — the pipeline file uses a shape this check cannot read; confirm by hand"
+    else
+      warn "Release pipeline $_v_rel is NOT WIRED into $_v_ci ($_v_how) — it will never run"
+    fi
   elif [ -f "$_v_rel" ]; then
     # Check if release pipeline still has uncommented TODO placeholders
     todo_count=$(grep -cE "# TODO|echo.*TODO" "$_v_rel" 2>/dev/null || true)

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -96,19 +96,49 @@ fi
 # ================================================================
 print_section "CI/CD Pipelines"
 
-[ -f ".github/workflows/ci.yml" ] && print_ok "CI pipeline" || fail "CI pipeline missing (.github/workflows/ci.yml)"
-
-if [ -f ".github/workflows/release.yml" ]; then
-  # Check if release pipeline still has uncommented TODO placeholders
-  todo_count=$(grep -cE "# TODO|echo.*TODO" .github/workflows/release.yml 2>/dev/null || true)
-  case "$todo_count" in ''|*[!0-9]*) todo_count=0 ;; esac
-  if [ "$todo_count" -gt 0 ]; then
-    print_ok "Release pipeline (${todo_count} TODOs remaining — configure before first release)"
-  else
-    print_ok "Release pipeline (configured)"
+# BL-229-VALIDATE-PIPELINE-PATH: resolve both paths from the RECORDED host.
+# Before this, both checks assumed the GitHub spelling, so a HEALTHY GitLab or
+# Bitbucket project was told `[FAIL] CI pipeline missing
+# (.github/workflows/ci.yml)`. That is not cosmetic: `fail` increments `errors`
+# and this script ends `exit $errors`, so a correct project failed validation
+# for having its files where its own host puts them. Measured before the fix on
+# two projects identical but for the host — GitHub exit 10, GitLab exit 11, the
+# difference being exactly this false failure.
+_v_ci=""; _v_rel=""; _v_how=""
+if [ -f "$SCRIPT_DIR/lib/host.sh" ]; then
+  # shellcheck disable=SC1090
+  source "$SCRIPT_DIR/lib/host.sh"
+  if host_pipeline_resolve >/dev/null 2>&1; then
+    _v_ci="$HOST_CI_PATH"; _v_rel="$HOST_RELEASE_PATH"; _v_how="$HOST_RELEASE_EXECUTES"
   fi
+fi
+
+if [ -z "$_v_ci" ]; then
+  # Unresolvable host is "cannot tell", which is NOT "clean" — say so rather
+  # than silently checking nothing, and rather than guessing GitHub.
+  warn "CI/release pipelines NOT CHECKED — could not resolve this project's host (record it: bash scripts/check-gate.sh --backfill-host)"
 else
-  warn "Release pipeline missing (.github/workflows/release.yml)"
+  [ -f "$_v_ci" ] && print_ok "CI pipeline ($_v_ci)" || fail "CI pipeline missing ($_v_ci)"
+
+  if [ -f "$_v_rel" ] && [ "$_v_how" != "file" ] \
+     && { [ ! -f "$_v_ci" ] || ! grep -q "$_v_rel" "$_v_ci" 2>/dev/null; }; then
+    # BL-229-VALIDATE-RELEASE-WIRED: existence is not execution. On GitLab and
+    # Bitbucket the release file is inert until the root pipeline references it,
+    # and init.sh shipped unreferenced release files on both hosts for months.
+    # Reporting "configured" here would bless exactly that state.
+    warn "Release pipeline $_v_rel is NOT WIRED into $_v_ci ($_v_how) — it will never run"
+  elif [ -f "$_v_rel" ]; then
+    # Check if release pipeline still has uncommented TODO placeholders
+    todo_count=$(grep -cE "# TODO|echo.*TODO" "$_v_rel" 2>/dev/null || true)
+    case "$todo_count" in ''|*[!0-9]*) todo_count=0 ;; esac
+    if [ "$todo_count" -gt 0 ]; then
+      print_ok "Release pipeline (${todo_count} TODOs remaining — configure before first release)"
+    else
+      print_ok "Release pipeline (configured; steps run: $_v_how)"
+    fi
+  else
+    warn "Release pipeline missing ($_v_rel)"
+  fi
 fi
 
 # ================================================================

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -264,16 +264,34 @@ check_project_structure() {
     # (bring-your-own CD), NOT a blocking MANUAL.
     register_warn "Release pipeline: configure manually" "Host '$_ci_host' has no canonical release destination — supply your own (bring-your-own CI/CD)"
   elif [ -n "$PLATFORM" ] && has_source && [ -f "$SOURCE_DIR/templates/pipelines/release/$_ci_host/${PLATFORM}.yml" ]; then
+    # BL-229-VERIFY-RELEASE-REGISTER: github and gitlab both have a real
+    # destination the fixer can write, so both register FIXABLE and both ask the
+    # resolver where that is. Only Bitbucket is genuinely manual, because it has
+    # no same-repo include and the steps must be merged into the CI file by
+    # hand. Registering gitlab as "manual" alongside bitbucket was the same
+    # wrong premise the fixer carried.
+    _reg_rel=""
+    if [ -f "$SOURCE_DIR/scripts/lib/host.sh" ]; then
+      # shellcheck disable=SC1090
+      source "$SOURCE_DIR/scripts/lib/host.sh"
+      host_pipeline_resolve "$_ci_host" >/dev/null 2>&1 && _reg_rel="$HOST_RELEASE_PATH"
+    fi
     case "$_ci_host" in
-      github)
-        if [ -f ".github/workflows/release.yml" ]; then
+      github|gitlab)
+        if [ -n "$_reg_rel" ] && [ -f "$_reg_rel" ]; then
           register_pass "Release pipeline exists"
         else
           register_fixable "Release pipeline missing" "fix_release_pipeline"
         fi
         ;;
-      bitbucket|gitlab)
-        register_manual "Release pipeline (host=$_ci_host)" "Integrate release steps from templates/pipelines/release/$_ci_host/${PLATFORM}.yml into the unified pipeline file"
+      bitbucket)
+        # BL-229: no longer manual. Bitbucket reaches a same-repo file through
+        # definitions.imports, so fix_release_pipeline writes AND wires it.
+        if [ -n "$_reg_rel" ] && [ -f "$_reg_rel" ]; then
+          register_pass "Release pipeline exists"
+        else
+          register_fixable "Release pipeline missing" "fix_release_pipeline"
+        fi
         ;;
     esac
   fi
@@ -1236,19 +1254,47 @@ fix_release_pipeline() {
     print_warn "fix_release_pipeline: no release template for host=$host platform=$PLATFORM at $src"
     return 1
   fi
+  # BL-229-VERIFY-RELEASE-PATH: take the destinations from the shared resolver
+  # rather than spelling them here, so this writer cannot drift from the gate
+  # and validate.sh that read them.
+  local _vi_ci="" _vi_rel=""
+  if [ -f "$SOURCE_DIR/scripts/lib/host.sh" ]; then
+    # shellcheck disable=SC1090
+    source "$SOURCE_DIR/scripts/lib/host.sh"
+    # stderr deliberately NOT silenced here (lint-fix-functions-stderr): the
+    # resolver's only output is its unknown-host diagnostic, which names the
+    # offending host — exactly what an operator needs to act on, and exactly
+    # what a `2>&1` would swallow.
+    if host_pipeline_resolve "$host" >/dev/null; then
+      _vi_ci="$HOST_CI_PATH"; _vi_rel="$HOST_RELEASE_PATH"
+    fi
+  fi
+  if [ -z "$_vi_rel" ]; then
+    print_warn "fix_release_pipeline: could not resolve a release destination for host '$host'"
+    return 1
+  fi
   case "$host" in
     github)
-      mkdir -p .github/workflows
-      cp "$src" .github/workflows/release.yml
+      mkdir -p "$(dirname "$_vi_rel")"
+      cp "$src" "$_vi_rel"
       ;;
-    bitbucket|gitlab)
-      # bitbucket and gitlab carry release steps inside the single
-      # bitbucket-pipelines.yml / .gitlab-ci.yml respectively — there
-      # is no separate release file at repo root. Surface a
-      # non-blocking warning rather than silently writing to
-      # .github/workflows/release.yml (the pre-fix bug).
-      print_warn "fix_release_pipeline: host '$host' carries release steps in the unified pipeline file; manual integration required (template at $src)"
-      return 1
+    gitlab|bitbucket)
+      # BL-229-VERIFY-WIRED-RELEASE: this arm used to be `bitbucket|gitlab)`
+      # refusing BOTH, on the stated grounds that neither has a same-repo
+      # include. That was false for GitLab (`include: local` takes a
+      # subdirectory path) AND false for Bitbucket (Atlassian documents
+      # `definitions: imports:` with a same-repo path). Both are auto-fixable;
+      # they differ only in HOW the root pipeline reaches the file, which is
+      # exactly what HOST_RELEASE_EXECUTES carries.
+      mkdir -p "$(dirname "$_vi_rel")"
+      cp "$src" "$_vi_rel"
+      # The wiring is host_wire_release's job, not this file's. A second copy
+      # here is the drift BL-229 is about, and the BL-229 suite's S1 fails if
+      # one reappears.
+      if ! host_wire_release "$_vi_ci" "$_vi_rel" "$HOST_RELEASE_EXECUTES"; then
+        print_warn "fix_release_pipeline: wrote $_vi_rel but could NOT wire it into $_vi_ci — the release pipeline will not run until it is referenced"
+        return 1
+      fi
       ;;
     *)
       print_warn "fix_release_pipeline: unsupported host '$host' — no canonical release destination"

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9767,8 +9767,32 @@ of the blocks:
   configured, and referenced by nothing.
 - **N1/N2/N3** pin the suffix rule, the merge-not-rival invariant, and the
   declared-is-not-invoked distinction.
+- **G4** pins that the READERS ask the shared predicate rather than re-deriving
+  it, across all three inert shapes — and, since review found G4 to be a pure
+  absence assertion, it now carries its **positive counterpart** too. Renaming
+  the gate's success string previously left all three negative rows passing for
+  the wrong reason at 16/16; that mutant now dies at 15/1. **That is this
+  entry's own lesson one level up: the check guarding the fix was itself
+  asserted on one side only.**
 - **S1** pins that the wiring has ONE owner — it caught a real duplicate in
   `verify-install.sh` the moment it was written.
+
+### The recurring failure, named once
+
+Four review rounds, and the mechanism was never the problem — **rigour stopped
+one layer short of where the answer is consumed**, every time:
+
+| round | rigour applied at | answer consumed at | result |
+|---|---|---|---|
+| 1 | the splice | the operator's project | reported a merge it never made |
+| 2 | the file's existence | the release gate | "configured" over zero release steps |
+| 3 | the writer's verifier | the gate's own grep | gate blessed what the writer refused |
+| 4 | G4's negative rows | the canary string they depend on | a rename would make all three vacuous |
+
+The structural answer is the shared predicate plus the three-state contract
+(**0** wired / **1** not wired / **2** cannot tell, callers failing closed on 2
+while saying something different). `## BL-213:` forced the same distinction on
+the cadence checker, and this entry is the second surface to need it.
 
 Mutations, each `sites==1`, 2 lines changed, `bash -n` clean: **M1** collapses
 the host mapping to the GitHub spelling; **M2** emits the import declaration

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9774,6 +9774,25 @@ of the blocks:
   the wrong reason at 16/16; that mutant now dies at 15/1. **That is this
   entry's own lesson one level up: the check guarding the fix was itself
   asserted on one side only.**
+### Absence is not the same defect as silence — corrected after CI
+
+The first version made a MISSING release pipeline block the 3→4 gate on every
+host. CI refused it: **13 assertions across three suites** encode the old
+contract, and their fixtures are light-track personal projects — a legitimate
+shape with no release pipeline, not a finding. The same over-reach applied to an
+unrecorded host.
+
+BL-229 is about the check not RUNNING; **blocking on absence was scope this
+branch added.** Karl's decision: report always, block only where the tier
+expects a release pipeline — the same predicate as `# BL-084-TIER-KEY`
+(`deployment = organizational` or `poc_mode = sponsored_poc`), and the same
+applicable-vs-unmeasurable rule `scripts/check-maintenance.sh` already
+documents. `# BL-229-RELEASE-ABSENT-TIER` covers both arms; **T1** pins that
+reporting is unconditional and blocking is not.
+
+An existing release file that is UNWIRED still blocks at every tier — that is a
+broken file, not an absent one.
+
 - **S1** pins that the wiring has ONE owner — it caught a real duplicate in
   `verify-install.sh` the moment it was written.
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9679,7 +9679,102 @@ nothing about it
 **Severity:** Medium-High. Not a wrong answer: an **absent** answer, on two of
 the three supported hosts, with no output distinguishing "checked and clean" from
 "never looked".
-**Status:** Open
+**Status:** Open — fix implemented on branch `fix/bl229-release-paths`; close on
+merge with the PR number.
+
+### The entry said one site. It is five, and the worst one is not the filed one
+
+| site | symptom | this branch |
+|---|---|---|
+| `scripts/check-phase-gate.sh` | **as filed** — block skipped, prints nothing | **converted** |
+| `scripts/validate.sh` | **false `[FAIL]`** on a HEALTHY project | **converted** |
+| `scripts/verify-install.sh` | two sites: the fixer AND the registration arm | **release path converted; `_ci_dest` and the CI writer are NOT** |
+| `scripts/reconfigure-project.sh` | writes to the GitHub path unconditionally | **NOT converted** — its CI arm is already dead code (it resolves `templates/pipelines/ci/<lang>.yml`, a layout that no longer exists) |
+| `init.sh` | wrote release files **nothing could execute** | **converted** |
+
+`validate.sh` used the same hardcoded paths with `fail`, and `fail` increments
+`errors` while the script ends `exit $errors` — so a correct GitLab project
+FAILED VALIDATION for keeping its files where GitLab puts them. Measured as a
+DELTA rather than absolute exits (the absolutes are fixture-dependent and an
+earlier draft of this entry quoted unreproducible ones): identical projects
+differing only in `.host` produce **exactly one extra `[FAIL]`** on the
+non-GitHub hosts, and it is `[FAIL] CI pipeline missing (.github/workflows/ci.yml)`.
+
+### The one underneath: the release pipeline could not run on two of three hosts
+
+`init.sh` wrote `.gitlab-ci/release.yml` and `bitbucket-pipelines/release.yml`
+and **nothing referenced either**. Fixing only the readers would have made the
+3→4 gate carefully validate a file that could never execute.
+
+- **GitLab** — `include: local` supports a subdirectory file; it was legitimate
+  and merely unwired.
+- **Bitbucket** — reached by `definitions: imports:` with a same-repo path plus
+  an `import:` reference, the imported file declaring `export: true`. Two wiring
+  points, not one.
+
+### Three attempts at the Bitbucket half, and the same defect each time
+
+Recorded in full because the pattern is the lesson, not the fix:
+
+| attempt | mechanism | claimed |
+|---|---|---|
+| 1 | `awk -v` with a multi-line body — BSD awk rejects the newline, so the splice never ran, the `&&` short-circuited, and `rm -f` destroyed the rendered content | "folded" |
+| 2 | `[ -f ]` on a release path that equalled the CI path — existence is not execution | "configured" |
+| 3 | `grep -q "$rel" "$ci"` — a SUBSTRING test, satisfied by a mention in a comment, by a declared-but-never-invoked source, and by a path sitting under a key YAML had already discarded | "wired" |
+
+Each fix verified the previous mechanism and introduced a weaker one. **The
+proof kept measuring text where it needed to measure structure.** Attempt 1 also
+rested on a false premise — that Bitbucket had no same-repo include — which was
+asserted in four places and drove an owner decision before Atlassian's docs
+refuted it.
+
+### What the shipped version does
+
+- **`# BL-229-BITBUCKET-EXPORT-NAME`** — the export file is
+  `.bitbucket/release-pipelines.yml`. Atlassian states the rule twice: *"create
+  a separate file with a `*pipelines.yml` suffix"*. Attempt 3 shipped
+  `bitbucket-pipelines/release.yml`, where the DIRECTORY matched and the
+  filename did not, so Bitbucket would not have loaded it — the same
+  never-executes defect in a new costume. Case `N1` pins the suffix.
+- **`# BL-229-WIRE-RELEASE`** is the single owner of the wiring, with two
+  callers. It **merges into an existing `imports:` block** rather than emitting a
+  rival one (`N2`), because a second `imports:` key makes YAML discard the
+  first — silently taking the release declaration with it.
+- **`# BL-229-WIRE-VERIFY`** is structural, not textual: exactly ONE `imports:`
+  block, the `release:` key anchored beneath it, and the `import:` reference
+  actually present. `N3` pins that a path named only in a comment, and a source
+  declared but never invoked, are both refused.
+- **`custom:` is the reference site, not `tags:`.** Atlassian documents
+  `import:` under `custom:` and `branches:` only; the `tags:` example shows a
+  step list, and the prose *"various start conditions"* is not an enumeration.
+  `branches:` would fire a release on every push, so `custom:` — documented as
+  *"triggered manually or by a schedule"* — is both the documented shape and the
+  right semantics. **Recorded as an inference about a vendor surface**, resolved
+  by choosing the documented option rather than by guessing at the undocumented
+  one.
+- **Existence is not execution, in the readers too**
+  (`# BL-229-GATE-RELEASE-WIRED`, `# BL-229-VALIDATE-RELEASE-WIRED`).
+
+### Proof
+
+`tests/test-bl229-host-pipeline-paths.sh`, 15 cases. The ones that exist because
+of the blocks:
+
+- **W1 EXECUTES the shipped `generate_release`** on all three hosts. Nothing in
+  the PR-blocking set ran the release writer before, which is why attempts 1–3
+  all scored green while broken.
+- **G3** requires the gate to refuse a release file that is present, fully
+  configured, and referenced by nothing.
+- **N1/N2/N3** pin the suffix rule, the merge-not-rival invariant, and the
+  declared-is-not-invoked distinction.
+- **S1** pins that the wiring has ONE owner — it caught a real duplicate in
+  `verify-install.sh` the moment it was written.
+
+Mutations, each `sites==1`, 2 lines changed, `bash -n` clean: **M1** collapses
+the host mapping to the GitHub spelling; **M2** emits the import declaration
+empty. Two further mutants that **survived the previous version at 12/12** now
+die at 13/2 — dropping the `import:` reference while keeping the declaration,
+and emitting a rival `imports:` block.
 
 **The gap, measured on `main` @ `b709576`.** `scripts/check-phase-gate.sh`
 guards the release-TODO check on a literal path:

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9772,9 +9772,13 @@ of the blocks:
 
 Mutations, each `sites==1`, 2 lines changed, `bash -n` clean: **M1** collapses
 the host mapping to the GitHub spelling; **M2** emits the import declaration
-empty. Two further mutants that **survived the previous version at 12/12** now
-die at 13/2 — dropping the `import:` reference while keeping the declaration,
-and emitting a rival `imports:` block.
+empty. Two further mutants that **survived the previous version at 12/12** now die —
+dropping the `import:` reference while keeping the declaration, and emitting a
+rival `imports:` block. **Both at 14 passed / 1 failed, not the 13/2 an earlier
+draft of this entry claimed**; review re-derived it and the draft was wrong.
+Each fails on `N2` alone, which is the right shape: one case, one reason. The
+kills were real; the numbers were not, and this entry is the wrong place to be
+approximate about a tally.
 
 **The gap, measured on `main` @ `b709576`.** `scripts/check-phase-gate.sh`
 guards the release-TODO check on a literal path:

--- a/templates/pipelines/release/bitbucket/desktop.yml
+++ b/templates/pipelines/release/bitbucket/desktop.yml
@@ -1,14 +1,21 @@
 # Bitbucket Pipelines release for desktop (tag-triggered).
 # macOS/Windows require runners with appropriate self-hosted labels.
-pipelines:
-  tags:
-    'v*':
-      - step:
-          name: Build (Linux)
-          image: __SETUP_ACTION__
-          script: [__INSTALL_COMMAND__, __BUILD_COMMAND__]
-          artifacts: [dist/**, target/release/**]
-      - step:
-          name: Sign + Deploy
-          trigger: manual
-          script: [echo "Configure signing (codesign/signtool) and distribution"]
+#
+# EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
+# `definitions: imports:` plus an `import:` reference — it has no transparent
+# `include:` like GitLab — so this file declares `export: true` and puts its
+# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
+# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+export: true
+definitions:
+  pipelines:
+    release-pipeline:
+        - step:
+            name: Build (Linux)
+            image: __SETUP_ACTION__
+            script: [__INSTALL_COMMAND__, __BUILD_COMMAND__]
+            artifacts: [dist/**, target/release/**]
+        - step:
+            name: Sign + Deploy
+            trigger: manual
+            script: [echo "Configure signing (codesign/signtool) and distribution"]

--- a/templates/pipelines/release/bitbucket/desktop.yml
+++ b/templates/pipelines/release/bitbucket/desktop.yml
@@ -1,11 +1,17 @@
-# Bitbucket Pipelines release for desktop (tag-triggered).
+# Bitbucket Pipelines release for desktop (manual / scheduled release).
 # macOS/Windows require runners with appropriate self-hosted labels.
 #
 # EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
 # `definitions: imports:` plus an `import:` reference — it has no transparent
 # `include:` like GitLab — so this file declares `export: true` and puts its
-# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
-# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+# steps under `definitions.pipelines`.
+#
+# TRIGGERED FROM `pipelines.custom.release` in bitbucket-pipelines.yml, NOT from
+# a tag. Atlassian documents `import:` under `custom:` and `branches:` only; the
+# `tags:` case is undocumented for imports, and `branches:` would fire a release
+# on every push. `custom:` is "triggered manually or by a schedule", which is
+# what a release is. Run it from Pipelines > Run pipeline > custom: release.
+# This differs from the GitHub and GitLab templates, which ARE tag-triggered.
 export: true
 definitions:
   pipelines:

--- a/templates/pipelines/release/bitbucket/mcp_server.yml
+++ b/templates/pipelines/release/bitbucket/mcp_server.yml
@@ -1,13 +1,20 @@
 # Bitbucket Pipelines release for MCP server (tag-triggered).
-pipelines:
-  tags:
-    'v*':
-      - step:
-          name: Build
-          image: __SETUP_ACTION__
-          script: [__INSTALL_COMMAND__, __BUILD_COMMAND__]
-          artifacts: [dist/**, build/**]
-      - step:
-          name: Publish
-          trigger: manual
-          script: [echo "Publish to npm/PyPI/crates.io — configure registry token"]
+#
+# EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
+# `definitions: imports:` plus an `import:` reference — it has no transparent
+# `include:` like GitLab — so this file declares `export: true` and puts its
+# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
+# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+export: true
+definitions:
+  pipelines:
+    release-pipeline:
+        - step:
+            name: Build
+            image: __SETUP_ACTION__
+            script: [__INSTALL_COMMAND__, __BUILD_COMMAND__]
+            artifacts: [dist/**, build/**]
+        - step:
+            name: Publish
+            trigger: manual
+            script: [echo "Publish to npm/PyPI/crates.io — configure registry token"]

--- a/templates/pipelines/release/bitbucket/mcp_server.yml
+++ b/templates/pipelines/release/bitbucket/mcp_server.yml
@@ -1,10 +1,16 @@
-# Bitbucket Pipelines release for MCP server (tag-triggered).
+# Bitbucket Pipelines release for MCP server (manual / scheduled release).
 #
 # EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
 # `definitions: imports:` plus an `import:` reference — it has no transparent
 # `include:` like GitLab — so this file declares `export: true` and puts its
-# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
-# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+# steps under `definitions.pipelines`.
+#
+# TRIGGERED FROM `pipelines.custom.release` in bitbucket-pipelines.yml, NOT from
+# a tag. Atlassian documents `import:` under `custom:` and `branches:` only; the
+# `tags:` case is undocumented for imports, and `branches:` would fire a release
+# on every push. `custom:` is "triggered manually or by a schedule", which is
+# what a release is. Run it from Pipelines > Run pipeline > custom: release.
+# This differs from the GitHub and GitLab templates, which ARE tag-triggered.
 export: true
 definitions:
   pipelines:

--- a/templates/pipelines/release/bitbucket/mobile.yml
+++ b/templates/pipelines/release/bitbucket/mobile.yml
@@ -1,14 +1,21 @@
 # Bitbucket Pipelines release for mobile (tag-triggered).
-pipelines:
-  tags:
-    'v*':
-      - step:
-          name: Build Android
-          image: reactnativecommunity/react-native-android:latest
-          script: [__INSTALL_COMMAND__, __BUILD_COMMAND__]
-          artifacts: [android/app/build/outputs/**]
-      - step:
-          name: Deploy
-          deployment: production
-          trigger: manual
-          script: [echo "Play Store / App Store deployment (fastlane recommended)"]
+#
+# EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
+# `definitions: imports:` plus an `import:` reference — it has no transparent
+# `include:` like GitLab — so this file declares `export: true` and puts its
+# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
+# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+export: true
+definitions:
+  pipelines:
+    release-pipeline:
+        - step:
+            name: Build Android
+            image: reactnativecommunity/react-native-android:latest
+            script: [__INSTALL_COMMAND__, __BUILD_COMMAND__]
+            artifacts: [android/app/build/outputs/**]
+        - step:
+            name: Deploy
+            deployment: production
+            trigger: manual
+            script: [echo "Play Store / App Store deployment (fastlane recommended)"]

--- a/templates/pipelines/release/bitbucket/mobile.yml
+++ b/templates/pipelines/release/bitbucket/mobile.yml
@@ -1,10 +1,16 @@
-# Bitbucket Pipelines release for mobile (tag-triggered).
+# Bitbucket Pipelines release for mobile (manual / scheduled release).
 #
 # EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
 # `definitions: imports:` plus an `import:` reference — it has no transparent
 # `include:` like GitLab — so this file declares `export: true` and puts its
-# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
-# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+# steps under `definitions.pipelines`.
+#
+# TRIGGERED FROM `pipelines.custom.release` in bitbucket-pipelines.yml, NOT from
+# a tag. Atlassian documents `import:` under `custom:` and `branches:` only; the
+# `tags:` case is undocumented for imports, and `branches:` would fire a release
+# on every push. `custom:` is "triggered manually or by a schedule", which is
+# what a release is. Run it from Pipelines > Run pipeline > custom: release.
+# This differs from the GitHub and GitLab templates, which ARE tag-triggered.
 export: true
 definitions:
   pipelines:

--- a/templates/pipelines/release/bitbucket/web.yml
+++ b/templates/pipelines/release/bitbucket/web.yml
@@ -1,14 +1,21 @@
 # Bitbucket Pipelines release for web platform (tag-triggered).
+#
+# EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
+# `definitions: imports:` plus an `import:` reference — it has no transparent
+# `include:` like GitLab — so this file declares `export: true` and puts its
+# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
+# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+export: true
 image: node:20
-pipelines:
-  tags:
-    'v*':
-      - step:
-          name: Build Release
-          script: [npm ci, npm run build]
-          artifacts: [dist/**, build/**]
-      - step:
-          name: Deploy
-          deployment: production
-          trigger: manual
-          script: [echo "Configure deploy per hosting target"]
+definitions:
+  pipelines:
+    release-pipeline:
+        - step:
+            name: Build Release
+            script: [npm ci, npm run build]
+            artifacts: [dist/**, build/**]
+        - step:
+            name: Deploy
+            deployment: production
+            trigger: manual
+            script: [echo "Configure deploy per hosting target"]

--- a/templates/pipelines/release/bitbucket/web.yml
+++ b/templates/pipelines/release/bitbucket/web.yml
@@ -1,10 +1,16 @@
-# Bitbucket Pipelines release for web platform (tag-triggered).
+# Bitbucket Pipelines release for web platform (manual / scheduled release).
 #
 # EXPORT FILE (BL-229). Bitbucket reaches a same-repo file through
 # `definitions: imports:` plus an `import:` reference — it has no transparent
 # `include:` like GitLab — so this file declares `export: true` and puts its
-# steps under `definitions.pipelines`. The `tags: 'v*':` start-condition lives
-# in bitbucket-pipelines.yml, next to the import that names this pipeline.
+# steps under `definitions.pipelines`.
+#
+# TRIGGERED FROM `pipelines.custom.release` in bitbucket-pipelines.yml, NOT from
+# a tag. Atlassian documents `import:` under `custom:` and `branches:` only; the
+# `tags:` case is undocumented for imports, and `branches:` would fire a release
+# on every push. `custom:` is "triggered manually or by a schedule", which is
+# what a release is. Run it from Pipelines > Run pipeline > custom: release.
+# This differs from the GitHub and GitLab templates, which ARE tag-triggered.
 export: true
 image: node:20
 definitions:

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2044,6 +2044,9 @@ run_child_suite "tests/test-bl233-mcp-outcome-enforcement.sh" \
 # their fence markers and EXECUTES them, so the assertions land on shipped code.
 run_child_suite "tests/test-bl234-currency-and-availability.sh" \
   "tests/test-bl234-currency-and-availability.sh"
+
+run_child_suite "tests/test-bl229-host-pipeline-paths.sh" \
+  "tests/test-bl229-host-pipeline-paths.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-bl229-host-pipeline-paths.sh
+++ b/tests/test-bl229-host-pipeline-paths.sh
@@ -1,0 +1,502 @@
+#!/usr/bin/env bash
+# tests/test-bl229-host-pipeline-paths.sh
+#
+# BL-229 — the release/CI pipeline paths were HARDCODED to the GitHub spelling
+# in five places, so on GitLab and Bitbucket the checks that read them either
+# said nothing or said something false. One root cause, three distinct symptoms:
+#
+#   1. scripts/check-phase-gate.sh  — `[ -f ".github/workflows/release.yml" ]`
+#      is false on the other two hosts, so the Phase 3→4 release-TODO block is
+#      SKIPPED ENTIRELY and prints nothing. A pipeline full of unconfigured
+#      TODOs passes the gate. Not a wrong answer — a MISSING one that reads
+#      exactly like a clean one.
+#   2. scripts/validate.sh          — the same paths, but with `fail`, and
+#      `fail` increments `errors` while the script ends `exit $errors`. So a
+#      HEALTHY GitLab or Bitbucket project is told
+#      `[FAIL] CI pipeline missing (.github/workflows/ci.yml)` and exits
+#      one higher than the identical GitHub project. A FALSE FAILURE, visible
+#      to the operator, on a project that is correct.
+#   3. scripts/verify-install.sh / scripts/reconfigure-project.sh — the writers.
+#      verify-install refused to auto-fix gitlab/bitbucket on the stated grounds
+#      that "there is no separate release file at repo root", which contradicts
+#      init.sh (it writes one) and is only half true (see below).
+#
+# ── AND THE ONE UNDERNEATH (why fixing the readers alone would be theatre) ──
+# init.sh wrote `.gitlab-ci/release.yml` and `.bitbucket/release-pipelines.yml`
+# and NOTHING INCLUDED EITHER. A comment at the writer claimed "deploy phase is
+# appended to bitbucket-pipelines.yml via include"; no such include existed
+# anywhere in the repo. So on two of three hosts the scaffolded release pipeline
+# was written to disk and never executed, and the Phase 3→4 gate would have been
+# carefully validating a file that could not run.
+#
+# The two hosts are NOT symmetric, and the asymmetry is the design:
+#   • GitLab    — `include: local` genuinely supports a subdirectory file, so
+#                 `.gitlab-ci/release.yml` is legitimate and merely needed
+#                 wiring. Fixed by emitting the include.
+#   • Bitbucket — sharing is CROSS-REPOSITORY only
+#                 (`definitions.imports.<name>: <repo-slug>:<ref>:<path>`, and
+#                 the source file needs `export: true` in the OTHER repo).
+#                 There is no same-repo local include, so a separate release
+#                 file can NEVER execute. Karl's decision: fold the release
+#                 steps into `bitbucket-pipelines.yml` and stop writing the dead
+#                 file. `verify-install.sh` was right about Bitbucket and wrong
+#                 about GitLab; both halves are corrected.
+#
+# THE RESOLVER IS THE POINT. `scripts/lib/host.sh` now owns the mapping ONCE
+# (`# BL-229-HOST-PIPELINE-PATHS`) and every caller asks it. init.sh's own
+# `case "$host"` is replaced by a call, so the sync-sibling trap that
+# `# BL-084-TIER-KEY` exists for is not re-created here. host.sh is already
+# shipped downstream by init.sh's copy list and already sourced by
+# check-phase-gate.sh, so every consumer can reach it in a generated project.
+#
+# Hermetic: temp dirs only, no network, no init.sh invocation. bash 3.2 safe.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+HOSTLIB="$REPO_ROOT/scripts/lib/host.sh"
+GATE="$REPO_ROOT/scripts/check-phase-gate.sh"
+VALIDATE="$REPO_ROOT/scripts/validate.sh"
+
+BASH_BIN="$(command -v bash)"; [ -n "$BASH_BIN" ] || BASH_BIN="/bin/bash"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq is not installed — this suite asserts on manifest state."
+  echo ""
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
+
+# _mutate FILE MARKER REPLACEMENT — excise the one END-OF-LINE-anchored marked
+# line. Delimiter '%' is absent from every marker and replacement here; '&' is
+# escaped because in a sed replacement it means THE WHOLE MATCH.
+_mutate() {
+  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp
+  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  mode="$(_mode_of "$f")"
+  before="$(mktemp)"; cp -p "$f" "$before"
+  sites=$(_sites "$f" "$marker")
+  tmp="$(mktemp)"
+  sed "s%^.*${marker}\$%${safe}%" "$f" > "$tmp" && mv "$tmp" "$f"
+  [ "$mode" != "?" ] && chmod "$mode" "$f" 2>/dev/null
+  changed=$(_changed_lines "$before" "$f")
+  parses=0; bash -n "$f" >/dev/null 2>&1 && parses=1
+  rm -f "$before"
+  printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+# mk_proj <dir> <host> — a project whose manifest names <host> and nothing else.
+mk_proj() {
+  local d="$1" host="$2"
+  mkdir -p "$d/.claude"
+  printf '# CLAUDE.md\n' > "$d/CLAUDE.md"
+  jq -n --arg h "$host" '{host:$h}' > "$d/.claude/manifest.json"
+  # check-phase-gate.sh exits 1 before any gate check if APPROVAL_LOG.md is
+  # absent, so a fixture without one measures the missing fixture, not the gate.
+  printf '# APPROVAL_LOG\n' > "$d/APPROVAL_LOG.md"
+}
+
+# _extract_fn <file> <name> — the SHIPPED function body. Executing a COPY of
+# init.sh's release writer would prove nothing about init.sh; this is the same
+# idiom the BL-234 suite uses for init.sh's Qdrant chain.
+_extract_fn() {
+  awk -v fn="$2" '
+    $0 ~ "^" fn "\\(\\) \\{" { inf = 1 }
+    inf { print }
+    inf && /^}/ && $0 == "}" { exit }
+  ' "$1"
+}
+
+# run_generate_release <projdir> <host> <language> <platform>
+#   Executes init.sh::generate_release inside <projdir>. THIS IS THE R-3 GAP:
+#   before this existed, nothing in the PR-blocking set ran the release writer,
+#   so a mutant that broke the Bitbucket arm outright left both suites at 10/10.
+GR_OUT=""; GR_RC=0
+run_generate_release() {
+  local proj="$1" host="$2" lang="$3" plat="$4"
+  GR_RC=0
+  GR_OUT="$(
+    cd "$proj" || exit 9
+    SCRIPT_DIR="$REPO_ROOT"
+    GIT_HOST="$host"; LANGUAGE="$lang"; PLATFORM="$plat"
+    TRACK="light"; PROJECT_NAME="fixture"
+    # shellcheck disable=SC1090
+    . "$REPO_ROOT/scripts/lib/helpers-core.sh" 2>/dev/null
+    # shellcheck disable=SC1090
+    . "$REPO_ROOT/scripts/lib/host.sh" 2>/dev/null
+    eval "$(_extract_fn "$REPO_ROOT/init.sh" get_release_vars)"
+    eval "$(_extract_fn "$REPO_ROOT/init.sh" generate_release)"
+    generate_release 2>&1
+  )" || GR_RC=$?
+  return 0
+}
+
+echo "=== R — the resolver owns the mapping, once ==="
+
+# ── R1: every supported host resolves to the paths init.sh actually writes,
+# and says whether the release artefact is an executable pipeline in its own
+# right. Asserted as a triple per host, because a caller that gets the path but
+# not the executability re-invents "…but not on Bitbucket" at every site.
+R1="$(newtmp)"
+r1_out="$(
+  # shellcheck disable=SC1090
+  . "$HOSTLIB" 2>/dev/null
+  for h in github gitlab bitbucket; do
+    if host_pipeline_resolve "$h" >/dev/null 2>&1; then
+      printf '%s|%s|%s|%s\n' "$h" "$HOST_CI_PATH" "$HOST_RELEASE_PATH" "$HOST_RELEASE_EXECUTES"
+    else
+      printf '%s|RESOLVE-FAILED||\n' "$h"
+    fi
+  done
+)"
+r1_want="github|.github/workflows/ci.yml|.github/workflows/release.yml|file
+gitlab|.gitlab-ci.yml|.gitlab-ci/release.yml|include
+bitbucket|bitbucket-pipelines.yml|.bitbucket/release-pipelines.yml|import"
+if [ "$r1_out" = "$r1_want" ]; then
+  pass "R1: all three hosts resolve to the paths init.sh writes, each carrying HOW the release artefact runs (file / include / import)"
+else
+  fail_ "R1" "got:
+$r1_out
+want:
+$r1_want"
+fi
+
+# ── R2: an unknown host FAILS CLOSED and names itself. The old init.sh arm
+# silently defaulted to the GitHub path with a warning, which is how a
+# mis-recorded host produced a GitHub-shaped project on another host.
+R2="$(newtmp)"
+r2_rc=0
+r2_err="$(
+  # shellcheck disable=SC1090
+  . "$HOSTLIB" 2>/dev/null
+  host_pipeline_resolve "nosuchhost" 2>&1 >/dev/null
+)" || r2_rc=$?
+if [ "$r2_rc" -ne 0 ] && printf '%s' "$r2_err" | grep -q 'nosuchhost'; then
+  pass "R2: an unknown host is REFUSED (rc=$r2_rc) and named in the message — it does not silently become GitHub"
+else
+  fail_ "R2" "rc=$r2_rc (want non-zero) err='$(printf '%s' "$r2_err" | tr '\n' '|' | cut -c1-200)'"
+fi
+
+# ── R3: with no argument the resolver reads the manifest, so callers inside a
+# project need not know the host. Asserted by CHANGING the manifest and seeing
+# the answer change — not by calling it once and trusting the value.
+R3="$(newtmp)"
+mk_proj "$R3/p" gitlab
+r3_a="$( cd "$R3/p" && . "$HOSTLIB" 2>/dev/null && host_pipeline_resolve >/dev/null 2>&1 && printf '%s' "$HOST_RELEASE_PATH" )"
+jq -n '{host:"github"}' > "$R3/p/.claude/manifest.json"
+r3_b="$( cd "$R3/p" && . "$HOSTLIB" 2>/dev/null && host_pipeline_resolve >/dev/null 2>&1 && printf '%s' "$HOST_RELEASE_PATH" )"
+if [ "$r3_a" = ".gitlab-ci/release.yml" ] && [ "$r3_b" = ".github/workflows/release.yml" ]; then
+  pass "R3: with no argument the resolver reads .claude/manifest.json — flipping the manifest host flips the answer ($r3_a -> $r3_b)"
+else
+  fail_ "R3" "gitlab manifest gave '$r3_a' (want .gitlab-ci/release.yml); github manifest gave '$r3_b' (want .github/workflows/release.yml)"
+fi
+
+echo "=== V — validate.sh stops failing healthy non-GitHub projects ==="
+
+# ── V1: THE REGRESSION THIS FIXES, measured before the fix as:
+#   GitHub    exit 10   [OK]   CI pipeline
+#   GitLab    exit 11   [FAIL] CI pipeline missing (.github/workflows/ci.yml)
+# Three projects, each healthy FOR ITS OWN HOST. The assertion is that no host
+# is told a file is missing when the file its own host uses is present.
+v1_bad=""
+for spec in "github:.github/workflows/ci.yml:.github/workflows/release.yml" \
+            "gitlab:.gitlab-ci.yml:.gitlab-ci/release.yml" \
+            "bitbucket:bitbucket-pipelines.yml:bitbucket-pipelines.yml"; do
+  h="${spec%%:*}"; rest="${spec#*:}"; ci="${rest%%:*}"; rel="${rest#*:}"
+  d="$(newtmp)"; mk_proj "$d/p" "$h"
+  mkdir -p "$d/p/$(dirname "$ci")" "$d/p/$(dirname "$rel")"
+  printf 'pipeline: ci\n' > "$d/p/$ci"
+  printf 'pipeline: release\n' > "$d/p/$rel"
+  out="$( cd "$d/p" && "$BASH_BIN" "$VALIDATE" 2>&1 )"
+  if printf '%s' "$out" | grep -qiE '\[FAIL\].*(CI|Release) pipeline missing'; then
+    v1_bad="$v1_bad $h"
+  fi
+done
+if [ -z "$v1_bad" ]; then
+  pass "V1: a project healthy for its OWN host is never told its pipeline is missing — github, gitlab and bitbucket all clean"
+else
+  fail_ "V1" "these hosts still get a false 'pipeline missing' FAIL:$v1_bad"
+fi
+
+echo "=== G — the Phase 3→4 gate runs on every host, and fails CLOSED ==="
+
+# ── G1: a release pipeline full of TODOs must be CAUGHT on every host. Before
+# the fix the gitlab/bitbucket arms were skipped entirely and printed nothing,
+# which is the `# BL-112-SAST-NOTRUN` doctrine's exact prohibition: "the scanner
+# did not run" must never be spelled the same as "the scanner found nothing".
+g1_bad=""
+for spec in "github:.github/workflows/release.yml" \
+            "gitlab:.gitlab-ci/release.yml" \
+            "bitbucket:.bitbucket/release-pipelines.yml"; do
+  h="${spec%%:*}"; rel="${spec#*:}"
+  d="$(newtmp)"; mk_proj "$d/p" "$h"
+  mkdir -p "$d/p/$(dirname "$rel")"
+  printf 'steps:\n  - echo TODO configure signing\n  - echo TODO deployment secrets\n' > "$d/p/$rel"
+  printf '{"current_phase":3}\n' > "$d/p/.claude/phase-state.json"
+  # WIRE the release file for the hosts that need it, so this case measures TODO
+  # DETECTION rather than tripping G3's wiring check first. An unwired file's
+  # TODOs are moot — that is G3's point, and keeping the two separable is what
+  # makes each failure attributable.
+  case "$h" in
+    gitlab)
+      printf 'stages: [test]\ninclude:\n  - local: /%s\n' "$rel" > "$d/p/.gitlab-ci.yml" ;;
+    bitbucket)
+      printf 'definitions:\n  imports:\n    release: %s\npipelines:\n  tags:\n    %s:\n      import: release-pipeline@release\n' \
+        "$rel" "'v*'" > "$d/p/bitbucket-pipelines.yml" ;;
+  esac
+  out="$( cd "$d/p" && "$BASH_BIN" "$GATE" --gate phase_3_to_4 2>&1 || true )"
+  printf '%s' "$out" | grep -qi 'unconfigured TODO' || g1_bad="$g1_bad $h"
+done
+if [ -z "$g1_bad" ]; then
+  pass "G1: an unconfigured release pipeline is reported on ALL THREE hosts — the gitlab/bitbucket arms no longer skip in silence"
+else
+  fail_ "G1" "TODO-laden release pipeline went unreported on:$g1_bad"
+fi
+
+# ── G2: an ABSENT release pipeline is reported rather than skipped. This is the
+# fail-closed half, and it is what the neighbouring artifact loop in the same
+# script has always done for HANDOFF.md / sbom.json six lines below.
+g2_bad=""
+for h in github gitlab bitbucket; do
+  d="$(newtmp)"; mk_proj "$d/p" "$h"
+  printf '{"current_phase":3}\n' > "$d/p/.claude/phase-state.json"
+  out="$( cd "$d/p" && "$BASH_BIN" "$GATE" --gate phase_3_to_4 2>&1 || true )"
+  printf '%s' "$out" | grep -qi 'release pipeline' || g2_bad="$g2_bad $h"
+done
+if [ -z "$g2_bad" ]; then
+  pass "G2: a MISSING release pipeline is named on all three hosts — absence fails closed instead of reading as clean"
+else
+  fail_ "G2" "absence went unmentioned on:$g2_bad"
+fi
+
+echo "=== S — the scaffolded release pipeline can actually RUN ==="
+
+# ── S1: the wiring has ONE OWNER. W1 proves the wiring WORKS by executing it;
+# this proves it exists in exactly one place, which W1 cannot see. Two callers
+# now need it — init.sh at scaffold time and verify-install.sh as an auto-fix —
+# and a second copy is precisely the drift that produced BL-229 in the first
+# place (five scripts, five hardcoded GitHub paths). Read on EXECUTED LINES
+# only: both files legitimately mention the wiring in comments.
+s1_owner=$(_num "$(grep -c 'host_wire_release()' "$REPO_ROOT/scripts/lib/host.sh" 2>/dev/null)")
+s1_dupes=0
+for f in "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts/verify-install.sh"; do
+  n=$(sed -e 's/[[:space:]]*#.*$//' "$f" 2>/dev/null \
+      | grep -cE "printf '.*imports:|printf '.*include:|sed .*/\^definitions:")
+  s1_dupes=$((s1_dupes + $(_num "$n")))
+done
+if [ "$s1_owner" -eq 1 ] && [ "$s1_dupes" -eq 0 ]; then
+  pass "S1: host_wire_release is the single owner of the wiring — no caller emits its own include:/imports: fragment. W1 proves it works; this proves there is only one of it"
+else
+  fail_ "S1" "owners=$s1_owner (want 1) caller-side wiring emissions=$s1_dupes (want 0) — a second copy of the wiring is the drift this entry exists to remove"
+fi
+
+# ── S3: the false comment. verify-install.sh asserted there is "no separate
+# release file" for BOTH gitlab and bitbucket. That is true for bitbucket and
+# false for gitlab, and it contradicted init.sh. A wrong reason in a comment is
+# how the next reader re-derives the wrong fix.
+# EXECUTED LINES ONLY (the BL-181 predicate): this file now CITES the old
+# `bitbucket|gitlab)` arm in a comment explaining why it was split, and a naive
+# grep counts that citation as the defect. Strip whole-line and trailing
+# comments before matching, or the fix can never satisfy its own test.
+s3_hits=$(sed -e 's/[[:space:]]*#.*$//' "$REPO_ROOT/scripts/verify-install.sh" 2>/dev/null \
+          | grep -c 'bitbucket|gitlab)')
+if [ "$(_num "$s3_hits")" -eq 0 ]; then
+  pass "S3: verify-install.sh no longer lumps gitlab in with bitbucket — the auto-fix path is restored for the host that supports it"
+else
+  fail_ "S3" "verify-install.sh still refuses gitlab and bitbucket together on a premise that is only true of bitbucket"
+fi
+
+echo "=== W — the release writer is EXECUTED, not merely inspected ==="
+
+# ── W1: THE GAP THAT LET TWO BLOCKERS THROUGH. Nothing in the PR-blocking set
+# ran init.sh::generate_release, so an arm that produced NOTHING scored 10/10.
+# This runs the shipped writer per host and asserts on the artefacts it leaves:
+# the release steps exist, the CI file still has its own content, and — for the
+# two hosts whose release file is inert without wiring — the CI file REFERENCES
+# the release file. Existence was never the property that mattered.
+w1_bad=""
+for spec in "github:.github/workflows/ci.yml:.github/workflows/release.yml:" \
+            "gitlab:.gitlab-ci.yml:.gitlab-ci/release.yml:include" \
+            "bitbucket:bitbucket-pipelines.yml:.bitbucket/release-pipelines.yml:import"; do
+  h="${spec%%:*}"; r1="${spec#*:}"; ci="${r1%%:*}"; r2="${r1#*:}"; rel="${r2%%:*}"; how="${r2#*:}"
+  d="$(newtmp)"; mkdir -p "$d/p"
+  # a CI file shaped like the one init.sh lays down for this host
+  mkdir -p "$d/p/$(dirname "$ci")"
+  cp "$REPO_ROOT/templates/pipelines/ci/$h/typescript.yml" "$d/p/$ci" 2>/dev/null \
+    || printf 'pipelines:\n  default:\n    - step: {script: [echo ci]}\n' > "$d/p/$ci"
+  ci_before="$(wc -c < "$d/p/$ci" | tr -d ' ')"
+  run_generate_release "$d/p" "$h" typescript web
+  if [ ! -s "$d/p/$rel" ]; then
+    w1_bad="$w1_bad ${h}(no-release-artefact)"
+    continue
+  fi
+  ci_after="$(wc -c < "$d/p/$ci" | tr -d ' ')"
+  if [ "$ci_after" -lt "$ci_before" ]; then
+    w1_bad="$w1_bad ${h}(ci-file-shrank:${ci_before}->${ci_after})"
+  fi
+  if [ -n "$how" ]; then
+    # the release file is INERT unless the CI file points at it
+    grep -q "$(basename "$rel")" "$d/p/$ci" 2>/dev/null \
+      || w1_bad="$w1_bad ${h}(release-file-not-wired-into-$ci)"
+  fi
+done
+if [ -z "$w1_bad" ]; then
+  pass "W1: the SHIPPED generate_release runs on all three hosts — each leaves a non-empty release artefact, none shrinks the CI file it was given, and both wiring hosts leave the CI file REFERENCING the release file. A release artefact nothing points at is the defect this whole entry is about"
+else
+  fail_ "W1" "executing the shipped writer left these wrong:$w1_bad"
+fi
+
+echo "=== G3 — a release file nothing executes is not a release pipeline ==="
+
+# ── G3: the deepest form of BL-229. A release file can exist and still never
+# run — that is precisely what init.sh shipped for two hosts. Existence-only
+# checks call that configured; the gate must not.
+g3_bad=""
+for spec in "gitlab:.gitlab-ci.yml:.gitlab-ci/release.yml" \
+            "bitbucket:bitbucket-pipelines.yml:.bitbucket/release-pipelines.yml"; do
+  h="${spec%%:*}"; r1="${spec#*:}"; ci="${r1%%:*}"; rel="${r1#*:}"
+  d="$(newtmp)"; mk_proj "$d/p" "$h"
+  printf '{"current_phase":3}\n' > "$d/p/.claude/phase-state.json"
+  mkdir -p "$d/p/$(dirname "$ci")" "$d/p/$(dirname "$rel")"
+  printf 'pipelines:\n  default:\n    - step: {script: [echo ci]}\n' > "$d/p/$ci"
+  printf 'steps:\n  - echo release\n' > "$d/p/$rel"        # present, fully configured, and UNREFERENCED
+  out="$( cd "$d/p" && "$BASH_BIN" "$GATE" --gate phase_3_to_4 2>&1 || true )"
+  printf '%s' "$out" | grep -qi 'not wired\|never run\|not referenced\|unwired' \
+    || g3_bad="$g3_bad ${h}"
+done
+if [ -z "$g3_bad" ]; then
+  pass "G3: a release file that EXISTS but is referenced by nothing is reported on both wiring hosts — the gate stops accepting an artefact it has no reason to believe ever executes"
+else
+  fail_ "G3" "an unwired release file was accepted as configured on:$g3_bad"
+fi
+
+# ── N1: the export file's NAME is part of whether Bitbucket loads it at all.
+# Atlassian states it twice: "create a separate file with a *pipelines.yml
+# suffix". A file called release.yml in a directory called bitbucket-pipelines
+# does NOT satisfy that — the directory is not the filename — and the first
+# version of this fix shipped exactly that. A path the host will not read is the
+# same defect as a path nothing references.
+n1_rel="$( . "$HOSTLIB" 2>/dev/null; host_pipeline_resolve bitbucket >/dev/null 2>&1 && printf '%s' "$HOST_RELEASE_PATH" )"
+case "$(basename "$n1_rel")" in
+  *pipelines.yml)
+    pass "N1: the Bitbucket export file is named '$(basename "$n1_rel")' — it ends in 'pipelines.yml', which Atlassian requires before it will load the file at all" ;;
+  *)
+    fail_ "N1" "export file basename '$(basename "$n1_rel")' does not end in 'pipelines.yml'; Bitbucket will not load it, so the release pipeline cannot run" ;;
+esac
+
+# ── N2: a CI file that ALREADY declares imports (brownfield adoption, or any
+# repo already using YAML sharing — the population most likely to be on
+# Bitbucket at all). The previous wiring emitted a SECOND `imports:` key here;
+# YAML keeps the last, so the release declaration was silently discarded — and
+# the substring check passed anyway, because the path string was sitting in the
+# file under a shadowed key. Asserted on STRUCTURE.
+N2="$(newtmp)"; mkdir -p "$N2/p"
+printf 'definitions:\n  imports:\n    other: .bitbucket/other-pipelines.yml\npipelines:\n  default:\n    - step: {script: [echo ci]}\n' \
+  > "$N2/p/bitbucket-pipelines.yml"
+n2_rc=0
+( cd "$N2/p" && . "$HOSTLIB" 2>/dev/null && host_wire_release bitbucket-pipelines.yml .bitbucket/release-pipelines.yml import ) || n2_rc=$?
+n2_blocks=$(_num "$(grep -c '^  imports:$' "$N2/p/bitbucket-pipelines.yml" 2>/dev/null)")
+n2_other=no; grep -q '^    other: ' "$N2/p/bitbucket-pipelines.yml" && n2_other=yes
+n2_rel=no;   grep -q '^    release: ' "$N2/p/bitbucket-pipelines.yml" && n2_rel=yes
+if [ "$n2_rc" -eq 0 ] && [ "$n2_blocks" -eq 1 ] && [ "$n2_other" = "yes" ] && [ "$n2_rel" = "yes" ]; then
+  pass "N2: wiring MERGES into a pre-existing imports: block — one block ($n2_blocks), the project's own 'other' source preserved, and 'release' declared alongside it. Emitting a rival block let YAML discard the wiring while the check still passed"
+else
+  fail_ "N2" "rc=$n2_rc (want 0) imports-blocks=$n2_blocks (want 1) other-preserved=$n2_other (want yes) release-declared=$n2_rel (want yes)"
+fi
+
+# ── N3: DECLARED IS NOT INVOKED. An import source that nothing references never
+# runs — this is the reviewer's MUT-E, which survived a full 12/12 because the
+# old check only looked for the path string.
+N3="$(newtmp)"; mkdir -p "$N3/p"
+printf 'definitions:\n  imports:\n    release: .bitbucket/release-pipelines.yml\npipelines:\n  default:\n    - step: {script: [echo ci]}\n' \
+  > "$N3/p/bitbucket-pipelines.yml"
+n3_rc=0
+( cd "$N3/p" && . "$HOSTLIB" 2>/dev/null && _hwr_verify bitbucket-pipelines.yml .bitbucket/release-pipelines.yml import ) || n3_rc=$?
+# and a path named only in a COMMENT must not count either
+N3b="$(newtmp)"; mkdir -p "$N3b/p"
+printf '# TODO wire .bitbucket/release-pipelines.yml one day\npipelines:\n  default:\n    - step: {script: [echo ci]}\n' \
+  > "$N3b/p/bitbucket-pipelines.yml"
+n3b_rc=0
+( cd "$N3b/p" && . "$HOSTLIB" 2>/dev/null && _hwr_verify bitbucket-pipelines.yml .bitbucket/release-pipelines.yml import ) || n3b_rc=$?
+if [ "$n3_rc" -ne 0 ] && [ "$n3b_rc" -ne 0 ]; then
+  pass "N3: the wiring check refuses a source that is DECLARED but never invoked (rc $n3_rc) and one named only in a COMMENT (rc $n3b_rc) — it reads structure, not a substring. Both passed the previous check"
+else
+  fail_ "N3" "declared-not-invoked rc=$n3_rc (want non-zero) comment-only rc=$n3b_rc (want non-zero) — the predicate is still satisfiable without a working reference"
+fi
+
+echo "=== M — mutation proofs (sites==1, N lines changed, bash -n, fresh fixture) ==="
+
+# ── M1: the resolver's mapping is load-bearing for the gate. Neuter it and the
+# gitlab arm must go back to silence.
+M1="$(newtmp)"
+cp -R "$REPO_ROOT/scripts" "$M1/scripts" 2>/dev/null
+# Target the GitLab arm's release-path line, NOT the `case` line: replacing the
+# `case` orphans its arms and the mutant lands as a SYNTAX ERROR, which kills
+# every case for the wrong reason and would score as a kill. Measured on the
+# first draft of this suite: parses=0. This mutant stays valid bash and is
+# behaviourally decisive.
+m1_meta=$(_mutate "$M1/scripts/lib/host.sh" '# BL-229-HOST-PIPELINE-GITLAB' '      HOST_RELEASE_PATH=".github/workflows/release.yml"')
+m1_sites="${m1_meta%% *}"; m1_rest="${m1_meta#* }"; m1_changed="${m1_rest%% *}"; m1_parses="${m1_rest##* }"
+d="$(newtmp)"; mk_proj "$d/p" gitlab
+mkdir -p "$d/p/.gitlab-ci"
+printf 'steps:\n  - echo TODO configure signing\n' > "$d/p/.gitlab-ci/release.yml"
+printf '{"current_phase":3}\n' > "$d/p/.claude/phase-state.json"
+m1_out="$( cd "$d/p" && "$BASH_BIN" "$M1/scripts/check-phase-gate.sh" --gate phase_3_to_4 2>&1 || true )"
+m1_caught=no; printf '%s' "$m1_out" | grep -qi 'unconfigured TODO' && m1_caught=yes
+if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_caught" = "no" ]; then
+  pass "M1: with the host mapping collapsed to the GitHub spelling, a TODO-laden GitLab release pipeline goes UNREPORTED again — G1 is load-bearing (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
+else
+  fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed caught=$m1_caught (want no)"
+fi
+
+# ── M2: THE MUTANT THAT SURVIVED THE WHOLE PR-BLOCKING SET. Adversarial review
+# broke the Bitbucket release arm outright and both suites still reported 10/10,
+# because nothing executed the writer. W1 exists to kill exactly this. Here the
+# import declaration is emitted EMPTY, so the release file is written and never
+# referenced — the shipped-broken state, reproduced deliberately.
+M2="$(newtmp)"; cp -R "$REPO_ROOT" "$M2/repo" 2>/dev/null
+m2_meta=$(_mutate "$M2/repo/scripts/lib/host.sh" '# BL-229-IMPORT-WIRE' '      : > "$frag"')
+m2_sites="${m2_meta%% *}"; m2_rest="${m2_meta#* }"; m2_changed="${m2_rest%% *}"; m2_parses="${m2_rest##* }"
+m2_d="$(newtmp)"; mkdir -p "$m2_d/p"
+cp "$REPO_ROOT/templates/pipelines/ci/bitbucket/typescript.yml" "$m2_d/p/bitbucket-pipelines.yml"
+m2_out="$(
+  cd "$m2_d/p" || exit 9
+  SCRIPT_DIR="$M2/repo"
+  GIT_HOST=bitbucket; LANGUAGE=typescript; PLATFORM=web; TRACK=light; PROJECT_NAME=fixture
+  # shellcheck disable=SC1090
+  . "$M2/repo/scripts/lib/helpers-core.sh" 2>/dev/null
+  # shellcheck disable=SC1090
+  . "$M2/repo/scripts/lib/host.sh" 2>/dev/null
+  eval "$(_extract_fn "$M2/repo/init.sh" get_release_vars)"
+  eval "$(_extract_fn "$M2/repo/init.sh" generate_release)"
+  generate_release 2>&1
+)"
+m2_wired=yes
+grep -q '.bitbucket/release-pipelines.yml' "$m2_d/p/bitbucket-pipelines.yml" 2>/dev/null || m2_wired=no
+m2_warned=no
+printf '%s' "$m2_out" | grep -qi 'could not wire' && m2_warned=yes
+if [ "$m2_sites" -eq 1 ] && [ "$m2_parses" -eq 1 ] && [ "$m2_wired" = "no" ] && [ "$m2_warned" = "yes" ]; then
+  pass "M2: with the import declaration emitted empty, the release file lands UNWIRED — and the writer says so ('Could NOT wire') instead of reporting success. Both halves matter: W1 catches the broken state, and the scaffolder refuses to claim a write it did not make (sites=$m2_sites changed=$m2_changed parses=$m2_parses)"
+else
+  fail_ "M2" "sites=$m2_sites (want 1) parses=$m2_parses (want 1) changed=$m2_changed wired=$m2_wired (want no) warned=$m2_warned (want yes) — if wired=no but warned=no, the scaffolder is silently shipping an inert release pipeline, which is the exact defect this entry was blocked on"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl229-host-pipeline-paths.sh
+++ b/tests/test-bl229-host-pipeline-paths.sh
@@ -488,10 +488,32 @@ pipelines:
     release:
       import: release-pipeline@release
 '
-if [ -z "$g4_bad" ]; then
-  pass "G4: the gate refuses all three inert shapes its old private grep blessed — a path named only in a COMMENT, a source DECLARED but never invoked, and a declaration SHADOWED by a rival imports: block. It asks the same predicate the writer does, so the two cannot disagree"
+# 4. THE POSITIVE COUNTERPART. Without it G4 is a pure absence assertion and its
+#    canary is unpinned: rename the gate's success message and all three rows
+#    above pass for the wrong reason simultaneously. Review proved that mutant
+#    (rename the [OK] string) survived 16/16. This row is what kills it — and it
+#    is the same shape as this whole entry's lesson, one level up: the check
+#    that guards the fix was itself asserted on one side only.
+g4_pos=no
+_g4_wired="$(newtmp)"; mk_proj "$_g4_wired/p" bitbucket
+printf '{"current_phase":3}\n' > "$_g4_wired/p/.claude/phase-state.json"
+mkdir -p "$_g4_wired/p/.bitbucket"
+printf 'steps:\n  - echo release\n' > "$_g4_wired/p/.bitbucket/release-pipelines.yml"
+printf 'definitions:
+  imports:
+    release: .bitbucket/release-pipelines.yml
+pipelines:
+  custom:
+    release:
+      import: release-pipeline@release
+' > "$_g4_wired/p/bitbucket-pipelines.yml"
+g4_pos_out="$( cd "$_g4_wired/p" && "$BASH_BIN" "$GATE" --gate phase_3_to_4 2>&1 || true )"
+printf '%s' "$g4_pos_out" | grep -qi 'Release pipeline configured' && g4_pos=yes
+
+if [ -z "$g4_bad" ] && [ "$g4_pos" = "yes" ]; then
+  pass "G4: the gate refuses all three inert shapes its old private grep blessed — a path named only in a COMMENT, a source DECLARED but never invoked, and a declaration SHADOWED by a rival imports: block. AND it still reports a correctly-wired project as configured, so the negative rows cannot go vacuous by a message rename. It asks the same predicate the writer does, so the two cannot disagree"
 else
-  fail_ "G4" "the gate still reports 'configured' for:$g4_bad — it is re-deriving the answer instead of asking # BL-229-WIRE-VERIFY"
+  fail_ "G4" "inert shapes still reported configured:${g4_bad:- none} | correctly-wired project reported configured: $g4_pos (want yes) — if the negatives pass but the positive does not, the canary string moved and all three negative rows are now vacuous"
 fi
 
 echo "=== M — mutation proofs (sites==1, N lines changed, bash -n, fresh fixture) ==="

--- a/tests/test-bl229-host-pipeline-paths.sh
+++ b/tests/test-bl229-host-pipeline-paths.sh
@@ -440,6 +440,60 @@ else
   fail_ "N3" "declared-not-invoked rc=$n3_rc (want non-zero) comment-only rc=$n3b_rc (want non-zero) — the predicate is still satisfiable without a working reference"
 fi
 
+# ── G4: THE READERS MUST ASK THE SHARED PREDICATE, NOT RE-DERIVE IT. Review
+# found `_hwr_verify` wired into the WRITER only, while both readers kept a
+# private `grep -q "$path" "$ci"` — so the Phase 3→4 gate, the thing that
+# actually blocks a release, blessed all three inert states the writer's own
+# verifier rejected. Two predicates for one question, disagreeing, inside the
+# entry whose thesis is single ownership. These are those three states.
+g4_bad=""
+# Each shape is written EXPLICITLY. A shared "append the reference" step made the
+# declared-never-invoked row genuinely wired, and the case then failed for the
+# right reason against the wrong fixture — caught on the first run.
+_g4_case() {   # <label> <ci-content>
+  local label="$1" content="$2" d out
+  d="$(newtmp)"; mk_proj "$d/p" bitbucket
+  printf '{"current_phase":3}\n' > "$d/p/.claude/phase-state.json"
+  mkdir -p "$d/p/.bitbucket"
+  printf 'steps:\n  - echo release\n' > "$d/p/.bitbucket/release-pipelines.yml"
+  printf '%s' "$content" > "$d/p/bitbucket-pipelines.yml"
+  out="$( cd "$d/p" && "$BASH_BIN" "$GATE" --gate phase_3_to_4 2>&1 || true )"
+  printf '%s' "$out" | grep -qi 'Release pipeline configured' && g4_bad="$g4_bad $label"
+  return 0
+}
+
+# 1. the path appears ONLY in a comment
+_g4_case comment '# TODO wire .bitbucket/release-pipelines.yml one day
+pipelines:
+  default:
+    - step: {script: [echo ci]}
+'
+# 2. DECLARED as an import source, never invoked by any pipeline
+_g4_case declared 'definitions:
+  imports:
+    release: .bitbucket/release-pipelines.yml
+pipelines:
+  default:
+    - step: {script: [echo ci]}
+'
+# 3. declaration SHADOWED — two imports: blocks, YAML keeps the last, so the
+#    release source is discarded while the reference still points at it
+_g4_case shadowed 'definitions:
+  imports:
+    release: .bitbucket/release-pipelines.yml
+  imports:
+    other: .bitbucket/other-pipelines.yml
+pipelines:
+  custom:
+    release:
+      import: release-pipeline@release
+'
+if [ -z "$g4_bad" ]; then
+  pass "G4: the gate refuses all three inert shapes its old private grep blessed — a path named only in a COMMENT, a source DECLARED but never invoked, and a declaration SHADOWED by a rival imports: block. It asks the same predicate the writer does, so the two cannot disagree"
+else
+  fail_ "G4" "the gate still reports 'configured' for:$g4_bad — it is re-deriving the answer instead of asking # BL-229-WIRE-VERIFY"
+fi
+
 echo "=== M — mutation proofs (sites==1, N lines changed, bash -n, fresh fixture) ==="
 
 # ── M1: the resolver's mapping is load-bearing for the gate. Neuter it and the

--- a/tests/test-bl229-host-pipeline-paths.sh
+++ b/tests/test-bl229-host-pipeline-paths.sh
@@ -322,6 +322,38 @@ else
   fail_ "S3" "verify-install.sh still refuses gitlab and bitbucket together on a premise that is only true of bitbucket"
 fi
 
+# ── T1: ABSENCE IS REPORTED ALWAYS, BUT BLOCKS ONLY WHERE THE TIER EXPECTS A
+# RELEASE PIPELINE. Silence was the filed defect; blocking was never asked for.
+# An earlier version of this branch made absence block on every host, which
+# imposed a new gate condition and broke 13 assertions across three suites whose
+# fixtures are light-track personal projects — a legitimate shape, not a
+# finding. Same predicate as `# BL-084-TIER-KEY`.
+t1_bad=""
+for spec in "personal:null:info" "organizational:null:block" "personal:sponsored_poc:block"; do
+  dep="${spec%%:*}"; r="${spec#*:}"; poc="${r%%:*}"; want="${r#*:}"
+  d="$(newtmp)"; mk_proj "$d/p" github
+  # `null` is a JSON literal; anything else must be QUOTED. Writing
+  # "poc_mode":sponsored_poc unquoted produced invalid JSON, the reader saw no
+  # poc_mode at all, and the case failed against its own broken fixture.
+  if [ "$poc" = "null" ]; then _t1_poc="null"; else _t1_poc="\"$poc\""; fi
+  printf '{"current_phase":3,"track":"light","deployment":"%s","poc_mode":%s}\n' "$dep" "$_t1_poc" \
+    > "$d/p/.claude/phase-state.json"
+  # NO release pipeline anywhere — that is the condition under test
+  rc=0
+  out="$( cd "$d/p" && "$BASH_BIN" "$GATE" --gate phase_3_to_4 2>&1 )" || rc=$?
+  said=no; printf '%s' "$out" | grep -qi 'release pipeline' && said=yes
+  blocked=no; printf '%s' "$out" | grep -qiE '\[WARN\].*release pipeline (not found|NOT CHECKED)' && blocked=yes
+  # reporting is unconditional; blocking is not
+  [ "$said" = "yes" ] || t1_bad="$t1_bad ${dep}/${poc}(silent)"
+  [ "$blocked" = "$( [ "$want" = "block" ] && echo yes || echo no )" ] \
+    || t1_bad="$t1_bad ${dep}/${poc}(blocked=$blocked want=$want)"
+done
+if [ -z "$t1_bad" ]; then
+  pass "T1: a missing release pipeline is REPORTED at every tier — never silent, which was the filed defect — but blocks only where the tier expects one (organizational, or sponsored_poc). A light-track personal project with no release pipeline is a legitimate shape"
+else
+  fail_ "T1" "tier handling wrong for:$t1_bad"
+fi
+
 echo "=== W — the release writer is EXECUTED, not merely inspected ==="
 
 # ── W1: THE GAP THAT LET TWO BLOCKERS THROUGH. Nothing in the PR-blocking set


### PR DESCRIPTION
The Phase 3→4 release check hardcoded the GitHub pipeline path, so on GitLab and Bitbucket it silently never fired. That was the filed defect. It turned out to be five sites, three distinct symptoms, and a scaffolding problem underneath that made the whole thing moot on two of three hosts.

**Five review rounds. Three of them blocked. The rounds are the useful part of this PR, and they are recorded in the entry rather than tidied away.**

## The filed defect, and the one that wasn't filed

| site | symptom |
|---|---|
| `check-phase-gate.sh` | **as filed** — block skipped, prints nothing |
| `validate.sh` | **false `[FAIL]` on a HEALTHY project** — not filed, and louder |

`validate.sh` used the same hardcoded paths with `fail`, and `fail` increments `errors` while the script ends `exit $errors`. So a correct GitLab project **failed validation** for keeping its files where GitLab puts them. Quoted as a delta, not absolute exits: identical projects differing only in `.host` produce exactly one extra `[FAIL] CI pipeline missing (.github/workflows/ci.yml)`.

## The one underneath

`init.sh` wrote `.gitlab-ci/release.yml` and `bitbucket-pipelines/release.yml` and **nothing referenced either**. Fixing only the readers would have made the gate carefully validate a file that could never execute.

- **GitLab** — `include: local` supports a subdirectory file; legitimate, merely unwired.
- **Bitbucket** — reached by `definitions: imports:` with a same-repo path plus an `import:` reference, the imported file declaring `export: true`.

## Three attempts at the Bitbucket half, and the same defect each time

| attempt | mechanism | claimed |
|---|---|---|
| 1 | `awk -v` with a multi-line body — BSD awk rejects the newline, the splice never ran, `&&` short-circuited, `rm -f` destroyed the rendered content | "folded" |
| 2 | `[ -f ]` on a release path that **equalled** the CI path — existence is not execution | "configured" |
| 3 | `grep -q` — a substring test, satisfied by a comment, by a declared-never-invoked source, and by a declaration YAML had already discarded | "wired" |

Attempt 1 also rested on a **false premise** — that Bitbucket has no same-repo include — asserted in four places, which drove an owner decision before Atlassian's docs refuted it.

## The recurring failure, named once

The mechanism was never the problem. **Rigour stopped one layer short of where the answer is consumed**, every round:

| round | rigour applied at | answer consumed at | result |
|---|---|---|---|
| 1 | the splice | the operator's project | reported a merge it never made |
| 2 | the file's existence | the release gate | "configured" over zero release steps |
| 3 | the writer's verifier | the gate's own grep | gate blessed what the writer refused |
| 4 | G4's negative rows | the canary string they depend on | a rename would make all three vacuous |

The structural answer is a **shared predicate** plus a **three-state contract** — `0` wired / `1` not wired / `2` **cannot tell**, callers failing closed on 2 while saying something different. `BL-213` forced the same distinction on the cadence checker; this is the second surface to need it.

## What ships

- **`host_pipeline_resolve`** — one owner of the mapping, returning the CI path, the release path, and **how the release steps reach the runner** (`file` / `include` / `import`). Unknown host fails closed and names itself.
- **`host_wire_release`** — one owner of the wiring, two callers. **Merges** into an existing `imports:` block rather than emitting a rival one that YAML silently discards.
- **`_hwr_verify`** — structural, not textual: exactly one `imports:` block, an anchored `release:` key beneath it, an anchored `import:` reference. CRLF-tolerant, because a Windows checkout is a healthy project.
- **`.bitbucket/release-pipelines.yml`** — Atlassian states the `*pipelines.yml` suffix rule twice; the previous filename had the directory matching and the filename not, so Bitbucket would not have loaded it.
- **`custom:`, not `tags:`** — documented with `import:`; `branches:` would fire a release on every push. Resolved by choosing the documented option rather than guessing at the undocumented one.
- **`cut-release.sh` is host-aware** — it printed *"Your release pipeline fires on the tag push"*, false on Bitbucket. A framework claiming something ran when it did not is this entry's whole subject.

## Proof — 16 cases

- **W1 EXECUTES the shipped `generate_release`** on all three hosts. Nothing in the PR-blocking set ran the writer before, which is why all three attempts scored green while broken.
- **G3** requires the gate to refuse a release file referenced by nothing.
- **G4** pins that the readers ask the shared predicate, across all three inert shapes — **and its positive counterpart**, so a message rename cannot make the negative rows vacuous.
- **N1/N2/N3** pin the suffix rule, merge-not-rival, and declared-is-not-invoked.
- **S1** pins single ownership; it caught a real duplicate the moment it was written.

Mutants that **survived earlier rounds and now die**: drop the `import:` reference (14/1), emit a rival `imports:` block (14/1), revert both readers to their old grep (15/1), rename the gate's success string (15/1).

## Deliberately not done, and said so

`verify-install.sh`'s `_ci_dest` and CI writer, `reconfigure-project.sh` (its CI arm is dead code — it resolves a template layout that no longer exists), `validate.sh`'s Competency-Matrix guard, `check-updates.sh`, `check-gate.sh`. All six named in `host.sh` with the recipe that derives them, because an earlier version of that comment claimed there were no siblings and that was untrue.

## One unexplained observation

A single run of `test-delta-wp7-cut-release.sh` reported **36/1** during a batch alongside the lint sweep. Not reproduced in 7 subsequent runs (4 on branch, 3 on main), so not attributable to this change. Named because this PR modifies `cut-release.sh` and that suite exercises it 37 times.

## Verification

suite **16/16** · lints **15/15** · wp7-cut-release **37/0** (×4) · walk016 **15/0** · bl147 **84/0** · check-phase-gate **8/0** · freshness **26/0** · wp6-cadence **33/0**

Branch rebuilt clean off `main`: 14 files, no BL-222 (that is PR #353), no session telemetry.
