### PR TITLE
fix(bl-251): a scanner already on PATH must not cost a resolver subprocess

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -808,7 +808,7 @@ jobs:
             #    its siblings are in `slow-misc`, which is the leg this pin
             #    deliberately avoids.)*
             tests/test-brownfield-wp9b-preflight-approval.sh   # 334s local / ~174s on the runner — THE pole
-            tests/test-brownfield-wp10a-tool-resolution.sh     #  30s local / ~20s on the runner
+            tests/test-brownfield-wp10a-tool-resolution.sh     #  45s local (S/MS block added nine adoptions) / ~30s on the runner
             #    The BL-221 suite that landed alongside this one is NOT pinned
             #    and is deliberately not named as a path here: it measures under
             #    a second, pinning it would buy nothing, and a commented path

--- a/scripts/lib/adopt/adopt-tools.sh
+++ b/scripts/lib/adopt/adopt-tools.sh
@@ -108,6 +108,50 @@ _adopt_tool_present() {
   command -v "$name" >/dev/null 2>&1
 }
 
+# ── `## BL-251:` — IS THE SCANNER ALREADY HERE, ANSWERED WITHOUT A SUBPROCESS ─
+# WP10a spawned the resolver on EVERY adoption before inspecting anything, at
+# 6.8s wall per invocation (3.2s of it CPU), to learn something a builtin knows
+# instantly: `templates/tool-matrix/common.json`'s gitleaks entry is selected by
+# every call this step makes (`phase: 1`, all tracks, both dev_os, all platforms
+# and languages) and its predicate is literally `"check_command": "command -v
+# gitleaks"`. So `command -v gitleaks` succeeding is equivalent to gitleaks
+# landing in `.already_installed`; the only divergence is the resolver's 10s
+# evaluation deadline (`RESOLVE_TOOLS_EVAL_TIMEOUT`), which errs toward saying
+# absent — i.e. toward the slow path, never toward a false all-clear.
+#
+# THE HOST PROBE MUST SIT BEHIND THE SEAM, AND THAT IS NOT A STYLE PREFERENCE.
+# Hoisting a bare `command -v gitleaks` to the top of `adopt_resolve_tools` —
+# the obvious placement, and the one this fix's own backlog entry proposed
+# before it was measured — puts a host probe ABOVE `SOIF_ADOPT_RESOLVER`. Every
+# stub-driven case in tests/test-brownfield-wp10a-tool-resolution.sh then stops
+# reaching its stub. Measured with the seam arm neutered: eleven failures on
+# a host WITH gitleaks, four on a host without, and the set of cases that fail
+# ONLY when gitleaks is present — derived by set difference, not subtraction —
+# is exactly X2b, X4, X5(linux), X5(brew), X6b, X7, X9, X9b and M2, the nine
+# the suite's header enumerates. Failure counts and names only, on purpose: a
+# passed-count written beside them went stale twice across tree changes while
+# labelled "measured", which is the failure mode that suite's header lectures
+# about. This is the local-vs-CI divergence the seam above was written to
+# prevent, and CLAUDE.md's standing trap. (A gitleaks-free host is not clean
+# either: R1/R2 fail there through the SCOUT seam, recorded on `## BL-251:`.)
+# S2 and MS2 in that suite hold this line in place.
+_adopt_scanner_present() {
+  # A stubbed resolver means the suite is driving this step deliberately; the
+  # host is not evidence about the case it is asserting.
+  [ -z "${SOIF_ADOPT_RESOLVER:-}" ] || return 1   # BL-251-PROBE-SEAM
+  # `SOIF_ADOPT_SCANNER_BIN` is the SECOND seam, and it exists because the
+  # scanner-ABSENT branch is the one a new operator actually takes and it was
+  # asserted NOWHERE in the first cut of this fix: every case ran with gitleaks
+  # present, so neutering the line below to `true` survived every PR-blocking
+  # check — while producing "Secret detection: already installed." and, three
+  # lines later, "the scanner is not installed", on the surface this package
+  # exists to make trustworthy. CI installs gitleaks unconditionally, so no
+  # required check could ever have seen it. Same shape as scout's own
+  # `SCOUT_GITLEAKS_BIN` (scripts/lib/scout/scout-secrets.sh); production sets
+  # neither.
+  _adopt_tool_present "${SOIF_ADOPT_SCANNER_BIN:-gitleaks}"   # BL-251-PROBE-HOST
+}
+
 # ── Step 2 ──────────────────────────────────────────────────────────────────
 # adopt_resolve_tools ROOT REPORT
 #
@@ -129,6 +173,36 @@ adopt_resolve_tools() {
     # HOST: gitleaks may well be installed, and a first cut returned here
     # without asking, losing a legitimate refresh.
     _adopt_rescan_secrets "$root" "$report"
+    return 0
+  fi
+
+  # `## BL-251:` — THE FAST PATH. When the scanner is on PATH the resolver
+  # reports it in `.already_installed` on the same predicate (see
+  # `_adopt_scanner_present`), the install arm does not run, and the step ends
+  # in exactly the two lines below — so taking them directly costs no
+  # subprocess. The re-scan is NOT skipped with it: `_adopt_rescan_secrets`
+  # carries its own `# BL-242-SECRETS-RESCAN` guard and is the whole point of
+  # resolving a scanner, so a degraded survey is still refreshed here.
+  #
+  # IT SITS BELOW THE RESOLVER-EXISTENCE ARM ON PURPOSE, AND THE FIRST CUT DID
+  # NOT. Above it, a broken framework checkout on a host that HAS gitleaks lost
+  # its only diagnostic ("The tool resolver is not where it should be") — a
+  # measured behaviour change under a comment that claimed to be
+  # behaviour-identical. Two `test` builtins is not a cost worth a false claim.
+  #
+  # ONE ARM IS STILL TRADED AWAY, AND IT IS STATED RATHER THAN DENIED: the
+  # empty-output arm below ("The tool resolver did not produce a result") is
+  # unreachable when the scanner is present. For a resolver that RUNS and
+  # returns nothing, that cannot be preserved — reaching it means having
+  # already paid the 6.8s this fix exists to avoid. The same arm also used to
+  # catch a resolver that is present but NOT RUNNABLE (a file the existence
+  # guard above lets through, `chmod 000` being the measured case); that
+  # sub-case is traded with it, and on a host that has the scanner it is a
+  # framework-checkout diagnostic lost, not a scan lost — the re-scan below
+  # still runs. S5 in the WP10a suite pins the arm this block sits UNDER.
+  if _adopt_scanner_present; then   # BL-251-FAST-PATH
+    adopt_note "Secret detection: already installed. The history scan can run."   # BL-251-ALREADY-LINE
+    _adopt_rescan_secrets "$root" "$report"   # BL-251-FAST-PATH-RESCAN
     return 0
   fi
 
@@ -162,7 +236,7 @@ adopt_resolve_tools() {
   # "already installed" and skip the bucket where gitleaks was actually
   # sitting, in the same payload. The scanner has a name; use it.
   if printf '%s' "$out" | jq -e '[.already_installed[]? | select((.name // "") == "gitleaks" or (.category // "") == "Secret Detection")] | length > 0' >/dev/null 2>&1; then
-    adopt_note "Secret detection: already installed. The history scan can run."
+    adopt_note "Secret detection: already installed. The history scan can run."   # BL-251-ALREADY-LINE
     _adopt_rescan_secrets "$root" "$report"
     return 0
   fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -14941,8 +14941,9 @@ to the top of `adopt_resolve_tools`, immediately after `adopt_head`, puts a
 HOST PROBE ABOVE THE `SOIF_ADOPT_RESOLVER` SEAM. All 18 stub-driven cases in
 `tests/test-brownfield-wp10a-tool-resolution.sh` then stop reaching their stub,
 and the suite goes **25 passed / 9 failed** on a host that has gitleaks and
-**34 passed / 0 failed** on one that does not — the single variable being what
-happens to be installed. That is exactly the local-vs-CI divergence the seam's
+**32 passed / 2 failed** on one that does not *(this line said "34 / 0" until 2026-09-06 — the
+suite is not host-independent at the scout seam, see the residual below)* — the single variable being
+what happens to be installed. That is exactly the local-vs-CI divergence the seam's
 own comment was written to prevent, and CLAUDE.md's standing trap. It fails
 loudly rather than silently (gitleaks is on this Mac AND installed in every CI
 unit-shard leg, `tests.yml` gitleaks step), which is the only mercy.
@@ -14963,6 +14964,101 @@ path and is owed tests. The pin should still land — `rest` is at 13s of slack
 and a cancelled leg reports nothing at all — but it must not be read as having
 addressed this.
 
+**Build note (2026-09-04 → 2026-09-06, branch `fix/bl251-resolver-fast-path`, three review rounds).**
+Built to the shape above, with the placement correction the review forced — and then a second
+placement correction the next round forced. Five markers in `scripts/lib/adopt/adopt-tools.sh`:
+`# BL-251-FAST-PATH` (the short-circuit — **below** the resolver-existence arm, NOT immediately after
+`adopt_head`: above it, a broken framework checkout on a host that has gitleaks lost its "The tool
+resolver is not where it should be" diagnostic, a measured behaviour change under a comment that
+claimed none); `# BL-251-PROBE-SEAM` (yields to `SOIF_ADOPT_RESOLVER`); `# BL-251-PROBE-HOST` (reads
+`SOIF_ADOPT_SCANNER_BIN`, a second test seam in scout's `SCOUT_GITLEAKS_BIN` idiom, added because
+the scanner-ABSENT branch was asserted nowhere in the first cut — forcing the probe to `true`
+survived every PR-blocking check); `# BL-251-FAST-PATH-RESCAN`; and `# BL-251-ALREADY-LINE` at
+exactly two sites (a sync-sibling marker on the duplicated operator line). Five cases (S1–S5) and six
+mutants (MS1–MS6) in `tests/test-brownfield-wp10a-tool-resolution.sh`; S2, S3 and S4 each pass on a
+tree with no fast path at all, so each carries its own mutant, and S5 is the regression test for the
+placement itself (it fails on the first cut's ordering directly). Neither `SOIF_ADOPT_RESOLVER` nor
+`SOIF_ADOPT_SCANNER_BIN` is set by any template, workflow, or `init.sh`; the new one is strictly less
+powerful than the old (a name, not an executable), so it opens no exposure class `main` did not
+already permit through X1's seam.
+
+**Measured on this host, same session, baseline taken from a `git worktree` at `main` (`c986595`)
+rather than from memory:**
+
+| suite | before | after | |
+|---|---|---|---|
+| `test-brownfield-wp4-driver.sh` | 133s | 22s | 6.0x |
+| `test-brownfield-wp9-act-boundaries.sh` | 95s | 20s | 4.8x |
+| `test-brownfield-wp9b-preflight-approval.sh` | 317s | 58s | 5.5x |
+
+545s → 100s, with the assertion counts unchanged (24 / 29 / 103, all passing). Every brownfield and
+adoption-touching suite green (13 suites, BL-225's T9 staging preflight included) and all 15 repo
+lints pass.
+
+**THE `pin_lint_scan` / `pin_lint_sweep` PINS STAY — do not revert them as "no longer needed".**
+Derived rather than assumed, and keyed to THIS BRANCH'S BASE rather than a remembered figure: run
+`33913600868` (`c986595`) measured `rest` 536s (74%), slow-misc 468s, sast 464s, lint-sweep 447s,
+lint-scan 418s. A first draft of this note said "unchanged at 567s" — a number that appears in the
+repo once, in `pin_lint_sweep`'s 2026-08-15 note, for a differently-composed complement; the
+conclusion survived the correction but the base was unattributable.
+
+`rest` really is unchanged: it holds exactly two suites that name `adopt-project.sh`
+(`test-bl221-tier-fail-closed.sh`, `test-lint-module-dependencies.sh`) and NEITHER runs an adoption,
+so the fast path cannot touch that leg. Applying the measured ratios: `lint-sweep` 447 → ~319s and
+`lint-scan` 418 → ~243s, leaving `rest` at 536s (74%) as the highest leg. Returning `wp4-driver` and
+`wp9-act-boundaries` to the complement would put it at ~564s (78%). The pins were the right response
+to the symptom even though this was the cause.
+
+**RESIDUAL SURFACED WHILE MEASURING THIS FIX — the WP10a suite is NOT host-independent, and its own
+header says it is.** `tests/test-brownfield-wp10a-tool-resolution.sh` states host-independence as a
+design invariant and pays real attention to it at the resolver seam. It does not hold at the SCOUT
+seam: on a host with no `gitleaks` on PATH, main's own 34-assertion suite measures **32 passed / 2
+failed** — R1 ("the persisted report still says 'tool-unavailable'") and R2 ("the secrets section was
+rewritten on a report that was already 'scanned'") both fail, through `scout_secrets_scan` rather
+than through `_adopt_resolver_path`. Every CI `unit-shard` leg installs gitleaks unconditionally, so
+no PR-blocking check sees it; it is a laptop-only red.
+
+This is recorded here rather than fixed because it predates the fast path and is a different seam.
+Note for whoever takes it: a draft of this entry wrote "34 / 0" for that condition in three places,
+meaning "the suite is host-independent without gitleaks". It is not, and the tidy tally is exactly
+what hid it. `scripts/lib/scout/scout-secrets.sh` already carries `SCOUT_GITLEAKS_BIN`, which is
+probably the lever.
+
 **Related:** `## BL-242:` (the work package that introduced it), `## BL-112:`
 (a scan that did not run must never read as a scan that found nothing — the
 doctrine the re-scan arm implements).
+
+---
+
+## BL-252: BL-125's commit-time test arm filters on a source-extension list with no shell extensions, so it is structurally inert for every product commit in THIS repository
+
+**Status:** Open
+
+**Logged:** 2026-09-06, out of the adversarial review of `fix/bl251-resolver-fast-path`. Noticed
+because a commit that staged `scripts/lib/adopt/adopt-tools.sh` printed
+`[OK] BL-125: no source files staged — project tests not required for this commit.`
+
+**Not a defect in that branch — the predicate did exactly what it says.**
+`scripts/lib/hook-templates.sh` (`# BL-179-TESTARM-FILTER`) counts staged files matching
+`\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|go|rs|java|kt|kts|swift|cs|dart|c|h|cc|cpp|hpp|php|scala|vue|svelte)$`.
+`sh` is absent. Applied to a commit staging a `.sh` library plus a `.md`, the count is 0, the arm
+skips, and it prints its receipt.
+
+**Why it matters here specifically.** This framework repo's product code is *entirely* `.sh`, and
+there is no `.claude/test-command` in it. So the arm is inert for **every** product commit in this
+repository — the one place the framework is actually built. That is the same shape as `## BL-233:`
+(enforcement wired into generated projects only, never running where the framework is written).
+
+**The receipt is the sharper half.** "no source files staged" is TRUE as a predicate and FALSE as
+English, on a commit that staged 67 lines of shell. Per `docs/messaging-standard.md` and
+`# BL-112-SAST-NOTRUN`'s doctrine, a check that did not run must never read as a check that found
+nothing — and "no source files staged" reads as the latter to anyone who did stage source.
+
+**Fix shape (unbuilt):** add `sh|bash|zsh` to the extension list, or add a `.claude/test-command` to
+this repo, or both — and re-word the receipt to name the predicate ("no files matching the test-arm
+extension list were staged") so it cannot be read as a clean result. Check the downstream blast
+radius before widening the list: every generated project shares this arm, and a project whose shell
+scripts are incidental would start requiring a test command it does not have.
+
+**Related:** `## BL-125:` (the arm), `## BL-179:` (the filter), `## BL-233:` (enforcement that ran
+downstream only), `## BL-112:` (a check that did not run must not read as a clean one).

--- a/tests/test-brownfield-wp10a-tool-resolution.sh
+++ b/tests/test-brownfield-wp10a-tool-resolution.sh
@@ -738,6 +738,393 @@ else
   esac
 fi
 
+echo "=== S — the fast path: a scanner already on the host costs no resolver run ==="
+
+# `## BL-251:` — WP10a spawned scripts/resolve-tools.sh on EVERY adoption,
+# unconditionally, before inspecting anything: 6.8s wall per invocation, and
+# the matrix's own gitleaks predicate is literally `command -v gitleaks`, so
+# the expensive subprocess was being paid to learn what one builtin already
+# knows. These cases pin the short-circuit AND the seam that keeps it out of
+# the other eighteen cases' way.
+#
+# THE OBVIOUS PLACEMENT IS WRONG AND THAT IS WHY THE SEAM ARM EXISTS. Hoisting
+# a bare `command -v gitleaks` to the top of adopt_resolve_tools puts a HOST
+# PROBE ABOVE `SOIF_ADOPT_RESOLVER`; every stub-driven case above then stops
+# reaching its stub. Measured with the seam arm neutered: ELEVEN failures on
+# a host WITH gitleaks against FOUR on a host without — the delta is exactly
+# X2b, X4, X5(linux), X5(brew), X6b, X7, X9, X9b and M2, the nine this file's
+# header enumerates. FAILURE COUNTS AND NAMES ONLY: a passed-count written
+# beside them went stale twice across tree changes while labelled "measured
+# on this tree" — the exact failure mode the header above lectures about.
+# The local-vs-CI divergence the seam comment was written to prevent. S2 is
+# what keeps it fixed.
+#
+# DO NOT WRITE "34 / 0" HERE. An earlier draft did, in three places, meaning
+# "the suite is host-independent without gitleaks". It is not: main's own
+# 34-assertion suite measures 32 passed / 2 failed on a gitleaks-free host.
+# R1 and R2 fail there through SCOUT, not through the resolver — a
+# PRE-EXISTING host-dependence in a suite whose header claims the opposite.
+# Recorded on `## BL-251:`; do not let a tidy tally hide it again.
+#
+# NEITHER CASE DEPENDS ON WHAT THIS HOST HAPPENS TO HAVE INSTALLED. A shim
+# directory is PREPENDED to PATH so `command -v gitleaks` is true either way,
+# and each case asserts the shim actually resolves before trusting the result.
+# (Prepending is safe where CLAUDE.md's PATH-isolation warning is not: that
+# trap is about a fixture that RE-ADDS the real PATH and so fails to remove a
+# tool. This adds one.)
+
+# _mk_gitleaks_shim <dir> → 0 if the shim is on PATH and resolves first
+_mk_gitleaks_shim() {
+  local d="$1"
+  mkdir -p "$d" || return 1
+  printf '#!/usr/bin/env bash\nexit 0\n' > "$d/gitleaks"
+  chmod +x "$d/gitleaks" || return 1
+  [ "$(PATH="$d:$PATH" command -v gitleaks 2>/dev/null)" = "$d/gitleaks" ] || return 1
+  return 0
+}
+
+# _mk_sentinel_resolver <path> <sentinel> [bucket] → a resolver stub that
+# RECORDS having been run and still emits a valid payload, so a case can tell
+# "did not run" from "ran and broke".
+#
+# IT PROVES ITSELF, to the standard `_mk_resolver` above sets ("a builder that
+# silently produced an empty stub is worse than one that failed"). A first cut
+# checked only that the file was non-empty — so a stub whose sentinel path was
+# unwritable ran, wrote nothing, and every "the resolver did not run" assertion
+# printed PASS over a resolver that HAD run. Measured: builder rc=0, stub rc=0,
+# sentinel absent, JSON valid. It now runs the stub once against a throwaway
+# path and requires the sentinel to appear AND the payload to parse.
+_mk_sentinel_resolver() {
+  local out="$1" sentinel="$2" bucket="${3:-already}" payload probe
+  case "$bucket" in
+    already) payload="$(jq -nc '{already_installed: [{name: "gitleaks", version: "8.30.1", category: "Secret Detection"}], auto_install: [], manual_install: [], deferred: []}')" ;;
+    auto)    payload="$(jq -nc '{already_installed: [], auto_install: [{name: "gitleaks", category: "Secret Detection", install_cmd: "true", install_cmds: ["true"]}], manual_install: [], deferred: []}')" ;;
+    *) return 1 ;;
+  esac
+  [ -n "$payload" ] || return 1
+  # THE SELF-TEST PROBES THE SENTINEL'S OWN DIRECTORY, not the stub's. A cut
+  # that probed `dirname "$out"` proved the wrong directory writable: in every
+  # real case those differ (the stub lives under fw/scripts, the sentinel under
+  # the case root), so a sentinel in a nonexistent directory still produced
+  # builder rc=0, stub rc=0, no sentinel, valid JSON — the false negative,
+  # intact. Measured.
+  probe="${sentinel}.selftest"
+  {
+    printf '#!/usr/bin/env bash\n'
+    printf ': > "${SENTINEL_PATH:-%s}"\n' "$sentinel"
+    printf 'cat <<%s\n' "'RESOLVERJSON'"
+    printf '%s\n' "$payload"
+    printf 'RESOLVERJSON\n'
+  } > "$out"
+  chmod +x "$out"
+  rm -f "$probe" 2>/dev/null
+  SENTINEL_PATH="$probe" "$out" 2>/dev/null | jq -e . >/dev/null 2>&1 || return 1
+  [ -e "$probe" ] || return 1
+  rm -f "$probe" 2>/dev/null
+  return 0
+}
+
+# ── S1 — PRODUCTION SHAPE: seam UNSET, scanner present, resolver must not run.
+# The framework is mirrored and its OWN scripts/resolve-tools.sh replaced, so
+# `_adopt_resolver_path`'s default branch is the one under test — this is the
+# path a real operator takes, not a seam-driven approximation.
+S1="$(newtmp)"
+mkdir -p "$S1/fw" "$S1/p" "$S1/bin"
+if ! mk_mirror "$S1/fw"; then
+  fail_ "S1 setup" "could not mirror the framework"
+elif ! _mk_gitleaks_shim "$S1/bin"; then
+  fail_ "S1 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$S1/fw/scripts/resolve-tools.sh" "$S1/ran"; then
+  fail_ "S1 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$S1/p"; then
+  fail_ "S1 setup" "could not build the adoptee"
+else
+  _ans 1 > "$S1/answers"
+  run_adopt "$S1/p" "$S1/answers" "$REPORT" "$S1/fw" "PATH=$S1/bin:$PATH"
+  S1_RC="$RUN_RC"
+  if [ -e "$S1/ran" ]; then
+    fail_ "S1" "the resolver RAN even though gitleaks is on PATH — the fast path did not fire"
+  else
+    pass "S1 — a present scanner short-circuits: resolve-tools.sh was never spawned"
+  fi
+  [ "$S1_RC" -eq 0 ] \
+    && pass "S1b — the adoption still completes (rc=0) on the fast path" \
+    || fail_ "S1b" "adoption exited $S1_RC on the fast path"
+  if grep -q "already installed" "$RUN_OUT" 2>/dev/null; then
+    pass "S1c — the fast path still SAYS the scanner is present"
+  else
+    fail_ "S1c" "the fast path went silent about the scanner it found"
+  fi
+fi
+
+# ── S2 — THE SEAM OUTRANKS THE HOST PROBE. With SOIF_ADOPT_RESOLVER set, the
+# resolver runs even though gitleaks is on PATH. This is the assertion that
+# stops the fast path from reaching past the seam and re-breaking the other
+# eighteen cases; `# BL-251-PROBE-SEAM` is the line it pins.
+S2="$(newtmp)"
+mkdir -p "$S2/p" "$S2/bin"
+if ! _mk_gitleaks_shim "$S2/bin"; then
+  fail_ "S2 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$S2/resolver" "$S2/ran"; then
+  fail_ "S2 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$S2/p"; then
+  fail_ "S2 setup" "could not build the adoptee"
+else
+  _ans 1 > "$S2/answers"
+  run_adopt "$S2/p" "$S2/answers" "$REPORT" "$REPO_ROOT" \
+    "SOIF_ADOPT_RESOLVER=$S2/resolver" "PATH=$S2/bin:$PATH"
+  if [ -e "$S2/ran" ]; then
+    pass "S2 — a stubbed resolver still runs: the fast path sits BEHIND the seam"
+  else
+    fail_ "S2" "the fast path reached past SOIF_ADOPT_RESOLVER — every stub-driven case above is now host-dependent"
+  fi
+fi
+
+# ── S3 — THE FAST PATH IS NOT A SHORTCUT PAST THE RE-SCAN. Skipping the
+# resolver must not also skip `_adopt_rescan_secrets`; a degraded survey is
+# exactly the state a present scanner exists to refresh.
+S3="$(newtmp)"
+mkdir -p "$S3/fw" "$S3/p" "$S3/bin"
+if ! mk_mirror "$S3/fw"; then
+  fail_ "S3 setup" "could not mirror the framework"
+elif ! _mk_gitleaks_shim "$S3/bin"; then
+  fail_ "S3 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$S3/fw/scripts/resolve-tools.sh" "$S3/ran"; then
+  fail_ "S3 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$S3/p"; then
+  fail_ "S3 setup" "could not build the adoptee"
+else
+  jq '.secrets.status = "tool-unavailable"' "$REPORT" > "$S3/report.json" 2>/dev/null
+  _ans 1 > "$S3/answers"
+  run_adopt "$S3/p" "$S3/answers" "$S3/report.json" "$S3/fw" "PATH=$S3/bin:$PATH"
+  if grep -q "The scan was re-run" "$RUN_OUT" 2>/dev/null; then
+    pass "S3 — the fast path still reaches the re-scan on a degraded survey"
+  else
+    fail_ "S3" "the fast path skipped the re-scan a degraded survey exists to trigger"
+  fi
+fi
+
+# ── S4 — THE SCANNER-ABSENT BRANCH, which the first cut of this fix asserted
+# NOWHERE. Every S/MS case above runs with gitleaks present, so neutering
+# `# BL-251-PROBE-HOST` to `true` survived the whole suite AND every
+# PR-blocking check — while making a gitleaks-free host print "Secret
+# detection: already installed." and, three lines later, "the scanner is not
+# installed." CI installs gitleaks unconditionally, so no required check could
+# have seen it. `SOIF_ADOPT_SCANNER_BIN` makes absence assertable WITHOUT
+# depending on what this host has, which a PATH-subtraction fixture cannot do
+# safely (CLAUDE.md's PATH-isolation trap).
+S4="$(newtmp)"
+mkdir -p "$S4/fw" "$S4/p" "$S4/bin"
+if ! mk_mirror "$S4/fw"; then
+  fail_ "S4 setup" "could not mirror the framework"
+elif ! _mk_gitleaks_shim "$S4/bin"; then
+  fail_ "S4 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$S4/fw/scripts/resolve-tools.sh" "$S4/ran" auto; then
+  fail_ "S4 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$S4/p"; then
+  fail_ "S4 setup" "could not build the adoptee"
+else
+  # gitleaks IS on PATH (the shim). The probe is pointed at a name that is not,
+  # so the case asserts the ABSENT branch on any host, in either direction.
+  _ans_install 1 2 > "$S4/answers"
+  run_adopt "$S4/p" "$S4/answers" "$REPORT" "$S4/fw" \
+    "PATH=$S4/bin:$PATH" "SOIF_ADOPT_SCANNER_BIN=gitleaks-bl251-absent"
+  if [ -e "$S4/ran" ]; then
+    pass "S4 — an absent scanner still reaches the resolver: the fast path is not unconditional"
+  else
+    fail_ "S4" "the fast path fired with NO scanner present — the resolver was never consulted"
+  fi
+  if grep -q "already installed" "$RUN_OUT" 2>/dev/null; then
+    fail_ "S4b" "a host with no scanner was told the scanner is already installed"
+  else
+    pass "S4b — an absent scanner is never announced as present"
+  fi
+fi
+
+# ── S5 — THE PLACEMENT IS PINNED, NOT ASSERTED. The fast path sits BELOW the
+# resolver-existence arm so a broken framework checkout keeps its diagnostic
+# on a host that has the scanner. A cut of this fix had it above, lost the
+# diagnostic, and shipped under a comment claiming behaviour-identity; the
+# review found it by running main and the branch side by side. Moving the
+# block back above the arm passed 51/0 — nothing here could see it. This case
+# is the regression test: it fails on that ordering directly, so it needs no
+# mutant of its own.
+S5="$(newtmp)"
+mkdir -p "$S5/fw" "$S5/p" "$S5/bin"
+if ! mk_mirror "$S5/fw"; then
+  fail_ "S5 setup" "could not mirror the framework"
+elif ! _mk_gitleaks_shim "$S5/bin"; then
+  fail_ "S5 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! mk_adoptee "$S5/p"; then
+  fail_ "S5 setup" "could not build the adoptee"
+else
+  rm -f "$S5/fw/scripts/resolve-tools.sh"
+  if [ -e "$S5/fw/scripts/resolve-tools.sh" ]; then
+    fail_ "S5 setup" "could not remove the mirror's resolver"
+  else
+    _ans 1 > "$S5/answers"
+    run_adopt "$S5/p" "$S5/answers" "$REPORT" "$S5/fw" "PATH=$S5/bin:$PATH"
+    if grep -q "The tool resolver is not where it should be" "$RUN_OUT" 2>/dev/null; then
+      pass "S5 — a missing resolver is still diagnosed when the scanner is present: the fast path sits below that arm"
+    else
+      fail_ "S5" "the fast path fired past a missing resolver — a broken checkout lost its only diagnostic"
+    fi
+    [ "$RUN_RC" -eq 0 ] \
+      && pass "S5b — and the adoption still completes (rc=0)" \
+      || fail_ "S5b" "adoption exited $RUN_RC on the missing-resolver arm"
+  fi
+fi
+
+echo "=== MS — mutation proofs for the fast path ==="
+
+# ── MS1 — remove the short-circuit and S1's non-execution assertion must die.
+MS1_MARK="# BL-251-FAST-PATH"
+MS1="$(newtmp)"
+mkdir -p "$MS1/fw" "$MS1/p" "$MS1/bin"
+if ! mk_mirror "$MS1/fw"; then
+  fail_ "MS1 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MS1/fw" "adopt-tools.sh" "$MS1_MARK" "  if false; then   $MS1_MARK")" != "1" ]; then
+  fail_ "MS1 setup" "the fast-path mutation did not apply cleanly"
+elif ! _mk_gitleaks_shim "$MS1/bin"; then
+  fail_ "MS1 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$MS1/fw/scripts/resolve-tools.sh" "$MS1/ran"; then
+  fail_ "MS1 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$MS1/p"; then
+  fail_ "MS1 setup" "could not build the adoptee"
+else
+  _ans 1 > "$MS1/answers"
+  run_adopt "$MS1/p" "$MS1/answers" "$REPORT" "$MS1/fw" "PATH=$MS1/bin:$PATH"
+  if [ -e "$MS1/ran" ]; then
+    pass "MS1 (MUTATION) — without the short-circuit the resolver IS spawned: S1 is what stops it"
+  else
+    fail_ "MS1 (MUTATION)" "disabling the short-circuit changed nothing — S1 may be passing for another reason"
+  fi
+fi
+
+# ── MS2 — remove the SEAM arm of the probe and S2 must die. This is the
+# defect the review measured: without this line the host probe outranks
+# SOIF_ADOPT_RESOLVER and nine assertions above turn host-dependent.
+MS2_MARK="# BL-251-PROBE-SEAM"
+MS2="$(newtmp)"
+mkdir -p "$MS2/fw" "$MS2/p" "$MS2/bin"
+if ! mk_mirror "$MS2/fw"; then
+  fail_ "MS2 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MS2/fw" "adopt-tools.sh" "$MS2_MARK" "  :   $MS2_MARK")" != "1" ]; then
+  fail_ "MS2 setup" "the probe-seam mutation did not apply cleanly"
+elif ! _mk_gitleaks_shim "$MS2/bin"; then
+  fail_ "MS2 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$MS2/resolver" "$MS2/ran"; then
+  fail_ "MS2 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$MS2/p"; then
+  fail_ "MS2 setup" "could not build the adoptee"
+else
+  _ans 1 > "$MS2/answers"
+  run_adopt "$MS2/p" "$MS2/answers" "$REPORT" "$MS2/fw" \
+    "SOIF_ADOPT_RESOLVER=$MS2/resolver" "PATH=$MS2/bin:$PATH"
+  if [ -e "$MS2/ran" ]; then
+    fail_ "MS2 (MUTATION)" "removing the seam arm changed nothing — S2 may be passing for another reason"
+  else
+    pass "MS2 (MUTATION) — without the seam arm the stub is bypassed: S2 is what keeps the suite host-independent"
+  fi
+fi
+
+# ── MS4 — the fast path must not become a shortcut past the re-scan. S3 is a
+# regression guard that passes on a tree with no fast path at all, so it needs
+# a mutant of its own or it proves nothing.
+MS4_MARK="# BL-251-FAST-PATH-RESCAN"
+MS4="$(newtmp)"
+mkdir -p "$MS4/fw" "$MS4/p" "$MS4/bin"
+if ! mk_mirror "$MS4/fw"; then
+  fail_ "MS4 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MS4/fw" "adopt-tools.sh" "$MS4_MARK" "    :   $MS4_MARK")" != "1" ]; then
+  fail_ "MS4 setup" "the fast-path-rescan mutation did not apply cleanly"
+elif ! _mk_gitleaks_shim "$MS4/bin"; then
+  fail_ "MS4 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$MS4/fw/scripts/resolve-tools.sh" "$MS4/ran"; then
+  fail_ "MS4 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$MS4/p"; then
+  fail_ "MS4 setup" "could not build the adoptee"
+else
+  jq '.secrets.status = "tool-unavailable"' "$REPORT" > "$MS4/report.json" 2>/dev/null
+  _ans 1 > "$MS4/answers"
+  run_adopt "$MS4/p" "$MS4/answers" "$MS4/report.json" "$MS4/fw" "PATH=$MS4/bin:$PATH"
+  if grep -q "The scan was re-run" "$RUN_OUT" 2>/dev/null; then
+    fail_ "MS4 (MUTATION)" "dropping the re-scan changed nothing — S3 may be passing for another reason"
+  else
+    pass "MS4 (MUTATION) — without the re-scan call a degraded survey is left stale: S3 is what stops it"
+  fi
+fi
+
+# ── MS5 — neuter the host probe and S4 must die. This is the mutant the first
+# cut of this fix did not have: it survived the entire suite and every
+# PR-blocking check, on the secret-scanner surface.
+MS5_MARK="# BL-251-PROBE-HOST"
+MS5="$(newtmp)"
+mkdir -p "$MS5/fw" "$MS5/p" "$MS5/bin"
+if ! mk_mirror "$MS5/fw"; then
+  fail_ "MS5 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MS5/fw" "adopt-tools.sh" "$MS5_MARK" "  true   $MS5_MARK")" != "1" ]; then
+  fail_ "MS5 setup" "the probe-host mutation did not apply cleanly"
+elif ! _mk_gitleaks_shim "$MS5/bin"; then
+  fail_ "MS5 setup" "the gitleaks shim did not resolve first on PATH"
+elif ! _mk_sentinel_resolver "$MS5/fw/scripts/resolve-tools.sh" "$MS5/ran" auto; then
+  fail_ "MS5 setup" "the sentinel resolver did not build"
+elif ! mk_adoptee "$MS5/p"; then
+  fail_ "MS5 setup" "could not build the adoptee"
+else
+  _ans_install 1 2 > "$MS5/answers"
+  run_adopt "$MS5/p" "$MS5/answers" "$REPORT" "$MS5/fw" \
+    "PATH=$MS5/bin:$PATH" "SOIF_ADOPT_SCANNER_BIN=gitleaks-bl251-absent"
+  if [ -e "$MS5/ran" ]; then
+    fail_ "MS5 (MUTATION)" "neutering the host probe changed nothing — S4 may be passing for another reason"
+  else
+    pass "MS5 (MUTATION) — with the probe forced true an absent scanner is announced as present: S4 is what stops it"
+  fi
+fi
+
+# ── MS3 — the four SINGLE-SITE markers are unique and end-of-line anchored, so the
+# mutations above cannot silently hit a second site.
+for _m in "$MS1_MARK" "$MS2_MARK" "$MS4_MARK" "$MS5_MARK"; do
+  _n="$(_sites "$L_TOOLS" "$_m")"
+  [ "$_n" = "1" ] \
+    && pass "MS3 — '$_m' occurs exactly once at end-of-line in adopt-tools.sh" \
+    || fail_ "MS3" "'$_m' occurs $_n times in adopt-tools.sh (need exactly 1)"
+done
+
+# ── MS7 — THE PROBE'S DEFAULT IS THE MATRIX'S OWN SCANNER NAME, derived rather
+# than transcribed. Every absence case sets SOIF_ADOPT_SCANNER_BIN explicitly
+# and every presence case is satisfied by whatever binary happens to exist, so
+# the literal default was asserted by NOTHING: changing it to `git` (always
+# present) survived the whole suite while a gitleaks-free host was told the
+# scanner was already installed. A typo or a rename would fail SAFE (the probe
+# stops matching and the resolver runs) — only a nonsense substitution is
+# dangerous — which is why this is a name-tie rather than a mutant: it also
+# pins the one hardcoded `gitleaks` in this file that has no category
+# fallback to the entry the resolver actually keys off.
+_mx="$(jq -r '[.tools[]|select(.substitution_category=="Secret Detection")|.name]|first // ""' "$REPO_ROOT/templates/tool-matrix/common.json" 2>/dev/null)"
+if [ -z "$_mx" ]; then
+  fail_ "MS7 setup" "could not derive the Secret Detection tool name from templates/tool-matrix/common.json"
+elif grep -q "SOIF_ADOPT_SCANNER_BIN:-${_mx}}\"   # BL-251-PROBE-HOST\$" "$L_TOOLS" 2>/dev/null; then
+  pass "MS7 — the probe's default is the matrix's own scanner name ($_mx)"
+else
+  fail_ "MS7" "the fast path probes for a different tool than the matrix resolves (matrix says '$_mx')"
+fi
+
+# ── MS6 — `# BL-251-ALREADY-LINE` is a SYNC-SIBLING marker, so its invariant is
+# TWO sites, not one: the fast path and the resolver's already-installed arm
+# print byte-identical text, and this repo's convention for text duplicated in
+# lockstep is a grep-able marker (`# BL-084-TIER-KEY`, "SYNC SIBLINGS") rather
+# than a prose pointer. If one line moves without the other the count changes.
+_al_sites="$(_sites "$L_TOOLS" "# BL-251-ALREADY-LINE")"
+[ "$_al_sites" = "2" ] \
+  && pass "MS6 — '# BL-251-ALREADY-LINE' marks both sync siblings (2 sites)" \
+  || fail_ "MS6" "'# BL-251-ALREADY-LINE' occurs $_al_sites times in adopt-tools.sh (need exactly 2)"
+
+_al_text="$(grep -c '^ *adopt_note "Secret detection: already installed\. The history scan can run\."   # BL-251-ALREADY-LINE$' "$L_TOOLS" 2>/dev/null)"
+[ "$(_num "$_al_text")" = "2" ] \
+  && pass "MS6b — both sync siblings still carry byte-identical operator text" \
+  || fail_ "MS6b" "the two '# BL-251-ALREADY-LINE' sites have drifted apart"
+
 echo ""
 if [ "$FAILED" -eq 0 ]; then
   echo "Results: $PASSED passed, $FAILED failed"


### PR DESCRIPTION
WP10a made every adoption spawn `scripts/resolve-tools.sh` unconditionally — **6.8s wall per invocation** — to learn something `command -v gitleaks` answers in microseconds. This is the fix, with the two placements that were measured wrong before they were measured right.

## Measured (this host, baselines from a worktree at `main` `c986595`)

| suite | before | after | |
|---|---|---|---|
| wp4-driver | 133s | **22s** | 6.0x |
| wp9-act-boundaries | 95s | **20s** | 4.8x |
| wp9b-preflight-approval | 317s | **58s** | 5.5x |

545s → 100s, assertion counts unchanged (24 / 29 / 103). Full adoption transcripts are byte-identical before and after in both report states (reviewer-verified).

## What holds it in place

- **`# BL-251-PROBE-SEAM`** — the host probe yields to `SOIF_ADOPT_RESOLVER`. The obvious placement (a bare `command -v` at the top of the function) puts a host probe *above* the test seam: all eighteen stub-driven cases stop reaching their stub, eleven failures with gitleaks present vs four without. Measured, not reasoned.
- **`# BL-251-PROBE-HOST`** — reads `SOIF_ADOPT_SCANNER_BIN` (scout's `SCOUT_GITLEAKS_BIN` idiom). Without it, the scanner-*absent* branch — the one a new operator takes — was asserted nowhere: forcing the probe to `true` survived every PR-blocking check while printing *"already installed"* and, three lines later, *"the scanner is not installed"*. CI installs gitleaks unconditionally, so no required check could see it. **S4/S4b + MS5** pin it; **MS7** ties the default name to `templates/tool-matrix/common.json` (a nonsense substitution to `git` also survived everything).
- **The fast path sits below the resolver-existence arm.** Above it, a broken framework checkout on a host with gitleaks silently lost its only diagnostic under a comment claiming behaviour-identity. **S5** is the regression test — moving the block back fails exactly S5. One arm *is* traded (empty resolver output, including a present-but-unrunnable resolver) and the comment says so.

## Tests

`tests/test-brownfield-wp10a-tool-resolution.sh` **54/0** (was 34). RED against `main` with the final file: 42 passed / 12 failed. Five new cases (S1–S5), seven mutants (MS1–MS7); S2/S3/S4 each pass on a fix-less tree, so each carries its own mutant. Thirteen adoption-touching suites green, BL-225's T9 included; 15/15 lints.

## Also

- The `#374` shard pins **stay** — `rest` holds no adoption-running suite (run `33913600868`: 536s, 74%); reverting would take it to ~564s (78%).
- Filed on `## BL-251:` — the WP10a suite is *not* host-independent at the scout seam (R1/R2 fail on a gitleaks-free host, 32/2 on main's own suite; the "34 / 0" it replaces is retracted in place).
- Filed `## BL-252:` — BL-125's commit-time test arm filters on an extension list with no shell extension, so it is inert for every product commit in this repository.

## Review

Three adversarial rounds: `major_concerns` → `major_concerns` → **`minor_concerns`** at `fcbd7d9`. The two residuals from the clean round (stale passed-counts in a "measured" sentence; the probe default asserted by nothing) were fixed to the reviewer's prescription after the verdict and verified locally: the reviewer's own OWN-H mutant now fails exactly MS7 (53/1), suite 54/0, lints 15/15. Those two edits are one comment paragraph and one test case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk