### PR TITLE
fix(bl-253): adoption writes poc_mode null for production, as init.sh does

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -531,6 +531,7 @@ jobs:
             tests/test-bl239-contributor-hooks.sh
             tests/test-bl230-workflow-html-lint-surface.sh
             tests/host-drivers/error-translate.test.sh
+            tests/test-bl253-adoption-state-parity.sh
           )
 
           # ── BL-190 shard pins ──────────────────────────────────────────

--- a/scripts/lib/adopt/adopt-state.sh
+++ b/scripts/lib/adopt/adopt-state.sh
@@ -686,7 +686,20 @@ adopt_write_approval_log() {
 # safety rule, so silently omitting them would ship the adoptee a weaker gate
 # than the operator chose — the exact direction §8.4 exists to prevent.
 ADOPT_DEPLOYMENT=""
-ADOPT_POC_MODE="production"
+# `## BL-253:` — PRODUCTION IS THE ABSENCE OF A POC MODE, and it is spelled
+# that way because every reader spells it that way. init.sh maps "Production"
+# to POC_MODE="" (collect_inputs_non_interactive: `production) POC_MODE=""`)
+# and writes JSON null into both state files; process-checklist.sh's
+# --start-phase4 and check-phase-gate.sh's organizational Pre-Phase-0 guard
+# both read a non-null value as THE NAME OF A POC MODE. This constant was
+# "production" for the whole of WP9a–WP10a, so every adoptee was refused at
+# Phase 4 ("project is in production mode… run --to-production") and every
+# organizational adoptee skipped six pre-conditions. Reproduced on main
+# c61edb1, both tiers, by the 2026-09-08 review's second pass; pinned by
+# tests/test-bl253-adoption-state-parity.sh against init.sh's own emitter.
+# Adoption asks no POC question (D9: one question), so this is a constant —
+# the sponsored_poc / private_poc rungs are a residual on the entry.
+ADOPT_POC_MODE=""   # BL-253-POC-MODE
 ADOPT_PROJECT_NAME=""
 
 ADOPT_AUDIENCE_Q="Who is this project for?"
@@ -711,7 +724,12 @@ adopt_ask_audience() {
 adopt_write_phase_state() {
   local root="$1"
   local adopt_landing=0   # BL-242-PHASE0-LANDING
-  jq -n --arg p "$ADOPT_PROJECT_NAME" --arg d "$ADOPT_DEPLOYMENT" --arg m "$ADOPT_POC_MODE" \
+  # NULL, NOT "" — init.sh's own idiom (`poc_json="null"` in create_project).
+  # The readers forgive an empty string; the parity oracle in the BL-253 suite
+  # does not, because a scaffolded project never carries one.
+  local poc_json='null'   # BL-253-POC-NULL
+  [ -n "$ADOPT_POC_MODE" ] && poc_json="\"$ADOPT_POC_MODE\""
+  jq -n --arg p "$ADOPT_PROJECT_NAME" --arg d "$ADOPT_DEPLOYMENT" --argjson m "$poc_json" \
         --argjson phase "$adopt_landing" \
     '{project: $p, framework_version: "1.0", current_phase: $phase, track: "full",
       deployment: $d, poc_mode: $m, compliance_ready: false, review_gate_enforced: true,
@@ -777,13 +795,16 @@ adopt_write_manifest() {
   # phase record cannot disagree about the tier. `enforcement_level` seeds to
   # `strict`, which is init.sh's default and the direction this framework
   # fails in.
-  local poc="$ADOPT_POC_MODE"
+  # NULL, NOT "" — the same idiom as adopt_write_phase_state, for the same
+  # reason: init.sh's prepare_initial_state_for_commit writes `poc_mode:null`.
+  local poc_json='null'   # BL-253-POC-NULL-MANIFEST
+  [ -n "$ADOPT_POC_MODE" ] && poc_json="\"$ADOPT_POC_MODE\""
   if [ -f "$root/.claude/manifest.json" ]; then
     adopt_jq_edit "$root" ".claude/manifest.json" \
       '.host = $h | .mode = $m | .deployment = $d | .poc_mode = $p | .enforcement_level = (.enforcement_level // "strict")' \
-      --arg h "$host" --arg m "$mode" --arg d "$mode" --arg p "$poc" || return 1
+      --arg h "$host" --arg m "$mode" --arg d "$mode" --argjson p "$poc_json" || return 1
   else
-    jq -n --arg h "$host" --arg m "$mode" --arg p "$poc" \
+    jq -n --arg h "$host" --arg m "$mode" --argjson p "$poc_json" \
       '{host: $h, mode: $m, remote_url: "", deployment: $m, poc_mode: $p, enforcement_level: "strict"}' \
       | adopt_write_file "$root" ".claude/manifest.json" || return 1
   fi

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15062,3 +15062,82 @@ scripts are incidental would start requiring a test command it does not have.
 
 **Related:** `## BL-125:` (the arm), `## BL-179:` (the filter), `## BL-233:` (enforcement that ran
 downstream only), `## BL-112:` (a check that did not run must not read as a clean one).
+
+---
+
+## BL-253: adoption stamps every project `poc_mode: "production"` — a value init.sh never writes and every reader takes as the NAME of a POC mode — so `--start-phase4` refuses every adoptee and the organizational Pre-Phase-0 guard skips its six pre-conditions
+
+**Status:** Open
+
+**Logged:** 2026-09-08, out of the adversarial codebase review (pass 1 headline #3, reproduced end-to-end
+on `main` `c61edb1` by the single-agent second pass, both tiers). Ranked #1 of the verified review's
+top ten: every adoptee, two gates read the key, S effort, unfiled — `## BL-249:` pins five other
+adoption invariants including D10's landing, not this one.
+
+**The defect, precisely.** The tier key is `deployment` + `poc_mode` (`# BL-084-TIER-KEY`). For a
+production project `init.sh` writes JSON **null** into both state files — `poc_json="null"` in
+`create_project`'s phase-state heredoc, and the explicit `poc_mode:null` branch in
+`prepare_initial_state_for_commit` — because its own comment says so: *"the interactive flow maps
+'Production' -> POC_MODE='' because Production is not a POC mode."* `adopt-state.sh` carried
+`ADOPT_POC_MODE="production"` and wrote that STRING into `phase-state.json` and `manifest.json`.
+Every consumer spells the test as *non-null ⇒ a POC*: `process-checklist.sh`'s `start_phase4`
+(`[ -n "$poc_mode" ] && [ "$poc_mode" != "null" ]` → `[FAIL] Phase 4 (production release) is blocked —
+project is in production mode… run upgrade-project.sh --to-production`, a dead end with a nonsense
+remedy), and `check-phase-gate.sh`'s organizational guard (`[ -z "$poc_mode_val" ] || … = "null"` →
+the six named Pre-Phase-0 pre-conditions), which therefore printed **zero** `Pre-Phase 0` lines for
+an organizational adoptee and four issues once the value was nulled by hand.
+
+**Why nothing caught it.** The design's headline promise ("indistinguishable from a scaffolded
+project in what the gates demand") was asserted in `docs/designs/2026-08-23-brownfield-adoption-v2.md`
+and `docs/adoption.md` and executed by no test: no suite diffs an adopted `phase-state.json` /
+`manifest.json` against a scaffolded one. `## BL-221:` (`# BL-221-ADOPT-TIER-KEYS`) made the manifest
+carry the same two keys as phase-state — "so the two birth paths produce the same shape" — and
+pinned the *shape* while leaving the *value* to the same wrong constant. And `init.sh` cannot be
+sourced for its emitter (it ends in an unconditional `main "$@"`), so a parity oracle was never cheap.
+
+**Fix shape (built on this branch; see the build note).** `ADOPT_POC_MODE=""` with the reason on the
+line, and both writers emit **null, not ""** via init.sh's own `poc_json` idiom (`--argjson`), so the
+readers' leniency toward `""` is never relied on. Parity suite
+`tests/test-bl253-adoption-state-parity.sh`: the oracle is init.sh's phase-state heredoc lifted by its
+`PHEOF` fence and parsed with jq — read as source, never executed, so the suite is hermetic and
+unit-lane. It pins the key set, every birth constant, `poc_mode == null` in both files, the two
+consumers by behaviour (`--start-phase4` no longer says "in production mode"; the organizational gate
+prints `Pre-Phase 0`), and three mutants (restore the string; write `""` in each writer).
+
+**Residuals, stated rather than hidden:**
+1. Adoption still asks no POC question (D9: one question). An adopted `sponsored_poc` /
+   `private_poc` project cannot be expressed at adoption; it lands as production and must be moved
+   with `upgrade-project.sh`. Whether that is a second question at step 1 is a design call, not a
+   defect in this fix.
+2. `tests/test-brownfield-wp5b-test-debt.sh`'s `set_tier` fixtures hand-write
+   `"poc_mode":"production"` into manifests as INPUT to the ratchet's tier read — a shape no birth path
+   produces after this fix. They do not fail (the ratchet only tests for `sponsored_poc`), but they
+   encode the wrong idiom and should be re-spelled `null` when that file is next opened.
+3. The parity oracle covers `phase-state.json` by value and `manifest.json` by key set + `poc_mode`;
+   `init.sh`'s manifest writer also stamps host/mode/currency fields adoption legitimately differs on,
+   so a full manifest value-diff is deliberately not asserted.
+
+**Build note (2026-09-08, branch `fix/bl253-adoption-poc-mode-parity`).** Three markers in
+`scripts/lib/adopt/adopt-state.sh`: `# BL-253-POC-MODE` (the constant, now `""`, with the reason on the
+comment above it), `# BL-253-POC-NULL` and `# BL-253-POC-NULL-MANIFEST` (init.sh's `poc_json` idiom in
+each writer, `--argjson`, so null is emitted rather than `""`). Suite
+`tests/test-bl253-adoption-state-parity.sh`: **RED against main 5 passed / 12 failed** (the oracle O0/O1/O1b
+and the key-set checks P1c/P1e already passed — only the VALUE differed), **GREEN 18 / 0** with four
+mutants (MP1 restores the string → P2's dead end returns AND P3's guard goes quiet; MP2/MP3 write `""`
+in each writer → the parity oracle rejects it while the readers would have forgiven it). Registered in
+`tests/full-project-test-suite.sh` and the `tests.yml` unit lane by hand — the suite NAMES `init.sh` on an
+executed line (the awk that lifts the heredoc) and never invokes it; `lint-tests-registered.sh --list`
+shows it `registered`, not exempt.
+
+**One existing suite was green because of the bug.** `tests/test-brownfield-wp4-driver.sh` S3/S4
+(interruption after phase-state / after intake) use that file's `_ans`, which defaults to the
+ORGANIZATIONAL tier, and asserted the gate reaches "Phase gates consistent" rc 0 — true only because the
+Pre-Phase-0 guard was being skipped. With `poc_mode: null` the organizational verdict is correctly a
+block ("named pre-condition(s) without a dated approval row: AI deployment path, Insurance, Liability,
+Sponsor, Backup maintainer, ITSM"). Since §8.4 is about interruption ORDER, S3/S4 now run on the personal
+tier (`_ans 1`) with the reason in a comment, and the organizational verdict is pinned in this entry's
+suite (P3, MP1b). 13 adoption-touching suites green (wp1 35, wp2 53, wp3-arms 33, wp3-regen 4, wp4 24,
+wp5b 57, wp6 45, wp9 29, wp9b 103, wp10a 54, bl221 12, bl225 35, lint-module-dependencies 43); 15/15 lints.
+
+**Related:** `## BL-242:` (the package that wrote the constant), `## BL-249:` (the sibling invariants),
+`## BL-221:` (the shape half of the same key), `## BL-084:` (the tier key), `## BL-095:` (the readers).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15087,10 +15087,12 @@ remedy), and `check-phase-gate.sh`'s organizational guard (`[ -z "$poc_mode_val"
 the six named Pre-Phase-0 pre-conditions), which therefore printed **zero** `Pre-Phase 0` lines for
 an organizational adoptee and four issues once the value was nulled by hand.
 
-**Why nothing caught it.** The design's headline promise ("indistinguishable from a scaffolded
-project in what the gates demand") was asserted in `docs/designs/2026-08-23-brownfield-adoption-v2.md`
-and `docs/adoption.md` and executed by no test: no suite diffs an adopted `phase-state.json` /
-`manifest.json` against a scaffolded one. `## BL-221:` (`# BL-221-ADOPT-TIER-KEYS`) made the manifest
+**Why nothing caught it.** The design's headline promise — verbatim, "an adopted project is
+indistinguishable from a scaffolded one in what the gates demand of it"
+(`docs/designs/2026-08-23-brownfield-adoption-v2.md`, with the same sentence in its v1 ancestor;
+`docs/adoption.md` makes narrower claims about the script set and commit-time treatment, not this one)
+— was executed by no test: no suite diffs an adopted `phase-state.json` / `manifest.json` against a
+scaffolded one. `## BL-221:` (`# BL-221-ADOPT-TIER-KEYS`) made the manifest
 carry the same two keys as phase-state — "so the two birth paths produce the same shape" — and
 pinned the *shape* while leaving the *value* to the same wrong constant. And `init.sh` cannot be
 sourced for its emitter (it ends in an unconditional `main "$@"`), so a parity oracle was never cheap.
@@ -15122,9 +15124,18 @@ prints `Pre-Phase 0`), and three mutants (restore the string; write `""` in each
 comment above it), `# BL-253-POC-NULL` and `# BL-253-POC-NULL-MANIFEST` (init.sh's `poc_json` idiom in
 each writer, `--argjson`, so null is emitted rather than `""`). Suite
 `tests/test-bl253-adoption-state-parity.sh`: **RED against main 5 passed / 12 failed** (the oracle O0/O1/O1b
-and the key-set checks P1c/P1e already passed — only the VALUE differed), **GREEN 18 / 0** with four
+and the key-set checks P1c/P1e already passed — only the VALUE differed), **GREEN 19 / 0** with four
 mutants (MP1 restores the string → P2's dead end returns AND P3's guard goes quiet; MP2/MP3 write `""`
-in each writer → the parity oracle rejects it while the readers would have forgiven it). Registered in
+in each writer → the parity oracle rejects it while the readers would have forgiven it). **P1f was added
+under review:** the reviewer's own mutant — delete the manifest writer's guard line — survived every
+case, an equivalent mutant while `ADOPT_POC_MODE` is a constant `""`, but combined with residual #1
+(`ADOPT_POC_MODE="sponsored_poc"`) it wrote `sponsored_poc` into phase-state and `null` into the
+manifest, the exact cross-file disagreement `## BL-221:` and `## BL-249:` item 2 exist to prevent. P1f
+asserts the two files agree on `deployment` and `poc_mode`; measured, that mutant now dies at P1f
+(14 / 5). The review also found P1c's `del(.adoption)` was a no-op (the stamp lives in
+`manifest.json`), so P1c is now strict key equality; and that O0 is the canary for shape breaks that
+stop parsing while P1c is the canary for a QUOTED new interpolation — both measured. Verdict
+`minor_concerns`, all findings folded in before push. Registered in
 `tests/full-project-test-suite.sh` and the `tests.yml` unit lane by hand — the suite NAMES `init.sh` on an
 executed line (the awk that lifts the heredoc) and never invokes it; `lint-tests-registered.sh --list`
 shows it `registered`, not exempt.

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -825,6 +825,14 @@ run_child_suite "tests/test-brownfield-wp10a-tool-resolution.sh" \
   "Adoption WP10a tool resolution (resolver at step 2, no non-command ever executed, §6.2 re-scan)" \
   "Adoption WP10a tool-resolution tests FAILED (run tests/test-brownfield-wp10a-tool-resolution.sh for details)"
 
+# BL-253: an adopted project is born with a scaffolded project's state — the
+# tier key's second half is null for production, as init.sh writes it, so
+# --start-phase4 does not refuse every adoptee and the organizational
+# Pre-Phase-0 guard fires. Oracle is init.sh's emitter read as source.
+run_child_suite "tests/test-bl253-adoption-state-parity.sh" \
+  "BL-253 adoption state parity (poc_mode null like init.sh; --start-phase4 and the org Pre-Phase-0 guard)" \
+  "BL-253 adoption state-parity tests FAILED (run tests/test-bl253-adoption-state-parity.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-bl253-adoption-state-parity.sh
+++ b/tests/test-bl253-adoption-state-parity.sh
@@ -3,8 +3,9 @@
 #
 # `## BL-253:` — an ADOPTED project must be born with the same state an
 # init.sh-SCAFFOLDED one is born with. The design's headline promise
-# (docs/designs/2026-08-23-brownfield-adoption-v2.md: "indistinguishable from a
-# scaffolded project in what the gates demand") was asserted in two documents
+# (docs/designs/2026-08-23-brownfield-adoption-v2.md, verbatim: "an adopted
+# project is indistinguishable from a scaffolded one in what the gates demand
+# of it"; its v1 ancestor carries the same sentence) was asserted in the design
 # and executed by no test, and the one key it got wrong was the tier key's
 # second half: init.sh writes `poc_mode: null` for a production project
 # (`poc_json="null"` in create_project; `poc_mode:null` in
@@ -22,8 +23,11 @@
 # would make this suite non-hermetic and full-lane-only. Instead the
 # phase-state heredoc is lifted out of create_project by its `PHEOF` fence,
 # its shell interpolations substituted with the values adoption would use, and
-# the result parsed with jq. If init.sh's emitter moves or changes shape, O0
-# fails LOUDLY and says so — that is the canary, not a defect in this suite.
+# the result parsed with jq. TWO CANARIES, AND THEY CATCH DIFFERENT THINGS:
+# O0 fails when the emitter moves or its shape stops parsing as JSON (an
+# UNQUOTED new interpolation, a renamed fence); a QUOTED new interpolation
+# still parses, so O0 passes and P1c is what fails, naming the new key.
+# Measured both ways under review. Either is loud; neither is a defect here.
 # This file therefore NAMES init.sh on executed lines (the awk below) and is
 # registered in the tests.yml unit lane by hand: it reads init.sh, it never
 # invokes it.
@@ -204,12 +208,15 @@ if adopt_one 1; then
   else
     fail_ "P1b" "adopted manifest.json has poc_mode $(jq -c '.poc_mode' "$P1/.claude/manifest.json" 2>/dev/null) — init.sh writes null"
   fi
-  # key-by-key against the oracle, allowing only what adoption adds on top
+  # key-by-key against the oracle — STRICT equality. Adoption's stamp lives in
+  # manifest.json, not here, so phase-state.json carries nothing on top of
+  # init.sh's set; a first cut allowed `.adoption` and that allowance was a
+  # no-op. If either side gains a key, this is the line that says which.
   if [ -n "$ORACLE_PS" ]; then
     ok_keys="$(printf '%s' "$ORACLE_PS" | jq -r 'keys | sort | join(",")')"
-    ad_keys="$(jq -r 'del(.adoption) | keys | sort | join(",")' "$P1/.claude/phase-state.json")"
+    ad_keys="$(jq -r 'keys | sort | join(",")' "$P1/.claude/phase-state.json")"
     [ "$ok_keys" = "$ad_keys" ] \
-      && pass "P1c — adopted phase-state.json has exactly init.sh's key set (minus .adoption)" \
+      && pass "P1c — adopted phase-state.json has exactly init.sh's key set" \
       || fail_ "P1c" "key sets differ — init.sh: [$ok_keys]  adoption: [$ad_keys]"
     # the constants a fresh project is born with must be byte-equal
     diffs="$(jq -rn --argjson o "$ORACLE_PS" --slurpfile a "$P1/.claude/phase-state.json" \
@@ -224,6 +231,19 @@ if adopt_one 1; then
     pass "P1e — adopted manifest.json carries init.sh's six tier/host keys"
   else
     fail_ "P1e" "adopted manifest.json is missing one of init.sh's six keys: $(jq -c 'keys' "$P1/.claude/manifest.json" 2>/dev/null)"
+  fi
+  # P1f — THE TWO FILES AGREE ON THE TIER KEY. `# BL-221-ADOPT-TIER-KEYS` made
+  # the manifest carry the same two keys as phase-state "so the two birth paths
+  # produce the same shape"; this pins that they carry the same VALUE. Under
+  # review, deleting the manifest writer's guard line survived every case
+  # above — an equivalent mutant while ADOPT_POC_MODE is a constant "", but the
+  # moment adoption learns a POC mode (the entry's residual #1) it would write
+  # sponsored_poc into phase-state and null into the manifest. This is the
+  # line that catches that, and it kills that mutant today.
+  if jq -e --slurpfile m "$P1/.claude/manifest.json" '.poc_mode == $m[0].poc_mode and .deployment == $m[0].deployment' "$P1/.claude/phase-state.json" >/dev/null 2>&1; then
+    pass "P1f — phase-state.json and manifest.json agree on deployment and poc_mode"
+  else
+    fail_ "P1f" "tier key disagrees across files — phase-state: $(jq -c '{deployment,poc_mode}' "$P1/.claude/phase-state.json") manifest: $(jq -c '{deployment,poc_mode}' "$P1/.claude/manifest.json" 2>/dev/null)"
   fi
 
   # P2 — the consumer that turned the string into a dead end.
@@ -279,7 +299,7 @@ else
     M1_OUT="$( cd "$M1" && bash scripts/process-checklist.sh --start-phase4 </dev/null 2>&1 )" || true
     printf '%s' "$M1_OUT" | grep -q "project is in production mode" \
       && pass "MP1 (MUTATION) — with the string restored, --start-phase4 refuses the adoptee again: P2 is what stops it" \
-      || fail_ "MP1 (MUTATION)" "restoring the string did not bring the dead end back — P2 may be passing for another reason"
+      || fail_ "MP1 (MUTATION)" "restoring the string did not bring the dead end back — P2 may be passing for another reason, or the phase-state poc_json guard line was removed so the constant never reached the file"
   fi
   if adopt_one 2 "$MP1/fw"; then
     M1o="$ADOPTED"

--- a/tests/test-bl253-adoption-state-parity.sh
+++ b/tests/test-bl253-adoption-state-parity.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+# tests/test-bl253-adoption-state-parity.sh
+#
+# `## BL-253:` — an ADOPTED project must be born with the same state an
+# init.sh-SCAFFOLDED one is born with. The design's headline promise
+# (docs/designs/2026-08-23-brownfield-adoption-v2.md: "indistinguishable from a
+# scaffolded project in what the gates demand") was asserted in two documents
+# and executed by no test, and the one key it got wrong was the tier key's
+# second half: init.sh writes `poc_mode: null` for a production project
+# (`poc_json="null"` in create_project; `poc_mode:null` in
+# prepare_initial_state_for_commit), adoption wrote the STRING "production",
+# and every reader treats a non-null value as the NAME OF A POC MODE — so
+# `process-checklist.sh --start-phase4` refused every adoptee ("project is in
+# production mode… run --to-production"), and the organizational Pre-Phase-0
+# guard in check-phase-gate.sh, keyed on `poc_mode` being null, skipped its six
+# pre-conditions for every organizational adoptee. Reproduced on main c61edb1,
+# both tiers, by the 2026-09-08 codebase review's second pass.
+#
+# THE ORACLE IS init.sh's OWN EMITTER, READ AS SOURCE — NEVER EXECUTED. init.sh
+# ends in an unconditional `main "$@"`, so it cannot be sourced for its
+# functions, and running it needs ~/.claude-dev-framework plus network, which
+# would make this suite non-hermetic and full-lane-only. Instead the
+# phase-state heredoc is lifted out of create_project by its `PHEOF` fence,
+# its shell interpolations substituted with the values adoption would use, and
+# the result parsed with jq. If init.sh's emitter moves or changes shape, O0
+# fails LOUDLY and says so — that is the canary, not a defect in this suite.
+# This file therefore NAMES init.sh on executed lines (the awk below) and is
+# registered in the tests.yml unit lane by hand: it reads init.sh, it never
+# invokes it.
+#
+# MUTATION HARNESS STANDARD (inherited from the WP9a/9b/10a suites): every
+# mutant is applied to a MIRROR of the framework, never the real tree; every
+# marker is asserted unique and end-of-line anchored (MP0) so a mutation cannot
+# silently hit a second site; every mutant must parse (`bash -n`) and must
+# have changed the file (>=2 diff lines) or the case fails as a setup error.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DRIVER="$REPO_ROOT/scripts/adopt-project.sh"
+LIB_DIR="$REPO_ROOT/scripts/lib/adopt"
+L_STATE="$LIB_DIR/adopt-state.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+_mode_of() { stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1" 2>/dev/null || printf '?\n'; }
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_parses() { bash -n "$1" >/dev/null 2>&1 && printf '1\n' || printf '0\n'; }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+
+_sed_inplace() {
+  local file="$1" expr="$2" tmp mode
+  mode="$(_mode_of "$file")"
+  tmp="$(mktemp)"
+  sed "$expr" "$file" > "$tmp" && mv "$tmp" "$file"
+  [ "$mode" != "?" ] && chmod "$mode" "$file" 2>/dev/null
+  return 0
+}
+_changed_lines() {
+  local n
+  n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]')
+  case "$n" in ''|*[!0-9]*) n=0 ;; esac
+  printf '%s\n' "$n"
+}
+
+if [ ! -f "$DRIVER" ]; then
+  echo "  [FAIL] setup — $DRIVER not found"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+  echo "  [FAIL] setup — jq is required by this suite"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1
+fi
+
+# ── Fixtures (same adoptee the WP4/WP10a suites drive) ──────────────────────
+mk_adoptee() {
+  local p="$1"
+  mkdir -p "$p/src" "$p/docs" || return 1
+  ( cd "$p" \
+      && git init -q . \
+      && git config user.email "bl253@test.invalid" \
+      && git config user.name  "BL253 Test" \
+      && git config core.excludesFile /dev/null ) >/dev/null 2>&1 || return 1
+  printf '{"name":"acme-api","scripts":{"test":"npm test"}}\n' > "$p/package.json"
+  printf '# acme-api\n' > "$p/README.md"
+  printf '# What this is for\n\nInvoice reconciliation for small firms.\n' > "$p/docs/product.md"
+  printf '# Architecture\n\nA node service and a postgres database.\n' > "$p/docs/architecture.md"
+  ( cd "$p" && git add -A && git commit -q -m "chore: their own history" ) >/dev/null 2>&1 || return 1
+  return 0
+}
+
+TEMPLATE="$(newtmp)/template"
+REPORT=""
+if mk_adoptee "$TEMPLATE" \
+   && bash "$REPO_ROOT/scripts/scout.sh" --root "$TEMPLATE" --out "$TOPTMP/scan" >/dev/null 2>&1 \
+   && [ -s "$TOPTMP/scan/scout-report.json" ]; then
+  REPORT="$TOPTMP/scan/scout-report.json"
+else
+  echo "  [FAIL] setup — scripts/scout.sh produced no report"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1
+fi
+
+# Five answers: the tier question (1 personal / 2 organizational) plus this
+# report's four scan-derived confirmations.
+_ans() { local tier="${1:-1}"; printf '%s\n1\n1\n1\n1\n' "$tier"; }
+
+RUN_RC=0; RUN_OUT=""; RUN_ERR=""
+# run_adopt <dir> <answers> <report> [fw] — the scanner probe is pinned to a
+# binary every host has (`sh`) so BL-251's fast path fires and the resolver is
+# never consulted: this suite is about STATE, not tools, and must not depend on
+# what the host has installed.
+run_adopt() {
+  local dir="$1" answers="$2" report="$3" fw="${4:-$REPO_ROOT}"
+  RUN_RC=0
+  RUN_OUT="$(dirname "$answers")/run-out"
+  RUN_ERR="$(dirname "$answers")/run-err"
+  ( cd "$dir" && env SOIF_ADOPT_SCANNER_BIN=sh bash "$fw/scripts/adopt-project.sh" --scan-report "$report" ) \
+    < "$answers" > "$RUN_OUT" 2> "$RUN_ERR" || RUN_RC=$?
+  return 0
+}
+
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  cp -Rp "$REPO_ROOT/templates" "$m/" || return 1
+  cp -p "$REPO_ROOT/init.sh" "$m/" || return 1
+  return 0
+}
+
+_mutate() {   # _mutate <mirror> <lib> <marker> <replacement>
+  local mir="$1" lib="$2" mark="$3" repl="$4" before after changed
+  before="$(mktemp)"; cp "$mir/scripts/lib/adopt/$lib" "$before"
+  # THE DELIMITER IS ABSENT FROM PATTERN AND REPLACEMENT — CLAUDE.md's sed trap,
+  # met head-on: a first cut used '#', which every marker contains, so all three
+  # mutations silently failed to apply and the setup guard caught it. No marker
+  # or replacement in this suite carries '|'; the >=2-changed-lines check below
+  # is what proves the edit applied rather than trusting sed's exit status.
+  _sed_inplace "$mir/scripts/lib/adopt/$lib" "s|^.*${mark}\$|${repl}|"
+  after="$mir/scripts/lib/adopt/$lib"
+  changed="$(_changed_lines "$before" "$after")"
+  rm -f "$before"
+  [ "$changed" -ge 2 ] || { printf '0\n'; return 0; }
+  [ "$(_parses "$after")" = "1" ] || { printf '0\n'; return 0; }
+  printf '1\n'
+}
+
+# adopt_one <tier> → sets ADOPTED (dir) or fails loudly; the caller asserts.
+ADOPTED=""
+adopt_one() {
+  local tier="$1" fw="${2:-$REPO_ROOT}" d
+  d="$(newtmp)"; mkdir -p "$d/p"
+  mk_adoptee "$d/p" || { fail_ "setup" "could not build the adoptee"; return 1; }
+  _ans "$tier" > "$d/answers"
+  run_adopt "$d/p" "$d/answers" "$REPORT" "$fw"
+  [ "$RUN_RC" -eq 0 ] || { fail_ "setup" "adoption (tier $tier) exited $RUN_RC — see $RUN_ERR"; return 1; }
+  [ -f "$d/p/.claude/phase-state.json" ] || { fail_ "setup" "adoption wrote no phase-state.json"; return 1; }
+  ADOPTED="$d/p"
+  return 0
+}
+
+echo "=== O — the oracle: init.sh's phase-state emitter, read as source ==="
+
+# O0 — lift the heredoc out of create_project by its PHEOF fence and parse it
+# with adoption's values in place of the shell interpolations. A production,
+# personal, full-track project named like the fixture — exactly what adoption
+# writes for tier 1.
+ORACLE_PS=""
+ORACLE_PS="$(awk '/cat > \.claude\/phase-state\.json << PHEOF/{f=1;next} /^PHEOF$/{f=0} f{print}' "$REPO_ROOT/init.sh" \
+  | sed -e 's/"\$PROJECT_NAME"/"acme-api"/' -e 's/"\$TRACK"/"full"/' -e 's/"\$DEPLOYMENT"/"personal"/' -e 's/\$poc_json/null/' \
+  | jq -c . 2>/dev/null)"
+if [ -n "$ORACLE_PS" ]; then
+  pass "O0 — init.sh's phase-state heredoc was lifted and parses (the oracle exists)"
+else
+  fail_ "O0" "init.sh's phase-state emitter has moved or changed shape — re-derive this suite's oracle before trusting anything below"
+fi
+
+# O1 — provenance pins: the two literals this suite's parity claim rests on.
+# If either goes, the oracle above may still parse while meaning something
+# else, so they are pinned by name.
+[ "$(grep -c 'poc_json="null"' "$REPO_ROOT/init.sh")" -ge 1 ] \
+  && pass "O1 — init.sh still writes poc_json=\"null\" for a production project (phase-state)" \
+  || fail_ "O1" "init.sh no longer writes poc_json=\"null\" — the phase-state half of the oracle is unanchored"
+[ "$(grep -c 'poc_mode:null' "$REPO_ROOT/init.sh")" -ge 2 ] \
+  && pass "O1b — init.sh still writes poc_mode:null for a production manifest (both branches)" \
+  || fail_ "O1b" "init.sh no longer writes poc_mode:null in prepare_initial_state_for_commit — the manifest half of the oracle is unanchored"
+
+echo "=== P — parity: an adopted project is born with a scaffolded project's state ==="
+
+# P1 — personal tier.
+if adopt_one 1; then
+  P1="$ADOPTED"
+  if jq -e '.poc_mode == null' "$P1/.claude/phase-state.json" >/dev/null 2>&1; then
+    pass "P1 — adopted phase-state.json carries poc_mode: null, as init.sh writes for production"
+  else
+    fail_ "P1" "adopted phase-state.json has poc_mode $(jq -c '.poc_mode' "$P1/.claude/phase-state.json") — init.sh writes null; every reader takes a non-null value as a POC mode name"
+  fi
+  if jq -e '.poc_mode == null' "$P1/.claude/manifest.json" >/dev/null 2>&1; then
+    pass "P1b — adopted manifest.json carries poc_mode: null"
+  else
+    fail_ "P1b" "adopted manifest.json has poc_mode $(jq -c '.poc_mode' "$P1/.claude/manifest.json" 2>/dev/null) — init.sh writes null"
+  fi
+  # key-by-key against the oracle, allowing only what adoption adds on top
+  if [ -n "$ORACLE_PS" ]; then
+    ok_keys="$(printf '%s' "$ORACLE_PS" | jq -r 'keys | sort | join(",")')"
+    ad_keys="$(jq -r 'del(.adoption) | keys | sort | join(",")' "$P1/.claude/phase-state.json")"
+    [ "$ok_keys" = "$ad_keys" ] \
+      && pass "P1c — adopted phase-state.json has exactly init.sh's key set (minus .adoption)" \
+      || fail_ "P1c" "key sets differ — init.sh: [$ok_keys]  adoption: [$ad_keys]"
+    # the constants a fresh project is born with must be byte-equal
+    diffs="$(jq -rn --argjson o "$ORACLE_PS" --slurpfile a "$P1/.claude/phase-state.json" \
+      '[ "framework_version","current_phase","track","deployment","poc_mode","compliance_ready","review_gate_enforced","gates" ]
+       | map(select($o[.] != $a[0][.])) | join(",")')"
+    [ -z "$diffs" ] \
+      && pass "P1d — every birth constant equals init.sh's (framework_version, phase, track, tier key, flags, gates)" \
+      || fail_ "P1d" "these keys differ from init.sh's birth values: $diffs"
+  fi
+  # the manifest's tier keys are the set init.sh writes
+  if jq -e 'has("host") and has("mode") and has("remote_url") and has("deployment") and has("poc_mode") and has("enforcement_level")' "$P1/.claude/manifest.json" >/dev/null 2>&1; then
+    pass "P1e — adopted manifest.json carries init.sh's six tier/host keys"
+  else
+    fail_ "P1e" "adopted manifest.json is missing one of init.sh's six keys: $(jq -c 'keys' "$P1/.claude/manifest.json" 2>/dev/null)"
+  fi
+
+  # P2 — the consumer that turned the string into a dead end.
+  P2_OUT="$( cd "$P1" && bash scripts/process-checklist.sh --start-phase4 </dev/null 2>&1 )" || true
+  if printf '%s' "$P2_OUT" | grep -q "project is in production mode"; then
+    fail_ "P2" "process-checklist.sh --start-phase4 refuses the adoptee as a POC: 'project is in production mode'"
+  else
+    pass "P2 — process-checklist.sh --start-phase4 does not read the adoptee as a POC"
+  fi
+fi
+
+# P3 — organizational tier: the Pre-Phase-0 guard must FIRE. It is keyed on
+# poc_mode being null; with the string it was silently skipped.
+if adopt_one 2; then
+  P3="$ADOPTED"
+  jq -e '.deployment == "organizational"' "$P3/.claude/phase-state.json" >/dev/null 2>&1 \
+    || fail_ "P3 setup" "tier 2 did not land as organizational"
+  P3_OUT="$( cd "$P3" && bash scripts/check-phase-gate.sh --gate phase_0_to_1 </dev/null 2>&1 )" || true
+  if printf '%s' "$P3_OUT" | grep -q "Pre-Phase 0"; then
+    pass "P3 — an organizational adoptee is held to the six Pre-Phase-0 pre-conditions"
+  else
+    fail_ "P3" "the organizational Pre-Phase-0 guard did not fire for the adoptee — six pre-conditions skipped"
+  fi
+  jq -e '.poc_mode == null' "$P3/.claude/phase-state.json" >/dev/null 2>&1 \
+    && pass "P3b — organizational adoptee's phase-state.json carries poc_mode: null" \
+    || fail_ "P3b" "organizational adoptee's poc_mode is $(jq -c '.poc_mode' "$P3/.claude/phase-state.json")"
+fi
+
+echo "=== MP — mutation proofs ==="
+
+MP_MODE="# BL-253-POC-MODE"
+MP_NULL="# BL-253-POC-NULL"
+MP_NULL_M="# BL-253-POC-NULL-MANIFEST"
+
+# MP0 — the markers are unique and end-of-line anchored.
+for _m in "$MP_MODE" "$MP_NULL" "$MP_NULL_M"; do
+  _n="$(_sites "$L_STATE" "$_m")"
+  [ "$_n" = "1" ] \
+    && pass "MP0 — '$_m' occurs exactly once at end-of-line in adopt-state.sh" \
+    || fail_ "MP0" "'$_m' occurs $_n times in adopt-state.sh (need exactly 1)"
+done
+
+# MP1 — restore the string and both consumers must regress: P2's dead end
+# returns and P3's guard goes quiet.
+MP1="$(newtmp)"; mkdir -p "$MP1/fw"
+if ! mk_mirror "$MP1/fw"; then
+  fail_ "MP1 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MP1/fw" "adopt-state.sh" "$MP_MODE" "ADOPT_POC_MODE=\"production\"   $MP_MODE")" != "1" ]; then
+  fail_ "MP1 setup" "the poc-mode mutation did not apply cleanly"
+else
+  if adopt_one 1 "$MP1/fw"; then
+    M1="$ADOPTED"
+    M1_OUT="$( cd "$M1" && bash scripts/process-checklist.sh --start-phase4 </dev/null 2>&1 )" || true
+    printf '%s' "$M1_OUT" | grep -q "project is in production mode" \
+      && pass "MP1 (MUTATION) — with the string restored, --start-phase4 refuses the adoptee again: P2 is what stops it" \
+      || fail_ "MP1 (MUTATION)" "restoring the string did not bring the dead end back — P2 may be passing for another reason"
+  fi
+  if adopt_one 2 "$MP1/fw"; then
+    M1o="$ADOPTED"
+    M1o_OUT="$( cd "$M1o" && bash scripts/check-phase-gate.sh --gate phase_0_to_1 </dev/null 2>&1 )" || true
+    printf '%s' "$M1o_OUT" | grep -q "Pre-Phase 0" \
+      && fail_ "MP1b (MUTATION)" "restoring the string did not silence the Pre-Phase-0 guard — P3 may be passing for another reason" \
+      || pass "MP1b (MUTATION) — with the string restored, the organizational guard goes quiet again: P3 is what stops it"
+  fi
+fi
+
+# MP2 — write "" instead of null in phase-state: the readers forgive it, the
+# parity oracle must not. This is what proves the null emission is
+# load-bearing and not just the constant.
+MP2="$(newtmp)"; mkdir -p "$MP2/fw"
+if ! mk_mirror "$MP2/fw"; then
+  fail_ "MP2 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MP2/fw" "adopt-state.sh" "$MP_NULL" "  local poc_json='\"\"'   $MP_NULL")" != "1" ]; then
+  fail_ "MP2 setup" "the phase-state null mutation did not apply cleanly"
+elif adopt_one 1 "$MP2/fw"; then
+  jq -e '.poc_mode == null' "$ADOPTED/.claude/phase-state.json" >/dev/null 2>&1 \
+    && fail_ "MP2 (MUTATION)" "writing \"\" still yielded null — P1 may be passing for another reason" \
+    || pass "MP2 (MUTATION) — with \"\" written, phase-state.json no longer matches init.sh: P1 is what stops it"
+fi
+
+# MP3 — the same for the manifest writer.
+MP3="$(newtmp)"; mkdir -p "$MP3/fw"
+if ! mk_mirror "$MP3/fw"; then
+  fail_ "MP3 setup" "could not mirror the framework"
+elif [ "$(_mutate "$MP3/fw" "adopt-state.sh" "$MP_NULL_M" "  local poc_json='\"\"'   $MP_NULL_M")" != "1" ]; then
+  fail_ "MP3 setup" "the manifest null mutation did not apply cleanly"
+elif adopt_one 1 "$MP3/fw"; then
+  jq -e '.poc_mode == null' "$ADOPTED/.claude/manifest.json" >/dev/null 2>&1 \
+    && fail_ "MP3 (MUTATION)" "writing \"\" still yielded null in the manifest — P1b may be passing for another reason" \
+    || pass "MP3 (MUTATION) — with \"\" written, manifest.json no longer matches init.sh: P1b is what stops it"
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0
+exit 1

--- a/tests/test-brownfield-wp4-driver.sh
+++ b/tests/test-brownfield-wp4-driver.sh
@@ -426,12 +426,23 @@ else
   fi
 fi
 
+# ── S3/S4 RUN ON THE PERSONAL TIER, AND THE REASON IS `## BL-253:`. This
+# file's `_ans` defaults to organizational, and until BL-253 an organizational
+# adoptee was born with `poc_mode: "production"` — a string the Pre-Phase-0
+# guard reads as a POC mode, so it never fired and the gate said "Phase gates
+# consistent" (rc 0) for a project that had cleared none of its six named
+# pre-conditions. That rc 0 was an artifact of the bug. With `poc_mode: null`
+# (init.sh's value) the organizational verdict is CORRECTLY a block, which is
+# not what §8.4 is about: §8.4 is the interruption ORDER, and its "reaches a
+# verdict, rc 0" clause is true of the personal tier. The organizational
+# verdict is pinned where it belongs, tests/test-bl253-adoption-state-parity.sh
+# P3/MP1b.
 S3D="$(newtmp)"
 if ! mk_adoptee "$S3D/p"; then
   fail_ "S3" "fixture setup failed"
 else
   report_with_phase 2 "$S3D/report.json"
-  _ans > "$S3D/answers"
+  _ans 1 > "$S3D/answers"
   run_adopt "$S3D/p" "$S3D/answers" "$S3D/report.json" phase_state
   _assert_safe_row "S3 (interruption after phase-state)" "$S3D/p"
 fi
@@ -441,7 +452,7 @@ if ! mk_adoptee "$S4D/p"; then
   fail_ "S4" "fixture setup failed"
 else
   report_with_phase 2 "$S4D/report.json"
-  _ans > "$S4D/answers"
+  _ans 1 > "$S4D/answers"
   run_adopt "$S4D/p" "$S4D/answers" "$S4D/report.json" intake
   _assert_safe_row "S4 (interruption after intake)" "$S4D/p"
 fi


### PR DESCRIPTION
Every adopted project was born with `poc_mode: "production"` — a value `init.sh` never writes (it maps Production to `POC_MODE=""` and emits JSON `null` in both state files, because *"Production is not a POC mode"*) and one every reader takes as **the name of a POC mode**. Reproduced on `main` `c61edb1`, both tiers:

- `process-checklist.sh --start-phase4` refused every adoptee: *"project is in production mode… run `upgrade-project.sh --to-production`"* — and the reviewer found that remedy is itself blocked by the Pre-Phase-0 pre-conditions the bug was hiding. A catch-22.
- `check-phase-gate.sh`'s organizational Pre-Phase-0 guard, keyed on the key being null, printed **zero** pre-condition lines for an organizational adoptee — six mandatory sign-offs silently skipped.

## Fix

`ADOPT_POC_MODE=""` (`# BL-253-POC-MODE`), and both writers emit **null**, not `""`, through init.sh's own `poc_json` idiom with `--argjson` (`# BL-253-POC-NULL`, `# BL-253-POC-NULL-MANIFEST`). The readers forgive `""`; the parity oracle does not, because a scaffolded project never carries one.

## Test — `tests/test-bl253-adoption-state-parity.sh`

The oracle is **init.sh's own emitter read as source, never executed**: the phase-state heredoc is lifted by its `PHEOF` fence, its interpolations substituted, and the result parsed with jq — hermetic and unit-lane. RED against `main` **5 / 12**, GREEN **19 / 0**. Cases: `poc_mode == null` in both files; strict key-set equality; every birth constant byte-equal; init.sh's six manifest keys; **P1f** the two files agree on the tier key; the two consumers by behaviour on both tiers. Four mutants (restore the string → both consumers regress; write `""` in each writer → the oracle rejects it). The reviewer's own seven mutants: six killed by the suite as written, the seventh (drop the manifest guard — equivalent today, a real cross-file split once adoption learns a POC mode) killed by P1f, added under review.

**One existing suite was green because of the bug.** `test-brownfield-wp4-driver.sh` S3/S4 adopt on that file's default *organizational* tier and asserted "Phase gates consistent" rc 0 — true only because the guard was skipped. The organizational verdict is now correctly a block; §8.4 is about interruption order, so S3/S4 run on the personal tier with the reason in a comment, and the organizational verdict is pinned in the new suite (P3, MP1b). The file still drives organizational adoption at 14 other sites including S5, the §8.4 order mutation itself.

13 adoption-touching suites green; 15/15 lints; `lint-tests-registered.sh --list` shows the new suite `registered`, not exempt.

## Review

One adversarial round (a first reviewer stalled 11h on a single Bash call and was replaced): **`minor_concerns`**. Every load-bearing claim reproduced independently — the defect on both tiers, the init.sh equivalence by reading, RED/GREEN case-for-case, every number checked, no reader distinguishes `null`/`""`/absent. Four prose-accuracy findings and the P1f gap were fixed before push (third commit `c25e4b8`). Not checked by the reviewer: six of the thirteen suite counts (wp1, wp2, wp3-regen, wp5b, wp6, wp9b — run locally, all green) and the CI lane end-to-end.

Residuals on `## BL-253:`: adoption still asks no POC question (D9 design call); wp5b's `set_tier` fixtures hand-write `"production"` as ratchet input (harmless, wrong idiom).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk
