### PR TITLE
fix(bl239): the contributor hook installer installed a no-op and said commits now faced the gates

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -522,6 +522,7 @@ jobs:
             tests/test-bl229-host-pipeline-paths.sh
             tests/test-bl221-tier-fail-closed.sh
             tests/test-bl235-tool-matrix-probes.sh
+            tests/test-bl239-contributor-hooks.sh
             tests/host-drivers/error-translate.test.sh
           )
 
@@ -574,6 +575,26 @@ jobs:
             #    567s -> 701s -> 700s over those same commits for ~2s of added
             #    test, so the pressure is the leg's, not the suite's.
             tests/test-bl234-currency-and-availability.sh  # 66.0s in CI (51 cases; ~62s local)
+            # ── Re-pinned 2026-08-17. `slow-misc` had become the leg closest to
+            #    the cap at 566s/720s (79%) — a fact that only surfaced because
+            #    PR #356's pin comment carried an ESTIMATE with an explicit
+            #    instruction to re-measure, and re-measuring moved the answer:
+            #    the leg everyone had been watching (`rest`) was down to 61%.
+            #    Derived from run 32048687734's slow-misc log, per-suite from
+            #    the group timestamps rather than a local stopwatch:
+            #      test-delta-wp5-hotfix-retro       185s   <- moved, the pole
+            #      test-pre-commit-gate-lints        123s
+            #      the other six                   21-54s each
+            #    Moving the single pole balances BOTH legs rather than trading
+            #    one hot leg for another: slow-misc 566 -> 381s (53%),
+            #    lint-sweep 201 -> 386s (54%). Moving two would have taken
+            #    slow-misc to 36% and changed nothing else, because the binding
+            #    constraint after this move is `sast`.
+            #    WATCH `sast` NEXT: 519s (72%) and untouched here. It is now the
+            #    highest leg, and its own pin note says bl132 is deliberately
+            #    pinned at its worst case (213s), so the next re-pin has to come
+            #    from somewhere other than moving bl132 around.
+            tests/test-delta-wp5-hotfix-retro.sh   # 185s measured (run 32048687734) — the pole; opens and closes deltas dozens of times, and each open also renders a brief and seeds a ledger row, so it grew with the feature rather than with the test
           )
           pin_lint_scan=(
             tests/test-lint-counter-antipattern.sh     # 243s at pin time — T9 re-scans the real repo; BL-191 made that scan single-pass, so re-measure before repinning
@@ -649,7 +670,9 @@ jobs:
             #    complement leg CANCELED at 736s). Nothing failed on that run —
             #    the cap fired. Per the doctrine above, that is the RE-PIN
             #    signal, not a reason to raise the cap.
-            tests/test-delta-wp5-hotfix-retro.sh       # 181s — THE long pole of the whole wave, and 3x the next one. It opens and closes deltas dozens of times, and each open now also renders a brief and seeds a ledger row, so it got slower as the feature landed rather than as the test grew
+            # ── MOVED OUT 2026-08-17 to pin_lint_sweep. It is still the pole
+            #    described below (185s measured, 1.5x the next member) — it just
+            #    is not this leg's problem any more. See the note there.
             tests/test-brownfield-wp1-scout.sh         #  55s — the second pole. Moved WITH the first deliberately: the first alone left the complement leg at ~77% of the cap, which is the same "approaching" state the sast note below was written about, and the complement has taken a new suite in nearly every work package this wave
             # ── Re-pinned 2026-08-10. Not a long pole in itself — it is the
             #    GROWTH that moved it. Measured locally: 87s at 125 rows before

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -590,10 +590,29 @@ jobs:
             #    lint-sweep 201 -> 386s (54%). Moving two would have taken
             #    slow-misc to 36% and changed nothing else, because the binding
             #    constraint after this move is `sast`.
-            #    WATCH `sast` NEXT: 519s (72%) and untouched here. It is now the
-            #    highest leg, and its own pin note says bl132 is deliberately
-            #    pinned at its worst case (213s), so the next re-pin has to come
-            #    from somewhere other than moving bl132 around.
+            #    DO NOT READ A "NEXT LEG TO WATCH" OUT OF ONE RUN. A first draft
+            #    of this note named `sast` at 519s (72%) as the new highest. The
+            #    very next run refuted it — and the two samples disagree by more
+            #    than the move being made here:
+            #
+            #      leg          run 32048687734   run 32050... (this PR)
+            #      slow-misc         566s              372s     <- the move, held
+            #      lint-sweep        201s              400s     <- the move, held
+            #      lint-scan         245s              240s
+            #      rest              438s              547s     <- +109s
+            #      sast              519s              477s     <- -42s
+            #
+            #    `rest` gained only 6s of new test here (measured: the bl239
+            #    suite), so ~100s of that swing is run-to-run noise. Which leg is
+            #    "highest" is therefore NOT stable from a single sample; take two
+            #    before re-pinning anything on it.
+            #
+            #    AND `rest` HAS NO POLE TO MOVE. Its 526s is 158 suites whose
+            #    largest is 40s — flat, ~3.3s mean. If the complement ever binds,
+            #    re-pinning cannot fix it: there is nothing to pin. That would
+            #    need a different mechanism (more shards, or splitting the
+            #    complement), and it is worth knowing BEFORE someone spends an
+            #    afternoon hunting for a long pole that does not exist.
             tests/test-delta-wp5-hotfix-retro.sh   # 185s measured (run 32048687734) — the pole; opens and closes deltas dozens of times, and each open also renders a brief and seeds a ledger row, so it grew with the feature rather than with the test
           )
           pin_lint_scan=(

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,11 +114,24 @@ The framework lives in two repositories — both must be cloned for the test sui
    bash tests/host-drivers/run-all.sh
    ```
    Alternatively, run `bash init.sh` from a throwaway directory to exercise the full installer flow.
-4. Install the pre-commit gate locally (`init.sh` does this for user projects; contributors working on the framework itself install it with one command — BL-096):
+4. Install the local git hooks (`init.sh` does this for user projects; contributors working on the framework itself install them with one command — BL-096):
    ```bash
    bash scripts/install-contributor-hooks.sh
    ```
-   (Equivalent to `cp scripts/pre-commit-gate.sh .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit`; re-run any time to refresh the hook to the current gate script.)
+   Installs **two** hooks, generated from the same `scripts/lib/hook-templates.sh`
+   emitters `init.sh` uses, so contributor and generated-project hooks cannot
+   drift: `.git/hooks/pre-commit` (gitleaks, SAST, test co-location,
+   blocked-commit ledger) and `.git/hooks/commit-msg` (BL-072 TDD ordering +
+   BL-006 Build-Loop message check). Re-run any time to refresh both.
+
+   > **Do NOT `cp scripts/pre-commit-gate.sh .git/hooks/pre-commit`.** This line
+   > used to say that was equivalent. It is not, and the difference is silent:
+   > `pre-commit-gate.sh` is a **PreToolUse** hook that reads tool-input JSON on
+   > stdin, where *no output* means ALLOW. Git runs a pre-commit hook with **no
+   > arguments and no such JSON**, so the copy took the allow path and exited 0
+   > on every commit. Measured on one fixture commit: the copy produced **zero**
+   > lines of gate output, the generated hook produced three (its gitleaks and
+   > semgrep arms actually ran). See `## BL-239:`.
 
 For deeper setup — MCP servers, profiles, CLAUDE.md authoring, host CLI installation — see `docs/cli-setup-addendum.md` and `docs/user-guide.md`.
 

--- a/scripts/install-contributor-hooks.sh
+++ b/scripts/install-contributor-hooks.sh
@@ -97,6 +97,31 @@ done
 echo ""
 echo "[OK] Contributor hooks installed from scripts/lib/hook-templates.sh —"
 echo "     the same emitters init.sh uses for generated projects."
-echo "     pre-commit: gitleaks, SAST, test co-location, blocked-commit ledger."
-echo "     commit-msg: BL-072 TDD ordering + BL-006 Build-Loop message check."
 echo "     Re-run any time to refresh both to the current templates."
+echo ""
+
+# REPORT WHICH ARMS CAN ACTUALLY FIRE HERE, rather than listing the arms the
+# hook contains. Listing them is what the old message did — "Local commits now
+# face the same gates CI runs" was true about the FILE and false about the
+# BEHAVIOUR. These hooks are shaped for a GENERATED project, and in the
+# framework checkout some of their arms have nothing to run against.
+echo "     Arms, as they stand in THIS checkout:"
+if command -v gitleaks >/dev/null 2>&1; then
+  echo "       gitleaks        LIVE   ($(gitleaks version 2>&1 | head -1))"
+else
+  echo "       gitleaks        INERT  (not installed — the arm WARNs, never blocks)"
+fi
+if [ -d "$ROOT/.semgrep" ]; then
+  echo "       SAST (semgrep)  LIVE"
+else
+  echo "       SAST (semgrep)  INERT  (.semgrep/ configs are written by init.sh for"
+  echo "                              GENERATED projects; absent here, so semgrep loads"
+  echo "                              no config and the arm reports SAST NOT ENFORCED)"
+fi
+echo "       BL-006 msg gate INERT  (framework repo, not a scaffolded project —"
+echo "                              the hook says so itself and allows the commit)"
+echo ""
+echo "     So in the framework repo this is mainly a SECRET-DETECTION gate."
+echo "     That is worth having and is more than the previous install did — which"
+echo "     was nothing — but it is not 'the same gates CI runs'. CI is the"
+echo "     authority; see \`## BL-239:\`."

--- a/scripts/install-contributor-hooks.sh
+++ b/scripts/install-contributor-hooks.sh
@@ -5,32 +5,98 @@
 #   bash scripts/install-contributor-hooks.sh
 #
 # init.sh installs gates for USER projects; contributors working on the
-# framework itself previously had to hand-run the cp+chmod documented in
-# CONTRIBUTING.md ("Local development setup") — and discovering that at PR
-# time meant local commits never faced the gates CI enforces. This script IS
-# that documented step: installs scripts/pre-commit-gate.sh as
-# .git/hooks/pre-commit (executable). Idempotent — re-running refreshes the
-# hook to the current gate script.
+# framework itself would otherwise have to hand-run a recipe from
+# CONTRIBUTING.md, and discovering that at PR time means local commits never
+# faced the gates CI enforces.
 #
-# Refuses outside a framework checkout root: it must find BOTH ./.git and
-# ./scripts/pre-commit-gate.sh at the invocation directory, so it cannot
-# stamp the framework gate into an unrelated repo by accident.
+# ── BL-239: THIS SCRIPT USED TO INSTALL A NO-OP AND SAY OTHERWISE ───────────
+# It did `cp scripts/pre-commit-gate.sh .git/hooks/pre-commit` and printed
+# "Local commits now face the same gates CI runs." They faced NOTHING.
+# `pre-commit-gate.sh` is a PreToolUse hook: with no flags it reads tool-input
+# JSON on stdin and "no output" means ALLOW. Git invokes a pre-commit hook with
+# NO arguments and no such JSON, so every commit took the allow path and exited
+# 0 SILENTLY. Measured, hermetically, both ways on the same fixture commit:
+#
+#   cp the gate (the old behaviour)      -> commit rc=0, 0 lines of gate output
+#   the hook init.sh generates (below)   -> commit rc=0, 3 lines: the gitleaks
+#                                           and semgrep arms actually ran, and
+#                                           semgrep reported SAST NOT ENFORCED
+#                                           per `# BL-112-SAST-NOTRUN`
+#
+# A false claim inside the one script whose entire job is installing
+# enforcement. That is why this now emits the SAME hooks init.sh does, from the
+# SAME library — `scripts/lib/hook-templates.sh` is the one owner, so the
+# contributor hook and the generated-project hook cannot drift:
+#
+#   .git/hooks/pre-commit   soif_write_precommit_hook       (gitleaks, SAST,
+#                                                            test co-location,
+#                                                            blocked-commit ledger)
+#   .git/hooks/commit-msg   soif_emit_tdd_commitmsg_block   (BL-072 TDD ordering
+#                                                            + BL-006 Build-Loop
+#                                                            message check)
+#
+# The commit-msg half was previously not installed AT ALL for contributors, so
+# the TDD-ordering gate and the Build-Loop message check never ran on a
+# framework contributor's commits either.
+#
+# Idempotent — re-running refreshes both hooks to the current templates.
+#
+# Refuses outside a framework checkout root: it must find `./.git` and the
+# template library at the invocation directory, so it cannot stamp framework
+# hooks into an unrelated repo by accident.
 set -euo pipefail
 
 ROOT="$(pwd)"
 
-if [ ! -d "$ROOT/.git" ] || [ ! -f "$ROOT/scripts/pre-commit-gate.sh" ]; then
-  echo "[FAIL] not a framework checkout root: need ./.git and ./scripts/pre-commit-gate.sh here." >&2
+if [ ! -d "$ROOT/.git" ] || [ ! -f "$ROOT/scripts/lib/hook-templates.sh" ]; then
+  echo "[FAIL] not a framework checkout root: need ./.git and ./scripts/lib/hook-templates.sh here." >&2
   echo "  Run from the root of your solo-orchestrator clone:" >&2
   echo "    bash scripts/install-contributor-hooks.sh" >&2
   exit 1
 fi
 
-mkdir -p "$ROOT/.git/hooks"
-# BL-096-CONTRIB-HOOK-INSTALL: the one load-bearing action — the real gate,
-# byte-identical, executable, at the path git consults.
-cp "$ROOT/scripts/pre-commit-gate.sh" "$ROOT/.git/hooks/pre-commit"
-chmod +x "$ROOT/.git/hooks/pre-commit"
+# shellcheck source=./lib/hook-templates.sh
+. "$ROOT/scripts/lib/hook-templates.sh"
 
-echo "[OK] pre-commit gate installed -> .git/hooks/pre-commit (from scripts/pre-commit-gate.sh)"
-echo "     Local commits now face the same gates CI runs. Re-run any time to refresh."
+for _fn in soif_write_precommit_hook soif_emit_tdd_commitmsg_block; do
+  if ! command -v "$_fn" >/dev/null 2>&1; then
+    echo "[FAIL] $ROOT/scripts/lib/hook-templates.sh does not provide $_fn — refusing to install a hook this script cannot generate." >&2
+    exit 1
+  fi
+done
+
+mkdir -p "$ROOT/.git/hooks"
+
+# BL-096-CONTRIB-HOOK-INSTALL: the load-bearing action — the REAL hooks, from
+# the same emitters init.sh uses, executable, at the paths git consults.
+soif_write_precommit_hook "$ROOT/.git/hooks/pre-commit"                # BL-239-CONTRIB-PRECOMMIT
+
+CM="$ROOT/.git/hooks/commit-msg"                                       # BL-239-CONTRIB-COMMITMSG
+if [ ! -f "$CM" ]; then
+  printf '%s\n' '#!/usr/bin/env bash' > "$CM"
+fi
+if grep -qF "$SOIF_TDD_OPEN" "$CM" 2>/dev/null; then
+  : # already present — idempotent, same predicate init.sh uses
+else
+  soif_emit_tdd_commitmsg_block >> "$CM"
+fi
+chmod +x "$CM"
+
+# VERIFY WHAT WAS INSTALLED, rather than reporting on what was intended. A hook
+# that is not executable, or that git will not run, is the defect this entry is
+# about; saying "installed" without looking is how it survived.
+_fail=0
+for h in pre-commit commit-msg; do
+  p="$ROOT/.git/hooks/$h"
+  if [ ! -x "$p" ]; then echo "[FAIL] $p is not executable" >&2; _fail=1; continue; fi
+  if [ ! -s "$p" ]; then echo "[FAIL] $p is empty" >&2; _fail=1; continue; fi
+  echo "[OK] .git/hooks/$h installed ($(wc -c < "$p" | tr -d ' ') bytes, executable)"
+done
+[ "$_fail" -eq 0 ] || exit 1
+
+echo ""
+echo "[OK] Contributor hooks installed from scripts/lib/hook-templates.sh —"
+echo "     the same emitters init.sh uses for generated projects."
+echo "     pre-commit: gitleaks, SAST, test co-location, blocked-commit ledger."
+echo "     commit-msg: BL-072 TDD ordering + BL-006 Build-Loop message check."
+echo "     Re-run any time to refresh both to the current templates."

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11842,6 +11842,31 @@ The installer now prints this arm-by-arm at install time instead of listing the
 arms the hook contains, because listing them is exactly what the old message
 did: true about the file, false about the behaviour.
 
+### A GREEN TEST WAS PINNING THE DEFECT
+
+`tests/test-bl096-cold-start.sh::T-contributor-hook-installs` asserted
+
+```
+cmp -s scripts/pre-commit-gate.sh .git/hooks/pre-commit
+```
+
+— that the installed hook is a **byte copy of the gate** — and its failure
+message called that *"the REAL gate installed"*. So the no-op was not merely
+undetected: it was **required**, by a passing test, in the suite named for the
+feature that introduced it. Any correct fix had to red that test first, which is
+exactly what happened on PR #358.
+
+The assertion is **inverted, not deleted**: the installed hook must NOT be that
+file. Deleting it would leave nothing standing between here and a future
+"simplification" back to `cp`. The behavioural half lives in
+`tests/test-bl239-contributor-hooks.sh`, whose `A1` control reproduces the
+no-op and requires zero gate output.
+
+**Process note, because the miss was mine.** I ran the new suite and the lints
+locally and did not run the suites that reference the thing I changed. The
+derivation is one line and would have caught it before CI:
+`grep -rln 'install-contributor-hooks' tests/`.
+
 ### Residual — the thing this entry does NOT fix
 
 **Nothing detects a pre-commit hook that is present but inert.** A hook that

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11767,3 +11767,73 @@ not after.
 **Related:** `## BL-196:` (the marker lint whose own suite this was found in),
 `## BL-112:` ("did not run" is not "found nothing" — same shape: a status that
 means something other than what the caller reads it as).
+
+---
+
+## BL-239: `install-contributor-hooks.sh` installed a NO-OP and printed "Local commits now face the same gates CI runs"
+
+**Logged:** 2026-08-17 (found while acting on "the installed hook is a stale
+snapshot" — it was not stale, it was the WRONG FILE, and had never enforced
+anything)
+**Category:** Silent-success — an enforcement installer reporting a capability
+it does not deliver
+**Severity:** **Real.** Every framework contributor who followed CONTRIBUTING.md
+has had **zero** local commit gating, while being told the opposite by the
+script that installed it. That includes every commit made during the BL-235
+wave.
+**Status:** Open — installer and CONTRIBUTING.md fixed
+(`# BL-239-CONTRIB-PRECOMMIT`, `# BL-239-CONTRIB-COMMITMSG`); see the residual.
+
+### The mechanism
+
+`scripts/pre-commit-gate.sh` is a **PreToolUse** hook. Its own header says so:
+*"Input: Claude Code passes tool input JSON on stdin / No output = allow."*
+Git invokes `.git/hooks/pre-commit` with **no arguments and no stdin JSON**, so
+the copied gate took its allow path and exited **0 silently, on every commit**.
+
+The installer's own words were `[OK] pre-commit gate installed …  Local commits
+now face the same gates CI runs.`
+
+### Measured, hermetically, both directions on the same fixture commit
+
+| install method | commit | gate-arm output |
+|---|---|---|
+| `cp scripts/pre-commit-gate.sh .git/hooks/pre-commit` (documented) | rc=0 | **0 lines** |
+| `soif_write_precommit_hook` (what `init.sh` generates, 122 KB) | rc=0 | **3 lines** — gitleaks and semgrep arms ran; semgrep reported `SAST NOT ENFORCED` per `# BL-112-SAST-NOTRUN` |
+
+The second is not "more output". It is the difference between a hook that runs
+its arms and one that runs nothing.
+
+### And the commit-msg half was never installed at all
+
+`init.sh` installs **two** hooks for generated projects: the pre-commit fallback
+AND a `commit-msg` hook delegating to
+`pre-commit-gate.sh --terminal-mode --tdd-only`, which is where the BL-072 TDD
+ordering gate and the BL-006 Build-Loop message check live (`## BL-010:`). The
+contributor path installed only the first — so for framework contributors those
+two gates have never run locally either.
+
+### The fix
+
+The installer now emits both hooks from `scripts/lib/hook-templates.sh`, the
+**same emitters `init.sh` uses**, so the contributor hook and the
+generated-project hook cannot drift — the sync-sibling rule applied to the one
+surface where drift means "no enforcement at all". It then **verifies what it
+installed** (present, non-empty, executable) instead of reporting on what it
+intended, which is how the original survived.
+
+### Residual — the thing this entry does NOT fix
+
+**Nothing detects a pre-commit hook that is present but inert.** A hook that
+exists, is executable, and exits 0 without running anything is indistinguishable
+from a healthy one by every check the repo has — which is exactly why this
+lasted. `scripts/verify-install.sh` inspects hook PRESENCE
+(`hooks: {commit-msg: present, pre-commit: present}` in the currency manifest),
+not hook BEHAVIOUR. The honest detector is the two-sided one used to find this:
+run a throwaway commit through the installed hook and require it to EMIT
+something attributable to a known arm. Not built.
+
+**Related:** `## BL-112:` ("the scanner did not run" ≠ "found nothing" — same
+shape, one layer down), `## BL-096:` (the entry that added this installer),
+`## BL-237:` (a mode bit turning enforcement into a silent skip),
+`## BL-234:` / `## BL-235:` (registered ≠ working, the family this belongs to).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -11822,6 +11822,26 @@ surface where drift means "no enforcement at all". It then **verifies what it
 installed** (present, non-empty, executable) instead of reporting on what it
 intended, which is how the original survived.
 
+### What the FIXED hook actually enforces here — measured, because the whole point of this entry is not to overstate a gate
+
+The emitted hooks are shaped for a **generated project**. In the framework
+checkout some arms have nothing to run against. Observed on the first real
+commit through the fixed hook:
+
+| arm | state here | evidence |
+|---|---|---|
+| gitleaks | **LIVE** | `gitleaks 8.30.1` present; the arm runs |
+| SAST (semgrep) | **INERT** | `[WARN] semgrep could not complete (exit 7) … SAST NOT ENFORCED … unable to find a config; path .semgrep/soif-dom-sinks.yml does not exist`. `.semgrep/` is written by `init.sh` for generated projects (grep `soif-dom-sinks` in init.sh); it does not exist in the framework repo |
+| BL-006 Build-Loop message | **N/A by design** | `[note] framework repo detected (not a scaffolded project) — Build-Loop message enforcement not applicable here` |
+| BL-125 test co-location | **did not fire** | `[OK] BL-125: no source files staged` on a commit staging five `.sh`/`.md`/`.yml` files. **Why it did not count them is NOT established here** — recorded as observed rather than explained |
+
+**So in the framework repo this is mainly a secret-detection gate.** That is
+worth having, and it is strictly more than the previous install did — which was
+nothing — but it is **not** "the same gates CI runs". CI remains the authority.
+The installer now prints this arm-by-arm at install time instead of listing the
+arms the hook contains, because listing them is exactly what the old message
+did: true about the file, false about the behaviour.
+
 ### Residual — the thing this entry does NOT fix
 
 **Nothing detects a pre-commit hook that is present but inert.** A hook that

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2056,6 +2056,8 @@ run_child_suite "tests/test-bl221-tier-fail-closed.sh" \
 
 run_child_suite "tests/test-bl235-tool-matrix-probes.sh" \
   "tests/test-bl235-tool-matrix-probes.sh"
+run_child_suite "tests/test-bl239-contributor-hooks.sh" \
+  "tests/test-bl239-contributor-hooks.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-bl096-cold-start.sh
+++ b/tests/test-bl096-cold-start.sh
@@ -160,20 +160,43 @@ echo "=== T-contributor-hook-installs ==="
 if [ ! -f "$INSTALLER" ]; then
   fail_ "T-contributor-hook-installs" "scripts/install-contributor-hooks.sh does not exist (F10: CONTRIBUTING's manual cp must be a one-liner script)"
 else
-  C="$TOPTMP/checkout"; mkdir -p "$C/scripts"
+  # BL-239: THIS CASE USED TO PIN THE DEFECT. It asserted
+  #   cmp -s scripts/pre-commit-gate.sh .git/hooks/pre-commit
+  # — i.e. that the installed hook is a BYTE COPY of the gate — and called that
+  # "the REAL gate installed". It is the opposite: `pre-commit-gate.sh` is a
+  # PreToolUse hook whose contract is "no output = ALLOW", and git runs a
+  # pre-commit hook with no arguments and no stdin JSON, so that copy exited 0
+  # silently on every commit. A green test asserted the no-op was correct.
+  #
+  # The identity assertion is therefore INVERTED, not deleted: the installed
+  # hook must NOT be that file. Deleting it would leave nothing standing between
+  # here and a future "simplification" back to `cp`. The behavioural half — that
+  # the installed hook actually RUNS its arms on a real commit — lives in
+  # tests/test-bl239-contributor-hooks.sh, whose A1 control reproduces this
+  # exact no-op and requires zero gate output.
+  C="$TOPTMP/checkout"; mkdir -p "$C/scripts/lib"
   ( cd "$C" && git init -q && git config user.email t@t.invalid && git config user.name t ) || true
   cp "$REPO_ROOT/scripts/pre-commit-gate.sh" "$C/scripts/"
+  # A real checkout has the emitters; the installer needs them to write the
+  # hooks init.sh writes, and refuses without them rather than falling back to
+  # something that does nothing.
+  cp "$REPO_ROOT/scripts/lib/hook-templates.sh" "$C/scripts/lib/"
   cp "$INSTALLER" "$C/scripts/"
   out=$( cd "$C" && bash scripts/install-contributor-hooks.sh 2>&1 ); rc=$?
-  if [ "$rc" -eq 0 ] && [ -x "$C/.git/hooks/pre-commit" ] && cmp -s "$C/scripts/pre-commit-gate.sh" "$C/.git/hooks/pre-commit"; then
+  hook_is_the_gate=no
+  cmp -s "$C/scripts/pre-commit-gate.sh" "$C/.git/hooks/pre-commit" && hook_is_the_gate=yes
+  if [ "$rc" -eq 0 ] && [ -x "$C/.git/hooks/pre-commit" ] && [ -x "$C/.git/hooks/commit-msg" ] \
+     && [ "$hook_is_the_gate" = "no" ]; then
     out2=$( cd "$C" && bash scripts/install-contributor-hooks.sh 2>&1 ); rc2=$?
-    if [ "$rc2" -eq 0 ] && cmp -s "$C/scripts/pre-commit-gate.sh" "$C/.git/hooks/pre-commit"; then
-      pass "T-contributor-hook-installs (idempotent)"
+    tdd_blocks=$(grep -cF 'SOIF BL-072 TDD gate (commit-msg)' "$C/.git/hooks/commit-msg" 2>/dev/null)
+    case "$tdd_blocks" in ''|*[!0-9]*) tdd_blocks=0 ;; esac
+    if [ "$rc2" -eq 0 ] && [ "$tdd_blocks" -eq 1 ]; then
+      pass "T-contributor-hook-installs: both hooks land executable, the pre-commit hook is NOT a copy of pre-commit-gate.sh (that copy is the no-op this case used to require), and a second run leaves exactly one TDD block"
     else
-      fail_ "T-contributor-hook-installs" "re-run rc=$rc2 — the installer must be idempotent: $(printf '%s' "$out2" | tail -1)"
+      fail_ "T-contributor-hook-installs" "re-run rc=$rc2 tdd_blocks=$tdd_blocks (want 1) — the installer must be idempotent: $(printf '%s' "$out2" | tail -1)"
     fi
   else
-    fail_ "T-contributor-hook-installs" "rc=$rc hook-exec=$([ -x "$C/.git/hooks/pre-commit" ] && echo yes || echo no) — expected the REAL gate installed executable at .git/hooks/pre-commit: $(printf '%s' "$out" | tail -1)"
+    fail_ "T-contributor-hook-installs" "rc=$rc pre-commit-exec=$([ -x "$C/.git/hooks/pre-commit" ] && echo yes || echo no) commit-msg-exec=$([ -x "$C/.git/hooks/commit-msg" ] && echo yes || echo no) hook_is_a_copy_of_the_gate=$hook_is_the_gate (want no) — expected BOTH hooks installed executable, generated from hook-templates.sh: $(printf '%s' "$out" | tail -1)"
   fi
 fi
 

--- a/tests/test-bl239-contributor-hooks.sh
+++ b/tests/test-bl239-contributor-hooks.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# tests/test-bl239-contributor-hooks.sh
+#
+# BL-239 — `scripts/install-contributor-hooks.sh` installed a NO-OP and said
+# otherwise. It did `cp scripts/pre-commit-gate.sh .git/hooks/pre-commit` and
+# printed "Local commits now face the same gates CI runs". They faced nothing:
+# `pre-commit-gate.sh` is a PreToolUse hook whose contract is "no output =
+# ALLOW", and git runs a pre-commit hook with no arguments and no stdin JSON, so
+# every commit took the allow path and exited 0 silently.
+#
+# ── WHAT THIS SUITE ASSERTS, AND WHY IT IS BEHAVIOURAL ──────────────────────
+# A hook that EXISTS, is EXECUTABLE, and exits 0 without running anything is
+# indistinguishable from a healthy one by every structural check this repo has —
+# which is precisely why the defect survived. `verify-install.sh` and the
+# currency manifest both record hook PRESENCE (`pre-commit: present`), not hook
+# BEHAVIOUR. So presence is not asserted here at all; every case runs a REAL
+# COMMIT through the installed hook and requires it to EMIT something
+# attributable to a known arm.
+#
+# A1 is the control that makes the rest mean anything: it reproduces the OLD
+# install and requires it to produce ZERO gate output. Without A1 a green A2
+# could mean "the hook works" or "this fixture cannot tell the difference".
+#
+# Hermetic: a throwaway git repo under a temp dir, `git init` with an explicit
+# branch name (# BL-234-FIXTURE-BARE-HEAD's sibling rule), a configured
+# identity, no remotes, no network. bash 3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INSTALLER="$REPO_ROOT/scripts/install-contributor-hooks.sh"
+TEMPLATES="$REPO_ROOT/scripts/lib/hook-templates.sh"
+GATE="$REPO_ROOT/scripts/pre-commit-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
+
+_num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+
+# ARM_RE — output only a hook that actually RAN its arms can produce. Kept
+# deliberately broad across the arms rather than pinned to one tool's wording,
+# because the point is "something ran", not "semgrep in particular said X".
+ARM_RE='gitleaks|[Ss]emgrep|SAST|\[WARN\]|\[BLOCKED\]|NOT ENFORCED'
+
+# mk_repo <dir> — a throwaway repo with one staged file and a git identity.
+# The branch is NAMED: an unnamed default differs between this host and an
+# ubuntu runner, and a fixture that depends on which one you get is broken on
+# exactly one of them.
+mk_repo() {
+  local d="$1"
+  mkdir -p "$d/scripts/lib"
+  ( cd "$d" && git init --quiet --initial-branch=main . 2>/dev/null || git init --quiet . )
+  ( cd "$d" && git symbolic-ref HEAD refs/heads/main 2>/dev/null )
+  ( cd "$d" && git config user.email t@example.invalid && git config user.name "Fixture" )
+  cp "$GATE" "$d/scripts/pre-commit-gate.sh"
+  cp "$TEMPLATES" "$d/scripts/lib/hook-templates.sh"
+  printf 'echo hi\n' > "$d/a.sh"
+  ( cd "$d" && git add -A )
+}
+
+# commit_arm_lines <dir> <msg> — commit, echo "<rc> <arm-output-line-count>".
+commit_arm_lines() {
+  local d="$1" msg="$2" out rc=0 n
+  out="$( cd "$d" && git commit -m "$msg" 2>&1 )" || rc=$?
+  n=$(printf '%s\n' "$out" | grep -cE "$ARM_RE")
+  printf '%s %s\n' "$rc" "$(_num "$n")"
+}
+
+echo "=== A — the installed hook must actually RUN, not merely exist ==="
+
+# ── A1 (CONTROL): the OLD install produces ZERO gate output.
+# This is the case that makes A2 meaningful. If this ever starts producing
+# output, the fixture has stopped discriminating and A2 proves nothing.
+A1="$(newtmp)"; mk_repo "$A1"
+cp "$A1/scripts/pre-commit-gate.sh" "$A1/.git/hooks/pre-commit"
+chmod +x "$A1/.git/hooks/pre-commit"
+a1=$(commit_arm_lines "$A1" "feat: the old install faced no gate")
+a1_rc="${a1%% *}"; a1_n="${a1##* }"
+if [ "$a1_rc" -eq 0 ] && [ "$a1_n" -eq 0 ]; then
+  pass "A1 (control): copying pre-commit-gate.sh as the hook lets the commit through with ZERO lines of gate output — git passes no arguments and no stdin JSON, so its 'no output = allow' path runs. This is the defect, reproduced"
+else
+  fail_ "A1" "rc=$a1_rc (want 0) arm_lines=$a1_n (want 0) — the control no longer reproduces the no-op install, so A2 below discriminates nothing"
+fi
+
+# ── A2: the installer's hook DOES run its arms.
+A2="$(newtmp)"; mk_repo "$A2"
+a2_install_rc=0
+( cd "$A2" && bash "$INSTALLER" >/dev/null 2>&1 ) || a2_install_rc=$?
+a2=$(commit_arm_lines "$A2" "feat: the fixed install faces a real gate")
+a2_rc="${a2%% *}"; a2_n="${a2##* }"
+if [ "$a2_install_rc" -eq 0 ] && [ "$a2_n" -ge 1 ]; then
+  pass "A2: after the installer runs, the same commit produces $a2_n line(s) of gate output — the hook's arms execute instead of returning ALLOW without looking"
+else
+  fail_ "A2" "installer rc=$a2_install_rc (want 0) arm_lines=$a2_n (want >=1) — the installed hook produced nothing attributable to any arm, which is what a no-op looks like"
+fi
+
+# ── A3: BOTH hooks are installed. The commit-msg half — where the BL-072 TDD
+# ordering gate and the BL-006 Build-Loop message check live — was never
+# installed for contributors at all, only for generated projects.
+A3="$(newtmp)"; mk_repo "$A3"
+( cd "$A3" && bash "$INSTALLER" >/dev/null 2>&1 ) || true
+a3_missing=""
+for h in pre-commit commit-msg; do
+  [ -x "$A3/.git/hooks/$h" ] || a3_missing="$a3_missing $h"
+done
+a3_tdd=0
+grep -qF 'SOIF BL-072 TDD gate' "$A3/.git/hooks/commit-msg" 2>/dev/null && a3_tdd=1
+if [ -z "$a3_missing" ] && [ "$a3_tdd" -eq 1 ]; then
+  pass "A3: both hooks land executable, and commit-msg carries the BL-072 TDD block — the half that generated projects always got and contributors never did"
+else
+  fail_ "A3" "missing/not-executable:$a3_missing tdd_block_present=$a3_tdd (want 1)"
+fi
+
+# ── A4: idempotent. Re-running must refresh, not append a second TDD block.
+A4="$(newtmp)"; mk_repo "$A4"
+( cd "$A4" && bash "$INSTALLER" >/dev/null 2>&1 ) || true
+( cd "$A4" && bash "$INSTALLER" >/dev/null 2>&1 ) || true
+a4_blocks=$(_num "$(grep -cF 'SOIF BL-072 TDD gate (commit-msg)' "$A4/.git/hooks/commit-msg" 2>/dev/null)")
+if [ "$a4_blocks" -eq 1 ]; then
+  pass "A4: running the installer twice leaves exactly one TDD block in commit-msg — the same idempotence predicate init.sh uses, so a refresh cannot stack duplicates"
+else
+  fail_ "A4" "TDD open-marker count=$a4_blocks (want exactly 1)"
+fi
+
+echo "=== M — mutation proof ==="
+
+# ── M1: restore the OLD install inside the installer and A2 must go dark.
+# The mutant is the literal line the script used to carry.
+M1="$(newtmp)"; mk_repo "$M1"
+cp "$INSTALLER" "$M1/installer.sh"
+m1_tmp="$(mktemp)"
+m1_changed=$(awk -v n=0 '
+  /^soif_write_precommit_hook "\$ROOT\/.git\/hooks\/pre-commit"/ {
+    print "cp \"$ROOT/scripts/pre-commit-gate.sh\" \"$ROOT/.git/hooks/pre-commit\"; chmod +x \"$ROOT/.git/hooks/pre-commit\""
+    n++; next }
+  { print }
+  END { print n+0 > "/dev/stderr" }
+' "$M1/installer.sh" 2>&1 >"$m1_tmp")
+mv "$m1_tmp" "$M1/installer.sh"
+m1_changed=$(_num "$m1_changed")
+m1_parses=0; bash -n "$M1/installer.sh" >/dev/null 2>&1 && m1_parses=1
+( cd "$M1" && bash "$M1/installer.sh" >/dev/null 2>&1 ) || true
+m1=$(commit_arm_lines "$M1" "feat: mutant restores the no-op install")
+m1_n="${m1##* }"
+if [ "$m1_changed" -eq 1 ] && [ "$m1_parses" -eq 1 ] && [ "$m1_n" -eq 0 ]; then
+  pass "M1: with the old \`cp the gate\` line restored, the same commit falls back to ZERO lines of gate output — A2 is measuring that the hook RUNS, not that a file exists (changed=$m1_changed parses=$m1_parses)"
+else
+  fail_ "M1" "changed=$m1_changed (want 1 — 0 means the mutation never applied and this proves nothing) parses=$m1_parses (want 1) arm_lines=$m1_n (want 0)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Acting on "the installed pre-commit hook is a stale snapshot" turned up something worse, plus the shard re-balance the measured figures in #357 called for.

## The hook was never stale — it was the wrong file, and had never enforced anything

`scripts/install-contributor-hooks.sh` did `cp scripts/pre-commit-gate.sh .git/hooks/pre-commit` and printed:

> `[OK] pre-commit gate installed … Local commits now face the same gates CI runs.`

They faced nothing. `pre-commit-gate.sh` is a **PreToolUse** hook — its own header says *"Input: Claude Code passes tool input JSON on stdin / No output = allow"* — and git invokes a pre-commit hook with **no arguments and no such JSON**. Every commit took the allow path and exited 0 silently.

**Measured hermetically, both directions, on the same fixture commit:**

| install method | commit | gate-arm output |
|---|---|---|
| `cp` the gate (documented) | rc=0 | **0 lines** |
| `soif_write_precommit_hook` (what `init.sh` generates, 122 KB) | rc=0 | **3 lines** — gitleaks and semgrep arms ran |

**And the `commit-msg` half was never installed for contributors at all.** `init.sh` writes two hooks for generated projects; the contributor path wrote one. So the BL-072 TDD-ordering gate and the BL-006 Build-Loop message check have never run locally for anyone working on the framework — including every commit in today's BL-235 wave.

### Fix

Both hooks now come from `scripts/lib/hook-templates.sh` — **the same emitters `init.sh` uses**, so contributor and generated-project hooks cannot drift. The installer then **verifies what it installed** (present, non-empty, executable) rather than reporting on what it intended, which is how the original survived.

### And the fix must not repeat the claim it was fixing

The first real commit through the fixed hook showed which arms actually fire *in the framework checkout*:

| arm | state | evidence |
|---|---|---|
| gitleaks | **LIVE** | 8.30.1 present, arm runs |
| SAST (semgrep) | **INERT** | `unable to find a config; path .semgrep/soif-dom-sinks.yml does not exist` → `SAST NOT ENFORCED`. `init.sh` writes `.semgrep/` for generated projects only |
| BL-006 message gate | **N/A by design** | `framework repo detected … not applicable here` |
| BL-125 co-location | **did not fire** | `no source files staged` on a commit staging five `.sh`/`.md`/`.yml` files — **why is not established**, recorded as observed, not explained |

So here this is **mainly a secret-detection gate**. Worth having, strictly more than nothing, but *not* "the same gates CI runs". The installer now prints this arm-by-arm at install time.

## Tests

`tests/test-bl239-contributor-hooks.sh` — 5 cases, all running a **real commit** through the installed hook and requiring output attributable to a known arm. Presence is deliberately never asserted: a present, executable, inert hook is exactly what this defect looks like.

- **`A1` is a control that reproduces the defect** (old install → 0 lines), so a green `A2` cannot mean "the fixture can't tell the difference"
- **`M1`** restores the old `cp` line and watches `A2` go dark

## Shard re-balance

#357 replaced an estimate with measured CI time, and the measurement moved the answer: `rest` — the leg everyone watches, cancelled at the cap on #351 — was down to **61%**, while `slow-misc` had become the closest at **566s/720s (79%)**.

Per-suite, derived from run `32048687734`'s group timestamps:

| | |
|---|---|
| `test-delta-wp5-hotfix-retro` | **185s** ← the pole, 1.5× the next |
| `test-pre-commit-gate-lints` | 123s |
| the other six | 21–54s |

Moving the single pole balances **both** legs instead of trading one hot leg for another: `slow-misc` 566→**381s (53%)**, `lint-sweep` 201→**386s (54%)**. Moving two would have taken `slow-misc` to 36% and changed nothing else, because the binding constraint after this move is **`sast` at 519s (72%)** — flagged in the file as the next one to watch.

Partition verified by executing the workflow's own arrays: **3+5+4+7+158 = 177 = the canonical list**, no duplicates, nothing pinned that isn't a member.

## Residual, stated

**Nothing detects a hook that is present but inert.** That is exactly why this lasted: `verify-install.sh` and the currency manifest record hook *presence*, not *behaviour*. The honest detector is the two-sided one used to find this. Not built — recorded on `## BL-239:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
