### PR TITLE
fix(bl-255): escape operator text before it is used as a sed replacement

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -534,6 +534,7 @@ jobs:
             tests/test-bl253-adoption-state-parity.sh
             tests/test-bl254-ci-templates-call-shipped-scripts.sh
             tests/test-lint-user-guide-scripts.sh
+            tests/test-bl255-sed-replacement-escape.sh
           )
 
           # ── BL-190 shard pins ──────────────────────────────────────────

--- a/init.sh
+++ b/init.sh
@@ -2946,12 +2946,14 @@ generate_approval_log() {
   local today
   today=$(date +%Y-%m-%d)
 
+  # `## BL-255:` — the project name is operator text (the interactive path is
+  # tr-normalised only) and is escaped for the replacement position.
   if [ "$DEPLOYMENT" = "organizational" ]; then
-    sed -e "s|__PROJECT_NAME__|$PROJECT_NAME|g" \
+    sed -e "s|__PROJECT_NAME__|$(soif_sed_repl_esc "$PROJECT_NAME" "|")|g" \
         -e "s|__TODAY__|$today|g" \
         "$SCRIPT_DIR/templates/generated/approval-log-org.tmpl" > APPROVAL_LOG.md
   else
-    sed -e "s|__PROJECT_NAME__|$PROJECT_NAME|g" \
+    sed -e "s|__PROJECT_NAME__|$(soif_sed_repl_esc "$PROJECT_NAME" "|")|g" \
         -e "s|__TODAY__|$today|g" \
         "$SCRIPT_DIR/templates/generated/approval-log-personal.tmpl" > APPROVAL_LOG.md
   fi
@@ -3296,7 +3298,7 @@ generate_release() {
       -e "s|__SETUP_VERSION_VALUE__|$RELEASE_SETUP_VERSION_VALUE|g" \
       -e "s|__INSTALL_COMMAND__|$RELEASE_INSTALL_COMMAND|g" \
       -e "s|__BUILD_COMMAND__|$RELEASE_BUILD_COMMAND|g" \
-      -e "s|__PROJECT_NAME__|$PROJECT_NAME|g" \
+      -e "s|__PROJECT_NAME__|$(soif_sed_repl_esc "$PROJECT_NAME" "|")|g" \
       "$release_template" > "$_rendered"
 
   # How the rendered steps reach the runner differs per host, and getting this

--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -973,7 +973,9 @@ soif_sed_repl_esc() {
   local t="$1" delim="${2:-|}"
   t="${t//\\/\\\\}"
   t="${t//&/\\&}"
-  t="${t//"$delim"/\\$delim}"
+  # `&` and `\` are already escaped above; escaping them again as the
+  # delimiter would double the backslash (measured under review).
+  case "$delim" in '&'|'\') ;; *) t="${t//"$delim"/\\$delim}" ;; esac
   t="${t//$'\n'/ }"
   printf '%s' "$t"   # BL-255-SED-REPL-ESC
 }

--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -938,6 +938,31 @@ prompt_install() {
   fi
 }
 
+# ── `## BL-255:` — OPERATOR TEXT USED AS A sed REPLACEMENT ────────────────────
+# soif_sed_repl_esc <text> [delim]
+#   Prints <text> escaped for use as the REPLACEMENT half of a sed `s` command
+#   whose delimiter is <delim> (default `|`). Three characters are special
+#   there and every one of them reached sed raw from `--description` and the
+#   interactive project name: `&` (the whole match — so "R&D tools" rendered as
+#   "R__PROJECT_DESCRIPTION__D tools"), `\` (starts an escape), and the
+#   delimiter itself (ends the replacement; what follows is parsed as FLAGS, so
+#   "a|w <path>|" wrote a file named "<path>||g" and emptied the description;
+#   GNU sed's `e` flag makes the same shape run a command). A newline would end
+#   the expression, so it becomes a space — descriptions are one sentence.
+#
+#   This is the replacement-side escape ONLY. Operator text used as the
+#   PATTERN half (reconfigure-project.sh's rename) needs a regex escape, which
+#   this is not; that site is recorded on the entry, not fixed here.
+#
+#   Measured, not reasoned: tests/test-bl255-sed-replacement-escape.sh pins the
+#   table (H) and both renderers end to end (E), and its M1 neuters the marked
+#   line below to prove E1's `&` case is what holds it.
+soif_sed_repl_esc() {
+  local text="$1" delim="${2:-|}" d='/'
+  [ "$delim" = '/' ] && d='#'
+  printf '%s' "$text" | tr '\n' ' ' | sed -e 's/[\\&]/\\&/g' -e "s${d}[${delim}]${d}\\\\&${d}g"   # BL-255-SED-REPL-ESC
+}
+
 # BL-095-STATE-READERS-BEGIN
 # ONE parsing surface for top-level phase-state keys — nine files previously
 # parsed `deployment`/`poc_mode` inline (three different grep-sed variants, a

--- a/scripts/lib/helpers-core.sh
+++ b/scripts/lib/helpers-core.sh
@@ -954,13 +954,28 @@ prompt_install() {
 #   PATTERN half (reconfigure-project.sh's rename) needs a regex escape, which
 #   this is not; that site is recorded on the entry, not fixed here.
 #
+#   PURE BASH, NO FORKS, BYTE-SAFE — and the first cut was none of those. It
+#   piped through `tr | sed`, and under review a description carrying a byte
+#   invalid in the current locale (latin-1 é pasted from a document) made `tr`
+#   fail while the pipeline's last element succeeded: rc 0, description
+#   silently TRUNCATED, a complete-looking CLAUDE.md. Before the fix the same
+#   input failed loudly (`sed: RE error: illegal byte sequence`, empty file).
+#   Turning a loud failure into silent data loss inverts this repo's rule, so
+#   the helper is now parameter expansion only: locale-independent, no
+#   subprocess, and a `^` or `]` delimiter (which broke the bracket expression)
+#   is just another literal. Backslash FIRST, or the escapes it adds are
+#   escaped again.
+#
 #   Measured, not reasoned: tests/test-bl255-sed-replacement-escape.sh pins the
 #   table (H) and both renderers end to end (E), and its M1 neuters the marked
 #   line below to prove E1's `&` case is what holds it.
 soif_sed_repl_esc() {
-  local text="$1" delim="${2:-|}" d='/'
-  [ "$delim" = '/' ] && d='#'
-  printf '%s' "$text" | tr '\n' ' ' | sed -e 's/[\\&]/\\&/g' -e "s${d}[${delim}]${d}\\\\&${d}g"   # BL-255-SED-REPL-ESC
+  local t="$1" delim="${2:-|}"
+  t="${t//\\/\\\\}"
+  t="${t//&/\\&}"
+  t="${t//"$delim"/\\$delim}"
+  t="${t//$'\n'/ }"
+  printf '%s' "$t"   # BL-255-SED-REPL-ESC
 }
 
 # BL-095-STATE-READERS-BEGIN

--- a/scripts/lib/render-project-docs.sh
+++ b/scripts/lib/render-project-docs.sh
@@ -27,6 +27,19 @@
 # <out>.bak, which is removed). NO globals are read EXCEPT where a birth-only
 # code path (the tooling summary's resolver output) is explicitly passed in.
 
+# ── `## BL-255:` — THIS FILE NOW DEPENDS ON helpers-core.sh ─────────────────
+# Both renderers call soif_sed_repl_esc. Every production caller reaches it
+# through helpers.sh, but sourced ALONE (as the "pure renderers" contract above
+# once allowed) the call is `command not found` inside a `$(…)`, and the render
+# then completes with rc 0 and an EMPTY name and description — measured under
+# review. The guard below is the idiom the sibling libs use: source the core
+# helpers from this file's own directory if the function is not yet defined.
+_soif_rpd_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if ! command -v soif_sed_repl_esc >/dev/null 2>&1; then
+  # shellcheck source=/dev/null
+  [ -f "$_soif_rpd_dir/helpers-core.sh" ] && . "$_soif_rpd_dir/helpers-core.sh"
+fi
+
 # ── CLAUDE.md (A1) ───────────────────────────────────────────────────────────
 # soif_render_claude_md <template> <out> \
 #     <project_name> <description> <platform> <track> <language> \

--- a/scripts/lib/render-project-docs.sh
+++ b/scripts/lib/render-project-docs.sh
@@ -39,6 +39,7 @@ if ! command -v soif_sed_repl_esc >/dev/null 2>&1; then
   # shellcheck source=/dev/null
   [ -f "$_soif_rpd_dir/helpers-core.sh" ] && . "$_soif_rpd_dir/helpers-core.sh"
 fi
+unset _soif_rpd_dir
 
 # ── CLAUDE.md (A1) ───────────────────────────────────────────────────────────
 # soif_render_claude_md <template> <out> \

--- a/scripts/lib/render-project-docs.sh
+++ b/scripts/lib/render-project-docs.sh
@@ -37,8 +37,11 @@
 soif_render_claude_md() {
   local tmpl="$1" out="$2" name="$3" desc="$4" platform="$5" track="$6" \
         language="$7" test_interval="$8" deployment="$9"
-  sed -e "s|__PROJECT_NAME__|$name|g" \
-      -e "s|__PROJECT_DESCRIPTION__|$desc|g" \
+  # `## BL-255:` — name and description are OPERATOR TEXT and are escaped for
+  # the replacement position (`&`, `\`, the `|` delimiter, newlines). The four
+  # values below them are init.sh-validated enums/integers and are not.
+  sed -e "s|__PROJECT_NAME__|$(soif_sed_repl_esc "$name" "|")|g" \
+      -e "s|__PROJECT_DESCRIPTION__|$(soif_sed_repl_esc "$desc" "|")|g" \
       -e "s|__PLATFORM__|$platform|g" \
       -e "s|__TRACK__|$track|g" \
       -e "s|__LANGUAGE__|$language|g" \
@@ -145,9 +148,11 @@ soif_render_project_intake() {
   local deployment_display
   deployment_display="$(echo "${deployment:0:1}" | tr '[:lower:]' '[:upper:]')${deployment:1}"
 
+  # `## BL-255:` — name and description are OPERATOR TEXT, escaped for the
+  # replacement position of a `~`-delimited expression.
   sed -i.bak \
-    -e "s~| \*\*Project name\*\* | |~| **Project name** | $name |~" \
-    -e "s~| \*\*One-sentence description\*\* | _What does this do, in plain language?_ |~| **One-sentence description** | $desc |~" \
+    -e "s~| \*\*Project name\*\* | |~| **Project name** | $(soif_sed_repl_esc "$name" "~") |~" \
+    -e "s~| \*\*One-sentence description\*\* | _What does this do, in plain language?_ |~| **One-sentence description** | $(soif_sed_repl_esc "$desc" "~") |~" \
     -e "s~| \*\*Project track\*\* | Light / Standard / Full .*~| **Project track** | $track_display |~" \
     -e "s~| \*\*Platform type\*\* | Web / Desktop / Mobile / CLI / Other: .*~| **Platform type** | $platform |~" \
     -e "s~| \*\*Platform Module\*\* | SOI-PM-WEB / SOI-PM-DESKTOP / SOI-PM-MOBILE / None .*~| **Platform Module** | $platform_module |~" \

--- a/scripts/reconfigure-project.sh
+++ b/scripts/reconfigure-project.sh
@@ -561,7 +561,10 @@ reconfigure() {
 
       # Update CLAUDE.md project name
       if [ -f "CLAUDE.md" ]; then
-        sed -i.bak "s|$old_name|$new_name|g" CLAUDE.md \
+        # `## BL-255:` — the NEW name is operator text in the replacement
+        # position and is escaped. The OLD name sits in the PATTERN position,
+        # which needs a regex escape this helper is not; recorded on the entry.
+        sed -i.bak "s|$old_name|$(soif_sed_repl_esc "$new_name" "|")|g" CLAUDE.md \
           || _rename_rollback "CLAUDE.md sed failed"
         rm -f CLAUDE.md.bak
         print_ok "Updated project name in CLAUDE.md"
@@ -569,7 +572,7 @@ reconfigure() {
 
       # Update PROJECT_INTAKE.md
       if [ -f "PROJECT_INTAKE.md" ]; then
-        sed -i.bak "s|$old_name|$new_name|g" PROJECT_INTAKE.md \
+        sed -i.bak "s|$old_name|$(soif_sed_repl_esc "$new_name" "|")|g" PROJECT_INTAKE.md \
           || _rename_rollback "PROJECT_INTAKE.md sed failed"
         rm -f PROJECT_INTAKE.md.bak
         print_ok "Updated project name in PROJECT_INTAKE.md"

--- a/scripts/verify-install.sh
+++ b/scripts/verify-install.sh
@@ -1111,8 +1111,10 @@ fix_claude_md() {
   # always clean up the partial file even on early failure.
   trap "rm -f '$staged'" RETURN
 
-  if ! sed -e "s|__PROJECT_NAME__|$proj_name|g" \
-           -e "s|__PROJECT_DESCRIPTION__|$proj_desc|g" \
+  # `## BL-255:` — name and description are operator text, escaped for the
+  # replacement position (`&`, `\`, the `|` delimiter, newlines).
+  if ! sed -e "s|__PROJECT_NAME__|$(soif_sed_repl_esc "$proj_name" "|")|g" \
+           -e "s|__PROJECT_DESCRIPTION__|$(soif_sed_repl_esc "$proj_desc" "|")|g" \
            -e "s|__PLATFORM__|$PLATFORM|g" \
            -e "s|__TRACK__|$TRACK|g" \
            -e "s|__LANGUAGE__|$LANGUAGE|g" \

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15314,33 +15314,59 @@ neuters the helper → the `&` splice returns; M2 bypasses the helper at the ren
 writes a file again).
 
 **Residuals, stated rather than hidden:**
-1. **The PATTERN side of the rename is still raw.** `reconfigure-project.sh` runs
-   `s|$old_name|$new_name|g`; the new name is now escaped, the old name is a regex pattern and needs a
-   different escape (`[]\.*^$/|` and friends). A current name containing a regex metacharacter is
-   already impossible via `--project` (regex-validated) but possible via the interactive path.
+1. **The PATTERN side of the rename is still raw, and it is a raw CLI argument.** `reconfigure-project.sh`
+   runs `s|$old_name|$new_name|g`; the new name is now escaped, the old name is a regex pattern and
+   needs a different escape (`[]\.*^$/|` and friends). `old_name` comes ONLY from the `--old` flag —
+   never auto-derived, never validated — so `reconfigure-project.sh --field name --old '<regex>'` puts
+   arbitrary operator text in the pattern position directly. (A first draft of this residual tied it
+   to `--project`'s validation; it is unrelated to `--project`.)
 2. **Validation would be the stronger fix and is not done here.** Escaping makes any description
    render verbatim; it does not decide whether a description containing `|` or a control character is
    something the framework should accept. That is an intake-policy call.
-3. Of the 18 `sed … $var` replacement sites in product code, the six not touched here carry generated
-   or validated values (`$today`, `$date`, `$id`, a `_slugify`'d slug, an integer, a `mktemp` path) —
-   listed so the next reader does not re-audit them: `intake-wizard.sh` (`$today`), `delta.sh`
-   (`$id`, `$slug`, `$class`, `$at`), `test-gate.sh` (`${n}`), `hook-templates.sh` (`$soif_idx_tree`),
-   `lint-bl-markers.sh` (`$WF_NORMALISED`, internal), `probe-tool.sh` (`${pkg}`, pattern side).
+3. **Seventeen `sed … $var` sites in product code, not eighteen** (a first draft miscounted): eleven now
+   escaped, six untouched. Of the six, three are PATTERN-side or literal-replacement and were never in
+   this class — `hook-templates.sh` (`${soif_idx_tree}`, empty replacement), `lint-bl-markers.sh`
+   (`$WF_NORMALISED`, literal replacement), `probe-tool.sh` (`${pkg}`, pattern) — and three are
+   replacement-side with generated or validated values: `intake-wizard.sh` (`$today`), `test-gate.sh`
+   (`${n}`, an integer), and `delta.sh`'s `_brief_render`, which splices SEVEN variables (`$id`, a
+   `_slugify`'d `$slug`, and `$class $at $risk $level $sev`, each enum-validated by `_set_attr` →
+   `_rank`). Listed so the next reader does not re-audit them.
+4. **`render-project-docs.sh` now depends on `helpers-core.sh`**, and its header once called it a pure
+   renderer. Every production caller reaches the helper through `helpers.sh`, but sourced alone the
+   `$(soif_sed_repl_esc …)` was `command not found` and the render completed at rc 0 with an EMPTY name
+   and description (measured under review). The file now guard-sources `helpers-core.sh` from its own
+   directory, the sibling libs' idiom. `test-scaffold-source-closure.sh` cannot see this class of
+   dependency (it derives from `$SCRIPT_DIR/…` path references), so it stays stated here.
 
-**Build note (2026-09-08, branch `fix/bl255-escape-sed-replacements`).** RED measured before any product
-change: `tests/test-bl255-sed-replacement-escape.sh` **0 passed / 11 failed** — H0 (no helper), E1
-(`R__PROJECT_DESCRIPTION__D tools`), E2 (a file written at `…/pwned||g`), E2b (description rendered as
-`a`), E3 (`# CLAUDE.md — acme__PROJECT_NAME__co`), E4 setup, G ×2 (init.sh three raw sites, verify-install
-one), M0/M1/M2. GREEN **18 / 0**: the helper by table (H ×8), both renderers end to end (E ×5), the
-scaffold-only sites by grep (G ×2: init.sh 3 escaped / 0 raw, verify-install 1 / 0), M0, and two mutants
-on a mirror — M1 neuters the marked line and the `&` splice returns; M2 bypasses the helper at the
-render site and the `w`-flag writes a file again. **The M2 harness itself fell into CLAUDE.md's sed
-trap on its first cut** — `|` as the delimiter with `|` in the pattern — and sed emitted an EMPTY mirror
-file that `bash -n` accepted and the changed-line count read as an applied mutation; the mutant then
-"changed nothing" because no renderer was left to run. It now uses `#`, asserts the raw line is present
-afterwards and that `soif_render_claude_md` still exists — a SHAPE assertion, not a count. Related suites
-green: plan-staging 25/0, reconfigure-field-handlers rc 0, verify-install bl030 8/0 / eval-factory 4/0 /
-fix-functions 16/0, scaffold-source-closure 9/0; all five edited product files parse; registered in the
+**Build note (2026-09-08, branch `fix/bl255-escape-sed-replacements`).** RED, measured with the branch's
+FINAL test file in a worktree at `c6da463`: **1 passed / 14 failed**. The one pass is M2 — it mirrors the
+tree under test, and on main the render site already carries the raw line, so its mutating `sed` is a
+no-op and the "mutant" writes the file: M2 is a fixed-tree site-proof, not a fixed-vs-unfixed
+discriminator, and it is recorded as such. (A first draft wrote "0 / 11" — the count of a
+then-11-case file, and wrong even for that file, since M2 passed on base then too; the review
+re-derived it.) The fourteen failures: H0 (no helper), E1 (`R__PROJECT_DESCRIPTION__D tools`), E2 (a file
+written at `…/pwned||g`), E2b (description rendered as `a`), E3 (`# CLAUDE.md — acme__PROJECT_NAME__co`),
+E4/E5 (intake description and name), E6a, G ×4, M0, M1 setup.
+
+**Review round 1: `major_concerns`, and the blocker was coverage, not the fix.** The reviewer reverted the
+escape at each of the eleven sites in turn; at FOUR of them every PR-blocking check stayed green —
+the intake renderer's NAME (E4 covered its description only), verify-install's DESCRIPTION (G greped
+`__PROJECT_NAME__` only), and both reconfigure sites (nothing mentioned the file). Closed by E5 (the
+intake name row, behavioural) and a rebuilt G that pins each file × placeholder at an EXACT escaped
+count with a delimiter-agnostic raw regex (`${VAR}` and `#`/`~` delimiters had slipped a first cut).
+Two more findings taken: the `tr | sed` helper turned a loud failure on a byte invalid in the locale
+into a description silently TRUNCATED at rc 0 (measured with latin-1 é) — the helper is now pure
+parameter expansion, byte-transparent, no forks, and E6a/E6b pin "complete under LC_ALL=C; complete
+or LOUD under the caller's locale, never cut short" (the harness runs the renderer under `set -e`, as
+every production caller does, so sed's own failure surfaces as the rc); and `render-project-docs.sh`
+sourced alone rendered an EMPTY name and description at rc 0 because the helper was `command not
+found` inside `$(…)` — it now guard-sources `helpers-core.sh` (residual 4). **The M2 harness itself
+fell into CLAUDE.md's sed trap on its first cut** — `|` as the delimiter with `|` in the pattern — and
+sed emitted an EMPTY mirror file that `bash -n` accepted and the changed-line count read as an
+applied mutation; it now uses `#` and asserts the resulting SHAPE. Related suites green: plan-staging
+25/0, reconfigure-field-handlers rc 0, enforcement-level-reconfigure 12/0, walk003 render 5/0,
+verify-install bl030 8/0 / eval-factory 4/0 / fix-functions 16/0, scaffold-source-closure 9/0,
+currency-manifest 53/0; `run-lints` 16/16; all five edited product files parse; registered in the
 aggregator and the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `registered`).
 
 **Related:** `## BL-164:` (shell-injectable generated CI from scaffold values — the sibling sink),

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15339,12 +15339,13 @@ writes a file again).
    dependency (it derives from `$SCRIPT_DIR/…` path references), so it stays stated here.
 
 **Build note (2026-09-08, branch `fix/bl255-escape-sed-replacements`).** RED, measured with the branch's
-FINAL test file in a worktree at `c6da463`: **1 passed / 14 failed**. The one pass is M2 — it mirrors the
-tree under test, and on main the render site already carries the raw line, so its mutating `sed` is a
-no-op and the "mutant" writes the file: M2 is a fixed-tree site-proof, not a fixed-vs-unfixed
-discriminator, and it is recorded as such. (A first draft wrote "0 / 11" — the count of a
-then-11-case file, and wrong even for that file, since M2 passed on base then too; the review
-re-derived it.) The fourteen failures: H0 (no helper), E1 (`R__PROJECT_DESCRIPTION__D tools`), E2 (a file
+FINAL test file in a worktree at `c6da463`: **2 passed / 14 failed**. The two passes are the two cases
+that guard against mistakes made DURING this work rather than against main: M2 mirrors the tree under
+test, and on main the render site already carries the raw line, so its mutating `sed` is a no-op and
+the "mutant" writes the file; E6b guards against the round-1 `tr | sed` helper's silent truncation,
+and main's raw sed already failed loudly on the invalid byte. Neither is a fixed-vs-unfixed
+discriminator, and both are recorded as such. (Earlier drafts wrote "0 / 11" and then "1 / 14" — each
+time a non-discriminating case was counted as if it discriminated; the review re-derived it twice.) The fourteen failures: H0 (no helper), E1 (`R__PROJECT_DESCRIPTION__D tools`), E2 (a file
 written at `…/pwned||g`), E2b (description rendered as `a`), E3 (`# CLAUDE.md — acme__PROJECT_NAME__co`),
 E4/E5 (intake description and name), E6a, G ×4, M0, M1 setup.
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15274,3 +15274,74 @@ parse.
 **Related:** `## BL-108:` (source-closure — the derived set this now feeds), `## BL-199:` (the class of
 docs naming things that do not ship), `## BL-112:` (a check that did not run must not read as clean),
 `## BL-196:` (the marker lint, the same shape one surface over).
+
+---
+
+## BL-255: `--description` and the interactive project name reach `sed` as a raw REPLACEMENT — `R&D tools` renders as `R__PROJECT_DESCRIPTION__D tools`, and `a|w <path>|` writes a file and empties the description
+
+**Status:** Open
+
+**Logged:** 2026-09-08, out of the adversarial codebase review (S6; pass 2 adjudicated it medium, not
+high: the file-write primitive is real, GNU sed's `e`-flag RCE plausible but not reproduced on BSD sed).
+Ranked #3 of the verified review's top ten. Reproduced on `main` `c6da463`.
+
+**The defect, precisely.** `soif_render_claude_md` and `soif_render_project_intake`
+(`scripts/lib/render-project-docs.sh`) splice the project name and one-sentence description into
+templates with `sed "s|__X__|$var|g"` and `s~…~$var~`. In a sed replacement three things are special and
+all three arrived raw: `&` is the whole match, `\` starts an escape, and the delimiter ends the
+replacement — what follows is parsed as FLAGS. Measured on this host (BSD sed 2.6.0):
+- description `R&D tools` → CLAUDE.md line `- **Description:** R__PROJECT_DESCRIPTION__D tools`;
+- description `a|w <scratch>/pwned|` → a **file written** at `<scratch>/pwned||g` (21 bytes — the `w`
+  filename runs to end-of-expression, so it picked up the trailing `|g`) and the description rendered
+  as `- **Description:** a`;
+- project name `acme&co` → `# CLAUDE.md — acme__PROJECT_NAME__co`.
+`--description` is unvalidated (`collect_inputs_non_interactive` regex-checks `ARG_PROJECT` only); the
+interactive project name is `tr`-normalised only (lower-case, spaces → hyphens), so `a&b` and `a|b`
+pass. The same raw splice sat in `init.sh` (two APPROVAL_LOG renders), `scripts/verify-install.sh`
+(its CLAUDE.md re-render on `--auto-fix`), and `scripts/reconfigure-project.sh` (the rename's new name).
+
+**Fix (built on this branch).** One helper, `soif_sed_repl_esc <text> [delim]` in
+`scripts/lib/helpers-core.sh` (`# BL-255-SED-REPL-ESC`): escapes `&`, `\` and the given delimiter,
+folds a newline to a space (a newline ends a sed expression; descriptions are one sentence), and picks
+its own internal delimiter so a caller delimiter of `/` is safe. Applied at every replacement-position
+site that carries operator text: both renderers (name + description; the four enum/integer values are
+init.sh-validated and left alone), `init.sh`'s two APPROVAL_LOG renders, `verify-install.sh`'s
+re-render (name + description), and `reconfigure-project.sh`'s two rename sites (replacement side).
+Suite `tests/test-bl255-sed-replacement-escape.sh`: the helper by table (H), both renderers end to end
+(E — `&`, the `|w` payload writes nothing and renders verbatim, a `&` in the name, `&`+`~` through the
+intake renderer), the scaffold-only name sites pinned by grep (G), and two mutants on a mirror (M1
+neuters the helper → the `&` splice returns; M2 bypasses the helper at the render site → the `w`-flag
+writes a file again).
+
+**Residuals, stated rather than hidden:**
+1. **The PATTERN side of the rename is still raw.** `reconfigure-project.sh` runs
+   `s|$old_name|$new_name|g`; the new name is now escaped, the old name is a regex pattern and needs a
+   different escape (`[]\.*^$/|` and friends). A current name containing a regex metacharacter is
+   already impossible via `--project` (regex-validated) but possible via the interactive path.
+2. **Validation would be the stronger fix and is not done here.** Escaping makes any description
+   render verbatim; it does not decide whether a description containing `|` or a control character is
+   something the framework should accept. That is an intake-policy call.
+3. Of the 18 `sed … $var` replacement sites in product code, the six not touched here carry generated
+   or validated values (`$today`, `$date`, `$id`, a `_slugify`'d slug, an integer, a `mktemp` path) —
+   listed so the next reader does not re-audit them: `intake-wizard.sh` (`$today`), `delta.sh`
+   (`$id`, `$slug`, `$class`, `$at`), `test-gate.sh` (`${n}`), `hook-templates.sh` (`$soif_idx_tree`),
+   `lint-bl-markers.sh` (`$WF_NORMALISED`, internal), `probe-tool.sh` (`${pkg}`, pattern side).
+
+**Build note (2026-09-08, branch `fix/bl255-escape-sed-replacements`).** RED measured before any product
+change: `tests/test-bl255-sed-replacement-escape.sh` **0 passed / 11 failed** — H0 (no helper), E1
+(`R__PROJECT_DESCRIPTION__D tools`), E2 (a file written at `…/pwned||g`), E2b (description rendered as
+`a`), E3 (`# CLAUDE.md — acme__PROJECT_NAME__co`), E4 setup, G ×2 (init.sh three raw sites, verify-install
+one), M0/M1/M2. GREEN **18 / 0**: the helper by table (H ×8), both renderers end to end (E ×5), the
+scaffold-only sites by grep (G ×2: init.sh 3 escaped / 0 raw, verify-install 1 / 0), M0, and two mutants
+on a mirror — M1 neuters the marked line and the `&` splice returns; M2 bypasses the helper at the
+render site and the `w`-flag writes a file again. **The M2 harness itself fell into CLAUDE.md's sed
+trap on its first cut** — `|` as the delimiter with `|` in the pattern — and sed emitted an EMPTY mirror
+file that `bash -n` accepted and the changed-line count read as an applied mutation; the mutant then
+"changed nothing" because no renderer was left to run. It now uses `#`, asserts the raw line is present
+afterwards and that `soif_render_claude_md` still exists — a SHAPE assertion, not a count. Related suites
+green: plan-staging 25/0, reconfigure-field-handlers rc 0, verify-install bl030 8/0 / eval-factory 4/0 /
+fix-functions 16/0, scaffold-source-closure 9/0; all five edited product files parse; registered in the
+aggregator and the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `registered`).
+
+**Related:** `## BL-164:` (shell-injectable generated CI from scaffold values — the sibling sink),
+`## BL-234:` (`_qdrant_key_escape` — the same escape-at-the-sink discipline one surface over).

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -843,6 +843,12 @@ run_child_suite "tests/test-lint-user-guide-scripts.sh" \
   "BL-254 lint-user-guide-scripts (table rows == shipped top-level set, both directions)" \
   "BL-254 lint-user-guide-scripts tests FAILED (run tests/test-lint-user-guide-scripts.sh for details)"
 
+# BL-255: operator text (project name, description) is escaped before it is
+# used as a sed replacement — `&`, `\`, the delimiter, newlines.
+run_child_suite "tests/test-bl255-sed-replacement-escape.sh" \
+  "BL-255 sed replacement escape (soif_sed_repl_esc; both renderers end to end; name sites pinned)" \
+  "BL-255 sed-replacement-escape tests FAILED (run tests/test-bl255-sed-replacement-escape.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-bl255-sed-replacement-escape.sh
+++ b/tests/test-bl255-sed-replacement-escape.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# tests/test-bl255-sed-replacement-escape.sh
+#
+# `## BL-255:` — OPERATOR TEXT REACHES sed AS A REPLACEMENT, UNESCAPED.
+#
+# `soif_render_claude_md` and `soif_render_project_intake` substitute the
+# project name and one-sentence description into templates with
+# `sed "s|__X__|$var|g"` (and `s~…~$var~`). In a sed replacement `&` means
+# "the whole match", `\` starts an escape, the delimiter ends the replacement
+# and whatever follows is parsed as FLAGS — so a description of `R&D tools`
+# rendered as `R__PROJECT_DESCRIPTION__D tools` (measured), and `a|w <path>|`
+# wrote a file named `<path>|g` and emptied the description (measured; GNU
+# sed's `e` flag makes the same shape run a command). `--description` is
+# unvalidated; the interactive project name is `tr`-normalised only. Found by
+# the 2026-09-07 codebase review (S6), reproduced on main c6da463.
+#
+# THE FIX IS ONE HELPER, `soif_sed_repl_esc <text> <delim>` in helpers-core.sh,
+# applied at every site that splices operator text into a replacement. This
+# suite pins the helper by table, each renderer end-to-end, and the two
+# init.sh / verify-install.sh name sites by grep (they run only inside a
+# scaffold, which this suite must not perform). Mutants on a MIRROR.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+CORE="$REPO_ROOT/scripts/lib/helpers-core.sh"
+RENDER="$REPO_ROOT/scripts/lib/render-project-docs.sh"
+TMPL_CLAUDE="$REPO_ROOT/templates/generated/claude-md.tmpl"
+TMPL_INTAKE="$REPO_ROOT/templates/project-intake.md"   # the path init.sh hands soif_render_project_intake
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); case "$n" in ''|*[!0-9]*) n=0 ;; esac; printf '%s\n' "$n"; }
+
+for f in "$CORE" "$RENDER" "$TMPL_CLAUDE"; do
+  [ -f "$f" ] || { echo "  [FAIL] setup — $f not found"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
+done
+[ -f "$TMPL_INTAKE" ] || TMPL_INTAKE="$(grep -o '"\$SCRIPT_DIR/templates/[^"]*intake[^"]*"' "$REPO_ROOT/init.sh" | head -1 | sed 's|"\$SCRIPT_DIR/|'"$REPO_ROOT"'/|; s|"$||')"
+
+# A fresh subshell per call so a mutated mirror can be sourced in isolation.
+# render_claude <lib_root> <desc> <name> <out>
+render_claude() {
+  ( . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+    . "$1/scripts/lib/render-project-docs.sh" >/dev/null 2>&1
+    soif_render_claude_md "$TMPL_CLAUDE" "$4" "$3" "$2" web standard typescript 3 personal ) 2>/dev/null
+}
+# render_intake <lib_root> <desc> <name> <out>
+render_intake() {
+  ( . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+    . "$1/scripts/lib/render-project-docs.sh" >/dev/null 2>&1
+    soif_render_project_intake "$TMPL_INTAKE" "$4" "$3" "$2" standard web personal 2026-09-08 ) 2>/dev/null
+}
+# esc <lib_root> <text> <delim>
+esc() { ( . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1; soif_sed_repl_esc "$2" "$3" ) 2>/dev/null; }
+
+mk_mirror() {
+  local m="$1"
+  mkdir -p "$m" || return 1
+  cp -Rp "$REPO_ROOT/scripts" "$m/" || return 1
+  return 0
+}
+
+echo "=== H — the helper, by table ==="
+
+# Each row: input, delimiter, expected escaped form. `&` and `\` are escaped for
+# any delimiter; the delimiter itself is escaped; a newline becomes a space.
+if ! esc "$REPO_ROOT" "x" "|" >/dev/null 2>&1; then
+  fail_ "H0" "soif_sed_repl_esc is not defined in helpers-core.sh"
+else
+  pass "H0 — soif_sed_repl_esc exists"
+  check_esc() {   # check_esc <label> <in> <delim> <want>
+    local got; got="$(esc "$REPO_ROOT" "$2" "$3")"
+    [ "$got" = "$4" ] && pass "H — $1" || fail_ "H — $1" "got [$got] want [$4]"
+  }
+  check_esc "plain text is unchanged"               'Invoice tools'        '|' 'Invoice tools'
+  check_esc "& is escaped"                          'R&D tools'            '|' 'R\&D tools'
+  check_esc "backslash is escaped"                  'a\b'                  '|' 'a\\b'
+  check_esc "the | delimiter is escaped"            'a|w /tmp/x|'          '|' 'a\|w /tmp/x\|'
+  check_esc "the ~ delimiter is escaped"            'home ~ sweet'         '~' 'home \~ sweet'
+  check_esc "a delimiter that is not the delimiter passes" 'a|b'           '~' 'a|b'
+  check_esc "a newline becomes a space"             "$(printf 'one\ntwo')" '|' 'one two'
+fi
+
+echo "=== E — end to end through the renderers ==="
+
+E1="$(newtmp)"
+render_claude "$REPO_ROOT" "R&D tools" "acme" "$E1/CLAUDE.md"
+if grep -q "R&D tools" "$E1/CLAUDE.md" 2>/dev/null; then
+  pass "E1 — a description containing & renders verbatim in CLAUDE.md"
+else
+  fail_ "E1" "rendered as: $(grep -m1 'Description' "$E1/CLAUDE.md" 2>/dev/null | cut -c1-100)"
+fi
+
+E2="$(newtmp)"
+render_claude "$REPO_ROOT" "a|w $E2/pwned|" "acme" "$E2/CLAUDE.md"
+if ls "$E2"/pwned* >/dev/null 2>&1; then
+  fail_ "E2" "a description carrying a sed w-flag wrote a file: $(ls "$E2"/pwned* | head -1)"
+else
+  pass "E2 — a description carrying the delimiter and a sed flag writes no file"
+fi
+grep -q "a|w $E2/pwned|" "$E2/CLAUDE.md" 2>/dev/null \
+  && pass "E2b — and renders verbatim" \
+  || fail_ "E2b" "the description was not rendered verbatim: $(grep -m1 'Description' "$E2/CLAUDE.md" 2>/dev/null | cut -c1-100)"
+
+E3="$(newtmp)"
+render_claude "$REPO_ROOT" "plain" "acme&co" "$E3/CLAUDE.md"
+grep -q "acme&co" "$E3/CLAUDE.md" 2>/dev/null \
+  && pass "E3 — a project name containing & renders verbatim (the interactive name path is tr-normalised only)" \
+  || fail_ "E3" "name rendered as: $(grep -m1 'acme' "$E3/CLAUDE.md" 2>/dev/null | cut -c1-100)"
+
+if [ -f "$TMPL_INTAKE" ]; then
+  E4="$(newtmp)"
+  render_intake "$REPO_ROOT" "R&D ~ tools" "acme" "$E4/PROJECT_INTAKE.md"
+  grep -q "R&D ~ tools" "$E4/PROJECT_INTAKE.md" 2>/dev/null \
+    && pass "E4 — the intake renderer (~ delimiter) renders a description with & and ~ verbatim" \
+    || fail_ "E4" "rendered as: $(grep -m1 'One-sentence' "$E4/PROJECT_INTAKE.md" 2>/dev/null | cut -c1-120)"
+else
+  fail_ "E4 setup" "no intake template found under templates/generated/"
+fi
+
+echo "=== G — the name sites that only run inside a scaffold are pinned by grep ==="
+
+# init.sh renders the project name into two files at birth; verify-install.sh
+# re-renders it on --auto-fix. Neither can be driven here without running
+# init.sh, so the ESCAPE CALL is pinned at the site rather than the behaviour.
+for site in "init.sh" "scripts/verify-install.sh"; do
+  n_raw="$(grep -cE 's\|__PROJECT_NAME__\|\$(PROJECT_NAME|proj_name)\|' "$REPO_ROOT/$site" 2>/dev/null)"
+  n_esc="$(grep -cE 's\|__PROJECT_NAME__\|\$\(soif_sed_repl_esc ' "$REPO_ROOT/$site" 2>/dev/null)"
+  if [ "$(_num "$n_raw")" -eq 0 ] && [ "$(_num "$n_esc")" -ge 1 ]; then
+    pass "G — $site splices the project name through soif_sed_repl_esc ($n_esc site(s)), never raw"
+  else
+    fail_ "G — $site" "raw name replacements: $n_raw, escaped: $n_esc"
+  fi
+done
+
+echo "=== M — mutation proofs on a mirror ==="
+
+M_MARK="# BL-255-SED-REPL-ESC"
+_n="$(_sites "$CORE" "$M_MARK")"
+[ "$_n" = "1" ] \
+  && pass "M0 — '$M_MARK' occurs exactly once at end-of-line in helpers-core.sh" \
+  || fail_ "M0" "'$M_MARK' occurs $_n times (need exactly 1)"
+
+# M1 — neuter the helper (identity) on a mirror: E1's & splice must return.
+M1="$(newtmp)/fw"
+if ! mk_mirror "$M1"; then
+  fail_ "M1 setup" "could not mirror the framework"
+else
+  before="$(mktemp)"; cp "$M1/scripts/lib/helpers-core.sh" "$before"
+  # the marked line is the one that does the escaping; replace it with a passthrough
+  sed "s|^.*${M_MARK}\$|  printf '%s' \"\$1\"   ${M_MARK}|" "$before" > "$M1/scripts/lib/helpers-core.sh"
+  if [ "$(_changed_lines "$before" "$M1/scripts/lib/helpers-core.sh")" -lt 2 ] || ! bash -n "$M1/scripts/lib/helpers-core.sh" 2>/dev/null; then
+    fail_ "M1 setup" "the helper mutation did not apply cleanly"
+  else
+    M1O="$(newtmp)"
+    render_claude "$M1" "R&D tools" "acme" "$M1O/CLAUDE.md"
+    grep -q "R&D tools" "$M1O/CLAUDE.md" 2>/dev/null \
+      && fail_ "M1 (MUTATION)" "with the helper neutered the & still rendered verbatim — E1 may be passing for another reason" \
+      || pass "M1 (MUTATION) — with the helper neutered, & splices the whole match again: E1 is what stops it"
+  fi
+fi
+
+# M2 — bypass the helper at the CLAUDE.md render site on a mirror: E2 must
+# see the file written again (proves the SITE calls the helper, not just that
+# the helper works).
+M2="$(newtmp)/fw"
+if ! mk_mirror "$M2"; then
+  fail_ "M2 setup" "could not mirror the framework"
+else
+  before="$(mktemp)"; cp "$M2/scripts/lib/render-project-docs.sh" "$before"
+  # THE DELIMITER IS ABSENT FROM BOTH SIDES, AND THE RESULT IS ASSERTED BY
+  # SHAPE. A first cut of this mutant used `|` as the sed delimiter with `|`
+  # in the pattern — CLAUDE.md's trap, inside the suite written to close it:
+  # sed emitted an EMPTY mirror file, `bash -n` accepted the empty file, and
+  # the changed-line count read the wreckage as an applied mutation. The
+  # mutant then "changed nothing" because there was no renderer left to run.
+  # `#` appears on neither side; the raw line must be present afterwards.
+  sed 's#__PROJECT_DESCRIPTION__|$(soif_sed_repl_esc "$desc" "|")|g#__PROJECT_DESCRIPTION__|$desc|g#' "$before" > "$M2/scripts/lib/render-project-docs.sh"
+  if ! grep -q 's|__PROJECT_DESCRIPTION__|$desc|g' "$M2/scripts/lib/render-project-docs.sh" \
+     || ! grep -q '^soif_render_claude_md()' "$M2/scripts/lib/render-project-docs.sh" \
+     || ! bash -n "$M2/scripts/lib/render-project-docs.sh" 2>/dev/null; then
+    fail_ "M2 setup" "the render-site mutation did not produce the raw line (or damaged the file)"
+  else
+    M2O="$(newtmp)"
+    render_claude "$M2" "a|w $M2O/pwned|" "acme" "$M2O/CLAUDE.md"
+    ls "$M2O"/pwned* >/dev/null 2>&1 \
+      && pass "M2 (MUTATION) — with the render site bypassing the helper, the w-flag writes a file again: E2 is what stops it" \
+      || fail_ "M2 (MUTATION)" "bypassing the helper at the render site changed nothing — E2 may be passing for another reason"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0
+exit 1

--- a/tests/test-bl255-sed-replacement-escape.sh
+++ b/tests/test-bl255-sed-replacement-escape.sh
@@ -96,6 +96,9 @@ else
   check_esc "the ~ delimiter is escaped"            'home ~ sweet'         '~' 'home \~ sweet'
   check_esc "a delimiter that is not the delimiter passes" 'a|b'           '~' 'a|b'
   check_esc "a newline becomes a space"             "$(printf 'one\ntwo')" '|' 'one two'
+  # `&` as the DELIMITER: sed permits it, and a first cut escaped it twice
+  # (the & step ran, then the delimiter step re-escaped the backslash it added)
+  check_esc "an & delimiter is escaped exactly once" 'a&b'                 '&' 'a\&b'
 fi
 
 echo "=== E — end to end through the renderers ==="
@@ -189,7 +192,11 @@ echo "=== G — the name sites that only run inside a scaffold are pinned by gre
 # escaped count. Raw = any `s<d>…<d>$VAR<d>` or `${VAR}` with ANY delimiter.
 _g_check() {   # _g_check <file> <label> <raw-regex> <esc-regex> <want-esc>
   local f="$REPO_ROOT/$1" n_raw n_esc
-  n_raw="$(grep -cE "$3" "$f" 2>/dev/null)"; n_esc="$(grep -cE "$4" "$f" 2>/dev/null)"
+  # COMMENTS ARE STRIPPED BEFORE COUNTING — the BL-181 class, and the review
+  # planted a decoy comment carrying the escaped shape that inflated n_esc and
+  # masked a deleted call. Whole-line and trailing comments both go.
+  n_raw="$(grep -vE '^[[:space:]]*#' "$f" | sed 's/[[:space:]][[:space:]]*#.*$//' | grep -cE "$3" 2>/dev/null)"
+  n_esc="$(grep -vE '^[[:space:]]*#' "$f" | sed 's/[[:space:]][[:space:]]*#.*$//' | grep -cE "$4" 2>/dev/null)"
   if [ "$(_num "$n_raw")" -eq 0 ] && [ "$(_num "$n_esc")" -eq "$5" ]; then
     pass "G — $1 $2: escaped at exactly $5 site(s), never raw"
   else

--- a/tests/test-bl255-sed-replacement-escape.sh
+++ b/tests/test-bl255-sed-replacement-escape.sh
@@ -9,8 +9,9 @@
 # "the whole match", `\` starts an escape, the delimiter ends the replacement
 # and whatever follows is parsed as FLAGS — so a description of `R&D tools`
 # rendered as `R__PROJECT_DESCRIPTION__D tools` (measured), and `a|w <path>|`
-# wrote a file named `<path>|g` and emptied the description (measured; GNU
-# sed's `e` flag makes the same shape run a command). `--description` is
+# wrote a 21-byte file named `<path>||g` and rendered the description as `a`
+# (measured; GNU sed's `e` flag makes the same shape run a command).
+# `--description` is
 # unvalidated; the interactive project name is `tr`-normalised only. Found by
 # the 2026-09-07 codebase review (S6), reproduced on main c6da463.
 #
@@ -46,15 +47,23 @@ done
 [ -f "$TMPL_INTAKE" ] || TMPL_INTAKE="$(grep -o '"\$SCRIPT_DIR/templates/[^"]*intake[^"]*"' "$REPO_ROOT/init.sh" | head -1 | sed 's|"\$SCRIPT_DIR/|'"$REPO_ROOT"'/|; s|"$||')"
 
 # A fresh subshell per call so a mutated mirror can be sourced in isolation.
+# `set -e` INSIDE the subshell, because every production caller of these
+# renderers (init.sh, verify-install.sh, reconfigure-project.sh,
+# upgrade-project.sh) runs under `set -euo pipefail`: a sed that fails inside
+# the renderer aborts them. Without it here, the renderer's trailing `if`
+# returned 0 over an empty file and E6b could not tell "failed loudly" from
+# "produced nothing and said nothing".
 # render_claude <lib_root> <desc> <name> <out>
 render_claude() {
-  ( . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+  ( set -e
+    . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1
     . "$1/scripts/lib/render-project-docs.sh" >/dev/null 2>&1
     soif_render_claude_md "$TMPL_CLAUDE" "$4" "$3" "$2" web standard typescript 3 personal ) 2>/dev/null
 }
 # render_intake <lib_root> <desc> <name> <out>
 render_intake() {
-  ( . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1
+  ( set -e
+    . "$1/scripts/lib/helpers-core.sh" >/dev/null 2>&1
     . "$1/scripts/lib/render-project-docs.sh" >/dev/null 2>&1
     soif_render_project_intake "$TMPL_INTAKE" "$4" "$3" "$2" standard web personal 2026-09-08 ) 2>/dev/null
 }
@@ -122,24 +131,83 @@ if [ -f "$TMPL_INTAKE" ]; then
   grep -q "R&D ~ tools" "$E4/PROJECT_INTAKE.md" 2>/dev/null \
     && pass "E4 — the intake renderer (~ delimiter) renders a description with & and ~ verbatim" \
     || fail_ "E4" "rendered as: $(grep -m1 'One-sentence' "$E4/PROJECT_INTAKE.md" 2>/dev/null | cut -c1-120)"
+  # E5 — the intake renderer's NAME splice. Under review, reverting this one
+  # site passed every check: E4 exercises the description only and G's grep
+  # covers only the `__PROJECT_NAME__` shape in init.sh / verify-install.sh.
+  E5="$(newtmp)"
+  render_intake "$REPO_ROOT" "plain" "acme&co" "$E5/PROJECT_INTAKE.md"
+  grep -q '| \*\*Project name\*\* | acme&co |' "$E5/PROJECT_INTAKE.md" 2>/dev/null \
+    && pass "E5 — the intake renderer renders a project name containing & verbatim in its own row" \
+    || fail_ "E5" "name row rendered as: $(grep -m1 'Project name' "$E5/PROJECT_INTAKE.md" 2>/dev/null | cut -c1-120)"
 else
-  fail_ "E4 setup" "no intake template found under templates/generated/"
+  fail_ "E4 setup" "no intake template found (looked at $TMPL_INTAKE)"
+fi
+
+# E6 — a byte that is invalid in the current locale must NEVER be silently
+# truncated. The first cut of the helper piped through `tr | sed`; `tr` failed
+# on latin-1 é, the pipeline's last element succeeded, and the description
+# came back cut short at rc 0 — silent data loss where the old code failed
+# loudly (`sed: RE error: illegal byte sequence`, empty file). Pure parameter
+# expansion is byte-transparent, so the helper no longer truncates; what the
+# OUTER sed then does is locale-dependent and either outcome is acceptable:
+#   under LC_ALL=C   the whole render is byte-wise and must be COMPLETE (E6a)
+#   under the caller's locale  it must be complete OR loud — a Description line
+#                              that exists but is cut short is the one forbidden
+#                              outcome (E6b)
+E6="$(newtmp)"
+E6_IN="$(printf 'Rapport g\xe9n\xe9ral for R&D')"
+LC_ALL=C render_claude "$REPO_ROOT" "$E6_IN" "acme" "$E6/CLAUDE.md"
+if LC_ALL=C grep -q 'Rapport g.n.ral for R&D' "$E6/CLAUDE.md" 2>/dev/null; then
+  pass "E6a — under LC_ALL=C a description with latin-1 bytes renders complete"
+else
+  fail_ "E6a" "rendered as: $(LC_ALL=C grep -m1 'Description' "$E6/CLAUDE.md" 2>/dev/null | cut -c1-100)"
+fi
+E6B="$(newtmp)"
+render_claude "$REPO_ROOT" "$E6_IN" "acme" "$E6B/CLAUDE.md"; e6b_rc=$?
+e6b_line="$(LC_ALL=C grep -m1 'Description' "$E6B/CLAUDE.md" 2>/dev/null)"
+if [ -n "$e6b_line" ] && ! printf '%s' "$e6b_line" | LC_ALL=C grep -q 'Rapport g.n.ral for R&D'; then
+  fail_ "E6b" "SILENT TRUNCATION: rc=$e6b_rc and the description line is cut short: $(printf '%s' "$e6b_line" | cut -c1-100)"
+elif [ -n "$e6b_line" ]; then
+  pass "E6b — under the caller's locale the description rendered complete"
+elif [ "$e6b_rc" -ne 0 ]; then
+  pass "E6b — under the caller's locale the render failed LOUDLY (rc=$e6b_rc, no description line) rather than truncating"
+else
+  fail_ "E6b" "rc=0 with no description line — a render that produced nothing and said nothing"
 fi
 
 echo "=== G — the name sites that only run inside a scaffold are pinned by grep ==="
 
-# init.sh renders the project name into two files at birth; verify-install.sh
-# re-renders it on --auto-fix. Neither can be driven here without running
-# init.sh, so the ESCAPE CALL is pinned at the site rather than the behaviour.
-for site in "init.sh" "scripts/verify-install.sh"; do
-  n_raw="$(grep -cE 's\|__PROJECT_NAME__\|\$(PROJECT_NAME|proj_name)\|' "$REPO_ROOT/$site" 2>/dev/null)"
-  n_esc="$(grep -cE 's\|__PROJECT_NAME__\|\$\(soif_sed_repl_esc ' "$REPO_ROOT/$site" 2>/dev/null)"
-  if [ "$(_num "$n_raw")" -eq 0 ] && [ "$(_num "$n_esc")" -ge 1 ]; then
-    pass "G — $site splices the project name through soif_sed_repl_esc ($n_esc site(s)), never raw"
+# init.sh renders the project name into three files at birth; verify-install.sh
+# re-renders name and description on --auto-fix; reconfigure-project.sh splices
+# the NEW name on rename. None can be driven here without a scaffold, so the
+# ESCAPE CALL is pinned at each site rather than the behaviour — and pinned
+# EXACTLY: a first cut asserted `>= 1` escaped and greped one shape with one
+# delimiter, so deleting two of init.sh's three calls passed, `${PROJECT_NAME}`
+# and a `#` delimiter slipped, and verify-install's description and both
+# reconfigure sites had no arm at all (reviewer mutants MX7/MX8 survived
+# every PR-blocking check). Each row: file | placeholder-or-shape | expected
+# escaped count. Raw = any `s<d>…<d>$VAR<d>` or `${VAR}` with ANY delimiter.
+_g_check() {   # _g_check <file> <label> <raw-regex> <esc-regex> <want-esc>
+  local f="$REPO_ROOT/$1" n_raw n_esc
+  n_raw="$(grep -cE "$3" "$f" 2>/dev/null)"; n_esc="$(grep -cE "$4" "$f" 2>/dev/null)"
+  if [ "$(_num "$n_raw")" -eq 0 ] && [ "$(_num "$n_esc")" -eq "$5" ]; then
+    pass "G — $1 $2: escaped at exactly $5 site(s), never raw"
   else
-    fail_ "G — $site" "raw name replacements: $n_raw, escaped: $n_esc"
+    fail_ "G — $1 $2" "raw: $n_raw (want 0), escaped: $n_esc (want $5)"
   fi
-done
+}
+_g_check init.sh "project name" \
+  's(.)__PROJECT_NAME__\1\$\{?(PROJECT_NAME|proj_name|name)\}?\1' \
+  's(.)__PROJECT_NAME__\1\$\(soif_sed_repl_esc ' 3
+_g_check scripts/verify-install.sh "project name" \
+  's(.)__PROJECT_NAME__\1\$\{?(PROJECT_NAME|proj_name|name)\}?\1' \
+  's(.)__PROJECT_NAME__\1\$\(soif_sed_repl_esc ' 1
+_g_check scripts/verify-install.sh "description" \
+  's(.)__PROJECT_DESCRIPTION__\1\$\{?(PROJECT_DESCRIPTION|proj_desc|desc)\}?\1' \
+  's(.)__PROJECT_DESCRIPTION__\1\$\(soif_sed_repl_esc ' 1
+_g_check scripts/reconfigure-project.sh "rename (new name)" \
+  's(.)\$\{?old_name\}?\1\$\{?new_name\}?\1' \
+  's(.)\$\{?old_name\}?\1\$\(soif_sed_repl_esc "\$new_name" ' 2
 
 echo "=== M — mutation proofs on a mirror ==="
 


### PR DESCRIPTION
`--description` and the interactive project name reached `sed` raw in the **replacement** position, where `&` is the whole match, `\` starts an escape, and the delimiter ends the replacement with *flags* after it. Reproduced on `main` `c6da463`:

- `R&D tools` → `- **Description:** R__PROJECT_DESCRIPTION__D tools`
- `a|w <path>|` → **a 21-byte file written** at `<path>||g`, description rendered as `a` (GNU sed's `e` flag makes the same shape run a command)
- `acme&co` → `# CLAUDE.md — acme__PROJECT_NAME__co`

`--description` is unvalidated; the interactive name is `tr`-normalised only.

## Fix

One helper, `soif_sed_repl_esc <text> [delim]` in `helpers-core.sh` (`# BL-255-SED-REPL-ESC`) — **pure parameter expansion**: escapes `&`, `\` and the delimiter, folds a newline to a space; no forks, byte-transparent, locale-independent. Applied at all eleven replacement-position sites carrying operator text: both renderers (name + description), three in `init.sh`, `verify-install.sh`'s re-render (name + description), `reconfigure-project.sh`'s rename (new name, both sites). `render-project-docs.sh` guard-sources `helpers-core.sh` so sourced alone it no longer renders an empty name at rc 0.

## Test — `tests/test-bl255-sed-replacement-escape.sh`

RED with the final file at `c6da463`: **2 / 14** (the two passes are non-discriminators — M2 and E6b — and are recorded as such). GREEN **24 / 0**: the helper by table (9 rows incl. `~`, `&` and newline), both renderers end to end with the three payloads above plus the intake name row, `E6a/E6b` — a latin-1 byte renders complete under `LC_ALL=C` and is **never silently truncated** under the caller's locale (the round-1 `tr|sed` helper truncated at rc 0; proven by splicing it back in), the four scaffold-only sites pinned at **exact** escaped counts with a delimiter-agnostic, comment-stripped grep, and two mutants on a mirror.

Related: plan-staging 25/0, reconfigure ×2, walk003 5/0, verify-install ×3, scaffold-source-closure 9/0, currency-manifest 53/0; 16/16 lints.

## Review

Two adversarial rounds: `major_concerns` → **`minor_concerns`**. Round 1 found four of the eleven sites unguarded (each reverted, every check stayed green), the `tr|sed` helper turning a loud failure into silent truncation, an undeclared lib dependency that blanked the render, and a RED tally off by one. Round 2 re-ran every mutant, added its own (a revert to an unlisted variable name — caught by the exact-count arm), and left four one-liners, all folded in before push. Residuals on `## BL-255:`: the rename's *pattern* side (`--old`, a raw unvalidated CLI argument) needs a regex escape this helper isn't; validation of the description would be the stronger fix and is an intake-policy call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk