### PR TITLE
docs(ledger): close BL-253, BL-254, BL-255 and BL-256 — the September receipts wave

### DIFF
--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15170,9 +15170,13 @@ wp5b 57, wp6 45, wp9 29, wp9b 103, wp10a 54, bl221 12, bl225 35, lint-module-dep
 generated CI steps already called are now shipped by the scaffold, and all 24 steps lose their `2>/dev/null
 || true` — measured 20 GitHub, 4 GitLab, 0 Bitbucket — so a failing check now blocks the job. **Neither host
 blocked before this PR**: the GitHub half was behind `|| true` too, which is the silent no-op in the entry's own
-headline. **Two** adversarial rounds (`major_concerns` → `minor_concerns`) found the user-guide table committing the exact defect the entry is about: four of the 22 new rows
-said "Automatic (CI)" for lints that run in NO generated pipeline. All corrected before push, plus one pre-existing
-wrong cell. **Residuals 1-6 below stay open**, chiefly that the governance steps are still not uniform across the
+headline. **Two** adversarial rounds (`major_concerns` → `minor_concerns`); **round 1** found the user-guide table
+committing the exact defect the entry is about: four of the 22 new rows said "Automatic (CI)" for lints that run in
+NO generated pipeline. All corrected before push, plus one pre-existing wrong cell (that one from the `--help`
+sweep, not from these four rows). **Round 2 is not documented below** — the body records round 1 only. Its three
+findings are in commit `552de5f` on the merged branch: comment-stripping (a commented-out entry is not an
+invocation), the deletion hole (deleting every governance step passed 8/0 until it was pinned), and a corrected RED
+figure. **Residuals 1-6 below stay open**, chiefly that the governance steps are still not uniform across the
 three hosts and that the table's Invocation and Phase cells are enforced for presence, not accuracy.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (pass 1 headline #2 → G0/G2/R4; verified
@@ -15419,8 +15423,11 @@ mutants. **Nine adversarial rounds** — rounds 2, 3 and 4 each broke the code t
 each of those mutants is now a permanent case; rounds 6-9 were CHIEFLY one paragraph of trap documentation that
 took three drafts to state correctly, but not only that — round 6 also caught MU1/MU3 passing vacuously under root
 (below), and round 9 caught the boundary claim asserted and refuted eighteen lines apart in this very entry.
-Rounds 1-8 are documented below; round 9's findings landed as the `5.1`→`5.2` correction in that paragraph and a
-provenance rewording, and its verdict was `minor_concerns` with no code finding. **Residuals 1-7 below stay open**, chiefly `_p3_scan_zap` carrying the same hole by
+Rounds 1-8 are documented below; round 9 is not, and its findings landed as the `5.1`→`5.2` correction in that
+paragraph and a provenance rewording — both in commit `50262d7`, which touches only this file, so round 9 produced
+no code finding. Its VERDICT is not in merged history: verdicts live in `.claude/process-state.json`, which is
+untracked runtime state, so treat the nine-round sequence as attested by these commits rather than by a record you
+can `git show`. **Residuals 1-7 below stay open**, chiefly `_p3_scan_zap` carrying the same hole by
 a different route, and `## BL-257:` for the other 23 unchecked state writes.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (ST2 + R2, both confirmed by the

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15070,10 +15070,11 @@ downstream only), `## BL-112:` (a check that did not run must not read as a clea
 **Status:** Closed — shipped + merged 2026-09-08 (PR #377, merge `d4e1466`). `ADOPT_POC_MODE` is `""` and both
 writers emit JSON `null` via `--argjson` (`# BL-253-POC-MODE`, `# BL-253-POC-NULL`, `# BL-253-POC-NULL-MANIFEST`), so
 an adopted project's tier key is byte-identical to what `init.sh` writes for the same answers. Suite
-`tests/test-bl253-adoption-state-parity.sh` 19/0 against RED 5/12, four mutants. Two adversarial rounds
-(`major_concerns` → `minor_concerns`): round 1 found the wp4-driver cases passing BECAUSE of the bug, and its own
-surviving mutant — deleting the manifest writer's guard — forced **P1f**, which asserts the two files agree on
-`deployment` and `poc_mode` and is the case that kills it. **Residuals 1-3 below stay open on this entry**, chiefly
+`tests/test-bl253-adoption-state-parity.sh` 19/0 against RED 5/12, four mutants. **One** adversarial round
+(`minor_concerns`). The BUILD found one existing suite green BECAUSE of the bug (`test-brownfield-wp4-driver.sh`,
+corrected in the fix commit `269ee02`, before any review ran); the REVIEW's own surviving mutant — deleting the
+manifest writer's guard — forced **P1f**, which asserts the two files agree on `deployment` and `poc_mode` and is
+the case that kills it. **Residuals 1-3 below stay open on this entry**, chiefly
 that adoption still asks no POC question, so an adopted POC lands as production and must be moved with
 `upgrade-project.sh`.
 
@@ -15166,9 +15167,10 @@ wp5b 57, wp6 45, wp9 29, wp9b 103, wp10a 54, bl221 12, bl225 35, lint-module-dep
 ## BL-254: 24 generated CI steps call two governance scripts the scaffold never ships, behind `2>/dev/null || true` — a silent no-op in every generated project, listed as "Automatic (CI)" in a user-guide table that names 19 of 39 shipped scripts
 
 **Status:** Closed — shipped + merged 2026-09-09 (PR #378, merge `c6da463`). The two governance scripts 24
-generated CI steps already called are now shipped by the scaffold, and the GitLab half's `|| true` is gone, so a
-failing check blocks the job as the GitHub half always did. One adversarial round (`major_concerns` →
-`minor_concerns`) found the user-guide table committing the exact defect the entry is about: four of the 22 new rows
+generated CI steps already called are now shipped by the scaffold, and all 24 steps lose their `2>/dev/null
+|| true` — measured 20 GitHub, 4 GitLab, 0 Bitbucket — so a failing check now blocks the job. **Neither host
+blocked before this PR**: the GitHub half was behind `|| true` too, which is the silent no-op in the entry's own
+headline. **Two** adversarial rounds (`major_concerns` → `minor_concerns`) found the user-guide table committing the exact defect the entry is about: four of the 22 new rows
 said "Automatic (CI)" for lints that run in NO generated pipeline. All corrected before push, plus one pre-existing
 wrong cell. **Residuals 1-6 below stay open**, chiefly that the governance steps are still not uniform across the
 three hosts and that the table's Invocation and Phase cells are enforced for presence, not accuracy.
@@ -15298,11 +15300,9 @@ docs naming things that do not ship), `## BL-112:` (a check that did not run mus
 replacement-position sites carrying operator text. Suite `tests/test-bl255-sed-replacement-escape.sh` 24/0 against
 RED 2/14. Two adversarial rounds (`major_concerns` → `minor_concerns`): round 1 found four of the eleven sites
 unguarded, and a `tr|sed` draft of the helper turning a loud failure into silent truncation. **Residuals stay open**
-— the rename's *pattern* side (`--old`) needs a regex escape this helper is not — and one more, found later by
-`## BL-256:`'s round 8 and worth reading before trusting a local green: **this suite's discrimination is
-version-dependent.** Mutate the helper's `${t//&/\\&}` to `\&` and it stays GREEN 24/0 on a bash-3.2 host and goes
-red 16/8 only on the 5.2 runner (measured in `ubuntu:24.04`). The suite that guards the `&` trap is itself subject
-to it; see CLAUDE.md's ENVIRONMENT TRAPS bullet on `${var/pat/rep}`.
+— the rename's *pattern* side (`--old`) needs a regex escape this helper is not — and **residual 5**, added
+here from `## BL-256:`'s round 8 and the one to read before trusting a local green: this suite's discrimination is
+version-dependent, staying GREEN 24/0 on a bash-3.2 host with the helper mutated.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (S6; pass 2 adjudicated it medium, not
 high: the file-write primitive is real, GNU sed's `e`-flag RCE plausible but not reproduced on BSD sed).
@@ -15361,6 +15361,15 @@ writes a file again).
    directory, the sibling libs' idiom. `test-scaffold-source-closure.sh` cannot see this class of
    dependency (it derives from `$SCRIPT_DIR/…` path references), so it stays stated here.
 
+5. **This suite's discrimination is VERSION-DEPENDENT, so a local green is not proof it still discriminates**
+   (found by `## BL-256:`'s review round 8, recorded here because this is where someone will look). Mutate the
+   helper's `${t//&/\\&}` to `\&` and the suite stays **GREEN 24 / 0** on this bash-3.2 host, going red
+   **16 / 8** only on a 5.2 runner (measured in `ubuntu:24.04` as a non-root user; the eight are the `&`-splice
+   rows H, H-delim, E1, E3, E4, E5, E6a, E6b). Cause: since bash 5.2 an unescaped `&` in a pattern-substitution
+   replacement is the whole match, and `\&` is an escaped literal `&` — so on 5.2 the mutation actually changes
+   behaviour and on 3.2 it does not. The suite that guards the `&` trap is itself subject to it. See CLAUDE.md's
+   ENVIRONMENT TRAPS bullet on `${var/pat/rep}`.
+
 **Build note (2026-09-08, branch `fix/bl255-escape-sed-replacements`).** RED, measured with the branch's
 FINAL test file in a worktree at `c6da463`: **2 passed / 14 failed**. The two passes are the two cases
 that guard against mistakes made DURING this work rather than against main: M2 mirrors the tree under
@@ -15407,8 +15416,11 @@ FAIL that says NOTHING WAS COUNTED; the UAT solo attestation and the general ste
 (`# BL-256-UAT-ATTEST-RECEIPT`/`-REFUSE`, `# BL-256-STEP-RECEIPT`/`-REFUSE`) print only inside the success arm and
 refuse at rc 1 otherwise. Suite `tests/test-bl256-unearned-receipts.sh` **49 / 0** against RED **11 / 38**, twelve
 mutants. **Nine adversarial rounds** — rounds 2, 3 and 4 each broke the code the round before had just added, and
-each of those mutants is now a permanent case; rounds 6-9 were all one paragraph of trap documentation that took
-three drafts to state correctly. **Residuals 1-6 below stay open**, chiefly `_p3_scan_zap` carrying the same hole by
+each of those mutants is now a permanent case; rounds 6-9 were CHIEFLY one paragraph of trap documentation that
+took three drafts to state correctly, but not only that — round 6 also caught MU1/MU3 passing vacuously under root
+(below), and round 9 caught the boundary claim asserted and refuted eighteen lines apart in this very entry.
+Rounds 1-8 are documented below; round 9's findings landed as the `5.1`→`5.2` correction in that paragraph and a
+provenance rewording, and its verdict was `minor_concerns` with no code finding. **Residuals 1-7 below stay open**, chiefly `_p3_scan_zap` carrying the same hole by
 a different route, and `## BL-257:` for the other 23 unchecked state writes.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (ST2 + R2, both confirmed by the

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15067,7 +15067,15 @@ downstream only), `## BL-112:` (a check that did not run must not read as a clea
 
 ## BL-253: adoption stamps every project `poc_mode: "production"` — a value init.sh never writes and every reader takes as the NAME of a POC mode — so `--start-phase4` refuses every adoptee and the organizational Pre-Phase-0 guard skips its six pre-conditions
 
-**Status:** Open
+**Status:** Closed — shipped + merged 2026-09-08 (PR #377, merge `d4e1466`). `ADOPT_POC_MODE` is `""` and both
+writers emit JSON `null` via `--argjson` (`# BL-253-POC-MODE`, `# BL-253-POC-NULL`, `# BL-253-POC-NULL-MANIFEST`), so
+an adopted project's tier key is byte-identical to what `init.sh` writes for the same answers. Suite
+`tests/test-bl253-adoption-state-parity.sh` 19/0 against RED 5/12, four mutants. Two adversarial rounds
+(`major_concerns` → `minor_concerns`): round 1 found the wp4-driver cases passing BECAUSE of the bug, and its own
+surviving mutant — deleting the manifest writer's guard — forced **P1f**, which asserts the two files agree on
+`deployment` and `poc_mode` and is the case that kills it. **Residuals 1-3 below stay open on this entry**, chiefly
+that adoption still asks no POC question, so an adopted POC lands as production and must be moved with
+`upgrade-project.sh`.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (pass 1 headline #3, reproduced end-to-end
 on `main` `c61edb1` by the single-agent second pass, both tiers). Ranked #1 of the verified review's
@@ -15157,7 +15165,13 @@ wp5b 57, wp6 45, wp9 29, wp9b 103, wp10a 54, bl221 12, bl225 35, lint-module-dep
 
 ## BL-254: 24 generated CI steps call two governance scripts the scaffold never ships, behind `2>/dev/null || true` — a silent no-op in every generated project, listed as "Automatic (CI)" in a user-guide table that names 19 of 39 shipped scripts
 
-**Status:** Open
+**Status:** Closed — shipped + merged 2026-09-09 (PR #378, merge `c6da463`). The two governance scripts 24
+generated CI steps already called are now shipped by the scaffold, and the GitLab half's `|| true` is gone, so a
+failing check blocks the job as the GitHub half always did. One adversarial round (`major_concerns` →
+`minor_concerns`) found the user-guide table committing the exact defect the entry is about: four of the 22 new rows
+said "Automatic (CI)" for lints that run in NO generated pipeline. All corrected before push, plus one pre-existing
+wrong cell. **Residuals 1-6 below stay open**, chiefly that the governance steps are still not uniform across the
+three hosts and that the table's Invocation and Phase cells are enforced for presence, not accuracy.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (pass 1 headline #2 → G0/G2/R4; verified
 by the single-agent second pass, counts exact: 14 templates call `check-changelog.sh` — 10 GitHub +
@@ -15279,7 +15293,16 @@ docs naming things that do not ship), `## BL-112:` (a check that did not run mus
 
 ## BL-255: `--description` and the interactive project name reach `sed` as a raw REPLACEMENT — `R&D tools` renders as `R__PROJECT_DESCRIPTION__D tools`, and `a|w <path>|` writes a file and empties the description
 
-**Status:** Open
+**Status:** Closed — shipped + merged 2026-09-09 (PR #379, merge `e3b2be5`). `soif_sed_repl_esc`
+(`# BL-255-SED-REPL-ESC`) escapes `&`, `\` and the delimiter by pure parameter expansion at all eleven
+replacement-position sites carrying operator text. Suite `tests/test-bl255-sed-replacement-escape.sh` 24/0 against
+RED 2/14. Two adversarial rounds (`major_concerns` → `minor_concerns`): round 1 found four of the eleven sites
+unguarded, and a `tr|sed` draft of the helper turning a loud failure into silent truncation. **Residuals stay open**
+— the rename's *pattern* side (`--old`) needs a regex escape this helper is not — and one more, found later by
+`## BL-256:`'s round 8 and worth reading before trusting a local green: **this suite's discrimination is
+version-dependent.** Mutate the helper's `${t//&/\\&}` to `\&` and it stays GREEN 24/0 on a bash-3.2 host and goes
+red 16/8 only on the 5.2 runner (measured in `ubuntu:24.04`). The suite that guards the `&` trap is itself subject
+to it; see CLAUDE.md's ENVIRONMENT TRAPS bullet on `${var/pat/rep}`.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (S6; pass 2 adjudicated it medium, not
 high: the file-write primitive is real, GNU sed's `e`-flag RCE plausible but not reproduced on BSD sed).
@@ -15377,7 +15400,16 @@ aggregator and the `tests.yml` unit lane (`lint-tests-registered.sh --list`: `re
 
 ## BL-256: two shipped gates hand out receipts they did not earn — `_p3_scan_semgrep` (and its twin `_p3_scan_snyk`) counts an unreadable archive as "0 findings → PASS", and the UAT solo attestation prints "RECORDED" whether or not the record was written
 
-**Status:** Open
+**Status:** Closed — shipped + merged 2026-09-09 (PR #380, merge `74be423`). Four receipts that were printed
+without the thing they attest to: the semgrep and snyk finding counts (`# BL-256-P3-COUNT-RECEIPT`,
+`# BL-256-P3-SNYK-COUNT-RECEIPT`) now count only when the key is present AND an array, every other outcome being a
+FAIL that says NOTHING WAS COUNTED; the UAT solo attestation and the general step write
+(`# BL-256-UAT-ATTEST-RECEIPT`/`-REFUSE`, `# BL-256-STEP-RECEIPT`/`-REFUSE`) print only inside the success arm and
+refuse at rc 1 otherwise. Suite `tests/test-bl256-unearned-receipts.sh` **49 / 0** against RED **11 / 38**, twelve
+mutants. **Nine adversarial rounds** — rounds 2, 3 and 4 each broke the code the round before had just added, and
+each of those mutants is now a permanent case; rounds 6-9 were all one paragraph of trap documentation that took
+three drafts to state correctly. **Residuals 1-6 below stay open**, chiefly `_p3_scan_zap` carrying the same hole by
+a different route, and `## BL-257:` for the other 23 unchecked state writes.
 
 **Logged:** 2026-09-08, out of the adversarial codebase review (ST2 + R2, both confirmed by the
 single-agent second pass). Ranked #4 of the verified review's top ten. Both are instances of the
@@ -15445,7 +15477,18 @@ was one. The four MCP/review attestations already refuse when they cannot record
    file. Reachable only for a step with no prior requirements (priors fail `step_is_completed` first).
    `jq -e` on both writes (exit 4 on no output; the filter's output is the whole document, never
    null/false) closes it; not folded here — fold it into `## BL-257:`'s helper.
-5. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
+5. (review round 5, R5-2) The suite does not pin the `>` truncate atom on the guarded step write: `>` → `>>`
+   survives 49/0. Not a no-op — with a stale `.tmp` in a **writable** `.claude/` that mutant yields rc 0, a receipt,
+   and a two-document state file. The two stale-`.tmp` cases (U2c, U4d) are both read-only-dir cases, so nothing
+   exercises the truncate. Shipped code is correct here; this is coverage, and it needs an already-corrupt
+   workspace (a crash between the redirect and the rename). One case — stale `.tmp` + writable dir, asserting the
+   state file is a single document — closes it.
+6. (review round 5, R5-3) MU5/MU6 anchor on `marker_line - 1`, a position rather than the guard's identity, and 24
+   lines in `process-checklist.sh` carry MU5's literal. A restructure putting a different `jq … > tmp && mv`
+   directly above the receipt would mutate the wrong line while still changing 2 lines and passing `bash -n`.
+   Bounded — MU5's own assertion then fails, so it is a red test with a misleading diagnostic, never a false
+   green. Anchor on the guard's own text when either mutant is next touched.
+7. `SOLO_TDD_ATTESTED` and `SOLO_LICENSE_ATTESTED` are recorded and fail-closed but do not require a
    reason; `SOLO_BP_ATTESTED` is missing from the inventory the review built. The review's proposed
    single table of every `_ATTESTED` escape with its three properties (reason-mandatory / recorded /
    fail-closed), plus a lint that every grep hit appears in it, is filed here as the follow-up.


### PR DESCRIPTION
Four entries shipped and merged while their status lines still said Open. This closes them.

| entry | PR | merge | what shipped |
|---|---|---|---|
| BL-253 | #377 | `d4e1466` | adoption writes `poc_mode` null, as init.sh does |
| BL-254 | #378 | `c6da463` | ship the two governance checks every generated CI already called |
| BL-255 | #379 | `e3b2be5` | escape operator text before it reaches `sed` |
| BL-256 | #380 | `74be423` | a count that could not be taken is not zero |

Each Closed line names what shipped, the review path that got it there, and which residuals stay open on the entry. **None of the four closes clean**, and the lines say so rather than implying otherwise.

## Residuals added

Two to `## BL-256:` from its review round 5. The `>` truncate atom on the guarded step write is unpinned, reachable only after a crash between the redirect and the rename. And two mutants anchor on a line position rather than the guard's identity, which after a restructure makes them a red test with a misleading diagnostic, never a false green.

One to `## BL-255:`, promoted out of a status line where it would have been lost, and the one to read before trusting a local green: **that suite's discrimination is version-dependent.** Mutate the helper it guards and it stays GREEN 24/0 on this bash-3.2 host, going red 16/8 only on a 5.2 runner. The suite that guards the `&` trap is itself subject to it.

## Review — and what it caught

Two adversarial rounds, `major_concerns` → `approve`.

Round 1 verified every merge coordinate against GitHub, re-ran all three cited suites (19/0, 24/0, 49/0), counted the mutants, diffed the residual renumbering byte-for-byte, and reproduced the version-dependence claim in a container. All of it held. What did not hold were **four sentences about how the work got reviewed**:

- BL-254 said the GitLab half's `|| true` is gone "as the GitHub half always did". Measured removals in `c6da463`: **20 GitHub, 4 GitLab, 0 Bitbucket**. Neither host blocked before that PR — the silent no-op named in the entry's own headline.
- The two round counts were **transposed**. BL-253 had one round, BL-254 two.
- BL-253 credited a review with finding a suite green because of the bug. That file was touched by the fix commit, hours before any review ran.
- BL-256 said "Residuals 1-6 stay open" after the same commit renumbered an item to 7, dropping it out of the range.

Every correction was re-measured from git and the PR bodies rather than transcribed from the review, because taking a reviewer's word is how a documentation error in the sibling PR survived three drafts. Round 2 approved all seven and left three notes, folded in the last commit: attribute a finding to the round that made it, disclose that BL-254's round 2 is not documented in the entry, and stop asserting round 9's verdict — verdicts live in untracked runtime state, so the line now says what the commits attest and where the verdict does not live.

An entry whose subject is unearned receipts should not carry an unearned account of its own review.

Lints 16/16. Docs-only: one file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk
