### PR TITLE
docs(ledger): close BL-221 and BL-235 on #356, and correct the shard estimate with the measured figure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -607,12 +607,20 @@ jobs:
             #      the ~1.6x local->CI ratio recorded for wp5b/wp6 above, that
             #      is ~18 + 34 = ~52s, which would take `rest` from 561s to
             #      ~85% of the cap if left unpinned.
-            #    RE-MEASURE ON CI AND CORRECT THIS LINE. An estimate is enough
-            #    to justify moving a suite OUT of a leg with a cancellation
-            #    history; it is not enough to leave in the file as though it
-            #    were data, which is what the stale figures above this array
-            #    became.
-            tests/test-bl235-tool-matrix-probes.sh       # ~52s ESTIMATED CI (38-40s local, ~18s of it sleep) — re-measure
+            #    RE-MEASURED ON CI AND CORRECTED, per the instruction this line
+            #    used to carry. Run 32046301464 (PR #356, the commit that added
+            #    it), per-shard job times:
+            #      lint-scan   4m05s = 245s   (34% of the 720s cap)  &lt;- this leg
+            #      lint-sweep  3m21s = 201s
+            #      rest        7m18s = 438s   (61%, from ~561s before the move)
+            #      sast        8m39s = 519s
+            #      slow-misc   9m26s = 566s   (79%, now the leg to watch)
+            #    The ~52s estimate is NOT separable from that total on one run —
+            #    what IS measured is that this leg sits at 34% with the suite in
+            #    it, and that `rest` came down to 61%. Both were the point.
+            #    NOTE FOR THE NEXT RE-PIN: `slow-misc` at 79% is now the closest
+            #    to the cap, not `rest`.
+            tests/test-bl235-tool-matrix-probes.sh       # leg measured 245s/720s (34%) with this suite in it — run 32046301464
             #    The BL-221 suite that landed alongside this one is NOT pinned
             #    and is deliberately not named as a path here: it measures under
             #    a second, pinning it would buy nothing, and a commented path

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9005,8 +9005,25 @@ permissive tier on absent data
 **Severity:** **Real, not cosmetic.** This is a fail-OPEN on the surface that
 decides whether a project is *allowed to weaken its own enforcement*. Every other
 tier reader in the framework fails closed on absent data; this one does not.
-**Status:** Open — BOTH candidate fixes implemented on branch
-`fix/bl221-tier-keys-and-probe`; close on merge with the PR number.
+**Status:** **Closed** — both fixes shipped in **PR #356**
+(`fix/bl221-tier-keys-and-probe`, merge `d243f77`).
+
+Five adversarial review rounds on that branch attacked this entry directly and
+**every BL-221 claim survived**: the reviewer built an adopted-shape
+organizational project and ran the real downgrade through
+`reconfigure-project.sh` — on base the tier gate raised zero objections and
+wrote the downgrade, on head it refuses before any mutation. The jq `//`
+behaviour across six input shapes, the `# BL-084-TIER-KEY` sync-sibling
+question and the adoption-parity variables all held.
+
+**One defect WAS found, and it was in the test, not the fix.** `W1` took three
+narrowings to stop being vacuous: it first passed because the fix's own
+explanatory COMMENT names all three keys in prose; then because
+`$ADOPT_DEPLOYMENT` and `$ADOPT_POC_MODE` occur as shell variables on executed
+lines; then because `adopt_write_phase_state` legitimately writes the same three
+keys to a DIFFERENT file. It is now scoped to `adopt_write_manifest`'s body,
+comments stripped, matching the key-ASSIGNMENT form — and `M2` requires all
+three to go missing at once. Suite 11 → 12 cases.
 
 ### Both, because neither subsumes the other
 
@@ -11085,8 +11102,44 @@ the behaviour), `## BL-221:` (missing key ⇒ permissive default).
 different surface, deliberately left unfixed there so the fix is not smuggled in
 under an unrelated diff)
 **Category:** Silent-success — declaration read as capability
-**Status:** Open — implemented on branch `fix/bl221-tier-keys-and-probe`; close
-on merge with the PR number.
+**Status:** **Closed** — shipped in **PR #356**
+(`fix/bl221-tier-keys-and-probe`, merge `d243f77`). CI tallies read rather than
+the tick: 176 unit files across five shards, 0 failed.
+
+**THREE RESIDUALS ARE DELIBERATELY NOT DONE, and none of them is "nothing left
+to do":**
+
+1. **The bound stops the WAIT, not the PIPELINE.** Orphaned pipeline members
+   outlive their `bash -c` parent and run to their own completion. They hold
+   only the capture temp file and `/dev/null` — never the consumer's pipe, which
+   is why the consumer returns at the bound. Measured on 12 rows × a 20s
+   pipeline at a 1s bound: returned in 12s, temp-file delta 0, process count
+   back to baseline once the orphans expired. A bounded-lifetime leak, not
+   handle exhaustion.
+2. **The resolver's half of the three-state contract.** `check-versions.sh` now
+   renders `rc=2` distinctly (`# BL-235-THIRD-STATE`), which is need #3 for the
+   human-facing surface. A distinct BUCKET in `scripts/resolve-tools.sh`'s JSON
+   is a schema change with many consumers and was not attempted.
+3. **`templates/tool-matrix/*.json` is in no sync set** — see below. Recorded,
+   not fixed; the ordering is safe and the entry says why.
+
+**What the five review rounds were actually evidence of.** The verdicts ran
+`block` → `block` → `minor_concerns` → `block` → `block` → `approve`, and **four
+of the five rounds found a defect in the TEST rather than the product**: an
+assertion of `-ne 0` where the truth was exactly 2; a `C6` that passed when the
+value it guarded vanished entirely; an `M13` message naming a range its mutant
+did not use; a `C5` grepping the wrong fixture row name. Worse, `_mutate`
+escaped `&` but not backslash-DIGIT — and `\0`…`\9` are BACKREFERENCES in a sed
+replacement — so **three mutation proofs silently proved nothing** while
+reporting `sites=1 parses=1`. Twelve `_mutate` cases now assert `changed >= 2`;
+`M2` uses `_mutate_json`, where jq's whole-file re-emit satisfies that guard
+even on a filter matching nothing, and that exception is noted in place rather
+than papered over.
+
+The product fixes held up under attack. The verification of them did not,
+repeatedly, and only an adversary reading the ASSERTIONS rather than the results
+caught it. That is the transferable finding of this entry, more than any single
+probe.
 
 ### The prerequisite the entry did not know it had
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11686,3 +11686,84 @@ was more careful than the hand.
 **Related:** `## BL-235:` (where it happened), `## BL-112:` ("did not run" is
 not "found nothing"), `## BL-104:` (a `[WARN]` label over a blocking outcome —
 the same text/behaviour mismatch, in the other direction).
+
+---
+
+## BL-238: `set -o pipefail` + `printf … | grep -q` returns 141 ON A MATCH — a latent CI flake in ~150 files, and the diagnosis of one that was already recorded as unexplained
+
+**Logged:** 2026-08-17 (diagnosed while `tests/test-lint-bl-markers.sh` failed
+the `rest` shard on PR #357, a DOCS-ONLY change — which is what made it
+obviously not the change under test)
+**Category:** Silent-success — a passing predicate reported as a failure by the
+death of its own writer
+**Status:** Open — the one site that was actually failing is fixed
+(`# BL-238-NO-SIGPIPE-RACE`); the repo-wide sweep is not done.
+
+### The mechanism, reproduced in one line
+
+```
+$ bash -c 'set -o pipefail; b=$(seq 1 200000); printf "%s\n" "$b" | grep -qF 1; echo $?'
+141
+$ bash -c '                b=$(seq 1 200000); printf "%s\n" "$b" | grep -qF 1; echo $?'
+0
+```
+
+`grep -q` exits the instant it matches. The writer then takes **SIGPIPE**, and
+`pipefail` promotes that death (141) over grep's success (0). **The pipeline
+reports failure precisely BECAUSE the match succeeded**, and the louder the
+match — the earlier in the stream — the more reliably it breaks.
+
+It is a **race on output size and scheduling**: the writer must still be writing
+when grep exits. Small inputs finish first and never fail; large ones fail
+often. That is why it reproduces on CI and not on the dev host.
+
+### What it actually did
+
+`unaccounted_allowlist_tokens` in `tests/test-lint-bl-markers.sh` asked, per
+allowlisted token, "does `--list` render a row for this?" — through
+`printf '%s\n' "$out" | grep -qF …`, where `$out` is the whole `--list` output.
+On CI two correctly-allowlisted tokens (`BL-186-PARSE-COVERAGE`,
+`BL-186-EMPTY-TARGETS`) were reported **unaccounted**, with
+`printf: write error: Broken pipe` printed beside each one. Locally: 20/0. On
+CI run `32046301634`: 18/2.
+
+**This is the flake the 2026-08-16 handoff recorded as "failed once on CI and
+passed unchanged on re-run. Not diagnosed, not dismissed."** Second sighting,
+now with a mechanism. A re-run would have gone green and taught nobody anything.
+
+### The fix, and its scope
+
+The one failing site takes a **herestring**: `grep -qF PATTERN <<<"$out"`. No
+second process, so there is no writer to kill and the status is grep's alone.
+
+**The class is NOT fixed and the count is large.** Derive it, do not trust this
+number:
+
+```
+for f in tests/*.sh scripts/*.sh scripts/lib/*.sh; do
+  grep -q 'set -o pipefail' "$f" || continue
+  n=$(grep -cE '(printf|echo)[^|]*\| *grep -[a-zA-Z]*q' "$f"); [ "$n" -gt 0 ] && echo "$f $n"
+done
+```
+
+At the time of writing that is ~150 files and >1000 sites. **Most are harmless**
+— they pipe a short string, the writer finishes first, and SIGPIPE never
+arrives. A blanket rewrite of a thousand call sites would be a far larger risk
+than the defect. What is needed is a predicate that finds the sites where the
+piped value can be LARGE, which is where the race lives.
+
+**`tests/test-bl168-tm-table-sigpipe.sh` already exists**, so this repo has met
+SIGPIPE before on a different surface. Whatever lint comes out of this should
+account for that entry rather than duplicate it.
+
+### The trap this entry set for itself, recorded because it cost a CI cycle
+
+Adding `# BL-238-NO-SIGPIPE-RACE` to a file under `tests/` **minted a marker
+naming an entry that did not yet exist**, and `scripts/lint-bl-markers.sh` reds
+on exactly that. The suite's own header warns about it in as many words: files
+under `tests/` ARE the lint's code surface. **File the entry before the marker**,
+not after.
+
+**Related:** `## BL-196:` (the marker lint whose own suite this was found in),
+`## BL-112:` ("did not run" is not "found nothing" — same shape: a status that
+means something other than what the caller reads it as).

--- a/tests/test-lint-bl-markers.sh
+++ b/tests/test-lint-bl-markers.sh
@@ -122,10 +122,32 @@ unaccounted_allowlist_tokens() {
   else
     out=$(bash "$lint" --list 2>&1)
   fi
+  # HERESTRINGS, NOT PIPES, AND THAT IS THIS SUITE'S CI FLAKE DIAGNOSED.
+  #
+  # This file runs `set -uo pipefail`. `printf '%s\n' "$out" | grep -qF PATTERN`
+  # returns 141, NOT 0, whenever grep finds its match EARLY and exits: the
+  # reader closes the pipe, printf takes SIGPIPE, and pipefail promotes that
+  # writer's death over grep's success. So a correctly-allowlisted token took
+  # the `&& continue` on neither line and was reported UNACCOUNTED — a false
+  # failure produced by a MATCH.
+  #
+  # It is a race on how much of "$out" printf can write before grep exits, so it
+  # depends on output size and scheduling: this suite passes 20/20 locally and
+  # failed 18/2 on CI run 32046301634 with `printf: write error: Broken pipe`
+  # beside each false row. That is the "failed once on CI, passed unchanged on
+  # re-run" flake recorded as NOT DIAGNOSED in the 2026-08-16 handoff.
+  #
+  # Reproduce the mechanism in one line:
+  #   bash -c 'set -o pipefail; b=$(seq 1 200000); printf "%s\n" "$b" | grep -qF 1; echo $?'
+  #   -> 141   (and 0 without pipefail)
+  #
+  # A herestring has no second process, so there is no writer to kill and the
+  # status is grep's alone. `## BL-238:` carries the repo-wide sweep; this is
+  # the one site that was actually failing.
   while IFS= read -r t; do
     [ -n "$t" ] || continue
-    printf '%s\n' "$out" | grep -qF "$(printf '\t%s\tresolved (EXACT)' "$t")" && continue
-    printf '%s\n' "$out" | grep -qF "$(printf '\t%s\tallowlist: ' "$t")" && continue
+    grep -qF "$(printf '\t%s\tresolved (EXACT)' "$t")" <<<"$out" && continue     # BL-238-NO-SIGPIPE-RACE
+    grep -qF "$(printf '\t%s\tallowlist: ' "$t")" <<<"$out" && continue
     printf '%s\n' "$t"
   done <<EOF
 $(allowlisted_tokens "$lint")


### PR DESCRIPTION
Ledger close for **#356**, plus one correction that PR's own comment asked for.

## Closes

- **`## BL-221:`** — every claim the five review rounds attacked survived. The reviewer built an adopted-shape organizational project and ran the real downgrade through `reconfigure-project.sh`: on base the tier gate raised zero objections and wrote it, on head it refuses before any mutation. The one defect found was in the **test** — `W1` took three narrowings to stop being vacuous (the fix's own comment named all three keys; then `$ADOPT_DEPLOYMENT`/`$ADOPT_POC_MODE` did; then a sibling writer did).
- **`## BL-235:`** — closed with **three residuals stated**, so "Closed" does not read as "nothing left":
  1. the bound stops the *wait*, not the *pipeline* — measured as a bounded-lifetime leak, not handle exhaustion;
  2. the resolver's JSON half of the three-state contract is a schema change with many consumers and was not attempted;
  3. `templates/tool-matrix/*.json` is in no sync set — ordering is safe and the entry says why.

`## BL-237:` stays **Open**: its general "a directly-invoked script must be executable" lint is genuinely undone.

## The correction

`tests.yml`'s pin comment carried an **estimate** with an explicit instruction to re-measure on CI. Measured from run `32046301464` (PR #356) and corrected:

| shard | measured | % of 720s cap |
|---|---|---|
| lint-scan | 245s | **34%** ← the suite's new home |
| lint-sweep | 201s | 28% |
| rest | 438s | **61%** ← was ~561s / 78% |
| sast | 519s | 72% |
| slow-misc | 566s | **79%** ← now the leg closest to the cap |

The re-pin did what it was for. The measurement also says something I did not predict, and the file now carries it: **the next re-pin signal is `slow-misc`, not `rest`.** The ~52s estimate for the suite itself is not separable from a single run's leg total, and the comment says so rather than inventing a number.

## Backlog

49 → 48 open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
