### PR TITLE
Backlog: file BL-245, BL-246, BL-247 — three defects the BL-243 rounds found and nobody owned

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -12566,6 +12566,149 @@ work whose PR this was blocking).
 
 ---
 
+## BL-245: the unit-lane membership lint scopes from a COMMENT, because the array-opening token appears above the array
+
+ **Status:** Open
+ **Filed:** 2026-08-26
+ **Owner:** unassigned
+ **Severity:** Low (latent — harmless today by coincidence, not by design)
+
+`CLAUDE.md` spells this trap out character-by-character and bans the literal
+array-opening token *below* the array. It appears **above** it, which the rule
+does not cover and which is the same defect from the other side.
+
+```
+grep -n 'tests=(' .github/workflows/tests.yml
+# 324:  # scopes with awk between `tests=(` and `)` and does not strip   <- a COMMENT
+# 349:  tests=(                                                          <- the array
+```
+
+`_build_unit_list_set` in `scripts/lint-tests-registered.sh` scopes with an
+UNANCHORED `awk '/tests=\(/'` and does not strip comments, so the scope opens at
+line 324 rather than 349 and folds lines 325-348 into the membership set. Any
+`tests/test-*.sh` path NAMED in that comment block therefore satisfies the lint
+without being in the array — i.e. without running.
+
+**Harmless today by coincidence:** the test the comment names is genuinely in the
+array too, so the set is the same either way. That is not a property anyone is
+maintaining.
+
+**Fix direction:** anchor the awk (`/^[[:space:]]*tests=\(/`) or strip comments
+before scoping — and extend the `CLAUDE.md` rule to say *anywhere else in that
+file*, not just *below*. Pre-existing on `main` — derived, not assumed:
+`git log --oneline -1 -S 'scopes with awk between' -- .github/workflows/tests.yml`
+returns `bb69806`, the BL-181-era docs commit, which predates this work.
+
+**The mutation proof has a trap in it, so specify the fixture:** plant the name
+of a **non-exempt** test — one whose executed lines never name `init.sh` — in the
+comment block, delete it from the array, and require the lint to go red. Using
+the test the comment already names does NOT discriminate: it carries
+`INIT="$REPO_ROOT/init.sh"` on an executed line, so `# BL-181-UNIT-LANE-PREDICATE`
+exempts it the moment it leaves the array and the probe stays green in both
+directions. Measured: a probe with that test was vacuous; the same probe with a
+non-exempt test went red on the control and green on the hole.
+
+**"Harmless today" is doubly coincidental**, which is worth saying because one
+coincidence sounds like a margin and two do not: the test the comment names is in
+the array AND would be exemption-masked if it were not.
+
+---
+
+## BL-246: the CI gitleaks download retries on failures that do not happen and not on the one that does
+
+ **Status:** Open
+ **Filed:** 2026-08-26
+ **Owner:** unassigned
+ **Severity:** Low (costs reruns; no correctness impact)
+
+`.github/workflows/tests.yml` fetches gitleaks at two sites with `--retry 3`:
+
+```
+grep -n 'curl -sSfL --retry' .github/workflows/tests.yml
+# 256:  curl -sSfL --retry 3 -o /tmp/gitleaks.tar.gz "$url"
+# 973:  curl -sSfL --retry 3 -o /tmp/gitleaks.tar.gz "$url"
+```
+
+**`--retry` does not cover the failure mode that actually occurs.** From
+`curl(1)` on this host, verbatim:
+
+> Transient error means either: a timeout, an FTP 4xx response code or an HTTP
+> 408, 429, 500, 502, 503 or 504 response code.
+
+A connection reset during the **TLS handshake** is not in that set, so the retry
+is inert for it. `curl(1)`'s exit-code table, verbatim: *"35 — SSL connect error.
+The SSL handshaking failed."* — no transfer ever began. **Measured 2026-08-25**, and pinned by run coordinates because the branch will
+be deleted and "a rerun passed" is otherwise checkable only from memory:
+`curl: (35) Recv failure: Connection reset by peer` failed the
+`unit-shard (lint-sweep)` leg of PR #364 in the *setup* step, before any test
+ran; the rerun passed. Run `32873055515`, attempt 1 job `97884420123`
+conclusion `failure`, latest attempt job `97888523823` conclusion `success` —
+re-derive with
+`gh api 'repos/kraulerson/solo-orchestrator/actions/runs/32873055515/attempts/1/jobs'`. The 135 ms between step start and failure corroborates
+that nothing was retried — a retried transient shows at least a 1 s backoff.
+
+**Fix direction:** `--retry-all-errors` alongside `--retry` (curl 7.71+). **NOT
+`--retry-connrefused`** — `curl(1)` says that option "consider[s] ECONNREFUSED as
+a transient error too", and the measured failure is a RESET during the handshake,
+which it would not retry; taking the narrower option ships a no-op for the one
+failure this entry documents, and the entry gets closed on it. `curl(1)`'s
+"sledgehammer" caveat about duplicated data does not bite here: `-o` writes a
+managed file and `scripts/ci-verify-sha256.sh` fail-closes on any corruption
+immediately after. Both sites, in sync.
+
+**Lane note:** the two sites are not equal. Line 256 is in `unit-shard`, which is
+PR-blocking; line 973 is in the `full` job, which is `workflow_dispatch`-only and
+never gates a PR. The rerun cost is real only at the first.
+
+---
+
+## BL-247: "no source files staged" is printed for commits that stage source — `.sh` is not in the classifier
+
+ **Status:** Open
+ **Filed:** 2026-08-26
+ **Owner:** unassigned
+ **Severity:** Low (a misleading receipt, not a missing gate)
+
+The BL-125 arm in `scripts/lib/hook-templates.sh` decides whether project tests
+are required by counting staged files against an extension list:
+
+```
+git diff --cached --name-only --diff-filter=ACMDRT \
+  | grep -cE '\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|kt|kts|swift|cs|dart|c|h|cc|cpp|hpp|php|scala|vue|svelte)$'
+```
+
+**27 extensions, and `.sh` is not among them.** So a commit staging shell source
+prints `[OK] BL-125: no source files staged — project tests not required for this
+commit.` — while source was staged. Derived across all 20 commits of the
+`## BL-243:` branch:
+
+```
+git diff-tree --no-commit-id --name-only --diff-filter=ACMDRT -r <sha> \
+  | grep -cE '\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|kt|kts|swift|cs|dart|c|h|cc|cpp|hpp|php|scala|vue|svelte)$'
+```
+
+returns **0 for all 20** — so the receipt fired on every one. (It is not that they
+staged `.sh` only: most also staged the backlog `.md`, and one staged
+`tests.yml`. What they have in common is staging no file the list matches.)
+
+**The gate's BEHAVIOUR is defensible**, and the reason is a property of the arm
+rather than a claim about the shell ecosystem (bats and shunit2 exist): the
+arm's DETECTION knows no shell runner — it reads `.claude/test-command`, then
+falls through package.json / pytest / Cargo / go.mod detection and nothing else —
+and when no command is found it degrades to `soif_tests_not_enforced`, a loud
+non-blocking WARN. **The RECEIPT is not:** it
+asserts something false about the commit, and a receipt that misdescribes what it
+measured is the failure class `# BL-112-SAST-NOTRUN` exists to name.
+
+**Fix direction:** say what is true — *"no source files this gate knows how to
+test"* — or add `sh`/`bash` to the list and let the existing
+no-command-detected arm handle it honestly. The second is better if any
+scaffolded project is shell-first; the first is a one-line correction either way.
+Needs the receipt pinned, per `## BL-243:` residual 3's lesson: assert the arm
+that fired, not the words it printed.
+
+---
+
 ## BL-244: almost every test suite can run its fixtures in the LAUNCH DIRECTORY when mktemp fails — and one of them did
 
  **Status:** Open
@@ -12829,6 +12972,14 @@ read stdin and does not exit before it.
    `CLAUDE.md`'s `[WARN]` trap — read the effect, not the label — landing twice
    on the same elif chain. Count the `register_manual` calls before trusting any
    sentence in this paragraph.)*
+   *(THE CHANNEL HALF, recorded here because commit `a5aa848` said "Recorded
+   rather than papered over" and no record existed — the omission shape residual
+   12 names, committed in the act of claiming otherwise. Of the install channels:
+   the contributor installer and the upgrade sync ARE pinned (`A3`/`A4b`/`A5`,
+   `T-prepush-notice`). **`init.sh`'s arm is unpinned in EVERY lane and cannot be
+   pinned in the PR-blocking one** — `# BL-181-UNIT-LANE-PREDICATE` excludes
+   init.sh-invoking tests by construction — so a regression there passes every
+   PR-blocking check by design. Only a full-lane pin can cover it.)*
 4. **The `scripts=(` manifest's "mirrors init.sh's chmod list exactly" invariant
    is a hand-maintained comment, and it is FALSE TODAY BY SEVEN FILES** — no lint
    compares the two lists. Measured during review: `check-maintenance.sh`,


### PR DESCRIPTION
Files three defects found during the sixteen-round `## BL-243:` review that were recorded nowhere the sweep reads — which `## BL-243:` residual 14 exists to say is the failure, not a filing style. Docs-only, one file.

## The entries

**`## BL-245:`** — `CLAUDE.md` bans the literal `tests=(` token *below* the array in `.github/workflows/tests.yml`. It appears **above** it (comment at 324, array at 349), which the rule does not cover and which is the same defect from the other side: `_build_unit_list_set`'s unanchored awk opens its scope at the comment, so any `tests/test-*.sh` named in lines 325–348 satisfies the membership lint **without running**.

Harmless today only because the test it names is in the array — and, as review found, would *also* be exemption-masked if it were not. Two coincidences, not a margin. The entry specifies a **non-exempt fixture** for the mutation proof, because using the test the comment names is provably vacuous: it carries `init.sh` on an executed line, so `# BL-181-UNIT-LANE-PREDICATE` exempts it the moment it leaves the array.

**`## BL-246:`** — the CI gitleaks fetch uses `--retry 3` at two sites, and `curl(1)` defines transient error as a timeout, an FTP 4xx, or HTTP 408/429/500/502/503/504. A reset during the **TLS handshake** is not in that set — `curl(1)`: *"35 — SSL connect error. The SSL handshaking failed."* — and it killed the `unit-shard (lint-sweep)` leg of PR #364 in setup, before any test ran. `--retry-all-errors` covers it; **`--retry-connrefused` does not**, and the entry says so, because an implementer taking the "narrower" option ships a no-op for the one failure the entry documents.

**`## BL-247:`** — the BL-125 arm prints `no source files staged` for commits that stage source, because its 27-extension classifier omits `.sh`. Derived across all 20 commits of the BL-243 branch: the classifier returns **0** for every one. The gate's *behaviour* is defensible — but for a reason about the **arm**, not the shell ecosystem, since bats and shunit2 exist: the arm's detection knows no shell runner. The **receipt** is what asserts something false, which is the class `# BL-112-SAST-NOTRUN` names.

**And a fourth, which review caught me omitting in the act of filing the others.** Commit `a5aa848` said of `init.sh`'s install arm: *"unpinned in every lane and CANNOT be pinned in the PR-blocking one … Recorded rather than papered over."* The backlog had **zero** hits for it. That is residual 12's shape — *a residual nobody wrote down is a residual nobody can sweep* — committed inside a commit whose whole subject is ending it. It now lives on `## BL-243:` residual 3, where the pinning question belongs.

## Review found three of this commit's own claims wrong, in two rounds

Both rounds returned `major_concerns`, and every finding was taken:

- **`--retry-connrefused`** was offered as a fix alternative that provably would not fix the filed defect.
- **"mid-transfer reset"** mischaracterised exit 35, which is an SSL handshake failure — and the phase is load-bearing, because it is *why* the narrower option cannot cover it.
- **"`.sh` files only"** was false for 17 of 18 source commits; what they share is staging nothing the list matches.

Then a third round caught a **wrong tally in the message that preaches re-deriving tallies** — twice. The marker-lint citation half scans `docs/**` on disk, so untracked files inflate it: this tree 656, clean clone **650**, drafts said 654 and 655. Neither was reproducible. The message now records the **rule** rather than a corrected digit — markers (496) are tree-derived and stable; the citation half is quotable only with the checkout it was measured on — and notes that the reviewer made the symmetric error measuring the first draft on the same dirty tree, because a correction that hides half the failure is the shape residual 12 names.

## Verification

Every claim carries its derivation recipe, and each recipe was run before it was written down:

- BL-246's CI coordinates: run `32873055515`, attempt 1 job `97884420123` `failure`, latest attempt job `97888523823` `success`.
- BL-245's provenance: `git log -S 'scopes with awk between'` → `bb69806`.
- BL-247's detection chain, read from the arm rather than assumed.

Measured on a **clean clone** of the tip — the tree a future reader gets: `15 lints — 15 passed, 0 failed`; marker lint `496 markers / 650 citations`; `lint-backlog-references` rc=0; gate suite `69 passed, 0 failed`.

**Not filed, because it already exists:** the same bare-`--since` defect in `session-test-gate-check.sh` is `## BL-233:` residual 21. It needs an owner, not an entry.
