### PR TITLE
fix(bl-256): a count that could not be taken is not zero, and a record that was not written is not recorded

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -535,6 +535,7 @@ jobs:
             tests/test-bl254-ci-templates-call-shipped-scripts.sh
             tests/test-lint-user-guide-scripts.sh
             tests/test-bl255-sed-replacement-escape.sh
+            tests/test-bl256-unearned-receipts.sh
           )
 
           # ── BL-190 shard pins ──────────────────────────────────────────

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,16 +68,25 @@ here.
   pattern instead (`lhs="${s%%"$pat"*}"; rhs="${s#*"$pat"}"`), which has no
   `&` rule in any version — and **assert the replacement LANDED**, by its
   own literal text, not by a line count. `soif_sed_repl_esc` in
-  `helpers-core.sh` is unaffected, but **not for the reason you would guess,
-  and the difference is the whole trap**: its `${t//&/\&}` is byte-identical
-  across versions ONLY because the pattern is the single character `&`, so
-  "the whole match" happens to BE `&`. The `\` does not survive as an escape
-  on 5.2 — it is consumed at quote removal and the bare `&` that remains is
-  the match. Measured, same script both hosts: with pattern `x` and that same
-  replacement, 3.2 gives `a \ & b` and 5.2 gives `a \ x b`. So `\&` is not a
-  portable way to write a literal `&`; that one call site is safe by
-  coincidence of its pattern, and `tests/test-bl255-sed-replacement-escape.sh`
-  pins its bytes in the unit lane, which is what would catch a change to it.
+  `helpers-core.sh` is unaffected, but **do not try to read that off the
+  spelling** — two drafts of this bullet reasoned about it and both were
+  wrong. Measure it. Double-quoted, `t='R&D tools'`, `u='one TWO three'`:
+  ```
+  replacement, as written   what it is        bash 3.2      bash 5.2
+  ${t//&/\\&}   <- REAL      two backslashes   R\&D tools    R\&D tools
+  ${t//&/\&}                  one backslash     R\&D tools    R&D tools
+  ${u//TWO/\\&}              two backslashes   one \& three  one \TWO three
+  ${u//TWO/&}                 bare &            one & three   one TWO three
+  ```
+  On 5.2, `\\` collapses at quote removal to a LITERAL backslash that does not
+  escape, so `\\&` is backslash-plus-*whole match*; a single `\&` is an escaped
+  `&` and yields a literal `&` with the backslash consumed; a bare `&` is the
+  whole match. On 3.2 all three are literal. So the real source line —
+  `t="${t//&/\\&}"`, two backslashes — is byte-identical across versions ONLY
+  because its pattern is the single character `&`, which makes "the whole
+  match" happen to be `&`. Change that pattern and the versions diverge in
+  silence. `tests/test-bl255-sed-replacement-escape.sh` pins those bytes in
+  the unit lane, and that is what would catch it.
   Reproduce the runner's bash on this host:
   ```
   docker run --rm -v "$PWD:/repo:ro" ubuntu:24.04 bash -c 'apt-get update -qq \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,13 @@ here.
   `bash -n`. See `## BL-224:` for the sibling case where a lint's own regex
   over-matched for the same reason.
 - **The same `&` trap lives in bash's own `${var/pat/rep}`, and it is
-  VERSION-SPLIT between this host and CI.** Since bash 5.1 an unescaped `&`
-  in the *replacement* of a pattern substitution means THE WHOLE MATCH,
-  exactly as in `sed`; **bash 3.2 has no such rule**. This Mac runs 3.2 and
+  VERSION-SPLIT between this host and CI.** Since bash **5.2** an unescaped
+  `&` in the *replacement* of a pattern substitution means THE WHOLE MATCH,
+  exactly as in `sed`; **bash 3.2 has no such rule**. 5.2 is the boundary, not
+  5.1 — measured, `u='one TWO three'; "${u//TWO/&}"` gives `one & three` on
+  3.2.57, 5.0.18 and 5.1.16 and `one TWO three` on 5.2.37, and the `shopt`
+  that governs it (`patsub_replacement`, on by default) does not exist before
+  5.2. This Mac runs 3.2 and
   the runners run 5.2, so a replacement carrying `&&` — which every shell
   guard does — produces the intended text locally and splices the match back
   in on CI. It is silent in the worst way: the line still changes, the
@@ -86,7 +90,10 @@ here.
   because its pattern is the single character `&`, which makes "the whole
   match" happen to be `&`. Change that pattern and the versions diverge in
   silence. `tests/test-bl255-sed-replacement-escape.sh` pins those bytes in
-  the unit lane, and that is what would catch it.
+  the unit lane, and that is what would catch it — **but only there.** Mutate
+  the helper's `\\&` to `\&` and that suite stays GREEN on this Mac and goes
+  red only on the runner, which is this same trap one level up: a local run
+  of the suite that guards the trap does not see the trap.
   Reproduce the runner's bash on this host:
   ```
   docker run --rm -v "$PWD:/repo:ro" ubuntu:24.04 bash -c 'apt-get update -qq \

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,8 +68,16 @@ here.
   pattern instead (`lhs="${s%%"$pat"*}"; rhs="${s#*"$pat"}"`), which has no
   `&` rule in any version — and **assert the replacement LANDED**, by its
   own literal text, not by a line count. `soif_sed_repl_esc` in
-  `helpers-core.sh` is unaffected (its `\&` is a literal backslash in both
-  3.2 and 5.2 — verified in a container, not assumed).
+  `helpers-core.sh` is unaffected, but **not for the reason you would guess,
+  and the difference is the whole trap**: its `${t//&/\&}` is byte-identical
+  across versions ONLY because the pattern is the single character `&`, so
+  "the whole match" happens to BE `&`. The `\` does not survive as an escape
+  on 5.2 — it is consumed at quote removal and the bare `&` that remains is
+  the match. Measured, same script both hosts: with pattern `x` and that same
+  replacement, 3.2 gives `a \ & b` and 5.2 gives `a \ x b`. So `\&` is not a
+  portable way to write a literal `&`; that one call site is safe by
+  coincidence of its pattern, and `tests/test-bl255-sed-replacement-escape.sh`
+  pins its bytes in the unit lane, which is what would catch a change to it.
   Reproduce the runner's bash on this host:
   ```
   docker run --rm -v "$PWD:/repo:ro" ubuntu:24.04 bash -c 'apt-get update -qq \
@@ -168,12 +176,15 @@ here.
 ## LINT GOTCHAS
 
 - `scripts/run-lints.sh` runs **every `scripts/lint-*.sh` EXCEPT
-  `lint-uat-scenarios.sh`** (12 of the 13 lint scripts as of 2026-07-31 — BL-196
-  added `lint-bl-markers.sh`, and run-lints discovers it by glob, no wiring).
+  `lint-uat-scenarios.sh`** (**16 of the 17** lint scripts as of 2026-09-09 — it
+  discovers them by glob, so a new lint needs no wiring; the count drifts, so
+  measure it rather than quoting this line: `ls scripts/lint-*.sh | wc -l`, and
+  `bash scripts/run-lints.sh` prints its own total on the last line).
 - `scripts/lint-uat-scenarios.sh` is a **parametrized tool, not a repo lint**:
   bare-invoked it exits **2** with a `Usage:` message because it needs a
   `<populated-html-file>` argument. It is **not** one of the CI lint jobs
-  (`.github/workflows/lint.yml`, 10 jobs as of 2026-07-31), so run-lints
+  (`.github/workflows/lint.yml`, **14** jobs as of 2026-09-09 —
+  `grep -cE '^  [a-z0-9-]+-lint:' .github/workflows/lint.yml`), so run-lints
   deliberately skips it.
 - Two lints are **slow full-tree scans**: `lint-counter-antipattern.sh` (~90s)
   and `lint-raw-read-prompt.sh` (~40s). A full `run-lints.sh` is a couple of

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,30 @@ here.
   an unescaped `&&` splices the original line back in, and that mutant passes
   `bash -n`. See `## BL-224:` for the sibling case where a lint's own regex
   over-matched for the same reason.
+- **The same `&` trap lives in bash's own `${var/pat/rep}`, and it is
+  VERSION-SPLIT between this host and CI.** Since bash 5.1 an unescaped `&`
+  in the *replacement* of a pattern substitution means THE WHOLE MATCH,
+  exactly as in `sed`; **bash 3.2 has no such rule**. This Mac runs 3.2 and
+  the runners run 5.2, so a replacement carrying `&&` — which every shell
+  guard does — produces the intended text locally and splices the match back
+  in on CI. It is silent in the worst way: the line still changes, the
+  changed-line count is still right, and `bash -n` is still clean, so a
+  mutation harness reports a healthy mutant that no longer mutates. That is
+  a red `rest` shard on PR #380, found only because the mutant stopped
+  killing its case. Two rules, the same two as for `sed`: **do not use
+  `${var/pat/rep}` when the replacement can contain `&`** — split on the
+  pattern instead (`lhs="${s%%"$pat"*}"; rhs="${s#*"$pat"}"`), which has no
+  `&` rule in any version — and **assert the replacement LANDED**, by its
+  own literal text, not by a line count. `soif_sed_repl_esc` in
+  `helpers-core.sh` is unaffected (its `\&` is a literal backslash in both
+  3.2 and 5.2 — verified in a container, not assumed).
+  Reproduce the runner's bash on this host:
+  ```
+  docker run --rm -v "$PWD:/repo:ro" ubuntu:24.04 bash -c 'apt-get update -qq \
+    && apt-get install -y -qq jq git && useradd -m t && cp -r /repo /home/t/r \
+    && chown -R t /home/t/r && su t -c "cd /home/t/r && bash tests/<file>.sh"'
+  ```
+  Run as a NON-root user or every `chmod 555` fixture silently stays writable.
 - **This Mac's git is configured and an ubuntu-latest runner's is not — and the
   difference is silent.** Xcode ships
   `/Applications/Xcode.app/Contents/Developer/usr/share/git-core/gitconfig`

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -1202,10 +1202,23 @@ BL120EOF
         local uat_reason uat_now uat_track
         uat_reason="${SOLO_UAT_REASON:-unspecified - attested via SOLO_UAT_SOLO_ATTESTED}"
         uat_now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-        jq --arg r "$uat_reason" --arg at "$uat_now" \
-           '.uat_session.solo_attestations = ((.uat_session.solo_attestations // []) + [{reason: $r, at: $at, step: "results_received"}])' \
-           "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"
-        print_ok "results_received: SOLO-MODE attested and RECORDED (reason: $uat_reason) — no external submissions required."
+        # `## BL-256:` — THE RECEIPT IS CONDITIONAL ON THE RECORD. The first cut
+        # printed "attested and RECORDED" unconditionally after a `jq … && mv`
+        # that can fail (read-only dir, disk, a corrupt state file), so an
+        # attestation that left no trace was announced as recorded — the
+        # advisory posture `# BL-233-ATTEST-REFUSE` exists to replace. An
+        # attested escape must be durably logged or REFUSED; it is never
+        # silently taken.
+        if jq --arg r "$uat_reason" --arg at "$uat_now" \
+             '.uat_session.solo_attestations = ((.uat_session.solo_attestations // []) + [{reason: $r, at: $at, step: "results_received"}])' \
+             "$PROCESS_STATE" > "$PROCESS_STATE.tmp" 2>/dev/null \
+           && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE" 2>/dev/null; then
+          print_ok "results_received: SOLO-MODE attested and RECORDED (reason: $uat_reason) — no external submissions required."   # BL-256-UAT-ATTEST-RECEIPT
+        else
+          rm -f "$PROCESS_STATE.tmp" 2>/dev/null
+          print_fail "results_received: SOLO-MODE attestation REFUSED — it could not be recorded to $PROCESS_STATE (jq/disk/permissions). An attested escape must be durably logged; nothing was marked complete."   # BL-256-UAT-ATTEST-REFUSE
+          exit 1
+        fi
         # Verifier SF#4: the escape is FOR the Light/solo track. It stays
         # usable elsewhere (recorded, never silent) but says so loudly —
         # reviewers of an organizational/standard project should expect to

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -1215,7 +1215,9 @@ BL120EOF
            && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE" 2>/dev/null; then
           print_ok "results_received: SOLO-MODE attested and RECORDED (reason: $uat_reason) — no external submissions required."   # BL-256-UAT-ATTEST-RECEIPT
         else
-          rm -f "$PROCESS_STATE.tmp" 2>/dev/null
+          # `|| true`: under set -e a stale .tmp in a now read-only dir makes
+          # this rm fail and would exit BEFORE the refusal is printed (R3-2)
+          rm -f "$PROCESS_STATE.tmp" 2>/dev/null || true
           print_fail "results_received: SOLO-MODE attestation REFUSED — it could not be recorded to $PROCESS_STATE (jq/disk/permissions). An attested escape must be durably logged; nothing was marked complete."   # BL-256-UAT-ATTEST-REFUSE
           exit 1
         fi
@@ -1316,7 +1318,7 @@ BL120EOF
   " "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"; then
     print_ok "Step '$step_id' completed for $process ($new_step_num/${#steps[@]})"   # BL-256-STEP-RECEIPT
   else
-    rm -f "$PROCESS_STATE.tmp" 2>/dev/null
+    rm -f "$PROCESS_STATE.tmp" 2>/dev/null || true
     print_fail "Step '$step_id' NOT recorded for $process — $PROCESS_STATE could not be written (jq/disk/permissions); nothing was marked complete."   # BL-256-STEP-REFUSE
     exit 1
   fi

--- a/scripts/process-checklist.sh
+++ b/scripts/process-checklist.sh
@@ -1305,12 +1305,21 @@ BL120EOF
 
   # All prior steps present + artifact checks passed — add step_id to steps_completed
   local new_step_num=$((target_index + 1))
-  jq --arg step "$step_id" --argjson num "$new_step_num" "
+  # `## BL-256:` (review round 2, R2-3) — the completion receipt is printed ONLY
+  # when the write landed. This `jq … && mv` used to be followed by an
+  # unconditional print_ok, so a read-only .claude/ announced "Step … completed"
+  # and exited 0 with the state file untouched. The other state writes in this
+  # file keep the old shape — recorded on the entry as a residual (`## BL-257:`).
+  if jq --arg step "$step_id" --argjson num "$new_step_num" "
     .${process}.steps_completed += [\$step] |
     .${process}.step = \$num
-  " "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"
-
-  print_ok "Step '$step_id' completed for $process ($new_step_num/${#steps[@]})"
+  " "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"; then
+    print_ok "Step '$step_id' completed for $process ($new_step_num/${#steps[@]})"   # BL-256-STEP-RECEIPT
+  else
+    rm -f "$PROCESS_STATE.tmp" 2>/dev/null
+    print_fail "Step '$step_id' NOT recorded for $process — $PROCESS_STATE could not be written (jq/disk/permissions); nothing was marked complete."   # BL-256-STEP-REFUSE
+    exit 1
+  fi
 
   # Auto-set phase2_init.verified when all steps completed via --complete-step
   if [ "$process" = "phase2_init" ] && [ "$new_step_num" -eq "${#steps[@]}" ]; then

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -1049,11 +1049,24 @@ _p3_scan_snyk() {
     P3_STATUS="FAIL"; P3_NOTE="snyk execution error (rc=$rc) — no usable report; treat as a scan failure, not a skip"
     return
   fi
-  local findings=0
-  if command -v jq >/dev/null 2>&1; then
-    findings=$(jq '(.vulnerabilities | length) // 0' "$archive" 2>/dev/null || echo 0)
-    case "$findings" in ''|*[!0-9]*) findings=0 ;; esac
+  # `## BL-256:` — the same count-receipt as `_p3_scan_semgrep`
+  # (`# BL-256-P3-COUNT-RECEIPT`): the first cut read `// 0` + `|| echo 0` and
+  # sanitised anything non-numeric to 0, so a renamed key, an unparseable
+  # report, or a host with no jq read as "0 vulnerabilities" → PASS. The count
+  # is taken ONLY when `.vulnerabilities` is present and is an array (a single
+  # `snyk test --json` emits one object; `--all-projects`, which this arm does
+  # not pass, would emit an ARRAY of them and must never count as clean here).
+  if ! command -v jq >/dev/null 2>&1; then
+    P3_STATUS="FAIL"; P3_NOTE="snyk ran but jq is not on PATH, so the report could not be counted — NOT a clean result; install jq and re-run"
+    return
   fi
+  local findings
+  findings=$(jq -e 'if (.vulnerabilities | type) == "array" then (.vulnerabilities | length) else error("no vulnerabilities array") end' "$archive" 2>/dev/null) || findings=""   # BL-256-P3-SNYK-COUNT-RECEIPT
+  case "$findings" in
+    ''|*[!0-9]*)
+      P3_STATUS="FAIL"; P3_NOTE="snyk ran but its report carries no .vulnerabilities array (schema drift or an unparseable report) — NOTHING WAS COUNTED, this is not a clean result; inspect $archive"
+      return ;;
+  esac
   if [ "$findings" -gt 0 ]; then
     P3_STATUS="FAIL"; P3_NOTE="$findings snyk vulnerability finding(s) — review $archive"
   else

--- a/scripts/run-phase3-validation.sh
+++ b/scripts/run-phase3-validation.sh
@@ -534,11 +534,26 @@ _p3_scan_semgrep() {
     return
   fi
   rm -f "$errlog" 2>/dev/null || true
-  local findings=0
-  if command -v jq >/dev/null 2>&1; then
-    findings=$(jq '(.results | length) // 0' "$archive" 2>/dev/null || echo 0)
-    case "$findings" in ''|*[!0-9]*) findings=0 ;; esac
+  # `## BL-256:` — A COUNT THAT COULD NOT BE TAKEN IS NOT ZERO. The first cut
+  # read `(.results | length) // 0` with `|| echo 0` and sanitised anything
+  # non-numeric to 0, so a renamed key on a future semgrep major, an archive
+  # that is not JSON, or a host with no jq at all every one read as
+  # "0 findings" → PASS: a clean bill of health for a scan nobody could read.
+  # That is `# BL-112-SAST-NOTRUN`'s class one arm over and the "no unearned
+  # receipt" rule (`# BL-182-NO-UNEARNED-RECEIPT`). The count is now taken
+  # ONLY when `.results` is present and is an array; every other outcome is a
+  # FAIL that says which, never a PASS.
+  if ! command -v jq >/dev/null 2>&1; then
+    P3_STATUS="FAIL"; P3_NOTE="semgrep ran but jq is not on PATH, so the archive could not be counted — NOT a clean result; install jq and re-run"
+    return
   fi
+  local findings
+  findings=$(jq -e 'if (.results | type) == "array" then (.results | length) else error("no results array") end' "$archive" 2>/dev/null) || findings=""   # BL-256-P3-COUNT-RECEIPT
+  case "$findings" in
+    ''|*[!0-9]*)
+      P3_STATUS="FAIL"; P3_NOTE="semgrep ran but its archive carries no .results array (schema drift or an unparseable report) — NOTHING WAS COUNTED, this is not a clean result; inspect $archive"
+      return ;;
+  esac
   if [ "$findings" -gt 0 ]; then
     P3_STATUS="FAIL"; P3_NOTE="$findings semgrep finding(s) — review $archive"
   else

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15409,7 +15409,10 @@ was one. The four MCP/review attestations already refuse when they cannot record
   when `.vulnerabilities` is an array, else FAIL / NOTHING WAS COUNTED; no jq → FAIL.
 - (b) The receipt is inside the `if jq … && mv …; then` (`# BL-256-UAT-ATTEST-RECEIPT`); the else arm
   removes the temp file, prints a REFUSED line naming the state file and the reason class, and
-  exits 1 (`# BL-256-UAT-ATTEST-REFUSE`) — nothing is marked complete.
+  exits 1 (`# BL-256-UAT-ATTEST-REFUSE`) — nothing is marked complete. **The general step write at the
+  end of `complete_step`** — the same command path, the same `jq … && mv` followed by an unconditional
+  "Step … completed" (review round 2, R2-3) — now has the same shape (`# BL-256-STEP-RECEIPT` /
+  `# BL-256-STEP-REFUSE`): a state file that could not be written is "NOT recorded", rc 1.
 - Suite `tests/test-bl256-unearned-receipts.sh` drives the real driver and the real checklist on
   fixtures: a PATH shim `semgrep` that writes a canned archive (no network, no real semgrep), and a
   process-state fixture at the `results_received` step with a writable and then a read-only `.claude/`.
@@ -15422,37 +15425,50 @@ was one. The four MCP/review attestations already refuse when they cannot record
    but its `.site[]?.alerts[]?` optional iterators turn a renamed or non-array `.site` into "0 Medium+
    alerts → PASS" (verified: `{"sites":[{"alerts":[{"riskcode":"3"}]}]}` counts 0), and a multi-document
    report reaches the surviving `case … findings=0` sanitiser. The fix is the semgrep shape (count only
-   when `.site` is an array) plus a docker-shim harness this suite does not build; filed here as
-   follow-up rather than folded, so the scope stays the two arms the review and its reviewer named.
-3. Currency (reviewer R-4): a semgrep archive can carry `.errors[]` / `paths.skipped[]` — a scan that
-   FINISHED but skipped files, or hit rule errors, still reads as "0 findings" when `.results` is an
-   empty array. That is a real scan with a real count, so it is a PASS on the rule this entry fixes, but
-   it is a weaker receipt than it looks; surfacing the skipped/error counts in `P3_NOTE` is follow-up.
-2. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
+   when `.site` is an array) plus one case in the harness that ALREADY exists in the PR-blocking lane
+   (`tests/test-bl070-snyk-zap-scanners.sh`, `setup_zap web with-docker` / `T-zap-malformed-report-fail`
+   — review round 2 corrected the first draft of this line, which claimed no harness). Not folded here
+   is a scope choice: the branch stays on the arms the review and its reviewers named. Follow-up.
+2. Currency (reviewer R-4): a semgrep archive can carry `.errors[]` — a scan that FINISHED but hit rule
+   or parse errors still reads as "0 findings" when `.results` is an empty array. That is a real scan
+   with a real count, so it is a PASS on the rule this entry fixes, but it is a weaker receipt than it
+   looks; surfacing `.errors | length` in the PASS note is a two-line follow-up. (`paths.skipped` is
+   emitted only under `--verbose`, which the driver does not pass — round 2 corrected that half.)
+3. `scripts/process-checklist.sh` carries **23 more** one-line `jq … > "$PROCESS_STATE.tmp" && mv …`
+   state writes with no check on the write (grep the literal `PROCESS_STATE.tmp" && mv`); the one on
+   this branch's command path is guarded, the rest still announce success on a write that may not have
+   landed. A lost non-terminal step is caught by the next step's prior-steps check; a process's LAST
+   step and the "Build loop closed" receipt are not. Filed as `## BL-257:` (one `_pc_write_state`
+   helper, every site through it).
+4. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
    reason; `SOLO_BP_ATTESTED` is missing from the inventory the review built. The review's proposed
    single table of every `_ATTESTED` escape with its three properties (reason-mandatory / recorded /
    fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.
 
 **Build note (2026-09-08/09, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's
-final test file in a worktree at `e3b2be5`: **8 passed / 19 failed** — S3 (no `.results` key → PASS "0
+final test file in a worktree at `e3b2be5`: **10 passed / 30 failed** — S3 (no `.results` key → PASS "0
 findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), S6 (`.results` an object → PASS), S7
-(`.results` a string → PASS), S8 (two concatenated documents → PASS), N3 (snyk: no `.vulnerabilities`
-key → PASS "0 vulnerabilities"), N4 (snyk: `.vulnerabilities` an object → PASS), U2 (read-only
-`.claude/` → "RECORDED" at rc 0 with the state file byte-identical), M0 ×4, MP1–MP5/MU1 setups. The
-eight passes are the honest-outcome cases (S0/N0 shim resolution, S1/N1 empty array PASS, S2/N2 two
-findings FAIL, U1 writable recorded, U2b state unchanged) — true on main by construction and not
-discriminators. **S6/S7 exist because a reviewer mutant survived the
+(`.results` a string → PASS), S8 (two concatenated documents → PASS), S9 (a top-level array → PASS), N3
+(snyk: no `.vulnerabilities` key → PASS "0 vulnerabilities"), N4 (`.vulnerabilities` an object → PASS),
+N5 (a top-level array → PASS), N6 (no jq → PASS), U2 (read-only `.claude/` → "RECORDED" at rc 0 with
+the state file byte-identical), U3 (rename fails → "RECORDED"), U4 (non-solo path, read-only `.claude/`
+→ "Step … completed" at rc 0), U3b (the `.tmp` left behind), M0 ×6, MP1–MP6/MU1–MU3 setups. The ten
+passes are the honest-outcome cases (S0/N0 shim resolution, S1/N1 empty array PASS, S2/S2b/N2 findings
+FAIL, U1 writable recorded, U2b/U4b state unchanged — a failed write changes nothing on main too) — true
+on main by construction and not discriminators. **S6/S7 exist because a reviewer mutant survived the
 first cut at 14/0**: it weakened the type check to a PRESENCE check (`has("results") and .results !=
 null`) and the suite could not tell, because no case fed a `.results` that was present but not an
 array — under that weakening `{"results":{}}` counts 0 → PASS and `{"results":"abcdefgh"}` counts the
 STRING'S LENGTH as eight findings. MP2 now applies exactly that mutant and S6/S7 kill it. (The reviewer
 that found it stalled mid-run and was killed 19 hours later; its last recorded words were "X4 survives
 14/0 and re-opens the defect" — the finding was recovered from its transcript, not from a verdict.)
-GREEN **27 / 0**: all six mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
+GREEN **40 / 0**: all nine mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
 again; MP2 the presence check → S6 PASS, S7 "8 semgrep finding(s)"; MP3 drops the `*[!0-9]*` sanitiser
 arm → S8's two-document archive reads PASS again; MP4/MP5 are MP1/MP2 applied to the snyk marker → N3 /
-N4 read PASS again; MU1 turns the REFUSE arm back into the unconditional receipt → U2 is announced
-RECORDED again). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
+N4 read PASS again; MP6 is round 2's surviving x10 — a top-level-array arm — → N5 reads PASS again; MU1
+turns the attestation REFUSE arm back into the unconditional receipt → U2 is announced RECORDED again;
+MU2 drops the `rm -f` on that path → U3b finds the `.tmp`; MU3 turns the step REFUSE arm back into the
+receipt → U4 is announced completed again). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
 the canned archive to `--output`) and `snyk` (answers `config get api` with a token and `test --json`
 with the canned report on stdout) on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
 (minus jq for S5), the exclusion asserted before measuring; a process-state fixture at
@@ -15460,9 +15476,16 @@ with the canned report on stdout) on a host-mirrored PATH minus real semgrep/sny
 delimiter because the markers carry `#` and the replacements `|` and `/` — the first cut hit
 CLAUDE.md's trap on that line and sed refused it, reported honestly as "did not apply cleanly". **Pre-PR
 review round 1 (single agent, `minor_concerns`)** folded before push: R-1 the untested multi-document
-sanitiser arm → S8 + MP3; R-3 the snyk twin → fix + section N + MP4/MP5; R-2 (the `.tmp` cleanup on the
-refuse path is untested — a fixture that makes `mv` fail after `jq` succeeds needs a same-dir
-permission split the suite does not build) left as noted; R-4 recorded as residual 3. All **66**
+sanitiser arm → S8 + MP3; R-3 the snyk twin → fix + section N + MP4/MP5; R-4 recorded as residual 2.
+**Round 2 (single agent, `major_concerns` — do-not-push)**: R2-1 a mutant that accepts a top-level
+array on the snyk line survived 27/0 and the BL-070 suite 48/0 → N5 + S9 + MP6; R2-2 no case pinned ONE
+semgrep finding (a `-gt 1` mutant survived) → S2b (re-verified ad hoc on a mirror: under `-gt 1` the
+one-finding archive reads PASS, which S2b rejects); R2-3 the general step write on the same command path → fix +
+U4/U4b + MU3, the other 23 sites → residual 3 / `## BL-257:`; R2-5 the `rm -f` on the refuse path
+untested → U3/U3b + MU2, which also REFUTED round 1's R-2 note that the fixture needed a "same-dir
+permission split" — a PATH `mv` shim that refuses only `process-state.json` is portable and the command
+path calls `mv` exactly once; R2-6 the snyk no-jq arm untested → N6; R2-4 / R2-7 corrected residuals 1
+and 2 (the zap harness exists; `paths.skipped` needs `--verbose`). All **66**
 unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` (this one included) re-run green
 (incl. `test-phase3-validation-gate` 51/0, `test-bl114-bl115-bl127-gate-integrity` 17/0, the three
 BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); registered in the aggregator and
@@ -15470,4 +15493,33 @@ the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `registered`).
 
 **Related:** `## BL-182:`, `## BL-112:`, `## BL-233:` (the refuse-when-unrecordable posture),
 `## BL-185:` (the other unrecorded escape), `## BL-070:` (the atomic attestation write this file
-already does for Phase-3 attestations — the shape (b) now follows).
+already does for Phase-3 attestations — the shape (b) now follows), `## BL-257:` (the other 23 writes).
+
+## BL-257: `process-checklist.sh` — 23 state writes announce success without checking that the write landed
+
+**Status:** Open
+
+**Logged:** 2026-09-09, out of the BL-256 pre-PR review (round 2, R2-3). Every state mutation in
+`scripts/process-checklist.sh` is a one-line `jq … "$PROCESS_STATE" > "$PROCESS_STATE.tmp" && mv
+"$PROCESS_STATE.tmp" "$PROCESS_STATE"` followed by an unconditional `print_ok`. On a read-only `.claude/`,
+a full disk, or a corrupt state file the write fails, the `.tmp` may be left behind, and the operator is
+told the step completed. BL-256 guarded the two sites on the `uat_session:results_received` path
+(`# BL-256-UAT-ATTEST-REFUSE`, `# BL-256-STEP-REFUSE`); this entry is the remaining **23** (count them,
+never transcribe — and use `-F`, a BRE `$P…` silently matches nothing on this host's grep:
+`grep -cF 'PROCESS_STATE.tmp" && mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"' scripts/process-checklist.sh`
+returned 24 on 2026-09-09, of which 1 — the `; then` one, `# BL-256-STEP-RECEIPT` — is guarded;
+the attestation arm is split over two lines and does not match the literal).
+
+**Exposure.** A lost NON-terminal step is caught by the next `--complete-step`'s prior-steps check (the
+step is simply not there). A process's LAST step — `feature_recorded`'s "Build loop closed",
+`phase2_init.verified = true`, the phase-4 release steps — and the `--start-*` initialisers have no later
+check, so a silent failure there is a false receipt that nothing self-corrects.
+
+**Proposed fix.** One `_pc_write_state <jq-filter> [jq args…]` helper that does the `jq > tmp && mv`,
+removes the `.tmp` on failure, prints a NOT-recorded line naming the state file, and returns 1; every
+site routed through it; the BL-256 suite's `mv` shim (`mk_mv_shim`) and read-only fixture reused for a
+site-count test that fails when a new bare `> "$PROCESS_STATE.tmp" && mv` appears (the grep above must
+return 0 once the helper is in). Lint or test, not prose — a "use the helper" rule in CONTRIBUTING.md is
+what the 23 sites already ignored.
+
+**Related:** `## BL-256:`, `## BL-233:` (`# BL-233-ATTEST-REFUSE`), `## BL-182:`.

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15420,13 +15420,21 @@ was one. The four MCP/review attestations already refuse when they cannot record
    single table of every `_ATTESTED` escape with its three properties (reason-mandatory / recorded /
    fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.
 
-**Build note (2026-09-08, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's final
-test file in a worktree at `e3b2be5`: **5 passed / 9 failed** — S3 (no `.results` key → PASS "0
-findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), U2 (read-only `.claude/` → "RECORDED" at rc
-0 with the state file byte-identical), M0 ×3, MP1/MU1 setups. The five passes are the honest-outcome
-cases (S0 shim resolution, S1 empty array PASS, S2 two findings FAIL, U1 writable recorded, U2b state
-unchanged) — true on main by construction and not discriminators. GREEN **14 / 0**: both mutants kill
-(MP1 restores the old `// 0 || echo 0` count → S3 reads PASS again; MU1 turns the REFUSE arm back into
+**Build note (2026-09-08/09, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's
+final test file in a worktree at `e3b2be5`: **5 passed / 12 failed** — S3 (no `.results` key → PASS "0
+findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), S6 (`.results` an object → PASS), S7
+(`.results` a string → PASS), U2 (read-only `.claude/` → "RECORDED" at rc 0 with the state file
+byte-identical), M0 ×3, MP1/MP2/MU1 setups. The five passes are the honest-outcome cases (S0 shim
+resolution, S1 empty array PASS, S2 two findings FAIL, U1 writable recorded, U2b state unchanged) — true
+on main by construction and not discriminators. **S6/S7 exist because a reviewer mutant survived the
+first cut at 14/0**: it weakened the type check to a PRESENCE check (`has("results") and .results !=
+null`) and the suite could not tell, because no case fed a `.results` that was present but not an
+array — under that weakening `{"results":{}}` counts 0 → PASS and `{"results":"abcdefgh"}` counts the
+STRING'S LENGTH as eight findings. MP2 now applies exactly that mutant and S6/S7 kill it. (The reviewer
+that found it stalled mid-run and was killed 19 hours later; its last recorded words were "X4 survives
+14/0 and re-opens the defect" — the finding was recovered from its transcript, not from a verdict.)
+GREEN **17 / 0**: all three mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
+again; MP2 the presence check → S6 PASS, S7 "8 semgrep finding(s)"; MU1 turns the REFUSE arm back into
 the unconditional receipt → U2 is announced RECORDED again). The suite drives the REAL driver and the
 REAL checklist: a PATH shim `semgrep` on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
 (minus jq for S5), the exclusion asserted before measuring; a process-state fixture at

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15446,29 +15446,32 @@ was one. The four MCP/review attestations already refuse when they cannot record
    fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.
 
 **Build note (2026-09-08/09, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's
-final test file in a worktree at `e3b2be5`: **10 passed / 30 failed** — S3 (no `.results` key → PASS "0
+final test file in a worktree at `e3b2be5`: **11 passed / 34 failed** — S3 (no `.results` key → PASS "0
 findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), S6 (`.results` an object → PASS), S7
 (`.results` a string → PASS), S8 (two concatenated documents → PASS), S9 (a top-level array → PASS), N3
 (snyk: no `.vulnerabilities` key → PASS "0 vulnerabilities"), N4 (`.vulnerabilities` an object → PASS),
 N5 (a top-level array → PASS), N6 (no jq → PASS), U2 (read-only `.claude/` → "RECORDED" at rc 0 with
 the state file byte-identical), U3 (rename fails → "RECORDED"), U4 (non-solo path, read-only `.claude/`
-→ "Step … completed" at rc 0), U3b (the `.tmp` left behind), M0 ×6, MP1–MP6/MU1–MU3 setups. The ten
-passes are the honest-outcome cases (S0/N0 shim resolution, S1/N1 empty array PASS, S2/S2b/N2 findings
-FAIL, U1 writable recorded, U2b/U4b state unchanged — a failed write changes nothing on main too) — true
-on main by construction and not discriminators. **S6/S7 exist because a reviewer mutant survived the
+→ "Step … completed" at rc 0), U3b (the `.tmp` left behind), U4c (rename fails → "completed" at rc 0),
+U2c/U4d (a stale `.tmp` in a read-only `.claude/` → rc 1 with NO refusal text: the unguarded `rm -f`
+under `set -e` exited first), M0 ×6, MP1–MP6/MU1–MU4 setups. The eleven passes are the honest-outcome
+cases (S0/N0 shim resolution, S1/N1 empty array PASS, S2/S2b/N2 findings FAIL, U1/U1b healthy writes
+recorded, U2b/U4b state unchanged — a failed write changes nothing on main too) — true on main by
+construction and not discriminators. **S6/S7 exist because a reviewer mutant survived the
 first cut at 14/0**: it weakened the type check to a PRESENCE check (`has("results") and .results !=
 null`) and the suite could not tell, because no case fed a `.results` that was present but not an
 array — under that weakening `{"results":{}}` counts 0 → PASS and `{"results":"abcdefgh"}` counts the
 STRING'S LENGTH as eight findings. MP2 now applies exactly that mutant and S6/S7 kill it. (The reviewer
 that found it stalled mid-run and was killed 19 hours later; its last recorded words were "X4 survives
 14/0 and re-opens the defect" — the finding was recovered from its transcript, not from a verdict.)
-GREEN **40 / 0**: all nine mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
+GREEN **45 / 0**: all ten mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
 again; MP2 the presence check → S6 PASS, S7 "8 semgrep finding(s)"; MP3 drops the `*[!0-9]*` sanitiser
 arm → S8's two-document archive reads PASS again; MP4/MP5 are MP1/MP2 applied to the snyk marker → N3 /
 N4 read PASS again; MP6 is round 2's surviving x10 — a top-level-array arm — → N5 reads PASS again; MU1
 turns the attestation REFUSE arm back into the unconditional receipt → U2 is announced RECORDED again;
 MU2 drops the `rm -f` on that path → U3b finds the `.tmp`; MU3 turns the step REFUSE arm back into the
-receipt → U4 is announced completed again). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
+receipt → U4 is announced completed again; MU4 is round 3's surviving m5 — the step guard covers only
+`jq` and tolerates a failed `mv` — → U4c is announced completed at rc 0 again). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
 the canned archive to `--output`) and `snyk` (answers `config get api` with a token and `test --json`
 with the canned report on stdout) on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
 (minus jq for S5), the exclusion asserted before measuring; a process-state fixture at
@@ -15483,9 +15486,20 @@ semgrep finding (a `-gt 1` mutant survived) → S2b (re-verified ad hoc on a mir
 one-finding archive reads PASS, which S2b rejects); R2-3 the general step write on the same command path → fix +
 U4/U4b + MU3, the other 23 sites → residual 3 / `## BL-257:`; R2-5 the `rm -f` on the refuse path
 untested → U3/U3b + MU2, which also REFUTED round 1's R-2 note that the fixture needed a "same-dir
-permission split" — a PATH `mv` shim that refuses only `process-state.json` is portable and the command
-path calls `mv` exactly once; R2-6 the snyk no-jq arm untested → N6; R2-4 / R2-7 corrected residuals 1
-and 2 (the zap harness exists; `paths.skipped` needs `--verbose`). All **66**
+permission split" — a PATH `mv` shim that refuses only `process-state.json` is portable — every `mv` on
+the path targets that file, once before the refusal exits and twice on a healthy solo run (the
+attestation write, then the step write; round 3 corrected "exactly once"); R2-6 the snyk no-jq arm
+untested → N6; R2-4 / R2-7 corrected residuals 1 and 2 (the zap harness exists; `paths.skipped` needs
+`--verbose`). **Round 3 (single agent, `major_concerns` — do-not-push)**, on the code round 2 added:
+R3-1 the step guard's RENAME half was unpinned — a mutant that guarded only `jq` and tolerated a failed
+`mv` (m5) announced "completed" at rc 0 and survived the BL-256 suite AND all 66 lane suites → U4c (the
+`mv` shim on the non-solo path) + MU4 = m5; R3-2 both refuse arms ran `rm -f "$PROCESS_STATE.tmp"`
+unguarded under `set -e`, so a stale `.tmp` inside a now read-only `.claude/` exited BEFORE the refusal
+was printed (rc honest, text missing) → `|| true` on both, pinned by U2c/U4d; R3-3 no healthy-path
+control for the step write (a guard refusing EVERY completion passed this suite) → U1b asserts rc 0,
+"completed", four steps; R3-4 the "exactly once" wording above. Round 3 also confirmed round 2's folds
+(MP6 = x10 kills; the `-gt 1` mutant reads PASS on S2b's archive and S2b rejects it; MU2's line-number
+mutation fails LOUD under four reformats) and the 66-suite claim in full. All **66**
 unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` (this one included) re-run green
 (incl. `test-phase3-validation-gate` 51/0, `test-bl114-bl115-bl127-gate-integrity` 17/0, the three
 BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); registered in the aggregator and

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15440,13 +15440,18 @@ was one. The four MCP/review attestations already refuse when they cannot record
    landed. A lost non-terminal step is caught by the next step's prior-steps check; a process's LAST
    step and the "Build loop closed" receipt are not. Filed as `## BL-257:` (one `_pc_write_state`
    helper, every site through it).
-4. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
+4. (review round 4, R4-2) Both guarded writes use plain `jq`, which exits 0 with NO output on an
+   already-empty state file — so a 0-byte `process-state.json` earns a receipt over another 0-byte
+   file. Reachable only for a step with no prior requirements (priors fail `step_is_completed` first).
+   `jq -e` on both writes (exit 4 on no output; the filter's output is the whole document, never
+   null/false) closes it; not folded here — fold it into `## BL-257:`'s helper.
+5. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
    reason; `SOLO_BP_ATTESTED` is missing from the inventory the review built. The review's proposed
    single table of every `_ATTESTED` escape with its three properties (reason-mandatory / recorded /
    fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.
 
 **Build note (2026-09-08/09, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's
-final test file in a worktree at `e3b2be5`: **11 passed / 34 failed** — S3 (no `.results` key → PASS "0
+final test file in a worktree at `e3b2be5`: **11 passed / 38 failed** — S3 (no `.results` key → PASS "0
 findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), S6 (`.results` an object → PASS), S7
 (`.results` a string → PASS), S8 (two concatenated documents → PASS), S9 (a top-level array → PASS), N3
 (snyk: no `.vulnerabilities` key → PASS "0 vulnerabilities"), N4 (`.vulnerabilities` an object → PASS),
@@ -15454,7 +15459,9 @@ N5 (a top-level array → PASS), N6 (no jq → PASS), U2 (read-only `.claude/` �
 the state file byte-identical), U3 (rename fails → "RECORDED"), U4 (non-solo path, read-only `.claude/`
 → "Step … completed" at rc 0), U3b (the `.tmp` left behind), U4c (rename fails → "completed" at rc 0),
 U2c/U4d (a stale `.tmp` in a read-only `.claude/` → rc 1 with NO refusal text: the unguarded `rm -f`
-under `set -e` exited first), M0 ×6, MP1–MP6/MU1–MU4 setups. The eleven passes are the honest-outcome
+under `set -e` exited first), U2d/U4e (jq fails on a WRITABLE dir — a corrupt `solo_attestations` /
+`steps_completed` — → "RECORDED" / "completed" at rc 0, the old `jq … && mv` short-circuiting past the
+rename and straight into the receipt), M0 ×6, MP1–MP6/MU1–MU6 setups. The eleven passes are the honest-outcome
 cases (S0/N0 shim resolution, S1/N1 empty array PASS, S2/S2b/N2 findings FAIL, U1/U1b healthy writes
 recorded, U2b/U4b state unchanged — a failed write changes nothing on main too) — true on main by
 construction and not discriminators. **S6/S7 exist because a reviewer mutant survived the
@@ -15464,14 +15471,16 @@ array — under that weakening `{"results":{}}` counts 0 → PASS and `{"results
 STRING'S LENGTH as eight findings. MP2 now applies exactly that mutant and S6/S7 kill it. (The reviewer
 that found it stalled mid-run and was killed 19 hours later; its last recorded words were "X4 survives
 14/0 and re-opens the defect" — the finding was recovered from its transcript, not from a verdict.)
-GREEN **45 / 0**: all ten mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
+GREEN **49 / 0**: all twelve mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
 again; MP2 the presence check → S6 PASS, S7 "8 semgrep finding(s)"; MP3 drops the `*[!0-9]*` sanitiser
 arm → S8's two-document archive reads PASS again; MP4/MP5 are MP1/MP2 applied to the snyk marker → N3 /
 N4 read PASS again; MP6 is round 2's surviving x10 — a top-level-array arm — → N5 reads PASS again; MU1
 turns the attestation REFUSE arm back into the unconditional receipt → U2 is announced RECORDED again;
 MU2 drops the `rm -f` on that path → U3b finds the `.tmp`; MU3 turns the step REFUSE arm back into the
 receipt → U4 is announced completed again; MU4 is round 3's surviving m5 — the step guard covers only
-`jq` and tolerates a failed `mv` — → U4c is announced completed at rc 0 again). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
+`jq` and tolerates a failed `mv` — → U4c is announced completed at rc 0 again; MU5/MU6 are round 4's
+x1b/x3 — each guard tolerating a failed `jq` (`> tmp || true && mv`, `; mv`) — → a failed jq renames an
+EMPTY `.tmp` over the state file and U4e / U2d are announced completed / RECORDED over a 0-byte file). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
 the canned archive to `--output`) and `snyk` (answers `config get api` with a token and `test --json`
 with the canned report on stdout) on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
 (minus jq for S5), the exclusion asserted before measuring; a process-state fixture at
@@ -15499,7 +15508,18 @@ was printed (rc honest, text missing) → `|| true` on both, pinned by U2c/U4d; 
 control for the step write (a guard refusing EVERY completion passed this suite) → U1b asserts rc 0,
 "completed", four steps; R3-4 the "exactly once" wording above. Round 3 also confirmed round 2's folds
 (MP6 = x10 kills; the `-gt 1` mutant reads PASS on S2b's archive and S2b rejects it; MU2's line-number
-mutation fails LOUD under four reformats) and the 66-suite claim in full. All **66**
+mutation fails LOUD under four reformats) and the 66-suite claim in full. **Round 4 (single agent,
+`major_concerns`)** verified every round-3 fold exactly (m3/m4/m5/m6/m9 all killed; each `|| true`
+removal killed by its named case and nothing else) and found the JQ half of both guards unpinned: U4
+fails both halves at once (the shell cannot create the `.tmp` in a read-only dir), so a guard that
+tolerated a jq failure survived 45/0 while renaming an empty `.tmp` over the state file — R4-1 → U2d /
+U4e (jq fails on a writable dir: `solo_attestations` / `steps_completed` a string; the prior-step check
+is a jq `index()` substring search, so it passes and the write is the first jq to fail) + MU5/MU6, and
+the U4c comment corrected; R4-2 (an already-EMPTY state file earns a receipt on the tip itself, jq on
+empty input exiting 0 with no output — `jq -e` on both writes would refuse it) recorded as residual 4;
+R4-3 (dropping the attestation `exit 1` is behaviourally equivalent — the step write on the same file
+fails next) no action. Round 4 was test-only; the 66-suite lane was not re-run for it (round 3's
+measurement stands: the only file that changed is this suite, 49/0). All **66**
 unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` (this one included) re-run green
 (incl. `test-phase3-validation-gate` 51/0, `test-bl114-bl115-bl127-gate-integrity` 17/0, the three
 BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); registered in the aggregator and

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15519,7 +15519,22 @@ the U4c comment corrected; R4-2 (an already-EMPTY state file earns a receipt on 
 empty input exiting 0 with no output — `jq -e` on both writes would refuse it) recorded as residual 4;
 R4-3 (dropping the attestation `exit 1` is behaviourally equivalent — the step write on the same file
 fails next) no action. Round 4 was test-only; the 66-suite lane was not re-run for it (round 3's
-measurement stands: the only file that changed is this suite, 49/0). All **66**
+measurement stands: the only file that changed is this suite, 49/0). **Round 5 returned `approve`** and the branch
+was pushed as PR #380 — where the `rest` unit shard came back RED on the suite's own MU5, at 48/1, having been
+49/0 on this Mac. Cause: `_mutate_line` built the mutant with `${orig/"$pat"/$rep}`, and **since bash 5.1 an
+unescaped `&` in the replacement of a pattern substitution means THE WHOLE MATCH** — the same rule as `sed`, which
+bash 3.2 does not have. Every shell guard's replacement carries `&&`, so on the 5.2 runner the mutant's line became
+`… || true > "$PROCESS_STATE.tmp" && mv> "$PROCESS_STATE.tmp" && mv mv …`: still one changed line, still `bash -n`
+clean, still 2 diff lines — and no longer a mutant, so MU5's own assertion failed and reported it. The harness had
+asserted the SHAPE of the edit and not its CONTENT, which is exactly the half of CLAUDE.md's sed rule that was not
+carried over. Fixed three ways: `_mutate_line` splits on the pattern (`${s%%"$pat"*}` / `${s#*"$pat"}`, no `&` rule
+in any version) and refuses when the replacement did not land literally, so a dud mutation is a LOUD setup failure;
+MU5/MU6/MP3 gained explicit `grep -cF` content assertions (the other nine mutants already had them, which is why
+only MU5 broke); and the trap is now the second bullet of CLAUDE.md's ENVIRONMENT TRAPS with a container recipe.
+Both directions verified rather than argued — `ubuntu:24.04` (bash 5.2.21), as a non-root user so the `chmod 555`
+fixtures bite: the pre-fix file reproduces CI exactly (48/1, same MU5 message, `rc=1 bytes=463`) and the fixed file
+is **49 / 0** on Linux and on this Mac. `soif_sed_repl_esc` (`## BL-255:`) was checked for the same hazard in the
+same container and is unaffected: its `\&` is a literal backslash under both 3.2 and 5.2. All **66**
 unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` (this one included) re-run green
 (incl. `test-phase3-validation-gate` 51/0, `test-bl114-bl115-bl127-gate-integrity` 17/0, the three
 BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); registered in the aggregator and

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15532,9 +15532,12 @@ in any version) and refuses when the replacement did not land literally, so a du
 MU5/MU6/MP3 gained explicit `grep -cF` content assertions (of the other nine, eight already asserted the mutated
 text and MU2 is a line-addressed `Nd` delete with a content PRE-check, where shape is content — which is why only
 MU5 broke); and the trap is now the second bullet of CLAUDE.md's ENVIRONMENT TRAPS with a container recipe,
-corrected in round 6 to say WHY `soif_sed_repl_esc` survives: not because `\&` escapes on 5.2 (it does not — the
-backslash is consumed and the bare `&` is the match) but because its pattern is the single character `&`, so the
-whole match IS `&`. Round 6 also found the `chmod 555` sites inside MU1/MU3 carried no root guard, so as root those
+whose explanation of why `soif_sed_repl_esc` survives took THREE drafts: round 6 refuted the first, round 7 the
+second — both for the same class of error the bullet exists to prevent, and the second also misquoted the source
+line (`${t//&/\\&}` carries TWO backslashes, not one). Measured directly on both versions rather than reasoned
+about: on 5.2 `\\&` is a literal backslash plus THE WHOLE MATCH, a single `\&` is an escaped literal `&` with the
+backslash consumed, and a bare `&` is the whole match; on 3.2 all three are literal. The helper is byte-identical
+across versions only because its pattern is the single character `&`, so the whole match happens to BE `&`. Round 6 also found the `chmod 555` sites inside MU1/MU3 carried no root guard, so as root those
 two passed vacuously while claiming a read-only `.claude/` (43/4 — contained, because the four guarded sites turn
 the suite red under root either way); both now guard, and the suite is loud on all six.
 Both directions verified rather than argued — `ubuntu:24.04` (bash 5.2.21), as a non-root user so the `chmod 555`

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15521,7 +15521,7 @@ R4-3 (dropping the attestation `exit 1` is behaviourally equivalent — the step
 fails next) no action. Round 4 was test-only; the 66-suite lane was not re-run for it (round 3's
 measurement stands: the only file that changed is this suite, 49/0). **Round 5 returned `approve`** and the branch
 was pushed as PR #380 — where the `rest` unit shard came back RED on the suite's own MU5, at 48/1, having been
-49/0 on this Mac. Cause: `_mutate_line` built the mutant with `${orig/"$pat"/$rep}`, and **since bash 5.1 an
+49/0 on this Mac. Cause: `_mutate_line` built the mutant with `${orig/"$pat"/$rep}`, and **since bash 5.2 an
 unescaped `&` in the replacement of a pattern substitution means THE WHOLE MATCH** — the same rule as `sed`, which
 bash 3.2 does not have. Every shell guard's replacement carries `&&`, so on the 5.2 runner the mutant's line became
 `… || true > "$PROCESS_STATE.tmp" && mv> "$PROCESS_STATE.tmp" && mv mv …`: still one changed line, still `bash -n`
@@ -15538,7 +15538,7 @@ line (`${t//&/\\&}` carries TWO backslashes, not one). Measured directly on both
 about: on 5.2 `\\&` is a literal backslash plus THE WHOLE MATCH, a single `\&` is an escaped literal `&` with the
 backslash consumed, and a bare `&` is the whole match; on 3.2 all three are literal. The helper is byte-identical
 across versions only because its pattern is the single character `&`, so the whole match happens to BE `&`. Round 8
-(`approve`) verified all eight cells of that table on 5.2.21 and 5.2.37 and caught one more error above them: the
+(`approve`) reproduced that table on 3.2 and on 5.2 (5.2.21 and 5.2.37) and caught one more error above it: the
 rule arrives in **5.2**, not 5.1 — measured absent in 5.0.18 and 5.1.16, and the `patsub_replacement` shopt that
 governs it does not exist before 5.2. It also measured a residual worth keeping: mutate the helper's `\\&` to `\&`
 and `test-bl255-sed-replacement-escape.sh` stays GREEN on this Mac, going red only on the runner — the suite that

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15375,7 +15375,7 @@ aggregator and the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `re
 
 ---
 
-## BL-256: two shipped gates hand out receipts they did not earn — `_p3_scan_semgrep` counts an unreadable archive as "0 findings → PASS", and the UAT solo attestation prints "RECORDED" whether or not the record was written
+## BL-256: two shipped gates hand out receipts they did not earn — `_p3_scan_semgrep` (and its twin `_p3_scan_snyk`) counts an unreadable archive as "0 findings → PASS", and the UAT solo attestation prints "RECORDED" whether or not the record was written
 
 **Status:** Open
 
@@ -15403,7 +15403,10 @@ was one. The four MCP/review attestations already refuse when they cannot record
 - (a) The count is taken only when `.results` is present AND an array (`jq -e … if type == "array"`,
   `# BL-256-P3-COUNT-RECEIPT`); no jq, no array, or unparseable JSON → `P3_STATUS="FAIL"` with a note
   that says NOTHING WAS COUNTED and names the archive. Never SKIP (SKIP means "could not run" and
-  routes to the attestation path; this scan ran), never PASS.
+  routes to the attestation path; this scan ran), never PASS. **`_p3_scan_snyk` carried the identical
+  count one function below** (`(.vulnerabilities | length) // 0` + `|| echo 0` + sanitise-to-0) — the
+  pre-PR reviewer's R-3 — and now takes the same shape (`# BL-256-P3-SNYK-COUNT-RECEIPT`): counted only
+  when `.vulnerabilities` is an array, else FAIL / NOTHING WAS COUNTED; no jq → FAIL.
 - (b) The receipt is inside the `if jq … && mv …; then` (`# BL-256-UAT-ATTEST-RECEIPT`); the else arm
   removes the temp file, prints a REFUSED line naming the state file and the reason class, and
   exits 1 (`# BL-256-UAT-ATTEST-REFUSE`) — nothing is marked complete.
@@ -15412,36 +15415,55 @@ was one. The four MCP/review attestations already refuse when they cannot record
   process-state fixture at the `results_received` step with a writable and then a read-only `.claude/`.
 
 **Residuals:**
-1. The other Phase-3 scanners' count arms were not audited here; `_p3_scan_semgrep` was the one the
-   review named. The pattern (`// 0` + sanitise-to-0 + `0 → PASS`) should be greped for across
-   `_p3_scan_*` by whoever next opens that file.
+1. The `_p3_scan_*` count arms were greped for the pattern (`// 0` + sanitise-to-0 + `0 → PASS`) on
+   this branch: semgrep and snyk carried it and are fixed above; license / threat-model do not count
+   via jq at all. **`_p3_scan_zap` has the same hole by a different route and is NOT fixed here:** it
+   FAILs an unparseable report (`# BL-122-ZAP-RISK-FILTER`, pinned by `T-zap-malformed-report-fail`),
+   but its `.site[]?.alerts[]?` optional iterators turn a renamed or non-array `.site` into "0 Medium+
+   alerts → PASS" (verified: `{"sites":[{"alerts":[{"riskcode":"3"}]}]}` counts 0), and a multi-document
+   report reaches the surviving `case … findings=0` sanitiser. The fix is the semgrep shape (count only
+   when `.site` is an array) plus a docker-shim harness this suite does not build; filed here as
+   follow-up rather than folded, so the scope stays the two arms the review and its reviewer named.
+3. Currency (reviewer R-4): a semgrep archive can carry `.errors[]` / `paths.skipped[]` — a scan that
+   FINISHED but skipped files, or hit rule errors, still reads as "0 findings" when `.results` is an
+   empty array. That is a real scan with a real count, so it is a PASS on the rule this entry fixes, but
+   it is a weaker receipt than it looks; surfacing the skipped/error counts in `P3_NOTE` is follow-up.
 2. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
    reason; `SOLO_BP_ATTESTED` is missing from the inventory the review built. The review's proposed
    single table of every `_ATTESTED` escape with its three properties (reason-mandatory / recorded /
    fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.
 
 **Build note (2026-09-08/09, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's
-final test file in a worktree at `e3b2be5`: **5 passed / 12 failed** — S3 (no `.results` key → PASS "0
+final test file in a worktree at `e3b2be5`: **8 passed / 19 failed** — S3 (no `.results` key → PASS "0
 findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), S6 (`.results` an object → PASS), S7
-(`.results` a string → PASS), U2 (read-only `.claude/` → "RECORDED" at rc 0 with the state file
-byte-identical), M0 ×3, MP1/MP2/MU1 setups. The five passes are the honest-outcome cases (S0 shim
-resolution, S1 empty array PASS, S2 two findings FAIL, U1 writable recorded, U2b state unchanged) — true
-on main by construction and not discriminators. **S6/S7 exist because a reviewer mutant survived the
+(`.results` a string → PASS), S8 (two concatenated documents → PASS), N3 (snyk: no `.vulnerabilities`
+key → PASS "0 vulnerabilities"), N4 (snyk: `.vulnerabilities` an object → PASS), U2 (read-only
+`.claude/` → "RECORDED" at rc 0 with the state file byte-identical), M0 ×4, MP1–MP5/MU1 setups. The
+eight passes are the honest-outcome cases (S0/N0 shim resolution, S1/N1 empty array PASS, S2/N2 two
+findings FAIL, U1 writable recorded, U2b state unchanged) — true on main by construction and not
+discriminators. **S6/S7 exist because a reviewer mutant survived the
 first cut at 14/0**: it weakened the type check to a PRESENCE check (`has("results") and .results !=
 null`) and the suite could not tell, because no case fed a `.results` that was present but not an
 array — under that weakening `{"results":{}}` counts 0 → PASS and `{"results":"abcdefgh"}` counts the
 STRING'S LENGTH as eight findings. MP2 now applies exactly that mutant and S6/S7 kill it. (The reviewer
 that found it stalled mid-run and was killed 19 hours later; its last recorded words were "X4 survives
 14/0 and re-opens the defect" — the finding was recovered from its transcript, not from a verdict.)
-GREEN **17 / 0**: all three mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
-again; MP2 the presence check → S6 PASS, S7 "8 semgrep finding(s)"; MU1 turns the REFUSE arm back into
-the unconditional receipt → U2 is announced RECORDED again). The suite drives the REAL driver and the
-REAL checklist: a PATH shim `semgrep` on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
+GREEN **27 / 0**: all six mutants kill (MP1 restores the old `// 0 || echo 0` count → S3 reads PASS
+again; MP2 the presence check → S6 PASS, S7 "8 semgrep finding(s)"; MP3 drops the `*[!0-9]*` sanitiser
+arm → S8's two-document archive reads PASS again; MP4/MP5 are MP1/MP2 applied to the snyk marker → N3 /
+N4 read PASS again; MU1 turns the REFUSE arm back into the unconditional receipt → U2 is announced
+RECORDED again). The suite drives the REAL driver and the REAL checklist: PATH shims `semgrep` (writes
+the canned archive to `--output`) and `snyk` (answers `config get api` with a token and `test --json`
+with the canned report on stdout) on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
 (minus jq for S5), the exclusion asserted before measuring; a process-state fixture at
-`results_received` on the Light track, writable then `chmod 555`. Both mutants use `~` as the sed
+`results_received` on the Light track, writable then `chmod 555`. The sed mutants use `~` as the
 delimiter because the markers carry `#` and the replacements `|` and `/` — the first cut hit
-CLAUDE.md's trap on that line and sed refused it, reported honestly as "did not apply cleanly". All
-**65** unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` re-run green
+CLAUDE.md's trap on that line and sed refused it, reported honestly as "did not apply cleanly". **Pre-PR
+review round 1 (single agent, `minor_concerns`)** folded before push: R-1 the untested multi-document
+sanitiser arm → S8 + MP3; R-3 the snyk twin → fix + section N + MP4/MP5; R-2 (the `.tmp` cleanup on the
+refuse path is untested — a fixture that makes `mv` fail after `jq` succeeds needs a same-dir
+permission split the suite does not build) left as noted; R-4 recorded as residual 3. All **66**
+unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` (this one included) re-run green
 (incl. `test-phase3-validation-gate` 51/0, `test-bl114-bl115-bl127-gate-integrity` 17/0, the three
 BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); registered in the aggregator and
 the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `registered`).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15529,8 +15529,14 @@ clean, still 2 diff lines — and no longer a mutant, so MU5's own assertion fai
 asserted the SHAPE of the edit and not its CONTENT, which is exactly the half of CLAUDE.md's sed rule that was not
 carried over. Fixed three ways: `_mutate_line` splits on the pattern (`${s%%"$pat"*}` / `${s#*"$pat"}`, no `&` rule
 in any version) and refuses when the replacement did not land literally, so a dud mutation is a LOUD setup failure;
-MU5/MU6/MP3 gained explicit `grep -cF` content assertions (the other nine mutants already had them, which is why
-only MU5 broke); and the trap is now the second bullet of CLAUDE.md's ENVIRONMENT TRAPS with a container recipe.
+MU5/MU6/MP3 gained explicit `grep -cF` content assertions (of the other nine, eight already asserted the mutated
+text and MU2 is a line-addressed `Nd` delete with a content PRE-check, where shape is content — which is why only
+MU5 broke); and the trap is now the second bullet of CLAUDE.md's ENVIRONMENT TRAPS with a container recipe,
+corrected in round 6 to say WHY `soif_sed_repl_esc` survives: not because `\&` escapes on 5.2 (it does not — the
+backslash is consumed and the bare `&` is the match) but because its pattern is the single character `&`, so the
+whole match IS `&`. Round 6 also found the `chmod 555` sites inside MU1/MU3 carried no root guard, so as root those
+two passed vacuously while claiming a read-only `.claude/` (43/4 — contained, because the four guarded sites turn
+the suite red under root either way); both now guard, and the suite is loud on all six.
 Both directions verified rather than argued — `ubuntu:24.04` (bash 5.2.21), as a non-root user so the `chmod 555`
 fixtures bite: the pre-fix file reproduces CI exactly (48/1, same MU5 message, `rc=1 bytes=463`) and the fixed file
 is **49 / 0** on Linux and on this Mac. `soif_sed_repl_esc` (`## BL-255:`) was checked for the same hazard in the

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15372,3 +15372,72 @@ aggregator and the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `re
 
 **Related:** `## BL-164:` (shell-injectable generated CI from scaffold values — the sibling sink),
 `## BL-234:` (`_qdrant_key_escape` — the same escape-at-the-sink discipline one surface over).
+
+---
+
+## BL-256: two shipped gates hand out receipts they did not earn — `_p3_scan_semgrep` counts an unreadable archive as "0 findings → PASS", and the UAT solo attestation prints "RECORDED" whether or not the record was written
+
+**Status:** Open
+
+**Logged:** 2026-09-08, out of the adversarial codebase review (ST2 + R2, both confirmed by the
+single-agent second pass). Ranked #4 of the verified review's top ten. Both are instances of the
+rule this repo already spells out at `# BL-182-NO-UNEARNED-RECEIPT` and `# BL-112-SAST-NOTRUN`: a
+check that did not run, or whose result could not be read, must never read as a clean one.
+
+**(a) `scripts/run-phase3-validation.sh::_p3_scan_semgrep`.** After semgrep wrote its archive, the
+finding count was `jq '(.results | length) // 0' "$archive" 2>/dev/null || echo 0`, then anything
+non-numeric was sanitised to 0, and `0 → P3_STATUS="PASS"`. So a renamed key on a future semgrep major
+(`.results` → anything), an archive that is not valid JSON, or a host with no `jq` at all every one
+produced `PASS — 0 findings (full-tree --config auto)`: a clean bill of health for a scan nobody
+could read, in the Phase-3 gate that decides production release. The same file already refuses a
+SKIP that would clear a prior FAIL; this arm was the one that did not refuse.
+
+**(b) `scripts/process-checklist.sh`, `uat_session:results_received`.** The Light/solo escape
+(`SOLO_UAT_SOLO_ATTESTED=1`) appends to `uat_session.solo_attestations[]` with `jq … > tmp && mv`, and
+then printed `results_received: SOLO-MODE attested and RECORDED` **unconditionally** — a read-only
+`.claude/`, a full disk, or a corrupt state file left no record while the operator was told there
+was one. The four MCP/review attestations already refuse when they cannot record
+(`# BL-233-ATTEST-REFUSE`); this one announced instead.
+
+**Fix (built on this branch).**
+- (a) The count is taken only when `.results` is present AND an array (`jq -e … if type == "array"`,
+  `# BL-256-P3-COUNT-RECEIPT`); no jq, no array, or unparseable JSON → `P3_STATUS="FAIL"` with a note
+  that says NOTHING WAS COUNTED and names the archive. Never SKIP (SKIP means "could not run" and
+  routes to the attestation path; this scan ran), never PASS.
+- (b) The receipt is inside the `if jq … && mv …; then` (`# BL-256-UAT-ATTEST-RECEIPT`); the else arm
+  removes the temp file, prints a REFUSED line naming the state file and the reason class, and
+  exits 1 (`# BL-256-UAT-ATTEST-REFUSE`) — nothing is marked complete.
+- Suite `tests/test-bl256-unearned-receipts.sh` drives the real driver and the real checklist on
+  fixtures: a PATH shim `semgrep` that writes a canned archive (no network, no real semgrep), and a
+  process-state fixture at the `results_received` step with a writable and then a read-only `.claude/`.
+
+**Residuals:**
+1. The other Phase-3 scanners' count arms were not audited here; `_p3_scan_semgrep` was the one the
+   review named. The pattern (`// 0` + sanitise-to-0 + `0 → PASS`) should be greped for across
+   `_p3_scan_*` by whoever next opens that file.
+2. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
+   reason; `SOLO_BP_ATTESTED` is missing from the inventory the review built. The review's proposed
+   single table of every `_ATTESTED` escape with its three properties (reason-mandatory / recorded /
+   fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.
+
+**Build note (2026-09-08, branch `fix/bl256-unearned-receipts`).** RED measured with the branch's final
+test file in a worktree at `e3b2be5`: **5 passed / 9 failed** — S3 (no `.results` key → PASS "0
+findings"), S4 (not JSON → PASS), S5 (no jq on PATH → PASS), U2 (read-only `.claude/` → "RECORDED" at rc
+0 with the state file byte-identical), M0 ×3, MP1/MU1 setups. The five passes are the honest-outcome
+cases (S0 shim resolution, S1 empty array PASS, S2 two findings FAIL, U1 writable recorded, U2b state
+unchanged) — true on main by construction and not discriminators. GREEN **14 / 0**: both mutants kill
+(MP1 restores the old `// 0 || echo 0` count → S3 reads PASS again; MU1 turns the REFUSE arm back into
+the unconditional receipt → U2 is announced RECORDED again). The suite drives the REAL driver and the
+REAL checklist: a PATH shim `semgrep` on a host-mirrored PATH minus real semgrep/snyk/docker/go-licenses
+(minus jq for S5), the exclusion asserted before measuring; a process-state fixture at
+`results_received` on the Light track, writable then `chmod 555`. Both mutants use `~` as the sed
+delimiter because the markers carry `#` and the replacements `|` and `/` — the first cut hit
+CLAUDE.md's trap on that line and sed refused it, reported honestly as "did not apply cleanly". All
+**65** unit-lane suites that drive `run-phase3-validation.sh` or `process-checklist.sh` re-run green
+(incl. `test-phase3-validation-gate` 51/0, `test-bl114-bl115-bl127-gate-integrity` 17/0, the three
+BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); registered in the aggregator and
+the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `registered`).
+
+**Related:** `## BL-182:`, `## BL-112:`, `## BL-233:` (the refuse-when-unrecordable posture),
+`## BL-185:` (the other unrecorded escape), `## BL-070:` (the atomic attestation write this file
+already does for Phase-3 attestations — the shape (b) now follows).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15537,7 +15537,12 @@ second — both for the same class of error the bullet exists to prevent, and th
 line (`${t//&/\\&}` carries TWO backslashes, not one). Measured directly on both versions rather than reasoned
 about: on 5.2 `\\&` is a literal backslash plus THE WHOLE MATCH, a single `\&` is an escaped literal `&` with the
 backslash consumed, and a bare `&` is the whole match; on 3.2 all three are literal. The helper is byte-identical
-across versions only because its pattern is the single character `&`, so the whole match happens to BE `&`. Round 6 also found the `chmod 555` sites inside MU1/MU3 carried no root guard, so as root those
+across versions only because its pattern is the single character `&`, so the whole match happens to BE `&`. Round 8
+(`approve`) verified all eight cells of that table on 5.2.21 and 5.2.37 and caught one more error above them: the
+rule arrives in **5.2**, not 5.1 — measured absent in 5.0.18 and 5.1.16, and the `patsub_replacement` shopt that
+governs it does not exist before 5.2. It also measured a residual worth keeping: mutate the helper's `\\&` to `\&`
+and `test-bl255-sed-replacement-escape.sh` stays GREEN on this Mac, going red only on the runner — the suite that
+guards the trap is itself subject to it. Round 6 also found the `chmod 555` sites inside MU1/MU3 carried no root guard, so as root those
 two passed vacuously while claiming a read-only `.claude/` (43/4 — contained, because the four guarded sites turn
 the suite red under root either way); both now guard, and the suite is loud on all six.
 Both directions verified rather than argued — `ubuntu:24.04` (bash 5.2.21), as a non-root user so the `chmod 555`

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -849,6 +849,13 @@ run_child_suite "tests/test-bl255-sed-replacement-escape.sh" \
   "BL-255 sed replacement escape (soif_sed_repl_esc; both renderers end to end; name sites pinned)" \
   "BL-255 sed-replacement-escape tests FAILED (run tests/test-bl255-sed-replacement-escape.sh for details)"
 
+# BL-256: two "no unearned receipt" breaks — a semgrep archive that cannot be
+# counted is not "0 findings", and a UAT solo attestation that cannot be
+# recorded is refused, not announced as recorded.
+run_child_suite "tests/test-bl256-unearned-receipts.sh" \
+  "BL-256 unearned receipts (P3 semgrep count needs a .results array; UAT attestation refused when unrecordable)" \
+  "BL-256 unearned-receipt tests FAILED (run tests/test-bl256-unearned-receipts.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -681,8 +681,10 @@ else
   tgt="$MP3/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
   # only the semgrep arm's sanitiser — the first `''|*[!0-9]*)` AFTER the marker line
   awk -v mark="$M_P3" 'index($0, mark) {seen=1} seen && !done && /^[[:space:]]*'"'"''"'"'\|\*\[!0-9\]\*\)/ {sub(/'"'"''"'"'\|\*\[!0-9\]\*\)/, "'"'"''"'"')"); done=1} {print}' "$before" > "$tgt"
-  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null; then
-    fail_ "MP3 setup" "the sanitiser mutation did not apply cleanly"
+  _mp3_b="$(grep -cF "''|*[!0-9]*)" "$before")"; _mp3_a="$(grep -cF "''|*[!0-9]*)" "$tgt")"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null \
+     || [ "$_mp3_a" -ne $(( _mp3_b - 1 )) ]; then
+    fail_ "MP3 setup" "the sanitiser mutation did not apply cleanly (arms $_mp3_b -> $_mp3_a)"
   elif [ -z "${PATH_S:-}" ]; then
     fail_ "MP3 setup" "no isolated PATH from section S"
   else
@@ -834,14 +836,29 @@ else
 fi
 
 # _mutate_line <src> <dst> <lineno> <literal-pattern> <replacement> — rewrite
-# one line by literal substitution (bash expansion, no sed/awk metachars —
-# the replacements below carry `&&`, `|`, `$` and `"`); returns 1 if the
-# pattern is not on that line
+# one line by literal substitution; returns 1 if the pattern is not on that
+# line OR if the replacement did not land literally.
+#
+# NOT `${orig/"$pat"/$rep}` — that is CLAUDE.md's sed `&` trap wearing a bash
+# costume. Since bash 5.1 an UNESCAPED `&` in the replacement of a pattern
+# substitution means THE WHOLE MATCH, exactly as in a sed replacement; bash
+# 3.2 has no such rule. This host runs 3.2 and CI runs 5.2, so a replacement
+# carrying `&&` (every shell guard here) produced the intended line locally
+# and spliced the match back in twice on the runner — `bash -n` clean, one
+# changed line, and a mutant that no longer mutates. It cost a red `rest`
+# shard on PR #380. Verified both ways: bash 3.2 gives `… || true && mv …`
+# and bash 5.2 gives `… || true > "$PROCESS_STATE.tmp" && mv> …`.
+# The prefix/suffix split below has no `&` rule in any version, and the
+# postcondition makes a replacement that did not land a LOUD setup failure
+# rather than a silently toothless mutant.
 _mutate_line() {
-  local src="$1" dst="$2" ln="$3" pat="$4" rep="$5" orig mut
+  local src="$1" dst="$2" ln="$3" pat="$4" rep="$5" orig lhs rhs mut
   orig="$(sed -n "${ln}p" "$src")"
   case "$orig" in *"$pat"*) ;; *) return 1 ;; esac
-  mut="${orig/"$pat"/$rep}"
+  lhs="${orig%%"$pat"*}"   # text before the first occurrence
+  rhs="${orig#*"$pat"}"    # text after it
+  mut="${lhs}${rep}${rhs}"
+  case "$mut" in *"$rep"*) ;; *) return 1 ;; esac
   { head -n $((ln - 1)) "$src"; printf '%s\n' "$mut"; tail -n +$((ln + 1)) "$src"; } > "$dst"
 }
 
@@ -856,7 +873,8 @@ else
   mline="$(grep -n "${M_SR}\$" "$before" | head -1 | cut -d: -f1)"
   gline=$(( ${mline:-0} - 1 ))
   if [ "$gline" -lt 1 ] || ! _mutate_line "$before" "$tgt" "$gline" '> "$PROCESS_STATE.tmp" && mv' '> "$PROCESS_STATE.tmp" || true && mv' \
-     || [ "$(_changed_lines "$before" "$tgt")" -ne 2 ] || ! bash -n "$tgt" 2>/dev/null; then
+     || [ "$(_changed_lines "$before" "$tgt")" -ne 2 ] || ! bash -n "$tgt" 2>/dev/null \
+     || [ "$(grep -cF '> "$PROCESS_STATE.tmp" || true && mv' "$tgt")" -ne 1 ]; then
     fail_ "MU5 setup" "the jq-tolerant step-guard mutation did not apply cleanly"
   else
     UM5="$(newtmp)"; mk_uat_fixture "$UM5"
@@ -882,7 +900,8 @@ else
   mline="$(grep -n "${M_UR}\$" "$before" | head -1 | cut -d: -f1)"
   gline=$(( ${mline:-0} - 1 ))
   if [ "$gline" -lt 1 ] || ! _mutate_line "$before" "$tgt" "$gline" '&& mv "$PROCESS_STATE.tmp"' '; mv "$PROCESS_STATE.tmp"' \
-     || [ "$(_changed_lines "$before" "$tgt")" -ne 2 ] || ! bash -n "$tgt" 2>/dev/null; then
+     || [ "$(_changed_lines "$before" "$tgt")" -ne 2 ] || ! bash -n "$tgt" 2>/dev/null \
+     || [ "$(grep -cF '; mv "$PROCESS_STATE.tmp" "$PROCESS_STATE" 2>/dev/null; then' "$tgt")" -ne 1 ]; then
     fail_ "MU6 setup" "the jq-tolerant attestation-guard mutation did not apply cleanly"
   else
     UM6="$(newtmp)"; mk_uat_fixture "$UM6"

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -14,7 +14,9 @@
 #   (b) scripts/process-checklist.sh's uat_session:results_received solo escape
 #       appended its attestation with `jq … > tmp && mv` and then printed
 #       "attested and RECORDED" unconditionally — a read-only .claude/ left no
-#       record while the operator was told there was one.
+#       record while the operator was told there was one. The general step
+#       write at the end of complete_step had the same shape (review round 2,
+#       R2-3): "Step … completed" at rc 0 with the state file untouched.
 #
 # Both drive the REAL scripts on fixtures. (a) uses a PATH shim `semgrep` that
 # writes a canned archive to --output, on a PATH mirrored from the host MINUS
@@ -216,6 +218,17 @@ else
     fail_ "S7" "summary line: ${l:-<none>}"
   fi
 
+  # S2b — ONE finding must be FAIL (the `-gt 0` boundary; a `-gt 1` mutant
+  # survived review round 2 because only 0 and 2 were pinned)
+  printf '{"results":[{"check_id":"only-one"}],"errors":[]}\n' > "$ARCH/one.json"
+  F2b="$(newtmp)"; mk_p3_fixture "$F2b"; run_p3 "$F2b" "$ARCH/one.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "1 semgrep finding"; then
+    pass "S2b — an archive with ONE result is FAIL, '1 semgrep finding(s)' (the >0 boundary)"
+  else
+    fail_ "S2b" "summary line: ${l:-<none>}"
+  fi
+
   # S8 — a MULTI-DOCUMENT archive (two JSON documents concatenated). jq emits
   # one count per document, so `findings` becomes "0\n0": the `*[!0-9]*`
   # sanitiser arm is the only thing between that and `[ "0\n0" -gt 0 ]`
@@ -230,6 +243,18 @@ else
     pass "S8 — a multi-document archive is FAIL and says NOTHING WAS COUNTED"
   else
     fail_ "S8" "summary line: ${l:-<none>}"
+  fi
+
+  # S9 — a TOP-LEVEL ARRAY archive (no object to carry .results) must not count
+  printf '[]\n' > "$ARCH/toparray.json"
+  F9="$(newtmp)"; mk_p3_fixture "$F9"; run_p3 "$F9" "$ARCH/toparray.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "S9" "a top-level array archive read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "S9 — a top-level ARRAY archive is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "S9" "summary line: ${l:-<none>}"
   fi
 
   # S5 — no jq at all must NOT read as 0 findings
@@ -310,6 +335,36 @@ else
   else
     fail_ "N4" "summary line: ${l:-<none>}"
   fi
+
+  # N5 — a TOP-LEVEL ARRAY report (the `--all-projects` shape this arm never
+  # asks for) must not be counted as clean. Review round 2's surviving mutant
+  # (x10) added an `if type == "array"` arm that summed `.[]?.vulnerabilities[]?`
+  # and read `[{"vulnerabilities":[]}]` as PASS — no case fed a top-level array.
+  printf '[{"ok":true,"vulnerabilities":[],"dependencyCount":3}]\n' > "$ARCH/snyk-toparray.json"
+  FN5="$(newtmp)"; mk_p3_fixture "$FN5"; run_p3 "$FN5" "$ARCH/snyk-toparray.json" "$PATH_N"
+  l="$(snyk_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "N5" "a top-level array report read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "N5 — a top-level ARRAY report (the --all-projects shape) is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "N5" "summary line: ${l:-<none>}"
+  fi
+
+  # N6 — no jq: the snyk row must say so (not "schema drift"), mirroring S5
+  if [ -z "${CLEAN5:-}" ]; then
+    fail_ "N6 setup" "no jq-less PATH from S5"
+  else
+    FN6="$(newtmp)"; mk_p3_fixture "$FN6"; run_p3 "$FN6" "$ARCH/snyk-empty.json" "$SNYKD:$SHIMD:$CLEAN5"
+    l="$(snyk_line)"
+    if printf '%s' "$l" | grep -q "PASS"; then
+      fail_ "N6" "with no jq on PATH the snyk scan read as PASS — an unearned receipt: ${l}"
+    elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -qi "jq is not on PATH"; then
+      pass "N6 — with no jq the snyk scan is FAIL and says jq is not on PATH (not schema drift)"
+    else
+      fail_ "N6" "summary line: ${l:-<none>}"
+    fi
+  fi
 fi
 
 echo "=== U — (b) the UAT solo attestation is announced only when it was recorded ==="
@@ -329,11 +384,35 @@ STATE
   printf '{"project":"p","current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"gates":{}}\n' > "$d/.claude/phase-state.json"
   return 0
 }
-# run_uat <fixture> [checklist] → UAT_OUT, UAT_RC
+# run_uat <fixture> [checklist] [PATH] → UAT_OUT, UAT_RC (the solo-attested path)
 run_uat() {
-  local fx="$1" pc="${2:-$PC}"
-  UAT_OUT="$( cd "$fx" && env SOLO_UAT_SOLO_ATTESTED=1 SOLO_UAT_REASON="bl256-test" bash "$pc" --complete-step uat_session:results_received 2>&1 )"; UAT_RC=$?
+  local fx="$1" pc="${2:-$PC}" path="${3:-$PATH}"
+  UAT_OUT="$( cd "$fx" && env PATH="$path" SOLO_UAT_SOLO_ATTESTED=1 SOLO_UAT_REASON="bl256-test" bash "$pc" --complete-step uat_session:results_received 2>&1 )"; UAT_RC=$?
   return 0
+}
+# run_step <fixture> [checklist] → UAT_OUT, UAT_RC (the NON-solo path: a real
+# submission file is present, so only the general step write is exercised)
+run_step() {
+  local fx="$1" pc="${2:-$PC}"
+  UAT_OUT="$( cd "$fx" && bash "$pc" --complete-step uat_session:results_received 2>&1 )"; UAT_RC=$?
+  return 0
+}
+# mk_mv_shim <dir> — an `mv` that refuses only when its LAST argument ends in
+# process-state.json (so jq succeeds and the rename fails — review round 2 showed
+# this is a portable fixture, not a "same-dir permission split"); everything
+# else is delegated to /bin/mv
+mk_mv_shim() {
+  local d="$1"
+  mkdir -p "$d" || return 1
+  cat > "$d/mv" <<'SHIM'
+#!/bin/sh
+# test shim: refuse to replace process-state.json; delegate everything else
+for last; do :; done
+case "$last" in *process-state.json) echo "mv: simulated failure" >&2; exit 1 ;; esac
+exec /bin/mv "$@"
+SHIM
+  chmod +x "$d/mv"
+  [ -x "$d/mv" ]
 }
 
 U1="$(newtmp)"; mk_uat_fixture "$U1"; run_uat "$U1"
@@ -363,13 +442,61 @@ else
     || fail_ "U2b" "the state file changed under a refused attestation"
 fi
 
+# U3 — jq succeeds, the rename fails: REFUSED, and the .tmp is not left behind
+MVD="$(newtmp)/mvshim"
+if ! mk_mv_shim "$MVD"; then
+  fail_ "U3 setup" "could not build the mv shim"
+else
+  U3="$(newtmp)"; mk_uat_fixture "$U3"
+  before="$(cat "$U3/.claude/process-state.json")"
+  run_uat "$U3" "$PC" "$MVD:$PATH"
+  if printf '%s' "$UAT_OUT" | grep -q "RECORDED"; then
+    fail_ "U3" "the attestation was announced as RECORDED after mv failed — an unearned receipt (rc=$UAT_RC)"
+  elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "REFUSED"; then
+    pass "U3 — with jq succeeding and the rename failing the attestation is REFUSED (rc=$UAT_RC)"
+  else
+    fail_ "U3" "rc=$UAT_RC out: $(printf '%s' "$UAT_OUT" | grep -i 'results_received\|REFUSED' | head -2 | tr '\n' ' ')"
+  fi
+  if [ ! -e "$U3/.claude/process-state.json.tmp" ] && [ "$(cat "$U3/.claude/process-state.json")" = "$before" ]; then
+    pass "U3b — no .tmp is left behind and the state file is byte-identical"
+  else
+    fail_ "U3b" "tmp-left-behind=$([ -e "$U3/.claude/process-state.json.tmp" ] && echo yes || echo no); state-unchanged=$([ "$(cat "$U3/.claude/process-state.json")" = "$before" ] && echo yes || echo no)"
+  fi
+fi
+
+# U4 — the NON-solo path (a real submission file, no attestation): the general
+# step write at the end of complete_step must not announce "completed" when the
+# state file could not be written (review round 2, R2-3)
+U4="$(newtmp)"; mk_uat_fixture "$U4"
+printf 'tester A results\n' > "$U4/tests/uat/sessions/s1/submissions/tester-a.md"
+before="$(cat "$U4/.claude/process-state.json")"
+chmod 555 "$U4/.claude"
+if [ -w "$U4/.claude" ]; then
+  fail_ "U4 setup" ".claude stayed writable after chmod 555 (running as root?)"
+else
+  run_step "$U4"
+  chmod 755 "$U4/.claude"
+  if printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed"; then
+    fail_ "U4" "the step was announced as completed with a read-only .claude/ — an unearned receipt (rc=$UAT_RC)"
+  elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "NOT recorded"; then
+    pass "U4 — with a read-only .claude/ the step completion is refused (rc=$UAT_RC), never announced"
+  else
+    fail_ "U4" "rc=$UAT_RC out: $(printf '%s' "$UAT_OUT" | grep -i 'results_received\|recorded' | head -2 | tr '\n' ' ')"
+  fi
+  [ "$(cat "$U4/.claude/process-state.json")" = "$before" ] \
+    && pass "U4b — and the state file is byte-identical to before" \
+    || fail_ "U4b" "the state file changed under a refused step completion"
+fi
+
 echo "=== M — mutation proofs on a mirror ==="
 
 M_P3="# BL-256-P3-COUNT-RECEIPT"
 M_PN="# BL-256-P3-SNYK-COUNT-RECEIPT"
 M_UR="# BL-256-UAT-ATTEST-RECEIPT"
 M_UF="# BL-256-UAT-ATTEST-REFUSE"
-for pair in "$P3|$M_P3" "$P3|$M_PN" "$PC|$M_UR" "$PC|$M_UF"; do
+M_SR="# BL-256-STEP-RECEIPT"
+M_SF="# BL-256-STEP-REFUSE"
+for pair in "$P3|$M_P3" "$P3|$M_PN" "$PC|$M_UR" "$PC|$M_UF" "$PC|$M_SR" "$PC|$M_SF"; do
   f="${pair%%|*}"; m="${pair#*|}"
   n="$(_sites "$f" "$m")"
   [ "$n" = "1" ] \
@@ -491,6 +618,75 @@ else
     printf '%s' "$l" | grep -q "PASS" \
       && pass "MP5 (MUTATION) — with a presence check, a .vulnerabilities object reads PASS again: N4 is what stops it" \
       || fail_ "MP5 (MUTATION)" "the snyk presence-check mutant did not re-open the defect: ${l:-<none>}"
+  fi
+fi
+
+# MP6 — review round 2's surviving mutant x10: an `if type == "array"` arm that
+# sums `.[]?.vulnerabilities[]?` over a top-level array. N5 must catch it.
+MP6="$(newtmp)/fw"
+if ! mk_mirror "$MP6"; then
+  fail_ "MP6 setup" "could not mirror scripts/"
+else
+  tgt="$MP6/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  sed "s~^.*${M_PN}\$~  findings=\$(jq -e 'if type == \"array\" then ([.[]?.vulnerabilities[]?] | length) elif (.vulnerabilities | type) == \"array\" then (.vulnerabilities | length) else error(\"x\") end' \"\$archive\" 2>/dev/null) || findings=\"\"   ${M_PN}~" "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || ! grep -q 'if type == "array" then (\[\.\[\]?\.vulnerabilities' "$tgt"; then
+    fail_ "MP6 setup" "the top-level-array mutation did not apply cleanly"
+  elif [ -z "${PATH_N:-}" ]; then
+    fail_ "MP6 setup" "no isolated PATH from section N"
+  else
+    FM6="$(newtmp)"; mk_p3_fixture "$FM6"; run_p3 "$FM6" "$ARCH/snyk-toparray.json" "$PATH_N" "$tgt"
+    l="$(snyk_line)"
+    printf '%s' "$l" | grep -q "PASS" \
+      && pass "MP6 (MUTATION) — with a top-level-array arm accepted, the --all-projects shape reads PASS again: N5 is what stops it" \
+      || fail_ "MP6 (MUTATION)" "the top-level-array mutant did not re-open the defect: ${l:-<none>}"
+  fi
+fi
+
+# MU2 — drop the `rm -f "$PROCESS_STATE.tmp"` on the attestation REFUSE path
+# (the line before the marker) on a mirror: U3b must see the .tmp left behind.
+MU2="$(newtmp)/fw"
+if ! mk_mirror "$MU2"; then
+  fail_ "MU2 setup" "could not mirror scripts/"
+else
+  tgt="$MU2/scripts/process-checklist.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  mline="$(grep -n "${M_UF}\$" "$before" | head -1 | cut -d: -f1)"
+  rmline=$(( ${mline:-0} - 1 ))
+  if [ "$rmline" -lt 1 ] || ! sed -n "${rmline}p" "$before" | grep -q 'rm -f "\$PROCESS_STATE.tmp"'; then
+    fail_ "MU2 setup" "the line before the REFUSE marker is not the rm -f"
+  else
+    sed "${rmline}d" "$before" > "$tgt"
+    if [ "$(_changed_lines "$before" "$tgt")" -ne 1 ] || ! bash -n "$tgt" 2>/dev/null; then
+      fail_ "MU2 setup" "the rm -f deletion did not apply cleanly"
+    elif [ -z "${MVD:-}" ]; then
+      fail_ "MU2 setup" "no mv shim from U3"
+    else
+      UM2="$(newtmp)"; mk_uat_fixture "$UM2"
+      run_uat "$UM2" "$tgt" "$MVD:$PATH"
+      [ -e "$UM2/.claude/process-state.json.tmp" ] \
+        && pass "MU2 (MUTATION) — with the rm -f dropped, a failed rename leaves the .tmp behind: U3b is what stops it" \
+        || fail_ "MU2 (MUTATION)" "dropping the rm -f left no .tmp — U3b may be passing for another reason (rc=$UAT_RC)"
+    fi
+  fi
+fi
+
+# MU3 — turn the step-completion REFUSE arm back into the old unconditional
+# receipt on a mirror: U4's read-only case must announce "completed" again.
+MU3="$(newtmp)/fw"
+if ! mk_mirror "$MU3"; then
+  fail_ "MU3 setup" "could not mirror scripts/"
+else
+  tgt="$MU3/scripts/process-checklist.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  sed "s~^.*${M_SF}\$~    print_ok \"Step '\$step_id' completed for \$process (\$new_step_num/\${#steps[@]})\"   ${M_SF}~" "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || [ "$(grep -c "print_ok \"Step '\$step_id' completed for" "$tgt")" -ne 2 ]; then
+    fail_ "MU3 setup" "the step refuse-arm mutation did not apply cleanly"
+  else
+    UM3="$(newtmp)"; mk_uat_fixture "$UM3"
+    printf 'tester A results\n' > "$UM3/tests/uat/sessions/s1/submissions/tester-a.md"
+    chmod 555 "$UM3/.claude"
+    run_step "$UM3" "$tgt"; chmod 755 "$UM3/.claude"
+    printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" \
+      && pass "MU3 (MUTATION) — with the step refuse arm turned back into a receipt, a read-only .claude/ is announced as completed: U4 is what stops it" \
+      || fail_ "MU3 (MUTATION)" "the mutant did not produce the false receipt — U4 may be passing for another reason"
   fi
 fi
 

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -478,6 +478,23 @@ else
   fi
 fi
 
+# U2d — the attestation write's jq half on a WRITABLE dir (review round 4,
+# R4-1): `.solo_attestations` is a string, so `(… // []) + [{…}]` is a jq
+# error; a guard that tolerated it (`; mv`) would rename an EMPTY .tmp over
+# the state file and print RECORDED. rc≠0, REFUSED, byte-identical, no .tmp.
+U2d="$(newtmp)"; mk_uat_fixture "$U2d"
+jq '.uat_session.solo_attestations = "corrupt"' "$U2d/.claude/process-state.json" > "$U2d/.claude/ps.new" && mv "$U2d/.claude/ps.new" "$U2d/.claude/process-state.json"
+before="$(cat "$U2d/.claude/process-state.json")"
+run_uat "$U2d"
+if printf '%s' "$UAT_OUT" | grep -q "RECORDED"; then
+  fail_ "U2d" "announced as RECORDED after jq failed on a corrupt solo_attestations (rc=$UAT_RC, state bytes=$(wc -c < "$U2d/.claude/process-state.json" | tr -d ' '))"
+elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "REFUSED" \
+     && [ "$(cat "$U2d/.claude/process-state.json")" = "$before" ] && [ ! -e "$U2d/.claude/process-state.json.tmp" ]; then
+  pass "U2d — with jq failing on a writable dir the attestation is REFUSED (rc=$UAT_RC), state byte-identical, no .tmp"
+else
+  fail_ "U2d" "rc=$UAT_RC refused=$(printf '%s' "$UAT_OUT" | grep -c REFUSED) tmp=$([ -e "$U2d/.claude/process-state.json.tmp" ] && echo yes || echo no) out: $(printf '%s' "$UAT_OUT" | tail -2 | tr '\n' ' ')"
+fi
+
 # U3 — jq succeeds, the rename fails: REFUSED, and the .tmp is not left behind
 MVD="$(newtmp)/mvshim"
 if ! mk_mv_shim "$MVD"; then
@@ -524,9 +541,11 @@ else
     || fail_ "U4b" "the state file changed under a refused step completion"
 fi
 
-# U4c — the step write's OTHER failure half: jq succeeds, the rename fails
-# (review round 3, R3-1: a guard that covered only jq and tolerated mv
-# announced "completed" at rc 0 and survived 40/0 — U4 only fails the jq half)
+# U4c — the step write's rename half: jq succeeds, the rename fails (review
+# round 3, R3-1: a guard that covered only jq and tolerated mv announced
+# "completed" at rc 0 and survived 40/0). U4 fails BOTH halves at once — the
+# shell cannot even create the .tmp in a read-only dir — so it pins neither
+# half on its own; U4c is the rename-only case and U4e the jq-only case.
 if [ -z "${MVD:-}" ]; then
   fail_ "U4c setup" "no mv shim from U3"
 else
@@ -562,6 +581,26 @@ else
   else
     fail_ "U4d" "rc=$UAT_RC notrec=$(printf '%s' "$UAT_OUT" | grep -c 'NOT recorded') out: $(printf '%s' "$UAT_OUT" | tail -2 | tr '\n' ' ')"
   fi
+fi
+
+# U4e — the step write's jq half on a WRITABLE dir (review round 4, R4-1):
+# `steps_completed` is a STRING carrying the prior names — the prior-step
+# check is jq `index($step)`, a substring search on a string, so it passes,
+# and the write's `+= [$step]` is the first jq to fail. A guard that
+# tolerated it (`> tmp || true && mv`) would rename an EMPTY .tmp over the
+# state file and print "completed": that mutant survived 45/0.
+U4e="$(newtmp)"; mk_uat_fixture "$U4e"
+printf 'tester A results\n' > "$U4e/tests/uat/sessions/s1/submissions/tester-a.md"
+jq '.uat_session.steps_completed = "agents_dispatched template_generated orchestrator_notified"' "$U4e/.claude/process-state.json" > "$U4e/.claude/ps.new" && mv "$U4e/.claude/ps.new" "$U4e/.claude/process-state.json"
+before="$(cat "$U4e/.claude/process-state.json")"
+run_step "$U4e"
+if printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed"; then
+  fail_ "U4e" "announced as completed after jq failed on a corrupt steps_completed (rc=$UAT_RC, state bytes=$(wc -c < "$U4e/.claude/process-state.json" | tr -d ' '))"
+elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "NOT recorded" \
+     && [ "$(cat "$U4e/.claude/process-state.json")" = "$before" ] && [ ! -e "$U4e/.claude/process-state.json.tmp" ]; then
+  pass "U4e — with jq failing on a writable dir the step is refused (rc=$UAT_RC), state byte-identical, no .tmp"
+else
+  fail_ "U4e" "rc=$UAT_RC notrec=$(printf '%s' "$UAT_OUT" | grep -c 'NOT recorded') tmp=$([ -e "$U4e/.claude/process-state.json.tmp" ] && echo yes || echo no) out: $(printf '%s' "$UAT_OUT" | grep -i 'recorded\|completed\|jq' | head -2 | tr '\n' ' ')"
 fi
 
 echo "=== M — mutation proofs on a mirror ==="
@@ -790,6 +829,69 @@ else
       [ "$UAT_RC" -eq 0 ] && printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" \
         && pass "MU4 (MUTATION) — with the guard covering only jq, a failed rename is announced as completed at rc 0: U4c is what stops it" \
         || fail_ "MU4 (MUTATION)" "the jq-only guard did not produce the false receipt (rc=$UAT_RC) — U4c may be passing for another reason"
+    fi
+  fi
+fi
+
+# _mutate_line <src> <dst> <lineno> <literal-pattern> <replacement> — rewrite
+# one line by literal substitution (bash expansion, no sed/awk metachars —
+# the replacements below carry `&&`, `|`, `$` and `"`); returns 1 if the
+# pattern is not on that line
+_mutate_line() {
+  local src="$1" dst="$2" ln="$3" pat="$4" rep="$5" orig mut
+  orig="$(sed -n "${ln}p" "$src")"
+  case "$orig" in *"$pat"*) ;; *) return 1 ;; esac
+  mut="${orig/"$pat"/$rep}"
+  { head -n $((ln - 1)) "$src"; printf '%s\n' "$mut"; tail -n +$((ln + 1)) "$src"; } > "$dst"
+}
+
+# MU5 — review round 4's surviving x1b: the step guard tolerates a jq failure
+# (`> tmp || true && mv`), so a failed jq renames an EMPTY .tmp over the state
+# file and prints the receipt. U4e must catch it.
+MU5="$(newtmp)/fw"
+if ! mk_mirror "$MU5"; then
+  fail_ "MU5 setup" "could not mirror scripts/"
+else
+  tgt="$MU5/scripts/process-checklist.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  mline="$(grep -n "${M_SR}\$" "$before" | head -1 | cut -d: -f1)"
+  gline=$(( ${mline:-0} - 1 ))
+  if [ "$gline" -lt 1 ] || ! _mutate_line "$before" "$tgt" "$gline" '> "$PROCESS_STATE.tmp" && mv' '> "$PROCESS_STATE.tmp" || true && mv' \
+     || [ "$(_changed_lines "$before" "$tgt")" -ne 2 ] || ! bash -n "$tgt" 2>/dev/null; then
+    fail_ "MU5 setup" "the jq-tolerant step-guard mutation did not apply cleanly"
+  else
+    UM5="$(newtmp)"; mk_uat_fixture "$UM5"
+    printf 'tester A results\n' > "$UM5/tests/uat/sessions/s1/submissions/tester-a.md"
+    jq '.uat_session.steps_completed = "agents_dispatched template_generated orchestrator_notified"' "$UM5/.claude/process-state.json" > "$UM5/.claude/ps.new" && mv "$UM5/.claude/ps.new" "$UM5/.claude/process-state.json"
+    run_step "$UM5" "$tgt"
+    if [ "$UAT_RC" -eq 0 ] && printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" && [ ! -s "$UM5/.claude/process-state.json" ]; then
+      pass "MU5 (MUTATION) — with the step guard tolerating jq, a failed jq zero-bytes the state file and is announced as completed: U4e is what stops it"
+    else
+      fail_ "MU5 (MUTATION)" "the jq-tolerant mutant did not produce the false receipt (rc=$UAT_RC, bytes=$(wc -c < "$UM5/.claude/process-state.json" | tr -d ' ')) — U4e may be passing for another reason"
+    fi
+  fi
+fi
+
+# MU6 — round 4's surviving x3: the attestation guard's `&& mv` becomes `; mv`
+# (the if-list's status is mv's), so a failed jq is RECORDED over an empty
+# state file. U2d must catch it.
+MU6="$(newtmp)/fw"
+if ! mk_mirror "$MU6"; then
+  fail_ "MU6 setup" "could not mirror scripts/"
+else
+  tgt="$MU6/scripts/process-checklist.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  mline="$(grep -n "${M_UR}\$" "$before" | head -1 | cut -d: -f1)"
+  gline=$(( ${mline:-0} - 1 ))
+  if [ "$gline" -lt 1 ] || ! _mutate_line "$before" "$tgt" "$gline" '&& mv "$PROCESS_STATE.tmp"' '; mv "$PROCESS_STATE.tmp"' \
+     || [ "$(_changed_lines "$before" "$tgt")" -ne 2 ] || ! bash -n "$tgt" 2>/dev/null; then
+    fail_ "MU6 setup" "the jq-tolerant attestation-guard mutation did not apply cleanly"
+  else
+    UM6="$(newtmp)"; mk_uat_fixture "$UM6"
+    jq '.uat_session.solo_attestations = "corrupt"' "$UM6/.claude/process-state.json" > "$UM6/.claude/ps.new" && mv "$UM6/.claude/ps.new" "$UM6/.claude/process-state.json"
+    run_uat "$UM6" "$tgt"
+    if printf '%s' "$UAT_OUT" | grep -q "RECORDED" && [ ! -s "$UM6/.claude/process-state.json" ]; then
+      pass "MU6 (MUTATION) — with the attestation guard tolerating jq, a failed jq zero-bytes the state file and is announced as RECORDED: U2d is what stops it"
+    else
+      fail_ "MU6 (MUTATION)" "the jq-tolerant mutant did not produce the false receipt (rc=$UAT_RC, bytes=$(wc -c < "$UM6/.claude/process-state.json" | tr -d ' ')) — U2d may be passing for another reason"
     fi
   fi
 fi

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -167,6 +167,32 @@ else
     fail_ "S4" "summary line: ${l:-<none>}"
   fi
 
+  # S6/S7 — `.results` PRESENT but NOT an array. A first cut had no such case,
+  # and a reviewer mutant that weakened the type check to a presence check
+  # (`has("results") and .results != null`) survived 14/0 while re-opening
+  # the defect: `{"results":{}}` counted 0 → PASS, and `{"results":"abcdefgh"}`
+  # counted the STRING'S LENGTH as eight findings.
+  printf '{"results":{},"errors":[]}\n' > "$ARCH/object.json"
+  printf '{"results":"abcdefgh","errors":[]}\n' > "$ARCH/string.json"
+  F6="$(newtmp)"; mk_p3_fixture "$F6"; run_p3 "$F6" "$ARCH/object.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "S6" "a .results that is an OBJECT read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "S6 — a .results that is an object (not an array) is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "S6" "summary line: ${l:-<none>}"
+  fi
+  F7="$(newtmp)"; mk_p3_fixture "$F7"; run_p3 "$F7" "$ARCH/string.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -qE "PASS|[0-9]+ semgrep finding"; then
+    fail_ "S7" "a .results that is a STRING was counted or passed — ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "S7 — a .results that is a string is FAIL and says NOTHING WAS COUNTED (never the string's length)"
+  else
+    fail_ "S7" "summary line: ${l:-<none>}"
+  fi
+
   # S5 — no jq at all must NOT read as 0 findings
   CLEAN5="$(newtmp)/cleanbin"
   if ! mk_cleanbin "$CLEAN5" semgrep snyk docker go-licenses jq; then
@@ -271,6 +297,32 @@ else
     printf '%s' "$l" | grep -q "PASS" \
       && pass "MP1 (MUTATION) — with the old count restored, a renamed key reads as PASS again: S3 is what stops it" \
       || fail_ "MP1 (MUTATION)" "restoring the old count changed nothing — S3 may be passing for another reason: ${l:-<none>}"
+  fi
+fi
+
+# MP2 — weaken the type check to a PRESENCE check on a mirror (the exact
+# mutant that survived a first cut of this suite): S6's object must read PASS
+# and S7's string must be "counted" again.
+MP2="$(newtmp)/fw"
+if ! mk_mirror "$MP2"; then
+  fail_ "MP2 setup" "could not mirror scripts/"
+else
+  tgt="$MP2/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  sed "s~^.*${M_P3}\$~  findings=\$(jq -e 'if has(\"results\") and .results != null then (.results | length) else error(\"x\") end' \"\$archive\" 2>/dev/null) || findings=\"\"   ${M_P3}~" "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || ! grep -q 'has("results") and .results != null' "$tgt"; then
+    fail_ "MP2 setup" "the presence-check mutation did not apply cleanly"
+  elif [ -z "${PATH_S:-}" ]; then
+    fail_ "MP2 setup" "no isolated PATH from section S"
+  else
+    FO="$(newtmp)"; mk_p3_fixture "$FO"; run_p3 "$FO" "$ARCH/object.json" "$PATH_S" "$tgt"
+    lo="$(semgrep_line)"
+    FS="$(newtmp)"; mk_p3_fixture "$FS"; run_p3 "$FS" "$ARCH/string.json" "$PATH_S" "$tgt"
+    ls_="$(semgrep_line)"
+    if printf '%s' "$lo" | grep -q "PASS" && printf '%s' "$ls_" | grep -q "8 semgrep finding"; then
+      pass "MP2 (MUTATION) — with a presence check, an object reads PASS and a string counts its own length: S6/S7 are what stop it"
+    else
+      fail_ "MP2 (MUTATION)" "the presence-check mutant did not re-open the defect — object: ${lo:-<none>} string: ${ls_:-<none>}"
+    fi
   fi
 fi
 

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+# tests/test-bl256-unearned-receipts.sh
+#
+# `## BL-256:` — TWO GATES HANDED OUT RECEIPTS THEY DID NOT EARN.
+#
+#   (a) scripts/run-phase3-validation.sh::_p3_scan_semgrep counted findings as
+#       `jq '(.results | length) // 0' … || echo 0`, then sanitised anything
+#       non-numeric to 0, and 0 meant PASS. A renamed key, an archive that is
+#       not JSON, or a host with no jq: every one read as "0 findings — PASS",
+#       a clean bill of health for a scan nobody could read, in the gate that
+#       decides production release.
+#   (b) scripts/process-checklist.sh's uat_session:results_received solo escape
+#       appended its attestation with `jq … > tmp && mv` and then printed
+#       "attested and RECORDED" unconditionally — a read-only .claude/ left no
+#       record while the operator was told there was one.
+#
+# Both drive the REAL scripts on fixtures. (a) uses a PATH shim `semgrep` that
+# writes a canned archive to --output, on a PATH mirrored from the host MINUS
+# the tools that would otherwise reach the network or the host (real semgrep,
+# snyk, docker, go-licenses) — CLAUDE.md's rule: mirror the real PATH minus the
+# excluded tools, and ASSERT the exclusion before trusting a measurement.
+# (b) runs the checklist against a process-state fixture at the
+# results_received step, once writable and once read-only. Mutants on a MIRROR.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+P3="$REPO_ROOT/scripts/run-phase3-validation.sh"
+PC="$REPO_ROOT/scripts/process-checklist.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+# read-only fixture dirs must be writable again before the trap removes them
+trap 'chmod -R u+w "$TOPTMP" 2>/dev/null; rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+_num() { case "$1" in ''|null|*[!0-9]*) printf '0\n' ;; *) printf '%s\n' "$1" ;; esac }
+_sites() { local n; n=$(grep -c "$2\$" "$1" 2>/dev/null); _num "$n"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); case "$n" in ''|*[!0-9]*) n=0 ;; esac; printf '%s\n' "$n"; }
+
+for f in "$P3" "$PC"; do
+  [ -f "$f" ] || { echo "  [FAIL] setup — $f not found"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
+done
+command -v jq >/dev/null 2>&1 || { echo "  [FAIL] setup — jq is required by this suite"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
+
+# ── PATH mirrors ─────────────────────────────────────────────────────────────
+# mk_cleanbin <dir> <excluded-basenames…> → a dir of symlinks to every
+# executable on the current PATH except the named ones; asserts the exclusion.
+mk_cleanbin() {
+  local d="$1"; shift
+  local ex=" $* " p f b
+  mkdir -p "$d" || return 1
+  local IFS=:
+  for p in $PATH; do
+    [ -d "$p" ] || continue
+    for f in "$p"/*; do
+      [ -x "$f" ] && [ ! -d "$f" ] || continue
+      b="$(basename "$f")"
+      case "$ex" in *" $b "*) continue ;; esac
+      [ -e "$d/$b" ] || ln -s "$f" "$d/$b" 2>/dev/null
+    done
+  done
+  unset IFS
+  for b in "$@"; do
+    if PATH="$d" command -v "$b" >/dev/null 2>&1; then
+      echo "  [FAIL] setup — '$b' is still reachable on the isolated PATH" ; return 1
+    fi
+  done
+  return 0
+}
+
+# mk_semgrep_shim <dir> — a `semgrep` that copies $P3_FAKE_ARCHIVE to --output
+mk_semgrep_shim() {
+  local d="$1"
+  mkdir -p "$d" || return 1
+  cat > "$d/semgrep" <<'SHIM'
+#!/usr/bin/env bash
+# test shim: stands in for semgrep; writes the canned archive to --output
+out=""
+while [ $# -gt 0 ]; do
+  case "$1" in --output) out="$2"; shift 2 ;; *) shift ;; esac
+done
+[ -n "$out" ] || exit 2
+cp "${P3_FAKE_ARCHIVE:?}" "$out"
+exit "${P3_FAKE_RC:-0}"
+SHIM
+  chmod +x "$d/semgrep"
+  [ -x "$d/semgrep" ]
+}
+
+# mk_p3_fixture <dir> — a minimal project the driver can scan
+mk_p3_fixture() {
+  local d="$1"
+  mkdir -p "$d/.claude" "$d/src" "$d/docs" || return 1
+  printf 'console.log(1)\n' > "$d/src/a.js"
+  printf '{"project":"p","current_phase":3,"track":"standard","deployment":"personal","poc_mode":null,"gates":{}}\n' > "$d/.claude/phase-state.json"
+  return 0
+}
+
+# run_p3 <fixture> <archive-json> <PATH> [driver] → sets P3_OUT (stdout+stderr), P3_RC, P3_SUMMARY
+run_p3() {
+  local fx="$1" archive="$2" path="$3" driver="${4:-$P3}" res
+  res="$fx/results"; mkdir -p "$res"
+  P3_OUT="$( cd "$fx" && env PATH="$path" P3_FAKE_ARCHIVE="$archive" bash "$driver" --results-dir "$res" --state "$fx/.claude/phase-state.json" 2>&1 )"; P3_RC=$?
+  P3_SUMMARY="$(ls -t "$res"/summary-*.md 2>/dev/null | head -1)"
+  return 0
+}
+# semgrep_line → the summary's line for the semgrep scanner (label from _p3_label)
+semgrep_line() { grep -m1 'Full-tree Semgrep SAST\|semgrep-full-tree' "${P3_SUMMARY:-/dev/null}" 2>/dev/null; }
+
+echo "=== S — (a) the semgrep count is a receipt only when a .results array was counted ==="
+
+CLEAN="$(newtmp)/cleanbin"
+SHIMD="$(newtmp)/shim"
+if ! mk_cleanbin "$CLEAN" semgrep snyk docker go-licenses; then
+  fail_ "S setup" "could not build the isolated PATH"
+elif ! mk_semgrep_shim "$SHIMD"; then
+  fail_ "S setup" "could not build the semgrep shim"
+else
+  PATH_S="$SHIMD:$CLEAN"
+  [ "$(PATH="$PATH_S" command -v semgrep)" = "$SHIMD/semgrep" ] \
+    && pass "S0 — on the isolated PATH, semgrep resolves to the shim and not the host's" \
+    || fail_ "S0" "semgrep resolves to $(PATH="$PATH_S" command -v semgrep)"
+
+  ARCH="$(newtmp)"
+  printf '{"results":[],"errors":[]}\n' > "$ARCH/empty.json"
+  printf '{"results":[{"check_id":"a"},{"check_id":"b"}],"errors":[]}\n' > "$ARCH/two.json"
+  printf '{"findings":[],"errors":[]}\n' > "$ARCH/renamed.json"
+  printf 'this is not json\n' > "$ARCH/garbage.json"
+
+  # S1 — a real empty result is a PASS
+  F1="$(newtmp)"; mk_p3_fixture "$F1"; run_p3 "$F1" "$ARCH/empty.json" "$PATH_S"
+  l="$(semgrep_line)"
+  printf '%s' "$l" | grep -q "PASS" && printf '%s' "$l" | grep -q "0 findings" \
+    && pass "S1 — an archive with an empty .results array is PASS, 0 findings" \
+    || fail_ "S1" "summary line: ${l:-<none>} (rc=$P3_RC, summary=$P3_SUMMARY)"
+
+  # S2 — two findings is a FAIL that counts them
+  F2="$(newtmp)"; mk_p3_fixture "$F2"; run_p3 "$F2" "$ARCH/two.json" "$PATH_S"
+  l="$(semgrep_line)"
+  printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "2 semgrep finding" \
+    && pass "S2 — an archive with two results is FAIL, '2 semgrep finding(s)'" \
+    || fail_ "S2" "summary line: ${l:-<none>}"
+
+  # S3 — a renamed key must NOT read as 0 findings
+  F3="$(newtmp)"; mk_p3_fixture "$F3"; run_p3 "$F3" "$ARCH/renamed.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "S3" "an archive with NO .results array read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "S3 — an archive with no .results array is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "S3" "summary line: ${l:-<none>}"
+  fi
+
+  # S4 — an unparseable archive must NOT read as 0 findings
+  F4="$(newtmp)"; mk_p3_fixture "$F4"; run_p3 "$F4" "$ARCH/garbage.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "S4" "an unparseable archive read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "S4 — an unparseable archive is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "S4" "summary line: ${l:-<none>}"
+  fi
+
+  # S5 — no jq at all must NOT read as 0 findings
+  CLEAN5="$(newtmp)/cleanbin"
+  if ! mk_cleanbin "$CLEAN5" semgrep snyk docker go-licenses jq; then
+    fail_ "S5 setup" "could not build the jq-less PATH"
+  else
+    F5="$(newtmp)"; mk_p3_fixture "$F5"; run_p3 "$F5" "$ARCH/empty.json" "$SHIMD:$CLEAN5"
+    l="$(semgrep_line)"
+    if printf '%s' "$l" | grep -q "PASS"; then
+      fail_ "S5" "with no jq on PATH the scan read as PASS — an unearned receipt: ${l}"
+    elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -qi "jq is not on PATH"; then
+      pass "S5 — with no jq the scan is FAIL and says the archive could not be counted"
+    else
+      fail_ "S5" "summary line: ${l:-<none>}"
+    fi
+  fi
+fi
+
+echo "=== U — (b) the UAT solo attestation is announced only when it was recorded ==="
+
+# mk_uat_fixture <dir> — process-state at the results_received step, Light track
+mk_uat_fixture() {
+  local d="$1"
+  mkdir -p "$d/.claude" "$d/tests/uat/sessions/s1/submissions" || return 1
+  cat > "$d/.claude/process-state.json" <<'STATE'
+{
+  "build_loop": {"feature": null, "step": 0, "steps_completed": [], "started_at": null},
+  "uat_session": {"session_id": "s1", "step": 3, "steps_completed": ["agents_dispatched","template_generated","orchestrator_notified"], "started_at": "2026-09-08T00:00:00Z"},
+  "phase1_architecture": {"steps_completed": [], "started_at": null},
+  "phase3_validation": {"steps_completed": [], "started_at": null}
+}
+STATE
+  printf '{"project":"p","current_phase":2,"track":"light","deployment":"personal","poc_mode":null,"gates":{}}\n' > "$d/.claude/phase-state.json"
+  return 0
+}
+# run_uat <fixture> [checklist] → UAT_OUT, UAT_RC
+run_uat() {
+  local fx="$1" pc="${2:-$PC}"
+  UAT_OUT="$( cd "$fx" && env SOLO_UAT_SOLO_ATTESTED=1 SOLO_UAT_REASON="bl256-test" bash "$pc" --complete-step uat_session:results_received 2>&1 )"; UAT_RC=$?
+  return 0
+}
+
+U1="$(newtmp)"; mk_uat_fixture "$U1"; run_uat "$U1"
+if printf '%s' "$UAT_OUT" | grep -q "RECORDED" && jq -e '.uat_session.solo_attestations[0].reason == "bl256-test"' "$U1/.claude/process-state.json" >/dev/null 2>&1; then
+  pass "U1 — with a writable state file the attestation is recorded AND announced (rc=$UAT_RC)"
+else
+  fail_ "U1" "rc=$UAT_RC; recorded=$(jq -c '.uat_session.solo_attestations' "$U1/.claude/process-state.json" 2>/dev/null); out: $(printf '%s' "$UAT_OUT" | grep -i 'results_received' | head -2 | tr '\n' ' ')"
+fi
+
+U2="$(newtmp)"; mk_uat_fixture "$U2"
+before="$(cat "$U2/.claude/process-state.json")"
+chmod 555 "$U2/.claude"
+if [ -w "$U2/.claude" ]; then
+  fail_ "U2 setup" ".claude stayed writable after chmod 555 (running as root?) — the read-only case cannot be measured"
+else
+  run_uat "$U2"
+  chmod 755 "$U2/.claude"
+  if printf '%s' "$UAT_OUT" | grep -q "RECORDED"; then
+    fail_ "U2" "the attestation was announced as RECORDED with a read-only .claude/ — an unearned receipt (rc=$UAT_RC)"
+  elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "REFUSED"; then
+    pass "U2 — with a read-only .claude/ the attestation is REFUSED (rc=$UAT_RC), never announced"
+  else
+    fail_ "U2" "rc=$UAT_RC out: $(printf '%s' "$UAT_OUT" | grep -i 'results_received\|REFUSED' | head -2 | tr '\n' ' ')"
+  fi
+  [ "$(cat "$U2/.claude/process-state.json")" = "$before" ] \
+    && pass "U2b — and the state file is byte-identical to before" \
+    || fail_ "U2b" "the state file changed under a refused attestation"
+fi
+
+echo "=== M — mutation proofs on a mirror ==="
+
+M_P3="# BL-256-P3-COUNT-RECEIPT"
+M_UR="# BL-256-UAT-ATTEST-RECEIPT"
+M_UF="# BL-256-UAT-ATTEST-REFUSE"
+for pair in "$P3|$M_P3" "$PC|$M_UR" "$PC|$M_UF"; do
+  f="${pair%%|*}"; m="${pair#*|}"
+  n="$(_sites "$f" "$m")"
+  [ "$n" = "1" ] \
+    && pass "M0 — '$m' occurs exactly once at end-of-line in $(basename "$f")" \
+    || fail_ "M0" "'$m' occurs $n times in $(basename "$f") (need exactly 1)"
+done
+
+mk_mirror() { local m="$1"; mkdir -p "$m" && cp -Rp "$REPO_ROOT/scripts" "$m/"; }
+
+# MP1 — restore the old count (`// 0` + `|| echo 0`) on a mirror: S3's renamed
+# key must read as PASS again.
+MP1="$(newtmp)/fw"
+if ! mk_mirror "$MP1"; then
+  fail_ "MP1 setup" "could not mirror scripts/"
+else
+  tgt="$MP1/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  # `~` is the delimiter because the marker carries `#` and the replacement
+  # carries `|` and `/` — CLAUDE.md's sed trap, hit on the first cut of this
+  # very line (the mutation "did not apply cleanly" was sed refusing it).
+  sed "s~^.*${M_P3}\$~  findings=\$(jq '(.results | length) // 0' \"\$archive\" 2>/dev/null || echo 0)   ${M_P3}~" "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || ! grep -q "(.results | length) // 0" "$tgt"; then
+    fail_ "MP1 setup" "the count mutation did not apply cleanly"
+  elif [ -z "${PATH_S:-}" ]; then
+    fail_ "MP1 setup" "no isolated PATH from section S"
+  else
+    FM="$(newtmp)"; mk_p3_fixture "$FM"; run_p3 "$FM" "$ARCH/renamed.json" "$PATH_S" "$tgt"
+    l="$(semgrep_line)"
+    printf '%s' "$l" | grep -q "PASS" \
+      && pass "MP1 (MUTATION) — with the old count restored, a renamed key reads as PASS again: S3 is what stops it" \
+      || fail_ "MP1 (MUTATION)" "restoring the old count changed nothing — S3 may be passing for another reason: ${l:-<none>}"
+  fi
+fi
+
+# MU1 — turn the REFUSE arm back into the old unconditional receipt on a
+# mirror: U2's read-only case must be announced as RECORDED again.
+MU1="$(newtmp)/fw"
+if ! mk_mirror "$MU1"; then
+  fail_ "MU1 setup" "could not mirror scripts/"
+else
+  tgt="$MU1/scripts/process-checklist.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  # `~` as the delimiter: the marker carries `#` (see MP1)
+  sed "s~^.*${M_UF}\$~          print_ok \"results_received: SOLO-MODE attested and RECORDED (reason: \$uat_reason) — no external submissions required.\"   ${M_UF}~" "$before" > "$tgt"
+  # count print_ok LINES, not the phrase — the fix's own comment quotes it
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || [ "$(grep -c 'print_ok "results_received: SOLO-MODE attested and RECORDED' "$tgt")" -ne 2 ]; then
+    fail_ "MU1 setup" "the refuse-arm mutation did not apply cleanly"
+  else
+    UM="$(newtmp)"; mk_uat_fixture "$UM"; chmod 555 "$UM/.claude"
+    run_uat "$UM" "$tgt"; chmod 755 "$UM/.claude"
+    printf '%s' "$UAT_OUT" | grep -q "RECORDED" \
+      && pass "MU1 (MUTATION) — with the refuse arm turned back into a receipt, a read-only .claude/ is announced as RECORDED: U2 is what stops it" \
+      || fail_ "MU1 (MUTATION)" "the mutant did not produce the false receipt — U2 may be passing for another reason"
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0
+exit 1

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -800,10 +800,17 @@ else
     UM3="$(newtmp)"; mk_uat_fixture "$UM3"
     printf 'tester A results\n' > "$UM3/tests/uat/sessions/s1/submissions/tester-a.md"
     chmod 555 "$UM3/.claude"
+    # review round 6, R6-3: as root `chmod 555` does not bite and this case
+    # passes VACUOUSLY while its text claims "a read-only .claude/"
+    if [ -w "$UM3/.claude" ]; then
+      chmod 755 "$UM3/.claude"
+      fail_ "MU3 setup" ".claude stayed writable after chmod 555 (running as root?) — the read-only case cannot be measured"
+    else
     run_step "$UM3" "$tgt"; chmod 755 "$UM3/.claude"
     printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" \
       && pass "MU3 (MUTATION) — with the step refuse arm turned back into a receipt, a read-only .claude/ is announced as completed: U4 is what stops it" \
       || fail_ "MU3 (MUTATION)" "the mutant did not produce the false receipt — U4 may be passing for another reason"
+    fi
   fi
 fi
 
@@ -929,10 +936,17 @@ else
     fail_ "MU1 setup" "the refuse-arm mutation did not apply cleanly"
   else
     UM="$(newtmp)"; mk_uat_fixture "$UM"; chmod 555 "$UM/.claude"
+    # review round 6, R6-3: as root `chmod 555` does not bite and this case
+    # passes VACUOUSLY while its text claims "a read-only .claude/"
+    if [ -w "$UM/.claude" ]; then
+      chmod 755 "$UM/.claude"
+      fail_ "MU1 setup" ".claude stayed writable after chmod 555 (running as root?) — the read-only case cannot be measured"
+    else
     run_uat "$UM" "$tgt"; chmod 755 "$UM/.claude"
     printf '%s' "$UAT_OUT" | grep -q "RECORDED" \
       && pass "MU1 (MUTATION) — with the refuse arm turned back into a receipt, a read-only .claude/ is announced as RECORDED: U2 is what stops it" \
       || fail_ "MU1 (MUTATION)" "the mutant did not produce the false receipt — U2 may be passing for another reason"
+    fi
   fi
 fi
 

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -393,8 +393,8 @@ run_uat() {
 # run_step <fixture> [checklist] → UAT_OUT, UAT_RC (the NON-solo path: a real
 # submission file is present, so only the general step write is exercised)
 run_step() {
-  local fx="$1" pc="${2:-$PC}"
-  UAT_OUT="$( cd "$fx" && bash "$pc" --complete-step uat_session:results_received 2>&1 )"; UAT_RC=$?
+  local fx="$1" pc="${2:-$PC}" path="${3:-$PATH}"
+  UAT_OUT="$( cd "$fx" && env PATH="$path" bash "$pc" --complete-step uat_session:results_received 2>&1 )"; UAT_RC=$?
   return 0
 }
 # mk_mv_shim <dir> — an `mv` that refuses only when its LAST argument ends in
@@ -422,6 +422,19 @@ else
   fail_ "U1" "rc=$UAT_RC; recorded=$(jq -c '.uat_session.solo_attestations' "$U1/.claude/process-state.json" 2>/dev/null); out: $(printf '%s' "$UAT_OUT" | grep -i 'results_received' | head -2 | tr '\n' ' ')"
 fi
 
+# U1b — the healthy NON-solo path: the step write lands and is announced (the
+# control for U4/U4c — without it a guard that refuses EVERY completion would
+# pass this suite; review round 3, R3-3)
+U1b="$(newtmp)"; mk_uat_fixture "$U1b"
+printf 'tester A results\n' > "$U1b/tests/uat/sessions/s1/submissions/tester-a.md"
+run_step "$U1b"
+if [ "$UAT_RC" -eq 0 ] && printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" \
+   && [ "$(jq -r '.uat_session.steps_completed | length' "$U1b/.claude/process-state.json" 2>/dev/null)" = "4" ]; then
+  pass "U1b — on the healthy non-solo path the step is recorded (4 steps) AND announced (rc=0)"
+else
+  fail_ "U1b" "rc=$UAT_RC steps=$(jq -c '.uat_session.steps_completed' "$U1b/.claude/process-state.json" 2>/dev/null); out: $(printf '%s' "$UAT_OUT" | grep -i 'results_received' | head -2 | tr '\n' ' ')"
+fi
+
 U2="$(newtmp)"; mk_uat_fixture "$U2"
 before="$(cat "$U2/.claude/process-state.json")"
 chmod 555 "$U2/.claude"
@@ -440,6 +453,29 @@ else
   [ "$(cat "$U2/.claude/process-state.json")" = "$before" ] \
     && pass "U2b — and the state file is byte-identical to before" \
     || fail_ "U2b" "the state file changed under a refused attestation"
+fi
+
+# U2c — a STALE .tmp (crash mid-write) inside a .claude/ that is now read-only:
+# jq's redirect into the writable file succeeds, mv fails, and the rm -f of
+# the .tmp fails too — under set -e that rm used to exit the script BEFORE
+# the refusal was printed (review round 3, R3-2). rc was honest; the text
+# was missing.
+U2c="$(newtmp)"; mk_uat_fixture "$U2c"
+printf '{"stale":true}\n' > "$U2c/.claude/process-state.json.tmp"
+before="$(cat "$U2c/.claude/process-state.json")"
+chmod 555 "$U2c/.claude"
+if [ -w "$U2c/.claude" ]; then
+  fail_ "U2c setup" ".claude stayed writable after chmod 555 (running as root?)"
+else
+  run_uat "$U2c"
+  chmod 755 "$U2c/.claude"
+  if printf '%s' "$UAT_OUT" | grep -q "RECORDED"; then
+    fail_ "U2c" "announced as RECORDED with a stale .tmp in a read-only .claude/ (rc=$UAT_RC)"
+  elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "REFUSED" && [ "$(cat "$U2c/.claude/process-state.json")" = "$before" ]; then
+    pass "U2c — with a stale .tmp in a read-only .claude/ the refusal is still PRINTED (rc=$UAT_RC), state unchanged"
+  else
+    fail_ "U2c" "rc=$UAT_RC refused=$(printf '%s' "$UAT_OUT" | grep -c REFUSED) out: $(printf '%s' "$UAT_OUT" | tail -2 | tr '\n' ' ')"
+  fi
 fi
 
 # U3 — jq succeeds, the rename fails: REFUSED, and the .tmp is not left behind
@@ -486,6 +522,46 @@ else
   [ "$(cat "$U4/.claude/process-state.json")" = "$before" ] \
     && pass "U4b — and the state file is byte-identical to before" \
     || fail_ "U4b" "the state file changed under a refused step completion"
+fi
+
+# U4c — the step write's OTHER failure half: jq succeeds, the rename fails
+# (review round 3, R3-1: a guard that covered only jq and tolerated mv
+# announced "completed" at rc 0 and survived 40/0 — U4 only fails the jq half)
+if [ -z "${MVD:-}" ]; then
+  fail_ "U4c setup" "no mv shim from U3"
+else
+  U4c="$(newtmp)"; mk_uat_fixture "$U4c"
+  printf 'tester A results\n' > "$U4c/tests/uat/sessions/s1/submissions/tester-a.md"
+  before="$(cat "$U4c/.claude/process-state.json")"
+  run_step "$U4c" "$PC" "$MVD:$PATH"
+  if printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed"; then
+    fail_ "U4c" "the step was announced as completed after mv failed — an unearned receipt (rc=$UAT_RC)"
+  elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "NOT recorded" \
+       && [ "$(cat "$U4c/.claude/process-state.json")" = "$before" ] && [ ! -e "$U4c/.claude/process-state.json.tmp" ]; then
+    pass "U4c — with jq succeeding and the rename failing the step is refused (rc=$UAT_RC), state unchanged, no .tmp"
+  else
+    fail_ "U4c" "rc=$UAT_RC tmp=$([ -e "$U4c/.claude/process-state.json.tmp" ] && echo yes || echo no) out: $(printf '%s' "$UAT_OUT" | grep -i 'recorded\|completed' | head -2 | tr '\n' ' ')"
+  fi
+fi
+
+# U4d — the stale-.tmp + read-only case on the STEP arm (R3-2, step half)
+U4d="$(newtmp)"; mk_uat_fixture "$U4d"
+printf 'tester A results\n' > "$U4d/tests/uat/sessions/s1/submissions/tester-a.md"
+printf '{"stale":true}\n' > "$U4d/.claude/process-state.json.tmp"
+before="$(cat "$U4d/.claude/process-state.json")"
+chmod 555 "$U4d/.claude"
+if [ -w "$U4d/.claude" ]; then
+  fail_ "U4d setup" ".claude stayed writable after chmod 555 (running as root?)"
+else
+  run_step "$U4d"
+  chmod 755 "$U4d/.claude"
+  if printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed"; then
+    fail_ "U4d" "announced as completed with a stale .tmp in a read-only .claude/ (rc=$UAT_RC)"
+  elif [ "$UAT_RC" -ne 0 ] && printf '%s' "$UAT_OUT" | grep -q "NOT recorded" && [ "$(cat "$U4d/.claude/process-state.json")" = "$before" ]; then
+    pass "U4d — with a stale .tmp in a read-only .claude/ the step refusal is still PRINTED (rc=$UAT_RC), state unchanged"
+  else
+    fail_ "U4d" "rc=$UAT_RC notrec=$(printf '%s' "$UAT_OUT" | grep -c 'NOT recorded') out: $(printf '%s' "$UAT_OUT" | tail -2 | tr '\n' ' ')"
+  fi
 fi
 
 echo "=== M — mutation proofs on a mirror ==="
@@ -687,6 +763,34 @@ else
     printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" \
       && pass "MU3 (MUTATION) — with the step refuse arm turned back into a receipt, a read-only .claude/ is announced as completed: U4 is what stops it" \
       || fail_ "MU3 (MUTATION)" "the mutant did not produce the false receipt — U4 may be passing for another reason"
+  fi
+fi
+
+# MU4 — review round 3's surviving m5: the step guard covers only jq and
+# tolerates a failed mv (`mv … || true` on its own line). U4c must catch it.
+MU4="$(newtmp)/fw"
+if ! mk_mirror "$MU4"; then
+  fail_ "MU4 setup" "could not mirror scripts/"
+else
+  tgt="$MU4/scripts/process-checklist.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  mline="$(grep -n "${M_SR}\$" "$before" | head -1 | cut -d: -f1)"
+  gline=$(( ${mline:-0} - 1 ))
+  if [ "$gline" -lt 1 ] || ! sed -n "${gline}p" "$before" | grep -qF '&& mv "$PROCESS_STATE.tmp" "$PROCESS_STATE"; then'; then
+    fail_ "MU4 setup" "the line before the STEP-RECEIPT marker is not the guarded write"
+  else
+    awk -v L="$gline" 'NR==L { sub(/ && mv "\$PROCESS_STATE\.tmp" "\$PROCESS_STATE"; then/, "; then"); print; print "    mv \"$PROCESS_STATE.tmp\" \"$PROCESS_STATE\" 2>/dev/null || true"; next } { print }' "$before" > "$tgt"
+    if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || [ "$(grep -cF 'mv "$PROCESS_STATE.tmp" "$PROCESS_STATE" 2>/dev/null || true' "$tgt")" -ne 1 ]; then
+      fail_ "MU4 setup" "the jq-only-guard mutation did not apply cleanly"
+    elif [ -z "${MVD:-}" ]; then
+      fail_ "MU4 setup" "no mv shim from U3"
+    else
+      UM4="$(newtmp)"; mk_uat_fixture "$UM4"
+      printf 'tester A results\n' > "$UM4/tests/uat/sessions/s1/submissions/tester-a.md"
+      run_step "$UM4" "$tgt" "$MVD:$PATH"
+      [ "$UAT_RC" -eq 0 ] && printf '%s' "$UAT_OUT" | grep -q "Step 'results_received' completed" \
+        && pass "MU4 (MUTATION) — with the guard covering only jq, a failed rename is announced as completed at rc 0: U4c is what stops it" \
+        || fail_ "MU4 (MUTATION)" "the jq-only guard did not produce the false receipt (rc=$UAT_RC) — U4c may be passing for another reason"
+    fi
   fi
 fi
 

--- a/tests/test-bl256-unearned-receipts.sh
+++ b/tests/test-bl256-unearned-receipts.sh
@@ -8,7 +8,9 @@
 #       non-numeric to 0, and 0 meant PASS. A renamed key, an archive that is
 #       not JSON, or a host with no jq: every one read as "0 findings — PASS",
 #       a clean bill of health for a scan nobody could read, in the gate that
-#       decides production release.
+#       decides production release. `_p3_scan_snyk`, one function below, carried
+#       the identical count (`.vulnerabilities`, `// 0`, `|| echo 0`, sanitise to
+#       0) — the reviewer's R-3 — and is covered by section N with its own shim.
 #   (b) scripts/process-checklist.sh's uat_session:results_received solo escape
 #       appended its attestation with `jq … > tmp && mv` and then printed
 #       "attested and RECORDED" unconditionally — a read-only .claude/ left no
@@ -91,6 +93,25 @@ SHIM
   [ -x "$d/semgrep" ]
 }
 
+# mk_snyk_shim <dir> — a `snyk` that answers `config get api` with a token and
+# `test --json` with $P3_FAKE_ARCHIVE on stdout (the driver redirects stdout
+# into its archive); anything else is an execution error
+mk_snyk_shim() {
+  local d="$1"
+  mkdir -p "$d" || return 1
+  cat > "$d/snyk" <<'SHIM'
+#!/usr/bin/env bash
+# test shim: stands in for snyk
+case "$*" in
+  "config get api") printf 'shim-token\n'; exit 0 ;;
+  "test --json")    cat "${P3_FAKE_ARCHIVE:?}"; exit "${P3_FAKE_RC:-0}" ;;
+  *)                exit 2 ;;
+esac
+SHIM
+  chmod +x "$d/snyk"
+  [ -x "$d/snyk" ]
+}
+
 # mk_p3_fixture <dir> — a minimal project the driver can scan
 mk_p3_fixture() {
   local d="$1"
@@ -110,6 +131,8 @@ run_p3() {
 }
 # semgrep_line → the summary's line for the semgrep scanner (label from _p3_label)
 semgrep_line() { grep -m1 'Full-tree Semgrep SAST\|semgrep-full-tree' "${P3_SUMMARY:-/dev/null}" 2>/dev/null; }
+# snyk_line → the summary's line for the snyk scanner (label from _p3_label)
+snyk_line() { grep -m1 '^| snyk |\|Snyk dependency scan' "${P3_SUMMARY:-/dev/null}" 2>/dev/null; }
 
 echo "=== S — (a) the semgrep count is a receipt only when a .results array was counted ==="
 
@@ -193,6 +216,22 @@ else
     fail_ "S7" "summary line: ${l:-<none>}"
   fi
 
+  # S8 — a MULTI-DOCUMENT archive (two JSON documents concatenated). jq emits
+  # one count per document, so `findings` becomes "0\n0": the `*[!0-9]*`
+  # sanitiser arm is the only thing between that and `[ "0\n0" -gt 0 ]`
+  # erroring into the PASS branch (the driver is deliberately not set -e).
+  # A reviewer mutant that dropped that arm survived 17/0; MP3 pins it.
+  printf '{"results":[],"errors":[]}\n{"results":[],"errors":[]}\n' > "$ARCH/multidoc.json"
+  F8="$(newtmp)"; mk_p3_fixture "$F8"; run_p3 "$F8" "$ARCH/multidoc.json" "$PATH_S"
+  l="$(semgrep_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "S8" "a two-document archive read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "S8 — a multi-document archive is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "S8" "summary line: ${l:-<none>}"
+  fi
+
   # S5 — no jq at all must NOT read as 0 findings
   CLEAN5="$(newtmp)/cleanbin"
   if ! mk_cleanbin "$CLEAN5" semgrep snyk docker go-licenses jq; then
@@ -207,6 +246,69 @@ else
     else
       fail_ "S5" "summary line: ${l:-<none>}"
     fi
+  fi
+fi
+
+echo "=== N — (a) again for snyk: the count is a receipt only when a .vulnerabilities array was counted ==="
+# The reviewer's R-3: `_p3_scan_snyk` carried the identical count one function
+# below the semgrep arm. Same drive: a `snyk` shim on the isolated PATH that
+# answers `config get api` with a token and `test --json` with the canned
+# report on stdout. The semgrep shim stays on the PATH and reads the same
+# report (its line says NOTHING WAS COUNTED — only the snyk line is read here).
+SNYKD="$(newtmp)/snykshim"
+if [ -z "${PATH_S:-}" ] || [ -z "${ARCH:-}" ]; then
+  fail_ "N setup" "no isolated PATH from section S"
+elif ! mk_snyk_shim "$SNYKD"; then
+  fail_ "N setup" "could not build the snyk shim"
+else
+  PATH_N="$SNYKD:$PATH_S"
+  [ "$(PATH="$PATH_N" command -v snyk)" = "$SNYKD/snyk" ] \
+    && pass "N0 — on the isolated PATH, snyk resolves to the shim and not the host's" \
+    || fail_ "N0" "snyk resolves to $(PATH="$PATH_N" command -v snyk)"
+
+  printf '{"ok":true,"vulnerabilities":[],"dependencyCount":3}\n' > "$ARCH/snyk-empty.json"
+  printf '{"ok":false,"vulnerabilities":[{"id":"a"},{"id":"b"}],"dependencyCount":3}\n' > "$ARCH/snyk-two.json"
+  printf '{"ok":true,"issues":[],"dependencyCount":3}\n' > "$ARCH/snyk-renamed.json"
+  printf '{"ok":true,"vulnerabilities":{},"dependencyCount":3}\n' > "$ARCH/snyk-object.json"
+
+  # N1 — a real empty array is a PASS (the honest-outcome control)
+  FN1="$(newtmp)"; mk_p3_fixture "$FN1"; run_p3 "$FN1" "$ARCH/snyk-empty.json" "$PATH_N"
+  l="$(snyk_line)"
+  if printf '%s' "$l" | grep -q "PASS" && printf '%s' "$l" | grep -q "0 vulnerabilities"; then
+    pass "N1 — a report with an empty .vulnerabilities array is PASS, 0 vulnerabilities"
+  else
+    fail_ "N1" "summary line: ${l:-<none>}"
+  fi
+
+  # N2 — two vulnerabilities is FAIL with the count
+  FN2="$(newtmp)"; mk_p3_fixture "$FN2"; run_p3 "$FN2" "$ARCH/snyk-two.json" "$PATH_N"
+  l="$(snyk_line)"
+  if printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "2 snyk vulnerability finding"; then
+    pass "N2 — a report with two vulnerabilities is FAIL, '2 snyk vulnerability finding(s)'"
+  else
+    fail_ "N2" "summary line: ${l:-<none>}"
+  fi
+
+  # N3 — a renamed key (no .vulnerabilities) must NOT read as 0
+  FN3="$(newtmp)"; mk_p3_fixture "$FN3"; run_p3 "$FN3" "$ARCH/snyk-renamed.json" "$PATH_N"
+  l="$(snyk_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "N3" "a report with no .vulnerabilities key read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "N3 — a report with no .vulnerabilities array is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "N3" "summary line: ${l:-<none>}"
+  fi
+
+  # N4 — a .vulnerabilities that is present but an OBJECT must not count as 0
+  FN4="$(newtmp)"; mk_p3_fixture "$FN4"; run_p3 "$FN4" "$ARCH/snyk-object.json" "$PATH_N"
+  l="$(snyk_line)"
+  if printf '%s' "$l" | grep -q "PASS"; then
+    fail_ "N4" "a .vulnerabilities object read as PASS — an unearned receipt: ${l}"
+  elif printf '%s' "$l" | grep -q "FAIL" && printf '%s' "$l" | grep -q "NOTHING WAS COUNTED"; then
+    pass "N4 — a .vulnerabilities that is an object (not an array) is FAIL and says NOTHING WAS COUNTED"
+  else
+    fail_ "N4" "summary line: ${l:-<none>}"
   fi
 fi
 
@@ -264,9 +366,10 @@ fi
 echo "=== M — mutation proofs on a mirror ==="
 
 M_P3="# BL-256-P3-COUNT-RECEIPT"
+M_PN="# BL-256-P3-SNYK-COUNT-RECEIPT"
 M_UR="# BL-256-UAT-ATTEST-RECEIPT"
 M_UF="# BL-256-UAT-ATTEST-REFUSE"
-for pair in "$P3|$M_P3" "$PC|$M_UR" "$PC|$M_UF"; do
+for pair in "$P3|$M_P3" "$P3|$M_PN" "$PC|$M_UR" "$PC|$M_UF"; do
   f="${pair%%|*}"; m="${pair#*|}"
   n="$(_sites "$f" "$m")"
   [ "$n" = "1" ] \
@@ -323,6 +426,71 @@ else
     else
       fail_ "MP2 (MUTATION)" "the presence-check mutant did not re-open the defect — object: ${lo:-<none>} string: ${ls_:-<none>}"
     fi
+  fi
+fi
+
+# MP3 — drop the `*[!0-9]*` sanitiser alternative on a mirror: S8's
+# two-document archive must read PASS again. The case line is the one after
+# the marked jq line; it is located by its own literal, not by the marker.
+MP3="$(newtmp)/fw"
+if ! mk_mirror "$MP3"; then
+  fail_ "MP3 setup" "could not mirror scripts/"
+else
+  tgt="$MP3/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  # only the semgrep arm's sanitiser — the first `''|*[!0-9]*)` AFTER the marker line
+  awk -v mark="$M_P3" 'index($0, mark) {seen=1} seen && !done && /^[[:space:]]*'"'"''"'"'\|\*\[!0-9\]\*\)/ {sub(/'"'"''"'"'\|\*\[!0-9\]\*\)/, "'"'"''"'"')"); done=1} {print}' "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null; then
+    fail_ "MP3 setup" "the sanitiser mutation did not apply cleanly"
+  elif [ -z "${PATH_S:-}" ]; then
+    fail_ "MP3 setup" "no isolated PATH from section S"
+  else
+    FM3="$(newtmp)"; mk_p3_fixture "$FM3"; run_p3 "$FM3" "$ARCH/multidoc.json" "$PATH_S" "$tgt"
+    l="$(semgrep_line)"
+    printf '%s' "$l" | grep -q "PASS" \
+      && pass "MP3 (MUTATION) — with the sanitiser arm dropped, a two-document archive reads PASS again: S8 is what stops it" \
+      || fail_ "MP3 (MUTATION)" "dropping the sanitiser arm changed nothing — S8 may be passing for another reason: ${l:-<none>}"
+  fi
+fi
+
+# MP4 — restore the old snyk count (`// 0` + `|| echo 0`) on a mirror: N3's
+# renamed key must read as PASS again.
+MP4="$(newtmp)/fw"
+if ! mk_mirror "$MP4"; then
+  fail_ "MP4 setup" "could not mirror scripts/"
+else
+  tgt="$MP4/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  sed "s~^.*${M_PN}\$~  findings=\$(jq '(.vulnerabilities | length) // 0' \"\$archive\" 2>/dev/null || echo 0)   ${M_PN}~" "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || ! grep -q "(.vulnerabilities | length) // 0" "$tgt"; then
+    fail_ "MP4 setup" "the snyk count mutation did not apply cleanly"
+  elif [ -z "${PATH_N:-}" ]; then
+    fail_ "MP4 setup" "no isolated PATH from section N"
+  else
+    FM4="$(newtmp)"; mk_p3_fixture "$FM4"; run_p3 "$FM4" "$ARCH/snyk-renamed.json" "$PATH_N" "$tgt"
+    l="$(snyk_line)"
+    printf '%s' "$l" | grep -q "PASS" \
+      && pass "MP4 (MUTATION) — with the old snyk count restored, a renamed key reads as PASS again: N3 is what stops it" \
+      || fail_ "MP4 (MUTATION)" "restoring the old snyk count changed nothing — N3 may be passing for another reason: ${l:-<none>}"
+  fi
+fi
+
+# MP5 — weaken the snyk type check to a PRESENCE check on a mirror: N4's object
+# must read PASS again.
+MP5="$(newtmp)/fw"
+if ! mk_mirror "$MP5"; then
+  fail_ "MP5 setup" "could not mirror scripts/"
+else
+  tgt="$MP5/scripts/run-phase3-validation.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  sed "s~^.*${M_PN}\$~  findings=\$(jq -e 'if has(\"vulnerabilities\") and .vulnerabilities != null then (.vulnerabilities | length) else error(\"x\") end' \"\$archive\" 2>/dev/null) || findings=\"\"   ${M_PN}~" "$before" > "$tgt"
+  if [ "$(_changed_lines "$before" "$tgt")" -lt 2 ] || ! bash -n "$tgt" 2>/dev/null || ! grep -q 'has("vulnerabilities") and .vulnerabilities != null' "$tgt"; then
+    fail_ "MP5 setup" "the snyk presence-check mutation did not apply cleanly"
+  elif [ -z "${PATH_N:-}" ]; then
+    fail_ "MP5 setup" "no isolated PATH from section N"
+  else
+    FM5="$(newtmp)"; mk_p3_fixture "$FM5"; run_p3 "$FM5" "$ARCH/snyk-object.json" "$PATH_N" "$tgt"
+    l="$(snyk_line)"
+    printf '%s' "$l" | grep -q "PASS" \
+      && pass "MP5 (MUTATION) — with a presence check, a .vulnerabilities object reads PASS again: N4 is what stops it" \
+      || fail_ "MP5 (MUTATION)" "the snyk presence-check mutant did not re-open the defect: ${l:-<none>}"
   fi
 fi
 


### PR DESCRIPTION
Four shipped receipts were printed without the thing they attest to having happened. All four are instances of the rule this repo already spells out at `# BL-182-NO-UNEARNED-RECEIPT` and `# BL-112-SAST-NOTRUN`: a check that did not run, or whose result could not be read, must never read as a clean one.

**Counts that could not be taken read as zero.** `_p3_scan_semgrep` counted findings as `jq '(.results | length) // 0' … || echo 0` and sanitised anything non-numeric to 0, and `0 → PASS`. A renamed key on a future semgrep major, an archive that is not JSON, two concatenated documents, or a host with no `jq` at all: every one produced `PASS — 0 findings (full-tree --config auto)`, a clean bill of health for a scan nobody could read, in the Phase-3 gate that decides production release. `_p3_scan_snyk`, one function below, carried the identical count on `.vulnerabilities`.

**Records that were not written read as recorded.** `process-checklist.sh`'s Light/solo UAT escape appended its attestation with `jq … > tmp && mv` and then printed `attested and RECORDED` unconditionally — a read-only `.claude/`, a full disk, or a corrupt state file left no record while the operator was told there was one. The general step write at the end of `complete_step` — the same command path, on every `--complete-step` of every process — had the same shape.

## Fix

**Counts** (`# BL-256-P3-COUNT-RECEIPT`, `# BL-256-P3-SNYK-COUNT-RECEIPT`): the count is taken only when the key is present **and is an array** — `jq -e 'if (.results | type) == "array" then (.results | length) else error(…) end'`. No jq, no array, unparseable JSON, or a multi-document archive → `P3_STATUS="FAIL"` with a note that says NOTHING WAS COUNTED and names the archive. Never SKIP (SKIP means "could not run" and routes to the attestation path; this scan ran), never PASS.

**Records** (`# BL-256-UAT-ATTEST-RECEIPT` / `-REFUSE`, `# BL-256-STEP-RECEIPT` / `-REFUSE`): the receipt sits inside the `if jq … && mv …; then`; the else arm removes the temp file, prints a REFUSED / NOT-recorded line naming the state file and the reason class, and exits 1 — nothing is marked complete. The `rm -f` takes `|| true` so a stale `.tmp` in a now read-only directory cannot exit the script under `set -e` **before** the refusal is printed.

## Test — `tests/test-bl256-unearned-receipts.sh`

Drives the REAL driver and the REAL checklist. PATH shims `semgrep` (writes a canned archive to `--output`) and `snyk` (answers `config get api` with a token, `test --json` with the canned report on stdout) on a PATH mirrored from the host **minus** real semgrep/snyk/docker/go-licenses — minus `jq` for the no-jq cases — with the exclusion asserted before anything is measured. A process-state fixture at `uat_session:results_received`, writable, `chmod 555`, with a stale `.tmp`, with a PATH `mv` shim that refuses only `process-state.json`, and with a corrupt `steps_completed`.

RED with the final file at `e3b2be5`: **11 passed / 38 failed**. The eleven passes are the honest-outcome controls (shim resolution, empty array PASS, findings FAIL, a healthy write recorded, state unchanged) — true on main by construction and not discriminators.

GREEN **49 / 0**, twelve mutants on a mirror, each pinned to the case that kills it: the old `// 0 || echo 0` count, a presence check instead of a type check (an object counts 0, a string counts its own length), the dropped `*[!0-9]*` sanitiser, both of those applied to the snyk marker, a top-level-array arm, a guard covering only `jq`, a guard tolerating a failed `mv`, a dropped `rm -f`, and each refuse arm turned back into an unconditional receipt.

All **66** unit-lane suites that drive either script re-run green (`test-phase3-validation-gate` 51/0, the three BL-070 scanner suites 51/48/26, `test-bl233-wpb-accumulation` 100/0); 16/16 lints.

## Review

Five adversarial rounds, single agent each, `minor_concerns` → `major_concerns` ×3 → clean. Round 1 found the multi-document sanitiser arm untested and the snyk twin unfixed. Round 2 wrote a mutant that accepted a list-shaped snyk report and survived the suite **and** all 66 lane suites, plus the unguarded step write on the same command path. Round 3 mutated the guard round 2 had just added so it covered only `jq`, and found both refuse arms exiting silently before their own refusal text. Round 4 found the jq half of both guards unpinned — a read-only directory fails both halves at once, so no case isolated either. Every finding was folded before push; each round's mutant is now a permanent case in the suite.

Round 5 returned `approve` with three minor residuals, none a defect in shipped code: the suite does not pin the `>` truncate atom (a stale `.tmp` in a **writable** dir, reachable only after a crash between the redirect and the rename), the two newest mutants anchor on a line offset rather than the guard's identity (a restructure would make them a red test with a misleading diagnostic, never a false green), and one comment overstates the empty-state case the ledger already records. All three go into the closing ledger PR for this wave.

Residuals on `## BL-256:`: `_p3_scan_zap` has the same hole by a different route (its `.site[]?.alerts[]?` optional iterators make a renamed `.site` count 0 — verified, not folded, so the branch stays on the arms the reviews named); a semgrep archive with `.errors[]` and an empty `.results` is a real count but a weaker receipt than it looks; plain `jq` exits 0 with no output on an already-empty state file. `## BL-257:` filed for the other **23** one-line `jq … > tmp && mv` state writes in `process-checklist.sh` that still announce success without checking the write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk
