### PR TITLE
fix(bl230): workflow.html joins both lint surfaces — the page nothing could tell you had rotted

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -523,6 +523,7 @@ jobs:
             tests/test-bl221-tier-fail-closed.sh
             tests/test-bl235-tool-matrix-probes.sh
             tests/test-bl239-contributor-hooks.sh
+            tests/test-bl230-workflow-html-lint-surface.sh
             tests/host-drivers/error-translate.test.sh
           )
 

--- a/scripts/lint-bl-markers.sh
+++ b/scripts/lint-bl-markers.sh
@@ -423,11 +423,19 @@ cat > "$EXTRACT_CITES" <<'AWK'
   if (probe ~ /lint-bl-markers:[ \t]*allow[ \t]+[^ \t]/) ann = "allow"
   else if (probe ~ /lint-bl-markers:[ \t]*allow/)        ann = "allow-empty"
   line = $0
-  while (match(line, /`[[:space:]]*#?[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*`|#[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*/)) {
+  # BL-230: `<!--` joins `#` as a COMMENT PREFIX. A marker in an HTML or
+  # markdown template is written `<!-- BL-170-APPEND-DESIGN -->`, because that
+  # file has no `#` comment syntax — and workflow.html cites it in exactly that
+  # form. It is a THIRD alternative rather than a tweak to the backticked one:
+  # the backticked branch requires a CLOSING backtick, and the real citation is
+  # `<!-- MARKER -->` with ` -->` between the token and that backtick, so the
+  # token would never reach it. The match still ends at the marker pattern, so
+  # the trailing ` -->` is simply never consumed.
+  while (match(line, /`[[:space:]]*#?[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*`|#[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*|<!--[[:space:]]*BL-[0-9]+[a-z]?-[A-Za-z][A-Za-z0-9_*-]*/)) {
     tok = substr(line, RSTART, RLENGTH)
     line = substr(line, RSTART + RLENGTH)
     gsub(/`/, "", tok)
-    sub(/^[[:space:]]*#?[[:space:]]*/, "", tok)
+    sub(/^[[:space:]]*(#|<!--)?[[:space:]]*/, "", tok)
     sub(/[-*]+$/, "", tok)
     print FILENAME "\t" FNR "\t" tok "\t" ann
   }
@@ -439,6 +447,51 @@ PROSE_FILES="$TMPD/prose-files"
 for prose_entry in CLAUDE.md README.md CONTRIBUTING.md solo-orchestrator-backlog.md; do
   [ -f "$ROOT/$prose_entry" ] && printf '%s\n' "$prose_entry" >> "$PROSE_FILES"
 done
+
+# ── BL-230: workflow.html joins the prose surface, via a NORMALISER ──────
+# The page cites 13 real markers and sat outside this lint entirely: the prose
+# surface was CLAUDE.md, README.md, CONTRIBUTING.md, the backlog and docs/**,
+# and a root-level .html is in none of them. Adversarial review corrupted a
+# cited marker there and this lint returned rc 0.
+#
+# IT IS NORMALISED, NOT PARSED BY A SECOND EXTRACTOR. `EXTRACT_CITES` above is
+# the one owner of "what counts as a citation", and a second HTML-shaped copy
+# of that rule would be the sync-sibling trap in the one place this repo has
+# paid for it repeatedly. So the HTML is rewritten into the shape the existing
+# extractor already reads, and then read by it:
+#
+#   <code> and </code>   ->  `        (HTML's "marked as code" IS the backtick)
+#   &nbsp; / &#160;      ->  space    (`#&nbsp;BL-…` is the page's normal form)
+#   &lt; &gt; &amp;      ->  < > &    (so `&lt;!-- BL-… --&gt;` becomes a comment)
+#
+# WHY THE ENTITY DECODE MATTERS, measured: of the page's 13 real marker
+# citations, 12 are `<code>#&nbsp;MARKER</code>` and ONE —
+# `BL-170-APPEND-DESIGN` — is `<code>&lt;!-- MARKER --&gt;</code>`, because the
+# file it marks is a `.tmpl` where the comment syntax is `<!-- -->` and not `#`.
+# A `#`-only reader silently checks 12 of 13 and reports a clean pass, which is
+# the vacuity `## BL-230:` explicitly warns this arm could take.
+#
+# WHAT IT DELIBERATELY DOES NOT MATCH, because the page contains both and
+# neither is a marker citation:
+#   <code>## BL-219:</code>                 an ENTRY id (`##`, trailing colon)
+#   <code>… --retro DELTA-NNN …</code>      a placeholder inside a command
+# Both are excluded by the same rule CLAUDE.md already states — a citation
+# counts only when prose marks it as CODE with a comment prefix — so this arm
+# inherits that predicate instead of inventing a looser one.
+WORKFLOW_HTML="$ROOT/workflow.html"                                    # BL-230-PROSE-HTML
+WF_NORMALISED=""
+if [ -f "$WORKFLOW_HTML" ]; then
+  WF_NORMALISED="$TMPD/workflow.html.normalised.md"
+  sed -e 's|</\{0,1\}code>|`|g' \
+      -e 's/&nbsp;/ /g' -e 's/&#160;/ /g' \
+      -e 's/&lt;/</g' -e 's/&gt;/>/g' -e 's/&amp;/\&/g' \
+      "$WORKFLOW_HTML" > "$WF_NORMALISED"
+  # ABSOLUTE path: the extractor runs under `cd "$ROOT"` and the normalised
+  # copy lives in TMPD, outside the tree. The temp path is rewritten back to
+  # `workflow.html` in the CITES output below, so no operator ever sees a
+  # /tmp path in a diagnostic about their page.
+  printf '%s\n' "$WF_NORMALISED" >> "$PROSE_FILES"
+fi
 if [ -d "$ROOT/docs" ]; then
   while IFS= read -r found; do
     [ -n "$found" ] || continue
@@ -454,6 +507,45 @@ CITES="$TMPD/cites"
 if [ -s "$PROSE_FILES" ]; then
   ( cd "$ROOT" && tr '\n' '\0' < "$PROSE_FILES" \
       | xargs -0 awk -f "$EXTRACT_CITES" 2>/dev/null ) > "$CITES"
+fi
+
+# BL-230: report the page by its real name, never the temp path it was
+# normalised into, and enforce a VACUITY FLOOR on it.
+if [ -n "$WF_NORMALISED" ] && [ -s "$CITES" ]; then
+  WF_CITES=$(grep -cF "$WF_NORMALISED" "$CITES" 2>/dev/null) || WF_CITES=0
+  case "$WF_CITES" in ''|*[!0-9]*) WF_CITES=0 ;; esac
+  # "The scan found nothing" is not "the page is clean". If the page is
+  # rewritten with different markup, the normaliser silently yields zero
+  # citations and this arm reports a clean pass over an unexamined file —
+  # which is the defect `## BL-230:` names as the risk of adding it.
+  #
+  # THE FLOOR IS 4 BECAUSE THIS ARM SEES 6, NOT 13, AND THAT IS NOT A BUG —
+  # it is this lint's vocabulary, and it is worth stating rather than rounding
+  # up. The page carries 13 real marker citations. This lint resolves markers
+  # against `## BL-NNN:` ENTRIES, so its extractors are `BL-[0-9]+-…`-shaped
+  # throughout, and only 6 of the 13 are that shape:
+  #     checked   BL-070-GATE-CHECK BL-071-WRITE BL-073-ESCALATE
+  #               BL-104-MANIFEST-ARM BL-115-DATE-CELL BL-170-APPEND-DESIGN
+  #     NOT       BF-ADOPT-BOUND BF-ADOPT-GATE-ISSUES CADENCE-DEFAULT-DEEP
+  #               CADENCE-DEFAULT-ROUTINE CADENCE-POLICY-READ
+  #               CUTREL-TAG-FORMAT DELTA-OPEN-ERA-GUARD
+  # Those seven have no backlog entry to resolve to, so covering them means
+  # widening the DEFINITION extractor's vocabulary across the whole code
+  # surface — a change to a required status check, with real false-positive
+  # risk on any `# FOO-BAR` comment. That is a separate decision, recorded on
+  # `## BL-230:` rather than smuggled in here. Set the floor for what this arm
+  # ACTUALLY covers; a floor of 8 would be enforcing a coverage it does not have.
+  # Under --root the floor defaults to 0, exactly as MIN_MARKERS/MIN_CITES/
+  # MIN_ENTRIES do above: a fixture tree is SUPPOSED to be small, and a floor
+  # that fires on every fixture would make this arm untestable — which is how
+  # an arm ends up with no mutation proof at all.
+  if [ -n "$ROOT_OVERRIDE" ]; then WF_FLOOR="${MIN_WORKFLOW_CITES:-0}"; else WF_FLOOR="${MIN_WORKFLOW_CITES:-4}"; fi
+  if [ "$WF_CITES" -lt "$WF_FLOOR" ]; then                             # BL-230-PROSE-FLOOR
+    echo "lint-bl-markers: workflow.html yielded $WF_CITES marker citation(s) — below the floor ($WF_FLOOR)." >&2
+    echo "  That is 'the extraction broke', not 'the page cites nothing'. The normaliser or the page's markup has changed. Refusing to report a verdict." >&2
+    exit 2
+  fi
+  sed -i.bak "s|$WF_NORMALISED|workflow.html|g" "$CITES" 2>/dev/null && rm -f "$CITES.bak"
 fi
 
 PROSE_CITES=$(grep -c . "$CITES" 2>/dev/null) || PROSE_CITES=0

--- a/scripts/lint-doc-anchors.sh
+++ b/scripts/lint-doc-anchors.sh
@@ -267,6 +267,92 @@ while IFS= read -r -d '' f; do
   process_file "$f"
 done < <(find "$DOCS_DIR" -type f -name '*.md' -print0 | sort -z)
 
+# ── BL-230: the workflow.html arm ────────────────────────────────────
+# `workflow.html` cites 7 relative doc paths and 2 in-page anchors and sits
+# OUTSIDE every lint surface: this script walks `find "$DOCS_DIR" -name '*.md'`,
+# and the file is neither `*.md` nor under `docs/`. Adversarial review proved
+# it by MUTATION — it broke a relative link and corrupted a cited marker, ran
+# both lints, and got rc 0 from each. The page's entire value is that an
+# operator can trust it; it went six weeks and ~40 PRs out of date once, and a
+# human asking was the only thing that caught it.
+#
+# SCOPED TO THIS ONE FILE, NOT `*.html`. `templates/uat/**` ships HTML fixtures
+# that carry placeholder paths ON PURPOSE and would red immediately.
+#
+# BLOCKING, unlike the BL-090 cross-file arm above, which is WARN-tier by a
+# measured-rollout decision about the whole docs corpus. This is one file whose
+# 7 links all resolve today, so the check starts green and only reds on a real
+# break — the rollout caution that justifies WARN there does not apply here.
+# The page is located BESIDE the docs dir, so `--docs-dir FIXTURE/docs` finds
+# `FIXTURE/workflow.html`. Without that this arm could only ever be exercised
+# against the real tree, and a check that cannot be pointed at a fixture cannot
+# have a mutation proof — which is how an arm ends up asserted rather than
+# measured.
+WF_ROOT="$REPO_ROOT"
+[ -n "$DOCS_DIR_OVERRIDE" ] && WF_ROOT="$(cd "$(dirname "$DOCS_DIR")" && pwd)"
+WF="$WF_ROOT/workflow.html"                                            # BL-230-WORKFLOW-ARM
+if [ -f "$WF" ]; then
+  wf_links=0; wf_anchors=0; wf_bad=0
+
+  # Relative doc references: href="…" that is not an in-page anchor, not
+  # absolute, and not external.
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+    wf_links=$((wf_links + 1))
+    if [ ! -e "$WF_ROOT/$target" ]; then
+      echo "lint-doc-anchors: workflow.html -> '$target' does not exist" >&2
+      wf_bad=$((wf_bad + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\tworkflow.html\t${target}\n"
+    else
+      LIST_ROWS="${LIST_ROWS}PASS\tworkflow.html\t${target}\n"
+    fi
+  done < <(grep -oE 'href="[^"#:]+"' "$WF" 2>/dev/null \
+             | sed -e 's/^href="//' -e 's/"$//' \
+             | grep -vE '^(https?|mailto|/)' | sort -u)
+
+  # In-page anchors: href="#id" must have a matching id="id" in the same file.
+  wf_ids="$(grep -oE 'id="[^"]+"' "$WF" 2>/dev/null | sed -e 's/^id="//' -e 's/"$//' | sort -u)"
+  while IFS= read -r a; do
+    [ -n "$a" ] || continue
+    wf_anchors=$((wf_anchors + 1))
+    if ! printf '%s\n' "$wf_ids" | grep -qxF "$a"; then
+      echo "lint-doc-anchors: workflow.html -> #$a has no matching id=" >&2
+      wf_bad=$((wf_bad + 1))
+      LIST_ROWS="${LIST_ROWS}FAIL\tworkflow.html\t#${a}\n"
+    else
+      LIST_ROWS="${LIST_ROWS}PASS\tworkflow.html\t#${a}\n"
+    fi
+  done < <(grep -oE 'href="#[^"]+"' "$WF" 2>/dev/null | sed -e 's/^href="#//' -e 's/"$//' | sort -u)
+
+  # ── VACUITY FLOOR ─────────────────────────────────────────────────
+  # "Found nothing to check" is NOT "everything checks out". If the page is
+  # rewritten with a different link syntax, the greps above quietly select zero
+  # rows and this arm reports a clean pass over an unexamined file — the exact
+  # shape `## BL-112:` is about, and the one BL-230 explicitly warns this arm
+  # could take. The floors are set BELOW today's counts (7 links, 2 anchors) so
+  # ordinary edits do not trip them, and any collapse toward zero does.
+  # Under --docs-dir the floors default to 0, exactly as lint-bl-markers.sh's
+  # do under --root: a fixture tree is SUPPOSED to be small, and a floor that
+  # fires on every fixture makes the arm untestable — which is how an arm ends
+  # up asserted instead of measured. The real-tree defaults (5/1) sit below
+  # today's 7/2.
+  if [ -n "$DOCS_DIR_OVERRIDE" ]; then
+    wf_min_links="${MIN_WORKFLOW_LINKS:-0}"; wf_min_anchors="${MIN_WORKFLOW_ANCHORS:-0}"
+  else
+    wf_min_links="${MIN_WORKFLOW_LINKS:-5}"; wf_min_anchors="${MIN_WORKFLOW_ANCHORS:-1}"
+  fi
+  if [ "$wf_links" -lt "$wf_min_links" ] || [ "$wf_anchors" -lt "$wf_min_anchors" ]; then   # BL-230-WORKFLOW-FLOOR
+    echo "lint-doc-anchors: workflow.html yielded $wf_links relative link(s) and $wf_anchors anchor(s) — below the floor ($wf_min_links/$wf_min_anchors)." >&2
+    echo "  That is 'the scan found nothing', not 'the page is clean'. The extraction has broken, or the page changed shape. Refusing to report a verdict." >&2
+    exit 2
+  fi
+
+  if [ "$wf_bad" -gt 0 ]; then
+    VIOLATIONS=$((VIOLATIONS + wf_bad))
+  fi
+  FILES_SCANNED=$((FILES_SCANNED + 1))
+fi
+
 if [ "$LIST_MODE" -eq 1 ]; then
   printf 'STATUS\tFILE:LINE\tANCHOR\n'
   printf '%b' "$LIST_ROWS"
@@ -286,5 +372,12 @@ if [ "$REF_WARNINGS" -gt 0 ]; then
   fi
 fi
 
-echo "OK: no broken in-document anchors across $FILES_SCANNED markdown file(s) under ${DOCS_DIR#"$REPO_ROOT"/}."
+# The verdict names BOTH surfaces. It used to say "N markdown file(s) under
+# docs/" while N had just been incremented for a root-level .html file — a
+# small false statement in the one line an operator reads as the answer.
+if [ -f "$WF" ]; then
+  echo "OK: no broken in-document anchors across $FILES_SCANNED file(s) — $(( FILES_SCANNED - 1 )) markdown under ${DOCS_DIR#"$REPO_ROOT"/}, plus workflow.html ($wf_links relative link(s), $wf_anchors anchor(s))."
+else
+  echo "OK: no broken in-document anchors across $FILES_SCANNED markdown file(s) under ${DOCS_DIR#"$REPO_ROOT"/}."
+fi
 exit 0

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10029,7 +10029,64 @@ true
 claim-by-claim against the tree. That is exactly why this is worth filing —
 **the accuracy has no way of surviving.** It went six weeks and ~40 PRs out of
 date last time, and the only thing that caught it was a human asking.
-**Status:** Open
+**Status:** Open — **three arms shipped**; two residuals below, one of them
+split out as `## BL-240:`.
+
+### What shipped (`# BL-230-WORKFLOW-ARM`, `# BL-230-PROSE-HTML`) <!-- lint-bl-markers: allow BL-230-PROSE-HTML lives inside lint-bl-markers.sh, which excludes ITSELF from the code surface (# BL-196-SELF-EXCLUDE-BEGIN) so it cannot self-certify; a marker defined there is unresolvable from prose by construction -->
+
+Re-derived first, and the entry's own counts needed correcting: the page carries
+**13 real marker citations, not 18**. Two of the 18 are extraction artefacts a
+naive lint would have red-ed on immediately — `BL-219` is a bare backlog ENTRY
+id (`<code>## BL-219:</code>`, no suffix) and `DELTA-NNN` is a placeholder inside
+a shell command. The page is **accurate today**: 13 markers, 3 entry refs, 7
+links and 2 in-page anchors all resolve.
+
+- **`lint-doc-anchors.sh`** gained a `workflow.html` arm: relative doc links and
+  in-page anchors must resolve. **BLOCKING**, unlike the BL-090 cross-file arm
+  beside it, whose warn-tier is a measured-rollout decision about the whole docs
+  corpus and does not apply to one file whose 7 links all resolve today.
+- **`lint-bl-markers.sh`** gained the page via a **NORMALISER, not a second
+  extractor** — `<code>`→backtick, `&nbsp;`→space, entity-decode — so the one
+  existing citation reader handles it and there is no HTML-shaped copy of "what
+  counts as a citation" to drift.
+- **`<!--` joins `#` as a comment prefix.** One real citation,
+  `BL-170-APPEND-DESIGN`, is written `<code>&lt;!-- MARKER --&gt;</code>` because
+  the file it marks is a `.tmpl` with no `#` syntax. A `#`-only reader checks 12
+  of 13 and reports clean — the exact vacuity this entry warned the arm could
+  take. `M4` in the suite deletes that alternative from a copy of the lint and
+  watches the corruption go undetected, so the branch is proven load-bearing.
+- **Vacuity floors on both arms** (`# BL-230-WORKFLOW-FLOOR`,
+  `# BL-230-PROSE-FLOOR`), exiting **2** — cannot tell — never 0. Both default <!-- lint-bl-markers: allow same self-exclusion as above: the marker is defined inside lint-bl-markers.sh, which is not part of its own code surface -->
+  to 0 under the fixture flags (`--docs-dir`, `--root`), matching the existing
+  floor convention, because a floor that fires on every fixture makes an arm
+  untestable and that is how an arm ends up asserted rather than measured.
+- **Proof:** `tests/test-bl230-workflow-html-lint-surface.sh`, 8 cases. The two
+  mutations adversarial review used to file this entry — break a link, corrupt a
+  cited marker — now red, and `F1` requires a CORRECT page to stay green with
+  the entry id and the placeholder present, so the fix cannot cry wolf.
+
+### RESIDUAL 1 — the marker arm covers 6 of the 13 citations
+
+`lint-bl-markers.sh` resolves markers against `## BL-NNN:` **entries**, so its
+extractors are `BL-[0-9]+-…`-shaped throughout. Only 6 of the page's 13
+citations are that shape:
+
+| checked | not checked |
+|---|---|
+| `BL-070-GATE-CHECK`, `BL-071-WRITE`, `BL-073-ESCALATE`, `BL-104-MANIFEST-ARM`, `BL-115-DATE-CELL`, `BL-170-APPEND-DESIGN` | `BF-ADOPT-BOUND`, `BF-ADOPT-GATE-ISSUES`, `CADENCE-DEFAULT-DEEP`, `CADENCE-DEFAULT-ROUTINE`, `CADENCE-POLICY-READ`, `CUTREL-TAG-FORMAT`, `DELTA-OPEN-ERA-GUARD` |
+
+The seven have no backlog entry to resolve to, so covering them means widening
+the DEFINITION extractor's vocabulary across the entire code surface — a change
+to a **required status check**, with real false-positive risk on any `# FOO-BAR`
+comment. That is a separate decision and is deliberately not smuggled in; the
+floor is set to what the arm ACTUALLY covers rather than to the number it would
+be flattering to claim.
+
+### RESIDUAL 2 — the footer stamp
+
+Split out as **`## BL-240:`**, because a staleness check reds from time passing
+rather than from a defect, and that deserves its own design argument rather than
+being bolted onto a lint that currently only reds when something is wrong.
 
 **Measured on the refresh branch.** The page cites **18 distinct code markers**
 (`BL-070-GATE-CHECK`, `BL-071-WRITE`, `BL-073-ESCALATE`, `BL-104-MANIFEST-ARM`,
@@ -11882,3 +11939,54 @@ something attributable to a known arm. Not built.
 shape, one layer down), `## BL-096:` (the entry that added this installer),
 `## BL-237:` (a mode bit turning enforcement into a silent skip),
 `## BL-234:` / `## BL-235:` (registered ≠ working, the family this belongs to).
+
+---
+
+## BL-240: `workflow.html`'s "Verified against the tree on YYYY-MM-DD" stamp has no mechanism — and a staleness check is a lint that can red without a defect
+
+**Logged:** 2026-08-17 (split out of `## BL-230:` deliberately, at Karl's
+direction, rather than built into the lint that entry produced)
+**Category:** Unguarded surface — but the guard has a cost the sibling arms do
+not, and that is the whole question
+**Status:** Open — **design decision first, not a build task**
+
+### What the marker and link arms structurally cannot catch
+
+`## BL-230:` shipped three checks over `workflow.html`: relative links resolve,
+in-page anchors resolve, and cited `BL-NNN-…` markers still exist. All three ask
+*"does the thing this page points at exist?"*
+
+**None of them can see a sentence that has become false while the marker it cites
+still exists.** That is the actual rot mode: `scripts/resume.sh` grew a fourth
+branch while `CLAUDE.md` and the script's own header still said three — every
+marker in that prose resolved perfectly the whole time. The page carries a
+footer stamp for exactly this reason, and nothing reads it.
+
+### Why this was NOT built alongside the other three
+
+A staleness check **fails from time passing, not from a defect**. Every other
+lint in this repo reds because something is wrong; this one would red because a
+calendar advanced while the page was still, possibly, entirely correct. That is
+cry-wolf by construction, and this repo has a standing position on checks that
+report something other than what they measure (`## BL-104:`'s `[WARN]` label over
+a blocking increment; `## BL-112:`'s "did not run" ≠ "found nothing").
+
+### The design question, which is the actual work
+
+**If it is built, WARN or BLOCK?** The argument for WARN is that the check
+cannot distinguish "stale" from "still true, just old", so blocking on it
+punishes the honest state. The argument against WARN is `## BL-090:`'s arm in
+`lint-doc-anchors.sh`, which has been warn-tier since 2026-07-21 with a standing
+"escalate once the population stays at zero" — a warn that nobody escalates is a
+lint nobody reads.
+
+**A better mechanism may exist.** Comparing the stamp against the page's own
+last-modified commit is one option (`git log -1 --format=%cI -- workflow.html`)
+— that at least measures *"the page changed after it was last verified"*, which
+IS a defect rather than a date. It reds only when someone edits the page without
+re-verifying, which is the behaviour worth enforcing. That framing may make the
+whole cry-wolf objection go away, and it is worth designing before coding.
+
+**Related:** `## BL-230:` (the three arms that DO exist, and why this one was
+held back), `## BL-090:` (a warn-tier arm still waiting to be escalated),
+`## BL-112:` (a status that means something other than what the caller reads).

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2058,6 +2058,8 @@ run_child_suite "tests/test-bl235-tool-matrix-probes.sh" \
   "tests/test-bl235-tool-matrix-probes.sh"
 run_child_suite "tests/test-bl239-contributor-hooks.sh" \
   "tests/test-bl239-contributor-hooks.sh"
+run_child_suite "tests/test-bl230-workflow-html-lint-surface.sh" \
+  "tests/test-bl230-workflow-html-lint-surface.sh"
 run_child_suite "tests/test-check-phase-gate.sh" "tests/test-check-phase-gate.sh"
 
 # BL-214 — the gate stalled its own next run. create_gate_snapshot writes into

--- a/tests/test-bl230-workflow-html-lint-surface.sh
+++ b/tests/test-bl230-workflow-html-lint-surface.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+# tests/test-bl230-workflow-html-lint-surface.sh
+#
+# BL-230 — `workflow.html` cites 13 code markers, 3 backlog entries, 7 relative
+# doc paths and 2 in-page anchors, and sat OUTSIDE every lint surface:
+# `lint-doc-anchors.sh` walks `find "$DOCS_DIR" -name '*.md'` and the file is
+# neither `*.md` nor under `docs/`; `lint-bl-markers.sh`'s prose surface is
+# CLAUDE.md, README.md, CONTRIBUTING.md, the backlog and `docs/**`. Adversarial
+# review proved it by MUTATION — it broke a relative link and corrupted a cited
+# marker, ran both lints, and got rc 0 from each.
+#
+# The page's whole value is that an operator can trust it. It went six weeks and
+# ~40 PRs out of date once, and a human asking was the only thing that noticed.
+#
+# ── WHAT THIS SUITE PINS, AND THE TWO TRAPS IT IS BUILT AROUND ──────────────
+# TRAP 1 — a naive extractor REDS ON A CORRECT PAGE. The page contains
+# marker-SHAPED tokens that are not marker citations:
+#     <code>## BL-219:</code>              a backlog ENTRY id (`##`, colon)
+#     <code>… --retro DELTA-NNN …</code>   a placeholder inside a command
+# `F1` requires the clean fixture to pass WITH both present, so a future
+# tightening cannot start crying wolf on legitimate prose.
+#
+# TRAP 2 — a `#`-only reader CHECKS 12 OF 13 AND REPORTS CLEAN. One real
+# citation, `BL-170-APPEND-DESIGN`, is written `<code>&lt;!-- MARKER --&gt;</code>`
+# because the file it marks is a `.tmpl` with no `#` comment syntax. `M3` breaks
+# exactly that citation, and `M4` proves the `<!--` alternative is load-bearing
+# by deleting it from a COPY of the lint and watching M3's mutation survive.
+#
+# Every case runs the REAL lint against a fixture tree. Hermetic: temp dirs,
+# no network, no writes to the repo. bash 3.2 safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ANCHORS="$REPO_ROOT/scripts/lint-doc-anchors.sh"
+MARKERS="$REPO_ROOT/scripts/lint-bl-markers.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/caseXXXXXX"; }
+_num() { case "$1" in ''|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+
+# mk_fixture <dir> — a miniature tree with the same shapes the real page uses.
+# The HTML deliberately carries BOTH citation forms, an entry id, and a
+# placeholder, so a clean run proves the extractor discriminates rather than
+# merely matching something.
+mk_fixture() {
+  local d="$1"
+  mkdir -p "$d/docs" "$d/scripts" "$d/templates"
+
+  printf '# Doc\n\nA heading to link to.\n' > "$d/docs/guide.md"
+  printf '# Readme\n' > "$d/README.md"
+
+  # Code surface: the markers the page cites must EXIST here.
+  cat > "$d/scripts/thing.sh" <<'SH'
+#!/usr/bin/env bash
+run_gate() { :; }            # BL-070-GATE-CHECK
+write_it()  { :; }           # BL-071-WRITE
+SH
+  # An HTML-comment marker, in a template — the shape with no `#` syntax.
+  printf '<!-- BL-170-APPEND-DESIGN -->\ncontent\n' > "$d/templates/approval.tmpl"
+
+  cat > "$d/solo-orchestrator-backlog.md" <<'MD'
+## BL-070: gate check
+**Status:** Closed — PR #1
+
+## BL-071: write
+**Status:** Closed — PR #1
+
+## BL-170: append design
+**Status:** Closed — PR #1
+
+## BL-219: an entry the page references by id
+**Status:** Open
+MD
+
+  cat > "$d/workflow.html" <<'HTML'
+<!doctype html>
+<html><body>
+<h2 id="alpha">Alpha</h2>
+<h2 id="beta">Beta</h2>
+<p>Jump to <a href="#alpha">Alpha</a> and <a href="#beta">Beta</a>.</p>
+<p>See <a href="docs/guide.md">the guide</a> and <a href="README.md">the readme</a>.</p>
+<p>The gate is <code>#&nbsp;BL-070-GATE-CHECK</code> and the writer is
+   <code>#&nbsp;BL-071-WRITE</code>.</p>
+<p>The append contract is <code>&lt;!-- BL-170-APPEND-DESIGN --&gt;</code>.</p>
+<p>Tracked as <code>## BL-219:</code>, and the command is
+   <code>scripts/delta.sh --retro DELTA-NNN --record "x"</code>.</p>
+</body></html>
+HTML
+}
+
+run_anchors() { ( cd "$1" && bash "$ANCHORS" --docs-dir "$1/docs" 2>&1 ); }
+run_markers() { ( cd "$1" && bash "$MARKERS" --root "$1" 2>&1 ); }
+
+echo "=== F — the clean fixture passes BOTH lints (and does not cry wolf) ==="
+
+F="$(newtmp)"; mk_fixture "$F"
+f1a=$(run_anchors "$F"); f1a_rc=$?
+f1m=$(run_markers "$F"); f1m_rc=$?
+if [ "$f1a_rc" -eq 0 ] && [ "$f1m_rc" -eq 0 ]; then
+  pass "F1: a correct page passes both lints WITH an entry id (<code>## BL-219:</code>) and a placeholder (DELTA-NNN) present — the extractor discriminates a citation from a marker-shaped token instead of matching anything that looks like one"
+else
+  fail_ "F1" "anchors rc=$f1a_rc markers rc=$f1m_rc (want 0/0) — a correct page must not red. anchors: $(printf '%s' "$f1a" | tail -2 | tr '\n' ' ') | markers: $(printf '%s' "$f1m" | tail -2 | tr '\n' ' ')"
+fi
+
+# F2: the marker lint must actually SEE the page — a pass proves nothing if it
+# scanned nothing. Both citation forms must be rendered as resolved rows.
+f2=$( cd "$F" && bash "$MARKERS" --root "$F" --list 2>/dev/null )
+f2_hash=$(_num "$(printf '%s' "$f2" | grep -c 'workflow.html.*BL-070-GATE-CHECK')")
+f2_html=$(_num "$(printf '%s' "$f2" | grep -c 'workflow.html.*BL-170-APPEND-DESIGN')")
+if [ "$f2_hash" -ge 1 ] && [ "$f2_html" -ge 1 ]; then
+  pass "F2: --list shows workflow.html rows for BOTH forms — the '#'-prefixed citation and the '<!--'-prefixed one. A green lint that rendered no rows would be a pass over an unscanned file"
+else
+  fail_ "F2" "hash-form rows=$f2_hash html-form rows=$f2_html (want >=1 each) — the page is not actually in the prose surface"
+fi
+
+echo "=== L — the link/anchor arm (lint-doc-anchors) ==="
+
+L2="$(newtmp)"; mk_fixture "$L2"
+sed -i.bak 's|href="docs/guide.md"|href="docs/GONE.md"|' "$L2/workflow.html" && rm -f "$L2/workflow.html.bak"
+l2=$(run_anchors "$L2"); l2_rc=$?
+if [ "$l2_rc" -eq 1 ] && printf '%s' "$l2" | grep -q 'docs/GONE.md'; then
+  pass "L2: a relative doc link that does not resolve fails the lint and names the target — this is the mutation adversarial review ran to prove the page was unguarded, and it now reds"
+else
+  fail_ "L2" "rc=$l2_rc (want 1) named=$(printf '%s' "$l2" | grep -c 'GONE') (want >=1)"
+fi
+
+L3="$(newtmp)"; mk_fixture "$L3"
+sed -i.bak 's|href="#beta"|href="#betaZ"|' "$L3/workflow.html" && rm -f "$L3/workflow.html.bak"
+l3=$(run_anchors "$L3"); l3_rc=$?
+if [ "$l3_rc" -eq 1 ] && printf '%s' "$l3" | grep -q 'betaZ'; then
+  pass "L3: an in-page anchor with no matching id= fails and names it — the page's own table of contents cannot rot silently"
+else
+  fail_ "L3" "rc=$l3_rc (want 1) named=$(printf '%s' "$l3" | grep -c 'betaZ') (want >=1)"
+fi
+
+# L4: THE VACUITY FLOOR. A page rewritten with different markup yields zero
+# links, and "found nothing" must not read as "clean".
+L4="$(newtmp)"; mk_fixture "$L4"
+printf '<html><body><p>nothing to see</p></body></html>\n' > "$L4/workflow.html"
+l4=$( cd "$L4" && MIN_WORKFLOW_LINKS=5 MIN_WORKFLOW_ANCHORS=1 bash "$ANCHORS" --docs-dir "$L4/docs" 2>&1 ); l4_rc=$?
+if [ "$l4_rc" -eq 2 ] && printf '%s' "$l4" | grep -q 'below the floor'; then
+  pass "L4: a page yielding no links or anchors exits 2 — CANNOT TELL, which is distinct from both clean (0) and broken (1). A silent 0 here would be the defect this arm was added to remove, one level up"
+else
+  fail_ "L4" "rc=$l4_rc (want 2) floor_message=$(printf '%s' "$l4" | grep -c 'below the floor')"
+fi
+
+echo "=== M — the marker arm (lint-bl-markers) ==="
+
+M2="$(newtmp)"; mk_fixture "$M2"
+sed -i.bak 's/BL-070-GATE-CHECK<\/code>/BL-070-GATE-CHECZ<\/code>/' "$M2/workflow.html" && rm -f "$M2/workflow.html.bak"
+m2=$(run_markers "$M2"); m2_rc=$?
+if [ "$m2_rc" -eq 1 ] && printf '%s' "$m2" | grep -q 'BL-070-GATE-CHECZ'; then
+  pass "M2: a corrupted '#'-form marker citation fails and names the dead token — the exact mutation that returned rc 0 before this arm existed"
+else
+  fail_ "M2" "rc=$m2_rc (want 1) named=$(printf '%s' "$m2" | grep -c 'CHECZ') (want >=1)"
+fi
+
+M3="$(newtmp)"; mk_fixture "$M3"
+sed -i.bak 's/BL-170-APPEND-DESIGN --&gt;/BL-170-APPEND-DESIGZ --\&gt;/' "$M3/workflow.html" && rm -f "$M3/workflow.html.bak"
+m3=$(run_markers "$M3"); m3_rc=$?
+if [ "$m3_rc" -eq 1 ] && printf '%s' "$m3" | grep -q 'BL-170-APPEND-DESIGZ'; then
+  pass "M3: a corrupted '<!--'-form citation ALSO fails — the form a '#'-only reader silently skips, which would have left 12 of 13 checked and reported clean"
+else
+  fail_ "M3" "rc=$m3_rc (want 1) named=$(printf '%s' "$m3" | grep -c 'DESIGZ') (want >=1)"
+fi
+
+# ── M4 (MUTATION ON THE LINT ITSELF): delete the `<!--` alternative from a COPY
+# and M3's corruption must survive undetected. This is what proves that
+# alternative is load-bearing rather than decorative — without it, M3 would pass
+# for the wrong reason and nobody could tell.
+M4="$(newtmp)"; mk_fixture "$M4"
+sed -i.bak 's/BL-170-APPEND-DESIGN --&gt;/BL-170-APPEND-DESIGZ --\&gt;/' "$M4/workflow.html" && rm -f "$M4/workflow.html.bak"
+mkdir -p "$M4/lint"
+cp "$MARKERS" "$M4/lint/lint-bl-markers.sh"
+before=$(_num "$(grep -c '<!--\[\[:space:\]\]\*BL-' "$M4/lint/lint-bl-markers.sh")")
+sed -i.bak 's/|<!--\[\[:space:\]\]\*BL-\[0-9\]+\[a-z\]?-\[A-Za-z\]\[A-Za-z0-9_\*-\]\*//' "$M4/lint/lint-bl-markers.sh" && rm -f "$M4/lint/lint-bl-markers.sh.bak"
+after=$(_num "$(grep -c '<!--\[\[:space:\]\]\*BL-' "$M4/lint/lint-bl-markers.sh")")
+m4_parses=0; bash -n "$M4/lint/lint-bl-markers.sh" >/dev/null 2>&1 && m4_parses=1
+m4=$( cd "$M4" && bash "$M4/lint/lint-bl-markers.sh" --root "$M4" 2>&1 ); m4_rc=$?
+if [ "$before" -ge 1 ] && [ "$after" -eq 0 ] && [ "$m4_parses" -eq 1 ] && [ "$m4_rc" -eq 0 ]; then
+  pass "M4: with the '<!--' alternative deleted from a copy of the lint, M3's corrupted citation goes UNDETECTED (rc=0) — so that alternative is what catches it, not something else (sites $before -> $after, parses=$m4_parses)"
+else
+  fail_ "M4" "alternative sites before=$before (want >=1) after=$after (want 0) parses=$m4_parses (want 1) mutant rc=$m4_rc (want 0 — a non-zero means something ELSE caught it and M3 proves less than it claims)"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]


### PR DESCRIPTION
`workflow.html` cites code markers, backlog entries, relative doc paths and in-page anchors, and sat **outside every lint surface**. Adversarial review filed `## BL-230:` by mutation — it broke a link, corrupted a cited marker, ran both lints, and got **rc 0 from each**.

## Re-derived first, and the entry's counts needed correcting

The page carries **13 real marker citations, not 18**. Two of the 18 are extraction artefacts that would have made a naive lint red on a **correct** page:

| token | what it actually is |
|---|---|
| `BL-219` | a bare backlog **entry id** (`<code>## BL-219:</code>`, no suffix) |
| `DELTA-NNN` | a **placeholder** inside a shell command |

The page is accurate today: 13 markers, 3 entry refs, 7 links, 2 anchors — all resolving.

## What shipped

- **`lint-doc-anchors.sh`** — a `workflow.html` arm (`# BL-230-WORKFLOW-ARM`): relative doc links and in-page anchors must resolve. **Blocking**, unlike the BL-090 arm beside it, whose warn-tier is a measured-rollout decision about the whole docs corpus and doesn't apply to one file whose links all resolve today.
- **`lint-bl-markers.sh`** — the page enters the prose surface through a **normaliser, not a second extractor** (`<code>`→backtick, `&nbsp;`→space, entity-decode), so the one existing citation reader handles it. A second HTML-shaped copy of "what counts as a citation" is the sync-sibling trap in the place this repo has paid for it most.
- **`<!--` joins `#` as a comment prefix** — and this is the part that matters. `BL-170-APPEND-DESIGN` is cited as `<code>&lt;!-- MARKER --&gt;</code>`, because the file it marks is a `.tmpl` with no `#` syntax. A `#`-only reader checks **12 of 13 and reports clean** — the exact vacuity the entry warned this arm could take.
- **Vacuity floors on both arms**, exiting **2** (*cannot tell*), never 0. Both default to 0 under the fixture flags, matching the existing convention — a floor that fires on every fixture makes an arm untestable, which is how an arm ends up asserted instead of measured.

## Tests — `tests/test-bl230-workflow-html-lint-surface.sh`, 8 cases

- **`F1`** requires a **correct** page to stay green *with* the entry id and the placeholder present — so the fix cannot cry wolf
- **`F2`** requires `--list` to render rows for **both** citation forms — a green lint that scanned nothing would be a pass over an unread file
- **`L2`/`L3`** are the two mutations that filed this entry; both now red
- **`L4`** is the link vacuity floor
- **`M4`** deletes the `<!--` alternative from a **copy of the lint** and confirms `M3`'s corruption then goes undetected — proving that branch is load-bearing rather than decorative

## Residual, stated rather than rounded up

**The marker arm covers 6 of the 13 citations.** `lint-bl-markers.sh` resolves markers against `## BL-NNN:` *entries*, so its extractors are `BL-`-shaped throughout; `BF-`, `CADENCE-`, `CUTREL-` and `DELTA-` markers have no entry to resolve to. Covering them means widening the definition extractor across the whole code surface — a change to a **required status check**, with real false-positive risk on any `# FOO-BAR` comment. That's a separate decision. **The floor is set to what the arm actually covers, not to the number it would flatter to claim.**

`## BL-240:` files the footer-stamp staleness check separately, per Karl's decision: a check that reds from *time passing* rather than from a defect deserves its own design argument — and comparing the stamp against the page's last-modified commit may remove the cry-wolf objection entirely.

## Note on two inline allowlist entries

Two citations in the entry use the inline allowlist **with reasons**: their markers live inside `lint-bl-markers.sh`, which excludes itself from its own code surface so it cannot self-certify. A marker defined there is unresolvable from prose by construction; the existing `BL-196` markers observe the same constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
