### PR TITLE
ci(bl-242): re-pin the rest shard's pole, and file the regression that built it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -614,13 +614,98 @@ jobs:
             #    "highest" is therefore NOT stable from a single sample; take two
             #    before re-pinning anything on it.
             #
-            #    AND `rest` HAS NO POLE TO MOVE. Its 526s is 158 suites whose
+            #    AND `rest` HAS NO POLE TO MOVE.  <<< SUPERSEDED 2026-09-04 —
+            #    FALSE SINCE WP10a; the measurement that refutes it is in the
+            #    re-pin note at the bottom of this array. Read that before
+            #    acting on the next SIX lines (through "afternoon hunting for a
+            #    long pole that does not exist"). >>>
+            #    Its 526s is 158 suites whose
             #    largest is 40s — flat, ~3.3s mean. If the complement ever binds,
             #    re-pinning cannot fix it: there is nothing to pin. That would
             #    need a different mechanism (more shards, or splitting the
             #    complement), and it is worth knowing BEFORE someone spends an
             #    afternoon hunting for a long pole that does not exist.
             tests/test-delta-wp5-hotfix-retro.sh   # 185s measured (run 32048687734) — the pole; opens and closes deltas dozens of times, and each open also renders a brief and seeds a ledger row, so it grew with the feature rather than with the test
+            # ── Re-pinned 2026-09-04, and this note REFUTES the paragraph
+            #    directly above it. "`rest` HAS NO POLE TO MOVE … 158 suites
+            #    whose largest is 40s, flat, ~3.3s mean" was true when it was
+            #    written and is now false by measurement. Run 33880279546's
+            #    `rest` log, per-suite from the ::group:: timestamps:
+            #      163 suites, 686.15s of the leg's 707s
+            #      test-brownfield-wp4-driver.sh        90.3s  <- the pole, 2.25x the claim
+            #      test-brownfield-wp9-act-boundaries   66.0s  <- the second
+            #      the next seven                     27-38s each (396.18s for the top nine)
+            #      the remaining 154                  289.97s TOTAL (1.88s mean)
+            #    The flat tail the old note described is still there underneath.
+            #    What sits on top of it is NOT family growth — that was this
+            #    note's first draft and it is wrong. It is a ONE-COMMIT STEP
+            #    CHANGE, and the pin is removing the only signal that showed
+            #    it. Same two suites, test files BYTE-IDENTICAL between the
+            #    two commits (`git diff 24dc321 4009790 -- <the suites>` is
+            #    empty):
+            #      suite                run 33592497086   run 33880279546
+            #                           (24dc321, pre-)   (4009790, WP10a)
+            #      wp4-driver                    17.0s             90.3s  5.3x
+            #      wp9-act-boundaries            15.3s             66.0s  4.3x
+            #      wp9b-preflight-approval       47.2s            222.6s  4.7x
+            #    (wp9b's two spans are from DIFFERENT LEGS — it sat in `rest`
+            #    on the first run and was pinned to `lint-scan` before the
+            #    second. Both legs are `ubuntu-latest` running the same suite
+            #    serially, so the comparison stands; it is named because a
+            #    reader tracing the figures back will otherwise find them in
+            #    two different job logs and assume one is a typo.)
+            #    Every other suite in the leg moved +5%..+40% — ordinary runner
+            #    drift. The cause is `# BL-242-RESOLVER-CALL`: WP10a made every
+            #    adoption spawn `scripts/resolve-tools.sh` unconditionally, at
+            #    6.8s wall per invocation, before it inspects anything. Filed
+            #    as `## BL-251:` WITH the fix shape; it is product code on the
+            #    adoption path and is owed its own tests, so it is not fixed
+            #    here. THIS PIN DOES NOT ADDRESS IT — do not read it as having.
+            #
+            #    WHY HERE. Same-run legs against the 720s cap:
+            #      lint-sweep  312s (43%)  <- this leg, the most headroom
+            #      sast        354s (49%)
+            #      slow-misc   469s (65%)
+            #      lint-scan   503s (70%)
+            #      rest        707s (98%)  <- 13s of slack
+            #    Moving both: lint-sweep -> ~468s (65%), rest -> ~551s (77%).
+            #    Nothing else was considered close: lint-scan would go to 92%
+            #    and slow-misc to 87%. Splitting the pair across lint-sweep and
+            #    sast distributes marginally better but does not move the
+            #    binding constraint, which is `rest` at ~551s either way.
+            #
+            #    THE TWO ERRORS THIS CORRECTS. The 2026-09-02 note in
+            #    `pin_lint_scan` missed BOTH its landing points, and they failed
+            #    for DIFFERENT reasons — a first draft of this paragraph blamed
+            #    one cause for both, which would have left the live one unnamed.
+            #      (a) `rest`: predicted ~539s, measured 707s (-168s). This one
+            #          IS arithmetic: ~539s was 733 - 194, and 733s was a
+            #          CANCELLED leg — killed at the cap mid-run, so it is a
+            #          FLOOR on that leg's runtime, not a total. Subtracting
+            #          from a floor yields a floor. NEVER DERIVE A LANDING POINT
+            #          FROM A CANCELLED LEG.
+            #      (b) `lint-scan`: predicted ~439s, measured 503s (+64s). 733
+            #          DOES NOT APPEAR in that sum — it was 245 + 194 — so the
+            #          cancelled leg cannot explain it even in principle. This
+            #          one is MEASUREMENT: the 194s was a local->CI
+            #          extrapolation, and wp9b actually ran 222.6s against the
+            #          "~174s on the runner" written beside it, 28% low. Real
+            #          total 245 + 252.7 = 497.7s vs 503s measured — the rest is
+            #          noise. A local stopwatch scaled by a remembered ratio is
+            #          not a CI measurement; this file says so two arrays up and
+            #          the estimate was made anyway.
+            #    The figures in THIS note come from uncancelled runs and from
+            #    per-suite CI spans, not from either of those methods.
+            #
+            #    ONE-SAMPLE CAVEAT, per the paragraph above: the LEG totals
+            #    carry ~100s of run-to-run noise (`rest` measured 493s/582s/
+            #    597s/597s across the four most recent main runs before this).
+            #    The SUITE figures do not — they are per-::group:: spans, and
+            #    90.3s vs a 40s claim is far outside that band. The move is
+            #    justified on the suite measurement; the leg percentages above
+            #    are context, not the evidence.
+            tests/test-brownfield-wp4-driver.sh            # 90.3s in CI (run 33880279546) — THE pole
+            tests/test-brownfield-wp9-act-boundaries.sh    # 66.0s in CI (run 33880279546) — the second
           )
           pin_lint_scan=(
             tests/test-lint-counter-antipattern.sh     # 243s at pin time — T9 re-scans the real repo; BL-191 made that scan single-pass, so re-measure before repinning
@@ -669,7 +754,9 @@ jobs:
             #    to the cap, not `rest`.
             tests/test-bl235-tool-matrix-probes.sh       # leg measured 245s/720s (34%) with this suite in it — run 32046301464
             # ── Re-pinned 2026-09-02, and this is the case the note in
-            #    `pin_slow_misc` said could not arise. `rest` was described as
+            #    `pin_lint_sweep` said could not arise (that note is in
+            #    `pin_lint_sweep`, not `pin_slow_misc` — this line named the
+            #    wrong array until 2026-09-04). `rest` was described as
             #    having NO POLE TO MOVE — "158 suites whose largest is 40s,
             #    flat, ~3.3s mean". THE BROWNFIELD ADOPTION SUITES BUILT THAT
             #    POLE: each of their cases runs a whole adoption, so they are
@@ -698,9 +785,24 @@ jobs:
             #    That is the family-coherence choice and it was rejected on the
             #    doctrine: `pin_slow_misc` already carries wp5b and wp6, and
             #    adding ~194s would take that leg to ~576s (80%) — the band its
-            #    own note calls "the leg to watch". `lint-scan` lands at ~439s
-            #    (61%) and `rest` falls to ~539s (75%), so no leg becomes the
-            #    next re-pin. Keeping a family together is worth less than not
+            #    own note calls "the leg to watch". `lint-scan` was predicted to
+            #    land at ~439s (61%) and `rest` to fall to ~539s (75%), so no
+            #    leg would become the next re-pin.
+            #      MEASURED ON RUN 33880279546 AND BOTH FIGURES WERE WRONG:
+            #      lint-scan 503s (70%) and `rest` 707s (98%) — 13s under the
+            #      cap, i.e. still the next re-pin, which is what the 2026-09-04
+            #      note in `pin_lint_sweep` then had to fix. THE TWO MISSES HAVE
+            #      DIFFERENT CAUSES and the diagnosis is NOT repeated here,
+            #      because a one-line version of it was wrong: an earlier draft
+            #      of this very block said "the cause is arithmetic, not
+            #      measurement", which is true of the `rest` miss and false of
+            #      the `lint-scan` one — 439 was 245 + 194 and never contained
+            #      733. Both are worked through, separately and with the
+            #      measurements, in the 2026-09-04 note in `pin_lint_sweep`;
+            #      read it there rather than trusting a summary here. The
+            #      `lint-scan` half of the decision below still holds; the "no
+            #      leg becomes the next re-pin" conclusion did not.
+            #    Keeping a family together is worth less than not
             #    creating the same problem one shard over. *(A draft of this
             #    comment said wp10a belongs "beside its sibling" — it does not:
             #    its siblings are in `slow-misc`, which is the leg this pin

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -5188,6 +5188,45 @@ list carrying the victim COMMENTED OUT must exit 1 and name the file; the same l
 exit 0. **Mutation proof:** revert the `!/^[[:space:]]*#/` predicate → the commented-out fixture
 flips from FAIL to PASS → RED → restore → GREEN.
 
+**Residual #2 ADDENDUM (2026-09-04, out of the `ci/bl242-rest-shard-repin` review).** The fix shape
+above closes the comment-body half and leaves the **scope-opening** half open, and the second one is
+ACTIVE ON THE MERGED TREE TODAY — not hypothetical.
+
+1. **The opening rule matches a comment, and ANCHORING ALONE IS NOT ENOUGH.** `/tests=\(/{f=1; next}`
+   is unanchored, so any comment line containing the literal token opens the scope, and the
+   `!/^[[:space:]]*#/` predicate cannot help — it filters what is COLLECTED, not what OPENS.
+   Anchoring the opener (`/^[[:space:]]*tests=\(/`) closes the COMMENT route ONLY: `[[:space:]]*`
+   still admits any real `tests=(` array below the canonical one. Proved by adding an ordinary
+   (uncommented) `tests=(…)` array to the `full` job's `run:` block — a plausible refactor, since
+   that job already loops `for t in tests/edge-cases-upgrade-input.sh …`: both spellings collect the
+   phantom, 183 → 184 entries, anchoring changes nothing. A mutation proof keyed only to a commented
+   path would pass while this route stayed open — the weak-proof class this entry already tracks.
+   **Anchor AND refuse when the opener count is not exactly 1**, mirroring the zero-entry refusal
+   `_build_unit_list_set` already carries ("parsed 0 entries from the tests.yml unit list … refusing
+   to claim a clean pass"). Today: unanchored openers 2, anchored 1 → passes; with a second array:
+   anchored 2 → refuses loudly. Anchoring alone leaves the hole; counting alone is red today because
+   of the line-324 comment. A `# UNIT-LIST-BEGIN/END` sentinel pair — the idiom
+   `# BL-154-UNIT-LANE-BEGIN`/`-END` already uses — is the more robust alternative.
+2. **It is open right now.** In `.github/workflows/tests.yml` the scope opens on the comment that
+   *explains this very hazard* ("scopes with awk between `tests=(` and `)` and does not strip
+   comments"), 25 lines above the real array, and the collected span therefore includes the comment
+   naming `tests/test-lint-no-live-remote.sh`. Verified by running both spellings over the merged
+   tree: anchored 183 entries, unanchored 183 entries — **identical only because that path is also a
+   genuine array member.** A comment naming a path that is NOT a member would silently become one.
+3. **End-to-end proof, so the mutation test has a target.** With a phantom fast test present in a
+   fixture, `scripts/lint-tests-registered.sh` reports `1 violation` (RED, "not listed in the
+   tests.yml unit lane"); add ONE comment line below the array carrying the token plus that path and
+   the same lint reports `OK: every test file is registered with an aggregator (or EXEMPT)` while
+   bash still never runs it. Membership set 183 → 184; the shard partition is unaffected, so no other
+   check notices.
+
+**Lane reachability:** no PR-blocking lane catches this — neither `.github/workflows/lint.yml` nor
+the `unit-shard`/`unit` chain. (The manual `full` job would still *execute* an aggregator-registered
+phantom, but executing it is not catching the defect, which is silent non-execution in the gating
+lane.) The prose rule in `tests.yml`
+("NOTHING BELOW THIS LINE MAY CONTAIN THE LITERAL ARRAY-OPENING TOKEN") is enforced by nothing.
+Fix both halves in one change, since one awk line carries both.
+
 ---
 
 ## BL-182: A ~958+ character repo-relative path is UNREPRESENTABLE in the BL-132 index temp tree — PATH_MAX aborts materialization and the whole commit goes NOTRUN (third instance of the same class)
@@ -14822,3 +14861,108 @@ whole cry-wolf objection go away, and it is worth designing before coding.
 **Related:** `## BL-230:` (the three arms that DO exist, and why this one was
 held back), `## BL-090:` (a warn-tier arm still waiting to be escalated),
 `## BL-112:` (a status that means something other than what the caller reads).
+
+---
+
+## BL-251: WP10a made every adoption pay a 6.8s tool-resolver subprocess it usually does not need — a 4.3x-5.3x step change, found only because it pushed a CI shard to 13s of slack
+
+**Status:** Open
+
+**Logged:** 2026-09-04, out of the adversarial review of the `rest`-shard re-pin
+(`ci/bl242-rest-shard-repin`). The re-pin's first draft explained the new pole
+as the brownfield family "growing a pole in nearly every work package". That
+explanation was wrong, and the review refused it: this is a **single-commit step
+change in shipped code**, and re-pinning the shard removes the only signal that
+was showing it.
+
+**Measured, per-suite, from the `::group::` spans of two CI runs — the test
+files are byte-identical between them** (`git diff 24dc321 4009790 --
+tests/test-brownfield-wp4-driver.sh tests/test-brownfield-wp9-act-boundaries.sh
+tests/test-brownfield-wp9b-preflight-approval.sh` is empty):
+
+| suite | run 33592497086 (`24dc321`, pre-WP10a) | run 33880279546 (`4009790`, WP10a) | factor |
+|---|---|---|---|
+| `test-brownfield-wp4-driver.sh` | 17.0s | 90.3s | **5.3x** |
+| `test-brownfield-wp9-act-boundaries.sh` | 15.3s | 66.0s | **4.3x** |
+| `test-brownfield-wp9b-preflight-approval.sh` | 47.2s | 222.6s | **4.7x** |
+
++299.4s across the three, against a `unit-shard` cap of 720s. Every other suite
+in the same leg moved within the +5%..+40% band that is ordinary runner drift.
+
+**Mechanism, and it is one line.** `# BL-242-RESOLVER-CALL` in
+`scripts/lib/adopt/adopt-state.sh` calls `adopt_resolve_tools` on **every**
+adoption, and `adopt_resolve_tools` invokes `scripts/resolve-tools.sh`
+**unconditionally, before it inspects anything**. Measured on this host:
+
+```
+$ time bash scripts/resolve-tools.sh --dev-os macos --platform web \
+      --language shell --track standard --phase 2 --matrix-dir templates/tool-matrix
+1.96s user 1.22s system 46% cpu 6.818 total
+```
+
+6.8s wall, of which only 3.2s is CPU — the rest is the resolver blocking. A
+suite that drives 20-odd adoptions pays it 20-odd times. The review confirmed
+the causal link independently by disabling that single call site: the suite went
+from 2m09s to 23s **and still passed 24/24**, because it does not assert on the
+resolver at all.
+
+**Why the cost is usually avoidable.** The step exists (design §6.2) to get a
+secret scanner in place so the history CAN be read. Everything it does is keyed
+to gitleaks — every `jq` select in `adopt_resolve_tools` hardcodes
+`(.name // "") == "gitleaks" or (.category // "") == "Secret Detection"`. So the
+resolver's payload is only needed for the **install recipe**, i.e. only when the
+scanner is ABSENT. When it is present, a `command -v` answers in microseconds
+what the 6.8s subprocess is being spawned to find out. **Note there is no such
+check on this path today** — `_adopt_tool_present` (the file's only `command -v`)
+is called exactly once, at `# BL-242-RESOLVER-VERIFY`, as a POST-INSTALL
+verification. The cheap predicate the fix needs does not exist yet; it has to be
+added, not merely moved. One layer down, `_adopt_rescan_secrets` does already
+carry the matching guard (`# BL-242-SECRETS-RESCAN` returns immediately when
+`.secrets.status` is `scanned`) — and the resolver call sits upstream of that
+one.
+
+**The equivalence holds — this was an open question and it is now answered.**
+`templates/tool-matrix/common.json`'s gitleaks entry is `phase: 1`,
+`tracks: [light, standard, full]`, `dev_os: [darwin, linux]`,
+`platforms: [all]`, `languages: [all]`, so the adopter's fixed
+`--phase 2 --track standard --platform web --language <any>` call always selects
+it; and its predicate is literally `"check_command": "command -v gitleaks"`,
+which `resolve-tools.sh` evaluates through `run_bounded`. So
+`command -v gitleaks` succeeding is equivalent to gitleaks landing in
+`.already_installed`, and the only divergence is the 10s evaluation deadline,
+which errs safe. **The semantics are not the risk. The seam is.**
+
+**Fix shape (not yet built; needs its own TDD + mutation proof).** Add the cheap
+predicate and take the existing already-installed arm directly, so
+`resolve-tools.sh` is never spawned when the scanner is present. **THE
+PLACEMENT IS THE WHOLE DIFFICULTY, and the obvious placement is wrong — this
+was measured, not reasoned:** hoisting a bare `_adopt_tool_present gitleaks`
+to the top of `adopt_resolve_tools`, immediately after `adopt_head`, puts a
+HOST PROBE ABOVE THE `SOIF_ADOPT_RESOLVER` SEAM. All 18 stub-driven cases in
+`tests/test-brownfield-wp10a-tool-resolution.sh` then stop reaching their stub,
+and the suite goes **25 passed / 9 failed** on a host that has gitleaks and
+**34 passed / 0 failed** on one that does not — the single variable being what
+happens to be installed. That is exactly the local-vs-CI divergence the seam's
+own comment was written to prevent, and CLAUDE.md's standing trap. It fails
+loudly rather than silently (gitleaks is on this Mac AND installed in every CI
+unit-shard leg, `tests.yml` gitleaks step), which is the only mercy.
+
+So the short-circuit must sit **behind the seam**: either gate it on
+`SOIF_ADOPT_RESOLVER` being unset, or route the probe through a seam-aware
+helper the suite can stub. The saving is real once it is placed correctly —
+the same hoist measured `test-brownfield-wp4-driver.sh` at **21.6s against a
+129.5s baseline, 24/24 passing**.
+
+One thing still to check: whether 6.8s is itself a defect in
+`resolve-tools.sh` (46% CPU says it blocks on something — establish on what
+before accepting the number as inherent).
+
+**Why this is filed rather than fixed in the re-pin:** the re-pin is a CI-config
+change to `.github/workflows/tests.yml`; this is product code on the adoption
+path and is owed tests. The pin should still land — `rest` is at 13s of slack
+and a cancelled leg reports nothing at all — but it must not be read as having
+addressed this.
+
+**Related:** `## BL-242:` (the work package that introduced it), `## BL-112:`
+(a scan that did not run must never read as a scan that found nothing — the
+doctrine the re-scan arm implements).


### PR DESCRIPTION
`rest` was measured at **707s against the 720s cap** on run 33880279546 — 13s of slack — after PR #373's pin predicted it would fall to ~539s. This moves its two poles to `lint-sweep` and records why the prediction missed.

## The pin

| leg | this run | after |
|---|---|---|
| lint-sweep | 312s (43%) | ~468s (65%) |
| sast | 354s (49%) | — |
| slow-misc | 469s (65%) | — |
| lint-scan | 503s (70%) | — |
| **rest** | **707s (98%)** | **~551s (77%)** |

`lint-scan` would go to 92% and `slow-misc` to 87%. `lint-sweep` is the lightest leg in both available samples, so the placement does not rest on one run. On the base-tree run 33881564446 the same computation gives ~540s (75%) and ~545s (76%) — the honest range is 65-75% for `lint-sweep`.

## Two prediction errors, different causes

- **`rest`** predicted ~539s, measured 707s. **Arithmetic**: ~539s was `733 - 194`, and 733s was a *cancelled* leg — a floor on its runtime, not a total.
- **`lint-scan`** predicted ~439s, measured 503s. **Measurement**: that sum was `245 + 194` and never contained 733. wp9b ran **222.6s** against the "~174s on the runner" written beside it — a local→CI extrapolation 28% low. Real total `245 + 252.7 = 497.7s`.

`pin_lint_scan` carried a one-line diagnosis ("the cause is arithmetic, not measurement") that is true of the first and false of the second. Replaced in place with a pointer, so the file no longer states two opposite diagnoses in two arrays.

## The pole is not family growth — it is a WP10a step change

Test files **byte-identical** between the two commits:

| suite | `24dc321` (pre) | `4009790` (WP10a) | |
|---|---|---|---|
| wp4-driver | 17.0s | 90.3s | 5.3x |
| wp9-act-boundaries | 15.3s | 66.0s | 4.3x |
| wp9b-preflight-approval | 47.2s | 222.6s | 4.7x |

Every other suite in the leg moved +5%..+40% (runner drift). Cause is `# BL-242-RESOLVER-CALL`: WP10a spawns `scripts/resolve-tools.sh` on every adoption, unconditionally, before inspecting anything — 6.8s wall per invocation, 3.2s of it CPU. **Filed as BL-251. This pin does not address it.**

BL-251 also records that the obvious fix is wrong: hoisting a bare `command -v` above the `SOIF_ADOPT_RESOLVER` seam takes the WP10a suite to 25 passed / 9 failed on a host with gitleaks and 34 / 0 without — the local-vs-CI divergence the seam exists to prevent. The saving is real (wp4-driver 21.6s vs 129.5s, 24/24) but the short-circuit must sit behind the seam.

## Also

- `pin_lint_sweep`'s "no pole to move, largest is 40s" claim now carries an in-line SUPERSEDED marker naming the six lines it governs.
- The 2026-09-02 note named `pin_slow_misc` as that claim's home; it is in `pin_lint_sweep`. Corrected in place.
- `## BL-181:` residual #2 gains an addendum: its recorded fix closes the comment-body half of the awk hazard and leaves the scope-opening half open, and that half is active on the merged tree today. Anchoring alone is insufficient — proved by adding an ordinary `tests=(…)` array to the `full` job; the fix needs anchor **and** an opener-count refusal.

## Verification

YAML parses. Shard-selection script extracted from the workflow gives `23 pinned + 161 rest == 184 canonical` on all five legs, with both suites in `lint-sweep` and neither in `rest`. The `unit` required-check job is untouched. `lint-tests-registered.sh`'s awk-scoped membership set is byte-identical to base (183 entries) and no added comment line carries a `tests/` path. All 15 repo lints pass. Two non-comment lines added, zero removed.

Reviewed adversarially across three rounds; final verdict `minor_concerns` with the one remaining finding folded into this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk