### PR TITLE
feat(bl-242): WP10a — the tool matrix ships a URL where a command is expected

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -519,6 +519,7 @@ jobs:
             tests/test-bl225-staging-preflight.sh
             tests/test-brownfield-wp9-act-boundaries.sh
             tests/test-brownfield-wp9b-preflight-approval.sh
+            tests/test-brownfield-wp10a-tool-resolution.sh
             tests/test-bl233-mcp-outcome-enforcement.sh
             tests/test-bl233-wpb-accumulation.sh
             tests/test-pr-review-gate.sh
@@ -667,6 +668,45 @@ jobs:
             #    NOTE FOR THE NEXT RE-PIN: `slow-misc` at 79% is now the closest
             #    to the cap, not `rest`.
             tests/test-bl235-tool-matrix-probes.sh       # leg measured 245s/720s (34%) with this suite in it — run 32046301464
+            # ── Re-pinned 2026-09-02, and this is the case the note in
+            #    `pin_slow_misc` said could not arise. `rest` was described as
+            #    having NO POLE TO MOVE — "158 suites whose largest is 40s,
+            #    flat, ~3.3s mean". THE BROWNFIELD ADOPTION SUITES BUILT THAT
+            #    POLE: each of their cases runs a whole adoption, so they are
+            #    tens of times the complement's mean. Measured on run
+            #    33657275895 (PR #373), where `rest` was CANCELLED at 733s
+            #    against the 720s cap with every suite in it PASSING — the cap
+            #    fired, nothing failed, which is this file's own RE-PIN signal
+            #    rather than a reason to raise it.
+            #
+            #    Same run's legs, which is why they land here and not elsewhere:
+            #      lint-scan   245s (34%)  <- this leg, the most headroom
+            #      slow-misc   382s (53%)
+            #      lint-sweep  397s (55%)
+            #      sast        488s (68%)
+            #      rest        733s        <- CANCELLED
+            #
+            #    Measured locally, and the disparity is the whole argument:
+            #      wp9b  334s   <- 8x the complement's previous largest member
+            #      wp9a   99s
+            #      wp10a  30s
+            #    `wp9b` alone is the pole; `wp10a` follows it because a suite
+            #    that drives full adoptions does not belong in a leg whose mean
+            #    is ~3.3s.
+            #
+            #    WHY NOT `slow-misc`, WHERE THE OTHER BROWNFIELD SUITES LIVE.
+            #    That is the family-coherence choice and it was rejected on the
+            #    doctrine: `pin_slow_misc` already carries wp5b and wp6, and
+            #    adding ~194s would take that leg to ~576s (80%) — the band its
+            #    own note calls "the leg to watch". `lint-scan` lands at ~439s
+            #    (61%) and `rest` falls to ~539s (75%), so no leg becomes the
+            #    next re-pin. Keeping a family together is worth less than not
+            #    creating the same problem one shard over. *(A draft of this
+            #    comment said wp10a belongs "beside its sibling" — it does not:
+            #    its siblings are in `slow-misc`, which is the leg this pin
+            #    deliberately avoids.)*
+            tests/test-brownfield-wp9b-preflight-approval.sh   # 334s local / ~174s on the runner — THE pole
+            tests/test-brownfield-wp10a-tool-resolution.sh     #  30s local / ~20s on the runner
             #    The BL-221 suite that landed alongside this one is NOT pinned
             #    and is deliberately not named as a path here: it measures under
             #    a second, pinning it would buy nothing, and a commented path

--- a/scripts/adopt-project.sh
+++ b/scripts/adopt-project.sh
@@ -137,7 +137,7 @@ done
 # THE GUARD, BEFORE ARGUMENT PARSING — see the header. Sibling posture, kept.
 guard_not_in_framework || exit 1
 
