### PR TITLE
feat(bl-242): WP9b — the preflight that stops adoption eating a scaffolded project

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -518,6 +518,7 @@ jobs:
             tests/test-brownfield-wp6-collision-archive.sh
             tests/test-bl225-staging-preflight.sh
             tests/test-brownfield-wp9-act-boundaries.sh
+            tests/test-brownfield-wp9b-preflight-approval.sh
             tests/test-bl233-mcp-outcome-enforcement.sh
             tests/test-bl233-wpb-accumulation.sh
             tests/test-pr-review-gate.sh

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -99,7 +99,7 @@ amendment folded. **Built and shipping** — the user-facing page is [delta-trac
 re-cut as **four acts**: Scout surveys, the shell driver prepares and lands the project at
 **phase 0**, a Claude Code session assesses, and the plan is presented. Ten settled decisions
 (D1–D10) plus eight delegated author decisions; full-history secret scanning tiered by audience,
-four archive classes, and an init-parity table with thirteen unowned rows. **Half built** — Scout,
+five archive classes, and an init-parity table with thirteen unowned rows. **Half built** — Scout,
 the driver, the test-debt ledger with its ratchet, the collision archive and WP9a's act boundaries
 ship; the secrets stop, the archive's two new classes, the assessment and the Adoption Record do
 not. User-facing pages: [scout.md](scout.md) and [adoption.md](adoption.md), which name every gap).

--- a/docs/adoption.md
+++ b/docs/adoption.md
@@ -272,17 +272,27 @@ verifies your Phase 2 setup). What holds is that the gates are **cumulative and
 keyed to evidence** — arriving at a rung without the evidence fails the gate on
 the evidence, regardless of what moved you there.
 
-**Today the gate refuses an adopted project even earlier, and for a different
-reason.** Adoption does not yet write `APPROVAL_LOG.md`, and the gate checks for
-it before it reads the phase at all:
+**Adoption now writes `APPROVAL_LOG.md`, and the gate runs.** Until WP9b it did
+not, and the gate exited on the missing file before it read the phase at all —
+so an adopted project could not run its own phase gate. Observed on a
+freshly-adopted project today:
 
 ```text
-[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.
+$ bash scripts/check-phase-gate.sh
+Phase Gate Consistency Check
+Current phase: 0
+
+
+Adoption Stamp Integrity
+[OK] Adoption stamp present and intact (adopted: …)
+
+Phase gates consistent.
 ```
 
-That is still a refusal, and still the safe direction — but it names the
-approval log rather than the classification, so do not expect the gate to point
-you at Route 3 until that file is written.
+The log adoption writes is the **tier-matched template**, carrying no dated
+gate-approval row — because this adoption approved nothing. It makes the
+question answerable; it does not answer it. What is still missing is the
+Adoption **Record** inside that log, which is WP7's.
 
 **You will still be asked.** Three routes reach the question, and all three are
 exercised by the test suite rather than assumed:
@@ -317,19 +327,28 @@ coerced:
 
 ## What gets written, and in what order
 
-### The order is `phase-state.json` → intake → `manifest.json`
+### The order is `APPROVAL_LOG.md` → `phase-state.json` → intake → `manifest.json`
 
 That order is data in the driver, not scattered through it, and it is chosen
 because the two half-states are **not symmetrical**:
 
 | Partial state | `check-phase-gate.sh` | Enforcement tier | Net |
 |---|---|---|---|
-| **phase-state present, manifest absent** | Runs. `[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.` → rc 1 | **strict** (missing file → strict) | **Gates live, strictest tier.** Blocked — the safe direction |
+| **phase-state present, manifest absent** | Runs to a verdict. At the resting state that is `Current phase: 0` / `Phase gates consistent.` → rc 0 | **strict** (missing manifest → strict) | **Gates live, strictest tier.** The commit-time ladder is what protects this row; before WP9b the phase gate appeared to block it, but only because `APPROVAL_LOG.md` was missing — an incidental refusal, not a consistency verdict |
 | **manifest present, phase-state absent** | `No .claude/phase-state.json found — skipping phase gate check.` → rc 0 | reads the field | **Gates entirely absent.** An adopted-looking project with no enforcement |
 
-Writing phase-state **first** means every interruption lands in the top row. That
-is what the help text means by *"it stops in the SAFE direction: the project ends
-up more strictly gated than it was, never less."*
+Writing the approval log and phase-state **before the manifest** means no
+interruption can land in the bottom row. That is what the help text means by
+*"it stops in the SAFE direction: the project ends up more strictly gated than
+it was, never less."*
+
+Since WP9b there is a third interruption point, between the approval log and
+phase-state, and it is inert: with no `.claude/phase-state.json` the gate prints
+`No .claude/phase-state.json found — skipping phase gate check.` and exits 0,
+exactly as it does on any project that has never been adopted. A log with no
+phase-state claims nothing. **That is why the log goes first** — written last,
+every death inside the state stage would land on phase-state-present /
+log-absent, which the gate hard-refuses.
 
 `init.sh` uses the opposite order, and that is not a counter-example: creation is
 one uninterrupted run ending in a commit, so it never leaves partial state
@@ -350,7 +369,7 @@ IDENTICAL — a halted run wrote nothing
 
 ```text
 ══ Committing exactly what was written
-   76 file(s), named one by one. Anything else you had in progress stays
+   77 file(s), named one by one. Anything else you had in progress stays
    exactly as you left it — unstaged, uncommitted, untouched.
 ```
 
@@ -360,20 +379,23 @@ counter-example this exists to avoid is `create_project()`'s
 your uncommitted work into a framework commit with verification bypassed.
 
 Observed on a completed run — one commit,
-`chore: adopt <project> into the Solo Orchestrator framework`, containing **76**
-files: the eight below, and the framework `scripts/` tree (68 of them).
+`chore: adopt <project> into the Solo Orchestrator framework`, containing **77**
+files: the nine below, and the framework `scripts/` tree (68 of them).
 **Your own files are not in it.**
 
 ```text
 .claude/adoption/scout-report.json   .claude/intake-progress.json
 .claude/manifest.json                .claude/orchestrator-source.json
 .claude/phase-state.json             .claude/process-state.json
-.claude/test-debt.json               PROJECT_INTAKE.md
+.claude/test-debt.json               APPROVAL_LOG.md
+PROJECT_INTAKE.md
 ```
 
-*(This list read six files and 69 until it was re-measured. It had been correct
-when written and was falsified twice over — by the test-debt ledger WP5b added,
-and by `orchestrator-source.json`, which **this package added**. An enumeration
+*(This list read six files and 69, then eight and 76, before each re-measure. It
+had been correct when written and has now been falsified three times over — by
+the test-debt ledger WP5b added, by `orchestrator-source.json`, and by
+`APPROVAL_LOG.md`, which **WP9b added while this very paragraph warned that
+whoever adds a writer must re-run the count**. An enumeration
 of what a run writes has to be re-run by whoever adds a writer; nothing checks
 it.)*
 
@@ -774,8 +796,18 @@ land on into `.claude/adoption-archive/<UTC-timestamp>-<pid>/`, mirroring your
 paths, and writes a `MANIFEST.json` and a `MANIFEST.md` beside them. The
 population is the archive-and-replace bucket: `.claude/settings.json`,
 `.claude/settings.local.json`, `.mcp.json`, your `.claude/skills/*/SKILL.md`,
-and every non-`.sample` file in `.git/hooks/`. **Only files that exist are
-archived** — an absent surface produces no file and no manifest row.
+every non-`.sample` file in `.git/hooks/`, and — since WP9b — `APPROVAL_LOG.md`.
+**Only files that exist are archived** — an absent surface produces no file and
+no manifest row.
+
+**`APPROVAL_LOG.md` is the one entry adoption REPLACES**, and its row says so:
+`disposition: "replaced"`, where every other entry reads `kept` (your file is
+still where it was) or `composed` (the framework appended a marked block to your
+commit-msg hook). Adoption writes its own tier-matched approval log at that path
+because the phase gate cannot run without one — so if you keep an approval
+record there already, **your copy is archived with a restore line and the
+framework's template is what sits at the path afterwards**. That is the only
+in-place replacement in the run.
 
 Nothing is deleted. Every entry carries a `restore` line you can paste, and
 every git-hook entry carries a short **advisory** description of what it
@@ -893,24 +925,38 @@ NOT DONE — the provenance headers on reconstructed documents
 
 NOT DONE — the Adoption Record, the audit rows and the CI carve-out
    Owner: WP7. This build does not do it, and does not pretend to.
-   APPROVAL_LOG.md is not written, so the phase gate will report it missing until WP7 lands.
-   That is the safe direction — a blocked project, not a silently-approved one — but it
-   means this adoption is recorded in the manifest and nowhere else yet.
+   APPROVAL_LOG.md exists and the phase gate reads it; what is missing is the Adoption Record INSIDE it.
+   The log this adoption wrote is the tier-matched template, carrying no approval of
+   any kind — which is correct, because this adoption approved nothing. Until WP7
+   lands, the adoption itself is recorded in the manifest and nowhere else.
 ```
 
-**The consequence is immediate and you will hit it.** Observed on a
-freshly-adopted project:
+**This no longer stops the gate.** Before WP9b, a freshly-adopted project got:
 
 ```text
 $ bash scripts/check-phase-gate.sh
 [FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.
 ```
 
-The gate stops there. That is the safe direction — a blocked project, not a
-silently-approved one — but it means an adopted project's phase gate does not
-pass until somebody writes an `APPROVAL_LOG.md`. It also means the **adoption
-stamp integrity check runs after that point**, so on a project with no
-`APPROVAL_LOG.md` the loss detector never gets to speak.
+Adoption no longer *creates* that state — it writes the log itself, first, so
+the gate reaches a verdict. Measured on a project adopted today:
+
+```text
+$ bash scripts/check-phase-gate.sh
+Phase Gate Consistency Check
+Current phase: 0
+
+
+Adoption Stamp Integrity
+[OK] Adoption stamp present and intact (adopted: …)
+
+Phase gates consistent.
+```
+
+The refusal above is still correct where it still applies: **delete the log and
+it returns**, at rc 1. That matters for the stamp check, which runs *after* the
+precondition — so on a project whose `APPROVAL_LOG.md` is genuinely missing, the
+adoption-loss detector never gets to speak.
 
 The **Adoption Record** itself — the one place a successor reads to understand
 how this project entered the framework, carrying the assessment's findings and

--- a/docs/designs/2026-08-23-brownfield-adoption-v2.md
+++ b/docs/designs/2026-08-23-brownfield-adoption-v2.md
@@ -11,7 +11,7 @@
 | **Audience** | (a) the adversarial design reviewer this document must survive; (b) the implementer of the work packages in §10 |
 | **Subject** | **Brownfield adoption, second architecture** — an existing codebase enters Solo Orchestrator through four acts: a read-only survey, a deterministic shell preparation that lands the project at phase 0, a model-driven assessment, and a documented plan the project proceeds from — **starting at the beginning, with no rung derived by anyone** (D10). Adoption **assesses** rather than asking the operator to classify the project; it asks exactly one thing — who the project is for (D9). |
 | **Companion documents** | ADOPT-001-ARCH (superseded; kept as the record of the first build and of §-citations in shipped code — see §0.2) · `## BL-242:` in `solo-orchestrator-backlog.md` (the D1–D10 decision record this document designs from) · `docs/adoption.md`, `docs/scout.md` (the shipped user-facing pages, which describe the v1 build and must be revised by §10-WP12b, except the chooser sections §4.2 gives to WP9) · `docs/messaging-standard.md` (the presentation contract D8 makes binding) · `docs/module-contract.md` (M1–M5) · SOI-002-BUILD (`docs/builders-guide.md`) |
-| **Status of the thing described** | **WP9a IS BUILT; NOTHING ELSE OF v2 IS.** This row said "nothing of v2 is built" until 2026-09-01, and it was stale for exactly the reason it warns about — **derivation (2) had stopped returning what the row claimed, and the row's own instruction is to re-run rather than quote.** v1's status row was wrong three times because it was a hand-maintained list; this one is a **set of derivations**, re-run at the tip on **2026-09-01**: (1) *What is still unbuilt* — the `adopt_stub_*` functions actually called, §1.2's recipe → **7** (unchanged in count, changed in membership: `adopt_stub_certification` went with WP5's retirement and `adopt_stub_assessment` took its place). (2) *Whether the chooser still exists* — `scripts/lib/adopt/adopt-chooser.sh` is **GONE**; the file is `adopt-evidence.sh` and Karl's sentence resolves in **no tracked file** but the frozen v1 design and the suite that must spell it to search for it (§4.2, §10-WP9's `C2`). (3) *That adoption still runs no tool resolution* — `grep -c 'resolve-tools'` over the driver and its lib returns **0** in every file, against **7** mentions in `init.sh`; still WP10's (§13-V3). (4) *That `scripts/resume.sh` knows nothing of adoption* — `grep -c 'adopt' "scripts/resume.sh"` returns **0**; the fifth branch is WP12a's, and WP9a deliberately did not pull it forward (§10-WP9). **When any derivation stops returning what this row says, this row is stale — re-run them; do not quote them.** **A caveat the derivations themselves taught:** the framework's install set measured **65** files on `main`, **67** on the branch this document was first verified against, and **68** re-derived on 2026-09-01 (§13-V6). Three values in nine days. A count in this document is a measurement with a date and a branch, never a property — which is also why this row was allowed to go stale: nobody re-ran it. |
+| **Status of the thing described** | **WP9 IS BUILT — 9a AND 9b; NOTHING ELSE OF v2 IS.** This row said "nothing of v2 is built" until 2026-09-01, and it was stale for exactly the reason it warns about — **derivation (2) had stopped returning what the row claimed, and the row's own instruction is to re-run rather than quote.** v1's status row was wrong three times because it was a hand-maintained list; this one is a **set of derivations**, re-run at the tip on **2026-09-01**, and re-run AGAIN after WP9b the same day. Of the **four** derivations the pre-WP9b row carried, exactly **one** moved — (3), and it moved because of a COMMENT; (5) and (6) are new here. *(A draft said "two of the five", counting a set that never existed.)* (1) *What is still unbuilt* — the `adopt_stub_*` functions actually called, §1.2's recipe → **7** (unchanged in count, changed in membership: `adopt_stub_certification` went with WP5's retirement and `adopt_stub_assessment` took its place). (2) *Whether the chooser still exists* — `scripts/lib/adopt/adopt-chooser.sh` is **GONE**; the file is `adopt-evidence.sh` and Karl's sentence resolves in **no tracked file** but the frozen v1 design and the suite that must spell it to search for it (§4.2, §10-WP9's `C2`). (3) *That adoption still runs no tool resolution* — **this derivation is now self-poisoning and is restated rather than quietly repaired**: `grep -c 'resolve-tools'` over the driver and its lib returns **1**, and the single hit is a COMMENT in `adopt-core.sh` about this very recipe. The property holds — no executed line invokes it — but the recipe as written no longer measures it. Read the hit before believing the count; against **7** mentions in `init.sh`; still WP10's (§13-V3). (4) *That `scripts/resume.sh` knows nothing of adoption* — `grep -c 'adopt' "scripts/resume.sh"` returns **0**; the fifth branch is WP12a's, and WP9a deliberately did not pull it forward (§10-WP9). (5) *That A1's preflight is live* — `grep -c 'BL-242-PREFLIGHT-ARM' scripts/lib/adopt/adopt-state.sh` returns **4**: one per arm plus `# BL-242-PREFLIGHT-ARM3-INSTALLED`, arm 3's third signal. **This derivation said 3 and was self-poisoned by the same commit that wrote it** — the prefix match catches the fourth marker — which is precisely what derivation (3) two rows up warns about. Read the markers, do not trust the count. (6) *That A4's log is written FIRST* — `_adopt_state_order` emits `approval_log phase_state intake manifest`. **When any derivation stops returning what this row says, this row is stale — re-run them; do not quote them.** **A caveat the derivations themselves taught:** the framework's install set measured **65** files on `main`, **67** on the branch this document was first verified against, and **68** re-derived on 2026-09-01 (§13-V6). Three values in nine days. A count in this document is a measurement with a date and a branch, never a property — which is also why this row was allowed to go stale: nobody re-ran it. |
 
 **Provenance.** Ten architecture decisions — **D1 through D10** — are settled and recorded in
 `## BL-242:` in `solo-orchestrator-backlog.md`. **D1–D8** were settled **by Karl on 2026-08-23**
@@ -386,11 +386,15 @@ three rows this document's own blast radius had missed.** Nothing here overturns
 is what building WP9 found. Five changes:
 
 1. **§8.7a — the init-parity table, delivered**, and its adoption half derived **by execution**
-   (a shipped adoption run against a hermetic adoptee, tree diffed: **76** files, 68 under
-   `scripts/`, **eight** elsewhere) rather than by grep, because grep has under-read this exact
-   surface twice before. **32 rows; thirteen UNOWNED.** *(This entry said 75 / seven / thirty-one
+   (a shipped adoption run against a hermetic adoptee, tree diffed: **77** files, 68 under
+   `scripts/`, **nine** elsewhere) rather than by grep, because grep has under-read this exact
+   surface twice before. **33 rows; thirteen UNOWNED.** *(This entry said 75 / seven / thirty-one
    for three rounds after §8.7a itself was re-measured — a changelog entry describing a
-   measurement is a SECOND carrier of it, and correcting the table did not correct this.)* §12-3 is rewritten from "not delivered" to what
+   measurement is a SECOND carrier of it, and correcting the table did not correct this. It then
+   said 76 / eight / thirty-two for one round more, because WP9b corrected `docs/adoption.md` AND
+   §8.7a and missed this THIRD carrier — the one whose own parenthetical explains the failure mode.
+   Writing the lesson down did not make its author apply it. **If you re-measure, `grep` for the
+   number.**)* §12-3 is rewritten from "not delivered" to what
    the table says, which is worse news than the residual expected.
 2. **WP12 is split into 12a and 12b**, on a recommendation the architecture review made twice.
    §10's sequencing line and both rows are re-cut; the A3 manifesto mutation moves to 12b with the
@@ -408,6 +412,70 @@ is what building WP9 found. Five changes:
 5. **`docs/adoption.md`'s chooser sections move from WP12 to WP9**, resolving a contradiction that
    had stood since v2.0: §4.2 set WP9's completion check as "the verbatim question's grep returns
    nothing" while assigning one of the four files carrying it to a later package.
+
+**2026-09-01, third pass — WP9b BUILT (A1's three arms, A4's approval log), and it changed
+two shipped behaviours that were pinned elsewhere.** The package itself is what §10 specified and
+the proofs are what §10 asked for; what is worth recording here is the collateral, because both
+items were caught by an existing suite going red rather than by anyone predicting them.
+
+1. **A4 RETIRES AN INCIDENTAL SAFETY BLOCK, and the safety did not move — the assertion did.**
+   `tests/test-brownfield-wp4-driver.sh`'s `_assert_safe_row` pinned §8.4's top row (phase-state
+   present, manifest absent) as *"the gate BLOCKS, and it blocks because `APPROVAL_LOG.md not
+   found but ...`"*. An adoption interrupted after the phase_state stage was therefore "safe"
+   **because a file was missing**. A4 writes that file first, so the precondition no longer fires
+   on a tree adoption produced and the gate now reaches a real verdict — MEASURED: `Current phase:
+   0`, `Phase gates consistent.`, **rc 0**. That verdict is TRUE. The property §8.4 actually
+   protects is untouched: the *opposite* row (manifest present, phase-state absent — the gate
+   prints "skipping" and exits 0 on an adopted-LOOKING project) is still unreachable, and the
+   commit-time ladder still reads **strict** on the interrupted tree because the manifest is
+   missing. The assertion was re-aimed at those two and the retired clause is NAMED in the helper
+   so nobody re-adds it. The gate's refusal on a *genuinely* missing log is untouched and WP9b's
+   own `AM1` mutates the write away to watch it return.
+
+2. **A1 SUPERSEDES THE `n_copied -eq 0` TRIPWIRE AS THE RE-RUN ANSWER**, and the WP4 suite's `R1`
+   pinned the tripwire's wording. The tripwire fires inside `adopt_install_framework` — after the
+   tier question, the reverse intake, the census and the archive; the preflight refuses the same
+   tree at step 0. `R1` now asserts the PROPERTY (refuses, says already adopted, never blames the
+   clone, names the route) rather than which function said it, and keeps the clone misdiagnosis
+   pinned as an absence. **This sentence has now been wrong twice, in opposite directions,
+   and the second time is the more instructive.** It first read "the tripwire is not
+   asserted dead — a tree carrying every framework script but no `.claude/` at all
+   still reaches it", which arm 3's third signal falsified. The replacement said the
+   `n_collided -gt 0` branch was "unreachable in shipped code" — **also false**, and
+   review reached it end-to-end through an INCOMPLETE framework root, the shape this
+   §0.3 warns about three bullets below. **The error was reasoning about two counts as
+   though they shared a denominator.** `adopt_install_framework` skips entries whose
+   SOURCE is absent (`[ -f "$src" ] || continue`) and tests the destination with `-e`;
+   the preflight counted EVERY parsed line and tested `-f`. Against a root missing its
+   top-level scripts the adoptee held 24 of the 24 that root could install while the
+   preflight scored 24 against 65, stayed silent, and let the run reach the tripwire.
+   **The fix is the alignment, not the sentence**: the preflight now counts the same
+   set the installer would. With that, `n_copied -eq 0` genuinely implies
+   `n_present == n_total > 0`, so arm 3 (or arm 1) refuses first and the
+   `n_collided -gt 0` branch is unreachable — the `n_total -gt 0` guard covering the
+   only remaining case, an install set that parses to nothing, where the OTHER tripwire
+   branch fires. Measured both ways: 68/68 with no `.claude/` refuses at step 0, and the
+   incomplete-root fixture now refuses at step 0 too, tripwire text absent in both. The
+   branch is kept because the mutants still need it and because a reader of
+   `adopt_install_framework` must know why it no longer fires on its own.
+
+**A third thing, and it is the one a future package will trip over.** The driver now reads
+`$ADOPT_FRAMEWORK_ROOT/templates/`, which no adoption code did before. Three suites mirror the
+framework as `scripts/` + `init.sh` and every adoption run against those mirrors began refusing —
+correctly, since a checkout without `templates/` genuinely cannot render the log. **A framework
+root is not `scripts/` plus `init.sh`**; the three mirrors now copy `templates/` and say why. The
+refusal names the missing path, so the next incomplete mirror produces a diagnosis rather than a
+mystery.
+
+**And one mutation the design specified could not have gone RED as written.** §10-WP9's A1 arm-1
+proof says *"drop arm 1 → phase-state reverts and its gate dates null → RED"*. On an untouched
+adopted tree it does not: every framework file is already present, so the shipped `n_copied -eq 0`
+tripwire refuses BEFORE the state stage and the mutant leaves phase-state intact — measured, and
+the proof was green against a build with **no arm 1 at all**. That tripwire is exactly what D1's
+framework-wins install unreaches at WP11. Rather than defer the proof to WP11, the fixture deletes
+one framework script so `n_copied` is non-zero today; the RED is the specified one, and a
+partly-deleted adopted tree is an ordinary thing to find. A same-fixture control (`PM1c`) asserts
+the shipped code holds where the mutant fails.
 
 **2026-09-01, second pass — adversarial review of WP9a, and the finding is about DEFERRAL.**
 Round 1 on the build branch returned **major_concerns** on two claims, refuted both by execution,
@@ -500,13 +568,17 @@ not prove.** Round 3 wrote ten mutants against WP9a's own new code and **nine su
 3. **The mechanism claim was wrong for the THIRD CONSECUTIVE ROUND.** The ZDR backstop is
    *unreachable* on an adopted project today: `check-phase-gate.sh` refuses on a missing
    `APPROVAL_LOG.md` and `exit 1`s **six lines before `current_phase` is parsed**, and adoption
-   does not write that file until **A4 lands in WP9b**. Fail-closed survives (rc 1 either way) and
+   did not write that file until **A4, which has since landed in WP9b** — the ZDR backstop is the
+   operative guard now. Fail-closed survives (rc 1 either way) and
    the refusal names the approval log rather than the classification. **This suite's own G section
    documents that early exit and stubs around it** — the claim was written beside a fixture that
    disproved it.
 4. **§8.7a's measured install set was stale, falsified by this package's own new writer**: 76
    files and EIGHT non-`scripts/` paths, not 75 and seven, the eighth being
-   `.claude/orchestrator-source.json` — named twelve lines below by row 23. And the UNOWNED count
+   `.claude/orchestrator-source.json` — named twelve lines below by row 23.
+   *(Those are THAT round's numbers and are left as its record; WP9b's
+   `APPROVAL_LOG.md` falsified them again — the current figures are 77 and
+   nine, per §8.7a. Same convention as the rounds-7-to-9 entry further down this section.)* And the UNOWNED count
    said twelve while §12-3, §0.3 and `docs/INDEX.md` said thirteen: row 23's split created row
    **23a**, itself unowned, so the count never moved.
 5. **`workflow.html` told operators to hand-edit enforcement-tier keys the tool already writes** —
@@ -558,7 +630,7 @@ stamp guard's stated ORDERING was unpinned.
 **Numbers, again.** `## BL-242:` — the entry `README.md` tells readers to *"prefer to this
 sentence"* — still carried four claims this document had already corrected, and contradicted itself
 about the unowned count seventeen lines apart. `docs/adoption.md`'s committed-set enumeration said
-69 files and six paths where the run prints **76 and eight**, omitting `orchestrator-source.json` —
+69 files and six paths where the run then printed **76 and eight**, omitting `orchestrator-source.json` —
 **this package's own new writer**, the identical failure §8.7a had just been corrected for, one file
 over. And `BUG-010` had been filed *inside* the bugs file's template code fence, scrambling the
 last 120 lines of it.
@@ -653,7 +725,9 @@ Scout row is amended (`scout-report.sh`'s floor-rule note was shipped operator-f
 describing deleted machinery); §4.2 gains the `scripts/lib/scout/` row — **its sixth omission, and
 the first created by this branch's own later commit**; §8.7a's measurement is re-derived to 76 files
 and eight paths across 32 rows, after this package's own new writer falsified it; and §12-3's
-unowned count is thirteen.
+unowned count is thirteen. *(Those three numbers are the values THAT round produced and are left
+as its record; WP9b's own writer falsified them again — the current figures are 77 / nine / 33,
+and this line is narration of a past round rather than a live claim.)*
 
 **Nine rounds, one class, and the conclusion the whole series earns.** Not one blocking finding in
 nine rounds has been a defect in shipped behaviour; **rounds 4 through 9 each verified that by
@@ -857,8 +931,9 @@ order and each constraint's justification is §8.2; the summary:
 4. **The test-debt census** — before the install, as the shipped code already orders it and for
    the reason its comment states: the census reads `git ls-files`, and independence from the
    index's timing is worth keeping explicit.
-5. **The collision archive** — before any writer, now covering **four classes** (§7.3): AI-layer
-   surfaces, git hooks, colliding `scripts/` (D1), colliding framework-named documents (D3).
+5. **The collision archive** — before any writer, now covering **five classes** (§7.3): AI-layer
+   surfaces, git hooks, colliding `scripts/` (D1), colliding framework-named documents (D3), and
+   `APPROVAL_LOG.md` (WP9b's `approval-log`, the only class adoption REPLACES).
 6. **The framework install** — framework-wins on script collisions (D1), with the archive receipt
    checked first (§7.1).
 7. **Minimal state, phase 0** — `phase_state` → `intake` (mechanical prefill only) →
@@ -1568,13 +1643,13 @@ init-writer derivation excludes both, because init writes neither. Left there: a
 exactly that population. WP11 derives from the union and keeps the init-writer set as a **drift
 check**, not as the definition.
 
-### §7.3 — One mechanism, four classes
+### §7.3 — One mechanism, FIVE classes (four by design, a fifth added at WP9b)
 
 `adopt_archive_inventory` already emits `<originalPath>\t<class>\t<archivedPath>` rows and the
 MANIFEST already carries per-entry class, sha256, mode, and restore lines; `git-hook` entries
 already get a what-it-did description. D1 and D3 add classes `script` and `document` to the same
 inventory, the same MANIFEST, the same disclosure block, the same `--re-add` route, and the same
-pre-staging secrets scan — one mechanism serving four cases rather than three mechanisms, which is
+pre-staging secrets scan — one mechanism serving four cases rather than three mechanisms — and a FIFTH, `approval-log`, added at WP9b for `APPROVAL_LOG.md`, the only entry adoption REPLACES (`disposition: "replaced"`; every other row is `kept` or `composed`). It is deliberately NOT folded into `document`, which WP11 owns (D3): borrowing that class here would poach its vocabulary and its notice text. **The emitted set is `ai-settings`, `skill`, `git-hook`, `approval-log` — derive it from `adopt_archive_inventory`, not from this sentence, which has been wrong once already**, which is
 `## BL-242:`'s stated reason for cutting it this way. The archive home
 (`.claude/adoption-archive/<timestamp>-<pid>/`) and its MANIFEST schema are unchanged from the
 shipped WP6.
@@ -1606,12 +1681,12 @@ completion is recorded in state (§8.3), which is what the `resume.sh` branch pr
 
 | # | Step | Constraint it satisfies |
 |---|---|---|
-| 0 | **The re-adoption preflight** (**A1**) — refuse before anything is asked or written | **Before the tier question**, so a second run neither re-interrogates the operator nor destroys what the first produced. **Three arms.** (1) `soif_adoption_adopted` true, **or the committed witness `_soif_adoption_head_copy_adopted`** (which catches a hand-edited manifest that defeats both the flag and the restamp refusal) → refuse, naming `scripts/resume.sh` (the assessment route) and `--re-add`. (2) Stamp absent but a prior `.claude/adoption-archive/` present → refuse and NAME that directory: an interrupted first run, whose recovery is the archive's own restore lines. (3) **`.claude/phase-state.json` present, or `.claude/manifest.json` present with no adoption block → refuse: this tree LOOKS already framework-managed** (scaffolded by `init.sh`, or an interrupted adoption's state half). The phase-state half is decisive — `init.sh` and the adoption driver are its only writers. The manifest half is strong evidence rather than proof, so the message says what was found and names the two explanations instead of asserting one. Without arm 3 a SCAFFOLDED GREENFIELD project passes every check, is archived as though its framework files were the operator's, has its gate-earned state overwritten, is stamped adopted and **committed at exit 0** — shipped v1 refuses it via the `n_copied -eq 0` tripwire that D1 unreaches. **Without this, `adopt_write_file` (`cat >`) overwrites `phase-state.json` and a completed `PROJECT_INTAKE.md` at steps 7's stages, and the second-stamp refusal does not fire until the manifest stage — after both** |
+| 0 | **The re-adoption preflight** (**A1**) — refuse before anything is asked or written | **Before the tier question**, so a second run neither re-interrogates the operator nor destroys what the first produced. **Three arms.** (1) `soif_adoption_adopted` true, **or the committed witness `_soif_adoption_head_copy_adopted`** (which catches a hand-edited manifest that defeats both the flag and the restamp refusal) → refuse, naming `scripts/resume.sh` (the assessment route) and `--re-add`. (2) Stamp absent but a prior `.claude/adoption-archive/` present → refuse and NAME that directory: an interrupted first run, whose recovery is the archive's own restore lines. (3) **`.claude/phase-state.json` present, or `.claude/manifest.json` present with no adoption block, OR at least half of the framework's own install set already present → refuse: this tree LOOKS already framework-managed** (scaffolded by `init.sh`, or an interrupted adoption's state half). The phase-state half is decisive — `init.sh` and the adoption driver are its only writers. The manifest half is strong evidence rather than proof, so the message says what was found and names the explanations instead of asserting one. **THE THIRD SIGNAL WAS ADDED AT WP9b AND IS NOT DECORATION EITHER**: an adoption interrupted after the framework install on a COLLISION-FREE adoptee has no manifest, no phase-state and no archive — the archive directory only materialises when something collides — so arms 1, 2 and 3 were all silent and the operator was re-asked the tier question and every confirmation before the `n_copied -eq 0` tripwire refused. That is this step's own promise going unmet. It is **at least half of the install set**, counted over the same source-filtered entries `adopt_install_framework` would copy, and NOT a single named file: keying it on one file false-refused an adoptee that legitimately vendors a script of its own at a framework path, which adopted cleanly before WP9b. A majority cannot be coincidence; one file can. Without arm 3 a SCAFFOLDED GREENFIELD project passes every check, is archived as though its framework files were the operator's, has its gate-earned state overwritten, is stamped adopted and **committed at exit 0** — shipped v1 refuses it via the `n_copied -eq 0` tripwire that D1 unreaches. **Without this, `adopt_write_file` (`cat >`) overwrites `phase-state.json` and a completed `PROJECT_INTAKE.md` at steps 7's stages, and the second-stamp refusal does not fire until the manifest stage — after both** |
 | 1 | **The tier question** — `adopt_ask_audience`, kept by D9 and re-purposed (§6.5) | **Before step 3**, which keys on its answer, and before step 2, which installs software: a run abandoned at the only question adoption asks has changed neither the repository nor the host. Shipped position, effectively unmoved — `adopt_main` already asks it before any writer (§13-V4) — so this row costs a re-purpose, not a re-order |
 | 2 | Tool resolution (`scripts/resolve-tools.sh` against `templates/tool-matrix/`) | Before the secrets check, which needs the scanner it installs (§6.2). The one genuinely new step in the order |
 | 3 | The secrets check (§6) — at `organizational` every non-clean status stops; at `personal` findings and `scan-failed` warn and carry on, while `tool-unavailable` stops unless an acceptance is recorded (§6.1's ladder) | Before any write, so a *stopped* adoption has changed nothing — today's `adopt_stub_secrets_disposition` fires after the reverse intake, which a stop (as opposed to a notice) must not. **It keys on step 1's answer, never on the manifest**, which is not written until step 7 — the tier must be carried in the run, and `ADOPT_DEPLOYMENT` is what carries it (§6.5) |
 | 4 | Test-debt census (`adopt_test_debt_record`) | **Before the install** — shipped and kept; the census reads `git ls-files` and its independence from the framework copies is stated in the code rather than resting on index timing |
-| 5 | Collision archive (`adopt_archive_write`), four classes | **Before any writer** — shipped and kept; an archive taken after a writer captures the framework's file under the operator's name. Now also before the D1 installs it newly precedes |
+| 5 | Collision archive (`adopt_archive_write`), five classes | **Before any writer** — shipped and kept; an archive taken after a writer captures the framework's file under the operator's name. Now also before the D1 installs it newly precedes |
 | 6 | Framework install, framework-wins + receipt check (§7.1) | After the archive that makes overwriting honest |
 | 7 | State: **the tier-matched `APPROVAL_LOG.md` (A4) FIRST**, then `phase_state` → `intake` (mechanical prefill only) → `manifest` + stamp | `# BF-ADOPT-STATE-ORDER`, carried; §8.4's fail-safe analysis carried. The intake's judgment sections move to Act 3, so Act 2 writes the prefill-confirmed cells and leaves judgment cells blank |
 | 8 | The adoption commit (`adopt_stage_and_commit`) | Explicit staging, carried. **`## BL-225:` sits exactly here** — the staged-tree/`.gitignore` defect — and §10's sequencing gates the build on its fix |
@@ -1652,7 +1727,7 @@ pattern with permission. **Any of these four may be overturned without overturni
 
 | # | Decision | Alternative rejected, and why |
 |---|---|---|
-| **A1** | **A step-0 re-adoption preflight that refuses before any question or write, on THREE arms** (§8.2 step 0): (1) `soif_adoption_adopted` true — and the **committed witness** (`_soif_adoption_head_copy_adopted`) too, which catches a hand-edited manifest that defeats both the flag and the restamp refusal; (2) an unstamped tree carrying a prior `.claude/adoption-archive/`; (3) **a tree that is already framework-managed but not adopted** — `.claude/phase-state.json` present, or `.claude/manifest.json` present with no adoption block. | *Let the second-stamp refusal handle it* — it fires at the manifest stage, after `adopt_write_file` has `cat >`-overwritten `phase-state.json` and the intake. Under D10 the clobbered `current_phase` is **gate-earned**. Refusing late is not refusing. **Arm 3 is not decoration and was missed in this decision's first draft:** on a SCAFFOLDED GREENFIELD project arms 1 and 2 both stay silent — no `.adoption` to read, and the archive this run creates is not a *prior* one — so adoption archives the scaffold's own framework files as the operator's, overwrites gate-earned state, stamps it adopted (no `.adoption` ⇒ no restamp refusal) and **commits, exit 0**. Shipped v1 refuses that tree via `adopt_install_framework`'s `n_copied -eq 0` tripwire, which **D1 unreaches**. Silent-success corruption, and worse in kind than the noisy case A1 was written for. |
+| **A1** | **A step-0 re-adoption preflight that refuses before any question or write, on THREE arms** (§8.2 step 0): (1) `soif_adoption_adopted` true — and the **committed witness** (`_soif_adoption_head_copy_adopted`) too, which catches a hand-edited manifest that defeats both the flag and the restamp refusal; (2) an unstamped tree carrying a prior `.claude/adoption-archive/`; (3) **a tree that is already framework-managed but not adopted** — `.claude/phase-state.json` present, or `.claude/manifest.json` present with no adoption block, **or at least half of the framework's own install set already on disk** (added at the build: the first two miss an adoption interrupted after the install on a collision-free adoptee, which has none of the three artefacts; counted over the installer's own source-filtered set, and a majority rather than a named file so an adoptee vendoring one script at a framework path is not false-refused). | *Let the second-stamp refusal handle it* — it fires at the manifest stage, after `adopt_write_file` has `cat >`-overwritten `phase-state.json` and the intake. Under D10 the clobbered `current_phase` is **gate-earned**. Refusing late is not refusing. **Arm 3 is not decoration and was missed in this decision's first draft:** on a SCAFFOLDED GREENFIELD project arms 1 and 2 both stay silent — no `.adoption` to read, and the archive this run creates is not a *prior* one — so adoption archives the scaffold's own framework files as the operator's, overwrites gate-earned state, stamps it adopted (no `.adoption` ⇒ no restamp refusal) and **commits, exit 0**. Shipped v1 refuses that tree via `adopt_install_framework`'s `n_copied -eq 0` tripwire, which **D1 unreaches**. Silent-success corruption, and worse in kind than the noisy case A1 was written for. |
 | **A2** | **Act 4 writes its assessment merge LAST**, and §7.2's receipt rule exempts a path whose existing content carries an Act-4 provenance header **whose adoption identity matches this tree's stamp** — and the exemption is from **REFUSAL, not from ARCHIVING**: the current content is re-archived (a second timestamped copy) before it is rewritten. | *Write the merge first* — a crash afterwards leaves documents unwritten while the resume predicate goes false: the largest deliverable silently skipped, the class this repo hunts. *Key the exemption on header PRESENCE* — v1 §8.6's header carries a `source:` commit, so presence alone also matches a `PROJECT_BIBLE.md` the operator copied in from **another** adopted project during the days-wide Act2→Act3 window: silently overwritten with no archive row, the unrecoverable-loss class the receipt rule exists to prevent. Bind it to `adoptedAtCommit`. *Exempt from archiving too* — rejected: re-archiving costs one copy and makes even a matched overwrite recoverable. **Stated failure mode:** a document whose header the operator hand-deleted is treated as theirs and refused — the safe direction. |
 | **A3** | **Act 4 does NOT write `PRODUCT_MANIFESTO.md`, and neither does anything else in adoption** — it arrives when the **ordinary Phase 0** produces it, exactly as for a greenfield project (D10). | *Write it in Act 4* — it is in §7.2's required set, and writing it flips OFF `resume.sh`'s §13 kickoff branch (its `[ ! -f "PRODUCT_MANIFESTO.md" ]` predicate, the branch the script's own header calls *"intake done, Phase 0 never started"*; there is no marker on it — `resume.sh` carries only `# BL-046` and `# BL-202-INTAKE-PREDICATE`), so a completed adoption lands in the classic resume prompt and skips the Phase 0 entry D10 promises. *Write it in WP12b after the intake is confirmed* — **rejected, and this decision's first draft said it**: `init.sh` writes no manifesto (*"PROJECT_BIBLE.md / PRODUCT_MANIFESTO.md are created by no script"*), the Phase-0 **agent** authors it for greenfield, and building an adoption-side writer duplicates that path — the two-owners pattern §5.1 itself warns against — while re-creating the same skip one step later for an operator who stops at intake-confirmation. |
 | **A4** | **Act 2 writes an `APPROVAL_LOG.md` FIRST in step 7**, rendered from the **tier-matched `init.sh` template** (adoption knows the tier from D9) and carrying **no dated gate-approval row**. | *Document the red window instead* — the gate refuses on the missing file and exits **before parsing the phase at all** (`# BL-166`-era precondition block in `check-phase-gate.sh`), so the resting state cannot run its own gate. *Write it last* — every mid-step-7 death then leaves phase-state-present/log-absent, the hard refusal; a log alone is inert, because with no phase-state the gate exits 0. *Invent an "empty, headed" shape* — rejected as a fourth approval-log spelling: `init.sh` renders tier-differentiated templates and `verify-install.sh` carries a `fix_approval_log` writer, and a fourth would drift from both. The template's pre-condition `__TODAY__` cells do not match the gate's evidence grep, so it stays un-approved, which is correct. |
@@ -1667,7 +1742,7 @@ judgment call about an operator-facing surface rather than a derivation.
 |---|---|---|
 | **A5** | **`scripts/lib/adopt/adopt-chooser.sh` is RENAMED to `adopt-evidence.sh`.** After D4 and D10 the file's remaining content is §4.2's evidence block and nothing else. | *Keep the name* — a file called `chooser` containing no chooser is the stale-string class this repo has paid for repeatedly (`adopt_stub_hooks`' owner line, `adopt-stubs.sh`'s WP5b section comment, `## BL-215:`'s status line). The rename is cheap and bounded: the name occurs at **three** live sites — the `for _part in …` source loop in `adopt-project.sh` and two in the WP4 suite — and the module-dependency lint keys on directory, not filename. *Fold the evidence functions into `adopt-core.sh` and delete the file* — rejected: `adopt-core.sh` is the shared primitives (I/O, ledger, refusals) and the evidence block is a feature surface; merging them makes the M2 header's per-file account less legible, not more |
 | **A6** | **The §4.2 evidence block SURVIVES, with its framing re-worded.** The four evidence functions stay; the two sentences that point at the deleted question go, and the block ends by saying plainly that the project lands at phase 0 whatever the evidence says. | *Delete it with the chooser* — the tempting cut, and wrong twice. §4.3 says in as many words that Scout's ladder, the census and the probes **survive and matter**; and the block is the only place in Act 2 where an operator sees what the survey found about their own project. What is honestly lost is its *purpose*: it fed a decision and now feeds none, so the re-wording must not imply otherwise — a block that still reads as "weigh this before answering" would be inviting weight for a judgment nobody is asked to make. **The known defect is CARRIED, not fixed:** three of the four signals (tags, commit shape, changelog) are derived here from the adoptee's git rather than read from the report, which the file's own header calls "one fact derived in two places is two chances to disagree about it". That duplication is unchanged by WP9 |
-| **A7** | **Act 2's reverse intake stops asking JUDGMENT and NON-SKIPPABLE rows, data classification included; it asks only the scan-derived confirmations.** `adopt_judgment_question`, `adopt_ops_addendum` and `adopt_ask_data_classification` go with them; `adopt_persist_phase1_artifacts` is KEPT, uncalled, marked for Act 4, and its process-state *creation* half is split out and still runs in Act 2. | *Leave the judgment questions in Act 2* — §8.2 step 7 is normative ("the intake's judgment sections move to Act 3, so Act 2 writes the prefill-confirmed cells and leaves judgment cells blank"), and leaving them means WP12a's interview asks the same operator the same questions twice. **The classification is the load-bearing half, and its Act-2 mandate has LOST ITS OWN STATED REASON:** `adopt-intake.sh`'s header derives non-skippability from "an S1 adoption lands at 4, i.e. above [the ZDR] threshold on its FIRST commit" — under D10 nothing lands above 0, so the mechanical necessity that justified the guard is gone and §5.2 has already re-anchored it to Act 4's intake write. **The window is real and is stated rather than defended:** between WP9 and WP12a an adoption records no classification at all. It is fail-closed, and the mechanism is stated CORRECTLY here after being stated wrongly at first: the project rests at phase 0, and the ZDR backstop is a hard `[FAIL]` — a real `issues` increment, not a cosmetic `[WARN]` — at `current_phase >= 2` **however that value came to be 2**. The first version of this sentence said *"the only route to 2 crosses the 1→2 gate where that backstop lives"*, and that is **FALSE**: `scripts/process-checklist.sh`'s `_set_current_phase_min` writes `current_phase` at five call sites, an adoptee **receives that script**, and its `--complete-step` / `--verify-init` path reaches `_set_current_phase_min 2` with **no gate consult** — unlike `--start-phase1` (`# BL-114-START1-GATE-CONSULT-BEGIN`) and `--start-phase4` (`# BL-105-START4-GATE-CONSULT-BEGIN`), which do consult. A brownfield adoptee is exactly the population that already has a remote, CI, a lockfile and hooks, so that path is the expected one rather than a contrived one, and adversarial review executed it: `current_phase` 0 → 2 with the classification still absent. **The conclusion survives and is stronger without the false premise**: the gates are cumulative and evidence-keyed, so a rung reached by any writer without the evidence simply fails the gate — which does not depend on an enumeration of who can write the value. **AND THE OPERATIVE GUARD TODAY IS NOT THAT ONE, WHICH IS THE THIRD CORRECTION THIS SENTENCE HAS TAKEN.** On an adopted tree as WP9a leaves it, `check-phase-gate.sh` refuses EARLIER still: its precondition block prints `[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.` and `exit 1`s **six lines before `current_phase` is parsed at all**, and adoption does not write that file until **A4 lands in WP9b**. So the ZDR backstop is *unreachable* on an adopted project right now — the refusal is real and fail-closed (rc 1 either way), but it names `APPROVAL_LOG.md` and never mentions the classification or `reconfigure-project.sh`. Once A4 writes the log, the ZDR backstop becomes the operative guard and the paragraph above describes what executes. **This suite's own G section documents the early exit and stubs around it**, which is how the claim came to be written beside a fixture that disproved it. **THE SECOND CONJUNCT — that the operator still MEETS the question — WAS ASSERTED BY NOBODY AND WAS FALSE ON ALL THREE ROUTES**, which adversarial review found by executing them: `resume.sh`'s kickoff branch pointed at a `## 13.` section the adoption-rendered intake never wrote; `intake-wizard.sh --resume` raised a **swallowed** `KeyError` (its `load_progress()` subscripts seven keys adoption did not write) and then resumed at Section 14 — **past Section 5, the classification** — printing *"Intake Complete!"* at rc 0; and `reconfigure-project.sh`, **the hatch the ZDR block names in its own FAIL text**, died on a `.claude/orchestrator-source.json` adoption never wrote. All three are FIXED and each is now asserted by execution (§10-WP9's `R1`–`R4`): Act 2 renders a real §13 prompt that names the classification as non-optional, writes the seven keys with `last_section: 0` so `--resume` walks Section 5, and writes the source path. **Deferring a requirement is only honest if the route that re-asks it exists; three of them did not, and "fail-closed" was carrying the whole argument alone.** Two defects in `intake-wizard.sh` itself are OUT of this fix and filed rather than absorbed — a `KeyError` that is swallowed rather than fatal, and a choice prompt that loops forever on EOF. *Delete `adopt_persist_phase1_artifacts` and let WP12a re-extract it* — rejected: it is reuse-by-extraction of `intake-wizard.sh`'s own writer and re-deriving it is how two owners of one merge appear |
+| **A7** | **Act 2's reverse intake stops asking JUDGMENT and NON-SKIPPABLE rows, data classification included; it asks only the scan-derived confirmations.** `adopt_judgment_question`, `adopt_ops_addendum` and `adopt_ask_data_classification` go with them; `adopt_persist_phase1_artifacts` is KEPT, uncalled, marked for Act 4, and its process-state *creation* half is split out and still runs in Act 2. | *Leave the judgment questions in Act 2* — §8.2 step 7 is normative ("the intake's judgment sections move to Act 3, so Act 2 writes the prefill-confirmed cells and leaves judgment cells blank"), and leaving them means WP12a's interview asks the same operator the same questions twice. **The classification is the load-bearing half, and its Act-2 mandate has LOST ITS OWN STATED REASON:** `adopt-intake.sh`'s header derives non-skippability from "an S1 adoption lands at 4, i.e. above [the ZDR] threshold on its FIRST commit" — under D10 nothing lands above 0, so the mechanical necessity that justified the guard is gone and §5.2 has already re-anchored it to Act 4's intake write. **The window is real and is stated rather than defended:** between WP9 and WP12a an adoption records no classification at all. It is fail-closed, and the mechanism is stated CORRECTLY here after being stated wrongly at first: the project rests at phase 0, and the ZDR backstop is a hard `[FAIL]` — a real `issues` increment, not a cosmetic `[WARN]` — at `current_phase >= 2` **however that value came to be 2**. The first version of this sentence said *"the only route to 2 crosses the 1→2 gate where that backstop lives"*, and that is **FALSE**: `scripts/process-checklist.sh`'s `_set_current_phase_min` writes `current_phase` at five call sites, an adoptee **receives that script**, and its `--complete-step` / `--verify-init` path reaches `_set_current_phase_min 2` with **no gate consult** — unlike `--start-phase1` (`# BL-114-START1-GATE-CONSULT-BEGIN`) and `--start-phase4` (`# BL-105-START4-GATE-CONSULT-BEGIN`), which do consult. A brownfield adoptee is exactly the population that already has a remote, CI, a lockfile and hooks, so that path is the expected one rather than a contrived one, and adversarial review executed it: `current_phase` 0 → 2 with the classification still absent. **The conclusion survives and is stronger without the false premise**: the gates are cumulative and evidence-keyed, so a rung reached by any writer without the evidence simply fails the gate — which does not depend on an enumeration of who can write the value. **AND THE OPERATIVE GUARD TODAY IS NOT THAT ONE, WHICH IS THE THIRD CORRECTION THIS SENTENCE HAS TAKEN.** On an adopted tree as WP9a leaves it, `check-phase-gate.sh` refuses EARLIER still: its precondition block prints `[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.` and `exit 1`s **six lines before `current_phase` is parsed at all**, and adoption did not write that file until A4. **A4 HAS NOW LANDED (WP9b), so this paragraph's regime is the FORMER one and the ZDR backstop is the operative guard** — the paragraph above describes what executes today. The pre-A4 behaviour is kept because projects adopted before it still rest in it, and because the correction history is the point: this sentence was written as "right now" and became false the moment the package it names shipped. Deleting the log on an adopted project reproduces the old refusal exactly (measured: `[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.`, rc 1). **This suite's own G section documents the early exit and stubs around it**, which is how the claim came to be written beside a fixture that disproved it. **THE SECOND CONJUNCT — that the operator still MEETS the question — WAS ASSERTED BY NOBODY AND WAS FALSE ON ALL THREE ROUTES**, which adversarial review found by executing them: `resume.sh`'s kickoff branch pointed at a `## 13.` section the adoption-rendered intake never wrote; `intake-wizard.sh --resume` raised a **swallowed** `KeyError` (its `load_progress()` subscripts seven keys adoption did not write) and then resumed at Section 14 — **past Section 5, the classification** — printing *"Intake Complete!"* at rc 0; and `reconfigure-project.sh`, **the hatch the ZDR block names in its own FAIL text**, died on a `.claude/orchestrator-source.json` adoption never wrote. All three are FIXED and each is now asserted by execution (§10-WP9's `R1`–`R4`): Act 2 renders a real §13 prompt that names the classification as non-optional, writes the seven keys with `last_section: 0` so `--resume` walks Section 5, and writes the source path. **Deferring a requirement is only honest if the route that re-asks it exists; three of them did not, and "fail-closed" was carrying the whole argument alone.** Two defects in `intake-wizard.sh` itself are OUT of this fix and filed rather than absorbed — a `KeyError` that is swallowed rather than fatal, and a choice prompt that loops forever on EOF. *Delete `adopt_persist_phase1_artifacts` and let WP12a re-extract it* — rejected: it is reuse-by-extraction of `intake-wizard.sh`'s own writer and re-deriving it is how two owners of one merge appear |
 | **A8** | **`scripts/check-phase-gate.sh`'s cosmetic `.adoption.scenario` read is retired with the field**, and the `[OK]` line stops naming a scenario. `adopt_stub_certification` is DELETED (WP5 is retired, §5.1) and `adopt_stub_project_docs`' owner string is corrected from *"unassigned — §10 names no owner"* to name D3/WP11+WP12b. `adopt_stub_hooks`' string is NOT touched — §10 routes it to WP7. | *Leave the gate read* — it would print `scenario: unknown` on every adopted project forever, and a gate that reports an unknown where the record is complete teaches operators to ignore it. **§4.2's blast-radius table does not list `check-phase-gate.sh` at all** — the same defect §4.2 itself names ("a blast-radius enumeration is the author's inference about consequences"), recurring inside the section that warns about it; the row is added below. *Leave `adopt_stub_certification`* — announcing a RETIRED package as not-yet-built is worse than silence: it tells an operator to expect something nobody will ever build. *Fix `adopt_stub_hooks` too* — rejected, and not on grounds of effort: `## BL-242:` establishes that the obvious rewrite ("WP7") would propagate a **false §10 attribution**, so that string needs the decision-naming spelling WP7 will give it |
 
 ### §8.4 — Fail-safe order — the between-acts row, and the Act 3/4 rows (A2)
@@ -1808,23 +1883,24 @@ A shipped adoption was run against a hermetic adoptee and the tree diffed before
 
 ```
 adopt rc=0
-total new files: 76   |  under scripts/: 68  |  under .claude/adoption-archive/: 0
+total new files: 77   |  under scripts/: 68  |  under .claude/adoption-archive/: 0
 ```
 
-The **eight** non-`scripts/` paths a completed adoption writes, in full — this is the whole of it,
+The **nine** non-`scripts/` paths a completed adoption writes, in full — this is the whole of it,
 and anything not on this list is skipped:
 
 ```
 .claude/adoption/scout-report.json   .claude/intake-progress.json   .claude/manifest.json
 .claude/orchestrator-source.json     .claude/phase-state.json       .claude/process-state.json
-.claude/test-debt.json               PROJECT_INTAKE.md
+.claude/test-debt.json               APPROVAL_LOG.md                PROJECT_INTAKE.md
 ```
 
-*(**This block said 75 and seven until adversarial review re-ran it.** The eighth path is
-`.claude/orchestrator-source.json` — added by **this very package**, and named twelve lines below
-by row 23 — so the section contradicted itself. A measurement is only true of the tree it was taken
-on, and this one was taken before the branch that quotes it had finished changing that tree.
-**Re-run it after any package that adds a writer.**)*
+*(**This block has now been wrong three times: 75 and seven, then 76 and eight, now 77 and nine.**
+The eighth path was `.claude/orchestrator-source.json`; the ninth is `APPROVAL_LOG.md`, added by
+**WP9b** — and WP9b corrected the identical list in `docs/adoption.md` while leaving THIS copy
+stale, in the paragraph carrying the instruction that would have prevented it. Two documents in one
+commit disagreeing about one measurement. A measurement is only true of the tree it was taken on.
+**Re-run it after any package that adds a writer — and re-run BOTH copies, or delete one.**)*
 
 (plus `.git/hooks/commit-msg`, which a tree diff cannot see because `.git` is pruned, and a
 `.claude/adoption-archive/` tree whose size depends entirely on what the adoptee already had —
@@ -1870,6 +1946,7 @@ plus the writers whose target is inside a function body (`generate_claude_md`,
 | 21 | `.claude/skills/<name>/SKILL.md` (vendored skills) | **UNOWNED** |
 | 22 | `.claude/last-checked-commit.txt` (2 sites) | **UNOWNED** — §8.7 named it; still nobody's |
 | 23 | `.claude/orchestrator-source.json` | **Act 2 (WP9a)** — `adopt_write_orchestrator_source`. **The one row in the unowned set that WP9a closed, and the boundary is stated so it does not read as arbitrary: A7's own safety argument depends on it.** Three shipped scripts an adoptee receives read it (`reconfigure-project.sh`, `verify-install.sh`, `check-versions.sh`), and the Phase 1→2 ZDR block names the first of them as its escape hatch **in its own FAIL text** — which died on the missing file. Closing a block while leaving the hatch it advertises unreachable is a pattern this repository has paid for |
+| 22a | `APPROVAL_LOG.md` | **Act 2 (WP9b)** — `adopt_write_approval_log`, rendered from the tier-matched `init.sh` template (A4). **It is also the archive's FIFTH class, `approval-log`, and the only entry adoption REPLACES** (`disposition: "replaced"`; every other entry is `kept` or `composed`). The class is deliberately not `document` — WP11 owns that vocabulary (D3) and folding this into it would poach the package's notice text. §7.3 carries the class list and names this one |
 | 23a | `.claude/build-progress.json`, `.claude/tool-usage.json` | **UNOWNED** — they travelled with row 23 until WP9a split it; nothing depends on them the way the escape hatch depended on the source path, so they stay recorded |
 | 24 | `docs/INDEX.md`, `docs/IDENTIFIERS.md`, `docs/archive/README.md`, `docs/test-results/go-live-checklist.md` | **UNOWNED** |
 | 25 | `evaluation-prompts/Projects/**` | **UNOWNED** |
@@ -1881,7 +1958,7 @@ plus the writers whose target is inside a function body (`generate_claude_md`,
 | 31 | `git init`, and BL-030's organizational⇒strict forcing | **COVERED** — the adoptee is already a repository; `enforcement_level` seeds `strict` in `adopt_write_manifest` |
 
 **THIRTEEN rows are UNOWNED (18–22, 23a, 24–30), one is UNSPECIFIED (17) and one is PARTIAL (16),
-across 32 rows.** *(This said twelve, and twelve was wrong in a way worth keeping: WP9a closed row
+across **33** rows.** *(The denominator was 32 until WP9b added row **22a** — `APPROVAL_LOG.md` — so this number was falsified by the very commit that wrote the row, inside the paragraph telling you to count the rows rather than trust it. The UNOWNED half did not move; only the denominator did. This also said twelve, and twelve was wrong in a way worth keeping: WP9a closed row
 23 and the split created row **23a**, itself unowned, so the count never moved. §12-3, §0.3 and
 `docs/INDEX.md` all said thirteen while this line said twelve — the document contradicted itself
 for one round. **The count is a MEASUREMENT of the table: read the rows, do not trust this
@@ -1904,7 +1981,7 @@ statement with a denominator.
 | Scout, **almost** whole | `scripts/scout.sh`, `scripts/lib/scout/` | Act 1 is the shipped Scout. Candidate future section (`chooserEvidence`) dies with the chooser. **AMENDED AT WP9a, and the amendment is here rather than only in the changelog because that is where a reader of this row looks:** `scout-report.sh` emitted, in the report and the rendered markdown, the note *"maximum satisfied rung; the interview may only lower this"* — the FLOOR RULE, whose interview D4 deleted and whose placement D10 deleted. Shipped operator-facing output making a claim about machinery that does not exist. Re-worded to *"…evidence for the Phase 0 intake, never a placement"* at four sites plus the WP1 suite's string-equality pin. Nothing else in Scout changes, and nothing outside Scout reads `phaseMap.suggestedPhase` any more, which is what made the note purely descriptive |
 | The in-core enabling arms | `scripts/lib/adoption-stamp.sh`, `# BF-ADOPT-FLAG-READ`, the TDD adoption-window arm | The `adopted` flag's meaning and every reader; the stamp's writer changes shape (§8.3), not home or discipline |
 | The test-debt ledger and ratchet | `scripts/lib/adopt/adopt-test-debt.sh` (WP5b, shipped) | Untouched; still kind (c)'s forward equivalent |
-| The collision archive mechanism | `scripts/lib/adopt/adopt-archive.sh` (WP6, shipped) | Gains two classes (§7.3); layout, MANIFEST, `--re-add`, pre-staging scan unchanged |
+| The collision archive mechanism | `scripts/lib/adopt/adopt-archive.sh` (WP6, shipped) | Gains three classes (§7.3) — `script` and `document` at WP11, and `approval-log` at WP9b, already shipped; layout, MANIFEST, `--re-add`, pre-staging scan unchanged |
 | The redaction projection | v1 §6.2's field allowlist, shipped in Scout's secrets section | Every §6 artifact inherits it; no artifact ever carries a value |
 | The state order and staging discipline | `# BF-ADOPT-STATE-ORDER`; explicit-path staging | Carried verbatim |
 | The module contract and its lint | `docs/module-contract.md` M1–M5; `scripts/lint-module-dependencies.sh`, `# BL-215-CORE-GLOB-SYNC` | §3.7 keeps both new contact points on the right side of M3 |
@@ -2032,7 +2109,7 @@ only, so WP9's stamp changes must add their pins to a PR-blocking suite, not tha
 2. **`## BL-226:`** ("moved" claimed where nothing moved) — WP11's notice rewrite touches the same
    strings and should close it in passing; recorded so it is checked rather than assumed.
 3. **The init-parity audit is DELIVERED at §8.7a, and it is worse news than this entry expected.**
-   **32 rows**; the adoption half measured by execution, the `init.sh` half read from source
+   **33 rows** (32 until WP9b added row 22a); the adoption half measured by execution, the `init.sh` half read from source
    and acknowledged partial. **Thirteen rows are UNOWNED, one UNSPECIFIED, one PARTIAL**, and the
    five packages after WP9 close none of the thirteen. Three of them are load-bearing for claims
    this document makes elsewhere: `docs/reference/*` (row 18) means **D8 binds
@@ -2051,15 +2128,23 @@ only, so WP9's stamp changes must add their pins to a PR-blocking suite, not tha
     designed** (A1, A2). A1 refuses on three arms and names the prior archive; it does not roll the
     tree back. `## BL-225:`'s entry asks for a preflight before any write and its fix so far covers
     the staging half only, so an interrupted Act 2 still leaves files on disk — the archive's
-    restore lines are the recovery path, and they are manual. **Three windows A1 does not close,
-    recorded rather than claimed shut:** (i) an interrupted run that died after the install on a
-    **collision-free** adoptee leaves no archive and no state, so no arm fires and the re-run's
-    archive misattributes the framework's own installed files as the operator's — the systematic
-    mitigation is for WP11's inventory to sha-compare colliding content against the install source
-    and label byte-identical entries honestly rather than as `script`-theirs; (ii) an adopted tree
-    whose `.claude/` was deleted defeats all three arms; (iii) **no deliberate full re-adoption
-    route is blessed** — arm 2 makes deleting the archive its price, which destroys the record the
-    archive exists to keep. Stated as unsupported rather than left to be discovered.
+    restore lines are the recovery path, and they are manual. **Three windows were recorded here as A1 does not
+    close, and the WP9b build CLOSED TWO OF THEM — the entry is corrected rather than left to
+    read as open, which is how a residual list becomes fiction.** (i) *an interrupted run that
+    died after the install on a collision-free adoptee leaves no archive and no state, so no arm
+    fires* — **CLOSED** by arm 3's third signal (`# BL-242-PREFLIGHT-ARM3-INSTALLED`, §8.2 step 0):
+    at-least-half of the install set present refuses at step 0, measured on a real
+    `SOIF_ADOPT_HALT_AFTER=install` tree at 68/68 with the operator never re-asked. The downstream
+    concern it named survives and is WP11's: an archive taken on such a tree would misattribute the
+    framework's own installed files as the operator's, and the systematic mitigation is for WP11's
+    inventory to sha-compare colliding content against the install source and label byte-identical
+    entries honestly rather than as `script`-theirs. (ii) *an adopted tree whose `.claude/` was
+    deleted defeats all three arms* — **CLOSED**, and by two different arms depending on how far
+    the deletion went: a working-copy-only deletion is caught by arm 1's committed witness
+    (`# BL-242-PREFLIGHT-WITNESS2`), and a deletion that was itself committed is caught by the same
+    third signal, since the framework's scripts are still on disk. Both measured. (iii) **no
+    deliberate full re-adoption route is blessed** — **STILL OPEN**: arm 2 makes deleting the
+    archive its price, which destroys the record the archive exists to keep.
 
 **Cannot be known before a real adoption:**
 

--- a/scripts/lib/adopt/adopt-archive.sh
+++ b/scripts/lib/adopt/adopt-archive.sh
@@ -109,6 +109,28 @@ adopt_archive_inventory() {
 $(_adopt_archive_ai_surfaces)
 AI
 
+  # ── APPROVAL_LOG.md, AND IT IS HERE BECAUSE WP9b MADE IT A REPLACE ────────
+  # §7.1's rule is not "AI surfaces are archived", it is "every
+  # archive-and-replace surface produces a row". Until A4 nothing in adoption
+  # wrote this path, so it belonged to §7.5 (keep theirs) and correctly had no
+  # row. A4 renders the tier-matched template OVER it, which makes it a
+  # replace — and a replace with no row is the silent-success class this whole
+  # archive exists to close.
+  #
+  # MEASURED BEFORE THE FIX, on an adoptee whose own APPROVAL_LOG.md was never
+  # committed: rc 0, the operator's sign-off record gone, ZERO blobs anywhere
+  # in the repository containing it, and the run printing "Nothing was
+  # deleted." in the same transcript. The disclosure was telling the truth
+  # about the list it had been given; the list was wrong.
+  #
+  # ITS OWN CLASS, NOT `document`. WP11 owns the `document` class (D3) and
+  # folding this into it now would poach that package's vocabulary and its
+  # notice text. A named class costs one row here and leaves WP11 free to
+  # absorb it deliberately.
+  if [ -f "$root/APPROVAL_LOG.md" ]; then
+    printf '%s\t%s\t%s\n' "APPROVAL_LOG.md" "approval-log" "APPROVAL_LOG.md"
+  fi
+
   # Skills are a directory shape, not a fixed path, so they are globbed. `find`
   # rather than a glob because bash 3.2 has no `nullglob` and an unmatched glob
   # would be passed through as a literal path.
@@ -563,8 +585,25 @@ adopt_archive_write() {
     # marker-composed bucket: the framework appends a MARKED block to their
     # commit-msg hook, so their file keeps working and the archive is the
     # pre-composition copy the restore line puts back.
+    # `APPROVAL_LOG.md` is REPLACED, not kept: A4 renders the tier-matched
+    # template over it, and `kept` — "the operator's original is still at the
+    # path" — would be false in the document an auditor reads to learn what
+    # happened to their files.
+    #
+    # THIS FIELD IS FORWARD-LOOKING, AND SAYING SO IS THE POINT. The MANIFEST is
+    # written at the archive stage, two steps before the state loop, so on a run
+    # interrupted between them the original IS still at the path while this says
+    # `replaced`. Review raised that as the value being wrong. It is not wrong;
+    # it is the same tense every neighbouring field already uses — MEASURED on
+    # `SOIF_ADOPT_HALT_AFTER=install`, the identical row reads
+    # `{"disposition":"replaced","stagedForCommit":true}` with no commit having
+    # happened. Re-deriving one field after the fact while its neighbours stay
+    # declarative would make the record less coherent, not more. What the record
+    # states is what this adoption WILL do to each file; an interrupted run
+    # leaves every such statement unfulfilled together.
     case "$rel" in
       .git/hooks/commit-msg) dispo="composed" ;;
+      APPROVAL_LOG.md)       dispo="replaced" ;;   # BL-242-ARCHIVE-DISPO
       *)                     dispo="kept" ;;
     esac
 

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -41,7 +41,15 @@
 
 # _adopt_state_order — §8.4's order, spelled ONCE, as data, so that reversing
 # it is a ONE-LINE edit and a mutation proof has a single site to hit.
+# A4 PUTS `approval_log` FIRST, AND THE ORDER IS A SAFETY PROPERTY, NOT A
+# PREFERENCE. Written LAST, every mid-step-7 death leaves the tree
+# phase-state-present/log-absent — the gate's hard refusal, the one state an
+# interrupted adoption must not rest in. Written FIRST, an interrupted run
+# leaves at worst a log with no phase-state, which is INERT: with no
+# phase-state the gate exits 0 and skips. Of the two orders only one has a safe
+# failure mode.
 _adopt_state_order() {
+  printf '%s\n' approval_log   # BL-242-APPROVAL-LOG-FIRST
   printf '%s\n' phase_state intake manifest   # BF-ADOPT-STATE-ORDER
 }
 
@@ -96,7 +104,16 @@ adopt_install_framework() {
     [ -n "$rel" ] || continue
     src="$ADOPT_FRAMEWORK_ROOT/$rel"
     dst="$root/$rel"
-    [ -f "$src" ] || continue
+    # SYNC SIBLING — `_adopt_preflight_managed` must count THIS set, filtered
+    # THIS way, or the two disagree about "is the framework here" and a design
+    # sentence gets written on the strength of the wrong one (§0.3). BOTH
+    # halves are needed for `n_copied -eq 0` to imply the preflight's
+    # `n_present == n_total`; a draft called this one "the load-bearing half",
+    # which understates the other. **`P6i`/`P6i2` in
+    # `tests/test-brownfield-wp9b-preflight-approval.sh` pin THIS line** — an
+    # incomplete root must still adopt a fresh project and must never emit
+    # `could not install`; `P6h` pins the sibling.
+    [ -f "$src" ] || continue   # BL-242-INSTALL-SET-KEY
     if [ -e "$dst" ]; then
       ADOPT_COLLISION_LIST="$ADOPT_COLLISION_LIST$rel
 "
@@ -194,6 +211,469 @@ adopt_write_orchestrator_source() {
   local root="$1"
   jq -n --arg s "$ADOPT_FRAMEWORK_ROOT" '{source_dir: $s}' \
     | adopt_write_file "$root" ".claude/orchestrator-source.json" || return 1
+  return 0
+}
+
+# ── §8.2 STEP 0 — THE RE-ADOPTION PREFLIGHT (A1) ────────────────────────────
+#
+# WHY IT IS BEFORE EVERY QUESTION AND EVERY WRITE. The obvious alternative —
+# "let the second-stamp refusal handle it" — refuses at the MANIFEST stage,
+# which is after `adopt_write_file` has `cat >`-overwritten `phase-state.json`
+# and the intake. Under D10 the clobbered `current_phase` is GATE-EARNED: the
+# operator crossed those boundaries with evidence, and no part of adoption can
+# give them back. Refusing after the damage is not refusing.
+#
+# THE ARMS ARE THREE SEPARATE FUNCTIONS ON THREE MARKED CALL LINES, so each has
+# exactly one thing a mutation proof can remove, and so that removing one
+# leaves the other two spelled exactly as they ship.
+adopt_preflight() {
+  local root="$1"
+  _adopt_preflight_adopted "$root" || return 1        # BL-242-PREFLIGHT-ARM1
+  _adopt_preflight_prior_archive "$root" || return 1  # BL-242-PREFLIGHT-ARM2
+  _adopt_preflight_managed "$root" || return 1        # BL-242-PREFLIGHT-ARM3
+  _adopt_preflight_templates || return 1              # BL-242-PREFLIGHT-TEMPLATES
+  _adopt_preflight_project_name "$root" || return 1   # BL-242-PREFLIGHT-NAME
+  return 0
+}
+
+# ── THE PROJECT NAME IS UNTRUSTED INPUT AND REACHES A GOVERNANCE DOCUMENT ──
+# `ADOPT_PROJECT_NAME` is `${root##*/}` — a directory basename — and A4 renders
+# it into `APPROVAL_LOG.md`, which `check-phase-gate.sh` PARSES for approval
+# evidence. A name containing a newline therefore injects arbitrary LINES into
+# that document, and `_cpg_gate_has_evidence` looks for exactly one shape: a
+# `## ` section header followed by a `| Date | YYYY-MM-DD |` row. A directory
+# named so as to carry those two lines makes the gate find approval evidence
+# nobody recorded — and `_cpg_record_gate_date` then SYNTHESISES that date into
+# `phase-state.json`, against its own header's rule that "a project with no
+# dated approval entry must NEVER get a date synthesized into phase-state.json".
+# The approval trail forging itself out of a folder name.
+#
+# A COMMENT IN THIS FILE ALREADY CLAIMED THIS REFUSED ("an embedded newline
+# still refuses loudly, which is correct"). IT DID NOT. What actually happened
+# on such a tree was an unrelated death further in, reporting `the scan report
+# classifies '' as ''` — a misleading message from a different mechanism, which
+# is how an unverified claim survived being written down as measured.
+#
+# Refused at step 0, before anything is asked or written, because a name of
+# this shape cannot be made safe by escaping at the render site alone: it also
+# flows into the intake, the manifest and the commit subject.
+_adopt_preflight_project_name() {
+  local root="$1" n stripped bad=""
+  n="${root##*/}"
+  # NOT a `case` pattern with `$(printf '\n')` in it — bash 3.2 mis-parses that
+  # construct and the resulting syntax error surfaces HUNDREDS OF LINES LATER,
+  # naming an innocent function. Strip the characters and compare instead:
+  # `tr -d` removes every newline and carriage return, so any name containing
+  # one differs from its stripped form.
+  stripped="$(printf '%s' "$n" | tr -d '\n\r')"
+  if [ -z "$n" ]; then
+    bad="it is empty"
+  elif [ "$stripped" != "$n" ]; then
+    bad="it contains a line break or carriage return"
+  fi
+  [ -n "$bad" ] || return 0
+  adopt_refuse "this project's directory name cannot be used: $bad"
+  adopt_note "Adoption writes the project's name into APPROVAL_LOG.md, PROJECT_INTAKE.md and"
+  adopt_note "the adoption commit. APPROVAL_LOG.md is the file the phase gate reads to decide"
+  adopt_note "whether a boundary was approved, so a name carrying line breaks could put rows"
+  adopt_note "into it that nobody approved."
+  adopt_blank
+  adopt_note "Rename the directory and run adoption again. Nothing has been written."
+  return 1
+}
+
+# NOT AN ARM — a precondition on the FRAMEWORK, not on the adoptee, and it is
+# here for the reason stated three functions below: "Refusing after the damage
+# is not refusing." Template presence is a static property of
+# `$ADOPT_FRAMEWORK_ROOT`, knowable before anything is asked or written. A
+# first cut checked it inside the state loop and MEASURED this on a checkout
+# without `templates/`: the refusal was honest and loud, and it arrived after
+# the archive was created and 74 files were on disk. The path is not
+# hypothetical — three of this repo's own test mirrors hit it in one build.
+#
+# BOTH templates are checked, not the tier-matched one: the tier is answered
+# after this point, so checking one would move the failure back into the state
+# loop for the other half of the operators.
+_adopt_preflight_templates() {
+  local t missing=""
+  # `-s`, NOT `-f`. A zero-byte template passes an existence check and then
+  # dies in the state loop with "the approval log rendered empty" — after the
+  # archive and 70 written files, which is precisely the failure this function
+  # was added to move earlier. Measured.
+  for t in approval-log-org approval-log-personal; do
+    [ -s "$ADOPT_FRAMEWORK_ROOT/templates/generated/$t.tmpl" ] && continue
+    # NEWLINE-DELIMITED, not space-delimited — see the loop that prints it.
+    missing="$missing$ADOPT_FRAMEWORK_ROOT/templates/generated/$t.tmpl
+"
+  done
+  [ -n "$missing" ] || return 0
+  adopt_refuse "this framework checkout is missing an approval-log template"
+  adopt_note "Adoption writes APPROVAL_LOG.md from a template shipped beside init.sh, and"
+  adopt_note "without it the adopted project could not run its own phase gate. Missing:"
+  # NOT `for t in $missing` — unquoted word-splitting breaks on the SPACE IN
+  # THIS REPOSITORY'S OWN PATH ("Claude Projects"), printing two nonexistent
+  # paths instead of one real one. CLAUDE.md's first environment trap, in a
+  # diagnostic this package added.
+  printf '%s' "$missing" | while IFS= read -r t; do
+    [ -n "$t" ] || continue
+    adopt_note "  $t"
+  done
+  adopt_note "Nothing has been written. Check out the framework completely and run again."
+  return 1
+}
+
+# ARM 1 — already adopted. TWO WITNESSES, and the second is the point.
+# `soif_adoption_adopted` reads the WORKING COPY, which a hand edit can blank;
+# `_soif_adoption_head_copy_adopted` reads HEAD's copy, which it cannot. An
+# operator who deletes the `.adoption` block to "start over" defeats the flag
+# AND the restamp refusal together, and lands exactly in the case this arm
+# exists for. Either witness refuses.
+_adopt_preflight_adopted() {
+  local root="$1"
+  local witness=""
+  ( cd "$root" && soif_adoption_adopted ".claude/manifest.json" ) && witness="the manifest"
+  # ONE LINE, and deliberately not wrapped: a mutation proof replaces this
+  # whole line with `:`, and a continuation would leave the mutant unparseable
+  # and the proof reporting a setup failure instead of a result.
+  if [ -z "$witness" ]; then
+    ( cd "$root" && _soif_adoption_head_copy_adopted ".claude/manifest.json" ) && witness="the committed copy of the manifest (the working copy no longer says so)"   # BL-242-PREFLIGHT-WITNESS2
+  fi
+  [ -n "$witness" ] || return 0
+
+  adopt_refuse "this project has already been adopted — $witness records it"
+  adopt_note "Adoption is a one-time act. It archives your files, installs the framework and"
+  adopt_note "lands the project at phase 0; running it again would overwrite state you have"
+  adopt_note "since earned through the gates."
+  adopt_blank
+  adopt_note "What you probably want instead:"
+  adopt_note "  bash scripts/resume.sh        — continue where this project actually is"
+  adopt_note "  --re-add <path>               — put one archived file back"
+  return 1
+}
+
+# ARM 2 — an unstamped tree carrying a PRIOR archive: a first run that died
+# before the state stage. NAME THE DIRECTORY, because that archive's own
+# MANIFEST carries the restore line for every file it holds, and a refusal
+# that does not say where it is sends the operator hunting for it.
+_adopt_preflight_prior_archive() {
+  local root="$1" prior=""
+  # THE STAMP-ABSENT CONJUNCT, and it is here for the same reason arm 3 carries
+  # its own: a COMPLETED adoption necessarily leaves an adoption-archive behind,
+  # so an arm 2 without this catches arm 1's whole population — and then
+  # dropping arm 1 changes nothing observable and its mutation proof is green
+  # forever. §8.2 spells this arm "stamp absent but a prior archive present";
+  # the first cut of this function dropped the first half and the suite's PM1
+  # caught it. An adopted tree is ARM 1's, and it says something different.
+  ( cd "$root" && soif_adoption_adopted ".claude/manifest.json" ) && return 0
+  ( cd "$root" && _soif_adoption_head_copy_adopted ".claude/manifest.json" ) && return 0
+  [ -d "$root/.claude/adoption-archive" ] || return 0
+  prior="$(cd "$root" && ls -d .claude/adoption-archive/*/ 2>/dev/null | head -1)"
+  prior="${prior%/}"
+  [ -n "$prior" ] || return 0
+
+  adopt_refuse "this project already carries an adoption archive: $prior"
+  adopt_note "That directory is what an earlier adoption wrote before it stopped. Adopting"
+  adopt_note "again would archive the same files a second time, and the copies already there"
+  adopt_note "are the ones with your original contents."
+  adopt_blank
+  adopt_note "Read what it holds, and restore anything you want back, from:"
+  adopt_note "  $prior/MANIFEST.md"
+  adopt_blank
+  # ── WHAT TO SAY NEXT DEPENDS ON HOW FAR THE FIRST RUN GOT ────────────────
+  # A first cut ended "Then move or delete $prior and run this again." — true
+  # for a run that died between the archive and the install, and FALSE for the
+  # larger population that died anywhere after it. Measured: move the archive
+  # aside on a tree whose framework install completed and the re-run hits
+  # `every framework script is already present ... RESUMING AN INTERRUPTED
+  # ADOPTION IS NOT BUILT YET`. The operator followed the instruction exactly
+  # and is stuck. Before A1 the tripwire answered first and told them that.
+  # Derive which population this is instead of asserting one.
+  # `scripts/check-phase-gate.sh`, AND THE PATH IS THE WHOLE POINT — a draft
+  # tested `scripts/lib/adopt/`, which `adopt_install_framework` NEVER creates:
+  # its set is `soif_parse_shipped_scripts`'s 68 entries and **zero** of them
+  # live under `scripts/lib/adopt/` (derived, not assumed). So the predicate
+  # was false for 100% of the population and only the wrong branch could ever
+  # print — the exact failure it was written to fix, now wearing a derivation
+  # that cannot fire. Worse, the fixture that "verified both ways" created
+  # `scripts/lib/adopt/` BY HAND, so it measured the fixture and not the
+  # install. Test a path the install actually writes, and let the suite drive
+  # a REAL adoption rather than a hand-built shape.
+  if [ -f "$root/scripts/check-phase-gate.sh" ]; then
+    adopt_note "The framework's own scripts are ALREADY INSTALLED here, so the earlier run got"
+    adopt_note "past the install. Re-running will not resume it — resuming an interrupted"
+    adopt_note "adoption is not built yet — and moving $prior aside will not change that."
+    adopt_note "Restore what you need from the MANIFEST above and carry on with:"
+    adopt_note "  bash scripts/resume.sh"
+  else
+    adopt_note "The framework is not installed yet, so the earlier run stopped early. Move or"
+    adopt_note "delete $prior and run this again."
+  fi
+  return 1
+}
+
+# ARM 3 — ALREADY FRAMEWORK-MANAGED BUT NOT ADOPTED, and it was missed in
+# A1's first draft. On a SCAFFOLDED GREENFIELD project arms 1 and 2 are both
+# silent: there is no `.adoption` to read, and the archive this run is about to
+# create is not a PRIOR one. So adoption archives the scaffold's own framework
+# files AS THE OPERATOR'S, overwrites gate-earned state, stamps it (no
+# `.adoption` ⇒ no restamp refusal) and commits, at EXIT 0. Shipped v1 refused
+# that tree through `adopt_install_framework`'s `n_copied -eq 0` tripwire,
+# which D1's framework-wins install unreaches. Silent-success corruption, and
+# worse in kind than the noisy case A1 was written for.
+#
+# THE `not adopted` CONJUNCT IS LOAD-BEARING AND IS NOT DEFENSIVE CODING. A
+# stamped tree necessarily has a `phase-state.json`, so an arm 3 without it
+# would catch arm 1's population too — and then dropping arm 1 would change
+# nothing observable and arm 1's mutation proof would be green forever. The
+# suite's PM1 is what pins it: strip this conjunct and PM1 goes red while PM1b
+# stays green. (A draft credited PM1b, which drops arm 3 to prove arm 1 stands
+# ALONE — a different property, and the mis-citation this file's own rule about
+# citing by marker exists to prevent.)
+_adopt_preflight_managed() {
+  local root="$1" found=""
+  ( cd "$root" && soif_adoption_adopted ".claude/manifest.json" ) && return 0
+  ( cd "$root" && _soif_adoption_head_copy_adopted ".claude/manifest.json" ) && return 0
+
+  if [ -f "$root/.claude/phase-state.json" ]; then
+    # DECISIVE. `init.sh` and this driver are its only writers, so its presence
+    # on an unadopted tree means the project was scaffolded.
+    found=".claude/phase-state.json is present"
+  elif [ -f "$root/.claude/manifest.json" ]; then
+    # STRONG EVIDENCE, NOT PROOF — so the message says what was found and names
+    # both explanations rather than asserting one.
+    found=".claude/manifest.json is present"
+  else
+    # ── THE THIRD SIGNAL, AND IT IS A MAJORITY, NOT A SINGLE FILE ──────────
+    # §8.3a-A1 specifies this arm on the two `.claude/` files. An adoption
+    # interrupted after the framework install on a COLLISION-FREE adoptee has
+    # neither — no manifest, no phase-state, and no archive either, because the
+    # archive directory only materialises when something collides. All three
+    # arms were silent there and the operator was re-asked the tier question
+    # and every confirmation before the `n_copied -eq 0` tripwire refused,
+    # which is this function's own "neither re-interrogate nor destroy" promise
+    # going unmet.
+    #
+    # A FIRST CUT KEYED ON ONE FILE (`scripts/check-phase-gate.sh`) AND THAT
+    # WAS A FALSE-REFUSAL BUG. An adoptee that legitimately vendors a script of
+    # its own at that path adopted cleanly before this package
+    # (`Installed 67 framework script(s); left 1 of your own file(s)
+    # untouched.`) and was refused after — with a message naming two causes,
+    # BOTH false for them. It was asymmetric too: vendoring `scripts/resume.sh`
+    # instead, equally one of the shipped set, still adopted.
+    #
+    # AT LEAST HALF of the shipped set cannot be a coincidence and a handful can.
+    # (`n_present * 2 -ge n_total` — at exactly half it REFUSES, so "majority" is
+    # the wrong word for it and the suite pins both sides of that boundary.)
+    # ── COUNT THE SAME SET THE INSTALLER WOULD, OR THE TWO DISAGREE ────────
+    # `adopt_install_framework` skips any entry whose SOURCE is absent
+    # (`# BL-242-INSTALL-SET-KEY`, pinned by `P6i`/`P6i2`) and tests the
+    # destination with `-e`. `P6j` pins the PREFLIGHT's copy of that test, the
+    # one below — NOT the installer's own `[ -e "$dst" ]`, which nothing pins
+    # (measured: flipping it to `-f` leaves all eleven adoption suites green).
+    # A draft attached `P6j` to both clauses, which is the mis-citation this
+    # file's own rule exists to prevent, for the third time here. THE TWO
+    # ARE SYNC SIBLINGS AND NOTHING IN THE LANGUAGE BINDS THEM — a first cut of
+    # this comment claimed they "cannot drift", which was false: they are two
+    # copies of one predicate in two functions, and review reverted this half
+    # with every suite staying green. The markers are the binding, and
+    # **`P6h` in `tests/test-brownfield-wp9b-preflight-approval.sh`** is the
+    # fixture that makes a drift red — an incomplete framework root whose
+    # adoptee holds every installable entry. *(A draft of this line cited `I2`,
+    # which is a different fixture in a different section and stays GREEN under
+    # both drift mutants. Mis-citing the proof is the failure this file's own
+    # rule about citing by marker or function name exists to prevent, and it is
+    # the second time in this file.)* A first
+    # cut of this loop counted EVERY parsed line and tested `-f`, and the
+    # mismatch was not academic: against an INCOMPLETE framework root — the
+    # shape §0.3 warns about in as many words — the adoptee carried 24 of the
+    # 24 files that root could install, while this counted 24 against a
+    # denominator of 65, stayed silent, and let the run reach the `n_copied
+    # -eq 0` tripwire. Two predicates about "is the framework here" that
+    # disagree are worse than one, and a design sentence asserting the tripwire
+    # unreachable was written on the strength of the wrong one.
+    local n_present=0 n_total=0 _rel
+    while IFS= read -r _rel; do
+      [ -n "$_rel" ] || continue
+      [ -f "$ADOPT_FRAMEWORK_ROOT/$_rel" ] || continue   # BL-242-INSTALL-SET-KEY-SIBLING
+      n_total=$((n_total + 1))
+      [ -e "$root/$_rel" ] && n_present=$((n_present + 1))
+    done <<PREFLIGHT_SET
+$(soif_parse_shipped_scripts "$ADOPT_FRAMEWORK_ROOT/init.sh" "$ADOPT_FRAMEWORK_ROOT/scripts")
+PREFLIGHT_SET
+    if [ "$n_total" -gt 0 ] && [ $((n_present * 2)) -ge "$n_total" ]; then
+      found="$n_present of the framework's own $n_total scripts are already here"   # BL-242-PREFLIGHT-ARM3-INSTALLED
+    fi
+  fi
+  [ -n "$found" ] || return 0
+
+  adopt_refuse "this project already looks framework-managed: $found"
+  adopt_note "Adoption is for a project that has never been under this framework. What is"
+  adopt_note "here is one of these, and this script cannot tell them apart:"
+  adopt_note "  • a project scaffolded by init.sh — in which case it is already set up,"
+  adopt_note "    and adopting it would overwrite the phase it has earned;"
+  adopt_note "  • an earlier adoption that stopped part-way, leaving its state behind;"
+  adopt_note "  • files of your own that happen to sit where the framework's would."
+  adopt_blank
+  adopt_note "Check which by looking at what is here, then either run scripts/resume.sh to"
+  adopt_note "carry on, or move it aside if you are certain this project was never"
+  adopt_note "scaffolded and these files are not yours."
+  return 1
+}
+
+# ── Stage 0 — APPROVAL_LOG.md (A4) ──────────────────────────────────────────
+# adopt_write_approval_log ROOT — the tier-matched init.sh template, rendered.
+#
+# WHY IT EXISTS AT ALL. `check-phase-gate.sh` refuses on a
+# phase-state-present/log-absent tree and `exit 1`s SIX LINES BEFORE
+# `current_phase` is parsed. Without this file the resting state adoption
+# leaves behind cannot run its own phase gate — the project is adopted and its
+# gates are unusable.
+#
+# WHY NOT A FOURTH SPELLING. `init.sh` renders two tier-differentiated
+# templates and `verify-install.sh` carries a third writer (`fix_approval_log`)
+# whose shape must agree with them. An "empty, headed" fourth would drift from
+# both, so this renders THE SAME template `init.sh` does, with the same two
+# substitutions.
+#
+# WHY IT STILL BLOCKS THE GATE, WHICH IS CORRECT. The template's pre-condition
+# rows carry `__TODAY__` in a `| # | Pre-Condition | Status | Date | Notes |`
+# table — column-shaped cells, not the `| Date | … |` ROW that
+# `_cpg_gate_has_evidence` greps for (`# BL-115-DATE-CELL`). So a freshly
+# rendered log records no approval, and the gate says the gate date is not
+# recorded. Adoption approves nothing; it only makes the question answerable.
+# _adopt_approval_template — the tier-matched template path. Spelled once so
+# the preflight's existence check and the writer cannot disagree about which
+# file they mean.
+_adopt_approval_template() {
+  case "$ADOPT_DEPLOYMENT" in
+    organizational) printf '%s\n' "$ADOPT_FRAMEWORK_ROOT/templates/generated/approval-log-org.tmpl" ;;
+    *)              printf '%s\n' "$ADOPT_FRAMEWORK_ROOT/templates/generated/approval-log-personal.tmpl" ;;
+  esac
+}
+
+adopt_write_approval_log() {
+  local root="$1" tmpl today rendered
+  tmpl="$(_adopt_approval_template)"
+  if [ ! -f "$tmpl" ]; then
+    # Reachable only if the checkout changed under a running adoption — the
+    # preflight checks both templates at step 0 (# BL-242-PREFLIGHT-TEMPLATES).
+    adopt_refuse "the approval-log template is missing: $tmpl"
+    adopt_note "Without it the adopted project cannot run its own phase gate, so this"
+    adopt_note "adoption stops rather than landing a project whose gates refuse."
+    return 1
+  fi
+  today="$(date +%Y-%m-%d)"
+
+  # ── NOT `sed`, AND THE REASON IS THE INPUT, NOT A PREFERENCE ─────────────
+  # `ADOPT_PROJECT_NAME` is `${root##*/}` — a DIRECTORY BASENAME the operator
+  # chose — and it lands in a substitution's REPLACEMENT half, the one place
+  # in this driver where an operator string does (everything else uses
+  # `jq --arg` or `git commit -m`). A first cut used `sed -e "s,__X__,$name,g"`
+  # and justified the `,` delimiter against this repo's `|`-vs-`||` trap. That
+  # rationale was refuted by the very input it named. Measured, all three at
+  # the tip:
+  #
+  #   amp&co      rc 0  — `&` is THE WHOLE MATCH (CLAUDE.md names this trap),
+  #                       rendering `amp__PROJECT_NAME__co`: two unrendered
+  #                       placeholders, SILENTLY, in a committed document
+  #   comma,inc   rc 1  — the delimiter itself; `sed` dies with `bad flag in
+  #                       substitute command`, `cat` still succeeds on empty
+  #                       input, so a ZERO-BYTE APPROVAL_LOG.md is written and
+  #                       `adopt_refuse` is NEVER CALLED — 68 scripts on disk
+  #                       and no honest refusal, against BL-225's contract
+  #   back\slash  rc 0  — the backslash silently eaten
+  #
+  # ── THIS TOOK THREE ATTEMPTS AND EACH ONE CARRIED THE DEFECT ACROSS ──────
+  # Attempt 1, `sed -e "s,__X__,$name,g"`: `amp&co` rendered
+  # `amp__PROJECT_NAME__co` at rc 0 — `&` is THE WHOLE MATCH, the trap
+  # CLAUDE.md names — and `comma,inc` collided with the delimiter, leaving a
+  # ZERO-BYTE log at rc 1 with `adopt_refuse` never called.
+  #
+  # Attempt 2, `awk -v` + `gsub`: POSIX awk gives `&` in a `gsub` REPLACEMENT
+  # the same whole-match meaning, so `amp&co` failed identically — the tool
+  # changed and the defect did not.
+  #
+  # Attempt 3, `awk -v` + this `index`/`substr` loop: the loop is innocent and
+  # the value never reaches it intact. **`-v` PERFORMS ESCAPE-SEQUENCE
+  # PROCESSING ON THE VALUE** (gawk manual, *Other Command-Line Arguments*:
+  # "Variable values provided on the command line are processed for escape
+  # sequences"), so `back\slash` arrived as `backslash` and was committed that
+  # way in the YAML frontmatter and the title. A comment here asserted the
+  # opposite — "`-v` protects the value on the way IN" — which is backwards,
+  # and the assertion is why two rounds of review were needed to catch it.
+  #
+  # `ENVIRON` is NOT escape-processed, and combined with `index`/`substr`
+  # (which has no replacement-string semantics at all — no `&`, no escape, no
+  # delimiter) the operator's string is copied verbatim on both legs. Measured
+  # verbatim on this host for: `back\slash`, `amp&co`, `comma,inc`, `tab\there`,
+  # `pct%d`, `dq"uote`, `dollar$var`, `-leading-dash`, UTF-8. An embedded
+  # newline still refuses loudly, which is correct.
+  #
+  # `init.sh`'s `generate_approval_log` shares attempt 1's `&` exposure and not
+  # its `,` one; it is the sibling shape and is left to its own change rather
+  # than edited from here.
+  rendered="$(SOIF_ADOPT_LOG_NAME="$ADOPT_PROJECT_NAME" SOIF_ADOPT_LOG_TODAY="$today" awk '
+    BEGIN { n = ENVIRON["SOIF_ADOPT_LOG_NAME"]; t = ENVIRON["SOIF_ADOPT_LOG_TODAY"] }
+    function repl(line, tok, val,   out, i) {
+      out = ""
+      while ((i = index(line, tok)) > 0) {
+        out = out substr(line, 1, i - 1) val
+        line = substr(line, i + length(tok))
+      }
+      return out line
+    }
+    # ORDER IS LOAD-BEARING AND IT IS THE OPPOSITE OF THE OBVIOUS ONE.
+    # These are NESTED: the outer pass scans the INNER pass output, including
+    # whatever it just inserted. With the name substituted first, a directory
+    # called pre__TODAY__post had the date written INTO its own name --
+    # pre2026-09-01post -- in both the frontmatter and the title, at rc 0,
+    # while the same run commit subject carried the real name. Two artifacts
+    # of one adoption disagreeing about the project.
+    # The date goes FIRST because it is framework-controlled (date +%F) and
+    # cannot contain either placeholder; the operator string goes LAST, so
+    # nothing rescans it.
+    # NO APOSTROPHES ABOVE, DELIBERATELY: this comment is inside a
+    # SINGLE-QUOTED shell string, so one apostrophe ends the awk program and
+    # the syntax error surfaces hundreds of lines away naming another function.
+    { print repl(repl($0, "__TODAY__", t), "__PROJECT_NAME__", n) }
+  ' "$tmpl")" || {   # BL-242-APPROVAL-LOG-RENDER
+    adopt_refuse "could not render the approval log from $tmpl"
+    return 1
+  }
+  # AND THE OUTPUT IS CHECKED, because "the renderer exited 0" and "the
+  # renderer produced a document" are different facts — the empty-output case
+  # above is exactly how a zero-byte log reached disk while the run said
+  # nothing.
+  case "$rendered" in
+    '') adopt_refuse "the approval log rendered empty from $tmpl"; return 1 ;;   # BL-242-APPROVAL-LOG-NONEMPTY
+  esac
+  # ── WRITE IT, THEN LET THE STAGING GUARD DECIDE WHETHER IT IS COMMITTED ──
+  # `adopt_write_file` records every path it writes for staging, and
+  # `adopt_stage_and_commit` stages the recorded set in ONE `git add` — so a
+  # recorded path git refuses aborts the whole adoption. MEASURED as a
+  # REGRESSION: an adoptee whose `.gitignore` contains `APPROVAL_LOG.md`
+  # adopted cleanly at rc 0 on `main` and, with A4 as first written, got
+  # `[BLOCKED] git will not stage every file this adoption must commit` and NO
+  # adoption commit — while the same run's archive half correctly printed
+  # `your .gitignore covers: APPROVAL_LOG.md`. Two halves of one run, opposite
+  # rules, and `docs/adoption.md` ships the archive's half as a guarantee.
+  #
+  # `_adopt_record_if_stageable` is that guarantee's existing implementation
+  # (`# BL-225-ORACLE-SYNC`): it writes nothing, records only what `git add
+  # --dry-run` accepts, and DISCLOSES the withholding by name. Routing through
+  # it makes the log land on disk, be usable by the gate, and stay out of the
+  # commit when the operator's own rule says so — instead of making a
+  # previously-adoptable project unadoptable.
+  #
+  # The gate reads the WORKING TREE, so a withheld log still does its job; what
+  # is lost is only its presence in history, which is what the operator asked
+  # for.
+  printf '%s\n' "$rendered" > "$root/APPROVAL_LOG.md" || {
+    adopt_refuse "could not write APPROVAL_LOG.md"
+    return 1
+  }
+  adopt_touched_disk   # BL-225-TOUCHED-DISK
+  _adopt_record_if_stageable "$root" "APPROVAL_LOG.md"   # BL-242-APPROVAL-LOG-STAGEABLE
   return 0
 }
 
@@ -566,6 +1046,12 @@ adopt_main() {
   adopt_note "Nothing is written until the questions are answered. If you stop partway,"
   adopt_note "this project ends up more strictly gated than it started, never less."
 
+  # §8.2 STEP 0 — THE RE-ADOPTION PREFLIGHT (A1), BEFORE THE TIER QUESTION AND
+  # BEFORE THE REPORT IS EVEN OBTAINED. Its position is the whole decision: a
+  # second run must neither re-interrogate the operator nor destroy what the
+  # first produced, and both of those start happening below this line.
+  adopt_preflight "$root" || return 1   # BL-242-PREFLIGHT-CALL
+
   report="$(adopt_obtain_report "$root" "$given_report")" || return 1
 
   # §4.2's evidence, which decides nothing and is printed anyway (A6): it is
@@ -622,6 +1108,7 @@ adopt_main() {
   while IFS= read -r stage; do
     [ -n "$stage" ] || continue
     case "$stage" in
+      approval_log) adopt_write_approval_log "$root" || return 1 ;;   # BL-242-APPROVAL-LOG-WRITE
       phase_state) adopt_write_phase_state "$root" || return 1 ;;
       intake)      adopt_write_intake "$root" "$report" || return 1 ;;
       manifest)    adopt_write_manifest "$root" "$report" || return 1 ;;

--- a/scripts/lib/adopt/adopt-stubs.sh
+++ b/scripts/lib/adopt/adopt-stubs.sh
@@ -138,15 +138,21 @@ adopt_stub_secrets_disposition() {
   adopt_note ".claude/adoption/scout-report.json's secrets section before you trust this repo."
 }
 
-# WP7 — the Adoption Record in APPROVAL_LOG.md, the audit rows, and the CI
-# carve-out. Named here because its absence has an immediate, visible effect:
-# check-phase-gate.sh exits 1 on a project with phase-state and no
-# APPROVAL_LOG.md, which is the SAFE direction but is not a finished adoption.
+# WP7 — the Adoption Record, the audit rows, and the CI carve-out.
+#
+# WHAT THIS USED TO SAY, AND WHY IT WAS WRONG AFTER WP9b. Both this comment and
+# the notice below asserted that `APPROVAL_LOG.md` "is not written, so the phase
+# gate will report it missing" — accurate until A4, and printed on every
+# successful run AFTER the state loop had written that very file and BEFORE the
+# commit that includes it. The stub told each operator the opposite of what the
+# same run had just done. What is still missing is the RECORD — the eight-clause
+# Adoption Record that WP7 appends INTO this log — not the log.
 adopt_stub_adoption_record() {
   adopt_stub_notice "the Adoption Record, the audit rows and the CI carve-out" "WP7" \
-    "APPROVAL_LOG.md is not written, so the phase gate will report it missing until WP7 lands."
-  adopt_note "That is the safe direction — a blocked project, not a silently-approved one — but it"
-  adopt_note "means this adoption is recorded in the manifest and nowhere else yet."
+    "APPROVAL_LOG.md exists and the phase gate reads it; what is missing is the Adoption Record INSIDE it."
+  adopt_note "The log this adoption wrote is the tier-matched template, carrying no approval of"
+  adopt_note "any kind — which is correct, because this adoption approved nothing. Until WP7"
+  adopt_note "lands, the adoption itself is recorded in the manifest and nowhere else."
 }
 
 # The fallback PRE-COMMIT hook. Not attributed to a work package, because §10

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -13975,6 +13975,81 @@ same standard as code rather than waved through as "docs-only".
    **stricter** than any default would have been. A fallback would have
    weakened shipped behaviour to solve a case that cannot occur.
 
+### BL-242 residual — adoption follows a SYMLINK out of the project and overwrites its target
+
+**Recorded at WP9b's review (2026-09-01), NOT fixed here, and pre-existing rather
+than introduced.** `adopt_write_file` is `cat > "$root/$rel"`, and no adoption
+code anywhere handles symlinks — `grep -rn '\-L \|symlink\|readlink'
+scripts/lib/adopt/` returns nothing. So an adoptee whose `APPROVAL_LOG.md` is a
+symlink to a document OUTSIDE the repository has that outside document rewritten
+with the rendered template, at **rc 0**, while the disclosure names
+`APPROVAL_LOG.md` and never the target. Measured at review.
+
+**Why it is recorded and not fixed in WP9b.** The behaviour is a property of
+`adopt_write_file`, which every state writer shares and which predates this
+package; WP9b only made it reachable at one more path. Fixing it belongs with
+the archive/install semantics (WP11) or as its own entry, not inside a package
+whose scope row is the preflight and the approval log — and a symlink-following
+write is exactly the kind of thing that should be decided once, for every
+writer, rather than special-cased at the newest one.
+
+**What softens it, stated so nobody reads this as worse than it is:** the
+content is recoverable — the target's bytes are archived under
+`APPROVAL_LOG.md` with a restore line before the write. What is missing is that
+the operator is never told the file they lost was somewhere else.
+
+**A repo-root governance document is a likelier symlink than `.claude/settings.json`**,
+which is why this surfaced now rather than at WP6.
+
+### WP9b's build (2026-09-01) — the two dogfood blockers, closed and MEASURED
+
+**WP9b is A1's three-arm preflight and A4's `APPROVAL_LOG.md`.** The design
+carries the specification; this section records only the two things a reader of
+THIS entry needs, both of which were reported here as dogfood blockers on
+2026-09-01 and are now closed by execution rather than by argument.
+
+**BLOCKER 1 — adoption silently corrupted a framework-managed project.** Pointed
+at a scaffolded greenfield tree, adoption archived the scaffold's own framework
+files as the operator's, overwrote gate-earned state, stamped it and committed,
+at **exit 0**. Re-measured on the same fixture shape after WP9b:
+
+```
+rc=1     [REFUSED] this project already looks framework-managed:
+                   .claude/phase-state.json is present
+                   Adoption did not begin. Nothing was committed and nothing was written.
+phase now : 2  (was 2)          gate dates : both intact
+stamped   : no                  HEAD moved : NO
+```
+
+**BLOCKER 2 — an adopted project could not run its own phase gate.** It exited
+on `[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.` —
+six lines before `current_phase` was parsed. Re-measured after WP9b: `adopt
+rc=0`, then the gate runs to `Current phase: 0` / `Adoption stamp present and
+intact` / **`Phase gates consistent.`**, rc 0, with `APPROVAL_LOG.md` in the
+adoption commit.
+
+**Two shipped behaviours changed as collateral, and both were caught by an
+existing suite going red rather than predicted.** They are written up in the
+design's §0.3 third pass; in one line each: A4 retires an *incidental* safety
+block (an interrupted adoption used to be "safe" because a file was missing —
+the property §8.4 protects is untouched and the commit-time ladder still reads
+`strict`), and A1 supersedes the `n_copied -eq 0` tripwire as the answer to a
+re-run, so the WP4 suite's `R1` now pins the property rather than which function
+said it.
+
+**One design-specified mutation could not have gone RED as written**, and the
+suite says so rather than quietly passing: §10-WP9's arm-1 proof ("drop arm 1 →
+phase-state reverts") is masked on an untouched adopted tree by that same
+`n_copied` tripwire — measured, and the proof was green against a build with no
+arm 1 at all. The fixture deletes one framework script so the tripwire does not
+fire; the RED is the specified one, and `PM1c` is the same-fixture control.
+
+**A trap for the next package:** the driver now reads
+`$ADOPT_FRAMEWORK_ROOT/templates/`, which no adoption code did before. Three
+suites mirrored the framework as `scripts/` + `init.sh` and every adoption
+against those mirrors began refusing. **A framework root is not `scripts/` plus
+`init.sh`.**
+
 ### WP9's build (2026-09-01) — what it settled, and the residual it created
 
 **The design document carries the changes; this section records only what a
@@ -14006,13 +14081,17 @@ reader of THIS entry needs and cannot get from the code.**
 **THE INIT-PARITY RESIDUAL — this is the part that is not recoverable from the
 code, and it is bigger than §10 implies.** §8.7's audit is delivered at §8.7a
 with the adoption half derived **by execution** (a shipped adoption run against
-a hermetic adoptee, tree diffed: **76** files written, 68 under `scripts/`,
-**eight** elsewhere) rather than by grep — grep having under-read this exact
-kind of surface twice already in this repository. **32 rows. Thirteen are
+a hermetic adoptee, tree diffed: **77** files written, 68 under `scripts/`,
+**nine** elsewhere) rather than by grep — grep having under-read this exact
+kind of surface twice already in this repository. **33 rows. Thirteen are
 UNOWNED, one UNSPECIFIED (`CHANGELOG.md`, which D3's reach ruling does not
 name), one PARTIAL (`.gitignore`).** *(75 / seven / thirty-one was the first
 measurement, taken before this package finished adding
-`.claude/orchestrator-source.json`. A measurement is only true of the tree it
+`.claude/orchestrator-source.json`; 76 / eight / 32 was the second, and it
+survived here for a further round because WP9b corrected the DESIGN's three
+carriers and never grepped this one — a FIFTH carrier, in an Open entry, of a
+number whose own paragraph is about carriers. A measurement is only true of the
+tree it
 was taken on, and this one outlived that tree by three commits.)* The five packages after WP9 close **none**
 of the thirteen. Three matter beyond bookkeeping:
 

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -794,6 +794,25 @@ run_child_suite "tests/test-brownfield-wp9-act-boundaries.sh" \
   "Adoption WP9a act boundaries (chooser deleted, tier question kept, phase-0 landing, stamp v2)" \
   "Adoption WP9a act-boundary tests FAILED (run tests/test-brownfield-wp9-act-boundaries.sh for details)"
 
+# WP9b — A1's three-arm re-adoption preflight and A4's APPROVAL_LOG.md. Its
+# two arms that matter most are the ones whose MUTANTS EXIT ZERO: dropping
+# preflight arm 2 or arm 3 completes an adoption over a tree that must be
+# refused, so neither of those assertions may key on an exit code — they read
+# the tree hash and the state. DERIVE the mutant count, never quote it:
+#   grep -c '_mutate_state "\|_mutate_lib "' tests/test-brownfield-wp9b-preflight-approval.sh
+# NOT `grep -c 'pass "[A-Z0-9]* (MUTATION)'` — that class cannot match the
+# lowercase `d` in `PM1d`, so it under-counted by exactly the mutant review
+# forced this suite to add. A recipe that silently drops the newest member is
+# worse than no recipe — AND THIS ONE DID IT AGAIN one round later, when the
+# suite grew a second mutation helper (`_mutate_lib`, for adopt-archive.sh) and
+# the recipe still named only the first. Both are matched now; add the next one
+# HERE when you add it.
+# Runs the driver against fixtures and a scratch framework MIRROR; reads
+# init.sh but never invokes it -> both lanes.
+run_child_suite "tests/test-brownfield-wp9b-preflight-approval.sh" \
+  "Adoption WP9b preflight + approval log (A1's three arms, A4's tier-matched log written first)" \
+  "Adoption WP9b preflight/approval-log tests FAILED (run tests/test-brownfield-wp9b-preflight-approval.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -209,10 +209,17 @@ run_adopt() {
 # anyway decided nothing and is not rendered". Spelling the name plainly and
 # registering the suite is the honest combination; dodging the predicate with
 # a glob would hide the decision instead of making it.
+# A FRAMEWORK ROOT IS NOT `scripts/` PLUS `init.sh`. `templates/` is part of
+# it: since WP9b the driver renders APPROVAL_LOG.md from
+# `$ADOPT_FRAMEWORK_ROOT/templates/generated/approval-log-*.tmpl` (A4), and a
+# mirror without it makes every adoption run against that mirror REFUSE — which
+# is the right behaviour on a real incomplete checkout and a silent wrecking
+# ball on an incomplete test double. Mirror the templates too.
 mk_mirror() {
   local m="$1"
   mkdir -p "$m" || return 1
   cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -Rp "$REPO_ROOT/templates" "$m/" || return 1
   cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
   return 0
 }
@@ -334,29 +341,71 @@ fi
 
 echo "=== S — the fail-safe state-creation order (§8.4, §5.5) ==="
 
+# WP9b PREPENDED `approval_log` (A4), and §8.4's property is UNCHANGED by it.
+# §8.4 is about which of two unsafe rows an interruption can rest in:
+# phase-state-present/manifest-absent BLOCKS (safe), manifest-present/
+# phase-state-absent silently SKIPS the gate (never reachable). The log sits
+# ahead of both and is inert on its own — with no phase-state the gate exits 0
+# — so adding it cannot create the unsafe row, while writing it LAST would
+# leave every mid-step-7 death in phase-state-present/log-absent, the gate's
+# hard refusal. Both halves are pinned: the order's HEAD is A4's, and its TAIL
+# is still §8.4's.
 s1_order="$( . "$L_STATE" >/dev/null 2>&1; _adopt_state_order | tr '\n' ' ' )"
 s1_sites=$(_sites "$L_STATE" 'BF-ADOPT-STATE-ORDER')
-if [ "$s1_order" = "phase_state intake manifest " ] && [ "$s1_sites" -eq 1 ]; then
-  pass "S1: the order is §8.4's, spelled once as data — phase_state, intake, manifest"
+s1_first_sites=$(_sites "$L_STATE" 'BL-242-APPROVAL-LOG-FIRST')
+if [ "$s1_order" = "approval_log phase_state intake manifest " ] \
+   && [ "$s1_sites" -eq 1 ] && [ "$s1_first_sites" -eq 1 ]; then
+  pass "S1: the order is A4's log first, then §8.4's — approval_log, phase_state, intake, manifest"
 else
-  fail_ "S1" "order=[$s1_order] (want 'phase_state intake manifest ') sites=$s1_sites (want 1)"
+  fail_ "S1" "order=[$s1_order] (want 'approval_log phase_state intake manifest ') order-sites=$s1_sites (want 1) first-sites=$s1_first_sites (want 1)"
 fi
 
 # _assert_safe_row LABEL DIR — §8.4's TOP row: phase-state present, manifest
-# absent => the gate BLOCKS and the tier ladder reads `strict`. Both halves,
-# because C4's correction says the single flat claim is not true of both.
+# absent. The tier ladder must read `strict`, and the row must NEVER be the
+# silently-skipped one.
+#
+# ── WHAT WP9b CHANGED HERE, AND WHY THE OLD ASSERTION WAS RETIRED ──────────
+# This used to require the gate to EXIT NON-ZERO and to do so because
+# `APPROVAL_LOG.md not found but ...` — i.e. the safety of an interrupted
+# adoption was resting on a MISSING FILE. A4 writes that file (first, before
+# phase-state), so the precondition never fires on a tree adoption produced,
+# and the gate now reaches a real verdict: MEASURED, `Current phase: 0`,
+# `Phase gates consistent.`, rc 0. That verdict is TRUE — the project is at
+# phase 0 and has crossed nothing — so re-pinning the old rc would be pinning
+# an artifact.
+#
+# THE SAFETY DID NOT MOVE, AND THIS ASSERTS WHERE IT ACTUALLY LIVES. §8.4's
+# concern is the OPPOSITE row — manifest present, phase-state absent — where
+# the gate prints "skipping phase gate check" and exits 0 on an
+# adopted-LOOKING project with no enforcement. That row is still unreachable
+# (approval_log and phase_state both precede manifest), and the commit-time
+# ladder still reads `strict` here because the manifest is missing. Both are
+# asserted below; the retired third clause is named rather than deleted so a
+# future reader does not re-add it.
+#
+# The gate's refusal on a GENUINELY missing log is untouched — WP9b's own
+# suite mutates the write away and watches the precondition death return.
 _assert_safe_row() {
   local label="$1" dir="$2"
-  local rc has_ps has_mf lvl why=0
+  local rc has_ps has_mf lvl skipped=0
   gate_in "$dir"; rc=$GATE_RC
   has_ps=0; [ -f "$dir/.claude/phase-state.json" ] && has_ps=1
   has_mf=0; [ -f "$dir/.claude/manifest.json" ] && has_mf=1
-  grep -q 'APPROVAL_LOG.md not found but' "$GATE_OUT" && why=1
+  grep -q 'skipping phase gate check' "$GATE_OUT" && skipped=1
+  # `skipped` ALONE CANNOT FAIL HERE, and saying so beats implying otherwise:
+  # its only producing site is inside `if [ ! -f "$PHASE_STATE" ]`, and this
+  # helper has already asserted the phase-state exists. A draft stopped there
+  # and printed "the gate RUNS" while interpolating an untested `rc` — under a
+  # mutant that removed A4's write, that line printed with the gate dead at
+  # rc 1 on the missing-log precondition. Assert the verdict itself.
+  local reached=0
+  grep -q 'Phase gates consistent' "$GATE_OUT" && reached=1
   lvl="$( . "$REPO_ROOT/scripts/lib/enforcement-level.sh" >/dev/null 2>&1; read_enforcement_level "$dir" )"
-  if [ "$rc" -ne 0 ] && [ "$has_ps" -eq 1 ] && [ "$has_mf" -eq 0 ] && [ "$why" -eq 1 ] && [ "$lvl" = "strict" ]; then
-    pass "$label: the safe row — phase-state present, manifest absent; the gate BLOCKS (rc $rc) for that reason and the tier ladder reads strict"
+  if [ "$has_ps" -eq 1 ] && [ "$has_mf" -eq 0 ] && [ "$skipped" -eq 0 ] \
+     && [ "$reached" -eq 1 ] && [ "$rc" -eq 0 ] && [ "$lvl" = "strict" ]; then
+    pass "$label: the safe row — phase-state present, manifest absent; the gate REACHES ITS VERDICT (rc 0, 'Phase gates consistent') and the tier ladder reads strict"
   else
-    fail_ "$label" "gate_rc=$rc (want non-zero) phase_state=$has_ps (want 1) manifest=$has_mf (want 0) blocked_for_that_reason=$why enforcement_level=$lvl (want strict)"
+    fail_ "$label" "phase_state=$has_ps (want 1) manifest=$has_mf (want 0) gate_skipped=$skipped (want 0) reached_verdict=$reached (want 1) gate_rc=$rc (want 0) enforcement_level=$lvl (want strict)"
   fi
 }
 
@@ -729,10 +778,47 @@ fi
 echo ""
 echo "=== R — the halted-run exits, and the record's evidence hash ==="
 
-# R1 — a re-run of an adoption that already installed everything must NAME the
-# real cause. This is the operator's most likely second move (something went
-# wrong at the commit, fix it, run again) and the first cut answered it by
-# blaming the clone — the one thing that was fine.
+# R1 — a re-run of an adoption that already completed must NAME the real cause.
+# This is the operator's most likely second move (something went wrong, fix it,
+# run again) and the driver's first cut answered it by blaming the clone — the
+# one thing that was fine.
+#
+# ── WP9b MOVED THE ANSWER EARLIER, AND THIS PIN MOVED WITH IT ──────────────
+# This used to assert the n_copied tripwire's text ("every framework script is
+# already present"), which fires inside `adopt_install_framework` — AFTER the
+# tier question, the reverse intake, the test-debt census and the archive.
+# A1's preflight now refuses the same tree at STEP 0, before any of that, so
+# the tripwire is not reached on this fixture and pinning its wording would
+# fail against a strictly better implementation.
+#
+# WHAT IS ASSERTED IS THE PROPERTY, NOT THE MESSAGE'S OWNER: the second run
+# refuses, it says the project is already adopted, it does NOT blame the clone,
+# and it points at the route that actually helps. The clone misdiagnosis is
+# still pinned as an ABSENCE, because that is the defect this test was born
+# for and it must not come back by any path.
+#
+# The tripwire itself is NOT asserted dead — the mutation proofs in the WP9b
+# suite still drive it. But it is no longer reachable through the shipped
+# driver: arm 3's third signal refuses on at-least-half of the install set
+# being present, and `n_copied -eq 0` implies all of it. A draft of this
+# comment claimed "a tree carrying every framework script but no `.claude/` at
+# all still reaches it" — built, measured, and refuted at step 0, with the
+# tripwire text absent. This comment was the surviving twin of a sentence the
+# design had already corrected.
+#
+# TWO CLAUSES WERE DROPPED AND ARE NAMED HERE RATHER THAN LEFT TO A DIFF, the
+# same discipline `_assert_safe_row` above applies to its one:
+#   • `said_resume_unbuilt` — the tripwire's "RESUMING AN INTERRUPTED ADOPTION
+#     IS NOT BUILT YET" line. The preflight answers first now, so that text is
+#     unreachable on this fixture. The property it protected did not vanish: an
+#     operator whose first run died AFTER the install still needs telling, and
+#     that is asserted where it now lives — `_adopt_preflight_prior_archive`
+#     derives whether the framework is installed and says so (WP9b suite).
+#   • `r1_gate` ("the safe row still holds after the refused re-run") — RETIRED
+#     for the same reason `_assert_safe_row`'s rc clause was: on a fully
+#     adopted tree the gate now reaches a true verdict at rc 0 instead of dying
+#     on a missing APPROVAL_LOG.md. Re-aiming it here would duplicate
+#     `_assert_safe_row`, which already pins gate-runs/not-skipped/strict.
 R1D="$(newtmp)"
 if ! mk_adoptee "$R1D/p"; then
   fail_ "R1" "fixture setup failed"
@@ -741,17 +827,15 @@ else
   _ans > "$R1D/answers"
   run_adopt "$R1D/p" "$R1D/answers" "$R1D/report.json"; r1_first=$RUN_RC
   run_adopt "$R1D/p" "$R1D/answers" "$R1D/report.json"; r1_second=$RUN_RC
-  r1_true=0; r1_false=0; r1_resume=0
-  grep -q 'every framework script is already present' "$RUN_ERR" && r1_true=1
-  grep -q 'is this a complete clone' "$RUN_ERR" && r1_false=1
-  grep -q 'RESUMING AN INTERRUPTED ADOPTION IS NOT BUILT YET' "$RUN_ERR" && r1_resume=1
-  # …and the safe row still holds after the refused re-run.
-  gate_in "$R1D/p"; r1_gate=$GATE_RC
-  if [ "$r1_first" -eq 0 ] && [ "$r1_second" -ne 0 ] && [ "$r1_true" -eq 1 ] \
-     && [ "$r1_false" -eq 0 ] && [ "$r1_resume" -eq 1 ] && [ "$r1_gate" -ne 0 ]; then
-    pass "R1: a second run on an already-installed project refuses with the TRUE cause, never the clone misdiagnosis, says resuming is not built yet, and leaves the gate still blocking"
+  r1_adopted=0; r1_false=0; r1_route=0
+  grep -q 'already been adopted' "$RUN_ERR" "$RUN_OUT" && r1_adopted=1
+  grep -q 'is this a complete clone' "$RUN_ERR" "$RUN_OUT" && r1_false=1
+  grep -q 'scripts/resume.sh' "$RUN_OUT" && r1_route=1
+  if [ "$r1_first" -eq 0 ] && [ "$r1_second" -ne 0 ] && [ "$r1_adopted" -eq 1 ] \
+     && [ "$r1_false" -eq 0 ] && [ "$r1_route" -eq 1 ]; then
+    pass "R1: a second run refuses at the preflight, says the project is already adopted, never blames the clone, and names the route that helps"
   else
-    fail_ "R1" "first_rc=$r1_first second_rc=$r1_second (want non-zero) named_true_cause=$r1_true blamed_the_clone=$r1_false (want 0) said_resume_unbuilt=$r1_resume gate_rc=$r1_gate (want non-zero)"
+    fail_ "R1" "first_rc=$r1_first second_rc=$r1_second (want non-zero) said_already_adopted=$r1_adopted (want 1) blamed_the_clone=$r1_false (want 0) named_the_route=$r1_route (want 1)"
   fi
 fi
 

--- a/tests/test-brownfield-wp6-collision-archive.sh
+++ b/tests/test-brownfield-wp6-collision-archive.sh
@@ -296,10 +296,17 @@ _add_surfaces() {
   return 0
 }
 
+# A FRAMEWORK ROOT IS NOT `scripts/` PLUS `init.sh`. `templates/` is part of
+# it: since WP9b the driver renders APPROVAL_LOG.md from
+# `$ADOPT_FRAMEWORK_ROOT/templates/generated/approval-log-*.tmpl` (A4), and a
+# mirror without it makes every adoption run against that mirror REFUSE — which
+# is the right behaviour on a real incomplete checkout and a silent wrecking
+# ball on an incomplete test double. Mirror the templates too.
 mk_mirror() {
   local m="$1"
   mkdir -p "$m" || return 1
   cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -Rp "$REPO_ROOT/templates" "$m/" || return 1
   cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
   return 0
 }

--- a/tests/test-brownfield-wp9-act-boundaries.sh
+++ b/tests/test-brownfield-wp9-act-boundaries.sh
@@ -146,10 +146,17 @@ run_adopt() {
   return 0
 }
 
+# A FRAMEWORK ROOT IS NOT `scripts/` PLUS `init.sh`. `templates/` is part of
+# it: since WP9b the driver renders APPROVAL_LOG.md from
+# `$ADOPT_FRAMEWORK_ROOT/templates/generated/approval-log-*.tmpl` (A4), and a
+# mirror without it makes every adoption run against that mirror REFUSE — which
+# is the right behaviour on a real incomplete checkout and a silent wrecking
+# ball on an incomplete test double. Mirror the templates too.
 mk_mirror() {
   local m="$1"
   mkdir -p "$m" || return 1
   cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -Rp "$REPO_ROOT/templates" "$m/" || return 1
   cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
   return 0
 }

--- a/tests/test-brownfield-wp9b-preflight-approval.sh
+++ b/tests/test-brownfield-wp9b-preflight-approval.sh
@@ -1,0 +1,1773 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp9b-preflight-approval.sh
+#
+# Brownfield adoption WP9b — A1's THREE-ARM RE-ADOPTION PREFLIGHT and A4's
+# APPROVAL_LOG.md.
+# Design: docs/designs/2026-08-23-brownfield-adoption-v2.md §8.2 step 0 (the
+# preflight and why it is before the tier question), §8.2 step 7 (the log
+# FIRST), §8.3a-A1, §8.3a-A4, §10-WP9.
+#
+# ── WHAT THIS FILE ASSERTS ON ───────────────────────────────────────────────
+# A VERDICT by exit code; a STATE CHANGE by reading the state; CONTENT by the
+# content. Never a printed label — and for the preflight, DELIBERATELY never
+# the refusal's wording, because that is what made A1's defect survivable:
+# arms 1 and 3 both refuse a stamped tree with near-identical text, so a
+# text assertion goes green against a build that dropped arm 1 entirely.
+#
+# ── THE TWO MUTANTS THAT EXIT ZERO ──────────────────────────────────────────
+# Arms 2 and 3 each guard a tree that adoption would otherwise complete on,
+# at rc 0. So NEITHER of their assertions may key on a non-zero exit: they
+# assert the REFUSAL happened and the TREE IS UNCHANGED. Arm 1's mutant does
+# exit 1 (the restamp refusal fires late), which is exactly why its assertion
+# reads the REVERTED STATE instead — a late refusal is still a refusal, and
+# the damage is already on disk by then.
+#
+# ── WHY ARM 3 CARRIES A `not adopted` CONJUNCT ──────────────────────────────
+# A stamped tree necessarily has a `.claude/phase-state.json`, so an arm 3
+# spelled only as "phase-state present" catches arm 1's fixture too, and
+# dropping arm 1 changes nothing observable — the mutation stays green
+# forever. Arm 3 is the "already framework-managed but NOT adopted" arm and
+# the conjunct is what makes arm 1's mutation discriminate. PM1 is the assertion
+# that pins it: strip either conjunct and PM1 goes red (measured).
+#
+# ── MUTATION HARNESS STANDARD (inherited from the WP4/WP9a suites) ──────────
+#   • anchored end-of-line markers, excised with `s|^.*MARKER$|…|`;
+#   • the anchor asserted at sites==1 in its OWN shipped source;
+#   • every mutant additionally asserts `bash -n`;
+#   • a MODE-PRESERVING in-place edit;
+#   • a FRESH fixture per scenario, from mktemp -d;
+#   • mutants run against a framework MIRROR — the tree under test is never
+#     edited, so a failure here cannot leave this repository mutated.
+#
+# Hermetic: temp dirs only, no network, no remote creation.
+#
+# LANE NOTE. mk_mirror below NAMES init.sh, which is the exemption predicate
+# `# BL-181-UNIT-LANE-PREDICATE` reads — but this suite only READS that file
+# (and renders a template beside it), never runs it, so it belongs in the fast
+# unit lane and is registered there.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
+LIB_DIR="$REPO_ROOT/scripts/lib/adopt"
+L_STATE="$LIB_DIR/adopt-state.sh"
+TMPL_ORG="$REPO_ROOT/templates/generated/approval-log-org.tmpl"
+TMPL_PERSONAL="$REPO_ROOT/templates/generated/approval-log-personal.tmpl"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+# ── THE TREE HASH, AND WHY IT INCLUDES UNTRACKED FILES ──────────────────────
+# Arms 2 and 3 are proven by "the tree did not change". A hash over `git
+# ls-files` alone would MISS the entire damage: the framework install writes
+# ~68 UNTRACKED files, the archive directory is untracked until the commit,
+# and a mutant that adopts the tree would therefore hash identical to one that
+# refused. Content is hashed, not just names, because `phase-state.json` is
+# overwritten in place at a path that already existed.
+_tree_hash() {
+  local p="$1"
+  ( cd "$p" 2>/dev/null && find . -path ./.git -prune -o -type f -print 2>/dev/null \
+      | LC_ALL=C sort \
+      | while IFS= read -r f; do
+          printf '%s ' "$f"
+          (shasum -a 256 "$f" 2>/dev/null || sha256sum "$f" 2>/dev/null || printf 'nohash\n') | awk '{print $1}'
+        done ) | (shasum -a 256 2>/dev/null || sha256sum 2>/dev/null) | awk '{print $1}'
+}
+
+_json_str() {  # _json_str <file> <jq-filter>
+  jq -r "$2 // \"\"" "$1" 2>/dev/null || printf '\n'
+}
+
+if [ ! -f "$DRIVER" ]; then
+  echo "  [FAIL] setup — $DRIVER not found"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [FAIL] setup — jq is required by this suite"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+mk_adoptee() {
+  local p="$1"
+  mkdir -p "$p/src" "$p/docs" || return 1
+  ( cd "$p" \
+      && git init -q . \
+      && git config user.email "wp9b@test.invalid" \
+      && git config user.name  "WP9b Test" \
+      && git config core.excludesFile /dev/null ) >/dev/null 2>&1 || return 1
+  printf '{"name":"acme-api","scripts":{"test":"npm test"}}\n' > "$p/package.json"
+  printf '# acme-api\n' > "$p/README.md"
+  printf '# What this is for\n\nInvoice reconciliation for small firms.\n' > "$p/docs/product.md"
+  printf '# Architecture\n\nA node service and a postgres database.\n' > "$p/docs/architecture.md"
+  ( cd "$p" && git add -A && git commit -q -m "chore: their own history" ) >/dev/null 2>&1 || return 1
+  return 0
+}
+
+TEMPLATE="$(newtmp)/template"
+REPORT=""
+REPORT_OK=0
+if mk_adoptee "$TEMPLATE"; then
+  if bash "$REPO_ROOT/scripts/scout.sh" --root "$TEMPLATE" --out "$TOPTMP/scan" >/dev/null 2>&1; then
+    REPORT="$TOPTMP/scan/scout-report.json"
+    [ -s "$REPORT" ] && REPORT_OK=1
+  fi
+fi
+if [ "$REPORT_OK" -ne 1 ]; then
+  echo "  [FAIL] setup — scripts/scout.sh produced no report"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# Five answers: the tier question plus this report's four scan-derived
+# confirmations (A7). Inherited from the WP9a suite, where the LENGTH is
+# documented as load-bearing; here it only has to be long enough to complete.
+_ans() { local tier="${1:-1}"; printf '%s\n1\n1\n1\n1\n' "$tier"; }
+
+RUN_RC=0; RUN_OUT=""; RUN_ERR=""
+run_adopt() {
+  local dir="$1" answers="$2" report="$3" fw="${4:-$REPO_ROOT}"
+  RUN_RC=0
+  RUN_OUT="$(dirname "$answers")/run-out"
+  RUN_ERR="$(dirname "$answers")/run-err"
+  ( cd "$dir" && bash "$fw/scripts/adopt-project.sh" --scan-report "$report" ) \
+    < "$answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+  return 0
+}
+
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -Rp "$REPO_ROOT/templates" "$m/" || return 1
+  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
+  return 0
+}
+
+GATE_RC=0; GATE_OUT=""
+gate_in() {
+  local dir="$1"; shift
+  GATE_RC=0
+  GATE_OUT="$TOPTMP/gate-out-$$-$RANDOM"
+  ( cd "$dir" && bash scripts/check-phase-gate.sh "$@" ) > "$GATE_OUT" 2>&1 || GATE_RC=$?
+  return 0
+}
+
+# `_adopted_fixture <dir>` — a completed Act 2 at its natural resting state.
+_adopted_fixture() {
+  local w="$1"
+  mkdir -p "$w/p" || return 1
+  mk_adoptee "$w/p" || return 1
+  _ans 1 > "$w/answers"
+  run_adopt "$w/p" "$w/answers" "$REPORT"
+  [ "$RUN_RC" -eq 0 ] || return 1
+  return 0
+}
+
+echo "=== P — A1's three-arm re-adoption preflight (§8.2 step 0) ==="
+
+# The tier question's own text, hoisted because three sections key on "was the
+# operator re-interrogated?" — the property §8.2 step 0 exists to guarantee.
+P4_Q="Who is this project for?"
+
+# ── ARM 1 — an ADOPTED tree, HAND-ADVANCED. ────────────────────────────────
+# THE STARTING STATE IS THE PROOF. At the natural resting state — phase 0 with
+# null gate dates — a mutant that reverts the project to phase 0 with null
+# gates produces a state IDENTICAL to the one it started in, so the revert is
+# invisible and the mutation is green forever. Advancing the fixture by hand
+# first is what makes the damage observable.
+P1="$(newtmp)"
+P1_OK=0
+if _adopted_fixture "$P1"; then
+  jq '.current_phase = 2
+      | .gates.phase_0_to_1 = "2026-01-05"
+      | .gates.phase_1_to_2 = "2026-02-09"' \
+     "$P1/p/.claude/phase-state.json" > "$P1/ps.new" 2>/dev/null \
+    && mv "$P1/ps.new" "$P1/p/.claude/phase-state.json" \
+    && ( cd "$P1/p" && git add -A && git commit -q -m "chore: earned two gates" ) >/dev/null 2>&1 \
+    && P1_OK=1
+fi
+
+if [ "$P1_OK" -ne 1 ]; then
+  fail_ "P setup (arm 1 fixture)" "could not build a hand-advanced adopted fixture"
+else
+  P1_PHASE_BEFORE="$(_json_str "$P1/p/.claude/phase-state.json" '.current_phase')"
+  P1_G1_BEFORE="$(_json_str "$P1/p/.claude/phase-state.json" '.gates.phase_0_to_1')"
+  P1_HASH_BEFORE="$(_tree_hash "$P1/p")"
+
+  _ans 1 > "$P1/answers2"
+  run_adopt "$P1/p" "$P1/answers2" "$REPORT"
+  P1_RC="$RUN_RC"
+  P1_PHASE_AFTER="$(_json_str "$P1/p/.claude/phase-state.json" '.current_phase')"
+  P1_G1_AFTER="$(_json_str "$P1/p/.claude/phase-state.json" '.gates.phase_0_to_1')"
+  P1_HASH_AFTER="$(_tree_hash "$P1/p")"
+
+  [ "$P1_RC" -ne 0 ] \
+    && pass "P1 — a second adoption of an adopted tree REFUSES (rc $P1_RC)" \
+    || fail_ "P1" "the second run exited 0 on an already-adopted tree"
+
+  # The load-bearing one. Not the wording — the STATE.
+  if [ "$P1_PHASE_AFTER" = "$P1_PHASE_BEFORE" ] && [ "$P1_G1_AFTER" = "$P1_G1_BEFORE" ]; then
+    pass "P1b — the hand-advanced state SURVIVES (phase $P1_PHASE_AFTER, gate $P1_G1_AFTER)"
+  else
+    fail_ "P1b" "state was clobbered: phase $P1_PHASE_BEFORE->$P1_PHASE_AFTER, gate '$P1_G1_BEFORE'->'$P1_G1_AFTER'"
+  fi
+
+  [ "$P1_HASH_AFTER" = "$P1_HASH_BEFORE" ] \
+    && pass "P1c — the tree is byte-identical after the refusal" \
+    || fail_ "P1c" "the refused run still changed the tree"
+fi
+
+# ── ARM 2 — an UNSTAMPED tree carrying a PRIOR archive. ────────────────────
+# The fixture must carry NO phase-state.json and NO manifest.json — an
+# interrupted run that died before the state stage — or arm 3 catches it too
+# and this mutation proves nothing.
+P2="$(newtmp)"
+mkdir -p "$P2/p"
+P2_OK=0
+if mk_adoptee "$P2/p"; then
+  mkdir -p "$P2/p/.claude/adoption-archive/2026-01-01T00-00-00Z-1234/.claude"
+  printf '{"a":1}\n' > "$P2/p/.claude/adoption-archive/2026-01-01T00-00-00Z-1234/.claude/settings.json"
+  printf '{"entries":[]}\n' > "$P2/p/.claude/adoption-archive/2026-01-01T00-00-00Z-1234/MANIFEST.json"
+  ( cd "$P2/p" && git add -A && git commit -q -m "chore: an interrupted first run" ) >/dev/null 2>&1 && P2_OK=1
+fi
+
+if [ "$P2_OK" -ne 1 ]; then
+  fail_ "P setup (arm 2 fixture)" "could not build a prior-archive fixture"
+else
+  # Positive control on the fixture's own shape: if either of these files
+  # existed, arm 3 would be the arm under test and P2M would prove nothing.
+  if [ ! -f "$P2/p/.claude/phase-state.json" ] && [ ! -f "$P2/p/.claude/manifest.json" ]; then
+    pass "P2ctl — the arm 2 fixture carries neither phase-state nor manifest (so arm 3 cannot mask it)"
+  else
+    fail_ "P2ctl" "the arm 2 fixture is also an arm 3 fixture; its mutation would prove nothing"
+  fi
+
+  P2_HASH_BEFORE="$(_tree_hash "$P2/p")"
+  _ans 1 > "$P2/answers"
+  run_adopt "$P2/p" "$P2/answers" "$REPORT"
+  P2_RC="$RUN_RC"
+  P2_HASH_AFTER="$(_tree_hash "$P2/p")"
+  P2_ERR="$(cat "$RUN_ERR" 2>/dev/null)"
+  P2_ALL="$(cat "$RUN_OUT" "$RUN_ERR" 2>/dev/null)"
+
+  [ "$P2_RC" -ne 0 ] \
+    && pass "P2 — an unstamped tree with a prior archive REFUSES (rc $P2_RC)" \
+    || fail_ "P2" "adoption completed over a prior archive"
+
+  [ "$P2_HASH_AFTER" = "$P2_HASH_BEFORE" ] \
+    && pass "P2b — the tree is byte-identical after the refusal" \
+    || fail_ "P2b" "the refused run still changed the tree"
+
+  # The design requires arm 2 to NAME the directory: its recovery is that
+  # archive's own restore lines, and a refusal that does not say where they
+  # are sends the operator looking.
+  case "$P2_ALL" in
+    *".claude/adoption-archive/2026-01-01T00-00-00Z-1234"*)
+      pass "P2c — the refusal names the prior archive directory" ;;
+    *) fail_ "P2c" "the refusal did not name .claude/adoption-archive/2026-01-01T00-00-00Z-1234" ;;
+  esac
+fi
+
+# ── ARM 3 — a SCAFFOLDED GREENFIELD tree. ──────────────────────────────────
+# Arms 1 and 2 are both silent here: no `.adoption` to read, and the archive
+# this run would create is not a PRIOR one. Shipped v1 refused this tree via
+# `adopt_install_framework`'s `n_copied -eq 0` tripwire, which D1 unreaches —
+# so without arm 3 the run archives the scaffold's OWN framework files as the
+# operator's, overwrites gate-earned state, stamps it and commits at EXIT 0.
+P3="$(newtmp)"
+mkdir -p "$P3/p"
+P3_OK=0
+if mk_adoptee "$P3/p"; then
+  mkdir -p "$P3/p/.claude"
+  printf '{"current_phase":2,"gates":{"phase_0_to_1":"2026-03-02","phase_1_to_2":"2026-04-08"}}\n' \
+    > "$P3/p/.claude/phase-state.json"
+  printf '{"version":"1.0.0","deployment":"personal"}\n' > "$P3/p/.claude/manifest.json"
+  ( cd "$P3/p" && git add -A && git commit -q -m "chore: scaffolded by init.sh" ) >/dev/null 2>&1 && P3_OK=1
+fi
+
+if [ "$P3_OK" -ne 1 ]; then
+  fail_ "P setup (arm 3 fixture)" "could not build a scaffolded-greenfield fixture"
+else
+  # Positive control: this fixture is NOT adopted, so arm 1 is genuinely
+  # silent on it and arm 3 is the only arm that can refuse.
+  if jq -e '.adoption.adopted == true' "$P3/p/.claude/manifest.json" >/dev/null 2>&1; then
+    fail_ "P3ctl" "the arm 3 fixture is stamped; arm 1 would refuse it and this proves nothing"
+  else
+    pass "P3ctl — the arm 3 fixture is framework-managed but NOT adopted"
+  fi
+
+  P3_PHASE_BEFORE="$(_json_str "$P3/p/.claude/phase-state.json" '.current_phase')"
+  P3_HASH_BEFORE="$(_tree_hash "$P3/p")"
+  _ans 1 > "$P3/answers"
+  run_adopt "$P3/p" "$P3/answers" "$REPORT"
+  P3_RC="$RUN_RC"
+  P3_PHASE_AFTER="$(_json_str "$P3/p/.claude/phase-state.json" '.current_phase')"
+  P3_HASH_AFTER="$(_tree_hash "$P3/p")"
+
+  [ "$P3_RC" -ne 0 ] \
+    && pass "P3 — a scaffolded greenfield tree REFUSES (rc $P3_RC)" \
+    || fail_ "P3" "adoption completed over a scaffolded greenfield project at exit $P3_RC"
+
+  [ "$P3_PHASE_AFTER" = "$P3_PHASE_BEFORE" ] \
+    && pass "P3b — its gate-earned phase survives (phase $P3_PHASE_AFTER)" \
+    || fail_ "P3b" "gate-earned phase clobbered: $P3_PHASE_BEFORE -> $P3_PHASE_AFTER"
+
+  [ "$P3_HASH_AFTER" = "$P3_HASH_BEFORE" ] \
+    && pass "P3c — the tree is byte-identical after the refusal" \
+    || fail_ "P3c" "the refused run still changed the tree"
+
+  if jq -e '.adoption' "$P3/p/.claude/manifest.json" >/dev/null 2>&1; then
+    fail_ "P3d" "the scaffolded project's manifest gained an .adoption block"
+  else
+    pass "P3d — the manifest gained no .adoption block"
+  fi
+fi
+
+# ── The preflight runs BEFORE the tier question. ───────────────────────────
+# §8.2's whole reason for putting it at step 0: a second run must neither
+# re-interrogate the operator nor destroy what the first produced.
+#
+# A DRAFT OF THIS PROVED IT BY STARVATION — no answers on stdin, assert the
+# run refuses — AND THAT ASSERTION WAS VACUOUS: a FIRST adoption with no
+# answers refuses too, by starving at the tier question. It passed against the
+# unmodified tree, before the preflight existed. The discriminator is not that
+# the run refused; it is that THE QUESTION WAS NEVER ASKED. Pinned on the
+# question constant, with a positive control proving the same probe SEES that
+# question on a tree the preflight does not refuse.
+P4="$(newtmp)"
+if _adopted_fixture "$P4"; then
+  : > "$P4/empty"
+  run_adopt "$P4/p" "$P4/empty" "$REPORT"
+  P4_ASKED=0
+  grep -qF "$P4_Q" "$RUN_OUT" 2>/dev/null && P4_ASKED=1
+  [ "$P4_ASKED" -eq 0 ] \
+    && pass "P4 — a re-adoption never reaches the tier question (the preflight precedes it)" \
+    || fail_ "P4" "the re-adoption asked the operator the tier question before refusing"
+fi
+
+P4C="$(newtmp)"
+mkdir -p "$P4C/p"
+if mk_adoptee "$P4C/p"; then
+  : > "$P4C/empty"
+  run_adopt "$P4C/p" "$P4C/empty" "$REPORT"
+  if grep -qF "$P4_Q" "$RUN_OUT" 2>/dev/null; then
+    pass "P4ctl — the same probe DOES see the tier question on a first adoption (P4 is not vacuous)"
+  else
+    fail_ "P4ctl" "the probe cannot see the tier question even on a first adoption; P4 proves nothing"
+  fi
+else
+  fail_ "P4ctl setup" "could not build a fresh adoptee"
+fi
+
+# ── ARM 1's SECOND WITNESS — the committed copy. ───────────────────────────
+# Arm 1 reads TWO witnesses and the commit message headlines the second, but a
+# review mutation deleted it and EVERY PR-blocking suite stayed green while the
+# mutant completed an adoption at exit 0 and destroyed gate-earned state. A
+# mechanism a package advertises and no check proves is a mechanism that leaves
+# by accident. This is that fixture: adopted, hand-advanced, and the
+# `.adoption` block deleted from the WORKING COPY ONLY — which defeats
+# `soif_adoption_adopted` AND the restamp refusal together, and is exactly what
+# an operator "starting over" does.
+P5="$(newtmp)"
+P5_OK=0
+if _adopted_fixture "$P5"; then
+  jq '.current_phase = 2 | .gates.phase_0_to_1 = "2026-01-05"' \
+     "$P5/p/.claude/phase-state.json" > "$P5/ps.new" 2>/dev/null \
+    && mv "$P5/ps.new" "$P5/p/.claude/phase-state.json" \
+    && rm -f "$P5/p/scripts/check-versions.sh" \
+    && ( cd "$P5/p" && git add -A && git commit -q -m "chore: earned a gate, lost a script" ) >/dev/null 2>&1 \
+    && jq 'del(.adoption)' "$P5/p/.claude/manifest.json" > "$P5/mf.new" 2>/dev/null \
+    && mv "$P5/mf.new" "$P5/p/.claude/manifest.json" \
+    && P5_OK=1
+fi
+
+if [ "$P5_OK" -ne 1 ]; then
+  fail_ "P5 setup" "could not build the blanked-manifest fixture"
+else
+  # The control: the working copy must NOT look adopted, or arm 1's first
+  # witness would answer and the second would never be reached.
+  if jq -e '.adoption.adopted == true' "$P5/p/.claude/manifest.json" >/dev/null 2>&1; then
+    fail_ "P5ctl" "the working copy still says adopted; the second witness is not under test"
+  else
+    pass "P5ctl — the working copy no longer says adopted (only HEAD's copy does)"
+  fi
+
+  P5_PHASE_BEFORE="$(_json_str "$P5/p/.claude/phase-state.json" '.current_phase')"
+  _ans 1 > "$P5/answers2"
+  run_adopt "$P5/p" "$P5/answers2" "$REPORT"
+  P5_RC="$RUN_RC"
+  P5_PHASE_AFTER="$(_json_str "$P5/p/.claude/phase-state.json" '.current_phase')"
+
+  [ "$P5_RC" -ne 0 ] \
+    && pass "P5 — a blanked working manifest still REFUSES on the committed witness (rc $P5_RC)" \
+    || fail_ "P5" "blanking the working manifest let the adoption run again at exit 0"
+
+  [ "$P5_PHASE_AFTER" = "$P5_PHASE_BEFORE" ] \
+    && pass "P5b — the gate-earned phase survives it (phase $P5_PHASE_AFTER)" \
+    || fail_ "P5b" "gate-earned phase destroyed: $P5_PHASE_BEFORE -> $P5_PHASE_AFTER"
+fi
+
+# ── ARM 3'S THIRD SIGNAL — the collision-free interrupted tree. ────────────
+# This shape escaped ALL THREE arms: an adoption interrupted after the install
+# on an adoptee with nothing to archive has no manifest, no phase-state and no
+# archive either, so the operator was re-interrogated before the `n_copied`
+# tripwire refused. The fix shipped one round with NO TEST — review excised it
+# and all six PR-blocking adoption suites passed with identical scores.
+#
+# THE FIXTURE IS A REAL INTERRUPTED ADOPTION, never a hand-built tree: the
+# first version of this arm's sibling was "verified" against a hand-created
+# directory and measured the fixture instead of the install.
+P6="$(newtmp)"
+mkdir -p "$P6/p"
+P6_OK=0
+if mk_adoptee "$P6/p"; then
+  _ans 1 > "$P6/answers"
+  ( cd "$P6/p" && SOIF_ADOPT_HALT_AFTER=install \
+      bash "$REPO_ROOT/scripts/adopt-project.sh" --scan-report "$REPORT" ) \
+    < "$P6/answers" > "$P6/out1" 2> "$P6/err1" || true
+  # The shape is only interesting if it really has none of the other signals.
+  if [ ! -d "$P6/p/.claude/adoption-archive" ] && [ ! -f "$P6/p/.claude/phase-state.json" ] \
+     && [ ! -f "$P6/p/.claude/manifest.json" ] && [ -f "$P6/p/scripts/check-phase-gate.sh" ]; then
+    P6_OK=1
+  fi
+fi
+
+if [ "$P6_OK" -ne 1 ]; then
+  fail_ "P6ctl" "could not produce a collision-free interrupted tree (no archive, no phase-state, no manifest, framework installed)"
+else
+  pass "P6ctl — a REAL interrupted adoption with NONE of arms 1-2's signals and no .claude/ state"
+  run_adopt "$P6/p" "$P6/answers" "$REPORT"
+  P6_RC="$RUN_RC"
+  [ "$P6_RC" -ne 0 ] \
+    && pass "P6 — arm 3 refuses it on the installed framework (rc $P6_RC)" \
+    || fail_ "P6" "the collision-free interrupted tree adopted again at exit 0"
+  if grep -q 'already looks framework-managed' "$RUN_ERR" 2>/dev/null; then
+    pass "P6b — it refuses for ARM 3's own reason, not the install tripwire's"
+  else
+    fail_ "P6b" "the refusal came from somewhere else; arm 3 did not fire"
+  fi
+  if grep -qF "$P4_Q" "$RUN_OUT" 2>/dev/null; then
+    fail_ "P6c" "the operator was re-interrogated before the refusal — the step-0 promise is unmet"
+  else
+    pass "P6c — the operator is NOT re-asked the tier question"
+  fi
+fi
+
+# ── P6d — THE CONTROL THAT MATTERS MORE THAN THE REFUSAL. ──────────────────
+# A first cut keyed arm 3 on a SINGLE file (`scripts/check-phase-gate.sh`) and
+# that false-refused an adoptee which legitimately vendors a script of its own
+# at that path — it adopted cleanly before this package. A majority of the
+# shipped set cannot be coincidence; one file can.
+P6D="$(newtmp)"
+mkdir -p "$P6D/p"
+if ! mk_adoptee "$P6D/p"; then
+  fail_ "P6d setup" "could not build the adoptee"
+else
+  mkdir -p "$P6D/p/scripts"
+  printf '#!/usr/bin/env bash\n# our own, not the framework1s\n' > "$P6D/p/scripts/check-phase-gate.sh"
+  ( cd "$P6D/p" && git add -A && git commit -q -m "chore: our own script at that path" ) >/dev/null 2>&1
+  _ans 1 > "$P6D/answers"
+  run_adopt "$P6D/p" "$P6D/answers" "$REPORT"
+  [ "$RUN_RC" -eq 0 ] \
+    && pass "P6d — an adoptee vendoring ONE file at a framework path still adopts (rc 0): arm 3 keys on a majority, not a coincidence" \
+    || fail_ "P6d" "adoption refused (rc $RUN_RC) a project that adopted cleanly before this package"
+fi
+
+# ── P6e — THE THRESHOLD'S BOUNDARY, not just its extremes. ────────────────
+# P6 pins 68/68 (must refuse) and P6d pins 1/68 (must not). ANY predicate
+# satisfying those two survives — review demonstrated three that do: requiring
+# unanimity (`n_present * 1`), shifting `-ge` to `-gt`, and dropping the
+# `n_total -gt 0` guard all passed the whole suite. A rule pinned only at its
+# extremes is a rule a later edit can narrow silently, which is this package's
+# own recurring lesson. Pin the two sides OF THE BOUNDARY.
+#
+# The predicate is `n_present * 2 -ge n_total` — AT LEAST HALF, not a strict
+# majority: at exactly half it refuses, and the fixtures below say so.
+_plant_k() {   # _plant_k <adoptee> <k> — copy K real framework scripts in
+  local p="$1" k="$2" n=0 rel
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    [ -f "$REPO_ROOT/$rel" ] || continue
+    [ "$n" -ge "$k" ] && break
+    mkdir -p "$p/$(dirname "$rel")" 2>/dev/null
+    cp -p "$REPO_ROOT/$rel" "$p/$rel" 2>/dev/null && n=$((n + 1))
+  done <<PLANT
+$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+   . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+   soif_parse_shipped_scripts "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" )
+PLANT
+  printf '%s\n' "$n"
+}
+
+P6E_TOTAL="$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+              . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+              soif_parse_shipped_scripts "$REPO_ROOT/init.sh" "$REPO_ROOT/scripts" \
+                | while IFS= read -r r; do [ -f "$REPO_ROOT/$r" ] && echo x; done | wc -l | tr -d ' ' )"
+P6E_TOTAL="$(_num "$P6E_TOTAL")"
+P6E_HALF=$(( (P6E_TOTAL + 1) / 2 ))
+P6E_UNDER=$(( P6E_HALF - 1 ))
+
+if [ "$P6E_TOTAL" -lt 4 ]; then
+  fail_ "P6e setup" "derived install set is $P6E_TOTAL; too small to have a boundary"
+else
+  pass "P6ectl — the install set derives to $P6E_TOTAL, so the boundary sits at $P6E_HALF (at least half)"
+
+  # AT the boundary: must refuse.
+  P6EA="$(newtmp)"; mkdir -p "$P6EA/p"
+  if mk_adoptee "$P6EA/p"; then
+    k="$(_plant_k "$P6EA/p" "$P6E_HALF")"
+    ( cd "$P6EA/p" && git add -A && git commit -q -m "chore: half the set" ) >/dev/null 2>&1
+    _ans 1 > "$P6EA/answers"
+    run_adopt "$P6EA/p" "$P6EA/answers" "$REPORT"
+    if [ "$RUN_RC" -ne 0 ] && grep -q 'already looks framework-managed' "$RUN_ERR" 2>/dev/null; then
+      pass "P6e — at the boundary ($k of $P6E_TOTAL) arm 3 REFUSES"
+    else
+      fail_ "P6e" "planted $k of $P6E_TOTAL and the run did not refuse on arm 3 (rc $RUN_RC)"
+    fi
+  else
+    fail_ "P6e setup" "could not build the adoptee"
+  fi
+
+  # ONE BELOW the boundary: must adopt. This is the assertion that kills the
+  # unanimity mutant and the `-gt` shift together.
+  P6EB="$(newtmp)"; mkdir -p "$P6EB/p"
+  if mk_adoptee "$P6EB/p"; then
+    k="$(_plant_k "$P6EB/p" "$P6E_UNDER")"
+    ( cd "$P6EB/p" && git add -A && git commit -q -m "chore: just under half" ) >/dev/null 2>&1
+    _ans 1 > "$P6EB/answers"
+    run_adopt "$P6EB/p" "$P6EB/answers" "$REPORT"
+    if [ "$RUN_RC" -eq 0 ]; then
+      pass "P6f — one below the boundary ($k of $P6E_TOTAL) it still ADOPTS: the rule is at-least-half, not unanimity"
+    else
+      fail_ "P6f" "planted $k of $P6E_TOTAL and adoption refused (rc $RUN_RC) — the threshold is narrower than documented"
+    fi
+  else
+    fail_ "P6f setup" "could not build the adoptee"
+  fi
+fi
+
+# ── P6g — THE `n_total -gt 0` GUARD. ──────────────────────────────────────
+# Without it the predicate is `0 * 2 >= 0`, which is TRUE — so a framework root
+# whose install set parses to NOTHING would make arm 3 refuse EVERY project,
+# with the nonsense message "0 of the framework's own 0 scripts are already
+# here". Review excised the guard and the whole suite stayed green, because
+# every other fixture uses a complete root. The mirror below keeps the driver
+# and its libs (the run has to be able to execute) and empties only what the
+# parser reads, which is what drives n_total to zero.
+P6G="$(newtmp)"
+mkdir -p "$P6G/fw" "$P6G/p"
+if ! mk_mirror "$P6G/fw" || ! mk_adoptee "$P6G/p"; then
+  fail_ "P6g setup" "could not build the mirror or the adoptee"
+else
+  printf '#!/usr/bin/env bash\n# a framework root whose install set parses to nothing\n' > "$P6G/fw/init.sh"
+  P6G_TOTAL="$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+                . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+                soif_parse_shipped_scripts "$P6G/fw/init.sh" "$P6G/fw/scripts" 2>/dev/null | grep -c . )"
+  P6G_TOTAL="$(_num "$P6G_TOTAL")"
+  if [ "$P6G_TOTAL" -ne 0 ]; then
+    fail_ "P6gctl" "the parse still yields $P6G_TOTAL entries; this fixture does not exercise the guard"
+  else
+    pass "P6gctl — the mirror's install set parses to 0 entries, so the guard is what is under test"
+    _ans 1 > "$P6G/answers"
+    run_adopt "$P6G/p" "$P6G/answers" "$REPORT" "$P6G/fw"
+    if grep -q 'already looks framework-managed' "$RUN_ERR" 2>/dev/null; then
+      fail_ "P6g" "arm 3 refused a FRESH adoptee because the install set was empty — 0*2 >= 0 is true and the guard is gone"
+    else
+      pass "P6g — a fresh adoptee is NOT refused by arm 3 when the install set is empty (rc $RUN_RC)"
+    fi
+  fi
+fi
+
+# ── P6h — THE INCOMPLETE FRAMEWORK ROOT, and the sibling that makes it work. ─
+# Arm 3 asks "is the framework already here" and so does
+# `adopt_install_framework`'s `n_copied` — TWO COPIES OF ONE PREDICATE in two
+# functions, with nothing in the language binding them. Round 6 aligned them
+# (both now skip entries whose SOURCE is absent); review reverted that and
+# EVERY suite stayed green, so the fix was real and nothing held it there.
+#
+# The discriminating shape is a framework root that cannot install its whole
+# set. Counting every PARSED line against an adoptee that holds every
+# INSTALLABLE one scores below the threshold, arm 3 goes silent, and the run
+# falls through to the tripwire — re-interrogating the operator and writing
+# into the project, which step 0 exists to prevent.
+#
+# ASSERTED IN BOTH DIRECTIONS: the arm-3 refusal is present AND the tripwire
+# text is ABSENT. Either alone is satisfiable by the wrong build.
+P6H="$(newtmp)"
+mkdir -p "$P6H/fw" "$P6H/p"
+P6H_MARKS_OK=1
+for m in "# BL-242-INSTALL-SET-KEY" "# BL-242-INSTALL-SET-KEY-SIBLING"; do
+  n="$(_sites "$L_STATE" "$m")"
+  [ "$n" = "1" ] || { fail_ "P6h-anchor" "'$m' occurs $n times (need exactly 1)"; P6H_MARKS_OK=0; }
+done
+[ "$P6H_MARKS_OK" -eq 1 ] && pass "P6h-anchor — both sync-sibling markers occur exactly once"
+
+if ! mk_mirror "$P6H/fw" || ! mk_adoptee "$P6H/p"; then
+  fail_ "P6h setup" "could not build the mirror or the adoptee"
+else
+  # Make the mirror INCOMPLETE: keep the libs the driver needs to run, drop the
+  # top-level scripts, so parsed >> installable.
+  find "$P6H/fw/scripts" -maxdepth 1 -type f -name '*.sh' ! -name 'adopt-project.sh' ! -name 'scout.sh' \
+    -exec rm -f {} + 2>/dev/null
+  # The adoptee holds everything that mirror CAN still install.
+  P6H_INSTALLABLE=0
+  while IFS= read -r rel; do
+    [ -n "$rel" ] || continue
+    [ -f "$P6H/fw/$rel" ] || continue
+    mkdir -p "$P6H/p/$(dirname "$rel")" 2>/dev/null
+    cp -p "$P6H/fw/$rel" "$P6H/p/$rel" 2>/dev/null && P6H_INSTALLABLE=$((P6H_INSTALLABLE + 1))
+  done <<P6HSET
+$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+   . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+   soif_parse_shipped_scripts "$P6H/fw/init.sh" "$P6H/fw/scripts" )
+P6HSET
+  P6H_PARSED="$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+                 . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+                 soif_parse_shipped_scripts "$P6H/fw/init.sh" "$P6H/fw/scripts" | grep -c . )"
+  P6H_PARSED="$(_num "$P6H_PARSED")"
+  ( cd "$P6H/p" && git add -A && git commit -q -m "chore: everything that root can install" ) >/dev/null 2>&1
+
+  # THE CONTROL ASSERTS THE INEQUALITY THAT ACTUALLY DISCRIMINATES, which is
+  # NOT `parsed > installable`. The buggy predicate scores
+  # `n_present * 2 >= n_total` with n_total = PARSED, and the adoptee holds
+  # every INSTALLABLE entry — so the mutant only fails while
+  # `2 * installable < parsed`. A draft asserted the weaker inequality and
+  # review proved it vacuous by widening the fixture five entries: the control
+  # still passed while the round-6 revert went green underneath it. Five files
+  # moving into `scripts/lib/` would have done the same, and WP10/11/12 each
+  # add files there.
+  if [ "$P6H_INSTALLABLE" -gt 0 ] && [ $((P6H_INSTALLABLE * 2)) -lt "$P6H_PARSED" ]; then
+    pass "P6hctl — the mirror parses $P6H_PARSED entries and can install $P6H_INSTALLABLE; 2×$P6H_INSTALLABLE < $P6H_PARSED, which is the margin the mutant needs to fail in"
+    _ans 1 > "$P6H/answers"
+    run_adopt "$P6H/p" "$P6H/answers" "$REPORT" "$P6H/fw"
+    if grep -q 'already looks framework-managed' "$RUN_ERR" 2>/dev/null; then
+      pass "P6h — arm 3 refuses on the INSTALLABLE set, not the parsed one (rc $RUN_RC)"
+    else
+      fail_ "P6h" "arm 3 stayed silent — it is counting parsed entries against an adoptee that holds every installable one"
+    fi
+    if grep -q 'every framework script is already present' "$RUN_ERR" 2>/dev/null; then
+      fail_ "P6h2" "the run fell through to the install tripwire, which is step 0's job to prevent"
+    else
+      pass "P6h2 — the install tripwire is never reached"
+    fi
+    if grep -qF "$P4_Q" "$RUN_OUT" 2>/dev/null; then
+      fail_ "P6h3" "the operator was re-interrogated before the refusal"
+    else
+      pass "P6h3 — the operator is not re-asked the tier question"
+    fi
+  else
+    fail_ "P6hctl" "parsed=$P6H_PARSED installable=$P6H_INSTALLABLE — 2×installable is not < parsed, so P6h cannot fail under the drift mutant and proves nothing"
+  fi
+fi
+
+# ── P6i — THE INSTALLER HALF, pinned by BEHAVIOUR and not by its marker. ───
+# Review neutered `# BL-242-INSTALL-SET-KEY` while LEAVING THE MARKER IN PLACE
+# and the whole suite stayed green: the binding on that half was existence, not
+# behaviour. The discriminating shape is an incomplete root plus a FRESH
+# adoptee — the preflight stays silent (nothing is installed yet), so the
+# install actually runs, and without the source filter it tries to copy a file
+# that is not there.
+P6I="$(newtmp)"
+mkdir -p "$P6I/fw" "$P6I/p"
+if ! mk_mirror "$P6I/fw" || ! mk_adoptee "$P6I/p"; then
+  fail_ "P6i setup" "could not build the mirror or the adoptee"
+else
+  find "$P6I/fw/scripts" -maxdepth 1 -type f -name '*.sh' ! -name 'adopt-project.sh' ! -name 'scout.sh' \
+    -exec rm -f {} + 2>/dev/null
+  # THE CONTROL P6h GOT AND THIS DID NOT. A COMPLETE root also adopts a fresh
+  # project at rc 0 and also never says "could not install", so both assertions
+  # below pass against a mirror that stopped being incomplete — review neutered
+  # this `find` and watched the pair go green with the filter mutant live.
+  # Assert the mirror is genuinely short of its own parse.
+  P6I_PARSED="$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+                 . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+                 soif_parse_shipped_scripts "$P6I/fw/init.sh" "$P6I/fw/scripts" | grep -c . )"
+  P6I_HAVE="$( . "$REPO_ROOT/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+               . "$REPO_ROOT/scripts/lib/scaffold-shipped-set.sh" >/dev/null 2>&1
+               soif_parse_shipped_scripts "$P6I/fw/init.sh" "$P6I/fw/scripts" \
+                 | while IFS= read -r r; do [ -f "$P6I/fw/$r" ] && echo x; done | grep -c . )"
+  P6I_PARSED="$(_num "$P6I_PARSED")"; P6I_HAVE="$(_num "$P6I_HAVE")"
+  if [ "$P6I_HAVE" -gt 0 ] && [ "$P6I_PARSED" -gt "$P6I_HAVE" ]; then
+    pass "P6ictl — the mirror parses $P6I_PARSED entries and holds only $P6I_HAVE: it is genuinely incomplete, so the assertions below discriminate"
+  else
+    fail_ "P6ictl" "parsed=$P6I_PARSED held=$P6I_HAVE — the mirror is complete; P6i/P6i2 would pass against any build"
+  fi
+  _ans 1 > "$P6I/answers"
+  run_adopt "$P6I/p" "$P6I/answers" "$REPORT" "$P6I/fw"
+  P6I_RC="$RUN_RC"
+  if [ "$P6I_RC" -eq 0 ]; then
+    pass "P6i — an incomplete framework root still adopts a fresh project (rc 0): the installer SKIPS entries it cannot copy"
+  else
+    fail_ "P6i" "adoption refused (rc $P6I_RC) on an incomplete root — the installer is trying to copy sources that are not there"
+  fi
+  if grep -q 'could not install' "$RUN_ERR" 2>/dev/null; then
+    fail_ "P6i2" "the run hit 'could not install' — the source filter is not skipping absent entries"
+  else
+    pass "P6i2 — no 'could not install' refusal: the filter did its job"
+  fi
+fi
+
+# ── P6j — THE `-e` HALF. ──────────────────────────────────────────────────
+# The preflight tests the adoptee with `-e`, the installer with `-e`; a draft
+# used `-f` on the preflight side and review showed reverting it is invisible.
+# They differ for a NON-REGULAR file at a framework script path, so the fixture
+# plants exactly the boundary count with one entry as a DIRECTORY: `-e` counts
+# it and refuses, `-f` does not and adopts.
+P6J="$(newtmp)"
+mkdir -p "$P6J/p"
+if ! mk_adoptee "$P6J/p"; then
+  fail_ "P6j setup" "could not build the adoptee"
+else
+  k="$(_plant_k "$P6J/p" "$P6E_HALF")"
+  # turn the LAST planted entry into a directory
+  P6J_VICTIM="$( ( cd "$P6J/p" && find scripts -type f -name '*.sh' 2>/dev/null | LC_ALL=C sort | tail -1 ) )"
+  if [ -n "$P6J_VICTIM" ]; then
+    rm -f "$P6J/p/$P6J_VICTIM" && mkdir -p "$P6J/p/$P6J_VICTIM"
+  fi
+  ( cd "$P6J/p" && git add -A && git commit -q -m "chore: boundary count, one of them a directory" ) >/dev/null 2>&1
+  # `-n` FIRST, and it is not belt-and-braces: with an empty victim the test
+  # degenerates to `[ -d "$P6J/p/" ]`, which is TRUE, so the control passed
+  # while nothing had been planted and P6j went green under the very mutant it
+  # exists to catch. Review demonstrated exactly that.
+  if [ -n "$P6J_VICTIM" ] && [ -d "$P6J/p/$P6J_VICTIM" ]; then
+    pass "P6jctl — $k planted at the boundary with '$P6J_VICTIM' as a DIRECTORY, which -e counts and -f does not"
+    _ans 1 > "$P6J/answers"
+    run_adopt "$P6J/p" "$P6J/answers" "$REPORT"
+    if [ "$RUN_RC" -ne 0 ] && grep -q 'already looks framework-managed' "$RUN_ERR" 2>/dev/null; then
+      pass "P6j — the directory still counts toward the threshold (rc $RUN_RC): the preflight tests -e, matching the installer"
+    else
+      fail_ "P6j" "rc=$RUN_RC — a non-regular file at a framework path was not counted; the preflight is testing -f while the installer tests -e"
+    fi
+  else
+    fail_ "P6jctl" "could not plant a directory at a framework script path"
+  fi
+fi
+
+echo ""
+echo "=== W — APPROVAL_LOG.md is an archive-and-replace surface (§7.1) ==="
+
+# A4 writes APPROVAL_LOG.md over whatever is there. §7.1's rule is not "AI
+# surfaces are archived", it is "every archive-and-replace surface produces a
+# row" — and the first cut of WP9b added the replace without the row. MEASURED
+# THEN: an operator's own never-committed APPROVAL_LOG.md was destroyed at
+# rc 0, with ZERO recoverable copies, in a run that printed "Nothing was
+# deleted." The fixture uses an UNCOMMITTED log deliberately: a committed one
+# is recoverable from history and would understate the loss.
+W1="$(newtmp)"
+mkdir -p "$W1/p"
+W1_OK=0
+if mk_adoptee "$W1/p"; then
+  printf '# OUR APPROVAL LOG\n\nSOX sign-off 2024-11-02, approved by the audit committee.\n' \
+    > "$W1/p/APPROVAL_LOG.md"
+  W1_OK=1
+fi
+
+if [ "$W1_OK" -ne 1 ]; then
+  fail_ "W setup" "could not build the approval-log fixture"
+else
+  if ( cd "$W1/p" && git ls-files --error-unmatch APPROVAL_LOG.md >/dev/null 2>&1 ); then
+    fail_ "W0ctl" "the fixture's APPROVAL_LOG.md is tracked; the unrecoverable case is not under test"
+  else
+    pass "W0ctl — the fixture's APPROVAL_LOG.md is UNCOMMITTED (so a loss here is unrecoverable)"
+  fi
+
+  _ans 1 > "$W1/answers"
+  run_adopt "$W1/p" "$W1/answers" "$REPORT"
+  W1_RC="$RUN_RC"
+  W1_ARC="$(cd "$W1/p" && ls -d .claude/adoption-archive/*/ 2>/dev/null | head -1)"
+  W1_ARC="${W1_ARC%/}"
+
+  [ "$W1_RC" -eq 0 ] \
+    && pass "W1ctl — the adoption completes over a pre-existing approval log (rc 0), so the assertions below are about the ARCHIVE, not a refusal" \
+    || fail_ "W1ctl" "the adoption refused (rc $W1_RC); this section cannot say anything about archiving"
+
+  if [ -n "$W1_ARC" ] && [ -f "$W1/p/$W1_ARC/APPROVAL_LOG.md" ]; then
+    pass "W1 — the operator's APPROVAL_LOG.md is IN the archive"
+  else
+    fail_ "W1" "the operator's APPROVAL_LOG.md was replaced and never archived"
+  fi
+
+  # Their bytes, not the template's — an archive holding the framework's own
+  # output under the operator's name is worse than no archive.
+  if grep -q 'OUR APPROVAL LOG' "$W1/p/$W1_ARC/APPROVAL_LOG.md" 2>/dev/null; then
+    pass "W2 — the archived copy carries THEIR content, not the rendered template"
+  else
+    fail_ "W2" "the archived copy is not the operator's original"
+  fi
+
+  # And the MANIFEST must name it, because the disclosure and the restore line
+  # are both driven from there — an archived file with no row is invisible.
+  if jq -e '[.entries[] | select(.originalPath == "APPROVAL_LOG.md")] | length > 0' \
+       "$W1/p/$W1_ARC/MANIFEST.json" >/dev/null 2>&1; then
+    pass "W3 — MANIFEST.json carries a row for it (so it has a restore line and reaches the disclosure)"
+  else
+    fail_ "W3" "APPROVAL_LOG.md is in the archive but absent from MANIFEST.json — invisible to the disclosure and to --re-add"
+  fi
+
+  # The row must say the file was REPLACED, not kept. `kept` means the
+  # operator's original is still at the path, which A4 makes false — and
+  # nothing in this repository read the field, so reverting it to `kept` was
+  # invisible to every check until this assertion existed.
+  W_DISPO="$(jq -r '[.entries[]|select(.originalPath=="APPROVAL_LOG.md")|.disposition]|first // ""' \
+    "$W1/p/$W1_ARC/MANIFEST.json" 2>/dev/null)"
+  [ "$W_DISPO" = "replaced" ] \
+    && pass "W6 — the MANIFEST records disposition=replaced for it (not 'kept', which would be false)" \
+    || fail_ "W6" "disposition is '$W_DISPO', want 'replaced'"
+
+  # The transcript must SAY so. "Nothing was deleted" is printed in this block;
+  # the first cut printed it in the same run that destroyed the file.
+  if grep -q 'yours: APPROVAL_LOG.md' "$RUN_OUT" 2>/dev/null; then
+    pass "W4 — the run TELLS the operator their approval log was archived"
+  else
+    fail_ "W4" "the archive disclosure never names APPROVAL_LOG.md, in a block that says 'Nothing was deleted'"
+  fi
+
+  # And the framework's log is the one now at the path.
+  if grep -q 'Pre-Phase 0' "$W1/p/APPROVAL_LOG.md" 2>/dev/null; then
+    pass "W5 — the rendered template is what sits at the path now (the replace still happened)"
+  else
+    fail_ "W5" "the path does not carry the rendered template; A4 did not run"
+  fi
+fi
+
+echo ""
+echo "=== X — the project name is DATA, not a substitution pattern ==="
+
+# `ADOPT_PROJECT_NAME` is `${root##*/}` — a directory basename the operator
+# chose — and it lands in a replacement. A first cut used `sed`, and all three
+# of these were measured against it: `&` rendered `amp__PROJECT_NAME__co` at
+# rc 0 (CLAUDE.md's whole-match trap), `,` collided with the delimiter and left
+# a ZERO-BYTE log at rc 1 with `adopt_refuse` never called, and `\` was eaten.
+# `back\slash` IS IN THIS LIST BECAUSE IT WAS THE ONE LEFT OUT. The commit
+# enumerated three measured failures and section X pinned two of them; the
+# unpinned one was still broken through two more fix attempts, because `awk -v`
+# escape-processes its value before the render loop ever sees it. Pin every
+# case you claim to have fixed.
+# `pre__TODAY__post` IS IN THIS LIST BECAUSE THE TWO SUBSTITUTIONS NEST. The
+# outer pass scans the inner pass output, so with the NAME substituted first a
+# directory called that had the date written into its own name — at rc 0, in
+# both fields, while the same run commit subject carried the real name. Order
+# swapped; this pins it.
+for xname in 'amp&co' 'comma,inc' 'back\slash' 'tab	here' 'dollar$var' 'pre__TODAY__post'; do
+  XD="$(newtmp)"
+  mkdir -p "$XD/$xname"
+  if ! mk_adoptee "$XD/$xname"; then
+    fail_ "X setup ($xname)" "could not build the adoptee"
+    continue
+  fi
+  _ans 1 > "$XD/answers"
+  run_adopt "$XD/$xname" "$XD/answers" "$REPORT"
+  x_rc="$RUN_RC"
+  x_bytes="$(wc -c < "$XD/$xname/APPROVAL_LOG.md" 2>/dev/null | tr -d ' ')"
+  x_bytes="$(_num "$x_bytes")"
+  # NOT a blanket placeholder count. `pre__TODAY__post` renders VERBATIM and
+  # therefore legitimately contains the literal `__TODAY__` — a count would
+  # fail the very case it was added to prove. Assert the two facts separately:
+  # no `__PROJECT_NAME__` survives anywhere, and the date WAS substituted.
+  x_left="$(grep -c '__PROJECT_NAME__' "$XD/$xname/APPROVAL_LOG.md" 2>/dev/null)"
+  x_left="$(_num "$x_left")"
+  x_dated=0
+  grep -q "$(date +%Y-%m-%d)" "$XD/$xname/APPROVAL_LOG.md" 2>/dev/null && x_dated=1
+  # BOTH substituted fields, not just the title: the claim under test is that
+  # the operator string is copied verbatim on every leg, and a draft checked
+  # only the title.
+  x_named=0
+  grep -qF "Approval Log — $xname" "$XD/$xname/APPROVAL_LOG.md" 2>/dev/null && x_named=1
+  x_front=0
+  grep -qF "project: $xname" "$XD/$xname/APPROVAL_LOG.md" 2>/dev/null && x_front=1
+  if [ "$x_rc" -eq 0 ] && [ "$x_left" -eq 0 ] && [ "$x_bytes" -gt 0 ] \
+     && [ "$x_named" -eq 1 ] && [ "$x_front" -eq 1 ] && [ "$x_dated" -eq 1 ]; then
+    pass "X ($xname) — verbatim in BOTH fields, date substituted, no __PROJECT_NAME__ left ($x_bytes bytes)"
+  else
+    fail_ "X ($xname)" "rc=$x_rc bytes=$x_bytes name_placeholder_left=$x_left title=$x_named frontmatter=$x_front date_substituted=$x_dated"
+  fi
+done
+
+echo ""
+echo "=== PM — the preflight's mutation proofs (one per arm) ==="
+
+PF_ARM1_MARK="# BL-242-PREFLIGHT-ARM1"
+PF_ARM2_MARK="# BL-242-PREFLIGHT-ARM2"
+PF_ARM3_MARK="# BL-242-PREFLIGHT-ARM3"
+
+for m in "$PF_ARM1_MARK" "$PF_ARM2_MARK" "$PF_ARM3_MARK"; do
+  n="$(_sites "$L_STATE" "$m")"
+  [ "$n" = "1" ] \
+    && pass "PM-anchor — '$m' occurs exactly once at end-of-line in adopt-state.sh" \
+    || fail_ "PM-anchor" "'$m' occurs $n times (need exactly 1) — the mutants below cannot be aimed"
+done
+
+# _mutate_lib <mirror> <lib-basename> <marker> <replacement>
+_mutate_lib() {
+  local mir="$1" lib="$2" mark="$3" repl="$4" before after changed
+  before="$(mktemp)"; cp "$mir/scripts/lib/adopt/$lib" "$before"
+  _sed_inplace "$mir/scripts/lib/adopt/$lib" "s|^.*${mark}\$|${repl}|"
+  after="$mir/scripts/lib/adopt/$lib"
+  changed="$(_changed_lines "$before" "$after")"
+  rm -f "$before"
+  [ "$changed" -ge 2 ] || { printf '0\n'; return 0; }
+  [ "$(_parses "$after")" = "1" ] || { printf '0\n'; return 0; }
+  printf '1\n'
+}
+
+# _mutate_state <mirror> <marker> <replacement>  → 1 on a clean, parsing edit
+_mutate_state() {
+  local mir="$1" mark="$2" repl="$3" before after changed
+  before="$(mktemp)"; cp "$mir/scripts/lib/adopt/adopt-state.sh" "$before"
+  _sed_inplace "$mir/scripts/lib/adopt/adopt-state.sh" "s|^.*${mark}\$|${repl}|"
+  after="$mir/scripts/lib/adopt/adopt-state.sh"
+  changed="$(_changed_lines "$before" "$after")"
+  rm -f "$before"
+  [ "$changed" -ge 2 ] || { printf '0\n'; return 0; }
+  [ "$(_parses "$after")" = "1" ] || { printf '0\n'; return 0; }
+  printf '1\n'
+}
+
+# ── PM1 — drop arm 1 on the hand-advanced adopted fixture. ─────────────────
+# ITS MUTANT EXITS 1 (a later refusal fires), so the assertion CANNOT read the
+# exit code. It reads the reverted state — which is the whole point: refusing
+# after `adopt_write_file` has already `cat >` overwritten phase-state.json is
+# not refusing.
+#
+# THE FIXTURE DELETES ONE FRAMEWORK SCRIPT, AND THAT IS NOT A CONTRIVANCE — it
+# is what makes the design's specified RED reachable TODAY. On an untouched
+# adopted tree every framework file is already present, so
+# `adopt_install_framework`'s `n_copied -eq 0` tripwire refuses BEFORE the
+# state stage and the mutant leaves phase-state intact: measured, dropping
+# arm 1 changed nothing, and this proof was green against a build with no
+# arm 1 at all. That tripwire is shipped v1's, and D1's framework-wins install
+# UNREACHES it at WP11 — at which point the untouched tree reaches the state
+# stage too. Deleting one script makes n_copied non-zero now, so this suite
+# proves the property at WP9b instead of waiting for WP11 to make it visible.
+# A partly-deleted adopted tree is also an ordinary thing to find in the wild.
+PM1="$(newtmp)"
+mkdir -p "$PM1/fw"
+if ! mk_mirror "$PM1/fw"; then
+  fail_ "PM1 setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$PM1/fw" "$PF_ARM1_MARK" "  :")" != "1" ]; then
+  fail_ "PM1 setup" "the arm-1 mutation did not apply cleanly (or the mutant does not parse)"
+elif ! _adopted_fixture "$PM1"; then
+  fail_ "PM1 setup" "could not build the adopted fixture"
+else
+  jq '.current_phase = 2 | .gates.phase_0_to_1 = "2026-01-05"' \
+     "$PM1/p/.claude/phase-state.json" > "$PM1/ps.new" 2>/dev/null \
+    && mv "$PM1/ps.new" "$PM1/p/.claude/phase-state.json"
+  rm -f "$PM1/p/scripts/check-versions.sh"
+  ( cd "$PM1/p" && git add -A && git commit -q -m "chore: earned a gate, lost a script" ) >/dev/null 2>&1
+  PM1_PHASE_BEFORE="$(_json_str "$PM1/p/.claude/phase-state.json" '.current_phase')"
+  _ans 1 > "$PM1/answers2"
+  run_adopt "$PM1/p" "$PM1/answers2" "$REPORT" "$PM1/fw"
+  PM1_PHASE_AFTER="$(_json_str "$PM1/p/.claude/phase-state.json" '.current_phase')"
+  PM1_G1_AFTER="$(_json_str "$PM1/p/.claude/phase-state.json" '.gates.phase_0_to_1')"
+  if [ "$PM1_PHASE_AFTER" != "$PM1_PHASE_BEFORE" ] || [ -z "$PM1_G1_AFTER" ]; then
+    pass "PM1 (MUTATION) — dropping arm 1 reverts the earned state (phase $PM1_PHASE_BEFORE -> $PM1_PHASE_AFTER, gate '$PM1_G1_AFTER'): arm 1 is what protects it"
+  else
+    fail_ "PM1 (MUTATION)" "dropping arm 1 changed nothing — arm 1 is not load-bearing, or another arm is masking it (see PM1b/PM1c)"
+  fi
+fi
+
+# ── PM1c — the SAME fixture, UNMUTATED. ────────────────────────────────────
+# PM1 above is only a proof if the shipped code holds where the mutant fails.
+# Without this control, a PM1 that went RED for an unrelated reason (the
+# deleted script breaking the run outright, say) would look like a proof.
+PM1C="$(newtmp)"
+if ! _adopted_fixture "$PM1C"; then
+  fail_ "PM1c setup" "could not build the adopted fixture"
+else
+  jq '.current_phase = 2 | .gates.phase_0_to_1 = "2026-01-05"' \
+     "$PM1C/p/.claude/phase-state.json" > "$PM1C/ps.new" 2>/dev/null \
+    && mv "$PM1C/ps.new" "$PM1C/p/.claude/phase-state.json"
+  rm -f "$PM1C/p/scripts/check-versions.sh"
+  ( cd "$PM1C/p" && git add -A && git commit -q -m "chore: earned a gate, lost a script" ) >/dev/null 2>&1
+  PM1C_PHASE_BEFORE="$(_json_str "$PM1C/p/.claude/phase-state.json" '.current_phase')"
+  _ans 1 > "$PM1C/answers2"
+  run_adopt "$PM1C/p" "$PM1C/answers2" "$REPORT"
+  PM1C_PHASE_AFTER="$(_json_str "$PM1C/p/.claude/phase-state.json" '.current_phase')"
+  PM1C_G1_AFTER="$(_json_str "$PM1C/p/.claude/phase-state.json" '.gates.phase_0_to_1')"
+  if [ "$PM1C_PHASE_AFTER" = "$PM1C_PHASE_BEFORE" ] && [ "$PM1C_G1_AFTER" = "2026-01-05" ]; then
+    pass "PM1c — on that same fixture the SHIPPED code holds the state (phase $PM1C_PHASE_AFTER, gate $PM1C_G1_AFTER)"
+  else
+    fail_ "PM1c" "the shipped code did not protect the fixture PM1 mutates: phase $PM1C_PHASE_BEFORE -> $PM1C_PHASE_AFTER, gate '$PM1C_G1_AFTER'"
+  fi
+fi
+
+# ── PM1b — arm 3 must NOT mask arm 1. ──────────────────────────────────────
+# If arm 3 were spelled as bare "phase-state present", it would refuse the
+# adopted fixture too and PM1 above would pass without arm 1 existing. This
+# drops arm 3 ONLY and requires arm 1 to hold alone — so PM1's red is
+# attributable to arm 1 rather than to arm 3 having been absent from that
+# mutant. (Review checked the other direction too: strip arm 3's `not adopted`
+# conjunct and PM1 goes red while PM1b stays green — PM1 is the assertion that
+# pins the conjunct, and a draft of the shipped comment credited PM1b.)
+PM1B="$(newtmp)"
+mkdir -p "$PM1B/fw"
+if ! mk_mirror "$PM1B/fw"; then
+  fail_ "PM1b setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$PM1B/fw" "$PF_ARM3_MARK" "  :")" != "1" ]; then
+  fail_ "PM1b setup" "the arm-3 mutation did not apply cleanly"
+elif ! _adopted_fixture "$PM1B"; then
+  fail_ "PM1b setup" "could not build the adopted fixture"
+else
+  jq '.current_phase = 2 | .gates.phase_0_to_1 = "2026-01-05"' \
+     "$PM1B/p/.claude/phase-state.json" > "$PM1B/ps.new" 2>/dev/null \
+    && mv "$PM1B/ps.new" "$PM1B/p/.claude/phase-state.json"
+  ( cd "$PM1B/p" && git add -A && git commit -q -m "chore: earned a gate" ) >/dev/null 2>&1
+  PM1B_PHASE_BEFORE="$(_json_str "$PM1B/p/.claude/phase-state.json" '.current_phase')"
+  _ans 1 > "$PM1B/answers2"
+  run_adopt "$PM1B/p" "$PM1B/answers2" "$REPORT" "$PM1B/fw"
+  PM1B_PHASE_AFTER="$(_json_str "$PM1B/p/.claude/phase-state.json" '.current_phase')"
+  [ "$PM1B_PHASE_AFTER" = "$PM1B_PHASE_BEFORE" ] \
+    && pass "PM1b — with arm 3 dropped, ARM 1 alone still protects an adopted tree (phase $PM1B_PHASE_AFTER)" \
+    || fail_ "PM1b" "arm 1 alone did not hold: phase $PM1B_PHASE_BEFORE -> $PM1B_PHASE_AFTER (arm 3 was masking arm 1)"
+fi
+
+# ── PM1d — drop arm 1's SECOND WITNESS. THE MUTANT EXITS ZERO. ─────────────
+# Review deleted this one line and every PR-blocking suite stayed green while
+# the mutant completed an adoption and destroyed gate-earned state. Arms 2 and
+# 3 cannot catch it: each returns 0 on its own head-copy check, so with the
+# second witness gone there is nothing left to refuse.
+PM1D="$(newtmp)"
+mkdir -p "$PM1D/fw"
+PM1D_MARK="# BL-242-PREFLIGHT-WITNESS2"
+pm1d_sites="$(_sites "$L_STATE" "$PM1D_MARK")"
+[ "$pm1d_sites" = "1" ] \
+  && pass "PM1d-anchor — '$PM1D_MARK' occurs exactly once at end-of-line" \
+  || fail_ "PM1d-anchor" "'$PM1D_MARK' occurs $pm1d_sites times (need exactly 1)"
+
+if ! mk_mirror "$PM1D/fw"; then
+  fail_ "PM1d setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$PM1D/fw" "$PM1D_MARK" "    :")" != "1" ]; then
+  fail_ "PM1d setup" "the second-witness mutation did not apply cleanly"
+elif ! _adopted_fixture "$PM1D"; then
+  fail_ "PM1d setup" "could not build the adopted fixture"
+else
+  jq '.current_phase = 2 | .gates.phase_0_to_1 = "2026-01-05"' \
+     "$PM1D/p/.claude/phase-state.json" > "$PM1D/ps.new" 2>/dev/null \
+    && mv "$PM1D/ps.new" "$PM1D/p/.claude/phase-state.json"
+  rm -f "$PM1D/p/scripts/check-versions.sh"
+  ( cd "$PM1D/p" && git add -A && git commit -q -m "chore: earned a gate, lost a script" ) >/dev/null 2>&1
+  # The `.adoption` deletion comes AFTER the commit, so HEAD's copy still says
+  # adopted and only the working copy is blanked — which is the whole point.
+  jq 'del(.adoption)' "$PM1D/p/.claude/manifest.json" > "$PM1D/mf.new" 2>/dev/null \
+    && mv "$PM1D/mf.new" "$PM1D/p/.claude/manifest.json"
+  PM1D_PHASE_BEFORE="$(_json_str "$PM1D/p/.claude/phase-state.json" '.current_phase')"
+  _ans 1 > "$PM1D/answers2"
+  run_adopt "$PM1D/p" "$PM1D/answers2" "$REPORT" "$PM1D/fw"
+  PM1D_RC="$RUN_RC"
+  PM1D_PHASE_AFTER="$(_json_str "$PM1D/p/.claude/phase-state.json" '.current_phase')"
+  if [ "$PM1D_PHASE_AFTER" != "$PM1D_PHASE_BEFORE" ]; then
+    pass "PM1d (MUTATION) — dropping the committed witness lets a blanked manifest re-adopt (rc $PM1D_RC) and reverts the earned state ($PM1D_PHASE_BEFORE -> $PM1D_PHASE_AFTER)"
+  else
+    fail_ "PM1d (MUTATION)" "dropping the second witness changed nothing — it is not load-bearing, or something else refuses first"
+  fi
+fi
+
+# ── PM1e — drop arm 3's INSTALLED-FRAMEWORK signal. ───────────────────────
+# Review excised exactly this line and every PR-blocking adoption suite passed
+# with identical scores. Fourth round running that a fix shipped with no mutant.
+PM1E="$(newtmp)"
+mkdir -p "$PM1E/fw" "$PM1E/p"
+PM1E_MARK="# BL-242-PREFLIGHT-ARM3-INSTALLED"
+pm1e_sites="$(_sites "$L_STATE" "$PM1E_MARK")"
+[ "$pm1e_sites" = "1" ] \
+  && pass "PM1e-anchor — '$PM1E_MARK' occurs exactly once at end-of-line" \
+  || fail_ "PM1e-anchor" "'$PM1E_MARK' occurs $pm1e_sites times (need exactly 1)"
+
+if ! mk_mirror "$PM1E/fw"; then
+  fail_ "PM1e setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$PM1E/fw" "$PM1E_MARK" "      found=\"\"")" != "1" ]; then
+  fail_ "PM1e setup" "the installed-signal mutation did not apply cleanly"
+elif ! mk_adoptee "$PM1E/p"; then
+  fail_ "PM1e setup" "could not build the adoptee"
+else
+  _ans 1 > "$PM1E/answers"
+  ( cd "$PM1E/p" && SOIF_ADOPT_HALT_AFTER=install \
+      bash "$PM1E/fw/scripts/adopt-project.sh" --scan-report "$REPORT" ) \
+    < "$PM1E/answers" > "$PM1E/out1" 2> "$PM1E/err1" || true
+  run_adopt "$PM1E/p" "$PM1E/answers" "$REPORT" "$PM1E/fw"
+  if grep -qF "$P4_Q" "$RUN_OUT" 2>/dev/null; then
+    pass "PM1e (MUTATION) — without the installed-framework signal the operator is re-interrogated before anything refuses"
+  else
+    fail_ "PM1e (MUTATION)" "excising the signal changed nothing observable"
+  fi
+fi
+
+# ── PM2 — drop arm 2. THE MUTANT EXITS ZERO. ───────────────────────────────
+PM2="$(newtmp)"
+mkdir -p "$PM2/fw" "$PM2/p"
+if ! mk_mirror "$PM2/fw"; then
+  fail_ "PM2 setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$PM2/fw" "$PF_ARM2_MARK" "  :")" != "1" ]; then
+  fail_ "PM2 setup" "the arm-2 mutation did not apply cleanly"
+elif ! mk_adoptee "$PM2/p"; then
+  fail_ "PM2 setup" "could not build the adoptee"
+else
+  mkdir -p "$PM2/p/.claude/adoption-archive/2026-01-01T00-00-00Z-1234/.claude"
+  printf '{"a":1}\n' > "$PM2/p/.claude/adoption-archive/2026-01-01T00-00-00Z-1234/.claude/settings.json"
+  ( cd "$PM2/p" && git add -A && git commit -q -m "chore: an interrupted first run" ) >/dev/null 2>&1
+  PM2_HASH_BEFORE="$(_tree_hash "$PM2/p")"
+  _ans 1 > "$PM2/answers"
+  run_adopt "$PM2/p" "$PM2/answers" "$REPORT" "$PM2/fw"
+  PM2_HASH_AFTER="$(_tree_hash "$PM2/p")"
+  [ "$PM2_HASH_AFTER" != "$PM2_HASH_BEFORE" ] \
+    && pass "PM2 (MUTATION) — dropping arm 2 lets the run write over a prior archive (rc $RUN_RC, tree changed)" \
+    || fail_ "PM2 (MUTATION)" "dropping arm 2 changed nothing — arm 2 is not load-bearing, or another arm masks it"
+fi
+
+# ── PM3 — drop arm 3. THE MUTANT EXITS ZERO — a completed adoption. ────────
+PM3="$(newtmp)"
+mkdir -p "$PM3/fw" "$PM3/p"
+if ! mk_mirror "$PM3/fw"; then
+  fail_ "PM3 setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$PM3/fw" "$PF_ARM3_MARK" "  :")" != "1" ]; then
+  fail_ "PM3 setup" "the arm-3 mutation did not apply cleanly"
+elif ! mk_adoptee "$PM3/p"; then
+  fail_ "PM3 setup" "could not build the adoptee"
+else
+  mkdir -p "$PM3/p/.claude"
+  printf '{"current_phase":2,"gates":{"phase_0_to_1":"2026-03-02"}}\n' > "$PM3/p/.claude/phase-state.json"
+  printf '{"version":"1.0.0","deployment":"personal"}\n' > "$PM3/p/.claude/manifest.json"
+  ( cd "$PM3/p" && git add -A && git commit -q -m "chore: scaffolded by init.sh" ) >/dev/null 2>&1
+  PM3_PHASE_BEFORE="$(_json_str "$PM3/p/.claude/phase-state.json" '.current_phase')"
+  _ans 1 > "$PM3/answers"
+  run_adopt "$PM3/p" "$PM3/answers" "$REPORT" "$PM3/fw"
+  PM3_RC="$RUN_RC"
+  PM3_PHASE_AFTER="$(_json_str "$PM3/p/.claude/phase-state.json" '.current_phase')"
+  PM3_ADOPTED=0
+  jq -e '.adoption' "$PM3/p/.claude/manifest.json" >/dev/null 2>&1 && PM3_ADOPTED=1
+  if [ "$PM3_PHASE_AFTER" != "$PM3_PHASE_BEFORE" ] && [ "$PM3_ADOPTED" -eq 1 ]; then
+    pass "PM3 (MUTATION) — dropping arm 3 overwrites a greenfield's gate-earned state ($PM3_PHASE_BEFORE -> $PM3_PHASE_AFTER) AND stamps it, at rc $PM3_RC"
+  else
+    fail_ "PM3 (MUTATION)" "dropping arm 3 changed nothing observable (phase $PM3_PHASE_BEFORE -> $PM3_PHASE_AFTER, stamped=$PM3_ADOPTED)"
+  fi
+fi
+
+echo ""
+echo "=== A — A4's APPROVAL_LOG.md (§8.2 step 7, §8.3a-A4) ==="
+
+A0="$(newtmp)"
+A0_OK=0
+_adopted_fixture "$A0" && A0_OK=1
+
+if [ "$A0_OK" -ne 1 ]; then
+  fail_ "A setup" "the resting-state adoption did not complete"
+else
+  [ -f "$A0/p/APPROVAL_LOG.md" ] \
+    && pass "A1 — Act 2 writes APPROVAL_LOG.md" \
+    || fail_ "A1" "APPROVAL_LOG.md is absent from a completed adoption"
+
+  # THE POINT OF A4: the gate must reach a VERDICT instead of dying on the
+  # precondition. Asserted on the absence of that specific refusal AND on the
+  # presence of the gate's own summary, because "no precondition failure" is
+  # trivially true of a gate that never ran.
+  gate_in "$A0/p" --gate phase_0_to_1
+  case "$(cat "$GATE_OUT" 2>/dev/null)" in
+    *"APPROVAL_LOG.md not found but"*)
+      fail_ "A2" "the gate still exits on the missing-approval-log precondition" ;;
+    *)
+      case "$(cat "$GATE_OUT" 2>/dev/null)" in
+        *"Phase Gate Consistency Check"*)
+          pass "A2 — the gate runs to a verdict instead of exiting on the precondition (rc $GATE_RC)" ;;
+        *) fail_ "A2" "the gate produced no consistency-check output at all" ;;
+      esac ;;
+  esac
+
+  # It is COMMITTED, not merely written: the adoption commit is what makes it
+  # survive a fresh clone, and `adopt_stage_and_commit` stages explicitly.
+  if ( cd "$A0/p" && git ls-tree -r --name-only HEAD 2>/dev/null | grep -qx 'APPROVAL_LOG.md' ); then
+    pass "A3 — APPROVAL_LOG.md is in the adoption commit"
+  else
+    fail_ "A3" "APPROVAL_LOG.md was written but never committed"
+  fi
+
+  # A4 forbids a fourth spelling: it must be the tier-matched init.sh
+  # template, rendered. Compared structurally, because __TODAY__ and
+  # __PROJECT_NAME__ legitimately differ from the template's own bytes.
+  #
+  # NOT BY SECTION COUNT — a draft did that and it cannot discriminate:
+  # MEASURED, both templates carry exactly 10 `## ` headers, so a count pins
+  # "some approval log" and says nothing about WHICH. The personal template's
+  # own header line is the discriminator, and A7ctl proves the two differ on it.
+  if grep -qx '## Pre-Phase 0: Pre-Conditions' "$A0/p/APPROVAL_LOG.md" 2>/dev/null; then
+    pass "A4 — the log is the PERSONAL template (its own pre-conditions header)"
+  else
+    fail_ "A4" "the personal template's header is absent — this is not the tier-matched rendered template"
+  fi
+
+  # No placeholder may survive rendering.
+  if grep -q '__TODAY__\|__PROJECT_NAME__' "$A0/p/APPROVAL_LOG.md" 2>/dev/null; then
+    fail_ "A5" "an unrendered placeholder survived into APPROVAL_LOG.md"
+  else
+    pass "A5 — every template placeholder is rendered"
+  fi
+
+  # And it carries NO dated gate-approval row — the adoption approved nothing.
+  gate_in "$A0/p" --gate phase_0_to_1
+  case "$(cat "$GATE_OUT" 2>/dev/null)" in
+    *"gate date not recorded"*)
+      pass "A6 — the rendered log carries no dated gate-approval row (the gate says so)" ;;
+    *) fail_ "A6" "the gate found approval evidence in a log the adoption just wrote" ;;
+  esac
+fi
+
+# ── A7 — the tier match. ───────────────────────────────────────────────────
+# D9's tier answer is the log's only input besides the name. A build that
+# ignores it and always renders one template passes every assertion above.
+A7="$(newtmp)"
+mkdir -p "$A7/p"
+if mk_adoptee "$A7/p"; then
+  _ans 2 > "$A7/answers"        # 2 = organizational
+  run_adopt "$A7/p" "$A7/answers" "$REPORT"
+  if [ "$RUN_RC" -ne 0 ]; then
+    fail_ "A7 setup" "the organizational adoption did not complete (rc $RUN_RC)"
+  else
+    A7_DEPLOY="$(_json_str "$A7/p/.claude/manifest.json" '.deployment')"
+    A7_ORG_H='## Pre-Phase 0: Organizational Pre-Conditions'
+    A7_PER_H='## Pre-Phase 0: Pre-Conditions'
+    # The control: the discriminator must actually separate the two templates,
+    # each appearing in its own and NOT in the other. Without this the two
+    # assertions below could both be true of one file.
+    if grep -qxF "$A7_ORG_H" "$TMPL_ORG" && ! grep -qxF "$A7_ORG_H" "$TMPL_PERSONAL" \
+       && grep -qxF "$A7_PER_H" "$TMPL_PERSONAL" && ! grep -qxF "$A7_PER_H" "$TMPL_ORG"; then
+      pass "A7ctl — the two templates are separated by their pre-conditions header (section COUNT cannot: both are 10)"
+      if [ "$A7_DEPLOY" != "organizational" ]; then
+        fail_ "A7" "answer 2 produced deployment '$A7_DEPLOY', not organizational — the fixture is not exercising the org arm"
+      elif grep -qxF "$A7_ORG_H" "$A7/p/APPROVAL_LOG.md" 2>/dev/null; then
+        pass "A7 — an organizational adoption renders the ORG template"
+      else
+        fail_ "A7" "deployment '$A7_DEPLOY' did not render the org template — the tier is being ignored"
+      fi
+    else
+      fail_ "A7ctl" "the pre-conditions headers do not separate the two templates; this assertion cannot discriminate"
+    fi
+  fi
+else
+  fail_ "A7 setup" "could not build the adoptee"
+fi
+
+echo ""
+echo "=== G — a gitignored APPROVAL_LOG.md must not make a project unadoptable ==="
+
+# MEASURED AS A REGRESSION against `main`: an adoptee whose `.gitignore` lists
+# APPROVAL_LOG.md adopted at rc 0 before this package and, once A4 recorded the
+# log for staging unconditionally, got `[BLOCKED] git will not stage every file
+# this adoption must commit` and NO adoption commit — while the SAME run's
+# archive half printed `your .gitignore covers: APPROVAL_LOG.md`. Two halves,
+# opposite rules, and `docs/adoption.md` publishes the archive's half as a
+# shipped guarantee.
+G1="$(newtmp)"
+mkdir -p "$G1/p"
+if ! mk_adoptee "$G1/p"; then
+  fail_ "G setup" "could not build the adoptee"
+else
+  printf 'APPROVAL_LOG.md\n' > "$G1/p/.gitignore"
+  ( cd "$G1/p" && git add -A && git commit -q -m "chore: we ignore the approval log" ) >/dev/null 2>&1
+  _ans 1 > "$G1/answers"
+  run_adopt "$G1/p" "$G1/answers" "$REPORT"
+  G1_RC="$RUN_RC"
+
+  [ "$G1_RC" -eq 0 ] \
+    && pass "G1 — an adoptee that gitignores APPROVAL_LOG.md still adopts (rc 0)" \
+    || fail_ "G1" "adoption refused (rc $G1_RC) on a project that adopted cleanly before this package"
+
+  if ( cd "$G1/p" && git log --oneline -1 2>/dev/null | grep -q 'adopt' ); then
+    pass "G1b — the adoption commit exists"
+  else
+    fail_ "G1b" "no adoption commit was created"
+  fi
+
+  # On disk (so the gate, which reads the working tree, still works)…
+  [ -f "$G1/p/APPROVAL_LOG.md" ] \
+    && pass "G1c — the log is on disk, so the phase gate still reads it" \
+    || fail_ "G1c" "the log is absent; the adopted project cannot run its own gate"
+  gate_in "$G1/p"
+  case "$(cat "$GATE_OUT" 2>/dev/null)" in
+    *"APPROVAL_LOG.md not found but"*) fail_ "G1d" "the gate died on the precondition despite the log being on disk" ;;
+    *) pass "G1d — the gate runs to a verdict (rc $GATE_RC)" ;;
+  esac
+
+  # …and NOT in the commit, because the operator said so.
+  if ( cd "$G1/p" && git ls-tree -r --name-only HEAD 2>/dev/null | grep -qx 'APPROVAL_LOG.md' ); then
+    fail_ "G1e" "the operator's ignore rule was overridden — APPROVAL_LOG.md is in the commit"
+  else
+    pass "G1e — it is NOT committed, honouring the operator's own .gitignore"
+  fi
+
+  # And the withholding is DISCLOSED, not silent.
+  if grep -q 'APPROVAL_LOG.md' "$RUN_OUT" 2>/dev/null && grep -q 'stays out of the commit' "$RUN_OUT" 2>/dev/null; then
+    pass "G1f — the run says so, by name"
+  else
+    fail_ "G1f" "the log was withheld from the commit and the operator was never told"
+  fi
+fi
+
+echo ""
+echo "=== AM — A4's mutation proofs (two arms, two fixtures) ==="
+
+AL_WRITE_MARK="# BL-242-APPROVAL-LOG-WRITE"
+AL_FIRST_MARK="# BL-242-APPROVAL-LOG-FIRST"
+
+for m in "$AL_WRITE_MARK" "$AL_FIRST_MARK"; do
+  n="$(_sites "$L_STATE" "$m")"
+  [ "$n" = "1" ] \
+    && pass "AM-anchor — '$m' occurs exactly once at end-of-line in adopt-state.sh" \
+    || fail_ "AM-anchor" "'$m' occurs $n times (need exactly 1)"
+done
+
+# ── AM1 — drop the write. The gate must go back to dying on the precondition.
+AM1="$(newtmp)"
+mkdir -p "$AM1/fw"
+if ! mk_mirror "$AM1/fw"; then
+  fail_ "AM1 setup" "could not mirror the framework"
+elif [ "$(_mutate_state "$AM1/fw" "$AL_WRITE_MARK" "      approval_log) : ;;")" != "1" ]; then
+  fail_ "AM1 setup" "the approval-log-write mutation did not apply cleanly"
+else
+  mkdir -p "$AM1/p"
+  if ! mk_adoptee "$AM1/p"; then
+    fail_ "AM1 setup" "could not build the adoptee"
+  else
+    _ans 1 > "$AM1/answers"
+    run_adopt "$AM1/p" "$AM1/answers" "$REPORT" "$AM1/fw"
+    gate_in "$AM1/p" --gate phase_0_to_1
+    case "$(cat "$GATE_OUT" 2>/dev/null)" in
+      *"APPROVAL_LOG.md not found but"*)
+        pass "AM1 (MUTATION) — dropping the write returns the gate to its precondition death (rc $GATE_RC)" ;;
+      *) fail_ "AM1 (MUTATION)" "dropping the approval-log write changed nothing the gate can see" ;;
+    esac
+  fi
+fi
+
+# ── AM2 — THE CONVERSE, and it needs a DIFFERENT fixture. ──────────────────
+# On the resting fixture `--gate phase_0_to_1` blocks for THREE independent
+# reasons (measured: gate date unrecorded, PRODUCT_MANIFESTO.md absent, and
+# the docs/phase-0 trio absent), so removing one leaves it blocked and "the
+# gate passes a boundary nobody approved" is UNREACHABLE there. This fixture
+# satisfies the other two so the approval is the only thing left.
+#
+# Two constraints the design names and this honours: the gate AUTO-RECORDS a
+# seeded date into phase-state, so each arm gets a FRESH tree; and a malformed
+# row adds issues rather than passing, so the seeded row is well-formed.
+_a4_converse_fixture() {   # <dir> — an adopted tree, phase-0-complete except approval
+  local w="$1"
+  _adopted_fixture "$w" || return 1
+  mkdir -p "$w/p/docs/phase-0" || return 1
+  printf '# Functional Requirements\n\nWhat it must do.\n' > "$w/p/docs/phase-0/frd.md"
+  printf '# User Journey\n\nHow they get through it.\n'   > "$w/p/docs/phase-0/user-journey.md"
+  printf '# Data Contract\n\nWhat is stored and why.\n'   > "$w/p/docs/phase-0/data-contract.md"
+  # THE SHAPE IS THE GATE'S, NOT A GUESS. check-phase-gate.sh requires eight
+  # sections spelled `## <n>.` AND rejects any whose body filters down to
+  # nothing after it strips headings, rules, blanks, comments, links and table
+  # rows — so each body here is an ordinary prose line. A draft used descriptive
+  # headings ("## The Problem") and the gate reported all eight missing, which
+  # left AM2ctl at 2 issues and AM2 unreachable.
+  {
+    printf '# Product Manifesto\n\n'
+    _i=1
+    for _s in "The Problem" "Who It Is For" "What It Does" "What It Does Not Do" \
+              "Why Now" "How We Know It Works" "Constraints" "Open Questions"; do
+      printf '## %s. %s\n\nA real paragraph about %s, long enough that the gate reads it as prose rather than a placeholder.\n\n' "$_i" "$_s" "$_s"
+      _i=$((_i + 1))
+    done
+  } > "$w/p/PRODUCT_MANIFESTO.md"
+  return 0
+}
+
+AM2="$(newtmp)"
+if ! _a4_converse_fixture "$AM2"; then
+  fail_ "AM2 setup" "could not build the phase-0-complete-except-approval fixture"
+else
+  gate_in "$AM2/p" --gate phase_0_to_1
+  AM2_ISSUES="$(grep -o '[0-9][0-9]* inconsistency' "$GATE_OUT" 2>/dev/null | head -1 | awk '{print $1}')"
+  AM2_ISSUES="$(_num "$AM2_ISSUES")"
+  if [ "$GATE_RC" -ne 0 ] && [ "$AM2_ISSUES" = "1" ]; then
+    pass "AM2ctl — the converse fixture blocks with EXACTLY 1 issue (the missing approval), so the mutation below is reachable"
+  else
+    fail_ "AM2ctl" "the converse fixture blocks with $AM2_ISSUES issue(s) at rc $GATE_RC — removing one would leave it blocked and AM2 could never go RED"
+    sed -n '1,20p' "$GATE_OUT" 2>/dev/null | sed 's/^/        /'
+  fi
+fi
+
+# The mutation: seed a well-formed dated gate-approval row into the log the
+# adoption wrote. A FRESH tree, because the gate above auto-records dates.
+AM2B="$(newtmp)"
+if ! _a4_converse_fixture "$AM2B"; then
+  fail_ "AM2 setup (fresh tree)" "could not rebuild the converse fixture"
+else
+  awk '
+    /^## Phase Gate: Phase 0 . Phase 1/ {
+      print
+      print ""
+      print "| Field | Value |"
+      print "|---|---|"
+      print "| Date | 2026-05-04 |"
+      print "| Approver | The operator |"
+      print "| Decision | Approved |"
+      next
+    }
+    { print }
+  ' "$AM2B/p/APPROVAL_LOG.md" > "$AM2B/log.new" 2>/dev/null && mv "$AM2B/log.new" "$AM2B/p/APPROVAL_LOG.md"
+  gate_in "$AM2B/p" --gate phase_0_to_1
+  [ "$GATE_RC" -eq 0 ] \
+    && pass "AM2 (MUTATION) — seeding a dated approval row makes the gate PASS (rc 0): the rendered log is what withholds approval" \
+    || fail_ "AM2 (MUTATION)" "the gate still blocked (rc $GATE_RC) with a well-formed dated row seeded — the assertion above is not measuring the approval"
+fi
+
+# ── AM3 — the ORDER: the log is written FIRST in step 7. ───────────────────
+# §8.2's constraint, and it is not cosmetic. Written last, every mid-step-7
+# death leaves phase-state-present/log-absent — the gate's hard refusal. A
+# log alone is inert (with no phase-state the gate exits 0), so first is the
+# only safe order. Proven by halting the run between stages.
+AM3="$(newtmp)"
+mkdir -p "$AM3/p"
+if ! mk_adoptee "$AM3/p"; then
+  fail_ "AM3 setup" "could not build the adoptee"
+else
+  _ans 1 > "$AM3/answers"
+  RUN_RC=0
+  RUN_OUT="$AM3/run-out"; RUN_ERR="$AM3/run-err"
+  ( cd "$AM3/p" && SOIF_ADOPT_HALT_AFTER=phase_state \
+      bash "$REPO_ROOT/scripts/adopt-project.sh" --scan-report "$REPORT" ) \
+    < "$AM3/answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+  if [ -f "$AM3/p/.claude/phase-state.json" ] && [ -f "$AM3/p/APPROVAL_LOG.md" ]; then
+    pass "AM3 — halted right after the phase_state stage, the log is ALREADY on disk (written first)"
+  elif [ -f "$AM3/p/.claude/phase-state.json" ]; then
+    fail_ "AM3" "phase-state exists and APPROVAL_LOG.md does not — exactly the state the gate hard-refuses"
+  else
+    fail_ "AM3 setup" "the halt did not reach the phase_state stage (rc $RUN_RC)"
+  fi
+fi
+
+# ── W7 — the disposition mutant. ───────────────────────────────────────────
+# Review reverted this field to `kept` and every suite in the repository stayed
+# green, because nothing read it. That is this package's own stated doctrine
+# failing on its own line: a fix with no mutant is a fix that leaves by
+# accident.
+W7="$(newtmp)"
+mkdir -p "$W7/fw" "$W7/p"
+W7_MARK="# BL-242-ARCHIVE-DISPO"
+w7_sites="$(_sites "$LIB_DIR/adopt-archive.sh" "$W7_MARK")"
+[ "$w7_sites" = "1" ] \
+  && pass "W7-anchor — '$W7_MARK' occurs exactly once at end-of-line in adopt-archive.sh" \
+  || fail_ "W7-anchor" "'$W7_MARK' occurs $w7_sites times (need exactly 1)"
+
+if ! mk_mirror "$W7/fw"; then
+  fail_ "W7 setup" "could not mirror the framework"
+elif [ "$(_mutate_lib "$W7/fw" "adopt-archive.sh" "$W7_MARK" "      APPROVAL_LOG.md)       dispo=\"kept\" ;;")" != "1" ]; then
+  fail_ "W7 setup" "the disposition mutation did not apply cleanly"
+elif ! mk_adoptee "$W7/p"; then
+  fail_ "W7 setup" "could not build the adoptee"
+else
+  printf '# OUR APPROVAL LOG\n\nSOX sign-off.\n' > "$W7/p/APPROVAL_LOG.md"
+  _ans 1 > "$W7/answers"
+  run_adopt "$W7/p" "$W7/answers" "$REPORT" "$W7/fw"
+  W7_ARC="$(cd "$W7/p" && ls -d .claude/adoption-archive/*/ 2>/dev/null | head -1)"; W7_ARC="${W7_ARC%/}"
+  W7_DISPO="$(jq -r '[.entries[]|select(.originalPath=="APPROVAL_LOG.md")|.disposition]|first // ""' \
+    "$W7/p/$W7_ARC/MANIFEST.json" 2>/dev/null)"
+  [ "$W7_DISPO" = "kept" ] \
+    && pass "W7 (MUTATION) — reverting the arm records disposition='kept' for a file that WAS replaced: W6 is what holds it" \
+    || fail_ "W7 (MUTATION)" "the mutant produced disposition='$W7_DISPO'; the mutation is not discriminating"
+fi
+
+echo ""
+echo "=== N — a directory name is untrusted input (it reaches the file the gate parses) ==="
+
+# APPROVAL_LOG.md is what `check-phase-gate.sh` reads for approval evidence, and
+# A4 renders the project's DIRECTORY BASENAME into it. A name carrying a line
+# break injects LINES into that document — and `_cpg_gate_has_evidence` needs
+# exactly two: a `## ` header and a `| Date | YYYY-MM-DD |` row. So a folder
+# name can forge approval evidence nobody recorded, which
+# `_cpg_record_gate_date` then synthesises into phase-state.json against its own
+# stated rule. A comment in the driver CLAIMED this already refused; it did not,
+# and what looked like a refusal was an unrelated death further in reporting
+# `the scan report classifies '' as ''`.
+N1="$(newtmp)"
+N1_NAME="$(printf 'proj\n## Phase Gate: Phase 0 . Phase 1\n| Date | 2026-01-01 |\ntail')"
+mkdir -p "$N1/holder"
+if ! mk_adoptee "$N1/holder/$N1_NAME" 2>/dev/null; then
+  fail_ "N setup" "could not create an adoptee whose directory name carries a line break"
+else
+  N1_P="$N1/holder/$N1_NAME"
+  N1_BEFORE="$( ( cd "$N1_P" && find . -path ./.git -prune -o -type f -print 2>/dev/null | wc -l | tr -d ' ' ) )"
+  _ans 1 > "$N1/answers"
+  run_adopt "$N1_P" "$N1/answers" "$REPORT"
+  N1_RC="$RUN_RC"
+  N1_AFTER="$( ( cd "$N1_P" && find . -path ./.git -prune -o -type f -print 2>/dev/null | wc -l | tr -d ' ' ) )"
+
+  [ "$N1_RC" -ne 0 ] \
+    && pass "N1 — a directory name containing a line break REFUSES (rc $N1_RC)" \
+    || fail_ "N1" "adoption proceeded on a name that can forge approval evidence"
+
+  # Asserted on the REFUSAL'S OWN CAUSE, because an unrelated later death also
+  # produces a non-zero exit — which is exactly what made the false claim
+  # survivable. This must be the name check, at step 0.
+  if grep -q "directory name cannot be used" "$RUN_ERR" 2>/dev/null; then
+    pass "N1b — it refuses for THAT reason (the name check), not incidentally"
+  else
+    fail_ "N1b" "the run refused for some other reason; the name check did not fire"
+  fi
+
+  [ "$N1_AFTER" = "$N1_BEFORE" ] \
+    && pass "N1c — nothing was written ($N1_AFTER files, unchanged)" \
+    || fail_ "N1c" "files were written before the refusal: $N1_BEFORE -> $N1_AFTER"
+
+  [ ! -f "$N1_P/APPROVAL_LOG.md" ] \
+    && pass "N1d — no APPROVAL_LOG.md exists, so no forged approval row can reach the gate" \
+    || fail_ "N1d" "an APPROVAL_LOG.md was written from a line-break-bearing name"
+fi
+
+# R-5 — THE CARRIAGE-RETURN HALF, PINNED SEPARATELY. The refusal text claims
+# both ("line break or carriage return") and N1's fixture carries only `\n`, so
+# narrowing `tr -d '\n\r'` to `tr -d '\n'` left half the predicate unproven and
+# survived the whole suite. CLAUDE.md records that exactly this class of
+# one-character narrowing re-opened BL-181 three times, passing both
+# PR-blocking checks each time. Measured honestly: a lone CR is NOT a record
+# separator for this host's grep/awk, so a CR-only name cannot forge evidence
+# by itself — this pins the predicate's stated width, not an exploit.
+N1R="$(newtmp)"
+N1R_NAME="$(printf 'projX\rtail')"
+mkdir -p "$N1R/holder"
+if ! mk_adoptee "$N1R/holder/$N1R_NAME" 2>/dev/null; then
+  fail_ "N1r setup" "could not create an adoptee whose name carries a carriage return"
+else
+  _ans 1 > "$N1R/answers"
+  run_adopt "$N1R/holder/$N1R_NAME" "$N1R/answers" "$REPORT"
+  if [ "$RUN_RC" -ne 0 ] && grep -q "directory name cannot be used" "$RUN_ERR" 2>/dev/null; then
+    pass "N1r — a carriage-return name refuses for the name check's own reason too"
+  else
+    fail_ "N1r" "rc=$RUN_RC and the name check did not fire — the predicate is narrower than its message claims"
+  fi
+fi
+
+# The control: an ORDINARY name must still adopt. A validator that refuses
+# everything would pass every assertion above.
+N2="$(newtmp)"
+mkdir -p "$N2/p"
+if mk_adoptee "$N2/p"; then
+  _ans 1 > "$N2/answers"
+  run_adopt "$N2/p" "$N2/answers" "$REPORT"
+  [ "$RUN_RC" -eq 0 ] \
+    && pass "N2ctl — an ordinary directory name still adopts (rc 0): the check refuses the shape, not every name" \
+    || fail_ "N2ctl" "an ordinary name was refused (rc $RUN_RC) — the validator is too broad"
+else
+  fail_ "N2ctl setup" "could not build the adoptee"
+fi
+
+echo ""
+echo "=== I — arm 2 tells each population the truth, driven by REAL adoptions ==="
+
+# Round 2 refuted arm 2's remediation twice: first the advice was flatly wrong
+# for anyone whose run died after the install, then the "derivation" that fixed
+# it tested `scripts/lib/adopt/` — a path the install NEVER creates (0 of its 68
+# entries), so only the wrong branch could ever print. BOTH fixtures below are
+# built by RUNNING ADOPTION and interrupting it, never by hand-creating the
+# directory the predicate reads; a hand-built shape is what let the second
+# defect through.
+I1="$(newtmp)"
+mkdir -p "$I1/p"
+I1_OK=0
+if mk_adoptee "$I1/p"; then
+  # A COLLIDING FILE IS REQUIRED, and this is not fixture decoration: the
+  # archive directory only materialises when there is something to archive, so
+  # without one the interrupted run leaves no prior archive and arm 2 never
+  # fires. The first draft omitted it and the setup assertion caught it.
+  mkdir -p "$I1/p/.claude"
+  printf '{"theirs":1}\n' > "$I1/p/.claude/settings.json"
+  ( cd "$I1/p" && git add -A && git commit -q -m "chore: their settings" ) >/dev/null 2>&1
+  _ans 1 > "$I1/answers"
+  RUN_RC=0
+  ( cd "$I1/p" && SOIF_ADOPT_HALT_AFTER=install \
+      bash "$REPO_ROOT/scripts/adopt-project.sh" --scan-report "$REPORT" ) \
+    < "$I1/answers" > "$I1/out1" 2> "$I1/err1" || RUN_RC=$?
+  # A real interrupted run: the framework is installed and an archive exists.
+  [ -d "$I1/p/.claude/adoption-archive" ] && [ -f "$I1/p/scripts/check-phase-gate.sh" ] && I1_OK=1
+fi
+
+if [ "$I1_OK" -ne 1 ]; then
+  fail_ "I1 setup" "the halt-after-install run did not leave an archive AND an installed framework"
+else
+  pass "I1ctl — a REAL interrupted adoption left both an archive and an installed framework"
+  run_adopt "$I1/p" "$I1/answers" "$REPORT"
+  if grep -q 'ALREADY INSTALLED' "$RUN_OUT" 2>/dev/null && grep -q 'scripts/resume.sh' "$RUN_OUT" 2>/dev/null; then
+    pass "I1 — it tells the post-install population the truth (already installed; resume.sh)"
+  else
+    fail_ "I1" "the post-install population got the wrong branch — the predicate did not fire"
+  fi
+  if grep -q 'Move or' "$RUN_OUT" 2>/dev/null; then
+    fail_ "I1b" "it ALSO printed the move-it-aside advice, which strands this population"
+  else
+    pass "I1b — it does NOT tell them to move the archive aside and retry"
+  fi
+fi
+
+# The other population: a run that died BEFORE the install. Built from the same
+# real adoption by removing what the install wrote — never by hand-crafting.
+I2="$(newtmp)"
+mkdir -p "$I2/p"
+if ! mk_adoptee "$I2/p"; then
+  fail_ "I2 setup" "could not build the adoptee"
+else
+  mkdir -p "$I2/p/.claude"
+  printf '{"theirs":1}\n' > "$I2/p/.claude/settings.json"
+  ( cd "$I2/p" && git add -A && git commit -q -m "chore: their settings" ) >/dev/null 2>&1
+  _ans 1 > "$I2/answers"
+  RUN_RC=0
+  ( cd "$I2/p" && SOIF_ADOPT_HALT_AFTER=install \
+      bash "$REPO_ROOT/scripts/adopt-project.sh" --scan-report "$REPORT" ) \
+    < "$I2/answers" > "$I2/out1" 2> "$I2/err1" || RUN_RC=$?
+  rm -rf "$I2/p/scripts"
+  if [ -d "$I2/p/.claude/adoption-archive" ] && [ ! -f "$I2/p/scripts/check-phase-gate.sh" ]; then
+    pass "I2ctl — the pre-install population: an archive, no installed framework"
+    run_adopt "$I2/p" "$I2/answers" "$REPORT"
+    if grep -q 'not installed yet' "$RUN_OUT" 2>/dev/null && grep -q 'Move or' "$RUN_OUT" 2>/dev/null; then
+      pass "I2 — it tells the pre-install population the truth (not installed; move it aside)"
+    else
+      fail_ "I2" "the pre-install population got the wrong branch"
+    fi
+  else
+    fail_ "I2ctl" "could not produce a pre-install interrupted tree"
+  fi
+fi
+
+echo ""
+echo "=== TM — the two fixes that shipped with no proof at all ==="
+
+# Both of these SURVIVED the whole PR-blocking suite when review excised them,
+# which is round 1's R-2 finding recurring on two more lines. A fix with no
+# mutant is a fix that leaves by accident.
+
+TPL_MARK="# BL-242-PREFLIGHT-TEMPLATES"
+EMPTY_MARK="# BL-242-APPROVAL-LOG-NONEMPTY"
+for m in "$TPL_MARK" "$EMPTY_MARK"; do
+  n="$(_sites "$L_STATE" "$m")"
+  [ "$n" = "1" ] \
+    && pass "TM-anchor — '$m' occurs exactly once at end-of-line" \
+    || fail_ "TM-anchor" "'$m' occurs $n times (need exactly 1)"
+done
+
+# TM1 — the step-0 template check. Shipped: refuse with NOTHING written.
+# Mutated: the run gets all the way to the state loop and dies with files on
+# disk, which is the failure the check was added to move earlier.
+_files_written() { ( cd "$1" 2>/dev/null && find . -path ./.git -prune -o -type f -print 2>/dev/null | wc -l | tr -d ' ' ); }
+
+TM1="$(newtmp)"
+mkdir -p "$TM1/fw" "$TM1/p" "$TM1/pm"
+if ! mk_mirror "$TM1/fw" || ! mk_adoptee "$TM1/p" || ! mk_adoptee "$TM1/pm"; then
+  fail_ "TM1 setup" "could not build the mirror or the adoptees"
+else
+  rm -rf "$TM1/fw/templates/generated/approval-log-personal.tmpl"
+  TM1_BEFORE="$(_files_written "$TM1/p")"
+  _ans 1 > "$TM1/answers"
+  run_adopt "$TM1/p" "$TM1/answers" "$REPORT" "$TM1/fw"
+  TM1_RC="$RUN_RC"; TM1_AFTER="$(_files_written "$TM1/p")"
+  if [ "$TM1_RC" -ne 0 ] && [ "$TM1_AFTER" = "$TM1_BEFORE" ]; then
+    pass "TM1 — a checkout missing a template refuses at step 0 with NOTHING written ($TM1_AFTER files, unchanged)"
+  else
+    fail_ "TM1" "rc=$TM1_RC files $TM1_BEFORE -> $TM1_AFTER (want a refusal with no writes)"
+  fi
+
+  # The mutant: same broken mirror, check excised.
+  if [ "$(_mutate_state "$TM1/fw" "$TPL_MARK" "  :")" != "1" ]; then
+    fail_ "TM1b setup" "the template-check mutation did not apply cleanly"
+  else
+    TM1B_BEFORE="$(_files_written "$TM1/pm")"
+    run_adopt "$TM1/pm" "$TM1/answers" "$REPORT" "$TM1/fw"
+    TM1B_AFTER="$(_files_written "$TM1/pm")"
+    [ "$TM1B_AFTER" -gt "$TM1B_BEFORE" ] \
+      && pass "TM1b (MUTATION) — without the step-0 check the same run writes $((TM1B_AFTER - TM1B_BEFORE)) files before failing" \
+      || fail_ "TM1b (MUTATION)" "excising the check changed nothing observable"
+  fi
+fi
+
+# TM2 — the rendered-empty guard, with a ZERO-BYTE template. `-s` at step 0 is
+# what should catch this; the guard is the second line of defence and both are
+# asserted, because a zero-byte template that reaches the writer produces a
+# one-byte APPROVAL_LOG.md committed as the project's approval record at rc 0.
+TM2="$(newtmp)"
+mkdir -p "$TM2/fw" "$TM2/p" "$TM2/pm"
+if ! mk_mirror "$TM2/fw" || ! mk_adoptee "$TM2/p" || ! mk_adoptee "$TM2/pm"; then
+  fail_ "TM2 setup" "could not build the mirror or the adoptees"
+else
+  : > "$TM2/fw/templates/generated/approval-log-personal.tmpl"
+  TM2_BEFORE="$(_files_written "$TM2/p")"
+  _ans 1 > "$TM2/answers"
+  run_adopt "$TM2/p" "$TM2/answers" "$REPORT" "$TM2/fw"
+  TM2_RC="$RUN_RC"; TM2_AFTER="$(_files_written "$TM2/p")"
+  if [ "$TM2_RC" -ne 0 ] && [ "$TM2_AFTER" = "$TM2_BEFORE" ]; then
+    pass "TM2 — a ZERO-BYTE template is caught at step 0 too (rc $TM2_RC, nothing written): the check is -s, not -f"
+  else
+    fail_ "TM2" "rc=$TM2_RC files $TM2_BEFORE -> $TM2_AFTER — a zero-byte template got past step 0"
+  fi
+
+  # Mutate the step-0 check away so the writer's own guard is what is under
+  # test, then mutate THAT away too and watch a 1-byte log get committed.
+  if [ "$(_mutate_state "$TM2/fw" "$TPL_MARK" "  :")" != "1" ]; then
+    fail_ "TM2b setup" "could not excise the step-0 check"
+  else
+    run_adopt "$TM2/pm" "$TM2/answers" "$REPORT" "$TM2/fw"
+    TM2B_RC="$RUN_RC"
+    if [ "$TM2B_RC" -ne 0 ] && [ ! -s "$TM2/pm/APPROVAL_LOG.md" ]; then
+      pass "TM2b — with step 0 gone the writer's own emptiness guard still refuses (rc $TM2B_RC)"
+    else
+      fail_ "TM2b" "rc=$TM2B_RC and APPROVAL_LOG.md is $(wc -c < "$TM2/pm/APPROVAL_LOG.md" 2>/dev/null | tr -d ' ') bytes"
+    fi
+
+    TM2C="$(newtmp)"; mkdir -p "$TM2C/p"
+    if [ "$(_mutate_state "$TM2/fw" "$EMPTY_MARK" "    *) : ;;")" != "1" ]; then
+      fail_ "TM2c setup" "the emptiness-guard mutation did not apply cleanly"
+    elif ! mk_adoptee "$TM2C/p"; then
+      fail_ "TM2c setup" "could not build the adoptee"
+    else
+      run_adopt "$TM2C/p" "$TM2/answers" "$REPORT" "$TM2/fw"
+      TM2C_RC="$RUN_RC"
+      TM2C_BYTES="$(wc -c < "$TM2C/p/APPROVAL_LOG.md" 2>/dev/null | tr -d ' ')"
+      TM2C_BYTES="$(_num "$TM2C_BYTES")"
+      if [ "$TM2C_RC" -eq 0 ] && [ "$TM2C_BYTES" -le 1 ]; then
+        pass "TM2c (MUTATION) — with BOTH guards gone a $TM2C_BYTES-byte APPROVAL_LOG.md is written at rc 0: the guards are what stop it"
+      else
+        fail_ "TM2c (MUTATION)" "rc=$TM2C_RC bytes=$TM2C_BYTES — the mutation produced no silent success"
+      fi
+    fi
+  fi
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 0
+fi
+echo "Results: $PASSED passed, $FAILED failed"
+exit 1


### PR DESCRIPTION
**WP9b of the brownfield-adoption v2 design** — A1's three-arm re-adoption preflight and A4's `APPROVAL_LOG.md`. Spec: `docs/designs/2026-08-23-brownfield-adoption-v2.md` §8.2 step 0, §8.2 step 7, §8.3a-A1, §8.3a-A4, §10-WP9.

## The two dogfood blockers, closed by measurement

**Adoption silently corrupted a framework-managed project.** Pointed at a scaffolded greenfield tree it archived the scaffold's own framework files as the operator's, overwrote gate-earned state, stamped it and committed, at **exit 0**. Shipped v1 refused that tree through `adopt_install_framework`'s `n_copied -eq 0` tripwire, which D1's framework-wins install unreaches. Now:

```
rc=1  [REFUSED] this project already looks framework-managed:
                .claude/phase-state.json is present
                Adoption did not begin. Nothing was committed and nothing was written.
phase now : 2  (was 2)     gate dates : both intact
stamped   : no             HEAD moved : NO
```

**An adopted project could not run its own phase gate** — it exited on `[FAIL] APPROVAL_LOG.md not found but .claude/phase-state.json exists.`, six lines before `current_phase` was parsed. Now: `adopt rc=0`, then `Current phase: 0` / `Adoption stamp present and intact` / **`Phase gates consistent.`** at rc 0, with `APPROVAL_LOG.md` in the adoption commit.

## Review

**Eleven adversarial rounds**, per the standing pre-PR gate. The verdict recorded against `45a749b` is **approve**.

Rounds 1–5 refuted defects in shipped behaviour:

| round | refuted |
|---|---|
| 1 | the Boundary named `_adopt_record_if_stageable` — the one function you can safely delete — instead of `_adopt_original_is_ignored` |
| 2 | "three withholding reasons"; a transcript line citing outside the block it claimed to be inside |
| 3 | the scope key `stagedForCommit == false` cannot reach the MANIFESTs |
| 4 | the replacement key went silent on an adoptee whose own `pre-commit` exits 1; the Proof list was mutually unsatisfiable |
| 5 | "on any refusal path it is the whole archive" — `adopt_install_hooks` refuses *after* the commit lands |

Two findings from that stretch are worth naming in full:

- **An approval record forgeable from a directory name.** A4 renders `${root##*/}` into `APPROVAL_LOG.md`, which `check-phase-gate.sh` parses for approval evidence, and nothing validated it. A folder named to carry a `## ` header and a `| Date | YYYY-MM-DD |` row made the gate find approval nobody recorded — and `_cpg_record_gate_date` then synthesised that date into `phase-state.json`, against its own rule that *"a project with no dated approval entry must NEVER get a date synthesized."* Closed by `_adopt_preflight_project_name` at step 0.
- **An operator's own `APPROVAL_LOG.md` destroyed at rc 0**, in a run that printed *"Nothing was deleted."* §7.1's rule is not "AI surfaces are archived" but *every archive-and-replace surface produces a row* — A4 added a replace without the row. `APPROVAL_LOG.md` is now an archive class (`approval-log`, `disposition: "replaced"`) with a restore line and a disclosure.

Rounds 6–8 found **no behavioural defect** under 13+ attack vectors each; every finding was a statement the branch falsified and did not re-derive. Round 9 refuted nothing. Round 10 returned `minor_concerns` on two wrong cross-references, both fixed. Round 11 verified those two by mutation and approved.

## Proofs

103 assertions, 11 code mutants — derive, never quote: `grep -c '_mutate_state "\|_mutate_lib "'`. Every mutant watched RED first; the suite ran **6 passed / 27 failed** against the unmodified tree.

Two arms have mutants that **exit zero** — dropping preflight arm 2 or arm 3 completes an adoption over a tree that must be refused — so neither assertion keys on an exit code; they read a tree hash that includes untracked files, because a hash over `git ls-files` would miss all ~68 installed files.

## Checks

- `bash scripts/run-lints.sh` → `run-lints: 15 lints — 15 passed, 0 failed`
- 9 adoption suites green: wp1, wp3-arms, wp4, wp5b, wp6, bl225, wp9a, wp9b, doc-foundations
- Registered in both lanes (`tests.yml` `unit-shard` + `full-project-test-suite.sh`)

## Recorded, not fixed

`adopt_write_file` follows a **symlink**, so an adoptee whose `APPROVAL_LOG.md` points outside the repository has that outside file rewritten at rc 0. Content is archived and recoverable. It is a property of every state writer and predates this package — filed on `## BL-242:` rather than special-cased at the newest writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk
