### PR TITLE
fix(bl-225): the adoption driver no longer half-stages, and no longer says nothing happened

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -516,6 +516,7 @@ jobs:
             tests/test-brownfield-wp4-driver.sh
             tests/test-brownfield-wp5b-test-debt.sh
             tests/test-brownfield-wp6-collision-archive.sh
+            tests/test-bl225-staging-preflight.sh
             tests/test-bl233-mcp-outcome-enforcement.sh
             tests/test-bl233-wpb-accumulation.sh
             tests/test-pr-review-gate.sh

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -135,7 +135,7 @@ service with no `README.md`, a weekend prototype with a tagged release.
 
 ```text
 [REFUSED] This question has no default and no skip, and no answer was given: the project's situation
-          Adoption did not complete. Nothing has been committed.
+          Adoption did not complete. Nothing has been committed and nothing was written.
 ```
 
 Inferring the scenario and asking you to confirm it was considered and rejected:
@@ -251,7 +251,7 @@ Which one describes it?
    Answer with the number or the words:
 
 [REFUSED] Data classification has no default, no guess and no skip — in either scenario. The Phase 1 to 2 gate is a hard FAIL without it, so an adoption that skipped it would produce a project that cannot pass its own next gate.
-          Adoption did not complete. Nothing has been committed.
+          Adoption did not complete. Nothing has been committed and nothing was written.
 rc=1
 ```
 
@@ -260,7 +260,7 @@ coerced:
 
 ```text
 [REFUSED] 'legacy-app' is not one of the answers offered for: who the project is for
-          Adoption did not complete. Nothing has been committed.
+          Adoption did not complete. Nothing has been committed and nothing was written.
 ```
 
 ---
@@ -914,7 +914,7 @@ not among them. Read them here, in the framework clone you run the driver from.
 | Code | Meaning |
 |---|---|
 | 0 | Adoption completed |
-| 1 | Adoption did not complete — a refusal, a blocker, or a halt. **Nothing has been committed** |
+| 1 | Adoption did not complete — a refusal, a blocker, or a halt. **Nothing has been committed**, and the refusal now says whether anything was WRITTEN: a halt before the first write says so, and one after it names the file count and points at `git status` (`# BL-225-REFUSE-HONEST`). **Nothing is ever left half-staged** — the staging preflight refuses whole (`# BL-225-STAGE-PREFLIGHT`) |
 | 2 | Bad usage, or a target the driver cannot use |
 
 ---

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -135,7 +135,7 @@ service with no `README.md`, a weekend prototype with a tagged release.
 
 ```text
 [REFUSED] This question has no default and no skip, and no answer was given: the project's situation
-          Adoption did not complete. Nothing has been committed and nothing was written.
+          Adoption did not begin. Nothing was committed and nothing was written.
 ```
 
 Inferring the scenario and asking you to confirm it was considered and rejected:
@@ -251,7 +251,7 @@ Which one describes it?
    Answer with the number or the words:
 
 [REFUSED] Data classification has no default, no guess and no skip — in either scenario. The Phase 1 to 2 gate is a hard FAIL without it, so an adoption that skipped it would produce a project that cannot pass its own next gate.
-          Adoption did not complete. Nothing has been committed and nothing was written.
+          Adoption did not begin. Nothing was committed and nothing was written.
 rc=1
 ```
 
@@ -260,7 +260,7 @@ coerced:
 
 ```text
 [REFUSED] 'legacy-app' is not one of the answers offered for: who the project is for
-          Adoption did not complete. Nothing has been committed and nothing was written.
+          Adoption did not begin. Nothing was committed and nothing was written.
 ```
 
 ---
@@ -914,7 +914,7 @@ not among them. Read them here, in the framework clone you run the driver from.
 | Code | Meaning |
 |---|---|
 | 0 | Adoption completed |
-| 1 | Adoption did not complete — a refusal, a blocker, or a halt. **Nothing has been committed**, and the refusal now says whether anything was WRITTEN: a halt before the first write says so, and one after it names the file count and points at `git status` (`# BL-225-REFUSE-HONEST`). **Nothing is ever left half-staged** — the staging preflight refuses whole (`# BL-225-STAGE-PREFLIGHT`) |
+| 1 | Adoption did not complete. The message distinguishes the two cases (`# BL-225-REFUSE-HONEST`): **`[REFUSED]`** when the run never began — nothing committed, nothing written; **`[BLOCKED]`** when it began and stopped — nothing committed, but *N* file(s) already on disk, with the count derived from the write ledger rather than assumed. It does **not** claim those files are visible to plain `git status`: on the staging-block path they provably are not, so it names `git status --ignored --untracked-files=all` instead. **Nothing is ever left half-staged** — `# BL-225-STAGE-PREFLIGHT` asks `git add --dry-run` before it stages, and stops whole |
 | 2 | Bad usage, or a target the driver cannot use |
 
 ---

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -525,10 +525,12 @@ adopt_archive_write() {
 
   arc_rel="$(adopt_archive_dir_new "$root")"
   arc_abs="$root/$arc_rel"
+  # BL-225-TOUCHED-DISK, raised BEFORE the mkdir rather than after it: a
+  # `mkdir -p` that creates the parents and then fails has still changed the
+  # tree, and the copy loop below runs ~110 lines before adopt_record_write, so
+  # the ledger is empty through the whole copy phase while these files exist.
+  ADOPT_TOUCHED_DISK=1
   mkdir -p "$arc_abs" 2>/dev/null || { adopt_refuse "could not create the collision archive at $arc_rel"; return 1; }
-  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK: the copy loop below runs ~110 lines
-                         # before adopt_record_write, so the ledger is empty for
-                         # the whole copy phase while these files exist.
 
   while IFS="$(printf '\t')" read -r rel class arel; do
     [ -n "$rel" ] || continue
@@ -536,6 +538,7 @@ adopt_archive_write() {
     # `cp -p` preserves the mode, which matters more here than anywhere else in
     # the driver: a git hook that comes back at 0644 does not run, and an
     # operator restoring one would get silence rather than an error.
+    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
     cp -p "$root/$rel" "$arc_abs/$arel" 2>/dev/null || { adopt_refuse "could not archive $rel"; return 1; }
   done < "$work/arcinv"
 
@@ -942,6 +945,7 @@ adopt_archive_readd() {
   # ABOVE the record and now runs there — which makes the residual documented
   # above the WHOLE residual rather than most of it. R5 forces that failure
   # with a regular file where a directory has to go and asserts zero rows.
+  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
   mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want") — nothing has been changed and nothing recorded"; return 1; }
   #
   # THE DETAILS ARE BUILT ON THEIR OWN LINE so that the emit is a COMPLETE
@@ -964,6 +968,7 @@ adopt_archive_readd() {
     return 1
   fi
 
+  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
   cp -p "$restored_from" "$root/$want" || { adopt_refuse "could not restore $want — the audit row was already written, so the ledger records an intent that did not complete"; return 1; }
   case "$mode" in ''|*[!0-7]*) : ;; *) chmod "$mode" "$root/$want" 2>/dev/null ;; esac
 
@@ -982,6 +987,7 @@ adopt_archive_readd() {
 # "re-adds are permitted" decision was the moment they had not yet formed an
 # opinion.
 adopt_readd_main() {
+  ADOPT_OPERATION="The re-add"   # BL-225-OPERATION: not an adoption run
   local root="$1" want="$2"
   if ! command -v jq >/dev/null 2>&1; then
     echo "adopt-project: jq is required." >&2

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -526,6 +526,9 @@ adopt_archive_write() {
   arc_rel="$(adopt_archive_dir_new "$root")"
   arc_abs="$root/$arc_rel"
   mkdir -p "$arc_abs" 2>/dev/null || { adopt_refuse "could not create the collision archive at $arc_rel"; return 1; }
+  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK: the copy loop below runs ~110 lines
+                         # before adopt_record_write, so the ledger is empty for
+                         # the whole copy phase while these files exist.
 
   while IFS="$(printf '\t')" read -r rel class arel; do
     [ -n "$rel" ] || continue
@@ -726,7 +729,17 @@ _adopt_record_if_stageable() {
   # refused it. Two contradictory oracles ten files apart is how the next reader
   # copies the refuted one.
   if ! ( cd "$root" && git add --dry-run -- "$rel" ) >/dev/null 2>&1; then
-    adopt_note "Your .gitignore excludes $rel, so it stays out of the commit — it is on disk."
+    # BL-225-ORACLE-SYNC (second half): `git add --dry-run` fails for ANY
+    # reason, not only an ignore rule — an unreadable file fails it too. Ask the
+    # namer whether an ignore rule is actually the cause before naming one; the
+    # first draft of this arm attributed every failure to `.gitignore`, which is
+    # a broken install disclosed with the wrong reason.
+    if adopt_name_ignored_paths "$root" "$rel" >/dev/null 2>&1; then
+      adopt_note "Your .gitignore excludes $rel, so it stays out of the commit — it is on disk."
+    else
+      adopt_note "git will not stage $rel, so it stays out of the commit — it is on disk. git says:"
+      ( cd "$root" && git add --dry-run -- "$rel" ) 2>&1 >/dev/null | grep -v '^hint:' | sed 's/^/    /'
+    fi
     return 0
   fi
   adopt_record_write "$rel"

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -988,6 +988,20 @@ adopt_archive_readd() {
 # opinion.
 adopt_readd_main() {
   ADOPT_OPERATION="The re-add"   # BL-225-OPERATION: not an adoption run
+  # BL-225-TOUCHED-DISK: `--re-add` is dispatched BEFORE `adopt_main`, which is
+  # the only place `ADOPT_WORK` is ever assigned — so without this the marker
+  # writes nowhere and `adopt_has_touched_disk` answers "nothing touched" for
+  # this whole command. That regressed the audit-row contradiction one round
+  # after it was fixed: the refusal said "the audit row was already written"
+  # and then "nothing was written". A marker that is present, correctly placed
+  # and INERT is worse than an absent one, because the guard reads it as green.
+  if [ -z "${ADOPT_WORK:-}" ]; then
+    ADOPT_WORK="$(mktemp -d "${TMPDIR:-/tmp}/adopt-readd.XXXXXXXX" 2>/dev/null)" || {
+      echo "adopt-project: could not create a temporary working directory." >&2
+      return 2
+    }
+    trap 'rm -rf "$ADOPT_WORK"' EXIT INT TERM
+  fi
   local root="$1" want="$2"
   if ! command -v jq >/dev/null 2>&1; then
     echo "adopt-project: jq is required." >&2

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -717,7 +717,15 @@ STAGEABLE
 _adopt_record_if_stageable() {
   local root="$1" rel="$2"
   [ -e "$root/$rel" ] || return 0
-  if ( cd "$root" && git check-ignore -q -- "$rel" ) 2>/dev/null; then
+  # BL-225-ORACLE-SYNC: `git add --dry-run`, not `git check-ignore`. The same
+  # oracle error BL-225 fixed one directory over lived here too, and it is a
+  # WRONG ANSWER rather than the rc-128 fail-open below it: check-ignore is
+  # index-aware and reports nothing for a TRACKED path, so a tracked
+  # `.claude/bypass-audit.json` under a later-added `.claude/` rule was recorded
+  # for staging — withholding nothing, disclosing nothing — and `git add` then
+  # refused it. Two contradictory oracles ten files apart is how the next reader
+  # copies the refuted one.
+  if ! ( cd "$root" && git add --dry-run -- "$rel" ) >/dev/null 2>&1; then
     adopt_note "Your .gitignore excludes $rel, so it stays out of the commit — it is on disk."
     return 0
   fi

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -529,7 +529,7 @@ adopt_archive_write() {
   # `mkdir -p` that creates the parents and then fails has still changed the
   # tree, and the copy loop below runs ~110 lines before adopt_record_write, so
   # the ledger is empty through the whole copy phase while these files exist.
-  ADOPT_TOUCHED_DISK=1
+  adopt_touched_disk
   mkdir -p "$arc_abs" 2>/dev/null || { adopt_refuse "could not create the collision archive at $arc_rel"; return 1; }
 
   while IFS="$(printf '\t')" read -r rel class arel; do
@@ -538,7 +538,7 @@ adopt_archive_write() {
     # `cp -p` preserves the mode, which matters more here than anywhere else in
     # the driver: a git hook that comes back at 0644 does not run, and an
     # operator restoring one would get silence rather than an error.
-    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+    adopt_touched_disk   # BL-225-TOUCHED-DISK
     cp -p "$root/$rel" "$arc_abs/$arel" 2>/dev/null || { adopt_refuse "could not archive $rel"; return 1; }
   done < "$work/arcinv"
 
@@ -945,7 +945,7 @@ adopt_archive_readd() {
   # ABOVE the record and now runs there — which makes the residual documented
   # above the WHOLE residual rather than most of it. R5 forces that failure
   # with a regular file where a directory has to go and asserts zero rows.
-  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+  adopt_touched_disk   # BL-225-TOUCHED-DISK
   mkdir -p "$(dirname "$root/$want")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$want") — nothing has been changed and nothing recorded"; return 1; }
   #
   # THE DETAILS ARE BUILT ON THEIR OWN LINE so that the emit is a COMPLETE
@@ -968,7 +968,7 @@ adopt_archive_readd() {
     return 1
   fi
 
-  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+  adopt_touched_disk   # BL-225-TOUCHED-DISK
   cp -p "$restored_from" "$root/$want" || { adopt_refuse "could not restore $want — the audit row was already written, so the ledger records an intent that did not complete"; return 1; }
   case "$mode" in ''|*[!0-7]*) : ;; *) chmod "$mode" "$root/$want" 2>/dev/null ;; esac
 

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -77,19 +77,34 @@ adopt_refuse() {
   local _n
   _n=$(adopt_written_paths 2>/dev/null | grep -c .) || _n=0
   case "$_n" in ''|*[!0-9]*) _n=0 ;; esac
-  if [ "$_n" -gt 0 ]; then
+  # BL-225-TOUCHED-DISK: THE LEDGER IS NOT THE DISK, and the first fix read one
+  # while claiming the other. `adopt_archive_write` copies in one loop and
+  # records ~110 lines later, so through the whole copy phase the ledger is
+  # empty while an archive directory and copied files exist — and the refusal
+  # said "nothing was written". Same class as the claim it replaced. The flag is
+  # set by every writer the moment it has touched the tree, so this reads a fact
+  # rather than a proxy for one.
+  if [ "$_n" -gt 0 ] || [ "${ADOPT_TOUCHED_DISK:-0}" -eq 1 ]; then
     printf '\n[BLOCKED] %s\n' "$1" >&2
     if [ "${ADOPT_COMMITTED:-0}" -eq 1 ]; then
       printf '          The adoption commit HAD already landed; a later step did not complete.\n' >&2
       printf '          %s file(s) were written and committed.\n' "$_n" >&2
-    else
+    elif [ "$_n" -gt 0 ]; then
       printf '          Nothing was committed. %s file(s) were already written into this project.\n' "$_n" >&2
+      # No promise about the index: adopt_refuse does not know the adoptee's
+      # root and will not claim a state it cannot read. Callers that DO know
+      # say so. The hint is in THIS arm only — after a commit the files are
+      # tracked and clean, so it would name a command showing nothing.
+      printf '          Some may be invisible to plain `git status` if your own ignore rules\n' >&2
+      printf '          cover them. This shows those too:\n' >&2
+      printf '            git status --ignored --untracked-files=all\n' >&2
+    else
+      # Touched the tree before anything reached the ledger — the archive's copy
+      # phase is the reachable case. Say exactly that, and no count.
+      printf '          Nothing was committed, and no file is recorded as written — but adoption\n' >&2
+      printf '          had already begun changing this project. Check `.claude/adoption-archive/`\n' >&2
+      printf '          and `git status --ignored --untracked-files=all` before re-running.\n' >&2
     fi
-    # No promise about the index: adopt_refuse does not know the adoptee's root
-    # and will not claim a state it cannot read. Callers that DO know say so.
-    printf '          Some may be invisible to plain `git status` if your own ignore rules\n' >&2
-    printf '          cover them. This shows those too:\n' >&2
-    printf '            git status --ignored --untracked-files=all\n' >&2
   else
     printf '\n[REFUSED] %s\n' "$1" >&2
     printf '          Adoption did not begin. Nothing was committed and nothing was written.\n' >&2
@@ -263,6 +278,10 @@ ADOPT_WRITTEN_LEDGER=""
 # succeeds, so adopt_refuse can state the truth about a refusal that arrives
 # AFTER the commit (adopt_install_hooks runs there). Derived, never assumed.
 ADOPT_COMMITTED=0
+# BL-225-TOUCHED-DISK: 1 as soon as ANY writer has changed the adoptee's tree,
+# including before the write is recorded. adopt_refuse reads it so it can never
+# again say "nothing was written" over files that exist.
+ADOPT_TOUCHED_DISK=0
 
 adopt_ledger_init() {
   ADOPT_WRITTEN_LEDGER="$1"
@@ -318,6 +337,7 @@ adopt_write_file() {
   local root="$1" rel="$2" dir
   dir="$(dirname "$root/$rel")"
   mkdir -p "$dir" 2>/dev/null || { adopt_refuse "could not create $dir"; return 1; }
+  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
   cat > "$root/$rel" || { adopt_refuse "could not write $rel"; return 1; }
   adopt_record_write "$rel"
   return 0

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -307,7 +307,9 @@ ADOPT_COMMITTED=0
 # reachable to create it.
 adopt_touched_disk() {          # BL-225-TOUCHED-DISK
   [ -n "${ADOPT_WORK:-}" ] || return 0
-  : > "$ADOPT_WORK/touched" 2>/dev/null || true
+  # Braced: redirections apply left to right, so `: > X 2>/dev/null` lets the
+  # `>` failure print before the `2>` is in effect. The suppression was inert.
+  { : > "$ADOPT_WORK/touched"; } 2>/dev/null || true
   return 0
 }
 adopt_has_touched_disk() {      # BL-225-TOUCHED-DISK

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -101,13 +101,13 @@ adopt_refuse() {
     else
       # Touched the tree before anything reached the ledger — the archive's copy
       # phase is the reachable case. Say exactly that, and no count.
-      printf '          Nothing was committed, and no file is recorded as written — but adoption\n' >&2
+      printf '          Nothing was committed, and no file is recorded as written — but %s\n' "$(printf '%s' "${ADOPT_OPERATION:-Adoption}" | tr '[:upper:]' '[:lower:]')" >&2
       printf '          had already begun changing this project. Check `.claude/adoption-archive/`\n' >&2
       printf '          and `git status --ignored --untracked-files=all` before re-running.\n' >&2
     fi
   else
     printf '\n[REFUSED] %s\n' "$1" >&2
-    printf '          Adoption did not begin. Nothing was committed and nothing was written.\n' >&2
+    printf '          %s did not begin. Nothing was committed and nothing was written.\n' "${ADOPT_OPERATION:-Adoption}" >&2
   fi
   return 1
 }
@@ -281,7 +281,24 @@ ADOPT_COMMITTED=0
 # BL-225-TOUCHED-DISK: 1 as soon as ANY writer has changed the adoptee's tree,
 # including before the write is recorded. adopt_refuse reads it so it can never
 # again say "nothing was written" over files that exist.
+#
+# THE FIRST VERSION OF THIS COMMENT WAS FALSE AND THAT IS WHY THE INVARIANT IS
+# NOW TESTED RATHER THAN ASSERTED. It claimed "ANY writer" while the flag was
+# set at two of the twelve sites that write to the adoptee's tree, so a failed
+# `cp -p` inside `adopt_install_framework` left a directory behind under a
+# refusal saying nothing was written — the same sentence, the same cause, one
+# writer over. `# BL-225-TOUCHED-DISK` is set at EVERY such site, and
+# tests/test-bl225-staging-preflight.sh's T9 DERIVES both sets and requires
+# them to match, so a thirteenth writer added without the flag fails the suite
+# instead of waiting for a sixth review round.
 ADOPT_TOUCHED_DISK=0
+# BL-225-OPERATION: `--re-add` is a DIFFERENT OPERATION, not a mode of the
+# adoption run (adopt-project.sh says so), and it never calls
+# adopt_ledger_init — so every one of its refusals landed in the arm that says
+# "Adoption did not begin". At the restore failure that became
+# self-contradicting: "the audit row was already written" two lines above
+# "nothing was written".
+ADOPT_OPERATION="Adoption"
 
 adopt_ledger_init() {
   ADOPT_WRITTEN_LEDGER="$1"
@@ -336,8 +353,8 @@ adopt_name_ignored_paths() {
 adopt_write_file() {
   local root="$1" rel="$2" dir
   dir="$(dirname "$root/$rel")"
-  mkdir -p "$dir" 2>/dev/null || { adopt_refuse "could not create $dir"; return 1; }
   ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+  mkdir -p "$dir" 2>/dev/null || { adopt_refuse "could not create $dir"; return 1; }
   cat > "$root/$rel" || { adopt_refuse "could not write $rel"; return 1; }
   adopt_record_write "$rel"
   return 0
@@ -350,6 +367,7 @@ adopt_jq_edit() {
   local f="$root/$rel"
   [ -f "$f" ] || { adopt_refuse "cannot edit $rel — it does not exist"; return 1; }
   command -v jq >/dev/null 2>&1 || { adopt_refuse "jq is required to adopt a project"; return 1; }
+  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
   jq "$@" "$filter" "$f" > "$f.tmp" 2>/dev/null || { rm -f "$f.tmp"; adopt_refuse "jq could not edit $rel"; return 1; }
   mv "$f.tmp" "$f" || { adopt_refuse "could not replace $rel"; return 1; }
   adopt_record_write "$rel"

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -59,7 +59,22 @@ adopt_blank() { printf '\n'; }
 # that does not exist.
 adopt_refuse() {
   printf '\n[REFUSED] %s\n' "$1" >&2
-  printf '          Adoption did not complete. Nothing has been committed.\n' >&2
+  # BL-225-REFUSE-HONEST: "Nothing has been committed" is TRUE of every refusal
+  # — adoption commits once, at the end — and it was the whole message, which
+  # made it read as "nothing happened". It does not follow: BL-225 measured a
+  # refusal arriving over 78 files already on disk. Say what is true of the
+  # DISK as well as of the history, and derive the count rather than implying
+  # one.
+  local _n
+  _n=$(adopt_written_paths 2>/dev/null | grep -c .) || _n=0
+  case "$_n" in ''|*[!0-9]*) _n=0 ;; esac
+  if [ "$_n" -gt 0 ]; then
+    printf '          Adoption did not complete and NOTHING WAS COMMITTED — but %s file(s) were\n' "$_n" >&2
+    printf '          already written into this project. They are on disk and unstaged; `git status`\n' >&2
+    printf '          lists them. Anything of yours that was moved aside was archived first.\n' >&2
+  else
+    printf '          Adoption did not complete. Nothing has been committed and nothing was written.\n' >&2
+  fi
   return 1
 }
 
@@ -243,6 +258,43 @@ adopt_written_paths() {
   [ -n "$ADOPT_WRITTEN_LEDGER" ] || return 0
   [ -f "$ADOPT_WRITTEN_LEDGER" ] || return 0
   sort -u "$ADOPT_WRITTEN_LEDGER"
+}
+
+# adopt_paths_ignored ROOT PATH... — do the adoptee's OWN ignore rules exclude
+# any of PATH...? Prints the excluded ones, one per line.
+#
+#   rc 0  -> DO NOT PROCEED. Either something is ignored (stdout names it), or
+#            the question could not be answered (stdout says so).
+#   rc 1  -> none of PATH... is ignored.
+#
+# WHY IT EXISTS (BL-225). `git add` on a MIXED pathspec stages the clean paths
+# and exits 1. The driver stages every recorded path in ONE `git add`, so a
+# single ignored entry left the adoptee HALF-STAGED under a refusal. Measured:
+# 78 written, 64 staged, rc 1. The only safe move is to ask BEFORE adding and
+# to refuse whole; withholding is not available here, because skipping
+# `.claude/manifest.json` produces a broken install rather than a disclosed
+# omission (that is `_adopt_record_if_stageable`'s job, for paths that CAN be
+# skipped).
+#
+# IT FAILS CLOSED, AND THAT IS THE LOAD-BEARING HALF. `git check-ignore` exits
+# 0 (some ignored), 1 (none) or 128 (fatal) — and it IS fatal under the
+# pathspec-magic environment variables, which
+# tests/test-brownfield-wp6-collision-archive.sh MEASURED rather than guessed
+# (its R-WP6-18). A probe that wraps the call in 2>/dev/null and tests only for
+# rc 0 scores that fatal as "nothing is ignored" and proceeds — the fail-open
+# this function refuses. "Could not measure" is never "nothing to measure".
+adopt_paths_ignored() {
+  local root="$1"; shift
+  [ "$#" -gt 0 ] || return 1
+  local out rc
+  out=$( cd "$root" 2>/dev/null && printf '%s\n' "$@" | git check-ignore --stdin 2>/dev/null )
+  rc=$?
+  case "$rc" in
+    0) printf '%s\n' "$out"; return 0 ;;
+    1) return 1 ;;
+  esac
+  printf 'could not determine whether these paths are ignored (git check-ignore failed, rc %s)\n' "$rc"
+  return 0  # BL-225-IGNORE-FAILCLOSED
 }
 
 # ── Writes ──────────────────────────────────────────────────────────────────

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -58,22 +58,41 @@ adopt_blank() { printf '\n'; }
 # reads is a claim nothing keeps, and it would have been read as a resume seam
 # that does not exist.
 adopt_refuse() {
-  printf '\n[REFUSED] %s\n' "$1" >&2
-  # BL-225-REFUSE-HONEST: "Nothing has been committed" is TRUE of every refusal
-  # — adoption commits once, at the end — and it was the whole message, which
-  # made it read as "nothing happened". It does not follow: BL-225 measured a
-  # refusal arriving over 78 files already on disk. Say what is true of the
-  # DISK as well as of the history, and derive the count rather than implying
-  # one.
+  # BL-225-REFUSE-HONEST. The original line was "Adoption did not complete.
+  # Nothing has been committed." — true, and the WHOLE message, so it read as
+  # "nothing happened" over 78 files on disk (BL-225's measurement).
+  #
+  # THE FIRST FIX ASSERTED THREE THINGS IT NEVER DERIVED, and review measured
+  # all three false on reachable paths: that the files were "unstaged" (they
+  # were staged at five call sites), that "`git status` lists them" (it CANNOT
+  # on the preflight path — that arm only fires when a written path is ignored,
+  # so the one file being complained about is the one git status hides), and
+  # that nothing was committed (adopt_install_hooks runs AFTER the commit).
+  # Everything below is now derived or dropped.
+  #
+  # THE LABEL FOLLOWS docs/messaging-standard.md, which already draws the line:
+  # a refusal is "the tool would not begin", a block is "a check ran and you did
+  # not pass it". With files on disk the run began, so it is a BLOCK. No change
+  # to the standard was needed; the code was using the wrong word.
   local _n
   _n=$(adopt_written_paths 2>/dev/null | grep -c .) || _n=0
   case "$_n" in ''|*[!0-9]*) _n=0 ;; esac
   if [ "$_n" -gt 0 ]; then
-    printf '          Adoption did not complete and NOTHING WAS COMMITTED — but %s file(s) were\n' "$_n" >&2
-    printf '          already written into this project. They are on disk and unstaged; `git status`\n' >&2
-    printf '          lists them. Anything of yours that was moved aside was archived first.\n' >&2
+    printf '\n[BLOCKED] %s\n' "$1" >&2
+    if [ "${ADOPT_COMMITTED:-0}" -eq 1 ]; then
+      printf '          The adoption commit HAD already landed; a later step did not complete.\n' >&2
+      printf '          %s file(s) were written and committed.\n' "$_n" >&2
+    else
+      printf '          Nothing was committed. %s file(s) were already written into this project.\n' "$_n" >&2
+    fi
+    # No promise about the index: adopt_refuse does not know the adoptee's root
+    # and will not claim a state it cannot read. Callers that DO know say so.
+    printf '          Some may be invisible to plain `git status` if your own ignore rules\n' >&2
+    printf '          cover them. This shows those too:\n' >&2
+    printf '            git status --ignored --untracked-files=all\n' >&2
   else
-    printf '          Adoption did not complete. Nothing has been committed and nothing was written.\n' >&2
+    printf '\n[REFUSED] %s\n' "$1" >&2
+    printf '          Adoption did not begin. Nothing was committed and nothing was written.\n' >&2
   fi
   return 1
 }
@@ -240,6 +259,10 @@ adopt_ask_free() {
 # `git commit --no-verify`, which on an adoptee would sweep their uncommitted
 # work into a framework commit with verification bypassed.
 ADOPT_WRITTEN_LEDGER=""
+# BL-225-REFUSE-HONEST: set to 1 by adopt_stage_and_commit the moment its commit
+# succeeds, so adopt_refuse can state the truth about a refusal that arrives
+# AFTER the commit (adopt_install_hooks runs there). Derived, never assumed.
+ADOPT_COMMITTED=0
 
 adopt_ledger_init() {
   ADOPT_WRITTEN_LEDGER="$1"
@@ -260,41 +283,31 @@ adopt_written_paths() {
   sort -u "$ADOPT_WRITTEN_LEDGER"
 }
 
-# adopt_paths_ignored ROOT PATH... — do the adoptee's OWN ignore rules exclude
-# any of PATH...? Prints the excluded ones, one per line.
+# adopt_name_ignored_paths ROOT PATH... — BEST-EFFORT NAMING ONLY. Prints the
+# paths of PATH... that the adoptee's ignore rules exclude, for a message. It
+# does NOT decide whether staging will work, and must never be used as if it
+# did.
 #
-#   rc 0  -> DO NOT PROCEED. Either something is ignored (stdout names it), or
-#            the question could not be answered (stdout says so).
-#   rc 1  -> none of PATH... is ignored.
+# WHY IT IS NOT THE DECIDER (measured, review finding 1). `git check-ignore` is
+# INDEX-AWARE — git-check-ignore(1): "tracked files are not shown at all since
+# they are not subject to exclude rules". `git add` is not: it refuses on the
+# pathspec's ignored leading directory whether or not the file is tracked, AND
+# STAGES THE REST ANYWAY. So on a TRACKED `.claude/manifest.json` under a
+# later-added `.claude/` rule, check-ignore reports rc 1 ("nothing ignored")
+# while git add returns 1 having staged. A preflight keyed on check-ignore
+# therefore let BL-225 through unchanged on exactly the path an adopted project
+# takes. `git add --dry-run` is the only oracle that matches ground truth in
+# all three shapes tested (directory rule, file rule, glob), and it is what
+# `# BL-225-STAGE-PREFLIGHT` now uses.
 #
-# WHY IT EXISTS (BL-225). `git add` on a MIXED pathspec stages the clean paths
-# and exits 1. The driver stages every recorded path in ONE `git add`, so a
-# single ignored entry left the adoptee HALF-STAGED under a refusal. Measured:
-# 78 written, 64 staged, rc 1. The only safe move is to ask BEFORE adding and
-# to refuse whole; withholding is not available here, because skipping
-# `.claude/manifest.json` produces a broken install rather than a disclosed
-# omission (that is `_adopt_record_if_stageable`'s job, for paths that CAN be
-# skipped).
-#
-# IT FAILS CLOSED, AND THAT IS THE LOAD-BEARING HALF. `git check-ignore` exits
-# 0 (some ignored), 1 (none) or 128 (fatal) — and it IS fatal under the
-# pathspec-magic environment variables, which
-# tests/test-brownfield-wp6-collision-archive.sh MEASURED rather than guessed
-# (its R-WP6-18). A probe that wraps the call in 2>/dev/null and tests only for
-# rc 0 scores that fatal as "nothing is ignored" and proceeds — the fail-open
-# this function refuses. "Could not measure" is never "nothing to measure".
-adopt_paths_ignored() {
-  local root="$1"; shift
-  [ "$#" -gt 0 ] || return 1
-  local out rc
-  out=$( cd "$root" 2>/dev/null && printf '%s\n' "$@" | git check-ignore --stdin 2>/dev/null )
-  rc=$?
-  case "$rc" in
-    0) printf '%s\n' "$out"; return 0 ;;
-    1) return 1 ;;
-  esac
-  printf 'could not determine whether these paths are ignored (git check-ignore failed, rc %s)\n' "$rc"
-  return 0  # BL-225-IGNORE-FAILCLOSED
+# It is kept because the two answer different questions: --dry-run names the
+# PATTERN that matched (`.claude`), this names the actual PATHS. The caller
+# wants both, and falls back to git's own diagnostic when this returns nothing.
+adopt_name_ignored_paths() {
+  [ "$#" -gt 1 ] || return 1        # guard BEFORE the assignment: under `set -u`
+  local root="$1"; shift            # a zero-arg call would otherwise abort the driver
+  [ -d "$root" ] || return 1
+  ( cd "$root" 2>/dev/null && printf '%s\n' "$@" | git check-ignore --stdin 2>/dev/null )
 }
 
 # ── Writes ──────────────────────────────────────────────────────────────────

--- a/scripts/lib/adopt/adopt-core.sh
+++ b/scripts/lib/adopt/adopt-core.sh
@@ -84,7 +84,7 @@ adopt_refuse() {
   # said "nothing was written". Same class as the claim it replaced. The flag is
   # set by every writer the moment it has touched the tree, so this reads a fact
   # rather than a proxy for one.
-  if [ "$_n" -gt 0 ] || [ "${ADOPT_TOUCHED_DISK:-0}" -eq 1 ]; then
+  if [ "$_n" -gt 0 ] || adopt_has_touched_disk; then
     printf '\n[BLOCKED] %s\n' "$1" >&2
     if [ "${ADOPT_COMMITTED:-0}" -eq 1 ]; then
       printf '          The adoption commit HAD already landed; a later step did not complete.\n' >&2
@@ -101,8 +101,13 @@ adopt_refuse() {
     else
       # Touched the tree before anything reached the ledger — the archive's copy
       # phase is the reachable case. Say exactly that, and no count.
+      # "ATTEMPTED", not "changed": the marker is raised BEFORE each write, so a
+      # `mkdir -p` that failed having created nothing also raises it. Claiming
+      # files exist would be the same unmeasured assertion this whole entry is
+      # about — in the opposite direction. Attempted is true in every case that
+      # reaches here, and it still sends the operator to look.
       printf '          Nothing was committed, and no file is recorded as written — but %s\n' "$(printf '%s' "${ADOPT_OPERATION:-Adoption}" | tr '[:upper:]' '[:lower:]')" >&2
-      printf '          had already begun changing this project. Check `.claude/adoption-archive/`\n' >&2
+      printf '          had already ATTEMPTED writes to this project. Check `.claude/adoption-archive/`\n' >&2
       printf '          and `git status --ignored --untracked-files=all` before re-running.\n' >&2
     fi
   else
@@ -291,7 +296,23 @@ ADOPT_COMMITTED=0
 # tests/test-bl225-staging-preflight.sh's T9 DERIVES both sets and requires
 # them to match, so a thirteenth writer added without the flag fails the suite
 # instead of waiting for a sixth review round.
-ADOPT_TOUCHED_DISK=0
+# BL-225-TOUCHED-DISK is a FILE, not a variable, and that is the whole point.
+# `adopt_write_file` — the driver's most-used writer, and the one that lands
+# PROJECT_INTAKE.md, phase-state.json, manifest.json, the scout report and the
+# test-debt ledger — is called at seven sites as the RIGHT-HAND SIDE OF A
+# PIPELINE. bash 3.2 has no `lastpipe`, so that side runs in a SUBSHELL and any
+# variable it sets is discarded when it returns: the flag was set where nobody
+# could read it. A file survives the subshell, and it also cannot be satisfied
+# by a line that merely APPEARS in the right place — the marker had to be
+# reachable to create it.
+adopt_touched_disk() {          # BL-225-TOUCHED-DISK
+  [ -n "${ADOPT_WORK:-}" ] || return 0
+  : > "$ADOPT_WORK/touched" 2>/dev/null || true
+  return 0
+}
+adopt_has_touched_disk() {      # BL-225-TOUCHED-DISK
+  [ -n "${ADOPT_WORK:-}" ] && [ -f "$ADOPT_WORK/touched" ]
+}
 # BL-225-OPERATION: `--re-add` is a DIFFERENT OPERATION, not a mode of the
 # adoption run (adopt-project.sh says so), and it never calls
 # adopt_ledger_init — so every one of its refusals landed in the arm that says
@@ -353,7 +374,7 @@ adopt_name_ignored_paths() {
 adopt_write_file() {
   local root="$1" rel="$2" dir
   dir="$(dirname "$root/$rel")"
-  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+  adopt_touched_disk   # BL-225-TOUCHED-DISK
   mkdir -p "$dir" 2>/dev/null || { adopt_refuse "could not create $dir"; return 1; }
   cat > "$root/$rel" || { adopt_refuse "could not write $rel"; return 1; }
   adopt_record_write "$rel"
@@ -367,7 +388,7 @@ adopt_jq_edit() {
   local f="$root/$rel"
   [ -f "$f" ] || { adopt_refuse "cannot edit $rel — it does not exist"; return 1; }
   command -v jq >/dev/null 2>&1 || { adopt_refuse "jq is required to adopt a project"; return 1; }
-  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+  adopt_touched_disk   # BL-225-TOUCHED-DISK
   jq "$@" "$filter" "$f" > "$f.tmp" 2>/dev/null || { rm -f "$f.tmp"; adopt_refuse "jq could not edit $rel"; return 1; }
   mv "$f.tmp" "$f" || { adopt_refuse "could not replace $rel"; return 1; }
   adopt_record_write "$rel"

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -308,11 +308,36 @@ STAGE_SET
     adopt_refuse "there is nothing to commit — no file was recorded as written"
     return 1
   fi
+  # BL-225-STAGE-PREFLIGHT: ask BEFORE adding, and refuse WHOLE.
+  #
+  # `git add` on a mixed pathspec STAGES THE CLEAN PATHS AND EXITS 1 — measured,
+  # not assumed (BL-225: 78 written, 64 staged, rc 1; reproduced as T1 of
+  # tests/test-bl225-staging-preflight.sh). The old code discovered that from
+  # `git add`'s exit status, by which point the index was already half-written
+  # and the refusal below could only ask a question about it. This asks first,
+  # so the index is never touched on the failing path.
+  #
+  # The check runs over FILES_TO_STAGE, which is COMPLETE BY CONSTRUCTION: it
+  # is exactly the set the `git add` would receive, so nothing can reach the
+  # index unexamined regardless of which writer recorded it.
+  local _ignored
+  if _ignored=$(adopt_paths_ignored "$root" "${FILES_TO_STAGE[@]}"); then
+    adopt_refuse "your project's own ignore rules exclude file(s) this adoption must commit"
+    {
+      printf '          NOTHING WAS STAGED — your index is exactly as you left it.\n'
+      printf '          The path(s) in question:\n'
+      printf '%s\n' "$_ignored" | sed 's/^/            /'
+      printf '          These are framework files the adoption needs tracked, so they cannot be\n'
+      printf '          quietly skipped: an install missing them is broken rather than reduced.\n'
+      printf '          Un-ignore them in .gitignore and run adoption again.\n'
+    } >&2
+    return 1
+  fi
   adopt_head "Committing exactly what was written"
   adopt_note "$n file(s), named one by one. Anything else you had in progress stays"
   adopt_note "exactly as you left it — unstaged, uncommitted, untouched."
   ( cd "$root" && git add -- "${FILES_TO_STAGE[@]}" ) || {   # BF-ADOPT-STAGE-EXPLICIT
-    adopt_refuse "could not stage the adoption files (are any of them ignored by .gitignore?)"
+    adopt_refuse "could not stage the adoption files"
     return 1
   }
   ( cd "$root" && git commit -q -m "chore: adopt ${ADOPT_PROJECT_NAME:-this project} into the Solo Orchestrator framework" ) || {

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -327,21 +327,34 @@ STAGE_SET
   #
   # The set checked is FILES_TO_STAGE, complete by construction: it is exactly
   # what the `git add` would receive.
-  local _dry _ignored
+  local _dry _ignored _named
   if ! _dry=$( cd "$root" && git add --dry-run -- "${FILES_TO_STAGE[@]}" 2>&1 >/dev/null ); then
     # --dry-run names the PATTERN that matched; the helper names the PATHS.
     # Keep git's own diagnostic as the fallback, so a cause this code did not
     # anticipate (a pathspec-magic fatal, say) is REPORTED rather than
     # misdiagnosed as an ignore rule.
-    _ignored=$(adopt_name_ignored_paths "$root" "${FILES_TO_STAGE[@]}") || _ignored=""
+    _named=$(adopt_name_ignored_paths "$root" "${FILES_TO_STAGE[@]}") || _named=""
+    _ignored="$_named"
     [ -n "$_ignored" ] || _ignored="$_dry"
     adopt_refuse "git will not stage every file this adoption must commit"
     {
       printf '          NOTHING WAS STAGED — your index is exactly as you left it.\n'
       printf '          git says:\n'
-      printf '%s\n' "$_ignored" | sed 's/^/            /'
+      # BL-225-NO-FORCE-HINT: strip git's `hint:` lines. git suggests `add -f`,
+      # and `docs/adoption.md` guarantees adoption NEVER commits a file the
+      # operator's .gitignore excludes — so relaying the hint would put two
+      # contradictory instructions three lines apart, and would make this
+      # message depend on the host's `advice.addIgnoredFile` setting.
+      printf '%s\n' "$_ignored" | grep -v '^hint:' | sed 's/^/            /'
       printf '          These are framework files the adoption needs tracked, so they cannot be\n'
       printf '          quietly skipped: an install missing them is broken rather than reduced.\n'
+      # The remedy, and ONLY when an ignore rule is the confirmed cause. The
+      # first fix deleted this line outright because it is wrong for an
+      # unmeasurable cause — which left the common case with no action at all,
+      # except git's `-f` hint, which is the wrong one.
+      if [ -n "$_named" ]; then
+        printf '          Un-ignore them in .gitignore and run adoption again.\n'
+      fi
     } >&2
     return 1
   fi

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -103,14 +103,14 @@ adopt_install_framework() {
       n_collided=$((n_collided + 1))
       continue
     fi
-    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+    adopt_touched_disk   # BL-225-TOUCHED-DISK
     mkdir -p "$(dirname "$dst")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$rel")"; return 1; }
     # `cp -p`, and NOT `cp` followed by `chmod +x`. The framework's own modes
     # are already right — entry scripts are 0755 and libs are 0644 — and a
     # blanket +x would land every sourced lib in the adoptee at 0755, a
     # difference from a scaffolded project that nothing downstream would ever
     # explain. Preserving the source mode keeps the two births identical.
-    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+    adopt_touched_disk   # BL-225-TOUCHED-DISK
     cp -p "$src" "$dst" 2>/dev/null || { adopt_refuse "could not install $rel"; return 1; }
     adopt_record_write "$rel"
     n_copied=$((n_copied + 1))
@@ -419,17 +419,17 @@ adopt_install_hooks() {
   local root="$1"
   local hooks="$root/.git/hooks"
   adopt_head "Turning the gates on"
-  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+  adopt_touched_disk   # BL-225-TOUCHED-DISK
   mkdir -p "$hooks" 2>/dev/null || { adopt_refuse "could not create $hooks"; return 1; }
 
   if [ ! -f "$hooks/commit-msg" ]; then
-    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+    adopt_touched_disk   # BL-225-TOUCHED-DISK
     printf '%s\n' '#!/usr/bin/env bash' > "$hooks/commit-msg" || { adopt_refuse "could not create the commit-msg hook"; return 1; }
   fi
   if grep -qF "$SOIF_TDD_OPEN" "$hooks/commit-msg" 2>/dev/null; then
     adopt_note "The commit-msg gate was already present — left as it was."
   else
-    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+    adopt_touched_disk   # BL-225-TOUCHED-DISK
     soif_emit_tdd_commitmsg_block >> "$hooks/commit-msg" || { adopt_refuse "could not extend the commit-msg hook"; return 1; }
     adopt_note "Commit-msg gate installed (it composes with whatever was already in that hook)."
   fi

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -103,12 +103,14 @@ adopt_install_framework() {
       n_collided=$((n_collided + 1))
       continue
     fi
+    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
     mkdir -p "$(dirname "$dst")" 2>/dev/null || { adopt_refuse "could not create $(dirname "$rel")"; return 1; }
     # `cp -p`, and NOT `cp` followed by `chmod +x`. The framework's own modes
     # are already right — entry scripts are 0755 and libs are 0644 — and a
     # blanket +x would land every sourced lib in the adoptee at 0755, a
     # difference from a scaffolded project that nothing downstream would ever
     # explain. Preserving the source mode keeps the two births identical.
+    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
     cp -p "$src" "$dst" 2>/dev/null || { adopt_refuse "could not install $rel"; return 1; }
     adopt_record_write "$rel"
     n_copied=$((n_copied + 1))
@@ -352,7 +354,12 @@ STAGE_SET
       # first fix deleted this line outright because it is wrong for an
       # unmeasurable cause — which left the common case with no action at all,
       # except git's `-f` hint, which is the wrong one.
-      if [ -n "$_named" ]; then
+      # The remedy fires when an ignore rule is the CONFIRMED cause — from the
+      # namer, or from git's own diagnostic. Gating on the namer alone left the
+      # tracked-path case (this branch's headline case) with no remedy at all,
+      # because `git check-ignore` is index-aware and structurally cannot name a
+      # tracked path. It must still NOT fire on an unmeasured cause.
+      if [ -n "$_named" ] || printf '%s' "$_dry" | grep -q 'ignored by one of your'; then
         printf '          Un-ignore them in .gitignore and run adoption again.\n'
       fi
     } >&2
@@ -412,14 +419,17 @@ adopt_install_hooks() {
   local root="$1"
   local hooks="$root/.git/hooks"
   adopt_head "Turning the gates on"
+  ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
   mkdir -p "$hooks" 2>/dev/null || { adopt_refuse "could not create $hooks"; return 1; }
 
   if [ ! -f "$hooks/commit-msg" ]; then
+    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
     printf '%s\n' '#!/usr/bin/env bash' > "$hooks/commit-msg" || { adopt_refuse "could not create the commit-msg hook"; return 1; }
   fi
   if grep -qF "$SOIF_TDD_OPEN" "$hooks/commit-msg" 2>/dev/null; then
     adopt_note "The commit-msg gate was already present — left as it was."
   else
+    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
     soif_emit_tdd_commitmsg_block >> "$hooks/commit-msg" || { adopt_refuse "could not extend the commit-msg hook"; return 1; }
     adopt_note "Commit-msg gate installed (it composes with whatever was already in that hook)."
   fi

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -308,28 +308,40 @@ STAGE_SET
     adopt_refuse "there is nothing to commit — no file was recorded as written"
     return 1
   fi
-  # BL-225-STAGE-PREFLIGHT: ask BEFORE adding, and refuse WHOLE.
+  # BL-225-STAGE-PREFLIGHT: ask BEFORE adding, and stop WHOLE.
   #
   # `git add` on a mixed pathspec STAGES THE CLEAN PATHS AND EXITS 1 — measured,
-  # not assumed (BL-225: 78 written, 64 staged, rc 1; reproduced as T1 of
-  # tests/test-bl225-staging-preflight.sh). The old code discovered that from
-  # `git add`'s exit status, by which point the index was already half-written
-  # and the refusal below could only ask a question about it. This asks first,
-  # so the index is never touched on the failing path.
+  # not assumed (T1 of tests/test-bl225-staging-preflight.sh). The old code
+  # learned that from `git add`'s exit status, by which point the index was
+  # already half-written.
   #
-  # The check runs over FILES_TO_STAGE, which is COMPLETE BY CONSTRUCTION: it
-  # is exactly the set the `git add` would receive, so nothing can reach the
-  # index unexamined regardless of which writer recorded it.
-  local _ignored
-  if _ignored=$(adopt_paths_ignored "$root" "${FILES_TO_STAGE[@]}"); then
-    adopt_refuse "your project's own ignore rules exclude file(s) this adoption must commit"
+  # THE ORACLE IS `git add --dry-run`, AND THAT CHOICE IS THE FIX. The first
+  # version asked `git check-ignore`, which is INDEX-AWARE and reports nothing
+  # for a TRACKED path — so a tracked `.claude/manifest.json` under a
+  # later-added `.claude/` rule passed the preflight and half-staged exactly as
+  # before. Measured against `git add` as ground truth across a directory rule,
+  # a file rule and a glob, `--dry-run` is the only oracle that agrees in all
+  # three; `check-ignore --no-index` swaps the false-clean for a FALSE REFUSAL
+  # on projects that work today. `--dry-run` writes nothing: `.git/` hashes
+  # byte-identical before and after, so the promise below holds by construction.
+  #
+  # The set checked is FILES_TO_STAGE, complete by construction: it is exactly
+  # what the `git add` would receive.
+  local _dry _ignored
+  if ! _dry=$( cd "$root" && git add --dry-run -- "${FILES_TO_STAGE[@]}" 2>&1 >/dev/null ); then
+    # --dry-run names the PATTERN that matched; the helper names the PATHS.
+    # Keep git's own diagnostic as the fallback, so a cause this code did not
+    # anticipate (a pathspec-magic fatal, say) is REPORTED rather than
+    # misdiagnosed as an ignore rule.
+    _ignored=$(adopt_name_ignored_paths "$root" "${FILES_TO_STAGE[@]}") || _ignored=""
+    [ -n "$_ignored" ] || _ignored="$_dry"
+    adopt_refuse "git will not stage every file this adoption must commit"
     {
       printf '          NOTHING WAS STAGED — your index is exactly as you left it.\n'
-      printf '          The path(s) in question:\n'
+      printf '          git says:\n'
       printf '%s\n' "$_ignored" | sed 's/^/            /'
       printf '          These are framework files the adoption needs tracked, so they cannot be\n'
       printf '          quietly skipped: an install missing them is broken rather than reduced.\n'
-      printf '          Un-ignore them in .gitignore and run adoption again.\n'
     } >&2
     return 1
   fi
@@ -344,6 +356,7 @@ STAGE_SET
     adopt_refuse "the adoption commit did not succeed — your own hooks or git identity may have refused it"
     return 1
   }
+  ADOPT_COMMITTED=1   # BL-225-REFUSE-HONEST: derived, so a later refusal tells the truth
   return 0
 }
 

--- a/scripts/lib/adopt/adopt-test-debt.sh
+++ b/scripts/lib/adopt/adopt-test-debt.sh
@@ -518,6 +518,7 @@ _td_write_body() {
   if command -v adopt_write_file >/dev/null 2>&1; then
     printf '%s\n' "$json" | adopt_write_file "$root" "$TD_LEDGER_REL" || return 1
   else
+    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
     mkdir -p "$root/.claude" 2>/dev/null || { echo "test-debt: could not create $root/.claude" >&2; return 2; }
     printf '%s\n' "$json" > "$ledger" || { echo "test-debt: could not write $ledger" >&2; return 2; }
   fi

--- a/scripts/lib/adopt/adopt-test-debt.sh
+++ b/scripts/lib/adopt/adopt-test-debt.sh
@@ -518,7 +518,7 @@ _td_write_body() {
   if command -v adopt_write_file >/dev/null 2>&1; then
     printf '%s\n' "$json" | adopt_write_file "$root" "$TD_LEDGER_REL" || return 1
   else
-    ADOPT_TOUCHED_DISK=1   # BL-225-TOUCHED-DISK
+    adopt_touched_disk   # BL-225-TOUCHED-DISK
     mkdir -p "$root/.claude" 2>/dev/null || { echo "test-debt: could not create $root/.claude" >&2; return 2; }
     printf '%s\n' "$json" > "$ledger" || { echo "test-debt: could not write $ledger" >&2; return 2; }
   fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9519,13 +9519,27 @@ residual, all measured:
   a small, reasoned exemption list. Its first version was an ALLOWLIST of
   variable spellings; review defeated it in one attempt with an ordinary new
   function writing to `"$dest"`. The denylist catches that.
-- **RESIDUAL: T9 is a net, not a proof.** It verifies that a marker call
-  appears before the write inside the same function; it does NOT verify
-  REACHABILITY, and a call wrapped in a never-true condition would satisfy it.
-  That is not statically decidable here. The mitigation is structural rather
-  than textual — because the marker is a file, an unreachable call creates
-  nothing and the behavioural assertions fail instead. Recorded rather than
-  implied.
+- **RESIDUAL: the guard is a NET, not a proof, and this is a finding about the
+  APPROACH rather than about any one recipe.** It was rewritten twice and
+  defeated twice, each rewrite opening a new blind spot of the same shape,
+  because **a shell regex cannot decide "does this line write into the
+  adoptee's tree" — the answer depends on variable provenance the line does not
+  carry.** `printf x > "$root/f"` and `printf x > "$TD_TMP/f"` are the same
+  shape and opposite answers. It was therefore labelled honestly instead of
+  rewritten a third time. **Named gaps, each measured:** `printf … > file` and
+  `echo … > file` (the output-function filter removes them, and it must, or it
+  removes nearly every real writer instead — two real sites in this codebase sit
+  in that gap and both carry markers); `tee`; a redirect with no space after
+  `>`; an exemption matching on the READ side of a line whose write target is in
+  the tree; and REACHABILITY, which is not statically decidable — a marker call
+  inside a never-true condition satisfies the text check. Two mitigations, both
+  structural rather than textual: the marker is a FILE, so an unreachable call
+  creates nothing and the behavioural assertions fail instead; and **T10** cross-
+  checks two independently derived sets — every file that raises the marker must
+  also yield a writer — which catches the recipe silently collapsing. That
+  collapse happened twice (a `/dev/null` arm matching `2>/dev/null`, and an
+  `adopt_refuse "` arm matching error tails) and T9 stayed green through both;
+  T10 fails on it.
 
 **THE NARROWING IS DELIBERATE AND IS RECORDED RATHER THAN LEFT TO A DIFF.** This
 entry's title asks for a preflight, and the natural reading is *before anything

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9536,10 +9536,22 @@ residual, all measured:
   structural rather than textual: the marker is a FILE, so an unreachable call
   creates nothing and the behavioural assertions fail instead; and **T10** cross-
   checks two independently derived sets — every file that raises the marker must
-  also yield a writer — which catches the recipe silently collapsing. That
-  collapse happened twice (a `/dev/null` arm matching `2>/dev/null`, and an
-  `adopt_refuse "` arm matching error tails) and T9 stayed green through both;
-  T10 fails on it.
+  also yield a writer — which catches a collapse that removes a whole FILE from
+  the recipe's view. That happened twice (a `/dev/null` arm matching
+  `2>/dev/null`, and an `adopt_refuse "` arm matching error tails); T9 stayed
+  green through both and T10 fails on it.
+- **RESIDUAL: T10 does NOT catch a whole-FUNCTION collapse.** Measured, not
+  supposed: a `$arc_abs` + `restore:` exemption pair — the second of which is a
+  *correct* cleanup of a jq string literal that is not a write — plus deleting
+  both markers in `adopt_archive_write` takes the recipe 16 hits to 11, leaves
+  the archive copy phase unguarded, and both checks stay green, 35/35. The file
+  stays "represented" because `adopt_archive_readd` still yields hits. A
+  per-function variant would not catch it either: once the markers are removed
+  the function leaves the check's domain, and the only thing that would catch it
+  is a coverage number pinned from outside the recipe — which rots. It needs two
+  independent mistakes to align, one of them a legitimate cleanup. Recorded
+  rather than answered with a third guard, because every guard added here has
+  itself had a hole.
 
 **THE NARROWING IS DELIBERATE AND IS RECORDED RATHER THAN LEFT TO A DIFF.** This
 entry's title asks for a preflight, and the natural reading is *before anything

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9496,6 +9496,39 @@ git names the culprit) but the adoptee is left half-written with no way back
 except by hand.
 **Status:** Open
 
+**PARTIALLY CLOSED 2026-08-31 — the STAGING half. The BEFORE-ANY-WRITE half is
+still open, and this entry stays Open for it.** What shipped: a preflight in
+`adopt_stage_and_commit` (`# BL-225-STAGE-PREFLIGHT`) that asks
+`git add --dry-run` before it stages and stops WHOLE, so the index is never
+half-written; an honest refusal (`# BL-225-REFUSE-HONEST`) that derives the
+written count and labels the two cases apart; and the same oracle correction in
+`_adopt_record_if_stageable` (`# BL-225-ORACLE-SYNC`).
+
+**THE NARROWING IS DELIBERATE AND IS RECORDED RATHER THAN LEFT TO A DIFF.** This
+entry's title asks for a preflight, and the natural reading is *before anything
+is written*. What shipped runs before **staging** — by which point ~78 files are
+already on disk. The index is protected; the disk is not. Closing that half needs
+a planned-path set derived before the first write, which is a different piece of
+work and is not attempted here.
+
+**THE FIRST FIX FOR THIS ENTRY WAS WRONG, AND THE REASON IS WORTH KEEPING.** It
+asked `git check-ignore`, which is INDEX-AWARE — git-check-ignore(1): *"tracked
+files are not shown at all since they are not subject to exclude rules"* — while
+`git add` is not. So on a TRACKED `.claude/manifest.json` under a later-added
+`.claude/` rule, check-ignore reported *nothing ignored* and the preflight said
+proceed, and `git add` then refused **and staged anyway**: this defect,
+unchanged, through the guard written to stop it. Adversarial review caught it.
+Measured against `git add` as ground truth across a directory rule, a file rule
+and a glob, `git add --dry-run` is the only oracle that agrees in all three;
+`check-ignore --no-index` swaps the false-clean for a FALSE REFUSAL on projects
+that work today. A second benefit fell out: `--dry-run` is immune to the
+pathspec-magic variables that make `check-ignore` exit 128, so the fail-open
+class the first fix's fail-closed arm was written to defend against is
+**eliminated** rather than guarded — and that arm, with its marker, is gone. (It
+is described here rather than cited: the marker no longer exists, and citing a
+withdrawn marker is what `scripts/lint-bl-markers.sh` exists to catch. It caught
+this paragraph.)
+
 **What happens.** `scripts/adopt-project.sh` stages every recorded path in ONE
 `git add`, and `git add` on a gitignored path FAILS. WP6 fixed this for the
 paths it owns — the collision archive's entries, both MANIFESTs and the audit

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -9504,6 +9504,29 @@ half-written; an honest refusal (`# BL-225-REFUSE-HONEST`) that derives the
 written count and labels the two cases apart; and the same oracle correction in
 `_adopt_record_if_stageable` (`# BL-225-ORACLE-SYNC`).
 
+**THE TOUCHED-DISK MARKER, AND WHAT ITS GUARD DOES NOT COVER.** The refusal can
+no longer say "nothing was written" over files that exist, because every writer
+raises a marker first and `adopt_refuse` reads it. Two design facts and one
+residual, all measured:
+
+- **The marker is a FILE (`$ADOPT_WORK/touched`), not a variable.**
+  `adopt_write_file` — the driver's most-used writer — is called at seven sites
+  as the RIGHT-HAND SIDE OF A PIPELINE, and bash 3.2 has no `lastpipe`, so a
+  variable set there dies with the subshell. The first version of this fix set a
+  variable and was therefore invisible to the driver at exactly those sites.
+- **`tests/test-bl225-staging-preflight.sh` T9 enforces the invariant** by
+  DERIVING the write sites from the source with a denylist of write shapes and
+  a small, reasoned exemption list. Its first version was an ALLOWLIST of
+  variable spellings; review defeated it in one attempt with an ordinary new
+  function writing to `"$dest"`. The denylist catches that.
+- **RESIDUAL: T9 is a net, not a proof.** It verifies that a marker call
+  appears before the write inside the same function; it does NOT verify
+  REACHABILITY, and a call wrapped in a never-true condition would satisfy it.
+  That is not statically decidable here. The mitigation is structural rather
+  than textual — because the marker is a file, an unreachable call creates
+  nothing and the behavioural assertions fail instead. Recorded rather than
+  implied.
+
 **THE NARROWING IS DELIBERATE AND IS RECORDED RATHER THAN LEFT TO A DIFF.** This
 entry's title asks for a preflight, and the natural reading is *before anything
 is written*. What shipped runs before **staging** — by which point ~78 files are

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -770,6 +770,15 @@ run_child_suite "tests/test-brownfield-wp6-collision-archive.sh" \
   "Collision archive (layout, MANIFEST, disclosure, re-add audit, archive-secrets refusal)" \
   "Adoption WP6 collision-archive tests FAILED (run tests/test-brownfield-wp6-collision-archive.sh for details)"
 
+# BL-225: the staging preflight. T1 REPRODUCES the defect (a mixed `git add`
+# pathspec stages the clean paths and exits 1) rather than describing it, so a
+# git that ever changed that behaviour would be caught here rather than in a
+# half-staged adoptee. Sources the adopt libs directly; never invokes the
+# scaffolder -> both lanes.
+run_child_suite "tests/test-bl225-staging-preflight.sh" \
+  "Adoption staging preflight (refuse whole, never half-stage; fail-closed check-ignore)" \
+  "BL-225 staging-preflight tests FAILED (run tests/test-bl225-staging-preflight.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -297,10 +297,13 @@ _writers() {
 # fail instead. Recorded on `## BL-225:` as a residual rather than implied.
 _marker_files() {   # files that call the marker, by basename
   grep -rlE '(^|[^A-Za-z0-9_])adopt_touched_disk([^A-Za-z0-9_]|$)' "$REPO_ROOT"/scripts/lib/adopt/*.sh \
-    | xargs -n1 basename | sort -u
+    | sed 's|.*/||' | sort -u
 }
 _writer_files() {   # files the recipe believes contain writers, by basename
-  _writers | cut -d: -f1 | xargs -n1 basename | sort -u
+  # `sed 's|.*/||'`, NOT `xargs -n1 basename`: this repo's path contains a
+  # space, and xargs word-splits on it. Both sets picked up a spurious "Space"
+  # entry and T10 passed only because both derivations corrupted identically.
+  _writers | cut -d: -f1 | sed 's|.*/||' | sort -u
 }
 t9_w=$(_writers | wc -l | tr -d ' ')
 chk "T9: the recipe still matches tree-writing sites at all" \
@@ -321,9 +324,13 @@ while IFS=: read -r wf wl; do
 done <<T9SET
 $(_writers)
 T9SET
-chk "T9: every tree-writing site is preceded by the marker (writers=$t9_w)" "$t9_missing" "0"
+# NOTE the count is of RECIPE HITS, not of writers: at least one hit is a `cp `
+# inside a jq string literal (`restore: ("cp " + ...)`), which is not a write.
+# Harmless — a false positive can only demand a marker that is already there —
+# but do not read `writers=N` as N writers.
+chk "T9: every recipe hit is preceded by the marker (hits=$t9_w)" "$t9_missing" "0"
 
-echo "== T10 — the recipe cannot collapse silently (two independently derived sets) =="
+echo "== T10 — a whole-FILE collapse cannot pass silently (two derived sets) =="
 # T9's weakness is that it can only fail on writers it FINDS. Twice now the
 # recipe has silently stopped finding almost everything — once via a `/dev/null`
 # exclusion that matched `2>/dev/null` on nearly every writer, once via an
@@ -334,6 +341,15 @@ echo "== T10 — the recipe cannot collapse silently (two independently derived 
 # files the recipe believes contain writers. A file that raises the marker but
 # yields no writer means the recipe stopped seeing that file. No transcribed
 # number is involved, so it cannot rot.
+#
+# WHAT IT DOES NOT CATCH, measured rather than supposed: a collapse that removes
+# one FUNCTION's writers while another function in the same file still yields
+# some. The file stays "represented" and both checks stay green. Demonstrated by
+# review with a `$arc_abs` + `restore:` exemption pair plus deleting both
+# markers in `adopt_archive_write` — writers 16 -> 11, archive copy phase
+# unguarded, 35/35. A per-function variant would not catch it either: once the
+# markers are gone the function leaves the check's domain. Recorded on
+# `## BL-225:` rather than answered with a third guard.
 t10_bad=0
 for _mf in $(_marker_files); do
   _writer_files | grep -qx "$_mf" || { t10_bad=$((t10_bad + 1)); echo "         (T10) $_mf calls the marker but the recipe finds no writer in it"; }

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -27,6 +27,7 @@ unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_COMMON_DIR
 # wraps it in 2>/dev/null scores the fatal as NOT IGNORED — fail-open. T5
 # pins that the product code refuses instead.
 unset GIT_LITERAL_PATHSPECS GIT_NOGLOB_PATHSPECS GIT_GLOB_PATHSPECS GIT_ICASE_PATHSPECS
+unset GITHUB_BASE_REF        # house rule: fixture git ops must not see the runner's base ref
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PASS=0; FAIL=0
@@ -37,7 +38,15 @@ chk()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; 
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/bl225.XXXXXX")" || exit 1
 # BL-244: mktemp must not silently land in the launch directory.
 case "$WORK" in "$REPO_ROOT"*) echo "FATAL: fixture inside repo"; exit 1 ;; esac
-trap 'rm -rf "$WORK"' EXIT
+trap 'rm -rf "$WORK"' EXIT INT TERM
+# THE HEADER ABOVE CLAIMED THIS AND THE FIRST DRAFT NEVER DID IT. Review
+# reproduced the gap: with a global excludes file carrying `.claude/`, the suite
+# went 16 passed / 1 failed. GIT_CONFIG_GLOBAL does not cover the excludes file
+# — it is found by a PATH default — so this is the knob, exactly as the header
+# says. A header that describes a neutralization the file does not perform is
+# worse than no header.
+export XDG_CONFIG_HOME="$WORK/xdg"; mkdir -p "$XDG_CONFIG_HOME"
+export HOME="$WORK/home"; mkdir -p "$HOME"
 
 _adoptee() {                     # _adoptee DIR [ignore-line...]
   local d="$1"; shift
@@ -59,28 +68,58 @@ mkdir -p "$P/.claude"; printf 'a\n' > "$P/a.txt"; printf 'b\n' > "$P/b.txt"; pri
 chk "T1: git add on a mixed pathspec exits non-zero" "$([ "$rc" -ne 0 ] && echo yes || echo no)" "yes"
 chk "T1: and it staged the clean paths anyway (the half-staged tree)" "$(_staged "$P")" "2"
 
-echo "== T2 — adopt_paths_ignored names an ignored path and fails closed =="
+echo "== T0 — the TRACKED-path case: check-ignore says clean, git add refuses =="
+# This is review finding 1, and it is why the oracle changed. A path that is
+# TRACKED is invisible to `git check-ignore` (git-check-ignore(1): "tracked
+# files are not shown at all"), but `git add` still refuses on its ignored
+# leading directory — and stages the rest. The first fix keyed on check-ignore
+# and therefore let BL-225 through unchanged on exactly this shape.
+P0="$WORK/t0"; _adoptee "$P0"
+mkdir -p "$P0/.claude"; printf 'x\n' > "$P0/.claude/manifest.json"; printf 'y\n' > "$P0/PROJECT_INTAKE.md"
+( cd "$P0" && git add -A && git commit -q -m tracked && printf '.claude/\n' > .gitignore && git add .gitignore && git commit -q -m ign ) >/dev/null 2>&1
+printf 'z\n' >> "$P0/.claude/manifest.json"; printf 'w\n' >> "$P0/PROJECT_INTAKE.md"
+( cd "$P0" && printf '%s\n' ".claude/manifest.json" "PROJECT_INTAKE.md" | git check-ignore --stdin ) >/dev/null 2>&1
+chk "T0: check-ignore reports the tracked path as NOT ignored (rc 1)" "$?" "1"
+( cd "$P0" && git add --dry-run -- .claude/manifest.json PROJECT_INTAKE.md ) >/dev/null 2>&1
+chk "T0: git add --dry-run DOES refuse it (the oracle that matches ground truth)" "$?" "1"
+
+echo "== T2 — adopt_name_ignored_paths NAMES paths (it does not decide) =="
 . "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" 2>/dev/null
-if ! command -v adopt_paths_ignored >/dev/null 2>&1; then
-  bad "T2: adopt_paths_ignored is not defined (RED before the fix)"
+if ! command -v adopt_name_ignored_paths >/dev/null 2>&1; then
+  bad "T2: adopt_name_ignored_paths is not defined (RED before the fix)"
   bad "T2: (dependent assertions skipped)"; bad "T3: (skipped)"; bad "T4: (skipped)"; bad "T5: (skipped)"
 else
   P2="$WORK/t2"; _adoptee "$P2" '.claude/'
-  out="$(adopt_paths_ignored "$P2" ".claude/manifest.json" "README.md" 2>&1)"; rc=$?
+  out="$(adopt_name_ignored_paths "$P2" "README.md" ".claude/manifest.json" 2>&1)"; rc=$?
   chk "T2: reports rc=0 when at least one path is ignored" "$rc" "0"
   chk "T2: and names the ignored path" "$(printf '%s' "$out" | grep -c 'manifest.json')" "1"
   chk "T2: and does NOT name the clean one" "$(printf '%s' "$out" | grep -c 'README.md')" "0"
 
   P3="$WORK/t3"; _adoptee "$P3"
-  adopt_paths_ignored "$P3" ".claude/manifest.json" "README.md" >/dev/null 2>&1
+  adopt_name_ignored_paths "$P3" "README.md" ".claude/manifest.json" >/dev/null 2>&1
   chk "T3: rc=1 when nothing is ignored" "$?" "1"
 
   echo "== T5 — a check-ignore that CANNOT RUN is not 'nothing is ignored' =="
   P5="$WORK/t5"; _adoptee "$P5" 'sub/*.txt'
   # GIT_NOGLOB_PATHSPECS makes check-ignore FATAL. A 2>/dev/null probe scores
   # that as clean; this must fail CLOSED instead (rc 0 = treat as ignored).
-  GIT_NOGLOB_PATHSPECS=1 adopt_paths_ignored "$P5" "sub/a.txt" >/dev/null 2>&1
-  chk "T5: fails CLOSED when check-ignore cannot run" "$?" "0"
+  # THE DECIDER IS IMMUNE TO THE HAZARD THAT BROKE THE OLD ONE, and that is a
+  # stronger property than the fail-closed guard it replaced. `git check-ignore`
+  # DIES (rc 128) under every pathspec-magic variable — the hazard
+  # tests/test-brownfield-wp6-collision-archive.sh measured (R-WP6-18) — so any
+  # probe wrapping it in 2>/dev/null scores the fatal as "clean". `git add
+  # --dry-run` answers correctly under all three, so the fail-open class is
+  # ELIMINATED here rather than defended against. Asserted in both directions:
+  # the hazard must be real, or this case proves nothing.
+  t5_ci_dead=0; t5_dry_ok=0
+  for _v in GIT_NOGLOB_PATHSPECS GIT_LITERAL_PATHSPECS GIT_ICASE_PATHSPECS; do
+    ( cd "$P5" && env "$_v=1" git check-ignore -q -- "README.md" ) >/dev/null 2>&1
+    [ "$?" -eq 128 ] && t5_ci_dead=$((t5_ci_dead + 1))
+    ( cd "$P5" && env "$_v=1" git add --dry-run -- "README.md" ) >/dev/null 2>&1
+    [ "$?" -eq 0 ] && t5_dry_ok=$((t5_dry_ok + 1))
+  done
+  chk "T5: the hazard is REAL — check-ignore dies (128) under all 3 magic vars" "$t5_ci_dead" "3"
+  chk "T5: and the chosen oracle is IMMUNE — --dry-run answers under all 3"     "$t5_dry_ok"  "3"
 fi
 
 echo "== T4 — the staging guard: refuse whole, never half =="
@@ -134,41 +173,71 @@ chk "T6: and stages NOTHING (no half-staged tree)" "${t6staged:-x}" "0"
 chk "T6: refused via the PREFLIGHT, naming the ignored path" "$(printf '%s' "$t6err" | grep -c 'manifest.json')" "1"
 chk "T6: not via the empty-ledger arm"                       "$(printf '%s' "$t6err" | grep -c 'no file was recorded as written')" "0"
 
-echo "== M2 — the mutation that matters: neuter the preflight =="
+echo "== M — mutation proofs =="
 MUTLIB="$WORK/mutlib"; mkdir -p "$MUTLIB"
 cp "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "$MUTLIB/adopt-core.sh"
-sed 's/^  if _ignored=$(adopt_paths_ignored "$root" "${FILES_TO_STAGE\[@\]}"); then$/  if false; then/' \
+
+# The TRACKED-path fixture: this is the shape finding 1 was found on, and the
+# shape a real adoptee takes once a `.claude/` rule is added after adoption.
+_tracked_fixture() {
+  local p="$1"
+  _adoptee "$p" || return 1
+  mkdir -p "$p/.claude"
+  printf 'x\n' > "$p/.claude/manifest.json"; printf 'y\n' > "$p/PROJECT_INTAKE.md"
+  ( cd "$p" && git add -A && git commit -q -m tracked \
+      && printf '.claude/\n' > .gitignore && git add .gitignore && git commit -q -m ign ) >/dev/null 2>&1 || return 1
+  printf 'z\n' >> "$p/.claude/manifest.json"; printf 'w\n' >> "$p/PROJECT_INTAKE.md"
+  printf '.claude/manifest.json\nPROJECT_INTAKE.md\n' > "$p/.ledger"
+}
+
+# M1 — THE ORACLE. Put the refuted oracle back and the tracked fixture
+# half-stages again. This is the mutation that pins review finding 1; the
+# suite's first version had no assertion that could see it.
+# Restore the refuted oracle WITH ITS ORIGINAL POLARITY: the first fix asked
+# "is anything ignored?" and refused on yes. On a TRACKED path check-ignore
+# answers no, so the mutant falls through to `git add` and half-stages — which
+# is the defect, reproduced on demand. (A first draft of this mutation kept the
+# `!` and so inverted the predicate instead of restoring it: the mutant refused
+# everything and "staged=0" looked like a pass. Restore the shape, not the tool.)
+sed 's|^  if ! _dry=$( cd "$root" && git add --dry-run -- "${FILES_TO_STAGE\[@\]}" 2>&1 >/dev/null ); then$|  if _ignored=$(adopt_name_ignored_paths "$root" "${FILES_TO_STAGE[@]}"); then|' \
   "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" > "$MUTLIB/adopt-state.sh"
-nchanged=$(diff "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" "$MUTLIB/adopt-state.sh" | grep -c '^<')
-if [ "$nchanged" -ne 1 ]; then
-  bad "M2: mutation did not apply cleanly (changed $nchanged line(s))"
-elif [ "$(_parses_ok "$MUTLIB/adopt-state.sh")" != "1" ]; then
-  bad "M2: mutant does not parse"
+n1=$(diff "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" "$MUTLIB/adopt-state.sh" | grep -c '^<')
+if [ "$n1" -ne 1 ]; then bad "M1: oracle mutation did not apply (changed $n1 line(s))"
+elif [ "$(_parses_ok "$MUTLIB/adopt-state.sh")" != "1" ]; then bad "M1: mutant does not parse"
 else
-  P7="$WORK/m2"; _stage_fixture "$P7"
-  IFS='|' read -r m2rc m2staged m2err <<<"$(_run_stage "$P7" "$MUTLIB")"
+  PM1="$WORK/m1"; _tracked_fixture "$PM1"
+  IFS='|' read -r m1rc m1staged m1err <<<"$(_run_stage "$PM1" "$MUTLIB")"
+  chk "M1: with check-ignore as the oracle the TRACKED fixture half-stages (RED)" \
+    "$([ "${m1staged:-0}" -gt 0 ] && echo half-staged || echo "staged=${m1staged}")" "half-staged"
+fi
+
+# M2 — THE GUARD ITSELF. Remove the preflight entirely; the same fixture
+# half-stages. Distinct from M1: M1 proves the ORACLE matters, M2 proves the
+# GUARD does.
+sed 's|^  if ! _dry=$( cd "$root" && git add --dry-run -- "${FILES_TO_STAGE\[@\]}" 2>&1 >/dev/null ); then$|  if false; then|' \
+  "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" > "$MUTLIB/adopt-state2.sh"
+n2=$(diff "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" "$MUTLIB/adopt-state2.sh" | grep -c '^<')
+if [ "$n2" -ne 1 ]; then bad "M2: guard mutation did not apply (changed $n2 line(s))"
+elif [ "$(_parses_ok "$MUTLIB/adopt-state2.sh")" != "1" ]; then bad "M2: mutant does not parse"
+else
+  cp "$MUTLIB/adopt-state2.sh" "$MUTLIB/adopt-state.sh"
+  PM2="$WORK/m2"; _stage_fixture "$PM2"
+  IFS='|' read -r m2rc m2staged m2err <<<"$(_run_stage "$PM2" "$MUTLIB")"
   chk "M2: without the preflight the SAME fixture HALF-STAGES (RED)" \
     "$([ "${m2staged:-0}" -gt 0 ] && echo half-staged || echo "staged=${m2staged} err=${m2err}")" "half-staged"
   chk "M2: and the mutant reached git add, not the empty-ledger arm" \
     "$(printf '%s' "$m2err" | grep -c 'no file was recorded as written')" "0"
 fi
 
-echo "== M — mutation proofs =="
-MUT="$WORK/mut"; mkdir -p "$MUT"
-cp "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "$MUT/core.orig"
-if command -v adopt_paths_ignored >/dev/null 2>&1; then
-  # M1: neuter the fail-closed arm -> a fatal check-ignore scores as clean.
-  sed 's/return 0  # BL-225-IGNORE-FAILCLOSED/return 1/' "$MUT/core.orig" > "$MUT/core.mut"
-  n=$(diff "$MUT/core.orig" "$MUT/core.mut" | grep -c '^<')
-  if [ "$n" -ne 1 ]; then bad "M1: mutation did not apply (changed $n line(s))"; else
-    ( set +e; unset -f adopt_paths_ignored; . "$MUT/core.mut" 2>/dev/null
-      P="$WORK/m1"; mkdir -p "$P" && ( cd "$P" && git init -q -b main . && git config user.email t@e && git config user.name T \
-        && printf 'x\n' > R.md && printf 'sub/*.txt\n' > .gitignore && git add -A && git commit -q -m b ) >/dev/null 2>&1
-      GIT_NOGLOB_PATHSPECS=1 adopt_paths_ignored "$P" "sub/a.txt" >/dev/null 2>&1
-      echo "$?" > "$WORK/m1.rc" )
-    chk "M1: with the fail-closed arm neutered, a FATAL probe reports 'clean' (RED)" "$(cat "$WORK/m1.rc" 2>/dev/null)" "1"
-  fi
-fi
+# T7 — the real code on the tracked fixture: refuses, stages nothing.
+PT7="$WORK/t7"; _tracked_fixture "$PT7"
+IFS='|' read -r t7rc t7staged t7err <<<"$(_run_stage "$PT7" "$REPO_ROOT/scripts/lib/adopt")"
+chk "T7: the TRACKED case now refuses (rc != 0)"     "$([ "${t7rc:-0}" -ne 0 ] && echo yes || echo no)" "yes"
+chk "T7: and stages NOTHING — BL-225 no longer reproduces" "${t7staged:-x}" "0"
+chk "T7: labelled BLOCKED, not REFUSED (files were written)" "$(printf '%s' "$t7err" | grep -c 'BLOCKED')" "1"
+chk "T7: and it does not promise plain \`git status\` lists them" \
+  "$(printf '%s' "$t7err" | grep -c 'git status --ignored --untracked-files=all')" "1"
+
 echo
 echo "Results: $PASS passed, $FAIL failed"
 [ "$FAIL" -eq 0 ]

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -201,7 +201,7 @@ chk "T8: and stages NOTHING — the decider sees the WHOLE set, not just [0]" "$
 chk "T8: git's force hint is never relayed"         "$(printf '%s' "$t8err" | grep -c 'really want to add them')" "0"
 chk "T8: and the remedy line is present"            "$(printf '%s' "$t8err" | grep -c 'Un-ignore them in .gitignore')" "1"
 
-echo "== T9 — every tree-writing site raises the touched marker (DENYLIST, not a list) =="
+echo "== T9 — a NET over the write shapes we know. Not a proof. =="
 # THE INVARIANT IS TESTED BECAUSE ASSERTING IT FAILED — TWICE, IN DIFFERENT WAYS.
 # First the flag's comment claimed "ANY writer" while it was set at two of
 # twelve sites. Then this check's own recipe was an ALLOWLIST of specific
@@ -273,7 +273,21 @@ _writers() {
 #                  it replaced, where an unrecognised target was silently absent
 #                  instead of loudly flagged.
 #
-# WHAT THIS IS AND IS NOT. It is a NET, not a proof. It catches a new writer
+# WHAT THIS IS AND IS NOT — AND THIS PARAGRAPH IS THE FINDING, NOT A CAVEAT.
+# This check has been rewritten twice and defeated twice, each rewrite opening a
+# new blind spot of the same shape. That is evidence about the APPROACH: **a
+# shell regex cannot decide "does this line write into the adoptee's tree",
+# because the answer depends on variable provenance the line does not carry.**
+# `printf x > "$root/f"` and `printf x > "$TD_TMP/f"` are the same shape and
+# opposite answers. So this stopped being rewritten, and is instead labelled
+# honestly and paired with a cross-check that does not depend on the recipe
+# being complete (T10). Known gaps, recorded on `## BL-225:` rather than
+# papered over: `printf … > file` and `echo … > file` (the output-function arm
+# removes them, and it must, or it removes nearly every real writer instead);
+# `tee`; a redirect with no space after `>`; and an exemption matching on the
+# READ side of a line whose write target is in the tree.
+#
+# It is a NET, not a proof. It catches a new writer
 # that uses any of the shapes above, which is how review defeated the previous
 # recipe — an ordinary new function writing to `"$dest"`. It does NOT verify
 # REACHABILITY: a marker call wrapped in a never-true condition would satisfy
@@ -281,7 +295,13 @@ _writers() {
 # rather than textual — the marker is a FILE, so a placed-but-unreachable call
 # creates nothing and the BEHAVIOURAL assertions (T7, and the archive probe)
 # fail instead. Recorded on `## BL-225:` as a residual rather than implied.
-_markers() { grep -rn 'adopt_touched_disk$\|adopt_touched_disk ' "$REPO_ROOT"/scripts/lib/adopt/*.sh | grep -v '^.*:[0-9]*: *#' | cut -d: -f1,2; }
+_marker_files() {   # files that call the marker, by basename
+  grep -rlE '(^|[^A-Za-z0-9_])adopt_touched_disk([^A-Za-z0-9_]|$)' "$REPO_ROOT"/scripts/lib/adopt/*.sh \
+    | xargs -n1 basename | sort -u
+}
+_writer_files() {   # files the recipe believes contain writers, by basename
+  _writers | cut -d: -f1 | xargs -n1 basename | sort -u
+}
 t9_w=$(_writers | wc -l | tr -d ' ')
 chk "T9: the recipe still matches tree-writing sites at all" \
   "$([ "${t9_w:-0}" -gt 0 ] && echo yes || echo no)" "yes"
@@ -302,6 +322,23 @@ done <<T9SET
 $(_writers)
 T9SET
 chk "T9: every tree-writing site is preceded by the marker (writers=$t9_w)" "$t9_missing" "0"
+
+echo "== T10 — the recipe cannot collapse silently (two independently derived sets) =="
+# T9's weakness is that it can only fail on writers it FINDS. Twice now the
+# recipe has silently stopped finding almost everything — once via a `/dev/null`
+# exclusion that matched `2>/dev/null` on nearly every writer, once via an
+# `adopt_refuse "` exclusion that matched their error tails — and T9 stayed
+# green over a collapsed set both times. `t9_w > 0` cannot see that.
+#
+# This compares two sets derived INDEPENDENTLY: files that call the marker, and
+# files the recipe believes contain writers. A file that raises the marker but
+# yields no writer means the recipe stopped seeing that file. No transcribed
+# number is involved, so it cannot rot.
+t10_bad=0
+for _mf in $(_marker_files); do
+  _writer_files | grep -qx "$_mf" || { t10_bad=$((t10_bad + 1)); echo "         (T10) $_mf calls the marker but the recipe finds no writer in it"; }
+done
+chk "T10: every file that raises the marker also yields a writer" "$t10_bad" "0"
 
 # ORDER-SENSITIVE: M2 and M3 each `cp` their own mutant over
 # "$MUTLIB/adopt-state.sh". Correct at the current ordering because each writes

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# tests/test-bl225-staging-preflight.sh — BL-225.
+#
+# THE DEFECT, reproduced in T1 rather than described: the driver writes its
+# files, stages every recorded path in ONE `git add`, and `git add` on a mixed
+# pathspec STAGES THE CLEAN ONES AND EXITS 1. The adoptee is left half-staged
+# under a refusal that says "nothing has been committed" — true of commits,
+# silent about the index.
+#
+# Measured here, not assumed (T1): with `.claude/` ignored, a three-path add
+# leaves two paths in the index and returns 1.
+#
+# ── HOST GIT CONFIG IS NEUTRALIZED, AND IT HAS TO BE ────────────────────────
+# Inherited verbatim from tests/test-brownfield-wp6-collision-archive.sh's
+# R-WP6-3, which MEASURED the cause on this host: `~/.config/git/ignore`
+# commonly carries `**/.claude/settings.local.json`, and it is found by a PATH
+# default (`$XDG_CONFIG_HOME/git/ignore`), NOT by a config key — so
+# GIT_CONFIG_GLOBAL does not cover it. XDG_CONFIG_HOME is the knob. A fixture
+# whose verdict depends on whose laptop runs it is not a fixture.
+export GIT_CONFIG_GLOBAL=/dev/null
+export GIT_CONFIG_NOSYSTEM=1
+unset GIT_CONFIG_COUNT GIT_CONFIG_PARAMETERS GIT_TEMPLATE_DIR
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY
+unset GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_NAMESPACE GIT_COMMON_DIR
+# The pathspec-magic family (R-WP6-18): with these set, `git check-ignore`
+# dies "pathspec magic not supported by this command", and any probe that
+# wraps it in 2>/dev/null scores the fatal as NOT IGNORED — fail-open. T5
+# pins that the product code refuses instead.
+unset GIT_LITERAL_PATHSPECS GIT_NOGLOB_PATHSPECS GIT_GLOB_PATHSPECS GIT_ICASE_PATHSPECS
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  [PASS] $1"; }
+bad()  { FAIL=$((FAIL+1)); echo "  [FAIL] $1"; }
+chk()  { if [ "$2" = "$3" ]; then ok "$1"; else bad "$1 (want '$3', got '$2')"; fi; }
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/bl225.XXXXXX")" || exit 1
+# BL-244: mktemp must not silently land in the launch directory.
+case "$WORK" in "$REPO_ROOT"*) echo "FATAL: fixture inside repo"; exit 1 ;; esac
+trap 'rm -rf "$WORK"' EXIT
+
+_adoptee() {                     # _adoptee DIR [ignore-line...]
+  local d="$1"; shift
+  mkdir -p "$d" && ( cd "$d" \
+    && git init -q -b main . \
+    && git config user.email t@example.com && git config user.name T \
+    && printf 'their code\n' > README.md \
+    && { [ "$#" -eq 0 ] || printf '%s\n' "$@" > .gitignore; } \
+    && git add -A && git commit -q -m 'chore: their history' ) || return 1
+}
+_staged()  { ( cd "$1" && git diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ' ); }
+_sites()   { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); case "$n" in ''|*[!0-9]*) echo 0 ;; *) echo "$n" ;; esac; }
+_parses_ok() { bash -n "$1" >/dev/null 2>&1 && echo 1 || echo 0; }
+
+echo "== T1 — the defect itself: a mixed pathspec half-stages =="
+P="$WORK/t1"; _adoptee "$P" '.claude/'
+mkdir -p "$P/.claude"; printf 'a\n' > "$P/a.txt"; printf 'b\n' > "$P/b.txt"; printf 'c\n' > "$P/.claude/manifest.json"
+( cd "$P" && git add -- a.txt b.txt .claude/manifest.json ) >/dev/null 2>&1; rc=$?
+chk "T1: git add on a mixed pathspec exits non-zero" "$([ "$rc" -ne 0 ] && echo yes || echo no)" "yes"
+chk "T1: and it staged the clean paths anyway (the half-staged tree)" "$(_staged "$P")" "2"
+
+echo "== T2 — adopt_paths_ignored names an ignored path and fails closed =="
+. "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" 2>/dev/null
+if ! command -v adopt_paths_ignored >/dev/null 2>&1; then
+  bad "T2: adopt_paths_ignored is not defined (RED before the fix)"
+  bad "T2: (dependent assertions skipped)"; bad "T3: (skipped)"; bad "T4: (skipped)"; bad "T5: (skipped)"
+else
+  P2="$WORK/t2"; _adoptee "$P2" '.claude/'
+  out="$(adopt_paths_ignored "$P2" ".claude/manifest.json" "README.md" 2>&1)"; rc=$?
+  chk "T2: reports rc=0 when at least one path is ignored" "$rc" "0"
+  chk "T2: and names the ignored path" "$(printf '%s' "$out" | grep -c 'manifest.json')" "1"
+  chk "T2: and does NOT name the clean one" "$(printf '%s' "$out" | grep -c 'README.md')" "0"
+
+  P3="$WORK/t3"; _adoptee "$P3"
+  adopt_paths_ignored "$P3" ".claude/manifest.json" "README.md" >/dev/null 2>&1
+  chk "T3: rc=1 when nothing is ignored" "$?" "1"
+
+  echo "== T5 — a check-ignore that CANNOT RUN is not 'nothing is ignored' =="
+  P5="$WORK/t5"; _adoptee "$P5" 'sub/*.txt'
+  # GIT_NOGLOB_PATHSPECS makes check-ignore FATAL. A 2>/dev/null probe scores
+  # that as clean; this must fail CLOSED instead (rc 0 = treat as ignored).
+  GIT_NOGLOB_PATHSPECS=1 adopt_paths_ignored "$P5" "sub/a.txt" >/dev/null 2>&1
+  chk "T5: fails CLOSED when check-ignore cannot run" "$?" "0"
+fi
+
+echo "== T4 — the staging guard: refuse whole, never half =="
+if ! grep -q '# BL-225-STAGE-PREFLIGHT' "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" 2>/dev/null; then
+  bad "T4: # BL-225-STAGE-PREFLIGHT marker absent (RED before the fix)"
+else
+  ok "T4: # BL-225-STAGE-PREFLIGHT marker present in adopt_stage_and_commit"
+  chk "T4: the guard precedes the git add" \
+    "$(awk '/# BL-225-STAGE-PREFLIGHT/{g=NR} /BF-ADOPT-STAGE-EXPLICIT/{a=NR} END{print (g && a && g<a) ? "yes" : "no"}' "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh")" "yes"
+  # NOT a grep of adopt-state.sh: the sentence never lived there, so that
+  # assertion was true of the unfixed tree too. The claim is adopt_refuse's,
+  # in adopt-core.sh, and it is asserted by BEHAVIOUR.
+  chk "T4: adopt_refuse no longer states the bare unconditional claim" \
+    "$(_sites "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "Adoption did not complete. Nothing has been committed.\\\\n' >&2")" "0"
+fi
+
+echo "== T6 — adopt_stage_and_commit refuses WHOLE: rc!=0 and index untouched =="
+_stage_fixture() {                # $1 = dir
+  local p="$1"
+  _adoptee "$p" '.claude/' || return 1
+  mkdir -p "$p/.claude"
+  printf 'a\n' > "$p/keep-a.txt"; printf 'b\n' > "$p/keep-b.txt"
+  printf '{}\n'  > "$p/.claude/manifest.json"
+  printf 'keep-a.txt\nkeep-b.txt\n.claude/manifest.json\n' > "$p/.ledger"
+}
+_run_stage() {                    # $1 = dir, $2 = lib dir -> "rc|staged|stderr"
+  ( set +e
+    ADOPT_PROJECT_NAME=t
+    . "$2/adopt-core.sh"  >/dev/null 2>&1
+    . "$2/adopt-state.sh" >/dev/null 2>&1
+    # SET THE LEDGER **AFTER** SOURCING. adopt-core.sh declares
+    # ADOPT_WRITTEN_LEDGER="" at load time, so an earlier draft that set it
+    # first had it silently wiped: the ledger read empty, adopt_stage_and_commit
+    # took its "nothing to commit" arm, and T6's rc!=0 / staged==0 assertions
+    # passed FOR THE WRONG REASON — both are equally true of an empty ledger.
+    # M2 exposed it, because mutant and control produced identical output.
+    # Hence the stderr discriminator: rc and a count cannot tell the two
+    # refusals apart, and only one of them is this suite's subject.
+    ADOPT_WRITTEN_LEDGER="$1/.ledger"
+    err=$(adopt_stage_and_commit "$1" 2>&1 >/dev/null); rc=$?
+    printf '%s|%s|%s\n' "$rc" \
+      "$( cd "$1" && git diff --cached --name-only | wc -l | tr -d ' ' )" \
+      "$(printf '%s' "$err" | tr '\n' ' ')" )
+}
+P6="$WORK/t6"; _stage_fixture "$P6"
+IFS='|' read -r t6rc t6staged t6err <<<"$(_run_stage "$P6" "$REPO_ROOT/scripts/lib/adopt")"
+chk "T6: refuses (rc != 0)"                        "$([ "${t6rc:-0}" -ne 0 ] && echo yes || echo no)" "yes"
+chk "T6: and stages NOTHING (no half-staged tree)" "${t6staged:-x}" "0"
+# POSITIVE CONTROLS. Without these the two assertions above are equally true of
+# an EMPTY ledger, which is how they first passed against unfixed code.
+chk "T6: refused via the PREFLIGHT, naming the ignored path" "$(printf '%s' "$t6err" | grep -c 'manifest.json')" "1"
+chk "T6: not via the empty-ledger arm"                       "$(printf '%s' "$t6err" | grep -c 'no file was recorded as written')" "0"
+
+echo "== M2 — the mutation that matters: neuter the preflight =="
+MUTLIB="$WORK/mutlib"; mkdir -p "$MUTLIB"
+cp "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "$MUTLIB/adopt-core.sh"
+sed 's/^  if _ignored=$(adopt_paths_ignored "$root" "${FILES_TO_STAGE\[@\]}"); then$/  if false; then/' \
+  "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" > "$MUTLIB/adopt-state.sh"
+nchanged=$(diff "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" "$MUTLIB/adopt-state.sh" | grep -c '^<')
+if [ "$nchanged" -ne 1 ]; then
+  bad "M2: mutation did not apply cleanly (changed $nchanged line(s))"
+elif [ "$(_parses_ok "$MUTLIB/adopt-state.sh")" != "1" ]; then
+  bad "M2: mutant does not parse"
+else
+  P7="$WORK/m2"; _stage_fixture "$P7"
+  IFS='|' read -r m2rc m2staged m2err <<<"$(_run_stage "$P7" "$MUTLIB")"
+  chk "M2: without the preflight the SAME fixture HALF-STAGES (RED)" \
+    "$([ "${m2staged:-0}" -gt 0 ] && echo half-staged || echo "staged=${m2staged} err=${m2err}")" "half-staged"
+  chk "M2: and the mutant reached git add, not the empty-ledger arm" \
+    "$(printf '%s' "$m2err" | grep -c 'no file was recorded as written')" "0"
+fi
+
+echo "== M — mutation proofs =="
+MUT="$WORK/mut"; mkdir -p "$MUT"
+cp "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "$MUT/core.orig"
+if command -v adopt_paths_ignored >/dev/null 2>&1; then
+  # M1: neuter the fail-closed arm -> a fatal check-ignore scores as clean.
+  sed 's/return 0  # BL-225-IGNORE-FAILCLOSED/return 1/' "$MUT/core.orig" > "$MUT/core.mut"
+  n=$(diff "$MUT/core.orig" "$MUT/core.mut" | grep -c '^<')
+  if [ "$n" -ne 1 ]; then bad "M1: mutation did not apply (changed $n line(s))"; else
+    ( set +e; unset -f adopt_paths_ignored; . "$MUT/core.mut" 2>/dev/null
+      P="$WORK/m1"; mkdir -p "$P" && ( cd "$P" && git init -q -b main . && git config user.email t@e && git config user.name T \
+        && printf 'x\n' > R.md && printf 'sub/*.txt\n' > .gitignore && git add -A && git commit -q -m b ) >/dev/null 2>&1
+      GIT_NOGLOB_PATHSPECS=1 adopt_paths_ignored "$P" "sub/a.txt" >/dev/null 2>&1
+      echo "$?" > "$WORK/m1.rc" )
+    chk "M1: with the fail-closed arm neutered, a FATAL probe reports 'clean' (RED)" "$(cat "$WORK/m1.rc" 2>/dev/null)" "1"
+  fi
+fi
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -178,8 +178,9 @@ echo "== T8 — the ignored path is NOT first, at the DECIDER =="
 # namer is no longer the decider. Every other fixture here sorts `.claude/...`
 # to index 0, so a decider that examined only FILES_TO_STAGE[0] passed the whole
 # suite 24/24 while half-staging. This fixture puts the offending path at index
-# 2: `.gitignore` excludes PROJECT_INTAKE.md, and the ledger sorts to
-# `.claude/manifest.json`, `PROJECT_INTAKE.md`, `keep.txt`.
+# a non-zero one: `.gitignore` excludes PROJECT_INTAKE.md. Where exactly it
+# lands depends on the host's collation — see the derivation below — so this
+# comment deliberately does not name an index.
 P8="$WORK/t8"; _adoptee "$P8" 'PROJECT_INTAKE.md'
 mkdir -p "$P8/.claude"
 printf '{}\n'  > "$P8/.claude/manifest.json"
@@ -200,6 +201,49 @@ chk "T8: and stages NOTHING — the decider sees the WHOLE set, not just [0]" "$
 chk "T8: git's force hint is never relayed"         "$(printf '%s' "$t8err" | grep -c 'really want to add them')" "0"
 chk "T8: and the remedy line is present"            "$(printf '%s' "$t8err" | grep -c 'Un-ignore them in .gitignore')" "1"
 
+echo "== T9 — every tree-writing site raises ADOPT_TOUCHED_DISK (derived, not listed) =="
+# THE INVARIANT IS TESTED BECAUSE ASSERTING IT FAILED. The flag's first comment
+# said "1 as soon as ANY writer has changed the adoptee's tree" while it was set
+# at two of twelve such sites — so a failed `cp -p` in adopt_install_framework
+# left a directory behind under a refusal saying nothing was written. A
+# site-by-site fix invites the same finding at a thirteenth writer, so this
+# DERIVES both sets and requires them to match. Add a writer without the flag
+# and this fails here, not in review.
+#
+# THE INVARIANT IS PER-FUNCTION, NOT PER-WRITER, and that was measured rather
+# than assumed. Removing the flag from `adopt_install_framework`'s `cp -p` does
+# NOT fail this check and SHOULD NOT: the `mkdir -p` two lines above has already
+# raised it, so the mutant is behaviourally identical. Removing the ONLY flag in
+# a function DOES fail it (verified against adopt-test-debt.sh). A per-writer
+# rule would demand redundant lines and report a no-op as a defect.
+_writers()  { grep -rn 'mkdir -p "\$root\|mkdir -p "\$dir"\|mkdir -p "\$(dirname "\$root\|mkdir -p "\$(dirname "\$dst")"\|mkdir -p "\$arc_abs"\|mkdir -p "\$hooks"\|cp -p "\$src" "\$dst"\|cp -p "\$root/\|cp -p "\$restored_from"\|cat > "\$root/\|printf .* > "\$hooks/\|soif_emit_tdd_commitmsg_block >> "\$hooks/\|> "\$f.tmp"' "$REPO_ROOT"/scripts/lib/adopt/*.sh | cut -d: -f1,2; }
+_flags()    { grep -rn 'ADOPT_TOUCHED_DISK=1' "$REPO_ROOT"/scripts/lib/adopt/*.sh | cut -d: -f1,2; }
+t9_w=$(_writers | wc -l | tr -d ' ')
+t9_f=$(_flags   | wc -l | tr -d ' ')
+chk "T9: at least one tree-writing site is found (the recipe still matches)" \
+  "$([ "${t9_w:-0}" -gt 0 ] && echo yes || echo no)" "yes"
+# THE INVARIANT IS "raised BEFORE the write, inside the same function" — not
+# "on the line immediately above", which two adjacent writers cannot both
+# satisfy without a redundant line. For each writer, scan back to the start of
+# its enclosing function and require a flag in between.
+t9_missing=0
+while IFS=: read -r wf wl; do
+  [ -n "$wl" ] || continue
+  fn_start=$(awk -v L="$wl" 'NR<L && /^[A-Za-z_][A-Za-z0-9_]*\(\) *\{/ {n=NR} END{print n+0}' "$wf")
+  [ "$fn_start" -gt 0 ] || fn_start=1
+  if ! awk -v A="$fn_start" -v B="$wl" 'NR>A && NR<B && /ADOPT_TOUCHED_DISK=1/ {f=1} END{exit !f}' "$wf"; then
+    t9_missing=$((t9_missing + 1))
+    echo "         (T9) no flag before $(basename "$wf"):$wl in its function"
+  fi
+done <<T9SET
+$(_writers)
+T9SET
+chk "T9: every tree-writing site is preceded by the flag (writers=$t9_w flags=$t9_f)" "$t9_missing" "0"
+
+# ORDER-SENSITIVE: M2 and M3 each `cp` their own mutant over
+# "$MUTLIB/adopt-state.sh". Correct at the current ordering because each writes
+# immediately before it runs, but a reorder would silently run one mutation
+# against the other's file. A third mutant needs its own path.
 echo "== M — mutation proofs =="
 MUTLIB="$WORK/mutlib"; mkdir -p "$MUTLIB"
 cp "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "$MUTLIB/adopt-core.sh"
@@ -282,6 +326,14 @@ chk "T7: and stages NOTHING — BL-225 no longer reproduces" "${t7staged:-x}" "0
 chk "T7: labelled BLOCKED, not REFUSED (files were written)" "$(printf '%s' "$t7err" | grep -c 'BLOCKED')" "1"
 chk "T7: and it does not promise plain \`git status\` lists them" \
   "$(printf '%s' "$t7err" | grep -c 'git status --ignored --untracked-files=all')" "1"
+# The TRACKED case is this branch's headline case and had NO message assertion,
+# so the remedy could go missing there while T8's untracked fixture stayed
+# green. `git check-ignore` is index-aware and cannot name a tracked path, so
+# gating the remedy on the namer alone skipped exactly here.
+chk "T7: the remedy is present on the TRACKED case too" \
+  "$(printf '%s' "$t7err" | grep -c 'Un-ignore them in .gitignore')" "1"
+chk "T7: and git's force hint is not relayed" \
+  "$(printf '%s' "$t7err" | grep -c 'really want to add them')" "0"
 
 echo
 echo "Results: $PASS passed, $FAIL failed"

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -201,44 +201,107 @@ chk "T8: and stages NOTHING — the decider sees the WHOLE set, not just [0]" "$
 chk "T8: git's force hint is never relayed"         "$(printf '%s' "$t8err" | grep -c 'really want to add them')" "0"
 chk "T8: and the remedy line is present"            "$(printf '%s' "$t8err" | grep -c 'Un-ignore them in .gitignore')" "1"
 
-echo "== T9 — every tree-writing site raises ADOPT_TOUCHED_DISK (derived, not listed) =="
-# THE INVARIANT IS TESTED BECAUSE ASSERTING IT FAILED. The flag's first comment
-# said "1 as soon as ANY writer has changed the adoptee's tree" while it was set
-# at two of twelve such sites — so a failed `cp -p` in adopt_install_framework
-# left a directory behind under a refusal saying nothing was written. A
-# site-by-site fix invites the same finding at a thirteenth writer, so this
-# DERIVES both sets and requires them to match. Add a writer without the flag
-# and this fails here, not in review.
+echo "== T9 — every tree-writing site raises the touched marker (DENYLIST, not a list) =="
+# THE INVARIANT IS TESTED BECAUSE ASSERTING IT FAILED — TWICE, IN DIFFERENT WAYS.
+# First the flag's comment claimed "ANY writer" while it was set at two of
+# twelve sites. Then this check's own recipe was an ALLOWLIST of specific
+# variable spellings ("$dir", "$dst", "$arc_abs", ...), so review added an
+# ordinary new function writing to "$dest" and the check reported all clear.
+# A transcribed set is not a derived one; that is this repo's own rule and this
+# guard broke it.
 #
-# THE INVARIANT IS PER-FUNCTION, NOT PER-WRITER, and that was measured rather
-# than assumed. Removing the flag from `adopt_install_framework`'s `cp -p` does
-# NOT fail this check and SHOULD NOT: the `mkdir -p` two lines above has already
-# raised it, so the mutant is behaviourally identical. Removing the ONLY flag in
-# a function DOES fail it (verified against adopt-test-debt.sh). A per-writer
-# rule would demand redundant lines and report a no-op as a defect.
-_writers()  { grep -rn 'mkdir -p "\$root\|mkdir -p "\$dir"\|mkdir -p "\$(dirname "\$root\|mkdir -p "\$(dirname "\$dst")"\|mkdir -p "\$arc_abs"\|mkdir -p "\$hooks"\|cp -p "\$src" "\$dst"\|cp -p "\$root/\|cp -p "\$restored_from"\|cat > "\$root/\|printf .* > "\$hooks/\|soif_emit_tdd_commitmsg_block >> "\$hooks/\|> "\$f.tmp"' "$REPO_ROOT"/scripts/lib/adopt/*.sh | cut -d: -f1,2; }
-_flags()    { grep -rn 'ADOPT_TOUCHED_DISK=1' "$REPO_ROOT"/scripts/lib/adopt/*.sh | cut -d: -f1,2; }
+# So the recipe is now a DENYLIST: match the general SHAPES that write, then
+# subtract an explicit, commented allowlist of lines whose target is not the
+# adoptee's tree. A new writer is caught by default, and an exemption has to be
+# written down with a reason — the shape `lint-bl-markers.sh` already uses.
+#
+# WHAT THIS STILL CANNOT DO, stated rather than implied: it checks that a
+# marker call appears before the write inside the same function. It does NOT
+# check reachability — a call wrapped in a never-true condition would satisfy
+# it. Reachability is not statically decidable here; the mitigation is that the
+# marker is a FILE, so a placed-but-unreachable call creates nothing and the
+# behavioural tests (T7, the archive probe) fail instead.
+_writers() {
+  # One grep per verb, not one giant alternation: a single ERE with a dozen
+  # alternatives silently matched fewer lines than its own first alternative
+  # while this was being built, and a recipe nobody can debug is a recipe
+  # nobody can trust.
+  # BOTH loops must feed the SAME pipeline. A first draft left the first loop
+  # un-piped, so its output bypassed every filter and comments came back as
+  # writers — the filters were there and simply were not reached.
+  { for _v in 'mkdir -p ' 'cp ' 'mv ' 'install ' 'ln ' 'touch ' 'cat > '; do
+      # WORD-BOUNDED: `grep -F 'touch '` matched `n_touch ` inside a `local`
+      # declaration — a variable name, not a command.
+      grep -rnE -- "(^|[^A-Za-z0-9_])$_v" "$REPO_ROOT"/scripts/lib/adopt/*.sh
+    done
+    for _v in '> "$' '>> "$'; do
+      grep -rnF -- "$_v" "$REPO_ROOT"/scripts/lib/adopt/*.sh
+    done; } \
+    | grep -vE ':[0-9]+: *#' \
+    | grep -vE ':[0-9]+:[[:space:]]*(adopt_note|adopt_say|adopt_head|adopt_refuse|printf|echo)([[:space:]]|$)' \
+    | grep -vE '\$ADOPT_WORK|\$TD_TMP|\$TMPDIR|mktemp|\$ADOPT_WRITTEN_LEDGER' \
+    | grep -vE '"\$work/|"\$ADOPT_ANSWERS"|> "\$names"' \
+    | cut -d: -f1,2 | sort -u
+}
+# ^ THE ALLOWLIST, and every arm carries its reason:
+#   :N: #        — a comment describing a write is not a write
+#   a line whose FIRST TOKEN is an output function
+#                — output functions whose ARGUMENTS contain write verbs
+#                  ("put it back: cp $arc/$ap $op"). Anchored to the first
+#                  token on purpose: a draft that excluded any line CONTAINING
+#                  `adopt_refuse "` removed nearly every real writer, because
+#                  almost all of them end `|| { adopt_refuse "..."; return 1; }`.
+#                  The writer count collapsed from 25 to 1 and the check went
+#                  green on nothing.
+#   $ADOPT_WORK / $TD_TMP / $TMPDIR / mktemp / the written-ledger
+#                — the driver's own state, not the operator's tree.
+#                  `/dev/null` IS DELIBERATELY ABSENT: excluding it removed
+#                  almost every real writer, because nearly all of them carry
+#                  `2>/dev/null` for error suppression. The writer set silently
+#                  collapsed to five while the check stayed green — the same
+#                  shape as the allowlist it replaced, arriving through an
+#                  exclusion instead of an omission.
+#   "$work/ , "$ADOPT_ANSWERS" , > "$names"
+#                — THREE NAMED EXEMPTIONS, named because they cannot be derived
+#                  from the line itself: `$work` and `$ADOPT_ANSWERS` arrive as
+#                  PARAMETERS (`local arc="$1" work="$2"`; `ADOPT_ANSWERS="$1"`)
+#                  and `$names` is assigned `"$TD_TMP/names"` a line earlier.
+#                  All three are driver scratch, not the adoptee's tree, and
+#                  tracing callers is beyond what a shell fixture should do.
+#                  AN EXEMPTION MUST ALWAYS CARRY A REASON LIKE THESE — that is
+#                  the whole difference between this denylist and the allowlist
+#                  it replaced, where an unrecognised target was silently absent
+#                  instead of loudly flagged.
+#
+# WHAT THIS IS AND IS NOT. It is a NET, not a proof. It catches a new writer
+# that uses any of the shapes above, which is how review defeated the previous
+# recipe — an ordinary new function writing to `"$dest"`. It does NOT verify
+# REACHABILITY: a marker call wrapped in a never-true condition would satisfy
+# it, and that is not statically decidable here. The mitigation is structural
+# rather than textual — the marker is a FILE, so a placed-but-unreachable call
+# creates nothing and the BEHAVIOURAL assertions (T7, and the archive probe)
+# fail instead. Recorded on `## BL-225:` as a residual rather than implied.
+_markers() { grep -rn 'adopt_touched_disk$\|adopt_touched_disk ' "$REPO_ROOT"/scripts/lib/adopt/*.sh | grep -v '^.*:[0-9]*: *#' | cut -d: -f1,2; }
 t9_w=$(_writers | wc -l | tr -d ' ')
-t9_f=$(_flags   | wc -l | tr -d ' ')
-chk "T9: at least one tree-writing site is found (the recipe still matches)" \
+chk "T9: the recipe still matches tree-writing sites at all" \
   "$([ "${t9_w:-0}" -gt 0 ] && echo yes || echo no)" "yes"
-# THE INVARIANT IS "raised BEFORE the write, inside the same function" — not
-# "on the line immediately above", which two adjacent writers cannot both
-# satisfy without a redundant line. For each writer, scan back to the start of
-# its enclosing function and require a flag in between.
+# For each writer, scan back to the start of its enclosing function and require
+# a marker call in between. PER-FUNCTION, not per-writer: two adjacent writers
+# cannot both carry a line above them without a redundant one, and removing a
+# redundant one is a genuine no-op. Measured both directions — see below.
 t9_missing=0
 while IFS=: read -r wf wl; do
   [ -n "$wl" ] || continue
   fn_start=$(awk -v L="$wl" 'NR<L && /^[A-Za-z_][A-Za-z0-9_]*\(\) *\{/ {n=NR} END{print n+0}' "$wf")
   [ "$fn_start" -gt 0 ] || fn_start=1
-  if ! awk -v A="$fn_start" -v B="$wl" 'NR>A && NR<B && /ADOPT_TOUCHED_DISK=1/ {f=1} END{exit !f}' "$wf"; then
+  if ! awk -v A="$fn_start" -v B="$wl" 'NR>A && NR<B && /adopt_touched_disk/ {f=1} END{exit !f}' "$wf"; then
     t9_missing=$((t9_missing + 1))
-    echo "         (T9) no flag before $(basename "$wf"):$wl in its function"
+    echo "         (T9) no marker before $(basename "$wf"):$wl in its function"
   fi
 done <<T9SET
 $(_writers)
 T9SET
-chk "T9: every tree-writing site is preceded by the flag (writers=$t9_w flags=$t9_f)" "$t9_missing" "0"
+chk "T9: every tree-writing site is preceded by the marker (writers=$t9_w)" "$t9_missing" "0"
 
 # ORDER-SENSITIVE: M2 and M3 each `cp` their own mutant over
 # "$MUTLIB/adopt-state.sh". Correct at the current ordering because each writes

--- a/tests/test-bl225-staging-preflight.sh
+++ b/tests/test-bl225-staging-preflight.sh
@@ -173,6 +173,33 @@ chk "T6: and stages NOTHING (no half-staged tree)" "${t6staged:-x}" "0"
 chk "T6: refused via the PREFLIGHT, naming the ignored path" "$(printf '%s' "$t6err" | grep -c 'manifest.json')" "1"
 chk "T6: not via the empty-ledger arm"                       "$(printf '%s' "$t6err" | grep -c 'no file was recorded as written')" "0"
 
+echo "== T8 — the ignored path is NOT first, at the DECIDER =="
+# Review finding 4 was fixed at the NAMER (T2/T3's argument order) — and the
+# namer is no longer the decider. Every other fixture here sorts `.claude/...`
+# to index 0, so a decider that examined only FILES_TO_STAGE[0] passed the whole
+# suite 24/24 while half-staging. This fixture puts the offending path at index
+# 2: `.gitignore` excludes PROJECT_INTAKE.md, and the ledger sorts to
+# `.claude/manifest.json`, `PROJECT_INTAKE.md`, `keep.txt`.
+P8="$WORK/t8"; _adoptee "$P8" 'PROJECT_INTAKE.md'
+mkdir -p "$P8/.claude"
+printf '{}\n'  > "$P8/.claude/manifest.json"
+printf 'i\n'   > "$P8/PROJECT_INTAKE.md"
+printf 'k\n'   > "$P8/keep.txt"
+printf '.claude/manifest.json\nPROJECT_INTAKE.md\nkeep.txt\n' > "$P8/.ledger"
+# DERIVE the index, never hardcode it: `sort` is LOCALE-DEPENDENT. On this host
+# the collation is case-insensitive and PROJECT_INTAKE.md lands at 3; under a
+# C-locale runner it lands at 2. Pinning either number makes the fixture pass on
+# one machine and fail on the other — the local-vs-CI divergence class CLAUDE.md
+# warns about. The PROPERTY this fixture needs is only "not first".
+t8_idx=$(cd "$P8" && sort -u .ledger | grep -n '^PROJECT_INTAKE.md$' | cut -d: -f1)
+chk "T8: the offending path is NOT at index 1 (derived: $t8_idx)" \
+  "$([ "${t8_idx:-1}" -gt 1 ] && echo not-first || echo first)" "not-first"
+IFS='|' read -r t8rc t8staged t8err <<<"$(_run_stage "$P8" "$REPO_ROOT/scripts/lib/adopt")"
+chk "T8: refuses"                                   "$([ "${t8rc:-0}" -ne 0 ] && echo yes || echo no)" "yes"
+chk "T8: and stages NOTHING — the decider sees the WHOLE set, not just [0]" "${t8staged:-x}" "0"
+chk "T8: git's force hint is never relayed"         "$(printf '%s' "$t8err" | grep -c 'really want to add them')" "0"
+chk "T8: and the remedy line is present"            "$(printf '%s' "$t8err" | grep -c 'Un-ignore them in .gitignore')" "1"
+
 echo "== M — mutation proofs =="
 MUTLIB="$WORK/mutlib"; mkdir -p "$MUTLIB"
 cp "$REPO_ROOT/scripts/lib/adopt/adopt-core.sh" "$MUTLIB/adopt-core.sh"
@@ -227,6 +254,24 @@ else
     "$([ "${m2staged:-0}" -gt 0 ] && echo half-staged || echo "staged=${m2staged} err=${m2err}")" "half-staged"
   chk "M2: and the mutant reached git add, not the empty-ledger arm" \
     "$(printf '%s' "$m2err" | grep -c 'no file was recorded as written')" "0"
+fi
+
+# M3 — THE DECIDER'S ARGUMENT SET. Feed the dry-run only the first path; the
+# M1/M2 sed anchors are left byte-identical so their guards do not fire instead.
+sed 's|git add --dry-run -- "${FILES_TO_STAGE\[@\]}" 2>&1 >/dev/null|git add --dry-run -- "${FILES_TO_STAGE[0]}" 2>\&1 >/dev/null|' \
+  "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" > "$MUTLIB/adopt-state3.sh"
+n3=$(diff "$REPO_ROOT/scripts/lib/adopt/adopt-state.sh" "$MUTLIB/adopt-state3.sh" | grep -c '^<')
+if [ "$n3" -ne 1 ]; then bad "M3: mutation did not apply (changed $n3 line(s))"
+elif [ "$(_parses_ok "$MUTLIB/adopt-state3.sh")" != "1" ]; then bad "M3: mutant does not parse"
+else
+  cp "$MUTLIB/adopt-state3.sh" "$MUTLIB/adopt-state.sh"
+  PM3="$WORK/m3"; _adoptee "$PM3" 'PROJECT_INTAKE.md'
+  mkdir -p "$PM3/.claude"; printf '{}\n' > "$PM3/.claude/manifest.json"
+  printf 'i\n' > "$PM3/PROJECT_INTAKE.md"; printf 'k\n' > "$PM3/keep.txt"
+  printf '.claude/manifest.json\nPROJECT_INTAKE.md\nkeep.txt\n' > "$PM3/.ledger"
+  IFS='|' read -r m3rc m3staged m3err <<<"$(_run_stage "$PM3" "$MUTLIB")"
+  chk "M3: a decider reading only FILES_TO_STAGE[0] half-stages (RED)" \
+    "$([ "${m3staged:-0}" -gt 0 ] && echo half-staged || echo "staged=${m3staged}")" "half-staged"
 fi
 
 # T7 — the real code on the tracked fixture: refuses, stages nothing.

--- a/workflow.html
+++ b/workflow.html
@@ -633,7 +633,7 @@
       supported (i.e. bug fixes, maintenance, new features add), or are you still in the process of building
       your project?"</em></p>
       <p><strong>There is no default and no skip.</strong> With no answer the run prints
-      <code>[REFUSED]</code> and stops: <em>"Adoption did not complete. Nothing has been committed."</em></p>
+      <code>[REFUSED]</code> and stops: <em>"Adoption did not begin. Nothing was committed and nothing was written."</em> — or <code>[BLOCKED]</code>, when the run had already written files, which then names the count (<code># BL-225-REFUSE-HONEST</code>).</p>
     </div>
     <div class="mod-card">
       <h4>Two scenarios</h4>


### PR DESCRIPTION
`## BL-225:` — the driver writes files into an adoptee, stages some, then a `.gitignore` refusal claims *"nothing has been committed"* over a half-staged tree. The design (`docs/designs/2026-08-23-brownfield-adoption-v2.md` §10) names this the precondition for every v2 work package: **"No v2 package lands before its fix."**

## The defect, reproduced rather than described

`git add` on a **mixed pathspec stages the clean paths and exits 1**. The driver staged every recorded path in one `git add`, so a single ignored entry left the adoptee half-staged. **T1 reproduces it**, so a git that ever changed that behaviour is caught here instead of in someone's repository.

## The first fix was wrong at the oracle, not the message

It asked `git check-ignore`, which is **index-aware** — *"tracked files are not shown at all since they are not subject to exclude rules"* — while `git add` is not. On a tracked `.claude/manifest.json` under a later-added `.claude/` rule, check-ignore reported nothing ignored, the preflight said proceed, and `git add` refused **having staged anyway**. BL-225 reproduced unchanged through the guard written to stop it.

Measured against `git add` as ground truth across a directory rule, a file rule and a glob, **`git add --dry-run` is the only oracle that agrees in all three**. `check-ignore --no-index` was proposed and rejected on measurement — it swaps the false-clean for a **false refusal** on projects that work today. `--dry-run` writes nothing: `.git/` hashes byte-identical before and after.

A second property fell out: `--dry-run` is immune to the pathspec-magic variables that make `check-ignore` exit 128, so that fail-open class is **eliminated** rather than guarded.

## The messages now derive what they say

Three claims were measured false on reachable paths — files called "unstaged" that were staged; *"`git status` lists them"*, which it **cannot** on the block path, since that arm only fires when a written path is ignored, so the one file being complained about is the one `git status` hides; and "nothing committed" after `adopt_install_hooks`, which runs past the commit.

`adopt_refuse` now derives all of it, and labels the arms apart: **`[BLOCKED]`** when files were written, **`[REFUSED]`** when the run never began. `docs/messaging-standard.md` already drew that line — the code was using the wrong word, so **no standard changed**.

The touched-disk marker is a **file**, not a variable: `adopt_write_file` is called at seven sites as the RHS of a pipeline, and bash 3.2 has no `lastpipe`, so a variable set there dies with the subshell.

## Seven review rounds

**block → block → block → major → major → major → minor_concerns (ship it).**

Rounds 4–7 were about the **guard**, not the shipped path — which the reviewer independently re-derived as correct at **18 of 18** write sites. The guard was rewritten twice and defeated twice, and the conclusion is recorded rather than patched a third time: *a shell regex cannot decide "does this line write into the adoptee's tree", because the answer depends on variable provenance the line does not carry.* T9 is labelled a **net, not a proof**, with every gap named; T10 cross-checks two independently derived sets and catches the collapse T9 structurally cannot see.

## Verification

- `tests/test-bl225-staging-preflight.sh` — **35 assertions**, three killing mutations; passes under hostile `XDG_CONFIG_HOME`, `LC_ALL=C`, runner-git config, and from a path containing a space
- Regression: wp3 33/33, wp4 39/39, wp5b 57/57, wp6 45/45
- `scripts/run-lints.sh` — **15/15**
- **`## BL-225:` stays Open**: the staging half is closed, the before-any-write half is not, and the narrowing is recorded in the entry rather than left to a diff
- **Not verified:** currency — context7 was quota-exhausted all session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J8Cg1dETKtB7hPyCLL5kh1