-for _part in adopt-core adopt-evidence adopt-intake adopt-state adopt-archive adopt-stubs adopt-test-debt; do
+for _part in adopt-core adopt-evidence adopt-intake adopt-tools adopt-state adopt-archive adopt-stubs adopt-test-debt; do
   if [ ! -f "$ADOPT_LIB_DIR/$_part.sh" ]; then
     echo "adopt-project: missing $ADOPT_LIB_DIR/$_part.sh — the driver needs its own lib directory." >&2
     exit 2

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -1072,6 +1072,19 @@ adopt_main() {
   # the host.
   adopt_ask_audience || return 1   # BL-242-TIER-QUESTION
 
+  # §8.2 STEP 2 — TOOL RESOLUTION, AND ITS POSITION IS THE CONSTRAINT.
+  # BEFORE the secrets check that reads its result (§6.2) and BEFORE any
+  # writer, so a run abandoned here has changed the repository not at all and
+  # the host only if the operator said yes. AFTER the tier question, because
+  # that is step 1 and a run abandoned at the only question adoption asks
+  # should not have installed anything first.
+  adopt_resolve_tools "$root" "$report" || return 1   # BL-242-RESOLVER-CALL
+  # §6.2: if the step re-scanned, every later step reads the REFRESHED report —
+  # including the state writer that persists it and the stamp that records its
+  # hash, so "the persisted copy reflects what was actually acted on" is true
+  # by construction rather than by a second write.
+  [ -n "${ADOPT_REPORT_REFRESHED:-}" ] && report="$ADOPT_REPORT_REFRESHED"   # BL-242-RESOLVER-REFRESH
+
   adopt_run_reverse_intake "$report" || return 1
 
   adopt_stub_secrets_disposition "$report"

--- a/scripts/lib/adopt/adopt-tools.sh
+++ b/scripts/lib/adopt/adopt-tools.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# scripts/lib/adopt/adopt-tools.sh — Act 2's SECOND step: tool resolution, and
+# the §6.2 re-scan it makes possible.
+#
+# SPEC: docs/designs/2026-08-23-brownfield-adoption-v2.md §6.2 (tool resolution
+# makes the scanner guaranteed), §8.2 step 2 (its position), §10-WP10.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# WHAT THIS FILE IS FOR, IN ONE SENTENCE. Scout may have run before gitleaks
+# was installed, so the report Act 2 consumes can say "nobody looked" about a
+# host where somebody now can — this step installs the scanner and asks again.
+#
+# WHAT IT DELIBERATELY DOES NOT DO. It makes no stop/proceed decision. §6.1's
+# tier table, §6.3's dispositions and §6.4's tiered escape are WP10b's, and a
+# `tool-unavailable` result still completes an adoption here exactly as it did
+# before this package. Deciding anything on the status in this file would move
+# a boundary §10 draws.
+#
+# ─────────────────────────────────────────────────────────────────────────────
+# THE POSITION IS THE CONSTRAINT (§8.2). Step 2 is BEFORE the secrets check
+# that reads its result and BEFORE any writer: a run abandoned here has changed
+# the repository not at all, and the host only if the operator said yes.
+#
+# bash-3.2 safe: no associative arrays, no `${var,,}`, no `((x++))`.
+
+# ── THE RESOLVER SEAM ───────────────────────────────────────────────────────
+# The shipped resolver probes the HOST, which makes it the wrong thing for a
+# test to drive: a suite that let it run would assert one thing on a laptop
+# with gitleaks and another on a runner without it (CLAUDE.md's local-vs-CI
+# divergence), and its install arm would install software on whatever machine
+# ran the tests. `SOIF_ADOPT_RESOLVER` names an alternative executable so the
+# suite can hand this function the exact JSON the real resolver was MEASURED to
+# emit for each case. It defaults to the real one, so nothing changes in use.
+_adopt_resolver_path() {
+  if [ -n "${SOIF_ADOPT_RESOLVER:-}" ]; then
+    printf '%s\n' "$SOIF_ADOPT_RESOLVER"
+  else
+    printf '%s\n' "$ADOPT_FRAMEWORK_ROOT/scripts/resolve-tools.sh"
+  fi
+}
+
+# _adopt_tools_language REPORT — the dominant language Scout detected, or a
+# neutral default. The resolver needs one; guessing loudly is worse than a
+# default, so an absent or unreadable stack yields the same value a scaffolded
+# project with no language would use.
+_adopt_tools_language() {
+  local report="$1" lang
+  lang="$(adopt_report_read "$report" '[.stack.languages[]? | .name] | first // ""')"
+  case "$lang" in ''|null) printf 'other\n' ;; *) printf '%s\n' "$lang" ;; esac
+}
+
+_adopt_tools_devos() {
+  case "$(uname -s 2>/dev/null)" in
+    Darwin) printf 'darwin\n' ;;
+    Linux)  printf 'linux\n' ;;
+    *)      printf 'linux\n' ;;
+  esac
+}
+
+# ── IS THIS STRING SOMETHING TO RUN? ────────────────────────────────────────
+# THE MATRIX SHIPS BOTH COMMANDS AND DOCUMENTATION, AND THE DIFFERENCE IS NOT
+# COSMETIC. `common.json`'s gitleaks entry carries `darwin_brew`, three linux
+# recipes AND a `manual` key whose value is
+# `https://github.com/gitleaks/gitleaks/releases`. MEASURED against the shipped
+# resolver: darwin with brew returns `brew install gitleaks`; with brew ALSO
+# absent it returns that URL — and, because `manual` is the last entry in the
+# resolver's own `INSTALL_KEYS`, the URL arrives in the **auto_install** bucket
+# rather than the manual one. A consumer that pipes it to a shell executes a
+# URL. `init.sh` has the same exposure through the same field; that is a defect
+# in the shared resolver with a wider blast radius than this package, filed on
+# `## BL-242:` rather than fixed from here, because §10 authorises WP10 to
+# INVOKE the resolver, not to change it.
+#
+# A FIRST CUT RESOLVED THE FIRST WORD AS A COMMAND AND THAT WAS WRONG ON LINUX.
+# The matrix's linux_apt/dnf/pacman values are ARRAYS, which the resolver joins
+# with ` && `, so the first token is `GITLEAKS_VERSION=$(curl` — not a command.
+# The guard therefore refused the only Linux install path the matrix has, told
+# the operator "this host has no package manager recipe for it" while printing
+# that recipe, and left §6.2's "tool resolution makes the scanner guaranteed"
+# false on every Linux host. A cleverer head-parse does not rescue it: the
+# string genuinely cannot be classified by its first word.
+#
+# WHAT IS LEFT IS A NARROW, TRUE TEST — a shell command never begins with a URL
+# scheme — BACKED BY A BEHAVIOURAL ONE. `_adopt_tool_present` re-probes after
+# the install, so even a string this misjudges cannot produce a false
+# "installed" claim. Syntax refuses the one shape the matrix is measured to
+# produce; behaviour catches everything else.
+_adopt_cmd_is_runnable() {
+  local cmd="$1"
+  [ -n "$cmd" ] || return 1
+  case "$cmd" in
+    http://*|https://*|ftp://*|www.*) return 1 ;;
+  esac
+  return 0
+}
+
+# _adopt_tool_present NAME — is the tool actually on PATH now?
+#
+# THE INSTALL'S EXIT STATUS IS NOT EVIDENCE. A recipe whose last stage exits 0
+# — a package manager that no-ops, a `curl | tar` that unpacks nothing, a
+# binary landing somewhere not on PATH — produces a zero exit and no tool. A
+# first cut printed "$name installed." on that exit status alone, which is the
+# same "an exit code is not a receipt" shape this repository has paid for
+# elsewhere.
+_adopt_tool_present() {
+  local name="$1"
+  [ -n "$name" ] || return 1
+  command -v "$name" >/dev/null 2>&1
+}
+
+# ── Step 2 ──────────────────────────────────────────────────────────────────
+# adopt_resolve_tools ROOT REPORT
+#
+# Returns 0 in every case it handles, INCLUDING the ones where the scanner ends
+# up absent. That is not leniency: §6.1's table is what decides whether an
+# unscanned project may be adopted, and it lands in WP10b. This step's job is
+# to remove the avoidable causes.
+adopt_resolve_tools() {
+  local root="$1" report="$2"
+  local resolver out lang devos name cmd
+
+  resolver="$(_adopt_resolver_path)"
+  adopt_head "Making sure the tools this needs are here"
+
+  if [ ! -x "$resolver" ] && [ ! -f "$resolver" ]; then
+    adopt_note "The tool resolver is not where it should be ($resolver), so this step could not"
+    adopt_note "check what is installed. Nothing was changed on this machine."
+    # STILL RE-SCAN. A broken framework checkout is not evidence about the
+    # HOST: gitleaks may well be installed, and a first cut returned here
+    # without asking, losing a legitimate refresh.
+    _adopt_rescan_secrets "$root" "$report"
+    return 0
+  fi
+
+  lang="$(_adopt_tools_language "$report")"
+  devos="$(_adopt_tools_devos)"
+
+  # `--platform web` and `--track standard` are the neutral values a project
+  # with no intake answer uses. Adoption HAS no platform answer — the reverse
+  # intake asks only scan-derived confirmations (A7) — and inventing one would
+  # be a guess in a field the resolver keys install recipes off.
+  out="$( "$resolver" \
+            --dev-os "$devos" \
+            --platform web \
+            --language "$lang" \
+            --track standard \
+            --phase 2 \
+            --matrix-dir "$ADOPT_FRAMEWORK_ROOT/templates/tool-matrix" 2>/dev/null )" || out=""
+
+  if [ -z "$out" ]; then
+    adopt_note "The tool resolver did not produce a result, so this step could not check what is"
+    adopt_note "installed. Nothing was changed on this machine."
+    _adopt_rescan_secrets "$root" "$report"
+    return 0
+  fi
+
+  # SELECT ON NAME **OR** CATEGORY — an unordered disjunction, not a priority
+  # order; a draft of this comment said "name first, category second" while the
+  # line beside it said the opposite and the code did neither. A first cut matched
+  # `.category | test("ecret")`, which also matches `Secrets Management` — so
+  # an unrelated installed tool in an adjacent category made this announce
+  # "already installed" and skip the bucket where gitleaks was actually
+  # sitting, in the same payload. The scanner has a name; use it.
+  if printf '%s' "$out" | jq -e '[.already_installed[]? | select((.name // "") == "gitleaks" or (.category // "") == "Secret Detection")] | length > 0' >/dev/null 2>&1; then
+    adopt_note "Secret detection: already installed. The history scan can run."
+    _adopt_rescan_secrets "$root" "$report"
+    return 0
+  fi
+
+  name="$(printf '%s' "$out" | jq -r '[.auto_install[]?, .manual_install[]? | select((.name // "") == "gitleaks" or (.category // "") == "Secret Detection")] | first | .name // ""' 2>/dev/null)"
+  # `install_cmd` in the auto bucket, `instructions` in the manual one — the
+  # resolver writes DIFFERENT FIELD NAMES per bucket
+  # (`--arg instructions "$INSTALL_CMD"` … `{name, category, instructions, …}`),
+  # and a first cut read only the first, so the manual arm printed
+  # "see the tool matrix" instead of the reference it had been handed.
+  cmd="$(printf '%s' "$out" | jq -r '[.auto_install[]?, .manual_install[]? | select((.name // "") == "gitleaks" or (.category // "") == "Secret Detection")] | first | (.install_cmd // .instructions // "")' 2>/dev/null)"
+  # THE BUCKET IS THE PRIMARY CLASSIFIER, not the string. `manual_install` is
+  # the resolver saying "this host cannot install it", whatever the payload
+  # looks like.
+  local in_manual=0
+  printf '%s' "$out" | jq -e '[.manual_install[]? | select((.name // "") == "gitleaks" or (.category // "") == "Secret Detection")] | length > 0' >/dev/null 2>&1 && in_manual=1
+
+  if [ -z "$name" ]; then
+    adopt_note "Secret detection: the tool matrix named nothing for this host, so nothing was"
+    adopt_note "installed. The scan will report what it can."
+    _adopt_rescan_secrets "$root" "$report"
+    return 0
+  fi
+
+  if [ "$in_manual" -eq 1 ] || ! _adopt_cmd_is_runnable "$cmd"; then   # BL-242-RESOLVER-NO-EXEC
+    # The matrix's `manual` fallback lands here — a documentation URL, not a
+    # command. Print it as a reference and never as something to run.
+    adopt_note "Secret detection ($name) is not installed, and this host has no package manager"
+    adopt_note "recipe for it — so adoption cannot install it for you. Install it yourself:"
+    adopt_note "  ${cmd:-see the tool matrix}"
+    adopt_note "Then run adoption again to scan this project's history."
+    _adopt_rescan_secrets "$root" "$report"
+    return 0
+  fi
+
+  adopt_blank
+  adopt_note "$name is not installed. It is what reads your git history for committed"
+  adopt_note "credentials, and without it this adoption cannot tell you whether there are any."
+  adopt_blank
+  # THE COMMAND IS SHOWN BEFORE THE QUESTION, NOT AFTER THE ANSWER. A first cut
+  # printed it only once the operator had already agreed, which is consent to
+  # `eval` a string they had not seen.
+  adopt_note "This would run, exactly as written:"
+  adopt_note "  $cmd"
+  # THE ANSWER WORDING AVOIDS THE LITERAL `install ` ON PURPOSE. `## BL-225:`'s
+  # T9 is a DENYLIST over write verbs — `install ` among them — anchored to
+  # exclude output functions by first token but not `adopt_ask_choice`'s
+  # arguments. A first cut offered "install it now" and T9 flagged two lines of
+  # prose as unmarked writers. Weakening that denylist so this package could
+  # phrase an answer differently would be the wrong trade: it catches new
+  # writers by default, and that default is worth more than these two words.
+  if ! adopt_ask_choice "setting up $name" "Set $name up now?" \
+        "set it up now" "skip it"; then
+    return 1
+  fi
+  case "$ADOPT_ANSWER" in
+    "set it up now")
+      # ── cd INTO THE RUN'S OWN WORK DIR FIRST ────────────────────────────
+      # `eval` inherits the adoptee's directory as cwd, so a recipe writing a
+      # relative path writes into the OPERATOR'S REPOSITORY — measured: an
+      # installer left two untracked files in the adoptee while `adopt_refuse`
+      # went on to say "Nothing was committed and nothing was written". Real
+      # matrix recipes do this (`npm init playwright@latest`, gitleaks'
+      # from-source `git clone` path). `## BL-225:`'s T9 is a STATIC check over
+      # the driver's own writer calls and cannot see through an `eval`, which
+      # is why it passed while the claim was false.
+      #
+      # `adopt_touched_disk` is called unconditionally BEFORE the eval, because
+      # the driver cannot know what an arbitrary recipe writes — the honest
+      # position is that from here on, something may have been.
+      adopt_touched_disk   # BL-225-TOUCHED-DISK
+      # `</dev/null` IS NOT TIDINESS. The eval inherits fd 0 — the same open
+      # file description `adopt_stdin_init`'s `exec 3<&0` reads the operator's
+      # answers from — so an installer that reads stdin CONSUMES THEM.
+      # Measured with a recipe of `read a; read b`: it swallowed two
+      # confirmations and the adoption then ran out of answers and aborted.
+      # Latent with today's matrix (neither gitleaks recipe reads stdin; `sudo`
+      # uses /dev/tty) and live the moment an eval-reachable recipe prompts —
+      # `npm init playwright@latest`, named in this file already, is one.
+      # Detaching stdin also means an interactive installer fails fast instead
+      # of hanging on a prompt this run has redirected to /dev/null.
+      if ( cd "$ADOPT_WORK" 2>/dev/null && eval "$cmd" ) </dev/null >/dev/null 2>&1; then   # BL-242-RESOLVER-INSTALL
+        :
+      fi
+      # VERIFIED, NOT ASSERTED (`# BL-242-RESOLVER-VERIFY`). The exit status of
+      # an install recipe is not evidence the tool is there.
+      if _adopt_tool_present "$name"; then   # BL-242-RESOLVER-VERIFY
+        adopt_note "$name is installed and on PATH."
+      else
+        # NOT "nothing else was changed" — the driver cannot know that. The
+        # comment ten lines above says so in as many words ("the driver cannot
+        # know what an arbitrary recipe writes"), and a recipe that created a
+        # directory outside the project then drew exactly that false claim.
+        # This is the shape round 1 blocked, relocated to the failure branch.
+        adopt_note "That did not put $name on PATH. Whatever the command did to this machine, it"
+        adopt_note "did not leave $name where the scan can find it, so the scan will report that"
+        adopt_note "nothing looked at your history."
+      fi
+      ;;
+    *)
+      adopt_note "Skipped. The scan will report that nothing looked at your history."
+      ;;
+  esac
+  _adopt_rescan_secrets "$root" "$report"
+  return 0
+}
+
+# ── §6.2's re-scan ──────────────────────────────────────────────────────────
+# _adopt_rescan_secrets ROOT REPORT
+#
+# WHY IT IS CONDITIONAL. A report that already says `scanned` is the one Act 2
+# consumed and is about to record an evidence hash for; re-running the scanner
+# over it would cost a full history walk and replace the measurement the stamp
+# names with a different one. Only a report that says nobody looked is worth
+# asking again.
+#
+# WHY IT REUSES SCOUT'S OWN TWO FUNCTIONS AND RE-IMPLEMENTS NOTHING.
+# `scout_secrets_scan` performs the field-allowlist projection AT EXTRACTION
+# TIME, and `_scout_emit_secrets` renders only what that projection produced —
+# scout-report.sh's own comment says it "does not see field names, does not
+# choose which to print, and has no access to anything the allowlist refused".
+# A second renderer here would be a second chance to leak a secret's value into
+# a committed artifact. There is exactly one projection and this calls it.
+# Set by _adopt_rescan_secrets when — and only when — it produced a refreshed
+# report. Empty otherwise, so `adopt_main`'s switch is a no-op on every path
+# that did not re-scan.
+ADOPT_REPORT_REFRESHED=""
+
+_adopt_rescan_secrets() {
+  local root="$1" report="$2"
+  local status work sec
+
+  status="$(adopt_report_read "$report" '.secrets.status // ""')"
+  [ "$status" != "scanned" ] || return 0   # BL-242-SECRETS-RESCAN
+
+  # THREE LIBRARIES, NOT TWO, and the third is the one a first cut missed.
+  # `_scout_emit_secrets` renders through `scout_json_str`,
+  # `scout_json_str_or_null` and `scout_json_array_from_file`, all of which
+  # live in `scout-core.sh` — Scout's own entry script sources it first for
+  # exactly this reason. Without it the renderer emits syntactically invalid
+  # JSON with every value blank (`"tool": ,`), which the splice below then
+  # refuses, so the failure was SILENT: the report kept its stale section and
+  # the run said the re-scan had happened. Measured before it was fixed.
+  local core_lib="$ADOPT_FRAMEWORK_ROOT/scripts/lib/scout/scout-core.sh"
+  local secrets_lib="$ADOPT_FRAMEWORK_ROOT/scripts/lib/scout/scout-secrets.sh"
+  local report_lib="$ADOPT_FRAMEWORK_ROOT/scripts/lib/scout/scout-report.sh"
+  # EVERY EARLY RETURN SAYS WHY. A first cut had five failure arms and only
+  # ONE of them spoke — and the silent four included the exact condition the
+  # commit message narrated as fixed (a missing `scout-core.sh`), because the
+  # existence guard short-circuits before the render arm ever runs. A re-scan
+  # that does not happen and says nothing leaves the operator reading a stale
+  # section as if it were current.
+  if [ ! -f "$core_lib" ] || [ ! -f "$secrets_lib" ] || [ ! -f "$report_lib" ]; then
+    adopt_note "The scan could not be re-run — this framework checkout is missing part of Scout,"
+    adopt_note "so the secrets section is still the one the survey produced."
+    return 0
+  fi
+
+  if ! work="$(mktemp -d "${TMPDIR:-/tmp}/adopt-rescan.XXXXXXXX" 2>/dev/null)"; then
+    adopt_note "The scan could not be re-run — no temporary directory could be created. The"
+    adopt_note "secrets section is still the one the survey produced."
+    return 0
+  fi
+
+  # A SUBSHELL, because these two libraries are Scout's and sourcing them into
+  # the driver's shell would put their helpers in scope for every later step —
+  # the module-boundary problem `scripts/lint-module-dependencies.sh` exists to
+  # police. What comes back is a string.
+  sec="$(
+    # shellcheck source=/dev/null
+    . "$core_lib" >/dev/null 2>&1 || exit 1
+    # shellcheck source=/dev/null
+    . "$secrets_lib" >/dev/null 2>&1 || exit 1
+    # shellcheck source=/dev/null
+    . "$report_lib" >/dev/null 2>&1 || exit 1
+    scout_secrets_scan "$root" "$work" >/dev/null 2>&1 || exit 1
+    _scout_emit_secrets "$work" 2>/dev/null || exit 1
+  )" || sec=""
+  rm -rf "$work" 2>/dev/null
+
+  if [ -z "$sec" ]; then
+    adopt_note "The scan could not be re-run — the scanner or its renderer did not produce a"
+    adopt_note "result. The secrets section is still the one the survey produced."
+    return 0
+  fi
+
+  # `_scout_emit_secrets` emits `"secrets": { … },` — a trailing comma and all,
+  # because it is written to sit inside the report's object. Splice it in with
+  # jq rather than by text, so a malformed render cannot corrupt the report.
+  local new_obj
+  new_obj="$(printf '{%s"_end": null}' "$sec" | jq -c '.secrets // empty' 2>/dev/null)" || new_obj=""
+  if [ -z "$new_obj" ]; then
+    # FAIL LOUDLY RATHER THAN LEAVE A STALE SECTION SILENTLY. This arm caught a
+    # missing `scout-core.sh` during the build; without it the run reported a
+    # re-scan that had not happened, which is the silent-success class this
+    # package exists inside.
+    adopt_note "The re-scan could not be rendered, so this project's secrets section is still the"
+    adopt_note "one the survey produced. Nothing was overwritten."
+    return 0
+  fi
+
+  # ── THE REFRESHED REPORT IS A NEW FILE IN THE RUN'S OWN WORK DIR ─────────
+  # NOT an in-place rewrite of the report the operator handed us. Two reasons,
+  # and the first is an invariant this package would otherwise have broken:
+  #
+  # (1) `## BL-225:`'s T9 requires every write into the adoptee's tree to be
+  #     preceded by `adopt_touched_disk`, so a refusal can say truthfully
+  #     whether anything was written. A first cut wrote the report in place and
+  #     T9 caught it — correctly. `$ADOPT_WORK` is already exempt there, with a
+  #     reason on the record ("the driver's own state, not the operator's
+  #     tree"), so refreshing into it satisfies the invariant by construction
+  #     rather than by an exemption argued for this package.
+  # (2) THE CONSUMED REPORT IS AN INPUT. Rewriting a file the operator passed
+  #     on the command line — possibly Scout's output directory, possibly
+  #     something they keep — is a side effect nobody asked for, and it would
+  #     make a re-run of adoption non-reproducible from the same inputs.
+  #
+  # §6.2 asks that "the persisted copy reflects what was actually acted on";
+  # `ADOPT_REPORT_REFRESHED` is how the rest of the run learns which file that
+  # is, and `adopt_main` switches to it immediately after this step.
+  local fresh="$ADOPT_WORK/scout-report-refreshed.json"
+  if jq --argjson s "$new_obj" '.secrets = $s' "$report" > "$fresh" 2>/dev/null \
+     && [ -s "$fresh" ]; then
+    ADOPT_REPORT_REFRESHED="$fresh"
+    # ── SAY WHAT THE RE-SCAN FOUND, NOT THAT IT RAN ───────────────────────
+    # A first cut printed "this project's history was read rather than
+    # skipped" whenever the SPLICE succeeded — including when the refreshed
+    # status was still `tool-unavailable`. Measured, three lines apart in one
+    # run: "adoption cannot install it for you" and then "your history was
+    # read", over a persisted record saying `"status": "tool-unavailable",
+    # "note": "…NOTHING WAS SCANNED."` A false all-clear on the one surface
+    # this package exists to make trustworthy, and — before the Linux fix
+    # above — the DEFAULT experience there.
+    local fresh_status
+    fresh_status="$(printf '%s' "$new_obj" | jq -r '.status // ""' 2>/dev/null)"
+    case "$fresh_status" in   # BL-242-RESCAN-HONEST
+      scanned)
+        adopt_note "The scan was re-run now that the tools are resolved: this project's history"
+        adopt_note "was read." ;;
+      tool-unavailable)
+        adopt_note "The scan was re-run and STILL could not look: the scanner is not installed."
+        adopt_note "Nothing is known about credentials in this project's history." ;;
+      scan-failed)
+        adopt_note "The scan was re-run and it FAILED. Nothing is known about credentials in this"
+        adopt_note "project's history — a scan that broke is not a scan that found nothing." ;;
+      *)
+        adopt_note "The scan was re-run; its status is '${fresh_status:-unknown}'." ;;
+    esac
+  else
+    # THE SIXTH EXIT, AND A FIRST CUT COUNTED FIVE. The scan RAN — measured at
+    # 755 bytes of refreshed secrets section — and the splice then failed
+    # (reachable: `adopt_obtain_report` only checks `[ -f ]`, so a report that
+    # is not valid JSON reaches here), after which the run said nothing at all
+    # and the operator was told the survey's stale answer instead. Throwing
+    # away a completed security scan in silence is the class this package sits
+    # inside; counting the arms and fixing "all five" is how it survived.
+    adopt_note "The scan was re-run, but its result could not be merged into this project's"
+    adopt_note "report — the report file may not be valid JSON. The secrets section is still"
+    adopt_note "the one the survey produced, and what the re-scan found was discarded."
+  fi
+  return 0
+}

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -13975,6 +13975,88 @@ same standard as code rather than waved through as "docs-only".
    **stricter** than any default would have been. A fallback would have
    weakened shipped behaviour to solve a case that cannot occur.
 
+### BL-242 residual — `resolve-tools.sh` files a documentation URL in the `auto_install` bucket, and `init.sh` executes that bucket
+
+**Found at WP10a's review (2026-09-02), NOT fixed there, and it is the shared
+resolver's defect rather than adoption's.** `scripts/resolve-tools.sh` builds
+`INSTALL_KEYS` with `manual` as its LAST entry, so the key loop treats the
+matrix's `manual` value — for gitleaks,
+`https://github.com/gitleaks/gitleaks/releases` — as a found install command
+and leaves `TOOL_AUTO` at the tool's own `auto_installable: true`. The entry
+therefore lands in **`auto_install`**, not `manual_install`. The fallback ten
+lines below (`if [ -z "$INSTALL_CMD" ] … TOOL_AUTO="false"`) is the arm that
+would have classified it correctly, and it is unreachable for any tool whose
+matrix entry has a `manual` key.
+
+**MEASURED**, real resolver, real matrix, darwin host:
+
+```
+brew present, gitleaks absent → auto_install[0].install_cmd = "brew install gitleaks"
+brew ABSENT,  gitleaks absent → auto_install[0].install_cmd = "https://github.com/gitleaks/gitleaks/releases"
+```
+
+*(Measuring this needs care: stripping gitleaks from `PATH` removes brew too —
+same directory — so the naive probe sees only the second row and concludes the
+matrix has no darwin recipe. A symlink shim of the brew directory minus one
+file is what separates them.)*
+
+**WHY IT MATTERS BEYOND ADOPTION.** `init.sh`'s installer loop reads
+`.auto_install[$i].install_cmd` and runs it. On a host without the package
+manager, that is a URL going to a shell. WP10a defends its own consumer with a
+URL-scheme refusal plus a post-install probe (`# BL-242-RESOLVER-NO-EXEC`,
+`# BL-242-RESOLVER-VERIFY`), but the defect is upstream of both consumers.
+
+**THE FIX IS ONE LINE AND ITS BLAST RADIUS IS NOT.** Dropping `manual` from
+`INSTALL_KEYS` sends the URL through the existing `TOOL_AUTO="false"` arm and
+into `manual_install` with the `instructions` field — after which `auto_install`
+means "runnable" by construction and no consumer needs to guess. **Eleven test files
+reference this resolver and SIX execute it** (`test-bl033-install-cmds-shape.sh`
+pins the `install_cmd`/`install_cmds` shape directly), so it wants its own
+change with its own proofs, not a drive-by inside a package whose §10 boundary
+is to *invoke* the resolver. **NO SINGLE GREP GETS THE SECOND NUMBER, and that is
+why it is enumerated rather than recipe'd.** This line has now been wrong
+THREE TIMES: "eight test files exercise this resolver"; then "seven invoke it",
+published beside a recipe that returns **three**; and then a "fix" that wrote
+the correct figure into a paragraph BELOW while leaving the bolded seven where
+it was — a correction appended under the sentence it corrects, so the operative
+clause still asserted the refuted number. The FIRST TWO were counts of grep
+hits rather than classifications (the third was a correction that never touched
+its subject), and two files defeat every pattern —
+`test-bl235-tool-matrix-probes.sh` matches on a COMMENT (`# init.sh EXECUTES
+it …`) and a mode check while never running it, and
+`test-bl137-ci-tools-scope.sh` runs it INDIRECTLY, by copying it into a fixture
+and invoking `check-phase-gate.sh`, which executes it. The references figure is
+derivable and the invokers figure is not:
+
+```
+grep -rl 'resolve-tools' tests/ | wc -l            # references: 11 (derivable)
+```
+
+**FIVE files execute it directly** — `test-bl033-install-cmds-shape.sh`,
+`edge-case-test-suite.sh`, `edge-cases-scripts.sh`, `full-project-test-suite.sh`,
+`upgrade-path-tests.sh` (the first and last through a `$RESOLVER` variable, which
+is why a `bash .*resolve-tools\.sh` pattern misses them) — **and one more
+indirectly**, `test-bl137-ci-tools-scope.sh`. **Six in total.** Re-classify by
+reading, not by counting matches.
+
+**A SECOND RESIDUAL, FOUND AT THE SAME REVIEW AND RECORDED RATHER THAN FIXED:
+the Linux recipe adoption now offers is an unpinned, unverified root install.**
+`curl -sSfL "…/releases/latest/…" | sudo tar -xz -C /usr/local/bin gitleaks` —
+no version pin, no checksum, extracted as root, and the consent prompt does not
+say it will elevate. This repository's OWN CI pins the identical artefact by
+version and checksum (`GITLEAKS_VERSION`, `GITLEAKS_SHA256`, verified through
+`scripts/ci-verify-sha256.sh`) and carries a comment explaining why a floating
+one is unacceptable — so the standard already exists here and the matrix does
+not meet it. The string is the matrix's, not WP10a's; what WP10a changed is
+that adoption can now run it. Fixing it belongs with the matrix and the
+resolver, in the same change as the row above.
+
+**A SECOND, SMALLER ROW IN THE SAME AREA:** the two buckets use DIFFERENT FIELD
+NAMES — `auto_install` carries `install_cmd`, `manual_install` carries
+`instructions` — which is a trap for every reader. WP10a reads
+`.install_cmd // .instructions`; a consumer that reads only the first prints
+nothing where the resolver handed it a reference.
+
 ### BL-242 residual — adoption follows a SYMLINK out of the project and overwrites its target
 
 **Recorded at WP9b's review (2026-09-01), NOT fixed here, and pre-existing rather

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -813,6 +813,18 @@ run_child_suite "tests/test-brownfield-wp9b-preflight-approval.sh" \
   "Adoption WP9b preflight + approval log (A1's three arms, A4's tier-matched log written first)" \
   "Adoption WP9b preflight/approval-log tests FAILED (run tests/test-brownfield-wp9b-preflight-approval.sh for details)"
 
+# WP10a — tool resolution at §8.2 step 2, and §6.2's re-scan-after-install.
+# Its sharpest assertion is a CANARY, not a string: `install_cmd` is not always
+# a command (the tool matrix ships a `manual` URL fallback), and X2 proves the
+# driver never pipes it to a shell. DERIVE the mutant count, never quote it:
+#   grep -c '_mutate "' tests/test-brownfield-wp10a-tool-resolution.sh
+# Drives the driver against fixtures and a scratch mirror, with the resolver
+# itself stubbed through SOIF_ADOPT_RESOLVER so no test installs anything on
+# the host -> both lanes.
+run_child_suite "tests/test-brownfield-wp10a-tool-resolution.sh" \
+  "Adoption WP10a tool resolution (resolver at step 2, no non-command ever executed, §6.2 re-scan)" \
+  "Adoption WP10a tool-resolution tests FAILED (run tests/test-brownfield-wp10a-tool-resolution.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-brownfield-wp10a-tool-resolution.sh
+++ b/tests/test-brownfield-wp10a-tool-resolution.sh
@@ -1,0 +1,747 @@
+#!/usr/bin/env bash
+# tests/test-brownfield-wp10a-tool-resolution.sh
+#
+# Brownfield adoption WP10a — TOOL RESOLUTION AT STEP 2, and §6.2's
+# re-scan-after-install mechanic.
+# Design: docs/designs/2026-08-23-brownfield-adoption-v2.md §6.2, §8.2 step 2,
+# §10-WP10.
+#
+# ── WHAT THIS HALF IS, AND WHAT IT DELIBERATELY IS NOT ──────────────────────
+# WP10 is built as two PRs. 10a runs the resolver and refreshes a stale
+# secrets section; 10b brings §6.1's eight status×tier cells, §6.3's
+# dispositions and §6.4's tiered escape. **10a therefore changes NO
+# stop/proceed decision** — a `tool-unavailable` report still completes an
+# adoption here, exactly as it did before this package, and 10b is what makes
+# it stop. Asserting otherwise in this file would pin behaviour the next PR is
+# specified to change.
+#
+# ── THE ONE THING THAT MUST NEVER HAPPEN ───────────────────────────────────
+# `install_cmd` IS NOT ALWAYS A COMMAND. Measured against the shipped matrix:
+# on a darwin host WITH brew and without gitleaks the resolver returns
+# `brew install gitleaks`; with brew ALSO absent it returns the matrix's
+# `manual` fallback, which is the string
+# `https://github.com/gitleaks/gitleaks/releases`. A build that pipes the
+# bucket's `install_cmd` to a shell executes a URL. X2 pins that it does not.
+#
+# ── MUTATION HARNESS STANDARD (inherited from the WP9a/9b suites) ──────────
+#   • anchored end-of-line markers, excised with `s|^.*MARKER$|…|`;
+#   • the anchor asserted at sites==1 in its OWN shipped source;
+#   • every mutant additionally asserts `bash -n`;
+#   • a MODE-PRESERVING in-place edit;
+#   • a FRESH fixture per scenario, from mktemp -d;
+#   • mutants run against a framework MIRROR — the tree under test is never
+#     edited, so a failure here cannot leave this repository mutated.
+#
+# Hermetic: temp dirs only, no network, no remote creation. The resolver is
+# driven through `SOIF_ADOPT_RESOLVER` (a test seam, see below) so no test
+# installs anything on the host running it.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
+LIB_DIR="$REPO_ROOT/scripts/lib/adopt"
+L_STATE="$LIB_DIR/adopt-state.sh"
+L_TOOLS="$LIB_DIR/adopt-tools.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+_tree_hash() {
+  local p="$1"
+  ( cd "$p" 2>/dev/null && find . -path ./.git -prune -o -type f -print 2>/dev/null \
+      | LC_ALL=C sort \
+      | while IFS= read -r f; do
+          printf '%s ' "$f"
+          (shasum -a 256 "$f" 2>/dev/null || sha256sum "$f" 2>/dev/null || printf 'nohash\n') | awk '{print $1}'
+        done ) | (shasum -a 256 2>/dev/null || sha256sum 2>/dev/null) | awk '{print $1}'
+}
+
+if [ ! -f "$DRIVER" ]; then
+  echo "  [FAIL] setup — $DRIVER not found"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [FAIL] setup — jq is required by this suite"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── Fixtures ────────────────────────────────────────────────────────────────
+mk_adoptee() {
+  local p="$1"
+  mkdir -p "$p/src" "$p/docs" || return 1
+  ( cd "$p" \
+      && git init -q . \
+      && git config user.email "wp10a@test.invalid" \
+      && git config user.name  "WP10a Test" \
+      && git config core.excludesFile /dev/null ) >/dev/null 2>&1 || return 1
+  printf '{"name":"acme-api","scripts":{"test":"npm test"}}\n' > "$p/package.json"
+  printf '# acme-api\n' > "$p/README.md"
+  printf '# What this is for\n\nInvoice reconciliation for small firms.\n' > "$p/docs/product.md"
+  printf '# Architecture\n\nA node service and a postgres database.\n' > "$p/docs/architecture.md"
+  ( cd "$p" && git add -A && git commit -q -m "chore: their own history" ) >/dev/null 2>&1 || return 1
+  return 0
+}
+
+TEMPLATE="$(newtmp)/template"
+REPORT=""
+REPORT_OK=0
+if mk_adoptee "$TEMPLATE"; then
+  if bash "$REPO_ROOT/scripts/scout.sh" --root "$TEMPLATE" --out "$TOPTMP/scan" >/dev/null 2>&1; then
+    REPORT="$TOPTMP/scan/scout-report.json"
+    [ -s "$REPORT" ] && REPORT_OK=1
+  fi
+fi
+if [ "$REPORT_OK" -ne 1 ]; then
+  echo "  [FAIL] setup — scripts/scout.sh produced no report"
+  echo ""
+  echo "Results: 0 passed, 1 failed"
+  exit 1
+fi
+
+# ── THE RESOLVER SEAM, and why the suite drives it rather than the real one ─
+# The shipped resolver probes the HOST. A suite that let it do so would assert
+# different things on a laptop with gitleaks and a runner without it — the
+# local-vs-CI divergence CLAUDE.md documents at length — and, worse, the
+# install arm would install software on whatever machine ran the tests.
+# `SOIF_ADOPT_RESOLVER` names an alternative resolver executable; every case
+# below points it at a stub emitting the exact JSON the real resolver was
+# MEASURED to emit for that case (see the header). The seam is not asserted
+# directly by any one case — a draft claimed X0 did that, and X0 only counts a
+# marker in a different file. It is pinned INCIDENTALLY: disabling it so the
+# real resolver runs reddens NINE assertions — X2b, X4, X5(linux), X5(brew),
+# X6b, X7, X9, X9b and M2 — while X3's two SURVIVE.
+#
+# THIS NUMBER HAS BEEN WRONG TWICE AND THE SECOND TIME IS THE INSTRUCTIVE ONE.
+# A draft enumerated "X2, X3, X4 and X5" and was wrong about X3. Its
+# replacement said EIGHT — measured correctly, on the tree BEFORE X9b was
+# narrowed in the same commit, and never re-run against the finished one. The
+# fix that made X9b discriminate is precisely what added the ninth failure, so
+# one fix invalidated another fix's number inside a single commit. Do not carry
+# this figure forward: disable `_adopt_resolver_path`'s branch and count.
+# _mk_resolver <path> <bucket> <install_cmd>  → 0 on a stub whose payload was
+# VERIFIED to carry the command it was asked for.
+#
+# BUILT WITH `jq`, NOT `sed`, AND THAT IS THIS REPOSITORY'S OWN DOCUMENTED
+# TRAP. A first cut interpolated $cmd into a `|`-delimited `sed` expression.
+# The real gitleaks Linux recipe contains a shell pipe, so the expression died
+# with `bad flag in substitute command` — and `_sed_inplace` returns 0
+# unconditionally, so the builder reported success while emitting a stub with
+# ALL FOUR BUCKETS EMPTY. Every case then exercised the "matrix named nothing"
+# arm, the absence assertions still printed PASS, and the real recipe was never
+# tested once. CLAUDE.md says it in as many words: "assert the edit actually
+# applied, because 'sed ran' is not 'sed edited'." This asserts the payload.
+_mk_resolver() {
+  local out="$1" bucket="$2" cmd="$3" tool="${4:-gitleaks}" payload=""
+  case "$bucket" in
+    already)
+      payload="$(jq -n --arg t "$tool" '{already_installed: [{name: $t, version: "8.30.1", category: "Secret Detection"}], auto_install: [], manual_install: [], deferred: []}')" ;;
+    auto)
+      payload="$(jq -n --arg c "$cmd" --arg t "$tool" '{already_installed: [], auto_install: [{name: $t, category: "Secret Detection", install_cmd: $c, install_cmds: [$c]}], manual_install: [], deferred: []}')" ;;
+    manual)
+      # THE REAL RESOLVER WRITES `instructions` HERE, NOT `install_cmd`
+      # (`--arg instructions "$INSTALL_CMD"` … `{name, category, instructions,
+      # required, description}`). A stub emitting `install_cmd` in this bucket
+      # is a shape the resolver cannot produce, and a driver read against it
+      # proves nothing about the real one.
+      payload="$(jq -n --arg c "$cmd" --arg t "$tool" '{already_installed: [], auto_install: [], manual_install: [{name: $t, category: "Secret Detection", instructions: $c, required: true}], deferred: []}')" ;;
+    *) return 1 ;;
+  esac
+  [ -n "$payload" ] || return 1
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf '# A stub standing in for scripts/resolve-tools.sh. Ignores its arguments.\n'
+    printf 'cat <<%s\n' "'RESOLVERJSON'"
+    printf '%s\n' "$payload"
+    printf 'RESOLVERJSON\n'
+  } > "$out"
+  chmod +x "$out"
+
+  # THE ASSERTION THE FIRST CUT LACKED: run the stub and require the payload to
+  # parse AND to carry the command asked for. A builder that silently produced
+  # an empty stub is worse than one that failed.
+  local got
+  got="$( "$out" 2>/dev/null | jq -e . >/dev/null 2>&1 && "$out" 2>/dev/null )" || return 1
+  [ -n "$got" ] || return 1
+  if [ -n "$cmd" ]; then
+    printf '%s' "$got" | jq -e --arg c "$cmd" \
+      '[.auto_install[]?.install_cmd, .manual_install[]?.instructions] | any(. == $c)' >/dev/null 2>&1 || return 1
+  fi
+  return 0
+}
+
+# Five answers: the tier question plus this report's four scan-derived
+# confirmations. A case that adds the install question passes six.
+_ans() { local tier="${1:-1}"; printf '%s\n1\n1\n1\n1\n' "$tier"; }
+_ans_install() { local tier="${1:-1}" install="${2:-2}"; printf '%s\n%s\n1\n1\n1\n1\n' "$tier" "$install"; }
+
+RUN_RC=0; RUN_OUT=""; RUN_ERR=""
+run_adopt() {   # run_adopt <dir> <answers> <report> [fw] [extra env assignments...]
+  local dir="$1" answers="$2" report="$3" fw="${4:-$REPO_ROOT}"; shift 4 2>/dev/null || shift 3
+  RUN_RC=0
+  RUN_OUT="$(dirname "$answers")/run-out"
+  RUN_ERR="$(dirname "$answers")/run-err"
+  ( cd "$dir" && env "$@" bash "$fw/scripts/adopt-project.sh" --scan-report "$report" ) \
+    < "$answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+  return 0
+}
+
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -Rp "$REPO_ROOT/templates" "$m/" || return 1
+  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
+  return 0
+}
+
+_mutate() {   # _mutate <mirror> <lib> <marker> <replacement>
+  local mir="$1" lib="$2" mark="$3" repl="$4" before after changed
+  before="$(mktemp)"; cp "$mir/scripts/lib/adopt/$lib" "$before"
+  _sed_inplace "$mir/scripts/lib/adopt/$lib" "s|^.*${mark}\$|${repl}|"
+  after="$mir/scripts/lib/adopt/$lib"
+  changed="$(_changed_lines "$before" "$after")"
+  rm -f "$before"
+  [ "$changed" -ge 2 ] || { printf '0\n'; return 0; }
+  [ "$(_parses "$after")" = "1" ] || { printf '0\n'; return 0; }
+  printf '1\n'
+}
+
+echo "=== X — the resolver runs at step 2, and never executes a non-command ==="
+
+X0_MARK="# BL-242-RESOLVER-CALL"
+x0_sites="$(_sites "$L_STATE" "$X0_MARK")"
+[ "$x0_sites" = "1" ] \
+  && pass "X0 — '$X0_MARK' occurs exactly once at end-of-line in adopt-state.sh" \
+  || fail_ "X0" "'$X0_MARK' occurs $x0_sites times (need exactly 1)"
+
+# X1 — the common case: the scanner is already there, so nothing is asked and
+# nothing is installed. The POSITIVE half matters as much as the absence: a
+# build that skipped resolution entirely would also ask nothing.
+X1="$(newtmp)"
+mkdir -p "$X1/p"
+if ! mk_adoptee "$X1/p"; then
+  fail_ "X1 setup" "could not build the adoptee"
+else
+  _mk_resolver "$X1/resolver" already "" || fail_ "X1 setup" "the resolver stub did not build"
+  _ans 1 > "$X1/answers"
+  run_adopt "$X1/p" "$X1/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X1/resolver"
+  X1_RC="$RUN_RC"
+  [ "$X1_RC" -eq 0 ] \
+    && pass "X1 — with the scanner already present the adoption completes (rc 0)" \
+    || fail_ "X1" "adoption refused (rc $X1_RC) when the scanner was already installed"
+  if grep -qi 'secret.detection\|gitleaks' "$RUN_OUT" 2>/dev/null; then
+    pass "X1b — the run SAYS it resolved the scanner (the resolver actually ran)"
+  else
+    fail_ "X1b" "no sign the resolver ran; X1's silence proves nothing"
+  fi
+  if grep -q 'Set .* up now?' "$RUN_OUT" 2>/dev/null; then
+    fail_ "X1c" "the operator was asked to set up a tool that is already present"
+  else
+    pass "X1c — no install question is asked in the common case"
+  fi
+fi
+
+# X2 — THE ONE THAT MUST NEVER HAPPEN. `install_cmd` is the matrix's `manual`
+# fallback, a URL. It must not be executed, and the operator must be told.
+X2="$(newtmp)"
+mkdir -p "$X2/p"
+if ! mk_adoptee "$X2/p"; then
+  fail_ "X2 setup" "could not build the adoptee"
+else
+  # a URL that would create this file if it were ever passed to a shell
+  X2_CANARY="$X2/EXECUTED"
+  _mk_resolver "$X2/resolver" manual "https://github.com/gitleaks/gitleaks/releases; touch $X2_CANARY" \
+    || fail_ "X2 setup" "the resolver stub did not build"
+  _ans 1 > "$X2/answers"
+  run_adopt "$X2/p" "$X2/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X2/resolver"
+  [ ! -e "$X2_CANARY" ] \
+    && pass "X2 — a manual-bucket install_cmd is NEVER executed (the canary was not created)" \
+    || fail_ "X2" "the install_cmd was piped to a shell — a URL from the tool matrix got executed"
+  if grep -qi 'install it yourself\|cannot install it for you' "$RUN_OUT" 2>/dev/null; then
+    pass "X2b — the operator is told to install it themselves, with the reference"
+  else
+    fail_ "X2b" "the run went silent about a scanner it could not install"
+  fi
+fi
+
+# X3 — the install question, and DECLINING it. Nothing is executed, and the
+# adoption still completes: 10a changes no stop/proceed decision.
+X3="$(newtmp)"
+mkdir -p "$X3/p"
+if ! mk_adoptee "$X3/p"; then
+  fail_ "X3 setup" "could not build the adoptee"
+else
+  X3_CANARY="$X3/INSTALLED"
+  _mk_resolver "$X3/resolver" auto "touch $X3_CANARY" || fail_ "X3 setup" "the resolver stub did not build"
+  _ans_install 1 2 > "$X3/answers"      # 2 = do not install
+  run_adopt "$X3/p" "$X3/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X3/resolver"
+  X3_RC="$RUN_RC"
+  [ ! -e "$X3_CANARY" ] \
+    && pass "X3 — declining the install runs nothing" \
+    || fail_ "X3" "the install command ran even though the operator declined"
+  [ "$X3_RC" -eq 0 ] \
+    && pass "X3b — and the adoption still completes (rc 0): 10a changes no stop/proceed decision" \
+    || fail_ "X3b" "declining the install refused the adoption (rc $X3_RC) — that is 10b's decision, not 10a's"
+fi
+
+# X4 — ACCEPTING it. The command runs, once.
+X4="$(newtmp)"
+mkdir -p "$X4/p"
+if ! mk_adoptee "$X4/p"; then
+  fail_ "X4 setup" "could not build the adoptee"
+else
+  X4_CANARY="$X4/INSTALLED"
+  _mk_resolver "$X4/resolver" auto "touch $X4_CANARY" || fail_ "X4 setup" "the resolver stub did not build"
+  _ans_install 1 1 > "$X4/answers"      # 1 = install it now
+  run_adopt "$X4/p" "$X4/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X4/resolver"
+  [ -e "$X4_CANARY" ] \
+    && pass "X4 — accepting the install runs the resolver's own command" \
+    || fail_ "X4" "the operator accepted and nothing ran"
+fi
+
+# ── X5 — THE REAL RECIPES, in both directions. ─────────────────────────────
+# The only "runnable" fixture above is `touch <path>`, a shape no matrix entry
+# has. These two are the SHIPPED strings, measured from the real resolver:
+# darwin+brew yields `brew install gitleaks`; linux+apt/dnf/pacman yields the
+# array joined with ` && `, whose first token is `GITLEAKS_VERSION=$(curl`.
+# A first cut resolved that first token as a command and therefore REFUSED the
+# only Linux install path the matrix has — telling the operator "this host has
+# no package manager recipe for it" while printing that recipe.
+X5_LINUX='GITLEAKS_VERSION=$(curl -sSf https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name) && curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/x.tar.gz" | sudo tar -xz -C /usr/local/bin gitleaks'
+X5_BREW='brew install gitleaks'
+X5_URL='https://github.com/gitleaks/gitleaks/releases'
+
+for _case in "linux:$X5_LINUX:accept" "brew:$X5_BREW:accept" "url:$X5_URL:refuse"; do
+  _label="${_case%%:*}"; _rest="${_case#*:}"; _cmd="${_rest%:*}"; _want="${_rest##*:}"
+  X5D="$(newtmp)"; mkdir -p "$X5D/p"
+  if ! mk_adoptee "$X5D/p"; then
+    fail_ "X5 setup ($_label)" "could not build the adoptee"
+    continue
+  fi
+  # The stub carries the REAL string. The builder now asserts its own payload,
+  # so a shell pipe in the recipe can no longer silently empty it.
+  if ! _mk_resolver "$X5D/resolver" auto "$_cmd"; then
+    fail_ "X5 ($_label)" "the resolver stub did not build with the real recipe — the builder ate it"
+    continue
+  fi
+  _ans_install 1 2 > "$X5D/answers"     # decline: this asserts CLASSIFICATION, not installation
+  run_adopt "$X5D/p" "$X5D/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X5D/resolver"
+  _asked=0
+  grep -q 'This would run, exactly as written' "$RUN_OUT" 2>/dev/null && _asked=1
+  case "$_want" in
+    accept)
+      [ "$_asked" -eq 1 ] \
+        && pass "X5 ($_label) — the shipped recipe is offered to the operator" \
+        || fail_ "X5 ($_label)" "the real recipe was refused as un-runnable; on this host adoption can never install the scanner" ;;
+    refuse)
+      [ "$_asked" -eq 0 ] \
+        && pass "X5 ($_label) — a URL is never offered as something to run" \
+        || fail_ "X5 ($_label)" "a URL was offered to the operator as a command" ;;
+  esac
+done
+
+# ── X6 — THE INSTALLER MUST NOT WRITE INTO THE OPERATOR'S REPOSITORY. ──────
+# `eval` inherits the adoptee's directory as cwd, so a recipe writing a
+# relative path writes into their repo — and `adopt_refuse` then says "nothing
+# was written". Measured before the fix: two untracked files left behind under
+# exactly that refusal. Real matrix recipes write relative paths.
+X6="$(newtmp)"
+mkdir -p "$X6/p"
+if ! mk_adoptee "$X6/p"; then
+  fail_ "X6 setup" "could not build the adoptee"
+elif ! _mk_resolver "$X6/resolver" auto "touch INSTALLER_WROTE_HERE"; then
+  fail_ "X6 setup" "the resolver stub did not build"
+else
+  _ans_install 1 1 > "$X6/answers"      # accept: the command must RUN, somewhere
+  run_adopt "$X6/p" "$X6/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X6/resolver"
+  [ ! -e "$X6/p/INSTALLER_WROTE_HERE" ] \
+    && pass "X6 — an installer writing a RELATIVE path does not write into the adoptee" \
+    || fail_ "X6" "the install ran with the operator's repository as its working directory"
+  # …and the driver admits the host may have been touched, rather than
+  # claiming otherwise on a later refusal.
+  if grep -q 'is installed and on PATH\|did not put' "$RUN_OUT" 2>/dev/null; then
+    pass "X6b — the run reports what the install actually achieved"
+  else
+    fail_ "X6b" "the install arm said nothing about its outcome"
+  fi
+fi
+
+# ── X7 — "installed" IS VERIFIED, NOT ASSERTED. ────────────────────────────
+# A recipe whose last stage exits 0 without putting anything on PATH must not
+# produce a success claim. `true` is that recipe.
+X7="$(newtmp)"
+mkdir -p "$X7/p"
+if ! mk_adoptee "$X7/p"; then
+  fail_ "X7 setup" "could not build the adoptee"
+elif ! _mk_resolver "$X7/resolver" auto "true" "gitleaks-wp10a-absent"; then
+  fail_ "X7 setup" "the resolver stub did not build"
+else
+  # THE TOOL NAME IS ONE THAT CANNOT EXIST, ON ANY HOST. A first cut named
+  # `gitleaks` and so took the "already present" branch on this laptop and the
+  # "absent" branch on a runner — asserting different things in the two places,
+  # which is the local-vs-CI divergence CLAUDE.md documents. Worse, it made the
+  # assertion VACUOUS here: the mutant that replaces the probe with `true`
+  # survived, because the probe was going to succeed anyway.
+  if command -v gitleaks-wp10a-absent >/dev/null 2>&1; then
+    fail_ "X7ctl" "a tool named gitleaks-wp10a-absent exists on this host; pick another name"
+  else
+    pass "X7ctl — the fixture names a tool that is absent on every host, so the probe must fail"
+    _ans_install 1 1 > "$X7/answers"
+    run_adopt "$X7/p" "$X7/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X7/resolver"
+    if grep -q 'did not put gitleaks-wp10a-absent on PATH' "$RUN_OUT" 2>/dev/null; then
+      pass "X7 — a recipe exiting 0 without installing anything does NOT produce a success claim"
+    else
+      fail_ "X7" "a recipe that installed nothing was reported as installed"
+    fi
+  fi
+fi
+
+# ── X8 — THE BUCKET BRANCH, with a payload the URL test cannot refuse. ────
+# `in_manual` is the "primary classifier", and every manual-bucket fixture in
+# this file carries a URL — which the syntactic backstop refuses on its own. So
+# the bucket branch was DEAD CODE under test: review deleted it and the whole
+# suite stayed green. It matters forward, not just now: the resolver fix filed
+# on `## BL-242:` is exactly what starts routing real recipes into
+# `manual_install`, and the branch would ship into that world untested.
+#
+# The payload here is a RUNNABLE command in the manual bucket — a shape the
+# resolver produces the moment `manual` leaves its `INSTALL_KEYS`.
+X8="$(newtmp)"
+mkdir -p "$X8/p"
+if ! mk_adoptee "$X8/p"; then
+  fail_ "X8 setup" "could not build the adoptee"
+else
+  X8_CANARY="$X8/EXECUTED"
+  if ! _mk_resolver "$X8/resolver" manual "touch $X8_CANARY"; then
+    fail_ "X8 setup" "the resolver stub did not build"
+  else
+    _ans 1 > "$X8/answers"
+    run_adopt "$X8/p" "$X8/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X8/resolver"
+    [ ! -e "$X8_CANARY" ] \
+      && pass "X8 — a RUNNABLE command in the manual bucket is still never executed (the bucket decides, not the string)" \
+      || fail_ "X8" "the manual bucket was ignored because the payload looked runnable"
+    if grep -q 'This would run, exactly as written' "$RUN_OUT" 2>/dev/null; then
+      fail_ "X8b" "a manual-bucket entry was offered to the operator as something to run"
+    else
+      pass "X8b — and it is not offered as something to run"
+    fi
+  fi
+fi
+
+# ── X9 — THE HONESTY FLAG, pinned by the sentence it changes. ─────────────
+# `adopt_touched_disk` before the eval is half of round 1's blocker fix, and
+# review excised it with the whole suite staying green. Its whole purpose is
+# what a LATER refusal says, so that is what this asserts: accept the install,
+# then answer something invalid, and read the refusal.
+X9="$(newtmp)"
+mkdir -p "$X9/p"
+if ! mk_adoptee "$X9/p"; then
+  fail_ "X9 setup" "could not build the adoptee"
+elif ! _mk_resolver "$X9/resolver" auto "true" "gitleaks-wp10a-absent"; then
+  fail_ "X9 setup" "the resolver stub did not build"
+else
+  # tier, accept the install, then an answer that is not on offer
+  printf '1\n1\nNOT-AN-OPTION\n' > "$X9/answers"
+  run_adopt "$X9/p" "$X9/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X9/resolver"
+  X9_ALL="$(cat "$RUN_ERR" "$RUN_OUT" 2>/dev/null)"
+  case "$X9_ALL" in
+    *"Nothing was committed and nothing was written"*)
+      fail_ "X9" "after running an installer the refusal still claims nothing was written" ;;
+    *)
+      pass "X9 — after an install attempt the refusal no longer claims nothing was written" ;;
+  esac
+  # `*ATTEMPTED*` ALONE. A first cut also accepted `*"already"*`, which the
+  # reverse-intake preamble prints on EVERY adoption ("Some of this the scan
+  # already answered…") — so X9b passed unconditionally, including over a run
+  # whose refusal read "Nothing was committed and nothing was written", the
+  # exact sentence it exists to detect the absence of. Proven by mutation: with
+  # `adopt_touched_disk` excised, X9 went red and X9b stayed green.
+  case "$X9_ALL" in
+    *ATTEMPTED*)
+      pass "X9b — it says an attempt was made against this project" ;;
+    *)
+      fail_ "X9b" "the refusal went quiet about the install attempt" ;;
+  esac
+fi
+
+# ── X10 — AN INSTALLER MUST NOT EAT THE OPERATOR'S ANSWERS. ───────────────
+# The eval inherits fd 0, the same open file description the driver reads
+# answers from, so a recipe that reads stdin CONSUMES THEM. Measured before the
+# fix with a recipe of `read a; read b`: two confirmations swallowed and the
+# adoption then aborted for want of answers. Latent with today's matrix and
+# live the moment an eval-reachable recipe prompts.
+X10="$(newtmp)"
+mkdir -p "$X10/p"
+if ! mk_adoptee "$X10/p"; then
+  fail_ "X10 setup" "could not build the adoptee"
+elif ! _mk_resolver "$X10/resolver" auto "read _a; read _b; true" "gitleaks-wp10a-absent"; then
+  fail_ "X10 setup" "the resolver stub did not build"
+else
+  # tier + accept the install + the four scan-derived confirmations. If the
+  # installer eats any of them the run cannot complete.
+  printf '1\n1\n1\n1\n1\n1\n' > "$X10/answers"
+  run_adopt "$X10/p" "$X10/answers" "$REPORT" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X10/resolver"
+  X10_RC="$RUN_RC"
+  [ "$X10_RC" -eq 0 ] \
+    && pass "X10 — a stdin-reading installer does not consume the operator's answers (rc 0)" \
+    || fail_ "X10" "the adoption failed (rc $X10_RC) because the installer read from the answer stream"
+fi
+
+# ── X11 — A COMPLETED SCAN MUST NEVER BE DISCARDED IN SILENCE. ────────────
+# The splice can fail on a report that is not valid JSON — `adopt_obtain_report`
+# only checks that the file exists. A first cut had no `else` there, so a scan
+# that RAN (measured: 755 bytes of refreshed section) was thrown away and the
+# run said nothing, leaving the operator reading the survey's stale answer.
+X11="$(newtmp)"
+mkdir -p "$X11/p"
+if ! mk_adoptee "$X11/p"; then
+  fail_ "X11 setup" "could not build the adoptee"
+else
+  printf 'this is not json at all\n' > "$X11/report.json"
+  _mk_resolver "$X11/resolver" already "" || fail_ "X11 setup" "the resolver stub did not build"
+  _ans 1 > "$X11/answers"
+  run_adopt "$X11/p" "$X11/answers" "$X11/report.json" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$X11/resolver"
+  X11_ALL="$(cat "$RUN_OUT" "$RUN_ERR" 2>/dev/null)"
+  # `"could not be merged"` ALONE. THREE of the FOUR sibling failure arms say
+  # "could not be re-run" (the fourth says "could not be rendered"; the fifth
+  # exit is the deliberate don't-rescan skip, which is not a failure arm and
+  # prints nothing) — so accepting that phrase made X11 pass over runs where no
+  # scan happened at all, weaker than its own name. Derived, not counted from
+  # memory: `grep -c 'could not be re-run' scripts/lib/adopt/adopt-tools.sh` = 3. (Those faults are
+  # caught by R1/R3b/M4; this assertion is about the SIXTH arm specifically.)
+  case "$X11_ALL" in
+    *"could not be merged"*)
+      pass "X11 — an unmergeable re-scan SAYS so rather than discarding the result silently" ;;
+    *)
+      fail_ "X11" "the re-scan result was discarded with no word to the operator" ;;
+  esac
+fi
+
+echo ""
+echo "=== R — §6.2's re-scan, and its converse ==="
+
+R_MARK="# BL-242-SECRETS-RESCAN"
+r_sites="$(_sites "$L_TOOLS" "$R_MARK")"
+[ "$r_sites" = "1" ] \
+  && pass "R0 — '$R_MARK' occurs exactly once at end-of-line in adopt-tools.sh" \
+  || fail_ "R0" "'$R_MARK' occurs $r_sites times (need exactly 1)"
+
+# A report whose secrets section says the scanner was never there — exactly
+# what §6.2 says Act 2 may be handed, because Scout can predate the install.
+_stale_report() {   # _stale_report <dest>
+  jq '.secrets.status = "tool-unavailable"
+      | .secrets.findingCount = 0
+      | .secrets.findings = []
+      | .secrets.note = "gitleaks is not installed, so NOTHING WAS SCANNED."' \
+     "$REPORT" > "$1" 2>/dev/null
+}
+
+R1="$(newtmp)"
+mkdir -p "$R1/p"
+if ! mk_adoptee "$R1/p" || ! _stale_report "$R1/report.json"; then
+  fail_ "R1 setup" "could not build the adoptee or the stale report"
+else
+  R1_BEFORE="$(jq -r '.secrets.status' "$R1/report.json" 2>/dev/null)"
+  [ "$R1_BEFORE" = "tool-unavailable" ] \
+    && pass "R1ctl — the consumed report says tool-unavailable, so there is something to refresh" \
+    || fail_ "R1ctl" "the fixture report says '$R1_BEFORE'; this case tests nothing"
+  _mk_resolver "$R1/resolver" already ""
+  _ans 1 > "$R1/answers"
+  run_adopt "$R1/p" "$R1/answers" "$R1/report.json" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$R1/resolver"
+  R1_AFTER="$(jq -r '.secrets.status // ""' "$R1/p/.claude/adoption/scout-report.json" 2>/dev/null)"
+  [ "$R1_AFTER" = "scanned" ] \
+    && pass "R1 — the PERSISTED report says 'scanned': Act 2 re-scanned rather than trusting a stale 'nobody looked'" \
+    || fail_ "R1" "the persisted report still says '$R1_AFTER' — the re-scan did not happen or did not land"
+fi
+
+# R2 — THE CONVERSE, and it is what stops the re-scan being unconditional. A
+# report that already says `scanned` is the one Act 2 acted on; re-running the
+# scanner would discard the evidence hash the stamp records and cost a full
+# history walk for nothing.
+R2="$(newtmp)"
+mkdir -p "$R2/p"
+if ! mk_adoptee "$R2/p"; then
+  fail_ "R2 setup" "could not build the adoptee"
+else
+  # a sentinel the re-scan would necessarily overwrite
+  jq '.secrets.note = "SENTINEL-DO-NOT-RESCAN"' "$REPORT" > "$R2/report.json" 2>/dev/null
+  _mk_resolver "$R2/resolver" already ""
+  _ans 1 > "$R2/answers"
+  run_adopt "$R2/p" "$R2/answers" "$R2/report.json" "$REPO_ROOT" "SOIF_ADOPT_RESOLVER=$R2/resolver"
+  R2_NOTE="$(jq -r '.secrets.note // ""' "$R2/p/.claude/adoption/scout-report.json" 2>/dev/null)"
+  case "$R2_NOTE" in
+    *SENTINEL-DO-NOT-RESCAN*)
+      pass "R2 — an already-scanned report is NOT re-scanned (its own note survives)" ;;
+    *)
+      fail_ "R2" "the secrets section was rewritten on a report that was already 'scanned'" ;;
+  esac
+fi
+
+# ── R3 — THE ATTESTATION TRACKS THE RESULT, NOT THE SPLICE. ───────────────
+# A first cut printed "this project's history was read rather than skipped"
+# whenever the splice succeeded — including when the refreshed status was
+# still `tool-unavailable`, three lines after saying the scanner could not be
+# installed. A false all-clear on a security surface.
+R3="$(newtmp)"
+mkdir -p "$R3/p"
+if ! mk_adoptee "$R3/p" || ! _stale_report "$R3/report.json"; then
+  fail_ "R3 setup" "could not build the adoptee or the stale report"
+elif ! _mk_resolver "$R3/resolver" manual "$X5_URL"; then
+  fail_ "R3 setup" "the resolver stub did not build"
+else
+  # Force the re-scan to come back tool-unavailable by pointing Scout's own
+  # seam at a binary that does not exist — the mechanism scout-secrets.sh
+  # documents for exactly this.
+  _ans 1 > "$R3/answers"
+  run_adopt "$R3/p" "$R3/answers" "$R3/report.json" "$REPO_ROOT" \
+    "SOIF_ADOPT_RESOLVER=$R3/resolver" "SCOUT_GITLEAKS_BIN=gitleaks-does-not-exist-wp10a"
+  R3_STATUS="$(jq -r '.secrets.status // ""' "$R3/p/.claude/adoption/scout-report.json" 2>/dev/null)"
+  if [ "$R3_STATUS" = "tool-unavailable" ]; then
+    pass "R3ctl — the re-scan still could not look, so the attestation is under test"
+    if grep -q "history[[:space:]]*$" "$RUN_OUT" 2>/dev/null && grep -q 'was read\.' "$RUN_OUT" 2>/dev/null; then
+      fail_ "R3" "the run said the history WAS READ over a record saying nothing was scanned"
+    else
+      pass "R3 — it does not claim the history was read"
+    fi
+    if grep -q 'STILL could not look' "$RUN_OUT" 2>/dev/null; then
+      pass "R3b — and it says plainly that nothing is known"
+    else
+      fail_ "R3b" "the run went quiet about a re-scan that found nothing to look with"
+    fi
+  else
+    fail_ "R3ctl" "the re-scan produced '$R3_STATUS'; this case cannot test the attestation"
+  fi
+fi
+
+echo ""
+echo "=== M — the mutation proofs ==="
+
+# M1 — drop the resolver call.
+M1="$(newtmp)"
+mkdir -p "$M1/fw" "$M1/p"
+if ! mk_mirror "$M1/fw"; then
+  fail_ "M1 setup" "could not mirror the framework"
+elif [ "$(_mutate "$M1/fw" "adopt-state.sh" "$X0_MARK" "  :")" != "1" ]; then
+  fail_ "M1 setup" "the resolver-call mutation did not apply cleanly"
+elif ! mk_adoptee "$M1/p"; then
+  fail_ "M1 setup" "could not build the adoptee"
+else
+  _mk_resolver "$M1/resolver" already ""
+  _ans 1 > "$M1/answers"
+  run_adopt "$M1/p" "$M1/answers" "$REPORT" "$M1/fw" "SOIF_ADOPT_RESOLVER=$M1/resolver"
+  if grep -qi 'secret.detection\|gitleaks' "$RUN_OUT" 2>/dev/null; then
+    fail_ "M1 (MUTATION)" "dropping the resolver call changed nothing observable"
+  else
+    pass "M1 (MUTATION) — dropping the call removes every sign the resolver ran: X1b is what pins it"
+  fi
+fi
+
+# M2 — execute the manual-bucket command. THE CANARY IS THE ASSERTION.
+M2="$(newtmp)"
+mkdir -p "$M2/fw" "$M2/p"
+M2_MARK="# BL-242-RESOLVER-NO-EXEC"
+m2_sites="$(_sites "$L_TOOLS" "$M2_MARK")"
+[ "$m2_sites" = "1" ] \
+  && pass "M2-anchor — '$M2_MARK' occurs exactly once at end-of-line" \
+  || fail_ "M2-anchor" "'$M2_MARK' occurs $m2_sites times (need exactly 1)"
+if ! mk_mirror "$M2/fw"; then
+  fail_ "M2 setup" "could not mirror the framework"
+elif [ "$(_mutate "$M2/fw" "adopt-tools.sh" "$M2_MARK" "  if false; then")" != "1" ]; then
+  fail_ "M2 setup" "the no-exec mutation did not apply cleanly"
+elif ! mk_adoptee "$M2/p"; then
+  fail_ "M2 setup" "could not build the adoptee"
+else
+  M2_CANARY="$M2/EXECUTED"
+  _mk_resolver "$M2/resolver" manual "https://example.invalid/x; touch $M2_CANARY"
+  _ans_install 1 1 > "$M2/answers"
+  run_adopt "$M2/p" "$M2/answers" "$REPORT" "$M2/fw" "SOIF_ADOPT_RESOLVER=$M2/resolver"
+  [ -e "$M2_CANARY" ] \
+    && pass "M2 (MUTATION) — without the guard the manual-bucket string IS executed: X2 is what stops it" \
+    || fail_ "M2 (MUTATION)" "removing the guard changed nothing — X2 may be passing for another reason"
+fi
+
+# M3 — drop the re-scan.
+M3="$(newtmp)"
+mkdir -p "$M3/fw" "$M3/p"
+if ! mk_mirror "$M3/fw"; then
+  fail_ "M3 setup" "could not mirror the framework"
+elif [ "$(_mutate "$M3/fw" "adopt-tools.sh" "$R_MARK" "  return 0")" != "1" ]; then
+  fail_ "M3 setup" "the re-scan mutation did not apply cleanly"
+elif ! mk_adoptee "$M3/p" || ! _stale_report "$M3/report.json"; then
+  fail_ "M3 setup" "could not build the adoptee or the stale report"
+else
+  _mk_resolver "$M3/resolver" already ""
+  _ans 1 > "$M3/answers"
+  run_adopt "$M3/p" "$M3/answers" "$M3/report.json" "$M3/fw" "SOIF_ADOPT_RESOLVER=$M3/resolver"
+  M3_AFTER="$(jq -r '.secrets.status // ""' "$M3/p/.claude/adoption/scout-report.json" 2>/dev/null)"
+  [ "$M3_AFTER" = "tool-unavailable" ] \
+    && pass "M3 (MUTATION) — without the re-scan the stale 'tool-unavailable' is persisted verbatim: R1 is what refreshes it" \
+    || fail_ "M3 (MUTATION)" "the persisted status is '$M3_AFTER' — the mutation changed nothing"
+fi
+
+# M4 — THE OPPOSITE DIRECTION ON THE SAME LINE, and one marker earns both.
+# M3 turns the guard into an unconditional return (no re-scan ever); M4 removes
+# the guard entirely (re-scan always). A build with only M3 would be satisfied
+# by a re-scan that runs on every report, which discards the very measurement
+# the adoption stamp is about to record a hash of.
+M4="$(newtmp)"
+mkdir -p "$M4/fw" "$M4/p"
+if ! mk_mirror "$M4/fw"; then
+  fail_ "M4 setup" "could not mirror the framework"
+elif [ "$(_mutate "$M4/fw" "adopt-tools.sh" "$R_MARK" "  :")" != "1" ]; then
+  fail_ "M4 setup" "the unconditional-rescan mutation did not apply cleanly"
+elif ! mk_adoptee "$M4/p"; then
+  fail_ "M4 setup" "could not build the adoptee"
+else
+  jq '.secrets.note = "SENTINEL-DO-NOT-RESCAN"' "$REPORT" > "$M4/report.json" 2>/dev/null
+  _mk_resolver "$M4/resolver" already ""
+  _ans 1 > "$M4/answers"
+  run_adopt "$M4/p" "$M4/answers" "$M4/report.json" "$M4/fw" "SOIF_ADOPT_RESOLVER=$M4/resolver"
+  M4_NOTE="$(jq -r '.secrets.note // ""' "$M4/p/.claude/adoption/scout-report.json" 2>/dev/null)"
+  case "$M4_NOTE" in
+    *SENTINEL-DO-NOT-RESCAN*)
+      fail_ "M4 (MUTATION)" "removing the guard changed nothing — R2 may be passing for another reason" ;;
+    *)
+      pass "M4 (MUTATION) — without the guard an already-scanned report IS re-scanned: R2 is what stops it" ;;
+  esac
+fi
+
+echo ""
+if [ "$FAILED" -eq 0 ]; then
+  echo "Results: $PASSED passed, $FAILED failed"
+  exit 0
+fi
+echo "Results: $PASSED passed, $FAILED failed"
+exit 1


### PR DESCRIPTION
**WP10a** — Act 2's second step (§8.2): tool resolution, and §6.2's re-scan-after-install. WP10 ships as two PRs on Karl's call; **10b** brings §6.1's eight status×tier cells, §6.3's dispositions and §6.4's tiered escape. Both land before WP11.

**10a changes no stop/proceed decision.** A `tool-unavailable` report still completes an adoption here, exactly as before — 10b is what makes it stop. The suite says so, so nothing pins behaviour the next PR is specified to change.

## The defect found before a line was written

`install_cmd` is not always a command. The gitleaks entry in `templates/tool-matrix/common.json` carries `darwin_brew`, three Linux recipes **and** a `manual` key whose value is a URL. Measured against the shipped resolver:

```
darwin, brew present → "brew install gitleaks"
darwin, brew absent  → "https://github.com/gitleaks/gitleaks/releases"
linux,  apt present  → "GITLEAKS_VERSION=$(curl …) && curl … | sudo tar -xz …"
```

A consumer that pipes that to a shell **executes a URL**, on exactly the hosts least able to cope. X2 pins it with a canary, not a string.

## Six review rounds

| round | blocked on |
|---|---|
| 1 | the guard refused the **shipped Linux recipe** — adoption could never install the scanner there, while telling the operator the host had no recipe; the install `eval` ran with the adoptee as cwd, leaving files in the operator's repo under a refusal saying nothing was written; the run attested the history was read when the re-scan still said `tool-unavailable` |
| 2 | a defect a **round-1 fix introduced** — the `eval` shared fd 0 with the operator's answer stream, so a stdin-reading recipe ate their answers; a sixth silent exit discarding a completed scan; a "nothing else was changed" that was measured false |
| 3–5 | prose and test-predicate defects only, each inside the previous round's own correction |
| 6 | binding re-check of the final delta — **approve** |

The classifier is now the resolver's **bucket**, with a narrow URL backstop and a **post-install probe** behind it, so a string either test misjudges still cannot produce a false "installed" claim.

## Recorded, not fixed

`resolve-tools.sh` lists `manual` last in `INSTALL_KEYS`, so the URL reaches the **`auto_install`** bucket — and `init.sh` executes that bucket. That is the shared resolver's defect with a blast radius beyond this package, and §10 authorises WP10 to *invoke* the resolver, not change it. Filed on `## BL-242:` with the measurement, the one-line fix, and why it needs its own proofs (11 test files reference that script, 6 execute it). The Linux recipe's unpinned, checksum-less root install is filed alongside it — this repo's own CI pins that same artefact by version and SHA.

## Checks

- `bash scripts/run-lints.sh` → `15 lints — 15 passed, 0 failed`
- `tests/test-brownfield-wp10a-tool-resolution.sh` → **34 passed, 0 failed**; 4 mutants, each watched RED first (the suite ran 7/10 against the unmodified tree)
- 11 adoption suites green, plus `test-bl033-install-cmds-shape.sh`, which pins the resolver shape this package reads
- Registered in both lanes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk
