### PR TITLE
fix(bl221,bl235): the tier predicate failed open, and the tool matrix asked a config file whether a tool worked

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -590,6 +590,34 @@ jobs:
             #    lint-scan measures 97s TOTAL — the three figures above it
             #    pre-date BL-191 and overstate it by roughly 3x.
             tests/test-brownfield-wp2-scout-sections.sh  # 108.5s in CI
+            # ── Pinned 2026-08-17 with BL-235. Landed here on the same
+            #    reasoning as the line above: this leg measured 97s TOTAL at its
+            #    last real measurement (~206s if the three stale pre-BL-191
+            #    figures above are believed), against `rest` at ~561s/720s
+            #    (78%) — a leg that was CANCELLED at the cap on PR #351 two days
+            #    before this, which per the walk006 note replaces a readable red
+            #    with nothing.
+            #    THE FIGURE BELOW IS A LOCAL MEASUREMENT, NOT CI TIME, and this
+            #    file's own doctrine says the pin is keyed to measured CI time —
+            #    so it is stated with its method rather than dressed up:
+            #      38s, 39s, 40s across three local runs, of which ~18s is
+            #      WALL-CLOCK SLEEP (T1/T2/T2b bounded at 2s; M1/M8 running a 6s
+            #      command unbounded to prove the bound is load-bearing) that
+            #      does NOT inflate on a slower runner, plus ~21s CPU-bound. At
+            #      the ~1.6x local->CI ratio recorded for wp5b/wp6 above, that
+            #      is ~18 + 34 = ~52s, which would take `rest` from 561s to
+            #      ~85% of the cap if left unpinned.
+            #    RE-MEASURE ON CI AND CORRECT THIS LINE. An estimate is enough
+            #    to justify moving a suite OUT of a leg with a cancellation
+            #    history; it is not enough to leave in the file as though it
+            #    were data, which is what the stale figures above this array
+            #    became.
+            tests/test-bl235-tool-matrix-probes.sh       # ~52s ESTIMATED CI (38-40s local, ~18s of it sleep) — re-measure
+            #    The BL-221 suite that landed alongside this one is NOT pinned
+            #    and is deliberately not named as a path here: it measures under
+            #    a second, pinning it would buy nothing, and a commented path
+            #    inside an array is the shape this file warns about two arrays
+            #    up. It stays in the computed complement.
           )
           pin_sast=(
             tests/test-bl132-sast-index-scan.sh        #  77s on main, 213s on PR #278 — pinned at the worst case

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -521,6 +521,7 @@ jobs:
             tests/test-bl222-security-clock-evidence.sh
             tests/test-bl229-host-pipeline-paths.sh
             tests/test-bl221-tier-fail-closed.sh
+            tests/test-bl235-tool-matrix-probes.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -520,6 +520,7 @@ jobs:
             tests/test-bl234-currency-and-availability.sh
             tests/test-bl222-security-clock-evidence.sh
             tests/test-bl229-host-pipeline-paths.sh
+            tests/test-bl221-tier-fail-closed.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -46,7 +46,8 @@ state-of-record is kept at top level rather than archived — as now — and in 
 case CLAUDE.md's "trust the non-stub" tie-break cannot resolve it: **use the
 newer date.**
 
-- **Live:** [handoffs/2026-08-15-currency-and-enforcement-wave.md](handoffs/2026-08-15-currency-and-enforcement-wave.md) — the current state-of-record (`main` at `a49ceaf`; #341–#351 shipped and merged; `## BL-234:` Closed; next is `## BL-222:` + `## BL-229:`, the Phase 3→4 release gate). Its § 10 is a paste-ready resume prompt, and its § 4.0 carries a ⚠ CORRECTION — read that before acting on the section.
+- **Live:** [handoffs/2026-08-16-declaration-vs-capability-wave.md](handoffs/2026-08-16-declaration-vs-capability-wave.md) — the current state-of-record (`main` at `86ceeb8`; #351–#355 merged; `## BL-234:`, `## BL-222:`, `## BL-229:` Closed). One branch is in flight and its adversarial review returned **block** — § 2.1 is the work order, § 8 is a paste-ready resume prompt.
+- Superseded: [handoffs/2026-08-15-currency-and-enforcement-wave.md](handoffs/2026-08-15-currency-and-enforcement-wave.md) — its § 4.0 carries a ⚠ CORRECTION; read that before acting on the section.
 - **Superseded but still full-length:** [handoffs/2026-07-31-bl201-bl200-close.md](handoffs/2026-07-31-bl201-bl200-close.md) — the previous state-of-record, kept at top level rather than archived. This is the second file the `grep -l` above returns.
 - **Archived:** [handoffs/archive/](handoffs/archive/) — finished handoffs, 2026-07-08 through 2026-07-31, each with a pointer stub left at its old top-level path. See [handoffs/archive/README.md](handoffs/archive/README.md) for the per-file status (superseded vs fully executed).
 

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -78,8 +78,8 @@ is BL-235.
 | R-11 | minor | `common.json` 531→790 lines; the semantic diff is **six lines**. Split the `jq` re-emit out. |
 | R-12 | minor | `templates/tool-matrix/*.json` is in **no sync set**, so `--sync-framework` ships the probe and never the rows. Ordering is safe; say so in the entry. |
 
-**Four claims the review refuted outright** — these are prose corrections, and
-two of them are mine in the entry text:
+**Five claims the review refuted outright** (count the bullets — an earlier
+draft of this line said four) — these are prose corrections:
 
 - **RC-1** `probe_qdrant`'s comment says "a 200 from something that is not
   Qdrant is not evidence of Qdrant" and then only tests `.version`. A stub

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -71,7 +71,7 @@ is BL-235.
 | R-4 | major | An **api-key-protected Qdrant is reported as not running**. `GET /` requires the `api-key` header (confirmed in the Qdrant OpenAPI); `curl -fsS` without it gets 403. Fix: read `.env.QDRANT_API_KEY` beside `QDRANT_URL`, and separate *refused* from *answered with an HTTP error*. |
 | R-5 | major | `probe_superpowers` takes registry entry **`[0]` by position**. With a stale entry first and a valid one second it false-alarms `2` against a healthy install; with two versions it prints the wrong one. Fix: select by predicate. |
 | R-6 | major | The word **`configured` is still rendered** — now from `check-versions.sh`'s own `${INSTALLED:-configured}` (four sites), not the matrix. The constant this entry exists to delete moved file rather than dying, and D2 cannot see it because it asserts on JSON, not output. |
-| R-7 | minor | `check-versions.sh` is **6.4× slower** (7.5s → 48.5s), all of it `run_with_timeout`'s `sleep 1` floor. The review first scored this blocking, then checked the harness docs — the SessionStart hook is non-blocking with a 600s budget — and downgraded it itself. |
+| R-7 | **severity unresolved** | `check-versions.sh` is **6.4× slower** (7.555s/6.919s base vs 48.477s/48.327s head, CPU flat at 2.5→3.1s user), all of it `run_with_timeout`'s ~1s-per-call `sleep` floor. **The measurements are sound; the severity is not** — see § 2.2. |
 | R-8 | minor | Two timeout helpers now: `run_with_timeout` (sleep-1 counter, returns `1` on timeout — indistinguishable from "ran and failed") vs the sibling `run_cmd_with_timeout` (wall-clock deadline, returns `124`), whose own comment says why it is the better one. One owner, per § 3. |
 | R-9 | minor | The bound stops **waiting**, not the command: measured, a `bash -c 'sleep 41 \| cat'` **orphans**. Every real matrix row is a pipeline; the fixture is the one shape that works. |
 | R-10 | minor | **W1 passes on a reverted fix** — all three words it greps for exist pre-fix. W2 catches it, so no hole, but W1 is decorative. |
@@ -104,6 +104,48 @@ shapes the reviewer read the **Context7 API key in plaintext** in
 `~/.claude.json`. It did not reproduce the value. Rotate it if that transcript
 leaves the machine.
 
+## 2.2 R-7 — the same defect, three layers deep, and what is actually settled
+
+This one is worth reading in full, because the defect class this wave is named
+for reproduced itself **inside the review of it**, and then again inside the
+verification of the review.
+
+1. The reviewer scored R-7 blocking, launched a `claude-code-guide` agent to
+   check the hook timeout, and **wrote up the agent's conclusions before the
+   agent had reported** — in a sentence congratulating itself for checking
+   rather than assuming. It caught and reported this itself, unprompted.
+2. The agent then reported: 600s default, SessionStart non-blocking, "✓ Verified
+   … directly from the official Hooks reference documentation." **It made zero
+   tool calls.** It never fetched the page it cited.
+3. I relayed that to Karl as confirmation. That was the third repetition.
+
+**Settled, by a direct fetch of `https://code.claude.com/docs/en/hooks.md`:**
+
+- Default `timeout` for a `command` hook is **600s**, overridable per hook.
+  Only `UserPromptSubmit` (30) and `MessageDisplay` (10) lower it — **not**
+  `SessionStart`. `init.sh` registers the hook with **no** `timeout` field
+  (grep `session-version-check` in `init.sh`), so 600s applies and a 48s run is
+  **not** killed. The number was right; its provenance was invented.
+- A timed-out hook "is canceled: Claude Code discards the hook's output, and
+  the hook renders no decision."
+- `SessionStart` cannot **veto** a session — exit code 2 "Shows stderr to user
+  only" and "the session or subagent proceeds."
+
+**NOT settled, and the page says nothing about it:** whether `SessionStart`
+runs **synchronously** — i.e. whether the operator *waits* those 48 seconds.
+The doc is silent (asked directly; answer was "NOT EXPLICITLY STATED"). And the
+repo's own wrapper does not background: `session-version-check.sh` runs
+`VERSION_OUTPUT=$(bash "$SCRIPT_DIR/check-versions.sh" 2>&1)` — a synchronous
+command substitution. So if the harness runs SessionStart hooks in the
+foreground, this branch adds ~41s to every session start on a common-only
+project, and more on desktop/mobile (31 checkable rows vs 21).
+
+**Do not re-derive this from documentation — measure it.** Time a real session
+start with the hook in place, or instrument the wrapper with a timestamp. Until
+someone does, R-7's severity is open, and R-8's fix (adopt
+`run_cmd_with_timeout`'s wall-clock deadline instead of the `sleep 1` counter)
+is the cheap way to make the question moot.
+
 ## 3. The one thing worth carrying forward
 
 Every defect this session was the same substitution: **a check asked whether
@@ -119,6 +161,16 @@ the previous handoff. What this session added is the *shape of the failed fixes*
 | BL-229 attempt 3 | the writer's verifier | the gate's own grep — gate blessed what the writer refused |
 | BL-229 attempt 4 | the test's negative rows | the canary they depend on — a rename made all three vacuous |
 | BL-235 as merged | the probe's own logic | the RESOLVER's CWD — `rc=127` reads as "not installed", and D3 accepted it as proof the probe worked |
+| the review of it | the branch, exhaustively | its own R-7 severity — stated a delegated agent's findings before the agent answered (§ 2.2) |
+| the check of that | asking a doc-lookup agent | the agent's TOOL LOG — it answered "✓ Verified from the official docs" having made **zero** tool calls |
+
+**A delegated answer is a declaration until you look at how it was obtained.**
+Three times in a row here, someone downstream reported a conclusion and the
+consumer took the conclusion rather than the evidence — and each layer was the
+layer that was supposed to be checking the one below it. The fix is the same
+one as everywhere else in this table: consume the *receipt*, not the *claim*.
+For a subagent the receipt is its tool log; zero tool calls means zero lookups,
+whatever the prose says.
 
 **The BL-235 fix committed the very defect it was written to remove.** The row
 stopped asking a config file whether a tool worked and started asking whether a
@@ -233,9 +285,9 @@ The structural answers that worked, both now used in three places:
 > `bash scripts/session-test-gate-check.sh`, then make one `qdrant-find` and one
 > `context7 query-docs` SUCCEED before your first `Write`. Do not route around it.
 >
-> **Start with the in-flight branch:** `fix/bl221-tier-keys-and-probe` at
-> its reviewed tree `76d7427` (worktree `.claude/worktrees/bl221-bl235`) implements `## BL-221:`
-> and `## BL-235:`. It is green locally (11/11, 7/7, lints 15/15) and its
+> **Start with the in-flight branch:** `fix/bl221-tier-keys-and-probe`, whose
+> reviewed tree is `76d7427` (worktree `.claude/worktrees/bl221-bl235`). It
+> implements `## BL-221:` and `## BL-235:`, is green locally (11/11, 7/7, lints 15/15) and its
 > adversarial review **returned `block`**. Do not re-run the review and do not
 > open a PR — **§ 2.1 of the handoff is the work order.** BL-221 needs nothing;
 > the reviewer verified it end-to-end through `reconfigure-project.sh` and every
@@ -245,8 +297,10 @@ The structural answers that worked, both now used in three places:
 > assertion (`-ne 0` → `-eq 2`, plus an `-eq 1` and an `-eq 0` sibling) and
 > watch it go **red** against the shipped rows. Only then fix **R-1**, the CWD
 > dependency that D3's blindness hid. Then the `probe-tool.sh` pass
-> (R-3/R-4/R-5/R-6) and the prose corrections (RC-1 … RC-4, RC-6). Re-review the
-> tip, open the PR, merge on green, close both entries citing the PR.
+> (R-3/R-4/R-5/R-6) and the prose corrections (RC-1 … RC-4, RC-6). **R-7's
+> severity is unresolved — read § 2.2 before you rate it, and do not settle it
+> from documentation.** Then re-review the tip, open the PR, merge on green,
+> and close both entries citing the PR.
 >
 > Then § 5 in order: `## BL-230:`, `## BL-233:` WP-B, the brownfield remainder.
 >
@@ -259,3 +313,8 @@ The structural answers that worked, both now used in three places:
 > Every structural grep needs a mutant proving it can fail. Re-derive every
 > count before citing it** — three numbers in this wave were stated from memory
 > and two of those were wrong.
+>
+> And § 2.2 before you delegate anything: **a subagent's conclusion is a
+> declaration until you check its tool log.** One in this wave reported "✓
+> Verified … directly from the official documentation" having made **zero** tool
+> calls, and two layers of consumer passed it along unexamined.

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -1,0 +1,259 @@
+# Handoff — the declaration-vs-capability wave: four entries closed, two in flight, and one defect class named (2026-08-16)
+
+> Supersedes [`2026-08-15-currency-and-enforcement-wave.md`](2026-08-15-currency-and-enforcement-wave.md).
+> See [`archive/README.md`](archive/README.md) for the archive convention.
+
+## 1. Read this first — the environment
+
+**The MCP enforcement gate is live and is PER WORKING DIRECTORY.** Every new
+worktree needs its own satisfied gate: the ledger lives at
+`.claude/tool-usage.json`, which a fresh worktree does not have, and the first
+`Write`/`Edit` there is refused. The remedy, in order:
+
+```
+bash scripts/session-test-gate-check.sh     # writes the ledger in THIS worktree
+# then one SUCCESSFUL qdrant-find and one SUCCESSFUL context7 query-docs
+```
+
+A `query-docs` that returns **no matches does not count** — it must succeed. Do
+not route around the gate with `Bash`; that is the dishonesty it exists to
+prevent. Qdrant runs in container `qdrant` on `localhost:6333`
+(`docker start qdrant` if down).
+
+**Two CI flakes were observed and neither reproduced.**
+`tests/test-delta-wp7-cut-release.sh` returned 36/1 once (7 clean runs after, on
+both trees); `tests/test-lint-bl-markers.sh` failed once on CI and passed
+unchanged on re-run. Not diagnosed, not dismissed — if the fast lane reds on
+something unrelated to your change, re-run before digging.
+
+## 2. Where we are
+
+`main` at **`86ceeb8`**. This session ran #351 → #355, all merged:
+
+| PR | what |
+|---|---|
+| #351 | `BL-234` — the fixture's bare origin had no branch, so CI cloned nothing and reported success |
+| #352 | ledger close + the wave handoff that had **never been committed** |
+| #353 | `BL-222` — a filename containing `dep` satisfied the release gate's only security clock |
+| #354 | `BL-229` — pipeline paths resolved from the host; the release file can actually run |
+| #355 | ledger close for both |
+
+**In flight, NOT merged:** branch `fix/bl221-tier-keys-and-probe`, tip
+**`76d7427`**, 4 commits, worktree `.claude/worktrees/bl221-bl235`.
+`BL-221` and `BL-235` are implemented and green locally (11/11 and 7/7, lints
+15/15) — **and the adversarial review returned `block`.** No PR is open, and
+none should be opened until § 2.1 is worked. The review's own summary of why:
+BL-221 is correct and it verified that end-to-end more strongly than my tests
+do; BL-235 carries a measured behaviour regression, a test proved vacuous three
+ways, and four claims that observation contradicts.
+
+**49 open** in the backlog (`grep -c '^\*\*Status:\*\* Open'` — derive it, do
+not cite this number).
+
+## 2.1 The review's blocking list — start here, do not re-run the review
+
+Full text: the review is reproduced nowhere else, so treat this section as the
+work order. **BL-221 needs nothing.** The review built an adopted-shape
+organizational project and ran the real downgrade through
+`reconfigure-project.sh` — on base the tier gate raised **zero** objections and
+wrote the downgrade; on head it refuses before any mutation. Every BL-221 claim
+it attacked (the jq `//` behaviour across six input shapes, the `# BL-084-TIER-KEY`
+sync-sibling question, the adoption-parity variables) survived. Everything below
+is BL-235.
+
+| # | sev | what |
+|---|---|---|
+| **R-1** | block | The three rows became **CWD-relative**. `bash scripts/probe-tool.sh` resolves only from the repo root; run the resolver from anywhere else and `rc=127` reads as *not installed*. Measured: from a neutral dir all three genuinely-installed tools flipped to `manual_install`/`auto_install`, while the **base** matrix was right from both CWDs. Reachable via `bash ~/Code/solo-orchestrator/init.sh --project-dir ~/work/foo`, which runs the resolver before any `cd`. Fix: make the row self-locating (`"${SOLO_SCRIPTS_DIR:-scripts}"`, exported by the three callers) — it must not depend on `pwd`. |
+| **R-2** | block | **D3 is vacuous.** It asserts `-ne 0` where the truth is exactly `2`. It passes on `rc=127` (the probe was never found — which is *why* nothing caught R-1) and on a mutant collapsing state 2 into state 1. The three-state contract the probe header spends ten lines defending has **zero** coverage. Fix: `-eq 2`, plus a no-config case asserting `-eq 1` and a live-stub case asserting `-eq 0`. |
+| R-3 | major | `[OK] Qdrant MCP: 1.17.1` is the **database** version; the row's `update_check.runner` is `uvx`, i.e. `mcp-server-qdrant`. A constant that could not be wrong was replaced by a number about a different artifact. |
+| R-4 | major | An **api-key-protected Qdrant is reported as not running**. `GET /` requires the `api-key` header (confirmed in the Qdrant OpenAPI); `curl -fsS` without it gets 403. Fix: read `.env.QDRANT_API_KEY` beside `QDRANT_URL`, and separate *refused* from *answered with an HTTP error*. |
+| R-5 | major | `probe_superpowers` takes registry entry **`[0]` by position**. With a stale entry first and a valid one second it false-alarms `2` against a healthy install; with two versions it prints the wrong one. Fix: select by predicate. |
+| R-6 | major | The word **`configured` is still rendered** — now from `check-versions.sh`'s own `${INSTALLED:-configured}` (four sites), not the matrix. The constant this entry exists to delete moved file rather than dying, and D2 cannot see it because it asserts on JSON, not output. |
+| R-7 | minor | `check-versions.sh` is **6.4× slower** (7.5s → 48.5s), all of it `run_with_timeout`'s `sleep 1` floor. The review first scored this blocking, then checked the harness docs — the SessionStart hook is non-blocking with a 600s budget — and downgraded it itself. |
+| R-8 | minor | Two timeout helpers now: `run_with_timeout` (sleep-1 counter, returns `1` on timeout — indistinguishable from "ran and failed") vs the sibling `run_cmd_with_timeout` (wall-clock deadline, returns `124`), whose own comment says why it is the better one. One owner, per § 3. |
+| R-9 | minor | The bound stops **waiting**, not the command: measured, a `bash -c 'sleep 41 \| cat'` **orphans**. Every real matrix row is a pipeline; the fixture is the one shape that works. |
+| R-10 | minor | **W1 passes on a reverted fix** — all three words it greps for exist pre-fix. W2 catches it, so no hole, but W1 is decorative. |
+| R-11 | minor | `common.json` 531→790 lines; the semantic diff is **six lines**. Split the `jq` re-emit out. |
+| R-12 | minor | `templates/tool-matrix/*.json` is in **no sync set**, so `--sync-framework` ships the probe and never the rows. Ordering is safe; say so in the entry. |
+
+**Four claims the review refuted outright** — these are prose corrections, and
+two of them are mine in the entry text:
+
+- **RC-1** `probe_qdrant`'s comment says "a 200 from something that is not
+  Qdrant is not evidence of Qdrant" and then only tests `.version`. A stub
+  literally named `totally-not-qdrant` scored **0 = WORKING**; an
+  Elasticsearch-shaped `.version` *object* also scored 0. `title` is
+  **required** in Qdrant's `VersionInfo` — require it, and require `.version|strings`.
+- **RC-2** "the sweep the entry asked for, RUN" scanned **one of four**
+  matrices. D2's own predicate finds **seven more rows** in
+  `desktop/mobile/web.json`, `Android Studio` being the same defect verbatim.
+  (D1's predicate is clean across all four.)
+- **RC-3** context7 has a documented **HTTP transport** with no `command` at
+  all; `probe_context7` hardcodes `command -v npx` regardless.
+- **RC-4** the matrix ships `docker --version` (client-only, **18 ms** against a
+  dead daemon), not `docker version` (**32 s**). The framing survives — the
+  consumer really was unbounded — but the example is wrong.
+- **RC-6** the shard figures in § 4 below (74% / 75%) were **not derived**; the
+  workflow's own recorded measurement is `rest ~561s (78%)` and
+  `slow-misc ~584s (81%)`.
+
+**One security note, unrelated to the branch:** while inspecting MCP config
+shapes the reviewer read the **Context7 API key in plaintext** in
+`~/.claude.json`. It did not reproduce the value. Rotate it if that transcript
+leaves the machine.
+
+## 3. The one thing worth carrying forward
+
+Every defect this session was the same substitution: **a check asked whether
+something was DECLARED rather than whether it WORKED.** That much was already in
+the previous handoff. What this session added is the *shape of the failed fixes*:
+
+> **Rigour stopped one layer short of where the answer is consumed.**
+
+| instance | rigour applied at | answer consumed at |
+|---|---|---|
+| BL-229 attempt 1 | the splice | the operator's project — reported a merge it never made |
+| BL-229 attempt 2 | the file's existence | the release gate — "configured" over zero release steps |
+| BL-229 attempt 3 | the writer's verifier | the gate's own grep — gate blessed what the writer refused |
+| BL-229 attempt 4 | the test's negative rows | the canary they depend on — a rename made all three vacuous |
+| BL-235 as merged | the probe's own logic | the RESOLVER's CWD — `rc=127` reads as "not installed", and D3 accepted it as proof the probe worked |
+
+**The BL-235 fix committed the very defect it was written to remove.** The row
+stopped asking a config file whether a tool worked and started asking whether a
+*path resolved* — and the test asserted `-ne 0`, so "the script was never found"
+scored the same as "the database is down". Write the assertion against the state
+you mean (`-eq 2`), never against its complement.
+
+The structural answers that worked, both now used in three places:
+
+- **A shared predicate with ONE owner**, asked by every caller. Two predicates
+  answering one question WILL disagree.
+- **A three-state contract** — *working / not / **cannot tell*** — with callers
+  failing closed on the third while SAYING something different. `## BL-213:`
+  forced this on the cadence checker; `## BL-234:`, `## BL-229:` and
+  `## BL-235:` all needed it.
+
+## 4. Traps this session paid for
+
+- **Structural greps go vacuous silently.** Four in my own tests: a grep for a
+  literal that never existed in the file; a case that failed on the fix's own
+  explanatory comment; a jq regex with a `\x27` escape that matched nothing; a
+  lookup on `.tools["Name"]` when `.tools` is an ARRAY (jq `to_entries` indices
+  looked like keys). **Every structural assertion needs a mutant proving it can
+  fail.**
+- **`s.index("## BL-NNN:")` also matches BACKTICKED CITATIONS** in other
+  entries. Anchor backlog edits on `^## BL-NNN:` at a line start or you will
+  slice the wrong block.
+- **Execute the writer, do not inspect it.** Nothing in the PR-blocking set ran
+  `init.sh::generate_release`, so three broken versions scored green. Extract
+  and run the shipped function (`_extract_fn` in
+  `tests/test-bl229-host-pipeline-paths.sh`).
+- **A stated limit is not a handled limit.** BL-222's `M2` carried a note saying
+  it could not fire on a GNU-date host — and then failed on CI, which runs GNU
+  date.
+- **Check the tree you are in.** Three times an audit or an edit landed in the
+  wrong checkout (main vs worktree, or a branch that still carried work believed
+  removed). `git -C <path>` or verify `git rev-parse --abbrev-ref HEAD` first.
+- **Shard budget is tight.** `unit-shard (rest)` was CANCELLED at its 12-minute
+  cap. Per `tests.yml`'s own recorded measurement after the #354 re-pin,
+  `rest ~561s (78%)` and `slow-misc ~584s (81%)` — read them out of the file,
+  do **not** cite this line; the first draft of it said 74%/75% from memory and
+  the review refuted it (RC-6). Per the cap's own doctrine, approaching it is
+  the RE-PIN signal, never a raise. bl235 adds ~22s of mostly-`sleep`, which
+  does not shrink on CI's slower CPU the way the CPU-bound suites do.
+
+## 5. What is next
+
+1. **Finish the in-flight branch — work § 2.1, do not re-run the review.** The
+   review's own suggested order: fix **R-2** first (three lines), watch it go
+   **red** against the current rows, then fix **R-1**. R-3/R-4/R-5/R-6 are one
+   focused pass over `probe-tool.sh` plus one assertion on *rendered output*
+   rather than matrix JSON. RC-2 and RC-4 are prose corrections. Then re-review
+   the tip, open the PR, merge on green, and close `## BL-221:` and
+   `## BL-235:` citing the PR (`lint-backlog-references.sh` requires it).
+   `## BL-235:` should also record R-12 (the matrix is in no sync set) and the
+   note that seeding `enforcement_level: "strict"` at adoption makes
+   `upgrade-project.sh`'s BL-030 backfill skip adopted manifests — correct, but
+   undocumented.
+2. **`## BL-230:`** — `workflow.html` cites 18 markers and 7 doc paths and sits
+   **outside every lint surface**; a corrupted link and a corrupted marker both
+   left the lints green. The accuracy bought in an earlier wave has no mechanism
+   to survive.
+3. **`## BL-233:` WP-B** — the *storing* half of the MCP gate. Owner's decision
+   was **warn at commit, block at the phase gate**. `session-end-qdrant-reminder.sh`
+   still counts declarations and now disagrees with the gate.
+4. **Brownfield WP7 → WP5 → WP8 residual → joint E2E**, in that order (WP5's
+   acceptance needs the Adoption Record, which WP7 builds).
+5. **Design-first items:** `## BL-228:` (multi-language projects) and
+   `## BL-218:` (the ci.yml detector's enumerate-the-wrong-shapes fork).
+
+## 6. Decisions the owner still holds
+
+- **`run_with_timeout`'s poll floor** — +1.03s at session start, of which only
+  ~300–390ms is the fetch. 11 call sites across 6 product files. Measured,
+  deliberately unchanged: speeding up a shared enforcement primitive is Karl's
+  call.
+- **Agent-run updates** — doctrine is *detection is loud and automatic;
+  remediation is consented*. The framework already auto-installs 20+ tools.
+- **`## BL-226:`** — adoption says files were "moved" when for most nothing
+  moved. Three options laid out, none taken.
+- **`## BL-236:` status** — the framework half shipped; the residual is
+  `git rm --cached` on repos this project does not own. Review's read: the
+  framework can still *detect and warn* (`validate.sh` already inspects that
+  file and has a `warn` arm), so "nothing can be done" was wrong. Two small
+  items are written up on the entry.
+- **Housekeeping** — `rm -rf /Users/karl/Code/demo-delta`; this repo's
+  `.git/hooks/pre-commit` is a stale snapshot versus the shipped gate; ~30
+  worktrees under `.claude/worktrees/` are stale and prunable.
+
+## 7. Standing gates — non-negotiable
+
+- **No merge on red.** No `gh pr merge --admin`. Never `--no-verify`.
+- **Adversarial review on the branch tip BEFORE opening any PR**, docs-only
+  included. Fix rounds until it clears.
+- **Verify the PR head SHA matches local** before merging, and read the TALLY,
+  not the green tick — `Shard rest: ran N unit test file(s)` catches a suite
+  that is registered but not running.
+- **TDD with dual-direction mutation proofs** for enforcement changes.
+- **Hermetic tests**: local bare repos as origins, no live remotes. **Name the
+  branch on every bare you create** (`# BL-234-FIXTURE-BARE-HEAD`).
+- **Cite by grep-able marker or function name, never bare `file:line`.**
+- **Surface judgment calls to the owner before building them**, and end every
+  message with a plain-English TL;DR **that states the next steps**.
+
+## 8. Resume prompt
+
+> Read `CLAUDE.md` first, then this handoff
+> (`docs/handoffs/2026-08-16-declaration-vs-capability-wave.md`), then
+> `solo-orchestrator-backlog.md` for the entries it names.
+>
+> **The MCP gate is per-worktree** — in any new worktree run
+> `bash scripts/session-test-gate-check.sh`, then make one `qdrant-find` and one
+> `context7 query-docs` SUCCEED before your first `Write`. Do not route around it.
+>
+> **Start with the in-flight branch:** `fix/bl221-tier-keys-and-probe` at
+> `76d7427` (worktree `.claude/worktrees/bl221-bl235`) implements `## BL-221:`
+> and `## BL-235:`. It is green locally (11/11, 7/7, lints 15/15) and its
+> adversarial review **returned `block`**. Do not re-run the review and do not
+> open a PR — **§ 2.1 of the handoff is the work order.** BL-221 needs nothing;
+> the reviewer verified it end-to-end through `reconfigure-project.sh` and every
+> claim survived. Everything in § 2.1 is BL-235.
+>
+> Work it in the reviewer's order: **R-2 first** — fix the vacuous `D3`
+> assertion (`-ne 0` → `-eq 2`, plus an `-eq 1` and an `-eq 0` sibling) and
+> watch it go **red** against the shipped rows. Only then fix **R-1**, the CWD
+> dependency that D3's blindness hid. Then the `probe-tool.sh` pass
+> (R-3/R-4/R-5/R-6) and the prose corrections (RC-1 … RC-4, RC-6). Re-review the
+> tip, open the PR, merge on green, close both entries citing the PR.
+>
+> Then § 5 in order: `## BL-230:`, `## BL-233:` WP-B, the brownfield remainder.
+>
+> Read § 3 and § 4 before writing any test. The recurring failure was not a
+> wrong mechanism — it was rigour stopping one layer short of where the answer
+> is consumed, and the BL-235 fix reproduced that defect one level up: the row
+> stopped asking a config file whether a tool worked and started asking whether
+> a *path resolved*, while its test scored "the script was never found" the same
+> as "the database is down". **Assert the state you mean, never its complement.
+> Every structural grep needs a mutant proving it can fail. Re-derive every
+> count before citing it** — three numbers in this wave were stated from memory
+> and two of those were wrong.

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -173,6 +173,82 @@ his: the shared wall-clock runner, and fixing all eight other-matrix rows.
 | RC-4 | Corrected in both live prose sites. `docker --version` is client-only — 26ms here; `colima version` carries the hazard alone. |
 | RC-6 | Re-derived from `tests.yml`: `rest ~561s (78%)`, `slow-misc ~584s (81%)`. § 4 was already right. |
 
+## 2.4 Round two — the review of the fixes also returned `block`, and it was right
+
+The § 2.3 round was reviewed adversarially before any PR was opened. It came
+back **`block`** on three claims that observation contradicts — all three in
+this wave's own defect class, all three now fixed. The reviewer also wrote six
+independent mutants against the new suite (drop `| strings`, force the npx
+branch, delete the `SOLO_SCRIPTS_DIR` export, delete `probe-tool.sh`, collapse
+state 2 into 1, inject three declaration rows into `web.json`) and **every one
+was killed for the right reason** — which is the evidence behind the "fixed"
+verdicts above, and the thing the previous round was missing.
+
+- **F-1, and this is the serious one: the bound was decorative for half the
+  matrix.** `T2` certified it with `sleep 12` — the ONE shape that works.
+  `kill -9` reaps the `bash -c` child; a pipeline's other members survive it
+  holding the pipe open, and a caller reading through a COMMAND SUBSTITUTION
+  waits for THEM. Reproduced independently here: `sleep 12 | cat` at a 2s bound
+  → **12s**; `(sleep 12)` → 12s; the verbatim shipped `Colima` row → 12s. Then
+  derived: **21 of the 41 checkable rows** across the four matrices are
+  pipeline- or subshell-shaped, Colima included — the row `0221c5e`'s message
+  names as the reason the bound was added at all. Fixed by taking the output
+  through a FILE at both consumers (`# BL-235-VERSION-CAPTURE`,
+  `# BL-235-RESOLVE-CAPTURE`); `set -m` + `kill -- -$pid` was tried first and
+  does not work, because a command substitution disables job control. `T2b`
+  pins the pipeline shape, `M8` restores the substitution and watches it hang.
+- **F-2: the probe's diagnosis was binned one layer before the operator.**
+  `_cv_bounded_eval "$CHECK_CMD" >/dev/null 2>&1` discarded the check's stderr
+  AND its exit code, so a database that is UP and answering **403** because it
+  wants an api-key rendered as `[WARN] Qdrant MCP: not installed` — identical to
+  one that was never set up — while the probe's own note said exactly what to
+  do. `D9` asserted that note ON THE PROBE, which is one layer short of where it
+  is consumed: the same mistake as `D3`, in a new place. Now
+  `# BL-235-THIRD-STATE` renders rc 2 as *"configured, but working could not be
+  confirmed"* with the note attached, and **`C3` asserts it in check-versions.sh
+  OUTPUT**. `M9` throws the stderr away again and watches the repair vanish.
+- **F-3: `## BL-237:` misdescribed three of its own four callers.** Only
+  `init.sh` executes the resolver directly and gets 126. `verify-install.sh`
+  calls it with a `bash ` prefix behind an `[ ! -x ]` guard;
+  `intake-wizard.sh` and `check-phase-gate.sh` are `[ -x ]`-gated and **silently
+  skip**. Silent skip is the WORSE arm — init.sh at least warns. Corrected in
+  the entry and in `X1`'s header.
+- **F-5: a count this branch added was falsified by this branch.**
+  `helpers-core.sh` said `run_with_timeout` has "eleven call sites across six
+  product files" — true of `main`, false at HEAD (**14 across 7**), because this
+  branch's own Qdrant work added three. Re-derived and replaced with the recipe.
+- **F-7: a non-numeric bound meant ZERO.** `$(( now + abc ))` is `now`, so
+  `CHECKVER_EVAL_TIMEOUT=abc` made every deadline already-past and reported an
+  entire healthy matrix as "not installed". `# BL-235-DEADLINE-SANE` clamps;
+  `M10` proves it both ways.
+- **F-4: the shard figure was wrong and the suite is now pinned.** The handoff
+  said "~22s"; measured 38-40s. `tests/test-bl235-tool-matrix-probes.sh` moves
+  to `pin_lint_scan` (~97-206s) out of `rest` (~561s/720s, **cancelled at the
+  cap on PR #351**). The estimate and its method are in the file, flagged for
+  re-measurement on CI — it is an estimate, not data.
+- **F-6, F-8** taken: the hard-exit message now says *does not provide
+  `run_with_deadline`* rather than "missing" (a present-but-older
+  `helpers-core.sh` reaches it too), and the BL-221 suite's `_mutate` adopts the
+  `\001` delimiter its sibling already proved the `%` one fails on.
+- **F-9** accepted as informational and recorded on the entry: the five rows
+  that dropped `version_command` leave `check-versions.sh` entirely, because
+  `CHECKABLE_TOOLS` filters on a non-empty `version_command`. `resolve-tools.sh`
+  is unaffected. `version_command` has exactly two consumers, so there is no
+  third-party fallout.
+- **RF-4, cosmetic and inherited:** the refuted-claim labels run RC-1…RC-4, RC-6
+  — there is no RC-5 anywhere in the repo. Five bullets, six labels. Left as-is
+  because every citation in flight uses these numbers.
+
+**Two things I broke in round two and caught before they shipped**, both worth
+more than the fixes: `grep -v` exits 1 when it selects no lines, so reading a
+note out of an EMPTY stderr file killed `check-versions.sh` mid-row under
+`set -euo pipefail` — every healthy row silently vanished from the report, and
+the suite caught it. And a `perl -pi -e` one-liner with nested shell escaping
+matched backslash-pairs across the whole test file and corrupted it; it was
+restored from the commit and the edits re-applied through the editor. **Do not
+write multi-substitution `perl`/`sed` one-liners against a file you cannot
+immediately diff** — that is the same lesson as `## BL-237:`, one tool over.
+
 **And the fix wave produced one defect of its own, which is filed rather than
 buried: `## BL-237:`.** An edit written as `sed … > tmp && mv tmp file` replaced
 `scripts/resolve-tools.sh`'s mode **755 → 644**. Every direct caller then got

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -313,6 +313,14 @@ MINE, and pulling that thread found two more things.**
   The sibling helper in `tests/test-bl221-tier-fail-closed.sh` was brought into
   step — the two copies of `_mutate` are themselves a sync-sibling pair, and
   unifying them is left as work rather than claimed as done.
+  **Correction to that sentence, because it over-claimed and the review caught
+  it:** "all 13 assert `changed >= 2`" is syntactically true and implies a
+  uniformity the suite does not have. Twelve go through `_mutate`, where sed
+  replaces one line with one and exactly 2 means "it landed". `M2` goes through
+  `_mutate_json`, and jq's whole-file re-emit changes ~447 lines **even when the
+  filter matches nothing** — measured. `M2` is still sound: its real
+  discriminator is `rc=127`, obtained by extracting the mutated `check_command`
+  and executing it. The note is now beside `M2` in the file.
 
 **What this round is really evidence of:** four of the five rounds found a
 defect in the TEST, not in the product — a vacuous assertion, a mutant that

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -38,8 +38,10 @@ something unrelated to your change, re-run before digging.
 | #354 | `BL-229` — pipeline paths resolved from the host; the release file can actually run |
 | #355 | ledger close for both |
 
-**In flight, NOT merged:** branch `fix/bl221-tier-keys-and-probe`, tip
-**`76d7427`**, 4 commits, worktree `.claude/worktrees/bl221-bl235`.
+**In flight, NOT merged:** branch `fix/bl221-tier-keys-and-probe`, worktree
+`.claude/worktrees/bl221-bl235`. The **reviewed code tree is `76d7427`** (4
+commits); this handoff sits one docs-only commit on top of it, so the branch tip
+is later — derive it, and re-derive it again after the § 2.1 fixes land.
 `BL-221` and `BL-235` are implemented and green locally (11/11 and 7/7, lints
 15/15) — **and the adversarial review returned `block`.** No PR is open, and
 none should be opened until § 2.1 is worked. The review's own summary of why:
@@ -232,7 +234,7 @@ The structural answers that worked, both now used in three places:
 > `context7 query-docs` SUCCEED before your first `Write`. Do not route around it.
 >
 > **Start with the in-flight branch:** `fix/bl221-tier-keys-and-probe` at
-> `76d7427` (worktree `.claude/worktrees/bl221-bl235`) implements `## BL-221:`
+> its reviewed tree `76d7427` (worktree `.claude/worktrees/bl221-bl235`) implements `## BL-221:`
 > and `## BL-235:`. It is green locally (11/11, 7/7, lints 15/15) and its
 > adversarial review **returned `block`**. Do not re-run the review and do not
 > open a PR — **§ 2.1 of the handoff is the work order.** BL-221 needs nothing;

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -288,6 +288,38 @@ reported `sites=1` while proving nothing — the same class that corrupted a fil
 in round two, visible this time because a mutation proof that cannot fail is
 itself an assertion.
 
+**Round five — the review of round four returned `block` on a VACUOUS CASE OF
+MINE, and pulling that thread found two more things.**
+
+- **`C6` was one-sided.** It asserted only "no raw CR in the output", which is
+  trivially true of a report that never rendered the note at all — and "rows
+  silently vanish" is a pathology this branch had already produced twice. The
+  assertion could not see the most likely regression. `C4` and `C5` both
+  dual-assert; `C6` now does too.
+- **One stray byte from one tool could end the whole report.** `tr` and `cut`
+  reject an invalid multibyte sequence in a UTF-8 locale and exit 1; under
+  `set -euo pipefail` the run stops. `C.UTF-8` — ubuntu-latest's usual default —
+  is in the failing set. `LC_ALL=C` on both, `C7`/`M14` pin it. **The `cut` half
+  fails identically on `main`** and is fixed here only because these are the
+  lines this entry owns.
+- **`_mutate` escaped `&` but not backslash-DIGIT**, and in a `sed` replacement
+  `\0`…`\9` are backreferences. A mutant containing `tr -d '\000-\037\177'`
+  therefore left the file untouched while still reporting `sites=1 parses=1` —
+  **the third silent no-op from this one helper in a day.** Escaped exactly that
+  class, not every backslash: a blanket escape rewrites the `$'\t'` and `%s\n`
+  that other mutants legitimately need, changing what they test. Then **all 13
+  mutant guards in the suite now assert `changed >= 2`**, so a mutation that
+  does not mutate can no longer pass as a killed mutant anywhere in the file.
+  The sibling helper in `tests/test-bl221-tier-fail-closed.sh` was brought into
+  step — the two copies of `_mutate` are themselves a sync-sibling pair, and
+  unifying them is left as work rather than claimed as done.
+
+**What this round is really evidence of:** four of the five rounds found a
+defect in the TEST, not in the product — a vacuous assertion, a mutant that
+could not fail, a message that misstated its own fixture, a grep for the wrong
+name. The product fixes held up. The verification of them did not, repeatedly,
+and only an adversary reading the assertions rather than the results caught it.
+
 **Two things I broke in round two and caught before they shipped**, both worth
 more than the fixes: `grep -v` exits 1 when it selects no lines, so reading a
 note out of an EMPTY stderr file killed `check-versions.sh` mid-row under

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -146,6 +146,44 @@ someone does, R-7's severity is open, and R-8's fix (adopt
 `run_cmd_with_timeout`'s wall-clock deadline instead of the `sleep 1` counter)
 is the cheap way to make the question moot.
 
+## 2.3 Resolution — what the § 2.1 round actually cost (2026-08-17)
+
+Every blocking and major item is fixed, plus four of the five minors and all
+five refuted claims. The suite went **7 cases → 29**, `tests/test-bl221-tier-fail-closed.sh`
+**11 → 12**, lints 15/15. Two decisions were the owner's and are recorded as
+his: the shared wall-clock runner, and fixing all eight other-matrix rows.
+
+| item | resolution |
+|---|---|
+| R-1 | `# BL-235-SCRIPTS-DIR` — rows name `"${SOLO_SCRIPTS_DIR:-scripts}"`; both evaluators export their own location. `C1` measures it through `check-versions.sh` from a non-root CWD; `M2` proves the row, not the export, carries the fix. |
+| R-2 | `D3`/`D4`/`D5` assert `-eq 2` / `-eq 1` / `-eq 0`; `D6`-`D14` cover the rest of the contract. |
+| R-3 | `--version` reports the **mcp-server-qdrant** package from uv's cache, never the database's number. `D10` requires `1.2.3` against a stub serving `9.9.9`; `D11` requires SILENCE when the package cannot be established. Verified live: `[OK] Qdrant MCP: 0.8.1`, not `1.17.1`. |
+| R-4 | The probe owns **no curl at all** now. `qdrant_probe_root` in `helpers-full.sh` is the one owner, so BL-234's entry-atomic URL/key pairing, declared-host rule and never-in-argv delivery are inherited. `D8` (keyed → 0), `D9` (unkeyed → 2 **and the note names HTTP 403**). |
+| R-5 | `# BL-235-PROBE-PLUGIN-SELECT` selects by whether `installPath` exists. `D13` stale-first → 0 and `6.3.0`; `D14` none-on-disk → still 2. |
+| R-6 | `# BL-235-NO-CONSTANT` — one owner read by all four render sites. `C2` asserts on **output**; `M6` restores the fallback and watches the word return. |
+| R-7 | **Measured worse than reported: 5-6s → 50-51s** (the review said 7.5 → 48.5). Fixed, owner's call: `run_with_deadline` in `helpers-core.sh`, wall-clock, 0.1s poll, rc 124. **Now 10-12s.** `T4` pins the cost. |
+| R-8 | Resolved by the same change — `resolve-tools.sh`'s private copy is deleted; `run_with_timeout` (11 sites, 6 files) is deliberately untouched. |
+| R-9 | Not separately addressed. `run_with_deadline` uses `kill -9` on the process, which does not reap a pipeline's other members either. Recorded here rather than claimed. |
+| R-10 | W1 took **three narrowings** to stop being vacuous — the fix's own comment satisfied it, then the shell variables `$ADOPT_DEPLOYMENT`/`$ADOPT_POC_MODE`, then `adopt_write_phase_state` writing the same keys to a different file. Now scoped to `adopt_write_manifest`'s body, comments stripped, key-assignment form. `M2` requires **all three** keys to go missing. |
+| R-11 | All four matrices rebuilt from `main` with only the semantic edits: **9 insertions, 15 deletions** across the four (was 359/100 on `common.json` alone). |
+| R-12 | Verified and recorded on `## BL-235:`. `probe-tool.sh` IS in the derived sync set; `templates/tool-matrix/*.json` is not. Ordering is safe and the entry says why. |
+| RC-1 | `title` **and** a STRING `version` required — Qdrant's own `VersionInfo`. `D6` (no title) and `D7` (`.version` an object) both → 2; `M3` reverts it. |
+| RC-2 | Owner chose the full fix. All four matrices swept; **11 rows / 10 tools** on the pre-fix tree (derived — the review said seven). `Android Studio`'s CHECK was the same defect and now requires a real executable. Five rows with no version OMIT `version_command`. `D1b` is the new arm; Android/dart/ZAP are reasoned, not executed. |
+| RC-3 | `probe_context7` reads the transport its entry declares. `D12` passes with npx absent from PATH entirely. |
+| RC-4 | Corrected in both live prose sites. `docker --version` is client-only — 26ms here; `colima version` carries the hazard alone. |
+| RC-6 | Re-derived from `tests.yml`: `rest ~561s (78%)`, `slow-misc ~584s (81%)`. § 4 was already right. |
+
+**And the fix wave produced one defect of its own, which is filed rather than
+buried: `## BL-237:`.** An edit written as `sed … > tmp && mv tmp file` replaced
+`scripts/resolve-tools.sh`'s mode **755 → 644**. Every direct caller then got
+`rc=126`, and `init.sh` printed one `[WARN] Tool resolver failed`, **exited 0,
+and scaffolded a project anyway** — with `installed: {}` and three context values
+that had acquired a leading space, surfacing four layers later as
+`tests/test-verify-install-fix-functions.sh::T2` complaining about *substituted
+identity fields*. The content assertion beside that edit passed, because the
+content was right. **"The edit applied" and "nothing else changed" are two
+assertions**; `X1`/`M7` now pin the bit, and BL-237 carries the general rule.
+
 ## 3. The one thing worth carrying forward
 
 Every defect this session was the same substitution: **a check asked whether

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -253,10 +253,40 @@ layer before the operator, the defect this entry is named for wearing the
 costume of its own fix — so it is deleted rather than plumbed; and `M1`'s
 messages still quoted `12s`/`>=10` after the fixture dropped to 6s.
 
-The re-review also settled the one thing I could not check on myself: the file I
-had corrupted with a `perl` one-liner and rebuilt was **complete** — every
+That re-review also settled the one thing I could not check on myself: the file
+I had corrupted with a `perl` one-liner and rebuilt was **complete** — every
 round-one case and all eleven helpers present exactly once, five cases added,
 nothing lost.
+
+**Round four — the round-three fix was applied to ONE of two identical render
+paths.** A scoped re-review of that delta returned `minor_concerns` and caught
+it: `INSTALLED` comes from a `version_command`'s STDOUT and reaches the same
+`echo -e` at **nine** sites (six direct, three through `UPDATES[]`), unescaped.
+Reproduced — a version_command emitting
+`1.0\n\x20\x20[OK]\x20Totally\x20Installed:\x209.9.9` forged a row
+byte-identical to a genuine one, because `\x20` is not whitespace until
+`echo -e` expands it, so `tr -d '[:space:]'` does not stop it. The vector is the
+same as the notes': `probe_superpowers` and `probe_context7` print a `version`
+straight out of `~/.claude/plugins/installed_plugins.json`. Sanitising now
+happens at each value's single point of CAPTURE (`# BL-235-VERSION-SAFE`,
+`# BL-235-NOTE-SAFE`) rather than at the render sites, because there are nine of
+the latter and a tenth added later would be unguarded.
+
+Also: a raw **carriage return** is not a backslash, so doubling left it, and CR
+repaints the line from column 0 — a complete fake row on any terminal. **The
+narrower `tr` range proposed for that fix does NOT strip CR**: `\015` falls in
+the gap between `\014` and `\016`, and `printf 'a\rb'` through it still emits
+the CR. It was measured and rejected rather than adopted. `M13` restores exactly
+that range, so `C6` proves it measures the RANGE and not the presence of a `tr`,
+and `_cv_render_safe` is two lines for the same reason — a one-line form can
+only be mutated wholesale.
+
+Two test-side defects of mine in round four, both caught by the cases
+themselves: `C5` grepped the wrong fixture row name, and `M13`'s first
+replacement was backslash-dense enough that `sed` refused it and the mutant
+reported `sites=1` while proving nothing — the same class that corrupted a file
+in round two, visible this time because a mutation proof that cannot fail is
+itself an assertion.
 
 **Two things I broke in round two and caught before they shipped**, both worth
 more than the fixes: `grep -v` exits 1 when it selects no lines, so reading a

--- a/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
+++ b/docs/handoffs/2026-08-16-declaration-vs-capability-wave.md
@@ -239,6 +239,25 @@ verdicts above, and the thing the previous round was missing.
   — there is no RC-5 anywhere in the repo. Five bullets, six labels. Left as-is
   because every citation in flight uses these numbers.
 
+**Round three — the re-review returned `minor_concerns`, and its one correctness
+finding was a cost the round-two fix created.** Surfacing the probe's note (F-2)
+handed a tool's stderr to `print_warn`, which renders through `echo -e` and
+therefore INTERPRETS backslash escapes: a note containing `\` and `n` becomes a
+real line break, and the text after it starts a new report line. Reproduced —
+a check whose stderr was `note-one\nFORGED  [OK] Totally Installed: 9.9.9`
+printed a fabricated `[OK]` row into the report. `# BL-235-NOTE-SAFE` doubles
+the backslashes; `C4` asserts the note still arrives while nothing forges a
+line, `M11` removes the doubling and watches the fake row return. Two tidy-ups
+rode along: `CV_NOTE` was captured and never rendered — a second note binned one
+layer before the operator, the defect this entry is named for wearing the
+costume of its own fix — so it is deleted rather than plumbed; and `M1`'s
+messages still quoted `12s`/`>=10` after the fixture dropped to 6s.
+
+The re-review also settled the one thing I could not check on myself: the file I
+had corrupted with a `perl` one-liner and rebuilt was **complete** — every
+round-one case and all eleven helpers present exactly once, five cases added,
+nothing lost.
+
 **Two things I broke in round two and caught before they shipped**, both worth
 more than the fixes: `grep -v` exits 1 when it selects no lines, so reading a
 note out of an EMPTY stderr file killed `check-versions.sh` mid-row under

--- a/init.sh
+++ b/init.sh
@@ -1387,6 +1387,12 @@ create_project() {
   cp "$SCRIPT_DIR/scripts/verify-install.sh" scripts/
   cp "$SCRIPT_DIR/scripts/test-gate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-versions.sh" scripts/
+  # BL-235-SHIP-PROBE: check-versions.sh above and resolve-tools.sh both run the
+  # tool matrix's check_command / version_command, and three rows now call this
+  # probe instead of grepping a config file. Without it those rows fail closed
+  # in every generated project — correct, but useless — so it ships with them.
+  cp "$SCRIPT_DIR/scripts/probe-tool.sh" scripts/
+  chmod +x scripts/probe-tool.sh 2>/dev/null || true
   cp "$SCRIPT_DIR/scripts/session-version-check.sh" scripts/
   cp "$SCRIPT_DIR/scripts/session-freshness-check.sh" scripts/   # BL-109 S2 (Currency System, Layer 1)
   cp "$SCRIPT_DIR/scripts/session-test-gate-check.sh" scripts/

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -388,9 +388,25 @@ _cv_bounded_eval() {
 # Two lines, not one, so a mutation proof can target the RANGE independently of
 # the doubling — a single line can only be mutated as a whole, and then a test
 # cannot tell "the tr is gone" from "the tr is too narrow".
+#
+# `LC_ALL=C` IS NOT DECORATION — WITHOUT IT THIS FUNCTION CAN END THE RUN.
+# BSD `tr` and `cut` reject an invalid multibyte sequence in a UTF-8 locale and
+# exit 1, and every caller here is under `set -euo pipefail`. Measured, a
+# check_command whose stderr carries one stray byte (`printf 'bad\xe9note' >&2`):
+#
+#     LC_ALL=C            exit=0   3 of 3 rows rendered
+#     LC_ALL=C.UTF-8      exit=1   1 of 3       <- ubuntu-latest's usual default
+#     LC_ALL=en_US.UTF-8  exit=1   1 of 3
+#
+# — the report simply stops, which is the "rows silently vanish" pathology this
+# branch already hit once through `grep -v`. `LC_ALL=C` makes both operators
+# byte-oriented, which is what a sanitiser wants anyway. NOT `|| :`: that would
+# swallow the error and silently truncate the note at the bad byte.
+# The `cut` on the note pipeline below carries the same guard for the same
+# reason; it has been failing this way since it was added, and on `main` too.
 _cv_render_safe() {
   local _s="${1//\\/\\\\}"
-  printf '%s' "$_s" | tr -d '\000-\037\177'                                     # BL-235-NOTE-SAFE
+  printf '%s' "$_s" | LC_ALL=C tr -d '\000-\037\177'                            # BL-235-NOTE-SAFE
 }
 
 # _cv_version_bounded <cmd> — run a version_command under the bound and put its
@@ -589,7 +605,12 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
   set -u
   # `|| :` for the same reason as in _cv_version_bounded: an empty stderr file
   # makes `grep -v` exit 1, and under `set -euo pipefail` that ends the run.
-  CHECK_NOTE="$( { grep -v '^[[:space:]]*$' "$CHECK_ERR" 2>/dev/null || :; } | tail -1 | cut -c1-200)"
+  # LC_ALL=C on the `cut` for the same reason as in _cv_render_safe: in a UTF-8
+  # locale it exits 1 on an invalid multibyte sequence, and under `set -e` that
+  # ends the whole report. This one has been failing that way since it was
+  # added — and on `main` too, so it is not a regression, but these are the
+  # lines this entry owns.
+  CHECK_NOTE="$( { grep -v '^[[:space:]]*$' "$CHECK_ERR" 2>/dev/null || :; } | tail -1 | LC_ALL=C cut -c1-200)"
   CHECK_NOTE="$(_cv_render_safe "$CHECK_NOTE")"
   rm -f "$CHECK_ERR"
   if [ "$CHECK_RC" -ne 0 ]; then

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -308,23 +308,46 @@ check_for_update() {
 # asymmetric bounding.
 #
 # That was already a live hazard, not a hypothetical: the shipped matrix carries
-# `colima version` and `docker --version`, and resolve-tools.sh's own header
-# records that those "can hang indefinitely when the daemon is unreachable" —
-# which is why it bounds them. This script could hang on an unreachable Docker
-# daemon before any of BL-235's probes existed.
+# `colima version` as a version command, and resolve-tools.sh's own header
+# records that daemon-backed commands "can hang indefinitely when the daemon is
+# unreachable" — which is why it bounds them. This script could hang on an
+# unreachable daemon before any of BL-235's probes existed.
 #
-# The `command -v run_with_timeout` guard is the same one BL-234 established
-# lower down: helpers-core.sh may be absent, and the fallback path does not
-# define it, so an unguarded call would exit 127 and read as "not installed".
+# `docker --version` is NOT one of them, and an earlier draft of this comment
+# named it. It is client-only — it prints a compiled-in string and never opens a
+# socket, measured at 26ms here. `docker version`, without the dashes, is the
+# one that contacts the daemon. The hazard is real; that example was not.
+#
+# The `command -v` guard is the same one BL-234 established lower down:
+# helpers-core.sh may be absent, and the fallback path above does not define its
+# helpers, so an unguarded call would exit 127 and read as "not installed".
+#
+# THE RUNNER IS `run_with_deadline`, NOT `run_with_timeout`, AND THAT IS A
+# MEASUREMENT. `run_with_timeout` polls on a `sleep 1` counter, so every bounded
+# call costs about a second whether the command takes 3ms or 3s. This loop makes
+# TWO bounded calls per row; on the 21-row shipped matrix that is ~42 of them,
+# and this script went from 5-6s to 50-51s the day the bound landed — inside the
+# SessionStart hook, which is the one place where seconds are the operator's.
+# `run_with_deadline` is the same bound on a wall-clock deadline with a 0.1s
+# poll, and it returns 124 for a timeout instead of 1, so "this took too long"
+# stops being spelled the same as "this ran and failed".
 CHECKVER_EVAL_TIMEOUT="${CHECKVER_EVAL_TIMEOUT:-10}"
 _cv_bounded_eval() {
   local _cmd="$1"
-  if command -v run_with_timeout >/dev/null 2>&1; then
-    run_with_timeout "$CHECKVER_EVAL_TIMEOUT" bash -c "$_cmd"
+  if command -v run_with_deadline >/dev/null 2>&1; then
+    run_with_deadline "$CHECKVER_EVAL_TIMEOUT" bash -c "$_cmd"
   else
     bash -c "$_cmd"
   fi
 }
+
+# THE MATRIX ROWS MUST NOT DEPEND ON THIS PROCESS'S `pwd`. Three rows invoke
+# scripts/probe-tool.sh; a relative path inside a JSON data file resolves
+# against whatever directory the consumer is standing in, and `rc=127` —
+# command-not-found — is read two lines below as "not installed". The probe
+# ships next to this script both here and in every generated project, so this
+# script's own location is the answer.
+export SOLO_SCRIPTS_DIR="${SOLO_SCRIPTS_DIR:-$SCRIPT_DIR}"                      # BL-235-SCRIPTS-DIR
 
 MATRIX_DIR="templates/tool-matrix"
 if [ ! -d "$MATRIX_DIR" ]; then
@@ -463,6 +486,18 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
     INSTALLED=$(_cv_bounded_eval "$VERSION_CMD" 2>/dev/null | tr -d '[:space:]' || echo "")   # BL-235-BOUND-VERSION
   fi
 
+  # THE WORD `configured` WAS THE WHOLE DEFECT AND IT NEARLY SURVIVED BY MOVING
+  # FILE. BL-235 deleted `version_command: echo 'configured'` from the matrix —
+  # and this script then rendered the identical word from its own
+  # `${INSTALLED:-configured}` fallback, at four sites, for exactly the rows
+  # that had just stopped declaring it. A JSON-level assertion cannot see that;
+  # only one that reads the OUTPUT can, which is why the suite now has one.
+  #
+  # What is true here is that the check PASSED and the version command produced
+  # nothing. The replacement says that and nothing more: it does not upgrade
+  # silence into a configuration claim. ONE owner, read by all four sites.
+  INSTALLED_DISPLAY="${INSTALLED:-installed, version not reported}"             # BL-235-NO-CONSTANT
+
   # Check minimum version
   MIN_MET=true
   MIN_DISPLAY=""
@@ -486,15 +521,15 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       UPDATE_CMDS+=("${UPDATE_CHECK_CMD:-}")
       UPDATE_NAMES+=("$NAME")
     elif [ "$UPDATE_CHECK_STATUS" = "behind" ]; then
-      print_warn "$NAME: ${INSTALLED:-configured} — $UPDATE_CHECK_MSG"
+      print_warn "$NAME: $INSTALLED_DISPLAY — $UPDATE_CHECK_MSG"
       UPDATES+=("$NAME — $UPDATE_CHECK_MSG")
       UPDATE_CMDS+=("${UPDATE_CHECK_CMD:-}")
       UPDATE_NAMES+=("$NAME")
     elif [ "$UPDATE_CHECK_STATUS" = "self_updating" ]; then
-      print_ok "$NAME: ${INSTALLED:-configured} — $UPDATE_CHECK_MSG"
+      print_ok "$NAME: $INSTALLED_DISPLAY — $UPDATE_CHECK_MSG"
       PASS_COUNT=$((PASS_COUNT + 1))
     else
-      print_ok "$NAME: ${INSTALLED:-configured} — ${UPDATE_CHECK_MSG:-up to date}"
+      print_ok "$NAME: $INSTALLED_DISPLAY — ${UPDATE_CHECK_MSG:-up to date}"
       PASS_COUNT=$((PASS_COUNT + 1))
     fi
   else
@@ -548,7 +583,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
       UPDATE_NAMES+=("$NAME")
       PASS_COUNT=$((PASS_COUNT + 1))
     else
-      print_ok "$NAME: ${INSTALLED:-configured}$MIN_DISPLAY$LATEST_DISPLAY"
+      print_ok "$NAME: $INSTALLED_DISPLAY$MIN_DISPLAY$LATEST_DISPLAY"
       PASS_COUNT=$((PASS_COUNT + 1))
     fi
   fi

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -341,6 +341,37 @@ _cv_bounded_eval() {
   fi
 }
 
+# _cv_version_bounded <cmd> — run a version_command under the bound and put its
+# output in INSTALLED. Also sets CV_NOTE to the command's last stderr line.
+#
+# THE FILE IS THE POINT. `INSTALLED=$(_cv_bounded_eval "$VERSION_CMD")` looks
+# equivalent and is not: a command substitution reads until the last WRITER
+# closes the pipe, and the bound only kills the `bash -c` child. Every pipeline
+# member survives it holding that pipe open, so the substitution waited out the
+# full command while the runner reported it had stopped. Measured on the
+# verbatim shipped Colima row (`colima version … | head -1 | awk …`): 12s
+# against a 2s bound. 21 of the 41 checkable rows are pipeline- or
+# subshell-shaped, so the bound was doing nothing for half the matrix — in the
+# one script that runs from a SessionStart hook, and for exactly the daemon-
+# backed rows it was added to protect. Redirecting to a file makes the reader
+# independent of who still holds the write end. T2b pins it.
+_cv_version_bounded() {
+  local _cmd="$1" _out _err                                                     # BL-235-VERSION-CAPTURE
+  INSTALLED=""
+  CV_NOTE=""
+  _out="$(mktemp)" || return 0
+  _err="$(mktemp)" || { rm -f "$_out"; return 0; }
+  _cv_bounded_eval "$_cmd" >"$_out" 2>"$_err" || true
+  # `|| :` IS LOAD-BEARING UNDER `set -euo pipefail`. `grep -v` exits 1 when it
+  # selects no lines, which for an EMPTY stderr file is the normal case — and
+  # with pipefail that failure propagates out of the command substitution and
+  # `set -e` kills the script mid-row. Measured: every healthy row vanished from
+  # the report and the run ended after the first category header.
+  INSTALLED="$(tr -d '[:space:]' < "$_out" 2>/dev/null || :)"
+  CV_NOTE="$( { grep -v '^[[:space:]]*$' "$_err" 2>/dev/null || :; } | tail -1 | cut -c1-200)"
+  rm -f "$_out" "$_err"
+}
+
 # THE MATRIX ROWS MUST NOT DEPEND ON THIS PROCESS'S `pwd`. Three rows invoke
 # scripts/probe-tool.sh; a relative path inside a JSON data file resolves
 # against whatever directory the consumer is standing in, and `rc=127` —
@@ -472,18 +503,47 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
   # Check if installed
   # Disable set -u: check_commands may reference env vars (e.g., $ANDROID_HOME)
   # that are legitimately unset on this system.
+  # THE PROBE WORKS OUT WHY, AND THIS LINE USED TO BIN IT. `>/dev/null 2>&1`
+  # discarded the check's stderr AND its exit code, so all three states of the
+  # contract probe-tool.sh spends ten lines defending arrived here as one word:
+  # "not installed". Measured before this fix — a database that is UP and
+  # answering 403 because it wants the api-key the operator has not configured
+  # rendered IDENTICALLY to one that was never set up:
+  #
+  #     [WARN] Qdrant MCP: not installed
+  #
+  # while the probe's own stderr, which the test suite was happily asserting on
+  # one layer upstream, said "answered HTTP 403 — the database is up and refused
+  # this probe. Add QDRANT_API_KEY to the same mcpServers entry…". That is this
+  # entry's defect exactly, committed by its own fix: rigour applied at the
+  # probe, consumed at a caller that could not hear it. C3 asserts the guidance
+  # in THIS script's output, not in the probe's.
+  #
+  # rc 2 is the shared three-state convention (0 working / 1 not configured /
+  # 2 cannot confirm). A row that does not implement it simply never returns 2.
   set +u
-  if ! _cv_bounded_eval "$CHECK_CMD" >/dev/null 2>&1; then                      # BL-235-BOUND-CHECK
-    set -u
-    print_warn "$NAME: not installed"
+  CHECK_ERR="$(mktemp)"
+  CHECK_RC=0
+  _cv_bounded_eval "$CHECK_CMD" >/dev/null 2>"$CHECK_ERR" || CHECK_RC=$?         # BL-235-BOUND-CHECK
+  set -u
+  # `|| :` for the same reason as in _cv_version_bounded: an empty stderr file
+  # makes `grep -v` exit 1, and under `set -euo pipefail` that ends the run.
+  CHECK_NOTE="$( { grep -v '^[[:space:]]*$' "$CHECK_ERR" 2>/dev/null || :; } | tail -1 | cut -c1-200)"
+  rm -f "$CHECK_ERR"
+  if [ "$CHECK_RC" -ne 0 ]; then
+    if [ "$CHECK_RC" -eq 2 ]; then                                              # BL-235-THIRD-STATE
+      print_warn "$NAME: configured, but working could not be confirmed${CHECK_NOTE:+ — $CHECK_NOTE}"
+    else
+      print_warn "$NAME: not installed${CHECK_NOTE:+ — $CHECK_NOTE}"
+    fi
     continue
   fi
-  set -u
 
   # Get installed version
   INSTALLED=""
+  CV_NOTE=""
   if [ -n "$VERSION_CMD" ]; then
-    INSTALLED=$(_cv_bounded_eval "$VERSION_CMD" 2>/dev/null | tr -d '[:space:]' || echo "")   # BL-235-BOUND-VERSION
+    _cv_version_bounded "$VERSION_CMD"                                          # BL-235-BOUND-VERSION
   fi
 
   # THE WORD `configured` WAS THE WHOLE DEFECT AND IT NEARLY SURVIVED BY MOVING

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -341,8 +341,35 @@ _cv_bounded_eval() {
   fi
 }
 
+# _cv_note_safe <text> — make a tool's stderr safe to render.
+#
+# `print_warn` renders through `echo -e`, which INTERPRETS backslash escapes in
+# whatever it is given. The note comes from a `check_command`'s stderr, so a
+# note containing the two characters `\` and `n` becomes a real line break —
+# and the line after it is attacker-chosen text at the start of a line, in the
+# one script whose entire job is reporting honestly. Measured, with a stderr of
+# `note-one\nFORGED  [OK] Totally Installed: 9.9.9`:
+#
+#     [WARN] P: configured, but working could not be confirmed — note-one
+#     FORGED  [OK] Totally Installed: 9.9.9        <- a fabricated report row
+#
+# Doubling the backslashes makes `echo -e` emit them literally. The rows ship
+# with the framework today, but the probe notes interpolate `$(qdrant_mcp_url)`
+# read out of `~/.claude.json`, so the text is not wholly ours. C4 pins it.
+_cv_note_safe() {
+  printf '%s' "${1//\\/\\\\}"                                                   # BL-235-NOTE-SAFE
+}
+
 # _cv_version_bounded <cmd> — run a version_command under the bound and put its
-# output in INSTALLED. Also sets CV_NOTE to the command's last stderr line.
+# output in INSTALLED.
+#
+# It does NOT keep the version command's stderr. An earlier version captured it
+# into CV_NOTE, which nothing ever rendered — a second note binned one layer
+# before the operator, which is the defect this entry is named for wearing the
+# costume of its own fix. A version_command that fails already renders honestly
+# as "installed, version not reported", so the row is not lying; adding a second
+# unrendered value only added a `mktemp`, a `grep` and a `cut` per row and a
+# second forgery surface. Dropped rather than plumbed.
 #
 # THE FILE IS THE POINT. `INSTALLED=$(_cv_bounded_eval "$VERSION_CMD")` looks
 # equivalent and is not: a command substitution reads until the last WRITER
@@ -356,20 +383,17 @@ _cv_bounded_eval() {
 # backed rows it was added to protect. Redirecting to a file makes the reader
 # independent of who still holds the write end. T2b pins it.
 _cv_version_bounded() {
-  local _cmd="$1" _out _err                                                     # BL-235-VERSION-CAPTURE
+  local _cmd="$1" _out                                                          # BL-235-VERSION-CAPTURE
   INSTALLED=""
-  CV_NOTE=""
   _out="$(mktemp)" || return 0
-  _err="$(mktemp)" || { rm -f "$_out"; return 0; }
-  _cv_bounded_eval "$_cmd" >"$_out" 2>"$_err" || true
-  # `|| :` IS LOAD-BEARING UNDER `set -euo pipefail`. `grep -v` exits 1 when it
-  # selects no lines, which for an EMPTY stderr file is the normal case — and
-  # with pipefail that failure propagates out of the command substitution and
-  # `set -e` kills the script mid-row. Measured: every healthy row vanished from
-  # the report and the run ended after the first category header.
+  _cv_bounded_eval "$_cmd" >"$_out" 2>/dev/null || true
+  # `|| :` IS LOAD-BEARING UNDER `set -euo pipefail`: a command that exits
+  # non-zero inside a command substitution propagates, and `set -e` then kills
+  # the script mid-row. Measured with the sibling `grep -v` this line used to
+  # carry — on an EMPTY stderr file it exits 1, which is the NORMAL case, and
+  # every healthy row vanished from the report after the first category header.
   INSTALLED="$(tr -d '[:space:]' < "$_out" 2>/dev/null || :)"
-  CV_NOTE="$( { grep -v '^[[:space:]]*$' "$_err" 2>/dev/null || :; } | tail -1 | cut -c1-200)"
-  rm -f "$_out" "$_err"
+  rm -f "$_out"
 }
 
 # THE MATRIX ROWS MUST NOT DEPEND ON THIS PROCESS'S `pwd`. Three rows invoke
@@ -529,6 +553,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
   # `|| :` for the same reason as in _cv_version_bounded: an empty stderr file
   # makes `grep -v` exit 1, and under `set -euo pipefail` that ends the run.
   CHECK_NOTE="$( { grep -v '^[[:space:]]*$' "$CHECK_ERR" 2>/dev/null || :; } | tail -1 | cut -c1-200)"
+  CHECK_NOTE="$(_cv_note_safe "$CHECK_NOTE")"
   rm -f "$CHECK_ERR"
   if [ "$CHECK_RC" -ne 0 ]; then
     if [ "$CHECK_RC" -eq 2 ]; then                                              # BL-235-THIRD-STATE
@@ -541,7 +566,6 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
 
   # Get installed version
   INSTALLED=""
-  CV_NOTE=""
   if [ -n "$VERSION_CMD" ]; then
     _cv_version_bounded "$VERSION_CMD"                                          # BL-235-BOUND-VERSION
   fi

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -301,6 +301,31 @@ check_for_update() {
 }
 
 # --- Load tool matrix ---
+# BL-235: `check_command` and `version_command` are ARBITRARY SHELL read out of
+# a JSON data file, and this consumer ran both through a bare `eval` with no
+# bound — while its sibling scripts/resolve-tools.sh has wrapped the identical
+# strings in a 10s timeout since 2026-06-26. Two readers of one data file,
+# asymmetric bounding.
+#
+# That was already a live hazard, not a hypothetical: the shipped matrix carries
+# `colima version` and `docker --version`, and resolve-tools.sh's own header
+# records that those "can hang indefinitely when the daemon is unreachable" —
+# which is why it bounds them. This script could hang on an unreachable Docker
+# daemon before any of BL-235's probes existed.
+#
+# The `command -v run_with_timeout` guard is the same one BL-234 established
+# lower down: helpers-core.sh may be absent, and the fallback path does not
+# define it, so an unguarded call would exit 127 and read as "not installed".
+CHECKVER_EVAL_TIMEOUT="${CHECKVER_EVAL_TIMEOUT:-10}"
+_cv_bounded_eval() {
+  local _cmd="$1"
+  if command -v run_with_timeout >/dev/null 2>&1; then
+    run_with_timeout "$CHECKVER_EVAL_TIMEOUT" bash -c "$_cmd"
+  else
+    bash -c "$_cmd"
+  fi
+}
+
 MATRIX_DIR="templates/tool-matrix"
 if [ ! -d "$MATRIX_DIR" ]; then
   # Try from orchestrator source
@@ -425,7 +450,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
   # Disable set -u: check_commands may reference env vars (e.g., $ANDROID_HOME)
   # that are legitimately unset on this system.
   set +u
-  if ! eval "$CHECK_CMD" &>/dev/null 2>&1; then
+  if ! _cv_bounded_eval "$CHECK_CMD" >/dev/null 2>&1; then                      # BL-235-BOUND-CHECK
     set -u
     print_warn "$NAME: not installed"
     continue
@@ -435,7 +460,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
   # Get installed version
   INSTALLED=""
   if [ -n "$VERSION_CMD" ]; then
-    INSTALLED=$(eval "$VERSION_CMD" 2>/dev/null | tr -d '[:space:]' || echo "")
+    INSTALLED=$(_cv_bounded_eval "$VERSION_CMD" 2>/dev/null | tr -d '[:space:]' || echo "")   # BL-235-BOUND-VERSION
   fi
 
   # Check minimum version

--- a/scripts/check-versions.sh
+++ b/scripts/check-versions.sh
@@ -341,7 +341,27 @@ _cv_bounded_eval() {
   fi
 }
 
-# _cv_note_safe <text> — make a tool's stderr safe to render.
+# _cv_render_safe <text> — make TOOL-SUPPLIED text safe to render.
+#
+# It is `_render_` and not `_note_` because the note was one of TWO surfaces and
+# fixing only it was the sync-sibling trap in miniature. `INSTALLED` comes from
+# a version_command's STDOUT and reaches the same `echo -e` at nine places —
+# six direct (`$INSTALLED` / `$INSTALLED_DISPLAY`) and three via `UPDATES[]` —
+# and it was not escaped. Measured: a version_command emitting
+# `1.0\n\x20\x20[OK]\x20Totally\x20Installed:\x209.9.9` produced
+#
+#     [OK] P: 1.0
+#     [OK] Totally Installed: 9.9.9 — up to date
+#
+# a fabricated row byte-identical to a genuine one. `tr -d '[:space:]'` does not
+# stop it, because `\x20` is not whitespace until `echo -e` expands it. That
+# path has the same external-input vector as the notes: `probe_superpowers` and
+# `probe_context7` print a `version` field straight out of
+# `~/.claude/plugins/installed_plugins.json`.
+#
+# So this is applied at the SOURCE of each value — once where the note is read
+# and once where the version is captured — rather than at the render sites,
+# because there are nine of the latter and the next one added would be unguarded.
 #
 # `print_warn` renders through `echo -e`, which INTERPRETS backslash escapes in
 # whatever it is given. The note comes from a `check_command`'s stderr, so a
@@ -356,8 +376,21 @@ _cv_bounded_eval() {
 # Doubling the backslashes makes `echo -e` emit them literally. The rows ship
 # with the framework today, but the probe notes interpolate `$(qdrant_mcp_url)`
 # read out of `~/.claude.json`, so the text is not wholly ours. C4 pins it.
-_cv_note_safe() {
-  printf '%s' "${1//\\/\\\\}"                                                   # BL-235-NOTE-SAFE
+# RAW CONTROL BYTES ARE STRIPPED AS WELL AS BACKSLASHES DOUBLED, and the range
+# is `\000-\037\177` — everything below space, plus DEL. A carriage return is
+# not a backslash, so doubling alone leaves it, and on a terminal it returns the
+# cursor to column 0 so the following text OVERWRITES the `[WARN]` prefix and
+# renders a complete fake row. The narrower range `\000-\010\013\014\016-\037`
+# was proposed for this and does NOT strip CR — `\015` falls in the gap between
+# `\014` and `\016`. Measured before adopting it: `printf 'a\rb' | tr -d
+# '\000-\010\013\014\016-\037\177'` still emits `a \r b`. Take the whole range;
+# a tab or newline inside a version string or a one-line note is worth nothing.
+# Two lines, not one, so a mutation proof can target the RANGE independently of
+# the doubling — a single line can only be mutated as a whole, and then a test
+# cannot tell "the tr is gone" from "the tr is too narrow".
+_cv_render_safe() {
+  local _s="${1//\\/\\\\}"
+  printf '%s' "$_s" | tr -d '\000-\037\177'                                     # BL-235-NOTE-SAFE
 }
 
 # _cv_version_bounded <cmd> — run a version_command under the bound and put its
@@ -392,7 +425,11 @@ _cv_version_bounded() {
   # the script mid-row. Measured with the sibling `grep -v` this line used to
   # carry — on an EMPTY stderr file it exits 1, which is the NORMAL case, and
   # every healthy row vanished from the report after the first category header.
-  INSTALLED="$(tr -d '[:space:]' < "$_out" 2>/dev/null || :)"
+  # Sanitised HERE, at the single point of capture, so all nine downstream
+  # render sites are covered and a tenth added later cannot be forgotten.
+  # `version_gte` strips to digits before comparing, so this cannot change a
+  # version verdict.
+  INSTALLED="$(_cv_render_safe "$(tr -d '[:space:]' < "$_out" 2>/dev/null || :)")"   # BL-235-VERSION-SAFE
   rm -f "$_out"
 }
 
@@ -553,7 +590,7 @@ for i in $(seq 0 $((TOOL_COUNT - 1))); do
   # `|| :` for the same reason as in _cv_version_bounded: an empty stderr file
   # makes `grep -v` exit 1, and under `set -euo pipefail` that ends the run.
   CHECK_NOTE="$( { grep -v '^[[:space:]]*$' "$CHECK_ERR" 2>/dev/null || :; } | tail -1 | cut -c1-200)"
-  CHECK_NOTE="$(_cv_note_safe "$CHECK_NOTE")"
+  CHECK_NOTE="$(_cv_render_safe "$CHECK_NOTE")"
   rm -f "$CHECK_ERR"
   if [ "$CHECK_RC" -ne 0 ]; then
     if [ "$CHECK_RC" -eq 2 ]; then                                              # BL-235-THIRD-STATE

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -222,10 +222,27 @@ adopt_write_manifest() {
   case "$host" in ''|null) host="other" ;; esac
   mode="$ADOPT_DEPLOYMENT"
 
+  # BL-221-ADOPT-TIER-KEYS: write the tier keys an init.sh-scaffolded manifest
+  # carries. This function wrote only `.host` and `.mode`, so an ADOPTED
+  # manifest had no `deployment`, `poc_mode` or `enforcement_level` at all —
+  # and `assert_choosable` read an absent `deployment` as the CHOOSABLE tier.
+  # The predicate is now fail-closed too (# BL-221-TIER-FAIL-CLOSED); this half
+  # removes the SOURCE of the divergence rather than defending against it, so
+  # the two birth paths produce the same shape.
+  #
+  # Values match what the driver already writes to phase-state.json in
+  # adopt_write_phase_state — same two variables, so the manifest and the
+  # phase record cannot disagree about the tier. `enforcement_level` seeds to
+  # `strict`, which is init.sh's default and the direction this framework
+  # fails in.
+  local poc="$ADOPT_POC_MODE"
   if [ -f "$root/.claude/manifest.json" ]; then
-    adopt_jq_edit "$root" ".claude/manifest.json" '.host = $h | .mode = $m' --arg h "$host" --arg m "$mode" || return 1
+    adopt_jq_edit "$root" ".claude/manifest.json" \
+      '.host = $h | .mode = $m | .deployment = $d | .poc_mode = $p | .enforcement_level = (.enforcement_level // "strict")' \
+      --arg h "$host" --arg m "$mode" --arg d "$mode" --arg p "$poc" || return 1
   else
-    jq -n --arg h "$host" --arg m "$mode" '{host: $h, mode: $m, remote_url: ""}' \
+    jq -n --arg h "$host" --arg m "$mode" --arg p "$poc" \
+      '{host: $h, mode: $m, remote_url: "", deployment: $m, poc_mode: $p, enforcement_level: "strict"}' \
       | adopt_write_file "$root" ".claude/manifest.json" || return 1
   fi
 

--- a/scripts/lib/enforcement-level.sh
+++ b/scripts/lib/enforcement-level.sh
@@ -49,8 +49,33 @@ assert_choosable() {
     return 1
   fi
   local deployment poc_mode
-  deployment=$(jq -r '.deployment // "personal"' "$manifest" 2>/dev/null)
+  # BL-221: `// "personal"` made an ABSENT key resolve to the CHOOSABLE tier —
+  # a fail-OPEN on the one surface that decides whether a project may weaken
+  # its own enforcement. jq's `//` coerces null, false AND empty to its
+  # right-hand side, so an absent key and an explicit `null` were both read as
+  # `personal`. Deleting one key from an organizational manifest flipped it
+  # from refusing the downgrade to allowing it.
+  #
+  # `read_enforcement_level` above has always failed CLOSED on the same inputs
+  # (missing file, unreadable, unknown value -> strict). Two readers in one
+  # library disagreeing about the same manifest was half the finding; they now
+  # agree.
+  deployment=$(jq -r '.deployment // ""' "$manifest" 2>/dev/null)                # BL-221-TIER-FAIL-CLOSED
   poc_mode=$(jq -r '.poc_mode // ""' "$manifest" 2>/dev/null)
+  case "$deployment" in
+    ''|null)
+      # A blocking predicate that will not say WHY is its own defect: name the
+      # key and how to supply it.
+      echo "[FAIL] enforcement-level: $manifest has no 'deployment' key, so the tier cannot be determined — refusing to treat an unknown tier as choosable." >&2
+      # Deliberately does NOT name the adoption driver: this is a CORE file and
+      # the brownfield driver is a SEVERABLE MODULE (M3 — core may never
+      # reference a module). lint-module-dependencies.sh caught the first
+      # draft of this line doing exactly that. Say what the operator must set;
+      # whichever tool created the project is not core's business.
+      echo "       Set '.deployment' to \"personal\" or \"organizational\" in that manifest, then retry." >&2
+      return 1
+      ;;
+  esac
   if [ "$deployment" = "personal" ]; then
     return 0
   fi

--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -112,12 +112,45 @@ run_with_timeout() {
 #   private copy of this in the first place; the copy is now deleted and this is
 #   the one owner.
 #
-# run_with_timeout is deliberately UNTOUCHED. It has eleven call sites across
-# six product files, several inside enforcement paths, and changing a shared
-# gate primitive is a separate decision from fixing a regression at two new
-# call sites.
+# run_with_timeout is deliberately UNTOUCHED — its body is byte-identical to
+# main's. Changing a shared gate primitive is a separate decision from fixing a
+# regression at two new call sites.
+#
+# Derive its reach, do not read it here. An earlier draft of this comment said
+# "eleven call sites across six product files", which was true of `main` and
+# false of the tree the comment shipped in: this branch's own Qdrant work added
+# three more, so HEAD is 14 across 7. A count stated on the page that falsifies
+# it is the failure this whole entry is named for.
+#
+#   for f in $(grep -rl run_with_timeout --include='*.sh' scripts/ init.sh \
+#             | grep -v helpers-core.sh); do
+#     sed 's/[[:space:]]*#.*$//' "$f" | grep -E 'run_with_timeout[[:space:]]' \
+#       | grep -vc 'command -v run_with_timeout'
+#   done
+# THE BOUND IS ON THE PROCESS, NOT ON THE PIPELINE, AND A CALLER CAN DEFEAT IT.
+# `kill -9` reaps the `bash -c` child; a pipeline's OTHER members survive it and
+# keep the write end of any pipe open. So a caller that consumes the output
+# through a COMMAND SUBSTITUTION — `v=$(run_with_deadline 2 bash -c 'sleep 12 |
+# cat')` — blocks for the full 12s while this function returns in 2, because the
+# substitution reads until the last writer closes, not until the child dies.
+# Measured: plain `sleep 12` returns at the bound; `sleep 12 | cat`, `(sleep 12)`
+# and the shipped Colima row's `… | head -1 | awk …` all ran to completion.
+# 21 of the 41 checkable matrix rows are that shape.
+#
+# Callers must therefore redirect to a FILE and read it afterwards, which is
+# what `_cv_version_bounded` (check-versions.sh) and `run_bounded_capture`
+# (resolve-tools.sh) do. Both are measured at the bound for every shape.
+# `set -m` + `kill -- -$pid` was tried first and does NOT work here: a command
+# substitution runs in a subshell with job control disabled, so the child never
+# gets its own process group.
 run_with_deadline() {
   local _rwd_secs="$1"; shift
+  # A NON-NUMERIC BOUND MUST NOT MEAN "ZERO". `$(( now + abc ))` is `now`, so an
+  # unparseable CHECKVER_EVAL_TIMEOUT made the deadline already-past and EVERY
+  # row timed out instantly and reported "not installed" — a whole matrix turned
+  # to "missing" by one malformed environment variable, silently. Same guard
+  # `qdrant_probe_root` already carries.
+  case "$_rwd_secs" in ''|*[!0-9]*|0) _rwd_secs=10 ;; esac                      # BL-235-DEADLINE-SANE
   # Probe fractional sleep ONCE per process, not once per call: the probe is
   # itself a sleep, and paying it 42 times would re-import a fraction of the
   # cost this function exists to remove.

--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -89,6 +89,55 @@ run_with_timeout() {
   wait "$_rto_pid" 2>/dev/null
 }
 
+# run_with_deadline <seconds> <command...> — the same job as run_with_timeout,
+# with the two properties its counter cannot have.                # BL-235-DEADLINE
+#
+#   rc 124 on timeout, and the command's own status otherwise. run_with_timeout
+#   returns 1 for a timeout, which is indistinguishable from "it ran and
+#   failed" — so a caller can never report "this took too long" as itself.
+#
+#   A POLL FLOOR OF 0.1s, NOT 1s. run_with_timeout sleeps a whole second before
+#   its first re-check, so every bounded call costs ~1s even when the command is
+#   instant. That is invisible at one call site and arithmetic at forty:
+#   check-versions.sh bounds a check_command AND a version_command per row, and
+#   on the 21-row shipped matrix it measured 5-6s before the bound and 50-51s
+#   after — inside the SessionStart hook. The bound was right; its price was
+#   never measured. `sleep 0.1` is not POSIX, so a shell that rejects it falls
+#   back to whole seconds rather than spinning: correctness first, speed if the
+#   platform allows it.
+#
+#   The deadline is WALL CLOCK, not an increment count, so a SIGCHLD from some
+#   other killed child — which cuts `sleep` short — cannot inflate the counter
+#   and kill a command early. That bug is why scripts/resolve-tools.sh grew a
+#   private copy of this in the first place; the copy is now deleted and this is
+#   the one owner.
+#
+# run_with_timeout is deliberately UNTOUCHED. It has eleven call sites across
+# six product files, several inside enforcement paths, and changing a shared
+# gate primitive is a separate decision from fixing a regression at two new
+# call sites.
+run_with_deadline() {
+  local _rwd_secs="$1"; shift
+  # Probe fractional sleep ONCE per process, not once per call: the probe is
+  # itself a sleep, and paying it 42 times would re-import a fraction of the
+  # cost this function exists to remove.
+  if [ -z "${_SOIF_FRACTIONAL_SLEEP:-}" ]; then
+    if sleep 0.05 2>/dev/null; then _SOIF_FRACTIONAL_SLEEP=1; else _SOIF_FRACTIONAL_SLEEP=0; fi
+  fi
+  "$@" &
+  local _rwd_pid=$!
+  local _rwd_deadline=$(( $(date +%s) + _rwd_secs ))
+  while kill -0 "$_rwd_pid" 2>/dev/null; do
+    if [ "$(date +%s)" -ge "$_rwd_deadline" ]; then
+      kill -9 "$_rwd_pid" 2>/dev/null || true
+      wait "$_rwd_pid" 2>/dev/null || true
+      return 124
+    fi
+    if [ "$_SOIF_FRACTIONAL_SLEEP" = "1" ]; then sleep 0.1; else sleep 1; fi
+  done
+  wait "$_rwd_pid" 2>/dev/null
+}
+
 # --- Prompt helpers ---
 
 # Prompt for text input with optional default value.

--- a/scripts/lib/helpers-full.sh
+++ b/scripts/lib/helpers-full.sh
@@ -195,17 +195,86 @@ qdrant_mcp_api_key() {
 # `"` and `\` are escaped because curl's config parser reads the quoted form,
 # and CR/LF are stripped because a header value cannot contain them: a newline
 # would end the config line and drop the header the same silent way.
+#
+# BL-235: the escaping is a FUNCTION now because a second caller needed it, and
+# a second copy of "how a credential is made safe for curl's config parser" is
+# exactly the sync-sibling trap `# BL-084-TIER-KEY` exists for. The `printf`
+# stays spelled out at each call site on purpose — `esc` must remain a live
+# local here, because M14 in tests/test-bl234-currency-and-availability.sh
+# mutates the marked line into an `-H "api-key: $esc"` form and reads the
+# stub's argv log to prove the credential travels off the command line.
+_qdrant_key_escape() {                                             # BL-234-QDRANT-KEY-ESCAPE
+  local e="$1"
+  e=${e//\\/\\\\}; e=${e//\"/\\\"}
+  e=${e//$'\n'/}; e=${e//$'\r'/}
+  printf '%s' "$e"
+}
+
 _qdrant_curl() {
   local secs="$1" key="$2" u="$3" rc=0 esc
   if [ -n "$key" ]; then
-    esc=${key//\\/\\\\}; esc=${esc//\"/\\\"}
-    esc=${esc//$'\n'/}; esc=${esc//$'\r'/}
+    esc="$(_qdrant_key_escape "$key")"
     run_with_timeout "$secs" curl -fsS --max-time "$secs" -o /dev/null \
       -K <(printf 'header = "api-key: %s"\n' "$esc") "$u" >/dev/null 2>&1 || rc=$?   # BL-234-QDRANT-KEY-STDIN
   else
     run_with_timeout "$secs" curl -fsS --max-time "$secs" -o /dev/null "$u" >/dev/null 2>&1 || rc=$?
   fi
   return "$rc"
+}
+
+# qdrant_probe_root <bodyfile> [url] — the ROOT endpoint's PAYLOAD, for the
+# caller that must check WHAT answered rather than merely THAT something did.
+#
+#   <bodyfile>            the response body is written here, and only on 2xx
+#   QDRANT_ROOT_STATUS    the HTTP status, or 000 when nothing answered
+#   rc 0                  the server answered (any status — 403 is an answer)
+#   rc 1                  nothing answered: refused, unresolvable, or timed out
+#   rc 2                  cannot tell — curl is absent, so no bounded socket
+#
+# THE BODY GOES TO A FILE, NOT TO STDOUT, AND THAT IS NOT A STYLE CHOICE.
+# A caller writing `payload="$(qdrant_probe_root)"` runs this function in a
+# SUBSHELL, so QDRANT_ROOT_STATUS is set in a process that exits immediately and
+# the caller reads an empty status — then reports "nothing answered" about a
+# server that answered. Returning two values through one stdout is what created
+# the hazard; the file removes it.
+#
+# WHY THIS IS NOT scripts/probe-tool.sh's OWN CURL. It was, and that copy had
+# neither of this file's two hard-won properties: it sent no api-key at all, so
+# a secured database answered 403 and `curl -fsS` reported the same failure a
+# dead port does; and it used `-f`, which collapses "answered with an error"
+# into "did not answer". Both are `## BL-234:`'s findings, re-made one file over
+# within a week. Everything credential-shaped — which file the entry is read
+# from, that the URL and the key come from the SAME entry, that the key travels
+# only to a host the registration itself declared, and that it never reaches
+# argv — is inherited from the helpers above rather than re-derived here.
+#
+# `-w %{http_code}` replaces `-f`: the status is the thing a caller needs to
+# tell "your key is missing" from "your database is down", and those are
+# different repairs.
+QDRANT_ROOT_STATUS=""
+qdrant_probe_root() {
+  local body="$1" url="${2:-}" base secs key regf declared code rc=0
+  QDRANT_ROOT_STATUS="000"
+  : > "$body" 2>/dev/null || return 2
+  command -v curl >/dev/null 2>&1 || return 2
+  regf="$(qdrant_mcp_reg_file)"
+  [ -n "$url" ] || url="$(qdrant_mcp_url "$regf")"
+  base="${url%/}"
+  secs="${SOLO_QDRANT_PROBE_TIMEOUT:-3}"
+  case "$secs" in ''|*[!0-9]*|0) secs=3 ;; esac
+  key=""; declared="$(qdrant_mcp_url_declared "$regf")"; declared="${declared%/}"
+  [ -n "$declared" ] && [ "$base" = "$declared" ] && key="$(qdrant_mcp_api_key "$regf")"   # BL-235-ROOT-KEY-HEADER
+  if [ -n "$key" ]; then
+    code="$(run_with_timeout "$secs" curl -sS -o "$body" -w '%{http_code}' --max-time "$secs" \
+      -K <(printf 'header = "api-key: %s"\n' "$(_qdrant_key_escape "$key")") "$base/" 2>/dev/null)" || rc=$?   # BL-235-ROOT-KEY-STDIN
+  else
+    code="$(run_with_timeout "$secs" curl -sS -o "$body" -w '%{http_code}' --max-time "$secs" "$base/" 2>/dev/null)" || rc=$?
+  fi
+  case "$code" in ''|*[!0-9]*) code="000" ;; esac
+  QDRANT_ROOT_STATUS="$code"
+  if [ "$rc" -ne 0 ] || [ "$code" = "000" ]; then : > "$body" 2>/dev/null; return 1; fi
+  case "$code" in 2??) : ;; *) : > "$body" 2>/dev/null ;; esac
+  return 0
 }
 
 # _qdrant_answered <secs> <key> <url> — 0 iff the server ANSWERED AT ALL.

--- a/scripts/probe-tool.sh
+++ b/scripts/probe-tool.sh
@@ -27,31 +27,44 @@ set -uo pipefail
 # either neighbour is how a declaration becomes a capability claim. Callers that
 # gate on this MUST treat 2 as not-working.
 #
+# THE FIRST VERSION OF THIS FILE HAD NO COVERAGE OF THAT CONTRACT. Its test
+# asserted `rc -ne 0` where the truth is exactly 2 — which also passes on
+# `rc=127`, the code you get when this script cannot be FOUND. That is how the
+# matrix rows shipped CWD-relative: the assertion could not tell "the database
+# is down" from "the probe was never run". Assert the state you mean.
+#
 # ── WHY THE THREE ROWS ARE NOT SYMMETRIC, STATED RATHER THAN AVERAGED ───────
 # Only ONE of them is a network service:
 #
 #   qdrant       a running database — reachability is testable, and its `/`
-#                payload reports a real version. Full three states apply.
-#   context7     a STDIO MCP server launched on demand by npx. There is no
-#                daemon to reach, so "reachable" is not a state it has. The
-#                strongest local truth is: registered AND its launcher exists.
+#                payload identifies the server. Full three states apply.
+#   context7     an MCP server reachable over EITHER transport its own entry
+#                declares: a stdio launcher, or a documented HTTP endpoint with
+#                no `command` field at all. The probe reads which one it is.
 #   superpowers  a Claude plugin. Not a service at all; working means enabled
-#                AND its files are present on disk.
+#                AND its recorded install actually exists on disk.
 #
 # Inventing a uniform "reachable" verdict for all three would be the same
 # substitution this entry is about, one level up. Each probe reports the
 # strongest evidence its tool actually admits of, and says which kind it got.
 #
-# ── VERSIONS ────────────────────────────────────────────────────────────────
+# ── VERSIONS: OF THE THING THE ROW NAMES ────────────────────────────────────
 # `--version` prints a FALSIFIABLE string or NOTHING. It never prints a
-# constant. `echo 'configured'` was true of a machine with nothing installed;
-# an empty version is honest, and check-versions.sh already handles it.
+# constant — and it never prints a number about a DIFFERENT ARTEFACT, which is
+# the same substitution one field over. The first version of this file reported
+# the DATABASE's version under a row named `Qdrant MCP` whose
+# `update_check.runner` is `uvx`, i.e. the `mcp-server-qdrant` package. The
+# number was real and it answered a question nobody asked. The package version
+# is read from uv's own cache; when it cannot be established, nothing is
+# printed, and check-versions.sh renders that state honestly.
 #
-# Every network read is BOUNDED. There is no timeout(1)/gtimeout(1) on the dev
-# host, so this uses run_with_timeout from helpers-core.sh when available and
-# curl's own --max-time as the floor.
+# Every network read is BOUNDED, and every Qdrant read goes through
+# scripts/lib/helpers-full.sh — see qdrant_probe_root there for why this file
+# no longer owns a curl of its own.
 
 PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1090
+[ -f "$PROBE_DIR/lib/helpers-full.sh" ] && . "$PROBE_DIR/lib/helpers-full.sh" 2>/dev/null
 # shellcheck disable=SC1090
 [ -f "$PROBE_DIR/lib/helpers-core.sh" ] && . "$PROBE_DIR/lib/helpers-core.sh" 2>/dev/null
 
@@ -59,15 +72,30 @@ PROBE_TIMEOUT="${PROBE_TOOL_TIMEOUT:-5}"
 
 _probe_note() { [ "${PROBE_QUIET:-0}" = "1" ] || printf '%s\n' "$*" >&2; }
 
-# _probe_http <url> — bounded GET, body on stdout. rc 0 only on a real response.
-_probe_http() {                                                      # BL-235-PROBE-BOUNDED
-  local url="$1"
-  command -v curl >/dev/null 2>&1 || return 1
-  if command -v run_with_timeout >/dev/null 2>&1; then
-    run_with_timeout "$PROBE_TIMEOUT" curl -fsS --max-time "$PROBE_TIMEOUT" "$url"
+# _probe_bounded <secs> <command...> — the bounded runner, whichever this tree
+# has. run_with_deadline is preferred (wall-clock, 0.1s poll, rc 124); an older
+# checkout may only carry run_with_timeout. With neither, curl's own --max-time
+# is the floor, which is a real bound for curl and nothing else.
+_probe_bounded() {                                                   # BL-235-PROBE-BOUNDED
+  local secs="$1"; shift
+  if command -v run_with_deadline >/dev/null 2>&1; then
+    run_with_deadline "$secs" "$@"
+  elif command -v run_with_timeout >/dev/null 2>&1; then
+    run_with_timeout "$secs" "$@"
   else
-    curl -fsS --max-time "$PROBE_TIMEOUT" "$url"
+    "$@"
   fi
+}
+
+# _probe_http <url> — bounded GET against a URL that carries NO credential.
+# Used for transports whose configuration declares a plain endpoint. rc 0 iff
+# the host answered at all; the status does not matter, because for "is there
+# an MCP server on the other end of this URL" a 404 from a live host is still
+# an answer and a refused connection is not.
+_probe_http() {
+  local url="$1"
+  command -v curl >/dev/null 2>&1 || return 2
+  _probe_bounded "$PROBE_TIMEOUT" curl -sS -o /dev/null --max-time "$PROBE_TIMEOUT" "$url" >/dev/null 2>&1
 }
 
 # _mcp_entry <jq-filter> — the first match across the two config files Claude
@@ -82,54 +110,172 @@ _mcp_entry() {
   return 1
 }
 
+# _uv_cached_version <dist-name> — the highest version of a package uv has
+# actually downloaded, or nothing.
+#
+# THIS IS A CACHE READ, AND IT IS DELIBERATELY ALLOWED TO FIND NOTHING. `uvx`
+# resolves the package at launch, so there is no installed copy to interrogate
+# and no `--version` to run that would not cost a network round trip at session
+# start. What uv has on disk is the build it most recently ran, which is a
+# falsifiable fact about the right artefact; when the layout changes or nothing
+# is cached, the answer is silence rather than a number about something else.
+# Measured at 14ms with `-maxdepth 2`.
+_uv_cached_version() {
+  local pkg="$1" cache=""
+  command -v uv >/dev/null 2>&1 && cache="$(uv cache dir 2>/dev/null)"
+  [ -n "$cache" ] || cache="${UV_CACHE_DIR:-$HOME/.cache/uv}"
+  [ -d "$cache/archive-v0" ] || return 1
+  find "$cache/archive-v0" -maxdepth 2 -name "${pkg}-*.dist-info" -print 2>/dev/null \
+    | sed -e 's#.*/##' -e "s#^${pkg}-##" -e 's#\.dist-info$##' \
+    | sort -t. -k1,1n -k2,2n -k3,3n \
+    | tail -1
+}
+
+# _plugin_entry <plugin-id> — the installed plugin registry entry that is
+# ACTUALLY ON DISK, printed as "<path><TAB><version>".
+#   rc 0  found: a recorded installPath that exists
+#   rc 1  no registry, or no entry for this id
+#   rc 2  entries exist but none of their recorded paths do
+#
+# SELECT BY PREDICATE, NOT BY POSITION. This read used to be
+# `.plugins[<id>][0].installPath` — index zero, whatever happens to be there.
+# With a stale entry first and the live one second, a perfectly healthy install
+# scored CANNOT CONFIRM; with two live versions it printed whichever the
+# installer had listed first. "The first one" is not a fact about the machine.
+#
+# THE PATH COMES FIRST IN THE RECORD, and that ordering is load-bearing. `read`
+# treats a TAB in IFS as whitespace, so it collapses runs and discards a LEADING
+# empty field: a `<version>\t<path>` record for an entry with no version would
+# arrive as version="/the/path", path="" — a directory test against an empty
+# string, silently false, for every unversioned entry. Path first cannot be
+# empty (empty paths are skipped), so nothing collapses.
+_plugin_entry() {
+  local id="$1" reg rows path ver
+  command -v jq >/dev/null 2>&1 || return 1
+  reg="$HOME/.claude/plugins/installed_plugins.json"                 # BL-235-PROBE-PLUGIN-REGISTRY
+  [ -f "$reg" ] || return 1
+  # Both registry shapes: entries under `.plugins[<id>]`, and older files that
+  # carry the id at the top level.
+  rows="$(jq -r --arg id "$id" '
+      ((.plugins[$id]? // .[$id]? // []) | if type == "array" then . else [.] end)[]
+      | select(type == "object")
+      | ((.installPath // "") + "\t" + (.version // ""))' "$reg" 2>/dev/null)"
+  [ -n "$rows" ] || return 1
+  while IFS=$'\t' read -r path ver; do                               # BL-235-PROBE-PLUGIN-SELECT
+    [ -n "${path:-}" ] || continue
+    if [ -d "$path" ]; then printf '%s\t%s\n' "$path" "${ver:-}"; return 0; fi
+  done <<EOF
+$rows
+EOF
+  return 2
+}
+
 probe_qdrant() {
-  local want_version="$1" url payload ver
-  _mcp_entry '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' >/dev/null || {
+  local want_version="$1" body title ver rc=0
+  # THE HELPERS ARE CHECKED FIRST, BEFORE THE CONFIG. Ask about the entry with
+  # helpers-full.sh missing and `is_qdrant_mcp_entry_present` is simply not a
+  # command: rc=127, which the `||` below would have reported as NOT CONFIGURED
+  # — the strongest of the three answers, produced by having no way to look.
+  if ! command -v qdrant_probe_root >/dev/null 2>&1 \
+     || ! command -v is_qdrant_mcp_entry_present >/dev/null 2>&1; then
+    _probe_note "qdrant: scripts/lib/helpers-full.sh is unavailable, so neither the registration nor the database can be read — cannot confirm"
+    return 2
+  fi
+  is_qdrant_mcp_entry_present || {
     _probe_note "qdrant: no mcpServers entry in ~/.claude/settings.json or ~/.claude.json"
     return 1
   }
-  url="$(_mcp_entry '(.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"]).env.QDRANT_URL // empty' 2>/dev/null)"
-  case "$url" in ''|null) url="http://localhost:6333" ;; esac
-  payload="$(_probe_http "$url/" 2>/dev/null)" || {
-    _probe_note "qdrant: configured at $url but the database did not answer — registered is not running"
-    return 2
-  }
-  # A 200 from something that is not Qdrant is not evidence of Qdrant.
-  ver="$(printf '%s' "$payload" | jq -r '.version // empty' 2>/dev/null)"
-  if [ -z "$ver" ]; then
-    _probe_note "qdrant: $url answered, but the payload carries no version field — cannot confirm it is Qdrant"
+  body="$(mktemp)" || { _probe_note "qdrant: no writable temp directory — cannot confirm"; return 2; }
+  qdrant_probe_root "$body" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    rm -f "$body"
+    _probe_note "qdrant: configured at $(qdrant_mcp_url) but nothing answered (HTTP ${QDRANT_ROOT_STATUS:-000}) — registered is not running"
     return 2
   fi
-  [ "$want_version" = "1" ] && printf '%s\n' "$ver"
+  case "${QDRANT_ROOT_STATUS:-}" in
+    2??) : ;;
+    *)
+      # THE SERVER ANSWERED AND REFUSED, WHICH IS NOT THE SAME AS SILENCE.
+      # A Qdrant secured with QDRANT__SERVICE__API_KEY answers an unkeyed probe
+      # 403; the operator's repair is a key, not a container.
+      rm -f "$body"
+      _probe_note "qdrant: $(qdrant_mcp_url) answered HTTP ${QDRANT_ROOT_STATUS} — the database is up and refused this probe. Add QDRANT_API_KEY to the same mcpServers entry that carries QDRANT_URL."
+      return 2
+      ;;
+  esac
+  # A 200 FROM SOMETHING THAT IS NOT QDRANT IS NOT EVIDENCE OF QDRANT. This
+  # check used to read `.version // empty` alone, and a stub literally named
+  # `totally-not-qdrant` scored WORKING, as did an Elasticsearch-shaped payload
+  # whose `.version` is an OBJECT. `title` and a STRING `version` are both
+  # REQUIRED in Qdrant's own VersionInfo schema (api.qdrant.tech, GET /), so
+  # this is the published contract and not a guess about response shapes.
+  title="$(jq -r '(.title | strings) // empty' "$body" 2>/dev/null)"   # BL-235-PROBE-IDENTITY
+  ver="$(jq -r '(.version | strings) // empty' "$body" 2>/dev/null)"
+  rm -f "$body"
+  if [ -z "$title" ] || [ -z "$ver" ]; then
+    _probe_note "qdrant: $(qdrant_mcp_url) answered 200 but the payload is not a Qdrant VersionInfo (title and a string version are both required) — cannot confirm it is Qdrant"
+    return 2
+  fi
+  if [ "$want_version" = "1" ]; then
+    # NOT $ver. That is the DATABASE's version; this row is the MCP server.
+    _uv_cached_version mcp_server_qdrant
+  fi
   return 0
 }
 
 probe_context7() {
-  local want_version="$1"
-  _mcp_entry '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty' >/dev/null \
-    || _mcp_entry '.enabledPlugins | to_entries[] | select(.key | test("^context7"; "i")) | select(.value == true)' >/dev/null \
-    || { _probe_note "context7: no mcpServers entry and no enabled plugin"; return 1; }
-  # A stdio MCP server has no daemon to reach. The falsifiable local fact is
-  # whether the launcher it is configured to run actually exists.
-  if ! command -v npx >/dev/null 2>&1; then
-    _probe_note "context7: registered, but npx is not on PATH — the configured launcher cannot start it"
-    return 2
+  local want_version="$1" entry url cmd pver rc=0
+  entry="$(_mcp_entry '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty')" || entry=""
+  if [ -n "$entry" ]; then
+    # THE TRANSPORT THE ENTRY DECLARES, NOT THE ONE THIS PROBE ASSUMED.
+    # context7 ships a documented HTTP transport whose entry carries a `url` and
+    # NO `command` at all; hardcoding `command -v npx` judged such an install by
+    # a launcher its own configuration never mentions.
+    url="$(printf '%s' "$entry" | jq -r '.url | strings // empty' 2>/dev/null)"
+    if [ -n "$url" ]; then
+      if _probe_http "$url"; then
+        return 0
+      fi
+      _probe_note "context7: registered over HTTP at $url, but nothing answered there"
+      return 2
+    fi
+    cmd="$(printf '%s' "$entry" | jq -r '.command | strings // empty' 2>/dev/null)"
+    [ -n "$cmd" ] || cmd="npx"
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+      _probe_note "context7: registered, but its configured launcher '$cmd' is not on PATH"
+      return 2
+    fi
+    if [ "$want_version" = "1" ]; then
+      # Only a CACHED version is cheap and offline-safe; no version is better
+      # than a constant that cannot be wrong.
+      pver="$(npm ls -g --depth=0 --json 2>/dev/null | jq -r '.dependencies["@upstash/context7-mcp"].version // empty' 2>/dev/null)"
+      [ -n "$pver" ] && printf '%s\n' "$pver"
+    fi
+    return 0
   fi
-  if [ "$want_version" = "1" ]; then
-    # Only a CACHED version is cheap and offline-safe; no version is better
-    # than a constant that cannot be wrong.
-    local v
-    v="$(npm ls -g --depth=0 --json 2>/dev/null | jq -r '.dependencies["@upstash/context7-mcp"].version // empty' 2>/dev/null)"
-    [ -n "$v" ] && printf '%s\n' "$v"
+
+  # Plugin-installed context7 surfaces under .enabledPlugins, not .mcpServers,
+  # and is answered by the same registry question superpowers asks.
+  local pid
+  pid="$(_mcp_entry '.enabledPlugins | to_entries[] | select(.key | test("^context7"; "i")) | select(.value == true) | .key')" || pid=""
+  if [ -z "$pid" ]; then
+    _probe_note "context7: no mcpServers entry and no enabled plugin"
+    return 1
   fi
-  return 0
+  local row
+  row="$(_plugin_entry "$pid")" || rc=$?
+  case "$rc" in
+    0) [ "$want_version" = "1" ] && printf '%s\n' "${row#*$'\t'}"; return 0 ;;
+    2) _probe_note "context7: plugin '$pid' is enabled but no recorded installPath exists on disk — enabled is not installed"; return 2 ;;
+    *) _probe_note "context7: plugin '$pid' is enabled but the plugin registry has no entry for it"; return 2 ;;
+  esac
 }
 
 probe_superpowers() {
-  local want_version="$1" enabled reg path ver
+  local want_version="$1" id="superpowers@claude-plugins-official" enabled row rc=0
   command -v jq >/dev/null 2>&1 || { _probe_note "superpowers: jq unavailable"; return 2; }
   [ -f "$HOME/.claude/settings.json" ] || { _probe_note "superpowers: no ~/.claude/settings.json"; return 1; }
-  enabled="$(jq -r '.enabledPlugins["superpowers@claude-plugins-official"] // false' "$HOME/.claude/settings.json" 2>/dev/null)"
+  enabled="$(jq -r --arg id "$id" '.enabledPlugins[$id] // false' "$HOME/.claude/settings.json" 2>/dev/null)"
   [ "$enabled" = "true" ] || { _probe_note "superpowers: not enabled in settings.json"; return 1; }
 
   # ENABLED IS A DECLARATION; THE INSTALLED FILES ARE THE CAPABILITY. Derive the
@@ -140,20 +286,12 @@ probe_superpowers() {
   # in the wrong place. The real layout is
   # plugins/cache/<marketplace>/<plugin>/<version>, and installed_plugins.json
   # carries installPath and version outright.
-  reg="$HOME/.claude/plugins/installed_plugins.json"                 # BL-235-PROBE-PLUGIN-REGISTRY
-  [ -f "$reg" ] || { _probe_note "superpowers: enabled, but no plugin registry at $reg"; return 2; }
-  path="$(jq -r '.plugins["superpowers@claude-plugins-official"][0].installPath // empty' "$reg" 2>/dev/null)"
-  [ -n "$path" ] || path="$(jq -r '.["superpowers@claude-plugins-official"][0].installPath // empty' "$reg" 2>/dev/null)"
-  if [ -z "$path" ] || [ ! -d "$path" ]; then
-    _probe_note "superpowers: enabled in settings but its recorded installPath is ${path:-absent} — enabled is not installed"
-    return 2
-  fi
-  if [ "$want_version" = "1" ]; then
-    ver="$(jq -r '.plugins["superpowers@claude-plugins-official"][0].version // empty' "$reg" 2>/dev/null)"
-    [ -n "$ver" ] || ver="$(jq -r '.["superpowers@claude-plugins-official"][0].version // empty' "$reg" 2>/dev/null)"
-    [ -n "$ver" ] && printf '%s\n' "$ver"
-  fi
-  return 0
+  row="$(_plugin_entry "$id")" || rc=$?
+  case "$rc" in
+    0) [ "$want_version" = "1" ] && printf '%s\n' "${row#*$'\t'}"; return 0 ;;
+    2) _probe_note "superpowers: enabled in settings, but no recorded installPath exists on disk — enabled is not installed"; return 2 ;;
+    *) _probe_note "superpowers: enabled, but the plugin registry has no entry for $id"; return 2 ;;
+  esac
 }
 
 main() {

--- a/scripts/probe-tool.sh
+++ b/scripts/probe-tool.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# scripts/probe-tool.sh — ask a tool whether it WORKS, not whether it is
+# mentioned in a config file.
+#
+# BL-235. The tool matrix decided "Qdrant MCP installed" by grepping
+# `~/.claude.json` for an `mcpServers.qdrant` key and reported
+# `version_command: echo 'configured'` — a value that cannot be wrong, and
+# therefore carries no information. A machine with no database running was
+# recorded `already_installed` and reported `[OK]` by every surface that
+# consumes the resolver. Two sibling rows (Context7 MCP, Superpowers) had the
+# same shape; the sweep that found them is in the BL-235 entry.
+#
+# ONE OWNER, because the alternative was three copies of probe logic inlined
+# into a JSON data file — the sync-sibling trap `# BL-084-TIER-KEY` exists for,
+# and the one this repo has re-learned repeatedly.
+#
+# ── THE EXIT CONTRACT ───────────────────────────────────────────────────────
+#   0  WORKING        — evidence was obtained that the tool functions
+#   1  NOT CONFIGURED — no configuration for it exists
+#   2  CANNOT CONFIRM — configured, but working could not be established
+#
+# 2 IS NOT A SOFTENED 1, AND MUST NOT BE COLLAPSED INTO 0. It is the state
+# `## BL-234:` established and `## BL-213:` forced on the cadence checker:
+# "I could not measure this" is a third answer, and spelling it the same as
+# either neighbour is how a declaration becomes a capability claim. Callers that
+# gate on this MUST treat 2 as not-working.
+#
+# ── WHY THE THREE ROWS ARE NOT SYMMETRIC, STATED RATHER THAN AVERAGED ───────
+# Only ONE of them is a network service:
+#
+#   qdrant       a running database — reachability is testable, and its `/`
+#                payload reports a real version. Full three states apply.
+#   context7     a STDIO MCP server launched on demand by npx. There is no
+#                daemon to reach, so "reachable" is not a state it has. The
+#                strongest local truth is: registered AND its launcher exists.
+#   superpowers  a Claude plugin. Not a service at all; working means enabled
+#                AND its files are present on disk.
+#
+# Inventing a uniform "reachable" verdict for all three would be the same
+# substitution this entry is about, one level up. Each probe reports the
+# strongest evidence its tool actually admits of, and says which kind it got.
+#
+# ── VERSIONS ────────────────────────────────────────────────────────────────
+# `--version` prints a FALSIFIABLE string or NOTHING. It never prints a
+# constant. `echo 'configured'` was true of a machine with nothing installed;
+# an empty version is honest, and check-versions.sh already handles it.
+#
+# Every network read is BOUNDED. There is no timeout(1)/gtimeout(1) on the dev
+# host, so this uses run_with_timeout from helpers-core.sh when available and
+# curl's own --max-time as the floor.
+
+PROBE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1090
+[ -f "$PROBE_DIR/lib/helpers-core.sh" ] && . "$PROBE_DIR/lib/helpers-core.sh" 2>/dev/null
+
+PROBE_TIMEOUT="${PROBE_TOOL_TIMEOUT:-5}"
+
+_probe_note() { [ "${PROBE_QUIET:-0}" = "1" ] || printf '%s\n' "$*" >&2; }
+
+# _probe_http <url> — bounded GET, body on stdout. rc 0 only on a real response.
+_probe_http() {                                                      # BL-235-PROBE-BOUNDED
+  local url="$1"
+  command -v curl >/dev/null 2>&1 || return 1
+  if command -v run_with_timeout >/dev/null 2>&1; then
+    run_with_timeout "$PROBE_TIMEOUT" curl -fsS --max-time "$PROBE_TIMEOUT" "$url"
+  else
+    curl -fsS --max-time "$PROBE_TIMEOUT" "$url"
+  fi
+}
+
+# _mcp_entry <jq-filter> — the first match across the two config files Claude
+# uses. Presence only; this decides CONFIGURED, never WORKING.
+_mcp_entry() {
+  local filter="$1" f
+  command -v jq >/dev/null 2>&1 || return 1
+  for f in "$HOME/.claude/settings.json" "$HOME/.claude.json"; do
+    [ -f "$f" ] || continue
+    jq -e "$filter" "$f" >/dev/null 2>&1 && { jq -r "$filter" "$f" 2>/dev/null; return 0; }
+  done
+  return 1
+}
+
+probe_qdrant() {
+  local want_version="$1" url payload ver
+  _mcp_entry '.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"] // empty' >/dev/null || {
+    _probe_note "qdrant: no mcpServers entry in ~/.claude/settings.json or ~/.claude.json"
+    return 1
+  }
+  url="$(_mcp_entry '(.mcpServers.qdrant // .mcpServers["mcp-server-qdrant"]).env.QDRANT_URL // empty' 2>/dev/null)"
+  case "$url" in ''|null) url="http://localhost:6333" ;; esac
+  payload="$(_probe_http "$url/" 2>/dev/null)" || {
+    _probe_note "qdrant: configured at $url but the database did not answer — registered is not running"
+    return 2
+  }
+  # A 200 from something that is not Qdrant is not evidence of Qdrant.
+  ver="$(printf '%s' "$payload" | jq -r '.version // empty' 2>/dev/null)"
+  if [ -z "$ver" ]; then
+    _probe_note "qdrant: $url answered, but the payload carries no version field — cannot confirm it is Qdrant"
+    return 2
+  fi
+  [ "$want_version" = "1" ] && printf '%s\n' "$ver"
+  return 0
+}
+
+probe_context7() {
+  local want_version="$1"
+  _mcp_entry '.mcpServers.context7 // .mcpServers["context7-mcp"] // empty' >/dev/null \
+    || _mcp_entry '.enabledPlugins | to_entries[] | select(.key | test("^context7"; "i")) | select(.value == true)' >/dev/null \
+    || { _probe_note "context7: no mcpServers entry and no enabled plugin"; return 1; }
+  # A stdio MCP server has no daemon to reach. The falsifiable local fact is
+  # whether the launcher it is configured to run actually exists.
+  if ! command -v npx >/dev/null 2>&1; then
+    _probe_note "context7: registered, but npx is not on PATH — the configured launcher cannot start it"
+    return 2
+  fi
+  if [ "$want_version" = "1" ]; then
+    # Only a CACHED version is cheap and offline-safe; no version is better
+    # than a constant that cannot be wrong.
+    local v
+    v="$(npm ls -g --depth=0 --json 2>/dev/null | jq -r '.dependencies["@upstash/context7-mcp"].version // empty' 2>/dev/null)"
+    [ -n "$v" ] && printf '%s\n' "$v"
+  fi
+  return 0
+}
+
+probe_superpowers() {
+  local want_version="$1" enabled reg path ver
+  command -v jq >/dev/null 2>&1 || { _probe_note "superpowers: jq unavailable"; return 2; }
+  [ -f "$HOME/.claude/settings.json" ] || { _probe_note "superpowers: no ~/.claude/settings.json"; return 1; }
+  enabled="$(jq -r '.enabledPlugins["superpowers@claude-plugins-official"] // false' "$HOME/.claude/settings.json" 2>/dev/null)"
+  [ "$enabled" = "true" ] || { _probe_note "superpowers: not enabled in settings.json"; return 1; }
+
+  # ENABLED IS A DECLARATION; THE INSTALLED FILES ARE THE CAPABILITY. Derive the
+  # location from the installer's own record rather than guessing paths — a
+  # first draft of this probe guessed ~/.claude/plugins/superpowers and reported
+  # "cannot confirm" against a perfectly healthy install, which is this entry's
+  # defect wearing the other face: a probe that false-alarms because IT looked
+  # in the wrong place. The real layout is
+  # plugins/cache/<marketplace>/<plugin>/<version>, and installed_plugins.json
+  # carries installPath and version outright.
+  reg="$HOME/.claude/plugins/installed_plugins.json"                 # BL-235-PROBE-PLUGIN-REGISTRY
+  [ -f "$reg" ] || { _probe_note "superpowers: enabled, but no plugin registry at $reg"; return 2; }
+  path="$(jq -r '.plugins["superpowers@claude-plugins-official"][0].installPath // empty' "$reg" 2>/dev/null)"
+  [ -n "$path" ] || path="$(jq -r '.["superpowers@claude-plugins-official"][0].installPath // empty' "$reg" 2>/dev/null)"
+  if [ -z "$path" ] || [ ! -d "$path" ]; then
+    _probe_note "superpowers: enabled in settings but its recorded installPath is ${path:-absent} — enabled is not installed"
+    return 2
+  fi
+  if [ "$want_version" = "1" ]; then
+    ver="$(jq -r '.plugins["superpowers@claude-plugins-official"][0].version // empty' "$reg" 2>/dev/null)"
+    [ -n "$ver" ] || ver="$(jq -r '.["superpowers@claude-plugins-official"][0].version // empty' "$reg" 2>/dev/null)"
+    [ -n "$ver" ] && printf '%s\n' "$ver"
+  fi
+  return 0
+}
+
+main() {
+  local tool="${1:-}" want_version=0
+  case "${2:-}" in --version) want_version=1 ;; esac
+  case "$tool" in
+    qdrant)      probe_qdrant "$want_version" ;;
+    context7)    probe_context7 "$want_version" ;;
+    superpowers) probe_superpowers "$want_version" ;;
+    *)
+      printf 'usage: probe-tool.sh <qdrant|context7|superpowers> [--version]\n' >&2
+      return 64
+      ;;
+  esac
+}
+
+main "$@"

--- a/scripts/resolve-tools.sh
+++ b/scripts/resolve-tools.sh
@@ -27,6 +27,8 @@ set -euo pipefail
 # Output: JSON with four buckets: auto_install, manual_install,
 #         already_installed, deferred
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # Portable wall-clock timeout for evaluated shell commands. Runs the
 # given command string via `bash -c` and kills it if it exceeds
 # RESOLVE_TOOLS_EVAL_TIMEOUT seconds. Exit code 124 signals timeout;
@@ -34,25 +36,38 @@ set -euo pipefail
 # already handle non-zero ("tool not installed") so the timeout case
 # is indistinguishable from a clean "missing tool" — which is what
 # we want for an unreachable daemon.
+#
+# BL-235: this file used to carry a PRIVATE copy of that runner
+# (`run_cmd_with_timeout`), while check-versions.sh — reading the same
+# data file — used helpers-core.sh's `run_with_timeout`. Two helpers
+# answering one question, and they disagreed in both directions that
+# matter: one returns 124 on timeout and the other returns 1
+# (indistinguishable from "ran and failed"), and one polls a wall-clock
+# deadline while the other sleeps a full second per call. The copy is
+# deleted; `run_with_deadline` in helpers-core.sh is the one owner.
 RESOLVE_TOOLS_EVAL_TIMEOUT="${RESOLVE_TOOLS_EVAL_TIMEOUT:-10}"
-run_cmd_with_timeout() {
-  local _secs="$1" _cmd="$2"
-  bash -c "$_cmd" &
-  local _pid=$!
-  # Use wall-clock deadline (not a sleep-1 counter) so SIGCHLD from
-  # other killed children — which interrupts `sleep` short — doesn't
-  # inflate the iteration count and kill commands prematurely.
-  local _deadline=$(( $(date +%s) + _secs ))
-  while kill -0 "$_pid" 2>/dev/null; do
-    if [ "$(date +%s)" -ge "$_deadline" ]; then
-      kill -9 "$_pid" 2>/dev/null || true
-      wait "$_pid" 2>/dev/null || true
-      return 124
-    fi
-    sleep 1
-  done
-  wait "$_pid" 2>/dev/null
+if [ -f "$SCRIPT_DIR/lib/helpers-core.sh" ]; then
+  # shellcheck source=./lib/helpers-core.sh
+  . "$SCRIPT_DIR/lib/helpers-core.sh"
+fi
+if ! command -v run_with_deadline >/dev/null 2>&1; then
+  echo "resolve-tools.sh: scripts/lib/helpers-core.sh is missing, so evaluated tool commands cannot be bounded. Refusing to run them unbounded — the matrix ships daemon-backed commands that hang when the daemon is unreachable." >&2
+  exit 1
+fi
+
+# run_bounded <secs> <shell-command-string> — the matrix's commands are strings,
+# not argv, so they go through `bash -c`.
+run_bounded() {                                                    # BL-235-RESOLVE-BOUND
+  run_with_deadline "$1" bash -c "$2"
 }
+
+# THE MATRIX ROWS MUST NOT DEPEND ON THIS PROCESS'S `pwd`. Three rows invoke
+# scripts/probe-tool.sh, and a relative path in a JSON data file resolves
+# against whatever directory the CONSUMER happens to be standing in. init.sh
+# runs this resolver before any `cd`, so `init.sh --project-dir ~/work/foo`
+# evaluated them from the operator's shell and every one returned 127 —
+# command-not-found, which every caller here reads as "not installed".
+export SOLO_SCRIPTS_DIR="${SOLO_SCRIPTS_DIR:-$SCRIPT_DIR}"         # BL-235-SCRIPTS-DIR
 
 # --- Parse arguments ---
 DEV_OS=""
@@ -230,10 +245,10 @@ while IFS=$'\t' read -r TOOL_NAME TOOL_CATEGORY TOOL_PHASE TOOL_REQUIRED TOOL_CH
   INSTALLED=false
   VERSION=""
   set +u
-  if run_cmd_with_timeout "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_CHECK" &>/dev/null; then
+  if run_bounded "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_CHECK" &>/dev/null; then
     INSTALLED=true
     if [ -n "$TOOL_VERSION_CMD" ]; then
-      VERSION=$(run_cmd_with_timeout "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_VERSION_CMD" 2>/dev/null || echo "")
+      VERSION=$(run_bounded "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_VERSION_CMD" 2>/dev/null || echo "")
     fi
   fi
   set -u
@@ -360,7 +375,7 @@ for i in $(seq 0 $((ADDITION_COUNT - 1))); do
   ADD_DESC=$(echo "$ADD_JSON" | jq -r '.description // ""')
 
   set +u
-  if [ -n "$ADD_CHECK" ] && run_cmd_with_timeout "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$ADD_CHECK" &>/dev/null; then
+  if [ -n "$ADD_CHECK" ] && run_bounded "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$ADD_CHECK" &>/dev/null; then
     set -u
     ALREADY_INSTALLED=$(echo "$ALREADY_INSTALLED" | jq \
       --arg name "$ADD_NAME" \

--- a/scripts/resolve-tools.sh
+++ b/scripts/resolve-tools.sh
@@ -51,7 +51,12 @@ if [ -f "$SCRIPT_DIR/lib/helpers-core.sh" ]; then
   . "$SCRIPT_DIR/lib/helpers-core.sh"
 fi
 if ! command -v run_with_deadline >/dev/null 2>&1; then
-  echo "resolve-tools.sh: scripts/lib/helpers-core.sh is missing, so evaluated tool commands cannot be bounded. Refusing to run them unbounded — the matrix ships daemon-backed commands that hang when the daemon is unreachable." >&2
+  # SAY WHAT IS ACTUALLY WRONG. The first wording said the file was "missing",
+  # which is one of two causes and not the likelier one: a PRESENT but older
+  # helpers-core.sh — a project vendored before `run_with_deadline` existed —
+  # reaches here too, and an operator told the file is missing will go looking
+  # for a file that is sitting right there.
+  echo "resolve-tools.sh: $SCRIPT_DIR/lib/helpers-core.sh does not provide run_with_deadline (absent file, or a copy predating it), so evaluated tool commands cannot be bounded. Refusing to run them unbounded — the matrix ships daemon-backed commands that hang when the daemon is unreachable." >&2
   exit 1
 fi
 
@@ -59,6 +64,24 @@ fi
 # not argv, so they go through `bash -c`.
 run_bounded() {                                                    # BL-235-RESOLVE-BOUND
   run_with_deadline "$1" bash -c "$2"
+}
+
+# run_bounded_capture <secs> <cmd> — the same bound, for output that is KEPT.
+#
+# NOT `$(run_bounded …)`. A command substitution reads until the last writer
+# closes the pipe, and the bound only kills the `bash -c` child — every other
+# member of a pipeline survives it holding that pipe open. Measured on the
+# verbatim shipped `Colima` version_command: 12s elapsed against a 2s bound.
+# 21 of the 41 checkable matrix rows are pipeline- or subshell-shaped, so for
+# half the matrix the bound was decorative in this position. Writing to a file
+# makes the reader independent of who still holds the write end.
+run_bounded_capture() {                                            # BL-235-RESOLVE-CAPTURE
+  local _f _v
+  _f="$(mktemp)" || { printf ''; return 0; }
+  run_with_deadline "$1" bash -c "$2" >"$_f" 2>/dev/null || true
+  _v="$(cat "$_f" 2>/dev/null)"
+  rm -f "$_f"
+  printf '%s' "$_v"
 }
 
 # THE MATRIX ROWS MUST NOT DEPEND ON THIS PROCESS'S `pwd`. Three rows invoke
@@ -248,7 +271,7 @@ while IFS=$'\t' read -r TOOL_NAME TOOL_CATEGORY TOOL_PHASE TOOL_REQUIRED TOOL_CH
   if run_bounded "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_CHECK" &>/dev/null; then
     INSTALLED=true
     if [ -n "$TOOL_VERSION_CMD" ]; then
-      VERSION=$(run_bounded "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_VERSION_CMD" 2>/dev/null || echo "")
+      VERSION=$(run_bounded_capture "$RESOLVE_TOOLS_EVAL_TIMEOUT" "$TOOL_VERSION_CMD")
     fi
   fi
   set -u

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11189,6 +11189,26 @@ assert the three shapes and `M11`/`M12`/`M13` restore each hole in turn —
 `M13` narrows the range specifically, so `C6` measures the RANGE rather than
 the presence of a `tr`.
 
+**And ONE STRAY BYTE FROM ONE TOOL COULD END THE WHOLE REPORT.** `tr` and `cut`
+reject an invalid multibyte sequence in a UTF-8 locale and exit 1, and every
+caller here runs under `set -euo pipefail`. Measured with a `check_command`
+whose stderr carries one non-UTF-8 byte:
+
+| locale | exit | rows rendered |
+|---|---|---|
+| `C` | 0 | 3 of 3 |
+| `C.UTF-8` | 1 | 1 of 3 |
+| `en_US.UTF-8` | 1 | 1 of 3 |
+
+`C.UTF-8` is ubuntu-latest's usual default. The symptom is the "rows silently
+vanish" pathology this branch has now produced three times — once through
+`grep -v` exiting on empty input, once here through `cut`, once here through
+`tr`. **The `cut` half is not this branch's**: it fails identically on `main`,
+and is fixed here only because these are the lines this entry owns. `LC_ALL=C`
+on both makes them byte-oriented, which is what a sanitiser wants anyway.
+`C7` asserts all three rows survive; `M14` removes the guard and watches the
+report truncate to zero.
+
 **One residual, stated rather than implied:** the bound stops the *wait*, not
 the *pipeline*. Orphaned pipeline members survive their `bash -c` parent and run
 to their own completion, holding only the capture temp file and `/dev/null` —

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11140,6 +11140,35 @@ it needs" below, for the human-facing consumer; the resolver half (a distinct
 bucket in `resolve-tools.sh`'s JSON) is a schema change with many consumers and
 is NOT done.
 
+**And surfacing the note handed a tool's stderr a way to FORGE REPORT LINES.**
+`print_warn` renders through `echo -e`, which interprets backslash escapes — so
+a note containing the two characters `\` and `n` becomes a real line break and
+whatever follows starts a new line of the report. Measured, from a stderr of
+`note-one\nFORGED  [OK] Totally Installed: 9.9.9`:
+
+```
+[WARN] P: configured, but working could not be confirmed — note-one
+FORGED  [OK] Totally Installed: 9.9.9
+```
+
+A fabricated `[OK]` row, in the script whose whole purpose is honest reporting.
+The rows ship with the framework, but the probe's notes interpolate
+`$(qdrant_mcp_url)` read out of `~/.claude.json`, so the text is not wholly
+ours. `# BL-235-NOTE-SAFE` doubles the backslashes; `C4` asserts the note still
+arrives while no line begins with the forged text, and `M11` removes the
+doubling and watches the fake row return. **This was a cost created by the fix
+above** — surfacing a diagnostic is not free, and it is recorded as the fix's
+own consequence rather than as a separate discovery.
+
+**One residual, stated rather than implied:** the bound stops the *wait*, not
+the *pipeline*. Orphaned pipeline members survive their `bash -c` parent and run
+to their own completion, holding only the capture temp file and `/dev/null` —
+never the consumer's pipe, which is why the consumer now returns at the bound.
+Measured on a worst case of 12 rows × a 20s pipeline at a 1s bound: the script
+returned in 12s, the temp-file delta was 0, and the process count returned to
+baseline once the orphans expired. That is a real leak with a bounded lifetime,
+not a handle exhaustion.
+
 **And a non-numeric bound meant zero.** `$(( now + abc ))` is `now`, so
 `CHECKVER_EVAL_TIMEOUT=abc` put every deadline in the past and reported a whole
 healthy matrix as "not installed" — silently, from one environment variable.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11154,11 +11154,40 @@ FORGED  [OK] Totally Installed: 9.9.9
 A fabricated `[OK]` row, in the script whose whole purpose is honest reporting.
 The rows ship with the framework, but the probe's notes interpolate
 `$(qdrant_mcp_url)` read out of `~/.claude.json`, so the text is not wholly
-ours. `# BL-235-NOTE-SAFE` doubles the backslashes; `C4` asserts the note still
-arrives while no line begins with the forged text, and `M11` removes the
-doubling and watches the fake row return. **This was a cost created by the fix
-above** — surfacing a diagnostic is not free, and it is recorded as the fix's
-own consequence rather than as a separate discovery.
+ours. **This was a cost created by the fix above** — surfacing a diagnostic is
+not free, and it is recorded as the fix's own consequence rather than as a
+separate discovery.
+
+**And fixing it on ONE of the two render paths was the sync-sibling trap in
+miniature.** The first attempt guarded the note and not the version. `INSTALLED`
+comes from a `version_command`'s stdout and reaches the same `echo -e` at
+**nine** places — six direct and three through `UPDATES[]`. Measured: a
+version_command emitting `1.0\n\x20\x20[OK]\x20Totally\x20Installed:\x209.9.9`
+produced
+
+```
+[OK] P: 1.0
+[OK] Totally Installed: 9.9.9 — up to date
+```
+
+byte-identical to a genuine row, and `tr -d '[:space:]'` does not stop it
+because `\x20` is not whitespace until `echo -e` expands it. Same external-input
+vector as the notes: `probe_superpowers` and `probe_context7` print a `version`
+straight out of `~/.claude/plugins/installed_plugins.json`.
+`# BL-235-VERSION-SAFE` sanitises at the single point of CAPTURE rather than at
+the render sites, because there are nine of the latter and the tenth added later
+would be unguarded.
+
+**And a raw carriage return is not a backslash.** Doubling alone left it, and on
+a terminal CR returns the cursor to column 0 so the following text overwrites
+the `[WARN]` prefix and renders a complete fake row. `# BL-235-NOTE-SAFE` strips
+`\000-\037\177` as well as doubling. **The narrower range proposed for this —
+`\000-\010\013\014\016-\037\177` — does NOT strip CR**: `\015` sits in the gap
+between `\014` and `\016`, and `printf 'a\rb'` through it still emits the CR.
+That range was measured before being rejected, not assumed wrong. `C4`/`C5`/`C6`
+assert the three shapes and `M11`/`M12`/`M13` restore each hole in turn —
+`M13` narrows the range specifically, so `C6` measures the RANGE rather than
+the presence of a `tr`.
 
 **One residual, stated rather than implied:** the bound stops the *wait*, not
 the *pipeline*. Orphaned pipeline members survive their `bash -c` parent and run

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11112,7 +11112,41 @@ that contacts the daemon is `docker version`, without the dashes, and the matrix
 does not ship it. The hazard is real and `colima version` carries it; the second
 example was wrong and citing two made the claim feel twice as established.
 
-**And the bound had a PRICE that shipping it did not measure.** The first
+**AND THE BOUND WAS DECORATIVE FOR HALF THE MATRIX, which the first fix
+certified as working.** `T1`/`T2` proved it with `sleep 12` — the one shape it
+handles. `kill -9` reaps the `bash -c` child; a pipeline's OTHER members survive
+it holding the pipe open, and a caller reading through a command substitution
+then waits for them. Measured: `sleep 12 | cat` at a 2s bound took **12s**, as
+did `(sleep 12)` and the verbatim shipped `Colima` version command. Derived
+across all four matrices, **21 of the 41 checkable rows** are pipeline- or
+subshell-shaped — including Colima, the row this entry names as the reason a
+bound was needed. Fixed at both consumers by taking the output through a FILE
+(`# BL-235-VERSION-CAPTURE`, `# BL-235-RESOLVE-CAPTURE`) so the reader does not
+depend on who still holds the write end; `set -m` plus a process-group kill was
+tried first and does not work, because a command substitution runs with job
+control disabled. `T2b` pins the pipeline shape and `M8` restores the
+substitution and watches it hang again.
+
+**And the three-state contract was discarded one layer before the operator.**
+`check-versions.sh` ran the check as `>/dev/null 2>&1`, throwing away both the
+exit code and the probe's note — so a database that is UP and answering **403**
+because it wants an api-key rendered as `[WARN] Qdrant MCP: not installed`,
+identical to one never installed, while the probe's own stderr said exactly what
+to change. `D9` asserted that note ON THE PROBE, one layer short of where it is
+consumed — the same mistake `D3` made, in a different place. `# BL-235-THIRD-STATE`
+now renders rc 2 as *"configured, but working could not be confirmed"* with the
+note, and **`C3` asserts it in this script's OUTPUT**. This is need #3 of "What
+it needs" below, for the human-facing consumer; the resolver half (a distinct
+bucket in `resolve-tools.sh`'s JSON) is a schema change with many consumers and
+is NOT done.
+
+**And a non-numeric bound meant zero.** `$(( now + abc ))` is `now`, so
+`CHECKVER_EVAL_TIMEOUT=abc` put every deadline in the past and reported a whole
+healthy matrix as "not installed" — silently, from one environment variable.
+`# BL-235-DEADLINE-SANE` clamps to the default; `M10` proves it in both
+directions.
+
+**The bound had a PRICE that shipping it did not measure.** The first
 implementation used `run_with_timeout`, which polls a `sleep 1` counter, so every
 bounded call costs ~1s regardless of the command. This loop makes two per row;
 on the 21-row shipped matrix `check-versions.sh` went from **5-6s to 50-51s** —
@@ -11225,6 +11259,16 @@ and **the review blocked it.** Everything below is that round.
   probe — cannot occur, because the rows only ever arrive via `init.sh`, which
   copies both. The consequence is that an existing project keeps the old
   declaration behaviour until it is re-initialised, not that it breaks.
+- **Five rows now leave `check-versions.sh` entirely.** The rows with genuinely
+  no version dropped `version_command`, and `CHECKABLE_TOOLS` filters on a
+  non-empty one — so `Android Studio`, both Apple Developer Program rows, the
+  Android keystore and the ZAP image no longer appear in the version report at
+  all. That is correct (they have no version to check) and it matches the
+  filter's own "skip presence-only tools" comment, but it IS a visible change to
+  the report. `resolve-tools.sh` is unaffected: it guards on
+  `[ -n "$TOOL_VERSION_CMD" ]` and still buckets those rows. `version_command`
+  has exactly two consumers (`grep -rn VERSION_CMD scripts/ init.sh`), so there
+  is no third-party fallout.
 - **Seeding `enforcement_level: "strict"` at adoption makes
   `upgrade-project.sh`'s BL-030 backfill SKIP adopted manifests.** That is
   correct — the backfill exists to fill an absent key, and the key is no longer
@@ -11451,19 +11495,23 @@ replaced mode **755 with 644**. `mv` from a fresh temp file does not carry the
 destination's mode, and nothing in the edit reported it: the content assertion
 that accompanied the edit passed, because the content was right.
 
-`scripts/resolve-tools.sh` is invoked **directly** — no `bash` prefix — by
-`init.sh`, `scripts/verify-install.sh`, `scripts/check-phase-gate.sh` and
-`scripts/intake-wizard.sh`. A non-executable file makes the shell return
-**126**, and init.sh's call site reads:
+**The four callers do NOT degrade alike, and a first draft of this entry said
+they did.** That draft claimed all four invoke the resolver directly and all
+four get 126. Derived instead:
 
-```
-resolver_output=$("$SCRIPT_DIR/scripts/resolve-tools.sh" … 2>/dev/null) || {
-  print_warn "Tool resolver failed. Falling back to basic tool checks."
-  return 0
-}
-```
+| caller | how it invokes | at mode 644 |
+|---|---|---|
+| `init.sh` | `resolver_output=$("$SCRIPT_DIR/scripts/resolve-tools.sh" …)` | **rc=126** → `[WARN] Tool resolver failed. Falling back to basic tool checks.` → `return 0` |
+| `scripts/verify-install.sh` | gated `[ ! -x … ] → register_manual "Tool check skipped …"; return`, and the call itself carries a **`bash ` prefix** | skipped; the mode never reaches `execve` |
+| `scripts/intake-wizard.sh` | gated `[ -x "scripts/resolve-tools.sh" ] && …` | **silently skipped** |
+| `scripts/check-phase-gate.sh` | gated `[ -x "$RESOLVER" ]` | **silently skipped** |
 
-So init.sh **printed one `[WARN]` line, exited 0, and scaffolded a project
+So exactly **one** caller produces 126; the other three **silently skip**, which
+is the worse arm — init.sh at least prints something. That correction matters
+for the general rule below: a mode check cannot be justified by "the shell will
+tell you", because for three of the four callers it will not.
+
+init.sh **printed one `[WARN]` line, exited 0, and scaffolded a project
 anyway** — one whose `.claude/tool-preferences.json` came from the fallback
 writer rather than from resolver output (`installed: {}`, and three context
 values that had silently acquired a leading space, which then propagated into a

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11098,12 +11098,33 @@ right, and the wrong half changed the design:
 | `scripts/resolve-tools.sh` | `run_cmd_with_timeout` — **bounded, 10s** |
 | `scripts/check-versions.sh` | `eval "$CHECK_CMD"` — **unbounded** |
 
-The unbounded one was **already a hazard**: the matrix ships `colima version`
-and `docker --version`, and `resolve-tools.sh`'s own header records that those
-"can hang indefinitely when the daemon is unreachable" — which is why IT bounds
-them. Fixed first and separately (`# BL-235-BOUND-CHECK`,
+The unbounded one was **already a hazard**: the matrix ships `colima version` as
+a version command, and `resolve-tools.sh`'s own header records that daemon-backed
+commands "can hang indefinitely when the daemon is unreachable" — which is why IT
+bounds them. Fixed first and separately (`# BL-235-BOUND-CHECK`,
 `# BL-235-BOUND-VERSION`) with WALL-CLOCK assertions: a 12s command at a 2s
 bound returns in 3s; the mutation puts it back to 12s.
+
+**One correction to that paragraph, kept rather than quietly edited.** It also
+named `docker --version` as a hang risk. It is not one: it prints a compiled-in
+string and never opens a socket — 26ms on this host with a live daemon. The one
+that contacts the daemon is `docker version`, without the dashes, and the matrix
+does not ship it. The hazard is real and `colima version` carries it; the second
+example was wrong and citing two made the claim feel twice as established.
+
+**And the bound had a PRICE that shipping it did not measure.** The first
+implementation used `run_with_timeout`, which polls a `sleep 1` counter, so every
+bounded call costs ~1s regardless of the command. This loop makes two per row;
+on the 21-row shipped matrix `check-versions.sh` went from **5-6s to 50-51s** —
+inside the SessionStart hook. `# BL-235-DEADLINE` adds `run_with_deadline` to
+`helpers-core.sh` (wall-clock deadline, 0.1s poll, rc 124 for a timeout instead
+of 1), both matrix consumers use it, and `resolve-tools.sh`'s private copy of the
+same idea is deleted — two helpers answering one question became one. Measured
+after: **10-12s**, the remainder being the three probes actually talking to
+things. `run_with_timeout` itself is untouched: eleven call sites across six
+product files, several in enforcement paths, and that is a separate decision.
+`T4` pins the cost so "a bound exists" cannot ship again without "the bound is
+affordable".
 
 ### The rows
 
@@ -11129,8 +11150,86 @@ and `installed_plugins.json` carries `installPath` and `version`
 `probe-tool.sh` ships downstream (`# BL-235-SHIP-PROBE`); without it the rows
 fail closed in every generated project.
 
-**Proof:** `tests/test-bl235-tool-matrix-probes.sh`, 7 cases, ~21s. `D1`/`D2`
-are derived sweeps over the shipped matrix, not lists in the test.
+**Proof:** `tests/test-bl235-tool-matrix-probes.sh`, 27 cases, ~32s. `D1`, `D1b`
+and `D2` are derived sweeps over **every** shipped matrix file, not lists in the
+test; `D3`-`D14` assert the three-state contract by **equality** against a
+loopback stub; `C1`/`C2` measure it where a consumer reads the answer; `M1`-`M6`
+are mutation proofs.
+
+### What the adversarial review turned up, and what it cost
+
+The first implementation of this entry passed its own suite, cleared the lints,
+and **the review blocked it.** Everything below is that round.
+
+- **The three rows became CWD-RELATIVE** (`bash scripts/probe-tool.sh …`). A
+  relative path inside a JSON data file resolves against whatever directory the
+  CONSUMER stands in, and `init.sh --project-dir ~/work/foo` runs the resolver
+  before any `cd`: measured, all three genuinely-installed tools flipped to
+  `manual_install`, because `rc=127` reads as "not installed". Fixed with
+  `# BL-235-SCRIPTS-DIR` — the rows name `"${SOLO_SCRIPTS_DIR:-scripts}"` and the
+  two evaluators export their own location.
+- **The test that should have caught it asserted `-ne 0` where the truth is
+  exactly `2`** — an assertion that passes on `rc=127`, i.e. on the probe never
+  having run. The three-state contract the probe's header spends ten lines
+  defending had zero coverage. **Assert the state you mean, never its
+  complement**; every state now has an equality case, and `C1` measures the row
+  through `check-versions.sh` from a non-root directory.
+- **A 200 from something that is not Qdrant was accepted as Qdrant.** The probe
+  tested `.version` alone; a stub named `totally-not-qdrant` scored WORKING, as
+  did an Elasticsearch-shaped payload whose `.version` is an OBJECT. `title` and
+  a STRING `version` are both **required** in Qdrant's own `VersionInfo` schema
+  (api.qdrant.tech, `GET /`) — `# BL-235-PROBE-IDENTITY`.
+- **An api-key-protected database was reported as not running** — and this file
+  had *just* re-made `## BL-234:`'s finding one file over: its own `curl -fsS`
+  sent no key and could not tell a 403 from a dead port. The probe now owns no
+  curl at all; `qdrant_probe_root` in `helpers-full.sh` is the one owner of every
+  Qdrant read, so the entry-atomic URL/key pairing, the declared-host rule and
+  the never-in-argv delivery are inherited rather than re-derived.
+- **`probe_superpowers` selected the registry entry by POSITION** (`[0]`). With
+  a stale entry first and the live one second a healthy install scored 2; with
+  two versions it printed the wrong one. `# BL-235-PROBE-PLUGIN-SELECT` selects
+  by whether the recorded `installPath` exists.
+- **`context7` was judged by `command -v npx` regardless of transport.** Its
+  documented HTTP form carries a `url` and no `command` at all. The probe now
+  reads the transport the entry declares.
+- **The word `configured` survived by MOVING FILE.** Deleting
+  `version_command: echo 'configured'` from the matrix left
+  `${INSTALLED:-configured}` inside `check-versions.sh` rendering the identical
+  word for exactly those rows — and the test could not see it, because it
+  asserted on matrix JSON rather than on output. `# BL-235-NO-CONSTANT` is one
+  owner read by all four render sites, and `C2` asserts on the rendered line.
+- **The sweep this entry asked for had scanned one matrix of four.** Across all
+  four, the pre-fix tree carried **11 rows / 10 distinct tools** with an
+  `echo`-constant version. All are fixed: `dart_license_checker` (twice) now
+  parses `dart pub global list`; `Android Studio` — whose CHECK was the same
+  defect, `[ -d … ] || [ -n "$ANDROID_HOME" ]`, true of an empty directory and a
+  stale export — now requires a real `sdkmanager`/`adb` executable; and the five
+  rows with genuinely no version (both Apple Developer Program rows, the EV
+  certificate, the Android keystore, the ZAP image) **omit `version_command`**
+  rather than inventing one, which is what `check-versions.sh`'s own
+  "presence-only tools" comment already assumed. The Android, dart and ZAP arms
+  are reasoned, not executed — this host has none of those toolchains.
+- **The diff was 20x its own meaning.** `common.json` came back 531→790 lines
+  from a `jq` re-emit around six changed fields. All four matrices are now
+  rebuilt from `main` with only the semantic edits: **9 insertions, 15
+  deletions** across the four.
+
+### Two facts the next reader needs
+
+- **`templates/tool-matrix/*.json` is in NO sync set.** `_bl099_sync_scripts`
+  derives its list from `init.sh`'s `cp` lines *under `scripts/`*, so
+  `--sync-framework` ships `probe-tool.sh` (verified present in the derived set)
+  and never the rows that call it. **The ordering is safe and that is worth
+  stating**: a synced project gets the probe alongside its OLD rows, which do not
+  reference it and keep behaving exactly as before; the reverse — rows without a
+  probe — cannot occur, because the rows only ever arrive via `init.sh`, which
+  copies both. The consequence is that an existing project keeps the old
+  declaration behaviour until it is re-initialised, not that it breaks.
+- **Seeding `enforcement_level: "strict"` at adoption makes
+  `upgrade-project.sh`'s BL-030 backfill SKIP adopted manifests.** That is
+  correct — the backfill exists to fill an absent key, and the key is no longer
+  absent — but it was undocumented, and a reader looking for why the backfill
+  reports nothing to do on an adopted project would otherwise find no answer.
 
 `templates/tool-matrix/common.json`'s `Qdrant MCP` entry has:
 
@@ -11334,3 +11433,77 @@ constraint — this line ships through the same two writers and is subject to th
 same lockstep rule), `## BL-030:` and `## BL-161:` (the two siblings),
 `## BL-233:` (what made this file load-bearing), `## BL-234:` (the work that
 found it).
+
+---
+
+## BL-237: a script's EXECUTE BIT is part of its contract, and losing it degrades init.sh to a warning that still exits 0
+
+**Logged:** 2026-08-17 (found while fixing `## BL-235:` — by causing it, not by
+auditing for it)
+**Category:** Silent-success — a capability lost to a file mode, reported as a
+recoverable warning
+**Status:** Open
+
+### What happened, measured
+
+An ad-hoc edit written as `sed … > /tmp/new && mv /tmp/new scripts/resolve-tools.sh`
+replaced mode **755 with 644**. `mv` from a fresh temp file does not carry the
+destination's mode, and nothing in the edit reported it: the content assertion
+that accompanied the edit passed, because the content was right.
+
+`scripts/resolve-tools.sh` is invoked **directly** — no `bash` prefix — by
+`init.sh`, `scripts/verify-install.sh`, `scripts/check-phase-gate.sh` and
+`scripts/intake-wizard.sh`. A non-executable file makes the shell return
+**126**, and init.sh's call site reads:
+
+```
+resolver_output=$("$SCRIPT_DIR/scripts/resolve-tools.sh" … 2>/dev/null) || {
+  print_warn "Tool resolver failed. Falling back to basic tool checks."
+  return 0
+}
+```
+
+So init.sh **printed one `[WARN]` line, exited 0, and scaffolded a project
+anyway** — one whose `.claude/tool-preferences.json` came from the fallback
+writer rather than from resolver output (`installed: {}`, and three context
+values that had silently acquired a leading space, which then propagated into a
+regenerated `CLAUDE.md` as `- **Platform:**  web`). The only test that caught it
+was `tests/test-verify-install-fix-functions.sh::T2`, four layers downstream,
+and it reported "missing substituted identity fields" — a symptom whose stated
+cause is nowhere near the mode.
+
+### What is already done
+
+`X1`/`M7` in `tests/test-bl235-tool-matrix-probes.sh` pin the bit on
+`resolve-tools.sh` specifically, with a mutation proof that a byte-identical copy
+at 644 returns 126. That closes the one file this incident touched.
+
+### What is NOT done — the general rule
+
+**There is no check that a directly-invoked script is executable.** The
+invariant is derivable rather than list-based: for each `scripts/*.sh`, find the
+product lines that name it at the START of a command (as opposed to `bash …`,
+`source …`, `cp …`), and require mode 755 for exactly those. Three top-level
+scripts are legitimately 644 today — `ci-verify-sha256.sh`,
+`lint-evalprompts-portability.sh`, `lint-module-dependencies.sh` — and a
+derived predicate should EXPLAIN them (nothing invokes them directly) rather
+than allowlist them, which is the `# BL-181-UNIT-LANE-PREDICATE` shape.
+
+**Two things the fix must not repeat.** A blanket "every `scripts/*.sh` is 755"
+rule is false today and would go red on those three. And `scripts/lib/*.sh` are
+SOURCED, so 644 is correct there; a rule that cannot tell sourcing from
+executing would demand the wrong mode for a whole directory.
+
+### The transferable lesson, which is wider than modes
+
+**"The edit applied" and "the file is unchanged in every other respect" are two
+assertions.** CLAUDE.md already requires the first — assert a changed-line
+count, because "sed ran" is not "sed edited". This entry adds the second: an
+edit that rewrites a file through a temp file must preserve MODE, and the proof
+is a mode comparison, not a diff. `_mutate` in the test suites has done this
+correctly for months (`_mode_of` + `chmod` around every mutation) — the harness
+was more careful than the hand.
+
+**Related:** `## BL-235:` (where it happened), `## BL-112:` ("did not run" is
+not "found nothing"), `## BL-104:` (a `[WARN]` label over a blocking outcome —
+the same text/behaviour mismatch, in the other direction).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9005,7 +9005,37 @@ permissive tier on absent data
 **Severity:** **Real, not cosmetic.** This is a fail-OPEN on the surface that
 decides whether a project is *allowed to weaken its own enforcement*. Every other
 tier reader in the framework fails closed on absent data; this one does not.
-**Status:** Open
+**Status:** Open — BOTH candidate fixes implemented on branch
+`fix/bl221-tier-keys-and-probe`; close on merge with the PR number.
+
+### Both, because neither subsumes the other
+
+- **`# BL-221-TIER-FAIL-CLOSED`** — `.deployment // "personal"` became `// ""`
+  with an explicit refusal. jq's `//` coerces `null`, `false` AND empty to its
+  right-hand side, so an absent key and an explicit `null` both resolved to the
+  CHOOSABLE tier; one guard now catches both. The refusal names the key.
+- **`# BL-221-ADOPT-TIER-KEYS`** — `adopt_write_manifest` writes `deployment`,
+  `poc_mode` and `enforcement_level` from the SAME variables
+  `adopt_write_phase_state` uses, so manifest and phase record cannot disagree.
+
+Option 1 alone left every other cause open (a hand-edited manifest, the
+regenerate path). Option 2 alone left the birth paths producing different
+shapes — the divergence that produced this.
+
+**Proof:** `tests/test-bl221-tier-fail-closed.sh`, 11 cases. `A3` is the entry's
+case C. `B1`–`B3` pin that the fix refuses absent data, not every project. `C2`
+pins that `assert_choosable` and `read_enforcement_level` now agree. `W2`
+**executes** the shipped jq filter rather than grepping for key names.
+
+**Two failures caught by the repo's own guards, both from one line of mine:** the
+refusal message named `scripts/adopt-project.sh` from a CORE file, which M3
+forbids. `lint-module-dependencies.sh` caught it and
+`test-brownfield-wp5b-test-debt.sh`'s F1 caught it independently.
+
+**Already worked around downstream, which is the tell:** `_td_tier_trusted` in
+`adopt-test-debt.sh` had added its own presence check before trusting
+`assert_choosable`. A caller defending itself against a shared predicate is the
+predicate's bug.
 
 **The predicate.** `assert_choosable` in `scripts/lib/enforcement-level.sh`:
 
@@ -11055,7 +11085,52 @@ the behaviour), `## BL-221:` (missing key ⇒ permissive default).
 different surface, deliberately left unfixed there so the fix is not smuggled in
 under an unrelated diff)
 **Category:** Silent-success — declaration read as capability
-**Status:** Open
+**Status:** Open — implemented on branch `fix/bl221-tier-keys-and-probe`; close
+on merge with the PR number.
+
+### The prerequisite the entry did not know it had
+
+The entry says a probe is unsafe because the schema expresses no bound. Half
+right, and the wrong half changed the design:
+
+| consumer | how it evaluates `check_command` |
+|---|---|
+| `scripts/resolve-tools.sh` | `run_cmd_with_timeout` — **bounded, 10s** |
+| `scripts/check-versions.sh` | `eval "$CHECK_CMD"` — **unbounded** |
+
+The unbounded one was **already a hazard**: the matrix ships `colima version`
+and `docker --version`, and `resolve-tools.sh`'s own header records that those
+"can hang indefinitely when the daemon is unreachable" — which is why IT bounds
+them. Fixed first and separately (`# BL-235-BOUND-CHECK`,
+`# BL-235-BOUND-VERSION`) with WALL-CLOCK assertions: a 12s command at a 2s
+bound returns in 3s; the mutation puts it back to 12s.
+
+### The rows
+
+All three declaration rows — Qdrant MCP, Context7 MCP, Superpowers — call
+**`scripts/probe-tool.sh`**, one owner. Exit contract is three-state:
+**0 working / 1 not configured / 2 cannot confirm**, and 2 is not a softened 1.
+
+**The three are NOT symmetric, and averaging them would have repeated the
+defect.** Only Qdrant has a reachable daemon; Context7 is a stdio server with no
+daemon; Superpowers is not a service. Each reports the strongest evidence its
+tool admits of.
+
+**Versions are falsifiable or absent, never constant.** Measured: qdrant
+`1.17.1` from the database's own payload, superpowers `6.3.0` from the
+installer's registry, context7 empty — honest.
+
+**A false alarm in the probe itself, recorded rather than quietly fixed.**
+`probe_superpowers` first GUESSED a path and returned CANNOT CONFIRM against a
+healthy install; the real layout is `plugins/cache/<marketplace>/<plugin>/<version>`
+and `installed_plugins.json` carries `installPath` and `version`
+(`# BL-235-PROBE-PLUGIN-REGISTRY`).
+
+`probe-tool.sh` ships downstream (`# BL-235-SHIP-PROBE`); without it the rows
+fail closed in every generated project.
+
+**Proof:** `tests/test-bl235-tool-matrix-probes.sh`, 7 cases, ~21s. `D1`/`D2`
+are derived sweeps over the shipped matrix, not lists in the test.
 
 `templates/tool-matrix/common.json`'s `Qdrant MCP` entry has:
 

--- a/templates/tool-matrix/common.json
+++ b/templates/tool-matrix/common.json
@@ -9,10 +9,21 @@
       "description": "Distributed version control system",
       "required": true,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v git",
       "version_command": "git --version | awk '{print $3}'",
       "min_version": "2.30.0",
@@ -35,14 +46,28 @@
       "description": "Command-line JSON processor (required by Development Guardrails for Claude Code)",
       "required": true,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v jq",
       "version_command": "jq --version 2>/dev/null",
       "min_version": "1.6",
-      "latest_check": {"method": "brew", "package": "jq"},
+      "latest_check": {
+        "method": "brew",
+        "package": "jq"
+      },
       "install": {
         "darwin_brew": "brew install jq",
         "linux_apt": "sudo apt install -y jq",
@@ -60,10 +85,21 @@
       "description": "JavaScript runtime (required for Snyk, license-checker, JS/TS projects)",
       "required": true,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v node",
       "version_command": "node --version | sed 's/v//'",
       "min_version": "18.17.0",
@@ -85,10 +121,21 @@
       "description": "Container runtime (needed for OWASP ZAP, Qdrant MCP)",
       "required": false,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v docker",
       "version_command": "docker --version 2>/dev/null | awk '{print $3}' | tr -d ','",
       "min_version": null,
@@ -119,14 +166,27 @@
       "description": "Lightweight Docker runtime for macOS (headless, no license required)",
       "required": false,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v colima",
       "version_command": "colima version 2>/dev/null | head -1 | awk '{print $3}' | tr -d 'v'",
       "min_version": "0.6.0",
-      "latest_check": {"method": "github_release", "package": "abiosoft/colima"},
+      "latest_check": {
+        "method": "github_release",
+        "package": "abiosoft/colima"
+      },
       "install": {
         "darwin_brew": [
           "brew install colima",
@@ -143,10 +203,21 @@
       "description": "GNU Privacy Guard (optional — used for commit signing)",
       "required": false,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v gpg",
       "version_command": "gpg --version 2>/dev/null | head -1 | awk '{print $3}'",
       "min_version": null,
@@ -168,14 +239,28 @@
       "description": "Static analysis security scanner (OWASP Top 10)",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v semgrep",
       "version_command": "semgrep --version 2>/dev/null | head -1",
       "min_version": "1.50.0",
-      "latest_check": {"method": "pip", "package": "semgrep"},
+      "latest_check": {
+        "method": "pip",
+        "package": "semgrep"
+      },
       "install": {
         "darwin_brew": "brew install semgrep",
         "linux_pip": "pip3 install semgrep",
@@ -191,14 +276,28 @@
       "description": "Secret detection in git repositories",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v gitleaks",
       "version_command": "gitleaks version 2>/dev/null",
       "min_version": "8.18.0",
-      "latest_check": {"method": "github_release", "package": "gitleaks/gitleaks"},
+      "latest_check": {
+        "method": "github_release",
+        "package": "gitleaks/gitleaks"
+      },
       "install": {
         "darwin_brew": "brew install gitleaks",
         "linux_apt": [
@@ -225,14 +324,28 @@
       "description": "Dependency vulnerability scanning",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v snyk",
       "version_command": "snyk --version 2>/dev/null",
       "min_version": "1.1290.0",
-      "latest_check": {"method": "npm", "package": "snyk"},
+      "latest_check": {
+        "method": "npm",
+        "package": "snyk"
+      },
       "install": {
         "npm": "npm install -g snyk",
         "manual": "https://docs.snyk.io/snyk-cli/install-or-update-the-snyk-cli"
@@ -247,14 +360,28 @@
       "description": "AI coding agent CLI",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "command -v claude",
       "version_command": "claude --version 2>/dev/null",
       "min_version": "2.0.0",
-      "latest_check": {"method": "npm", "package": "@anthropic-ai/claude-code"},
+      "latest_check": {
+        "method": "npm",
+        "package": "@anthropic-ai/claude-code"
+      },
       "install": {
         "darwin_brew": "brew install claude-code",
         "npm": "npm install -g @anthropic-ai/claude-code",
@@ -270,15 +397,29 @@
       "description": "Git hook-based guardrails for coding standards, security scanning, and documentation",
       "required": false,
       "phase": 0,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
       "check_command": "[ -d \"$HOME/.claude-dev-framework/.git\" ] && [ -f \"$HOME/.claude-dev-framework/scripts/init.sh\" ]",
       "version_command": "cd \"$HOME/.claude-dev-framework\" && git describe --tags --always 2>/dev/null || echo 'installed'",
       "min_version": null,
       "latest_check": null,
-      "update_check": {"method": "git_repo", "path": "$HOME/.claude-dev-framework"},
+      "update_check": {
+        "method": "git_repo",
+        "path": "$HOME/.claude-dev-framework"
+      },
       "install": {
         "manual": "Auto-installed by init.sh during project creation"
       },
@@ -292,15 +433,28 @@
       "description": "Agentic skills plugin for Claude Code (TDD, debugging, code review, git worktrees)",
       "required": false,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
-      "check_command": "[ -f \"$HOME/.claude/settings.json\" ] && command -v jq &>/dev/null && [ \"$(jq -r '.enabledPlugins[\"superpowers@claude-plugins-official\"] // false' \"$HOME/.claude/settings.json\" 2>/dev/null)\" = \"true\" ]",
-      "version_command": "echo 'installed'",
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
+      "check_command": "bash scripts/probe-tool.sh superpowers",
+      "version_command": "bash scripts/probe-tool.sh superpowers --version",
       "min_version": null,
       "latest_check": null,
-      "update_check": {"method": "claude_plugin"},
+      "update_check": {
+        "method": "claude_plugin"
+      },
       "install": {
         "darwin_brew": "claude plugins add superpowers",
         "linux_apt": "claude plugins add superpowers",
@@ -317,15 +471,29 @@
       "description": "Up-to-date library documentation via MCP (recommended for Phase 1 and Phase 2)",
       "required": false,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
-      "check_command": "command -v jq &>/dev/null && (( [ -f \"$HOME/.claude/settings.json\" ] && jq -e '.mcpServers.context7 // .mcpServers[\"context7-mcp\"] // empty' \"$HOME/.claude/settings.json\" >/dev/null 2>&1 ) || ( [ -f \"$HOME/.claude.json\" ] && jq -e '.mcpServers.context7 // .mcpServers[\"context7-mcp\"] // empty' \"$HOME/.claude.json\" >/dev/null 2>&1 ) || ( [ -f \"$HOME/.claude/settings.json\" ] && jq -e '.enabledPlugins | to_entries[] | select(.key | test(\"^context7\"; \"i\")) | select(.value == true)' \"$HOME/.claude/settings.json\" >/dev/null 2>&1 ))",
-      "version_command": "echo 'configured'",
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
+      "check_command": "bash scripts/probe-tool.sh context7",
+      "version_command": "bash scripts/probe-tool.sh context7 --version",
       "min_version": null,
       "latest_check": null,
-      "update_check": {"method": "ephemeral", "runner": "npx"},
+      "update_check": {
+        "method": "ephemeral",
+        "runner": "npx"
+      },
       "install": {
         "npm": "echo y | claude mcp add context7 --scope user -- npx -y @upstash/context7-mcp@latest",
         "manual": "Run: echo y | claude mcp add context7 --scope user -- npx -y @upstash/context7-mcp@latest"
@@ -340,15 +508,29 @@
       "description": "Persistent semantic memory across Claude Code sessions",
       "required": false,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["all"],
-      "check_command": "command -v jq &>/dev/null && (( [ -f \"$HOME/.claude/settings.json\" ] && jq -e '.mcpServers.qdrant // .mcpServers[\"mcp-server-qdrant\"] // empty' \"$HOME/.claude/settings.json\" >/dev/null 2>&1 ) || ( [ -f \"$HOME/.claude.json\" ] && jq -e '.mcpServers.qdrant // .mcpServers[\"mcp-server-qdrant\"] // empty' \"$HOME/.claude.json\" >/dev/null 2>&1 ))",
-      "version_command": "echo 'configured'",
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "all"
+      ],
+      "check_command": "bash scripts/probe-tool.sh qdrant",
+      "version_command": "bash scripts/probe-tool.sh qdrant --version",
       "min_version": null,
       "latest_check": null,
-      "update_check": {"method": "ephemeral", "runner": "uvx"},
+      "update_check": {
+        "method": "ephemeral",
+        "runner": "uvx"
+      },
       "install": {
         "manual": "Requires Docker. Setup: (1) docker run -d --name qdrant -p 6333:6333 -p 6334:6334 -v qdrant_storage:/qdrant/storage --restart unless-stopped qdrant/qdrant:latest (2) claude mcp add -s user -e QDRANT_URL=http://localhost:6333 -e COLLECTION_NAME=claude-memory qdrant -- uvx --python 3.13 mcp-server-qdrant"
       },
@@ -362,10 +544,21 @@
       "description": "Python runtime",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["python"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "python"
+      ],
       "check_command": "command -v python3 || command -v python",
       "version_command": "python3 --version 2>/dev/null | awk '{print $2}' || python --version 2>/dev/null | awk '{print $2}'",
       "min_version": "3.10.0",
@@ -387,10 +580,21 @@
       "description": "Rust toolchain via rustup",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["rust"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "rust"
+      ],
       "check_command": "command -v cargo",
       "version_command": "rustc --version 2>/dev/null | awk '{print $2}'",
       "min_version": "1.70.0",
@@ -417,10 +621,21 @@
       "description": "Go programming language",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["go"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "go"
+      ],
       "check_command": "command -v go",
       "version_command": "go version 2>/dev/null | awk '{print $3}' | sed 's/go//'",
       "min_version": "1.21.0",
@@ -442,10 +657,21 @@
       "description": "C# / .NET development kit",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["csharp"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "csharp"
+      ],
       "check_command": "command -v dotnet",
       "version_command": "dotnet --version 2>/dev/null",
       "min_version": "7.0.0",
@@ -464,10 +690,22 @@
       "description": "Java Development Kit",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["kotlin", "java"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "kotlin",
+        "java"
+      ],
       "check_command": "command -v java",
       "version_command": "java --version 2>/dev/null | head -1",
       "min_version": "17.0.0",
@@ -489,10 +727,21 @@
       "description": "Flutter cross-platform framework",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin", "linux"],
-      "platforms": ["all"],
-      "languages": ["dart"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin",
+        "linux"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "dart"
+      ],
       "check_command": "command -v flutter",
       "version_command": "flutter --version 2>/dev/null | head -1 | awk '{print $2}'",
       "min_version": "3.10.0",
@@ -511,10 +760,20 @@
       "description": "Swift compiler and standard library (via Xcode). Required for iOS native development.",
       "required": true,
       "phase": 1,
-      "tracks": ["light", "standard", "full"],
-      "dev_os": ["darwin"],
-      "platforms": ["all"],
-      "languages": ["swift"],
+      "tracks": [
+        "light",
+        "standard",
+        "full"
+      ],
+      "dev_os": [
+        "darwin"
+      ],
+      "platforms": [
+        "all"
+      ],
+      "languages": [
+        "swift"
+      ],
       "check_command": "command -v swift",
       "version_command": "swift --version 2>/dev/null | head -1 | sed 's/.*version //' | awk '{print $1}'",
       "min_version": "5.9.0",

--- a/templates/tool-matrix/common.json
+++ b/templates/tool-matrix/common.json
@@ -9,21 +9,10 @@
       "description": "Distributed version control system",
       "required": true,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v git",
       "version_command": "git --version | awk '{print $3}'",
       "min_version": "2.30.0",
@@ -46,28 +35,14 @@
       "description": "Command-line JSON processor (required by Development Guardrails for Claude Code)",
       "required": true,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v jq",
       "version_command": "jq --version 2>/dev/null",
       "min_version": "1.6",
-      "latest_check": {
-        "method": "brew",
-        "package": "jq"
-      },
+      "latest_check": {"method": "brew", "package": "jq"},
       "install": {
         "darwin_brew": "brew install jq",
         "linux_apt": "sudo apt install -y jq",
@@ -85,21 +60,10 @@
       "description": "JavaScript runtime (required for Snyk, license-checker, JS/TS projects)",
       "required": true,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v node",
       "version_command": "node --version | sed 's/v//'",
       "min_version": "18.17.0",
@@ -121,21 +85,10 @@
       "description": "Container runtime (needed for OWASP ZAP, Qdrant MCP)",
       "required": false,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v docker",
       "version_command": "docker --version 2>/dev/null | awk '{print $3}' | tr -d ','",
       "min_version": null,
@@ -166,27 +119,14 @@
       "description": "Lightweight Docker runtime for macOS (headless, no license required)",
       "required": false,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v colima",
       "version_command": "colima version 2>/dev/null | head -1 | awk '{print $3}' | tr -d 'v'",
       "min_version": "0.6.0",
-      "latest_check": {
-        "method": "github_release",
-        "package": "abiosoft/colima"
-      },
+      "latest_check": {"method": "github_release", "package": "abiosoft/colima"},
       "install": {
         "darwin_brew": [
           "brew install colima",
@@ -203,21 +143,10 @@
       "description": "GNU Privacy Guard (optional — used for commit signing)",
       "required": false,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v gpg",
       "version_command": "gpg --version 2>/dev/null | head -1 | awk '{print $3}'",
       "min_version": null,
@@ -239,28 +168,14 @@
       "description": "Static analysis security scanner (OWASP Top 10)",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v semgrep",
       "version_command": "semgrep --version 2>/dev/null | head -1",
       "min_version": "1.50.0",
-      "latest_check": {
-        "method": "pip",
-        "package": "semgrep"
-      },
+      "latest_check": {"method": "pip", "package": "semgrep"},
       "install": {
         "darwin_brew": "brew install semgrep",
         "linux_pip": "pip3 install semgrep",
@@ -276,28 +191,14 @@
       "description": "Secret detection in git repositories",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v gitleaks",
       "version_command": "gitleaks version 2>/dev/null",
       "min_version": "8.18.0",
-      "latest_check": {
-        "method": "github_release",
-        "package": "gitleaks/gitleaks"
-      },
+      "latest_check": {"method": "github_release", "package": "gitleaks/gitleaks"},
       "install": {
         "darwin_brew": "brew install gitleaks",
         "linux_apt": [
@@ -324,28 +225,14 @@
       "description": "Dependency vulnerability scanning",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v snyk",
       "version_command": "snyk --version 2>/dev/null",
       "min_version": "1.1290.0",
-      "latest_check": {
-        "method": "npm",
-        "package": "snyk"
-      },
+      "latest_check": {"method": "npm", "package": "snyk"},
       "install": {
         "npm": "npm install -g snyk",
         "manual": "https://docs.snyk.io/snyk-cli/install-or-update-the-snyk-cli"
@@ -360,28 +247,14 @@
       "description": "AI coding agent CLI",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "command -v claude",
       "version_command": "claude --version 2>/dev/null",
       "min_version": "2.0.0",
-      "latest_check": {
-        "method": "npm",
-        "package": "@anthropic-ai/claude-code"
-      },
+      "latest_check": {"method": "npm", "package": "@anthropic-ai/claude-code"},
       "install": {
         "darwin_brew": "brew install claude-code",
         "npm": "npm install -g @anthropic-ai/claude-code",
@@ -397,29 +270,15 @@
       "description": "Git hook-based guardrails for coding standards, security scanning, and documentation",
       "required": false,
       "phase": 0,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
       "check_command": "[ -d \"$HOME/.claude-dev-framework/.git\" ] && [ -f \"$HOME/.claude-dev-framework/scripts/init.sh\" ]",
       "version_command": "cd \"$HOME/.claude-dev-framework\" && git describe --tags --always 2>/dev/null || echo 'installed'",
       "min_version": null,
       "latest_check": null,
-      "update_check": {
-        "method": "git_repo",
-        "path": "$HOME/.claude-dev-framework"
-      },
+      "update_check": {"method": "git_repo", "path": "$HOME/.claude-dev-framework"},
       "install": {
         "manual": "Auto-installed by init.sh during project creation"
       },
@@ -433,28 +292,15 @@
       "description": "Agentic skills plugin for Claude Code (TDD, debugging, code review, git worktrees)",
       "required": false,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
-      "check_command": "bash scripts/probe-tool.sh superpowers",
-      "version_command": "bash scripts/probe-tool.sh superpowers --version",
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
+      "check_command": "bash \"${SOLO_SCRIPTS_DIR:-scripts}/probe-tool.sh\" superpowers",
+      "version_command": "bash \"${SOLO_SCRIPTS_DIR:-scripts}/probe-tool.sh\" superpowers --version",
       "min_version": null,
       "latest_check": null,
-      "update_check": {
-        "method": "claude_plugin"
-      },
+      "update_check": {"method": "claude_plugin"},
       "install": {
         "darwin_brew": "claude plugins add superpowers",
         "linux_apt": "claude plugins add superpowers",
@@ -471,29 +317,15 @@
       "description": "Up-to-date library documentation via MCP (recommended for Phase 1 and Phase 2)",
       "required": false,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
-      "check_command": "bash scripts/probe-tool.sh context7",
-      "version_command": "bash scripts/probe-tool.sh context7 --version",
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
+      "check_command": "bash \"${SOLO_SCRIPTS_DIR:-scripts}/probe-tool.sh\" context7",
+      "version_command": "bash \"${SOLO_SCRIPTS_DIR:-scripts}/probe-tool.sh\" context7 --version",
       "min_version": null,
       "latest_check": null,
-      "update_check": {
-        "method": "ephemeral",
-        "runner": "npx"
-      },
+      "update_check": {"method": "ephemeral", "runner": "npx"},
       "install": {
         "npm": "echo y | claude mcp add context7 --scope user -- npx -y @upstash/context7-mcp@latest",
         "manual": "Run: echo y | claude mcp add context7 --scope user -- npx -y @upstash/context7-mcp@latest"
@@ -508,29 +340,15 @@
       "description": "Persistent semantic memory across Claude Code sessions",
       "required": false,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "all"
-      ],
-      "check_command": "bash scripts/probe-tool.sh qdrant",
-      "version_command": "bash scripts/probe-tool.sh qdrant --version",
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
+      "check_command": "bash \"${SOLO_SCRIPTS_DIR:-scripts}/probe-tool.sh\" qdrant",
+      "version_command": "bash \"${SOLO_SCRIPTS_DIR:-scripts}/probe-tool.sh\" qdrant --version",
       "min_version": null,
       "latest_check": null,
-      "update_check": {
-        "method": "ephemeral",
-        "runner": "uvx"
-      },
+      "update_check": {"method": "ephemeral", "runner": "uvx"},
       "install": {
         "manual": "Requires Docker. Setup: (1) docker run -d --name qdrant -p 6333:6333 -p 6334:6334 -v qdrant_storage:/qdrant/storage --restart unless-stopped qdrant/qdrant:latest (2) claude mcp add -s user -e QDRANT_URL=http://localhost:6333 -e COLLECTION_NAME=claude-memory qdrant -- uvx --python 3.13 mcp-server-qdrant"
       },
@@ -544,21 +362,10 @@
       "description": "Python runtime",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "python"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["python"],
       "check_command": "command -v python3 || command -v python",
       "version_command": "python3 --version 2>/dev/null | awk '{print $2}' || python --version 2>/dev/null | awk '{print $2}'",
       "min_version": "3.10.0",
@@ -580,21 +387,10 @@
       "description": "Rust toolchain via rustup",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "rust"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["rust"],
       "check_command": "command -v cargo",
       "version_command": "rustc --version 2>/dev/null | awk '{print $2}'",
       "min_version": "1.70.0",
@@ -621,21 +417,10 @@
       "description": "Go programming language",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "go"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["go"],
       "check_command": "command -v go",
       "version_command": "go version 2>/dev/null | awk '{print $3}' | sed 's/go//'",
       "min_version": "1.21.0",
@@ -657,21 +442,10 @@
       "description": "C# / .NET development kit",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "csharp"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["csharp"],
       "check_command": "command -v dotnet",
       "version_command": "dotnet --version 2>/dev/null",
       "min_version": "7.0.0",
@@ -690,22 +464,10 @@
       "description": "Java Development Kit",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "kotlin",
-        "java"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["kotlin", "java"],
       "check_command": "command -v java",
       "version_command": "java --version 2>/dev/null | head -1",
       "min_version": "17.0.0",
@@ -727,21 +489,10 @@
       "description": "Flutter cross-platform framework",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin",
-        "linux"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "dart"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["dart"],
       "check_command": "command -v flutter",
       "version_command": "flutter --version 2>/dev/null | head -1 | awk '{print $2}'",
       "min_version": "3.10.0",
@@ -760,20 +511,10 @@
       "description": "Swift compiler and standard library (via Xcode). Required for iOS native development.",
       "required": true,
       "phase": 1,
-      "tracks": [
-        "light",
-        "standard",
-        "full"
-      ],
-      "dev_os": [
-        "darwin"
-      ],
-      "platforms": [
-        "all"
-      ],
-      "languages": [
-        "swift"
-      ],
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin"],
+      "platforms": ["all"],
+      "languages": ["swift"],
       "check_command": "command -v swift",
       "version_command": "swift --version 2>/dev/null | head -1 | sed 's/.*version //' | awk '{print $1}'",
       "min_version": "5.9.0",

--- a/templates/tool-matrix/desktop.json
+++ b/templates/tool-matrix/desktop.json
@@ -153,7 +153,7 @@
       "platforms": ["desktop"],
       "languages": ["dart"],
       "check_command": "dart pub global list 2>/dev/null | grep -q dart_license_checker",
-      "version_command": "echo 'installed via dart pub global'",
+      "version_command": "dart pub global list 2>/dev/null | awk '$1==\"dart_license_checker\"{print $2; exit}'",
       "min_version": null,
       "latest_check": null,
       "install": {
@@ -201,7 +201,6 @@
       "platforms": ["desktop"],
       "languages": ["all"],
       "check_command": "security find-identity -v -p codesigning 2>/dev/null | grep -q 'Developer ID'",
-      "version_command": "echo 'signing identity present'",
       "min_version": null,
       "latest_check": null,
       "install": {
@@ -222,7 +221,6 @@
       "platforms": ["desktop"],
       "languages": ["all"],
       "check_command": "false",
-      "version_command": "echo 'N/A'",
       "min_version": null,
       "latest_check": null,
       "install": {

--- a/templates/tool-matrix/mobile.json
+++ b/templates/tool-matrix/mobile.json
@@ -80,8 +80,7 @@
       "dev_os": ["darwin", "linux"],
       "platforms": ["mobile"],
       "languages": ["kotlin", "dart", "typescript"],
-      "check_command": "[ -d \"$HOME/Library/Android/sdk\" ] || [ -d \"$HOME/Android/Sdk\" ] || [ -n \"$ANDROID_HOME\" ]",
-      "version_command": "echo 'SDK present'",
+      "check_command": "command -v sdkmanager >/dev/null 2>&1 || command -v adb >/dev/null 2>&1 || [ -x \"${ANDROID_HOME:-$HOME/Library/Android/sdk}/platform-tools/adb\" ] || [ -x \"$HOME/Library/Android/sdk/platform-tools/adb\" ] || [ -x \"$HOME/Android/Sdk/platform-tools/adb\" ]",
       "min_version": null,
       "latest_check": null,
       "install": {
@@ -125,7 +124,7 @@
       "platforms": ["mobile"],
       "languages": ["dart"],
       "check_command": "dart pub global list 2>/dev/null | grep -q dart_license_checker",
-      "version_command": "echo 'installed via dart pub global'",
+      "version_command": "dart pub global list 2>/dev/null | awk '$1==\"dart_license_checker\"{print $2; exit}'",
       "min_version": null,
       "latest_check": null,
       "install": {
@@ -194,7 +193,6 @@
       "platforms": ["mobile"],
       "languages": ["swift", "dart", "typescript"],
       "check_command": "security find-identity -v -p codesigning 2>/dev/null | grep -q 'Apple Development'",
-      "version_command": "echo 'signing identity present'",
       "min_version": null,
       "latest_check": null,
       "install": {
@@ -215,7 +213,6 @@
       "platforms": ["mobile"],
       "languages": ["kotlin", "dart", "typescript"],
       "check_command": "false",
-      "version_command": "echo 'N/A'",
       "min_version": null,
       "latest_check": null,
       "install": {

--- a/templates/tool-matrix/web.json
+++ b/templates/tool-matrix/web.json
@@ -36,7 +36,6 @@
       "platforms": ["web"],
       "languages": ["all"],
       "check_command": "command -v docker && docker image inspect ghcr.io/zaproxy/zaproxy:stable &>/dev/null 2>&1",
-      "version_command": "echo 'docker image present'",
       "min_version": null,
       "latest_check": null,
       "install": {

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2050,6 +2050,9 @@ run_child_suite "tests/test-bl222-security-clock-evidence.sh" \
 
 run_child_suite "tests/test-bl229-host-pipeline-paths.sh" \
   "tests/test-bl229-host-pipeline-paths.sh"
+
+run_child_suite "tests/test-bl221-tier-fail-closed.sh" \
+  "tests/test-bl221-tier-fail-closed.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2053,6 +2053,9 @@ run_child_suite "tests/test-bl229-host-pipeline-paths.sh" \
 
 run_child_suite "tests/test-bl221-tier-fail-closed.sh" \
   "tests/test-bl221-tier-fail-closed.sh"
+
+run_child_suite "tests/test-bl235-tool-matrix-probes.sh" \
+  "tests/test-bl235-tool-matrix-probes.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-bl221-tier-fail-closed.sh
+++ b/tests/test-bl221-tier-fail-closed.sh
@@ -73,14 +73,24 @@ _mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || 
 _sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
 _changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
 
+#
+# THE DELIMITER IS \001. `%` was the delimiter here until its sibling suite
+# proved the class live: a mutant containing `printf %s` produced `bad flag in
+# substitute command`, the file was left untouched, and the case reported
+# `sites=0` — a mutation proof that proved nothing. `|` is worse (shell
+# replacements are `||`-dense) and `@` collides with plugin ids. A control
+# character cannot occur in a shell one-liner, so the class is closed rather
+# than dodged. Today's replacements happen to contain no `%`; this is changed
+# because the NEXT one might.
 _mutate() {
-  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp
+  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp d
+  d=$(printf '\001')
   safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
   mode="$(_mode_of "$f")"
   before="$(mktemp)"; cp -p "$f" "$before"
   sites=$(_sites "$f" "$marker")
   tmp="$(mktemp)"
-  sed "s%^.*${marker}\$%${safe}%" "$f" > "$tmp" && mv "$tmp" "$f"
+  sed "s${d}^.*${marker}\$${d}${safe}${d}" "$f" > "$tmp" && mv "$tmp" "$f"
   [ "$mode" != "?" ] && chmod "$mode" "$f" 2>/dev/null
   changed=$(_changed_lines "$before" "$f")
   parses=0; bash -n "$f" >/dev/null 2>&1 && parses=1

--- a/tests/test-bl221-tier-fail-closed.sh
+++ b/tests/test-bl221-tier-fail-closed.sh
@@ -1,0 +1,260 @@
+#!/usr/bin/env bash
+# tests/test-bl221-tier-fail-closed.sh
+#
+# BL-221 — `assert_choosable` fails OPEN on a manifest with no `deployment`
+# key, so an adopted organizational project can downgrade its own enforcement.
+#
+# THE PREDICATE, and why `//` is the whole bug:
+#
+#   deployment=$(jq -r '.deployment // "personal"' "$manifest")
+#   if [ "$deployment" = "personal" ]; then return 0; fi
+#
+# jq's `//` coerces `null`, `false` AND `empty` to its right-hand side, so an
+# ABSENT key and an EXPLICIT null both resolve to `personal` — the CHOOSABLE
+# tier. This is the surface that decides whether a project may weaken its own
+# enforcement, and it defaults to the permissive answer on missing data.
+#
+# ITS SIBLING IN THE SAME FILE FAILS CLOSED. `read_enforcement_level` treats a
+# missing file, an unreadable one and an unknown value as `strict`. Two readers,
+# one library, opposite postures on the same manifest — A8 pins that they now
+# agree.
+#
+# THE DECISIVE CASE IS A3, and it is the entry's case C reproduced: take an
+# organizational manifest that correctly REFUSES the downgrade, delete one key,
+# change nothing else, and it starts ALLOWING it.
+#
+# WHY ADOPTION IS THE TRIGGER. The two birth paths write different manifests:
+#
+#   key                 init.sh        adopt-project.sh
+#   deployment          "personal"     ABSENT
+#   poc_mode            null           ABSENT
+#   enforcement_level   "strict"       ABSENT
+#
+# and `reconfigure-project.sh` — which calls `validate_transition` ->
+# `assert_choosable` — ships into every adopted project. So this is reachable
+# from an operator command, not a library curiosity. W1 pins the write half.
+#
+# BOTH HALVES ARE FIXED HERE, on Karl's decision. Writing the keys closes the
+# divergence at its source; defaulting the predicate closed fixes every OTHER
+# cause of an absent key — a hand-edited manifest, or the regenerate path that
+# `soif_adoption_integrity_lost` exists to detect — and makes the library
+# self-consistent. Neither subsumes the other.
+#
+# EVIDENCE THAT THE WORKAROUND ALREADY EXISTS DOWNSTREAM: `_td_tier_trusted` in
+# scripts/lib/adopt/adopt-test-debt.sh already adds its own presence check
+# before trusting `assert_choosable`, and its comment says so ("this adds a
+# presence check, not a fifth spelling"). A caller defending itself against a
+# shared predicate is the predicate's bug, not the caller's.
+#
+# Hermetic: temp dirs only, no network, no init.sh. bash 3.2 safe.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENFLIB="$REPO_ROOT/scripts/lib/enforcement-level.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq is not installed — this suite asserts on manifest state."
+  echo ""; echo "Results: 0 passed, 0 failed"; exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
+
+_num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
+
+_mutate() {
+  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp
+  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  mode="$(_mode_of "$f")"
+  before="$(mktemp)"; cp -p "$f" "$before"
+  sites=$(_sites "$f" "$marker")
+  tmp="$(mktemp)"
+  sed "s%^.*${marker}\$%${safe}%" "$f" > "$tmp" && mv "$tmp" "$f"
+  [ "$mode" != "?" ] && chmod "$mode" "$f" 2>/dev/null
+  changed=$(_changed_lines "$before" "$f")
+  parses=0; bash -n "$f" >/dev/null 2>&1 && parses=1
+  rm -f "$before"
+  printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+# mk_manifest <dir> <json> — a project root whose manifest is exactly <json>.
+mk_manifest() {
+  local d="$1" json="$2"
+  mkdir -p "$d/.claude"
+  printf '%s\n' "$json" > "$d/.claude/manifest.json"
+}
+
+# choosable <dir> [lib] — rc of assert_choosable, and CHOOSE_ERR its stderr.
+CHOOSE_ERR=""
+choosable() {
+  local d="$1" lib="${2:-$ENFLIB}" rc=0
+  CHOOSE_ERR="$(
+    # shellcheck disable=SC1090
+    . "$lib" 2>/dev/null
+    assert_choosable "$d" 2>&1 >/dev/null
+  )" || rc=$?
+  return $rc
+}
+
+echo "=== A — the predicate fails CLOSED on absent tier data ==="
+
+# ── A1: no `deployment` key at all. This is the shape adopt-project.sh writes.
+A1="$(newtmp)"; mk_manifest "$A1" '{"host":"github","mode":"personal"}'
+if choosable "$A1"; then a1=allowed; else a1=refused; fi
+if [ "$a1" = "refused" ]; then
+  pass "A1: a manifest with NO deployment key is REFUSED — the shape adopt-project.sh writes no longer resolves to the choosable tier by default"
+else
+  fail_ "A1" "assert_choosable ALLOWED a manifest with no deployment key (jq's // coerced the absent key to 'personal')"
+fi
+
+# ── A2: an EXPLICIT null. jq's `//` treats null and absent identically, so a
+# fix that only checks for a missing key would leave this one open.
+A2="$(newtmp)"; mk_manifest "$A2" '{"deployment":null,"poc_mode":null}'
+if choosable "$A2"; then a2=allowed; else a2=refused; fi
+if [ "$a2" = "refused" ]; then
+  pass "A2: an EXPLICIT \"deployment\": null is refused too — jq's // coerces null and absent alike, so both must be caught by the same guard"
+else
+  fail_ "A2" "explicit null was ALLOWED; a fix keyed only on key-absence does not close this"
+fi
+
+# ── A3: THE FINDING. The entry's case C: one key removed from an
+# organizational manifest, nothing else changed.
+A3="$(newtmp)"
+mk_manifest "$A3/full" '{"deployment":"organizational","poc_mode":"production","enforcement_level":"strict"}'
+mk_manifest "$A3/minus" '{"poc_mode":"production","enforcement_level":"strict"}'
+if choosable "$A3/full"; then a3_full=allowed; else a3_full=refused; fi
+if choosable "$A3/minus"; then a3_minus=allowed; else a3_minus=refused; fi
+if [ "$a3_full" = "refused" ] && [ "$a3_minus" = "refused" ]; then
+  pass "A3: deleting ONE key from an organizational manifest no longer flips it from refused to allowed — both answer '$a3_full'. This is the entry's case C, and it was the finding"
+else
+  fail_ "A3" "organizational=$a3_full, organizational-minus-deployment=$a3_minus — a project that refuses to weaken its enforcement starts allowing it when one key goes missing"
+fi
+
+echo "=== B — the tiers that MUST still work are unchanged ==="
+
+# ── B1: personal is still choosable. Without this the fix could pass by
+# refusing everything, which is the over-tightening failure mode.
+B1="$(newtmp)"; mk_manifest "$B1" '{"deployment":"personal","poc_mode":null}'
+if choosable "$B1"; then
+  pass "B1: deployment=personal is still CHOOSABLE — the fix refuses absent data, not every project"
+else
+  fail_ "B1" "a legitimate personal project can no longer choose its enforcement level; the guard is over-tightened"
+fi
+
+# ── B2: organizational + private_poc stays choosable (BL-129's carve-out).
+B2="$(newtmp)"; mk_manifest "$B2" '{"deployment":"organizational","poc_mode":"private_poc"}'
+if choosable "$B2"; then
+  pass "B2: organizational + private_poc is still choosable — BL-129's carve-out survives"
+else
+  fail_ "B2" "BL-129's organizational+private_poc carve-out was broken by this change"
+fi
+
+# ── B3: organizational + production is still refused (the control).
+B3="$(newtmp)"; mk_manifest "$B3" '{"deployment":"organizational","poc_mode":"production"}'
+if choosable "$B3"; then
+  fail_ "B3" "organizational+production is CHOOSABLE — the forced-strict tier is broken"
+else
+  pass "B3: organizational + production is still refused — the forced-strict tier is intact"
+fi
+
+echo "=== C — the refusal is actionable, and the library agrees with itself ==="
+
+# ── C1: a refusal an operator cannot act on is a dead end. The message must
+# name the missing key AND how to supply it.
+C1="$(newtmp)"; mk_manifest "$C1" '{"host":"github"}'
+choosable "$C1" || true
+c1_names_key=no;  printf '%s' "$CHOOSE_ERR" | grep -q 'deployment' && c1_names_key=yes
+c1_actionable=no; printf '%s' "$CHOOSE_ERR" | grep -qiE 'reconfigure|adopt|backfill|set|add' && c1_actionable=yes
+if [ "$c1_names_key" = "yes" ] && [ "$c1_actionable" = "yes" ]; then
+  pass "C1: the refusal names the missing key and tells the operator what to do — a blocking predicate that will not say why is its own defect"
+else
+  fail_ "C1" "names-key=$c1_names_key actionable=$c1_actionable err='$(printf '%s' "$CHOOSE_ERR" | tr '\n' '|' | cut -c1-200)'"
+fi
+
+# ── C2: POSTURE AGREEMENT. read_enforcement_level already failed closed on the
+# same input; the two now answer the same way about the same manifest.
+C2="$(newtmp)"; mk_manifest "$C2" '{"host":"github"}'
+c2_level="$( . "$ENFLIB" 2>/dev/null; read_enforcement_level "$C2" )"
+if choosable "$C2"; then c2_choose=allowed; else c2_choose=refused; fi
+if [ "$c2_level" = "strict" ] && [ "$c2_choose" = "refused" ]; then
+  pass "C2: on one absent-key manifest both readers now fail closed — read_enforcement_level says '$c2_level' and assert_choosable says '$c2_choose'. Two readers in one library disagreeing about the same file was half the finding"
+else
+  fail_ "C2" "read_enforcement_level=$c2_level (want strict) assert_choosable=$c2_choose (want refused)"
+fi
+
+echo "=== W — adoption writes the tier keys, so the divergence has no source ==="
+
+# ── W1: the adopted manifest carries the same tier keys a scaffolded one does.
+# Asserted on the WRITER's shipped code, not on a copy of it.
+W1_missing=""
+for k in deployment poc_mode enforcement_level; do
+  grep -q "$k" "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" || W1_missing="$W1_missing $k"
+done
+w1_marked=$(_num "$(grep -c 'BL-221-ADOPT-TIER-KEYS' "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" 2>/dev/null)")
+if [ -z "$W1_missing" ] && [ "$w1_marked" -ge 1 ]; then
+  pass "W1: adopt_write_manifest writes the tier keys (# BL-221-ADOPT-TIER-KEYS) — the two birth paths now produce the same manifest shape, which is where the divergence came from"
+else
+  fail_ "W1" "adopt-state.sh missing:$W1_missing marker-sites=$w1_marked — an adopted manifest still lacks the keys a scaffolded one has"
+fi
+
+# ── W2: EXECUTE the shipped jq filter rather than grepping for the key names.
+# W1 is a structural check and this session has already produced two vacuous
+# ones, so the write half gets a behavioural assertion too: pull the filter out
+# of adopt-state.sh, run it over a bare manifest, and require the result to
+# satisfy assert_choosable for the tier it claims.
+W2="$(newtmp)"
+w2_filter="$(sed -n '/adopt_jq_edit .*manifest.json/,+2p' "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" | grep -oE "'[.]host = [$]h[^']*'" | head -1 | sed "s/^'//; s/'$//")"
+w2_ok=no; w2_note=""
+if [ -z "$w2_filter" ]; then
+  w2_note="could not extract the shipped jq filter"
+else
+  for tier in personal organizational; do
+    printf '{"host":"github","mode":"%s"}\n' "$tier" > "$W2/in.json"
+    jq "$w2_filter" --arg h github --arg m "$tier" --arg d "$tier" --arg p production \
+       "$W2/in.json" > "$W2/out.json" 2>/dev/null || { w2_note="jq refused the shipped filter for $tier"; break; }
+    mkdir -p "$W2/$tier/.claude"; cp "$W2/out.json" "$W2/$tier/.claude/manifest.json"
+    got_dep="$(jq -r '.deployment // "ABSENT"' "$W2/out.json")"
+    got_enf="$(jq -r '.enforcement_level // "ABSENT"' "$W2/out.json")"
+    [ "$got_dep" = "$tier" ] || { w2_note="$tier: deployment=$got_dep"; break; }
+    [ "$got_enf" = "strict" ] || { w2_note="$tier: enforcement_level=$got_enf"; break; }
+    if choosable "$W2/$tier"; then r=choosable; else r=refused; fi
+    case "$tier:$r" in
+      personal:choosable|organizational:refused) w2_ok=yes ;;
+      *) w2_note="$tier answered $r"; w2_ok=no; break ;;
+    esac
+  done
+fi
+if [ "$w2_ok" = "yes" ]; then
+  pass "W2: the SHIPPED jq filter, executed, produces a manifest that assert_choosable reads correctly — personal choosable, organizational refused, enforcement_level seeded strict. W1 proves the keys are named; this proves they land"
+else
+  fail_ "W2" "${w2_note:-the shipped filter did not produce a manifest the predicate reads correctly}"
+fi
+
+echo "=== M — mutation proof ==="
+
+# ── M1: restore the permissive default and A3 must flip back to allowing.
+M1="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M1/scripts" 2>/dev/null
+m1_meta=$(_mutate "$M1/scripts/lib/enforcement-level.sh" '# BL-221-TIER-FAIL-CLOSED' '  deployment=$(jq -r '"'"'.deployment // "personal"'"'"' "$manifest" 2>/dev/null)')
+m1_sites="${m1_meta%% *}"; m1_rest="${m1_meta#* }"; m1_changed="${m1_rest%% *}"; m1_parses="${m1_rest##* }"
+M1D="$(newtmp)"; mk_manifest "$M1D" '{"poc_mode":"production","enforcement_level":"strict"}'
+if choosable "$M1D" "$M1/scripts/lib/enforcement-level.sh"; then m1_res=allowed; else m1_res=refused; fi
+if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_res" = "allowed" ]; then
+  pass "M1: with the permissive default restored, an organizational manifest missing its deployment key is CHOOSABLE again — the one-line guard is what stands between a forced-strict project and its own downgrade (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
+else
+  fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed result=$m1_res (want allowed)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl221-tier-fail-closed.sh
+++ b/tests/test-bl221-tier-fail-closed.sh
@@ -197,9 +197,35 @@ echo "=== W — adoption writes the tier keys, so the divergence has no source =
 
 # ── W1: the adopted manifest carries the same tier keys a scaffolded one does.
 # Asserted on the WRITER's shipped code, not on a copy of it.
+#
+# COMMENTS ARE STRIPPED FIRST, AND THAT IS THE WHOLE POINT OF THIS BLOCK. The
+# first version of W1 grepped the file whole — and `# BL-221-ADOPT-TIER-KEYS`'s
+# own explanatory comment names all three keys, in prose, three lines above the
+# jq filter. So the check passed on a tree where the fix had been reverted and
+# only the comment survived: it was measuring that someone had once written
+# about the keys, not that the writer writes them. Reading executed lines only
+# is the same correction `# BL-181-UNIT-LANE-PREDICATE` made to the unit-lane
+# exemption, for the same reason.
+#
+# IT TOOK THREE NARROWINGS TO STOP BEING VACUOUS, and M2 measured each one.
+#   1. Whole file, bare word — satisfied by the fix's own COMMENT, which names
+#      all three keys in prose three lines above the filter.
+#   2. Comments stripped, bare word — satisfied by the SHELL VARIABLES
+#      `$ADOPT_DEPLOYMENT` and `$ADOPT_POC_MODE` on executed lines; only
+#      `enforcement_level`, which has no matching variable, could fail.
+#   3. Comments stripped, key-assignment form (`.deployment =` / `deployment:`)
+#      — satisfied by `adopt_write_phase_state`, which legitimately writes the
+#      same three keys to a DIFFERENT file.
+# So the scope is `adopt_write_manifest`'s body and the pattern is the
+# key-assignment form. M2 now requires ALL THREE to go missing, which is the
+# only version of this assertion that a reverted manifest writer cannot survive.
+W1_SRC="$(newtmp)/adopt-state.exec"
+awk '/^adopt_write_manifest\(\)/{i=1} i{print} i&&/^}/{exit}' \
+  "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" | sed -e 's/[[:space:]]*#.*$//' > "$W1_SRC"
+[ -s "$W1_SRC" ] || { fail_ "W1" "could not extract adopt_write_manifest from adopt-state.sh — the scope this case asserts in is empty, which would make it pass on anything"; }
 W1_missing=""
 for k in deployment poc_mode enforcement_level; do
-  grep -q "$k" "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" || W1_missing="$W1_missing $k"
+  grep -Eq "[.]${k}[[:space:]]*=|${k}:" "$W1_SRC" || W1_missing="$W1_missing $k"
 done
 w1_marked=$(_num "$(grep -c 'BL-221-ADOPT-TIER-KEYS' "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" 2>/dev/null)")
 if [ -z "$W1_missing" ] && [ "$w1_marked" -ge 1 ]; then
@@ -253,6 +279,46 @@ if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_res" = "allowed" ];
   pass "M1: with the permissive default restored, an organizational manifest missing its deployment key is CHOOSABLE again — the one-line guard is what stands between a forced-strict project and its own downgrade (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
 else
   fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed result=$m1_res (want allowed)"
+fi
+
+# ── M2: revert the WRITE half but leave its comment standing, and W1 must go
+# red. This is the mutant W1 did not have: the explanatory comment above
+# `# BL-221-ADOPT-TIER-KEYS` names all three keys in prose, so a whole-file grep
+# stayed green against a tree where the jq filter had been stripped back to
+# `.host` and `.mode`. The mutant reproduces exactly that state — comment
+# intact, behaviour gone — and the assertion below is on W1's OWN predicate, run
+# against the mutated file.
+#
+# awk, not sed: the two lines being replaced ARE the jq filter, which is
+# `|`-dense, and CLAUDE.md records three separate occasions on which a
+# `|`-delimited sed with a `|`-bearing replacement left the file unchanged while
+# reporting success. `m2_rewrites` is asserted for the same reason — "the
+# mutation ran" is not "the mutation edited".
+M2="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M2/scripts" 2>/dev/null
+M2F="$M2/scripts/lib/adopt/adopt-state.sh"
+m2_tmp="$(mktemp)"
+m2_rewrites=$(awk '
+  /\.host = \$h \| \.mode = \$m \| \.deployment/ { print "      \x27.host = $h | .mode = $m\x27 \\"; n++; next }
+  /\{host: \$h, mode: \$m, remote_url/          { print "      \x27{host: $h, mode: $m, remote_url: \"\"}\x27 \\"; n++; next }
+  { print }
+  END { print n+0 > "/dev/stderr" }
+' "$M2F" 2>&1 >"$m2_tmp" )
+mv "$m2_tmp" "$M2F"
+m2_rewrites=$(_num "$m2_rewrites")
+m2_parses=0; bash -n "$M2F" >/dev/null 2>&1 && m2_parses=1
+M2_SRC="$(newtmp)/adopt-state.exec"
+awk '/^adopt_write_manifest\(\)/{i=1} i{print} i&&/^}/{exit}' "$M2F" | sed -e 's/[[:space:]]*#.*$//' > "$M2_SRC"
+m2_missing=""
+m2_n=0
+for k in deployment poc_mode enforcement_level; do
+  grep -Eq "[.]${k}[[:space:]]*=|${k}:" "$M2_SRC" || { m2_missing="$m2_missing $k"; m2_n=$((m2_n + 1)); }
+done
+m2_whole_file_hits=$(_num "$(grep -c 'deployment' "$M2F" 2>/dev/null)")
+if [ "$m2_rewrites" -eq 2 ] && [ "$m2_parses" -eq 1 ] \
+   && [ "$m2_n" -eq 3 ] && [ "$m2_whole_file_hits" -ge 1 ]; then
+  pass "M2: with the tier keys stripped from both jq filters and only the comment left, W1's predicate reports ALL THREE missing ($m2_missing) while a whole-file grep for 'deployment' still finds $m2_whole_file_hits hits — comment prose and shell variable names, which is exactly what the original W1 was measuring (rewrites=$m2_rewrites parses=$m2_parses)"
+else
+  fail_ "M2" "rewrites=$m2_rewrites (want 2) parses=$m2_parses (want 1) missing='$m2_missing' n=$m2_n (want 3 — fewer means a reverted key is still satisfying W1 from somewhere) whole_file_hits=$m2_whole_file_hits (want >=1)"
 fi
 
 echo ""

--- a/tests/test-bl221-tier-fail-closed.sh
+++ b/tests/test-bl221-tier-fail-closed.sh
@@ -85,7 +85,11 @@ _changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _
 _mutate() {
   local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp d
   d=$(printf '\001')
-  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  # Backslash-DIGIT is escaped as well as `&`: in a sed replacement `\0`…`\9`
+  # are backreferences, so a mutant containing one leaves the file unchanged
+  # while still reporting `sites`. Kept in step with the sibling helper in
+  # tests/test-bl235-tool-matrix-probes.sh, where that cost three silent no-ops.
+  safe=$(printf '%s' "$repl" | sed -e 's/\\\([0-9]\)/\\\\\1/g' -e 's/&/\\&/g')
   mode="$(_mode_of "$f")"
   before="$(mktemp)"; cp -p "$f" "$before"
   sites=$(_sites "$f" "$marker")

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -291,6 +291,31 @@ else
   fail_ "T2" "elapsed ${t2_elapsed}s for a 12s version_command at a 2s bound"
 fi
 
+# ── T2b: A PIPELINE, WHICH IS THE SHAPE THE MATRIX ACTUALLY SHIPS.
+#
+# T2 above passes on `sleep 12` and certified the bound using the ONE shape that
+# works. `kill -9` reaps the `bash -c` child; a pipeline's other members survive
+# it holding the pipe open, and a caller reading through a COMMAND SUBSTITUTION
+# then waits for THEM. Measured before the fix: `sleep 12 | cat` at a 2s bound
+# took 12s, as did `(sleep 12)` and the verbatim shipped Colima row
+# (`colima version … | head -1 | awk …`). 21 of the 41 checkable rows across the
+# four matrices are that shape, so the bound was decorative for half the matrix
+# — including the daemon-backed rows it exists for.
+#
+# Derive the reach rather than trusting this comment:
+#   for f in templates/tool-matrix/*.json; do
+#     jq -r '.tools[] | select((.version_command // "") | test("[|]|[(]|&")) | .name' "$f"
+#   done | wc -l
+T2B="$(newtmp)"; mk_matrix_proj "$T2B" 'true' 'sleep 12 | cat'
+t2b_start=$(date +%s)
+( cd "$T2B" && CHECKVER_EVAL_TIMEOUT=2 "$BASH_BIN" "$CHECKVER" >/dev/null 2>&1 ) || true
+t2b_elapsed=$(( $(date +%s) - t2b_start ))
+if [ "$t2b_elapsed" -lt 9 ]; then
+  pass "T2b: a 12s PIPELINE version_command is bounded too (elapsed ${t2b_elapsed}s) — the reader takes the output through a file, so an unreaped pipeline member holding the write end can no longer outlast the bound"
+else
+  fail_ "T2b" "elapsed ${t2b_elapsed}s for a 12s pipeline at a 2s bound — the bound reaps only the 'bash -c' child, and a command substitution waits for every other writer. This is the shape 21 of 41 shipped rows use, Colima included"
+fi
+
 # ── T3: the bound must not break a NORMAL row. Over-tightening would turn every
 # healthy tool into 'not installed', which is the same class of wrong answer.
 T3="$(newtmp)"; mk_matrix_proj "$T3" 'true' "echo 9.9.9"
@@ -586,22 +611,54 @@ else
   fail_ "C2" "out='$(printf '%s' "$c2_out" | tr '\n' '|' | cut -c1-300)' — the word 'configured' is still rendered, or the row vanished entirely"
 fi
 
+# ── C3: THE DIAGNOSIS MUST REACH THE OPERATOR, NOT JUST THE PROBE'S STDERR.
+#
+# D9 asserts that a secured-but-unkeyed database produces a note naming HTTP
+# 403 — and asserts it ON THE PROBE. check-versions.sh then ran the check as
+# `>/dev/null 2>&1`, so all three states arrived as one word: a database that is
+# UP and refusing for want of a key rendered identically to one that was never
+# installed. That is this entry's own defect, one layer out, and D9 could not
+# see it because D9 stops where the answer is PRODUCED rather than where it is
+# CONSUMED. This case reads the rendered report.
+if [ -z "$STUB_PORT" ]; then
+  skip_ "C3" "no stub server — the 403 path needs a database that answers and refuses"
+else
+  C3="$(newtmp)"; mk_shipped_row_proj "$C3" "Qdrant MCP"
+  mk_qdrant_home "$C3/home" "http://127.0.0.1:$STUB_PORT/authed"   # key deliberately absent
+  c3_out="$( cd "$C3" && HOME="$C3/home" "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+  if printf '%s' "$c3_out" | grep -q 'HTTP 403' \
+     && printf '%s' "$c3_out" | grep -q 'QDRANT_API_KEY' \
+     && ! printf '%s' "$c3_out" | grep -q 'Qdrant MCP: not installed'; then
+    pass "C3: a running database refusing an unkeyed probe is reported BY check-versions.sh as HTTP 403 with the QDRANT_API_KEY repair — the third state and its diagnosis survive the trip to the operator instead of being flattened to 'not installed'"
+  else
+    fail_ "C3" "out='$(printf '%s' "$c3_out" | tr '\n' '|' | cut -c1-300)' — wanted the 403 and the QDRANT_API_KEY guidance, and NOT 'not installed' for a database that is up"
+  fi
+fi
+
 echo "=== X — the resolver is EXECUTED, so its mode is part of its contract ==="
 
 # ── X1: `scripts/resolve-tools.sh` must be executable.
 #
-# THIS IS NOT HYGIENE, IT IS THIS ENTRY'S OWN DEFECT CLASS. init.sh, verify-
-# install.sh, check-phase-gate.sh and intake-wizard.sh all invoke it DIRECTLY —
-# `"$SCRIPT_DIR/scripts/resolve-tools.sh" --dev-os …`, no `bash` prefix — so a
-# lost execute bit makes the command substitution return 126 and init.sh take
-# its `|| { print_warn "Tool resolver failed. Falling back to basic tool
-# checks."; return 0; }` arm. It then **exits 0 and scaffolds a project
-# anyway**, one whose `.claude/tool-preferences.json` was written by the
-# fallback writer instead of from resolver output. Measured, because it happened
-# during this very fix: an editor of mine wrote the file through
-# `sed > tmp && mv`, which silently replaced 755 with 644, and the only visible
-# trace was a single `[WARN]` line and three context values that had acquired a
-# leading space. A green test suite, a zero exit code, and a wrong project.
+# THIS IS NOT HYGIENE, IT IS THIS ENTRY'S OWN DEFECT CLASS — and the four
+# callers do NOT behave alike, which an earlier version of this comment got
+# wrong by asserting they did. Derived, per caller:
+#
+#   init.sh                 EXECUTES it (`"$SCRIPT_DIR/scripts/resolve-tools.sh" …`)
+#                           -> rc=126 -> `|| { print_warn "Tool resolver
+#                           failed. Falling back to basic tool checks."; return 0; }`
+#   verify-install.sh       gated `[ ! -x … ] -> register_manual "Tool check
+#                           skipped …"; return`, and the call itself carries a
+#                           `bash ` prefix, so the mode never reaches execve
+#   intake-wizard.sh        gated `[ -x … ] && …` -> the block is SKIPPED
+#   check-phase-gate.sh     gated `[ -x "$RESOLVER" ]` -> the block is SKIPPED
+#
+# So exactly ONE caller produces 126 and the other three degrade by SILENT SKIP
+# — the worse arm, not the milder one: init.sh at least prints a warning. That
+# is also why "the shell will tell you" does not justify skipping this check.
+# Measured, because it happened during this very fix: an editor of mine wrote
+# the file through `sed > tmp && mv`, which silently replaced 755 with 644, and
+# the only visible trace was one `[WARN]` line and three context values that had
+# acquired a leading space. A green suite, a zero exit code, and a wrong project.
 #
 # `bash tests/foo.sh` is how tests are run, so test files are exempt by
 # construction; this asserts the mode only where something executes the file.
@@ -616,13 +673,16 @@ echo "=== M — mutation proofs ==="
 
 # ── M1: remove the bound and T1 must hang again.
 M1="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M1/scripts" 2>/dev/null
-m1_meta=$(_mutate "$M1/scripts/check-versions.sh" '# BL-235-BOUND-CHECK' '  if ! eval "$CHECK_CMD" >/dev/null 2>&1; then')
+m1_meta=$(_mutate "$M1/scripts/check-versions.sh" '# BL-235-BOUND-CHECK' '  eval "$CHECK_CMD" >/dev/null 2>"$CHECK_ERR" || CHECK_RC=$?')
 m1_sites="${m1_meta%% *}"; m1_rest="${m1_meta#* }"; m1_changed="${m1_rest%% *}"; m1_parses="${m1_rest##* }"
-M1D="$(newtmp)"; mk_matrix_proj "$M1D" 'sleep 12' "echo 1.0"
+# 6s, not 12s: the discrimination is "returns at the 2s bound" vs "runs to
+# completion", and 6 separates those as cleanly as 12 for half the wall clock.
+# This suite is pinned to a CI shard, so its own duration is a cost.
+M1D="$(newtmp)"; mk_matrix_proj "$M1D" 'sleep 6' "echo 1.0"
 m1_start=$(date +%s)
 ( cd "$M1D" && "$BASH_BIN" "$M1/scripts/check-versions.sh" >/dev/null 2>&1 ) || true
 m1_elapsed=$(( $(date +%s) - m1_start ))
-if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 10 ]; then
+if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 5 ]; then
   pass "M1: with the bound removed, a 12s check_command holds the script for ${m1_elapsed}s again — the bound is load-bearing and measured in seconds, not asserted (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
 else
   fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed elapsed=${m1_elapsed}s (want >=10)"
@@ -713,6 +773,57 @@ if [ "$m6_sites" -ge 1 ] && [ "$m6_parses" -eq 1 ] && printf '%s' "$m6_out" | gr
   pass "M6: with the fallback restored, 'configured' is rendered again for a version-less row — C2 reads the OUTPUT, which is the surface D2 could never see (sites=$m6_sites changed=$m6_changed)"
 else
   fail_ "M6" "sites=$m6_sites (want >=1) parses=$m6_parses (want 1) out='$(printf '%s' "$m6_out" | tr '\n' '|' | cut -c1-200)'"
+fi
+
+# ── M8: put the version read back on a command substitution and T2b must hang
+# again. The mutant is ONE LINE and behaviour-identical for every non-pipeline
+# row, which is exactly why the original shipped through a review.
+M8="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M8/scripts"
+m8_meta=$(_mutate "$M8/scripts/check-versions.sh" '# BL-235-BOUND-VERSION' \
+  '    INSTALLED=$(_cv_bounded_eval "$VERSION_CMD" 2>/dev/null | tr -d "[:space:]" || echo ""); CV_NOTE=""')
+m8_sites="${m8_meta%% *}"; m8_rest="${m8_meta#* }"; m8_changed="${m8_rest%% *}"; m8_parses="${m8_rest##* }"
+M8D="$(newtmp)"; mk_matrix_proj "$M8D" 'true' 'sleep 6 | cat'
+m8_start=$(date +%s)
+( cd "$M8D" && CHECKVER_EVAL_TIMEOUT=2 "$BASH_BIN" "$M8/scripts/check-versions.sh" >/dev/null 2>&1 ) || true
+m8_elapsed=$(( $(date +%s) - m8_start ))
+if [ "$m8_sites" -eq 1 ] && [ "$m8_parses" -eq 1 ] && [ "$m8_elapsed" -ge 5 ]; then
+  pass "M8: with the version read back on a command substitution, a 6s pipeline holds the script for ${m8_elapsed}s against a 2s bound — T2b measures the CONSUMPTION, which is where the bound was being defeated (sites=$m8_sites changed=$m8_changed)"
+else
+  fail_ "M8" "sites=$m8_sites (want 1) parses=$m8_parses (want 1) changed=$m8_changed elapsed=${m8_elapsed}s (want >=5)"
+fi
+
+# ── M9: discard the check's stderr and exit code again, and C3 must lose both
+# the status and the repair — the exact line this branch shipped first.
+if [ -n "$STUB_PORT" ]; then
+  M9="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M9/scripts"
+  m9_meta=$(_mutate "$M9/scripts/check-versions.sh" '# BL-235-BOUND-CHECK' \
+    '  _cv_bounded_eval "$CHECK_CMD" >/dev/null 2>&1 || CHECK_RC=$?')
+  m9_sites="${m9_meta%% *}"; m9_rest="${m9_meta#* }"; m9_changed="${m9_rest%% *}"; m9_parses="${m9_rest##* }"
+  M9D="$(newtmp)"; mk_shipped_row_proj "$M9D" "Qdrant MCP"
+  mk_qdrant_home "$M9D/home" "http://127.0.0.1:$STUB_PORT/authed"
+  m9_out="$( cd "$M9D" && HOME="$M9D/home" "$BASH_BIN" "$M9/scripts/check-versions.sh" 2>&1 )" || true
+  if [ "$m9_sites" -eq 1 ] && [ "$m9_parses" -eq 1 ] \
+     && ! printf '%s' "$m9_out" | grep -q 'HTTP 403'; then
+    pass "M9: with the check's stderr discarded again, a live database refusing on 403 loses its status and its repair on the way to the operator — C3 reads the report, which is the only surface this is visible on (sites=$m9_sites changed=$m9_changed)"
+  else
+    fail_ "M9" "sites=$m9_sites (want 1) parses=$m9_parses (want 1) out='$(printf '%s' "$m9_out" | tr '\n' '|' | cut -c1-200)'"
+  fi
+fi
+
+# ── M10: a non-numeric bound must not mean ZERO. `$(( now + abc ))` is `now`,
+# so an unparseable timeout made every deadline already-past and turned a whole
+# healthy matrix into "not installed" — silently, from one environment variable.
+M10="$(newtmp)"; mk_matrix_proj "$M10" 'true' "echo 9.9.9"
+m10_ctl="$( cd "$M10" && CHECKVER_EVAL_TIMEOUT=abc "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+M10M="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M10M/scripts"
+m10_meta=$(_mutate "$M10M/scripts/lib/helpers-core.sh" '# BL-235-DEADLINE-SANE' '  :')
+m10_sites="${m10_meta%% *}"; m10_rest="${m10_meta#* }"; m10_changed="${m10_rest%% *}"; m10_parses="${m10_rest##* }"
+m10_mut="$( cd "$M10" && CHECKVER_EVAL_TIMEOUT=abc "$BASH_BIN" "$M10M/scripts/check-versions.sh" 2>&1 )" || true
+m10_c=$(printf '%s' "$m10_ctl" | grep -c '9.9.9'); m10_m=$(printf '%s' "$m10_mut" | grep -c '9.9.9')
+if [ "$(_num "$m10_c")" -ge 1 ] && [ "$m10_sites" -eq 1 ] && [ "$m10_parses" -eq 1 ] && [ "$(_num "$m10_m")" -eq 0 ]; then
+  pass "M10: CHECKVER_EVAL_TIMEOUT=abc still reports 9.9.9; with the clamp removed the same healthy row vanishes — an unparseable bound makes the deadline equal now, so every row times out instantly and a whole matrix reads as missing from one malformed environment variable (sites=$m10_sites changed=$m10_changed)"
+else
+  fail_ "M10" "control_hits=$m10_c (want >=1) sites=$m10_sites (want 1) parses=$m10_parses (want 1) mutant_hits=$m10_m (want 0)"
 fi
 
 # ── M7: X1 must be able to fail. Strip the bit from a COPY and re-run the same

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -635,6 +635,33 @@ else
   fi
 fi
 
+# ── C4: A TOOL'S STDERR MUST NOT BE ABLE TO FORGE A REPORT LINE.
+#
+# Surfacing the note (C3) handed a tool's stderr straight to `print_warn`, which
+# renders through `echo -e` — and `echo -e` INTERPRETS backslash escapes. A note
+# containing the two characters `\` and `n` therefore becomes a real line break,
+# and whatever follows it starts a new line of the report. Measured before the
+# fix, from a check_command whose stderr was
+# `note-one\nFORGED  [OK] Totally Installed: 9.9.9`:
+#
+#     [WARN] P: configured, but working could not be confirmed — note-one
+#     FORGED  [OK] Totally Installed: 9.9.9
+#
+# — a fabricated `[OK]` row, in the one script whose whole job is reporting
+# honestly. The rows ship with the framework, but the probe notes interpolate
+# `$(qdrant_mcp_url)` read from `~/.claude.json`, so the text is not all ours.
+# This is the cost of C3's fix and it is paid here rather than left standing.
+C4="$(newtmp)"
+mk_matrix_proj "$C4" 'printf %s "note-one\nFORGED  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
+c4_out="$( cd "$C4" && "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+c4_forged=$(_num "$(printf '%s' "$c4_out" | grep -c '^FORGED')")
+c4_kept=$(_num "$(printf '%s' "$c4_out" | grep -c 'note-one')")
+if [ "$c4_forged" -eq 0 ] && [ "$c4_kept" -ge 1 ]; then
+  pass "C4: a note carrying a literal backslash-n is rendered as text, not as a line break — the note still reaches the operator (note-one seen) but cannot start a new line, so a tool's stderr cannot forge an [OK] row"
+else
+  fail_ "C4" "lines beginning FORGED=$c4_forged (want 0) note-present=$c4_kept (want >=1) — out='$(printf '%s' "$c4_out" | tr '\n' '|' | cut -c1-300)'"
+fi
+
 echo "=== X — the resolver is EXECUTED, so its mode is part of its contract ==="
 
 # ── X1: `scripts/resolve-tools.sh` must be executable.
@@ -683,9 +710,9 @@ m1_start=$(date +%s)
 ( cd "$M1D" && "$BASH_BIN" "$M1/scripts/check-versions.sh" >/dev/null 2>&1 ) || true
 m1_elapsed=$(( $(date +%s) - m1_start ))
 if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 5 ]; then
-  pass "M1: with the bound removed, a 12s check_command holds the script for ${m1_elapsed}s again — the bound is load-bearing and measured in seconds, not asserted (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
+  pass "M1: with the bound removed, a 6s check_command holds the script for ${m1_elapsed}s again — the bound is load-bearing and measured in seconds, not asserted (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
 else
-  fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed elapsed=${m1_elapsed}s (want >=10)"
+  fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed elapsed=${m1_elapsed}s (want >=5)"
 fi
 
 # ── M2: put the rows back to a CWD-relative path and C1's condition must return.
@@ -824,6 +851,20 @@ if [ "$(_num "$m10_c")" -ge 1 ] && [ "$m10_sites" -eq 1 ] && [ "$m10_parses" -eq
   pass "M10: CHECKVER_EVAL_TIMEOUT=abc still reports 9.9.9; with the clamp removed the same healthy row vanishes — an unparseable bound makes the deadline equal now, so every row times out instantly and a whole matrix reads as missing from one malformed environment variable (sites=$m10_sites changed=$m10_changed)"
 else
   fail_ "M10" "control_hits=$m10_c (want >=1) sites=$m10_sites (want 1) parses=$m10_parses (want 1) mutant_hits=$m10_m (want 0)"
+fi
+
+# ── M11: remove the escape-doubling and C4's forged line must come back.
+M11="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M11/scripts"
+m11_meta=$(_mutate "$M11/scripts/check-versions.sh" '# BL-235-NOTE-SAFE' '  printf "%s" "$1"')
+m11_sites="${m11_meta%% *}"; m11_rest="${m11_meta#* }"; m11_changed="${m11_rest%% *}"; m11_parses="${m11_rest##* }"
+M11D="$(newtmp)"
+mk_matrix_proj "$M11D" 'printf %s "note-one\nFORGED  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
+m11_out="$( cd "$M11D" && "$BASH_BIN" "$M11/scripts/check-versions.sh" 2>&1 )" || true
+m11_forged=$(_num "$(printf '%s' "$m11_out" | grep -c '^FORGED')")
+if [ "$m11_sites" -eq 1 ] && [ "$m11_parses" -eq 1 ] && [ "$m11_forged" -ge 1 ]; then
+  pass "M11: with the escape-doubling removed, the note's literal backslash-n becomes a real line break again and a fabricated '[OK] Totally Installed' row appears in the report — C4 measures forgery, not merely that a note is printed (sites=$m11_sites changed=$m11_changed)"
+else
+  fail_ "M11" "sites=$m11_sites (want 1) parses=$m11_parses (want 1) forged_lines=$m11_forged (want >=1)"
 fi
 
 # ── M7: X1 must be able to fail. Strip the bit from a COPY and re-run the same

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -662,6 +662,44 @@ else
   fail_ "C4" "lines beginning FORGED=$c4_forged (want 0) note-present=$c4_kept (want >=1) — out='$(printf '%s' "$c4_out" | tr '\n' '|' | cut -c1-300)'"
 fi
 
+# ── C5: THE VERSION STRING IS THE OTHER RENDER PATH, AND FIXING ONLY THE NOTE
+# WAS THE SYNC-SIBLING TRAP IN MINIATURE.
+#
+# `INSTALLED` comes from a version_command's STDOUT and reaches the same
+# `echo -e` at NINE places — six direct and three through `UPDATES[]`. C4 fixed
+# the note; this path stayed open, and `tr -d '[:space:]'` does not close it
+# because `\x20` is not whitespace until `echo -e` expands it. Measured before
+# the fix, a version_command emitting `1.0\n\x20\x20[OK]\x20Totally…`:
+#
+#     [OK] P: 1.0
+#     [OK] Totally Installed: 9.9.9 — up to date     <- byte-identical to a real row
+C5="$(newtmp)"
+mk_matrix_proj "$C5" 'true' 'printf %s "1.0\n\x20\x20[OK]\x20Totally\x20Installed:\x209.9.9"'
+c5_out="$( cd "$C5" && "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+c5_forged=$(_num "$(printf '%s' "$c5_out" | grep -c '^  \[OK\] Totally Installed')")
+c5_kept=$(_num "$(printf '%s' "$c5_out" | grep -c 'Probe: 1.0')")
+if [ "$c5_forged" -eq 0 ] && [ "$c5_kept" -ge 1 ]; then
+  pass "C5: a version_command emitting an escaped newline plus a complete fake row cannot forge one — the real row still reports 1.0, and the version string is sanitised at its single point of capture so all nine render sites are covered at once"
+else
+  fail_ "C5" "forged_rows=$c5_forged (want 0) real_row_present=$c5_kept (want >=1) — out='$(printf '%s' "$c5_out" | tr '\n' '|' | cut -c1-300)'"
+fi
+
+# ── C6: a RAW carriage return is not a backslash, so escape-doubling alone
+# leaves it — and on a terminal it returns the cursor to column 0, letting the
+# text after it overwrite the `[WARN]` prefix and render a complete fake row.
+# The narrower control-byte range proposed for this does NOT strip CR: measured,
+# `printf 'a\rb' | tr -d '\000-\010\013\014\016-\037\177'` still emits a CR,
+# because \015 falls in the gap between \014 and \016.
+C6="$(newtmp)"
+mk_matrix_proj "$C6" 'printf "note\r  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
+c6_out="$( cd "$C6" && "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+c6_cr=$(_num "$(printf '%s' "$c6_out" | LC_ALL=C grep -c $'\r')")
+if [ "$c6_cr" -eq 0 ]; then
+  pass "C6: a note carrying a RAW carriage return has it stripped before rendering — no byte in the report can return the cursor to column 0 and overwrite the [WARN] prefix with tool-supplied text"
+else
+  fail_ "C6" "lines containing a raw CR=$c6_cr (want 0) — escape-doubling does not touch control bytes, and CR is the one that repaints the line"
+fi
+
 echo "=== X — the resolver is EXECUTED, so its mode is part of its contract ==="
 
 # ── X1: `scripts/resolve-tools.sh` must be executable.
@@ -865,6 +903,43 @@ if [ "$m11_sites" -eq 1 ] && [ "$m11_parses" -eq 1 ] && [ "$m11_forged" -ge 1 ];
   pass "M11: with the escape-doubling removed, the note's literal backslash-n becomes a real line break again and a fabricated '[OK] Totally Installed' row appears in the report — C4 measures forgery, not merely that a note is printed (sites=$m11_sites changed=$m11_changed)"
 else
   fail_ "M11" "sites=$m11_sites (want 1) parses=$m11_parses (want 1) forged_lines=$m11_forged (want >=1)"
+fi
+
+# ── M12: leave the version string unsanitised and C5's fake row returns. This
+# is the mutant that matters most of the set, because the round-three fix
+# ORIGINALLY looked like this — the note was guarded and the version was not.
+M12="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M12/scripts"
+m12_meta=$(_mutate "$M12/scripts/check-versions.sh" '# BL-235-VERSION-SAFE' \
+  '  INSTALLED="$(tr -d "[:space:]" < "$_out" 2>/dev/null || :)"')
+m12_sites="${m12_meta%% *}"; m12_rest="${m12_meta#* }"; m12_changed="${m12_rest%% *}"; m12_parses="${m12_rest##* }"
+M12D="$(newtmp)"
+mk_matrix_proj "$M12D" 'true' 'printf %s "1.0\n\x20\x20[OK]\x20Totally\x20Installed:\x209.9.9"'
+m12_out="$( cd "$M12D" && "$BASH_BIN" "$M12/scripts/check-versions.sh" 2>&1 )" || true
+m12_forged=$(_num "$(printf '%s' "$m12_out" | grep -c '^  \[OK\] Totally Installed')")
+if [ "$m12_sites" -eq 1 ] && [ "$m12_parses" -eq 1 ] && [ "$m12_forged" -ge 1 ]; then
+  pass "M12: with the version string left unsanitised, a version_command forges a complete '[OK] Totally Installed' row again — C5 measures the SECOND render path, which the first version of this fix left open (sites=$m12_sites changed=$m12_changed)"
+else
+  fail_ "M12" "sites=$m12_sites (want 1) parses=$m12_parses (want 1) forged_rows=$m12_forged (want >=1)"
+fi
+
+# ── M13: restore the narrower control-byte range and C6's raw CR survives.
+# Proves C6 measures the RANGE, not merely that a `tr` is present.
+M13="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M13/scripts"
+# The replacement keeps the doubling and NARROWS ONLY THE RANGE, which is the
+# whole point — and it is written with single backslashes inside single quotes,
+# because a backslash-dense replacement is how the previous attempt at this
+# mutant silently produced a line sed refused.
+m13_meta=$(_mutate "$M13/scripts/check-versions.sh" '# BL-235-NOTE-SAFE' \
+  "  printf '%s' \"\$_s\" | tr -d '\013\014'")
+m13_sites="${m13_meta%% *}"; m13_rest="${m13_meta#* }"; m13_changed="${m13_rest%% *}"; m13_parses="${m13_rest##* }"
+M13D="$(newtmp)"
+mk_matrix_proj "$M13D" 'printf "note\r  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
+m13_out="$( cd "$M13D" && "$BASH_BIN" "$M13/scripts/check-versions.sh" 2>&1 )" || true
+m13_cr=$(_num "$(printf '%s' "$m13_out" | LC_ALL=C grep -c $'\r')")
+if [ "$m13_sites" -eq 1 ] && [ "$m13_parses" -eq 1 ] && [ "$m13_cr" -ge 1 ]; then
+  pass "M13: with the range narrowed to \\000-\\010\\013\\014\\016-\\037, the raw CR survives into the report again — \\015 sits in the gap between \\014 and \\016, so C6 is measuring the range and not the presence of a tr (sites=$m13_sites changed=$m13_changed)"
+else
+  fail_ "M13" "sites=$m13_sites (want 1) parses=$m13_parses (want 1) cr_lines=$m13_cr (want >=1)"
 fi
 
 # ── M7: X1 must be able to fail. Strip the bit from a COPY and re-run the same

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -116,10 +116,23 @@ _changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _
 # character cannot occur in a shell one-liner, so the class is closed rather
 # than dodged. `&` is still escaped, because an unescaped one splices the whole
 # match back in and that mutant passes `bash -n`.
+#
+# BACKSLASH-DIGIT IS ESCAPED TOO, AND NOT ESCAPING IT COST A THIRD SILENT
+# NO-OP. In a sed REPLACEMENT `\0`…`\9` are BACKREFERENCES, so a mutant
+# containing `tr -d '\000-\037\177'` made sed abort with "\1 not defined in the
+# RE" — the file unchanged, while `sites=1 parses=1` still reported. The case
+# then read "the mutant changed nothing", which is indistinguishable from "the
+# guard is not load-bearing": a mutation proof wearing the costume of a passing
+# control. `&` has always been escaped here for the same reason.
+#
+# ONLY backslash-DIGIT, not every backslash. A blanket `s/\\/\\\\/g` also
+# rewrites the `$'\t'` and `%s\n` that other mutants in this file legitimately
+# need, changing what those mutants test. `changed` is asserted by every case
+# that uses this, which is the backstop for the next spelling nobody predicted.
 _mutate() {
   local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp d
   d=$(printf '\001')
-  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  safe=$(printf '%s' "$repl" | sed -e 's/\\\([0-9]\)/\\\\\1/g' -e 's/&/\\&/g')
   mode="$(_mode_of "$f")"
   before="$(mktemp)"; cp -p "$f" "$before"
   sites=$(_sites "$f" "$marker")
@@ -694,10 +707,58 @@ C6="$(newtmp)"
 mk_matrix_proj "$C6" 'printf "note\r  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
 c6_out="$( cd "$C6" && "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
 c6_cr=$(_num "$(printf '%s' "$c6_out" | LC_ALL=C grep -c $'\r')")
-if [ "$c6_cr" -eq 0 ]; then
-  pass "C6: a note carrying a RAW carriage return has it stripped before rendering — no byte in the report can return the cursor to column 0 and overwrite the [WARN] prefix with tool-supplied text"
+# THE PRESENCE ARM IS NOT OPTIONAL, and its absence made the first version of
+# this case VACUOUS. `no raw CR in the output` is trivially true of a report
+# that never rendered the note at all — and "rows silently vanish" is a
+# pathology this very branch has already produced twice (a `grep -v` exiting 1,
+# and a `tr` exiting 1 on a stray byte). So C6 asserted an absence while the
+# most likely regression was an absence. C4 and C5 both dual-assert; this now
+# does too.
+c6_kept=$(_num "$(printf '%s' "$c6_out" | grep -c 'note')")
+if [ "$c6_cr" -eq 0 ] && [ "$c6_kept" -ge 1 ]; then
+  pass "C6: a note carrying a RAW carriage return still reaches the operator, with the CR stripped — no byte in the report can return the cursor to column 0 and overwrite the [WARN] prefix, and the assertion cannot be satisfied by the note vanishing"
 else
-  fail_ "C6" "lines containing a raw CR=$c6_cr (want 0) — escape-doubling does not touch control bytes, and CR is the one that repaints the line"
+  fail_ "C6" "lines containing a raw CR=$c6_cr (want 0) note-present=$c6_kept (want >=1) — escape-doubling does not touch control bytes, and CR is the one that repaints the line"
+fi
+
+# ── C7: a NON-UTF-8 BYTE ON A TOOL'S STDERR MUST NOT END THE REPORT.
+#
+# `tr` and `cut` reject an invalid multibyte sequence in a UTF-8 locale and exit
+# 1, and every caller here runs under `set -euo pipefail`. Measured on this
+# tree before the guard, with a check_command emitting `printf 'bad\xe9note'`:
+#
+#     LC_ALL=C            exit=0   3 of 3 rows
+#     LC_ALL=C.UTF-8      exit=1   1 of 3      <- ubuntu-latest's usual default
+#     LC_ALL=en_US.UTF-8  exit=1   1 of 3
+#
+# The `cut` half predates this branch and fails the same way on `main`; the `tr`
+# half is this branch's. Both are lines this entry owns, and the symptom is the
+# same "rows silently vanish" the suite has already caught twice.
+c7_locale=""
+for _l in C.UTF-8 en_US.UTF-8 en_GB.UTF-8; do
+  if ! printf 'a\xe9b' | LC_ALL="$_l" tr -d '\000-\037' >/dev/null 2>&1; then c7_locale="$_l"; break; fi
+done
+if [ -z "$c7_locale" ]; then
+  skip_ "C7" "no locale on this host makes tr reject an invalid multibyte sequence — the condition cannot be created, and asserting against it would prove nothing"
+else
+  C7="$(newtmp)"
+  mkdir -p "$C7/templates/tool-matrix" "$C7/.claude"
+  jq -n '{description:"fixture", schema_version:1, scope:"common",
+          tools:{ A:{name:"A",category:"runtime",phase:2,required:false,
+                     check_command:"printf \"bad\\xe9note\" >&2; exit 2", version_command:"echo 1.0", description:"f"},
+                  B:{name:"B",category:"runtime",phase:2,required:false,
+                     check_command:"true", version_command:"echo 2.0", description:"f"},
+                  C:{name:"C",category:"runtime",phase:2,required:false,
+                     check_command:"true", version_command:"echo 3.0", description:"f"} } }' \
+    > "$C7/templates/tool-matrix/common.json"
+  c7_rc=0
+  c7_out="$( cd "$C7" && LC_ALL="$c7_locale" "$BASH_BIN" "$CHECKVER" 2>&1 )" || c7_rc=$?
+  c7_rows=$(_num "$(printf '%s' "$c7_out" | grep -cE '^ *\[(OK|WARN)\]')")
+  if [ "$c7_rc" -eq 0 ] && [ "$c7_rows" -eq 3 ]; then
+    pass "C7: under $c7_locale a check_command emitting a non-UTF-8 byte still leaves all 3 rows rendered and the script exiting 0 — the sanitisers are byte-oriented, so one stray byte from one tool cannot end the whole report"
+  else
+    fail_ "C7" "locale=$c7_locale exit=$c7_rc (want 0) rows=$c7_rows (want 3) — a byte-oriented operator failed on a multibyte error and set -e ended the run, so every tool after the offending one silently disappeared"
+  fi
 fi
 
 echo "=== X — the resolver is EXECUTED, so its mode is part of its contract ==="
@@ -747,7 +808,7 @@ M1D="$(newtmp)"; mk_matrix_proj "$M1D" 'sleep 6' "echo 1.0"
 m1_start=$(date +%s)
 ( cd "$M1D" && "$BASH_BIN" "$M1/scripts/check-versions.sh" >/dev/null 2>&1 ) || true
 m1_elapsed=$(( $(date +%s) - m1_start ))
-if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 5 ]; then
+if [ "$m1_sites" -eq 1 ] && [ "$m1_changed" -ge 2 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 5 ]; then
   pass "M1: with the bound removed, a 6s check_command holds the script for ${m1_elapsed}s again — the bound is load-bearing and measured in seconds, not asserted (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
 else
   fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed elapsed=${m1_elapsed}s (want >=5)"
@@ -781,7 +842,7 @@ if [ -n "$STUB_PORT" ]; then
   M3H="$(newtmp)"; mk_qdrant_home "$M3H/home" "http://127.0.0.1:$STUB_PORT/notqdrant"
   m3_rc=0
   ( cd "$REPO_ROOT" && HOME="$M3H/home" PROBE_QUIET=1 "$BASH_BIN" "$M3/scripts/probe-tool.sh" qdrant >/dev/null 2>&1 ) || m3_rc=$?
-  if [ "$m3_sites" -ge 1 ] && [ "$m3_parses" -eq 1 ] && [ "$m3_rc" -eq 0 ]; then
+  if [ "$m3_sites" -ge 1 ] && [ "$m3_changed" -ge 2 ] && [ "$m3_parses" -eq 1 ] && [ "$m3_rc" -eq 0 ]; then
     pass "M3: with the identity check reduced to '.version // empty', a stub named totally-not-qdrant scores 0 again — D6 is discriminating, not decorative (sites=$m3_sites changed=$m3_changed)"
   else
     fail_ "M3" "sites=$m3_sites (want >=1) parses=$m3_parses (want 1) rc=$m3_rc (want 0)"
@@ -802,7 +863,7 @@ if [ -n "$STUB_PORT" ]; then
   M4H="$(newtmp)"; mk_qdrant_home "$M4H/home" "http://127.0.0.1:$STUB_PORT/authed" "s3cr3t"
   m4_rc=0
   ( cd "$REPO_ROOT" && HOME="$M4H/home" PROBE_QUIET=1 "$BASH_BIN" "$M4/scripts/probe-tool.sh" qdrant >/dev/null 2>&1 ) || m4_rc=$?
-  if [ "$m4_sites" -ge 1 ] && [ "$m4_parses" -eq 1 ] && [ "$m4_rc" -eq 2 ]; then
+  if [ "$m4_sites" -ge 1 ] && [ "$m4_changed" -ge 2 ] && [ "$m4_parses" -eq 1 ] && [ "$m4_rc" -eq 2 ]; then
     pass "M4: with the configured api-key discarded, the healthy secured database scores 2 again — D8 measures the header, not the happy path (sites=$m4_sites changed=$m4_changed)"
   else
     fail_ "M4" "sites=$m4_sites (want >=1) parses=$m4_parses (want 1) rc=$m4_rc (want 2)"
@@ -821,7 +882,7 @@ m5_meta=$(_mutate "$M5/scripts/probe-tool.sh" '# BL-235-PROBE-PLUGIN-SELECT' \
 m5_sites="${m5_meta%% *}"; m5_rest="${m5_meta#* }"; m5_changed="${m5_rest%% *}"; m5_parses="${m5_rest##* }"
 m5_rc=0
 ( cd "$REPO_ROOT" && HOME="$D13/home" PROBE_QUIET=1 "$BASH_BIN" "$M5/scripts/probe-tool.sh" superpowers >/dev/null 2>&1 ) || m5_rc=$?
-if [ "$m5_sites" -ge 1 ] && [ "$m5_parses" -eq 1 ] && [ "$m5_rc" -eq 2 ]; then
+if [ "$m5_sites" -ge 1 ] && [ "$m5_changed" -ge 2 ] && [ "$m5_parses" -eq 1 ] && [ "$m5_rc" -eq 2 ]; then
   pass "M5: with selection back at index [0], the healthy install behind a stale first entry scores 2 again — D13 pins the predicate, not the happy ordering (sites=$m5_sites changed=$m5_changed)"
 else
   fail_ "M5" "sites=$m5_sites (want >=1) parses=$m5_parses (want 1) rc=$m5_rc (want 2)"
@@ -834,7 +895,7 @@ m6_meta=$(_mutate "$M6/scripts/check-versions.sh" '# BL-235-NO-CONSTANT' \
 m6_sites="${m6_meta%% *}"; m6_rest="${m6_meta#* }"; m6_changed="${m6_rest%% *}"; m6_parses="${m6_rest##* }"
 M6D="$(newtmp)"; mk_matrix_proj "$M6D" 'true' 'true'
 m6_out="$( cd "$M6D" && "$BASH_BIN" "$M6/scripts/check-versions.sh" 2>&1 )" || true
-if [ "$m6_sites" -ge 1 ] && [ "$m6_parses" -eq 1 ] && printf '%s' "$m6_out" | grep -qi 'configured'; then
+if [ "$m6_sites" -ge 1 ] && [ "$m6_changed" -ge 2 ] && [ "$m6_parses" -eq 1 ] && printf '%s' "$m6_out" | grep -qi 'configured'; then
   pass "M6: with the fallback restored, 'configured' is rendered again for a version-less row — C2 reads the OUTPUT, which is the surface D2 could never see (sites=$m6_sites changed=$m6_changed)"
 else
   fail_ "M6" "sites=$m6_sites (want >=1) parses=$m6_parses (want 1) out='$(printf '%s' "$m6_out" | tr '\n' '|' | cut -c1-200)'"
@@ -851,7 +912,7 @@ M8D="$(newtmp)"; mk_matrix_proj "$M8D" 'true' 'sleep 6 | cat'
 m8_start=$(date +%s)
 ( cd "$M8D" && CHECKVER_EVAL_TIMEOUT=2 "$BASH_BIN" "$M8/scripts/check-versions.sh" >/dev/null 2>&1 ) || true
 m8_elapsed=$(( $(date +%s) - m8_start ))
-if [ "$m8_sites" -eq 1 ] && [ "$m8_parses" -eq 1 ] && [ "$m8_elapsed" -ge 5 ]; then
+if [ "$m8_sites" -eq 1 ] && [ "$m8_changed" -ge 2 ] && [ "$m8_parses" -eq 1 ] && [ "$m8_elapsed" -ge 5 ]; then
   pass "M8: with the version read back on a command substitution, a 6s pipeline holds the script for ${m8_elapsed}s against a 2s bound — T2b measures the CONSUMPTION, which is where the bound was being defeated (sites=$m8_sites changed=$m8_changed)"
 else
   fail_ "M8" "sites=$m8_sites (want 1) parses=$m8_parses (want 1) changed=$m8_changed elapsed=${m8_elapsed}s (want >=5)"
@@ -867,7 +928,7 @@ if [ -n "$STUB_PORT" ]; then
   M9D="$(newtmp)"; mk_shipped_row_proj "$M9D" "Qdrant MCP"
   mk_qdrant_home "$M9D/home" "http://127.0.0.1:$STUB_PORT/authed"
   m9_out="$( cd "$M9D" && HOME="$M9D/home" "$BASH_BIN" "$M9/scripts/check-versions.sh" 2>&1 )" || true
-  if [ "$m9_sites" -eq 1 ] && [ "$m9_parses" -eq 1 ] \
+  if [ "$m9_sites" -eq 1 ] && [ "$m9_changed" -ge 2 ] && [ "$m9_parses" -eq 1 ] \
      && ! printf '%s' "$m9_out" | grep -q 'HTTP 403'; then
     pass "M9: with the check's stderr discarded again, a live database refusing on 403 loses its status and its repair on the way to the operator — C3 reads the report, which is the only surface this is visible on (sites=$m9_sites changed=$m9_changed)"
   else
@@ -885,7 +946,7 @@ m10_meta=$(_mutate "$M10M/scripts/lib/helpers-core.sh" '# BL-235-DEADLINE-SANE' 
 m10_sites="${m10_meta%% *}"; m10_rest="${m10_meta#* }"; m10_changed="${m10_rest%% *}"; m10_parses="${m10_rest##* }"
 m10_mut="$( cd "$M10" && CHECKVER_EVAL_TIMEOUT=abc "$BASH_BIN" "$M10M/scripts/check-versions.sh" 2>&1 )" || true
 m10_c=$(printf '%s' "$m10_ctl" | grep -c '9.9.9'); m10_m=$(printf '%s' "$m10_mut" | grep -c '9.9.9')
-if [ "$(_num "$m10_c")" -ge 1 ] && [ "$m10_sites" -eq 1 ] && [ "$m10_parses" -eq 1 ] && [ "$(_num "$m10_m")" -eq 0 ]; then
+if [ "$(_num "$m10_c")" -ge 1 ] && [ "$m10_sites" -eq 1 ] && [ "$m10_changed" -ge 2 ] && [ "$m10_parses" -eq 1 ] && [ "$(_num "$m10_m")" -eq 0 ]; then
   pass "M10: CHECKVER_EVAL_TIMEOUT=abc still reports 9.9.9; with the clamp removed the same healthy row vanishes — an unparseable bound makes the deadline equal now, so every row times out instantly and a whole matrix reads as missing from one malformed environment variable (sites=$m10_sites changed=$m10_changed)"
 else
   fail_ "M10" "control_hits=$m10_c (want >=1) sites=$m10_sites (want 1) parses=$m10_parses (want 1) mutant_hits=$m10_m (want 0)"
@@ -899,7 +960,7 @@ M11D="$(newtmp)"
 mk_matrix_proj "$M11D" 'printf %s "note-one\nFORGED  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
 m11_out="$( cd "$M11D" && "$BASH_BIN" "$M11/scripts/check-versions.sh" 2>&1 )" || true
 m11_forged=$(_num "$(printf '%s' "$m11_out" | grep -c '^FORGED')")
-if [ "$m11_sites" -eq 1 ] && [ "$m11_parses" -eq 1 ] && [ "$m11_forged" -ge 1 ]; then
+if [ "$m11_sites" -eq 1 ] && [ "$m11_changed" -ge 2 ] && [ "$m11_parses" -eq 1 ] && [ "$m11_forged" -ge 1 ]; then
   pass "M11: with the escape-doubling removed, the note's literal backslash-n becomes a real line break again and a fabricated '[OK] Totally Installed' row appears in the report — C4 measures forgery, not merely that a note is printed (sites=$m11_sites changed=$m11_changed)"
 else
   fail_ "M11" "sites=$m11_sites (want 1) parses=$m11_parses (want 1) forged_lines=$m11_forged (want >=1)"
@@ -916,7 +977,7 @@ M12D="$(newtmp)"
 mk_matrix_proj "$M12D" 'true' 'printf %s "1.0\n\x20\x20[OK]\x20Totally\x20Installed:\x209.9.9"'
 m12_out="$( cd "$M12D" && "$BASH_BIN" "$M12/scripts/check-versions.sh" 2>&1 )" || true
 m12_forged=$(_num "$(printf '%s' "$m12_out" | grep -c '^  \[OK\] Totally Installed')")
-if [ "$m12_sites" -eq 1 ] && [ "$m12_parses" -eq 1 ] && [ "$m12_forged" -ge 1 ]; then
+if [ "$m12_sites" -eq 1 ] && [ "$m12_changed" -ge 2 ] && [ "$m12_parses" -eq 1 ] && [ "$m12_forged" -ge 1 ]; then
   pass "M12: with the version string left unsanitised, a version_command forges a complete '[OK] Totally Installed' row again — C5 measures the SECOND render path, which the first version of this fix left open (sites=$m12_sites changed=$m12_changed)"
 else
   fail_ "M12" "sites=$m12_sites (want 1) parses=$m12_parses (want 1) forged_rows=$m12_forged (want >=1)"
@@ -936,10 +997,28 @@ M13D="$(newtmp)"
 mk_matrix_proj "$M13D" 'printf "note\r  [OK] Totally Installed: 9.9.9" >&2; exit 2' 'echo 1'
 m13_out="$( cd "$M13D" && "$BASH_BIN" "$M13/scripts/check-versions.sh" 2>&1 )" || true
 m13_cr=$(_num "$(printf '%s' "$m13_out" | LC_ALL=C grep -c $'\r')")
-if [ "$m13_sites" -eq 1 ] && [ "$m13_parses" -eq 1 ] && [ "$m13_cr" -ge 1 ]; then
-  pass "M13: with the range narrowed to \\000-\\010\\013\\014\\016-\\037, the raw CR survives into the report again — \\015 sits in the gap between \\014 and \\016, so C6 is measuring the range and not the presence of a tr (sites=$m13_sites changed=$m13_changed)"
+if [ "$m13_sites" -eq 1 ] && [ "$m13_changed" -ge 2 ] && [ "$m13_parses" -eq 1 ] && [ "$m13_cr" -ge 1 ]; then
+  pass "M13: with the range narrowed to \\013\\014, the raw CR survives into the report again — CR is \\015 and sits outside it, exactly as it sits in the gap between \\014 and \\016 in the wider range that was proposed and rejected, so C6 measures the RANGE and not the presence of a tr (sites=$m13_sites changed=$m13_changed)"
 else
-  fail_ "M13" "sites=$m13_sites (want 1) parses=$m13_parses (want 1) cr_lines=$m13_cr (want >=1)"
+  fail_ "M13" "sites=$m13_sites (want 1) changed=$m13_changed (want >=2 — 0 means the mutation never applied) parses=$m13_parses (want 1) cr_lines=$m13_cr (want >=1)"
+fi
+
+# ── M14: drop LC_ALL=C from the sanitiser and C7's report truncates again.
+if [ -n "$c7_locale" ]; then
+  M14="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M14/scripts"
+  m14_meta=$(_mutate "$M14/scripts/check-versions.sh" '# BL-235-NOTE-SAFE' \
+    "  printf '%s' \"\$_s\" | tr -d '\000-\037\177'")
+  m14_sites="${m14_meta%% *}"; m14_rest="${m14_meta#* }"; m14_changed="${m14_rest%% *}"; m14_parses="${m14_rest##* }"
+  m14_rc=0
+  m14_out="$( cd "$C7" && LC_ALL="$c7_locale" "$BASH_BIN" "$M14/scripts/check-versions.sh" 2>&1 )" || m14_rc=$?
+  m14_rows=$(_num "$(printf '%s' "$m14_out" | grep -cE '^ *\[(OK|WARN)\]')")
+  # `changed` is asserted, not merely reported. Its absence from this case's
+  # first failure message is what hid a sed that had silently applied nothing.
+  if [ "$m14_sites" -eq 1 ] && [ "$m14_changed" -ge 2 ] && [ "$m14_parses" -eq 1 ] && [ "$m14_rows" -lt 3 ]; then
+    pass "M14: with LC_ALL=C removed from the sanitiser, the same stray byte truncates the report to $m14_rows of 3 rows under $c7_locale — C7 measures the locale guard, not merely that the row renders in this host's C locale (sites=$m14_sites changed=$m14_changed)"
+  else
+    fail_ "M14" "sites=$m14_sites (want 1) changed=$m14_changed (want >=2 — 0 means the mutation never applied and this case proves nothing) parses=$m14_parses (want 1) rows=$m14_rows (want <3) exit=$m14_rc"
+  fi
 fi
 
 # ── M7: X1 must be able to fail. Strip the bit from a COPY and re-run the same

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# tests/test-bl235-tool-matrix-probes.sh
+#
+# BL-235 — the tool matrix records "Qdrant MCP installed" from a CONFIG ENTRY
+# and never asks the database. `check_command` greps `~/.claude.json` for an
+# `mcpServers.qdrant` key and `version_command` is `echo 'configured'` — a value
+# that cannot be wrong, and therefore carries no information. A project with no
+# running database is recorded `already_installed` and reported `[OK]` by every
+# surface that consumes the resolver.
+#
+# THE SWEEP THE ENTRY ASKED FOR, RUN: the Qdrant row is NOT the only one.
+# Derive it rather than trusting this comment:
+#
+#   jq -r '.tools | to_entries[]
+#          | select((.value.check_command // "") | test("jq -e|settings\\.json"))
+#          | .value.name' templates/tool-matrix/common.json
+#
+# Three rows today — Qdrant MCP, Context7 MCP and Superpowers — each pairing a
+# config-grep check with an `echo`ed version string.
+#
+# ── THE PREREQUISITE, MEASURED, AND WHY IT COMES FIRST ──────────────────────
+# The entry says a probe is unsafe because "the matrix schema does not currently
+# express a bound". That is half right, and the half that is wrong changes the
+# design:
+#
+#   scripts/resolve-tools.sh   run_cmd_with_timeout "$RESOLVE_TOOLS_EVAL_TIMEOUT"  BOUNDED (10s)
+#   scripts/check-versions.sh  eval "$CHECK_CMD"                                   UNBOUNDED
+#
+# Two consumers of the same data, asymmetric bounding — and the unbounded one is
+# ALREADY a live hazard: the matrix ships `colima version` and `docker --version`
+# as version commands, and resolve-tools.sh's own header records that those
+# "can hang indefinitely when the daemon is unreachable", which is why IT bounds
+# them. So check-versions.sh can hang today, before this entry adds anything.
+# Adding a network probe to the matrix without bounding that consumer would put
+# a third hang path into the one script that cannot survive it. T1/T2 pin the
+# bound; everything else depends on it.
+#
+# ASSERTIONS ARE WALL CLOCK, EXIT CODES AND EMITTED STATE — never the presence
+# of a call. A probe that is merely ATTEMPTED is the defect restated.
+#
+# Hermetic: temp dirs, stub binaries on PATH, no network, no real database.
+# bash 3.2 safe. No `timeout`/`gtimeout` (absent on the dev host).
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CHECKVER="$REPO_ROOT/scripts/check-versions.sh"
+MATRIX="$REPO_ROOT/templates/tool-matrix/common.json"
+
+BASH_BIN="$(command -v bash)"; [ -n "$BASH_BIN" ] || BASH_BIN="/bin/bash"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq is not installed — this suite asserts on matrix JSON."
+  echo ""; echo "Results: 0 passed, 0 failed"; exit 0
+fi
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
+
+_num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
+
+_mutate() {
+  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp
+  safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
+  mode="$(_mode_of "$f")"
+  before="$(mktemp)"; cp -p "$f" "$before"
+  sites=$(_sites "$f" "$marker")
+  tmp="$(mktemp)"
+  sed "s%^.*${marker}\$%${safe}%" "$f" > "$tmp" && mv "$tmp" "$f"
+  [ "$mode" != "?" ] && chmod "$mode" "$f" 2>/dev/null
+  changed=$(_changed_lines "$before" "$f")
+  parses=0; bash -n "$f" >/dev/null 2>&1 && parses=1
+  rm -f "$before"
+  printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+# mk_matrix_proj <dir> <check_cmd> <version_cmd> — a project whose matrix holds
+# exactly one tool, with the given commands. check-versions.sh reads
+# templates/tool-matrix relative to CWD.
+mk_matrix_proj() {
+  local d="$1" chk="$2" ver="$3"
+  mkdir -p "$d/templates/tool-matrix" "$d/.claude"
+  jq -n --arg c "$chk" --arg v "$ver" \
+    '{description:"fixture", schema_version:1, scope:"common",
+      tools:{ Probe:{ name:"Probe", category:"mcp_server", phase:2, required:false,
+                      check_command:$c, version_command:$v, description:"fixture row" } } }' \
+    > "$d/templates/tool-matrix/common.json"
+}
+
+echo "=== T — the unbounded consumer is bounded (the prerequisite) ==="
+
+# ── T1: a check_command that sleeps must NOT hold check-versions.sh for its
+# full duration. Asserted on WALL CLOCK, because "a timeout exists" is a claim
+# and elapsed seconds are a measurement.
+T1="$(newtmp)"; mk_matrix_proj "$T1" 'sleep 12' "echo 1.0"
+t1_start=$(date +%s)
+( cd "$T1" && CHECKVER_EVAL_TIMEOUT=2 "$BASH_BIN" "$CHECKVER" >/dev/null 2>&1 ) || true
+t1_elapsed=$(( $(date +%s) - t1_start ))
+if [ "$t1_elapsed" -lt 9 ]; then
+  pass "T1: a 12s check_command did not hold check-versions.sh for 12s (elapsed ${t1_elapsed}s) — the eval is bounded, so a matrix row can probe without freezing the one consumer that never had a timeout"
+else
+  fail_ "T1" "elapsed ${t1_elapsed}s for a 12s check_command at a 2s bound — the eval is unbounded, and the matrix already ships 'colima version' / 'docker --version', which hang when the daemon is unreachable"
+fi
+
+# ── T2: the same for version_command. Both evals are unbounded today, and a
+# probe would most naturally live in the version command.
+T2="$(newtmp)"; mk_matrix_proj "$T2" 'true' 'sleep 12'
+t2_start=$(date +%s)
+( cd "$T2" && CHECKVER_EVAL_TIMEOUT=2 "$BASH_BIN" "$CHECKVER" >/dev/null 2>&1 ) || true
+t2_elapsed=$(( $(date +%s) - t2_start ))
+if [ "$t2_elapsed" -lt 9 ]; then
+  pass "T2: a 12s version_command is bounded too (elapsed ${t2_elapsed}s) — bounding only the check would leave the other half of every row unbounded"
+else
+  fail_ "T2" "elapsed ${t2_elapsed}s for a 12s version_command at a 2s bound"
+fi
+
+# ── T3: the bound must not break a NORMAL row. Over-tightening would turn every
+# healthy tool into 'not installed', which is the same class of wrong answer.
+T3="$(newtmp)"; mk_matrix_proj "$T3" 'true' "echo 9.9.9"
+t3_out="$( cd "$T3" && "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+if printf '%s' "$t3_out" | grep -q '9.9.9'; then
+  pass "T3: a fast, healthy row still reports its version through the bounded runner (9.9.9 seen) — the bound refuses hangs, not tools"
+else
+  fail_ "T3" "the bounded runner lost a healthy row's version; out='$(printf '%s' "$t3_out" | tr '\n' '|' | cut -c1-200)'"
+fi
+
+echo "=== D — the three declaration rows now exercise the tool ==="
+
+# ── D1: the sweep. No shipped row may decide 'installed' by grepping a config
+# file. Derived from the matrix, not from a list in this file.
+d1_bad="$(jq -r '.tools | to_entries[]
+  | select((.value.check_command // "") | test("jq -e|settings\\.json|[.]claude[.]json"))
+  | "  " + (.value.name // .key)' "$MATRIX" 2>/dev/null)"
+if [ -z "$d1_bad" ]; then
+  pass "D1: no shipped row decides 'installed' by grepping a config file — the check exercises the tool, which is the difference between configured and working"
+else
+  fail_ "D1" "rows still deciding installed-ness from a config file:
+$d1_bad"
+fi
+
+# ── D2: a version that cannot be wrong carries no information. `echo
+# 'configured'` is true of a machine with nothing installed.
+d2_bad="$(jq -r '.tools | to_entries[]
+  | select((.value.version_command // "") | test("^echo "))
+  | "  " + (.value.name // .key)' "$MATRIX" 2>/dev/null)"
+if [ -z "$d2_bad" ]; then
+  pass "D2: no shipped row reports a hardcoded version string — a value that cannot be wrong is not evidence, and all three of these were 'configured'/'installed'"
+else
+  fail_ "D2" "rows whose version_command cannot be wrong:
+$d2_bad"
+fi
+
+# ── D3: the probe must be reachability, not presence-of-config. Asserted
+# behaviourally: with the config present but NOTHING listening, the row must not
+# report installed.
+D3="$(newtmp)"
+qdrant_chk="$(jq -r '.tools | to_entries[] | select(.value.name == "Qdrant MCP") | .value.check_command // ""' "$MATRIX" 2>/dev/null)"
+if [ -z "$qdrant_chk" ]; then
+  fail_ "D3" "no Qdrant MCP row found in the matrix"
+else
+  mkdir -p "$D3/home"
+  printf '{"mcpServers":{"qdrant":{"env":{"QDRANT_URL":"http://127.0.0.1:59999"}}}}\n' > "$D3/home/.claude.json"
+  # 59999 is chosen to be closed; the config says the server is there and it is not.
+  d3_rc=0
+  ( HOME="$D3/home" bash -c "$qdrant_chk" >/dev/null 2>&1 ) || d3_rc=$?
+  if [ "$d3_rc" -ne 0 ]; then
+    pass "D3: with the MCP config present and NOTHING listening, the Qdrant check fails (rc=$d3_rc) — 'registered' stopped meaning 'working', which is the whole entry"
+  else
+    fail_ "D3" "the Qdrant check passed against a closed port with only a config entry present — it is still reading a declaration"
+  fi
+fi
+
+echo "=== M — mutation proofs ==="
+
+# ── M1: remove the bound and T1 must hang again.
+M1="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M1/scripts" 2>/dev/null
+m1_meta=$(_mutate "$M1/scripts/check-versions.sh" '# BL-235-BOUND-CHECK' '  if ! eval "$CHECK_CMD" >/dev/null 2>&1; then')
+m1_sites="${m1_meta%% *}"; m1_rest="${m1_meta#* }"; m1_changed="${m1_rest%% *}"; m1_parses="${m1_rest##* }"
+M1D="$(newtmp)"; mk_matrix_proj "$M1D" 'sleep 12' "echo 1.0"
+m1_start=$(date +%s)
+( cd "$M1D" && "$BASH_BIN" "$M1/scripts/check-versions.sh" >/dev/null 2>&1 ) || true
+m1_elapsed=$(( $(date +%s) - m1_start ))
+if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 10 ]; then
+  pass "M1: with the bound removed, a 12s check_command holds the script for ${m1_elapsed}s again — the bound is load-bearing and measured in seconds, not asserted (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
+else
+  fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed elapsed=${m1_elapsed}s (want >=10)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -826,6 +826,14 @@ if [ -n "$STUB_PORT" ]; then
   m2_chk="$(jq -r '.tools | to_entries[] | select(.value.name == "Qdrant MCP") | .value.check_command' "$M2D/templates/tool-matrix/common.json")"
   m2_rc=0
   ( cd "$M2D" && HOME="$M2D/home" SOLO_SCRIPTS_DIR="$REPO_ROOT/scripts" "$BASH_BIN" -c "$m2_chk" >/dev/null 2>&1 ) || m2_rc=$?
+  # M2 IS THE ONE CASE WHERE `changed >= 2` PROVES NOTHING, and saying so here
+  # is the point: `_mutate_json` rewrites through jq, whose whole-file re-emit
+  # changes ~447 lines even when the filter matches nothing at all — measured.
+  # Every OTHER mutant in this file goes through `_mutate`, where sed replaces
+  # one line with one line, so exactly 2 means "it landed" and 0 means "it did
+  # not". Do not read the uniform `changed >= 2` across this suite as uniform
+  # rigour. M2's real discriminator is `m2_rc -eq 127`, obtained by EXTRACTING
+  # the mutated check_command and executing it — a receipt, not a line count.
   if [ "$m2_changed" -ge 2 ] && [ "$m2_parses" -eq 1 ] && [ "$m2_rc" -eq 127 ]; then
     pass "M2: reverted to 'bash scripts/probe-tool.sh', the row returns rc=127 from a non-root CWD even with SOLO_SCRIPTS_DIR exported — the fix lives in the row, and its absence is visible as the command-not-found it really is (changed=$m2_changed parses=$m2_parses)"
   else
@@ -871,6 +879,15 @@ if [ -n "$STUB_PORT" ]; then
 fi
 
 # ── M5: restore [0]-by-position and D13's healthy install false-alarms again.
+#
+# THE LANDED LINE IS NOT BYTE-IDENTICAL TO THE STRING BELOW, and that is
+# expected rather than a defect — but the next person to edit it should know,
+# because there are now three interacting escaping layers (bash's, `_mutate`'s
+# backreference guard, and sed's own replacement handling). Instrumented and
+# measured: sed collapses `\\n` to `\n` and renders `$'\t'` as a literal tab, so
+# what lands is `printf "%s\n"` and `IFS=$'<TAB>'`. Both are semantically what
+# this mutant intends — a literal tab IS `$'\t'` — and it still kills with
+# rc=2. Verify what LANDS, not what you wrote, if you change this.
 # The mutant TRUNCATES the candidate list to its first row and leaves the
 # on-disk test in place — which is exactly what `.plugins[<id>][0].installPath`
 # did. A first draft replaced the FUNCTION HEADER (the marker had been parked

--- a/tests/test-bl235-tool-matrix-probes.sh
+++ b/tests/test-bl235-tool-matrix-probes.sh
@@ -8,45 +8,73 @@
 # running database is recorded `already_installed` and reported `[OK]` by every
 # surface that consumes the resolver.
 #
-# THE SWEEP THE ENTRY ASKED FOR, RUN: the Qdrant row is NOT the only one.
-# Derive it rather than trusting this comment:
+# ── THE SWEEP, ACROSS ALL FOUR MATRICES ─────────────────────────────────────
+# A first draft of this file swept `common.json` ALONE and called that "the
+# sweep the entry asked for, RUN". It was one of four. Derive the truth rather
+# than trusting this comment — note the `for f in` over the whole directory,
+# which is the correction:
 #
-#   jq -r '.tools | to_entries[]
-#          | select((.value.check_command // "") | test("jq -e|settings\\.json"))
-#          | .value.name' templates/tool-matrix/common.json
+#   for f in templates/tool-matrix/*.json; do
+#     jq -r '.tools | to_entries[]
+#            | select((.value.version_command // "") | test("^echo "))
+#            | .value.name' "$f"
+#   done
 #
-# Three rows today — Qdrant MCP, Context7 MCP and Superpowers — each pairing a
-# config-grep check with an `echo`ed version string.
+# On the pre-fix tree that returned ELEVEN rows across TEN distinct tools —
+# three in common.json (Qdrant MCP, Context7 MCP, Superpowers) and eight more in
+# desktop/mobile/web (dart_license_checker twice, both Apple Developer Program
+# rows, the EV Code Signing Certificate, Android Keystore, OWASP ZAP and Android
+# Studio). `Android Studio` carried the defect in BOTH fields: its check was
+# `[ -d "$HOME/Library/Android/sdk" ] || [ -n "$ANDROID_HOME" ]`, which is true
+# of an empty directory and of a stale export — a declaration, not a working
+# SDK. D1/D1b/D2 now assert over every matrix file, so the next one cannot hide.
 #
 # ── THE PREREQUISITE, MEASURED, AND WHY IT COMES FIRST ──────────────────────
 # The entry says a probe is unsafe because "the matrix schema does not currently
 # express a bound". That is half right, and the half that is wrong changes the
 # design:
 #
-#   scripts/resolve-tools.sh   run_cmd_with_timeout "$RESOLVE_TOOLS_EVAL_TIMEOUT"  BOUNDED (10s)
-#   scripts/check-versions.sh  eval "$CHECK_CMD"                                   UNBOUNDED
+#   scripts/resolve-tools.sh   run_with_deadline "$RESOLVE_TOOLS_EVAL_TIMEOUT"  BOUNDED (10s)
+#   scripts/check-versions.sh  eval "$CHECK_CMD"                                UNBOUNDED
 #
 # Two consumers of the same data, asymmetric bounding — and the unbounded one is
-# ALREADY a live hazard: the matrix ships `colima version` and `docker --version`
-# as version commands, and resolve-tools.sh's own header records that those
-# "can hang indefinitely when the daemon is unreachable", which is why IT bounds
-# them. So check-versions.sh can hang today, before this entry adds anything.
-# Adding a network probe to the matrix without bounding that consumer would put
-# a third hang path into the one script that cannot survive it. T1/T2 pin the
-# bound; everything else depends on it.
+# ALREADY a live hazard: the matrix ships `colima version` as a version command
+# (grep it in templates/tool-matrix/common.json), and resolve-tools.sh's own
+# header records that daemon-backed commands "can hang indefinitely when the
+# daemon is unreachable", which is why IT bounds them.
+# (`docker --version` is NOT one of them, and an earlier draft of this comment
+# named it as the example. It is client-only — a compiled-in string, no socket —
+# measured at 26ms on this host. `docker version`, without the dashes, is the
+# one that talks to the daemon. The hazard is real; that example was not.)
+# So check-versions.sh could hang today, before this entry adds anything. Adding
+# a network probe to the matrix without bounding that consumer would put a third
+# hang path into the one script that cannot survive it. T1/T2 pin the bound;
+# everything else depends on it. T4 pins its COST, which is a separate question
+# from its existence and was answered wrongly once.
 #
 # ASSERTIONS ARE WALL CLOCK, EXIT CODES AND EMITTED STATE — never the presence
 # of a call. A probe that is merely ATTEMPTED is the defect restated.
 #
-# Hermetic: temp dirs, stub binaries on PATH, no network, no real database.
-# bash 3.2 safe. No `timeout`/`gtimeout` (absent on the dev host).
+# ── ASSERT THE STATE YOU MEAN, NEVER ITS COMPLEMENT ─────────────────────────
+# The first version of D3 asserted `rc -ne 0` where the truth is exactly `2`.
+# That passes on `rc=127` — the probe script was never FOUND — and it is why
+# nothing here caught the rows becoming CWD-relative. The three-state contract
+# the probe header spends ten lines defending had zero coverage. Every state is
+# now asserted by equality, and C1 measures the contract where a caller actually
+# consumes it rather than where this file can most conveniently reach it.
+#
+# Hermetic: temp dirs, stub binaries on PATH, a loopback-only stub HTTP server,
+# no external network, no real database. bash 3.2 safe. No `timeout`/`gtimeout`
+# (absent on the dev host).
 
 set -o pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 CHECKVER="$REPO_ROOT/scripts/check-versions.sh"
-MATRIX="$REPO_ROOT/templates/tool-matrix/common.json"
+PROBE="$REPO_ROOT/scripts/probe-tool.sh"
+MATRIX_DIR="$REPO_ROOT/templates/tool-matrix"
+MATRIX="$MATRIX_DIR/common.json"
 
 BASH_BIN="$(command -v bash)"; [ -n "$BASH_BIN" ] || BASH_BIN="/bin/bash"
 
@@ -54,6 +82,7 @@ PASSED=0
 FAILED=0
 pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
 fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+skip_() { echo "  [SKIP] $1 — $2"; }
 
 if ! command -v jq >/dev/null 2>&1; then
   echo "  [SKIP] jq is not installed — this suite asserts on matrix JSON."
@@ -61,7 +90,13 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 TOPTMP="$(mktemp -d)"
-trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+STUB_PID=""
+cleanup() {
+  [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null
+  chmod -R u+rwX "$TOPTMP" 2>/dev/null
+  rm -rf "$TOPTMP"
+}
+trap cleanup EXIT INT TERM
 newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
 
 _num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
@@ -69,19 +104,45 @@ _mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || 
 _sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
 _changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
 
+# _mutate <file> <end-of-line marker> <replacement line>
+# Replaces every line ENDING in the marker. Returns "sites changed parses".
+#
+# THE DELIMITER IS \001, NOT A PRINTABLE CHARACTER. `|` is out because shell
+# replacements are `||`-dense and sed terminates the expression early while
+# reporting success. `%` replaced it and lasted exactly one case: a mutant
+# containing `printf %s` produced `bad flag in substitute command`, and the
+# mutant then reported sites=0 — a mutation proof that silently proved nothing.
+# `@` fails identically on `superpowers@claude-plugins-official`. A control
+# character cannot occur in a shell one-liner, so the class is closed rather
+# than dodged. `&` is still escaped, because an unescaped one splices the whole
+# match back in and that mutant passes `bash -n`.
 _mutate() {
-  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp
+  local f="$1" marker="$2" repl="$3" before sites changed parses safe mode tmp d
+  d=$(printf '\001')
   safe=$(printf '%s' "$repl" | sed 's/&/\\&/g')
   mode="$(_mode_of "$f")"
   before="$(mktemp)"; cp -p "$f" "$before"
   sites=$(_sites "$f" "$marker")
   tmp="$(mktemp)"
-  sed "s%^.*${marker}\$%${safe}%" "$f" > "$tmp" && mv "$tmp" "$f"
+  sed "s${d}^.*${marker}\$${d}${safe}${d}" "$f" > "$tmp" && mv "$tmp" "$f"
   [ "$mode" != "?" ] && chmod "$mode" "$f" 2>/dev/null
   changed=$(_changed_lines "$before" "$f")
   parses=0; bash -n "$f" >/dev/null 2>&1 && parses=1
   rm -f "$before"
   printf '%s %s %s\n' "$sites" "$changed" "$parses"
+}
+
+# _mutate_json <file> <jq filter> — rewrite a matrix file through jq. Returns
+# "changed parses" (parses = the result is still valid JSON).
+_mutate_json() {
+  local f="$1" filter="$2" before changed parses tmp
+  before="$(mktemp)"; cp -p "$f" "$before"
+  tmp="$(mktemp)"
+  if jq "$filter" "$f" > "$tmp" 2>/dev/null && [ -s "$tmp" ]; then mv "$tmp" "$f"; else rm -f "$tmp"; fi
+  changed=$(_changed_lines "$before" "$f")
+  parses=0; jq -e . "$f" >/dev/null 2>&1 && parses=1
+  rm -f "$before"
+  printf '%s %s\n' "$changed" "$parses"
 }
 
 # mk_matrix_proj <dir> <check_cmd> <version_cmd> — a project whose matrix holds
@@ -97,6 +158,112 @@ mk_matrix_proj() {
     > "$d/templates/tool-matrix/common.json"
 }
 
+# mk_shipped_row_proj <dir> <tool name> — a project whose matrix holds exactly
+# the row the framework SHIPS for that tool, copied verbatim. Used to measure
+# the row where a consumer evaluates it rather than where this file can most
+# easily reach it.
+#
+# `.tools` IS AN ARRAY in all four shipped matrices. `to_entries | from_entries`
+# round-trips an OBJECT; on an array it yields integer keys and jq dies with
+# "Cannot use number (13) as object key" — after which this fixture writes an
+# EMPTY file and the case fails for a reason that has nothing to do with the
+# defect. `map(select(...))` is the array-shaped form.
+mk_shipped_row_proj() {
+  local d="$1" tool="$2"
+  mkdir -p "$d/templates/tool-matrix" "$d/.claude"
+  jq --arg t "$tool" \
+    '{description:"fixture", schema_version:1, scope:"common",
+      tools: (.tools | map(select(.name == $t)))}' \
+    "$MATRIX" > "$d/templates/tool-matrix/common.json"
+  [ -s "$d/templates/tool-matrix/common.json" ] || return 1
+  [ "$(jq '.tools | length' "$d/templates/tool-matrix/common.json" 2>/dev/null)" = "1" ] || return 1
+}
+
+# ── the stub HTTP server ────────────────────────────────────────────────────
+# ONE loopback server, many routes, so the suite pays one startup. QDRANT_URL
+# carries the route as a path prefix; the probe appends `/`.
+STUB_PORT=""
+start_stub() {
+  command -v python3 >/dev/null 2>&1 || return 1
+  local d="$TOPTMP/stub" i=0
+  mkdir -p "$d"
+  cat > "$d/routes.json" <<'ROUTES'
+{
+  "/qdrant/":    {"body": {"title": "qdrant - vector search engine", "version": "1.17.1", "commit": "deadbee"}},
+  "/dbnine/":    {"body": {"title": "qdrant - vector search engine", "version": "9.9.9"}},
+  "/notqdrant/": {"body": {"name": "totally-not-qdrant", "version": "8.11.0"}},
+  "/esshape/":   {"body": {"title": "es", "version": {"number": "8.11.0", "build_flavor": "default"}}},
+  "/authed/":    {"api_key": "s3cr3t", "body": {"title": "qdrant - vector search engine", "version": "1.17.1"}},
+  "/ctx7/":      {"body": {"jsonrpc": "2.0"}}
+}
+ROUTES
+  cat > "$d/stub.py" <<'PY'
+import json, os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+ROUTES = json.load(open(os.environ["STUB_ROUTES"]))
+
+class H(BaseHTTPRequestHandler):
+    def do_GET(self):
+        r = ROUTES.get(self.path)
+        if r is None:
+            self._send(404, b'{"status":{"error":"Not found"}}')
+            return
+        need = r.get("api_key")
+        if need and self.headers.get("api-key") != need:
+            self._send(403, b'{"status":{"error":"Must provide an API key or an Authorization bearer token"}}')
+            return
+        self._send(r.get("code", 200), json.dumps(r.get("body", {})).encode())
+
+    def _send(self, code, body):
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *a):
+        pass
+
+srv = HTTPServer(("127.0.0.1", 0), H)
+print(srv.server_port, flush=True)
+srv.serve_forever()
+PY
+  STUB_ROUTES="$d/routes.json" python3 "$d/stub.py" > "$d/port.txt" 2>"$d/err.txt" &
+  STUB_PID=$!
+  while [ "$i" -lt 60 ]; do
+    STUB_PORT="$(head -1 "$d/port.txt" 2>/dev/null)"
+    case "$STUB_PORT" in ''|*[!0-9]*) : ;; *) return 0 ;; esac
+    sleep 0.1
+    i=$((i + 1))
+  done
+  STUB_PORT=""
+  return 1
+}
+
+# mk_qdrant_home <dir> <url> [api-key] — a HOME whose ~/.claude.json registers
+# the qdrant MCP server at the given URL.
+mk_qdrant_home() {
+  local h="$1" url="$2" key="${3:-}"
+  mkdir -p "$h"
+  if [ -n "$key" ]; then
+    jq -n --arg u "$url" --arg k "$key" \
+      '{mcpServers:{qdrant:{command:"uvx", env:{QDRANT_URL:$u, QDRANT_API_KEY:$k}}}}' > "$h/.claude.json"
+  else
+    jq -n --arg u "$url" \
+      '{mcpServers:{qdrant:{command:"uvx", env:{QDRANT_URL:$u}}}}' > "$h/.claude.json"
+  fi
+}
+
+# probe_rc <home> <cwd> <args...> — run the SHIPPED probe with a controlled HOME
+# from a controlled CWD. Echoes the exit code.
+probe_rc() {
+  local home="$1" cwd="$2"; shift 2
+  local rc=0
+  ( cd "$cwd" && HOME="$home" PROBE_QUIET=1 "$BASH_BIN" "$PROBE" "$@" >/dev/null 2>&1 ) || rc=$?
+  printf '%s\n' "$rc"
+}
+
 echo "=== T — the unbounded consumer is bounded (the prerequisite) ==="
 
 # ── T1: a check_command that sleeps must NOT hold check-versions.sh for its
@@ -109,11 +276,11 @@ t1_elapsed=$(( $(date +%s) - t1_start ))
 if [ "$t1_elapsed" -lt 9 ]; then
   pass "T1: a 12s check_command did not hold check-versions.sh for 12s (elapsed ${t1_elapsed}s) — the eval is bounded, so a matrix row can probe without freezing the one consumer that never had a timeout"
 else
-  fail_ "T1" "elapsed ${t1_elapsed}s for a 12s check_command at a 2s bound — the eval is unbounded, and the matrix already ships 'colima version' / 'docker --version', which hang when the daemon is unreachable"
+  fail_ "T1" "elapsed ${t1_elapsed}s for a 12s check_command at a 2s bound — the eval is unbounded, and the matrix already ships 'colima version', which hangs when the daemon is unreachable"
 fi
 
-# ── T2: the same for version_command. Both evals are unbounded today, and a
-# probe would most naturally live in the version command.
+# ── T2: the same for version_command. Both evals were unbounded, and a probe
+# would most naturally live in the version command.
 T2="$(newtmp)"; mk_matrix_proj "$T2" 'true' 'sleep 12'
 t2_start=$(date +%s)
 ( cd "$T2" && CHECKVER_EVAL_TIMEOUT=2 "$BASH_BIN" "$CHECKVER" >/dev/null 2>&1 ) || true
@@ -134,50 +301,315 @@ else
   fail_ "T3" "the bounded runner lost a healthy row's version; out='$(printf '%s' "$t3_out" | tr '\n' '|' | cut -c1-200)'"
 fi
 
-echo "=== D — the three declaration rows now exercise the tool ==="
-
-# ── D1: the sweep. No shipped row may decide 'installed' by grepping a config
-# file. Derived from the matrix, not from a list in this file.
-d1_bad="$(jq -r '.tools | to_entries[]
-  | select((.value.check_command // "") | test("jq -e|settings\\.json|[.]claude[.]json"))
-  | "  " + (.value.name // .key)' "$MATRIX" 2>/dev/null)"
-if [ -z "$d1_bad" ]; then
-  pass "D1: no shipped row decides 'installed' by grepping a config file — the check exercises the tool, which is the difference between configured and working"
+# ── T4: THE BOUND MUST NOT COST A SECOND PER CALL. `run_with_timeout` polls on a
+# `sleep 1` counter, so a bounded call pays ~1s even when the command is instant.
+# Measured on the real matrix: 21 checkable rows x 2 evals turned a 5-6s script
+# into a 50-51s one — inside the SessionStart hook. "A bound exists" and "the
+# bound is affordable" are two claims, and the first one shipped alone.
+T4="$(newtmp)"
+mkdir -p "$T4/templates/tool-matrix" "$T4/.claude"
+jq -n '{description:"fixture", schema_version:1, scope:"common",
+        tools: ( [range(0;12) | {key:("T"+(.|tostring)),
+                 value:{name:("T"+(.|tostring)), category:"mcp_server", phase:2, required:false,
+                        check_command:"true", version_command:"echo 1.0.0", description:"fixture"}}]
+                 | from_entries )}' > "$T4/templates/tool-matrix/common.json"
+t4_start=$(date +%s)
+( cd "$T4" && "$BASH_BIN" "$CHECKVER" >/dev/null 2>&1 ) || true
+t4_elapsed=$(( $(date +%s) - t4_start ))
+if [ "$t4_elapsed" -le 8 ]; then
+  pass "T4: 12 instant rows (24 bounded evals) completed in ${t4_elapsed}s — the bound polls a wall-clock deadline, not a 1s-per-call sleep floor that would cost ~24s here and +45s on the shipped matrix"
 else
-  fail_ "D1" "rows still deciding installed-ness from a config file:
+  fail_ "T4" "elapsed ${t4_elapsed}s for 24 evals of instant commands (want <=8s) — the bounded runner is charging ~1s per call, which is +45s inside a SessionStart hook"
+fi
+
+echo "=== D — the declaration rows now exercise the tool ==="
+
+# ── D1: the sweep, over EVERY matrix file. No shipped row may decide 'installed'
+# by grepping a config file. Derived from the matrices, not from a list here.
+d1_files=$(ls "$MATRIX_DIR"/*.json 2>/dev/null | wc -l | tr -d ' ')
+d1_bad=""
+for f in "$MATRIX_DIR"/*.json; do
+  d1_hits="$(jq -r --arg f "$(basename "$f")" '.tools | to_entries[]
+    | select((.value.check_command // "") | test("jq -e|settings\\.json|[.]claude[.]json"))
+    | "  " + $f + ": " + (.value.name // .key)' "$f" 2>/dev/null)"
+  [ -n "$d1_hits" ] && d1_bad="$d1_bad
+$d1_hits"
+done
+d1_bad="$(printf '%s' "$d1_bad" | sed '/^$/d')"
+if [ -z "$d1_bad" ] && [ "$d1_files" -ge 4 ]; then
+  pass "D1: across all $d1_files matrix files, no row decides 'installed' by grepping a config file — the check exercises the tool, which is the difference between configured and working"
+else
+  fail_ "D1" "files=$d1_files (want >=4; a sweep that reads one file is not a sweep) rows still deciding installed-ness from a config file:
 $d1_bad"
 fi
 
-# ── D2: a version that cannot be wrong carries no information. `echo
-# 'configured'` is true of a machine with nothing installed.
-d2_bad="$(jq -r '.tools | to_entries[]
-  | select((.value.version_command // "") | test("^echo "))
-  | "  " + (.value.name // .key)' "$MATRIX" 2>/dev/null)"
-if [ -z "$d2_bad" ]; then
-  pass "D2: no shipped row reports a hardcoded version string — a value that cannot be wrong is not evidence, and all three of these were 'configured'/'installed'"
+# ── D1b: 'a directory exists' and 'an env var is set' are the same substitution
+# wearing a different face. Android Studio decided an SDK was present from
+# `[ -d ... ] || [ -n "$ANDROID_HOME" ]`, which is true of an empty directory
+# and of a stale export.
+#
+# THE PREDICATE'S OWN WIDTH, stated rather than tuned until green: a `[ -n "$…"`
+# branch is flagged unconditionally, because an env-var arm can decide the whole
+# check on its own no matter what it is OR-ed with. A `[ -d …` is flagged only
+# when nothing in the same check names a concrete artefact — `[ -x`, `[ -f` or
+# `command -v`. That let-out is deliberate and it has exactly one live consumer:
+# `Development Guardrails for Claude Code` is a cloned repository of shell
+# scripts, so `[ -d $HOME/.claude-dev-framework/.git ] && [ -f …/scripts/init.sh ]`
+# names a specific file and IS the capability. Narrow this to `[ -x` alone and
+# that row goes red for no defect.
+d1b_bad=""
+for f in "$MATRIX_DIR"/*.json; do
+  d1b_hits="$(jq -r --arg f "$(basename "$f")" '.tools[]
+    | select((.check_command // "") | test("\\[ -n \"\\$")
+             or (test("\\[ -d ") and (test("\\[ -x |\\[ -f |command -v ") | not)))
+    | "  " + $f + ": " + (.name // "?") + "  ->  " + (.check_command // "")' "$f" 2>/dev/null)"
+  [ -n "$d1b_hits" ] && d1b_bad="$d1b_bad
+$d1b_hits"
+done
+d1b_bad="$(printf '%s' "$d1b_bad" | sed '/^$/d')"
+if [ -z "$d1b_bad" ]; then
+  pass "D1b: no row decides installed-ness from a bare directory test or a set environment variable without also requiring an executable — a set \$ANDROID_HOME is a declaration, and an empty SDK directory is one too"
 else
-  fail_ "D2" "rows whose version_command cannot be wrong:
+  fail_ "D1b" "rows deciding installed-ness from a path or an env var alone:
+$d1b_bad"
+fi
+
+# ── D2: a version that cannot be wrong carries no information. `echo
+# 'configured'` is true of a machine with nothing installed. Every matrix file.
+d2_bad=""
+for f in "$MATRIX_DIR"/*.json; do
+  d2_hits="$(jq -r --arg f "$(basename "$f")" '.tools | to_entries[]
+    | select((.value.version_command // "") | test("^echo "))
+    | "  " + $f + ": " + (.value.name // .key) + "  ->  " + (.value.version_command // "")' "$f" 2>/dev/null)"
+  [ -n "$d2_hits" ] && d2_bad="$d2_bad
+$d2_hits"
+done
+d2_bad="$(printf '%s' "$d2_bad" | sed '/^$/d')"
+if [ -z "$d2_bad" ] && [ "$d1_files" -ge 4 ]; then
+  pass "D2: across all $d1_files matrix files, no row reports a hardcoded version string — a value that cannot be wrong is not evidence, and a tool with genuinely no version now OMITS version_command rather than inventing one"
+else
+  fail_ "D2" "files=$d1_files (want >=4) rows whose version_command cannot be wrong:
 $d2_bad"
 fi
 
-# ── D3: the probe must be reachability, not presence-of-config. Asserted
-# behaviourally: with the config present but NOTHING listening, the row must not
-# report installed.
-D3="$(newtmp)"
-qdrant_chk="$(jq -r '.tools | to_entries[] | select(.value.name == "Qdrant MCP") | .value.check_command // ""' "$MATRIX" 2>/dev/null)"
-if [ -z "$qdrant_chk" ]; then
-  fail_ "D3" "no Qdrant MCP row found in the matrix"
+echo "=== D — the three-state probe contract, asserted by EQUALITY ==="
+
+if ! start_stub; then
+  skip_ "D5-D12, C1, M2-M4" "python3 is unavailable, or the loopback stub server did not bind — the probe's reachability states cannot be exercised without one"
+fi
+
+# ── D3: CONFIGURED BUT UNREACHABLE is exactly 2. Not "non-zero": `-ne 0` also
+# passes on 127 (the probe was never found) and on a mutant that collapses 2
+# into 1, which is how the CWD regression went unseen.
+D3="$(newtmp)"; mk_qdrant_home "$D3/home" "http://127.0.0.1:59999"
+d3_rc="$(probe_rc "$D3/home" "$REPO_ROOT" qdrant)"
+if [ "$d3_rc" -eq 2 ]; then
+  pass "D3: MCP config present, nothing listening — rc=2 CANNOT CONFIRM, not 0 and not 1. 'registered' stopped meaning 'working', and 'unreachable' did not become 'absent'"
 else
-  mkdir -p "$D3/home"
-  printf '{"mcpServers":{"qdrant":{"env":{"QDRANT_URL":"http://127.0.0.1:59999"}}}}\n' > "$D3/home/.claude.json"
-  # 59999 is chosen to be closed; the config says the server is there and it is not.
-  d3_rc=0
-  ( HOME="$D3/home" bash -c "$qdrant_chk" >/dev/null 2>&1 ) || d3_rc=$?
-  if [ "$d3_rc" -ne 0 ]; then
-    pass "D3: with the MCP config present and NOTHING listening, the Qdrant check fails (rc=$d3_rc) — 'registered' stopped meaning 'working', which is the whole entry"
+  fail_ "D3" "rc=$d3_rc (want exactly 2). 0 = still reading a declaration; 1 = a reachability failure collapsed into 'not configured'; 127 = the probe script was not found from this CWD"
+fi
+
+# ── D4: NOT CONFIGURED is exactly 1.
+D4="$(newtmp)"; mkdir -p "$D4/home"; printf '{}\n' > "$D4/home/.claude.json"
+d4_rc="$(probe_rc "$D4/home" "$REPO_ROOT" qdrant)"
+if [ "$d4_rc" -eq 1 ]; then
+  pass "D4: no mcpServers entry at all — rc=1 NOT CONFIGURED. The state below 'cannot confirm' has its own code, so a caller can tell 'you never set this up' from 'it is down'"
+else
+  fail_ "D4" "rc=$d4_rc (want exactly 1)"
+fi
+
+if [ -n "$STUB_PORT" ]; then
+STUB="http://127.0.0.1:$STUB_PORT"
+
+# ── D5: WORKING is exactly 0, and only against a real answer.
+D5="$(newtmp)"; mk_qdrant_home "$D5/home" "$STUB/qdrant"
+d5_rc="$(probe_rc "$D5/home" "$REPO_ROOT" qdrant)"
+if [ "$d5_rc" -eq 0 ]; then
+  pass "D5: a database that answers with a Qdrant VersionInfo payload — rc=0 WORKING. The positive state is measured too; a probe that can only ever fail proves nothing"
+else
+  fail_ "D5" "rc=$d5_rc (want exactly 0) against a live stub serving {title, version}"
+fi
+
+# ── D6: a 200 from something that is not Qdrant is not evidence of Qdrant. The
+# probe's own comment said so and then tested `.version` alone — which a stub
+# literally named `totally-not-qdrant` satisfies. `title` is REQUIRED in
+# Qdrant's VersionInfo schema (api.qdrant.tech, GET /), so requiring it is the
+# published contract rather than a heuristic.
+D6="$(newtmp)"; mk_qdrant_home "$D6/home" "$STUB/notqdrant"
+d6_rc="$(probe_rc "$D6/home" "$REPO_ROOT" qdrant)"
+if [ "$d6_rc" -eq 2 ]; then
+  pass "D6: a 200 carrying {name, version} but no 'title' scores 2, not 0 — the payload is checked against Qdrant's own required VersionInfo fields rather than for any '.version' whatsoever"
+else
+  fail_ "D6" "rc=$d6_rc (want exactly 2) — a service named 'totally-not-qdrant' was accepted as Qdrant"
+fi
+
+# ── D7: `.version` as an OBJECT is the Elasticsearch shape. jq's `.version //
+# empty` yields a non-empty object, so an emptiness test passes on it.
+D7="$(newtmp)"; mk_qdrant_home "$D7/home" "$STUB/esshape"
+d7_rc="$(probe_rc "$D7/home" "$REPO_ROOT" qdrant)"
+if [ "$d7_rc" -eq 2 ]; then
+  pass "D7: a payload whose '.version' is an OBJECT scores 2 — the probe requires a version STRING, so an Elasticsearch-shaped answer cannot pass as a Qdrant one"
+else
+  fail_ "D7" "rc=$d7_rc (want exactly 2) — '.version' as an object was read as a version"
+fi
+
+# ── D8: an api-key-protected database is WORKING, not missing. Qdrant's GET /
+# takes an `api-key` header (qdrant.tech/documentation/security); without it a
+# secured instance answers 403 and `curl -fsS` reports a failure that is
+# indistinguishable from a refused connection.
+D8="$(newtmp)"; mk_qdrant_home "$D8/home" "$STUB/authed" "s3cr3t"
+d8_rc="$(probe_rc "$D8/home" "$REPO_ROOT" qdrant)"
+if [ "$d8_rc" -eq 0 ]; then
+  pass "D8: a database behind an api-key, with QDRANT_API_KEY beside QDRANT_URL in the same MCP entry — rc=0. The probe sends the key the operator already configured instead of reporting a healthy database as down"
+else
+  fail_ "D8" "rc=$d8_rc (want exactly 0) — an api-key-protected Qdrant is being reported as not working"
+fi
+
+# ── D9: and when the key is absent, the operator must be told WHICH of the two
+# things happened. 'it refused my request' and 'it did not answer at all' are
+# different repairs.
+D9="$(newtmp)"; mk_qdrant_home "$D9/home" "$STUB/authed"
+d9_rc=0
+d9_note="$( cd "$REPO_ROOT" && HOME="$D9/home" "$BASH_BIN" "$PROBE" qdrant 2>&1 >/dev/null )" || d9_rc=$?
+if [ "$d9_rc" -eq 2 ] && printf '%s' "$d9_note" | grep -q 'HTTP 403'; then
+  pass "D9: a secured database with no key configured is rc=2 AND the note names the HTTP status (403) — 'answered and refused me' is reported as itself, not as 'the database did not answer'"
+else
+  fail_ "D9" "rc=$d9_rc (want 2) note='$(printf '%s' "$d9_note" | tr '\n' '|' | cut -c1-200)' (want it to name HTTP 403)"
+fi
+
+# ── D10: the version reported under a row named `Qdrant MCP` must be about the
+# MCP SERVER, which `update_check.runner: uvx` names as mcp-server-qdrant — not
+# about the DATABASE. A constant that could not be wrong was first replaced by a
+# number about a different artifact, which is the same substitution one field
+# over.
+D10="$(newtmp)"; mk_qdrant_home "$D10/home" "$STUB/dbnine"
+mkdir -p "$D10/bin" "$D10/uvcache/archive-v0/abc123/mcp_server_qdrant-1.2.3.dist-info"
+printf '#!/bin/sh\n[ "$1" = "cache" ] && [ "$2" = "dir" ] && { echo "%s/uvcache"; exit 0; }\nexit 1\n' "$D10" > "$D10/bin/uv"
+chmod +x "$D10/bin/uv"
+d10_out="$( cd "$REPO_ROOT" && HOME="$D10/home" PATH="$D10/bin:$PATH" PROBE_QUIET=1 "$BASH_BIN" "$PROBE" qdrant --version 2>/dev/null )" || true
+if [ "$d10_out" = "1.2.3" ]; then
+  pass "D10: --version reports 1.2.3, the cached mcp-server-qdrant package the uvx runner would launch — not 9.9.9, the version of the DATABASE the same probe just talked to"
+else
+  fail_ "D10" "printed '$d10_out' (want '1.2.3'); '9.9.9' means the database's version is being reported under the MCP server's name"
+fi
+
+# ── D11: and when the package version cannot be established, print NOTHING.
+# Absence is honest; the database's number is not a substitute for it.
+D11="$(newtmp)"; mk_qdrant_home "$D11/home" "$STUB/dbnine"
+mkdir -p "$D11/bin" "$D11/nocache"; printf '#!/bin/sh\nexit 1\n' > "$D11/bin/uv"; chmod +x "$D11/bin/uv"
+# UV_CACHE_DIR is pointed at an EMPTY directory, not left to default. The
+# fallback when `uv cache dir` fails is the real cache, and this developer's
+# machine genuinely has mcp_server_qdrant cached there — so without this the
+# case would read 0.8.1 off the host and fail for a reason unrelated to it.
+d11_out="$( cd "$REPO_ROOT" && HOME="$D11/home" UV_CACHE_DIR="$D11/nocache" PATH="$D11/bin:$PATH" PROBE_QUIET=1 "$BASH_BIN" "$PROBE" qdrant --version 2>/dev/null )" || true
+if [ -z "$d11_out" ]; then
+  pass "D11: with no uv cache to read, --version prints nothing at all — an empty version is honest, and check-versions.sh already renders that state"
+else
+  fail_ "D11" "printed '$d11_out' with no package version obtainable (want empty)"
+fi
+
+# ── D12: context7 has a documented HTTP transport with NO `command` field. A
+# probe hardcoding `command -v npx` judges such an install by a launcher its
+# configuration never mentions.
+D12="$(newtmp)"; mkdir -p "$D12/home" "$D12/emptybin"
+jq -n --arg u "$STUB/ctx7/" '{mcpServers:{context7:{type:"http", url:$u}}}' > "$D12/home/.claude.json"
+d12_rc=0
+( cd "$REPO_ROOT" && HOME="$D12/home" PATH="$D12/emptybin:/usr/bin:/bin" PROBE_QUIET=1 "$BASH_BIN" "$PROBE" context7 >/dev/null 2>&1 ) || d12_rc=$?
+if [ "$d12_rc" -eq 0 ]; then
+  pass "D12: an HTTP-transport context7 entry is probed by FETCHING ITS URL — rc=0 with npx absent from PATH entirely, because npx is not what that configuration runs"
+else
+  fail_ "D12" "rc=$d12_rc (want 0) — an HTTP-transport context7 is judged by whether npx exists, which its config never mentions"
+fi
+
+fi  # stub available
+
+# ── D13: probe_superpowers must select the registry entry by PREDICATE, not by
+# position. A stale entry sitting first made a healthy install score 2 and made
+# the printed version the wrong one.
+D13="$(newtmp)"; mkdir -p "$D13/home/.claude/plugins" "$D13/real/superpowers"
+jq -n '{enabledPlugins:{"superpowers@claude-plugins-official":true}}' > "$D13/home/.claude/settings.json"
+jq -n --arg p "$D13/real/superpowers" \
+  '{plugins:{"superpowers@claude-plugins-official":[
+      {installPath:"/nonexistent/stale/6.0.0", version:"6.0.0"},
+      {installPath:$p, version:"6.3.0"}]}}' > "$D13/home/.claude/plugins/installed_plugins.json"
+d13_rc="$(probe_rc "$D13/home" "$REPO_ROOT" superpowers)"
+d13_ver="$( cd "$REPO_ROOT" && HOME="$D13/home" PROBE_QUIET=1 "$BASH_BIN" "$PROBE" superpowers --version 2>/dev/null )" || true
+if [ "$d13_rc" -eq 0 ] && [ "$d13_ver" = "6.3.0" ]; then
+  pass "D13: with a stale registry entry FIRST and the real install second, the probe scores 0 and prints 6.3.0 — the entry is chosen by whether its installPath exists, not by sitting at index [0]"
+else
+  fail_ "D13" "rc=$d13_rc (want 0) version='$d13_ver' (want 6.3.0) — [0]-by-position false-alarms against a healthy install and prints the wrong version"
+fi
+
+# ── D14: and a registry in which NO recorded path exists is still 2. Fixing the
+# selection must not turn 'cannot confirm' into 'working'.
+D14="$(newtmp)"; mkdir -p "$D14/home/.claude/plugins"
+jq -n '{enabledPlugins:{"superpowers@claude-plugins-official":true}}' > "$D14/home/.claude/settings.json"
+jq -n '{plugins:{"superpowers@claude-plugins-official":[
+      {installPath:"/nonexistent/a", version:"6.0.0"},
+      {installPath:"/nonexistent/b", version:"6.3.0"}]}}' > "$D14/home/.claude/plugins/installed_plugins.json"
+d14_rc="$(probe_rc "$D14/home" "$REPO_ROOT" superpowers)"
+if [ "$d14_rc" -eq 2 ]; then
+  pass "D14: enabled, registry present, but no recorded installPath exists on disk — still rc=2. Selecting by predicate did not soften the third state into the first"
+else
+  fail_ "D14" "rc=$d14_rc (want exactly 2)"
+fi
+
+echo "=== C — measured where a CONSUMER reads the answer ==="
+
+# ── C1: THE ROW MUST NOT DEPEND ON `pwd`. `bash scripts/probe-tool.sh` resolves
+# only from the repo root; a consumer invoked from anywhere else gets rc=127 and
+# reads it as 'not installed'. init.sh runs the resolver before any `cd`, so
+# this is reachable by the ordinary `init.sh --project-dir` invocation. Measured
+# at the consumer, from a directory that is NOT the repo root, against the
+# SHIPPED row rather than a fixture copy of it.
+if [ -z "$STUB_PORT" ]; then
+  skip_ "C1" "no stub server — this case needs a database that WOULD answer, or 'not installed' is the right answer for the wrong reason"
+else
+  C1="$(newtmp)"; mk_shipped_row_proj "$C1" "Qdrant MCP"
+  mk_qdrant_home "$C1/home" "http://127.0.0.1:$STUB_PORT/qdrant"
+  c1_out="$( cd "$C1" && HOME="$C1/home" "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+  if printf '%s' "$c1_out" | grep -q 'Qdrant MCP' && ! printf '%s' "$c1_out" | grep -q 'Qdrant MCP: not installed'; then
+    pass "C1: run from a project directory that is not the repo root, with a database that answers, check-versions.sh reports the Qdrant row as present — the row locates the probe itself instead of trusting the caller's pwd"
   else
-    fail_ "D3" "the Qdrant check passed against a closed port with only a config entry present — it is still reading a declaration"
+    fail_ "C1" "out='$(printf '%s' "$c1_out" | tr '\n' '|' | cut -c1-300)' — a working database read as 'not installed' from a non-root CWD is rc=127 wearing the costume of a real answer"
   fi
+fi
+
+# ── C2: the constant must not survive by MOVING FILE. D2 asserts on matrix JSON
+# and cannot see `${INSTALLED:-configured}` inside check-versions.sh, which
+# renders the same word for exactly the same rows.
+C2="$(newtmp)"; mk_matrix_proj "$C2" 'true' 'true'
+c2_out="$( cd "$C2" && "$BASH_BIN" "$CHECKVER" 2>&1 )" || true
+if printf '%s' "$c2_out" | grep -q 'Probe' && ! printf '%s' "$c2_out" | grep -qi 'configured'; then
+  pass "C2: a row that passes its check but reports no version renders WITHOUT the word 'configured' — the constant this entry exists to delete is gone from the rendered OUTPUT, not just from the data file"
+else
+  fail_ "C2" "out='$(printf '%s' "$c2_out" | tr '\n' '|' | cut -c1-300)' — the word 'configured' is still rendered, or the row vanished entirely"
+fi
+
+echo "=== X — the resolver is EXECUTED, so its mode is part of its contract ==="
+
+# ── X1: `scripts/resolve-tools.sh` must be executable.
+#
+# THIS IS NOT HYGIENE, IT IS THIS ENTRY'S OWN DEFECT CLASS. init.sh, verify-
+# install.sh, check-phase-gate.sh and intake-wizard.sh all invoke it DIRECTLY —
+# `"$SCRIPT_DIR/scripts/resolve-tools.sh" --dev-os …`, no `bash` prefix — so a
+# lost execute bit makes the command substitution return 126 and init.sh take
+# its `|| { print_warn "Tool resolver failed. Falling back to basic tool
+# checks."; return 0; }` arm. It then **exits 0 and scaffolds a project
+# anyway**, one whose `.claude/tool-preferences.json` was written by the
+# fallback writer instead of from resolver output. Measured, because it happened
+# during this very fix: an editor of mine wrote the file through
+# `sed > tmp && mv`, which silently replaced 755 with 644, and the only visible
+# trace was a single `[WARN]` line and three context values that had acquired a
+# leading space. A green test suite, a zero exit code, and a wrong project.
+#
+# `bash tests/foo.sh` is how tests are run, so test files are exempt by
+# construction; this asserts the mode only where something executes the file.
+x1_mode="$(_mode_of "$REPO_ROOT/scripts/resolve-tools.sh")"
+if [ -x "$REPO_ROOT/scripts/resolve-tools.sh" ]; then
+  pass "X1: scripts/resolve-tools.sh is executable (mode $x1_mode) — its four callers invoke it directly, and losing the bit turns 'the tool matrix was resolved' into a WARN that still exits 0"
+else
+  fail_ "X1" "mode=$x1_mode — resolve-tools.sh is not executable, so every direct caller gets rc=126 and init.sh silently falls back to basic tool checks while still reporting success"
 fi
 
 echo "=== M — mutation proofs ==="
@@ -194,6 +626,109 @@ if [ "$m1_sites" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_elapsed" -ge 10 ]; 
   pass "M1: with the bound removed, a 12s check_command holds the script for ${m1_elapsed}s again — the bound is load-bearing and measured in seconds, not asserted (sites=$m1_sites changed=$m1_changed parses=$m1_parses)"
 else
   fail_ "M1" "sites=$m1_sites (want 1) parses=$m1_parses (want 1) changed=$m1_changed elapsed=${m1_elapsed}s (want >=10)"
+fi
+
+# ── M2: put the rows back to a CWD-relative path and C1's condition must return.
+if [ -n "$STUB_PORT" ]; then
+  M2="$(newtmp)"; cp -R "$MATRIX_DIR" "$M2/tool-matrix"
+  m2_meta=$(_mutate_json "$M2/tool-matrix/common.json" \
+    '.tools |= map(if (.check_command // "") | test("probe-tool") then .check_command = "bash scripts/probe-tool.sh qdrant" else . end)')
+  m2_changed="${m2_meta%% *}"; m2_parses="${m2_meta##* }"
+  M2D="$(newtmp)"; mkdir -p "$M2D/templates" "$M2D/home"
+  cp -R "$M2/tool-matrix" "$M2D/templates/tool-matrix"
+  mk_qdrant_home "$M2D/home" "http://127.0.0.1:$STUB_PORT/qdrant"
+  m2_chk="$(jq -r '.tools | to_entries[] | select(.value.name == "Qdrant MCP") | .value.check_command' "$M2D/templates/tool-matrix/common.json")"
+  m2_rc=0
+  ( cd "$M2D" && HOME="$M2D/home" SOLO_SCRIPTS_DIR="$REPO_ROOT/scripts" "$BASH_BIN" -c "$m2_chk" >/dev/null 2>&1 ) || m2_rc=$?
+  if [ "$m2_changed" -ge 2 ] && [ "$m2_parses" -eq 1 ] && [ "$m2_rc" -eq 127 ]; then
+    pass "M2: reverted to 'bash scripts/probe-tool.sh', the row returns rc=127 from a non-root CWD even with SOLO_SCRIPTS_DIR exported — the fix lives in the row, and its absence is visible as the command-not-found it really is (changed=$m2_changed parses=$m2_parses)"
+  else
+    fail_ "M2" "changed=$m2_changed (want >=2) parses=$m2_parses (want 1) rc=$m2_rc (want 127)"
+  fi
+fi
+
+# ── M3: drop the `title` requirement and D6 must accept `totally-not-qdrant`.
+if [ -n "$STUB_PORT" ]; then
+  M3="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M3/scripts"
+  m3_meta=$(_mutate "$M3/scripts/probe-tool.sh" '# BL-235-PROBE-IDENTITY' \
+    '  ver="$(printf %s "$payload" | jq -r ".version // empty" 2>/dev/null)"; title="x"')
+  m3_sites="${m3_meta%% *}"; m3_rest="${m3_meta#* }"; m3_changed="${m3_rest%% *}"; m3_parses="${m3_rest##* }"
+  M3H="$(newtmp)"; mk_qdrant_home "$M3H/home" "http://127.0.0.1:$STUB_PORT/notqdrant"
+  m3_rc=0
+  ( cd "$REPO_ROOT" && HOME="$M3H/home" PROBE_QUIET=1 "$BASH_BIN" "$M3/scripts/probe-tool.sh" qdrant >/dev/null 2>&1 ) || m3_rc=$?
+  if [ "$m3_sites" -ge 1 ] && [ "$m3_parses" -eq 1 ] && [ "$m3_rc" -eq 0 ]; then
+    pass "M3: with the identity check reduced to '.version // empty', a stub named totally-not-qdrant scores 0 again — D6 is discriminating, not decorative (sites=$m3_sites changed=$m3_changed)"
+  else
+    fail_ "M3" "sites=$m3_sites (want >=1) parses=$m3_parses (want 1) rc=$m3_rc (want 0)"
+  fi
+fi
+
+# ── M4: drop the api-key read and D8's protected database goes dark again.
+# THE MARKER IS IN helpers-full.sh, NOT IN THE PROBE. Everything credential-
+# shaped for Qdrant has one owner there — which file the entry is read from,
+# that the URL and key come from the SAME entry, that the key travels only to a
+# declared host, and that it never reaches argv. A first draft of this case
+# mutated probe-tool.sh, found zero sites, and reported a mutation proof that
+# proved nothing.
+if [ -n "$STUB_PORT" ]; then
+  M4="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M4/scripts"
+  m4_meta=$(_mutate "$M4/scripts/lib/helpers-full.sh" '# BL-235-ROOT-KEY-HEADER' '  key=""')
+  m4_sites="${m4_meta%% *}"; m4_rest="${m4_meta#* }"; m4_changed="${m4_rest%% *}"; m4_parses="${m4_rest##* }"
+  M4H="$(newtmp)"; mk_qdrant_home "$M4H/home" "http://127.0.0.1:$STUB_PORT/authed" "s3cr3t"
+  m4_rc=0
+  ( cd "$REPO_ROOT" && HOME="$M4H/home" PROBE_QUIET=1 "$BASH_BIN" "$M4/scripts/probe-tool.sh" qdrant >/dev/null 2>&1 ) || m4_rc=$?
+  if [ "$m4_sites" -ge 1 ] && [ "$m4_parses" -eq 1 ] && [ "$m4_rc" -eq 2 ]; then
+    pass "M4: with the configured api-key discarded, the healthy secured database scores 2 again — D8 measures the header, not the happy path (sites=$m4_sites changed=$m4_changed)"
+  else
+    fail_ "M4" "sites=$m4_sites (want >=1) parses=$m4_parses (want 1) rc=$m4_rc (want 2)"
+  fi
+fi
+
+# ── M5: restore [0]-by-position and D13's healthy install false-alarms again.
+# The mutant TRUNCATES the candidate list to its first row and leaves the
+# on-disk test in place — which is exactly what `.plugins[<id>][0].installPath`
+# did. A first draft replaced the FUNCTION HEADER (the marker had been parked
+# there), so the mutant did not parse and `parses=0` reported the case as
+# broken rather than as proof. A mutant that fails to parse kills nothing.
+M5="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M5/scripts"
+m5_meta=$(_mutate "$M5/scripts/probe-tool.sh" '# BL-235-PROBE-PLUGIN-SELECT' \
+  '  rows="$(printf "%s\\n" "$rows" | head -1)"; while IFS=$'"'"'\t'"'"' read -r path ver; do')
+m5_sites="${m5_meta%% *}"; m5_rest="${m5_meta#* }"; m5_changed="${m5_rest%% *}"; m5_parses="${m5_rest##* }"
+m5_rc=0
+( cd "$REPO_ROOT" && HOME="$D13/home" PROBE_QUIET=1 "$BASH_BIN" "$M5/scripts/probe-tool.sh" superpowers >/dev/null 2>&1 ) || m5_rc=$?
+if [ "$m5_sites" -ge 1 ] && [ "$m5_parses" -eq 1 ] && [ "$m5_rc" -eq 2 ]; then
+  pass "M5: with selection back at index [0], the healthy install behind a stale first entry scores 2 again — D13 pins the predicate, not the happy ordering (sites=$m5_sites changed=$m5_changed)"
+else
+  fail_ "M5" "sites=$m5_sites (want >=1) parses=$m5_parses (want 1) rc=$m5_rc (want 2)"
+fi
+
+# ── M6: restore the `configured` fallback and C2 must see the word return.
+M6="$(newtmp)"; cp -R "$REPO_ROOT/scripts" "$M6/scripts"
+m6_meta=$(_mutate "$M6/scripts/check-versions.sh" '# BL-235-NO-CONSTANT' \
+  '  INSTALLED_DISPLAY="${INSTALLED:-configured}"')
+m6_sites="${m6_meta%% *}"; m6_rest="${m6_meta#* }"; m6_changed="${m6_rest%% *}"; m6_parses="${m6_rest##* }"
+M6D="$(newtmp)"; mk_matrix_proj "$M6D" 'true' 'true'
+m6_out="$( cd "$M6D" && "$BASH_BIN" "$M6/scripts/check-versions.sh" 2>&1 )" || true
+if [ "$m6_sites" -ge 1 ] && [ "$m6_parses" -eq 1 ] && printf '%s' "$m6_out" | grep -qi 'configured'; then
+  pass "M6: with the fallback restored, 'configured' is rendered again for a version-less row — C2 reads the OUTPUT, which is the surface D2 could never see (sites=$m6_sites changed=$m6_changed)"
+else
+  fail_ "M6" "sites=$m6_sites (want >=1) parses=$m6_parses (want 1) out='$(printf '%s' "$m6_out" | tr '\n' '|' | cut -c1-200)'"
+fi
+
+# ── M7: X1 must be able to fail. Strip the bit from a COPY and re-run the same
+# predicate on it — and confirm the copy's content is byte-identical, so the
+# only thing that changed is the mode.
+M7="$(newtmp)"; cp "$REPO_ROOT/scripts/resolve-tools.sh" "$M7/resolve-tools.sh"
+chmod 644 "$M7/resolve-tools.sh"
+m7_same=0; cmp -s "$REPO_ROOT/scripts/resolve-tools.sh" "$M7/resolve-tools.sh" && m7_same=1
+m7_x=0; [ -x "$M7/resolve-tools.sh" ] && m7_x=1
+m7_rc=0
+( cd "$M7" && ./resolve-tools.sh --dev-os darwin --platform web --language typescript \
+    --track light --phase 2 --matrix-dir "$MATRIX_DIR" >/dev/null 2>&1 ) || m7_rc=$?
+if [ "$m7_same" -eq 1 ] && [ "$m7_x" -eq 0 ] && [ "$m7_rc" -eq 126 ]; then
+  pass "M7: a byte-identical copy at mode 644 is refused by the shell with rc=126 — X1 measures the bit, and 126 is exactly what init.sh's resolver call substitution returns before it warns and carries on (content_identical=$m7_same)"
+else
+  fail_ "M7" "content_identical=$m7_same (want 1) executable=$m7_x (want 0) rc=$m7_rc (want 126)"
 fi
 
 echo ""


### PR DESCRIPTION
Closes the in-flight work on `## BL-221:` and `## BL-235:`, and files `## BL-237:`.

## What was broken

**`## BL-221:`** — `assert_choosable` read an absent `deployment` key as the *permissive* tier, so an adopted organizational project could downgrade its own enforcement. Both halves fixed: the predicate fails closed (`# BL-221-TIER-FAIL-CLOSED`), and `adopt_write_manifest` writes the tier keys so the two birth paths cannot diverge (`# BL-221-ADOPT-TIER-KEYS`).

**`## BL-235:`** — the tool matrix decided "Qdrant MCP installed" by grepping `~/.claude.json` and reported `version_command: echo 'configured'`, a value that cannot be wrong. A machine with no database was recorded `already_installed` and reported `[OK]` by every surface. Three rows now call `scripts/probe-tool.sh`, which asks the tool.

## Five adversarial review rounds

`block` → `block` → `minor_concerns` → `block` → `block` → `approve`. The blocking findings, each reproduced independently before being fixed:

| | |
|---|---|
| The rows resolved from the **caller's `pwd`** | `init.sh --project-dir` runs the resolver before any `cd`; all three installed tools flipped to `manual_install`. The test that should have caught it asserted `-ne 0`, which also passes on `rc=127`. |
| The bound was **decorative for 21 of 41 rows** | `kill -9` reaps the `bash -c` child; a pipeline's other members hold the pipe open and a command substitution waits for them. Colima — the row cited as the reason a bound was needed — is one of the 21. |
| The probe's diagnosis was **binned one layer before the operator** | A database that is *up* and answering 403 for want of an api-key rendered as `not installed`. |
| Surfacing that note let a tool's stderr **forge a report line** | And fixing it on the note but not the version string left the worse path open: a `version_command` could forge `[OK] Totally Installed: 9.9.9` byte-identically. |
| One **non-UTF-8 byte** ended the whole report | `tr`/`cut` exit 1 in a UTF-8 locale; `C.UTF-8` is ubuntu-latest's default. The `cut` half fails the same way on `main` and is fixed here because these are the lines this entry owns. |

## Not fixed, deliberately

- **R-9** — the bound stops the *wait*, not the *pipeline*. Orphans run to completion holding only a temp file and `/dev/null`. Measured as a bounded-lifetime leak, not handle exhaustion. Recorded on the entry.
- **The resolver's JSON half of the three-state contract.** `check-versions.sh` surfaces `rc=2` distinctly; a distinct bucket in `resolve-tools.sh`'s output is a schema change with many consumers. Stated as not done.
- **`## BL-237:`** — the general "a directly-invoked script must be executable" lint. The one file this incident touched is pinned by `X1`/`M7`.

## Verification

- `tests/test-bl235-tool-matrix-probes.sh` **7 → 42 cases**; `tests/test-bl221-tier-fail-closed.sh` **11 → 12**
- Full canonical unit lane locally: **176 of 176, 0 failures**
- `scripts/run-lints.sh` **15/15**
- `check-versions.sh` **5-6s → 50-51s → 10-12s** (the bound shipped without its cost measured; `run_with_deadline` fixes it, `T4` pins it)
- Live: `[OK] Qdrant MCP: 0.8.1` — the uvx package, not the database's `1.17.1`

## Shard budget

`tests/test-bl235-tool-matrix-probes.sh` is pinned to `lint-scan` (~97-206s) rather than left in `rest` (~561s/720s, **cancelled at the cap on PR #351**). The CI figure in the file is an **estimate with its method stated** and flagged for re-measurement — 38-40s local, ~18s of it wall-clock sleep that does not inflate on a slower runner.

## A note on what this PR is evidence of

Four of the five review rounds found a defect in the **test**, not the product — a vacuous assertion, a mutant that could not fail, a message misstating its own fixture, a grep for the wrong name. `_mutate` escaped `&` but not backslash-digit, so three mutation proofs silently proved nothing. All 12 `_mutate` cases now assert `changed >= 2`; `M2` uses `_mutate_json` and cannot, which is noted in place rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
