### PR TITLE
BL-233 WP-B: the accumulation half — warn at commit, block at the phase gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -517,6 +517,7 @@ jobs:
             tests/test-brownfield-wp5b-test-debt.sh
             tests/test-brownfield-wp6-collision-archive.sh
             tests/test-bl233-mcp-outcome-enforcement.sh
+            tests/test-bl233-wpb-accumulation.sh
             tests/test-bl234-currency-and-availability.sh
             tests/test-bl222-security-clock-evidence.sh
             tests/test-bl229-host-pipeline-paths.sh

--- a/init.sh
+++ b/init.sh
@@ -2335,6 +2335,25 @@ TUEOF
 }
 QDEOF
       print_ok "Qdrant MCP configured with project-specific collection: $PROJECT_NAME"
+
+      # BL-233-WPB-MANIFEST-DECL: record the requirement where a CLONE can see it.
+      # settings.local.json above cannot carry this: Claude Code adds that file
+      # to the user's global git excludes by design, so it never leaves this
+      # machine. check-phase-gate.sh's accumulation gate asks git whether the
+      # declaring file is tracked, and .claude/manifest.json is the one that is.
+      # Without this line the gate is correct here and inert on CI.
+      if [ -f .claude/manifest.json ]; then
+        if jq '.mcp = ((.mcp // {}) | .qdrant_required = true)' .claude/manifest.json \
+             > .claude/manifest.json.tmp 2>/dev/null; then
+          mv .claude/manifest.json.tmp .claude/manifest.json
+          print_ok "Qdrant accumulation requirement recorded in .claude/manifest.json (survives a clone)"
+        else
+          rm -f .claude/manifest.json.tmp
+          print_warn "Could not record mcp.qdrant_required in .claude/manifest.json — the phase-gate accumulation check will not fire in a fresh clone until it is added."
+        fi
+      else
+        print_warn "No .claude/manifest.json to record mcp.qdrant_required in — the phase-gate accumulation check will not fire in a fresh clone until it is added."
+      fi
     fi
   fi
 

--- a/init.sh
+++ b/init.sh
@@ -1369,6 +1369,13 @@ create_project() {
   # though --plan itself runs framework-side only.
   cp "$SCRIPT_DIR/scripts/lib/render-project-docs.sh"  scripts/lib/
   cp "$SCRIPT_DIR/scripts/lib/plan-staging.sh"         scripts/lib/
+  # BL-233 WP-B: the accumulation predicates, sourced by BOTH shipped gates
+  # (check-phase-gate.sh and pre-commit-gate.sh). Source-closure (BL-088) is not
+  # optional here — without this line the commit gate dies at its `source` line
+  # in every generated project, which either blocks every commit with a bash
+  # error or, on the PreToolUse path, makes the whole gate exit non-zero before
+  # any check runs. tests/test-scaffold-source-closure.sh enforces it.
+  cp "$SCRIPT_DIR/scripts/lib/accumulation.sh"         scripts/lib/
   cp "$SCRIPT_DIR/scripts/validate.sh" scripts/
   cp "$SCRIPT_DIR/scripts/check-phase-gate.sh" scripts/
   # BL-088: check-phase-gate.sh's Phase-3→4 gate auto-runs (and points the

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -580,11 +580,20 @@ _cpg_record_reviewer_attestation() {
 #
 # Reading it from .claude/tool-usage.json is the obvious answer and is wrong
 # twice: the ledger is untracked runtime scratch that `startup` wipes, so
-# deleting it would switch a blocking gate off (`## BL-231:`); and of the 61
-# suites that name check-phase-gate.sh under tests/, 29 drive it at
-# current_phase >= 2 across 74 fixture-creation sites and NOT ONE writes a
-# ledger, so a ledger-derived requirement would have forced 74 fixture edits to
-# say nothing.
+# deleting it would switch a blocking gate off (`## BL-231:`); and MEASURED ON
+# MERGE-BASE 2344b13 — the tree the decision was made against, and stated as such
+# because these numbers move with the PR — of the 60 suites that name
+# check-phase-gate.sh under tests/, 29 drive it at current_phase >= 2 and NOT ONE
+# writes a ledger, so a ledger-derived requirement would have forced an edit to
+# every one of them to say nothing. The recipe is on `## BL-233:`; the
+# load-bearing number is the ZERO.
+#
+# The earlier form of this comment said "61 suites" and "74 fixture-creation
+# sites". The 61 was read off a working tree that already contained this
+# feature's own new suite, and the 74 reproduces under no derivation anyone can
+# write down, so it is WITHDRAWN. Both are corrected here and not only in the
+# backlog: shipping a retraction to the ledger while the code keeps asserting the
+# retracted figure is the same defect one file over.
 #
 # The first fix for that read .claude/settings.local.json instead, on the
 # reasoning that init.sh writes it and `git add -A` commits it. THAT WAS ALSO
@@ -596,7 +605,8 @@ _cpg_record_reviewer_attestation() {
 # inference from an ignore file you happened to read. accum_file_tracked asks it
 # (scripts/lib/accumulation.sh, shared with the commit-time warning).
 #
-# $HOME is still never read, for the original reason: zero of those 29 fixtures
+# $HOME is still never read, for the original reason: on that same base tree,
+# zero of those 29 fixtures
 # redirect HOME, so a host-derived verdict passes on a developer box with Qdrant
 # configured and fails on a runner without it — `## BL-234:`'s class. A5 and
 # mutant M3 pin the project-only scope in both directions.
@@ -685,13 +695,62 @@ _cpg_accum_after() {
 # follows _cpg_accum_after's precedent in this file: it guards its persisted
 # timestamp and pointedly does not guard its gate date, because an arm that
 # cannot fire is `## BL-104:`'s shape.
+_ACCUM_WINDOW_REASON=""
 _cpg_accum_window_measurable() {
-  local w="$1" a today
-  [ -n "$w" ] || return 0   # no start = the whole history, which is measurable
+  local w="$1" key="$2" raw="$3" a today _nan
+  _ACCUM_WINDOW_REASON=""
+
+  # AN EMPTY WINDOW START IS AMBIGUOUS, and reading it as "no gate recorded" was
+  # a SECOND silent off switch through the same field. `get_gate_date` maps BOTH
+  # "no gate recorded" AND "a gate is recorded whose value will not parse" to "",
+  # and "" then reaches _cpg_accum_after, whose `[ -z "$gate" ] && return 0`
+  # makes ANY store ever recorded satisfy the gate. Measured: one edit of
+  # gates.* to `not-a-date` took a blocking fixture from 9 inconsistencies to 8,
+  # landing on the no-requirement control, with a 2020 store reported as
+  # satisfying. Same shape as the future window, no clock skew required.
+  if [ -z "$w" ]; then
+    # NON-EMPTY IS NOT ENOUGH — the raw value must also FAIL the date regex, or
+    # every project with a perfectly good gate date is refused. That was the
+    # first cut of this arm and it refused three fixtures out of four.
+    #
+    # $raw is a SNAPSHOT taken at the same instant as $w and BEFORE any check
+    # ran, not a fresh read (`# BL-233-WPB-RAW-SNAPSHOT`). Re-reading the file
+    # here is what the second cut did, and it measured a different file:
+    # `_cpg_record_gate_date` rewrites gates.* from APPROVAL_LOG evidence DURING
+    # the run, so `not-a-date` had already normalised to today's date by the
+    # time this line saw it — the arm reported "parses fine", and the fail-open
+    # it was written to close stayed open while the test for it went green.
+    if [ -n "$raw" ] && ! grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$' <<< "$raw"; then   # BL-233-WPB-AMBIGUOUS-WINDOW
+      _ACCUM_WINDOW_REASON="a gate date IS recorded for $key and does not parse as YYYY-MM-DD (\"$raw\")"
+      return 1
+    fi
+    return 0   # genuinely no gate recorded: the window is the whole history
+  fi
+
+  # THE NUMERIC GUARD IS NOT DEAD CODE, and the reasoning that removed it was
+  # refuted by this same file 230 lines away. `get_gate_date` validates with a
+  # per-line `grep -qE`, so a DUPLICATE key in phase-state.json (which jq
+  # accepts, so the file is not malformed) yields a multi-line value that passes
+  # validation if ANY line is a date; accum_oneline then concatenates the lines.
+  # Without this guard `ZZZZZZZZZZ2026-02-01` reached `[ -le ]`, which blocks —
+  # correct direction — while printing a raw `integer expression expected` from
+  # the shell into a blocking verdict. The sibling half of this feature already
+  # re-validates the same field for the same reason
+  # (`# BL-233-WPB-ACCPREV-ONELINE`); this half now agrees with it.
   a="${w:0:10}"; a="${a//-/}"
-  today=$(date +%Y%m%d 2>/dev/null) || return 1
-  case "$today" in ''|*[!0-9]*) return 1 ;; esac
-  [ "$a" -le "$today" ]   # BL-233-WPB-FUTURE-WINDOW
+  _nan="the recorded gate date does not reduce to a number (\"$w\") — a duplicate key in .claude/phase-state.json yields a multi-line value that per-line validation accepts"
+  case "$a" in ''|*[!0-9]*) _ACCUM_WINDOW_REASON="$_nan"; return 1 ;; esac   # BL-233-WPB-WINDOW-NUMERIC
+
+  today=$(date +%Y%m%d 2>/dev/null) || today=""
+  case "$today" in
+    ''|*[!0-9]*)
+      _ACCUM_WINDOW_REASON="the system date could not be read, so no window can be placed in time"
+      return 1 ;;
+  esac
+
+  [ "$a" -le "$today" ] && return 0   # BL-233-WPB-FUTURE-WINDOW
+  _ACCUM_WINDOW_REASON="it opens at $w, which is not in the past, so no commit and no store can fall inside it"
+  return 1
 }
 
 # _cpg_accum_source_work <since_date> — did this phase produce SOURCE commits?
@@ -716,8 +775,21 @@ _cpg_accum_source_work() {
   local since="$1" paths
   if ! command -v git >/dev/null 2>&1; then return 0; fi
   if ! git rev-parse --git-dir >/dev/null 2>&1; then return 0; fi
+  # `00:00:00` IS LOAD-BEARING, and its absence was a fail-open found by a test
+  # of this feature going intermittently green. git's approxidate fills the
+  # fields a date string omits FROM THE CURRENT CLOCK, so a bare `--since=<date>`
+  # means "that date at the time of day it happens to be right now", not
+  # midnight. Measured on git 2.x: a commit made at 10:35:18 today is INVISIBLE
+  # to `--since=<today>` two seconds later, and visible to
+  # `--since=<today> 00:00:00`.
+  #
+  # Consequence without it: every source commit made earlier in the day on the
+  # window's opening date is silently outside the window, so a phase whose
+  # previous gate was recorded today reports "nothing owed" all afternoon — and
+  # the SAME TREE yields a different verdict depending on the hour the gate runs,
+  # which is `## BL-234:`'s class wearing a clock instead of a hostname.
   if [ -n "$since" ]; then
-    paths=$(git log --since="$since" --name-only --pretty=format: 2>/dev/null) || return 0
+    paths=$(git log --since="$since 00:00:00" --name-only --pretty=format: 2>/dev/null) || return 0   # BL-233-WPB-SINCE-MIDNIGHT
   else
     paths=$(git log --name-only --pretty=format: 2>/dev/null) || return 0
   fi
@@ -987,14 +1059,43 @@ _cpg_check_accumulation() {
 
   # THE WINDOW MUST BE MEASURABLE BEFORE EITHER QUESTION ABOUT IT MEANS ANYTHING,
   # so this precedes both "was anything stored in it" and "was source work done
-  # in it". A future window answers BOTH questions with a confident falsehood:
-  # nothing can be stored after it, and nothing can be committed after it.
-  if ! _cpg_accum_window_measurable "$prev"; then
-    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — the window opens at ' "${RED}" "${NC}" "$label"
-    printf '%s' "$prev"
-    printf ', which is not in the past, so no commit and no store can fall inside it.\n'
+  # in it". An unmeasurable window answers BOTH with a confident falsehood.
+  #
+  # A CONSEQUENCE THIS PLACEMENT OWNS, stated rather than discovered later: a
+  # project that HAS stored, but whose window is unmeasurable, now blocks where
+  # it previously read `[OK] satisfied`, and the attested escape below is not
+  # reached either. That is deliberate — an attestation excuses "nothing was
+  # stored", not "the gate does not know what it is measuring" — and the remedy
+  # is in the message: the recorded date is the thing that is wrong. Note the
+  # earlier draft of this comment justified the placement with "nothing can be
+  # stored after it", which is FALSE in the clock-skew case it cites as
+  # motivation: a machine that is ahead writes both the gate date AND the store
+  # timestamp in the future. The placement is right; that argument for it was
+  # not. Recorded as residual 19.
+  #
+  # THE REASON IS CARRIED, NOT ASSUMED. The first version hard-coded ", which is
+  # not in the past" into this line — and that is false on two of the four paths
+  # that reach it (an unparseable recorded date, and a `date` that will not
+  # answer), so the arm added to remove a false affirmative about the project
+  # printed one of its own. `_ACCUM_STALE_REASON` is the precedent in this file.
+  # THE KEY THE WINDOW OPENS AT IS THE PREVIOUS GATE, NOT THIS ONE. Passing
+  # $gate_key read phase_2_to_3's value while checking phase_2_to_3, so a
+  # tampered phase_1_to_2 was reported by quoting an untouched, valid date — and
+  # a legitimately NULL previous gate was refused because the SUCCESSOR was set.
+  # Caught by driving all four shapes; it would have shipped as a message that
+  # named the wrong field and a gate that blocked correct projects.
+  local _accum_prev_key=""
+  case "$gate_key" in
+    phase_1_to_2) _accum_prev_key="phase_0_to_1" ;;
+    phase_2_to_3) _accum_prev_key="phase_1_to_2" ;;
+    phase_3_to_4) _accum_prev_key="phase_2_to_3" ;;
+  esac
+  if ! _cpg_accum_window_measurable "$prev" "$_accum_prev_key" "$4"; then
+    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — the window cannot be measured: ' "${RED}" "${NC}" "$label"
+    printf '%s' "$(accum_oneline "${_ACCUM_WINDOW_REASON}")"
+    printf '.\n'
     echo "        Nothing is being claimed about this project: a window that cannot be measured is not an empty one."
-    echo "        Fix the date in .claude/phase-state.json (gates.$gate_key), or check the clock on the machine that recorded it."
+    echo "        Fix gates.${_accum_prev_key:-$gate_key} in .claude/phase-state.json, or check the clock on the machine that recorded it."
     return 1
   fi
 
@@ -1096,13 +1197,34 @@ _cpg_check_accumulation() {
 
 # The ONE increment site for the accumulation gate.
 _cpg_accum_gate() {
-  _cpg_check_accumulation "$1" "$2" "$3" || issues=$((issues + 1))   # BL-233-WPB-BLOCK
+  _cpg_check_accumulation "$1" "$2" "$3" "$4" || issues=$((issues + 1))   # BL-233-WPB-BLOCK
+}
+
+# _cpg_raw_gate_value <gate_key> — the gates.* value EXACTLY AS RECORDED.
+# get_gate_date maps BOTH "absent" and "present but unparseable" to "", and the
+# accumulation arm has to tell those apart: the first legitimately means "the
+# window is the whole history", the second means the window cannot be measured.
+_cpg_raw_gate_value() {
+  local v=""
+  if [ -f "$PHASE_STATE" ] && command -v jq >/dev/null 2>&1; then
+    v=$(jq -r --arg k "$1" '.gates[$k] // ""' "$PHASE_STATE" 2>/dev/null || printf '')
+    [ "$v" = "null" ] && v=""
+  fi
+  if [ "${SOIF_ACCUM_LIB_LOADED:-0}" = "1" ]; then
+    v=$(accum_oneline "$v")   # boundary rule: sanitise where it ENTERS
+  fi
+  printf '%s' "$v"
 }
 
 gate_0_to_1=$(get_gate_date "phase_0_to_1")
 gate_1_to_2=$(get_gate_date "phase_1_to_2")
 gate_2_to_3=$(get_gate_date "phase_2_to_3")
 gate_3_to_4=$(get_gate_date "phase_3_to_4")
+# Captured HERE, beside the validated values and before any check runs, because
+# `_cpg_record_gate_date` rewrites gates.* mid-run from APPROVAL_LOG evidence.
+raw_gate_0_to_1=$(_cpg_raw_gate_value "phase_0_to_1")   # BL-233-WPB-RAW-SNAPSHOT
+raw_gate_1_to_2=$(_cpg_raw_gate_value "phase_1_to_2")
+raw_gate_2_to_3=$(_cpg_raw_gate_value "phase_2_to_3")
 
 # Extract deployment type and track for conditional checks.
 # BL-095: parsing goes through the # BL-095-STATE-READERS fence in
@@ -2154,9 +2276,9 @@ fi
 # and the conditional would never fire anyway — an arm that cannot fire is the
 # `## BL-104:` shape and is better absent than decorative.
 case "$current_phase" in
-  2) _cpg_accum_gate "phase_1_to_2" "$gate_0_to_1" "Phase 1→2" ;;
-  3) _cpg_accum_gate "phase_2_to_3" "$gate_1_to_2" "Phase 2→3" ;;
-  4) _cpg_accum_gate "phase_3_to_4" "$gate_2_to_3" "Phase 3→4" ;;
+  2) _cpg_accum_gate "phase_1_to_2" "$gate_0_to_1" "Phase 1→2" "$raw_gate_0_to_1" ;;
+  3) _cpg_accum_gate "phase_2_to_3" "$gate_1_to_2" "Phase 2→3" "$raw_gate_1_to_2" ;;
+  4) _cpg_accum_gate "phase_3_to_4" "$gate_2_to_3" "Phase 3→4" "$raw_gate_2_to_3" ;;
 esac
 
 # Check: if current_phase >= 4, gate 3→4 should have a date (BL-071: see

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -657,6 +657,43 @@ _cpg_accum_after() {
   [ "$a" -ge "$b" ]
 }
 
+# _cpg_accum_window_measurable <window_start> — can this window be measured?
+#
+# `git log --since=<date>` with a date in the FUTURE returns zero commits and
+# exits 0. Git ANSWERED, so none of the three cannot-tell arms in
+# _cpg_accum_source_work fire; the empty payload then matches `^$` in the exempt
+# set and the gate announces "nothing owed — every change since 2099-12-31 was
+# documentation". That is a false affirmative about the project — the same
+# substitution the extension allow-list was rewritten to remove — arrived at by
+# a different route, and it is a silent OFF SWITCH for a blocking gate. Refusing
+# a silent off switch is the whole reason `## BL-233:` declined to read the
+# requirement from the ledger; one reached through gates.* is no better.
+#
+# NOT hypothetical, and not only tampering. `_cpg_record_gate_date` PRESERVES a
+# date already recorded (its idempotent branch), so a date written by a machine
+# whose clock or timezone is ahead of the one running the gate is in the future
+# THERE and nowhere else — `## BL-234:`'s silent local-vs-CI class, which this
+# feature has now been bitten by twice.
+#
+# Answering "measurable" rather than "future" is deliberate: the caller must
+# block on ANY reason the window cannot be read, not on one named reason. A
+# `date` that will not answer therefore reads as NOT measurable — "could not
+# measure" must never resolve to "nothing to measure".
+#
+# The window start is get_gate_date output, already anchored to YYYY-MM-DD or
+# "" by that function, so it gets NO numeric guard here. That is deliberate and
+# follows _cpg_accum_after's precedent in this file: it guards its persisted
+# timestamp and pointedly does not guard its gate date, because an arm that
+# cannot fire is `## BL-104:`'s shape.
+_cpg_accum_window_measurable() {
+  local w="$1" a today
+  [ -n "$w" ] || return 0   # no start = the whole history, which is measurable
+  a="${w:0:10}"; a="${a//-/}"
+  today=$(date +%Y%m%d 2>/dev/null) || return 1
+  case "$today" in ''|*[!0-9]*) return 1 ;; esac
+  [ "$a" -le "$today" ]   # BL-233-WPB-FUTURE-WINDOW
+}
+
 # _cpg_accum_source_work <since_date> — did this phase produce SOURCE commits?
 #
 # Ground truth from git, NOT from a hook-maintained counter. `## BL-239:` — this
@@ -709,12 +746,16 @@ _cpg_accum_source_work() {
 
 # _cpg_accum_source_since <sha> — source work committed after <sha>?
 # Same classifier as _cpg_accum_source_work, over a commit RANGE instead of a
-# date. Returns 1 (no source work) when it CANNOT tell, and that permissive
-# direction is correct ONLY here: this decides whether an attestation already on
-# record has gone stale, and inventing staleness would re-block work the
-# operator legitimately excused.
-# Returns 0 = "the attestation no longer covers the tree" (stale), 1 = still
-# covers it.
+# date. Returns 0 = "the attestation no longer covers the tree" (stale),
+# 1 = still covers it.
+#
+# THE PARAGRAPH THAT USED TO OPEN THIS BLOCK IS DELETED, NOT AMENDED. It said
+# this function "returns 1 (no source work) when it CANNOT tell, and that
+# permissive direction is correct ONLY here" — the pre-inversion behaviour,
+# left in place when the inversion landed (backlog residual 5,
+# `# BL-233-WPB-STALE-FAILCLOSED`), directly contradicted by the next paragraph.
+# A reader who stopped at the first one would believe the permanent bypass was
+# still by design.
 #
 # IT FAILS CLOSED, and it says why. The first version returned 1 (still valid)
 # for an empty, malformed, tampered or garbage-collected `head` — so ANY
@@ -942,6 +983,19 @@ _cpg_check_accumulation() {
     # survive a clone.
     echo -e "${YELLOW}[WARN]${NC} $label accumulation: the Qdrant requirement is declared ONLY in a file git does not track (.claude/settings.local.json is in Claude Code's global excludes; .claude/tool-usage.json is in the generated .gitignore). Enforcing it HERE, but a fresh clone or CI runner will not see it."
     echo "        Make it durable: jq '.mcp.qdrant_required = true' .claude/manifest.json   (and commit it)"
+  fi
+
+  # THE WINDOW MUST BE MEASURABLE BEFORE EITHER QUESTION ABOUT IT MEANS ANYTHING,
+  # so this precedes both "was anything stored in it" and "was source work done
+  # in it". A future window answers BOTH questions with a confident falsehood:
+  # nothing can be stored after it, and nothing can be committed after it.
+  if ! _cpg_accum_window_measurable "$prev"; then
+    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — the window opens at ' "${RED}" "${NC}" "$label"
+    printf '%s' "$prev"
+    printf ', which is not in the past, so no commit and no store can fall inside it.\n'
+    echo "        Nothing is being claimed about this project: a window that cannot be measured is not an empty one."
+    echo "        Fix the date in .claude/phase-state.json (gates.$gate_key), or check the clock on the machine that recorded it."
+    return 1
   fi
 
   last=$(_cpg_accum_last_store)

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -667,7 +667,8 @@ _cpg_accum_after() {
   [ "$a" -ge "$b" ]
 }
 
-# _cpg_accum_window_measurable <window_start> — can this window be measured?
+# _cpg_accum_window_measurable <window_start> <window_key> <raw_window_value>
+#   — can this window be measured at all?
 #
 # `git log --since=<date>` with a date in the FUTURE returns zero commits and
 # exits 0. Git ANSWERED, so none of the three cannot-tell arms in
@@ -690,11 +691,11 @@ _cpg_accum_after() {
 # `date` that will not answer therefore reads as NOT measurable — "could not
 # measure" must never resolve to "nothing to measure".
 #
-# The window start is get_gate_date output, already anchored to YYYY-MM-DD or
-# "" by that function, so it gets NO numeric guard here. That is deliberate and
-# follows _cpg_accum_after's precedent in this file: it guards its persisted
-# timestamp and pointedly does not guard its gate date, because an arm that
-# cannot fire is `## BL-104:`'s shape.
+# THE WINDOW START IS VALIDATED HERE, and the earlier version of this paragraph
+# argued the opposite — that get_gate_date's anchoring made a guard an arm that
+# could not fire (`## BL-104:`). That was refuted by this same file: that
+# anchoring is a PER-LINE `grep -qE`, so a duplicate key passes it. The guard is
+# `# BL-233-WPB-WINDOW-SHAPE`, it fires, and M23 kills the tree without it.
 _ACCUM_WINDOW_REASON=""
 _cpg_accum_window_measurable() {
   local w="$1" key="$2" raw="$3" a today _nan
@@ -709,6 +710,18 @@ _cpg_accum_window_measurable() {
   # landing on the no-requirement control, with a 2020 store reported as
   # satisfying. Same shape as the future window, no clock skew required.
   if [ -z "$w" ]; then
+    # AN UNREADABLE STATE FILE IS NOT AN ABSENT GATE. The snapshot below reads
+    # gates.* through jq, and jq's failure was swallowed to "" — which is the
+    # very signal this arm keys on. Measured: one stray `,,,` in
+    # phase-state.json alongside `"phase_1_to_2":"not-a-date"` produced
+    # `[OK] accumulation: satisfied` off a 2020 store on a 2026 phase, with the
+    # corruption surfacing only as a NON-COUNTING [WARN] elsewhere in the run,
+    # so on an otherwise-consistent project nothing saved the gate. `gates` not
+    # being an object does the same thing.
+    if [ "${_ACCUM_GATES_READABLE:-1}" != "1" ]; then
+      _ACCUM_WINDOW_REASON=".claude/phase-state.json does not parse (or its .gates is not an object), so \"no gate recorded\" and \"a gate recorded as garbage\" cannot be told apart"
+      return 1
+    fi
     # NON-EMPTY IS NOT ENOUGH — the raw value must also FAIL the date regex, or
     # every project with a perfectly good gate date is refused. That was the
     # first cut of this arm and it refused three fixtures out of four.
@@ -727,19 +740,37 @@ _cpg_accum_window_measurable() {
     return 0   # genuinely no gate recorded: the window is the whole history
   fi
 
-  # THE NUMERIC GUARD IS NOT DEAD CODE, and the reasoning that removed it was
-  # refuted by this same file 230 lines away. `get_gate_date` validates with a
-  # per-line `grep -qE`, so a DUPLICATE key in phase-state.json (which jq
-  # accepts, so the file is not malformed) yields a multi-line value that passes
-  # validation if ANY line is a date; accum_oneline then concatenates the lines.
-  # Without this guard `ZZZZZZZZZZ2026-02-01` reached `[ -le ]`, which blocks —
-  # correct direction — while printing a raw `integer expression expected` from
-  # the shell into a blocking verdict. The sibling half of this feature already
-  # re-validates the same field for the same reason
-  # (`# BL-233-WPB-ACCPREV-ONELINE`); this half now agrees with it.
+  # THE WHOLE STRING IS VALIDATED, NOT ITS FIRST TEN CHARACTERS, and the
+  # difference is a live fail-open. `get_gate_date` validates with a PER-LINE
+  # `grep -qE`, so a DUPLICATE key in phase-state.json (which jq accepts, so the
+  # file is not malformed) yields a multi-line value that passes if ANY line is a
+  # date; accum_oneline then concatenates the lines.
+  #
+  # The first guard here sliced `${w:0:10}` and asked only whether that reduced
+  # to a number. With the GARBAGE first — `ZZZZZZZZZZ2026-02-01` — that catches
+  # it. With the DATE first it does not, and the full concatenation is what
+  # reaches `git log --since`, where approxidate reads it as some other instant
+  # entirely. Measured: `--since="2026-02-01 2099-12-31 00:00:00"` resolves to
+  # --max-age=4102383600 (2099-12-31) and `--since="2026-02-012099-12-31 …"` to
+  # 1798696800 (2026-12-31) — both FUTURE, both producing verbatim the
+  # "nothing owed" verdict `# BL-233-WPB-FUTURE-WINDOW` exists to remove, at the
+  # same 9 -> 8 issue delta. A guard that catches one operand order is not a
+  # guard on the value.
+  #
+  # Anchored and whole, therefore: after this line $w IS a single YYYY-MM-DD, so
+  # the slice below cannot be non-numeric and `git log --since` cannot be handed
+  # anything approxidate can reinterpret.
+  _nan="the recorded gate date is not a single YYYY-MM-DD value (\"${w:0:40}\") — a duplicate key in .claude/phase-state.json yields a multi-line value that per-line validation accepts, and git reads the concatenation as some other instant"
+  # THE LINE COUNT IS PART OF THE CHECK. `grep` matches PER LINE, so an anchored
+  # pattern alone passes any multi-line value whose FIRST line is a date — the
+  # same per-line hole in `get_gate_date` that created this defect, reproduced
+  # inside the guard for it. It happens to be unreachable in the shipped tree
+  # because accum_oneline flattens $prev at ingest, and that is exactly the
+  # reason to close it: a guard that is only correct because something upstream
+  # is correct is not a guard, and D15 drives a tree where the upstream strip is
+  # gone.
+  if [ "$(grep -c . <<< "$w")" != "1" ] || ! grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$' <<< "$w"; then _ACCUM_WINDOW_REASON="$_nan"; return 1; fi   # BL-233-WPB-WINDOW-SHAPE
   a="${w:0:10}"; a="${a//-/}"
-  _nan="the recorded gate date does not reduce to a number (\"$w\") — a duplicate key in .claude/phase-state.json yields a multi-line value that per-line validation accepts"
-  case "$a" in ''|*[!0-9]*) _ACCUM_WINDOW_REASON="$_nan"; return 1 ;; esac   # BL-233-WPB-WINDOW-NUMERIC
 
   today=$(date +%Y%m%d 2>/dev/null) || today=""
   case "$today" in
@@ -1074,10 +1105,15 @@ _cpg_check_accumulation() {
   # not. Recorded as residual 19.
   #
   # THE REASON IS CARRIED, NOT ASSUMED. The first version hard-coded ", which is
-  # not in the past" into this line — and that is false on two of the four paths
-  # that reach it (an unparseable recorded date, and a `date` that will not
-  # answer), so the arm added to remove a false affirmative about the project
-  # printed one of its own. `_ACCUM_STALE_REASON` is the precedent in this file.
+  # not in the past" into this line — and that is false on EVERY path that
+  # reaches it except one: an unreadable state file, a gate date recorded as
+  # garbage, a window that is not a single YYYY-MM-DD, and a `date` that will not
+  # answer all block on a window that may well be in the past. An arm added to
+  # remove a false affirmative about the project was printing one of its own, and
+  # an earlier draft of this very comment then MIScounted the paths as "two of
+  # four". The count is not restated here on purpose: the paths are enumerated in
+  # `_cpg_accum_window_measurable` and a number here is a second place to be
+  # wrong. `_ACCUM_STALE_REASON` is the precedent for carrying it.
   # THE KEY THE WINDOW OPENS AT IS THE PREVIOUS GATE, NOT THIS ONE. Passing
   # $gate_key read phase_2_to_3's value while checking phase_2_to_3, so a
   # tampered phase_1_to_2 was reported by quoting an untouched, valid date — and
@@ -1211,7 +1247,12 @@ _cpg_raw_gate_value() {
     [ "$v" = "null" ] && v=""
   fi
   if [ "${SOIF_ACCUM_LIB_LOADED:-0}" = "1" ]; then
-    v=$(accum_oneline "$v")   # boundary rule: sanitise where it ENTERS
+    # Boundary rule: sanitise where it ENTERS. NOT mutation-pinned, and that is
+    # stated rather than hidden — removing it leaves the suite green because the
+    # only display site sanitises again. It stays because the rule is "every
+    # value that arrives from a file passes through accum_oneline where it
+    # enters", and a rule with an exception is a search.
+    v=$(accum_oneline "$v")
   fi
   printf '%s' "$v"
 }
@@ -1222,6 +1263,15 @@ gate_2_to_3=$(get_gate_date "phase_2_to_3")
 gate_3_to_4=$(get_gate_date "phase_3_to_4")
 # Captured HERE, beside the validated values and before any check runs, because
 # `_cpg_record_gate_date` rewrites gates.* mid-run from APPROVAL_LOG evidence.
+# Whether gates.* could be READ AT ALL, captured with them. Without this a jq
+# failure is indistinguishable from an absent gate, and "absent" is the
+# permissive answer.
+_ACCUM_GATES_READABLE=1
+if [ -f "$PHASE_STATE" ] && command -v jq >/dev/null 2>&1; then
+  if ! jq -e '(.gates // {}) | type == "object"' "$PHASE_STATE" >/dev/null 2>&1; then
+    _ACCUM_GATES_READABLE=0   # BL-233-WPB-GATES-READABLE
+  fi
+fi
 raw_gate_0_to_1=$(_cpg_raw_gate_value "phase_0_to_1")   # BL-233-WPB-RAW-SNAPSHOT
 raw_gate_1_to_2=$(_cpg_raw_gate_value "phase_1_to_2")
 raw_gate_2_to_3=$(_cpg_raw_gate_value "phase_2_to_3")

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -863,6 +863,15 @@ _cpg_check_accumulation() {
     echo "          jq '.mcp.qdrant_required = true' .claude/manifest.json"
     return 0
   fi
+  if [ "$_accum_state" = "unreadable" ]; then
+    # FAIL CLOSED. A declaration that will not parse has been read by nobody, so
+    # reporting "this project declares no Qdrant MCP server" would assert a fact
+    # about content nothing examined.
+    echo -e "${RED}[FAIL]${NC} $label accumulation: CANNOT BE VERIFIED — a declaration file exists but is not valid JSON (.claude/manifest.json or .claude/settings*.json), so the requirement could not be read."
+    echo "        Fix the JSON, then re-run. Passing silently here would report a project fact that was never parsed."
+    return 1   # BL-233-WPB-UNREADABLE-FAILCLOSED
+  fi
+
   if [ "$_accum_state" = "untracked" ]; then
     # Enforce, but say plainly that the enforcement is local-only. Blocking here
     # would fail every project that predates the manifest field; staying silent

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -856,7 +856,7 @@ _cpg_record_accum_attestation() {
 # outside this pair decides either one.
 _cpg_check_accumulation() {
   local gate_key="$1" prev="$2" label="$3"
-  local last reason recorded recorded_head
+  local last reason recorded recorded_head _accum_bad
   local _accum_state
 
   # FAIL CLOSED on a missing jq, rather than reporting a project fact that was
@@ -893,8 +893,14 @@ _cpg_check_accumulation() {
     # FAIL CLOSED. A declaration that will not parse has been read by nobody, so
     # reporting "this project declares no Qdrant MCP server" would assert a fact
     # about content nothing examined.
-    echo -e "${RED}[FAIL]${NC} $label accumulation: CANNOT BE VERIFIED — a declaration file exists but is not valid JSON (.claude/manifest.json or .claude/settings*.json), so the requirement could not be read."
-    echo "        Fix the JSON, then re-run. Passing silently here would report a project fact that was never parsed."
+    # NAME THE FILE. The first version listed the two files it might have been,
+    # and an operator whose ledger was corrupt was sent to inspect a manifest and
+    # a settings file that were both healthy — which makes "fixing the JSON is
+    # the honest escape" untrue, since it does not say which JSON.
+    _accum_bad=$(accum_unreadable_path)
+    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — a declaration file exists but is not valid JSON: ' "${RED}" "${NC}" "$label"
+    printf '%s' "$(accum_oneline "${_accum_bad:-<unknown>}")"
+    printf '\n        Fix that file, then re-run. Passing silently here would report a project fact that was never parsed.\n'
     return 1   # BL-233-WPB-UNREADABLE-FAILCLOSED
   fi
 
@@ -909,7 +915,22 @@ _cpg_check_accumulation() {
 
   last=$(_cpg_accum_last_store)
   if _cpg_accum_after "$last" "$prev"; then
-    echo -e "${GREEN}  [OK]${NC} $label accumulation: satisfied — last successful qdrant-store $last (window opens ${prev:-project start})."
+    # printf for $last: it is a PERSISTED value (jq out of process-state.json),
+    # so `echo -e` renders \n in it as real newlines and a stored timestamp can
+    # forge "[OK] …" verdict lines on every run. Found on the SIXTH recurrence of
+    # this class, three lines from the arm fixed for it — because the sweep that
+    # was supposed to close the class grepped for the WORDS `reason|recorded|
+    # attest`, which is an instance search wearing a sweep's clothes. $last
+    # carries none of those words.
+    #
+    # THE SWEEP THAT FINDS THIS ONE IS BY PROVENANCE, NOT KEYWORD: every `echo -e`
+    # whose argument interpolates a value that came out of jq, a file, or the
+    # environment. Under that rule the feature has exactly two ($last here,
+    # ACC_PREV in pre-commit-gate.sh) and both are fixed; $label is a code
+    # constant and $prev is regex-validated by get_gate_date.
+    printf '%b  [OK]%b %s accumulation: satisfied — last successful qdrant-store ' "${GREEN}" "${NC}" "$label"
+    printf '%s' "$(accum_oneline "$last")"
+    printf ' (window opens %s).\n' "${prev:-project start}"
     return 0
   fi
 
@@ -939,7 +960,7 @@ _cpg_check_accumulation() {
       # (`grep -n 'echo -e .*\$' | grep -iE 'reason|recorded|attest'`) after
       # fixing only the named instance — which is the recurring failure here.
       printf '%b[WARN]%b %s accumulation: the attestation on record ("' "${YELLOW}" "${NC}" "$label"
-      printf '%s' "$recorded"
+      printf '%s' "$(accum_oneline "$recorded")"
       printf '") no longer covers this tree — %s. Re-attest, or store what changed.\n' "${_ACCUM_STALE_REASON}"   # BL-233-WPB-ATTEST-STALE
       recorded=""
     fi
@@ -961,7 +982,7 @@ _cpg_check_accumulation() {
       # skims. The durable record was never at risk (jq --arg stores it
       # literally); the transcript was.
       printf '%b  [OK]%b %s accumulation: ATTESTED (reason: ' "${GREEN}" "${NC}" "$label"
-      printf '%s' "$reason"
+      printf '%s' "$(accum_oneline "$reason")"
       printf ') — recorded to .claude/process-state.json, not silenced.\n'
       return 0
     fi

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -739,7 +739,13 @@ _cpg_accum_source_since() {
   # attest` keywords, then `echo -e`), and was blind to the surface the fix had
   # just created. Cleaning the value where it ENTERS makes the display sites
   # irrelevant, which is the only version of this that stays true.
-  sha=$(accum_oneline "$1")   # BL-233-WPB-SHA-ONELINE
+  # RAW for git, CLEANED only where it is displayed. Sanitising this at ingest
+  # was wrong in a way no test caught: `HE\001AD` is an INVALID ref that becomes
+  # the VALID ref `HEAD` once C0 bytes are stripped, so a tampered attestation
+  # resolved instead of failing and the arm's verdict flipped FAIL -> OK — the
+  # exact fail-closed posture this function's own header promises. A display
+  # filter must not decide whether a commit exists.
+  sha="$1"   # BL-233-WPB-SHA-RAW-FOR-GIT
   _ACCUM_STALE_REASON="source work has landed since the attested commit"
   if ! command -v git >/dev/null 2>&1; then return 1; fi
   if ! git rev-parse --git-dir >/dev/null 2>&1; then return 1; fi
@@ -754,14 +760,14 @@ _cpg_accum_source_since() {
     return 0   # BL-233-WPB-STALE-FAILCLOSED
   fi
   if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
-    _ACCUM_STALE_REASON="the commit it named ($sha) is not reachable in this repository"
+    _ACCUM_STALE_REASON="the commit it named ($(accum_oneline "$sha")) is not reachable in this repository"
     return 0
   fi
   paths=$(git log "${sha}..HEAD" --name-only --pretty=format: 2>/dev/null) || {
-    _ACCUM_STALE_REASON="the history since $sha could not be read"
+    _ACCUM_STALE_REASON="the history since $(accum_oneline "$sha") could not be read"
     return 0
   }
-  _ACCUM_STALE_REASON="source work has landed since $sha"
+  _ACCUM_STALE_REASON="source work has landed since $(accum_oneline "$sha")"
   if accum_paths_have_source "$paths"; then
     return 0
   fi
@@ -960,7 +966,9 @@ _cpg_check_accumulation() {
   fi
 
   if ! _cpg_accum_source_work "$prev"; then
-    echo -e "${GREEN}  [OK]${NC} $label accumulation: nothing owed — every change since ${prev:-project start} was documentation, config or a dependency manifest."
+    printf '%b  [OK]%b %s accumulation: nothing owed — every change since ' "${GREEN}" "${NC}" "$label"
+    printf '%s' "${prev:-project start}"
+    printf ' was documentation, config or a dependency manifest.\n'
     return 0
   fi
 
@@ -1023,7 +1031,9 @@ _cpg_check_accumulation() {
     echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — .claude/process-state.json exists but is not valid JSON, so neither a store nor an attestation could be read from it. Fix that file first; re-storing or re-attesting will not help until it parses."
     return 1
   fi
-  echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — source commits since ${prev:-project start}, and NO successful qdrant-store in that window."
+  printf '%b[FAIL]%b %s accumulation: BLOCKED — source commits since ' "${RED}" "${NC}" "$label"
+  printf '%s' "${prev:-project start}"
+  printf ', and NO successful qdrant-store in that window.\n'
   echo "        A retrieval requirement with no accumulation requirement is a ratchet with nothing behind it (## BL-233:)."
   echo "        Store what this phase decided (qdrant-store), then re-run — or attest:"
   echo "          SOLO_MCP_ACCUM_ATTESTED=1 SOLO_MCP_ACCUM_ATTESTED_REASON=\"<why nothing was worth storing>\" bash scripts/check-phase-gate.sh"

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -654,16 +654,43 @@ _cpg_accum_last_store() {
 # Same-day counts. gates.* carry a DATE with no time, so a store on the gate's
 # own date cannot be ordered against it — rejecting it would be a coin flip
 # dressed up as a rule.
+_ACCUM_STORE_FUTURE=0
 _cpg_accum_after() {
-  local ts="$1" gate="$2" a b
+  local ts="$1" gate="$2" a b today_utc
   if [ -z "$ts" ]; then return 1; fi
-  if [ -z "$gate" ]; then return 0; fi
   a="${ts:0:10}";   a="${a//-/}"
-  b="${gate:0:10}"; b="${b//-/}"
-  # Only $a is guarded: $b is get_gate_date output, which that function already
-  # regex-validates to YYYY-MM-DD or "" — and "" returned above. A guard here
-  # could not fire, and an arm that cannot fire is the `## BL-104:` shape.
+
+  # THE OTHER OPERAND OF THE SAME COMPARISON. Rounds 10-11 validated the window
+  # START four ways and left the STORE TIMESTAMP unguarded — on the identical
+  # hazard those guards cite. `_cpg_accum_window_measurable` justifies itself by
+  # clock skew, and residual 19 says in as many words that a machine which is
+  # ahead writes the gate date AND the store timestamp in the future. Only one
+  # of the two was checked.
+  #
+  # It is the WORSE half to leave open. A future window start fails LOUDLY (the
+  # gate refuses and names it); a future store timestamp satisfies the gate
+  # SILENTLY and PERMANENTLY — measured, `9999-12-31` and `2099-01-01` both take
+  # a blocking fixture from 11 issues to 10 — and `.claude/process-state.json`
+  # is tracked (residual 17), so the bad value is committed and reaches every
+  # clone.
+  #
+  # THE COMPARISON IS UTC-TO-UTC and that is what makes it exact rather than
+  # slack-tolerant: the tracker writes this field with `date -u`
+  # (`TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)`), so a correct clock can never
+  # produce a value after `date -u` now, and no timezone allowance is needed.
+  # Comparing against a LOCAL today would have needed a day of slack and would
+  # have been a second thing to get wrong. A `date` that will not answer reads
+  # as NOT satisfied — the fail-closed direction, consistent with the window.
   case "$a" in ''|*[!0-9]*) return 1 ;; esac
+  today_utc=$(date -u +%Y%m%d 2>/dev/null) || today_utc=""
+  case "$today_utc" in ''|*[!0-9]*) return 1 ;; esac
+  if [ "$a" -gt "$today_utc" ]; then _ACCUM_STORE_FUTURE=1; return 1; fi   # BL-233-WPB-STORE-FUTURE
+
+  if [ -z "$gate" ]; then return 0; fi
+  b="${gate:0:10}"; b="${b//-/}"
+  # $b needs no guard: it is get_gate_date output, regex-validated to YYYY-MM-DD
+  # or "" by that function, and "" returned above. $a is guarded ABOVE, before
+  # the future check that needs it numeric.
   [ "$a" -ge "$b" ]
 }
 
@@ -1023,7 +1050,7 @@ _cpg_check_accumulation() {
   # duplicate keys, so the file is not even malformed. That predates this work,
   # but three display sites here interpolate $prev, so it is cleaned on the way in.
   prev=$(accum_oneline "$2")   # BL-233-WPB-PREV-ONELINE
-  local last reason recorded recorded_head _accum_bad
+  local last reason recorded recorded_head _accum_bad _accum_window_bad
   local _accum_state
 
   # FAIL CLOSED on a missing jq, rather than reporting a project fact that was
@@ -1126,17 +1153,26 @@ _cpg_check_accumulation() {
     phase_2_to_3) _accum_prev_key="phase_1_to_2" ;;
     phase_3_to_4) _accum_prev_key="phase_2_to_3" ;;
   esac
+  # IT SETS A FLAG, IT DOES NOT RETURN. An earlier version returned 1 right here,
+  # which put the block AHEAD of the attested escape and therefore made the
+  # escape unreachable for it. That is `## BL-149:`'s rule violated by the very
+  # entry that cites it: a gate an honest operator cannot satisfy is a gate they
+  # delete. A wrong clock or a half-written state file is not misconduct, and
+  # the operator staring at "your gate date is unreadable" must be able to say
+  # so and move on — the attestation is still RECORDED, so nothing is silenced.
+  #
+  # What the flag buys is the part that mattered: the two PERMISSIVE shortcuts
+  # below (a store "inside" the window, and "nothing owed") are skipped, because
+  # those are the questions an unmeasurable window answers with a confident
+  # falsehood. Fail-closed on the automatic paths, open to a human on the
+  # attested one.
+  _accum_window_bad=0
   if ! _cpg_accum_window_measurable "$prev" "$_accum_prev_key" "$4"; then
-    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — the window cannot be measured: ' "${RED}" "${NC}" "$label"
-    printf '%s' "$(accum_oneline "${_ACCUM_WINDOW_REASON}")"
-    printf '.\n'
-    echo "        Nothing is being claimed about this project: a window that cannot be measured is not an empty one."
-    echo "        Fix gates.${_accum_prev_key:-$gate_key} in .claude/phase-state.json, or check the clock on the machine that recorded it."
-    return 1
+    _accum_window_bad=1   # BL-233-WPB-WINDOW-ATTESTABLE
   fi
 
   last=$(_cpg_accum_last_store)
-  if _cpg_accum_after "$last" "$prev"; then
+  if [ "$_accum_window_bad" -eq 0 ] && _cpg_accum_after "$last" "$prev"; then
     # printf for $last: it is a PERSISTED value (jq out of process-state.json),
     # so `echo -e` renders \n in it as real newlines and a stored timestamp can
     # forge "[OK] …" verdict lines on every run. Found on the SIXTH recurrence of
@@ -1156,7 +1192,7 @@ _cpg_check_accumulation() {
     return 0
   fi
 
-  if ! _cpg_accum_source_work "$prev"; then
+  if [ "$_accum_window_bad" -eq 0 ] && ! _cpg_accum_source_work "$prev"; then
     printf '%b  [OK]%b %s accumulation: nothing owed — every change since ' "${GREEN}" "${NC}" "$label"
     printf '%s' "${prev:-project start}"
     printf ' was documentation, config or a dependency manifest.\n'
@@ -1215,6 +1251,17 @@ _cpg_check_accumulation() {
     return 1   # BL-233-WPB-ATTEST-REFUSE
   fi
 
+  if [ "$_accum_window_bad" -eq 1 ]; then
+    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — the window cannot be measured: ' "${RED}" "${NC}" "$label"
+    printf '%s' "$(accum_oneline "${_ACCUM_WINDOW_REASON}")"
+    printf '.\n'
+    echo "        Nothing is being claimed about this project: a window that cannot be measured is not an empty one."
+    echo "        Fix gates.${_accum_prev_key:-$gate_key} in .claude/phase-state.json, or check the clock on the machine that recorded it."
+    echo "        If the date is wrong and the work IS stored, say so — it is recorded, not silenced:"
+    echo "          SOLO_MCP_ACCUM_ATTESTED=1 SOLO_MCP_ACCUM_ATTESTED_REASON=\"<why the window is unreadable>\" bash scripts/check-phase-gate.sh"
+    return 1
+  fi
+
   if _cpg_accum_record_unreadable; then
     # Say which cause. Without this the operator is told to store or attest when
     # the real problem is a corrupt record — and any attestation already on
@@ -1225,6 +1272,13 @@ _cpg_check_accumulation() {
   printf '%b[FAIL]%b %s accumulation: BLOCKED — source commits since ' "${RED}" "${NC}" "$label"
   printf '%s' "${prev:-project start}"
   printf ', and NO successful qdrant-store in that window.\n'
+  if [ "${_ACCUM_STORE_FUTURE:-0}" = "1" ]; then
+    # Name the real cause. Without this the operator is told to store again when
+    # the record already HAS a store — one whose timestamp is in the future, and
+    # re-storing will not help while the clock that wrote it is wrong.
+    echo "        NOTE: .claude/process-state.json records a store dated in the FUTURE (UTC), so it cannot be counted."
+    echo "        The clock on the machine that wrote it is ahead. Fix the clock and store again, or attest."
+  fi
   echo "        A retrieval requirement with no accumulation requirement is a ratchet with nothing behind it (## BL-233:)."
   echo "        Store what this phase decided (qdrant-store), then re-run — or attest:"
   echo "          SOLO_MCP_ACCUM_ATTESTED=1 SOLO_MCP_ACCUM_ATTESTED_REASON=\"<why nothing was worth storing>\" bash scripts/check-phase-gate.sh"

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -729,7 +729,17 @@ _cpg_accum_source_work() {
 # compare against, so staleness is not a question that can be asked.
 _ACCUM_STALE_REASON=""
 _cpg_accum_source_since() {
-  local sha="$1" paths
+  local sha paths
+  # SANITISE AT THE BOUNDARY, not at each display site. $1 is `recorded_head`,
+  # read by jq out of .claude/process-state.json — identical provenance to the
+  # values that forged verdict lines twice already — and it is interpolated into
+  # _ACCUM_STALE_REASON, which is rendered by the caller. Wrapping every display
+  # site is how the sixth and seventh instances of this class got in: the sweep
+  # each round described the PREVIOUS round's syntax (first `reason|recorded|
+  # attest` keywords, then `echo -e`), and was blind to the surface the fix had
+  # just created. Cleaning the value where it ENTERS makes the display sites
+  # irrelevant, which is the only version of this that stays true.
+  sha=$(accum_oneline "$1")   # BL-233-WPB-SHA-ONELINE
   _ACCUM_STALE_REASON="source work has landed since the attested commit"
   if ! command -v git >/dev/null 2>&1; then return 1; fi
   if ! git rev-parse --git-dir >/dev/null 2>&1; then return 1; fi
@@ -855,7 +865,14 @@ _cpg_record_accum_attestation() {
 # outcomes. Here the label and the increment cannot drift apart, because nothing
 # outside this pair decides either one.
 _cpg_check_accumulation() {
-  local gate_key="$1" prev="$2" label="$3"
+  local gate_key="$1" prev label="$3"
+  # Same boundary rule. `get_gate_date` extracts with `grep -o` and validates
+  # with an ANCHORED `grep -qE` — and grep matches PER LINE, so a duplicate
+  # `"phase_1_to_2"` key in phase-state.json yields a multi-line value whose
+  # FIRST line is a valid date and which therefore passes validation. jq accepts
+  # duplicate keys, so the file is not even malformed. That predates this work,
+  # but three display sites here interpolate $prev, so it is cleaned on the way in.
+  prev=$(accum_oneline "$2")   # BL-233-WPB-PREV-ONELINE
   local last reason recorded recorded_head _accum_bad
   local _accum_state
 
@@ -874,6 +891,14 @@ _cpg_check_accumulation() {
     echo -e "${RED}[FAIL]${NC} $label accumulation: CANNOT BE VERIFIED — jq is unavailable, so neither the requirement nor the durable record can be read."
     echo "        Install jq. Passing silently here would be the substitution this gate exists to remove: \"could not check\" is not \"nothing to check\"."
     return 1   # BL-233-WPB-JQ-FAILCLOSED
+  fi
+
+  # ANNOUNCED BEFORE the requirement is resolved, because the `none` arm returns
+  # early — and `none` is exactly the verdict a corrupt ledger produces for a
+  # project whose only declaration lived there. Placing this after the resolution
+  # meant it never printed in the one case it exists for.
+  if [ -f ".claude/tool-usage.json" ] && ! accum_json_readable ".claude/tool-usage.json"; then
+    echo -e "${YELLOW}[WARN]${NC} $label accumulation: .claude/tool-usage.json does not parse and was skipped. It is session scratch that SessionStart rewrites, so it does not block — but if it carried this project's only Qdrant declaration, the requirement is not being seen."   # BL-233-WPB-LEDGER-SKIPPED
   fi
 
   _accum_state=$(accum_requirement_state)

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -605,9 +605,27 @@ _cpg_record_reviewer_attestation() {
 # from the durable record that scripts/track-tool-usage.sh writes. A missing
 # object reads as "" (no stores): a missing key defaulting RESTRICTIVE, which is
 # the inverse of `## BL-221:`.
+# _cpg_accum_record_unreadable — does the durable record exist but not parse?
+#
+# A SEPARATE PREDICATE, not a flag set inside _cpg_accum_last_store. That was the
+# first attempt and it could not work: the caller reads that function through a
+# COMMAND SUBSTITUTION, which is a subshell, so any global it assigns dies with
+# it. Same subshell class that hid a meta-failure in this feature's own mutation
+# harness earlier in this work.
+_cpg_accum_record_unreadable() {
+  [ -f ".claude/process-state.json" ] || return 1
+  command -v jq >/dev/null 2>&1 || return 1
+  if _accum_json_ok ".claude/process-state.json"; then return 1; fi
+  return 0   # BL-233-WPB-RECORD-UNREADABLE
+}
+
 _cpg_accum_last_store() {
   local v
   if [ ! -f ".claude/process-state.json" ] || ! command -v jq >/dev/null 2>&1; then
+    printf ''
+    return 0
+  fi
+  if ! _accum_json_ok ".claude/process-state.json"; then
     printf ''
     return 0
   fi
@@ -772,6 +790,14 @@ _cpg_record_accum_attestation() {
   # operator did exactly what it advised, `head` was never refreshed, and the
   # next run blocked again. Escaping required inventing a NEW reason string —
   # an incentive to write junk reasons, which is the shape `## BL-149:` deletes.
+  # An unparseable record is refused HERE, with the reason named. Reaching this
+  # function with a corrupt file already failed closed — the jq write below
+  # errors and the caller refuses — but the message then said only "could not be
+  # recorded", which does not tell the operator that the file itself is the
+  # problem. Closing the sweep's last real hit.
+  if [ -f "$file" ] && ! _accum_json_ok "$file"; then
+    return 2
+  fi
   if [ -f "$file" ]; then
     cur=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' "$file" 2>/dev/null || printf '')
     cur_head=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].head // ""' "$file" 2>/dev/null || printf '')
@@ -896,7 +922,8 @@ _cpg_check_accumulation() {
   # it cannot be recorded. An escape that leaves no trace is the advisory
   # posture `## BL-233:` exists to replace.
   reason=""
-  if [ -f ".claude/process-state.json" ] && command -v jq >/dev/null 2>&1; then
+  if [ -f ".claude/process-state.json" ] && command -v jq >/dev/null 2>&1 \
+     && _accum_json_ok ".claude/process-state.json"; then
     # `// ""` already collapses null, so no "null" guard follows — it could not fire.
     recorded=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' ".claude/process-state.json" 2>/dev/null || printf '')
     recorded_head=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].head // ""' ".claude/process-state.json" 2>/dev/null || printf '')
@@ -905,7 +932,15 @@ _cpg_check_accumulation() {
     # the operator attests again, or stores something. Without this one attested
     # run permanently disabled the boundary for the rest of the phase.
     if [ -n "$recorded" ] && _cpg_accum_source_since "$recorded_head"; then
-      echo -e "${YELLOW}[WARN]${NC} $label accumulation: the attestation on record (\"$recorded\") no longer covers this tree — ${_ACCUM_STALE_REASON}. Re-attest, or store what changed."   # BL-233-WPB-ATTEST-STALE
+      # printf for the REASON, same as the ATTESTED line below. This one is the
+      # MORE exploitable of the two: that one needs the env var on the current
+      # invocation, this renders from the PERSISTED record on every subsequent
+      # run, through the fully supported workflow. Found by sweeping the class
+      # (`grep -n 'echo -e .*\$' | grep -iE 'reason|recorded|attest'`) after
+      # fixing only the named instance — which is the recurring failure here.
+      printf '%b[WARN]%b %s accumulation: the attestation on record ("' "${YELLOW}" "${NC}" "$label"
+      printf '%s' "$recorded"
+      printf '") no longer covers this tree — %s. Re-attest, or store what changed.\n' "${_ACCUM_STALE_REASON}"   # BL-233-WPB-ATTEST-STALE
       recorded=""
     fi
     reason="$recorded"
@@ -920,7 +955,14 @@ _cpg_check_accumulation() {
 
   if [ -n "$reason" ]; then
     if _cpg_record_accum_attestation "$gate_key" "$reason"; then
-      echo -e "${GREEN}  [OK]${NC} $label accumulation: ATTESTED (reason: $reason) — recorded to .claude/process-state.json, not silenced."
+      # printf %s for the REASON, not echo -e. The reason is operator-supplied,
+      # and `echo -e` interprets \n in it — so an attestation reason could forge
+      # additional "[OK] …" lines into the gate transcript a human or a CI log
+      # skims. The durable record was never at risk (jq --arg stores it
+      # literally); the transcript was.
+      printf '%b  [OK]%b %s accumulation: ATTESTED (reason: ' "${GREEN}" "${NC}" "$label"
+      printf '%s' "$reason"
+      printf ') — recorded to .claude/process-state.json, not silenced.\n'
       return 0
     fi
     echo -e "${RED}[FAIL]${NC} $label accumulation: an attestation was supplied but COULD NOT BE RECORDED to .claude/process-state.json — refusing it."
@@ -928,6 +970,13 @@ _cpg_check_accumulation() {
     return 1   # BL-233-WPB-ATTEST-REFUSE
   fi
 
+  if _cpg_accum_record_unreadable; then
+    # Say which cause. Without this the operator is told to store or attest when
+    # the real problem is a corrupt record — and any attestation already on
+    # record has been silently discarded, so the advice names the wrong thing.
+    echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — .claude/process-state.json exists but is not valid JSON, so neither a store nor an attestation could be read from it. Fix that file first; re-storing or re-attesting will not help until it parses."
+    return 1
+  fi
   echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — source commits since ${prev:-project start}, and NO successful qdrant-store in that window."
   echo "        A retrieval requirement with no accumulation requirement is a ratchet with nothing behind it (## BL-233:)."
   echo "        Store what this phase decided (qdrant-store), then re-run — or attest:"

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -543,6 +543,272 @@ _cpg_record_reviewer_attestation() {
   return "$rc"
 }
 
+# ══ BL-233 WP-B: the ACCUMULATION gate ═════════════════════════════════════
+# WP-A made the RETRIEVAL half score outcomes instead of declarations. Nothing
+# anywhere required that anything was ever WRITTEN for a later session to
+# retrieve, and the entry names the consequence in one line: *a retrieval
+# requirement with no accumulation requirement is a ratchet with nothing behind
+# it.*
+#
+# Karl's decision (2026-08-17): WARN at commit, BLOCK here. Storing is not
+# per-commit work — a commit that produced no insight has nothing to store, and
+# a gate people cannot satisfy honestly is a gate they delete (`## BL-149:`).
+# The phase boundary is where accumulation is genuinely owed, because it is the
+# boundary the memory is supposed to carry across.
+
+# _cpg_accum_required — does THIS PROJECT require memory accumulation?
+#
+# THE SCOPE IN THE LOOP IS LOAD-BEARING AND IS DELIBERATELY NARROWER THAN
+# session-test-gate-check.sh's. That hook reads four settings files, two of them
+# under $HOME. Reading $HOME here would make a phase gate's verdict depend on
+# whose machine ran it: measured on this tree, ZERO of the 29 suites that drive
+# this script at current_phase >= 2 redirect HOME, so a host-derived answer
+# passes on a developer box with Qdrant configured and fails on a runner without
+# it. That is `## BL-234:`'s class — a silent local-vs-CI divergence — and A5/M3
+# in tests/test-bl233-wpb-accumulation.sh pin the narrow scope in both
+# directions.
+#
+# The project-scope files are the better source anyway: init.sh writes
+# .claude/settings.local.json carrying the mcpServers.qdrant entry, the
+# generated .gitignore ignores only .claude/cache/, and the scaffolder's
+# `git add -A` commits it. The declaration is therefore COMMITTED and travels
+# with the repo — unlike .claude/tool-usage.json, which is runtime scratch that
+# a `startup` wipes. Reading the ledger ALONE would have reintroduced
+# `## BL-231:`'s "tracking file absent => no enforcement, silently" row inside a
+# blocking gate, and would have forced 74 fixture edits across 29 suites to say
+# nothing.
+#
+# The ledger is still consulted as an OR arm, for the one case the project file
+# misses: a project initialised without Qdrant that adopted it later.
+# Callers MUST have established that jq is present (see the fail-closed arm in
+# _cpg_check_accumulation). There is deliberately no jq guard here: a guard that
+# returned "not required" on a missing jq would report a PROJECT FACT it never
+# checked, and an arm that cannot be reached is the `## BL-104:` shape.
+_cpg_accum_required() {
+  local _f
+  for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE
+    [ -f "$_f" ] || continue
+    if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
+      return 0
+    fi
+  done
+  if [ -f ".claude/tool-usage.json" ]; then
+    if [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
+      return 0
+    fi
+  fi
+  return 1
+}
+
+# _cpg_accum_last_store — ISO timestamp of the last SUCCESSFUL qdrant-store,
+# from the durable record that scripts/track-tool-usage.sh writes. A missing
+# object reads as "" (no stores): a missing key defaulting RESTRICTIVE, which is
+# the inverse of `## BL-221:`.
+_cpg_accum_last_store() {
+  local v
+  if [ ! -f ".claude/process-state.json" ] || ! command -v jq >/dev/null 2>&1; then
+    printf ''
+    return 0
+  fi
+  v=$(jq -r '.mcp_accumulation.last_store_at // ""' ".claude/process-state.json" 2>/dev/null || printf '')
+  if [ "$v" = "null" ]; then v=""; fi
+  printf '%s' "$v"
+}
+
+# _cpg_accum_after <iso_timestamp> <gate_date> — is the store inside the window?
+#
+# Compared as INTEGERS (YYYYMMDD), never as strings: `[ "$a" \> "$b" ]` is a
+# LOCALE-COLLATED comparison, and this repo has already been bitten by locale on
+# tr/cut. The date halves are sliced with bash parameter expansion rather than
+# tr/cut for the same reason.
+#
+# Same-day counts. gates.* carry a DATE with no time, so a store on the gate's
+# own date cannot be ordered against it — rejecting it would be a coin flip
+# dressed up as a rule.
+_cpg_accum_after() {
+  local ts="$1" gate="$2" a b
+  if [ -z "$ts" ]; then return 1; fi
+  if [ -z "$gate" ]; then return 0; fi
+  a="${ts:0:10}";   a="${a//-/}"
+  b="${gate:0:10}"; b="${b//-/}"
+  case "$a" in ''|*[!0-9]*) return 1 ;; esac
+  case "$b" in ''|*[!0-9]*) return 0 ;; esac
+  [ "$a" -ge "$b" ]
+}
+
+# _cpg_accum_source_work <since_date> — did this phase produce SOURCE commits?
+#
+# Ground truth from git, NOT from a hook-maintained counter. `## BL-239:` — this
+# week — shipped a contributor hook that was a silent no-op on every commit
+# anyone ever made, and a blocking gate that trusts a skippable counter inherits
+# that failure mode wholesale.
+#
+# Returns 0 (source work happened) when it CANNOT TELL: no git, not a repo, or a
+# log that will not read. "Could not measure" must never resolve to "nothing to
+# measure" — `# BL-112-SAST-NOTRUN`'s doctrine, and here also the fail-closed
+# direction.
+#
+# The matches use HERE-STRINGS, not `printf | grep -q`. Under `set -o pipefail`
+# that pipeline returns 141 ON A MATCH once the payload is big enough: grep -q
+# exits the instant it matches, the writer takes SIGPIPE, and pipefail promotes
+# that death over grep's success (`## BL-238:`). Here a spurious 141 would read
+# as "no source work" — the fail-OPEN direction — on exactly the large-history
+# repos where the check matters most.
+_cpg_accum_source_work() {
+  local since="$1" paths
+  if ! command -v git >/dev/null 2>&1; then return 0; fi
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then return 0; fi
+  if [ -n "$since" ]; then
+    paths=$(git log --since="$since" --name-only --pretty=format: 2>/dev/null) || return 0
+  else
+    paths=$(git log --name-only --pretty=format: 2>/dev/null) || return 0
+  fi
+  if grep -qE '\.(py|ts|tsx|js|jsx|rs|go|cs|kt|java|dart|swift|c|cpp|h)$' <<< "$paths"; then
+    return 0
+  fi
+  if grep -qE '^(src|lib|app|pkg|internal|cmd)/' <<< "$paths"; then
+    return 0
+  fi
+  return 1   # BL-233-WPB-SOURCEWORK
+}
+
+# _cpg_record_accum_attestation <gate_key> <reason>
+#   0 — recorded (or idempotent no-op: already recorded with the same reason)
+#   2 — could not write (jq unavailable, lock timeout, unwritable state, jq error)
+# Same atomic-finalize shape as _cpg_record_gate_date and
+# _cpg_record_reviewer_attestation, and the same lock, because all three write
+# .claude/process-state.json and must exclude one another.
+_cpg_record_accum_attestation() {
+  local gate_key="$1" reason="$2"
+  local file=".claude/process-state.json"
+  local today actor lock_dir attempts rc cur
+
+  if ! command -v jq >/dev/null 2>&1; then return 2; fi
+
+  if [ -f "$file" ]; then
+    cur=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' "$file" 2>/dev/null || printf '')
+    if [ "$cur" = "$reason" ]; then return 0; fi
+  else
+    echo '{}' > "$file" 2>/dev/null || return 2
+  fi
+
+  today=$(date +%Y-%m-%d)
+  actor=$(_cpg_gate_actor)
+  lock_dir="$file.lockdir"
+  attempts=0
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    if [ "$attempts" -ge 100 ]; then return 2; fi
+    sleep 0.1
+  done
+
+  rc=0
+  (
+    tmp=$(mktemp "${file}.XXXXXX") || exit 1
+    trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
+    if jq --arg g "$gate_key" --arg reason "$reason" --arg date "$today" --arg by "$actor" \
+          '.mcp_accumulation = ((.mcp_accumulation // {})
+             | .attestations = ((.attestations // {}) + {($g): {reason: $reason, date: $date, by: $by}}))' \
+          "$file" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$file" || exit 1
+      trap - EXIT INT TERM
+      exit 0
+    else
+      rm -f "$tmp"
+      trap - EXIT INT TERM
+      exit 1
+    fi
+  ) || rc=1
+  rmdir "$lock_dir" 2>/dev/null || true
+  if [ "$rc" -ne 0 ]; then return 2; fi
+  return 0
+}
+
+# _cpg_check_accumulation <gate_key> <prev_gate_date> <label>
+#   0 — satisfied, nothing owed, attested, or not applicable
+#   1 — BLOCK
+#
+# This function emits the LABEL and returns the VERDICT together, and
+# _cpg_accum_gate below is the single increment site. `## BL-104:`'s trap is
+# that the [WARN]/[FAIL] text is cosmetic while the exit predicate is
+# `if [ $issues -eq 0 ]`, so two arms printing the same word can have opposite
+# outcomes. Here the label and the increment cannot drift apart, because nothing
+# outside this pair decides either one.
+_cpg_check_accumulation() {
+  local gate_key="$1" prev="$2" label="$3"
+  local last reason recorded
+
+  # FAIL CLOSED on a missing jq, rather than reporting a project fact that was
+  # never read. This is the `degradation` row of `## BL-233:`'s own table —
+  # "absent must fail closed, not exit 0" — and it follows this file's existing
+  # precedent: the Phase 3→4 review gate already degrades to a BLOCKING warn
+  # when the manifest is present but jq is not, rather than silently passing.
+  if ! command -v jq >/dev/null 2>&1; then
+    echo -e "${RED}[FAIL]${NC} $label accumulation: CANNOT BE VERIFIED — jq is unavailable, so neither the requirement nor the durable record can be read."
+    echo "        Install jq. Passing silently here would be the substitution this gate exists to remove: \"could not check\" is not \"nothing to check\"."
+    return 1   # BL-233-WPB-JQ-FAILCLOSED
+  fi
+
+  if ! _cpg_accum_required; then
+    # [NOTE], deliberately NOT [NEXT]. In this file [NEXT] means "belongs to a
+    # later gate and is not counted against this one", and
+    # tests/test-bl166-gate-scope.sh asserts it appears ONLY as the 3→4 scoping
+    # line — a bare run or `--gate phase_3_to_4` emitting any other [NEXT] is a
+    # BL-166 regression. This line means something different: the check did not
+    # apply here.
+    echo -e "${BLUE}  [NOTE]${NC} $label accumulation: NOT CHECKED — this project declares no Qdrant MCP server (no mcpServers.qdrant in .claude/settings.local.json or .claude/settings.json, and no qdrant_required in .claude/tool-usage.json). Nothing is owed here, and nothing was verified."
+    return 0
+  fi
+
+  last=$(_cpg_accum_last_store)
+  if _cpg_accum_after "$last" "$prev"; then
+    echo -e "${GREEN}  [OK]${NC} $label accumulation: satisfied — last successful qdrant-store $last (window opens ${prev:-project start})."
+    return 0
+  fi
+
+  if ! _cpg_accum_source_work "$prev"; then
+    echo -e "${GREEN}  [OK]${NC} $label accumulation: nothing owed — no source commits since ${prev:-project start}."
+    return 0
+  fi
+
+  # Escape hatch in BL-072's shape: attested, durably recorded, and REFUSED if
+  # it cannot be recorded. An escape that leaves no trace is the advisory
+  # posture `## BL-233:` exists to replace.
+  reason=""
+  if [ -f ".claude/process-state.json" ] && command -v jq >/dev/null 2>&1; then
+    recorded=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' ".claude/process-state.json" 2>/dev/null || printf '')
+    if [ "$recorded" != "null" ]; then reason="$recorded"; fi
+  fi
+  if [ "${SOLO_MCP_ACCUM_ATTESTED:-}" = "1" ] && [ -n "${SOLO_MCP_ACCUM_ATTESTED_REASON:-}" ]; then
+    reason="$SOLO_MCP_ACCUM_ATTESTED_REASON"
+  fi
+  # Trim BEFORE the non-empty test so a whitespace-only reason is REJECTED —
+  # an attestation must carry a justification, not blank space (BL-070's
+  # tightener, mirrored).
+  reason=$(printf '%s' "$reason" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+  if [ -n "$reason" ]; then
+    if _cpg_record_accum_attestation "$gate_key" "$reason"; then
+      echo -e "${GREEN}  [OK]${NC} $label accumulation: ATTESTED (reason: $reason) — recorded to .claude/process-state.json, not silenced."
+      return 0
+    fi
+    echo -e "${RED}[FAIL]${NC} $label accumulation: an attestation was supplied but COULD NOT BE RECORDED to .claude/process-state.json — refusing it."
+    echo "        An escape that leaves no trace is not an escape. Make the state file writable (and install jq), then re-run."
+    return 1   # BL-233-WPB-ATTEST-REFUSE
+  fi
+
+  echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — source commits since ${prev:-project start}, and NO successful qdrant-store in that window."
+  echo "        A retrieval requirement with no accumulation requirement is a ratchet with nothing behind it (## BL-233:)."
+  echo "        Store what this phase decided (qdrant-store), then re-run — or attest:"
+  echo "          SOLO_MCP_ACCUM_ATTESTED=1 SOLO_MCP_ACCUM_ATTESTED_REASON=\"<why nothing was worth storing>\" bash scripts/check-phase-gate.sh"
+  return 1
+}
+
+# The ONE increment site for the accumulation gate.
+_cpg_accum_gate() {
+  _cpg_check_accumulation "$1" "$2" "$3" || issues=$((issues + 1))   # BL-233-WPB-BLOCK
+}
+
 gate_0_to_1=$(get_gate_date "phase_0_to_1")
 gate_1_to_2=$(get_gate_date "phase_1_to_2")
 gate_2_to_3=$(get_gate_date "phase_2_to_3")
@@ -1574,6 +1840,25 @@ if [ "$current_phase" -ge 3 ]; then
     issues=$((issues + 1))
   fi
 fi
+
+# ── BL-233 WP-B: accumulation, checked ONCE, for the gate being crossed ────
+# `-eq`, not `-ge`, and the difference from every sibling check in this file is
+# deliberate. The gate-date and artifact checks use `-ge` because their evidence
+# must exist INDEPENDENTLY at each boundary, so all of them firing at phase 4 is
+# correct. Accumulation is not like that: the windows NEST. A store that
+# satisfies "since phase_2_to_3" necessarily satisfies "since phase_1_to_2", so
+# the latest gate's window is the strictest and subsumes the earlier ones.
+# Firing all three would count ONE missing store as THREE inconsistencies and
+# print the same sentence three times.
+#
+# phase_0_to_1 has no arm: Phase 0 is pre-code discovery, it writes no source,
+# and the conditional would never fire anyway — an arm that cannot fire is the
+# `## BL-104:` shape and is better absent than decorative.
+case "$current_phase" in
+  2) _cpg_accum_gate "phase_1_to_2" "$gate_0_to_1" "Phase 1→2" ;;
+  3) _cpg_accum_gate "phase_2_to_3" "$gate_1_to_2" "Phase 2→3" ;;
+  4) _cpg_accum_gate "phase_3_to_4" "$gate_2_to_3" "Phase 3→4" ;;
+esac
 
 # Check: if current_phase >= 4, gate 3→4 should have a date (BL-071: see
 # the Phase 0→1 block for the evidence-first auto-write rationale).

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -16,6 +16,26 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # BL-046: uses run_with_timeout + prompt_yes_no only — source core subset.
 source "$SCRIPT_DIR/lib/helpers-core.sh"
+# BL-233 WP-B: the accumulation predicates the commit-time warning must match.
+#
+# GUARDED, and the degradation is deliberate. Hard-failing here was the first
+# attempt and it was WRONG: a project that predates this lib — every existing
+# install, and every brownfield-adopted tree until it re-syncs — would have had
+# its ENTIRE phase gate killed by a feature it never opted into. Measured: that
+# reds test-walk-phase-lifecycle.sh, test-brownfield-wp3-adoption-arms.sh and
+# test-brownfield-wp3-regenerate-path.sh, all of which model exactly that
+# population.
+#
+# So the ACCUMULATION ARM alone goes unavailable and says so, naming the remedy;
+# every other check in this gate runs untouched. It does NOT count against the
+# gate: a project that never had this feature has not failed it. That is the
+# same shape as the `none` requirement state, for the same reason.
+SOIF_ACCUM_LIB_LOADED=0
+if [ -f "$SCRIPT_DIR/lib/accumulation.sh" ]; then
+  # shellcheck source=scripts/lib/accumulation.sh
+  . "$SCRIPT_DIR/lib/accumulation.sh"
+  SOIF_ACCUM_LIB_LOADED=1
+fi
 # Brownfield adoption WP3 — the in-core enabling arms (the `adopted` flag
 # accessor and the regenerate-path loss detector). Guarded: a checkout that
 # predates adoption simply has no such file, and the arm below no-ops.
@@ -573,64 +593,13 @@ _cpg_record_reviewer_attestation() {
 # requirement was invisible in every fresh clone and the gate blocked on the
 # author's machine while printing NOT CHECKED on CI. The lesson is not "use a
 # different file" — it is that TRACKEDNESS IS A QUESTION FOR GIT, not an
-# inference from an ignore file you happened to read. _cpg_file_tracked asks it.
+# inference from an ignore file you happened to read. accum_file_tracked asks it
+# (scripts/lib/accumulation.sh, shared with the commit-time warning).
 #
 # $HOME is still never read, for the original reason: zero of those 29 fixtures
 # redirect HOME, so a host-derived verdict passes on a developer box with Qdrant
 # configured and fails on a runner without it — `## BL-234:`'s class. A5 and
 # mutant M3 pin the project-only scope in both directions.
-
-# _cpg_file_tracked <path> — does git actually track this file? This is ASKED,
-# never assumed. The first cut of this gate reasoned "init.sh writes
-# .claude/settings.local.json, the generated .gitignore covers only
-# .claude/cache/, and `git add -A` commits it" — and all three clauses were
-# false. Claude Code adds settings.local.json to the user's GLOBAL git excludes
-# by design (it is personal configuration), and templates/generated/gitignore-base.tmpl
-# — which generate_gitignore COPIES before appending — already ignores
-# .claude/tool-usage.json. Both arms were therefore absent from every fresh
-# clone, and the gate reported NOT CHECKED on CI while blocking on the author's
-# machine: BL-231's silent-non-enforcement row, rebuilt inside the gate meant to
-# end it. Asking git is the only answer that cannot rot when an ignore rule
-# changes somewhere else.
-_cpg_file_tracked() {
-  git ls-files --error-unmatch -- "$1" >/dev/null 2>&1   # BL-233-WPB-TRACKED
-}
-
-# _cpg_accum_requirement_state — echoes one of:
-#   tracked   — a declaration git TRACKS says Qdrant is required (survives a clone)
-#   untracked — only an UNTRACKED file says so (true here, invisible on CI)
-#   none      — nothing declares it
-#
-# Three states, not a boolean, because "required" and "required everywhere" are
-# different facts and conflating them is what produced the defect above.
-# Scope stays PROJECT-only — never $HOME — for the reason given on the loop
-# below (`BL-233-WPB-SCOPE`): zero of the 29 suites driving this script at current_phase >= 2 redirect
-# HOME, so a host-derived verdict passes on a developer box and fails on a
-# runner (## BL-234:).
-_cpg_accum_requirement_state() {
-  local _f _tracked_hit=0 _untracked_hit=0
-  # .claude/manifest.json is the TRACKED declaration init.sh writes for exactly
-  # this purpose; it is not covered by the generated .gitignore.
-  if [ -f ".claude/manifest.json" ] && \
-     [ "$(jq -r '.mcp.qdrant_required // false' ".claude/manifest.json" 2>/dev/null)" = "true" ]; then
-    if _cpg_file_tracked ".claude/manifest.json"; then _tracked_hit=1; else _untracked_hit=1; fi
-  fi
-  for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE
-    [ -f "$_f" ] || continue
-    if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
-      if _cpg_file_tracked "$_f"; then _tracked_hit=1; else _untracked_hit=1; fi
-    fi
-  done
-  if [ -f ".claude/tool-usage.json" ]; then
-    if [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
-      if _cpg_file_tracked ".claude/tool-usage.json"; then _tracked_hit=1; else _untracked_hit=1; fi
-    fi
-  fi
-  if [ "$_tracked_hit" -eq 1 ]; then printf 'tracked'; return 0; fi
-  if [ "$_untracked_hit" -eq 1 ]; then printf 'untracked'; return 0; fi
-  printf 'none'
-  return 0
-}
 
 # _cpg_accum_last_store — ISO timestamp of the last SUCCESSFUL qdrant-store,
 # from the durable record that scripts/track-tool-usage.sh writes. A missing
@@ -669,16 +638,6 @@ _cpg_accum_after() {
   case "$a" in ''|*[!0-9]*) return 1 ;; esac
   [ "$a" -ge "$b" ]
 }
-
-# ONE exempt set, shared by both source-work classifiers and mirrored from this
-# repo's own docs-only rule (process-checklist.sh's
-# `\.(md|json|yml|yaml|toml|tmpl)$` plus _is_dep_manifest). Two copies would
-# drift, and a drifted classifier is how the allow-list version of this check
-# silently exempted Ruby, PHP, shell, Vue, Elixir, SQL and Scala.
-# The `^$` alternative is load-bearing: `git log --name-only --pretty=format:`
-# emits a BLANK LINE between commits, and a blank line matches no extension —
-# without excluding it every window would look like source work.
-_ACCUM_EXEMPT_RE='^$|\.(md|json|yml|yaml|toml|tmpl)$|(^|/)(Pipfile|Gemfile|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|Package\.resolved|gradle\.lockfile|requirements(-[^/]*)?\.txt)$'   # BL-233-WPB-EXEMPT-SET
 
 # _cpg_accum_source_work <since_date> — did this phase produce SOURCE commits?
 #
@@ -724,7 +683,7 @@ _cpg_accum_source_work() {
   # The `^$` alternative is load-bearing: `git log --name-only --pretty=format:`
   # emits a BLANK LINE between commits, and a blank line matches no extension —
   # without excluding it, every window would look like source work.
-  if grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$paths"; then   # BL-233-WPB-SOURCE-NEGATION
+  if accum_paths_have_source "$paths"; then
     return 0
   fi
   return 1   # BL-233-WPB-SOURCEWORK
@@ -736,14 +695,46 @@ _cpg_accum_source_work() {
 # direction is correct ONLY here: this decides whether an attestation already on
 # record has gone stale, and inventing staleness would re-block work the
 # operator legitimately excused.
+# Returns 0 = "the attestation no longer covers the tree" (stale), 1 = still
+# covers it.
+#
+# IT FAILS CLOSED, and it says why. The first version returned 1 (still valid)
+# for an empty, malformed, tampered or garbage-collected `head` — so ANY
+# unresolvable value silently restored the permanent bypass this check was added
+# to remove, reachable by editing one JSON field OR by an ordinary
+# `git gc --prune=now`. Its twin `_cpg_accum_source_work`, written in the same
+# commit, fails CLOSED on the identical question and cites
+# `# BL-112-SAST-NOTRUN` for doing so: "could not measure" must never resolve to
+# "nothing to measure". This one now agrees with it.
+#
+# The one genuinely permissive arm is "no git at all": there is no history to
+# compare against, so staleness is not a question that can be asked.
+_ACCUM_STALE_REASON=""
 _cpg_accum_source_since() {
   local sha="$1" paths
-  if [ -z "$sha" ]; then return 1; fi
+  _ACCUM_STALE_REASON="source work has landed since the attested commit"
   if ! command -v git >/dev/null 2>&1; then return 1; fi
   if ! git rev-parse --git-dir >/dev/null 2>&1; then return 1; fi
-  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then return 1; fi
-  paths=$(git log "${sha}..HEAD" --name-only --pretty=format: 2>/dev/null) || return 1
-  if grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$paths"; then
+  # In a repo, an unresolvable commit means the record cannot be trusted.
+  # The two causes are reported SEPARATELY. An earlier rewrite merged them into
+  # one sentence and the operator could no longer tell whether the recorded
+  # commit had vanished (history rewritten, gc'd, record tampered) or whether
+  # work had simply landed after it — which are different problems with
+  # different remedies.
+  if [ -z "$sha" ]; then
+    _ACCUM_STALE_REASON="no commit was recorded with it"
+    return 0   # BL-233-WPB-STALE-FAILCLOSED
+  fi
+  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then
+    _ACCUM_STALE_REASON="the commit it named ($sha) is not reachable in this repository"
+    return 0
+  fi
+  paths=$(git log "${sha}..HEAD" --name-only --pretty=format: 2>/dev/null) || {
+    _ACCUM_STALE_REASON="the history since $sha could not be read"
+    return 0
+  }
+  _ACCUM_STALE_REASON="source work has landed since $sha"
+  if accum_paths_have_source "$paths"; then
     return 0
   fi
   return 1
@@ -763,23 +754,34 @@ _cpg_accum_source_since() {
 _cpg_record_accum_attestation() {
   local gate_key="$1" reason="$2"
   local file=".claude/process-state.json"
-  local today actor lock_dir attempts rc cur _att_head
+  local today actor lock_dir attempts rc cur cur_head _att_head
 
   if ! command -v jq >/dev/null 2>&1; then return 2; fi
 
+  # The commit this attestation EXCUSES. An escape that never expires is a
+  # permanent bypass: without it one attested run would excuse every future
+  # source commit in the phase. BL-072's TDD attestation is scoped per commit
+  # and session-mcp-gate.sh's must be re-exported per session; this is the
+  # phase-gate equivalent. Computed BEFORE the idempotence check, which reads it.
+  _att_head=$(git rev-parse HEAD 2>/dev/null || printf '')
+
+  # IDEMPOTENCE IS NOW HEAD-SENSITIVE. This early return once compared the reason
+  # alone, which was safe while the record held only {reason,date,by}. Adding
+  # `head` made the record COMMIT-DEPENDENT, and the unchanged early return then
+  # made re-attesting with the same reason a NO-OP: the stale warning fired, the
+  # operator did exactly what it advised, `head` was never refreshed, and the
+  # next run blocked again. Escaping required inventing a NEW reason string —
+  # an incentive to write junk reasons, which is the shape `## BL-149:` deletes.
   if [ -f "$file" ]; then
     cur=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' "$file" 2>/dev/null || printf '')
-    if [ "$cur" = "$reason" ]; then return 0; fi
+    cur_head=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].head // ""' "$file" 2>/dev/null || printf '')
+    if [ "$cur" = "$reason" ] && [ -n "$cur_head" ] && [ "$cur_head" = "$_att_head" ]; then
+      return 0   # BL-233-WPB-ATTEST-IDEMPOTENT
+    fi
   fi
 
   today=$(date +%Y-%m-%d)
   actor=$(_cpg_gate_actor)
-  # The commit this attestation EXCUSED. An escape that never expires is a
-  # permanent bypass: without it, one attested run would excuse every future
-  # source commit in the phase. BL-072's TDD attestation is scoped per commit
-  # and session-mcp-gate.sh's must be re-exported per session; this is the
-  # phase-gate equivalent.
-  _att_head=$(git rev-parse HEAD 2>/dev/null || printf '')
   lock_dir="$file.lockdir"
   attempts=0
   while ! mkdir "$lock_dir" 2>/dev/null; do
@@ -836,13 +838,19 @@ _cpg_check_accumulation() {
   # "absent must fail closed, not exit 0" — and it follows this file's existing
   # precedent: the Phase 3→4 review gate already degrades to a BLOCKING warn
   # when the manifest is present but jq is not, rather than silently passing.
+  if [ "$SOIF_ACCUM_LIB_LOADED" != "1" ]; then
+    echo -e "${BLUE}  [NOTE]${NC} $label accumulation: NOT CHECKED — scripts/lib/accumulation.sh is absent, so this project predates the accumulation gate or its install is incomplete. Not counted against the gate."
+    echo "        Enable it: bash scripts/upgrade-project.sh --sync-framework"
+    return 0
+  fi
+
   if ! command -v jq >/dev/null 2>&1; then
     echo -e "${RED}[FAIL]${NC} $label accumulation: CANNOT BE VERIFIED — jq is unavailable, so neither the requirement nor the durable record can be read."
     echo "        Install jq. Passing silently here would be the substitution this gate exists to remove: \"could not check\" is not \"nothing to check\"."
     return 1   # BL-233-WPB-JQ-FAILCLOSED
   fi
 
-  _accum_state=$(_cpg_accum_requirement_state)
+  _accum_state=$(accum_requirement_state)
   if [ "$_accum_state" = "none" ]; then
     # [NOTE], deliberately NOT [NEXT]. In this file [NEXT] means "belongs to a
     # later gate and is not counted against this one", and
@@ -887,8 +895,8 @@ _cpg_check_accumulation() {
     # follows it. If source work landed after the commit it named, it is STALE:
     # the operator attests again, or stores something. Without this one attested
     # run permanently disabled the boundary for the rest of the phase.
-    if [ -n "$recorded" ] && [ -n "$recorded_head" ] && _cpg_accum_source_since "$recorded_head"; then
-      echo -e "${YELLOW}[WARN]${NC} $label accumulation: the attestation on record (\"$recorded\") named commit ${recorded_head}, and source work has landed since. It does not excuse that work."   # BL-233-WPB-ATTEST-STALE
+    if [ -n "$recorded" ] && _cpg_accum_source_since "$recorded_head"; then
+      echo -e "${YELLOW}[WARN]${NC} $label accumulation: the attestation on record (\"$recorded\") no longer covers this tree — ${_ACCUM_STALE_REASON}. Re-attest, or store what changed."   # BL-233-WPB-ATTEST-STALE
       recorded=""
     fi
     reason="$recorded"

--- a/scripts/check-phase-gate.sh
+++ b/scripts/check-phase-gate.sh
@@ -556,48 +556,80 @@ _cpg_record_reviewer_attestation() {
 # The phase boundary is where accumulation is genuinely owed, because it is the
 # boundary the memory is supposed to carry across.
 
-# _cpg_accum_required — does THIS PROJECT require memory accumulation?
+# WHERE THE REQUIREMENT COMES FROM — the decision most likely to be re-litigated.
 #
-# THE SCOPE IN THE LOOP IS LOAD-BEARING AND IS DELIBERATELY NARROWER THAN
-# session-test-gate-check.sh's. That hook reads four settings files, two of them
-# under $HOME. Reading $HOME here would make a phase gate's verdict depend on
-# whose machine ran it: measured on this tree, ZERO of the 29 suites that drive
-# this script at current_phase >= 2 redirect HOME, so a host-derived answer
-# passes on a developer box with Qdrant configured and fails on a runner without
-# it. That is `## BL-234:`'s class — a silent local-vs-CI divergence — and A5/M3
-# in tests/test-bl233-wpb-accumulation.sh pin the narrow scope in both
-# directions.
+# Reading it from .claude/tool-usage.json is the obvious answer and is wrong
+# twice: the ledger is untracked runtime scratch that `startup` wipes, so
+# deleting it would switch a blocking gate off (`## BL-231:`); and of the 61
+# suites that name check-phase-gate.sh under tests/, 29 drive it at
+# current_phase >= 2 across 74 fixture-creation sites and NOT ONE writes a
+# ledger, so a ledger-derived requirement would have forced 74 fixture edits to
+# say nothing.
 #
-# The project-scope files are the better source anyway: init.sh writes
-# .claude/settings.local.json carrying the mcpServers.qdrant entry, the
-# generated .gitignore ignores only .claude/cache/, and the scaffolder's
-# `git add -A` commits it. The declaration is therefore COMMITTED and travels
-# with the repo — unlike .claude/tool-usage.json, which is runtime scratch that
-# a `startup` wipes. Reading the ledger ALONE would have reintroduced
-# `## BL-231:`'s "tracking file absent => no enforcement, silently" row inside a
-# blocking gate, and would have forced 74 fixture edits across 29 suites to say
-# nothing.
+# The first fix for that read .claude/settings.local.json instead, on the
+# reasoning that init.sh writes it and `git add -A` commits it. THAT WAS ALSO
+# WRONG, and worse, because it looked committed: Claude Code adds
+# settings.local.json to the user's GLOBAL git excludes by design, so the
+# requirement was invisible in every fresh clone and the gate blocked on the
+# author's machine while printing NOT CHECKED on CI. The lesson is not "use a
+# different file" — it is that TRACKEDNESS IS A QUESTION FOR GIT, not an
+# inference from an ignore file you happened to read. _cpg_file_tracked asks it.
 #
-# The ledger is still consulted as an OR arm, for the one case the project file
-# misses: a project initialised without Qdrant that adopted it later.
-# Callers MUST have established that jq is present (see the fail-closed arm in
-# _cpg_check_accumulation). There is deliberately no jq guard here: a guard that
-# returned "not required" on a missing jq would report a PROJECT FACT it never
-# checked, and an arm that cannot be reached is the `## BL-104:` shape.
-_cpg_accum_required() {
-  local _f
+# $HOME is still never read, for the original reason: zero of those 29 fixtures
+# redirect HOME, so a host-derived verdict passes on a developer box with Qdrant
+# configured and fails on a runner without it — `## BL-234:`'s class. A5 and
+# mutant M3 pin the project-only scope in both directions.
+
+# _cpg_file_tracked <path> — does git actually track this file? This is ASKED,
+# never assumed. The first cut of this gate reasoned "init.sh writes
+# .claude/settings.local.json, the generated .gitignore covers only
+# .claude/cache/, and `git add -A` commits it" — and all three clauses were
+# false. Claude Code adds settings.local.json to the user's GLOBAL git excludes
+# by design (it is personal configuration), and templates/generated/gitignore-base.tmpl
+# — which generate_gitignore COPIES before appending — already ignores
+# .claude/tool-usage.json. Both arms were therefore absent from every fresh
+# clone, and the gate reported NOT CHECKED on CI while blocking on the author's
+# machine: BL-231's silent-non-enforcement row, rebuilt inside the gate meant to
+# end it. Asking git is the only answer that cannot rot when an ignore rule
+# changes somewhere else.
+_cpg_file_tracked() {
+  git ls-files --error-unmatch -- "$1" >/dev/null 2>&1   # BL-233-WPB-TRACKED
+}
+
+# _cpg_accum_requirement_state — echoes one of:
+#   tracked   — a declaration git TRACKS says Qdrant is required (survives a clone)
+#   untracked — only an UNTRACKED file says so (true here, invisible on CI)
+#   none      — nothing declares it
+#
+# Three states, not a boolean, because "required" and "required everywhere" are
+# different facts and conflating them is what produced the defect above.
+# Scope stays PROJECT-only — never $HOME — for the reason given on the loop
+# below (`BL-233-WPB-SCOPE`): zero of the 29 suites driving this script at current_phase >= 2 redirect
+# HOME, so a host-derived verdict passes on a developer box and fails on a
+# runner (## BL-234:).
+_cpg_accum_requirement_state() {
+  local _f _tracked_hit=0 _untracked_hit=0
+  # .claude/manifest.json is the TRACKED declaration init.sh writes for exactly
+  # this purpose; it is not covered by the generated .gitignore.
+  if [ -f ".claude/manifest.json" ] && \
+     [ "$(jq -r '.mcp.qdrant_required // false' ".claude/manifest.json" 2>/dev/null)" = "true" ]; then
+    if _cpg_file_tracked ".claude/manifest.json"; then _tracked_hit=1; else _untracked_hit=1; fi
+  fi
   for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE
     [ -f "$_f" ] || continue
     if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
-      return 0
+      if _cpg_file_tracked "$_f"; then _tracked_hit=1; else _untracked_hit=1; fi
     fi
   done
   if [ -f ".claude/tool-usage.json" ]; then
     if [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
-      return 0
+      if _cpg_file_tracked ".claude/tool-usage.json"; then _tracked_hit=1; else _untracked_hit=1; fi
     fi
   fi
-  return 1
+  if [ "$_tracked_hit" -eq 1 ]; then printf 'tracked'; return 0; fi
+  if [ "$_untracked_hit" -eq 1 ]; then printf 'untracked'; return 0; fi
+  printf 'none'
+  return 0
 }
 
 # _cpg_accum_last_store — ISO timestamp of the last SUCCESSFUL qdrant-store,
@@ -631,10 +663,22 @@ _cpg_accum_after() {
   if [ -z "$gate" ]; then return 0; fi
   a="${ts:0:10}";   a="${a//-/}"
   b="${gate:0:10}"; b="${b//-/}"
+  # Only $a is guarded: $b is get_gate_date output, which that function already
+  # regex-validates to YYYY-MM-DD or "" — and "" returned above. A guard here
+  # could not fire, and an arm that cannot fire is the `## BL-104:` shape.
   case "$a" in ''|*[!0-9]*) return 1 ;; esac
-  case "$b" in ''|*[!0-9]*) return 0 ;; esac
   [ "$a" -ge "$b" ]
 }
+
+# ONE exempt set, shared by both source-work classifiers and mirrored from this
+# repo's own docs-only rule (process-checklist.sh's
+# `\.(md|json|yml|yaml|toml|tmpl)$` plus _is_dep_manifest). Two copies would
+# drift, and a drifted classifier is how the allow-list version of this check
+# silently exempted Ruby, PHP, shell, Vue, Elixir, SQL and Scala.
+# The `^$` alternative is load-bearing: `git log --name-only --pretty=format:`
+# emits a BLANK LINE between commits, and a blank line matches no extension —
+# without excluding it every window would look like source work.
+_ACCUM_EXEMPT_RE='^$|\.(md|json|yml|yaml|toml|tmpl)$|(^|/)(Pipfile|Gemfile|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|Package\.resolved|gradle\.lockfile|requirements(-[^/]*)?\.txt)$'   # BL-233-WPB-EXEMPT-SET
 
 # _cpg_accum_source_work <since_date> — did this phase produce SOURCE commits?
 #
@@ -663,37 +707,79 @@ _cpg_accum_source_work() {
   else
     paths=$(git log --name-only --pretty=format: 2>/dev/null) || return 0
   fi
-  if grep -qE '\.(py|ts|tsx|js|jsx|rs|go|cs|kt|java|dart|swift|c|cpp|h)$' <<< "$paths"; then
-    return 0
-  fi
-  if grep -qE '^(src|lib|app|pkg|internal|cmd)/' <<< "$paths"; then
+  # SOURCE IS DEFINED BY NEGATION, matching this repo's own docs-only classifier
+  # (process-checklist.sh's `\.(md|json|yml|yaml|toml|tmpl)$` plus _is_dep_manifest).
+  # The first cut used an extension ALLOW-LIST lifted from pre-commit-gate.sh's
+  # HAS_SOURCE check — ~14 extensions — and a Ruby, PHP, shell, Vue, Elixir, SQL
+  # or Scala project therefore sailed through this gate AND was told
+  # "no source commits since <date>", an affirmative claim about the project
+  # that was false. That is the same substitution the jq arm above was rewritten
+  # to avoid. In its original home the allow-list only gated a WARNING; reusing
+  # it in a BLOCKING position is what made the gap consequential.
+  #
+  # Over-eager is the correct direction here: a commit touching only .gitignore
+  # now counts as source work, which asks for a memory store that may not be
+  # owed. Under-eager silently voids the gate, which is the defect being fixed.
+  #
+  # The `^$` alternative is load-bearing: `git log --name-only --pretty=format:`
+  # emits a BLANK LINE between commits, and a blank line matches no extension —
+  # without excluding it, every window would look like source work.
+  if grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$paths"; then   # BL-233-WPB-SOURCE-NEGATION
     return 0
   fi
   return 1   # BL-233-WPB-SOURCEWORK
 }
 
+# _cpg_accum_source_since <sha> — source work committed after <sha>?
+# Same classifier as _cpg_accum_source_work, over a commit RANGE instead of a
+# date. Returns 1 (no source work) when it CANNOT tell, and that permissive
+# direction is correct ONLY here: this decides whether an attestation already on
+# record has gone stale, and inventing staleness would re-block work the
+# operator legitimately excused.
+_cpg_accum_source_since() {
+  local sha="$1" paths
+  if [ -z "$sha" ]; then return 1; fi
+  if ! command -v git >/dev/null 2>&1; then return 1; fi
+  if ! git rev-parse --git-dir >/dev/null 2>&1; then return 1; fi
+  if ! git cat-file -e "${sha}^{commit}" 2>/dev/null; then return 1; fi
+  paths=$(git log "${sha}..HEAD" --name-only --pretty=format: 2>/dev/null) || return 1
+  if grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$paths"; then
+    return 0
+  fi
+  return 1
+}
+
 # _cpg_record_accum_attestation <gate_key> <reason>
 #   0 — recorded (or idempotent no-op: already recorded with the same reason)
 #   2 — could not write (jq unavailable, lock timeout, unwritable state, jq error)
-# Same atomic-finalize shape as _cpg_record_gate_date and
-# _cpg_record_reviewer_attestation, and the same lock, because all three write
-# .claude/process-state.json and must exclude one another.
+# Same atomic-finalize shape as _cpg_record_gate_date, and the same lock as
+# _cpg_record_reviewer_attestation — which is the ONE other locked writer of
+# .claude/process-state.json. (_cpg_record_gate_date writes phase-state.json
+# under its own lock; an earlier draft of this comment claimed all three shared
+# a lock, which was false.) Note that pre-commit-gate.sh's tdd_record_attestation
+# and check-gate.sh's protection repair both read-modify-write this same file
+# WITHOUT a lock, so exclusion here is partial; a lost update drops
+# last_store_at, which blocks rather than passes.
 _cpg_record_accum_attestation() {
   local gate_key="$1" reason="$2"
   local file=".claude/process-state.json"
-  local today actor lock_dir attempts rc cur
+  local today actor lock_dir attempts rc cur _att_head
 
   if ! command -v jq >/dev/null 2>&1; then return 2; fi
 
   if [ -f "$file" ]; then
     cur=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' "$file" 2>/dev/null || printf '')
     if [ "$cur" = "$reason" ]; then return 0; fi
-  else
-    echo '{}' > "$file" 2>/dev/null || return 2
   fi
 
   today=$(date +%Y-%m-%d)
   actor=$(_cpg_gate_actor)
+  # The commit this attestation EXCUSED. An escape that never expires is a
+  # permanent bypass: without it, one attested run would excuse every future
+  # source commit in the phase. BL-072's TDD attestation is scoped per commit
+  # and session-mcp-gate.sh's must be re-exported per session; this is the
+  # phase-gate equivalent.
+  _att_head=$(git rev-parse HEAD 2>/dev/null || printf '')
   lock_dir="$file.lockdir"
   attempts=0
   while ! mkdir "$lock_dir" 2>/dev/null; do
@@ -702,13 +788,19 @@ _cpg_record_accum_attestation() {
     sleep 0.1
   done
 
+  # Created INSIDE the lock. The tracker's writer already did this; this one
+  # created it outside, so a concurrent writer could observe a half-built file.
+  if [ ! -f "$file" ]; then
+    echo '{}' > "$file" 2>/dev/null || { rmdir "$lock_dir" 2>/dev/null; return 2; }
+  fi
+
   rc=0
   (
     tmp=$(mktemp "${file}.XXXXXX") || exit 1
     trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
-    if jq --arg g "$gate_key" --arg reason "$reason" --arg date "$today" --arg by "$actor" \
+    if jq --arg g "$gate_key" --arg reason "$reason" --arg date "$today" --arg by "$actor" --arg head "$_att_head" \
           '.mcp_accumulation = ((.mcp_accumulation // {})
-             | .attestations = ((.attestations // {}) + {($g): {reason: $reason, date: $date, by: $by}}))' \
+             | .attestations = ((.attestations // {}) + {($g): {reason: $reason, date: $date, by: $by, head: $head}}))' \
           "$file" > "$tmp" 2>/dev/null; then
       mv "$tmp" "$file" || exit 1
       trap - EXIT INT TERM
@@ -736,7 +828,8 @@ _cpg_record_accum_attestation() {
 # outside this pair decides either one.
 _cpg_check_accumulation() {
   local gate_key="$1" prev="$2" label="$3"
-  local last reason recorded
+  local last reason recorded recorded_head
+  local _accum_state
 
   # FAIL CLOSED on a missing jq, rather than reporting a project fact that was
   # never read. This is the `degradation` row of `## BL-233:`'s own table —
@@ -749,15 +842,26 @@ _cpg_check_accumulation() {
     return 1   # BL-233-WPB-JQ-FAILCLOSED
   fi
 
-  if ! _cpg_accum_required; then
+  _accum_state=$(_cpg_accum_requirement_state)
+  if [ "$_accum_state" = "none" ]; then
     # [NOTE], deliberately NOT [NEXT]. In this file [NEXT] means "belongs to a
     # later gate and is not counted against this one", and
     # tests/test-bl166-gate-scope.sh asserts it appears ONLY as the 3→4 scoping
     # line — a bare run or `--gate phase_3_to_4` emitting any other [NEXT] is a
     # BL-166 regression. This line means something different: the check did not
     # apply here.
-    echo -e "${BLUE}  [NOTE]${NC} $label accumulation: NOT CHECKED — this project declares no Qdrant MCP server (no mcpServers.qdrant in .claude/settings.local.json or .claude/settings.json, and no qdrant_required in .claude/tool-usage.json). Nothing is owed here, and nothing was verified."
+    echo -e "${BLUE}  [NOTE]${NC} $label accumulation: NOT CHECKED — this project declares no Qdrant MCP server that git tracks (.claude/manifest.json has no .mcp.qdrant_required, and no tracked .claude/settings*.json names mcpServers.qdrant). Nothing is owed here, and nothing was verified."
+    echo "        If this project DOES use Qdrant, record it where a clone can see it:"
+    echo "          jq '.mcp.qdrant_required = true' .claude/manifest.json"
     return 0
+  fi
+  if [ "$_accum_state" = "untracked" ]; then
+    # Enforce, but say plainly that the enforcement is local-only. Blocking here
+    # would fail every project that predates the manifest field; staying silent
+    # would repeat the defect. The operator is told exactly how to make it
+    # survive a clone.
+    echo -e "${YELLOW}[WARN]${NC} $label accumulation: the Qdrant requirement is declared ONLY in a file git does not track (.claude/settings.local.json is in Claude Code's global excludes; .claude/tool-usage.json is in the generated .gitignore). Enforcing it HERE, but a fresh clone or CI runner will not see it."
+    echo "        Make it durable: jq '.mcp.qdrant_required = true' .claude/manifest.json   (and commit it)"
   fi
 
   last=$(_cpg_accum_last_store)
@@ -767,7 +871,7 @@ _cpg_check_accumulation() {
   fi
 
   if ! _cpg_accum_source_work "$prev"; then
-    echo -e "${GREEN}  [OK]${NC} $label accumulation: nothing owed — no source commits since ${prev:-project start}."
+    echo -e "${GREEN}  [OK]${NC} $label accumulation: nothing owed — every change since ${prev:-project start} was documentation, config or a dependency manifest."
     return 0
   fi
 
@@ -776,8 +880,18 @@ _cpg_check_accumulation() {
   # posture `## BL-233:` exists to replace.
   reason=""
   if [ -f ".claude/process-state.json" ] && command -v jq >/dev/null 2>&1; then
+    # `// ""` already collapses null, so no "null" guard follows — it could not fire.
     recorded=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].reason // ""' ".claude/process-state.json" 2>/dev/null || printf '')
-    if [ "$recorded" != "null" ]; then reason="$recorded"; fi
+    recorded_head=$(jq -r --arg g "$gate_key" '.mcp_accumulation.attestations[$g].head // ""' ".claude/process-state.json" 2>/dev/null || printf '')
+    # An attestation excuses the work it was written for, NOT everything that
+    # follows it. If source work landed after the commit it named, it is STALE:
+    # the operator attests again, or stores something. Without this one attested
+    # run permanently disabled the boundary for the rest of the phase.
+    if [ -n "$recorded" ] && [ -n "$recorded_head" ] && _cpg_accum_source_since "$recorded_head"; then
+      echo -e "${YELLOW}[WARN]${NC} $label accumulation: the attestation on record (\"$recorded\") named commit ${recorded_head}, and source work has landed since. It does not excuse that work."   # BL-233-WPB-ATTEST-STALE
+      recorded=""
+    fi
+    reason="$recorded"
   fi
   if [ "${SOLO_MCP_ACCUM_ATTESTED:-}" = "1" ] && [ -n "${SOLO_MCP_ACCUM_ATTESTED_REASON:-}" ]; then
     reason="$SOLO_MCP_ACCUM_ATTESTED_REASON"
@@ -1850,6 +1964,15 @@ fi
 # the latest gate's window is the strictest and subsumes the earlier ones.
 # Firing all three would count ONE missing store as THREE inconsistencies and
 # print the same sentence three times.
+#
+# THE NESTING ARGUMENT COVERS THE STORE HALF ONLY, and the difference is a real
+# limit rather than a proof: `_cpg_accum_source_work` is evaluated over the
+# NARROW window too, so an earlier phase's unpaid debt is not re-litigated once
+# that boundary is behind you. A phase-2 project that committed source and
+# stored nothing blocks at 1→2; advance it to phase 3 and the 2→3 arm reports
+# "nothing owed" if phase 3 itself committed only docs. Running
+# `--gate phase_1_to_2` still finds it. This is deliberate — a passed gate is
+# passed — but it is a limit, not something the nesting claim establishes.
 #
 # phase_0_to_1 has no arm: Phase 0 is pre-code discovery, it writes no source,
 # and the conditional would never fire anyway — an arm that cannot fire is the

--- a/scripts/lib/accumulation.sh
+++ b/scripts/lib/accumulation.sh
@@ -23,7 +23,8 @@
 #                      with one, and a blank line matches no extension
 #   docs extensions    md/markdown/rst/adoc/txt/tmpl
 #   dep manifests      a SUPERSET of _is_dep_manifest: its entries plus the
-#                      ecosystems it predates (uv, mix, flake, deno, bun,
+#                      ecosystems it predates (uv, mix, flake, deno, bun —
+#                      BOTH `bun.lock` and the pre-1.2 binary `bun.lockb`,
 #                      Podfile, Gopkg). A lockfile bump is not an insight
 #   project metadata   package.json, pyproject.toml, tsconfig.json, …
 #   dotfile rc files   .eslintrc, .prettierrc.yaml, …
@@ -38,7 +39,7 @@
 # bypass answers a different question (does this commit need a Build Loop entry)
 # than this gate does (did this phase produce knowledge worth storing).
 # Unrecognised structured data therefore fails CLOSED.
-_ACCUM_EXEMPT_RE='^$|\.(md|markdown|rst|adoc|txt|tmpl)$|(^|/)(Pipfile(\.lock)?|Gemfile(\.lock)?|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|pnpm-lock\.yaml|pubspec\.lock|uv\.lock|mix\.lock|flake\.lock|deno\.lock|bun\.lockb|Podfile\.lock|Gopkg\.lock|Package\.resolved|gradle\.lockfile|package-lock\.json|npm-shrinkwrap\.json|packages\.lock\.json|composer\.lock|requirements([-_][^/]*)?\.txt)$|(^|/)(package\.json|composer\.json|tsconfig([.-][^/]*)?\.json|jsconfig\.json|pyproject\.toml|Cargo\.toml|renovate\.json)$|(^|/)\.[A-Za-z0-9_-]+rc(\.(json|ya?ml|toml))?$|(^|/)\.claude/[^/]*\.json$|(^|/)(\.gitignore|\.gitattributes|\.dockerignore|\.editorconfig|\.gitkeep|LICENSE|LICENCE|NOTICE|CODEOWNERS|README|CHANGELOG|AUTHORS|CONTRIBUTING)$'   # BL-233-WPB-EXEMPT-SET
+_ACCUM_EXEMPT_RE='^$|\.(md|markdown|rst|adoc|txt|tmpl)$|(^|/)(Pipfile(\.lock)?|Gemfile(\.lock)?|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|pnpm-lock\.yaml|pubspec\.lock|uv\.lock|mix\.lock|flake\.lock|deno\.lock|bun\.lock(b)?|Podfile\.lock|Gopkg\.lock|Package\.resolved|gradle\.lockfile|package-lock\.json|npm-shrinkwrap\.json|packages\.lock\.json|composer\.lock|requirements([-_][^/]*)?\.txt)$|(^|/)(package\.json|composer\.json|tsconfig([.-][^/]*)?\.json|jsconfig\.json|pyproject\.toml|Cargo\.toml|renovate\.json)$|(^|/)\.[A-Za-z0-9_-]+rc(\.(json|ya?ml|toml))?$|(^|/)\.claude/[^/]*\.json$|(^|/)(\.gitignore|\.gitattributes|\.dockerignore|\.editorconfig|\.gitkeep|LICENSE|LICENCE|NOTICE|CODEOWNERS|README|CHANGELOG|AUTHORS|CONTRIBUTING)$'   # BL-233-WPB-EXEMPT-SET
 
 # accum_paths_have_source <newline-separated-paths> — 0 if any path is source.
 # A HERE-STRING, never `printf | grep -q`: under `set -o pipefail` that pipeline
@@ -75,41 +76,71 @@ accum_file_tracked() {
 # A FOURTH state, `unreadable`, exists because a corrupt declaration must not
 # fold into `none`. `none` says "this project declares no Qdrant MCP server" —
 # a claim about CONTENT — and a file that will not parse has had its content
-# read by nobody. One missing brace in .claude/manifest.json silently turned the
-# gate off while asserting a fact it never established: the same
-# could-not-measure/nothing-to-measure substitution `# BL-233-WPB-STALE-FAILCLOSED`
-# was added to remove, one function away.
+# read by nobody. One missing brace silently turned the gate off while asserting
+# a fact it never established.
+#
+# ALL THREE declaration files get the check. The first cut guarded manifest.json
+# and settings*.json and forgot the ledger — the same defect in one of the three
+# places it lives, which is this work's recurring failure: fixing the named
+# instance instead of the class. `scripts/validate.sh` already warns that
+# tool-usage.json is unparseable in practice, so the case is real, not theoretical.
+#
+# `jq -e 'true'` — and neither of the two obvious alternatives.
+#   `jq -e .`     tests the DOCUMENT's truthiness, so valid JSON `null`/`false`
+#                 read as corrupt. That was the reported bug.
+#   `jq empty`    succeeds on a file holding ZERO documents, so a zero-byte or
+#                 whitespace-only file reads as VALID — the fix for the first
+#                 bug opened a fail-OPEN hole in its place. A truncated write, a
+#                 full disk, or a `>` redirect that died all produce that file.
+# A constant filter asks the only question that matters — did the parse RUN —
+# and never consults the document's own value.
+# Public alias: consumers outside this file call accum_json_readable. Same
+# function; the leading-underscore name stays for the internal call sites.
+accum_json_readable() {
+  _accum_json_ok "$1"
+}
+
+_accum_json_ok() {
+  jq -e 'true' "$1" >/dev/null 2>&1
+}
+
 accum_requirement_state() {
   local _f _tracked_hit=0 _untracked_hit=0 _unreadable=0
   # No jq guard: every caller establishes jq before calling. A guard here would
   # return the PERMISSIVE answer for a tool-availability problem, and it could
   # not fire anyway (`## BL-104:`).
-  # .claude/manifest.json is the declaration init.sh writes for exactly this
-  # purpose; the generated .gitignore does not cover it, so it survives a clone.
+
+  # .claude/manifest.json is the TRACKED declaration init.sh writes for exactly
+  # this purpose; the generated .gitignore does not cover it, so it survives a clone.
   if [ -f ".claude/manifest.json" ]; then
-    if ! jq -e . ".claude/manifest.json" >/dev/null 2>&1; then
+    if ! _accum_json_ok ".claude/manifest.json"; then
       _unreadable=1
     elif [ "$(jq -r '.mcp.qdrant_required // false' ".claude/manifest.json" 2>/dev/null)" = "true" ]; then
       if accum_file_tracked ".claude/manifest.json"; then _tracked_hit=1; else _untracked_hit=1; fi
     fi
   fi
+
   for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE
     [ -f "$_f" ] || continue
-    if ! jq -e . "$_f" >/dev/null 2>&1; then
+    if ! _accum_json_ok "$_f"; then
       _unreadable=1
     elif jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
       if accum_file_tracked "$_f"; then _tracked_hit=1; else _untracked_hit=1; fi
     fi
   done
+
   # The ledger is the weakest arm: `startup` wipes it, and in a pre-BL-236
   # project it may even be TRACKED, which would make scratch authoritative.
   # It is kept only so a project that adopted Qdrant after init is still covered,
   # and it can never upgrade the verdict to `tracked`.
   if [ -f ".claude/tool-usage.json" ]; then
-    if [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
+    if ! _accum_json_ok ".claude/tool-usage.json"; then
+      _unreadable=1   # BL-233-WPB-LEDGER-UNREADABLE
+    elif [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
       _untracked_hit=1   # BL-233-WPB-LEDGER-NEVER-TRACKED
     fi
   fi
+
   if [ "$_tracked_hit" -eq 1 ]; then printf 'tracked'; return 0; fi
   if [ "$_untracked_hit" -eq 1 ]; then printf 'untracked'; return 0; fi
   # A real declaration outranks an unreadable one; only fall to `unreadable`

--- a/scripts/lib/accumulation.sh
+++ b/scripts/lib/accumulation.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scripts/lib/accumulation.sh — BL-233 WP-B: the predicates that decide whether
+# a phase owes a stored memory. Sourced by BOTH scripts/check-phase-gate.sh
+# (which BLOCKS on them) and scripts/pre-commit-gate.sh (which WARNS on them).
+#
+# It is one file because the warning exists to predict the block. If the two
+# disagree, the warning is worse than absent: it tells a developer they are fine
+# and the gate then stops them. They were two hand-copied literals once, and
+# they had already drifted. See `## BL-233:` for that history — it does not
+# belong here.
+#
+# EDITING THE EXEMPT SET: the rule is that anything NOT matched is source work.
+# Get the direction right when you add to it. An entry here is a claim that a
+# change of that kind produces nothing worth remembering; adding one too many
+# silently voids the gate, adding one too few is a nuisance block the operator
+# can clear by storing or attesting. Prefer the nuisance.
+#
+# SYNC SIBLING: scripts/process-checklist.sh::_is_dep_manifest — the dep-manifest
+# arm below must stay a superset of it.
+
+# ── What is NOT source work ────────────────────────────────────────────────
+#   ^$                 blank lines — `git log --name-only` separates commits
+#                      with one, and a blank line matches no extension
+#   docs extensions    md/markdown/rst/adoc/txt/tmpl
+#   dep manifests      mirrors _is_dep_manifest entry for entry
+#   project metadata   package.json, pyproject.toml, tsconfig.json, …
+#   dotfile rc files   .eslintrc, .prettierrc.yaml, …
+#   .claude/*.json     framework state (phase-state, process-state, manifest);
+#                      these churn on every gate run and are not authored work
+#   extension-less     LICENSE, README, CODEOWNERS, .gitignore, …
+#
+# json/yml/yaml/toml are NOT blanket-exempt, and that is the one place this
+# deliberately diverges from process-checklist.sh's docs-only rule. A blanket
+# exemption meant a Kubernetes, Helm, Ansible or OpenAPI phase counted as
+# "nothing owed" — infrastructure as code is authored work, and the docs-only
+# bypass answers a different question (does this commit need a Build Loop entry)
+# than this gate does (did this phase produce knowledge worth storing).
+# Unrecognised structured data therefore fails CLOSED.
+_ACCUM_EXEMPT_RE='^$|\.(md|markdown|rst|adoc|txt|tmpl)$|(^|/)(Pipfile(\.lock)?|Gemfile(\.lock)?|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|pnpm-lock\.yaml|pubspec\.lock|Package\.resolved|gradle\.lockfile|package-lock\.json|npm-shrinkwrap\.json|packages\.lock\.json|composer\.lock|requirements([-_][^/]*)?\.txt)$|(^|/)(package\.json|composer\.json|tsconfig([.-][^/]*)?\.json|jsconfig\.json|pyproject\.toml|Cargo\.toml|renovate\.json)$|(^|/)\.[A-Za-z0-9_-]+rc(\.(json|ya?ml|toml))?$|(^|/)\.claude/[^/]*\.json$|(^|/)(\.gitignore|\.gitattributes|\.dockerignore|\.editorconfig|\.gitkeep|LICENSE|LICENCE|NOTICE|CODEOWNERS|README|CHANGELOG|AUTHORS|CONTRIBUTING)$'   # BL-233-WPB-EXEMPT-SET
+
+# accum_paths_have_source <newline-separated-paths> — 0 if any path is source.
+# A HERE-STRING, never `printf | grep -q`: under `set -o pipefail` that pipeline
+# returns 141 ON A MATCH once the payload is big enough (`## BL-238:`), and here
+# a spurious 141 would read as "no source work" — the fail-OPEN direction — on
+# exactly the large-history repos where the check matters most.
+accum_paths_have_source() {
+  grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$1"   # BL-233-WPB-SOURCE-NEGATION
+}
+
+# accum_file_tracked <path> — does git actually track this file?
+#
+# ASKED, never inferred. WP-B's first fix reasoned that init.sh writes
+# .claude/settings.local.json and `git add -A` commits it. Claude Code adds that
+# file to the user's GLOBAL git excludes by design, and generate_gitignore
+# COPIES templates/generated/gitignore-base.tmpl (which ignores
+# .claude/tool-usage.json) before appending — so BOTH declaration arms were
+# absent from every fresh clone and the gate blocked locally while reporting
+# NOT CHECKED on CI. Trackedness is a question for git; git answers it.
+accum_file_tracked() {
+  git ls-files --error-unmatch -- "$1" >/dev/null 2>&1   # BL-233-WPB-TRACKED
+}
+
+# accum_requirement_state — echoes tracked | untracked | none.
+#
+# Three states, not a boolean: "required" and "required everywhere" are
+# different facts, and conflating them is what produced the defect above.
+#
+# PROJECT SCOPE ONLY — never $HOME, even though session-test-gate-check.sh reads
+# both scopes. Zero of the 29 suites that drive check-phase-gate.sh at
+# current_phase >= 2 redirect HOME, so a host-derived verdict passes on a
+# developer box with Qdrant configured and fails on a runner without it:
+# `## BL-234:`'s class.
+accum_requirement_state() {
+  local _f _tracked_hit=0 _untracked_hit=0
+  if ! command -v jq >/dev/null 2>&1; then
+    printf 'none'
+    return 0
+  fi
+  # .claude/manifest.json is the declaration init.sh writes for exactly this
+  # purpose; the generated .gitignore does not cover it, so it survives a clone.
+  if [ -f ".claude/manifest.json" ] && \
+     [ "$(jq -r '.mcp.qdrant_required // false' ".claude/manifest.json" 2>/dev/null)" = "true" ]; then
+    if accum_file_tracked ".claude/manifest.json"; then _tracked_hit=1; else _untracked_hit=1; fi
+  fi
+  for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE
+    [ -f "$_f" ] || continue
+    if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
+      if accum_file_tracked "$_f"; then _tracked_hit=1; else _untracked_hit=1; fi
+    fi
+  done
+  # The ledger is the weakest arm: `startup` wipes it, and in a pre-BL-236
+  # project it may even be TRACKED, which would make scratch authoritative.
+  # It is kept only so a project that adopted Qdrant after init is still covered,
+  # and it can never upgrade the verdict to `tracked`.
+  if [ -f ".claude/tool-usage.json" ]; then
+    if [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
+      _untracked_hit=1   # BL-233-WPB-LEDGER-NEVER-TRACKED
+    fi
+  fi
+  if [ "$_tracked_hit" -eq 1 ]; then printf 'tracked'; return 0; fi
+  if [ "$_untracked_hit" -eq 1 ]; then printf 'untracked'; return 0; fi
+  printf 'none'
+  return 0
+}

--- a/scripts/lib/accumulation.sh
+++ b/scripts/lib/accumulation.sh
@@ -101,7 +101,43 @@ accum_json_readable() {
 }
 
 _accum_json_ok() {
-  jq -e 'true' "$1" >/dev/null 2>&1
+  jq -e 'true' "$1" >/dev/null 2>&1 || return 1
+  # EXACTLY ONE document. `jq -e 'true'` reports the LAST output's status, so a
+  # file written twice (`>>` instead of `>` — the same accident class as the
+  # zero-byte case) parses fine and then makes `jq -r '.mcp.qdrant_required'`
+  # emit "true\ntrue", which fails a `= "true"` compare and reads as NO
+  # declaration. That is a fail-OPEN on a file that WAS parsed and mis-read.
+  [ "$(jq -s 'length' "$1" 2>/dev/null)" = "1" ]
+}
+
+# accum_oneline <value> — render a persisted or operator-supplied value as ONE
+# line of display text.
+#
+# `printf '%s'` alone is NOT enough, and D11 is why. It defeats a value carrying
+# the two-character sequence `\n`, which is what an env var supplies — but a
+# value that reaches the record through jq carries a REAL newline, and printf
+# reproduces it faithfully, forging a verdict line just the same. The class is
+# "a stored value reaches the transcript", and the defence has to strip the
+# control characters, not merely avoid interpreting them.
+#
+# LC_ALL=C because `tr` rejects invalid multibyte sequences in a UTF-8 locale
+# and exits 1 — and this value is arbitrary bytes out of a file.
+accum_oneline() {
+  printf '%s' "$1" | LC_ALL=C tr -d '\000-\037'   # BL-233-WPB-ONELINE
+}
+
+# accum_unreadable_path — WHICH declaration file will not parse. A separate
+# derivation rather than state set inside accum_requirement_state, because that
+# function is read through a command substitution (a subshell) and any global it
+# assigned would die with it — the trap this feature already fell into once.
+accum_unreadable_path() {
+  local _f
+  command -v jq >/dev/null 2>&1 || return 0
+  for _f in ".claude/manifest.json" ".claude/settings.local.json" ".claude/settings.json"; do
+    [ -f "$_f" ] || continue
+    if ! _accum_json_ok "$_f"; then printf '%s' "$_f"; return 0; fi
+  done
+  return 0
 }
 
 accum_requirement_state() {
@@ -133,10 +169,21 @@ accum_requirement_state() {
   # project it may even be TRACKED, which would make scratch authoritative.
   # It is kept only so a project that adopted Qdrant after init is still covered,
   # and it can never upgrade the verdict to `tracked`.
-  if [ -f ".claude/tool-usage.json" ]; then
-    if ! _accum_json_ok ".claude/tool-usage.json"; then
-      _unreadable=1   # BL-233-WPB-LEDGER-UNREADABLE
-    elif [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
+  # A CORRUPT LEDGER DOES NOT MAKE THE PROJECT `unreadable`. It cannot grant a
+  # requirement either — it simply contributes nothing.
+  #
+  # The first cut let it set `_unreadable`, which handed the weakest input in the
+  # lattice the strongest power: this file is untracked runtime scratch that
+  # `session-test-gate-check.sh` WIPES and rewrites at the next SessionStart, and
+  # one corrupt byte in it hard-blocked the phase gate of a project with NO
+  # Qdrant involvement at all — with no attested escape. The comment two arms up
+  # already says the ledger "can never upgrade the verdict to `tracked`"; it must
+  # not be able to produce the only unconditional block either.
+  #
+  # The DURABLE declarations (manifest, settings*) still fail closed when corrupt.
+  # That is where a real declaration lives, and where the operator can fix it.
+  if [ -f ".claude/tool-usage.json" ] && _accum_json_ok ".claude/tool-usage.json"; then   # BL-233-WPB-LEDGER-EPHEMERAL
+    if [ "$(jq -r '.mcp_requirements.qdrant_required // false' ".claude/tool-usage.json" 2>/dev/null)" = "true" ]; then
       _untracked_hit=1   # BL-233-WPB-LEDGER-NEVER-TRACKED
     fi
   fi

--- a/scripts/lib/accumulation.sh
+++ b/scripts/lib/accumulation.sh
@@ -22,7 +22,9 @@
 #   ^$                 blank lines — `git log --name-only` separates commits
 #                      with one, and a blank line matches no extension
 #   docs extensions    md/markdown/rst/adoc/txt/tmpl
-#   dep manifests      mirrors _is_dep_manifest entry for entry
+#   dep manifests      a SUPERSET of _is_dep_manifest: its entries plus the
+#                      ecosystems it predates (uv, mix, flake, deno, bun,
+#                      Podfile, Gopkg). A lockfile bump is not an insight
 #   project metadata   package.json, pyproject.toml, tsconfig.json, …
 #   dotfile rc files   .eslintrc, .prettierrc.yaml, …
 #   .claude/*.json     framework state (phase-state, process-state, manifest);
@@ -36,7 +38,7 @@
 # bypass answers a different question (does this commit need a Build Loop entry)
 # than this gate does (did this phase produce knowledge worth storing).
 # Unrecognised structured data therefore fails CLOSED.
-_ACCUM_EXEMPT_RE='^$|\.(md|markdown|rst|adoc|txt|tmpl)$|(^|/)(Pipfile(\.lock)?|Gemfile(\.lock)?|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|pnpm-lock\.yaml|pubspec\.lock|Package\.resolved|gradle\.lockfile|package-lock\.json|npm-shrinkwrap\.json|packages\.lock\.json|composer\.lock|requirements([-_][^/]*)?\.txt)$|(^|/)(package\.json|composer\.json|tsconfig([.-][^/]*)?\.json|jsconfig\.json|pyproject\.toml|Cargo\.toml|renovate\.json)$|(^|/)\.[A-Za-z0-9_-]+rc(\.(json|ya?ml|toml))?$|(^|/)\.claude/[^/]*\.json$|(^|/)(\.gitignore|\.gitattributes|\.dockerignore|\.editorconfig|\.gitkeep|LICENSE|LICENCE|NOTICE|CODEOWNERS|README|CHANGELOG|AUTHORS|CONTRIBUTING)$'   # BL-233-WPB-EXEMPT-SET
+_ACCUM_EXEMPT_RE='^$|\.(md|markdown|rst|adoc|txt|tmpl)$|(^|/)(Pipfile(\.lock)?|Gemfile(\.lock)?|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|pnpm-lock\.yaml|pubspec\.lock|uv\.lock|mix\.lock|flake\.lock|deno\.lock|bun\.lockb|Podfile\.lock|Gopkg\.lock|Package\.resolved|gradle\.lockfile|package-lock\.json|npm-shrinkwrap\.json|packages\.lock\.json|composer\.lock|requirements([-_][^/]*)?\.txt)$|(^|/)(package\.json|composer\.json|tsconfig([.-][^/]*)?\.json|jsconfig\.json|pyproject\.toml|Cargo\.toml|renovate\.json)$|(^|/)\.[A-Za-z0-9_-]+rc(\.(json|ya?ml|toml))?$|(^|/)\.claude/[^/]*\.json$|(^|/)(\.gitignore|\.gitattributes|\.dockerignore|\.editorconfig|\.gitkeep|LICENSE|LICENCE|NOTICE|CODEOWNERS|README|CHANGELOG|AUTHORS|CONTRIBUTING)$'   # BL-233-WPB-EXEMPT-SET
 
 # accum_paths_have_source <newline-separated-paths> — 0 if any path is source.
 # A HERE-STRING, never `printf | grep -q`: under `set -o pipefail` that pipeline
@@ -70,21 +72,32 @@ accum_file_tracked() {
 # current_phase >= 2 redirect HOME, so a host-derived verdict passes on a
 # developer box with Qdrant configured and fails on a runner without it:
 # `## BL-234:`'s class.
+# A FOURTH state, `unreadable`, exists because a corrupt declaration must not
+# fold into `none`. `none` says "this project declares no Qdrant MCP server" —
+# a claim about CONTENT — and a file that will not parse has had its content
+# read by nobody. One missing brace in .claude/manifest.json silently turned the
+# gate off while asserting a fact it never established: the same
+# could-not-measure/nothing-to-measure substitution `# BL-233-WPB-STALE-FAILCLOSED`
+# was added to remove, one function away.
 accum_requirement_state() {
-  local _f _tracked_hit=0 _untracked_hit=0
-  if ! command -v jq >/dev/null 2>&1; then
-    printf 'none'
-    return 0
-  fi
+  local _f _tracked_hit=0 _untracked_hit=0 _unreadable=0
+  # No jq guard: every caller establishes jq before calling. A guard here would
+  # return the PERMISSIVE answer for a tool-availability problem, and it could
+  # not fire anyway (`## BL-104:`).
   # .claude/manifest.json is the declaration init.sh writes for exactly this
   # purpose; the generated .gitignore does not cover it, so it survives a clone.
-  if [ -f ".claude/manifest.json" ] && \
-     [ "$(jq -r '.mcp.qdrant_required // false' ".claude/manifest.json" 2>/dev/null)" = "true" ]; then
-    if accum_file_tracked ".claude/manifest.json"; then _tracked_hit=1; else _untracked_hit=1; fi
+  if [ -f ".claude/manifest.json" ]; then
+    if ! jq -e . ".claude/manifest.json" >/dev/null 2>&1; then
+      _unreadable=1
+    elif [ "$(jq -r '.mcp.qdrant_required // false' ".claude/manifest.json" 2>/dev/null)" = "true" ]; then
+      if accum_file_tracked ".claude/manifest.json"; then _tracked_hit=1; else _untracked_hit=1; fi
+    fi
   fi
   for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE
     [ -f "$_f" ] || continue
-    if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
+    if ! jq -e . "$_f" >/dev/null 2>&1; then
+      _unreadable=1
+    elif jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_f" >/dev/null 2>&1; then
       if accum_file_tracked "$_f"; then _tracked_hit=1; else _untracked_hit=1; fi
     fi
   done
@@ -99,6 +112,9 @@ accum_requirement_state() {
   fi
   if [ "$_tracked_hit" -eq 1 ]; then printf 'tracked'; return 0; fi
   if [ "$_untracked_hit" -eq 1 ]; then printf 'untracked'; return 0; fi
+  # A real declaration outranks an unreadable one; only fall to `unreadable`
+  # when nothing legible said yes.
+  if [ "$_unreadable" -eq 1 ]; then printf 'unreadable'; return 0; fi
   printf 'none'
   return 0
 }

--- a/scripts/lib/accumulation.sh
+++ b/scripts/lib/accumulation.sh
@@ -123,7 +123,21 @@ _accum_json_ok() {
 # LC_ALL=C because `tr` rejects invalid multibyte sequences in a UTF-8 locale
 # and exits 1 — and this value is arbitrary bytes out of a file.
 accum_oneline() {
-  printf '%s' "$1" | LC_ALL=C tr -d '\000-\037'   # BL-233-WPB-ONELINE
+  # C0 controls AND the BACKSLASH. Stripping controls alone was not enough and
+  # the eighth instance of this class proved it: `echo -e` MANUFACTURES a real
+  # newline out of the two-character sequence `\` `n`, which survives a control
+  # strip untouched — so a value cleaned at ingest was re-weaponised at display.
+  # Ingest sanitising and `printf '%s'` are COMPLEMENTS, not substitutes; round 7
+  # replaced one with the other and the hole reopened.
+  #
+  # Removing the backslash makes `echo -e` inert on these values, which is what
+  # finally makes the stated rule true: clean at the boundary and the display
+  # syntax genuinely stops mattering. The two `echo -e` sites are ALSO converted
+  # to printf, because a rule that depends on one primitive staying correct is
+  # thinner than a rule plus the belt.
+  #
+  # LC_ALL=C because tr rejects invalid multibyte sequences in a UTF-8 locale.
+  printf '%s' "$1" | LC_ALL=C tr -d '\000-\037\\'   # BL-233-WPB-ONELINE
 }
 
 # accum_unreadable_path — WHICH declaration file will not parse. A separate

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1442,7 +1442,13 @@ PHASE_STATE=".claude/phase-state.json"
 WARNINGS=""
 
 if [ "$IS_COMMIT" = true ] && [ -f "$TOOL_USAGE" ] && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null; then
-  CURRENT_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null)
+  # Same guard, same reason, and it is fixed HERE TOO because otherwise the one
+  # below is inert: under `set -euo pipefail` this line aborts the hook FIRST, so
+  # guarding only the accumulation block would have looked correct and changed
+  # nothing observable — measured, rc=5 either way until both were guarded.
+  # Pre-existing, predating `## BL-233:`; half a fix to a silent-non-enforcement
+  # class is worse than none, and this entry is why anyone looked.
+  CURRENT_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null || printf '0')   # BL-233-WPB-CURPHASE-GUARD
 
   if [ "$CURRENT_PHASE" = "2" ]; then
     # Check if this is a source commit (reuse staged file check)
@@ -1484,7 +1490,17 @@ fi
 # window opens at the gate that put you IN phase N. Same rule, different tense.
 if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
    && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null; then
-  ACC_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null)
+  # `|| printf '0'` IS NOT DECORATION. This file is `set -euo pipefail`, so an
+  # unguarded command substitution that fails takes the whole hook with it — and
+  # on the PreToolUse path that discards the ENTIRE $WARNINGS accumulator
+  # (Context7, qdrant-find, TDD), silently, for a reason unrelated to any of
+  # them. Both siblings below already carry the guard; this one did not, and the
+  # block it sits in has no `[ -f "$TOOL_USAGE" ]` precondition, so the abort
+  # became reachable for any project with an unparseable phase-state.json.
+  # That is this file's own header rule — "silently disabling every gate in the
+  # file is the exact non-enforcement class `## BL-233:` exists to remove" —
+  # applied at the source line and not 1,460 lines later.
+  ACC_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null || printf '0')   # BL-233-WPB-ACCPHASE-GUARD
   ACC_PREV_KEY=""
   case "$ACC_PHASE" in
     1) ACC_PREV_KEY="phase_0_to_1" ;;

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1521,6 +1521,10 @@ if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
       if [ "$ACC_HAS_SOURCE" = true ]; then
         ACC_PREV=$(jq -r --arg k "$ACC_PREV_KEY" '.gates[$k] // ""' "$PHASE_STATE" 2>/dev/null || printf '')
         [ "$ACC_PREV" = "null" ] && ACC_PREV=""
+        # Kept BEFORE validation blanks it, so this half can tell "no gate
+        # recorded" from "a gate recorded as garbage" — the same distinction the
+        # phase gate makes with `# BL-233-WPB-RAW-SNAPSHOT`.
+        ACC_PREV_RAW=$(accum_oneline "$ACC_PREV")
         # VALIDATE before it reaches the warning text. This value is spliced into
         # WARNINGS, which is emitted through a hand-rolled `sed 's/"/\\"/g'` JSON
         # envelope — and a backslash or control character in it makes the whole
@@ -1559,18 +1563,36 @@ if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
         ACC_SATISFIED=false
         if [ -n "$ACC_LAST" ]; then
           if [ -z "$ACC_PREV" ]; then
-            ACC_SATISFIED=true
+            # AN UNREADABLE WINDOW IS NOT AN ABSENT ONE, and this branch used to
+            # answer as though it were — under a comment that said in as many
+            # words "the gate treats any store as satisfying, so stay quiet".
+            # The phase gate NO LONGER does: `# BL-233-WPB-AMBIGUOUS-WINDOW` and
+            # `# BL-233-WPB-WINDOW-SHAPE` refuse a gate date that is recorded but
+            # will not parse. Left alone, the half that WARNS went silent exactly
+            # where the half that BLOCKS started refusing — the failure this
+            # file's own comments call worse than no warning at all.
+            if [ -n "$ACC_PREV_RAW" ]; then
+              :   # BL-233-WPB-WARN-UNREADABLE-WINDOW
+            else
+              ACC_SATISFIED=true
+            fi
           else
             _acc_a="${ACC_LAST:0:10}"; _acc_a="${_acc_a//-/}"
             _acc_b="${ACC_PREV:0:10}"; _acc_b="${_acc_b//-/}"
             # The two unparseable cases resolve in OPPOSITE directions, and each
-            # matches _cpg_accum_after so this warning predicts the gate it is
-            # warning about. A corrupt last_store_at is NOT a store (the gate
-            # will block, so warn); a corrupt gate date means no window can be
-            # computed (the gate treats any store as satisfying, so stay quiet).
+            # matches the gate, so this warning predicts the gate it is warning
+            # about. A corrupt last_store_at is NOT a store (the gate blocks, so
+            # warn). A gate date that is ABSENT means the window is the whole
+            # history and any store satisfies it (stay quiet); a gate date that
+            # is RECORDED BUT UNPARSEABLE means the window cannot be measured,
+            # and the gate now BLOCKS on it — so this warns.
             case "$_acc_a" in
               ''|*[!0-9]*) : ;;
               *) case "$_acc_b" in
+                   # UNREACHABLE by construction and left as it was: $ACC_PREV
+                   # empty is handled by the outer branch above, so $_acc_b can
+                   # only be empty there. Making this arm "smart" would be an
+                   # arm that cannot fire (`## BL-104:`).
                    ''|*[!0-9]*) ACC_SATISFIED=true ;;
                    *) [ "$_acc_a" -ge "$_acc_b" ] && ACC_SATISFIED=true ;;
                  esac ;;

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1451,6 +1451,99 @@ if [ "$IS_COMMIT" = true ] && [ -f "$TOOL_USAGE" ] && [ -f "$PHASE_STATE" ] && c
   fi
 fi
 
+# ── BL-233 WP-B: the COMMIT half of "warn at commit, block at the phase gate" ─
+# Karl's decision (2026-08-17). Storing is NOT per-commit work: a commit that
+# produced no insight has nothing to store, so a per-commit BLOCK would be a
+# gate people cannot satisfy honestly — and `## BL-149:` is the standing rule
+# that such a gate gets deleted. This arm therefore only ever WARNS, and it is
+# emitted through the same `permissionDecision: allow` envelope below.
+#
+# The window here is FORWARD-looking and differs from check-phase-gate.sh's on
+# purpose. The gate, run at current_phase N, verifies the crossing INTO N — so
+# its window opens at gate (N-1). This warning is about the gate you have not
+# hit yet: while working in phase N you are heading for the N→N+1 gate, whose
+# window opens at the gate that put you IN phase N. Same rule, different tense.
+if [ "$IS_COMMIT" = true ] && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null; then
+  ACC_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null)
+  ACC_PREV_KEY=""
+  case "$ACC_PHASE" in
+    1) ACC_PREV_KEY="phase_0_to_1" ;;
+    2) ACC_PREV_KEY="phase_1_to_2" ;;
+    3) ACC_PREV_KEY="phase_2_to_3" ;;
+  esac
+
+  if [ -n "$ACC_PREV_KEY" ]; then
+    # Same project-scope-only derivation the phase gate uses. $HOME is NOT read
+    # here either: a warning whose text depends on the developer's own MCP
+    # config would say different things to two people committing the same change.
+    ACC_REQUIRED=false
+    for _acc_f in ".claude/settings.local.json" ".claude/settings.json"; do
+      [ -f "$_acc_f" ] || continue
+      if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_acc_f" >/dev/null 2>&1; then
+        ACC_REQUIRED=true
+        break
+      fi
+    done
+    if [ "$ACC_REQUIRED" = false ] && [ -f "$TOOL_USAGE" ]; then
+      if [ "$(jq -r '.mcp_requirements.qdrant_required // false' "$TOOL_USAGE" 2>/dev/null)" = "true" ]; then
+        ACC_REQUIRED=true
+      fi
+    fi
+
+    if [ "$ACC_REQUIRED" = true ]; then
+      ACC_STAGED=$(git diff --cached --name-only 2>/dev/null || true)
+      ACC_HAS_SOURCE=false
+      # Here-strings, not `echo | grep -q`: under `set -o pipefail` that
+      # pipeline returns 141 on a MATCH once the payload is big enough
+      # (`## BL-238:`), and here a spurious 141 would silently drop the warning.
+      if grep -qE '\.(py|ts|tsx|js|jsx|rs|go|cs|kt|java|dart|swift|c|cpp|h)$' <<< "$ACC_STAGED"; then
+        ACC_HAS_SOURCE=true
+      elif grep -qE '^(src|lib|app|pkg|internal|cmd)/' <<< "$ACC_STAGED"; then
+        ACC_HAS_SOURCE=true
+      fi
+
+      if [ "$ACC_HAS_SOURCE" = true ]; then
+        ACC_PREV=$(jq -r --arg k "$ACC_PREV_KEY" '.gates[$k] // ""' "$PHASE_STATE" 2>/dev/null || printf '')
+        [ "$ACC_PREV" = "null" ] && ACC_PREV=""
+        ACC_LAST=""
+        if [ -f ".claude/process-state.json" ]; then
+          ACC_LAST=$(jq -r '.mcp_accumulation.last_store_at // ""' ".claude/process-state.json" 2>/dev/null || printf '')
+          [ "$ACC_LAST" = "null" ] && ACC_LAST=""
+        fi
+
+        # Integer date compare, same reasoning as the gate's _cpg_accum_after:
+        # `[ a \> b ]` is locale-collated, and same-day counts because gates.*
+        # carry a date with no time.
+        ACC_SATISFIED=false
+        if [ -n "$ACC_LAST" ]; then
+          if [ -z "$ACC_PREV" ]; then
+            ACC_SATISFIED=true
+          else
+            _acc_a="${ACC_LAST:0:10}"; _acc_a="${_acc_a//-/}"
+            _acc_b="${ACC_PREV:0:10}"; _acc_b="${_acc_b//-/}"
+            # The two unparseable cases resolve in OPPOSITE directions, and each
+            # matches _cpg_accum_after so this warning predicts the gate it is
+            # warning about. A corrupt last_store_at is NOT a store (the gate
+            # will block, so warn); a corrupt gate date means no window can be
+            # computed (the gate treats any store as satisfying, so stay quiet).
+            case "$_acc_a" in
+              ''|*[!0-9]*) : ;;
+              *) case "$_acc_b" in
+                   ''|*[!0-9]*) ACC_SATISFIED=true ;;
+                   *) [ "$_acc_a" -ge "$_acc_b" ] && ACC_SATISFIED=true ;;
+                 esac ;;
+            esac
+          fi
+        fi
+
+        if [ "$ACC_SATISFIED" = false ]; then   # BL-233-WPB-COMMIT-WARN
+          WARNINGS="${WARNINGS}Nothing has been stored to Qdrant since ${ACC_PREV:-project start}, and this is a source commit. The phase gate BLOCKS on this — a phase with source commits and no successful qdrant-store does not advance. Store what this phase decided before you reach it. "
+        fi
+      fi
+    fi
+  fi
+fi
+
 if [ -n "$WARNINGS" ]; then
   # Output warnings as additional context (not blocking)
   ESCAPED_WARNINGS=$(echo "$WARNINGS" | sed 's/"/\\"/g')

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1496,9 +1496,13 @@ if [ "$IS_COMMIT" = true ] && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null
       # Here-strings, not `echo | grep -q`: under `set -o pipefail` that
       # pipeline returns 141 on a MATCH once the payload is big enough
       # (`## BL-238:`), and here a spurious 141 would silently drop the warning.
-      if grep -qE '\.(py|ts|tsx|js|jsx|rs|go|cs|kt|java|dart|swift|c|cpp|h)$' <<< "$ACC_STAGED"; then
-        ACC_HAS_SOURCE=true
-      elif grep -qE '^(src|lib|app|pkg|internal|cmd)/' <<< "$ACC_STAGED"; then
+      # Same negation the phase gate uses, so this warning predicts the gate it
+      # warns about. An extension ALLOW-LIST here would go quiet for Ruby, PHP,
+      # shell, Vue, Elixir, SQL and Scala projects — exactly the stacks whose
+      # phase gate would then block without warning. (The staged list has no
+      # blank-line separator, unlike `git log --name-only`, but the `^$` arm is
+      # kept so both predicates read identically.)
+      if grep -qvE '^$|\.(md|json|yml|yaml|toml|tmpl)$|(^|/)(Pipfile|Gemfile|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|Package\.resolved|gradle\.lockfile|requirements(-[^/]*)?\.txt)$' <<< "$ACC_STAGED"; then
         ACC_HAS_SOURCE=true
       fi
 

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -11,6 +11,25 @@ set -euo pipefail
 #   - JSON with permissionDecision: "deny" = block
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# BL-233 WP-B: the accumulation predicates, shared with check-phase-gate.sh so
+# this warning cannot drift from the gate it is warning about.
+#
+# GUARDED, in this file's own idiom (see tdd-classify.sh above), and the
+# degradation is DELIBERATE. A bare `source` here was measured taking the whole
+# commit gate down in any project installed before this lib existed: on the
+# PreToolUse path it exits non-zero before ANY check runs — remote, TDD,
+# Build Loop, all of it — and on the commit-msg path it blocks every commit with
+# a bash error whose rc is 1, so `soif_ledger_blocked` never records the block
+# either. Silently disabling every gate in the file is the exact
+# non-enforcement class `## BL-233:` exists to remove, so the accumulation
+# WARNING no-ops when the lib is absent and every other gate keeps running.
+# Safe because this arm is warn-only; the phase gate is where it blocks.
+SOIF_ACCUM_LIB_LOADED=0
+if [ -f "$SCRIPT_DIR/lib/accumulation.sh" ]; then
+  # shellcheck source=scripts/lib/accumulation.sh
+  . "$SCRIPT_DIR/lib/accumulation.sh"
+  SOIF_ACCUM_LIB_LOADED=1
+fi
 
 # BL-072 Phase C1: shared TDD file-classification core. Sourced (not
 # re-implemented) so the live gate below and the dogfood replay
@@ -1463,7 +1482,8 @@ fi
 # its window opens at gate (N-1). This warning is about the gate you have not
 # hit yet: while working in phase N you are heading for the N→N+1 gate, whose
 # window opens at the gate that put you IN phase N. Same rule, different tense.
-if [ "$IS_COMMIT" = true ] && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null; then
+if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
+   && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null; then
   ACC_PHASE=$(jq -r '.current_phase // 0' "$PHASE_STATE" 2>/dev/null)
   ACC_PREV_KEY=""
   case "$ACC_PHASE" in
@@ -1473,21 +1493,16 @@ if [ "$IS_COMMIT" = true ] && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null
   esac
 
   if [ -n "$ACC_PREV_KEY" ]; then
-    # Same project-scope-only derivation the phase gate uses. $HOME is NOT read
-    # here either: a warning whose text depends on the developer's own MCP
-    # config would say different things to two people committing the same change.
+    # THE SAME derivation the phase gate uses, from the SAME file
+    # (scripts/lib/accumulation.sh). It used to be a hand-copied loop that read
+    # settings*.json and the ledger but NOT .claude/manifest.json — so on a
+    # clone of a project scaffolded by init.sh, where the manifest is the only
+    # declaration, the gate blocked and this warning said nothing. The whole
+    # posture is "warn at commit, block at the phase gate"; a warning that is
+    # silent on the path the fix creates is worse than absent.
     ACC_REQUIRED=false
-    for _acc_f in ".claude/settings.local.json" ".claude/settings.json"; do
-      [ -f "$_acc_f" ] || continue
-      if jq -e '(.mcpServers // {}) | (has("qdrant") or has("mcp-server-qdrant"))' "$_acc_f" >/dev/null 2>&1; then
-        ACC_REQUIRED=true
-        break
-      fi
-    done
-    if [ "$ACC_REQUIRED" = false ] && [ -f "$TOOL_USAGE" ]; then
-      if [ "$(jq -r '.mcp_requirements.qdrant_required // false' "$TOOL_USAGE" 2>/dev/null)" = "true" ]; then
-        ACC_REQUIRED=true
-      fi
+    if [ "$(accum_requirement_state)" != "none" ]; then
+      ACC_REQUIRED=true
     fi
 
     if [ "$ACC_REQUIRED" = true ]; then
@@ -1496,13 +1511,10 @@ if [ "$IS_COMMIT" = true ] && [ -f "$PHASE_STATE" ] && command -v jq &>/dev/null
       # Here-strings, not `echo | grep -q`: under `set -o pipefail` that
       # pipeline returns 141 on a MATCH once the payload is big enough
       # (`## BL-238:`), and here a spurious 141 would silently drop the warning.
-      # Same negation the phase gate uses, so this warning predicts the gate it
-      # warns about. An extension ALLOW-LIST here would go quiet for Ruby, PHP,
-      # shell, Vue, Elixir, SQL and Scala projects — exactly the stacks whose
-      # phase gate would then block without warning. (The staged list has no
-      # blank-line separator, unlike `git log --name-only`, but the `^$` arm is
-      # kept so both predicates read identically.)
-      if grep -qvE '^$|\.(md|json|yml|yaml|toml|tmpl)$|(^|/)(Pipfile|Gemfile|Cargo\.lock|go\.(mod|sum)|poetry\.lock|yarn\.lock|Package\.resolved|gradle\.lockfile|requirements(-[^/]*)?\.txt)$' <<< "$ACC_STAGED"; then
+      # THE SAME predicate the phase gate uses, from the same library — not a
+      # copy. Two literals is what the earlier version had, and they had already
+      # drifted from process-checklist.sh's dep-manifest list.
+      if accum_paths_have_source "$ACC_STAGED"; then
         ACC_HAS_SOURCE=true
       fi
 

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1522,7 +1522,11 @@ if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
         ACC_PREV=$(jq -r --arg k "$ACC_PREV_KEY" '.gates[$k] // ""' "$PHASE_STATE" 2>/dev/null || printf '')
         [ "$ACC_PREV" = "null" ] && ACC_PREV=""
         ACC_LAST=""
-        if [ -f ".claude/process-state.json" ]; then
+        # Guarded, same as the phase gate: an unparseable record must not read
+        # as "nothing stored". Here it stays a WARNING either way, so the
+        # consequence is only a misleading nudge — but the two surfaces must
+        # answer the same question the same way.
+        if [ -f ".claude/process-state.json" ] && accum_json_readable ".claude/process-state.json"; then
           ACC_LAST=$(jq -r '.mcp_accumulation.last_store_at // ""' ".claude/process-state.json" 2>/dev/null || printf '')
           [ "$ACC_LAST" = "null" ] && ACC_LAST=""
         fi

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1521,6 +1521,18 @@ if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
       if [ "$ACC_HAS_SOURCE" = true ]; then
         ACC_PREV=$(jq -r --arg k "$ACC_PREV_KEY" '.gates[$k] // ""' "$PHASE_STATE" 2>/dev/null || printf '')
         [ "$ACC_PREV" = "null" ] && ACC_PREV=""
+        # VALIDATE before it reaches the warning text. This value is spliced into
+        # WARNINGS, which is emitted through a hand-rolled `sed 's/"/\\"/g'` JSON
+        # envelope — and a backslash or control character in it makes the whole
+        # hook envelope unparseable, so the warning is silently discarded. The
+        # phase gate validates the same field (get_gate_date's YYYY-MM-DD regex);
+        # this surface did not. Same rule, same place, both sides.
+        #
+        # This repo's own tracker comment names the antipattern: hand-escaping
+        # for a LIST of characters "is a list, not the control CLASS".
+        if ! printf '%s' "$ACC_PREV" | grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'; then
+          ACC_PREV=""
+        fi
         ACC_LAST=""
         # Guarded, same as the phase gate: an unparseable record must not read
         # as "nothing stored". Here it stays a WARNING either way, so the

--- a/scripts/pre-commit-gate.sh
+++ b/scripts/pre-commit-gate.sh
@@ -1530,6 +1530,16 @@ if [ "$IS_COMMIT" = true ] && [ "$SOIF_ACCUM_LIB_LOADED" = "1" ] \
         #
         # This repo's own tracker comment names the antipattern: hand-escaping
         # for a LIST of characters "is a list, not the control CLASS".
+        # SANITISE FIRST, then validate. `grep` matches PER LINE, so a value whose
+        # FIRST line is a valid date passed this check while still carrying a
+        # newline — and jq emits a real newline for a JSON `\n` escape. The value
+        # then reached `ESCAPED_WARNINGS=$(echo "$WARNINGS" | sed 's/"/\\"/g')`,
+        # which escapes quotes only, making the whole hook envelope invalid JSON.
+        # $WARNINGS is the SHARED accumulator, so that discarded every warning the
+        # hook had collected — TDD, Context7, qdrant-find — with no error anywhere.
+        # The guard's own comment said "a backslash or control character"; it
+        # closed the backslash half and left the control-character half open.
+        ACC_PREV=$(accum_oneline "$ACC_PREV")   # BL-233-WPB-ACCPREV-ONELINE
         if ! printf '%s' "$ACC_PREV" | grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])$'; then
           ACC_PREV=""
         fi

--- a/scripts/session-end-qdrant-reminder.sh
+++ b/scripts/session-end-qdrant-reminder.sh
@@ -66,6 +66,16 @@ if [ -f "$TOOL_USAGE" ] && command -v jq &>/dev/null; then
   echo ""
   echo "TOOL USAGE THIS SESSION: Context7: $CTX7_COUNT calls | Qdrant-find: $QDRANT_FIND_COUNT calls | Qdrant-store: $QDRANT_STORE_COUNT calls"
 
+  # A store that SUCCEEDED but whose DURABLE record could not be written. The
+  # tracker increments this and, until now, nothing read it anywhere in the
+  # repo — so its own comment, promising the operator would not "face a phase
+  # gate that blocks for no visible reason", was unearned. This is that surface.
+  STORE_RECORD_FAILED=$(jq -r '.qdrant_store_record_failed // 0' "$TOOL_USAGE" 2>/dev/null || echo 0)
+  case "$STORE_RECORD_FAILED" in ''|*[!0-9]*) STORE_RECORD_FAILED=0 ;; esac
+  if [ "$STORE_RECORD_FAILED" -gt 0 ]; then
+    echo "  WARNING: $STORE_RECORD_FAILED successful qdrant-store(s) could NOT be written to .claude/process-state.json. The phase gate reads THAT record, not this session's ledger, so it will block as though nothing was stored. Make the file writable and store again."   # BL-233-WPB-RECORD-FAILED-VISIBLE
+  fi
+
   # Report the failed round trips rather than omitting them. An absent failure
   # is indistinguishable from an idle session, and that ambiguity is what let a
   # dead Qdrant look healthy for weeks (`## BL-231:`).

--- a/scripts/session-end-qdrant-reminder.sh
+++ b/scripts/session-end-qdrant-reminder.sh
@@ -33,15 +33,46 @@ TOOL_USAGE=".claude/tool-usage.json"
 PHASE_STATE=".claude/phase-state.json"
 
 if [ -f "$TOOL_USAGE" ] && command -v jq &>/dev/null; then
-  CTX7_COUNT=$(jq '[.calls[] | select(.tool | contains("context7"))] | length' "$TOOL_USAGE" 2>/dev/null || echo "0")
-  case "$CTX7_COUNT" in ''|*[!0-9]*) CTX7_COUNT=0 ;; esac
-  QDRANT_FIND_COUNT=$(jq '[.calls[] | select(.tool | contains("qdrant")) | select(.tool | contains("find"))] | length' "$TOOL_USAGE" 2>/dev/null || echo "0")
-  case "$QDRANT_FIND_COUNT" in ''|*[!0-9]*) QDRANT_FIND_COUNT=0 ;; esac
-  QDRANT_STORE_COUNT=$(jq '[.calls[] | select(.tool | contains("qdrant")) | select(.tool | contains("store"))] | length' "$TOOL_USAGE" 2>/dev/null || echo "0")
-  case "$QDRANT_STORE_COUNT" in ''|*[!0-9]*) QDRANT_STORE_COUNT=0 ;; esac
+  # ── BL-233 WP-B: this summary counts OUTCOMES, not DECLARATIONS ──────────
+  # It used to read `.calls | length` and the `*_called` flags, so a call that
+  # FAILED was reported as a call that happened. After WP-A made the gate score
+  # outcomes, this surface actively DISAGREED with the gate it sits beside —
+  # the ledger already carried `.outcome` on every row and the `*_succeeded`
+  # flags; only the reader was stale.
+  #
+  # A row written BEFORE WP-A carries no `.outcome`, and its absence is read as
+  # success: the pre-WP-A tracker was registered on PostToolUse only, so the
+  # rows it wrote are exactly the calls that fired without error. Defaulting
+  # those to "failure" would invent failures that never happened.
+  _ledger_count() {   # _ledger_count <select-expr> <outcome-expr>
+    local n
+    n=$(jq "[.calls[]? | select($1) | select($2)] | length" "$TOOL_USAGE" 2>/dev/null || echo "0")
+    case "$n" in ''|*[!0-9]*) n=0 ;; esac
+    printf '%s\n' "$n"
+  }
+  _OK_EXPR='(.outcome // "success") == "success"'
+  _BAD_EXPR='(.outcome // "success") != "success"'
+  _C7_SEL='(.tool | contains("context7"))'
+  _QF_SEL='(.tool | contains("qdrant")) and (.tool | contains("find"))'
+  _QS_SEL='(.tool | contains("qdrant")) and (.tool | contains("store"))'
+
+  CTX7_COUNT=$(_ledger_count "$_C7_SEL" "$_OK_EXPR")
+  QDRANT_FIND_COUNT=$(_ledger_count "$_QF_SEL" "$_OK_EXPR")
+  QDRANT_STORE_COUNT=$(_ledger_count "$_QS_SEL" "$_OK_EXPR")
+  CTX7_BAD=$(_ledger_count "$_C7_SEL" "$_BAD_EXPR")
+  QDRANT_FIND_BAD=$(_ledger_count "$_QF_SEL" "$_BAD_EXPR")
+  QDRANT_STORE_BAD=$(_ledger_count "$_QS_SEL" "$_BAD_EXPR")
 
   echo ""
   echo "TOOL USAGE THIS SESSION: Context7: $CTX7_COUNT calls | Qdrant-find: $QDRANT_FIND_COUNT calls | Qdrant-store: $QDRANT_STORE_COUNT calls"
+
+  # Report the failed round trips rather than omitting them. An absent failure
+  # is indistinguishable from an idle session, and that ambiguity is what let a
+  # dead Qdrant look healthy for weeks (`## BL-231:`).
+  TOTAL_BAD=$((CTX7_BAD + QDRANT_FIND_BAD + QDRANT_STORE_BAD))
+  if [ "$TOTAL_BAD" -gt 0 ]; then
+    echo "  Those are SUCCESSFUL round trips. $TOTAL_BAD MCP call(s) failed or were interrupted this session (Context7: $CTX7_BAD, Qdrant-find: $QDRANT_FIND_BAD, Qdrant-store: $QDRANT_STORE_BAD) — a call that failed is not a call that happened."
+  fi
 
   # Phase 2 warnings
   CURRENT_PHASE="0"
@@ -51,12 +82,16 @@ if [ -f "$TOOL_USAGE" ] && command -v jq &>/dev/null; then
 
   if [ "$CURRENT_PHASE" = "2" ]; then
     COMMITS_MADE=$(jq -r '.commits_since_last_context7 // 0' "$TOOL_USAGE" 2>/dev/null)
-    QDRANT_STORED=$(jq -r '.qdrant_store_called // false' "$TOOL_USAGE" 2>/dev/null)
+    # `_called` is the DECLARATION ("a store tool was invoked"); `_succeeded` is
+    # the outcome. A store that returned "All connection attempts failed" used
+    # to silence this warning — the precise shape BL-233 exists to remove.
+    QDRANT_STORED=$(jq -r '.qdrant_store_succeeded // false' "$TOOL_USAGE" 2>/dev/null)   # BL-233-WPB-OUTCOME
 
     if [ "$COMMITS_MADE" -gt 0 ] 2>/dev/null && [ "$QDRANT_STORED" = "false" ]; then
       echo ""
       echo "WARNING: You made source commits this session but stored nothing in Qdrant."
       echo "Before ending, store any architecture decisions, debugging breakthroughs, or integration patterns."
+      echo "The phase gate BLOCKS on this: a phase with source commits and no successful qdrant-store does not advance (## BL-233: WP-B)."
     fi
 
     if [ "$CTX7_COUNT" -eq 0 ] 2>/dev/null && [ "$COMMITS_MADE" -gt 0 ] 2>/dev/null; then

--- a/scripts/track-tool-usage.sh
+++ b/scripts/track-tool-usage.sh
@@ -258,6 +258,63 @@ if [ "$OUTCOME" = "failure" ] && [ -n "$TOOL_ERROR" ]; then
     "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
 fi
 
+# ── BL-233 WP-B: the DURABLE accumulation record ────────────────────────────
+# The per-session ledger cannot answer "did this PHASE accumulate anything".
+# `session-test-gate-check.sh` WIPES .claude/tool-usage.json on every `startup`
+# (it merges only on resume/compact/clear), and a phase spans many sessions —
+# so a phase gate reading the ledger would be asking "did THIS SESSION store",
+# which one junk store ten seconds before the gate satisfies. The gate therefore
+# reads .claude/process-state.json::mcp_accumulation, which survives session
+# boundaries, and this function is its ONLY writer.
+#
+# It takes the same mkdir advisory lock as check-phase-gate.sh's two writers of
+# that same file (_cpg_record_gate_date, _cpg_record_reviewer_attestation). An
+# unlocked third writer would not merely race itself — it would break THEIR
+# mutual exclusion. The budget is deliberately short (3s, vs the gate's 10s):
+# this runs on a PostToolUse hook, and a tool call must not stall behind a lock.
+#
+# A failed write is RECORDED in the ledger, never swallowed. A store that never
+# reached the durable record would otherwise leave the operator in front of a
+# phase gate that blocks for no visible reason.
+_tt_record_accumulation() {
+  local ts="$1"
+  local file=".claude/process-state.json"
+  local lock_dir="$file.lockdir"
+  local attempts=0 rc=0
+
+  mkdir -p .claude 2>/dev/null || return 1
+  while ! mkdir "$lock_dir" 2>/dev/null; do
+    attempts=$((attempts + 1))
+    [ "$attempts" -ge 30 ] && return 1
+    sleep 0.1
+  done
+
+  if [ ! -f "$file" ]; then
+    echo '{}' > "$file" 2>/dev/null || { rmdir "$lock_dir" 2>/dev/null; return 1; }
+  fi
+
+  (
+    tmp=$(mktemp "${file}.XXXXXX") || exit 1
+    trap 'rm -f "$tmp"; rmdir "$lock_dir" 2>/dev/null' EXIT INT TERM
+    if jq --arg ts "$ts" \
+        '.mcp_accumulation = ((.mcp_accumulation // {})
+           | .store_success_count = ((.store_success_count // 0) + 1)
+           | .last_store_at = $ts
+           | .attestations = (.attestations // {}))' \
+        "$file" > "$tmp" 2>/dev/null; then
+      mv "$tmp" "$file" || exit 1
+      trap - EXIT INT TERM
+      exit 0
+    else
+      rm -f "$tmp"
+      trap - EXIT INT TERM
+      exit 1
+    fi
+  ) || rc=1
+  rmdir "$lock_dir" 2>/dev/null || true
+  return "$rc"
+}
+
 # ── Context7 ────────────────────────────────────────────────────────────────
 if echo "$TOOL_NAME" | grep -q "context7" 2>/dev/null; then
   # context7_called stays name-derived on purpose: it is the OBSERVABILITY
@@ -298,8 +355,14 @@ if echo "$TOOL_NAME" | grep -q "qdrant" 2>/dev/null; then
     fi
   elif echo "$TOOL_NAME" | grep -q "store" 2>/dev/null; then
     jq '.qdrant_store_called = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
-    if [ "$OUTCOME" = "success" ]; then
+    if [ "$OUTCOME" = "success" ]; then   # BL-233-WPB-ACCUM-WRITE
       jq '.qdrant_store_succeeded = true' "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+      # The session-scoped flag above and the durable record below answer two
+      # different questions. Only the durable one crosses a phase boundary.
+      if ! _tt_record_accumulation "$TIMESTAMP"; then
+        jq '.qdrant_store_record_failed = ((.qdrant_store_record_failed // 0) + 1)' \
+          "$TOOL_USAGE" > "$TOOL_USAGE.tmp" 2>/dev/null && mv "$TOOL_USAGE.tmp" "$TOOL_USAGE" 2>/dev/null
+      fi
     fi
   fi
 fi

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -386,6 +386,11 @@ check_scripts() {
     "scripts/lib/tdd-classify.sh"
     "scripts/lib/phase2-state.sh"
     "scripts/lib/cdf-refresh.sh"
+    # BL-233 WP-B: sourced by BOTH shipped gates. Its absence is exactly the
+    # criterion above — check-phase-gate.sh's accumulation arm goes unavailable
+    # and pre-commit-gate.sh's warning no-ops — and without this row
+    # verify-install reported a healthy install with the enforcement lib gone.
+    "scripts/lib/accumulation.sh"
   )
   local lib_name
   for lib in "${libs[@]}"; do
@@ -1367,6 +1372,7 @@ fix_lib_copy_gate-principles()   { if has_source && [ -f "$SOURCE_DIR/scripts/li
 # — they are sourced, not executed (mirrors enforcement-level/gate-principles).
 fix_lib_copy_tdd-classify()      { if has_source && [ -f "$SOURCE_DIR/scripts/lib/tdd-classify.sh" ];      then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/tdd-classify.sh"      scripts/lib/; else return 1; fi; }
 fix_lib_copy_phase2-state()      { if has_source && [ -f "$SOURCE_DIR/scripts/lib/phase2-state.sh" ];      then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/phase2-state.sh"      scripts/lib/; else return 1; fi; }
+fix_lib_copy_accumulation()      { if has_source && [ -f "$SOURCE_DIR/scripts/lib/accumulation.sh" ];      then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/accumulation.sh"      scripts/lib/; else return 1; fi; }
 fix_lib_copy_cdf-refresh()       { if has_source && [ -f "$SOURCE_DIR/scripts/lib/cdf-refresh.sh" ];       then mkdir -p scripts/lib && cp "$SOURCE_DIR/scripts/lib/cdf-refresh.sh"       scripts/lib/; else return 1; fi; }
 # Hooks live in a subdirectory; chmod + copy paths reflect that. The
 # basename of scripts/hooks/bypass-detector.sh is `bypass-detector`, so

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,7 +10409,7 @@ the two WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — 49 assertions, 12 mutants. Measured
+`tests/test-bl233-wpb-accumulation.sh` — 56 assertions, 13 mutants. Measured
 against the base tree `7b94e4b`: **2 passed / 47 failed**, and the 2 are named
 rather than glossed (J2/J3 assert an *exempt* verdict, which a tree with no
 accumulation gate also produces; mutant M12 is what makes them attributable).
@@ -10466,8 +10466,9 @@ from every fresh clone: the gate blocked on the author's machine and printed
 run), which is the test that was missing; the I-group now carries it.
 
 **The fix is not "a different file" — it is that TRACKEDNESS IS A QUESTION FOR
-GIT.** `_cpg_file_tracked` (`# BL-233-WPB-TRACKED`) asks `git ls-files`, and the
-derivation returns three states rather than a boolean: `tracked` (survives a
+GIT.** `accum_file_tracked` (`# BL-233-WPB-TRACKED`, now in
+`scripts/lib/accumulation.sh` and shared with the commit-time warning) asks
+`git ls-files`, and the derivation returns three states rather than a boolean: `tracked` (survives a
 clone), `untracked` (true here, invisible on CI — enforced, with a warning
 naming the remedy), `none`. `init.sh` now records the durable declaration in
 `.claude/manifest.json` (`# BL-233-WPB-MANIFEST-DECL`), which the generated
@@ -10499,18 +10500,31 @@ and printed the same sentence three times.
    decides the window; the counter is observability and nothing reads it for a
    verdict. It is recorded so nobody later mistakes it for a per-phase quota —
    a count target is exactly the shape that invites junk stores to hit a number.
-3. **Legacy projects stay unenforced until someone adds the manifest field.**
+3. **Structured data is judged by BASENAME, and that list will need tending.**
+   `json`/`yml`/`yaml`/`toml` are not blanket-exempt — a blanket exemption made
+   an entire Kubernetes / Helm / Ansible / OpenAPI phase read as "nothing owed",
+   which is the allow-list defect one layer over. Recognised metadata
+   (`package.json`, `pyproject.toml`, `.claude/*.json`, rc-files, …) is exempt
+   and everything else in those extensions is source. The list rots
+   FAIL-CLOSED — a new metadata filename produces a nuisance block the operator
+   clears by storing or attesting, never a silent pass — which is the tolerable
+   direction, but it is a list and it will need entries.
+4. **Legacy projects stay unenforced until someone adds the manifest field.**
    A project scaffolded before `# BL-233-WPB-MANIFEST-DECL` declares Qdrant only
    in files git does not track, so in a clone the gate reports `NOT CHECKED` and
    names the one-line remedy. It is reported, never silent — but it IS a real
    gap, and it is the honest residual of the fix rather than a claim that every
    project is now covered.
-4. **`_cpg_accum_source_since` is the one PERMISSIVE arm.** It decides whether an
-   attestation already on record has gone stale, and returns "no source work"
-   when it cannot tell — because inventing staleness would re-block work the
-   operator legitimately excused. Every other cannot-tell arm in this feature
-   fails closed.
-5. **Every successful store now DIRTIES A TRACKED FILE.**
+5. ~~**`_cpg_accum_source_since` is the one PERMISSIVE arm.**~~ **INVERTED after
+   review, 2026-08-18.** It was permissive, and that was wrong: an empty,
+   malformed, tampered or garbage-collected `head` silently restored the
+   permanent bypass the staleness check exists to remove — reachable by editing
+   one JSON field OR by an ordinary `git gc --prune=now`, and its twin
+   `_cpg_accum_source_work` fails CLOSED on the identical question. It now fails
+   closed too and names WHICH cause (`# BL-233-WPB-STALE-FAILCLOSED`). The only
+   remaining permissive arm is "no git at all", where staleness is not a
+   question that can be asked.
+6. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,11 +10409,11 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **78 assertions, 19 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **82 assertions, 21 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
 consecutive revisions. Measured against the CURRENT merge-base `2344b13` with
-this suite dropped into a `git archive` of that tree: **2 passed / 79 failed**.
+this suite dropped into a `git archive` of that tree: **2 passed / 83 failed**.
 The tally exceeds 78 for one derived reason, and the first explanation offered
 for it was INVENTED — in the paragraph whose whole subject is not transcribing
 numbers, which is why the derivation is printed here:
@@ -10423,8 +10423,8 @@ grep -E '^  \[FAIL\]' <run> | sed 's/^  \[FAIL\] //; s/ — .*//; s/\[.*//' \
 ```
 `D6` reports PER HEAD SHAPE — three loop iterations plus one final line against
 a single `pass` site — so it contributes 4 lines for 1 label and every other
-label contributes exactly 1. 2 passes + 76 distinct failing labels = 78, + D6's
-3 extra lines = 79. The **meta arms do not contribute**, which is what the first
+label contributes exactly 1. 2 passes + 80 distinct failing labels = 82, + D6's
+3 extra lines = 83. The **meta arms do not contribute**, which is what the first
 explanation claimed: `_mk_mutant_repo` returns 1 on a meta failure, so the
 assertion it guards is SKIPPED, and all 20 meta lines in that run stand IN PLACE
 OF an assertion rather than beside one. The two passes are NAMED
@@ -10473,10 +10473,33 @@ Qdrant" is the ledger's `mcp_requirements.qdrant_required`. It is the wrong
 source twice: the ledger is untracked runtime scratch, so *deleting it* would
 switch a blocking gate off — `## BL-231:`'s "tracking file absent ⇒ no
 enforcement, silently" row, reintroduced inside the very gate meant to end it;
-and measured on this tree, of the 61 suites that execute `check-phase-gate.sh`,
-**29 drive it at `current_phase >= 2`, across 74 fixture-creation sites, and not
-one writes a ledger** — so a ledger-derived requirement would have forced 74
-fixture edits to say nothing. The first fix for that read `.claude/settings.local.json`
+and measured **on the merge-base tree `2344b13`, with the recipe printed** —
+because this figure was the last one in the entry still carrying no derivation,
+and one of its three numbers does not survive being asked for one:
+```
+cd <pristine 2344b13 checkout>
+grep -rl 'check-phase-gate' tests/ | wc -l                                  # 60
+S=$(grep -rl 'check-phase-gate' tests/ \
+      | xargs grep -lE '"current_phase"[[:space:]]*:[[:space:]]*[2-9]')
+echo "$S" | wc -l                                                           # 29
+echo "$S" | xargs grep -hcE '"current_phase"[[:space:]]*:[[:space:]]*[2-9]' \
+  | awk '{n+=$1} END{print n}'                                              # 52
+echo "$S" | xargs grep -l 'tool-usage.json' | wc -l                         # 0
+```
+**29 suites drive it at `current_phase >= 2` and not one writes a ledger** — so
+a ledger-derived requirement would have forced an edit to every one of them to
+say nothing. Two corrections to what this paragraph used to assert. (1) The
+**60**, not 61: the 61 was measured on a working tree that already contained
+this entry's own new suite, and stating it as a property of "this tree" made a
+number that grows with the PR read as a fixed measurement. (2) The **74
+fixture-creation sites is withdrawn** — no derivation reproduces it (the site
+count is 52; the nearest alternatives give 79 and 84), so it was hand-counted or
+produced by a one-liner nobody wrote down, which is the whole failure mode this
+entry keeps recording. The load-bearing number was never 74 anyway; it is the
+**0**. Note also that the "not one writes a ledger" claim is true of `2344b13`
+and **false of this branch's head** — `tests/test-bl233-wpb-accumulation.sh`
+writes ledgers deliberately (`grep -oE '\bledger "' tests/test-bl233-wpb-accumulation.sh | wc -l` → 8) — which is why the
+measurement is scoped to the tree the decision was made against. The first fix for that read `.claude/settings.local.json`
 instead, reasoning that `init.sh` writes it and `git add -A` commits it. **THAT
 WAS ALSO WRONG, and worse, because it looked committed.** Claude Code adds
 `settings.local.json` to the user's GLOBAL git excludes by design (it is
@@ -10512,7 +10535,48 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**WP-B residuals — 17, all real, none blocking.** (This header read "two" while
+**The one fail-open ten rounds of review found, and it was in the dimension the
+suite never drove.** `_cpg_accum_source_work` asks git for the window's commits
+with `git log --since=<gate date>`. A gate date in the FUTURE returns zero
+commits and exit 0 — git ANSWERED, so none of the function's three cannot-tell
+arms fire — the empty payload then matches `^$` in the exempt set, and the gate
+printed `[OK] accumulation: nothing owed — every change since 2099-12-31 was
+documentation`. Measured: issue count 9 → 8, landing exactly on the
+no-requirement control. That is two defects at once: an affirmative claim about
+the project that is false (the same substitution the extension allow-list was
+rewritten to remove, reached by a different route), and a **silent off switch
+for a blocking gate** — the precise thing this entry refused to accept from the
+ledger, arriving instead through `gates.*`. It also put the two halves of the
+feature into open disagreement: the commit gate reads source from STAGED PATHS
+and warned, while the phase gate read it from a DATE WINDOW and said nothing was
+owed, which the shared library's own header calls worse than a missing warning.
+
+**Not only tampering.** `_cpg_record_gate_date` PRESERVES a date already
+recorded, so a machine whose clock or timezone is ahead of the one running the
+gate writes a window that is in the future THERE and nowhere else — `## BL-234:`'s
+silent local-vs-CI class, for the third time inside this one feature.
+
+The fix is `_cpg_accum_window_measurable` (`# BL-233-WPB-FUTURE-WINDOW`), asked
+BEFORE either question about the window, because a future window answers both
+with a confident falsehood: nothing can be stored after it and nothing can be
+committed after it. It answers "measurable", not "future", so the caller blocks
+on ANY reason the window cannot be read — a `date` that will not respond reads
+as not measurable. The window start needs no numeric guard: it is `get_gate_date`
+output, already anchored to `YYYY-MM-DD` or empty, and an arm that cannot fire
+is `## BL-104:`'s shape (this follows `_cpg_accum_after`'s precedent in the same
+file, which guards its persisted timestamp and pointedly does not guard its gate
+date). Pinned in both directions, because an over-strict guard fails as silently
+as an over-permissive one: **N1** (future window → refused, same issue count as
+the past-window control, and no claim made about the project), **N2** (a window
+opening TODAY stays measurable — the comparison is `-le`, not `-lt`, or every
+gate would be refused on the day its own date was recorded), **M20** (neuter the
+guard → the fail-open returns verbatim, `nothing owed` 0 → 1), **M21** (`-le` →
+`-lt` → today's window refused, 0 → 1). N2 and M21 re-derive the date if it
+moves under the fixture, because a midnight crossing would otherwise read as a
+real failure and this suite has already shipped one clock-race flake
+(`## BL-241:`).
+
+**WP-B residuals — 18, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10679,6 +10743,16 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    and survive a clone, which an untracked file would not. The change is
    frequency, not kind. Verified live on this tree: a real store through the
    registered hook wrote `{"store_success_count":1,"last_store_at":"…"}`.
+18. **A stale `process-state.json.lockdir` has no breaker.** If a writer is
+   killed between `mkdir` and `rmdir`, every subsequent `qdrant-store`
+   PostToolUse hook spins for its full 3s budget, never records, and the phase
+   gate then blocks indefinitely on a project that is storing correctly. It
+   fails CLOSED and it is VISIBLE (`# BL-233-WPB-RECORD-FAILED-VISIBLE` names
+   the condition at session end), so this is a latency-and-durability residual
+   rather than a correctness hole — but 3s on a hook that fires per tool call is
+   a real cost, and nothing ages the lock out. The lock pattern is inherited
+   from the two pre-existing writers of that file, so a breaker belongs to all
+   three at once and not to this entry alone.
 
 **WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
 done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10407,10 +10407,23 @@ storing half) landed 2026-08-17** on `feat/bl233-wpb-accumulation`, closing item
 the two WP-B residuals recorded with it.
 
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
-`347f619`. `tests/test-bl233-wpb-accumulation.sh` (38 assertions, 8 mutants,
-watched RED at **0 passed / 35 failed** against the base tree before a line of
-product changed). Regression on the same tree: 29/29 phase-gate suites, 38/38
-suites that reference the four changed scripts, 15/15 repo lints.
+`347f619`, corrected by the follow-up commit on the same branch after an
+adversarial review found the derivation defect recorded below.
+`tests/test-bl233-wpb-accumulation.sh` — 49 assertions, 12 mutants. Measured
+against the base tree `7b94e4b`: **2 passed / 47 failed**, and the 2 are named
+rather than glossed (J2/J3 assert an *exempt* verdict, which a tree with no
+accumulation gate also produces; mutant M12 is what makes them attributable).
+An earlier draft of this entry claimed "0 passed / 35 failed" — that was a
+35-assertion draft of the suite, carried forward unchanged after the suite grew,
+and re-deriving it is the whole of `## BL-230:`'s lesson.
+
+**Three counts in the first draft of this entry were wrong; they are corrected
+here rather than quietly dropped.** (1) The regression set was derived with a
+grep that OMITTED `check-phase-gate` — 41 files instead of the 91 that name any
+of the four changed scripts. (2) The "61 suites" figure is reproducible, but
+only with the derivation actually used, `grep -rl 'check-phase-gate' tests/`;
+a path-prefixed pattern yields 56. State the command, not the number. (3) The
+RED figure above.
 Karl decided the posture up front: **WARN at commit, BLOCK at the phase gate**,
 because storing is not per-commit work and a gate people cannot satisfy honestly
 gets deleted (`## BL-149:`). He then decided the three things the entry left
@@ -10441,12 +10454,24 @@ enforcement, silently" row, reintroduced inside the very gate meant to end it;
 and measured on this tree, of the 61 suites that execute `check-phase-gate.sh`,
 **29 drive it at `current_phase >= 2`, across 74 fixture-creation sites, and not
 one writes a ledger** — so a ledger-derived requirement would have forced 74
-fixture edits to say nothing. `init.sh` instead writes
-`.claude/settings.local.json` carrying the `mcpServers.qdrant` entry, the
-generated `.gitignore` ignores only `.claude/cache/`, and the scaffolder's
-`git add -A` commits it. The declaration is therefore **committed and travels
-with the repo**, and that is what `# BL-233-WPB-SCOPE` reads, with the ledger
-kept only as an OR arm for a project that adopted Qdrant after init.
+fixture edits to say nothing. The first fix for that read `.claude/settings.local.json`
+instead, reasoning that `init.sh` writes it and `git add -A` commits it. **THAT
+WAS ALSO WRONG, and worse, because it looked committed.** Claude Code adds
+`settings.local.json` to the user's GLOBAL git excludes by design (it is
+personal configuration), and `generate_gitignore` COPIES
+`templates/generated/gitignore-base.tmpl` — which already ignores
+`.claude/tool-usage.json` — before appending. Both OR arms were therefore absent
+from every fresh clone: the gate blocked on the author's machine and printed
+`NOT CHECKED` on CI. Proved by round trip (build → commit → local bare → clone →
+run), which is the test that was missing; the I-group now carries it.
+
+**The fix is not "a different file" — it is that TRACKEDNESS IS A QUESTION FOR
+GIT.** `_cpg_file_tracked` (`# BL-233-WPB-TRACKED`) asks `git ls-files`, and the
+derivation returns three states rather than a boolean: `tracked` (survives a
+clone), `untracked` (true here, invisible on CI — enforced, with a warning
+naming the remedy), `none`. `init.sh` now records the durable declaration in
+`.claude/manifest.json` (`# BL-233-WPB-MANIFEST-DECL`), which the generated
+`.gitignore` does not cover.
 
 **`$HOME` is deliberately NOT read** — `session-test-gate-check.sh` reads four
 settings files, two of them under `$HOME`, and copying that here would make a
@@ -10474,7 +10499,18 @@ and printed the same sentence three times.
    decides the window; the counter is observability and nothing reads it for a
    verdict. It is recorded so nobody later mistakes it for a per-phase quota —
    a count target is exactly the shape that invites junk stores to hit a number.
-3. **Every successful store now DIRTIES A TRACKED FILE.**
+3. **Legacy projects stay unenforced until someone adds the manifest field.**
+   A project scaffolded before `# BL-233-WPB-MANIFEST-DECL` declares Qdrant only
+   in files git does not track, so in a clone the gate reports `NOT CHECKED` and
+   names the one-line remedy. It is reported, never silent — but it IS a real
+   gap, and it is the honest residual of the fix rather than a claim that every
+   project is now covered.
+4. **`_cpg_accum_source_since` is the one PERMISSIVE arm.** It decides whether an
+   attestation already on record has gone stale, and returns "no source work"
+   when it cannot tell — because inventing staleness would re-block work the
+   operator legitimately excused. Every other cannot-tell arm in this feature
+   fails closed.
+5. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,10 +10409,14 @@ the two WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — 56 assertions, 13 mutants. Measured
-against the base tree `7b94e4b`: **2 passed / 47 failed**, and the 2 are named
-rather than glossed (J2/J3 assert an *exempt* verdict, which a tree with no
-accumulation gate also produces; mutant M12 is what makes them attributable).
+`tests/test-bl233-wpb-accumulation.sh` — **59 assertions, 13 mutants**, both
+derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
+than transcribed, because this entry has now carried a wrong count in three
+consecutive revisions. Measured against the base tree `7b94e4b`: **3 passed /
+59 failed**, and the three are NAMED rather than rounded to zero — A8, H2 and
+H4 assert absences (no bash error; never denies; a store inside the window
+produces no warning) which a tree with no accumulation gate also satisfies.
+They are regression guards, not discriminators.
 An earlier draft of this entry claimed "0 passed / 35 failed" — that was a
 35-assertion draft of the suite, carried forward unchanged after the suite grew,
 and re-deriving it is the whole of `## BL-230:`'s lesson.
@@ -10524,7 +10528,14 @@ and printed the same sentence three times.
    closed too and names WHICH cause (`# BL-233-WPB-STALE-FAILCLOSED`). The only
    remaining permissive arm is "no git at all", where staleness is not a
    question that can be asked.
-6. **Every successful store now DIRTIES A TRACKED FILE.**
+6. **The test suite runs the commit gate, and env must go on the RIGHT of the
+   pipe.** `HOME=... SKIP_LINT=1 printf ... | bash gate` sets both variables for
+   `printf`, not for the gate — so the fixtures read the REAL `$HOME` and the
+   two slow full-tree lints ran on every call. Measured: 505s -> 27s once
+   corrected, and it was also a host-dependence bug sitting inside the suite
+   written to pin host-dependence. It burst the `unit-shard` 12-minute cap and
+   cancelled CI before it was found.
+7. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,11 +10409,11 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **94 assertions, 25 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **100 assertions, 28 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
 consecutive revisions. Measured against the CURRENT merge-base `2344b13` with
-this suite dropped into a `git archive` of that tree: **2 passed / 95 failed**.
+this suite dropped into a `git archive` of that tree: **2 passed / 101 failed**.
 The tally exceeds 78 for one derived reason, and the first explanation offered
 for it was INVENTED — in the paragraph whose whole subject is not transcribing
 numbers, which is why the derivation is printed here:
@@ -10423,8 +10423,8 @@ grep -E '^  \[FAIL\]' <run> | sed 's/^  \[FAIL\] //; s/ — .*//; s/\[.*//' \
 ```
 `D6` reports PER HEAD SHAPE — three loop iterations plus one final line against
 a single `pass` site — so it contributes 4 lines for 1 label and every other
-label contributes exactly 1. 2 passes + 92 distinct failing labels = 94, + D6's
-3 extra lines = 95. The **meta arms do not contribute**, which is what the first
+label contributes exactly 1. 2 passes + 98 distinct failing labels = 100, + D6's
+3 extra lines = 101. The **meta arms do not contribute**, which is what the first
 explanation claimed: `_mk_mutant_repo` returns 1 on a meta failure, so the
 assertion it guards is SKIPPED, and all 20 meta lines in that run stand IN PLACE
 OF an assertion rather than beside one. The two passes are NAMED
@@ -10498,7 +10498,7 @@ produced by a one-liner nobody wrote down, which is the whole failure mode this
 entry keeps recording. The load-bearing number was never 74 anyway; it is the
 **0**. Note also that the "not one writes a ledger" claim is true of `2344b13`
 and **false of this branch's head** — `tests/test-bl233-wpb-accumulation.sh`
-writes ledgers deliberately (`grep -oE '\bledger "' tests/test-bl233-wpb-accumulation.sh | wc -l` → 8) — which is why the
+writes ledgers deliberately (`grep -oE '\bledger "' tests/test-bl233-wpb-accumulation.sh | wc -l` → 11) — which is why the
 measurement is scoped to the tree the decision was made against. The first fix for that read `.claude/settings.local.json`
 instead, reasoning that `init.sh` writes it and `git add -A` commits it. **THAT
 WAS ALSO WRONG, and worse, because it looked committed.** Claude Code adds
@@ -10591,6 +10591,41 @@ stabilising the fixture is the only reason this is recorded here. Closed by
 00:00:01 on the opening day — no clock race in the assertion itself) and killed
 by **M24**.
 
+**(4) THE OTHER OPERAND OF THE SAME COMPARISON, left unguarded for two rounds
+while the first was hardened four ways.** `_cpg_accum_after` compares the window
+START against the persisted STORE TIMESTAMP. Rounds 10-11 validated the start
+against future dates, unparseable values, duplicate keys and an unreadable state
+file; the store timestamp got nothing but a numeric check. It is the WORSE half
+to leave open: a future window start fails LOUDLY, a future store timestamp
+satisfies the gate SILENTLY and on every later run — measured, `2099-01-01` and
+`9999-12-31` both take a blocking fixture from 11 issues to 10 — and
+`.claude/process-state.json` is TRACKED (residual 17), so the bad value is
+committed and reaches every clone. The hazard was named in this entry's own
+prose (residual 19: *"a machine that is ahead writes the gate date AND the store
+timestamp in the future"*) and guarded on one side only. Closed by
+`# BL-233-WPB-STORE-FUTURE`, compared UTC-to-UTC because the tracker writes the
+field with `date -u`, which makes the check exact and removes any need for
+timezone slack. **N11** pins it (and asserts the transcript NAMES the clock, so
+the operator is not told to re-store when re-storing cannot help), **M27** kills
+it. **The suite was leaning on the hole**: D14's fixture used a store dated
+twelve days in the future, and its own floor went red the moment the guard
+landed — which is what a floor is for.
+
+**And a regression this entry introduced in the OTHER file.** `pre-commit-gate.sh`
+is `set -euo pipefail`, and the accumulation block's `jq` read of
+`.current_phase` had no `|| printf '0'` while both siblings below it did. On the
+PreToolUse path that abort discards the ENTIRE `$WARNINGS` accumulator —
+Context7, qdrant-find, TDD — silently, and the new block has no
+`[ -f "$TOOL_USAGE" ]` precondition, so it became reachable for any project whose
+state file will not parse. Guarded (`# BL-233-WPB-ACCPHASE-GUARD`), and the
+PRE-EXISTING sibling at `# BL-233-WPB-CURPHASE-GUARD` had to be guarded with it:
+under errexit that line aborts FIRST, so fixing only the new one looked correct
+and changed nothing observable (rc=5 either way until both were done). **H8**
+pins survival, **M28** measures the rc=5 without it. H4 — which should have
+caught this — was a pure double-absence, and a hook that DIED satisfied it
+exactly as well as one that correctly stayed quiet; it now carries an exit-code
+floor.
+
 **Also refuted in the same round: a "guard that cannot fire".** The numeric guard
 on the window start was omitted, justified by `get_gate_date` validating to
 `YYYY-MM-DD`. This file refutes that 200 lines away: that validation is a
@@ -10629,7 +10664,7 @@ moves under the fixture, because a midnight crossing would otherwise read as a
 real failure and this suite has already shipped one clock-race flake
 (`## BL-241:`).
 
-**WP-B residuals — 21, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 24, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10807,20 +10842,24 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    from the two pre-existing writers of that file, so a breaker belongs to all
    three at once and not to this entry alone.
 
-19. **An unmeasurable window blocks a project that DID store, and the attested
-   escape does not reach it.** The measurability check runs before both the
-   "was anything stored" and the "was source work done" questions, so a project
-   whose gate date is unreadable or in the future now blocks where it previously
-   printed `[OK] satisfied`, and `SOLO_MCP_ACCUM_ATTESTED=1` does not clear it.
-   Deliberate — an attestation excuses "nothing was stored", not "the gate does
-   not know what it is measuring" — and the remedy is named in the message,
-   because the recorded date is the thing that is wrong. Recorded because the
-   trade is real and because the first draft of the placement comment justified
-   it with "nothing can be stored after it", which is FALSE in the clock-skew
-   case that motivates the check: a machine that is ahead writes the gate date
-   AND the store timestamp in the future. The placement is right; that argument
-   for it was not.
-
+19. ~~**An unmeasurable window blocks a project that DID store, and the attested
+   escape does not reach it.**~~ **FIXED, and the fix is the more important half
+   of this whole wave.** Filed as a deliberate trade; it was not one. Every
+   window guard added in rounds 10-11 fails CLOSED, and the block sat AHEAD of
+   the escape, so a wrong clock or a half-written state file left an honest
+   operator with no way past a blocking gate except hand-editing a date. That is
+   `## BL-149:`'s standing rule — *a gate people cannot satisfy honestly gets
+   deleted* — broken by the entry that cites it.
+   **The bypasses these guards close were rated improbable on review; an honest
+   operator hitting a dead end was not.** The measurability check now sets a flag
+   instead of returning (`# BL-233-WPB-WINDOW-ATTESTABLE`): the two PERMISSIVE
+   shortcuts stay skipped, because a store "inside" an unmeasurable window and
+   "nothing owed" are the answers that were false; the ATTESTED path is reached,
+   and the attestation is durably recorded exactly as elsewhere. Fail-closed to
+   a script, open to a human who says why. **N10** asserts both halves — the
+   store that must not satisfy, and the attestation that must clear and be
+   recorded — and **M26** kills the early return, because reading as "tighter"
+   is precisely why that edit gets made.
 20. **The raw `gates.*` value now reaches a verdict line, and flattening it is
    not the same as neutralising it.** `# BL-233-WPB-AMBIGUOUS-WINDOW` and
    `# BL-233-WPB-WINDOW-SHAPE` quote the offending value so the operator can see
@@ -10842,6 +10881,29 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    only other `--since` under `scripts/`. Left out of this entry deliberately —
    it belongs to a different feature's counter and this entry claims no sweep of
    the class — but recorded with the one-token fix so it is not rediscovered.
+
+22. **The commit-time warning still lags the gate on TWO window shapes.** After
+   `# BL-233-WPB-WARN-UNREADABLE-WINDOW`, the two halves agree on a valid
+   window, a future window, an unparseable gate date and an absent gate. They
+   still DISAGREE on a duplicate `gates.*` key whose last value is a valid date
+   (the gate sees both via `get_gate_date`'s per-line `grep -o`; the commit half
+   reads with `jq`, which is last-wins) and on a `.gates` that is not an object.
+   The gate BLOCKS, the warning stays silent. **Deliberately not fixed**: both
+   shapes require hand-crafting the JSON, and the consequence is a missing
+   nudge, not a fail-open. Recorded because "warn at commit, block at the gate"
+   is the posture, and a known gap in it should be written down rather than
+   discovered twice.
+23. **`GIT_DIR` / `GIT_WORK_TREE` redirect the source-work measurement.** Setting
+   them makes `_cpg_accum_source_work` read another repository, which reports
+   "nothing owed" — a silent, unrecorded bypass, unlike the documented
+   `SOIF_PHASE_GATES=warn` and the recorded `SOLO_MCP_ACCUM_ATTESTED`.
+   Pre-existing and not specific to this arm: the class affects every `git` read
+   in `check-phase-gate.sh`. Noted here because the accumulation gate is the
+   first BLOCKING check whose failure direction is "pass".
+24. **An unreadable `phase-state.json` (mode 000) makes the WHOLE gate report
+   `Phase gates consistent`, rc=0.** Verified byte-identical on merge-base
+   `2344b13`, so it predates this entry entirely and is out of its scope — but
+   it is the same silent-non-enforcement class and belongs on the record.
 
 **WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
 done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,10 +10409,10 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **75 assertions, 18 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **77 assertions, 18 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
-consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 75 failed**,
+consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 77 failed**,
 and the three are NAMED rather than rounded to zero — A8, H2 and
 H4 assert absences (no bash error; never denies; a store inside the window
 produces no warning) which a tree with no accumulation gate also satisfies.
@@ -10494,7 +10494,7 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**WP-B residuals — 13, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 15, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10598,7 +10598,23 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    or from the environment is passed through `accum_oneline` where it ENTERS**,
    and no display site needs to be audited at all. M17 and M18 are the proofs
    that the ingest wrap is load-bearing.
-13. **Every successful store now DIRTIES A TRACKED FILE.**
+13. **The rule needed the backslash, and that is the whole lesson.** Residual 12
+   said "clean at the boundary and no display site needs auditing". That was
+   false as written: `accum_oneline` stripped REAL control bytes, but `echo -e`
+   MANUFACTURES a real newline out of the two-character sequence backslash-n,
+   which a control strip leaves untouched. An eighth instance followed — ingest
+   sanitising and `printf '%s'` are COMPLEMENTS, and round 7 had replaced one
+   with the other. The primitive now removes the backslash too, so `echo -e` is
+   inert on these values and the sentence is finally true; D15 proves it by
+   reverting a display site to `echo -e` and measuring no new forgery.
+14. **Sanitising for display must not sanitise for SEMANTICS.** Cleaning the
+   attestation head at ingest turned a display filter into a git-ref normaliser:
+   an invalid ref became a valid one once C0 bytes were stripped, so a tampered
+   attestation resolved and the verdict flipped FAIL to OK — inverting the
+   fail-closed posture that function's own header promises. The value now
+   reaches git RAW (`# BL-233-WPB-SHA-RAW-FOR-GIT`) and is cleaned only where it
+   is displayed.
+15. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,14 +10409,20 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **77 assertions, 19 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **78 assertions, 19 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
-consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 77 failed**,
-and the three are NAMED rather than rounded to zero — A8, H2 and
-H4 assert absences (no bash error; never denies; a store inside the window
-produces no warning) which a tree with no accumulation gate also satisfies.
-They are regression guards, not discriminators.
+consecutive revisions. Measured against the CURRENT merge-base `2344b13` with
+this suite dropped into a `git archive` of that tree: **2 passed / 79 failed**.
+The tally exceeds 78 because the meta arms fire an EXTRA `fail_` alongside the
+assertion they guard, which is what they are for. The two passes are NAMED
+rather than rounded to zero — H2 and H4 assert absences (the commit arm never
+denies; a store inside the window produces no warning) which a tree with no
+accumulation gate also satisfies. They are regression guards, not
+discriminators. **A8 used to be a third such pass and is not any more**: its
+control is now applied, so on a tree with no `scripts/lib/accumulation.sh` the
+control cannot warn and A8's meta arm fires. That is the difference between a
+control that is computed and a control that is read.
 An earlier draft of this entry claimed "0 passed / 35 failed" — that was a
 35-assertion draft of the suite, carried forward unchanged after the suite grew,
 and re-deriving it is the whole of `## BL-230:`'s lesson.
@@ -10614,17 +10620,25 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    fail-closed posture that function's own header promises. The value now
    reaches git RAW (`# BL-233-WPB-SHA-RAW-FOR-GIT`) and is cleaned only where it
    is displayed.
-15. **A test was DELETED rather than fixed a fourth time.** D13 asserted that
-   this feature's display of a duplicate-key gate date adds no forged line, and
-   it was vacuous in three successive forms: scoped by a substring a forgery can
-   never contain; then rewritten with a real control but a payload writing TWO
-   backslashes on disk (so `echo -e` emitted one line, not two) and the forged
-   text never beginning a line; then with the APPROVAL_LOG evidence dropped, and
-   still measuring 0/0. A vacuity floor was added and it FIRED, which is why this
-   is a deletion and not a fourth silent pass. Coverage is not lost: M19 drives
-   the same mechanism with a payload proved to discriminate (control 1 → mutant
-   2), and M19's control leg IS that assertion. One working test beats two, one
-   of which cannot fail.
+15. **A test was vacuous three times, then DELETED on BACKWARDS reasoning, and
+   is now RESTORED with a floor.** D13 asserts that this feature's display of a
+   duplicate-key gate date adds no forged line to the transcript. It was vacuous
+   in three successive forms: scoped by a substring a forgery can never contain;
+   then rewritten with a real control but a payload writing TWO backslashes on
+   disk (so `echo -e` emitted one line, not two) and the forged text never
+   beginning a line; then with `mk_proj`'s `APPROVAL_LOG.md` evidence dropped,
+   still measuring 0/0. The deletion that followed reasoned that the evidence
+   SUPPRESSED the forging arm. It does the opposite: that evidence is what lets
+   `_cpg_record_gate_date` render the gate date at all, and the rendered date is
+   where the baseline forged line comes from — so removing it is what CAUSED the
+   0/0. The assertion was sound throughout; the fixture had been broken by the
+   edit meant to fix it. Restored with the evidence intact and a vacuity floor at
+   `base >= 1`, it measures 1 → 1, and a silent return to 0/0 now fails loudly.
+   **M19 does not subsume it**, which the deletion also claimed. M19's predicate
+   is `mutant > control` with NO upper bound on the control, so a new raw display
+   site added later reads control=2 / mutant=3 and passes green, while D13 reads
+   1 → 2 and fails. The two watch opposite trees — M19 the mutated one, D13 the
+   shipped one — so both are wanted.
 16. **`accum_oneline` mangles legitimate backslashes IN THE TRANSCRIPT ONLY.** An
    attestation reason like `ported C:\Users\karl\src … the \d+ regex` displays
    as `ported C:Userskarlsrc … the d+ regex`. Storage, idempotence and staleness

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,11 +10409,11 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **90 assertions, 24 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **94 assertions, 25 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
 consecutive revisions. Measured against the CURRENT merge-base `2344b13` with
-this suite dropped into a `git archive` of that tree: **2 passed / 91 failed**.
+this suite dropped into a `git archive` of that tree: **2 passed / 95 failed**.
 The tally exceeds 78 for one derived reason, and the first explanation offered
 for it was INVENTED — in the paragraph whose whole subject is not transcribing
 numbers, which is why the derivation is printed here:
@@ -10423,8 +10423,8 @@ grep -E '^  \[FAIL\]' <run> | sed 's/^  \[FAIL\] //; s/ — .*//; s/\[.*//' \
 ```
 `D6` reports PER HEAD SHAPE — three loop iterations plus one final line against
 a single `pass` site — so it contributes 4 lines for 1 label and every other
-label contributes exactly 1. 2 passes + 88 distinct failing labels = 90, + D6's
-3 extra lines = 91. The **meta arms do not contribute**, which is what the first
+label contributes exactly 1. 2 passes + 92 distinct failing labels = 94, + D6's
+3 extra lines = 95. The **meta arms do not contribute**, which is what the first
 explanation claimed: `_mk_mutant_repo` returns 1 on a meta failure, so the
 assertion it guards is SKIPPED, and all 20 meta lines in that run stand IN PLACE
 OF an assertion rather than beside one. The two passes are NAMED
@@ -10598,9 +10598,13 @@ PER-LINE `grep -qE`, so a duplicate key yields a multi-line value that passes if
 ANY line is a date, and `accum_oneline` concatenates them. `ZZZZZZZZZZ2026-02-01`
 reached `[ -le ]`, which blocks — right direction — while printing a raw
 `integer expression expected` from the shell INTO a blocking verdict. Guard
-restored (`# BL-233-WPB-WINDOW-NUMERIC`), pinned by **N6**, killed by **M23**.
+restored — and then WIDENED, because the first form validated only the first ten
+characters and therefore caught the garbage-first operand order while waving
+through date-first, whose concatenation git reads as a future instant. It now
+validates the WHOLE window string and its LINE COUNT
+(`# BL-233-WPB-WINDOW-SHAPE`), pinned by **N6** and **N8**, killed by **M23**.
 And the FAIL line no longer hard-codes ", which is not in the past": that reason
-is false on two of the four paths that reach it, so an arm written to remove a
+is false on every path that reaches it but one, so an arm written to remove a
 false affirmative printed one of its own. The reason is now carried in
 `_ACCUM_WINDOW_REASON` (the `_ACCUM_STALE_REASON` precedent) and **N5** shims
 `date` to fail on a past window to prove it.
@@ -10625,7 +10629,7 @@ moves under the fixture, because a midnight crossing would otherwise read as a
 real failure and this suite has already shipped one clock-race flake
 (`## BL-241:`).
 
-**WP-B residuals — 19, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 21, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10816,6 +10820,28 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    case that motivates the check: a machine that is ahead writes the gate date
    AND the store timestamp in the future. The placement is right; that argument
    for it was not.
+
+20. **The raw `gates.*` value now reaches a verdict line, and flattening it is
+   not the same as neutralising it.** `# BL-233-WPB-AMBIGUOUS-WINDOW` and
+   `# BL-233-WPB-WINDOW-SHAPE` quote the offending value so the operator can see
+   what is wrong with it. `accum_oneline` strips its control characters and
+   backslashes, so it cannot begin a line and cannot forge an `[OK]` verdict —
+   exit code and issue count are provably unaffected — but a value containing
+   the TEXT `accumulation: satisfied` will still be counted by a bare
+   `grep -c 'accumulation: satisfied'`, which is this suite's own verdict
+   primitive. The quoted value is truncated to 40 characters to bound the
+   surface. The real fix is for assertions about verdicts to anchor on the
+   line, and most here already do.
+21. **The same bare-`--since` defect exists in `session-test-gate-check.sh` and
+   is NOT fixed here.** That script reads the same `gates.phase_1_to_2` field
+   and runs `git log --oneline --since="$PHASE2_DATE" --no-merges`, so its
+   commit counter has exactly the fault
+   `# BL-233-WPB-SINCE-MIDNIGHT` removes from the gate: the window starts at the
+   current clock time on that date, not midnight, so commits made earlier in the
+   day are uncounted and the same tree counts differently by the hour. It is the
+   only other `--since` under `scripts/`. Left out of this entry deliberately —
+   it belongs to a different feature's counter and this entry claims no sweep of
+   the class — but recorded with the one-token fix so it is not rediscovered.
 
 **WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
 done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,10 +10409,11 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **65 assertions, 15 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **70 assertions, 16 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
-consecutive revisions. Measured against the base tree `7b94e4b`: **3 passed / 65 failed**, and the three are NAMED rather than rounded to zero — A8, H2 and
+consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 70 failed**,
+and the three are NAMED rather than rounded to zero — A8, H2 and
 H4 assert absences (no bash error; never denies; a store inside the window
 produces no warning) which a tree with no accumulation gate also satisfies.
 They are regression guards, not discriminators.
@@ -10493,7 +10494,7 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**WP-B residuals — 9, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 11, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10550,13 +10551,31 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    JSON *is* an honest escape, and it is the only one that resolves the actual
    problem, so `## BL-149:` is satisfied without an env-var bypass. If that ever
    proves wrong the fix is to move the arm below the attestation block.
-8. **The same `echo -e` forging surface survives in BL-073's reviewer
-   attestation** (`check-phase-gate.sh` ~2656 and ~2730), which renders
-   `$cpg_attest_reason` and can forge `[OK]` verdict lines exactly as the
-   accumulation arms could before this work. Left deliberately: pre-existing,
-   out of this entry's scope, and it needs its own mutation proofs. Filed here
-   so the asymmetry is recorded rather than discovered.
-9. **Every successful store now DIRTIES A TRACKED FILE.**
+8. **The same forging surface survives in BL-073's reviewer attestation** — the
+   two `echo -e` sites that render `$cpg_attest_reason` in
+   `_cpg_check_reviewers`' no-manifest and incomplete-reviews arms. Cited by
+   FUNCTION and variable rather than by line: the first draft of this residual
+   said "~2656 and ~2730" and those numbers had already drifted to 2698/2772 by
+   the next day, which is exactly the failure CLAUDE.md's CITATION RULE exists to
+   prevent — recorded here because being caught by it while writing a residual
+   about care is the useful part. Left deliberately: pre-existing, out of this
+   entry's scope, needs its own mutation proofs.
+9. **The accumulation gate does not run in solo-orchestrator itself.**
+   Measured: `. scripts/lib/accumulation.sh && accum_requirement_state` returns
+   `none` in this checkout, because there is no `.claude/manifest.json` and the
+   tracked `.claude/settings.json` declares no `mcpServers`. The RETRIEVAL half
+   (the PostToolUse/PreToolUse hooks) does fire here; the accumulation half does
+   not. Every proof that it works therefore comes from synthetic fixtures and
+   from CI, never from the one environment the author uses interactively — which
+   is the same "validated where written, not where it runs" axis this work has
+   been caught on repeatedly. Recorded rather than quietly relied upon.
+10. **`# BL-233-WPB-MANIFEST-DECL` has no test.** `init.sh`'s line writing
+   `.claude/manifest.json::mcp.qdrant_required` is what makes the whole
+   tracked-declaration design work in a real generated project, and the I-group
+   hand-builds its fixtures rather than running the scaffolder. It cannot be
+   closed inside the fast lane: a test that invokes `init.sh` is unit-lane
+   exempt by the BL-181 predicate, so it would have to live in the full lane.
+11. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,10 +10409,10 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **70 assertions, 16 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **75 assertions, 18 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
-consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 70 failed**,
+consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 75 failed**,
 and the three are NAMED rather than rounded to zero — A8, H2 and
 H4 assert absences (no bash error; never denies; a store inside the window
 produces no warning) which a tree with no accumulation gate also satisfies.
@@ -10494,7 +10494,7 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**WP-B residuals — 11, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 13, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10552,14 +10552,18 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    problem, so `## BL-149:` is satisfied without an env-var bypass. If that ever
    proves wrong the fix is to move the arm below the attestation block.
 8. **The same forging surface survives in BL-073's reviewer attestation** — the
-   two `echo -e` sites that render `$cpg_attest_reason` in
-   `_cpg_check_reviewers`' no-manifest and incomplete-reviews arms. Cited by
-   FUNCTION and variable rather than by line: the first draft of this residual
-   said "~2656 and ~2730" and those numbers had already drifted to 2698/2772 by
-   the next day, which is exactly the failure CLAUDE.md's CITATION RULE exists to
-   prevent — recorded here because being caught by it while writing a residual
-   about care is the useful part. Left deliberately: pre-existing, out of this
-   entry's scope, needs its own mutation proofs.
+   two `echo -e` sites that render `$cpg_attest_reason`, in the no-manifest and
+   incomplete-reviews arms of the Phase 3→4 review gate. Left deliberately:
+   pre-existing, out of this entry's scope, and it needs its own mutation proofs.
+
+   **Cited by VARIABLE (`$cpg_attest_reason`), because the two previous attempts
+   at this one citation were both wrong.** The first said "~2656 and ~2730";
+   those had already drifted to 2698/2772 when review measured them, and to
+   2719/2793 a day later — three values in two days. The second said
+   `_cpg_check_reviewers`, and no such function exists; those arms sit in the
+   script body. A grep-able token is the only form that survives, which is
+   exactly what CLAUDE.md's CITATION RULE says and why it says it.
+
 9. **The accumulation gate does not run in solo-orchestrator itself.**
    Measured: `. scripts/lib/accumulation.sh && accum_requirement_state` returns
    `none` in this checkout, because there is no `.claude/manifest.json` and the
@@ -10575,7 +10579,26 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    hand-builds its fixtures rather than running the scaffolder. It cannot be
    closed inside the fast lane: a test that invokes `init.sh` is unit-lane
    exempt by the BL-181 predicate, so it would have to live in the full lane.
-11. **Every successful store now DIRTIES A TRACKED FILE.**
+11. **The same forging surface exists on PRE-EXISTING gate-date arms.** A
+   DUPLICATE `"phase_1_to_2"` key in `.claude/phase-state.json` — which jq
+   accepts, so the file is not malformed — makes `get_gate_date` return a
+   multi-line value, because it extracts with `grep -o` and validates with an
+   anchored `grep -qE`, and **grep matches per line**. BL-071's
+   "gate dated …, but APPROVAL_LOG.md has no dated entry" arm then renders it
+   through `echo -e` and a forged `[OK]` line appears. Measured, out of this
+   entry's scope, left deliberately — this entry's own arms clean the value at
+   ingest (`# BL-233-WPB-PREV-ONELINE`), so D13 is scoped to the accumulation
+   output rather than to the whole transcript.
+12. **THE RULE, because the sweep was wrong twice in a row.** Round 5 swept for
+   the KEYWORDS `reason|recorded|attest` and missed `$last`. Round 6 swept for
+   the SYNTAX `echo -e` — in the same round that moved four sites onto `printf`,
+   so the sweep was blind to the surface it had just created — and missed `$sha`.
+   Each sweep described the PREVIOUS round's shape. The rule that holds is a
+   BOUNDARY rule, not a search: **every value that arrives from a file, from jq,
+   or from the environment is passed through `accum_oneline` where it ENTERS**,
+   and no display site needs to be audited at all. M17 and M18 are the proofs
+   that the ingest wrap is load-bearing.
+13. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,7 +10409,7 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **77 assertions, 18 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **77 assertions, 19 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
 consecutive revisions. Measured against the CURRENT merge-base `2344b13`: **3 passed / 77 failed**,
@@ -10494,7 +10494,7 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**WP-B residuals — 15, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 17, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10614,7 +10614,24 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    fail-closed posture that function's own header promises. The value now
    reaches git RAW (`# BL-233-WPB-SHA-RAW-FOR-GIT`) and is cleaned only where it
    is displayed.
-15. **Every successful store now DIRTIES A TRACKED FILE.**
+15. **A test was DELETED rather than fixed a fourth time.** D13 asserted that
+   this feature's display of a duplicate-key gate date adds no forged line, and
+   it was vacuous in three successive forms: scoped by a substring a forgery can
+   never contain; then rewritten with a real control but a payload writing TWO
+   backslashes on disk (so `echo -e` emitted one line, not two) and the forged
+   text never beginning a line; then with the APPROVAL_LOG evidence dropped, and
+   still measuring 0/0. A vacuity floor was added and it FIRED, which is why this
+   is a deletion and not a fourth silent pass. Coverage is not lost: M19 drives
+   the same mechanism with a payload proved to discriminate (control 1 → mutant
+   2), and M19's control leg IS that assertion. One working test beats two, one
+   of which cannot fail.
+16. **`accum_oneline` mangles legitimate backslashes IN THE TRANSCRIPT ONLY.** An
+   attestation reason like `ported C:\Users\karl\src … the \d+ regex` displays
+   as `ported C:Userskarlsrc … the d+ regex`. Storage, idempotence and staleness
+   all round-trip the value VERBATIM (verified). The trade is deliberate — it is
+   what makes `echo -e` inert and therefore what makes residual 13's rule true —
+   and it is recorded so the display loss is a choice rather than a surprise.
+17. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10404,16 +10404,15 @@ mechanism intact.
 **Status:** Open — **WP-A landed** on `feat/bl233-mcp-enforcement`; **WP-B (the
 storing half) landed 2026-08-17** on `feat/bl233-wpb-accumulation`, closing item
 6. Open for the three WP-A residuals below (1-3; residual 4 is now fixed) plus
-the two WP-B residuals recorded with it.
+the WP-B residuals recorded with it.
 
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **59 assertions, 13 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **65 assertions, 15 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
-consecutive revisions. Measured against the base tree `7b94e4b`: **3 passed /
-59 failed**, and the three are NAMED rather than rounded to zero — A8, H2 and
+consecutive revisions. Measured against the base tree `7b94e4b`: **3 passed / 65 failed**, and the three are NAMED rather than rounded to zero — A8, H2 and
 H4 assert absences (no bash error; never denies; a store inside the window
 produces no warning) which a tree with no accumulation gate also satisfies.
 They are regression guards, not discriminators.
@@ -10494,7 +10493,17 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**WP-B residuals — two, both real, neither blocking.**
+**WP-B residuals — 9, all real, none blocking.** (This header read "two" while
+enumerating seven: it was written at two and never updated as items were
+added, including by the commit whose own subject was "derive the counts
+instead of transcribing them". The first correction of it said 15, because the
+derivation ran past the section into the WP-A list — a derived number is only
+as good as its boundary. Both halves, checked:
+```
+awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
+  solo-orchestrator-backlog.md | grep -cE '^[0-9]+\. (\*\*|~~)'
+```
+)
 1. **Plugin-provided MCP servers are still invisible**, now on a second surface.
    WP-A residual 2 records that `session-test-gate-check.sh` classifies by NAME
    from `.mcpServers`; the WP-B derivation reads the same key in the project
@@ -10535,7 +10544,19 @@ and printed the same sentence three times.
    corrected, and it was also a host-dependence bug sitting inside the suite
    written to pin host-dependence. It burst the `unit-shard` 12-minute cap and
    cancelled CI before it was found.
-7. **Every successful store now DIRTIES A TRACKED FILE.**
+7. **The `unreadable` arm is the ONE blocking arm with no attested escape** —
+   it returns before the attestation block, so `SOLO_MCP_ACCUM_ATTESTED=1`
+   cannot clear it. Recorded as a decision rather than inherited: fixing the
+   JSON *is* an honest escape, and it is the only one that resolves the actual
+   problem, so `## BL-149:` is satisfied without an env-var bypass. If that ever
+   proves wrong the fix is to move the arm below the attestation block.
+8. **The same `echo -e` forging surface survives in BL-073's reviewer
+   attestation** (`check-phase-gate.sh` ~2656 and ~2730), which renders
+   `$cpg_attest_reason` and can forge `[OK]` verdict lines exactly as the
+   accumulation arms could before this work. Left deliberately: pre-existing,
+   out of this entry's scope, and it needs its own mutation proofs. Filed here
+   so the asymmetry is recorded rather than discovered.
+9. **Every successful store now DIRTIES A TRACKED FILE.**
    `.claude/process-state.json` is tracked here and in generated projects
    (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
    session leaves a modified file that a later `git add -A` sweeps into an

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10409,11 +10409,11 @@ the WP-B residuals recorded with it.
 **WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
 `347f619`, corrected by the follow-up commit on the same branch after an
 adversarial review found the derivation defect recorded below.
-`tests/test-bl233-wpb-accumulation.sh` — **82 assertions, 21 mutants**, both
+`tests/test-bl233-wpb-accumulation.sh` — **90 assertions, 24 mutants**, both
 derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
 consecutive revisions. Measured against the CURRENT merge-base `2344b13` with
-this suite dropped into a `git archive` of that tree: **2 passed / 83 failed**.
+this suite dropped into a `git archive` of that tree: **2 passed / 91 failed**.
 The tally exceeds 78 for one derived reason, and the first explanation offered
 for it was INVENTED — in the paragraph whose whole subject is not transcribing
 numbers, which is why the derivation is printed here:
@@ -10423,8 +10423,8 @@ grep -E '^  \[FAIL\]' <run> | sed 's/^  \[FAIL\] //; s/ — .*//; s/\[.*//' \
 ```
 `D6` reports PER HEAD SHAPE — three loop iterations plus one final line against
 a single `pass` site — so it contributes 4 lines for 1 label and every other
-label contributes exactly 1. 2 passes + 80 distinct failing labels = 82, + D6's
-3 extra lines = 83. The **meta arms do not contribute**, which is what the first
+label contributes exactly 1. 2 passes + 88 distinct failing labels = 90, + D6's
+3 extra lines = 91. The **meta arms do not contribute**, which is what the first
 explanation claimed: `_mk_mutant_repo` returns 1 on a meta failure, so the
 assertion it guards is SKIPPED, and all 20 meta lines in that run stand IN PLACE
 OF an assertion rather than beside one. The two passes are NAMED
@@ -10535,8 +10535,11 @@ a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
 rest. With `-ge`, one missing store would have counted as three inconsistencies
 and printed the same sentence three times.
 
-**The one fail-open ten rounds of review found, and it was in the dimension the
-suite never drove.** `_cpg_accum_source_work` asks git for the window's commits
+**THREE fail-opens, all in the dimension the suite never drove — the window
+itself. The first was found by review, the second by review of the fix, and the
+third by this suite's own test going intermittently green.**
+
+**(1) A window that opens in the FUTURE.** `_cpg_accum_source_work` asks git for the window's commits
 with `git log --since=<gate date>`. A gate date in the FUTURE returns zero
 commits and exit 0 — git ANSWERED, so none of the function's three cannot-tell
 arms fire — the empty payload then matches `^$` in the exempt set, and the gate
@@ -10555,6 +10558,52 @@ owed, which the shared library's own header calls worse than a missing warning.
 recorded, so a machine whose clock or timezone is ahead of the one running the
 gate writes a window that is in the future THERE and nowhere else — `## BL-234:`'s
 silent local-vs-CI class, for the third time inside this one feature.
+
+**(2) A window that is RECORDED but UNPARSEABLE — reached without any clock
+skew.** `get_gate_date` maps BOTH "no gate recorded" and "a gate recorded whose
+value will not parse" to `""`, and `""` then reaches `_cpg_accum_after`, whose
+`[ -z "$gate" ]` arm makes ANY store ever recorded satisfy the gate. One edit of
+`gates.*` to `not-a-date` took a blocking fixture from 9 inconsistencies to 8,
+with a 2020 store reported as satisfying a 2026 phase. Closed by
+`# BL-233-WPB-AMBIGUOUS-WINDOW`, which needs the raw value; and the raw value
+needs `# BL-233-WPB-RAW-SNAPSHOT`, because `_cpg_record_gate_date` REWRITES
+`gates.*` from APPROVAL_LOG evidence DURING the run — the second cut of this fix
+re-read the file and measured a different one, saw `not-a-date` already
+normalised to today's date, reported "parses fine", and left the hole open while
+its own test went green. **N3** pins the resolution, **N4** pins that a
+genuinely absent gate still means "the whole history" (the first cut refused
+three fixtures out of four), and **M22** kills it.
+
+**(3) THE WINDOW DID NOT OPEN AT MIDNIGHT, and this one was found by a TEST
+FLAKING, not by review.** `_cpg_accum_source_work` passed a bare date to
+`git log --since`. git's approxidate fills the fields a date string OMITS from
+the CURRENT CLOCK, so `--since=<date>` means "that date at whatever time it is
+right now". Measured: a commit made at 10:35:18 today is invisible to
+`--since=<today>` two seconds later and visible to `--since=<today> 00:00:00`.
+Every source commit made earlier in the day on the window's opening date was
+therefore outside its own window — so a phase whose previous gate was recorded
+today reported "nothing owed" all afternoon, and the SAME TREE returned a
+different verdict depending on the hour, which is `## BL-234:`'s class wearing a
+clock instead of a hostname. Surfaced as N2 passing 32 times out of 40; the
+eight failures were the product, and chasing them into it rather than
+stabilising the fixture is the only reason this is recorded here. Closed by
+`# BL-233-WPB-SINCE-MIDNIGHT`, pinned by **N7** (a source commit back-dated to
+00:00:01 on the opening day — no clock race in the assertion itself) and killed
+by **M24**.
+
+**Also refuted in the same round: a "guard that cannot fire".** The numeric guard
+on the window start was omitted, justified by `get_gate_date` validating to
+`YYYY-MM-DD`. This file refutes that 200 lines away: that validation is a
+PER-LINE `grep -qE`, so a duplicate key yields a multi-line value that passes if
+ANY line is a date, and `accum_oneline` concatenates them. `ZZZZZZZZZZ2026-02-01`
+reached `[ -le ]`, which blocks — right direction — while printing a raw
+`integer expression expected` from the shell INTO a blocking verdict. Guard
+restored (`# BL-233-WPB-WINDOW-NUMERIC`), pinned by **N6**, killed by **M23**.
+And the FAIL line no longer hard-codes ", which is not in the past": that reason
+is false on two of the four paths that reach it, so an arm written to remove a
+false affirmative printed one of its own. The reason is now carried in
+`_ACCUM_WINDOW_REASON` (the `_ACCUM_STALE_REASON` precedent) and **N5** shims
+`date` to fail on a past window to prove it.
 
 The fix is `_cpg_accum_window_measurable` (`# BL-233-WPB-FUTURE-WINDOW`), asked
 BEFORE either question about the window, because a future window answers both
@@ -10576,7 +10625,7 @@ moves under the fixture, because a midnight crossing would otherwise read as a
 real failure and this suite has already shipped one clock-race flake
 (`## BL-241:`).
 
-**WP-B residuals — 18, all real, none blocking.** (This header read "two" while
+**WP-B residuals — 19, all real, none blocking.** (This header read "two" while
 enumerating seven: it was written at two and never updated as items were
 added, including by the commit whose own subject was "derive the counts
 instead of transcribing them". The first correction of it said 15, because the
@@ -10753,6 +10802,20 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    a real cost, and nothing ages the lock out. The lock pattern is inherited
    from the two pre-existing writers of that file, so a breaker belongs to all
    three at once and not to this entry alone.
+
+19. **An unmeasurable window blocks a project that DID store, and the attested
+   escape does not reach it.** The measurability check runs before both the
+   "was anything stored" and the "was source work done" questions, so a project
+   whose gate date is unreadable or in the future now blocks where it previously
+   printed `[OK] satisfied`, and `SOLO_MCP_ACCUM_ATTESTED=1` does not clear it.
+   Deliberate — an attestation excuses "nothing was stored", not "the gate does
+   not know what it is measuring" — and the remedy is named in the message,
+   because the recorded date is the thing that is wrong. Recorded because the
+   trade is real and because the first draft of the placement comment justified
+   it with "nothing can be stored after it", which is FALSE in the clock-skew
+   case that motivates the check: a machine that is ahead writes the gate date
+   AND the store timestamp in the future. The placement is right; that argument
+   for it was not.
 
 **WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
 done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10414,8 +10414,20 @@ derived (`grep -cE '^\s*pass "'` and `grep -cE '_mk_mutant_repo "M'`) rather
 than transcribed, because this entry has now carried a wrong count in three
 consecutive revisions. Measured against the CURRENT merge-base `2344b13` with
 this suite dropped into a `git archive` of that tree: **2 passed / 79 failed**.
-The tally exceeds 78 because the meta arms fire an EXTRA `fail_` alongside the
-assertion they guard, which is what they are for. The two passes are NAMED
+The tally exceeds 78 for one derived reason, and the first explanation offered
+for it was INVENTED — in the paragraph whose whole subject is not transcribing
+numbers, which is why the derivation is printed here:
+```
+grep -E '^  \[FAIL\]' <run> | sed 's/^  \[FAIL\] //; s/ — .*//; s/\[.*//' \
+  | sort | uniq -c | awk '$1>1'     #  ->  4 D6
+```
+`D6` reports PER HEAD SHAPE — three loop iterations plus one final line against
+a single `pass` site — so it contributes 4 lines for 1 label and every other
+label contributes exactly 1. 2 passes + 76 distinct failing labels = 78, + D6's
+3 extra lines = 79. The **meta arms do not contribute**, which is what the first
+explanation claimed: `_mk_mutant_repo` returns 1 on a meta failure, so the
+assertion it guards is SKIPPED, and all 20 meta lines in that run stand IN PLACE
+OF an assertion rather than beside one. The two passes are NAMED
 rather than rounded to zero — H2 and H4 assert absences (the commit arm never
 denies; a store inside the window produces no warning) which a tree with no
 accumulation gate also satisfies. They are regression guards, not
@@ -10593,8 +10605,19 @@ awk '/^\*\*WP-B residuals/{f=1} f&&/^\*\*WP-A, 2026-08-13/{exit} f' \\
    "gate dated …, but APPROVAL_LOG.md has no dated entry" arm then renders it
    through `echo -e` and a forged `[OK]` line appears. Measured, out of this
    entry's scope, left deliberately — this entry's own arms clean the value at
-   ingest (`# BL-233-WPB-PREV-ONELINE`), so D13 is scoped to the accumulation
-   output rather than to the whole transcript.
+   ingest (`# BL-233-WPB-PREV-ONELINE`), so nothing this PR adds can widen it.
+   **Two details here were wrong until now and are corrected rather than
+   dropped.** (a) The arm that renders it is NOT BL-071's "gate dated …, but
+   APPROVAL_LOG.md has no dated entry" branch — it is the OPPOSITE branch of the
+   same `if`, `_cpg_record_gate_date`'s `gate date already recorded (…) —
+   preserving first-pass timestamp (idempotent)` message, which is why removing
+   `APPROVAL_LOG.md` does not merely change the count but aborts the gate before
+   any gate-date arm runs (that is residual 15's causal point, measured). (b)
+   D13 is **not** "scoped to the accumulation output" — that describes D13's
+   FIRST vacuous form, the one residual 15 calls scoping by a substring a forgery
+   can never contain. The restored D13 counts forged lines across the WHOLE
+   transcript and subtracts a control fixture, which is precisely what lets it
+   bound a new raw display site anywhere in the file.
 12. **THE RULE, because the sweep was wrong twice in a row.** Round 5 swept for
    the KEYWORDS `reason|recorded|attest` and missed `$last`. Round 6 swept for
    the SYNTAX `echo -e` — in the same round that moved four sites onto `printf`,

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -10402,8 +10402,89 @@ document the two visible symptoms and should be read first for the evidence;
 neither should be fixed on its own, because a patch to either leaves the
 mechanism intact.
 **Status:** Open — **WP-A landed** on `feat/bl233-mcp-enforcement`; **WP-B (the
-storing half: warn at commit, block at the phase gate) is still open**, and so
-is item 6's underlying question of whether accumulation is enforced at all.
+storing half) landed 2026-08-17** on `feat/bl233-wpb-accumulation`, closing item
+6. Open for the three WP-A residuals below (1-3; residual 4 is now fixed) plus
+the two WP-B residuals recorded with it.
+
+**WP-B, 2026-08-17 — what shipped, and the four decisions behind it.** Landed in
+`347f619`. `tests/test-bl233-wpb-accumulation.sh` (38 assertions, 8 mutants,
+watched RED at **0 passed / 35 failed** against the base tree before a line of
+product changed). Regression on the same tree: 29/29 phase-gate suites, 38/38
+suites that reference the four changed scripts, 15/15 repo lints.
+Karl decided the posture up front: **WARN at commit, BLOCK at the phase gate**,
+because storing is not per-commit work and a gate people cannot satisfy honestly
+gets deleted (`## BL-149:`). He then decided the three things the entry left
+open, and they are recorded here because none is recoverable from the diff:
+
+- **The window is DURABLE and phase-scoped** — at least one *successful*
+  `qdrant-store` since the previous gate's date. It could NOT come from
+  `.claude/tool-usage.json`: `session-test-gate-check.sh` WIPES that file on
+  every `startup`, so a phase spanning twenty sessions would have been satisfied
+  by one junk store in whichever session happened to run the gate. The record
+  lives in `.claude/process-state.json::mcp_accumulation`, written by
+  `# BL-233-WPB-ACCUM-WRITE` in the tracker and read by the gate. A **missing**
+  object reads as zero stores — a missing key defaulting RESTRICTIVE, the exact
+  inverse of `## BL-221:`.
+- **Conditional, plus an attested escape.** It blocks only when the phase made
+  SOURCE commits and stored nothing; a docs-only or exploratory phase passes
+  clean with no ceremony (`# BL-233-WPB-SOURCEWORK`). The escape is BL-072's
+  shape — `SOLO_MCP_ACCUM_ATTESTED=1` plus a mandatory reason, recorded, and
+  **refused if it cannot be recorded** (`# BL-233-WPB-ATTEST-REFUSE`).
+- **Gates 1→2, 2→3 and 3→4.** Phase 0→1 is pre-code discovery and is exempt.
+
+**The requirement-derivation decision is the one most likely to be re-litigated,
+so here is the measurement.** The obvious source for "does this project require
+Qdrant" is the ledger's `mcp_requirements.qdrant_required`. It is the wrong
+source twice: the ledger is untracked runtime scratch, so *deleting it* would
+switch a blocking gate off — `## BL-231:`'s "tracking file absent ⇒ no
+enforcement, silently" row, reintroduced inside the very gate meant to end it;
+and measured on this tree, of the 61 suites that execute `check-phase-gate.sh`,
+**29 drive it at `current_phase >= 2`, across 74 fixture-creation sites, and not
+one writes a ledger** — so a ledger-derived requirement would have forced 74
+fixture edits to say nothing. `init.sh` instead writes
+`.claude/settings.local.json` carrying the `mcpServers.qdrant` entry, the
+generated `.gitignore` ignores only `.claude/cache/`, and the scaffolder's
+`git add -A` commits it. The declaration is therefore **committed and travels
+with the repo**, and that is what `# BL-233-WPB-SCOPE` reads, with the ledger
+kept only as an OR arm for a project that adopted Qdrant after init.
+
+**`$HOME` is deliberately NOT read** — `session-test-gate-check.sh` reads four
+settings files, two of them under `$HOME`, and copying that here would make a
+phase gate's verdict depend on whose machine ran it. **Zero of those 29 fixtures
+redirect `HOME`**, so a host-derived answer passes on a developer box with
+Qdrant configured and fails on a runner without it: `## BL-234:`'s class exactly.
+A5 and mutant M3 pin the narrow scope in both directions.
+
+**One deliberate asymmetry, called out because it looks like a bug.** The
+accumulation arm dispatches on `case "$current_phase"` with **`-eq`**, while
+every sibling check in that file uses `-ge`. The siblings are right to: their
+evidence must exist independently at each boundary. Accumulation windows NEST —
+a store satisfying "since `phase_2_to_3`" necessarily satisfies "since
+`phase_1_to_2`" — so the latest gate's window is the strictest and subsumes the
+rest. With `-ge`, one missing store would have counted as three inconsistencies
+and printed the same sentence three times.
+
+**WP-B residuals — two, both real, neither blocking.**
+1. **Plugin-provided MCP servers are still invisible**, now on a second surface.
+   WP-A residual 2 records that `session-test-gate-check.sh` classifies by NAME
+   from `.mcpServers`; the WP-B derivation reads the same key in the project
+   files, so a Qdrant reachable only through a plugin derives NOT REQUIRED and
+   the accumulation gate silently switches off. One fix serves both.
+2. **`store_success_count` is LIFETIME, not per-phase.** Only `last_store_at`
+   decides the window; the counter is observability and nothing reads it for a
+   verdict. It is recorded so nobody later mistakes it for a per-phase quota —
+   a count target is exactly the shape that invites junk stores to hit a number.
+3. **Every successful store now DIRTIES A TRACKED FILE.**
+   `.claude/process-state.json` is tracked here and in generated projects
+   (`init.sh` writes it and `git add -A` commits it), so a `qdrant-store` mid-
+   session leaves a modified file that a later `git add -A` sweeps into an
+   unrelated commit. This is consistent with what that file already is — the
+   Build-Loop step counter and the two existing gate writers
+   (`_cpg_record_gate_date`, `_cpg_record_reviewer_attestation`) all mutate it —
+   and being tracked is what makes the accumulation record auditable in history
+   and survive a clone, which an untracked file would not. The change is
+   frequency, not kind. Verified live on this tree: a real store through the
+   registered hook wrote `{"store_success_count":1,"last_store_at":"…"}`.
 
 **WP-A, 2026-08-13 — what shipped and what was decided.** Items 1-5 and 7 are
 done for the retrieval half; `tests/test-bl233-mcp-outcome-enforcement.sh` is
@@ -10474,13 +10555,19 @@ None of these blocks the WP-A work; all three are real and none is fixed:
    which falls through to **deny** with a parseable envelope and no stderr leak
    — fail-closed, as intended, though the message does not tell the operator
    their pattern is the problem.
-4. **`session-end-qdrant-reminder.sh` still counts DECLARATIONS.** It reads
-   `.calls | length` and the `*_called` flags, so its end-of-session summary
-   reports calls that FAILED as calls that happened — it now disagrees with the
-   gate. It is a Stop-hook reminder and nothing enforces on it, so this is
-   cosmetic today, but the outcome fields it needs
-   (`qdrant_find_succeeded`, `qdrant_find_failed`, `qdrant_find_interrupted`)
-   are already in the ledger. **WP-B pickup.**
+4. ~~**`session-end-qdrant-reminder.sh` still counts DECLARATIONS.**~~
+   **FIXED in WP-B (2026-08-17).** It read `.calls | length` and the `*_called`
+   flags, so a call that FAILED was reported as a call that happened, and after
+   WP-A it actively disagreed with the gate beside it. It now filters on
+   `.outcome`, reads `qdrant_store_succeeded` rather than `qdrant_store_called`
+   (`# BL-233-WPB-OUTCOME`, mutant M6), and REPORTS the failed round trips
+   instead of omitting them — an absent failure is indistinguishable from an
+   idle session, and that ambiguity is what let a dead Qdrant look healthy for
+   weeks. One subtlety worth keeping: a row written *before* WP-A carries no
+   `.outcome`, and its absence is read as **success**, because the pre-WP-A
+   tracker was registered on `PostToolUse` only and the rows it wrote are
+   exactly the calls that fired without error. Defaulting those to failure would
+   have invented failures that never happened.
 
 ### The mechanism
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -2032,6 +2032,15 @@ run_child_suite "tests/test-delta-db-ledger-close.sh" \
 run_child_suite "tests/test-bl233-mcp-outcome-enforcement.sh" \
   "tests/test-bl233-mcp-outcome-enforcement.sh"
 
+# BL-233 WP-B — the ACCUMULATION half: warn at commit, BLOCK at the phase gate.
+# Pins the durable record (process-state.json::mcp_accumulation, written only on
+# a SUCCEEDING qdrant-store), the phase-scoped window, the source-work honest
+# path, the attested escape that is refused when it cannot be recorded, and the
+# project-scope-only requirement derivation that keeps the verdict independent
+# of the machine running it. Never touches init.sh, so it runs in the unit lane.
+run_child_suite "tests/test-bl233-wpb-accumulation.sh" \
+  "tests/test-bl233-wpb-accumulation.sh"
+
 # BL-234 — currency and availability MEASURED, not declared. Four checks read a
 # declaration as a capability: freshness never fetched (so `pin-behind` compared
 # the pin against the clone it was cut from), `is_qdrant_mcp_registered` tested

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -30,10 +30,16 @@
 #   • The ledger is an untracked runtime scratch file. Deleting it would switch
 #     the requirement off — BL-231's "tracking file absent => no enforcement,
 #     silently" row, reintroduced in a blocking gate.
-#   • Measured on this tree: of the 61 suites that execute check-phase-gate.sh,
-#     29 drive it at current_phase >= 2, across 74 fixture-creation sites, and
-#     NOT ONE of them writes a `.claude/tool-usage.json`. A requirement read
-#     from the ledger would have forced 74 fixture edits to say nothing.
+#   • Measured on MERGE-BASE 2344b13, and scoped to it deliberately: of the 60
+#     suites that execute check-phase-gate.sh, 29 drive it at current_phase >= 2
+#     and NOT ONE writes a `.claude/tool-usage.json`. A ledger-derived
+#     requirement would have forced an edit to every one of them to say nothing.
+#     Both halves of that sentence are FALSE of this branch's head — the count is
+#     61 and one of them writes ledgers, because THIS suite does — which is why
+#     it names the tree. The earlier "61 suites / 74 fixture-creation sites" form
+#     read the 61 off a working tree already carrying this file, and the 74
+#     reproduces under no derivation, so it is withdrawn. The recipe is on
+#     `## BL-233:`; the load-bearing number is the ZERO.
 #
 # The first fix for that read `.claude/settings.local.json`, reasoning that
 # `init.sh` writes it and `git add -A` commits it. THAT WAS ALSO WRONG: Claude
@@ -47,7 +53,8 @@
 #
 # A5 IS THE LOAD-BEARING ONE. The derivation reads the two PROJECT-scope
 # settings files ONLY, never `$HOME/.claude.json` — even though
-# `session-test-gate-check.sh` reads both scopes. Zero of those 29 fixtures
+# `session-test-gate-check.sh` reads both scopes. On that same base tree, zero of
+# those 29 fixtures
 # redirect HOME, so a host-derived verdict passes on a developer machine with
 # Qdrant configured and fails on a runner without it, or the reverse. That is
 # `## BL-234:`'s class exactly: a silent local-vs-CI divergence. Every gate run
@@ -1066,7 +1073,7 @@ n1_ctrl_blocked=$(grep -c 'accumulation: BLOCKED' <<< "$GOUT")
 N1="$(newtmp)"; mk_proj "$N1" 3; want_qdrant "$N1"; source_commit "$N1"
 _set_gate "$N1" phase_1_to_2 "2099-12-31"
 _run "$N1" --gate phase_2_to_3; n1_issues=$GISSUES; n1_out=$GOUT
-n1_refused=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$n1_out")
+n1_refused=$(grep -c 'CANNOT BE VERIFIED — the window cannot be measured' <<< "$n1_out")
 n1_claimed=$(grep -c 'nothing owed' <<< "$n1_out")
 
 if [ "$n1_ctrl_blocked" -lt 1 ]; then
@@ -1093,14 +1100,144 @@ while :; do
   n2_try=$((n2_try + 1))
   [ "$n2_try" -ge 2 ] && break
 done
-n2_refused=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$n2_out")
-n2_ran=$(grep -c 'accumulation:' <<< "$n2_out")
+n2_refused=$(grep -c 'CANNOT BE VERIFIED — the window cannot be measured' <<< "$n2_out")
+# THE TREATMENT BY NAME, not any line containing "accumulation:". The loose form
+# also counts `NOT CHECKED` and `nothing owed`, so this floor passed vacuously on
+# a tree with scripts/lib/accumulation.sh removed — the arm never ran at all.
+# That is exactly what D15's floor was fixed for, shipped in the same commit.
+n2_ran=$(grep -c 'accumulation: BLOCKED' <<< "$n2_out")
 if [ "$_n2_d1" != "$_n2_d2" ]; then
   fail_ "N2 (meta)" "the date moved under the fixture on two consecutive attempts ($_n2_d1 -> $_n2_d2); this boundary cannot be measured across a midnight crossing"
 elif [ "$n2_refused" -eq 0 ] && [ "$n2_ran" -ge 1 ]; then
   pass "N2: a window opening TODAY is measurable — the comparison is -le, not -lt, so a gate is not refused on the day its own date was recorded (positive control: the arm ran, $n2_ran line(s))"
 else
   fail_ "N2" "today's window was refused as unmeasurable: refused=$n2_refused arm-ran=$n2_ran"
+fi
+
+# N3 — THE SECOND off switch through the same field, and the reason this group
+# exists rather than one assertion. `get_gate_date` maps BOTH "no gate recorded"
+# AND "a gate recorded whose value will not parse" to "", and "" reaches
+# _cpg_accum_after, whose `[ -z "$gate" ]` arm makes ANY store ever recorded
+# satisfy the gate. One edit of gates.* to `not-a-date` took a blocking fixture
+# from 9 inconsistencies to 8 with a 2020 store reported as satisfying — no
+# clock skew required.
+#
+# The fixture carries an ANCIENT store on purpose: without one the fixture would
+# block for the ordinary reason and the assertion could not tell the two apart.
+_ancient_store() { stored "$1" "2020-01-01T10:00:00Z"; }
+
+# CONTROL: the same fixture with a VALID window. The ancient store is outside it,
+# so it blocks for the ordinary reason.
+N3C="$(newtmp)"; mk_proj "$N3C" 3; want_qdrant "$N3C"; source_commit "$N3C"; _ancient_store "$N3C"
+_run "$N3C" --gate phase_2_to_3; n3_ctrl=$GISSUES
+n3_ctrl_blocked=$(grep -c 'accumulation: BLOCKED' <<< "$GOUT")
+
+N3="$(newtmp)"; mk_proj "$N3" 3; want_qdrant "$N3"; source_commit "$N3"; _ancient_store "$N3"
+_set_gate "$N3" phase_1_to_2 "not-a-date"
+_run "$N3" --gate phase_2_to_3; n3_issues=$GISSUES; n3_out=$GOUT
+n3_refused=$(grep -c 'a gate date IS recorded for phase_1_to_2 and does not parse' <<< "$n3_out")
+n3_named=$(grep -c '"not-a-date"' <<< "$n3_out")
+n3_satisfied=$(grep -c 'accumulation: satisfied' <<< "$n3_out")
+if [ "$n3_ctrl_blocked" -lt 1 ]; then
+  fail_ "N3 (meta)" "the valid-window CONTROL did not block (issues=$n3_ctrl); the fixture is not reaching the arm"
+elif [ "$n3_issues" -eq "$n3_ctrl" ] && [ "$n3_refused" -ge 1 ] && [ "$n3_named" -ge 1 ] && [ "$n3_satisfied" -eq 0 ]; then
+  pass "N3: a gate date that is RECORDED but will not parse is refused as unmeasurable instead of collapsing into 'no gate recorded' — same count as the valid-window control ($n3_ctrl), the offending field is NAMED, and a 2020 store no longer satisfies a 2026 phase"
+else
+  fail_ "N3" "unparseable gate date: issues=$n3_issues (control $n3_ctrl); refused=$n3_refused; named=$n3_named; satisfied=$n3_satisfied"
+fi
+
+# N4 — THE OTHER SIDE, and it is the one an over-eager fix breaks. A gate that is
+# genuinely ABSENT means the window is the whole history, which IS measurable,
+# and the first cut of N3's arm refused it — three fixtures out of four — because
+# it tested only that the raw value was non-empty. The ancient store must still
+# satisfy here.
+N4="$(newtmp)"; mk_proj "$N4" 3; want_qdrant "$N4"; source_commit "$N4"; _ancient_store "$N4"
+_set_gate_null() {   # phase-state with the key present and NULL
+  local f="$1/.claude/phase-state.json"
+  jq --arg k "$2" '.gates[$k] = null' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+}
+_set_gate_null "$N4" phase_1_to_2
+_run "$N4" --gate phase_2_to_3
+n4_satisfied=$(grep -c 'accumulation: satisfied' <<< "$GOUT")
+n4_refused=$(grep -c 'CANNOT BE VERIFIED' <<< "$GOUT")
+if [ "$n4_satisfied" -ge 1 ] && [ "$n4_refused" -eq 0 ]; then
+  pass "N4: a gate date that is genuinely ABSENT still means 'the window is the whole history' — the store satisfies, and the unmeasurable arm does not fire on a project that did nothing wrong"
+else
+  fail_ "N4" "absent gate date: satisfied=$n4_satisfied (want >=1), refused=$n4_refused (want 0)"
+fi
+
+# N5 — THE REASON MUST BE THE REAL ONE. The first version of this arm hard-coded
+# ", which is not in the past" into the FAIL line, and that is false on two of
+# the four paths that reach it. An arm added to remove a false affirmative about
+# the project printed one of its own. Here `date` is shimmed to fail while the
+# window is comfortably in the PAST.
+N5="$(newtmp)"; mk_proj "$N5" 3; want_qdrant "$N5"; source_commit "$N5"
+N5BIN="$(newtmp)/bin"; mkdir -p "$N5BIN"
+printf '#!/bin/sh\nexit 1\n' > "$N5BIN/date"; chmod +x "$N5BIN/date"
+n5_out=$( ( cd "$N5" && HOME="$N5/home" PATH="$N5BIN:$PATH" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+n5_refused=$(grep -c 'CANNOT BE VERIFIED — the window cannot be measured' <<< "$n5_out")
+n5_wrong=$(grep -c 'which is not in the past' <<< "$n5_out")
+n5_right=$(grep -c 'the system date could not be read' <<< "$n5_out")
+if [ "$n5_refused" -ge 1 ] && [ "$n5_right" -ge 1 ] && [ "$n5_wrong" -eq 0 ]; then
+  pass "N5: when the clock cannot be read the gate blocks and says SO — it does not claim a past window 'is not in the past', which is the false affirmative this whole arm exists to remove"
+else
+  fail_ "N5" "date-failure path: refused=$n5_refused; correct-reason=$n5_right; false-reason=$n5_wrong"
+fi
+
+# N6 — the numeric guard, whose omission was justified by reasoning this file
+# refutes 200 lines away. `get_gate_date` validates with a PER-LINE `grep -qE`,
+# so a DUPLICATE key yields a multi-line value that passes if ANY line is a date,
+# and accum_oneline then concatenates them. Without the guard the concatenation
+# reached `[ -le ]`, which blocks — right direction — while printing a raw
+# `integer expression expected` from the shell INTO a blocking verdict.
+N6="$(newtmp)"; mk_proj "$N6" 3; want_qdrant "$N6"; source_commit "$N6"
+python3 - "$N6/.claude/phase-state.json" <<'PYN6'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"ZZZZZZZZZZ",\n "phase_1_to_2":"2026-02-01"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYN6
+_run "$N6" --gate phase_2_to_3; n6_out=$GOUT
+n6_refused=$(grep -c 'does not reduce to a number' <<< "$n6_out")
+n6_shellerr=$(grep -c 'integer expression expected' <<< "$n6_out")
+n6_owed=$(grep -c 'nothing owed' <<< "$n6_out")
+if [ "$n6_refused" -ge 1 ] && [ "$n6_shellerr" -eq 0 ] && [ "$n6_owed" -eq 0 ]; then
+  pass "N6: a duplicate key in phase-state.json yields a window that does not reduce to a number — the gate names it and blocks, with no raw shell diagnostic leaking into the verdict"
+else
+  fail_ "N6" "duplicate-key window: refused=$n6_refused; shell-error=$n6_shellerr (want 0); nothing-owed=$n6_owed (want 0)"
+fi
+
+# N7 — THE WINDOW OPENS AT MIDNIGHT, NOT AT THE CURRENT CLOCK TIME. Found by N2
+# going intermittently green (8 flakes in 40 runs) and chased into the product
+# rather than papered over in the test: git's approxidate fills the fields a
+# date string OMITS from the current clock, so a bare `--since=<date>` means
+# "that date at whatever time it is right now". A commit made at 10:35:18 today
+# is invisible to `--since=<today>` two seconds later.
+#
+# The fixture back-dates the source commit to 00:00:01 on the gate date, so the
+# assertion carries NO clock race of its own: with the fix the commit is inside
+# the window at every hour of the day, and without it the commit is outside the
+# window at every hour after 00:00:01.
+N7="$(newtmp)"; mk_proj "$N7" 3; want_qdrant "$N7"
+_n7_day=$(date +%Y-%m-%d)
+( cd "$N7" || exit 1
+  unset GITHUB_BASE_REF
+  mkdir -p src && echo "print(1)" > src/main.py
+  git add -A >/dev/null 2>&1
+  GIT_AUTHOR_DATE="${_n7_day}T00:00:01" GIT_COMMITTER_DATE="${_n7_day}T00:00:01" \
+    git commit -qm "feat: first thing this morning" >/dev/null 2>&1 )
+_set_gate "$N7" phase_1_to_2 "$_n7_day"
+_run "$N7" --gate phase_2_to_3; n7_out=$GOUT
+n7_blocked=$(grep -c 'accumulation: BLOCKED' <<< "$n7_out")
+n7_owed=$(grep -c 'nothing owed' <<< "$n7_out")
+n7_has_commit=$( ( cd "$N7" && git log --oneline -- src/main.py 2>/dev/null | grep -c . ) | tr -d ' ')
+if [ "$n7_has_commit" -lt 1 ]; then
+  fail_ "N7 (meta)" "the back-dated source commit did not land, so nothing is being measured"
+elif [ "$n7_blocked" -ge 1 ] && [ "$n7_owed" -eq 0 ]; then
+  pass "N7: a source commit made at 00:00:01 on the window's OPENING DAY is inside the window — the window starts at midnight, not at the hour the gate happens to run, so the same tree does not change verdict over the course of a day"
+else
+  fail_ "N7" "morning commit on the opening day: blocked=$n7_blocked (want >=1), nothing-owed=$n7_owed (want 0)"
 fi
 
 # A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
@@ -2126,8 +2263,8 @@ fi
 # future window reports "nothing owed" and the issue count drops. This is the
 # direction that matters; the guard exists for it.
 if _mk_mutant_repo "M20" "scripts/check-phase-gate.sh" "# BL-233-WPB-FUTURE-WINDOW" \
-      '  [ "$a" -le "$today" ]   # BL-233-WPB-FUTURE-WINDOW' \
-      '  return 0                # BL-233-WPB-FUTURE-WINDOW'; then
+      '  [ "$a" -le "$today" ] && return 0   # BL-233-WPB-FUTURE-WINDOW' \
+      '  return 0                            # BL-233-WPB-FUTURE-WINDOW'; then
   M20F="$(newtmp)"; mk_proj "$M20F" 3; want_qdrant "$M20F"; source_commit "$M20F"
   _set_gate "$M20F" phase_1_to_2 "2099-12-31"
   m20_mut=$( ( cd "$M20F" && HOME="$M20F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
@@ -2145,8 +2282,8 @@ fi
 # and that failure is silent in the opposite way: it blocks work that is fine.
 # `-le` -> `-lt` refuses a gate on the day its own date was recorded.
 if _mk_mutant_repo "M21" "scripts/check-phase-gate.sh" "# BL-233-WPB-FUTURE-WINDOW" \
-      '  [ "$a" -le "$today" ]   # BL-233-WPB-FUTURE-WINDOW' \
-      '  [ "$a" -lt "$today" ]   # BL-233-WPB-FUTURE-WINDOW'; then
+      '  [ "$a" -le "$today" ] && return 0   # BL-233-WPB-FUTURE-WINDOW' \
+      '  [ "$a" -lt "$today" ] && return 0   # BL-233-WPB-FUTURE-WINDOW'; then
   m21_try=0
   while :; do
     _m21_d1=$(date +%Y-%m-%d)
@@ -2159,14 +2296,86 @@ if _mk_mutant_repo "M21" "scripts/check-phase-gate.sh" "# BL-233-WPB-FUTURE-WIND
     m21_try=$((m21_try + 1))
     [ "$m21_try" -ge 2 ] && break
   done
-  m21_m=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$m21_mut")
-  m21_c=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$m21_ctrl")
+  m21_m=$(grep -c 'CANNOT BE VERIFIED — the window cannot be measured' <<< "$m21_mut")
+  m21_c=$(grep -c 'CANNOT BE VERIFIED — the window cannot be measured' <<< "$m21_ctrl")
   if [ "$_m21_d1" != "$_m21_d2" ]; then
     fail_ "M21 (meta)" "the date moved under the fixture on two consecutive attempts ($_m21_d1 -> $_m21_d2); this mutant cannot be measured across a midnight crossing"
   elif [ "$m21_m" -ge 1 ] && [ "$m21_c" -eq 0 ]; then
     pass "M21: tightening the comparison to -lt refuses a window opening TODAY ($m21_c -> $m21_m) — the boundary is load-bearing in both directions, and an over-strict gate fails as silently as an over-permissive one"
   else
     fail_ "M21" "mutant refused=$m21_m (want >=1), control refused=$m21_c (want 0)"
+  fi
+fi
+
+# M22 — neuter the ambiguity resolution and the SECOND off switch is back: an
+# unparseable gate date collapses into "no gate recorded", the window becomes
+# the whole history, and a 2020 store satisfies a 2026 phase.
+if _mk_mutant_repo "M22" "scripts/check-phase-gate.sh" "# BL-233-WPB-AMBIGUOUS-WINDOW" \
+      "    if [ -n \"\$raw\" ] && ! grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])\$' <<< \"\$raw\"; then   # BL-233-WPB-AMBIGUOUS-WINDOW" \
+      '    if false; then   # BL-233-WPB-AMBIGUOUS-WINDOW'; then
+  M22F="$(newtmp)"; mk_proj "$M22F" 3; want_qdrant "$M22F"; source_commit "$M22F"; stored "$M22F" "2020-01-01T10:00:00Z"
+  _set_gate "$M22F" phase_1_to_2 "not-a-date"
+  m22_mut=$( ( cd "$M22F" && HOME="$M22F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m22_ctrl=$( ( cd "$M22F" && HOME="$M22F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m22_m=$(grep -c 'accumulation: satisfied' <<< "$m22_mut")
+  m22_c=$(grep -c 'accumulation: satisfied' <<< "$m22_ctrl")
+  if [ "$m22_m" -ge 1 ] && [ "$m22_c" -eq 0 ]; then
+    pass "M22: collapsing 'recorded but unparseable' back into 'not recorded' lets a 2020 store satisfy a 2026 phase ($m22_c -> $m22_m) — N3 measures the resolution, not the [FAIL] text"
+  else
+    fail_ "M22" "mutant satisfied=$m22_m (want >=1), control satisfied=$m22_c (want 0)"
+  fi
+fi
+
+# M23 — remove the numeric guard and the concatenated duplicate-key value reaches
+# `[ -le ]` again: still fail-closed, but a raw shell diagnostic is printed into
+# a blocking verdict. N6 asserts the ABSENCE of that leak, which an unimplemented
+# guard also satisfies — this is what makes N6 a discriminator.
+if _mk_mutant_repo "M23" "scripts/check-phase-gate.sh" "# BL-233-WPB-WINDOW-NUMERIC" \
+      "  case \"\$a\" in ''|*[!0-9]*) _ACCUM_WINDOW_REASON=\"\$_nan\"; return 1 ;; esac   # BL-233-WPB-WINDOW-NUMERIC" \
+      '  :   # BL-233-WPB-WINDOW-NUMERIC'; then
+  M23F="$(newtmp)"; mk_proj "$M23F" 3; want_qdrant "$M23F"; source_commit "$M23F"
+  python3 - "$M23F/.claude/phase-state.json" <<'PYM23'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"ZZZZZZZZZZ",\n "phase_1_to_2":"2026-02-01"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYM23
+  m23_mut=$( ( cd "$M23F" && HOME="$M23F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m23_ctrl=$( ( cd "$M23F" && HOME="$M23F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m23_m=$(grep -c 'integer expression expected' <<< "$m23_mut")
+  m23_c=$(grep -c 'integer expression expected' <<< "$m23_ctrl")
+  if [ "$m23_m" -ge 1 ] && [ "$m23_c" -eq 0 ]; then
+    pass "M23: removing the numeric guard leaks a raw shell diagnostic into a blocking verdict ($m23_c -> $m23_m) — the guard is reachable, which is exactly what the comment justifying its omission denied"
+  else
+    fail_ "M23" "mutant shell-error=$m23_m (want >=1), control=$m23_c (want 0)"
+  fi
+fi
+
+# M24 — drop the explicit midnight and the window silently starts at the current
+# clock time, exactly as it did before N7 was written. This is the mutant for a
+# defect a TEST found by flaking, not a reviewer: N2 went green 32 times out of
+# 40 and the eight failures were the product, not the fixture.
+if _mk_mutant_repo "M24" "scripts/check-phase-gate.sh" "# BL-233-WPB-SINCE-MIDNIGHT" \
+      '    paths=$(git log --since="$since 00:00:00" --name-only --pretty=format: 2>/dev/null) || return 0   # BL-233-WPB-SINCE-MIDNIGHT' \
+      '    paths=$(git log --since="$since" --name-only --pretty=format: 2>/dev/null) || return 0   # BL-233-WPB-SINCE-MIDNIGHT'; then
+  M24F="$(newtmp)"; mk_proj "$M24F" 3; want_qdrant "$M24F"
+  _m24_day=$(date +%Y-%m-%d)
+  ( cd "$M24F" || exit 1
+    unset GITHUB_BASE_REF
+    mkdir -p src && echo "print(1)" > src/main.py
+    git add -A >/dev/null 2>&1
+    GIT_AUTHOR_DATE="${_m24_day}T00:00:01" GIT_COMMITTER_DATE="${_m24_day}T00:00:01" \
+      git commit -qm "feat: first thing this morning" >/dev/null 2>&1 )
+  _set_gate "$M24F" phase_1_to_2 "$_m24_day"
+  m24_mut=$( ( cd "$M24F" && HOME="$M24F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m24_ctrl=$( ( cd "$M24F" && HOME="$M24F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m24_m=$(grep -c 'nothing owed' <<< "$m24_mut")
+  m24_c=$(grep -c 'nothing owed' <<< "$m24_ctrl")
+  if [ "$m24_m" -ge 1 ] && [ "$m24_c" -eq 0 ]; then
+    pass "M24: a bare --since makes git fill the time of day from the CURRENT clock, so a morning commit falls outside its own window ($m24_c -> $m24_m) — the explicit midnight is what makes the verdict independent of the hour"
+  else
+    fail_ "M24" "mutant nothing-owed=$m24_m (want >=1), control=$m24_c (want 0)"
   fi
 fi
 

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -928,29 +928,47 @@ else
   fail_ "D12" "forged=$d12_forged (want 0); stale-warning=$d12_warned (want >=1)"
 fi
 
-# D13 — the same rule for the gate DATE. get_gate_date extracts with `grep -o`
+# D13 — the same rule for the gate DATE. `get_gate_date` extracts with `grep -o`
 # and validates with an anchored `grep -qE`, and grep matches PER LINE — so a
-# DUPLICATE JSON key (which jq accepts, so the file is not malformed) yields a
-# multi-line value whose first line is a valid date and which passes validation.
+# DUPLICATE JSON key (which jq accepts, last-wins, so the file is not malformed)
+# yields a multi-line value whose first line is a valid date and which passes
+# validation.
+#
+# THE ASSERTION IS ATTRIBUTABLE BY CONTROL, not by substring. The first version
+# scoped with `grep 'accumulation'` to exclude a pre-existing BL-071 arm that
+# forges from the same value — and a SUCCESSFULLY forged line never contains the
+# word "accumulation", so that filter removed the very thing it was looking for.
+# It reported forged=0 on a tree emitting two forged lines, and a mutant with
+# this round's fix removed still passed it.
+#
+# Instead: measure the forged STANDALONE verdict lines with the accumulation arm
+# OFF (no Qdrant declared — the pre-existing arm still fires), then with it ON.
+# The count must not increase. That isolates this feature's contribution without
+# needing to fix, or ignore, the pre-existing one.
+D13C="$(newtmp)"; mk_proj "$D13C" 3; source_commit "$D13C"
+python3 - "$D13C/.claude/phase-state.json" <<'PYD'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\\\n  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYD
+_run "$D13C" --gate phase_2_to_3
+d13_base=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-DATE')
+
 D13="$(newtmp)"; mk_proj "$D13" 3; want_qdrant "$D13"; source_commit "$D13"
 python3 - "$D13/.claude/phase-state.json" <<'PYD'
 import io,sys
-f=sys.argv[1]
-s=io.open(f,encoding="utf-8").read()
-s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\n  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\\\n  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
 io.open(f,"w",encoding="utf-8").write(s)
 PYD
 _run "$D13" --gate phase_2_to_3
-# Scoped to the ACCUMULATION arm's own output. The same duplicate-key value also
-# reaches a PRE-EXISTING BL-071 arm ("Phase 1→2: gate dated $gate_1_to_2, but
-# APPROVAL_LOG.md has no dated entry"), which forges a line there too — measured,
-# out of this entry's scope, and filed as a residual rather than silently widened.
-d13_forged=$(printf '%s\n' "$GOUT" | grep 'accumulation' | grep -cE 'FORGED-VIA-DATE')
+d13_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-DATE')
 d13_ran=$(printf '%s\n' "$GOUT" | grep -c 'accumulation:')
-if [ "$d13_forged" -eq 0 ] && [ "$d13_ran" -ge 1 ]; then
-  pass "D13: a duplicate-key gate date cannot forge a verdict line either — the boundary rule covers every externally-sourced value the arm displays, not the ones a sweep happened to name"
+if [ "$d13_forged" -eq "$d13_base" ] && [ "$d13_ran" -ge 1 ]; then
+  pass "D13: turning the accumulation arm ON adds NO forged verdict line to a transcript that already carries one from a pre-existing arm ($d13_base) — this feature's displays of the duplicate-key date are inert, measured against a control rather than filtered by a substring the forgery cannot contain"
 else
-  fail_ "D13" "forged=$d13_forged (want 0); arm-ran=$d13_ran (want >=1)"
+  fail_ "D13" "forged with arm ON=$d13_forged, with arm OFF=$d13_base (must be equal); arm-ran=$d13_ran"
 fi
 
 # A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
@@ -963,6 +981,27 @@ if echo "$GOUT" | grep -q 'tool-usage.json does not parse and was skipped'; then
   pass "A14: a corrupt ledger is announced as skipped rather than silently ignored — it does not block, but a project whose only declaration lived there is told the requirement is not being seen"
 else
   fail_ "A14" "no skip notice: $(echo "$GOUT" | grep -i accumulation | head -c 180)"
+fi
+
+# D14 — the WIDTH of the stripped class is load-bearing, and only a literal
+# find-string in M16 defended it. Narrowing the class to newline alone passes the
+# whole suite while leaving CR and ESC alive — and an ESC-bracket-2-K erase plus
+# CR rewrites the line on a terminal, forging a verdict without ever emitting a
+# newline. CLAUDE.md records this hazard exactly: "a one-character narrowing — a
+# quantifier, a character class — re-opened BL-181 three times and passed both
+# PR-blocking checks every time."
+D14="$(newtmp)"; mk_proj "$D14" 3; want_qdrant "$D14"; source_commit "$D14"
+jq -n '{mcp_accumulation:{store_success_count:1,
+        last_store_at:"2026-09-01\u001b[2K\r  [OK] Phase 3 review gate: FORGED-BY-ESC",
+        attestations:{}}}' > "$D14/.claude/process-state.json"
+d14_raw=$( ( cd "$D14" && HOME="$D14/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) )
+d14_ctl=$(printf '%s' "$d14_raw" | LC_ALL=C tr -dc '\001-\010\013\014\016-\037' | wc -c | tr -d ' ')
+_run "$D14" --gate phase_2_to_3
+d14_ran=$(printf '%s\n' "$GOUT" | grep -c 'accumulation: satisfied')
+if [ "$d14_ctl" -eq 0 ] && [ "$d14_ran" -ge 1 ]; then
+  pass "D14: CR and ESC are stripped too, not just newline — a terminal-erase payload cannot rewrite the line it was printed on, so the class width is pinned by behaviour rather than by a mutant find-string"
+else
+  fail_ "D14" "non-newline control bytes surviving in transcript=$d14_ctl (want 0); satisfied-arm-ran=$d14_ran (want >=1)"
 fi
 
 # ══ E. Gate scoping ═══════════════════════════════════════════════════════
@@ -1767,7 +1806,7 @@ fi
 # would keep passing on the two-character `\n` case while a REAL newline sailed
 # through — which is precisely how the sixth recurrence got in.
 if _mk_mutant_repo "M16" "scripts/lib/accumulation.sh" "# BL-233-WPB-ONELINE" \
-      "printf '%s' \"\$1\" | LC_ALL=C tr -d '\\000-\\037'   # BL-233-WPB-ONELINE" \
+      "printf '%s' \"\$1\" | LC_ALL=C tr -d '\\000-\\037\\\\'   # BL-233-WPB-ONELINE" \
       "printf '%s' \"\$1\"   # BL-233-WPB-ONELINE"; then
   M16F="$(newtmp)"; mk_proj "$M16F" 3; want_qdrant "$M16F"; source_commit "$M16F"
   jq -n '{mcp_accumulation:{store_success_count:1,
@@ -1788,9 +1827,9 @@ fi
 # each wrapped the display sites a sweep had named, and each time the next
 # instance appeared at a site the sweep's syntax could not see. Cleaning at
 # ingest is only worth anything if something proves it is load-bearing.
-if _mk_mutant_repo "M17" "scripts/check-phase-gate.sh" "# BL-233-WPB-SHA-ONELINE" \
-      'sha=$(accum_oneline "$1")   # BL-233-WPB-SHA-ONELINE' \
-      'sha="$1"                    # BL-233-WPB-SHA-ONELINE'; then
+if _mk_mutant_repo "M17" "scripts/check-phase-gate.sh" "# BL-233-WPB-SHA-RAW-FOR-GIT" \
+      '_ACCUM_STALE_REASON="the commit it named ($(accum_oneline "$sha")) is not reachable in this repository"' \
+      '_ACCUM_STALE_REASON="the commit it named ($sha) is not reachable in this repository"'; then
   M17F="$(newtmp)"; mk_proj "$M17F" 3; want_qdrant "$M17F"; source_commit "$M17F"
   jq -n '{mcp_accumulation:{store_success_count:0,last_store_at:null,
           attestations:{phase_2_to_3:{reason:"ordinary",date:"2026-03-02",by:"T",
@@ -1836,6 +1875,54 @@ PYM
     fail_ "M18" "mutant-invalid=$m18_bad control-valid=$m18_ok; CONTROL=[$(printf '%s' "$m18_ctrl" | head -c 150)]"
   fi
 fi
+# D15 — DEFENCE IN DEPTH, stated as a measurement rather than a hope.
+#
+# M19 was going to remove the ingest wrap on $prev and watch a forgery return.
+# It could not: `get_gate_date` greps the raw file LINE BY LINE, so $prev can
+# never carry a real newline, and with the display sites converted to printf a
+# literal backslash-n is inert anyway. The wrap is therefore belt, not braces —
+# and saying so is worth more than a mutant that dies for the wrong reason.
+#
+# What IS load-bearing is the primitive. This drives that directly: revert the
+# BLOCKED display site to `echo -e` — the exact eighth-instance condition — and
+# confirm the backslash strip alone still holds the line. If someone later
+# "simplifies" a display site back, the hole does not reopen.
+D15ROOT="$(newtmp)/repo"; mkdir -p "$D15ROOT"
+cp -R "$REPO_ROOT/scripts" "$D15ROOT/scripts" 2>/dev/null
+ln -s "$REPO_ROOT/tests" "$D15ROOT/tests" 2>/dev/null
+ln -s "$REPO_ROOT/.github" "$D15ROOT/.github" 2>/dev/null
+python3 - "$D15ROOT/scripts/check-phase-gate.sh" <<'PYR'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+old=("""  printf '%b[FAIL]%b %s accumulation: BLOCKED — source commits since ' "${RED}" "${NC}" "$label"\n"""
+     """  printf '%s' "${prev:-project start}"\n"""
+     """  printf ', and NO successful qdrant-store in that window.\\n'""")
+new=("""  echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — source commits since ${prev:-project start}, and NO successful qdrant-store in that window." """)
+assert s.count(old)==1, "d15 anchor %d" % s.count(old)
+io.open(f,"w",encoding="utf-8").write(s.replace(old,new))
+PYR
+D15="$(newtmp)"; mk_proj "$D15" 3; want_qdrant "$D15"; source_commit "$D15"
+python3 - "$D15/.claude/phase-state.json" <<'PYD'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\n  [OK] Phase 3 review gate: FORGED-D15"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYD
+d15_out=$( ( cd "$D15" && HOME="$D15/home" bash "$D15ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+d15_forged=$(printf '%s\n' "$d15_out" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-D15')
+d15_ran=$(printf '%s\n' "$d15_out" | grep -c 'accumulation:')
+# CONTROL: the same fixture through the UNMUTATED scripts. The pre-existing
+# BL-071 "gate dated ..." arm renders this value through echo -e too, so a raw
+# count is not attributable to the reverted accumulation site — the comparison is.
+d15_ctrl=$( ( cd "$D15" && HOME="$D15/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+d15_base=$(printf '%s\n' "$d15_ctrl" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-D15')
+if [ "$d15_forged" -eq "$d15_base" ] && [ "$d15_ran" -ge 1 ]; then
+  pass "D15: reverting a display site to echo -e — the exact eighth-instance condition — does NOT reopen the forgery, because accum_oneline removes the backslash that echo -e would have interpreted — the count matches the unmutated baseline ($d15_base, from a pre-existing arm this PR does not touch). The rule holds without depending on every display site staying correct."
+else
+  fail_ "D15" "forged with reverted display=$d15_forged, unmutated baseline=$d15_base (must be equal); arm-ran=$d15_ran"
+fi
+
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -1167,8 +1167,8 @@ else
 fi
 
 # N5 — THE REASON MUST BE THE REAL ONE. The first version of this arm hard-coded
-# ", which is not in the past" into the FAIL line, and that is false on two of
-# the four paths that reach it. An arm added to remove a false affirmative about
+# ", which is not in the past" into the FAIL line, and that is false on every
+# path that reaches it but one. An arm added to remove a false affirmative about
 # the project printed one of its own. Here `date` is shimmed to fail while the
 # window is comfortably in the PAST.
 N5="$(newtmp)"; mk_proj "$N5" 3; want_qdrant "$N5"; source_commit "$N5"
@@ -1199,13 +1199,68 @@ s=s.replace('"phase_1_to_2":"2026-02-01"',
 io.open(f,"w",encoding="utf-8").write(s)
 PYN6
 _run "$N6" --gate phase_2_to_3; n6_out=$GOUT
-n6_refused=$(grep -c 'does not reduce to a number' <<< "$n6_out")
+n6_refused=$(grep -c 'is not a single YYYY-MM-DD value' <<< "$n6_out")
 n6_shellerr=$(grep -c 'integer expression expected' <<< "$n6_out")
 n6_owed=$(grep -c 'nothing owed' <<< "$n6_out")
 if [ "$n6_refused" -ge 1 ] && [ "$n6_shellerr" -eq 0 ] && [ "$n6_owed" -eq 0 ]; then
   pass "N6: a duplicate key in phase-state.json yields a window that does not reduce to a number — the gate names it and blocks, with no raw shell diagnostic leaking into the verdict"
 else
   fail_ "N6" "duplicate-key window: refused=$n6_refused; shell-error=$n6_shellerr (want 0); nothing-owed=$n6_owed (want 0)"
+fi
+
+# N8 — THE SAME DUPLICATE KEY, OPERANDS THE OTHER WAY ROUND. N6 alone was not a
+# guard on the value, only on one operand order: the first guard sliced
+# ${w:0:10} and asked whether that reduced to a number, which catches
+# ZZZZZZZZZZ2026-02-01 and waves through 2026-02-01 + a future date. The FULL
+# concatenation is what reaches `git log --since`, and approxidate reads it as
+# some other instant — measured, `--since="2026-02-01 2099-12-31 00:00:00"`
+# resolves to --max-age=4102383600, i.e. 2099. The result was verbatim the
+# "nothing owed" verdict the future-window guard exists to remove, at the same
+# 9 -> 8 delta.
+N8C="$(newtmp)"; mk_proj "$N8C" 3; want_qdrant "$N8C"; source_commit "$N8C"
+_run "$N8C" --gate phase_2_to_3; n8_ctrl=$GISSUES
+n8_ctrl_blocked=$(grep -c 'accumulation: BLOCKED' <<< "$GOUT")
+
+N8="$(newtmp)"; mk_proj "$N8" 3; want_qdrant "$N8"; source_commit "$N8"
+python3 - "$N8/.claude/phase-state.json" <<'PYN8'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":" 2099-12-31"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYN8
+_run "$N8" --gate phase_2_to_3; n8_issues=$GISSUES; n8_out=$GOUT
+n8_refused=$(grep -c 'is not a single YYYY-MM-DD value' <<< "$n8_out")
+n8_owed=$(grep -c 'nothing owed' <<< "$n8_out")
+if [ "$n8_ctrl_blocked" -lt 1 ]; then
+  fail_ "N8 (meta)" "the single-key CONTROL did not block (issues=$n8_ctrl); nothing is being measured"
+elif [ "$n8_issues" -eq "$n8_ctrl" ] && [ "$n8_refused" -ge 1 ] && [ "$n8_owed" -eq 0 ]; then
+  pass "N8: a duplicate gate date with the VALID value FIRST is refused too — the shape check reads the whole string, so git is never handed a concatenation approxidate can reinterpret as a future instant (count matches the single-key control, $n8_ctrl)"
+else
+  fail_ "N8" "date-first duplicate: issues=$n8_issues (control $n8_ctrl); refused=$n8_refused; nothing-owed=$n8_owed"
+fi
+
+# N9 — A STATE FILE THAT WILL NOT PARSE IS NOT AN ABSENT GATE. The raw snapshot
+# reads gates.* through jq, and jq's failure was swallowed to "" — which is the
+# exact signal the ambiguity arm keys on, so one stray comma restored the
+# collapse the ambiguity arm was written to close. The corruption surfaces
+# elsewhere in the run only as a NON-COUNTING [WARN], so on an otherwise-clean
+# project nothing else saved the gate.
+N9="$(newtmp)"; mk_proj "$N9" 3; want_qdrant "$N9"; source_commit "$N9"; stored "$N9" "2020-01-01T10:00:00Z"
+python3 - "$N9/.claude/phase-state.json" <<'PYN9'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"', '"phase_1_to_2":"not-a-date"')
+s=s.replace('"track":"light"', '"track":"light",,,')      # jq can no longer read it
+io.open(f,"w",encoding="utf-8").write(s)
+PYN9
+_run "$N9" --gate phase_2_to_3; n9_out=$GOUT
+n9_refused=$(grep -c 'does not parse (or its .gates is not an object)' <<< "$n9_out")
+n9_satisfied=$(grep -c 'accumulation: satisfied' <<< "$n9_out")
+if [ "$n9_refused" -ge 1 ] && [ "$n9_satisfied" -eq 0 ]; then
+  pass "N9: a phase-state.json jq cannot read is refused as unmeasurable rather than collapsing into 'no gate recorded' — a 2020 store does not satisfy a 2026 phase because a comma is in the wrong place"
+else
+  fail_ "N9" "unreadable state file: refused=$n9_refused (want >=1); satisfied=$n9_satisfied (want 0)"
 fi
 
 # N7 — THE WINDOW OPENS AT MIDNIGHT, NOT AT THE CURRENT CLOCK TIME. Found by N2
@@ -2160,102 +2215,134 @@ PYM
     fail_ "M18" "mutant-invalid=$m18_bad control-valid=$m18_ok; CONTROL=[$(printf '%s' "$m18_ctrl" | head -c 150)]"
   fi
 fi
-# D15 — DEFENCE IN DEPTH, stated as a measurement rather than a hope.
+# D15 — DEFENCE IN DEPTH, stated as a measurement rather than a hope, and
+# RETARGETED because the feature outgrew its old fixture.
 #
-# CORRECTION, kept visible rather than quietly restated. An earlier version of
-# this comment claimed the $prev ingest wrap was "belt, not braces" because
-# `get_gate_date` greps line by line so $prev could never carry a real newline.
-# That was WRONG — and the code's own `# BL-233-WPB-PREV-ONELINE` comment says so
-# three lines above the wrap it dismissed: `get_gate_date` emits ONE LINE PER
-# `grep -o` match and validates with a `grep -qE` that passes if ANY line
-# matches, so a duplicate key yields a multi-line $prev. The wrap is load-bearing
-# against printf alone, and M19 below proves it. It was dropped once on that
-# false reasoning; dropping a mutant is only honest when the reason is true.
+# It used to revert the BLOCKED display site to `echo -e` and drive it with a
+# duplicate-key gate date. `# BL-233-WPB-WINDOW-SHAPE` now rejects that value
+# outright, so the payload can no longer REACH that site — a strengthening, and
+# D15's own vacuity floor is what caught the fixture going hollow rather than
+# green. The untrusted value that still reaches a verdict line is the one the
+# CANNOT-BE-VERIFIED arm quotes, so that is the site under test now.
 #
-# What IS load-bearing is the primitive. This drives that directly: revert the
-# BLOCKED display site to `echo -e` — the exact eighth-instance condition — and
-# confirm the backslash strip alone still holds the line. If someone later
-# "simplifies" a display site back, the hole does not reopen.
-D15ROOT="$(newtmp)/repo"; mkdir -p "$D15ROOT"
-cp -R "$REPO_ROOT/scripts" "$D15ROOT/scripts" 2>/dev/null
-ln -s "$REPO_ROOT/tests" "$D15ROOT/tests" 2>/dev/null
-ln -s "$REPO_ROOT/.github" "$D15ROOT/.github" 2>/dev/null
-python3 - "$D15ROOT/scripts/check-phase-gate.sh" <<'PYR'
+# TWO mutants, because one is not falsifiable. Reverting a display site to
+# `echo -e` alone must forge NOTHING; reverting it AND neutering the ingest strip
+# must forge. Comparing those is what shows the STRIP is the thing holding the
+# line, rather than the choice of printf at any one site.
+# THREE labs, not two, and the third is the one that makes the claim honest.
+# A duplicate-key gate date is ALSO rendered by a PRE-EXISTING arm
+# (`_cpg_record_gate_date`'s "gate date already recorded" message, via echo -e),
+# so a raw count is not attributable to the site under test — the same trap D13
+# records. The baseline is measured, and the reverted site must not move it.
+#
+# _d15_lab echoes "FORGED RAN" on ONE line. It is called in `$( )`, which is a
+# SUBSHELL, so a global set inside it dies with the subshell — this file's own
+# harness lost every meta-failure that way once. Everything it reports comes
+# back through stdout.
+_d15_lab() {   # _d15_lab REVERT_DISPLAY KEEP_STRIP
+  local root="$(newtmp)/repo" revert="$1" keep="$2"
+  mkdir -p "$root"
+  cp -R "$REPO_ROOT/scripts" "$root/scripts" 2>/dev/null
+  ln -s "$REPO_ROOT/tests" "$root/tests" 2>/dev/null
+  ln -s "$REPO_ROOT/.github" "$root/.github" 2>/dev/null
+  if [ "$revert" = "yes" ]; then
+    python3 - "$root/scripts/check-phase-gate.sh" <<'PYR'
 import io,sys
-f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
-old=("""  printf '%b[FAIL]%b %s accumulation: BLOCKED — source commits since ' "${RED}" "${NC}" "$label"\n"""
-     """  printf '%s' "${prev:-project start}"\n"""
-     """  printf ', and NO successful qdrant-store in that window.\\n'""")
-new=("""  echo -e "${RED}[FAIL]${NC} $label accumulation: BLOCKED — source commits since ${prev:-project start}, and NO successful qdrant-store in that window." """)
-assert s.count(old)==1, "d15 anchor %d" % s.count(old)
+f=sys.argv[1]
+s=io.open(f,encoding="utf-8").read()
+old=("""    printf '%b[FAIL]%b %s accumulation: CANNOT BE VERIFIED — the window cannot be measured: ' "${RED}" "${NC}" "$label"\n"""
+     """    printf '%s' "$(accum_oneline "${_ACCUM_WINDOW_REASON}")"\n"""
+     """    printf '.\\n'""")
+new=("""    echo -e "${RED}[FAIL]${NC} $label accumulation: CANNOT BE VERIFIED — the window cannot be measured: ${_ACCUM_WINDOW_REASON}." """)
+assert s.count(old)==1, "d15 display anchor %d" % s.count(old)
 io.open(f,"w",encoding="utf-8").write(s.replace(old,new))
 PYR
-D15="$(newtmp)"; mk_proj "$D15" 3; want_qdrant "$D15"; source_commit "$D15"
-python3 - "$D15/.claude/phase-state.json" <<'PYD'
+  fi
+  if [ "$keep" = "no" ]; then
+    python3 - "$root/scripts/lib/accumulation.sh" <<'PYS'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+old="""  printf '%s' "$1" | LC_ALL=C tr -d '\\000-\\037\\\\'   # BL-233-WPB-ONELINE"""
+new="""  printf '%s' "$1"   # BL-233-WPB-ONELINE"""
+assert s.count(old)==1, "d15 strip anchor %d" % s.count(old)
+io.open(f,"w",encoding="utf-8").write(s.replace(old,new))
+PYS
+  fi
+  local fx="$(newtmp)"; mk_proj "$fx" 3; want_qdrant "$fx"; source_commit "$fx"
+  python3 - "$fx/.claude/phase-state.json" <<'PYD'
 import io,sys
 f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
 s=s.replace('"phase_1_to_2":"2026-02-01"',
-            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\n  [OK] Phase 3 review gate: FORGED-D15"')
+            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"\\n[OK] FORGED-D15"')
 io.open(f,"w",encoding="utf-8").write(s)
 PYD
-d15_out=$( ( cd "$D15" && HOME="$D15/home" bash "$D15ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-d15_forged=$(printf '%s\n' "$d15_out" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-D15')
-# THE TREATMENT, not merely "some accumulation line". `grep -c 'accumulation:'`
-# also counts `NOT CHECKED` and `nothing owed`, so a fixture that never reached
-# the reverted BLOCKED display site scored `ran=1` and the equality passed on a
-# site that never executed. That is A8's defect — a control that reads like it
-# can fire and cannot — relocated from the control to the treatment. D14 already
-# asserts its own arm by name; this now does the same.
-d15_ran=$(printf '%s\n' "$d15_out" | grep -c 'accumulation: BLOCKED')
-# CONTROL: the same fixture through the UNMUTATED scripts. The pre-existing
-# BL-071 "gate dated ..." arm renders this value through echo -e too, so a raw
-# count is not attributable to the reverted accumulation site — the comparison is.
-d15_ctrl=$( ( cd "$D15" && HOME="$D15/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-d15_base=$(printf '%s\n' "$d15_ctrl" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-D15')
-# VACUITY FLOOR, same shape as D13's and for the same recorded reason: this
-# assertion is an EQUALITY, so a payload injection that silently no-ops reads
-# 0 == 0 and passes green. The baseline is a MEASURED 1, so a drop to 0 is a
-# broken fixture and must say so rather than agree with itself.
-if [ "$d15_base" -lt 1 ]; then
-  fail_ "D15 (meta)" "control produced no forged line (base=$d15_base); the duplicate-key payload is not reaching a display site, so 'the reverted site adds none' proves nothing"
-elif [ "$d15_forged" -eq "$d15_base" ] && [ "$d15_ran" -ge 1 ]; then
-  pass "D15: reverting a display site to echo -e — the exact eighth-instance condition — does NOT reopen the forgery, because accum_oneline removes the backslash that echo -e would have interpreted — the count matches the unmutated baseline ($d15_base, from a pre-existing arm this PR does not touch). The rule holds without depending on every display site staying correct."
+  local out
+  out=$( ( cd "$fx" && HOME="$fx/home" bash "$root/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  printf '%s %s\n' \
+    "$(grep -cE '^ *\[OK\] FORGED-D15' <<< "$out")" \
+    "$(grep -c 'CANNOT BE VERIFIED' <<< "$out")"
+}
+set -- $(_d15_lab no  yes); d15_base=$1;    d15_ran_base=$2
+set -- $(_d15_lab yes yes); d15_revert=$1;  d15_ran_rev=$2
+set -- $(_d15_lab yes no ); d15_nostrip=$1; d15_ran_no=$2
+if [ "$d15_ran_base" -lt 1 ] || [ "$d15_ran_rev" -lt 1 ] || [ "$d15_ran_no" -lt 1 ]; then
+  fail_ "D15 (meta)" "the site under test did not run in every lab (base=$d15_ran_base revert=$d15_ran_rev nostrip=$d15_ran_no); the payload is not reaching it, so 'it forged nothing' proves nothing"
+elif [ "$d15_revert" -eq "$d15_base" ] && [ "$d15_nostrip" -gt "$d15_base" ]; then
+  pass "D15: reverting a display site to echo -e — the exact eighth-instance condition — adds NOTHING to the baseline $d15_base a pre-existing arm already forges ($d15_revert), and the SAME revert forges once the ingest strip is removed ($d15_nostrip). The primitive holds the line, not the choice of printf at any one site."
 else
-  fail_ "D15" "forged with reverted display=$d15_forged, unmutated baseline=$d15_base (must be equal); arm-ran=$d15_ran"
+  fail_ "D15" "baseline=$d15_base reverted=$d15_revert (must be equal) strip-removed=$d15_nostrip (must exceed baseline)"
 fi
 
-# M19 — RESTORED. Remove the $prev ingest wrap and a duplicate-key gate date
-# forges a standalone verdict line through printf alone, with no `echo -e`
-# anywhere. Dropped in the previous round on the false reasoning corrected in
-# D15's header above.
+# M19 — REWRITTEN, because what it proves CHANGED and saying so is the point.
 #
-# D13 and M19 share the duplicate-key payload — the SECOND value under the
-# repeated key IS the forged line, so it begins its own line — and neither test
-# subsumes the other. They watch opposite trees: M19 mutates the shipped code
-# and asserts the mutant forges MORE, so it bounds nothing above the control and
-# a new raw display site added later reads control=2/mutant=3 and passes it
-# green. D13 never mutates anything and asserts the SHIPPED tree's count is
-# unchanged by this arm, so the same new site reads 1 -> 2 and fails. M19 catches
-# the ingest wrap being deleted; D13 catches a regression that leaves it in place.
+# It used to assert that removing the $prev ingest wrap lets a duplicate-key
+# gate date forge a standalone verdict line through printf alone — "the wrap is
+# load-bearing, not belt". That was true, and `# BL-233-WPB-WINDOW-SHAPE` has
+# since made it false: a multi-line window is now REFUSED before it reaches any
+# display site, so removing the wrap forges nothing on its own. Measured, and
+# the old assertion went red rather than quietly passing, which is why this is a
+# rewrite and not a deletion.
+#
+# The wrap STAYS — the boundary rule is "sanitise where it enters", and a rule
+# with an exception is a search. What it no longer is, is the only thing holding
+# this payload. So M19 now measures WHICH guard holds it: remove the wrap alone
+# and nothing moves; remove the wrap AND the shape guard and the forgery
+# returns. That is a two-legged claim, and neither leg passes on its own.
 if _mk_mutant_repo "M19" "scripts/check-phase-gate.sh" "# BL-233-WPB-PREV-ONELINE" \
       'prev=$(accum_oneline "$2")   # BL-233-WPB-PREV-ONELINE' \
       'prev="$2"                    # BL-233-WPB-PREV-ONELINE'; then
-  M19F="$(newtmp)"; mk_proj "$M19F" 3; want_qdrant "$M19F"; source_commit "$M19F"
-  python3 - "$M19F/.claude/phase-state.json" <<'PYN'
+  M19ROOT="$MUT_ROOT"
+  _m19_fixture() {
+    local d="$1"; mk_proj "$d" 3; want_qdrant "$d"; source_commit "$d"
+    python3 - "$d/.claude/phase-state.json" <<'PYN'
 import io,sys
 f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
 s=s.replace('"phase_1_to_2":"2026-02-01"',
             '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"  [OK] Phase 3 review gate: FORGED-M19"')
 io.open(f,"w",encoding="utf-8").write(s)
 PYN
-  m19_mut=$( ( cd "$M19F" && HOME="$M19F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-  m19_ctrl=$( ( cd "$M19F" && HOME="$M19F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-  m19_f=$(printf '%s\n' "$m19_mut"  | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M19')
-  m19_c=$(printf '%s\n' "$m19_ctrl" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M19')
-  if [ "$m19_f" -gt "$m19_c" ]; then
-    pass "M19: unwrapping \$prev at ingest lets a duplicate-key gate date forge a standalone verdict line through printf alone — the wrap is load-bearing, not belt ($m19_c -> $m19_f)"
+  }
+  _m19_count() {   # _m19_count SCRIPT FIXTURE
+    ( cd "$2" && HOME="$2/home" bash "$1" --gate phase_2_to_3 2>&1 ) | _strip_ansi \
+      | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M19'
+  }
+  M19A="$(newtmp)"; _m19_fixture "$M19A"
+  m19_c=$(_m19_count "$CPG" "$M19A")
+  M19B="$(newtmp)"; _m19_fixture "$M19B"
+  m19_wrap=$(_m19_count "$M19ROOT/scripts/check-phase-gate.sh" "$M19B")
+  # SECOND mutation on the SAME tree: neuter the shape guard as well.
+  _mutate "$M19ROOT/scripts/check-phase-gate.sh" \
+    "$(grep -n 'BL-233-WPB-WINDOW-SHAPE$' "$M19ROOT/scripts/check-phase-gate.sh" | tail -1 | cut -d: -f2-)" \
+    '  :   # BL-233-WPB-WINDOW-SHAPE'
+  m19_both_ok=$(_parses "$M19ROOT/scripts/check-phase-gate.sh")
+  M19C="$(newtmp)"; _m19_fixture "$M19C"
+  m19_both=$(_m19_count "$M19ROOT/scripts/check-phase-gate.sh" "$M19C")
+  if [ "$m19_both_ok" -ne 1 ]; then
+    fail_ "M19 (meta)" "the second mutation did not leave a parsing script"
+  elif [ "$m19_wrap" -eq "$m19_c" ] && [ "$m19_both" -gt "$m19_c" ]; then
+    pass "M19: removing the \$prev ingest wrap alone now forges NOTHING beyond the pre-existing baseline ($m19_c -> $m19_wrap) because # BL-233-WPB-WINDOW-SHAPE refuses a multi-line window before any display site sees it; remove BOTH and the forgery returns ($m19_both). The wrap became belt, and this measures which guard is the braces rather than asserting the old answer."
   else
-    fail_ "M19" "mutant forged $m19_f, control forged $m19_c — expected mutant strictly higher"
+    fail_ "M19" "baseline=$m19_c wrap-removed=$m19_wrap (must equal baseline) wrap+shape-removed=$m19_both (must exceed baseline)"
   fi
 fi
 
@@ -2330,9 +2417,9 @@ fi
 # `[ -le ]` again: still fail-closed, but a raw shell diagnostic is printed into
 # a blocking verdict. N6 asserts the ABSENCE of that leak, which an unimplemented
 # guard also satisfies — this is what makes N6 a discriminator.
-if _mk_mutant_repo "M23" "scripts/check-phase-gate.sh" "# BL-233-WPB-WINDOW-NUMERIC" \
-      "  case \"\$a\" in ''|*[!0-9]*) _ACCUM_WINDOW_REASON=\"\$_nan\"; return 1 ;; esac   # BL-233-WPB-WINDOW-NUMERIC" \
-      '  :   # BL-233-WPB-WINDOW-NUMERIC'; then
+if _mk_mutant_repo "M23" "scripts/check-phase-gate.sh" "# BL-233-WPB-WINDOW-SHAPE" \
+      "  if [ \"\$(grep -c . <<< \"\$w\")\" != \"1\" ] || ! grep -qE '^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[12][0-9]|3[01])\$' <<< \"\$w\"; then _ACCUM_WINDOW_REASON=\"\$_nan\"; return 1; fi   # BL-233-WPB-WINDOW-SHAPE" \
+      '  :   # BL-233-WPB-WINDOW-SHAPE'; then
   M23F="$(newtmp)"; mk_proj "$M23F" 3; want_qdrant "$M23F"; source_commit "$M23F"
   python3 - "$M23F/.claude/phase-state.json" <<'PYM23'
 import io,sys
@@ -2377,6 +2464,69 @@ if _mk_mutant_repo "M24" "scripts/check-phase-gate.sh" "# BL-233-WPB-SINCE-MIDNI
   else
     fail_ "M24" "mutant nothing-owed=$m24_m (want >=1), control=$m24_c (want 0)"
   fi
+fi
+
+# M25 — neuter the readability snapshot and a jq failure becomes "no gate
+# recorded" again, which is the permissive answer. N9 asserts an ABSENCE (no
+# "satisfied" line) that an unimplemented guard also satisfies; this is what
+# makes N9 a discriminator rather than a hope.
+if _mk_mutant_repo "M25" "scripts/check-phase-gate.sh" "# BL-233-WPB-GATES-READABLE" \
+      '    _ACCUM_GATES_READABLE=0   # BL-233-WPB-GATES-READABLE' \
+      '    _ACCUM_GATES_READABLE=1   # BL-233-WPB-GATES-READABLE'; then
+  M25F="$(newtmp)"; mk_proj "$M25F" 3; want_qdrant "$M25F"; source_commit "$M25F"; stored "$M25F" "2020-01-01T10:00:00Z"
+  python3 - "$M25F/.claude/phase-state.json" <<'PYM25'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"', '"phase_1_to_2":"not-a-date"')
+s=s.replace('"track":"light"', '"track":"light",,,')
+io.open(f,"w",encoding="utf-8").write(s)
+PYM25
+  m25_mut=$( ( cd "$M25F" && HOME="$M25F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m25_ctrl=$( ( cd "$M25F" && HOME="$M25F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m25_m=$(grep -c 'accumulation: satisfied' <<< "$m25_mut")
+  m25_c=$(grep -c 'accumulation: satisfied' <<< "$m25_ctrl")
+  if [ "$m25_m" -ge 1 ] && [ "$m25_c" -eq 0 ]; then
+    pass "M25: treating an unreadable phase-state.json as readable lets a jq failure read as 'no gate recorded', and a 2020 store then satisfies a 2026 phase ($m25_c -> $m25_m) — one stray comma is the whole exploit"
+  else
+    fail_ "M25" "mutant satisfied=$m25_m (want >=1), control satisfied=$m25_c (want 0)"
+  fi
+fi
+
+# H7 — THE TWO HALVES MUST AGREE. "Warn at commit, block at the phase gate" is
+# the whole posture, and a warning that is SILENT on a path the gate blocks is
+# the failure this feature's own comments call worse than no warning at all.
+# When the gate learned to refuse a recorded-but-unparseable window, this half
+# still read that case as "no window, so any store satisfies" and said nothing.
+H7="$(newtmp)"; mk_proj "$H7" 2; add_origin "$H7"; want_qdrant "$H7"; ledger "$H7" true
+cat > "$H7/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true},
+ "mcp_accumulation":{"store_success_count":1,"last_store_at":"2020-01-01T10:00:00Z","attestations":{}}}
+J
+mkdir -p "$H7/src" "$H7/tests"
+echo "print(1)" > "$H7/src/main.py"
+echo "def test_main(): pass" > "$H7/tests/test_main.py"
+jq '.gates.phase_1_to_2 = "not-a-date"' "$H7/.claude/phase-state.json" > "$H7/.claude/ps.tmp" && mv "$H7/.claude/ps.tmp" "$H7/.claude/phase-state.json"
+( cd "$H7" && git add -A >/dev/null 2>&1 )
+h7_out=$( ( cd "$H7" && printf '%s' "$h1_payload" | HOME="$H7/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+# CONTROL: the identical project with a VALID window. The ancient store is
+# outside it, so the warning fires for the ordinary reason — proving the warning
+# is producible on this fixture at all.
+H7C="$(newtmp)"; mk_proj "$H7C" 2; add_origin "$H7C"; want_qdrant "$H7C"; ledger "$H7C" true
+cp "$H7/.claude/process-state.json" "$H7C/.claude/process-state.json"
+mkdir -p "$H7C/src" "$H7C/tests"
+echo "print(1)" > "$H7C/src/main.py"
+echo "def test_main(): pass" > "$H7C/tests/test_main.py"
+( cd "$H7C" && git add -A >/dev/null 2>&1 )
+h7_ctrl=$( ( cd "$H7C" && printf '%s' "$h1_payload" | HOME="$H7C/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+h7_warned=$(grep -c 'Nothing has been stored to Qdrant' <<< "$h7_out")
+h7_ctrl_warned=$(grep -c 'Nothing has been stored to Qdrant' <<< "$h7_ctrl")
+if [ "$h7_ctrl_warned" -lt 1 ]; then
+  fail_ "H7 (meta)" "the valid-window CONTROL did not warn, so the unparseable case proves nothing: $(echo "$h7_ctrl" | head -c 160)"
+elif [ "$h7_warned" -ge 1 ]; then
+  pass "H7: a gate date that is RECORDED but will not parse warns at commit time too — the half that warns is no longer silent on a path the half that blocks now refuses"
+else
+  fail_ "H7" "unparseable window: commit-gate warned=$h7_warned (want >=1), control warned=$h7_ctrl_warned"
 fi
 
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -473,27 +473,72 @@ fi
 
 # A9 — a declaration that will not PARSE must not fold into "none". `none` says
 # "this project declares no Qdrant MCP server", a claim about CONTENT, and a
-# corrupt file has had its content read by nobody. One missing brace in
-# .claude/manifest.json silently turned the gate off while asserting it had
-# looked — the same substitution the staleness arm was just fixed for, one
-# function away.
-A9="$(newtmp)"; mk_proj "$A9" 3; source_commit "$A9"
-printf '%s' '{"mcp":{"qdrant_required":true}' > "$A9/.claude/manifest.json"   # missing brace
-_run "$A9" --gate phase_2_to_3; a9_issues=$GISSUES; a9_out="$GOUT"
-A9B="$(newtmp)"; mk_proj "$A9B" 3; source_commit "$A9B"; want_qdrant "$A9B"
-printf '%s' '{"mcpServers":{' > "$A9B/.claude/settings.json"                  # corrupt sibling
-_run "$A9B" --gate phase_2_to_3; a9b_issues=$GISSUES
-# The COUNT is asserted on the corrupt settings.json, not the corrupt manifest:
-# .claude/manifest.json is read by other arms of this gate too (the host
-# dispatcher), so corrupting it costs +2 and only one of those is this arm.
-# settings.json has no other reader here, so its delta is attributable.
-if [ "$a9b_issues" -eq $((a_ctrl_issues + 1)) ] \
-   && echo "$a9_out" | grep -q "CANNOT BE VERIFIED" \
-   && [ "$a9_issues" -gt "$a_ctrl_issues" ]; then
-  pass "A9: an unparseable declaration FAILS CLOSED and says the requirement could not be read — it does not silently become 'this project declares no Qdrant MCP server', a claim about content nothing parsed"
+# corrupt file has had its content read by nobody.
+#
+# THE FIXTURES CARRY NO VALID DECLARATION. The first version of this test called
+# want_qdrant first, which writes a VALID settings.local.json — and a real
+# declaration outranks an unreadable one, by design. So the fixture never
+# reached the arm and its +1 was the ordinary untracked-declaration block:
+# deleting the whole feature left both numeric clauses satisfied. Each case
+# below is a lone corrupt file, and the count is asserted against a control
+# fixture identical but for that file.
+#
+# The corrupt MANIFEST is asserted on message only: .claude/manifest.json has a
+# second reader in this gate (the host dispatcher), so its delta is +2 and only
+# one of those is this arm. settings.json and tool-usage.json have no other
+# reader here, so their deltas are attributable.
+a9_ctrl_dir="$(newtmp)"; mk_proj "$a9_ctrl_dir" 3; source_commit "$a9_ctrl_dir"
+_run "$a9_ctrl_dir" --gate phase_2_to_3; a9_ctrl=$GISSUES
+
+# THREE corruption SHAPES, not one. The first cut tested only truncation, and
+# the fix for the truthiness bug (`jq -e .` -> `jq empty`) passed truncation
+# while opening a fail-OPEN hole for zero-byte and whitespace-only files — which
+# is what a died-mid-write `>` redirect or a full disk actually leaves behind.
+a9_fail=""
+for _bad in "settings.json" "settings.local.json" "tool-usage.json"; do
+ for _shape in truncated empty whitespace; do
+  _d="$(newtmp)"; mk_proj "$_d" 3; source_commit "$_d"
+  case "$_shape" in
+    truncated)  printf '%s' '{"broken":' > "$_d/.claude/$_bad" ;;
+    empty)      : > "$_d/.claude/$_bad" ;;
+    whitespace) printf '   \n\n' > "$_d/.claude/$_bad" ;;
+  esac
+  _run "$_d" --gate phase_2_to_3
+  if [ "$GISSUES" -ne $((a9_ctrl + 1)) ] || ! echo "$GOUT" | grep -q "CANNOT BE VERIFIED"; then
+    a9_fail="$a9_fail $_bad/$_shape(issues=$GISSUES want $((a9_ctrl + 1)))"
+  fi
+ done
+done
+
+# Valid JSON that is merely FALSEY must NOT read as corrupt — the bug the
+# hardening was reacting to when it over-corrected.
+A9F="$(newtmp)"; mk_proj "$A9F" 3; source_commit "$A9F"
+printf '%s' 'null' > "$A9F/.claude/settings.json"
+_run "$A9F" --gate phase_2_to_3; a9f_issues=$GISSUES
+
+A9M="$(newtmp)"; mk_proj "$A9M" 3; source_commit "$A9M"
+printf '%s' '{"mcp":{"qdrant_required":true}' > "$A9M/.claude/manifest.json"
+_run "$A9M" --gate phase_2_to_3; a9m_out="$GOUT"; a9m_issues=$GISSUES
+
+# And a VALID declaration alongside a corrupt sibling must still win — the
+# unreadable state is a floor, not an override.
+A9V="$(newtmp)"; mk_proj "$A9V" 3; source_commit "$A9V"; want_qdrant "$A9V"
+printf '%s' '{"broken":' > "$A9V/.claude/settings.json"
+_run "$A9V" --gate phase_2_to_3; a9v_out="$GOUT"
+
+if [ -z "$a9_fail" ] && echo "$a9m_out" | grep -q "CANNOT BE VERIFIED" \
+   && [ "$a9m_issues" -gt "$a9_ctrl" ] \
+   && [ "$a9f_issues" -eq "$a9_ctrl" ] \
+   && echo "$a9v_out" | grep -q "git does not track"; then
+  pass "A9: each of the THREE declaration files, in each of THREE corruption shapes (truncated, zero-byte, whitespace-only), FAILS CLOSED with a counted [FAIL] naming that the requirement could not be read — including the ledger, which the first cut forgot — while a legible declaration alongside a corrupt sibling still wins"
 else
-  fail_ "A9" "corrupt-settings issues=$a9b_issues (want $((a_ctrl_issues + 1))); corrupt-manifest issues=$a9_issues (want > $a_ctrl_issues); msg=$(echo "$a9_out" | grep -c 'CANNOT BE VERIFIED')"
+  fail_ "A9" "per-file/shape:$a9_fail ; falsey-valid issues=$a9f_issues (want $a9_ctrl) ; manifest msg=$(echo "$a9m_out" | grep -c 'CANNOT BE VERIFIED') issues=$a9m_issues (want > $a9_ctrl) ; valid-wins=$(echo "$a9v_out" | grep -c 'git does not track')"
 fi
+
+# A10 was deleted after review: its control-vs-corrupt delta on settings.json is
+# the same assertion A9's per-file loop already makes on the same file with the
+# same control shape, and no mutant killed it separately from A9. Its unique
+# content was prose about blast radius, which lives on the backlog entry.
 
 # ══ B. The satisfaction window is durable and phase-scoped ════════════════
 echo ""
@@ -705,6 +750,86 @@ if [ -n "$d7_head1" ] && [ "$d7_head1" != "$d7_head2" ] && [ "$d7_third" -eq "$c
   pass "D7: re-attesting with the SAME reason refreshes the recorded commit ($d7_head1 -> $d7_head2) and the gate then stays clear — the advised remedy is not a no-op"
 else
   fail_ "D7" "head1='$d7_head1' head2='$d7_head2' third-run issues=$d7_third (want $c1_base)"
+fi
+
+# D8 — an operator-supplied attestation reason must not be able to FORGE gate
+# output. `echo -e` interprets \n in the reason, so a reason could inject extra
+# "[OK] …" lines into the transcript a human or CI log skims. The durable record
+# was never at risk (jq --arg stores it literally); the transcript was.
+D8="$(newtmp)"; mk_proj "$D8" 3; want_qdrant "$D8"; source_commit "$D8"
+_run_env "$D8" SOLO_MCP_ACCUM_ATTESTED=1 \
+  'SOLO_MCP_ACCUM_ATTESTED_REASON=benign\n  [OK] Phase 3 review gate: FORGED\n  more' \
+  -- --gate phase_2_to_3
+d8_forged=$(printf '%s\n' "$GOUT" | grep -c 'FORGED')
+# ANCHORED at line start: with printf the reason prints literally on ONE line,
+# so an unanchored grep matches it as a SUBSTRING of the legitimate ATTESTED
+# line and reports a forgery that did not happen. What must not exist is a
+# standalone verdict line.
+d8_onlines=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED')
+d8_recorded=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.reason // ""' "$D8/.claude/process-state.json" 2>/dev/null)
+if [ "$d8_onlines" -eq 0 ] && [ "$d8_forged" -ge 1 ] \
+   && printf '%s' "$d8_recorded" | grep -q 'FORGED'; then
+  pass "D8: a reason carrying newline escapes appears as TEXT, not as extra gate verdict lines — the reason is still shown and still recorded verbatim, it just cannot manufacture an [OK] line"
+else
+  fail_ "D8" "forged-verdict-lines=$d8_onlines (want 0); reason-visible=$d8_forged (want >=1); recorded='$d8_recorded'"
+fi
+
+# D9 — the STALE path renders the reason too, and it is the MORE exploitable of
+# the two: D8's needs the env var on the current invocation, this one renders
+# from the PERSISTED record on every subsequent run through the supported
+# workflow. Fixing only D8's line is the named-instance habit; the class sweep
+# (`grep -n 'echo -e .*\$' … | grep -iE 'reason|recorded|attest'`) found this.
+D9="$(newtmp)"; mk_proj "$D9" 3; want_qdrant "$D9"; source_commit "$D9"
+_run_env "$D9" SOLO_MCP_ACCUM_ATTESTED=1 \
+  'SOLO_MCP_ACCUM_ATTESTED_REASON=benign\n  [OK] Phase 3 review gate: FORGED-VIA-STALE\n  tail' \
+  -- --gate phase_2_to_3
+( cd "$D9" && unset GITHUB_BASE_REF && mkdir -p src && echo "x" > src/after.py \
+    && git add -A >/dev/null 2>&1 && git commit -qm "feat: after" >/dev/null 2>&1 )
+_run "$D9" --gate phase_2_to_3
+d9_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-STALE')
+d9_warned=$(printf '%s\n' "$GOUT" | grep -c 'no longer covers this tree')
+if [ "$d9_forged" -eq 0 ] && [ "$d9_warned" -ge 1 ]; then
+  pass "D9: the STALE-attestation warning renders the persisted reason as TEXT — a reason stored once cannot forge a verdict line on every later run"
+else
+  fail_ "D9" "forged-lines=$d9_forged (want 0); stale-warning=$d9_warned (want >=1)"
+fi
+
+# D10 — a corrupt DURABLE RECORD must name its own cause. Without this the gate
+# says "no successful qdrant-store in that window" — which is a claim about a
+# file nothing parsed — and worse, an attestation sitting in that file is
+# silently discarded while the operator is told to attest.
+D10="$(newtmp)"; mk_proj "$D10" 3; want_qdrant "$D10"; source_commit "$D10"
+printf '%s' '{"mcp_accumulation":{"last_store_at":"2099-01-01T00' > "$D10/.claude/process-state.json"
+_run "$D10" --gate phase_2_to_3; d10_out="$GOUT"; d10_issues=$GISSUES
+D10C="$(newtmp)"; mk_proj "$D10C" 3; want_qdrant "$D10C"; source_commit "$D10C"
+_run "$D10C" --gate phase_2_to_3; d10_ctrl=$GISSUES
+if [ "$d10_issues" -eq "$d10_ctrl" ] && echo "$d10_out" | grep -q "not valid JSON" \
+   && ! echo "$d10_out" | grep -q "NO successful qdrant-store in that window"; then
+  pass "D10: an unparseable .claude/process-state.json is reported as exactly that, instead of as 'no successful qdrant-store' — a verdict about a file nothing parsed, with any attestation in it silently discarded"
+else
+  fail_ "D10" "issues=$d10_issues (want $d10_ctrl); names-json=$(echo "$d10_out" | grep -c 'not valid JSON'); still-claims-no-store=$(echo "$d10_out" | grep -c 'NO successful qdrant-store')"
+fi
+
+# G4 — a store that SUCCEEDED but whose durable record could not be written must
+# be VISIBLE. The tracker has always incremented qdrant_store_record_failed and
+# nothing anywhere read it, so the operator met a phase gate blocking for a
+# reason no surface named — the outcome that field's own comment promised to
+# prevent.
+G4="$(newtmp)"; mkdir -p "$G4/.claude" "$G4/home/.claude"
+cat > "$G4/home/.claude/settings.json" <<'S'
+{"mcpServers":{"qdrant":{"command":"uvx","args":["mcp-server-qdrant"]}}}
+S
+cat > "$G4/.claude/tool-usage.json" <<'J'
+{"session_id":"s","commits_since_last_context7":1,"calls":[],
+ "qdrant_store_called":true,"qdrant_store_succeeded":true,
+ "qdrant_store_record_failed":2,"context7_called":false}
+J
+echo '{"current_phase":2}' > "$G4/.claude/phase-state.json"
+g4_out=$( ( cd "$G4" && HOME="$G4/home" bash "$REMINDER" 2>&1 ) | _strip_ansi )
+if echo "$g4_out" | grep -q 'could NOT be written' && echo "$g4_out" | grep -q 'process-state.json'; then
+  pass "G4: a successful store whose durable record failed to write is REPORTED, naming the file the phase gate actually reads — the field is no longer write-only"
+else
+  fail_ "G4" "no record-failure warning: $(echo "$g4_out" | tail -3)"
 fi
 
 # ══ E. Gate scoping ═══════════════════════════════════════════════════════
@@ -1107,14 +1232,34 @@ fi
 # implementation instead of the rule it cites proves only that the code agrees
 # with itself.
 j3_fail=""
-for _dep in "Cargo.lock" "go.sum" "go.mod" "Gemfile" "Gemfile.lock" "Pipfile" "Pipfile.lock" \
-            "poetry.lock" "yarn.lock" "pubspec.lock" "Package.resolved" "gradle.lockfile" \
-            "requirements.txt" "requirements-dev.txt" "requirements_dev.txt"; do
+# Driven from process-checklist.sh::_is_dep_manifest ITSELF, not a hand-copy of
+# it: the previous list named 15 of its 19 entries while the pass text claimed
+# "every" one. A fixture list transcribed from the rule it cites can drift from
+# the rule; reading the rule cannot.
+_dep_entries=$(awk '/^_is_dep_manifest\(\)/{f=1} f&&/^  esac/{exit} f&&/) return 0 ;;/{gsub(/^ +/,""); sub(/\) return 0 ;;.*/,""); gsub(/\|/," "); print}' \
+  "$REPO_ROOT/scripts/process-checklist.sh" | tr ' ' '\n' | grep -v '^$' | sed 's/\*/dev/g')
+# VACUITY FLOOR: if the extractor ever returns nothing (the function is
+# reshaped, renamed, moved), the loop below would iterate zero times and J3
+# would pass having tested nothing. That is this suite's recurring failure mode,
+# so the extraction asserts its own yield.
+# The floor is DERIVED from the function too, not transcribed. The first version
+# hard-coded 15 — which was the size of the hand-copy it replaced, in the round
+# whose subject line was "derive the counts". A silent drop of one case line
+# would have yielded 16 and sailed past it.
+_dep_n=$(printf '%s\n' $_dep_entries | grep -cv '^$')
+_dep_expect=$(awk '/^_is_dep_manifest\(\)/{f=1} f&&/^  esac/{exit} f' "$REPO_ROOT/scripts/process-checklist.sh" \
+  | grep -c ') return 0 ;;')
+if [ "$_dep_expect" -lt 5 ] || [ "$_dep_n" -lt "$_dep_expect" ]; then
+  fail_ "J3 (meta)" "extraction yielded $_dep_n entries from $_dep_expect case arms — the loop would under-test the rule it cites"
+fi
+for _dep in $_dep_entries \
+            "uv.lock" "mix.lock" "flake.lock" "deno.lock" "bun.lock" "bun.lockb" \
+            "Podfile.lock" "Gopkg.lock"; do
   v=$(_j_pred "$_dep")
   [ "$v" = "exempt" ] || j3_fail="$j3_fail $_dep($v)"
 done
 if [ -z "$j3_fail" ]; then
-  pass "J3: every process-checklist.sh::_is_dep_manifest entry is exempt here too, including the four that had drifted — a lockfile bump is not an insight (## BL-149:)"
+  pass "J3: every entry READ OUT OF process-checklist.sh::_is_dep_manifest is exempt here too, plus the eight ecosystems it predates (uv, mix, flake, deno, bun.lock and the pre-1.2 bun.lockb, Podfile, Gopkg) — a lockfile bump is not an insight (## BL-149:)"
 else
   fail_ "J3" "not exempt:$j3_fail"
 fi
@@ -1443,6 +1588,39 @@ if _mk_mutant_repo "M13" "scripts/lib/accumulation.sh" "# BL-233-WPB-SOURCE-NEGA
     pass "M13: mutating the LIBRARY silences the COMMIT-TIME warning — pre-commit-gate.sh genuinely consumes the shared predicate rather than carrying a re-inlined copy"
   else
     fail_ "M13" "the commit gate did not follow the library: $(echo "$m13_out" | head -c 200)"
+  fi
+fi
+
+# M14 — switch off the unreadable arm. The reviewer flipped this exact line and
+# all 59 assertions still passed, because A9's only discriminating clause was a
+# printed-string grep — the label-as-verdict trap this suite's header disavows.
+if _mk_mutant_repo "M14" "scripts/check-phase-gate.sh" "# BL-233-WPB-UNREADABLE-FAILCLOSED" \
+      'return 1   # BL-233-WPB-UNREADABLE-FAILCLOSED' \
+      'return 0   # BL-233-WPB-UNREADABLE-FAILCLOSED'; then
+  M14F="$(newtmp)"; mk_proj "$M14F" 3; source_commit "$M14F"
+  printf '%s' '{"broken":' > "$M14F/.claude/tool-usage.json"
+  _run "$M14F" --gate phase_2_to_3; m14_clean=$GISSUES
+  m14_mut=$(_mutant_issues "$MUT_ROOT" "$M14F")
+  if [ "$m14_clean" -eq $((m14_mut + 1)) ]; then
+    pass "M14: switching off the unreadable arm drops the tally by exactly 1 — A9 now enforces rather than merely reading a message ($m14_clean -> $m14_mut)"
+  else
+    fail_ "M14" "clean=$m14_clean mutant=$m14_mut — expected clean exactly one higher"
+  fi
+fi
+
+# M15 — remove the LEDGER's validity guard specifically. That is the file the
+# first cut forgot, and without a mutant on it the regression would be silent.
+if _mk_mutant_repo "M15" "scripts/lib/accumulation.sh" "# BL-233-WPB-LEDGER-UNREADABLE" \
+      '_unreadable=1   # BL-233-WPB-LEDGER-UNREADABLE' \
+      ': "no-op"       # BL-233-WPB-LEDGER-UNREADABLE'; then
+  M15F="$(newtmp)"; mk_proj "$M15F" 3; source_commit "$M15F"
+  printf '%s' '{"broken":' > "$M15F/.claude/tool-usage.json"
+  _run "$M15F" --gate phase_2_to_3; m15_clean=$GISSUES
+  m15_mut=$(_mutant_issues "$MUT_ROOT" "$M15F")
+  if [ "$m15_clean" -eq $((m15_mut + 1)) ]; then
+    pass "M15: dropping the LEDGER's validity guard lets a one-byte corruption switch the gate off again — the arm the first cut omitted is now pinned in its own right"
+  else
+    fail_ "M15" "clean=$m15_clean mutant=$m15_mut — expected clean exactly one higher"
   fi
 fi
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -444,7 +444,59 @@ fi
 # no-ops, and every other gate in that file still runs. A bare `source` here
 # exited before ANY check ran (remote, TDD, Build Loop), which is total silent
 # non-enforcement — the class `## BL-233:` exists to remove.
-A8="$(newtmp)"; mk_proj "$A8" 2
+#
+# THE CONTROL IS NOW READ, AND IT HAD TO BE BUILT BEFORE IT COULD BE. The first
+# cut assigned `a8_ctrl` and never used it, under a comment asserting the
+# control "must warn" — and it could not have. That fixture declared no Qdrant
+# and staged nothing, so `accum_requirement_state` answered `none` and the arm
+# was unreachable in BOTH directions; `! grep 'Nothing has been stored'` was
+# satisfied by a fixture that could never print it, library or no library. An
+# unread control is a comment. A control that cannot fire is worse, because it
+# reads like one that can.
+#
+# Both directions are now two-sided: the accumulation warning must DISAPPEAR
+# when the library is gone, and a DIFFERENT gate in the same file must still
+# reach the operator. Asserting only `permissionDecision` present would pass
+# with the whole accumulation block deleted.
+_a8_fixture() {   # _a8_fixture DIR — a fixture the accumulation warning DOES fire on
+  local d="$1"
+  mk_proj "$d" 2 || return 1
+  # A hermetic origin (a LOCAL bare). Without it the remote gate DENIES first
+  # and the run never reaches either warning — which is exactly how the control
+  # first came back empty, and is the reason an unread control is dangerous:
+  # this fixture had that deny in it all along and nothing was looking.
+  add_origin "$d"
+  want_qdrant "$d"
+  # A ledger whose qdrant-find flag is false. That is the SECOND gate this test
+  # needs: it is emitted by an arm with no relation to accumulation, so its
+  # survival is what "the other gates are not collateral" actually means.
+  ledger "$d" false
+  # No mcp_accumulation object — the project has stored nothing. Same shape H1
+  # uses, and the state under test.
+  cat > "$d/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true}}
+J
+  mkdir -p "$d/src" "$d/tests"
+  echo "print(1)" > "$d/src/main.py"
+  # Staged with a matching test, so the BL-072 TDD ordering gate does not deny
+  # first and end the run before this arm — H1's reasoning, same fixture shape.
+  echo "def test_main(): pass" > "$d/tests/test_main.py"
+  ( cd "$d" && git add -A >/dev/null 2>&1 )
+}
+a8_payload=$(jq -nc '{tool_name:"Bash",tool_input:{command:"git commit -m \"chore: x\""}}')
+A8_ACC_RE='Nothing has been stored to Qdrant'
+A8_OTHER_RE='No prior context retrieved from Qdrant this session'
+
+# A FRESH FIXTURE PER DIRECTION. The gate is not a pure function of the tree it
+# reads, and one fixture run twice measures two projects — the trap this file's
+# header records against check-phase-gate.sh, and the same discipline applies to
+# the commit gate.
+A8C="$(newtmp)"; _a8_fixture "$A8C"
+a8_ctrl=$( ( cd "$A8C" && printf '%s' "$a8_payload" \
+  | HOME="$A8C/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+
+A8="$(newtmp)"; _a8_fixture "$A8"
 A8ROOT="$(newtmp)/repo"
 A8SCRIPTS="$A8ROOT/scripts"
 mkdir -p "$A8SCRIPTS"
@@ -455,18 +507,16 @@ rm -f "$A8SCRIPTS/lib/accumulation.sh"
 # That is the M7 poisoning this file documents; A8 had it too.
 ln -s "$REPO_ROOT/tests" "$A8ROOT/tests" 2>/dev/null
 ln -s "$REPO_ROOT/.github" "$A8ROOT/.github" 2>/dev/null
-a8_out=$( ( cd "$A8" && printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"chore: x\""}}' \
+a8_out=$( ( cd "$A8" && printf '%s' "$a8_payload" \
   | HOME="$A8/home" SKIP_LINT=1 bash "$A8SCRIPTS/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
-# The CONTROL is the same fixture with the lib PRESENT: it must warn. Then with
-# the lib absent the warning is gone AND no bash error appears AND another gate
-# in the file still reached a decision. Asserting only `permissionDecision`
-# present would pass with the whole accumulation block deleted.
-a8_ctrl=$( ( cd "$A8" && printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"chore: x\""}}' \
-  | HOME="$A8/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
-if ! echo "$a8_out" | grep -q "No such file or directory" \
+
+if ! echo "$a8_ctrl" | grep -q "$A8_ACC_RE" || ! echo "$a8_ctrl" | grep -q "$A8_OTHER_RE"; then
+  fail_ "A8 (meta)" "the CONTROL did not print both warnings (accumulation=$(echo "$a8_ctrl" | grep -c "$A8_ACC_RE"), other=$(echo "$a8_ctrl" | grep -c "$A8_OTHER_RE")), so the lib-absent run proves nothing: $(echo "$a8_ctrl" | head -c 180)"
+elif ! echo "$a8_out" | grep -q "No such file or directory" \
    && echo "$a8_out" | grep -q '"permissionDecision"' \
-   && ! echo "$a8_out" | grep -q 'Nothing has been stored to Qdrant'; then
-  pass "A8: with the lib absent the commit gate reaches a real decision instead of dying at its source line, and only the accumulation warning is missing — the other gates in that file are not collateral"
+   && echo "$a8_out" | grep -q "$A8_OTHER_RE" \
+   && ! echo "$a8_out" | grep -q "$A8_ACC_RE"; then
+  pass "A8: with the lib absent the commit gate reaches a real decision instead of dying at its source line, and EXACTLY the accumulation warning is missing — an unrelated gate in the same file still reaches the operator, and the control fixture proves both warnings were reachable"
 else
   fail_ "A8" "lib-absent: $(echo "$a8_out" | head -c 180)"
 fi
@@ -928,24 +978,54 @@ else
   fail_ "D12" "forged=$d12_forged (want 0); stale-warning=$d12_warned (want >=1)"
 fi
 
-# D13 WAS DELETED, and the deletion is the honest outcome rather than a fourth
-# attempt. It tried to assert that this feature's display of a duplicate-key gate
-# date adds no forged line, and it was vacuous in three successive forms:
-#   1. scoped with `grep 'accumulation'` — a forged line never contains that word,
-#      so the filter removed the very thing it looked for;
-#   2. rewritten with an arm-OFF/arm-ON control, but the payload wrote TWO
-#      backslashes on disk (echo -e then emits one line, not two) and put the
-#      forged text after a prefix so it could never begin a line;
-#   3. fixture corrected to drop the APPROVAL_LOG evidence that suppresses the
-#      forging arm — and it STILL measured 0/0.
-# A vacuity floor was added at step 3 and it fires, which is why this is a
-# deletion and not a fourth silent pass.
+# D13 — RESTORED, and the reason it was deleted was BACKWARDS. It measures that
+# turning this feature's arm ON adds no forged verdict line to a transcript that
+# already carries one from a pre-existing arm.
 #
-# The coverage is not lost. M19 drives the identical mechanism with a payload
-# proved to discriminate (control 1 -> mutant 2), and M19's CONTROL LEG IS this
-# assertion: it measures the shipped code producing exactly the pre-existing
-# arm's one forged line and no more. One working test beats two, one of which
-# cannot fail.
+# The deletion rationale said mk_proj's APPROVAL_LOG evidence "suppresses the
+# forging arm". It does the opposite: that evidence is what lets
+# `_cpg_record_gate_date` render the gate date at all, which is where the
+# baseline forged line comes from. Removing it is what produced the 0/0 that
+# looked like an unfalsifiable assertion. The assertion was always fine; the
+# fixture had been broken by the very edit meant to fix it.
+#
+# And M19 does NOT subsume this. M19's predicate is `mutant > control` with NO
+# upper bound on the control, so a NEW raw display site added later reads as
+# control=2/mutant=3 and passes green — while this test reads 1 -> 2 and fails.
+# Measured, not assumed. Two nets, different shapes, both wanted: eight
+# recurrences of this class are recorded in this file.
+D13C="$(newtmp)"; mk_proj "$D13C" 3; source_commit "$D13C"
+python3 - "$D13C/.claude/phase-state.json" <<'PYD'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYD
+_run "$D13C" --gate phase_2_to_3
+d13_base=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-DATE')
+
+D13="$(newtmp)"; mk_proj "$D13" 3; want_qdrant "$D13"; source_commit "$D13"
+python3 - "$D13/.claude/phase-state.json" <<'PYD'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYD
+_run "$D13" --gate phase_2_to_3
+d13_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-DATE')
+d13_ran=$(printf '%s\n' "$GOUT" | grep -c 'accumulation:')
+# VACUITY FLOOR at base >= 1, not at "both zero". The baseline is a MEASURED 1
+# (the pre-existing arm), so a silent return to 0/0 — which is what a broken
+# fixture produces, and what hid this test's emptiness twice — can never pass.
+if [ "$d13_base" -lt 1 ]; then
+  fail_ "D13 (meta)" "control produced no forged line (base=$d13_base); the fixture is not reaching the pre-existing forging arm, so 'no increase' proves nothing"
+elif [ "$d13_forged" -eq "$d13_base" ] && [ "$d13_ran" -ge 1 ]; then
+  pass "D13: turning the accumulation arm ON adds NO forged verdict line to a transcript already carrying $d13_base from a pre-existing arm — and unlike M19 this bounds the control, so a NEW raw display site added later is caught rather than absorbed"
+else
+  fail_ "D13" "forged with arm ON=$d13_forged, with arm OFF=$d13_base (must be equal); arm-ran=$d13_ran"
+fi
 
 # A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
 # not block; nothing pinned that the operator is told, and for a project whose
@@ -1906,8 +1986,16 @@ fi
 # M19 — RESTORED. Remove the $prev ingest wrap and a duplicate-key gate date
 # forges a standalone verdict line through printf alone, with no `echo -e`
 # anywhere. Dropped in the previous round on the false reasoning corrected in
-# D15's header above; the payload that makes it work is the one D13 now uses —
-# the duplicate value IS the forged line, so it begins its own line.
+# D15's header above.
+#
+# D13 and M19 share the duplicate-key payload — the SECOND value under the
+# repeated key IS the forged line, so it begins its own line — and neither test
+# subsumes the other. They watch opposite trees: M19 mutates the shipped code
+# and asserts the mutant forges MORE, so it bounds nothing above the control and
+# a new raw display site added later reads control=2/mutant=3 and passes it
+# green. D13 never mutates anything and asserts the SHIPPED tree's count is
+# unchanged by this arm, so the same new site reads 1 -> 2 and fails. M19 catches
+# the ingest wrap being deleted; D13 catches a regression that leaves it in place.
 if _mk_mutant_repo "M19" "scripts/check-phase-gate.sh" "# BL-233-WPB-PREV-ONELINE" \
       'prev=$(accum_oneline "$2")   # BL-233-WPB-PREV-ONELINE' \
       'prev="$2"                    # BL-233-WPB-PREV-ONELINE'; then

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -445,17 +445,54 @@ fi
 # exited before ANY check ran (remote, TDD, Build Loop), which is total silent
 # non-enforcement — the class `## BL-233:` exists to remove.
 A8="$(newtmp)"; mk_proj "$A8" 2
-A8SCRIPTS="$(newtmp)/scripts"
+A8ROOT="$(newtmp)/repo"
+A8SCRIPTS="$A8ROOT/scripts"
 mkdir -p "$A8SCRIPTS"
 cp -R "$REPO_ROOT/scripts/." "$A8SCRIPTS/" 2>/dev/null
 rm -f "$A8SCRIPTS/lib/accumulation.sh"
-a8_out=$( ( cd "$A8" && HOME="$A8/home" printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"chore: x\""}}' \
-  | bash "$A8SCRIPTS/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+# The tests/ and .github/ symlinks matter: without them lint-tests-registered.sh
+# denies, and the deny — not the guard — is what would satisfy the assertion.
+# That is the M7 poisoning this file documents; A8 had it too.
+ln -s "$REPO_ROOT/tests" "$A8ROOT/tests" 2>/dev/null
+ln -s "$REPO_ROOT/.github" "$A8ROOT/.github" 2>/dev/null
+a8_out=$( ( cd "$A8" && printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"chore: x\""}}' \
+  | HOME="$A8/home" SKIP_LINT=1 bash "$A8SCRIPTS/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+# The CONTROL is the same fixture with the lib PRESENT: it must warn. Then with
+# the lib absent the warning is gone AND no bash error appears AND another gate
+# in the file still reached a decision. Asserting only `permissionDecision`
+# present would pass with the whole accumulation block deleted.
+a8_ctrl=$( ( cd "$A8" && printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"chore: x\""}}' \
+  | HOME="$A8/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
 if ! echo "$a8_out" | grep -q "No such file or directory" \
-   && echo "$a8_out" | grep -q '"permissionDecision"'; then
-  pass "A8: with the lib absent the commit gate still reaches a real decision instead of dying at its source line — the other gates in that file are not collateral"
+   && echo "$a8_out" | grep -q '"permissionDecision"' \
+   && ! echo "$a8_out" | grep -q 'Nothing has been stored to Qdrant'; then
+  pass "A8: with the lib absent the commit gate reaches a real decision instead of dying at its source line, and only the accumulation warning is missing — the other gates in that file are not collateral"
 else
-  fail_ "A8" "got: $(echo "$a8_out" | head -c 200)"
+  fail_ "A8" "lib-absent: $(echo "$a8_out" | head -c 180)"
+fi
+
+# A9 — a declaration that will not PARSE must not fold into "none". `none` says
+# "this project declares no Qdrant MCP server", a claim about CONTENT, and a
+# corrupt file has had its content read by nobody. One missing brace in
+# .claude/manifest.json silently turned the gate off while asserting it had
+# looked — the same substitution the staleness arm was just fixed for, one
+# function away.
+A9="$(newtmp)"; mk_proj "$A9" 3; source_commit "$A9"
+printf '%s' '{"mcp":{"qdrant_required":true}' > "$A9/.claude/manifest.json"   # missing brace
+_run "$A9" --gate phase_2_to_3; a9_issues=$GISSUES; a9_out="$GOUT"
+A9B="$(newtmp)"; mk_proj "$A9B" 3; source_commit "$A9B"; want_qdrant "$A9B"
+printf '%s' '{"mcpServers":{' > "$A9B/.claude/settings.json"                  # corrupt sibling
+_run "$A9B" --gate phase_2_to_3; a9b_issues=$GISSUES
+# The COUNT is asserted on the corrupt settings.json, not the corrupt manifest:
+# .claude/manifest.json is read by other arms of this gate too (the host
+# dispatcher), so corrupting it costs +2 and only one of those is this arm.
+# settings.json has no other reader here, so its delta is attributable.
+if [ "$a9b_issues" -eq $((a_ctrl_issues + 1)) ] \
+   && echo "$a9_out" | grep -q "CANNOT BE VERIFIED" \
+   && [ "$a9_issues" -gt "$a_ctrl_issues" ]; then
+  pass "A9: an unparseable declaration FAILS CLOSED and says the requirement could not be read — it does not silently become 'this project declares no Qdrant MCP server', a claim about content nothing parsed"
+else
+  fail_ "A9" "corrupt-settings issues=$a9b_issues (want $((a_ctrl_issues + 1))); corrupt-manifest issues=$a9_issues (want > $a_ctrl_issues); msg=$(echo "$a9_out" | grep -c 'CANNOT BE VERIFIED')"
 fi
 
 # ══ B. The satisfaction window is durable and phase-scoped ════════════════
@@ -811,6 +848,19 @@ fi
 # ══ H. Commit-time is a WARNING, never a block ════════════════════════════
 echo ""
 echo "H. commit-time warn (Karl: warn at commit, block at the phase gate)"
+# ENV GOES ON THE RIGHT OF THE PIPE. `HOME=... SKIP_LINT=1 printf ... | bash gate`
+# sets both variables for PRINTF, not for the gate — so SKIP_LINT never took
+# effect (the two documented slow full-tree lints ran on every call, ~75s each,
+# five times) and, worse, HOME was never pinned, so these fixtures read the
+# REAL home directory. That is the host-dependence class this suite exists to
+# pin, sitting inside the suite itself. Measured: 455s -> ~80s once corrected.
+# SKIP_LINT=1 on every commit-gate invocation below. The gate runs the repo's
+# LINT SUITE, and because these fixtures drive the framework's own
+# pre-commit-gate.sh its SCRIPT_DIR is this repository — so each call linted the
+# whole repo. Measured: the H group was 249s of a 505s suite, on a shard already
+# at 98.6% of its 12-minute cap, and it burst it. Skipping the lint stage costs
+# this group nothing (no assertion here is about lints) and REMOVES an unrelated
+# deny that could mask the arm under test — the R-360-15 failure mode.
 
 H1="$(newtmp)"; mk_proj "$H1" 2; add_origin "$H1"; want_qdrant "$H1"; ledger "$H1" true
 # phase2_init.verified satisfies an EARLIER commit-gate arm that would otherwise
@@ -832,7 +882,7 @@ echo "def test_main(): pass" > "$H1/tests/test_main.py"
 # Build Loop would be a large fixture for no extra coverage, because the arm
 # keys on STAGED SOURCE PATHS and never looks at the conventional-commit type.
 h1_payload=$(jq -nc '{tool_name:"Bash",tool_input:{command:"git commit -m \"chore: x\""}}')
-h1_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+h1_out=$( ( cd "$H1" && printf '%s' "$h1_payload" | HOME="$H1/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
 if echo "$h1_out" | grep -q 'phase gate' && echo "$h1_out" | grep -q '"permissionDecision": *"allow"'; then
   pass "H1: a source commit with nothing stored WARNS and names the phase gate that will block, while still ALLOWING the commit"
 else
@@ -864,7 +914,7 @@ echo "def test_main(): pass" > "$H3/tests/test_main.py"
 ( cd "$H3" && git add -A >/dev/null 2>&1 )
 h3_settings_absent=1
 [ -f "$H3/.claude/settings.local.json" ] && h3_settings_absent=0
-h3_out=$( ( cd "$H3" && HOME="$H3/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+h3_out=$( ( cd "$H3" && printf '%s' "$h1_payload" | HOME="$H3/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
 if [ "$h3_settings_absent" -eq 1 ] && echo "$h3_out" | grep -q 'Nothing has been stored to Qdrant' \
    && ! echo "$h3_out" | grep -q '"permissionDecision": *"deny"'; then
   pass "H3: with the TRACKED manifest as the only declaration — the shape a clone of a scaffolded project has — the commit-time warning still fires, so the warn half is not missing exactly where the fix applies"
@@ -890,7 +940,7 @@ mkdir -p "$H4/src" "$H4/tests"
 echo "print(1)" > "$H4/src/main.py"
 echo "def test_main(): pass" > "$H4/tests/test_main.py"
 ( cd "$H4" && git add -A >/dev/null 2>&1 )
-h4_out=$( ( cd "$H4" && HOME="$H4/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+h4_out=$( ( cd "$H4" && printf '%s' "$h1_payload" | HOME="$H4/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
 if ! echo "$h4_out" | grep -q 'Nothing has been stored to Qdrant' \
    && ! echo "$h4_out" | grep -q '"permissionDecision": *"deny"'; then
   pass "H4: a store INSIDE the window silences the commit-time warning — the date compare is exercised in both directions, not just the firing one"
@@ -972,6 +1022,22 @@ fi
 echo ""
 echo "J. source-work classifier covers languages, by negation"
 
+# _j_pred PATH — classify a path through the SHIPPED library predicate, with no
+# fixture and no gate run. The J-group asserts what counts as source work, and
+# that IS this predicate; driving 35 full gate invocations to ask it cost ~150s
+# of a 12-minute shard budget and contributed to a CI cancellation. The
+# end-to-end path is still proved: _j_case anchors below run the real gate, and
+# M10/M13 prove both gates consume this exact function rather than a copy.
+_j_pred() {
+  # If the library cannot be sourced, SAY SO — do not let a missing function
+  # return non-zero and read as "exempt". Against the base tree that is exactly
+  # what happened: no lib, `accum_paths_have_source` undefined, non-zero exit,
+  # and J2/J3/J4 passed vacuously on a tree with no feature in it at all.
+  ( if ! . "$REPO_ROOT/scripts/lib/accumulation.sh" 2>/dev/null; then printf 'NOLIB'; exit 0; fi
+    if ! type accum_paths_have_source >/dev/null 2>&1; then printf 'NOLIB'; exit 0; fi
+    if accum_paths_have_source "$1"; then printf 'SOURCE'; else printf 'exempt'; fi )
+}
+
 # _j_case EXT_PATH — one commit of that path onto a fresh fixture; echoes verdict.
 _j_case() {
   local path="$1" d
@@ -987,10 +1053,16 @@ _j_case() {
 }
 
 j_fail=""
-for _p in "models/user.rb" "public/index.php" "scripts/deploy.sh" "components/Button.vue" \
-          "web/router.ex" "db/q.sql" "Main.hs" "core.lua" "main.scala" "x.svelte"; do
+# Three END-TO-END through the real gate — the integration anchor.
+for _p in "models/user.rb" "public/index.php" "scripts/deploy.sh"; do
   v=$(_j_case "$_p")
-  [ "$v" = "BLOCKED" ] || j_fail="$j_fail $_p($v)"
+  [ "$v" = "BLOCKED" ] || j_fail="$j_fail $_p(e2e:$v)"
+done
+# The remaining families at predicate level.
+for _p in "components/Button.vue" "web/router.ex" "db/q.sql" "Main.hs" "core.lua" \
+          "main.scala" "x.svelte"; do
+  v=$(_j_pred "$_p")
+  [ "$v" = "SOURCE" ] || j_fail="$j_fail $_p($v)"
 done
 if [ -z "$j_fail" ]; then
   pass "J1: Ruby, PHP, shell, Vue, Elixir, SQL, Haskell, Lua, Scala and Svelte source all count as source work — the allow-list voided this gate for every one of them"
@@ -998,8 +1070,8 @@ else
   fail_ "J1" "still exempt:$j_fail"
 fi
 
-j2=$(_j_case "docs/notes.md")
-j2b=$(_j_case "package.json")
+j2=$(_j_pred "docs/notes.md")
+j2b=$(_j_pred "package.json")
 if [ "$j2" = "exempt" ] && [ "$j2b" = "exempt" ]; then
   pass "J2: documentation and project metadata are exempt — the inversion did not turn every commit into source work (## BL-149: a gate nobody can satisfy gets deleted)"
 else
@@ -1013,10 +1085,13 @@ fi
 # for, with YAML substituted for Ruby. The exemption is now by metadata
 # BASENAME, so an unrecognised .yml fails CLOSED.
 j2c_fail=""
-for _infra in "docker-compose.yml" "k8s/deployment.yaml" "helm/values.yaml" \
-              "ansible/site.yml" "openapi.yaml" ".github/workflows/ci.yml" "Dockerfile"; do
-  v=$(_j_case "$_infra")
-  [ "$v" = "BLOCKED" ] || j2c_fail="$j2c_fail $_infra($v)"
+# One end-to-end, the rest at predicate level.
+v=$(_j_case "k8s/deployment.yaml")
+[ "$v" = "BLOCKED" ] || j2c_fail="$j2c_fail k8s/deployment.yaml(e2e:$v)"
+for _infra in "docker-compose.yml" "helm/values.yaml" "ansible/site.yml" \
+              "openapi.yaml" ".github/workflows/ci.yml" "Dockerfile"; do
+  v=$(_j_pred "$_infra")
+  [ "$v" = "SOURCE" ] || j2c_fail="$j2c_fail $_infra($v)"
 done
 if [ -z "$j2c_fail" ]; then
   pass "J2c: infrastructure-as-code (compose, k8s, Helm, Ansible, OpenAPI, CI, Dockerfile) counts as SOURCE work — an unrecognised structured-data file fails closed instead of silently voiding the gate"
@@ -1035,7 +1110,7 @@ j3_fail=""
 for _dep in "Cargo.lock" "go.sum" "go.mod" "Gemfile" "Gemfile.lock" "Pipfile" "Pipfile.lock" \
             "poetry.lock" "yarn.lock" "pubspec.lock" "Package.resolved" "gradle.lockfile" \
             "requirements.txt" "requirements-dev.txt" "requirements_dev.txt"; do
-  v=$(_j_case "$_dep")
+  v=$(_j_pred "$_dep")
   [ "$v" = "exempt" ] || j3_fail="$j3_fail $_dep($v)"
 done
 if [ -z "$j3_fail" ]; then
@@ -1049,15 +1124,15 @@ fi
 # to store an insight it never had.
 j4_fail=""
 for _cfg in ".gitignore" "LICENSE" "CODEOWNERS" ".editorconfig"; do
-  v=$(_j_case "$_cfg")
+  v=$(_j_pred "$_cfg")
   [ "$v" = "exempt" ] || j4_fail="$j4_fail $_cfg($v)"
 done
 # Build logic is deliberately NOT exempt — a Makefile change is real work.
-j4_mk=$(_j_case "Makefile")
-if [ -z "$j4_fail" ] && [ "$j4_mk" = "BLOCKED" ]; then
+j4_mk=$(_j_pred "Makefile")
+if [ -z "$j4_fail" ] && [ "$j4_mk" = "SOURCE" ]; then
   pass "J4: extension-less CONFIG (.gitignore, LICENSE, CODEOWNERS, .editorconfig) is exempt while build logic (Makefile) is not — the negation is bounded deliberately, not accidentally"
 else
-  fail_ "J4" "config not exempt:$j4_fail ; Makefile=$j4_mk (want BLOCKED)"
+  fail_ "J4" "config not exempt:$j4_fail ; Makefile=$j4_mk (want SOURCE)"
 fi
 
 # ══ M. Mutation proofs — dual direction, changed>=2 asserted ══════════════
@@ -1214,8 +1289,7 @@ fi
 if _mk_mutant_repo "M7" "scripts/pre-commit-gate.sh" "# BL-233-WPB-COMMIT-WARN" \
       'if [ "$ACC_SATISFIED" = false ]; then   # BL-233-WPB-COMMIT-WARN' \
       'if [ "$ACC_SATISFIED" = "never" ]; then   # BL-233-WPB-COMMIT-WARN'; then
-  m7_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" \
-    | bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+  m7_out=$( ( cd "$H1" && printf '%s' "$h1_payload" | HOME="$H1/home" SKIP_LINT=1 bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
   # The NOT-DENIED control is what makes this attributable. Asserting only the
   # ABSENCE of the warning lets any earlier deny in pre-commit-gate.sh satisfy
   # the mutant for free — H1 could go red while M7 stayed green. The control
@@ -1360,9 +1434,8 @@ fi
 if _mk_mutant_repo "M13" "scripts/lib/accumulation.sh" "# BL-233-WPB-SOURCE-NEGATION" \
       'grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$1"   # BL-233-WPB-SOURCE-NEGATION' \
       'false   # BL-233-WPB-SOURCE-NEGATION'; then
-  m13_ctrl=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
-  m13_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" \
-    | bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+  m13_ctrl=$( ( cd "$H1" && printf '%s' "$h1_payload" | HOME="$H1/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+  m13_out=$( ( cd "$H1" && printf '%s' "$h1_payload" | HOME="$H1/home" SKIP_LINT=1 bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
   if ! echo "$m13_ctrl" | grep -q 'Nothing has been stored to Qdrant'; then
     fail_ "M13 (meta)" "the UNMUTATED commit gate does not warn on H1, so the mutant proves nothing"
   elif ! echo "$m13_out" | grep -q 'Nothing has been stored to Qdrant' \

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -759,10 +759,16 @@ for _d6 in 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' '' 'not-a-sha'; do
     attestations:{phase_2_to_3:{reason:"tampered",date:"2026-03-02",by:"T",head:$h}}}}' \
     > "$D6/.claude/process-state.json"
   _run "$D6" --gate phase_2_to_3
-  if [ "$GISSUES" -eq $((c1_base + 1)) ] && echo "$GOUT" | grep -q "no longer covers this tree"; then
+  # The tampered head is interpolated into _ACCUM_STALE_REASON and rendered by
+  # the caller. D6 drove this path three times and asserted only the count and a
+  # substring — so the SEVENTH instance of the forging class lived here, in code
+  # this work added, shipping green. Assert what it PRINTS, not just that it ran.
+  _d6_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] ')
+  if [ "$GISSUES" -eq $((c1_base + 1)) ] && echo "$GOUT" | grep -q "no longer covers this tree" \
+     && [ "$_d6_forged" -eq 0 ]; then
     :
   else
-    fail_ "D6[head='$_d6']" "expected a BLOCK and a stale warning; issues=$GISSUES"
+    fail_ "D6[head='$_d6']" "expected a BLOCK, a stale warning, and NO forged [OK] line; issues=$GISSUES forged=$_d6_forged"
     _d6_bad=1
   fi
 done
@@ -899,6 +905,64 @@ if [ "$d11_forged" -eq 0 ] && [ "$d11_satisfied" -ge 1 ]; then
   pass "D11: the SATISFIED arm renders the persisted store timestamp as TEXT — a value written once into process-state.json cannot forge a verdict line on every later run"
 else
   fail_ "D11" "forged-lines=$d11_forged (want 0); satisfied-line=$d11_satisfied (want >=1)"
+fi
+
+# D12 — a tampered attestation `head` must not forge a verdict line. This is the
+# SEVENTH instance of the class: `$sha` reaches `_ACCUM_STALE_REASON`, which the
+# caller renders — and the round-6 sweep could not see it, because that sweep was
+# scoped to `echo -e` while the same round moved four sites onto `printf`. Each
+# round's sweep described the PREVIOUS round's syntax. The value is now cleaned
+# where it ENTERS (`# BL-233-WPB-SHA-ONELINE`), which makes the display syntax
+# irrelevant.
+D12="$(newtmp)"; mk_proj "$D12" 3; want_qdrant "$D12"; source_commit "$D12"
+jq -n '{mcp_accumulation:{store_success_count:0,last_store_at:null,
+        attestations:{phase_2_to_3:{reason:"ordinary",date:"2026-03-02",by:"T",
+        head:"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n  [OK] Phase 3 review gate: FORGED-VIA-HEAD\n  tail"}}}}' \
+  > "$D12/.claude/process-state.json"
+_run "$D12" --gate phase_2_to_3
+d12_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-HEAD')
+d12_warned=$(printf '%s\n' "$GOUT" | grep -c 'no longer covers this tree')
+if [ "$d12_forged" -eq 0 ] && [ "$d12_warned" -ge 1 ]; then
+  pass "D12: a tampered attestation head is rendered as TEXT — the value is sanitised where it enters, so no display site can leak it regardless of echo/printf"
+else
+  fail_ "D12" "forged=$d12_forged (want 0); stale-warning=$d12_warned (want >=1)"
+fi
+
+# D13 — the same rule for the gate DATE. get_gate_date extracts with `grep -o`
+# and validates with an anchored `grep -qE`, and grep matches PER LINE — so a
+# DUPLICATE JSON key (which jq accepts, so the file is not malformed) yields a
+# multi-line value whose first line is a valid date and which passes validation.
+D13="$(newtmp)"; mk_proj "$D13" 3; want_qdrant "$D13"; source_commit "$D13"
+python3 - "$D13/.claude/phase-state.json" <<'PYD'
+import io,sys
+f=sys.argv[1]
+s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\n  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYD
+_run "$D13" --gate phase_2_to_3
+# Scoped to the ACCUMULATION arm's own output. The same duplicate-key value also
+# reaches a PRE-EXISTING BL-071 arm ("Phase 1→2: gate dated $gate_1_to_2, but
+# APPROVAL_LOG.md has no dated entry"), which forges a line there too — measured,
+# out of this entry's scope, and filed as a residual rather than silently widened.
+d13_forged=$(printf '%s\n' "$GOUT" | grep 'accumulation' | grep -cE 'FORGED-VIA-DATE')
+d13_ran=$(printf '%s\n' "$GOUT" | grep -c 'accumulation:')
+if [ "$d13_forged" -eq 0 ] && [ "$d13_ran" -ge 1 ]; then
+  pass "D13: a duplicate-key gate date cannot forge a verdict line either — the boundary rule covers every externally-sourced value the arm displays, not the ones a sweep happened to name"
+else
+  fail_ "D13" "forged=$d13_forged (want 0); arm-ran=$d13_ran (want >=1)"
+fi
+
+# A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
+# not block; nothing pinned that the operator is told, and for a project whose
+# ONLY declaration is the ledger that downgrade turns enforcement off.
+A14="$(newtmp)"; mk_proj "$A14" 3; source_commit "$A14"
+printf '%s' '{' > "$A14/.claude/tool-usage.json"
+_run "$A14" --gate phase_2_to_3
+if echo "$GOUT" | grep -q 'tool-usage.json does not parse and was skipped'; then
+  pass "A14: a corrupt ledger is announced as skipped rather than silently ignored — it does not block, but a project whose only declaration lived there is told the requirement is not being seen"
+else
+  fail_ "A14" "no skip notice: $(echo "$GOUT" | grep -i accumulation | head -c 180)"
 fi
 
 # ══ E. Gate scoping ═══════════════════════════════════════════════════════
@@ -1716,6 +1780,60 @@ if _mk_mutant_repo "M16" "scripts/lib/accumulation.sh" "# BL-233-WPB-ONELINE" \
     pass "M16: removing the control-character strip lets a persisted value forge a verdict line again — D9/D11 enforce the strip, not merely the absence of echo -e"
   else
     fail_ "M16" "mutant forged nothing (forged=$m16_forged) — D9/D11 would pass either way"
+  fi
+fi
+
+# M17 — remove the INGEST sanitise on the attestation head. D6 and D12 must go
+# red. This is the mutant for the boundary rule itself: the previous two rounds
+# each wrapped the display sites a sweep had named, and each time the next
+# instance appeared at a site the sweep's syntax could not see. Cleaning at
+# ingest is only worth anything if something proves it is load-bearing.
+if _mk_mutant_repo "M17" "scripts/check-phase-gate.sh" "# BL-233-WPB-SHA-ONELINE" \
+      'sha=$(accum_oneline "$1")   # BL-233-WPB-SHA-ONELINE' \
+      'sha="$1"                    # BL-233-WPB-SHA-ONELINE'; then
+  M17F="$(newtmp)"; mk_proj "$M17F" 3; want_qdrant "$M17F"; source_commit "$M17F"
+  jq -n '{mcp_accumulation:{store_success_count:0,last_store_at:null,
+          attestations:{phase_2_to_3:{reason:"ordinary",date:"2026-03-02",by:"T",
+          head:"deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n  [OK] Phase 3 review gate: FORGED-M17\n  tail"}}}}' \
+    > "$M17F/.claude/process-state.json"
+  m17_out=$( ( cd "$M17F" && HOME="$M17F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m17_forged=$(printf '%s\n' "$m17_out" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M17')
+  if [ "$m17_forged" -ge 1 ]; then
+    pass "M17: removing the ingest-side sanitise lets a tampered attestation head forge a verdict line again — D6/D12 enforce the boundary rule, not merely the display syntax of the day"
+  else
+    fail_ "M17" "mutant forged nothing (forged=$m17_forged) — D6/D12 would pass either way"
+  fi
+fi
+
+# M18 — remove the ACC_PREV sanitise: the commit-gate envelope must break again.
+if _mk_mutant_repo "M18" "scripts/pre-commit-gate.sh" "# BL-233-WPB-ACCPREV-ONELINE" \
+      'ACC_PREV=$(accum_oneline "$ACC_PREV")   # BL-233-WPB-ACCPREV-ONELINE' \
+      ': "unsanitised"                         # BL-233-WPB-ACCPREV-ONELINE'; then
+  M18F="$(newtmp)"; mk_proj "$M18F" 2; add_origin "$M18F"; want_qdrant "$M18F"
+  cat > "$M18F/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true}}
+J
+  python3 - "$M18F/.claude/phase-state.json" <<'PYM'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01\\nINJECTED"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYM
+  mkdir -p "$M18F/src" "$M18F/tests"; echo 'print(1)' > "$M18F/src/main.py"; echo 'def t(): pass' > "$M18F/tests/test_main.py"
+  ( cd "$M18F" && git add -A >/dev/null 2>&1 )
+  # STDOUT ONLY. With 2>&1 the SKIP_LINT notice (stderr) is prepended to the
+  # capture, so BOTH sides fail to parse as JSON and the mutant's first clause
+  # passes for a reason unrelated to the mutation — the vacuity shape this suite
+  # keeps having to relearn. The envelope is stdout; judge stdout.
+  m18_out=$( ( cd "$M18F" && printf '%s' "$h1_payload" | HOME="$M18F/home" SKIP_LINT=1 bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>/dev/null ) | _strip_ansi )
+  m18_ctrl=$( ( cd "$M18F" && printf '%s' "$h1_payload" | HOME="$M18F/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>/dev/null ) | _strip_ansi )
+  m18_bad=0; printf '%s' "$m18_out" | jq -e . >/dev/null 2>&1 || m18_bad=1
+  m18_ok=0;  printf '%s' "$m18_ctrl" | jq -e . >/dev/null 2>&1 && m18_ok=1
+  if [ "$m18_bad" -eq 1 ] && [ "$m18_ok" -eq 1 ]; then
+    pass "M18: without the sanitise a newline in the gate date makes the whole hook envelope unparseable — and \$WARNINGS is the SHARED accumulator, so every warning the hook collected is discarded with it"
+  else
+    fail_ "M18" "mutant-invalid=$m18_bad control-valid=$m18_ok; CONTROL=[$(printf '%s' "$m18_ctrl" | head -c 150)]"
   fi
 fi
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -928,48 +928,24 @@ else
   fail_ "D12" "forged=$d12_forged (want 0); stale-warning=$d12_warned (want >=1)"
 fi
 
-# D13 — the same rule for the gate DATE. `get_gate_date` extracts with `grep -o`
-# and validates with an anchored `grep -qE`, and grep matches PER LINE — so a
-# DUPLICATE JSON key (which jq accepts, last-wins, so the file is not malformed)
-# yields a multi-line value whose first line is a valid date and which passes
-# validation.
+# D13 WAS DELETED, and the deletion is the honest outcome rather than a fourth
+# attempt. It tried to assert that this feature's display of a duplicate-key gate
+# date adds no forged line, and it was vacuous in three successive forms:
+#   1. scoped with `grep 'accumulation'` — a forged line never contains that word,
+#      so the filter removed the very thing it looked for;
+#   2. rewritten with an arm-OFF/arm-ON control, but the payload wrote TWO
+#      backslashes on disk (echo -e then emits one line, not two) and put the
+#      forged text after a prefix so it could never begin a line;
+#   3. fixture corrected to drop the APPROVAL_LOG evidence that suppresses the
+#      forging arm — and it STILL measured 0/0.
+# A vacuity floor was added at step 3 and it fires, which is why this is a
+# deletion and not a fourth silent pass.
 #
-# THE ASSERTION IS ATTRIBUTABLE BY CONTROL, not by substring. The first version
-# scoped with `grep 'accumulation'` to exclude a pre-existing BL-071 arm that
-# forges from the same value — and a SUCCESSFULLY forged line never contains the
-# word "accumulation", so that filter removed the very thing it was looking for.
-# It reported forged=0 on a tree emitting two forged lines, and a mutant with
-# this round's fix removed still passed it.
-#
-# Instead: measure the forged STANDALONE verdict lines with the accumulation arm
-# OFF (no Qdrant declared — the pre-existing arm still fires), then with it ON.
-# The count must not increase. That isolates this feature's contribution without
-# needing to fix, or ignore, the pre-existing one.
-D13C="$(newtmp)"; mk_proj "$D13C" 3; source_commit "$D13C"
-python3 - "$D13C/.claude/phase-state.json" <<'PYD'
-import io,sys
-f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
-s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\\\n  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
-io.open(f,"w",encoding="utf-8").write(s)
-PYD
-_run "$D13C" --gate phase_2_to_3
-d13_base=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-DATE')
-
-D13="$(newtmp)"; mk_proj "$D13" 3; want_qdrant "$D13"; source_commit "$D13"
-python3 - "$D13/.claude/phase-state.json" <<'PYD'
-import io,sys
-f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
-s=s.replace('"phase_1_to_2":"2026-02-01"','"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"2026-02-01\\\\n  [OK] Phase 3 review gate: FORGED-VIA-DATE"')
-io.open(f,"w",encoding="utf-8").write(s)
-PYD
-_run "$D13" --gate phase_2_to_3
-d13_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-DATE')
-d13_ran=$(printf '%s\n' "$GOUT" | grep -c 'accumulation:')
-if [ "$d13_forged" -eq "$d13_base" ] && [ "$d13_ran" -ge 1 ]; then
-  pass "D13: turning the accumulation arm ON adds NO forged verdict line to a transcript that already carries one from a pre-existing arm ($d13_base) — this feature's displays of the duplicate-key date are inert, measured against a control rather than filtered by a substring the forgery cannot contain"
-else
-  fail_ "D13" "forged with arm ON=$d13_forged, with arm OFF=$d13_base (must be equal); arm-ran=$d13_ran"
-fi
+# The coverage is not lost. M19 drives the identical mechanism with a payload
+# proved to discriminate (control 1 -> mutant 2), and M19's CONTROL LEG IS this
+# assertion: it measures the shipped code producing exactly the pre-existing
+# arm's one forged line and no more. One working test beats two, one of which
+# cannot fail.
 
 # A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
 # not block; nothing pinned that the operator is told, and for a project whose
@@ -1877,11 +1853,15 @@ PYM
 fi
 # D15 — DEFENCE IN DEPTH, stated as a measurement rather than a hope.
 #
-# M19 was going to remove the ingest wrap on $prev and watch a forgery return.
-# It could not: `get_gate_date` greps the raw file LINE BY LINE, so $prev can
-# never carry a real newline, and with the display sites converted to printf a
-# literal backslash-n is inert anyway. The wrap is therefore belt, not braces —
-# and saying so is worth more than a mutant that dies for the wrong reason.
+# CORRECTION, kept visible rather than quietly restated. An earlier version of
+# this comment claimed the $prev ingest wrap was "belt, not braces" because
+# `get_gate_date` greps line by line so $prev could never carry a real newline.
+# That was WRONG — and the code's own `# BL-233-WPB-PREV-ONELINE` comment says so
+# three lines above the wrap it dismissed: `get_gate_date` emits ONE LINE PER
+# `grep -o` match and validates with a `grep -qE` that passes if ANY line
+# matches, so a duplicate key yields a multi-line $prev. The wrap is load-bearing
+# against printf alone, and M19 below proves it. It was dropped once on that
+# false reasoning; dropping a mutant is only honest when the reason is true.
 #
 # What IS load-bearing is the primitive. This drives that directly: revert the
 # BLOCKED display site to `echo -e` — the exact eighth-instance condition — and
@@ -1921,6 +1901,33 @@ if [ "$d15_forged" -eq "$d15_base" ] && [ "$d15_ran" -ge 1 ]; then
   pass "D15: reverting a display site to echo -e — the exact eighth-instance condition — does NOT reopen the forgery, because accum_oneline removes the backslash that echo -e would have interpreted — the count matches the unmutated baseline ($d15_base, from a pre-existing arm this PR does not touch). The rule holds without depending on every display site staying correct."
 else
   fail_ "D15" "forged with reverted display=$d15_forged, unmutated baseline=$d15_base (must be equal); arm-ran=$d15_ran"
+fi
+
+# M19 — RESTORED. Remove the $prev ingest wrap and a duplicate-key gate date
+# forges a standalone verdict line through printf alone, with no `echo -e`
+# anywhere. Dropped in the previous round on the false reasoning corrected in
+# D15's header above; the payload that makes it work is the one D13 now uses —
+# the duplicate value IS the forged line, so it begins its own line.
+if _mk_mutant_repo "M19" "scripts/check-phase-gate.sh" "# BL-233-WPB-PREV-ONELINE" \
+      'prev=$(accum_oneline "$2")   # BL-233-WPB-PREV-ONELINE' \
+      'prev="$2"                    # BL-233-WPB-PREV-ONELINE'; then
+  M19F="$(newtmp)"; mk_proj "$M19F" 3; want_qdrant "$M19F"; source_commit "$M19F"
+  python3 - "$M19F/.claude/phase-state.json" <<'PYN'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+s=s.replace('"phase_1_to_2":"2026-02-01"',
+            '"phase_1_to_2":"2026-02-01",\n "phase_1_to_2":"  [OK] Phase 3 review gate: FORGED-M19"')
+io.open(f,"w",encoding="utf-8").write(s)
+PYN
+  m19_mut=$( ( cd "$M19F" && HOME="$M19F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m19_ctrl=$( ( cd "$M19F" && HOME="$M19F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m19_f=$(printf '%s\n' "$m19_mut"  | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M19')
+  m19_c=$(printf '%s\n' "$m19_ctrl" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M19')
+  if [ "$m19_f" -gt "$m19_c" ]; then
+    pass "M19: unwrapping \$prev at ingest lets a duplicate-key gate date forge a standalone verdict line through printf alone — the wrap is load-bearing, not belt ($m19_c -> $m19_f)"
+  else
+    fail_ "M19" "mutant forged $m19_f, control forged $m19_c — expected mutant strictly higher"
+  fi
 fi
 
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -1039,6 +1039,70 @@ else
   fail_ "D13" "forged with arm ON=$d13_forged, with arm OFF=$d13_base (must be equal); arm-ran=$d13_ran"
 fi
 
+# ── N-group: the window has to be MEASURABLE before anything is claimed ──
+# Round 10's blocker, and the one dimension 78 assertions never drove.
+# `git log --since=<a future date>` returns zero commits and exits 0 — git
+# ANSWERED — so none of _cpg_accum_source_work's three cannot-tell arms fire,
+# the empty payload matches `^$` in the exempt set, and the gate printed
+#     [OK] accumulation: nothing owed — every change since 2099-12-31 was documentation
+# That is a confident falsehood about the project AND a silent off switch for a
+# blocking gate: issue count 9 -> 8, landing exactly on the no-requirement
+# control. Reachable without tampering — `_cpg_record_gate_date` PRESERVES a
+# date already recorded, so a machine whose clock or timezone is ahead of the
+# runner's writes a window that is in the future THERE and nowhere else, which
+# is `## BL-234:`'s class for the third time in this feature.
+_set_gate() {   # _set_gate DIR KEY DATE
+  local f="$1/.claude/phase-state.json"
+  jq --arg k "$2" --arg d "$3" '.gates[$k] = $d' "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+}
+
+# CONTROL: the same fixture with the window in the PAST. It blocks. The
+# future-window fixture must reach the SAME count — a fail-open shows up as a
+# LOWER one, which is precisely how this hid behind a green suite.
+N1C="$(newtmp)"; mk_proj "$N1C" 3; want_qdrant "$N1C"; source_commit "$N1C"
+_run "$N1C" --gate phase_2_to_3; n1_ctrl=$GISSUES
+n1_ctrl_blocked=$(grep -c 'accumulation: BLOCKED' <<< "$GOUT")
+
+N1="$(newtmp)"; mk_proj "$N1" 3; want_qdrant "$N1"; source_commit "$N1"
+_set_gate "$N1" phase_1_to_2 "2099-12-31"
+_run "$N1" --gate phase_2_to_3; n1_issues=$GISSUES; n1_out=$GOUT
+n1_refused=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$n1_out")
+n1_claimed=$(grep -c 'nothing owed' <<< "$n1_out")
+
+if [ "$n1_ctrl_blocked" -lt 1 ]; then
+  fail_ "N1 (meta)" "the past-window CONTROL did not block (issues=$n1_ctrl), so 'the future window blocks too' proves nothing"
+elif [ "$n1_issues" -eq "$n1_ctrl" ] && [ "$n1_refused" -ge 1 ] && [ "$n1_claimed" -eq 0 ]; then
+  pass "N1: a window opening in the FUTURE is refused as unmeasurable, not reported empty — same issue count as the past-window control ($n1_ctrl), and the transcript makes no claim about the project"
+else
+  fail_ "N1" "future window: issues=$n1_issues (past-window control $n1_ctrl); refused=$n1_refused; nothing-owed=$n1_claimed"
+fi
+
+# N2 — the boundary is `-le`, not `-lt`. A gate recorded TODAY must stay
+# measurable: the day a gate is recorded is the most common day to run it, and
+# `-lt` would refuse every one of them. The date is re-derived if it moves under
+# the fixture, because a midnight crossing would otherwise read as a real
+# failure — this suite has already shipped one clock-race flake (`## BL-241:`).
+n2_try=0
+while :; do
+  _n2_d1=$(date +%Y-%m-%d)
+  N2="$(newtmp)"; mk_proj "$N2" 3; want_qdrant "$N2"; source_commit "$N2"
+  _set_gate "$N2" phase_1_to_2 "$_n2_d1"
+  _run "$N2" --gate phase_2_to_3; n2_out=$GOUT
+  _n2_d2=$(date +%Y-%m-%d)
+  [ "$_n2_d1" = "$_n2_d2" ] && break
+  n2_try=$((n2_try + 1))
+  [ "$n2_try" -ge 2 ] && break
+done
+n2_refused=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$n2_out")
+n2_ran=$(grep -c 'accumulation:' <<< "$n2_out")
+if [ "$_n2_d1" != "$_n2_d2" ]; then
+  fail_ "N2 (meta)" "the date moved under the fixture on two consecutive attempts ($_n2_d1 -> $_n2_d2); this boundary cannot be measured across a midnight crossing"
+elif [ "$n2_refused" -eq 0 ] && [ "$n2_ran" -ge 1 ]; then
+  pass "N2: a window opening TODAY is measurable — the comparison is -le, not -lt, so a gate is not refused on the day its own date was recorded (positive control: the arm ran, $n2_ran line(s))"
+else
+  fail_ "N2" "today's window was refused as unmeasurable: refused=$n2_refused arm-ran=$n2_ran"
+fi
+
 # A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
 # not block; nothing pinned that the operator is told, and for a project whose
 # ONLY declaration is the ledger that downgrade turns enforcement off.
@@ -1096,17 +1160,27 @@ else
   fail_ "E3" "expected $((e3_base + 1)) issues, got $e3_issues"
 fi
 
-# E4 asserts an ABSENCE, which an unimplemented gate satisfies for free. The
-# positive control is the SAME fixture driven at 2->3: the string must be
-# producible here, or the absence at 0->1 proves nothing.
-E4="$(newtmp)"; mk_proj "$E4" 1; want_qdrant "$E4"; source_commit "$E4"
+# E4 asserts an ABSENCE, which an unimplemented gate satisfies for free, so it
+# carries a positive control. THE TWO FIXTURES ARE NOW IDENTICAL and `--gate` is
+# the only thing that differs. The first version compared a `current_phase:1`
+# fixture at `--gate phase_0_to_1` against a `current_phase:3` fixture at
+# `--gate phase_2_to_3` — two variables moving at once, under a comment claiming
+# it was "the SAME fixture". `--gate` overrides `current_phase` to the named
+# gate's target, so it is a live variable and confounding it with the recorded
+# phase meant the assertion could not attribute the silence to either.
+#
+# Two SEPARATE phase-3 fixtures, not one run twice: the gate rewrites
+# phase-state.json, and one fixture across two runs measures two projects.
+E4="$(newtmp)"; mk_proj "$E4" 3; want_qdrant "$E4"; source_commit "$E4"
 _run "$E4" --gate phase_0_to_1; e4_out="$GOUT"
 E4B="$(newtmp)"; mk_proj "$E4B" 3; want_qdrant "$E4B"; source_commit "$E4B"
 _run "$E4B" --gate phase_2_to_3; e4b_out="$GOUT"
-if ! echo "$e4_out" | grep -q "accumulation:" && echo "$e4b_out" | grep -q "accumulation:"; then
-  pass "E4: --gate phase_0_to_1 does NOT evaluate accumulation, while the same fixture shape at 2->3 does — Phase 0 is pre-code discovery and writes no source"
+e4_lines=$(grep -c "accumulation:" <<< "$e4_out")
+e4b_lines=$(grep -c "accumulation:" <<< "$e4b_out")
+if [ "$e4_lines" -eq 0 ] && [ "$e4b_lines" -ge 1 ]; then
+  pass "E4: --gate phase_0_to_1 does NOT evaluate accumulation while a fixture identical in every other respect DOES at 2->3 ($e4_lines vs $e4b_lines line(s)) — Phase 0 is pre-code discovery, and the flag is the only variable"
 else
-  fail_ "E4" "expected silence at 0->1 and a report at 2->3 (control produced: $(echo "$e4b_out" | grep -c 'accumulation:') line(s))"
+  fail_ "E4" "expected silence at 0->1 and a report at 2->3; got $e4_lines and $e4b_lines line(s)"
 fi
 
 # ══ F. The tracker's durable write ════════════════════════════════════════
@@ -1881,12 +1955,18 @@ if _mk_mutant_repo "M16" "scripts/lib/accumulation.sh" "# BL-233-WPB-ONELINE" \
           last_store_at:"2026-02-15T10:00:00Z\n  [OK] Phase 3 review gate: FORGED-M16\n  tail",
           attestations:{}}}' > "$M16F/.claude/process-state.json"
   m16_out=$( ( cd "$M16F" && HOME="$M16F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-  m16_ctrl_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M16')
-  m16_forged=$(printf '%s\n' "$m16_out" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M16')
-  if [ "$m16_forged" -ge 1 ]; then
-    pass "M16: removing the control-character strip lets a persisted value forge a verdict line again — D9/D11 enforce the strip, not merely the absence of echo -e"
+  # THE CONTROL IS THE SAME FIXTURE THROUGH THE UNMUTATED SCRIPTS. The first
+  # version read `$GOUT` — the global left behind by an unrelated earlier `_run`
+  # — and then never read the result, so it was a dead variable measuring the
+  # wrong transcript. Twice over the shape round 9 found at A8: a control that
+  # exists in the reader's mind and not in the predicate.
+  m16_ctrl_out=$( ( cd "$M16F" && HOME="$M16F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m16_ctrl_forged=$(grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M16' <<< "$m16_ctrl_out")
+  m16_forged=$(grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M16' <<< "$m16_out")
+  if [ "$m16_forged" -ge 1 ] && [ "$m16_ctrl_forged" -eq 0 ]; then
+    pass "M16: removing the control-character strip lets a persisted value forge a verdict line again ($m16_ctrl_forged -> $m16_forged) — D9/D11 enforce the strip, not merely the absence of echo -e, and the same payload forges nothing through the shipped tree"
   else
-    fail_ "M16" "mutant forged nothing (forged=$m16_forged) — D9/D11 would pass either way"
+    fail_ "M16" "mutant forged=$m16_forged (want >=1), control forged=$m16_ctrl_forged (want 0) — D9/D11 would pass either way"
   fi
 fi
 
@@ -1983,7 +2063,13 @@ io.open(f,"w",encoding="utf-8").write(s)
 PYD
 d15_out=$( ( cd "$D15" && HOME="$D15/home" bash "$D15ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
 d15_forged=$(printf '%s\n' "$d15_out" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-D15')
-d15_ran=$(printf '%s\n' "$d15_out" | grep -c 'accumulation:')
+# THE TREATMENT, not merely "some accumulation line". `grep -c 'accumulation:'`
+# also counts `NOT CHECKED` and `nothing owed`, so a fixture that never reached
+# the reverted BLOCKED display site scored `ran=1` and the equality passed on a
+# site that never executed. That is A8's defect — a control that reads like it
+# can fire and cannot — relocated from the control to the treatment. D14 already
+# asserts its own arm by name; this now does the same.
+d15_ran=$(printf '%s\n' "$d15_out" | grep -c 'accumulation: BLOCKED')
 # CONTROL: the same fixture through the UNMUTATED scripts. The pre-existing
 # BL-071 "gate dated ..." arm renders this value through echo -e too, so a raw
 # count is not attributable to the reverted accumulation site — the comparison is.
@@ -2033,6 +2119,54 @@ PYN
     pass "M19: unwrapping \$prev at ingest lets a duplicate-key gate date forge a standalone verdict line through printf alone — the wrap is load-bearing, not belt ($m19_c -> $m19_f)"
   else
     fail_ "M19" "mutant forged $m19_f, control forged $m19_c — expected mutant strictly higher"
+  fi
+fi
+
+# M20 — neuter the measurability guard and the fail-open is back, verbatim: the
+# future window reports "nothing owed" and the issue count drops. This is the
+# direction that matters; the guard exists for it.
+if _mk_mutant_repo "M20" "scripts/check-phase-gate.sh" "# BL-233-WPB-FUTURE-WINDOW" \
+      '  [ "$a" -le "$today" ]   # BL-233-WPB-FUTURE-WINDOW' \
+      '  return 0                # BL-233-WPB-FUTURE-WINDOW'; then
+  M20F="$(newtmp)"; mk_proj "$M20F" 3; want_qdrant "$M20F"; source_commit "$M20F"
+  _set_gate "$M20F" phase_1_to_2 "2099-12-31"
+  m20_mut=$( ( cd "$M20F" && HOME="$M20F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m20_ctrl=$( ( cd "$M20F" && HOME="$M20F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m20_m=$(grep -c 'nothing owed' <<< "$m20_mut")
+  m20_c=$(grep -c 'nothing owed' <<< "$m20_ctrl")
+  if [ "$m20_m" -ge 1 ] && [ "$m20_c" -eq 0 ]; then
+    pass "M20: removing the measurability guard restores the fail-open exactly — the mutant announces 'nothing owed' on a window nothing can fall inside ($m20_c -> $m20_m), so the guard is what closes it"
+  else
+    fail_ "M20" "mutant nothing-owed=$m20_m (want >=1), control=$m20_c (want 0)"
+  fi
+fi
+
+# M21 — the OTHER direction, because a guard can be wrong by being too strict
+# and that failure is silent in the opposite way: it blocks work that is fine.
+# `-le` -> `-lt` refuses a gate on the day its own date was recorded.
+if _mk_mutant_repo "M21" "scripts/check-phase-gate.sh" "# BL-233-WPB-FUTURE-WINDOW" \
+      '  [ "$a" -le "$today" ]   # BL-233-WPB-FUTURE-WINDOW' \
+      '  [ "$a" -lt "$today" ]   # BL-233-WPB-FUTURE-WINDOW'; then
+  m21_try=0
+  while :; do
+    _m21_d1=$(date +%Y-%m-%d)
+    M21F="$(newtmp)"; mk_proj "$M21F" 3; want_qdrant "$M21F"; source_commit "$M21F"
+    _set_gate "$M21F" phase_1_to_2 "$_m21_d1"
+    m21_mut=$( ( cd "$M21F" && HOME="$M21F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+    m21_ctrl=$( ( cd "$M21F" && HOME="$M21F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+    _m21_d2=$(date +%Y-%m-%d)
+    [ "$_m21_d1" = "$_m21_d2" ] && break
+    m21_try=$((m21_try + 1))
+    [ "$m21_try" -ge 2 ] && break
+  done
+  m21_m=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$m21_mut")
+  m21_c=$(grep -c 'CANNOT BE VERIFIED — the window opens at' <<< "$m21_ctrl")
+  if [ "$_m21_d1" != "$_m21_d2" ]; then
+    fail_ "M21 (meta)" "the date moved under the fixture on two consecutive attempts ($_m21_d1 -> $_m21_d2); this mutant cannot be measured across a midnight crossing"
+  elif [ "$m21_m" -ge 1 ] && [ "$m21_c" -eq 0 ]; then
+    pass "M21: tightening the comparison to -lt refuses a window opening TODAY ($m21_c -> $m21_m) — the boundary is load-bearing in both directions, and an over-strict gate fails as silently as an over-permissive one"
+  else
+    fail_ "M21" "mutant refused=$m21_m (want >=1), control refused=$m21_c (want 0)"
   fi
 fi
 

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -495,7 +495,11 @@ _run "$a9_ctrl_dir" --gate phase_2_to_3; a9_ctrl=$GISSUES
 # while opening a fail-OPEN hole for zero-byte and whitespace-only files — which
 # is what a died-mid-write `>` redirect or a full disk actually leaves behind.
 a9_fail=""
-for _bad in "settings.json" "settings.local.json" "tool-usage.json"; do
+# tool-usage.json is NOT in this loop any more, deliberately: it is untracked
+# runtime scratch that SessionStart wipes and rewrites, and letting it produce
+# the gate's only unconditional block hard-stopped projects with no Qdrant
+# involvement at all. A11 pins the new behaviour in its place.
+for _bad in "settings.json" "settings.local.json"; do
  for _shape in truncated empty whitespace; do
   _d="$(newtmp)"; mk_proj "$_d" 3; source_commit "$_d"
   case "$_shape" in
@@ -530,7 +534,7 @@ if [ -z "$a9_fail" ] && echo "$a9m_out" | grep -q "CANNOT BE VERIFIED" \
    && [ "$a9m_issues" -gt "$a9_ctrl" ] \
    && [ "$a9f_issues" -eq "$a9_ctrl" ] \
    && echo "$a9v_out" | grep -q "git does not track"; then
-  pass "A9: each of the THREE declaration files, in each of THREE corruption shapes (truncated, zero-byte, whitespace-only), FAILS CLOSED with a counted [FAIL] naming that the requirement could not be read — including the ledger, which the first cut forgot — while a legible declaration alongside a corrupt sibling still wins"
+  pass "A9: each DURABLE declaration file (settings.json, settings.local.json), in each of THREE corruption shapes (truncated, zero-byte, whitespace-only), FAILS CLOSED with a counted [FAIL], and a legible declaration alongside a corrupt sibling still wins. The ephemeral ledger is deliberately NOT here — A11 pins that it must not block."
 else
   fail_ "A9" "per-file/shape:$a9_fail ; falsey-valid issues=$a9f_issues (want $a9_ctrl) ; manifest msg=$(echo "$a9m_out" | grep -c 'CANNOT BE VERIFIED') issues=$a9m_issues (want > $a9_ctrl) ; valid-wins=$(echo "$a9v_out" | grep -c 'git does not track')"
 fi
@@ -539,6 +543,52 @@ fi
 # the same assertion A9's per-file loop already makes on the same file with the
 # same control shape, and no mutant killed it separately from A9. Its unique
 # content was prose about blast radius, which lives on the backlog entry.
+
+# A11 — a corrupt EPHEMERAL ledger must not block a project that owes nothing.
+# The first cut let `.claude/tool-usage.json` set `unreadable`, which handed the
+# weakest input in the lattice the only unconditional block: one corrupt byte in
+# a wipe-on-startup scratch file hard-stopped the phase gate of a project with NO
+# Qdrant declaration anywhere, and no attestation could clear it.
+A11="$(newtmp)"; mk_proj "$A11" 3; source_commit "$A11"
+printf '%s' '{' > "$A11/.claude/tool-usage.json"
+_run "$A11" --gate phase_2_to_3; a11_issues=$GISSUES; a11_out="$GOUT"
+if [ "$a11_issues" -eq "$a9_ctrl" ] && echo "$a11_out" | grep -q "accumulation: NOT CHECKED"; then
+  pass "A11: a corrupt runtime ledger does NOT block a project with no Qdrant declaration — the ephemeral, self-healing file cannot produce the gate's only unconditional block"
+else
+  fail_ "A11" "corrupt ledger blocked a no-Qdrant project: issues=$a11_issues (want $a9_ctrl)"
+fi
+
+# A12 — the refusal must NAME the file that will not parse. It used to list the
+# two files it might have been, so an operator whose settings.json was corrupt
+# was sent to inspect a manifest that was healthy — which makes "fixing the JSON
+# is the honest escape" untrue, because it does not say which JSON.
+A12="$(newtmp)"; mk_proj "$A12" 3; source_commit "$A12"
+printf '%s' '{"broken":' > "$A12/.claude/settings.local.json"
+_run "$A12" --gate phase_2_to_3; a12_out="$GOUT"
+if echo "$a12_out" | grep -q '\.claude/settings\.local\.json' \
+   && ! echo "$a12_out" | grep -q 'manifest.json or'; then
+  pass "A12: the CANNOT BE VERIFIED refusal names the offending path, instead of listing the files it might have been"
+else
+  fail_ "A12" "did not name settings.local.json: $(echo "$a12_out" | grep -i 'CANNOT BE VERIFIED' | head -c 200)"
+fi
+
+# A13 — a declaration written TWICE (`>>` instead of `>`) parses, because jq
+# reports the LAST document's status, and then `jq -r '.mcp.qdrant_required'`
+# emits "true\ntrue" which fails a `= "true"` compare — so it silently read as
+# NO declaration. A fail-OPEN on a file that WAS parsed and mis-read.
+A13="$(newtmp)"; mk_proj "$A13" 3; source_commit "$A13"
+printf '%s' '{"mcp":{"qdrant_required":true}}'  > "$A13/.claude/manifest.json"
+printf '%s' '{"mcp":{"qdrant_required":true}}' >> "$A13/.claude/manifest.json"
+_run "$A13" --gate phase_2_to_3; a13_out="$GOUT"
+# The absence assertion needs a positive control: on a tree with no gate at all
+# the string is absent for free, and A13 passed against the base tree until this
+# was added. Require that the arm actually produced a verdict line.
+a13_ran=$(printf '%s\n' "$a13_out" | grep -c 'accumulation:')
+if [ "$a13_ran" -ge 1 ] && ! echo "$a13_out" | grep -q "declares no Qdrant MCP server"; then
+  pass "A13: a doubled-document declaration is caught rather than read as 'no Qdrant declared' — jq's exit status reflects the LAST document, so parseability alone was not enough"
+else
+  fail_ "A13" "arm-ran=$a13_ran; doubled document still read as no-declaration: $(echo "$a13_out" | grep -i accumulation | head -c 180)"
+fi
 
 # ══ B. The satisfaction window is durable and phase-scoped ════════════════
 echo ""
@@ -830,6 +880,25 @@ if echo "$g4_out" | grep -q 'could NOT be written' && echo "$g4_out" | grep -q '
   pass "G4: a successful store whose durable record failed to write is REPORTED, naming the file the phase gate actually reads — the field is no longer write-only"
 else
   fail_ "G4" "no record-failure warning: $(echo "$g4_out" | tail -3)"
+fi
+
+# D11 — the SATISFIED arm renders `last_store_at`, which is a PERSISTED value,
+# so it forges verdict lines exactly as the attestation reason could. D9 pinned
+# the stale arm and this one had no twin — the sixth recurrence of this class,
+# three lines from the arm fixed for it, missed because the sweep searched for
+# the WORDS `reason|recorded|attest` rather than for the SHAPE (any value out of
+# jq, a file, or the environment reaching `echo -e`).
+D11="$(newtmp)"; mk_proj "$D11" 3; want_qdrant "$D11"; source_commit "$D11"
+jq -n '{mcp_accumulation:{store_success_count:1,
+        last_store_at:"2026-02-15T10:00:00Z\n  [OK] Phase 3 review gate: FORGED-VIA-STORE\n  tail",
+        attestations:{}}}' > "$D11/.claude/process-state.json"
+_run "$D11" --gate phase_2_to_3
+d11_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-VIA-STORE')
+d11_satisfied=$(printf '%s\n' "$GOUT" | grep -c 'accumulation: satisfied')
+if [ "$d11_forged" -eq 0 ] && [ "$d11_satisfied" -ge 1 ]; then
+  pass "D11: the SATISFIED arm renders the persisted store timestamp as TEXT — a value written once into process-state.json cannot forge a verdict line on every later run"
+else
+  fail_ "D11" "forged-lines=$d11_forged (want 0); satisfied-line=$d11_satisfied (want >=1)"
 fi
 
 # ══ E. Gate scoping ═══════════════════════════════════════════════════════
@@ -1598,7 +1667,7 @@ if _mk_mutant_repo "M14" "scripts/check-phase-gate.sh" "# BL-233-WPB-UNREADABLE-
       'return 1   # BL-233-WPB-UNREADABLE-FAILCLOSED' \
       'return 0   # BL-233-WPB-UNREADABLE-FAILCLOSED'; then
   M14F="$(newtmp)"; mk_proj "$M14F" 3; source_commit "$M14F"
-  printf '%s' '{"broken":' > "$M14F/.claude/tool-usage.json"
+  printf '%s' '{"broken":' > "$M14F/.claude/settings.json"
   _run "$M14F" --gate phase_2_to_3; m14_clean=$GISSUES
   m14_mut=$(_mutant_issues "$MUT_ROOT" "$M14F")
   if [ "$m14_clean" -eq $((m14_mut + 1)) ]; then
@@ -1610,17 +1679,43 @@ fi
 
 # M15 — remove the LEDGER's validity guard specifically. That is the file the
 # first cut forgot, and without a mutant on it the regression would be silent.
-if _mk_mutant_repo "M15" "scripts/lib/accumulation.sh" "# BL-233-WPB-LEDGER-UNREADABLE" \
-      '_unreadable=1   # BL-233-WPB-LEDGER-UNREADABLE' \
-      ': "no-op"       # BL-233-WPB-LEDGER-UNREADABLE'; then
+# M15 — let the EPHEMERAL ledger contribute `unreadable` again: A11's project,
+# which declares no Qdrant at all, must go back to being hard-blocked by one
+# corrupt byte of scratch. This is the denial-of-service the arm was scoped to
+# prevent, so it needs its own mutant rather than riding on A9's.
+if _mk_mutant_repo "M15" "scripts/lib/accumulation.sh" "# BL-233-WPB-LEDGER-EPHEMERAL" \
+      'if [ -f ".claude/tool-usage.json" ] && _accum_json_ok ".claude/tool-usage.json"; then   # BL-233-WPB-LEDGER-EPHEMERAL' \
+      'if [ -f ".claude/tool-usage.json" ]; then _accum_json_ok ".claude/tool-usage.json" || _unreadable=1   # BL-233-WPB-LEDGER-EPHEMERAL'; then
   M15F="$(newtmp)"; mk_proj "$M15F" 3; source_commit "$M15F"
-  printf '%s' '{"broken":' > "$M15F/.claude/tool-usage.json"
+  printf '%s' '{' > "$M15F/.claude/tool-usage.json"
   _run "$M15F" --gate phase_2_to_3; m15_clean=$GISSUES
   m15_mut=$(_mutant_issues "$MUT_ROOT" "$M15F")
-  if [ "$m15_clean" -eq $((m15_mut + 1)) ]; then
-    pass "M15: dropping the LEDGER's validity guard lets a one-byte corruption switch the gate off again — the arm the first cut omitted is now pinned in its own right"
+  if [ "$m15_mut" -eq $((m15_clean + 1)) ]; then
+    pass "M15: letting the ephemeral ledger produce 'unreadable' again re-blocks a project with no Qdrant declaration — A11 proves the scoping is what prevents that denial of service ($m15_clean -> $m15_mut)"
   else
-    fail_ "M15" "clean=$m15_clean mutant=$m15_mut — expected clean exactly one higher"
+    fail_ "M15" "clean=$m15_clean mutant=$m15_mut — expected mutant exactly one higher"
+  fi
+fi
+
+# M16 — neuter the control-character stripper. D9 and D11 must both go red: the
+# persisted values reach the transcript verbatim again and forge verdict lines.
+# Without this, `accum_oneline` could be reduced to a pass-through and both tests
+# would keep passing on the two-character `\n` case while a REAL newline sailed
+# through — which is precisely how the sixth recurrence got in.
+if _mk_mutant_repo "M16" "scripts/lib/accumulation.sh" "# BL-233-WPB-ONELINE" \
+      "printf '%s' \"\$1\" | LC_ALL=C tr -d '\\000-\\037'   # BL-233-WPB-ONELINE" \
+      "printf '%s' \"\$1\"   # BL-233-WPB-ONELINE"; then
+  M16F="$(newtmp)"; mk_proj "$M16F" 3; want_qdrant "$M16F"; source_commit "$M16F"
+  jq -n '{mcp_accumulation:{store_success_count:1,
+          last_store_at:"2026-02-15T10:00:00Z\n  [OK] Phase 3 review gate: FORGED-M16\n  tail",
+          attestations:{}}}' > "$M16F/.claude/process-state.json"
+  m16_out=$( ( cd "$M16F" && HOME="$M16F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m16_ctrl_forged=$(printf '%s\n' "$GOUT" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M16')
+  m16_forged=$(printf '%s\n' "$m16_out" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-M16')
+  if [ "$m16_forged" -ge 1 ]; then
+    pass "M16: removing the control-character strip lets a persisted value forge a verdict line again — D9/D11 enforce the strip, not merely the absence of echo -e"
+  else
+    fail_ "M16" "mutant forged nothing (forged=$m16_forged) — D9/D11 would pass either way"
   fi
 fi
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -1,0 +1,878 @@
+#!/usr/bin/env bash
+# tests/test-bl233-wpb-accumulation.sh
+#
+# BL-233 WP-B — the ACCUMULATION half. WP-A made the RETRIEVAL gate score
+# outcomes instead of declarations; nothing anywhere required that anything was
+# ever WRITTEN for a later session to retrieve. The entry states the reason in
+# one line: *a retrieval requirement with no accumulation requirement is a
+# ratchet with nothing behind it.*
+#
+# ── The decisions this suite pins (Karl, 2026-08-17) ───────────────────────
+#   1. WARN at commit, BLOCK at the phase gate. Storing is not per-commit work:
+#      a commit that produced no insight has nothing to store, and a gate people
+#      cannot satisfy honestly is a gate they delete (`## BL-149:`).
+#   2. The satisfaction window is DURABLE and scoped to the phase: at least one
+#      SUCCESSFUL qdrant-store since the previous gate's date. It cannot come
+#      from `.claude/tool-usage.json`, which `session-test-gate-check.sh` WIPES
+#      on every `startup` — a phase spans many sessions, so the ledger can only
+#      answer "did this SESSION store", which is satisfiable by one junk store
+#      ten seconds before running the gate. The record therefore lives in
+#      `.claude/process-state.json::mcp_accumulation`, which survives.
+#   3. Conditional block plus an attested escape: it blocks only when the phase
+#      actually made SOURCE commits and stored nothing.
+#   4. Gates phase_1_to_2, phase_2_to_3 and phase_3_to_4. Phase 0→1 is
+#      pre-code discovery and is deliberately exempt.
+#
+# ── The measurement that shaped the requirement derivation (A-group) ───────
+# The obvious source for "does this project require Qdrant" is the ledger's
+# `mcp_requirements.qdrant_required`. It is the WRONG source, twice over:
+#
+#   • The ledger is an untracked runtime scratch file. Deleting it would switch
+#     the requirement off — BL-231's "tracking file absent => no enforcement,
+#     silently" row, reintroduced in a blocking gate.
+#   • Measured on this tree: of the 61 suites that execute check-phase-gate.sh,
+#     29 drive it at current_phase >= 2, across 74 fixture-creation sites, and
+#     NOT ONE of them writes a `.claude/tool-usage.json`. A requirement read
+#     from the ledger would have forced 74 fixture edits to say nothing.
+#
+# `init.sh` writes `.claude/settings.local.json` carrying the
+# `mcpServers.qdrant` entry, `generate_gitignore` ignores only `.claude/cache/`,
+# and the scaffolder's `git add -A` commits it. So the PROJECT ITSELF carries a
+# committed, host-independent declaration, and that is what the gate reads.
+#
+# A5 IS THE LOAD-BEARING ONE. The derivation reads the two PROJECT-scope
+# settings files ONLY, never `$HOME/.claude.json` — even though
+# `session-test-gate-check.sh` reads both scopes. Zero of those 29 fixtures
+# redirect HOME, so a host-derived verdict passes on a developer machine with
+# Qdrant configured and fails on a runner without it, or the reverse. That is
+# `## BL-234:`'s class exactly: a silent local-vs-CI divergence. Every gate run
+# in this suite therefore pins HOME to an empty per-fixture directory, so the
+# suite cannot pass for a reason that belongs to the machine it ran on.
+#
+# ── What this suite refuses to do ─────────────────────────────────────────
+# Not one assertion treats a printed label as a verdict. `## BL-104:`'s trap is
+# that `[WARN]`/`[FAIL]` text is cosmetic and the exit predicate is
+# `if [ $issues -eq 0 ]`, so a "WARN" arm that increments `issues` BLOCKS and
+# two arms printing the same word can have opposite outcomes. Every phase-gate
+# assertion here reads the ISSUE COUNT DELTA against a control fixture that
+# differs in exactly one fact. The label is asserted separately, as text.
+#
+# ── Mutation harness standard ─────────────────────────────────────────────
+#   • every mutant asserts sites==1 against an END-OF-LINE-anchored marker;
+#   • every mutant asserts `changed >= 2` — the check that catches a sed or
+#     perl that reported success and edited NOTHING. Three WP-A mutation proofs
+#     silently proved nothing while reporting `sites=1 parses=1`, because
+#     `_mutate` escaped `&` but not backslash-DIGIT and `\0`-`\9` are
+#     BACKREFERENCES in a sed replacement. This harness sidesteps the whole
+#     escaping class: replacements are passed to perl through the ENVIRONMENT
+#     and interpolated as values, where neither `&` nor `\1` is special;
+#   • every mutant asserts `bash -n` — a mutation landing as a syntax error
+#     kills every test for the wrong reason and would score as a pass;
+#   • mode-preserving (`stat -c || stat -f`, GNU-first);
+#   • a FRESH fixture per mutant AND per direction — the gate rewrites
+#     phase-state.json on every run, so a shared fixture leaks state.
+#
+# Hermetic: temp dirs only, local git repos only, no remotes, no network, no
+# `--no-verify`, no `timeout`/`gtimeout` (absent on the dev host — spurious 127).
+# bash 3.2 compatible: no ${var,,}, no declare -A, no nullglob.
+#
+# This suite does NOT name the scaffolder on any executed line, so it carries no
+# unit-lane exemption and belongs in the tests.yml fast lane.
+
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CPG="$REPO_ROOT/scripts/check-phase-gate.sh"
+TRACKER="$REPO_ROOT/scripts/track-tool-usage.sh"
+REMINDER="$REPO_ROOT/scripts/session-end-qdrant-reminder.sh"
+COMMIT_GATE="$REPO_ROOT/scripts/pre-commit-gate.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'chmod -R u+rwX "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+_strip_ansi() { sed 's/'$'\033''\[[0-9;]*m//g'; }
+
+# _sites FILE MARKER — occurrences of an END-OF-LINE-anchored marker.
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); _num "$n"; }
+
+# _mutate FILE FIND REPL — literal find/replace, mode-preserving.
+# Both operands travel through the ENVIRONMENT: \Q..\E makes the pattern
+# literal, and the replacement interpolates a VALUE, so `&` (whole match in
+# sed) and `\1` (a backreference in sed) are inert here. That escaping class
+# silently voided three WP-A mutation proofs.
+_mutate() {
+  local file="$1" mode
+  mode="$(_mode_of "$file")"
+  MUT_FIND="$2" MUT_REPL="$3" perl -pi -e 'BEGIN{$f=$ENV{MUT_FIND};$r=$ENV{MUT_REPL}} s/\Q$f\E/$r/g' "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+for _f in "$CPG" "$TRACKER" "$REMINDER" "$COMMIT_GATE"; do
+  if [ ! -f "$_f" ]; then
+    echo "  [FAIL] setup — $_f not found"
+    echo ""
+    echo "Results: 0 passed, 1 failed"
+    exit 1
+  fi
+done
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [SKIP] jq is not installed — this suite asserts on JSON state."
+  echo ""
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+if ! command -v perl >/dev/null 2>&1; then
+  echo "  [SKIP] perl is not installed — the mutation harness needs it."
+  echo ""
+  echo "Results: 0 passed, 0 failed"
+  exit 0
+fi
+
+# ── Fixture builders ────────────────────────────────────────────────────────
+
+# mk_proj DIR PHASE — a project at PHASE with prior gate dates recorded and an
+# APPROVAL_LOG carrying matching evidence, inside a local git repo with an
+# identity configured. HOME is a per-fixture empty dir (see A5).
+mk_proj() {
+  local d="$1" phase="$2"
+  mkdir -p "$d/.claude" "$d/home" || return 1
+  cat > "$d/.claude/phase-state.json" <<J
+{"project":"fix","framework_version":"1.0","current_phase":$phase,"track":"light",
+ "deployment":"personal","poc_mode":null,"compliance_ready":false,
+ "review_gate_enforced":false,
+ "gates":{"phase_0_to_1":"2026-01-01","phase_1_to_2":"2026-02-01",
+          "phase_2_to_3":"2026-03-01","phase_3_to_4":null}}
+J
+  cat > "$d/APPROVAL_LOG.md" <<'M'
+# Approval Log
+
+## Phase Gate: Phase 0 -> Phase 1
+| Field | Value |
+|---|---|
+| Approver | Test Owner |
+| Date | 2026-01-01 |
+
+## Phase Gate: Phase 1 -> Phase 2
+| Field | Value |
+|---|---|
+| Approver | Test Owner |
+| Date | 2026-02-01 |
+
+## Phase Gate: Phase 2 -> Phase 3
+| Field | Value |
+|---|---|
+| Approver | Test Owner |
+| Date | 2026-03-01 |
+
+## Phase Gate: Phase 3 -> Phase 4
+| Field | Value |
+|---|---|
+| Approver | Test Owner |
+| Date | 2026-04-01 |
+M
+  (
+    cd "$d" || exit 1
+    unset GITHUB_BASE_REF
+    # BL-234-FIXTURE-BARE-HEAD sibling: name the branch rather than inheriting
+    # a host default that differs between this Mac and an ubuntu runner.
+    git init -q -b main . >/dev/null 2>&1 || { git init -q . >/dev/null 2>&1; git checkout -q -b main >/dev/null 2>&1; }
+    git config user.email "t@e.x"
+    git config user.name "Test Owner"
+    echo "readme" > README.md
+    git add -A >/dev/null 2>&1
+    git commit -qm "docs: initial" >/dev/null 2>&1
+  ) || return 1
+  return 0
+}
+
+# want_qdrant DIR [FILE] — declare Qdrant in a PROJECT-scope settings file.
+want_qdrant() {
+  local d="$1" f="${2:-settings.local.json}"
+  cat > "$d/.claude/$f" <<'S'
+{"mcpServers":{"qdrant":{"command":"uvx","args":["mcp-server-qdrant"]}}}
+S
+}
+
+# want_qdrant_in_home DIR — declare Qdrant ONLY in the fixture's HOME. The gate
+# must NOT see this (A5).
+want_qdrant_in_home() {
+  local d="$1"
+  cat > "$d/home/.claude.json" <<'S'
+{"mcpServers":{"qdrant":{"command":"uvx","args":["mcp-server-qdrant"]}}}
+S
+}
+
+# ledger DIR REQUIRED — a tool-usage ledger declaring the requirement.
+ledger() {
+  local d="$1" req="$2"
+  cat > "$d/.claude/tool-usage.json" <<J
+{"session_id":"s","calls":[],"commits_since_last_context7":0,
+ "qdrant_find_called":false,"qdrant_store_called":false,"context7_called":false,
+ "mcp_gate_satisfied":false,
+ "mcp_requirements":{"qdrant_required":$req,"context7_required":false,"additional_required":[]}}
+J
+}
+
+# stored DIR TIMESTAMP — a durable accumulation record.
+stored() {
+  local d="$1" ts="$2"
+  local f="$d/.claude/process-state.json"
+  [ -f "$f" ] || echo '{}' > "$f"
+  jq --arg ts "$ts" '.mcp_accumulation = {store_success_count: 1, last_store_at: $ts, attestations: {}}' \
+    "$f" > "$f.tmp" && mv "$f.tmp" "$f"
+}
+
+# source_commit DIR — a commit touching a SOURCE path.
+source_commit() {
+  local d="$1"
+  ( cd "$d" || exit 1
+    unset GITHUB_BASE_REF
+    mkdir -p src
+    echo "print(1)" > src/main.py
+    git add -A >/dev/null 2>&1
+    git commit -qm "feat: source" >/dev/null 2>&1 )
+}
+
+# add_origin DIR — a HERMETIC origin: a LOCAL bare repo, never a live remote
+# (`lint-no-live-remote-in-tests.sh` enforces; a live `gh repo create` leaked a
+# real repo on 2026-07-06). The branch is NAMED on the bare, because this Mac's
+# Xcode gitconfig sets init.defaultbranch=main and an ubuntu runner's does not —
+# an unnamed bare produces a dangling HEAD symref there and the divergence is
+# silent (## BL-234:).
+add_origin() {
+  local d="$1" bare="$TOPTMP/$(basename "$d").origin.git"
+  git init -q --bare -b main "$bare" >/dev/null 2>&1 || {
+    git init -q --bare "$bare" >/dev/null 2>&1
+    git --git-dir="$bare" symbolic-ref HEAD refs/heads/main >/dev/null 2>&1
+  }
+  ( cd "$d" || exit 1
+    unset GITHUB_BASE_REF
+    git remote add origin "$bare" >/dev/null 2>&1
+    git push -q origin main >/dev/null 2>&1 )
+}
+
+# _run DIR ARGS... — run the gate ONCE with a pinned empty HOME, publishing both
+# the output ($GOUT) and the tally ($GISSUES) from that SINGLE invocation.
+#
+# IT MUST BE ONE INVOCATION. The first draft had separate `_gate` and `_issues`
+# helpers and assertions called both on the same fixture — but the gate
+# AUTO-WRITES gates.* into phase-state.json from APPROVAL_LOG evidence
+# (`_cpg_record_gate_date`), so the second run reads state the first run
+# created. B4, whose whole point is an UNRECORDED gate date, silently measured
+# two different projects: run one saw no previous gate and passed, run two saw
+# the date the first run had just written and blocked. Every other assertion
+# passed only because mk_proj pre-records all three dates, making the auto-write
+# idempotent — i.e. the bug was invisible everywhere it did not happen to bite.
+GOUT=""
+GISSUES=0
+_run() {
+  local d="$1"; shift
+  GOUT=$( ( cd "$d" && HOME="$d/home" bash "$CPG" "$@" 2>&1 ) | _strip_ansi )
+  GISSUES=$(_num "$(printf '%s\n' "$GOUT" | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1)")
+}
+
+# _run_env DIR "VAR=VAL" ... -- ARGS... — the same, with environment overrides.
+_run_env() {
+  local d="$1"; shift
+  # An ARRAY, not a string: a reason carries spaces, and `env $envs` unquoted
+  # word-splits it into bogus assignments that env rejects.
+  local envs
+  envs=()
+  while [ "$1" != "--" ]; do envs[${#envs[@]}]="$1"; shift; done
+  shift
+  GOUT=$( ( cd "$d" && HOME="$d/home" env "${envs[@]}" bash "$CPG" "$@" 2>&1 ) | _strip_ansi )
+  GISSUES=$(_num "$(printf '%s\n' "$GOUT" | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1)")
+}
+
+echo "BL-233 WP-B — accumulation: warn at commit, block at the phase gate"
+echo ""
+
+# ══ A. Requirement derivation — PROJECT scope only ═════════════════════════
+echo "A. requirement derivation (project-scope, host-independent)"
+
+A_CTRL="$(newtmp)"; mk_proj "$A_CTRL" 3; source_commit "$A_CTRL"
+_run "$A_CTRL" --gate phase_2_to_3
+a_ctrl_issues=$GISSUES
+a4_out="$GOUT"
+
+A1="$(newtmp)"; mk_proj "$A1" 3; source_commit "$A1"; want_qdrant "$A1"
+_run "$A1" --gate phase_2_to_3; a1_issues=$GISSUES
+if [ "$a1_issues" -eq $((a_ctrl_issues + 1)) ]; then
+  pass "A1: .claude/settings.local.json naming mcpServers.qdrant makes accumulation REQUIRED (issues $a_ctrl_issues -> $a1_issues)"
+else
+  fail_ "A1" "expected $((a_ctrl_issues + 1)) issues, got $a1_issues"
+fi
+
+A2="$(newtmp)"; mk_proj "$A2" 3; source_commit "$A2"; want_qdrant "$A2" "settings.json"
+_run "$A2" --gate phase_2_to_3; a2_issues=$GISSUES
+if [ "$a2_issues" -eq $((a_ctrl_issues + 1)) ]; then
+  pass "A2: .claude/settings.json is read too (issues $a_ctrl_issues -> $a2_issues)"
+else
+  fail_ "A2" "expected $((a_ctrl_issues + 1)) issues, got $a2_issues"
+fi
+
+A3="$(newtmp)"; mk_proj "$A3" 3; source_commit "$A3"; ledger "$A3" true
+_run "$A3" --gate phase_2_to_3; a3_issues=$GISSUES
+if [ "$a3_issues" -eq $((a_ctrl_issues + 1)) ]; then
+  pass "A3: OR arm — a ledger with qdrant_required=true and NO project settings still requires accumulation (covers a project that adopted Qdrant after init)"
+else
+  fail_ "A3" "expected $((a_ctrl_issues + 1)) issues, got $a3_issues"
+fi
+
+if [ "$a_ctrl_issues" -gt 0 ] && echo "$a4_out" | grep -q "accumulation: NOT CHECKED"; then
+  pass "A4: no Qdrant declared anywhere — the arm does NOT count, and says so explicitly rather than passing silently (# BL-112-SAST-NOTRUN doctrine)"
+else
+  fail_ "A4" "expected a 'NOT CHECKED' line and no increment; issues=$a_ctrl_issues"
+fi
+
+A5="$(newtmp)"; mk_proj "$A5" 3; source_commit "$A5"; want_qdrant_in_home "$A5"
+_run "$A5" --gate phase_2_to_3; a5_issues=$GISSUES; a5_out="$GOUT"
+if [ "$a5_issues" -eq "$a_ctrl_issues" ] && echo "$a5_out" | grep -q "accumulation: NOT CHECKED"; then
+  pass "A5: Qdrant configured in \$HOME but NOT in the project is IGNORED — the verdict cannot depend on whose machine ran the gate (## BL-234: class)"
+else
+  fail_ "A5" "host config leaked into the verdict: expected $a_ctrl_issues issues, got $a5_issues"
+fi
+
+# A6 — jq absent. The first draft of this arm printed "this project declares no
+# Qdrant MCP server" when jq was missing: a claim about the PROJECT that it had
+# never read, which is `## BL-233:`'s own substitution committed inside the fix
+# for it. It now fails closed and names jq. The tally cannot discriminate here
+# (without jq, the required and not-required fixtures are indistinguishable by
+# construction), so the honesty half is asserted as text and the ENFORCING half
+# is proved by M8 below.
+A6="$(newtmp)"; mk_proj "$A6" 3; source_commit "$A6"; want_qdrant "$A6"
+# The isolated PATH MIRRORS the real one minus jq, rather than listing the
+# handful of tools the gate looks like it needs. The first draft did the latter
+# and appended /usr/bin:/bin as a safety net — which is where jq actually lives
+# on many hosts, so the fixture silently ran WITH jq and A6 measured nothing.
+# An allow-list of "the tools it needs" is a guess about another script's
+# dependencies; excluding the single tool under test is a fact.
+A6BIN="$(newtmp)/bin"; mkdir -p "$A6BIN"
+_a6_ifs="$IFS"
+IFS=:
+for _p in $PATH; do
+  IFS="$_a6_ifs"
+  if [ -d "$_p" ]; then
+    for _x in "$_p"/*; do
+      [ -x "$_x" ] || continue
+      _n="${_x##*/}"
+      [ "$_n" = "jq" ] && continue
+      [ -e "$A6BIN/$_n" ] && continue
+      ln -s "$_x" "$A6BIN/$_n" 2>/dev/null
+    done
+  fi
+  IFS=:
+done
+IFS="$_a6_ifs"
+if PATH="$A6BIN" command -v jq >/dev/null 2>&1; then
+  fail_ "A6 (meta)" "the isolated PATH still resolves jq — the fixture would measure nothing"
+fi
+a6_out=$( ( cd "$A6" && HOME="$A6/home" PATH="$A6BIN" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+if echo "$a6_out" | grep -q "accumulation: CANNOT BE VERIFIED" && echo "$a6_out" | grep -q "jq is unavailable"; then
+  pass "A6: with jq unavailable the arm says it COULD NOT VERIFY and names jq — it never reports an unread project fact as a project fact"
+else
+  fail_ "A6" "expected a 'CANNOT BE VERIFIED ... jq is unavailable' line; got: $(echo "$a6_out" | grep -i 'accumulation' || echo '<no accumulation line>')"
+fi
+
+# ══ B. The satisfaction window is durable and phase-scoped ════════════════
+echo ""
+echo "B. satisfaction window (durable, since the previous gate)"
+
+B1="$(newtmp)"; mk_proj "$B1" 3; source_commit "$B1"; want_qdrant "$B1"; stored "$B1" "2026-02-15T10:00:00Z"
+_run "$B1" --gate phase_2_to_3; b1_issues=$GISSUES; b1_out="$GOUT"
+if [ "$b1_issues" -eq "$a_ctrl_issues" ] && echo "$b1_out" | grep -q "accumulation: satisfied"; then
+  pass "B1: a successful store AFTER the previous gate (2026-02-01) satisfies the requirement"
+else
+  fail_ "B1" "expected $a_ctrl_issues issues, got $b1_issues"
+fi
+
+B2="$(newtmp)"; mk_proj "$B2" 3; source_commit "$B2"; want_qdrant "$B2"; stored "$B2" "2026-01-15T10:00:00Z"
+_run "$B2" --gate phase_2_to_3; b2_issues=$GISSUES
+if [ "$b2_issues" -eq $((a_ctrl_issues + 1)) ]; then
+  pass "B2: a store from BEFORE the previous gate does NOT satisfy it — the window is the phase, not all history"
+else
+  fail_ "B2" "expected $((a_ctrl_issues + 1)) issues, got $b2_issues"
+fi
+
+B3="$(newtmp)"; mk_proj "$B3" 3; source_commit "$B3"; want_qdrant "$B3"
+echo '{"build_loop":{"step":0}}' > "$B3/.claude/process-state.json"
+_run "$B3" --gate phase_2_to_3; b3_issues=$GISSUES
+if [ "$b3_issues" -eq $((a_ctrl_issues + 1)) ]; then
+  pass "B3: a process-state.json with NO mcp_accumulation object reads as zero stores and BLOCKS — a missing key defaults RESTRICTIVE, the inverse of ## BL-221:"
+else
+  fail_ "B3" "expected $((a_ctrl_issues + 1)) issues, got $b3_issues"
+fi
+
+B4="$(newtmp)"; mk_proj "$B4" 2; source_commit "$B4"; want_qdrant "$B4"; stored "$B4" "2025-06-01T10:00:00Z"
+jq '.gates.phase_0_to_1 = null' "$B4/.claude/phase-state.json" > "$B4/.claude/ps.tmp" && mv "$B4/.claude/ps.tmp" "$B4/.claude/phase-state.json"
+b4_ctrl="$(newtmp)"; mk_proj "$b4_ctrl" 2; source_commit "$b4_ctrl"
+jq '.gates.phase_0_to_1 = null' "$b4_ctrl/.claude/phase-state.json" > "$b4_ctrl/.claude/ps.tmp" && mv "$b4_ctrl/.claude/ps.tmp" "$b4_ctrl/.claude/phase-state.json"
+_run "$b4_ctrl" --gate phase_1_to_2; b4_base=$GISSUES
+_run "$B4" --gate phase_1_to_2; b4_issues=$GISSUES; b4_out="$GOUT"
+# The "no increment" half of this assertion is TRUE OF AN UNIMPLEMENTED GATE.
+# The output half is what makes it a discriminator: the arm must have run and
+# reported satisfied, not merely failed to fire.
+if [ "$b4_issues" -eq "$b4_base" ] && echo "$b4_out" | grep -q "accumulation: satisfied"; then
+  pass "B4: with no previous gate date recorded, ANY successful store ever counts — an unscopeable window falls back to a satisfiable floor, not to a block nobody can clear (## BL-149:)"
+else
+  fail_ "B4" "expected $b4_base issues, got $b4_issues"
+fi
+
+B5="$(newtmp)"; mk_proj "$B5" 3; source_commit "$B5"; want_qdrant "$B5"; stored "$B5" "2026-02-01T00:00:01Z"
+_run "$B5" --gate phase_2_to_3; b5_issues=$GISSUES; b5_out="$GOUT"
+if [ "$b5_issues" -eq "$a_ctrl_issues" ] && echo "$b5_out" | grep -q "accumulation: satisfied"; then
+  pass "B5: a store ON the previous gate's date counts — gates.* carry a DATE with no time, so same-day is the only honest direction"
+else
+  fail_ "B5" "expected $a_ctrl_issues issues, got $b5_issues"
+fi
+
+# ══ C. The honest path — nothing owed when no source work happened ════════
+echo ""
+echo "C. source-work conditional (the ## BL-149: honest path)"
+
+C1="$(newtmp)"; mk_proj "$C1" 3; want_qdrant "$C1"
+c1_ctrl="$(newtmp)"; mk_proj "$c1_ctrl" 3
+_run "$c1_ctrl" --gate phase_2_to_3; c1_base=$GISSUES
+_run "$C1" --gate phase_2_to_3; c1_issues=$GISSUES; c1_out="$GOUT"
+if [ "$c1_issues" -eq "$c1_base" ] && echo "$c1_out" | grep -q "accumulation: nothing owed"; then
+  pass "C1: a phase whose only commit was docs owes nothing and passes clean — no ceremony, no attestation"
+else
+  fail_ "C1" "expected $c1_base issues, got $c1_issues"
+fi
+
+C2="$(newtmp)"; mk_proj "$C2" 3; want_qdrant "$C2"; source_commit "$C2"
+_run "$C2" --gate phase_2_to_3; c2_issues=$GISSUES; c2_out="$GOUT"
+if [ "$c2_issues" -eq $((c1_base + 1)) ] && echo "$c2_out" | grep -q "accumulation: BLOCKED"; then
+  pass "C2: source commits since the previous gate + zero stores BLOCKS (issues $c1_base -> $c2_issues)"
+else
+  fail_ "C2" "expected $((c1_base + 1)) issues, got $c2_issues"
+fi
+
+C3="$(newtmp)"; mk_proj "$C3" 3; want_qdrant "$C3"
+rm -rf "$C3/.git"
+c3_ctrl="$(newtmp)"; mk_proj "$c3_ctrl" 3; rm -rf "$c3_ctrl/.git"
+_run "$c3_ctrl" --gate phase_2_to_3; c3_base=$GISSUES
+_run "$C3" --gate phase_2_to_3; c3_issues=$GISSUES
+if [ "$c3_issues" -eq $((c3_base + 1)) ]; then
+  pass "C3: when git cannot answer whether source work happened, the conditional resolves to BLOCK — 'could not measure' must never read as 'nothing to measure'"
+else
+  fail_ "C3" "expected $((c3_base + 1)) issues, got $c3_issues"
+fi
+
+# ══ D. The attested escape ════════════════════════════════════════════════
+echo ""
+echo "D. attested escape (BL-072 shape: recorded, or refused)"
+
+D1="$(newtmp)"; mk_proj "$D1" 3; want_qdrant "$D1"; source_commit "$D1"
+_run_env "$D1" SOLO_MCP_ACCUM_ATTESTED=1 \
+  "SOLO_MCP_ACCUM_ATTESTED_REASON=offline sprint, nothing novel decided" \
+  -- --gate phase_2_to_3
+d1_issues=$GISSUES
+d1_recorded=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.reason // ""' "$D1/.claude/process-state.json" 2>/dev/null)
+if [ "$d1_issues" -eq "$c1_base" ] && [ "$d1_recorded" = "offline sprint, nothing novel decided" ]; then
+  pass "D1: an attested escape clears the block AND is durably recorded to .claude/process-state.json (not silenced)"
+else
+  fail_ "D1" "issues=$d1_issues (want $c1_base), recorded='$d1_recorded'"
+fi
+
+D2="$(newtmp)"; mk_proj "$D2" 3; want_qdrant "$D2"; source_commit "$D2"
+_run_env "$D2" SOLO_MCP_ACCUM_ATTESTED=1 "SOLO_MCP_ACCUM_ATTESTED_REASON=   " \
+  -- --gate phase_2_to_3
+d2_issues=$GISSUES
+if [ "$d2_issues" -eq $((c1_base + 1)) ]; then
+  pass "D2: a whitespace-only reason is REJECTED — an attestation must carry a justification, not blank space (BL-070 tightener)"
+else
+  fail_ "D2" "expected $((c1_base + 1)) issues, got $d2_issues"
+fi
+
+D3="$(newtmp)"; mk_proj "$D3" 3; want_qdrant "$D3"; source_commit "$D3"
+mkdir -p "$D3/.claude/process-state.json"   # unwritable: a directory where the record must go
+d3_ctrl="$(newtmp)"; mk_proj "$d3_ctrl" 3; mkdir -p "$d3_ctrl/.claude/process-state.json"
+_run "$d3_ctrl" --gate phase_2_to_3; d3_base=$GISSUES
+_run_env "$D3" SOLO_MCP_ACCUM_ATTESTED=1 "SOLO_MCP_ACCUM_ATTESTED_REASON=a real reason" \
+  -- --gate phase_2_to_3
+d3_issues=$GISSUES
+if [ "$d3_issues" -eq $((d3_base + 1)) ]; then
+  pass "D3: an attestation that CANNOT be recorded is REFUSED, not honoured — an escape that leaves no trace is the advisory posture BL-233 exists to replace"
+else
+  fail_ "D3" "expected $((d3_base + 1)) issues, got $d3_issues"
+fi
+
+D4="$(newtmp)"; mk_proj "$D4" 3; want_qdrant "$D4"; source_commit "$D4"
+cat > "$D4/.claude/process-state.json" <<'J'
+{"mcp_accumulation":{"store_success_count":0,"last_store_at":null,
+ "attestations":{"phase_2_to_3":{"reason":"prior recorded exception","date":"2026-03-02","by":"Test Owner"}}}}
+J
+_run "$D4" --gate phase_2_to_3; d4_issues=$GISSUES; d4_out="$GOUT"
+if [ "$d4_issues" -eq "$c1_base" ] && echo "$d4_out" | grep -q "accumulation: ATTESTED"; then
+  pass "D4: an attestation already on record clears the gate without re-supplying the env vars (idempotent across runs)"
+else
+  fail_ "D4" "expected $c1_base issues, got $d4_issues"
+fi
+
+# ══ E. Gate scoping ═══════════════════════════════════════════════════════
+echo ""
+echo "E. which gates the arm belongs to"
+
+E1="$(newtmp)"; mk_proj "$E1" 2; want_qdrant "$E1"; source_commit "$E1"
+e1_ctrl="$(newtmp)"; mk_proj "$e1_ctrl" 2; source_commit "$e1_ctrl"
+_run "$e1_ctrl" --gate phase_1_to_2; e1_base=$GISSUES
+_run "$E1" --gate phase_1_to_2; e1_issues=$GISSUES
+if [ "$e1_issues" -eq $((e1_base + 1)) ]; then
+  pass "E1: --gate phase_1_to_2 enforces accumulation against the phase_0_to_1 date"
+else
+  fail_ "E1" "expected $((e1_base + 1)) issues, got $e1_issues"
+fi
+
+E3="$(newtmp)"; mk_proj "$E3" 4; want_qdrant "$E3"; source_commit "$E3"
+e3_ctrl="$(newtmp)"; mk_proj "$e3_ctrl" 4; source_commit "$e3_ctrl"
+_run "$e3_ctrl" --gate phase_3_to_4; e3_base=$GISSUES
+_run "$E3" --gate phase_3_to_4; e3_issues=$GISSUES
+if [ "$e3_issues" -eq $((e3_base + 1)) ]; then
+  pass "E3: --gate phase_3_to_4 enforces accumulation against the phase_2_to_3 date"
+else
+  fail_ "E3" "expected $((e3_base + 1)) issues, got $e3_issues"
+fi
+
+# E4 asserts an ABSENCE, which an unimplemented gate satisfies for free. The
+# positive control is the SAME fixture driven at 2->3: the string must be
+# producible here, or the absence at 0->1 proves nothing.
+E4="$(newtmp)"; mk_proj "$E4" 1; want_qdrant "$E4"; source_commit "$E4"
+_run "$E4" --gate phase_0_to_1; e4_out="$GOUT"
+E4B="$(newtmp)"; mk_proj "$E4B" 3; want_qdrant "$E4B"; source_commit "$E4B"
+_run "$E4B" --gate phase_2_to_3; e4b_out="$GOUT"
+if ! echo "$e4_out" | grep -q "accumulation:" && echo "$e4b_out" | grep -q "accumulation:"; then
+  pass "E4: --gate phase_0_to_1 does NOT evaluate accumulation, while the same fixture shape at 2->3 does — Phase 0 is pre-code discovery and writes no source"
+else
+  fail_ "E4" "expected silence at 0->1 and a report at 2->3 (control produced: $(echo "$e4b_out" | grep -c 'accumulation:') line(s))"
+fi
+
+# ══ F. The tracker's durable write ════════════════════════════════════════
+echo ""
+echo "F. tracker records the durable accumulation (outcome-gated)"
+
+_fire() {   # _fire DIR EVENT TOOL
+  local d="$1" ev="$2" tool="$3" payload
+  if [ "$ev" = "PostToolUse" ]; then
+    payload=$(jq -nc --arg t "$tool" '{session_id:"s",hook_event_name:"PostToolUse",tool_name:$t,tool_input:{information:"x"},tool_response:[{type:"text",text:"stored"}]}')
+  else
+    payload=$(jq -nc --arg t "$tool" '{session_id:"s",hook_event_name:"PostToolUseFailure",tool_name:$t,tool_input:{information:"x"},error:"All connection attempts failed",is_interrupt:false}')
+  fi
+  ( cd "$d" && printf '%s' "$payload" | bash "$TRACKER" >/dev/null 2>&1 )
+}
+
+F1="$(newtmp)"; mkdir -p "$F1/.claude"; ledger "$F1" true
+_fire "$F1" PostToolUse "mcp__qdrant__qdrant-store"
+f1_count=$(jq -r '.mcp_accumulation.store_success_count // 0' "$F1/.claude/process-state.json" 2>/dev/null)
+f1_at=$(jq -r '.mcp_accumulation.last_store_at // ""' "$F1/.claude/process-state.json" 2>/dev/null)
+if [ "$(_num "$f1_count")" -eq 1 ] && [ -n "$f1_at" ] && [ "$f1_at" != "null" ]; then
+  pass "F1: a SUCCESSFUL qdrant-store writes the durable record (count=$f1_count, last_store_at=$f1_at)"
+else
+  fail_ "F1" "count='$f1_count' last_store_at='$f1_at'"
+fi
+
+# F2 and F3 assert a count of ZERO, which an unimplemented tracker gives for
+# free. Each therefore fires a SUCCEEDING store into the SAME fixture
+# afterwards and requires the count to reach 1 — proving the fixture was
+# capable of accumulating and that the first event was rejected on its merits.
+F2="$(newtmp)"; mkdir -p "$F2/.claude"; ledger "$F2" true
+_fire "$F2" PostToolUseFailure "mcp__qdrant__qdrant-store"
+f2_count=$(jq -r '.mcp_accumulation.store_success_count // 0' "$F2/.claude/process-state.json" 2>/dev/null)
+_fire "$F2" PostToolUse "mcp__qdrant__qdrant-store"
+f2_after=$(jq -r '.mcp_accumulation.store_success_count // 0' "$F2/.claude/process-state.json" 2>/dev/null)
+if [ "$(_num "$f2_count")" -eq 0 ] && [ "$(_num "$f2_after")" -eq 1 ]; then
+  pass "F2: a FAILED qdrant-store (PostToolUseFailure) writes NO durable record, while a succeeding one in the same fixture does — the accumulation half scores outcomes, exactly as WP-A made retrieval do"
+else
+  fail_ "F2" "failure->count=$f2_count (want 0), then success->count=$f2_after (want 1)"
+fi
+
+F3="$(newtmp)"; mkdir -p "$F3/.claude"; ledger "$F3" true
+_fire "$F3" PostToolUse "mcp__qdrant__qdrant-find"
+f3_count=$(jq -r '.mcp_accumulation.store_success_count // 0' "$F3/.claude/process-state.json" 2>/dev/null)
+_fire "$F3" PostToolUse "mcp__qdrant__qdrant-store"
+f3_after=$(jq -r '.mcp_accumulation.store_success_count // 0' "$F3/.claude/process-state.json" 2>/dev/null)
+if [ "$(_num "$f3_count")" -eq 0 ] && [ "$(_num "$f3_after")" -eq 1 ]; then
+  pass "F3: a successful qdrant-FIND does not count as accumulation, while a store in the same fixture does — retrieval is the other half"
+else
+  fail_ "F3" "find->count=$f3_count (want 0), then store->count=$f3_after (want 1)"
+fi
+
+F4="$(newtmp)"; mkdir -p "$F4/.claude"; ledger "$F4" true
+_fire "$F4" PostToolUse "mcp__qdrant__qdrant-store"
+_fire "$F4" PostToolUse "mcp__qdrant__qdrant-store"
+f4_count=$(jq -r '.mcp_accumulation.store_success_count // 0' "$F4/.claude/process-state.json" 2>/dev/null)
+if [ "$(_num "$f4_count")" -eq 2 ]; then
+  pass "F4: the counter accumulates across calls (count=$f4_count)"
+else
+  fail_ "F4" "expected 2, got $f4_count"
+fi
+
+# ══ G. The Stop-hook reminder counts OUTCOMES ═════════════════════════════
+echo ""
+echo "G. session-end reminder counts outcomes, not declarations (WP-A residual 4)"
+
+G1="$(newtmp)"; mkdir -p "$G1/.claude" "$G1/home"
+mkdir -p "$G1/home/.claude"
+cat > "$G1/home/.claude/settings.json" <<'S'
+{"mcpServers":{"qdrant":{"command":"uvx","args":["mcp-server-qdrant"]}}}
+S
+cat > "$G1/.claude/tool-usage.json" <<'J'
+{"session_id":"s","commits_since_last_context7":3,
+ "calls":[
+  {"tool":"mcp__qdrant__qdrant-find","event":"PostToolUseFailure","outcome":"failure","empty_result":false},
+  {"tool":"mcp__qdrant__qdrant-find","event":"PostToolUseFailure","outcome":"failure","empty_result":false},
+  {"tool":"mcp__qdrant__qdrant-find","event":"PostToolUse","outcome":"success","empty_result":false},
+  {"tool":"mcp__qdrant__qdrant-store","event":"PostToolUseFailure","outcome":"failure","empty_result":false}
+ ],
+ "qdrant_find_called":true,"qdrant_find_succeeded":true,"qdrant_find_failed":2,
+ "qdrant_store_called":true,"qdrant_store_succeeded":false,
+ "context7_called":false,"context7_query_docs_succeeded":false}
+J
+echo '{"current_phase":2}' > "$G1/.claude/phase-state.json"
+g1_out=$( ( cd "$G1" && HOME="$G1/home" bash "$REMINDER" 2>&1 ) | _strip_ansi )
+if echo "$g1_out" | grep -q "Qdrant-find: 1 "; then
+  pass "G1: three find CALLS of which one succeeded is reported as 1, not 3 — the reminder no longer disagrees with the gate WP-A shipped"
+else
+  fail_ "G1" "declaration count leaked into the summary: $(echo "$g1_out" | grep -i 'TOOL USAGE' || echo '<no summary line>')"
+fi
+
+if echo "$g1_out" | grep -qi "stored nothing in Qdrant"; then
+  pass "G2: qdrant_store_called=true with qdrant_store_succeeded=false still WARNS — a store that failed is not a store"
+else
+  fail_ "G2" "a failed store silenced the warning"
+fi
+
+if echo "$g1_out" | grep -qi "failed"; then
+  pass "G3: the failed round trips are VISIBLE in the summary rather than absent — a broken server is reportable"
+else
+  fail_ "G3" "failures are invisible in the summary"
+fi
+
+# ══ H. Commit-time is a WARNING, never a block ════════════════════════════
+echo ""
+echo "H. commit-time warn (Karl: warn at commit, block at the phase gate)"
+
+H1="$(newtmp)"; mk_proj "$H1" 2; add_origin "$H1"; want_qdrant "$H1"; ledger "$H1" true
+# phase2_init.verified satisfies an EARLIER commit-gate arm that would otherwise
+# deny before this one runs. It deliberately carries NO mcp_accumulation object,
+# which is the state under test: the project has stored nothing.
+cat > "$H1/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true}}
+J
+mkdir -p "$H1/src" "$H1/tests"
+echo "print(1)" > "$H1/src/main.py"
+# A matching test is staged alongside the source: without it the BL-072 TDD
+# ordering gate fires FIRST and this arm is never reached, so the fixture would
+# be measuring the wrong gate.
+echo "def test_main(): pass" > "$H1/tests/test_main.py"
+( cd "$H1" && git add -A >/dev/null 2>&1 )
+# `chore:`, not `feat:`. A `feat:` commit is denied outright without an active
+# Build Loop, which would stop the run before this arm — and standing up a
+# Build Loop would be a large fixture for no extra coverage, because the arm
+# keys on STAGED SOURCE PATHS and never looks at the conventional-commit type.
+h1_payload=$(jq -nc '{tool_name:"Bash",tool_input:{command:"git commit -m \"chore: x\""}}')
+h1_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+if echo "$h1_out" | grep -q 'phase gate' && echo "$h1_out" | grep -q '"permissionDecision": *"allow"'; then
+  pass "H1: a source commit with nothing stored WARNS and names the phase gate that will block, while still ALLOWING the commit"
+else
+  fail_ "H1" "no allow-shaped warning naming the phase gate: $(echo "$h1_out" | head -2)"
+fi
+
+if ! echo "$h1_out" | grep -q '"permissionDecision": *"deny"'; then
+  pass "H2: the commit-time arm never denies — storing is not per-commit work, and a gate people cannot satisfy honestly gets deleted (## BL-149:)"
+else
+  fail_ "H2" "the commit-time arm denied a commit"
+fi
+
+# ══ M. Mutation proofs — dual direction, changed>=2 asserted ══════════════
+echo ""
+echo "M. mutation proofs"
+
+# _mk_mutant_repo LABEL FILE MARKER FIND REPL — copies the repo, mutates, and
+# publishes the mutated root in the GLOBAL $MUT_ROOT. Meta-assertions (sites,
+# changed, parses) are enforced here so a mutation that did not apply can never
+# score as a killed mutant.
+#
+# IT PUBLISHES THROUGH A GLOBAL ON PURPOSE. The first draft of this harness
+# echoed the path and was called as `root=$(_mk_mutant_repo ...)`. That is a
+# SUBSHELL: every `fail_` it emitted was captured into the variable instead of
+# printed, and every `FAILED=$((FAILED + 1))` incremented a counter that died
+# with the subshell. A meta-failure — the mutation not applying at all — was
+# therefore INVISIBLE and scored as nothing. That is the same silent-success
+# class this suite exists to pin, reproduced in its own harness.
+MUT_ROOT=""
+_mk_mutant_repo() {
+  local label="$1" relfile="$2" marker="$3" find="$4" repl="$5"
+  local root file before sites changed parses
+  MUT_ROOT=""
+  root="$(newtmp)/repo"
+  mkdir -p "$root"
+  cp -R "$REPO_ROOT/scripts" "$root/scripts" 2>/dev/null
+  file="$root/$relfile"
+  sites=$(_sites "$file" "$marker")
+  if [ "$sites" -ne 1 ]; then
+    fail_ "$label (meta)" "marker '$marker' has $sites end-of-line sites in $relfile, want exactly 1"
+    return 1
+  fi
+  before="$(mktemp)"; cp "$file" "$before"
+  _mutate "$file" "$find" "$repl"
+  changed=$(_changed_lines "$before" "$file")
+  parses=$(_parses "$file")
+  if [ "$changed" -lt 2 ]; then
+    fail_ "$label (meta)" "mutation did not apply — changed=$changed (<2). A mutation that does not mutate must not pass as a killed mutant."
+    return 1
+  fi
+  if [ "$parses" -ne 1 ]; then
+    fail_ "$label (meta)" "mutant does not parse (bash -n) — it would kill every test for the wrong reason"
+    return 1
+  fi
+  MUT_ROOT="$root"
+  return 0
+}
+
+# _mutant_issues MUTANT_ROOT FIXTURE [ENV_ASSIGNMENTS...] — run a mutated gate.
+_mutant_issues() {
+  local root="$1" fix="$2"; shift 2
+  local n
+  n=$( cd "$fix" && HOME="$fix/home" env "$@" bash "$root/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 \
+       | _strip_ansi | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1 )
+  _num "$n"
+}
+
+# M1 — remove the single increment site: C2's block must evaporate.
+if _mk_mutant_repo "M1" "scripts/check-phase-gate.sh" "# BL-233-WPB-BLOCK" \
+      '|| issues=$((issues + 1))   # BL-233-WPB-BLOCK' \
+      '|| : "no-op"                # BL-233-WPB-BLOCK'; then
+  M1F="$(newtmp)"; mk_proj "$M1F" 3; want_qdrant "$M1F"; source_commit "$M1F"
+  m1_issues=$(_mutant_issues "$MUT_ROOT" "$M1F")
+  if [ "$m1_issues" -eq "$c1_base" ]; then
+    pass "M1: excising the ONE increment site flips C2 from BLOCK to pass — the increment, not the [FAIL] label, is what enforces (## BL-104:)"
+  else
+    fail_ "M1" "mutant still blocked: issues=$m1_issues, want $c1_base"
+  fi
+fi
+
+# M2 — invert the source-work verdict: C1's honest path must start blocking.
+if _mk_mutant_repo "M2" "scripts/check-phase-gate.sh" "# BL-233-WPB-SOURCEWORK" \
+      'return 1   # BL-233-WPB-SOURCEWORK' \
+      'return 0   # BL-233-WPB-SOURCEWORK'; then
+  M2F="$(newtmp)"; mk_proj "$M2F" 3; want_qdrant "$M2F"
+  m2_issues=$(_mutant_issues "$MUT_ROOT" "$M2F")
+  if [ "$m2_issues" -eq $((c1_base + 1)) ]; then
+    pass "M2: inverting the source-work verdict makes a docs-only phase block — C1 is a real discriminator, not a vacuous pass"
+  else
+    fail_ "M2" "mutant did not block the docs-only phase: issues=$m2_issues, want $((c1_base + 1))"
+  fi
+fi
+
+# M3 — widen the settings scan to $HOME: A5's host-independence must break.
+if _mk_mutant_repo "M3" "scripts/check-phase-gate.sh" "# BL-233-WPB-SCOPE" \
+      'for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE' \
+      'for _f in ".claude/settings.local.json" ".claude/settings.json" "$HOME/.claude.json"; do   # BL-233-WPB-SCOPE'; then
+  M3F="$(newtmp)"; mk_proj "$M3F" 3; source_commit "$M3F"; want_qdrant_in_home "$M3F"
+  m3_issues=$(_mutant_issues "$MUT_ROOT" "$M3F")
+  if [ "$m3_issues" -eq $((a_ctrl_issues + 1)) ]; then
+    pass "M3: adding \$HOME to the settings scan makes the host's own config decide the verdict — A5 pins the scope that keeps local and CI in agreement"
+  else
+    fail_ "M3" "widening the scope changed nothing: issues=$m3_issues, want $((a_ctrl_issues + 1))"
+  fi
+fi
+
+# M4 — drop the tracker's outcome guard: F2 must start accumulating failures.
+if _mk_mutant_repo "M4" "scripts/track-tool-usage.sh" "# BL-233-WPB-ACCUM-WRITE" \
+      'if [ "$OUTCOME" = "success" ]; then   # BL-233-WPB-ACCUM-WRITE' \
+      'if [ "$OUTCOME" != "zzz" ]; then   # BL-233-WPB-ACCUM-WRITE'; then
+  m4_root="$MUT_ROOT"
+  M4F="$(newtmp)"; mkdir -p "$M4F/.claude"; ledger "$M4F" true
+  m4_payload=$(jq -nc '{session_id:"s",hook_event_name:"PostToolUseFailure",tool_name:"mcp__qdrant__qdrant-store",tool_input:{information:"x"},error:"All connection attempts failed",is_interrupt:false}')
+  ( cd "$M4F" && printf '%s' "$m4_payload" | bash "$m4_root/scripts/track-tool-usage.sh" >/dev/null 2>&1 )
+  m4_count=$(jq -r '.mcp_accumulation.store_success_count // 0' "$M4F/.claude/process-state.json" 2>/dev/null)
+  if [ "$(_num "$m4_count")" -eq 1 ]; then
+    pass "M4: removing the outcome guard makes a FAILED store accumulate — F2 proves the guard is what separates outcomes from declarations"
+  else
+    fail_ "M4" "mutant did not accumulate the failure: count=$m4_count"
+  fi
+fi
+
+# M5 — honour an unrecordable attestation: D3's refusal must evaporate.
+if _mk_mutant_repo "M5" "scripts/check-phase-gate.sh" "# BL-233-WPB-ATTEST-REFUSE" \
+      'return 1   # BL-233-WPB-ATTEST-REFUSE' \
+      'return 0   # BL-233-WPB-ATTEST-REFUSE'; then
+  m5_root="$MUT_ROOT"
+  M5F="$(newtmp)"; mk_proj "$M5F" 3; want_qdrant "$M5F"; source_commit "$M5F"
+  mkdir -p "$M5F/.claude/process-state.json"
+  m5_ctrl="$(newtmp)"; mk_proj "$m5_ctrl" 3; mkdir -p "$m5_ctrl/.claude/process-state.json"
+  m5_base=$(_mutant_issues "$m5_root" "$m5_ctrl")
+  m5_issues=$(_mutant_issues "$m5_root" "$M5F" \
+    SOLO_MCP_ACCUM_ATTESTED=1 SOLO_MCP_ACCUM_ATTESTED_REASON="a real reason")
+  if [ "$m5_issues" -eq "$m5_base" ]; then
+    pass "M5: removing the refusal lets an unrecordable attestation clear the gate — D3 proves the record, not the env var, is the authority"
+  else
+    fail_ "M5" "mutant still refused: issues=$m5_issues, want $m5_base"
+  fi
+fi
+
+# M6 — point the reminder back at the DECLARATION flag: G2 must go quiet.
+if _mk_mutant_repo "M6" "scripts/session-end-qdrant-reminder.sh" "# BL-233-WPB-OUTCOME" \
+      ".qdrant_store_succeeded // false' \"\$TOOL_USAGE\" 2>/dev/null)   # BL-233-WPB-OUTCOME" \
+      ".qdrant_store_called // false' \"\$TOOL_USAGE\" 2>/dev/null)   # BL-233-WPB-OUTCOME"; then
+  m6_out=$( ( cd "$G1" && HOME="$G1/home" bash "$MUT_ROOT/scripts/session-end-qdrant-reminder.sh" 2>&1 ) | _strip_ansi )
+  if ! echo "$m6_out" | grep -qi "stored nothing in Qdrant"; then
+    pass "M6: reading the *_called declaration instead of *_succeeded silences the warning on a session whose only store FAILED — G2 is a real discriminator"
+  else
+    fail_ "M6" "mutant still warned — G2 would pass either way"
+  fi
+fi
+
+# M7 — suppress the commit-time warning: H1 must go quiet. The commit arm is
+# non-enforcing by design, so its mutant proves the WARNING is real rather than
+# that a block is real — H1 asserts the text, and without this it would be the
+# only new surface with no mutant behind it.
+if _mk_mutant_repo "M7" "scripts/pre-commit-gate.sh" "# BL-233-WPB-COMMIT-WARN" \
+      'if [ "$ACC_SATISFIED" = false ]; then   # BL-233-WPB-COMMIT-WARN' \
+      'if [ "$ACC_SATISFIED" = "never" ]; then   # BL-233-WPB-COMMIT-WARN'; then
+  m7_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" \
+    | bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+  if ! echo "$m7_out" | grep -q 'Nothing has been stored to Qdrant'; then
+    pass "M7: neutering the commit-time predicate silences the warning — H1 asserts a message that is actually produced, not one that happens to appear"
+  else
+    fail_ "M7" "mutant still warned — H1 would pass either way"
+  fi
+fi
+
+# M8 — make the jq-missing arm non-counting: the tally must drop by exactly 1.
+# A6 asserts only the TEXT, so without this the fail-closed half would be unproven —
+# a [FAIL] label that increments nothing is precisely `## BL-104:`'s trap.
+if _mk_mutant_repo "M8" "scripts/check-phase-gate.sh" "# BL-233-WPB-JQ-FAILCLOSED" \
+      'return 1   # BL-233-WPB-JQ-FAILCLOSED' \
+      'return 0   # BL-233-WPB-JQ-FAILCLOSED'; then
+  m8_clean=$( ( cd "$A6" && HOME="$A6/home" PATH="$A6BIN" bash "$CPG" --gate phase_2_to_3 2>&1 ) \
+    | _strip_ansi | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1 )
+  m8_mut=$( ( cd "$A6" && HOME="$A6/home" PATH="$A6BIN" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) \
+    | _strip_ansi | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1 )
+  m8_clean=$(_num "$m8_clean"); m8_mut=$(_num "$m8_mut")
+  if [ "$m8_clean" -eq $((m8_mut + 1)) ]; then
+    pass "M8: making the jq-missing arm non-counting drops the tally by exactly 1 — the [FAIL] label A6 reads actually enforces (## BL-104:)"
+  else
+    fail_ "M8" "clean=$m8_clean mutant=$m8_mut — expected clean to be exactly one higher"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ]

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -467,9 +467,13 @@ _a8_fixture() {   # _a8_fixture DIR — a fixture the accumulation warning DOES 
   # this fixture had that deny in it all along and nothing was looking.
   add_origin "$d"
   want_qdrant "$d"
-  # A ledger whose qdrant-find flag is false. That is the SECOND gate this test
-  # needs: it is emitted by an arm with no relation to accumulation, so its
-  # survival is what "the other gates are not collateral" actually means.
+  # A ledger. Its `false` argument sets `mcp_requirements.qdrant_required`, NOT
+  # the qdrant-find flag — `ledger()` hardcodes `qdrant_find_called:false`, and
+  # that hardcoded flag is what fires the SECOND warning this test needs. That
+  # warning comes from an arm with no relation to accumulation, so its survival
+  # is what "the other gates are not collateral" actually means. The argument is
+  # `false` so the ledger does not become a second requirement source: the
+  # declaration under test is the settings file written just above.
   ledger "$d" false
   # No mcp_accumulation object — the project has stored nothing. Same shape H1
   # uses, and the state under test.
@@ -492,6 +496,14 @@ A8_OTHER_RE='No prior context retrieved from Qdrant this session'
 # reads, and one fixture run twice measures two projects — the trap this file's
 # header records against check-phase-gate.sh, and the same discipline applies to
 # the commit gate.
+#
+# TWO TESTS IN THIS FILE DO NOT FOLLOW THE RULE, and that is recorded rather
+# than papered over: D15 and M19 each run two gates against ONE fixture. Both
+# are benign TODAY and it was measured, not assumed — those fixtures pre-record
+# every gate date, so `_cpg_record_gate_date` returns on its idempotent branch
+# before writing, and the phase-state file is byte-identical after three
+# successive runs. It is benign by a property of the fixture, not of the gate,
+# so a future edit that drops a pre-recorded date reopens it there.
 A8C="$(newtmp)"; _a8_fixture "$A8C"
 a8_ctrl=$( ( cd "$A8C" && printf '%s' "$a8_payload" \
   | HOME="$A8C/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
@@ -516,7 +528,7 @@ elif ! echo "$a8_out" | grep -q "No such file or directory" \
    && echo "$a8_out" | grep -q '"permissionDecision"' \
    && echo "$a8_out" | grep -q "$A8_OTHER_RE" \
    && ! echo "$a8_out" | grep -q "$A8_ACC_RE"; then
-  pass "A8: with the lib absent the commit gate reaches a real decision instead of dying at its source line, and EXACTLY the accumulation warning is missing — an unrelated gate in the same file still reaches the operator, and the control fixture proves both warnings were reachable"
+  pass "A8: with the lib absent the commit gate reaches a real decision instead of dying at its source line, and EXACTLY the accumulation warning is missing — an unrelated gate in the same file still EMITS (this greps raw stdout; whether the JSON envelope around it parses is M18's assertion, not this one), and the control fixture proves both warnings were reachable"
 else
   fail_ "A8" "lib-absent: $(echo "$a8_out" | head -c 180)"
 fi
@@ -1977,7 +1989,13 @@ d15_ran=$(printf '%s\n' "$d15_out" | grep -c 'accumulation:')
 # count is not attributable to the reverted accumulation site — the comparison is.
 d15_ctrl=$( ( cd "$D15" && HOME="$D15/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
 d15_base=$(printf '%s\n' "$d15_ctrl" | grep -cE '^ *\[OK\] Phase 3 review gate: FORGED-D15')
-if [ "$d15_forged" -eq "$d15_base" ] && [ "$d15_ran" -ge 1 ]; then
+# VACUITY FLOOR, same shape as D13's and for the same recorded reason: this
+# assertion is an EQUALITY, so a payload injection that silently no-ops reads
+# 0 == 0 and passes green. The baseline is a MEASURED 1, so a drop to 0 is a
+# broken fixture and must say so rather than agree with itself.
+if [ "$d15_base" -lt 1 ]; then
+  fail_ "D15 (meta)" "control produced no forged line (base=$d15_base); the duplicate-key payload is not reaching a display site, so 'the reverted site adds none' proves nothing"
+elif [ "$d15_forged" -eq "$d15_base" ] && [ "$d15_ran" -ge 1 ]; then
   pass "D15: reverting a display site to echo -e — the exact eighth-instance condition — does NOT reopen the forgery, because accum_oneline removes the backslash that echo -e would have interpreted — the count matches the unmutated baseline ($d15_base, from a pre-existing arm this PR does not touch). The rule holds without depending on every display site staying correct."
 else
   fail_ "D15" "forged with reverted display=$d15_forged, unmutated baseline=$d15_base (must be equal); arm-ran=$d15_ran"

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -1295,6 +1295,82 @@ else
   fail_ "N7" "morning commit on the opening day: blocked=$n7_blocked (want >=1), nothing-owed=$n7_owed (want 0)"
 fi
 
+# N10 — THE ESCAPE MUST REACH THE UNMEASURABLE WINDOW, and the two halves of
+# that are asserted separately because they pull in opposite directions.
+#
+# The first cut returned 1 the moment the window could not be measured, which
+# put the block AHEAD of the attested escape and made the escape unreachable for
+# it — `## BL-149:`'s rule broken by the entry that cites it, since a wrong
+# clock or a half-written state file is not misconduct and the operator had no
+# way to say so. Reviewers rated the bypasses these guards close as improbable;
+# an honest operator hitting a dead end is not.
+#
+# (a) FAIL-CLOSED half: an unmeasurable window with a store that would look
+#     "inside" it must still block, NOT report satisfied. The permissive
+#     shortcuts stay skipped.
+N10A="$(newtmp)"; mk_proj "$N10A" 3; want_qdrant "$N10A"; source_commit "$N10A"
+stored "$N10A" "2099-12-31T10:00:00Z"
+_set_gate "$N10A" phase_1_to_2 "2099-12-31"
+_run "$N10A" --gate phase_2_to_3; n10a_issues=$GISSUES
+n10a_refused=$(grep -c 'CANNOT BE VERIFIED' <<< "$GOUT")
+n10a_sat=$(grep -c 'accumulation: satisfied' <<< "$GOUT")
+
+# (b) OPEN-TO-A-HUMAN half: the same fixture, attested, must pass AND be
+#     recorded. An escape that leaves no trace is the posture this entry
+#     replaces, so the durable record is asserted, not just the exit.
+N10B="$(newtmp)"; mk_proj "$N10B" 3; want_qdrant "$N10B"; source_commit "$N10B"
+stored "$N10B" "2099-12-31T10:00:00Z"
+_set_gate "$N10B" phase_1_to_2 "2099-12-31"
+n10b_out=$( ( cd "$N10B" && HOME="$N10B/home" SOLO_MCP_ACCUM_ATTESTED=1 \
+  SOLO_MCP_ACCUM_ATTESTED_REASON="the release box clock is ahead" \
+  bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+n10b_issues=$(_num "$(printf '%s\n' "$n10b_out" | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1)")
+n10b_attested=$(grep -c 'accumulation: ATTESTED' <<< "$n10b_out")
+n10b_recorded=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.reason // ""' "$N10B/.claude/process-state.json" 2>/dev/null)
+
+if [ "$n10a_refused" -lt 1 ] || [ "$n10a_sat" -ne 0 ]; then
+  fail_ "N10 (fail-closed)" "an unmeasurable window with a store 'inside' it did not block: refused=$n10a_refused satisfied=$n10a_sat"
+elif [ "$n10b_attested" -ge 1 ] && [ "$n10b_issues" -lt "$n10a_issues" ] && [ "$n10b_recorded" = "the release box clock is ahead" ]; then
+  pass "N10: an unmeasurable window still refuses the AUTOMATIC paths (a store that looks 'inside' it does not satisfy) and is clearable by an ATTESTATION that is durably recorded ($n10a_issues -> $n10b_issues) — fail-closed to a script, open to a human who says why"
+else
+  fail_ "N10" "attested run: attested=$n10b_attested issues=$n10b_issues (unattested $n10a_issues); recorded reason='$n10b_recorded'"
+fi
+
+# N11 — THE OTHER OPERAND OF THE SAME COMPARISON. Two rounds validated the
+# window START four ways and left the STORE TIMESTAMP unguarded, on the identical
+# hazard those guards cite: clock skew. It is the worse half to leave open — a
+# future window start fails LOUDLY, a future store timestamp satisfies the gate
+# SILENTLY and FOREVER, and process-state.json is tracked, so the bad value is
+# committed and reaches every clone.
+_n11_fix() {   # _n11_fix DIR TIMESTAMP — an in-window source commit, one store
+  local d="$1" ts="$2"
+  mk_proj "$d" 3; want_qdrant "$d"
+  ( cd "$d" || exit 1
+    unset GITHUB_BASE_REF
+    mkdir -p src && echo "print(1)" > src/main.py
+    git add -A >/dev/null 2>&1
+    GIT_AUTHOR_DATE="2026-05-01T10:00:00" GIT_COMMITTER_DATE="2026-05-01T10:00:00" \
+      git commit -qm "feat: inside the window" >/dev/null 2>&1 )
+  stored "$d" "$ts"
+}
+# CONTROL: a store INSIDE the window satisfies. Without this the refusal below
+# would be satisfied by a gate that never counts any store at all.
+N11C="$(newtmp)"; _n11_fix "$N11C" "2026-05-10T10:00:00Z"
+_run "$N11C" --gate phase_2_to_3; n11_ctrl=$GISSUES
+n11_ctrl_sat=$(grep -c 'accumulation: satisfied' <<< "$GOUT")
+
+N11="$(newtmp)"; _n11_fix "$N11" "2099-01-01T10:00:00Z"
+_run "$N11" --gate phase_2_to_3; n11_issues=$GISSUES; n11_out=$GOUT
+n11_sat=$(grep -c 'accumulation: satisfied' <<< "$n11_out")
+n11_named=$(grep -c 'records a store dated in the FUTURE' <<< "$n11_out")
+if [ "$n11_ctrl_sat" -lt 1 ]; then
+  fail_ "N11 (meta)" "the in-window CONTROL did not satisfy (issues=$n11_ctrl); the fixture never reaches the arm, so refusing a future store proves nothing"
+elif [ "$n11_sat" -eq 0 ] && [ "$n11_issues" -gt "$n11_ctrl" ] && [ "$n11_named" -ge 1 ]; then
+  pass "N11: a store timestamp dated in the FUTURE does not satisfy the gate ($n11_ctrl -> $n11_issues) and the transcript NAMES the clock as the cause — re-storing will not help while the machine that wrote it is ahead"
+else
+  fail_ "N11" "future store: satisfied=$n11_sat (want 0); issues=$n11_issues (control $n11_ctrl); cause-named=$n11_named"
+fi
+
 # A14 — the corrupt-ledger downgrade must not be SILENT. A11 pins that it does
 # not block; nothing pinned that the operator is told, and for a project whose
 # ONLY declaration is the ledger that downgrade turns enforcement off.
@@ -1307,6 +1383,12 @@ else
   fail_ "A14" "no skip notice: $(echo "$GOUT" | grep -i accumulation | head -c 180)"
 fi
 
+# NOTE ON THE DATE BELOW: it must be in the PAST. This fixture reaches the
+# SATISFIED arm, and `# BL-233-WPB-STORE-FUTURE` now refuses a store timestamp
+# dated after today (UTC) — so the original `2026-09-01` stopped reaching the
+# arm the moment that guard landed, and D14's own floor caught it. A test whose
+# fixture leans on a hole goes red when the hole closes, which is the point of
+# having the floor.
 # D14 — the WIDTH of the stripped class is load-bearing, and only a literal
 # find-string in M16 defended it. Narrowing the class to newline alone passes the
 # whole suite while leaving CR and ESC alive — and an ESC-bracket-2-K erase plus
@@ -1316,7 +1398,7 @@ fi
 # PR-blocking checks every time."
 D14="$(newtmp)"; mk_proj "$D14" 3; want_qdrant "$D14"; source_commit "$D14"
 jq -n '{mcp_accumulation:{store_success_count:1,
-        last_store_at:"2026-09-01\u001b[2K\r  [OK] Phase 3 review gate: FORGED-BY-ESC",
+        last_store_at:"2026-04-01\u001b[2K\r  [OK] Phase 3 review gate: FORGED-BY-ESC",
         attestations:{}}}' > "$D14/.claude/process-state.json"
 d14_raw=$( ( cd "$D14" && HOME="$D14/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) )
 d14_ctl=$(printf '%s' "$d14_raw" | LC_ALL=C tr -dc '\001-\010\013\014\016-\037' | wc -c | tr -d ' ')
@@ -1571,12 +1653,24 @@ mkdir -p "$H4/src" "$H4/tests"
 echo "print(1)" > "$H4/src/main.py"
 echo "def test_main(): pass" > "$H4/tests/test_main.py"
 ( cd "$H4" && git add -A >/dev/null 2>&1 )
-h4_out=$( ( cd "$H4" && printf '%s' "$h1_payload" | HOME="$H4/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
-if ! echo "$h4_out" | grep -q 'Nothing has been stored to Qdrant' \
-   && ! echo "$h4_out" | grep -q '"permissionDecision": *"deny"'; then
-  pass "H4: a store INSIDE the window silences the commit-time warning — the date compare is exercised in both directions, not just the firing one"
+h4_out=$( ( cd "$H4" && printf '%s' "$h1_payload" | HOME="$H4/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ); echo "H4RC=$?" )
+h4_rc=$(printf '%s\n' "$h4_out" | sed -n 's/^H4RC=//p' | tail -1)
+h4_out=$(printf '%s\n' "$h4_out" | grep -v '^H4RC=' | _strip_ansi)
+h4_warned=$(grep -c 'Nothing has been stored to Qdrant' <<< "$h4_out")
+h4_denied=$(grep -c '"permissionDecision": *"deny"' <<< "$h4_out")
+# THE EXIT CODE IS THE FLOOR, and its absence had a measured consequence. This
+# was a pure DOUBLE ABSENCE — no warning, no deny — which a hook that DIED and
+# printed nothing satisfies exactly as well as one that correctly stayed quiet.
+# `scripts/pre-commit-gate.sh` is `set -euo pipefail`, and an unguarded `jq` in
+# the accumulation block aborted it on any project with an unparseable
+# phase-state.json, discarding every warning the hook had collected. The suite
+# stayed 94/0 with that bug present AND with it fixed: nothing discriminated.
+if [ "$h4_rc" != "0" ]; then
+  fail_ "H4 (meta)" "the commit gate exited $h4_rc — a hook that died also produces 'no warning', so silence proves nothing"
+elif [ "$h4_warned" -eq 0 ] && [ "$h4_denied" -eq 0 ]; then
+  pass "H4: a store INSIDE the window silences the commit-time warning while the hook still exits 0 — the date compare is exercised in both directions, and silence is distinguished from death"
 else
-  fail_ "H4" "warned despite a store inside the window: $(echo "$h4_out" | head -c 200)"
+  fail_ "H4" "warned=$h4_warned denied=$h4_denied despite a store inside the window: $(echo "$h4_out" | head -c 200)"
 fi
 
 # ══ I. The clone round trip — the test that was missing ═══════════════════
@@ -2527,6 +2621,114 @@ elif [ "$h7_warned" -ge 1 ]; then
   pass "H7: a gate date that is RECORDED but will not parse warns at commit time too — the half that warns is no longer silent on a path the half that blocks now refuses"
 else
   fail_ "H7" "unparseable window: commit-gate warned=$h7_warned (want >=1), control warned=$h7_ctrl_warned"
+fi
+
+# M26 — put the block back AHEAD of the escape and N10's second half dies. This
+# is the mutant for a usability property rather than a security one, and it is
+# here because the reverse edit is the natural one: returning early reads as
+# tighter, and it is how this arm was first written.
+if _mk_mutant_repo "M26" "scripts/check-phase-gate.sh" "# BL-233-WPB-WINDOW-ATTESTABLE" \
+      '    _accum_window_bad=1   # BL-233-WPB-WINDOW-ATTESTABLE' \
+      '    return 1              # BL-233-WPB-WINDOW-ATTESTABLE'; then
+  M26F="$(newtmp)"; mk_proj "$M26F" 3; want_qdrant "$M26F"; source_commit "$M26F"
+  _set_gate "$M26F" phase_1_to_2 "2099-12-31"
+  M26G="$(newtmp)"; mk_proj "$M26G" 3; want_qdrant "$M26G"; source_commit "$M26G"
+  _set_gate "$M26G" phase_1_to_2 "2099-12-31"
+  _m26_run() {   # _m26_run SCRIPT FIXTURE
+    ( cd "$2" && HOME="$2/home" SOLO_MCP_ACCUM_ATTESTED=1 \
+      SOLO_MCP_ACCUM_ATTESTED_REASON="the release box clock is ahead" \
+      bash "$1" --gate phase_2_to_3 2>&1 ) | _strip_ansi | grep -c 'accumulation: ATTESTED'
+  }
+  m26_mut=$(_m26_run "$MUT_ROOT/scripts/check-phase-gate.sh" "$M26F")
+  m26_ctrl=$(_m26_run "$CPG" "$M26G")
+  if [ "$m26_ctrl" -ge 1 ] && [ "$m26_mut" -eq 0 ]; then
+    pass "M26: returning early instead of flagging puts the block ahead of the escape and an honest operator has no way past it ($m26_ctrl -> $m26_mut) — N10's second half measures the escape, not the exit code"
+  else
+    fail_ "M26" "control attested=$m26_ctrl (want >=1), mutant attested=$m26_mut (want 0)"
+  fi
+fi
+
+# M27 — neuter the store-timestamp future check and the silent, permanent
+# satisfaction returns. N11 asserts an ABSENCE (no "satisfied" line), which an
+# unimplemented guard also satisfies; this is what makes N11 discriminate.
+if _mk_mutant_repo "M27" "scripts/check-phase-gate.sh" "# BL-233-WPB-STORE-FUTURE" \
+      '  if [ "$a" -gt "$today_utc" ]; then _ACCUM_STORE_FUTURE=1; return 1; fi   # BL-233-WPB-STORE-FUTURE' \
+      '  :   # BL-233-WPB-STORE-FUTURE'; then
+  M27F="$(newtmp)"; _n11_fix "$M27F" "2099-01-01T10:00:00Z"
+  M27G="$(newtmp)"; _n11_fix "$M27G" "2099-01-01T10:00:00Z"
+  m27_mut=$( ( cd "$M27F" && HOME="$M27F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m27_ctrl=$( ( cd "$M27G" && HOME="$M27G/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  m27_m=$(grep -c 'accumulation: satisfied' <<< "$m27_mut")
+  m27_c=$(grep -c 'accumulation: satisfied' <<< "$m27_ctrl")
+  if [ "$m27_m" -ge 1 ] && [ "$m27_c" -eq 0 ]; then
+    pass "M27: removing the refusal lets a store dated 2099 satisfy the gate again ($m27_c -> $m27_m) — and it would do so on every later run, from a value that is committed to the repo"
+  else
+    fail_ "M27" "mutant satisfied=$m27_m (want >=1), control satisfied=$m27_c (want 0)"
+  fi
+fi
+
+# H8 — AN UNPARSEABLE phase-state.json MUST NOT KILL THE HOOK. This file is
+# `set -euo pipefail`, and the accumulation block's `jq` read of .current_phase
+# had no `|| printf '0'` while both siblings below it did. On the PreToolUse
+# path that abort discards the ENTIRE $WARNINGS accumulator — Context7,
+# qdrant-find, TDD — silently, for a reason unrelated to any of them. The block
+# has no `[ -f "$TOOL_USAGE" ]` precondition, so this PR made the abort
+# reachable for any project whose state file will not parse.
+#
+# The assertion is the SURVIVAL OF AN UNRELATED WARNING, not the exit code
+# alone: a hook can exit 0 having produced nothing at all.
+H8="$(newtmp)"; mk_proj "$H8" 2; add_origin "$H8"; want_qdrant "$H8"; ledger "$H8" true
+cat > "$H8/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true}}
+J
+mkdir -p "$H8/src" "$H8/tests"
+echo "print(1)" > "$H8/src/main.py"
+echo "def test_main(): pass" > "$H8/tests/test_main.py"
+( cd "$H8" && git add -A >/dev/null 2>&1 )
+# CONTROL first, on a HEALTHY state file: the unrelated warning must be
+# producible on this fixture at all.
+h8_ctrl=$( ( cd "$H8" && printf '%s' "$h1_payload" | HOME="$H8/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+h8_ctrl_other=$(grep -c 'No prior context retrieved from Qdrant this session' <<< "$h8_ctrl")
+# Now corrupt it — one stray comma, the shape a half-written file leaves.
+python3 - "$H8/.claude/phase-state.json" <<'PYH8'
+import io,sys
+f=sys.argv[1]; s=io.open(f,encoding="utf-8").read()
+io.open(f,"w",encoding="utf-8").write(s.replace('"track":"light"', '"track":"light",,,'))
+PYH8
+h8_raw=$( ( cd "$H8" && printf '%s' "$h1_payload" | HOME="$H8/home" SKIP_LINT=1 bash "$COMMIT_GATE" 2>&1 ); echo "H8RC=$?" )
+h8_rc=$(printf '%s\n' "$h8_raw" | sed -n 's/^H8RC=//p' | tail -1)
+h8_out=$(printf '%s\n' "$h8_raw" | grep -v '^H8RC=' | _strip_ansi)
+h8_other=$(grep -c 'No prior context retrieved from Qdrant this session' <<< "$h8_out")
+# WHAT IS AND IS NOT CLAIMED. The unrelated warnings this fixture produces are
+# gated on `current_phase == 2`, and with the state file unreadable the phase is
+# unknown — so they correctly do NOT fire, and asserting their survival would be
+# asserting a bug. The claim is narrower and is the one that matters: the hook
+# RUNS TO COMPLETION instead of being killed by errexit partway through. The
+# control proves the fixture is otherwise live, and M28 supplies the other
+# direction by measuring rc=5 without the guard.
+if [ "$h8_ctrl_other" -lt 1 ]; then
+  fail_ "H8 (meta)" "the healthy-state CONTROL produced no warning at all, so this fixture is not exercising the hook and 'it survived' proves nothing"
+elif [ "$h8_rc" = "0" ]; then
+  pass "H8: an unparseable phase-state.json leaves the commit hook ALIVE (rc=$h8_rc) instead of killing it under errexit partway through — the phase-gated warnings correctly stay quiet because the phase is unknown, but nothing else in the file is silently disabled (M28 measures the rc=5 the unguarded form produces)"
+else
+  fail_ "H8" "corrupt state file killed the hook: rc=$h8_rc (want 0); control warning=$h8_ctrl_other"
+fi
+
+# M28 — remove the guard and the hook dies on a corrupt state file, taking every
+# warning with it. H8 asserts survival, which an unguarded tree also shows if the
+# abort happens to be unreachable; this proves it is reachable.
+if _mk_mutant_repo "M28" "scripts/pre-commit-gate.sh" "# BL-233-WPB-ACCPHASE-GUARD" \
+      "  ACC_PHASE=\$(jq -r '.current_phase // 0' \"\$PHASE_STATE\" 2>/dev/null || printf '0')   # BL-233-WPB-ACCPHASE-GUARD" \
+      "  ACC_PHASE=\$(jq -r '.current_phase // 0' \"\$PHASE_STATE\" 2>/dev/null)   # BL-233-WPB-ACCPHASE-GUARD"; then
+  m28_raw=$( ( cd "$H8" && printf '%s' "$h1_payload" | HOME="$H8/home" SKIP_LINT=1 bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ); echo "M28RC=$?" )
+  m28_rc=$(printf '%s\n' "$m28_raw" | sed -n 's/^M28RC=//p' | tail -1)
+  m28_other=$(printf '%s\n' "$m28_raw" | grep -c 'No prior context retrieved from Qdrant this session')
+  if [ "$m28_rc" != "0" ]; then
+    pass "M28: without the guard a corrupt phase-state.json aborts the hook (rc=$m28_rc) and every warning it had collected is discarded — H8 measures survival, not the absence of one message"
+  else
+    fail_ "M28" "mutant rc=$m28_rc (want non-zero); the abort is not reachable, so H8 proves nothing"
+  fi
 fi
 
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -197,6 +197,27 @@ M
     git init -q -b main . >/dev/null 2>&1 || { git init -q . >/dev/null 2>&1; git checkout -q -b main >/dev/null 2>&1; }
     git config user.email "t@e.x"
     git config user.name "Test Owner"
+
+    # ── FORCE THE IGNORE CONDITION, NEVER INHERIT IT ──────────────────────
+    # This is where the suite previously diverged local-vs-CI, and it did so in
+    # the very tests written to close a `## BL-234:` defect. This Mac's
+    # ~/.config/git/ignore carries `**/.claude/settings.local.json` (Claude Code
+    # writes it there itself); an ubuntu runner has no such file. The fixture
+    # ignore rules were being written AFTER the first `git add -A`, so on the
+    # Mac the file was skipped and on CI it was committed — I2a/I2b then
+    # measured two different projects and CI went red.
+    #
+    # Both halves are now forced: core.excludesFile points at a fixture-owned
+    # (empty) file so the host's global excludes cannot reach in from either
+    # direction, and the project .gitignore below is the sole authority. It is
+    # written BEFORE any staging.
+    : > "$d/.git/fixture-excludes"
+    git config core.excludesFile "$d/.git/fixture-excludes"
+    cat > .gitignore <<'GITIG'
+.claude/settings.local.json
+.claude/tool-usage.json
+GITIG
+
     echo "readme" > README.md
     git add -A >/dev/null 2>&1
     git commit -qm "docs: initial" >/dev/null 2>&1
@@ -393,6 +414,50 @@ else
   fail_ "A6" "expected a 'CANNOT BE VERIFIED ... jq is unavailable' line; got: $(echo "$a6_out" | grep -i 'accumulation' || echo '<no accumulation line>')"
 fi
 
+# A7 — the LEGACY / BROWNFIELD-ADOPTED environment: a project whose scripts/lib
+# predates accumulation.sh. Hard-failing here was the first attempt and it
+# killed the ENTIRE phase gate for a feature the project never opted into —
+# measured as three red suites (walk-phase-lifecycle, brownfield-wp3-adoption-arms,
+# brownfield-wp3-regenerate-path), all of which model exactly that population.
+# The arm must go unavailable and SAY SO without counting, while every other
+# check in the gate keeps running.
+A7="$(newtmp)"; mk_proj "$A7" 3; want_qdrant "$A7"; source_commit "$A7"
+A7SCRIPTS="$(newtmp)/scripts"
+mkdir -p "$A7SCRIPTS"
+cp -R "$REPO_ROOT/scripts/." "$A7SCRIPTS/" 2>/dev/null
+rm -f "$A7SCRIPTS/lib/accumulation.sh"
+a7_out=$( ( cd "$A7" && HOME="$A7/home" bash "$A7SCRIPTS/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+a7_issues=$(_num "$(printf '%s\n' "$a7_out" | sed -n 's/^\([0-9][0-9]*\) inconsistency(ies) found.*/\1/p' | tail -1)")
+# The control: the SAME fixture with the lib present blocks (so the fixture is
+# one the gate would otherwise have an opinion about).
+_run "$A7" --gate phase_2_to_3; a7_with_lib=$GISSUES
+if echo "$a7_out" | grep -q "accumulation: NOT CHECKED" \
+   && echo "$a7_out" | grep -q "sync-framework" \
+   && echo "$a7_out" | grep -q "inconsistency(ies) found" \
+   && [ "$a7_issues" -eq $((a7_with_lib - 1)) ]; then
+  pass "A7: with scripts/lib/accumulation.sh absent the arm reports NOT CHECKED, names the remedy, does NOT count, and the rest of the gate still runs to a verdict ($a7_issues vs $a7_with_lib with the lib)"
+else
+  fail_ "A7" "issues=$a7_issues (want $((a7_with_lib - 1))); ran-to-verdict=$(echo "$a7_out" | grep -c 'inconsistency(ies) found'); line: $(echo "$a7_out" | grep -i 'accumulation' | head -1)"
+fi
+
+# A8 — the same environment for the COMMIT gate: the accumulation warning
+# no-ops, and every other gate in that file still runs. A bare `source` here
+# exited before ANY check ran (remote, TDD, Build Loop), which is total silent
+# non-enforcement — the class `## BL-233:` exists to remove.
+A8="$(newtmp)"; mk_proj "$A8" 2
+A8SCRIPTS="$(newtmp)/scripts"
+mkdir -p "$A8SCRIPTS"
+cp -R "$REPO_ROOT/scripts/." "$A8SCRIPTS/" 2>/dev/null
+rm -f "$A8SCRIPTS/lib/accumulation.sh"
+a8_out=$( ( cd "$A8" && HOME="$A8/home" printf '%s' '{"tool_name":"Bash","tool_input":{"command":"git commit -m \"chore: x\""}}' \
+  | bash "$A8SCRIPTS/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+if ! echo "$a8_out" | grep -q "No such file or directory" \
+   && echo "$a8_out" | grep -q '"permissionDecision"'; then
+  pass "A8: with the lib absent the commit gate still reaches a real decision instead of dying at its source line — the other gates in that file are not collateral"
+else
+  fail_ "A8" "got: $(echo "$a8_out" | head -c 200)"
+fi
+
 # ══ B. The satisfaction window is durable and phase-scoped ════════════════
 echo ""
 echo "B. satisfaction window (durable, since the previous gate)"
@@ -518,10 +583,10 @@ else
 fi
 
 D4="$(newtmp)"; mk_proj "$D4" 3; want_qdrant "$D4"; source_commit "$D4"
-cat > "$D4/.claude/process-state.json" <<'J'
-{"mcp_accumulation":{"store_success_count":0,"last_store_at":null,
- "attestations":{"phase_2_to_3":{"reason":"prior recorded exception","date":"2026-03-02","by":"Test Owner"}}}}
-J
+d4_head=$( cd "$D4" && git rev-parse HEAD )
+jq -n --arg h "$d4_head" '{mcp_accumulation:{store_success_count:0,last_store_at:null,
+  attestations:{phase_2_to_3:{reason:"prior recorded exception",date:"2026-03-02",by:"Test Owner",head:$h}}}}' \
+  > "$D4/.claude/process-state.json"
 _run "$D4" --gate phase_2_to_3; d4_issues=$GISSUES; d4_out="$GOUT"
 if [ "$d4_issues" -eq "$c1_base" ] && echo "$d4_out" | grep -q "accumulation: ATTESTED"; then
   pass "D4: an attestation already on record clears the gate without re-supplying the env vars (idempotent across runs)"
@@ -544,10 +609,65 @@ d5_head=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.head // ""' "$D5/.c
     && git add -A >/dev/null 2>&1 && git commit -qm "feat: more source" >/dev/null 2>&1 )
 _run "$D5" --gate phase_2_to_3; d5_second=$GISSUES; d5_out="$GOUT"
 if [ "$d5_first" -eq "$c1_base" ] && [ -n "$d5_head" ] && [ "$d5_second" -eq $((c1_base + 1)) ] \
-   && echo "$d5_out" | grep -q "does not excuse that work"; then
+   && echo "$d5_out" | grep -q "no longer covers this tree"; then
   pass "D5: the attestation records the commit it excused ($d5_head) and goes STALE when source work lands after it — an escape that never expires is a permanent bypass"
 else
   fail_ "D5" "first=$d5_first (want $c1_base) head='$d5_head' second=$d5_second (want $((c1_base + 1)))"
+fi
+
+# D6 — an attestation whose `head` cannot be resolved must be treated as STALE,
+# LOUDLY. The first version of the staleness check returned "still valid" for an
+# empty, malformed, tampered or garbage-collected head, so any unresolvable
+# value silently restored the permanent bypass the check was added to remove —
+# reachable by editing one JSON field, or by an ordinary `git gc --prune=now`.
+# Its twin _cpg_accum_source_work fails CLOSED on the identical question.
+for _d6 in 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' '' 'not-a-sha'; do
+  D6="$(newtmp)"; mk_proj "$D6" 3; want_qdrant "$D6"; source_commit "$D6"
+  jq -n --arg h "$_d6" '{mcp_accumulation:{store_success_count:0,last_store_at:null,
+    attestations:{phase_2_to_3:{reason:"tampered",date:"2026-03-02",by:"T",head:$h}}}}' \
+    > "$D6/.claude/process-state.json"
+  _run "$D6" --gate phase_2_to_3
+  if [ "$GISSUES" -eq $((c1_base + 1)) ] && echo "$GOUT" | grep -q "no longer covers this tree"; then
+    :
+  else
+    fail_ "D6[head='$_d6']" "expected a BLOCK and a stale warning; issues=$GISSUES"
+    _d6_bad=1
+  fi
+done
+# A record with NO head key at all — the shape a pre-staleness attestation has.
+D6B="$(newtmp)"; mk_proj "$D6B" 3; want_qdrant "$D6B"; source_commit "$D6B"
+cat > "$D6B/.claude/process-state.json" <<'J'
+{"mcp_accumulation":{"store_success_count":0,"last_store_at":null,
+ "attestations":{"phase_2_to_3":{"reason":"legacy, no head","date":"2026-03-02","by":"T"}}}}
+J
+_run "$D6B" --gate phase_2_to_3
+if [ -z "${_d6_bad:-}" ] && [ "$GISSUES" -eq $((c1_base + 1)) ] && echo "$GOUT" | grep -q "no longer covers this tree"; then
+  pass "D6: an unresolvable, tampered, empty or absent attestation head FAILS CLOSED and says so — 'could not measure' never resolves to 'nothing to measure' (# BL-112-SAST-NOTRUN)"
+else
+  fail_ "D6" "a headless record did not fail closed: issues=$GISSUES"
+fi
+
+# D7 — re-attesting with the SAME reason must refresh the record. The staleness
+# WARN tells the operator to re-attest; before this, doing exactly that was a
+# no-op, because the idempotence early-return compared only the reason. Escaping
+# then required inventing a NEW reason string — an incentive to write junk
+# reasons, which is the shape `## BL-149:` deletes.
+D7="$(newtmp)"; mk_proj "$D7" 3; want_qdrant "$D7"; source_commit "$D7"
+_run_env "$D7" SOLO_MCP_ACCUM_ATTESTED=1 "SOLO_MCP_ACCUM_ATTESTED_REASON=same reason throughout" \
+  -- --gate phase_2_to_3
+d7_head1=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.head // ""' "$D7/.claude/process-state.json")
+( cd "$D7" && unset GITHUB_BASE_REF && mkdir -p src && echo "x" > src/more.py \
+    && git add -A >/dev/null 2>&1 && git commit -qm "feat: more" >/dev/null 2>&1 )
+# the remedy the WARN advises, verbatim: same reason, again
+_run_env "$D7" SOLO_MCP_ACCUM_ATTESTED=1 "SOLO_MCP_ACCUM_ATTESTED_REASON=same reason throughout" \
+  -- --gate phase_2_to_3
+d7_head2=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.head // ""' "$D7/.claude/process-state.json")
+# and it must now STICK on a plain re-run with no env vars
+_run "$D7" --gate phase_2_to_3; d7_third=$GISSUES
+if [ -n "$d7_head1" ] && [ "$d7_head1" != "$d7_head2" ] && [ "$d7_third" -eq "$c1_base" ]; then
+  pass "D7: re-attesting with the SAME reason refreshes the recorded commit ($d7_head1 -> $d7_head2) and the gate then stays clear — the advised remedy is not a no-op"
+else
+  fail_ "D7" "head1='$d7_head1' head2='$d7_head2' third-run issues=$d7_third (want $c1_base)"
 fi
 
 # ══ E. Gate scoping ═══════════════════════════════════════════════════════
@@ -726,6 +846,58 @@ else
 fi
 
 
+# H3 — the commit-time warning on the path the FIX creates. In a clone of a
+# project scaffolded by init.sh the manifest is the ONLY declaration, and the
+# warning's requirement loop used to read settings*.json and the ledger but not
+# the manifest — so the phase gate blocked and the warning said nothing, on
+# exactly the projects the manifest fix produces. "Warn at commit, block at the
+# phase gate" with the warn half missing is worse than no warning at all.
+H3="$(newtmp)"; mk_proj "$H3" 2; add_origin "$H3"
+cat > "$H3/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true}}
+J
+jq -n '{mcp:{qdrant_required:true}}' > "$H3/.claude/manifest.json"
+mkdir -p "$H3/src" "$H3/tests"
+echo "print(1)" > "$H3/src/main.py"
+echo "def test_main(): pass" > "$H3/tests/test_main.py"
+( cd "$H3" && git add -A >/dev/null 2>&1 )
+h3_settings_absent=1
+[ -f "$H3/.claude/settings.local.json" ] && h3_settings_absent=0
+h3_out=$( ( cd "$H3" && HOME="$H3/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+if [ "$h3_settings_absent" -eq 1 ] && echo "$h3_out" | grep -q 'Nothing has been stored to Qdrant' \
+   && ! echo "$h3_out" | grep -q '"permissionDecision": *"deny"'; then
+  pass "H3: with the TRACKED manifest as the only declaration — the shape a clone of a scaffolded project has — the commit-time warning still fires, so the warn half is not missing exactly where the fix applies"
+else
+  fail_ "H3" "settings.local absent=$h3_settings_absent; got: $(echo "$h3_out" | head -c 200)"
+fi
+
+# H4 — the OTHER direction of the commit-time window. H1/H3 only ever assert
+# that the warning FIRES; nothing asserted it stays SILENT when a store is
+# genuinely inside the window. That half is what makes the warning trustworthy
+# rather than constant noise, and the date compare it depends on is the one
+# predicate the library did NOT unify — so it is the most likely to drift.
+H4="$(newtmp)"; mk_proj "$H4" 2; add_origin "$H4"
+cat > "$H4/.claude/process-state.json" <<'J'
+{"build_loop":{"feature":null,"step":0,"steps_completed":[],"started_at":null},
+ "phase2_init":{"steps_completed":[],"verified":true}}
+J
+jq -n '{mcp:{qdrant_required:true}}' > "$H4/.claude/manifest.json"
+# gates.phase_1_to_2 is 2026-02-01 in mk_proj; this store is after it.
+jq '.mcp_accumulation = {store_success_count: 1, last_store_at: "2026-02-15T10:00:00Z", attestations: {}}' \
+  "$H4/.claude/process-state.json" > "$H4/.claude/ps.tmp" && mv "$H4/.claude/ps.tmp" "$H4/.claude/process-state.json"
+mkdir -p "$H4/src" "$H4/tests"
+echo "print(1)" > "$H4/src/main.py"
+echo "def test_main(): pass" > "$H4/tests/test_main.py"
+( cd "$H4" && git add -A >/dev/null 2>&1 )
+h4_out=$( ( cd "$H4" && HOME="$H4/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+if ! echo "$h4_out" | grep -q 'Nothing has been stored to Qdrant' \
+   && ! echo "$h4_out" | grep -q '"permissionDecision": *"deny"'; then
+  pass "H4: a store INSIDE the window silences the commit-time warning — the date compare is exercised in both directions, not just the firing one"
+else
+  fail_ "H4" "warned despite a store inside the window: $(echo "$h4_out" | head -c 200)"
+fi
+
 # ══ I. The clone round trip — the test that was missing ═══════════════════
 echo ""
 echo "I. tracked-vs-untracked declaration (the fresh-clone question)"
@@ -739,10 +911,9 @@ echo "I. tracked-vs-untracked declaration (the fresh-clone question)"
 # is the ## BL-234: divergence class all over again.
 mk_clone_pair() {
   local d="$1"
-  cat > "$d/.gitignore" <<'G'
-.claude/settings.local.json
-.claude/tool-usage.json
-G
+  # The ignore rules live in mk_proj now, written before the first `git add -A`.
+  # Writing them here was one step too late: source_commit had already staged
+  # settings.local.json on any host without a matching global exclude.
   ( cd "$d" || exit 1
     unset GITHUB_BASE_REF
     git add -A >/dev/null 2>&1
@@ -828,19 +999,65 @@ else
 fi
 
 j2=$(_j_case "docs/notes.md")
-j3=$(_j_case "config/app.yml")
-if [ "$j2" = "exempt" ] && [ "$j3" = "exempt" ]; then
-  pass "J2: documentation and config are still exempt — the inversion did not turn every commit into source work (## BL-149: a gate nobody can satisfy gets deleted)"
+j2b=$(_j_case "package.json")
+if [ "$j2" = "exempt" ] && [ "$j2b" = "exempt" ]; then
+  pass "J2: documentation and project metadata are exempt — the inversion did not turn every commit into source work (## BL-149: a gate nobody can satisfy gets deleted)"
 else
-  fail_ "J2" "docs=$j2 config=$j3, expected both exempt"
+  fail_ "J2" "docs=$j2 metadata=$j2b, expected both exempt"
 fi
 
-j4=$(_j_case "Cargo.lock")
-j5=$(_j_case "go.sum")
-if [ "$j4" = "exempt" ] && [ "$j5" = "exempt" ]; then
-  pass "J3: dependency manifests are exempt — a lockfile bump is not an insight, and demanding a store for one is the shape BL-149 deletes"
+# J2c — INFRASTRUCTURE AS CODE IS SOURCE WORK. A blanket `\.(json|yml|yaml|toml)$`
+# exemption meant an entire Kubernetes, Helm, Ansible or OpenAPI phase counted
+# as "nothing owed" and the gate SAID SO — "every change was documentation,
+# config or a dependency manifest" — which is the allow-list defect J1 exists
+# for, with YAML substituted for Ruby. The exemption is now by metadata
+# BASENAME, so an unrecognised .yml fails CLOSED.
+j2c_fail=""
+for _infra in "docker-compose.yml" "k8s/deployment.yaml" "helm/values.yaml" \
+              "ansible/site.yml" "openapi.yaml" ".github/workflows/ci.yml" "Dockerfile"; do
+  v=$(_j_case "$_infra")
+  [ "$v" = "BLOCKED" ] || j2c_fail="$j2c_fail $_infra($v)"
+done
+if [ -z "$j2c_fail" ]; then
+  pass "J2c: infrastructure-as-code (compose, k8s, Helm, Ansible, OpenAPI, CI, Dockerfile) counts as SOURCE work — an unrecognised structured-data file fails closed instead of silently voiding the gate"
 else
-  fail_ "J3" "Cargo.lock=$j4 go.sum=$j5, expected both exempt"
+  fail_ "J2c" "still exempt:$j2c_fail"
+fi
+
+# The exempt set claims to mirror process-checklist.sh::_is_dep_manifest. The
+# first version listed only SOME of it and drifted on day one: Gemfile.lock,
+# Pipfile.lock, pubspec.lock and requirements_dev.txt were exempt to the
+# Build-Loop classifier and SOURCE to this one. Every entry is now driven,
+# including the four that drifted — a fixture set calibrated to the
+# implementation instead of the rule it cites proves only that the code agrees
+# with itself.
+j3_fail=""
+for _dep in "Cargo.lock" "go.sum" "go.mod" "Gemfile" "Gemfile.lock" "Pipfile" "Pipfile.lock" \
+            "poetry.lock" "yarn.lock" "pubspec.lock" "Package.resolved" "gradle.lockfile" \
+            "requirements.txt" "requirements-dev.txt" "requirements_dev.txt"; do
+  v=$(_j_case "$_dep")
+  [ "$v" = "exempt" ] || j3_fail="$j3_fail $_dep($v)"
+done
+if [ -z "$j3_fail" ]; then
+  pass "J3: every process-checklist.sh::_is_dep_manifest entry is exempt here too, including the four that had drifted — a lockfile bump is not an insight (## BL-149:)"
+else
+  fail_ "J3" "not exempt:$j3_fail"
+fi
+
+# Extension-less config: a negation-based classifier calls these source unless
+# named. A phase whose only commits touched .gitignore would otherwise be told
+# to store an insight it never had.
+j4_fail=""
+for _cfg in ".gitignore" "LICENSE" "CODEOWNERS" ".editorconfig"; do
+  v=$(_j_case "$_cfg")
+  [ "$v" = "exempt" ] || j4_fail="$j4_fail $_cfg($v)"
+done
+# Build logic is deliberately NOT exempt — a Makefile change is real work.
+j4_mk=$(_j_case "Makefile")
+if [ -z "$j4_fail" ] && [ "$j4_mk" = "BLOCKED" ]; then
+  pass "J4: extension-less CONFIG (.gitignore, LICENSE, CODEOWNERS, .editorconfig) is exempt while build logic (Makefile) is not — the negation is bounded deliberately, not accidentally"
+else
+  fail_ "J4" "config not exempt:$j4_fail ; Makefile=$j4_mk (want BLOCKED)"
 fi
 
 # ══ M. Mutation proofs — dual direction, changed>=2 asserted ══════════════
@@ -889,7 +1106,7 @@ _mk_mutant_repo() {
     return 1
   fi
   if [ "$parses" -ne 1 ]; then
-    fail_ "$label (meta)" "mutant does not parse (bash -n) — it would kill every test for the wrong reason"
+    fail_ "$label (meta)" "mutant does not parse (bash -n): $(bash -n "$file" 2>&1 | head -2)"
     return 1
   fi
   MUT_ROOT="$root"
@@ -932,7 +1149,7 @@ if _mk_mutant_repo "M2" "scripts/check-phase-gate.sh" "# BL-233-WPB-SOURCEWORK" 
 fi
 
 # M3 — widen the settings scan to $HOME: A5's host-independence must break.
-if _mk_mutant_repo "M3" "scripts/check-phase-gate.sh" "# BL-233-WPB-SCOPE" \
+if _mk_mutant_repo "M3" "scripts/lib/accumulation.sh" "# BL-233-WPB-SCOPE" \
       'for _f in ".claude/settings.local.json" ".claude/settings.json"; do   # BL-233-WPB-SCOPE' \
       'for _f in ".claude/settings.local.json" ".claude/settings.json" "$HOME/.claude.json"; do   # BL-233-WPB-SCOPE'; then
   M3F="$(newtmp)"; mk_proj "$M3F" 3; source_commit "$M3F"; want_qdrant_in_home "$M3F"
@@ -1036,12 +1253,21 @@ fi
 # declaration then looks durable, and I2a's warning disappears. This is the
 # mutant for the blocking defect the reviewer found — the gate reported a
 # requirement as project-wide when it was machine-local.
-if _mk_mutant_repo "M9" "scripts/check-phase-gate.sh" "# BL-233-WPB-TRACKED" \
+if _mk_mutant_repo "M9" "scripts/lib/accumulation.sh" "# BL-233-WPB-TRACKED" \
       'git ls-files --error-unmatch -- "$1" >/dev/null 2>&1   # BL-233-WPB-TRACKED' \
       'true   # BL-233-WPB-TRACKED'; then
   M9F="$(newtmp)"; mk_proj "$M9F" 3; want_qdrant "$M9F"; source_commit "$M9F"
+  # POSITIVE CONTROL FIRST. M9 asserts an ABSENCE, and an absence is free: on a
+  # runner the UNMUTATED gate printed no warning either (the fixture reached a
+  # different state), so M9 passed for a reason unrelated to its mutation. That
+  # is the exact defect M7 had just been fixed for, reintroduced here in the
+  # same commit. The control asserts the unmutated gate DOES warn on this very
+  # fixture before the mutant's silence is allowed to mean anything.
+  m9_ctrl=$( ( cd "$M9F" && HOME="$M9F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
   m9_out=$( ( cd "$M9F" && HOME="$M9F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-  if ! echo "$m9_out" | grep -q "git does not track"; then
+  if ! echo "$m9_ctrl" | grep -q "git does not track"; then
+    fail_ "M9 (meta)" "the UNMUTATED gate does not warn on this fixture, so the mutant's silence proves nothing"
+  elif ! echo "$m9_out" | grep -q "git does not track"; then
     pass "M9: assuming trackedness instead of asking git silences the local-only warning — I2a proves the gate now distinguishes 'required here' from 'required everywhere'"
   else
     fail_ "M9" "mutant still warned — I2a would pass either way"
@@ -1051,9 +1277,9 @@ fi
 # M10 — restore the extension ALLOW-LIST the reviewer refuted: a Ruby commit
 # must stop being source work, which is exactly how the gate silently voided
 # itself for whole language families.
-if _mk_mutant_repo "M10" "scripts/check-phase-gate.sh" "# BL-233-WPB-SOURCE-NEGATION" \
-      'if grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$paths"; then   # BL-233-WPB-SOURCE-NEGATION' \
-      'if grep -qE "\.(py|ts|js|rs|go)$" <<< "$paths"; then   # BL-233-WPB-SOURCE-NEGATION'; then
+if _mk_mutant_repo "M10" "scripts/lib/accumulation.sh" "# BL-233-WPB-SOURCE-NEGATION" \
+      'grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$1"   # BL-233-WPB-SOURCE-NEGATION' \
+      'grep -qE "\.(py|ts|js|rs|go)$" <<< "$1"   # BL-233-WPB-SOURCE-NEGATION'; then
   M10F="$(newtmp)"; mk_proj "$M10F" 3; want_qdrant "$M10F"
   ( cd "$M10F" || exit 1
     unset GITHUB_BASE_REF
@@ -1061,8 +1287,15 @@ if _mk_mutant_repo "M10" "scripts/check-phase-gate.sh" "# BL-233-WPB-SOURCE-NEGA
     echo "x" > models/user.rb
     git add -A >/dev/null 2>&1
     git commit -qm "add ruby" >/dev/null 2>&1 )
+  # POSITIVE CONTROL. M10 asserts an ABSENCE on a fixture no unmutated assertion
+  # touches, which is M9's defect exactly — named in review, fixed on M9 only,
+  # and left here. The unmutated gate must BLOCK this fixture before the
+  # mutant's silence is allowed to mean anything.
+  m10_ctrl=$( ( cd "$M10F" && HOME="$M10F/home" bash "$CPG" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
   m10_out=$( ( cd "$M10F" && HOME="$M10F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
-  if ! echo "$m10_out" | grep -q "accumulation: BLOCKED"; then
+  if ! echo "$m10_ctrl" | grep -q "accumulation: BLOCKED"; then
+    fail_ "M10 (meta)" "the UNMUTATED gate does not block this Ruby fixture, so the mutant's silence proves nothing"
+  elif ! echo "$m10_out" | grep -q "accumulation: BLOCKED"; then
     pass "M10: an extension allow-list lets a Ruby-only phase through — J1 proves the negation is what closes that hole, not the [FAIL] text"
   else
     fail_ "M10" "mutant still blocked — J1 would pass either way"
@@ -1072,8 +1305,8 @@ fi
 
 # M11 — neuter the staleness check: the attestation becomes permanent again.
 if _mk_mutant_repo "M11" "scripts/check-phase-gate.sh" "# BL-233-WPB-ATTEST-STALE" \
-      'if [ -n "$recorded" ] && [ -n "$recorded_head" ] && _cpg_accum_source_since "$recorded_head"; then' \
-      'if [ -n "$recorded" ] && [ -n "$recorded_head" ] && false; then'; then
+      'if [ -n "$recorded" ] && _cpg_accum_source_since "$recorded_head"; then' \
+      'if [ -n "$recorded" ] && false; then'; then
   M11F="$(newtmp)"; mk_proj "$M11F" 3; want_qdrant "$M11F"; source_commit "$M11F"
   cat > "$M11F/.claude/process-state.json" <<'J'
 {"mcp_accumulation":{"store_success_count":0,"last_store_at":null,
@@ -1101,9 +1334,9 @@ fi
 # BASE TREE also produces (nothing blocks there at all) — measured: they are the
 # only 2 of 48 that pass against `main`. This mutant is what makes them
 # attributable rather than free.
-if _mk_mutant_repo "M12" "scripts/check-phase-gate.sh" "# BL-233-WPB-EXEMPT-SET" \
-      "_ACCUM_EXEMPT_RE='^\$|\\.(md|json|yml|yaml|toml|tmpl)\$|(^|/)(Pipfile|Gemfile|Cargo\\.lock|go\\.(mod|sum)|poetry\\.lock|yarn\\.lock|Package\\.resolved|gradle\\.lockfile|requirements(-[^/]*)?\\.txt)\$'   # BL-233-WPB-EXEMPT-SET" \
-      "_ACCUM_EXEMPT_RE='^ZZZ_NEVER_MATCHES_ZZZ\$'   # BL-233-WPB-EXEMPT-SET"; then
+if _mk_mutant_repo "M12" "scripts/lib/accumulation.sh" "# BL-233-WPB-EXEMPT-SET" \
+      "_ACCUM_EXEMPT_RE='^\$|" \
+      "_ACCUM_EXEMPT_RE='^ZZZ_NEVER_MATCHES\$'; _ACCUM_PARKED='"; then
   M12F="$(newtmp)"; mk_proj "$M12F" 3; want_qdrant "$M12F"
   ( cd "$M12F" || exit 1
     unset GITHUB_BASE_REF
@@ -1116,6 +1349,27 @@ if _mk_mutant_repo "M12" "scripts/check-phase-gate.sh" "# BL-233-WPB-EXEMPT-SET"
     pass "M12: emptying the exempt set makes a docs-only phase BLOCK — J2/J3 are real guards on the inversion, not passes inherited from the base tree"
   else
     fail_ "M12" "mutant did not block the docs-only phase: issues=$m12_issues, want $((c1_base + 1))"
+  fi
+fi
+
+# M13 — prove pre-commit-gate.sh actually CONSUMES the shared predicate. M10 and
+# M12 mutate the library but assert only on check-phase-gate.sh, so a re-inlined
+# copy inside pre-commit-gate.sh would survive both. This mutant changes the
+# LIBRARY and asserts the COMMIT-TIME warning changes — which is the entire
+# point of the extraction, and was otherwise unpinned.
+if _mk_mutant_repo "M13" "scripts/lib/accumulation.sh" "# BL-233-WPB-SOURCE-NEGATION" \
+      'grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$1"   # BL-233-WPB-SOURCE-NEGATION' \
+      'false   # BL-233-WPB-SOURCE-NEGATION'; then
+  m13_ctrl=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" | bash "$COMMIT_GATE" 2>&1 ) | _strip_ansi )
+  m13_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" \
+    | bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
+  if ! echo "$m13_ctrl" | grep -q 'Nothing has been stored to Qdrant'; then
+    fail_ "M13 (meta)" "the UNMUTATED commit gate does not warn on H1, so the mutant proves nothing"
+  elif ! echo "$m13_out" | grep -q 'Nothing has been stored to Qdrant' \
+       && ! echo "$m13_out" | grep -q '"permissionDecision": *"deny"'; then
+    pass "M13: mutating the LIBRARY silences the COMMIT-TIME warning — pre-commit-gate.sh genuinely consumes the shared predicate rather than carrying a re-inlined copy"
+  else
+    fail_ "M13" "the commit gate did not follow the library: $(echo "$m13_out" | head -c 200)"
   fi
 fi
 echo ""

--- a/tests/test-bl233-wpb-accumulation.sh
+++ b/tests/test-bl233-wpb-accumulation.sh
@@ -35,10 +35,15 @@
 #     NOT ONE of them writes a `.claude/tool-usage.json`. A requirement read
 #     from the ledger would have forced 74 fixture edits to say nothing.
 #
-# `init.sh` writes `.claude/settings.local.json` carrying the
-# `mcpServers.qdrant` entry, `generate_gitignore` ignores only `.claude/cache/`,
-# and the scaffolder's `git add -A` commits it. So the PROJECT ITSELF carries a
-# committed, host-independent declaration, and that is what the gate reads.
+# The first fix for that read `.claude/settings.local.json`, reasoning that
+# `init.sh` writes it and `git add -A` commits it. THAT WAS ALSO WRONG: Claude
+# Code adds that file to the user's GLOBAL git excludes by design, and
+# `generate_gitignore` COPIES templates/generated/gitignore-base.tmpl (which
+# already ignores `.claude/tool-usage.json`) before appending. Both arms were
+# absent from every fresh clone, so the gate blocked on the author's machine and
+# printed NOT CHECKED on CI. The I-group is the round trip that catches it:
+# build, commit, push to a local bare, clone back, and run the gate in the clone.
+# TRACKEDNESS IS ASKED OF GIT (`# BL-233-WPB-TRACKED`), never inferred.
 #
 # A5 IS THE LOAD-BEARING ONE. The derivation reads the two PROJECT-scope
 # settings files ONLY, never `$HOME/.claude.json` — even though
@@ -524,6 +529,27 @@ else
   fail_ "D4" "expected $c1_base issues, got $d4_issues"
 fi
 
+# D5 — an attestation excuses the work it named, not the phase forever.
+# The reviewer's R-360-5: one attested run permanently disabled the boundary,
+# because the recorded reason was read back before the environment was
+# consulted. BL-072's TDD escape is scoped per commit and session-mcp-gate.sh's
+# per session; this is the phase-gate equivalent.
+D5="$(newtmp)"; mk_proj "$D5" 3; want_qdrant "$D5"; source_commit "$D5"
+_run_env "$D5" SOLO_MCP_ACCUM_ATTESTED=1 "SOLO_MCP_ACCUM_ATTESTED_REASON=one-off, nothing novel" \
+  -- --gate phase_2_to_3
+d5_first=$GISSUES
+d5_head=$(jq -r '.mcp_accumulation.attestations.phase_2_to_3.head // ""' "$D5/.claude/process-state.json" 2>/dev/null)
+# NEW source work, and NO environment variables this time.
+( cd "$D5" && unset GITHUB_BASE_REF && mkdir -p src && echo "print(2)" > src/later.py \
+    && git add -A >/dev/null 2>&1 && git commit -qm "feat: more source" >/dev/null 2>&1 )
+_run "$D5" --gate phase_2_to_3; d5_second=$GISSUES; d5_out="$GOUT"
+if [ "$d5_first" -eq "$c1_base" ] && [ -n "$d5_head" ] && [ "$d5_second" -eq $((c1_base + 1)) ] \
+   && echo "$d5_out" | grep -q "does not excuse that work"; then
+  pass "D5: the attestation records the commit it excused ($d5_head) and goes STALE when source work lands after it — an escape that never expires is a permanent bypass"
+else
+  fail_ "D5" "first=$d5_first (want $c1_base) head='$d5_head' second=$d5_second (want $((c1_base + 1)))"
+fi
+
 # ══ E. Gate scoping ═══════════════════════════════════════════════════════
 echo ""
 echo "E. which gates the arm belongs to"
@@ -699,6 +725,124 @@ else
   fail_ "H2" "the commit-time arm denied a commit"
 fi
 
+
+# ══ I. The clone round trip — the test that was missing ═══════════════════
+echo ""
+echo "I. tracked-vs-untracked declaration (the fresh-clone question)"
+
+# mk_clone_pair DIR — a project carrying the REAL generated ignore rules for the
+# two untracked declaration files, committed, pushed to a LOCAL bare, and cloned
+# back out. The ignore rules are written INTO the fixture rather than inherited
+# from the host: this machine's ~/.config/git/ignore already excludes
+# **/.claude/settings.local.json (Claude Code writes that itself), an
+# ubuntu-latest runner's does not, and a fixture that depends on which is true
+# is the ## BL-234: divergence class all over again.
+mk_clone_pair() {
+  local d="$1"
+  cat > "$d/.gitignore" <<'G'
+.claude/settings.local.json
+.claude/tool-usage.json
+G
+  ( cd "$d" || exit 1
+    unset GITHUB_BASE_REF
+    git add -A >/dev/null 2>&1
+    git commit -qm "docs: declarations" >/dev/null 2>&1 )
+  add_origin "$d"
+  local clone="$TOPTMP/$(basename "$d").clone"
+  git clone -q "$TOPTMP/$(basename "$d").origin.git" "$clone" >/dev/null 2>&1 || return 1
+  # BL-234-FIXTURE-CLONE-RECEIPT: a clone's exit code is not proof it checked
+  # anything out — a dangling HEAD symref clones successfully and empty.
+  [ -f "$clone/.claude/phase-state.json" ] || return 1
+  mkdir -p "$clone/home"
+  printf '%s' "$clone"
+}
+
+# I1 — declaration in the TRACKED manifest: the clone must still enforce.
+I1="$(newtmp)"; mk_proj "$I1" 3; want_qdrant "$I1"; source_commit "$I1"
+jq '.mcp = {qdrant_required: true}' <<< '{}' > "$I1/.claude/manifest.json"
+i1_clone=$(mk_clone_pair "$I1")
+if [ -n "$i1_clone" ]; then
+  ( cd "$i1_clone" && git config user.email t@e.x && git config user.name "Test Owner" ) >/dev/null 2>&1
+  _run "$i1_clone" --gate phase_2_to_3; i1_out="$GOUT"
+  i1_tracked=$( cd "$i1_clone" && git ls-files .claude/ | tr '\n' ' ' )
+  if echo "$i1_out" | grep -q "accumulation: BLOCKED"; then
+    pass "I1: a declaration in the TRACKED .claude/manifest.json survives clone->CI and still BLOCKS (clone tracks: $i1_tracked)"
+  else
+    fail_ "I1" "the gate went inert in a fresh clone: $(echo "$i1_out" | grep -i 'accumulation' || echo '<no line>')"
+  fi
+else
+  fail_ "I1 (meta)" "clone fixture did not build"
+fi
+
+# I2 — declaration ONLY in the untracked settings.local.json. On the authoring
+# machine it must ENFORCE and say the enforcement is local-only; in the clone it
+# is genuinely absent, and the gate must say so rather than imply it checked.
+I2="$(newtmp)"; mk_proj "$I2" 3; want_qdrant "$I2"; source_commit "$I2"
+i2_clone=$(mk_clone_pair "$I2")
+_run "$I2" --gate phase_2_to_3; i2_local_out="$GOUT"
+if echo "$i2_local_out" | grep -q "accumulation: BLOCKED" && echo "$i2_local_out" | grep -q "git does not track"; then
+  pass "I2a: an untracked-only declaration still ENFORCES on the authoring machine, and warns in as many words that a clone will not see it"
+else
+  fail_ "I2a" "expected a BLOCK plus an untracked warning; got: $(echo "$i2_local_out" | grep -i 'accumulation' || echo '<no line>')"
+fi
+if [ -n "$i2_clone" ]; then
+  ( cd "$i2_clone" && git config user.email t@e.x && git config user.name "Test Owner" ) >/dev/null 2>&1
+  _run "$i2_clone" --gate phase_2_to_3; i2_out="$GOUT"
+  if echo "$i2_out" | grep -q "NOT CHECKED" && echo "$i2_out" | grep -q "manifest.json"; then
+    pass "I2b: in the clone that declaration is genuinely gone, and the gate says NOT CHECKED and names the fix — the honest report of a real limit, not a silent pass"
+  else
+    fail_ "I2b" "expected NOT CHECKED naming manifest.json; got: $(echo "$i2_out" | grep -i 'accumulation' || echo '<no line>')"
+  fi
+else
+  fail_ "I2b (meta)" "clone fixture did not build"
+fi
+
+# ══ J. Source-work coverage ═══════════════════════════════════════════════
+echo ""
+echo "J. source-work classifier covers languages, by negation"
+
+# _j_case EXT_PATH — one commit of that path onto a fresh fixture; echoes verdict.
+_j_case() {
+  local path="$1" d
+  d="$(newtmp)"; mk_proj "$d" 3 >/dev/null 2>&1; want_qdrant "$d"
+  ( cd "$d" || exit 1
+    unset GITHUB_BASE_REF
+    mkdir -p "$(dirname "$path")" 2>/dev/null
+    echo "x" > "$path"
+    git add -A >/dev/null 2>&1
+    git commit -qm "add $path" >/dev/null 2>&1 )
+  _run "$d" --gate phase_2_to_3
+  if echo "$GOUT" | grep -q "accumulation: BLOCKED"; then printf 'BLOCKED'; else printf 'exempt'; fi
+}
+
+j_fail=""
+for _p in "models/user.rb" "public/index.php" "scripts/deploy.sh" "components/Button.vue" \
+          "web/router.ex" "db/q.sql" "Main.hs" "core.lua" "main.scala" "x.svelte"; do
+  v=$(_j_case "$_p")
+  [ "$v" = "BLOCKED" ] || j_fail="$j_fail $_p($v)"
+done
+if [ -z "$j_fail" ]; then
+  pass "J1: Ruby, PHP, shell, Vue, Elixir, SQL, Haskell, Lua, Scala and Svelte source all count as source work — the allow-list voided this gate for every one of them"
+else
+  fail_ "J1" "still exempt:$j_fail"
+fi
+
+j2=$(_j_case "docs/notes.md")
+j3=$(_j_case "config/app.yml")
+if [ "$j2" = "exempt" ] && [ "$j3" = "exempt" ]; then
+  pass "J2: documentation and config are still exempt — the inversion did not turn every commit into source work (## BL-149: a gate nobody can satisfy gets deleted)"
+else
+  fail_ "J2" "docs=$j2 config=$j3, expected both exempt"
+fi
+
+j4=$(_j_case "Cargo.lock")
+j5=$(_j_case "go.sum")
+if [ "$j4" = "exempt" ] && [ "$j5" = "exempt" ]; then
+  pass "J3: dependency manifests are exempt — a lockfile bump is not an insight, and demanding a store for one is the shape BL-149 deletes"
+else
+  fail_ "J3" "Cargo.lock=$j4 go.sum=$j5, expected both exempt"
+fi
+
 # ══ M. Mutation proofs — dual direction, changed>=2 asserted ══════════════
 echo ""
 echo "M. mutation proofs"
@@ -723,6 +867,13 @@ _mk_mutant_repo() {
   root="$(newtmp)/repo"
   mkdir -p "$root"
   cp -R "$REPO_ROOT/scripts" "$root/scripts" 2>/dev/null
+  # The mutant needs a COMPLETE-ENOUGH tree, not just scripts/. pre-commit-gate.sh
+  # resolves its lints relative to its own directory, and a root with no tests/
+  # and no .github/ makes lint-tests-registered.sh DENY — which silences the
+  # commit-time warning for a reason that has nothing to do with the mutation.
+  # M7 passed that way until its not-denied control was added.
+  ln -s "$REPO_ROOT/tests" "$root/tests" 2>/dev/null
+  ln -s "$REPO_ROOT/.github" "$root/.github" 2>/dev/null
   file="$root/$relfile"
   sites=$(_sites "$file" "$marker")
   if [ "$sites" -ne 1 ]; then
@@ -848,10 +999,17 @@ if _mk_mutant_repo "M7" "scripts/pre-commit-gate.sh" "# BL-233-WPB-COMMIT-WARN" 
       'if [ "$ACC_SATISFIED" = "never" ]; then   # BL-233-WPB-COMMIT-WARN'; then
   m7_out=$( ( cd "$H1" && HOME="$H1/home" printf '%s' "$h1_payload" \
     | bash "$MUT_ROOT/scripts/pre-commit-gate.sh" 2>&1 ) | _strip_ansi )
-  if ! echo "$m7_out" | grep -q 'Nothing has been stored to Qdrant'; then
+  # The NOT-DENIED control is what makes this attributable. Asserting only the
+  # ABSENCE of the warning lets any earlier deny in pre-commit-gate.sh satisfy
+  # the mutant for free — H1 could go red while M7 stayed green. The control
+  # cannot be "an allow envelope is present": with the sole warning suppressed,
+  # WARNINGS is empty and the gate emits NOTHING and exits 0, which is the whole
+  # point of a non-blocking arm.
+  if ! echo "$m7_out" | grep -q 'Nothing has been stored to Qdrant' \
+     && ! echo "$m7_out" | grep -q '"permissionDecision": *"deny"'; then
     pass "M7: neutering the commit-time predicate silences the warning — H1 asserts a message that is actually produced, not one that happens to appear"
   else
-    fail_ "M7" "mutant still warned — H1 would pass either way"
+    fail_ "M7" "expected the warning gone AND no deny; got: $(echo "$m7_out" | head -c 260)"
   fi
 fi
 
@@ -873,6 +1031,93 @@ if _mk_mutant_repo "M8" "scripts/check-phase-gate.sh" "# BL-233-WPB-JQ-FAILCLOSE
   fi
 fi
 
+
+# M9 — make _cpg_file_tracked always answer "tracked": the untracked-only
+# declaration then looks durable, and I2a's warning disappears. This is the
+# mutant for the blocking defect the reviewer found — the gate reported a
+# requirement as project-wide when it was machine-local.
+if _mk_mutant_repo "M9" "scripts/check-phase-gate.sh" "# BL-233-WPB-TRACKED" \
+      'git ls-files --error-unmatch -- "$1" >/dev/null 2>&1   # BL-233-WPB-TRACKED' \
+      'true   # BL-233-WPB-TRACKED'; then
+  M9F="$(newtmp)"; mk_proj "$M9F" 3; want_qdrant "$M9F"; source_commit "$M9F"
+  m9_out=$( ( cd "$M9F" && HOME="$M9F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  if ! echo "$m9_out" | grep -q "git does not track"; then
+    pass "M9: assuming trackedness instead of asking git silences the local-only warning — I2a proves the gate now distinguishes 'required here' from 'required everywhere'"
+  else
+    fail_ "M9" "mutant still warned — I2a would pass either way"
+  fi
+fi
+
+# M10 — restore the extension ALLOW-LIST the reviewer refuted: a Ruby commit
+# must stop being source work, which is exactly how the gate silently voided
+# itself for whole language families.
+if _mk_mutant_repo "M10" "scripts/check-phase-gate.sh" "# BL-233-WPB-SOURCE-NEGATION" \
+      'if grep -qvE "$_ACCUM_EXEMPT_RE" <<< "$paths"; then   # BL-233-WPB-SOURCE-NEGATION' \
+      'if grep -qE "\.(py|ts|js|rs|go)$" <<< "$paths"; then   # BL-233-WPB-SOURCE-NEGATION'; then
+  M10F="$(newtmp)"; mk_proj "$M10F" 3; want_qdrant "$M10F"
+  ( cd "$M10F" || exit 1
+    unset GITHUB_BASE_REF
+    mkdir -p models
+    echo "x" > models/user.rb
+    git add -A >/dev/null 2>&1
+    git commit -qm "add ruby" >/dev/null 2>&1 )
+  m10_out=$( ( cd "$M10F" && HOME="$M10F/home" bash "$MUT_ROOT/scripts/check-phase-gate.sh" --gate phase_2_to_3 2>&1 ) | _strip_ansi )
+  if ! echo "$m10_out" | grep -q "accumulation: BLOCKED"; then
+    pass "M10: an extension allow-list lets a Ruby-only phase through — J1 proves the negation is what closes that hole, not the [FAIL] text"
+  else
+    fail_ "M10" "mutant still blocked — J1 would pass either way"
+  fi
+fi
+
+
+# M11 — neuter the staleness check: the attestation becomes permanent again.
+if _mk_mutant_repo "M11" "scripts/check-phase-gate.sh" "# BL-233-WPB-ATTEST-STALE" \
+      'if [ -n "$recorded" ] && [ -n "$recorded_head" ] && _cpg_accum_source_since "$recorded_head"; then' \
+      'if [ -n "$recorded" ] && [ -n "$recorded_head" ] && false; then'; then
+  M11F="$(newtmp)"; mk_proj "$M11F" 3; want_qdrant "$M11F"; source_commit "$M11F"
+  cat > "$M11F/.claude/process-state.json" <<'J'
+{"mcp_accumulation":{"store_success_count":0,"last_store_at":null,
+ "attestations":{"phase_2_to_3":{"reason":"stale one","date":"2026-03-02","by":"T","head":"HEADSHA"}}}}
+J
+  m11_head=$( cd "$M11F" && git rev-parse HEAD )
+  python3 - "$M11F/.claude/process-state.json" "$m11_head" <<'PYX'
+import io,sys
+f,h=sys.argv[1],sys.argv[2]
+s=io.open(f,encoding="utf-8").read().replace("HEADSHA",h)
+io.open(f,"w",encoding="utf-8").write(s)
+PYX
+  ( cd "$M11F" && unset GITHUB_BASE_REF && mkdir -p src && echo "x" > src/after.py \
+      && git add -A >/dev/null 2>&1 && git commit -qm "feat: after attestation" >/dev/null 2>&1 )
+  m11_issues=$(_mutant_issues "$MUT_ROOT" "$M11F")
+  if [ "$m11_issues" -eq "$c1_base" ]; then
+    pass "M11: without the staleness check the stale attestation clears the gate again — D5 proves the scoping is what expires it"
+  else
+    fail_ "M11" "mutant still blocked: issues=$m11_issues, want $c1_base"
+  fi
+fi
+
+# M12 — empty the exempt set: every commit becomes source work, so a docs-only
+# phase starts demanding a store. J2/J3 assert an "exempt" verdict, which the
+# BASE TREE also produces (nothing blocks there at all) — measured: they are the
+# only 2 of 48 that pass against `main`. This mutant is what makes them
+# attributable rather than free.
+if _mk_mutant_repo "M12" "scripts/check-phase-gate.sh" "# BL-233-WPB-EXEMPT-SET" \
+      "_ACCUM_EXEMPT_RE='^\$|\\.(md|json|yml|yaml|toml|tmpl)\$|(^|/)(Pipfile|Gemfile|Cargo\\.lock|go\\.(mod|sum)|poetry\\.lock|yarn\\.lock|Package\\.resolved|gradle\\.lockfile|requirements(-[^/]*)?\\.txt)\$'   # BL-233-WPB-EXEMPT-SET" \
+      "_ACCUM_EXEMPT_RE='^ZZZ_NEVER_MATCHES_ZZZ\$'   # BL-233-WPB-EXEMPT-SET"; then
+  M12F="$(newtmp)"; mk_proj "$M12F" 3; want_qdrant "$M12F"
+  ( cd "$M12F" || exit 1
+    unset GITHUB_BASE_REF
+    mkdir -p docs
+    echo "notes" > docs/notes.md
+    git add -A >/dev/null 2>&1
+    git commit -qm "docs: notes" >/dev/null 2>&1 )
+  m12_issues=$(_mutant_issues "$MUT_ROOT" "$M12F")
+  if [ "$m12_issues" -eq $((c1_base + 1)) ]; then
+    pass "M12: emptying the exempt set makes a docs-only phase BLOCK — J2/J3 are real guards on the inversion, not passes inherited from the base tree"
+  else
+    fail_ "M12" "mutant did not block the docs-only phase: issues=$m12_issues, want $((c1_base + 1))"
+  fi
+fi
 echo ""
 echo "Results: $PASSED passed, $FAILED failed"
 [ "$FAILED" -eq 0 ]


### PR DESCRIPTION
Closes item 6 of `## BL-233:`. WP-A made the **retrieval** half score outcomes instead of declarations; nothing anywhere required that anything was ever **written** for a later session to retrieve. The entry names the consequence in one line: *a retrieval requirement with no accumulation requirement is a ratchet with nothing behind it.*

## The posture, and why it isn't a per-commit block

**WARN at commit, BLOCK at the phase gate.** Storing is not per-commit work — a commit that produced no insight has nothing to store — so a per-commit block would be a gate people cannot satisfy honestly, and `## BL-149:` is the standing rule that such a gate gets deleted. The phase boundary is where accumulation is genuinely owed, because it is the boundary the memory is supposed to carry across.

It blocks **only** when the phase made source commits and stored nothing. A docs-only or exploratory phase passes clean with no ceremony.

## The window is durable, and it could not have come from the ledger

`session-test-gate-check.sh` **wipes** `.claude/tool-usage.json` on every `startup` (it merges only on resume/compact/clear). A phase spans many sessions, so a ledger-scoped window is satisfiable by one junk store ten seconds before running the gate. The record lives in `.claude/process-state.json::mcp_accumulation`, written by `# BL-233-WPB-ACCUM-WRITE` only on `OUTCOME=success`, under the same mkdir lock as the two existing writers of that file.

## The decision most likely to be re-litigated, measured rather than argued

Reading the requirement from the ledger's `mcp_requirements.qdrant_required` is the obvious answer. It is wrong twice:

- the ledger is **untracked runtime scratch**, so *deleting it* would switch a blocking gate off — `## BL-231:`'s *"tracking file absent ⇒ no enforcement, silently"* row, reintroduced inside the gate meant to end it;
- **measured on this tree:** of the 61 suites that execute `check-phase-gate.sh`, **29** drive it at `current_phase >= 2` across **74** fixture-creation sites, and **not one writes a ledger**. A ledger-derived requirement would have forced 74 fixture edits to say nothing.

`init.sh` instead writes `.claude/settings.local.json` carrying the `mcpServers.qdrant` entry, the generated `.gitignore` covers only `.claude/cache/`, and the scaffolder's `git add -A` commits it — so the declaration is **committed and travels with the repo**. That is what `# BL-233-WPB-SCOPE` reads, with the ledger kept only as an OR arm for a project that adopted Qdrant after init. This removed the fail-open row entirely rather than narrowing it, and needed zero fixture edits.

**`$HOME` is deliberately not read**, though `session-test-gate-check.sh` reads it. Zero of those 29 fixtures redirect `HOME`, so a host-derived verdict passes on a developer box with Qdrant configured and fails on a runner without it — `## BL-234:`'s class exactly. A5 and mutant M3 pin the scope in both directions.

## Two things that look like bugs and are not

- **`-eq`, not `-ge`,** in the dispatch, unlike every sibling check in the file. The siblings are right to use `-ge`: their evidence must exist independently at each boundary. Accumulation windows **nest** — a store satisfying "since `phase_2_to_3`" necessarily satisfies "since `phase_1_to_2`" — so the latest gate's window is strictest and subsumes the rest. With `-ge`, one missing store would count as three inconsistencies and print the same sentence three times.
- **`[NOTE]`, not `[NEXT]`,** on the not-applicable line. `[NEXT]` is reserved in this script for "belongs to a later gate", and `test-bl166-gate-scope.sh` asserts it appears only as the 3→4 scoping line. Using `[NEXT]` broke that suite until it was changed.

## Four more properties, each with a mutant behind it

- source-work is read from **git**, not a hook-maintained counter — `## BL-239:` shipped a hook that was a silent no-op on every commit anyone ever made — and resolves to **BLOCK when it cannot tell** (`# BL-233-WPB-SOURCEWORK`);
- the attested escape is BL-072's shape and is **refused when it cannot be recorded** (`# BL-233-WPB-ATTEST-REFUSE`) — an escape that leaves no trace is the advisory posture this entry exists to replace;
- a missing `jq` **fails closed and names jq** (`# BL-233-WPB-JQ-FAILCLOSED`) rather than reporting a project fact it never read;
- label and verdict are produced together with **one** increment site (`# BL-233-WPB-BLOCK`), so `## BL-104:`'s `[WARN]`/`[FAIL]` trap cannot reopen here.

## Also closes WP-A residual 4

`session-end-qdrant-reminder.sh` counted `.calls | length` and the `*_called` flags, so a **failed** call was reported as a call that happened — it actively disagreed with the gate beside it. It now filters on `.outcome`, reads `qdrant_store_succeeded` (`# BL-233-WPB-OUTCOME`), and **reports** failed round trips instead of omitting them. Rows predating WP-A carry no `.outcome` and are read as success, because the old tracker was registered on `PostToolUse` only — defaulting them to failure would invent failures that never happened.

## Verification

Every number here is derived by the recipe printed beside it. This section has itself been wrong before — an earlier revision claimed 78 assertions and 17 residuals while the branch carried 94 and 21, which under-disclosed four residuals to anyone reading only the PR. `## BL-233:` is the source of truth; this is regenerated from it.

- `tests/test-bl233-wpb-accumulation.sh` — **100 assertions, 28 dual-direction mutants**, every mutant asserting `sites==1` against an end-of-line-anchored marker, `changed >= 2`, and `bash -n`.
  ```
  grep -cE '^[[:space:]]*pass "' tests/test-bl233-wpb-accumulation.sh   # 100
  grep -cE '_mk_mutant_repo "M'  tests/test-bl233-wpb-accumulation.sh   # 28
  ```
- **Watched RED at 2 passed / 101 failed** against merge-base `2344b13` — this suite dropped into a `git archive` of that tree, so it is reproducible rather than remembered. The two passes are **named**: `H2` and `H4` assert absences a tree with no accumulation gate also satisfies. The tally exceeds 100 because `D6` reports per head shape (4 lines for 1 label); the meta arms contribute nothing, because `_mk_mutant_repo` returns 1 on a meta failure and the assertion it guards is skipped rather than doubled.
- **Green across six environments**: host, `LC_ALL=C`, `TZ=UTC`, `TZ=Pacific/Kiritimati`, a runner-like git config (`GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null`), and an empty `XDG_CONFIG_HOME`.
- **Regression**: the 45 `check-phase-gate` suites that do not name `init.sh` on an executed line (derived by stripping comments first — `grep -L 'init\.sh'` is forbidden by CLAUDE.md and under-counts by 20), count printed, all rc=0.
- **15/15 repo lints** locally; on CI all 13 lint jobs plus the 5 `unit-shard` legs and the `unit` aggregator. The ~3h `full` lane is `workflow_dispatch`-only and was **not** run.

## Six fail-opens, all in one dimension — the window

The gate asks two questions about a window running from the previous gate's date. Twelve adversarial review rounds found six ways the window could answer them falsely. They are enumerated with measurements on `## BL-233:`; in short:

1. A window opening in the **future** read as empty (`# BL-233-WPB-FUTURE-WINDOW`).
2. A gate date **recorded but unparseable** collapsed into "no gate recorded", so any store ever made satisfied it (`# BL-233-WPB-AMBIGUOUS-WINDOW`, needing `# BL-233-WPB-RAW-SNAPSHOT` because the gate rewrites `gates.*` mid-run).
3. The window **did not open at midnight** — `git log --since=<bare date>` fills the time from the current clock, so morning commits fell outside their own window and the same tree changed verdict by the hour (`# BL-233-WPB-SINCE-MIDNIGHT`). Found by a test flaking 8 runs in 40, not by review.
4. A **duplicate key** concatenated into a string git rereads as a future instant; the first guard checked only the first ten characters and so caught one operand order (`# BL-233-WPB-WINDOW-SHAPE`).
5. A **jq failure** on `phase-state.json` read as "no gate recorded" (`# BL-233-WPB-GATES-READABLE`).
6. The **other operand of the same comparison** — the persisted store timestamp — was never guarded at all, while the window start was hardened four ways. This is the worst of the six: a future window start fails loudly, a future store timestamp satisfies the gate silently and forever, and `.claude/process-state.json` is tracked, so the bad value reaches every clone (`# BL-233-WPB-STORE-FUTURE`).

**Honest scoping.** Reviewers rated the reachability of these unevenly, and so do I: (3) and (6) are ordinary-usage bugs (a clock that is ahead, or simply running the gate in the afternoon); (1) and (5) need clock skew or a corrupted file; (2) and (4) essentially need someone hand-editing JSON. Three further findings from round 12 were judged **not worth the fail-closed surface** and are recorded as residuals 22-24 rather than fixed.

**The correction that matters more than any of them.** Every one of those guards fails CLOSED, and the block initially sat AHEAD of the attested escape — so a wrong clock left an honest operator with no way past a blocking gate. That is `## BL-149:`'s standing rule broken by the entry that cites it. `# BL-233-WPB-WINDOW-ATTESTABLE` fixes it: the permissive shortcuts stay skipped, the attested path is reached, and the attestation is durably recorded. Fail-closed to a script, open to a human who says why.

## Residuals — 24, all real, none blocking

All twenty-four are enumerated on `## BL-233:` with a derivation recipe for the count. The ones worth knowing before merge:

1. **Plugin-provided MCP servers are invisible** to requirement derivation, on a second surface now — a Qdrant reachable only via a plugin derives NOT REQUIRED and the gate silently switches off.
2. **Legacy and brownfield projects stay unenforced** until someone adds the manifest declaration; the gate degrades to a non-counting `NOT CHECKED` rather than hard-failing.
3. **The commit-time warning still lags the gate on two window shapes** (residual 22) — a missing nudge, not a fail-open.
4. **`GIT_DIR`/`GIT_WORK_TREE` redirect the source-work measurement** (residual 23) — pre-existing, affects every git read in the script.
5. **Every successful store dirties a tracked `.claude/process-state.json`** — consistent with what that file already is, at higher frequency.

## Unrelated, found while verifying — not fixed here

`tests/test-bl166-gate-scope.sh` is **locale-dependent**: 8/8 normally, **6/2 under `LC_ALL=C`**, because it matches the multibyte `→` with `.`. It **reproduces identically on `origin/main`**, so it is pre-existing and outside this PR. CI does not set `LC_ALL=C`, which is why main is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


