### PR TITLE
fix(bl-259): the resolver loses install instructions for every tool with no version_command

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -536,6 +536,7 @@ jobs:
             tests/test-lint-user-guide-scripts.sh
             tests/test-bl255-sed-replacement-escape.sh
             tests/test-bl256-unearned-receipts.sh
+            tests/test-bl259-tsv-empty-field-shift.sh
           )
 
           # ── BL-190 shard pins ──────────────────────────────────────────

--- a/scripts/resolve-tools.sh
+++ b/scripts/resolve-tools.sh
@@ -260,6 +260,17 @@ DEFERRED="[]"
 # field contains one. `awk -F'\t'` reads it correctly; only bash's `read` does not.
 # So split it here, by hand, which preserves empty fields exactly.
 while IFS= read -r _bl259_row; do
+  # Arity guard. Without it a SHORT row is read worse than the collapsing
+  # `read` handled it: the hand split duplicates the last available field into
+  # every remaining slot, where `read` at least left them empty — plausible
+  # data instead of missing data. Unreachable today (the producer emits exactly
+  # eight tabs for every row) and cheap, so assert it rather than trust it: a
+  # producer/reader drift is a programming error and must be loud.
+  _bl259_tabs="${_bl259_row//[!$'\t']/}"
+  if [ "${#_bl259_tabs}" -ne 8 ]; then
+    echo "resolve-tools: malformed tool row — expected 8 tab separators, got ${#_bl259_tabs}. The @tsv producer and this reader have drifted; refusing to guess." >&2
+    exit 1
+  fi
   _bl259_rest="$_bl259_row"
   TOOL_NAME="${_bl259_rest%%$'\t'*}";        _bl259_rest="${_bl259_rest#*$'\t'}"
   TOOL_CATEGORY="${_bl259_rest%%$'\t'*}";    _bl259_rest="${_bl259_rest#*$'\t'}"

--- a/scripts/resolve-tools.sh
+++ b/scripts/resolve-tools.sh
@@ -246,7 +246,30 @@ DEFERRED="[]"
 # --- Check each tool and categorize ---
 # Extract all fields per tool in a single jq call (tab-separated) to avoid N*8 subprocess forks.
 # Fields: name, category, phase, required, check_command, auto_installable, version_command, description, install_json
-while IFS=$'\t' read -r TOOL_NAME TOOL_CATEGORY TOOL_PHASE TOOL_REQUIRED TOOL_CHECK TOOL_AUTO TOOL_VERSION_CMD TOOL_DESCRIPTION TOOL_INSTALL_B64; do
+# `## BL-259:` — DO NOT read this row with `IFS=$'\t' read -r f1 f2 …`. Tab is an
+# IFS *whitespace* character, so bash collapses runs of tabs: an EMPTY field does
+# not arrive as an empty field, it vanishes, and every later field shifts left one.
+# `version_command` is optional (the producer below emits `// ""` for it), so for
+# the six catalogued tools that omit it the install blob landed in TOOL_DESCRIPTION
+# and TOOL_INSTALL_B64 arrived EMPTY — after which `base64 -d` and `jq` each
+# succeeded at rc 0 producing nothing, so their `|| echo "{}"` and
+# `// "See documentation"` defaults never fired and the operator was handed an
+# empty install instruction. Silent at every step.
+# The row itself is well-formed: `@tsv` escapes an embedded tab as a literal `\t`
+# and a newline as `\n`, so a row is one line with exactly eight real tabs and no
+# field contains one. `awk -F'\t'` reads it correctly; only bash's `read` does not.
+# So split it here, by hand, which preserves empty fields exactly.
+while IFS= read -r _bl259_row; do
+  _bl259_rest="$_bl259_row"
+  TOOL_NAME="${_bl259_rest%%$'\t'*}";        _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_CATEGORY="${_bl259_rest%%$'\t'*}";    _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_PHASE="${_bl259_rest%%$'\t'*}";       _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_REQUIRED="${_bl259_rest%%$'\t'*}";    _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_CHECK="${_bl259_rest%%$'\t'*}";       _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_AUTO="${_bl259_rest%%$'\t'*}";        _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_VERSION_CMD="${_bl259_rest%%$'\t'*}"; _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_DESCRIPTION="${_bl259_rest%%$'\t'*}"; _bl259_rest="${_bl259_rest#*$'\t'}"
+  TOOL_INSTALL_B64="$_bl259_rest"   # BL-259-TSV-SPLIT
 
   # Decode base64-encoded install JSON (avoids @tsv double-escaping embedded quotes)
   TOOL_INSTALL_JSON=$(echo "$TOOL_INSTALL_B64" | base64 -d 2>/dev/null || echo "{}")

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15802,10 +15802,12 @@ shape recorded as `## BL-256:` residual 4.)
 
 **The same shift also fed catalogue text to a command evaluator.** With the row shifted the description
 landed in `TOOL_VERSION_CMD`, and that variable is passed to `run_bounded_capture`, which EVALUATES it
-as a shell command whenever the tool is detected as installed. On the shipped catalogue this only
-produced shell-syntax errors into a swallowed stderr (`Apple Developer Program`'s description is prose),
-but the catalogue is data and downstream projects supply their own with `--matrix-dir`, so the class is
-data-as-code, not cosmetic. The fix closes the path; no separate change was needed for it.
+as a shell command whenever the tool is detected as installed. On the shipped catalogue every one of the six
+fails INERTLY into a swallowed stderr, but not all the same way — measured by evaluating each: rc 2
+(syntax error) for the three descriptions containing a parenthesis, rc 127 (command not found) for the
+other three, **ZAP's among them**, which matters because ZAP is the one that actually reaches the
+evaluator on this Mac. The catalogue is data, though, and downstream projects supply their own with
+`--matrix-dir`, so the class is data-as-code rather than cosmetic. The fix closes the path; no separate change was needed for it.
 
 **Blast radius — measured, not estimated.** Of 47 tools across the four catalogs, **6 declare no
 `version_command`** and are affected today:
@@ -15819,11 +15821,15 @@ desktop.json: Apple Developer Program (Desktop), EV Code Signing Certificate (Wi
 mobile.json: Android Studio, Apple Developer Program, Android Keystore
 web.json: OWASP ZAP
 ```
-It does not fire on a common-only tool set (0 of 21). It DOES fire on any mobile or desktop project,
-and — the case a first draft of this line got wrong — on **every standard- or full-track WEB project
-from phase 3 onward**, because `OWASP ZAP` is `"required": true, "phase": 3,
-"tracks": ["standard","full"], "platforms": ["web"]` and declares no `version_command`. That is the
-framework's most common configuration, and it was losing the install text for a REQUIRED tool.
+Who it reaches, by the six tools' own `tracks` — measured, and **this line has now been wrong twice,
+once in each direction**, so read the field values rather than the sentence:
+- **common**: never (0 of 21 declare no `version_command`).
+- **mobile**: every track. `Android Studio` is `["light","standard","full"]`.
+- **desktop**: standard and full only. Both entries are `["standard","full"]`, so a **light-track
+  desktop project is unaffected** — the claim "any desktop project" was wrong.
+- **web**: standard and full, from phase 3. `OWASP ZAP` is `"required": true, "phase": 3,
+  "tracks": ["standard","full"], "platforms": ["web"]` with no `version_command` — so a web project
+  was losing the install text for a REQUIRED tool. The first draft said web was unaffected; wrong.
 **Why the first draft missed it:** ZAP's `check_command` is
 `command -v docker && docker image inspect ghcr.io/zaproxy/zaproxy:stable …`, and that image is pulled
 on this Mac, so ZAP resolves to `already_installed` here and never reaches the `manual_install` list
@@ -15880,8 +15886,8 @@ A first cut carried a seventh case asserting the description never appears as a 
 the plan. It was **vacuous** — no tool in the fixture is installed, so the plan contains no `version`
 field at all and the case could not fail in either direction. Dropped rather than kept as decoration.
 Both the review's surviving mutants (deleting the sole `TOOL_VERSION_CMD=` assignment; exchanging the
-`check`/`auto` fields) pass this suite and are killed by the unit lane — this suite pins fields 1, 7, 8
-and 9, and the lane covers the rest; recorded rather than papered over. All **8** unit-lane suites that
+`check`/`auto` fields) pass this suite and are killed by the unit lane — this suite pins fields 1, 8 and 9 BY VALUE and
+field 7 only POSITIONALLY (its offset feeds 8 and 9), and the lane covers the rest; recorded rather than papered over. All **8** unit-lane suites that
 drive `resolve-tools.sh` re-run green (`test-brownfield-wp10a-tool-resolution`
 54/0, `test-bl235-tool-matrix-probes` 42/0); registered in the aggregator and the `tests.yml` unit lane
 (`lint-tests-registered.sh --list`: `registered`).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15771,8 +15771,8 @@ caught by review, not by the lint.
 **Status:** Open
 
 **Logged:** 2026-09-10, reproducing `## BL-258:`'s lead #5, fourth atom ("the resolver's `@tsv` output
-is consumed with a shifted field index"). **The lead reproduces.** This entry is the reproduction; the
-fix is not built yet.
+is consumed with a shifted field index"). **The lead reproduces.** Filed as the reproduction at
+`4583b0d`; **fixed later on the same branch** — see the Fix section below.
 
 **The defect.** `scripts/resolve-tools.sh` reads its tool rows with a nine-variable
 `while IFS=$'\t' read -r TOOL_NAME … TOOL_INSTALL_B64` whose producer is the `jq -r '… | @tsv'` at the
@@ -15800,6 +15800,13 @@ exits **0** with NO output, so the `// "See documentation"` default never fires 
 `--arg instructions "$INSTALL_CMD"`. (The jq half is the same "jq on empty input is a silent success"
 shape recorded as `## BL-256:` residual 4.)
 
+**The same shift also fed catalogue text to a command evaluator.** With the row shifted the description
+landed in `TOOL_VERSION_CMD`, and that variable is passed to `run_bounded_capture`, which EVALUATES it
+as a shell command whenever the tool is detected as installed. On the shipped catalogue this only
+produced shell-syntax errors into a swallowed stderr (`Apple Developer Program`'s description is prose),
+but the catalogue is data and downstream projects supply their own with `--matrix-dir`, so the class is
+data-as-code, not cosmetic. The fix closes the path; no separate change was needed for it.
+
 **Blast radius — measured, not estimated.** Of 47 tools across the four catalogs, **6 declare no
 `version_command`** and are affected today:
 ```
@@ -15812,14 +15819,30 @@ desktop.json: Apple Developer Program (Desktop), EV Code Signing Certificate (Wi
 mobile.json: Android Studio, Apple Developer Program, Android Keystore
 web.json: OWASP ZAP
 ```
-So it does not fire on a plain web/common project, which is why it has gone unnoticed: it needs a
-mobile or desktop platform, or ZAP on web.
+It does not fire on a common-only tool set (0 of 21). It DOES fire on any mobile or desktop project,
+and — the case a first draft of this line got wrong — on **every standard- or full-track WEB project
+from phase 3 onward**, because `OWASP ZAP` is `"required": true, "phase": 3,
+"tracks": ["standard","full"], "platforms": ["web"]` and declares no `version_command`. That is the
+framework's most common configuration, and it was losing the install text for a REQUIRED tool.
+**Why the first draft missed it:** ZAP's `check_command` is
+`command -v docker && docker image inspect ghcr.io/zaproxy/zaproxy:stable …`, and that image is pulled
+on this Mac, so ZAP resolves to `already_installed` here and never reaches the `manual_install` list
+where the damage is visible. On a clean host it does. Measured in `ubuntu:24.04` with no docker: at
+`681beb3` the plan carries `OWASP ZAP instructions=[]`; at the fix it carries
+`Requires Docker. Run: docker pull ghcr.io/zaproxy/zaproxy:stable`.
 
 **Fix — BUILT on this branch, option 1.** `# BL-259-TSV-SPLIT`: the loop reads one whole line
-(`while IFS= read -r`) and splits it by hand with `${rest%%$'\t'*}` / `${rest#*$'\t'}`, nine times, which
-preserves empty fields exactly. No producer change, so `@tsv`'s escaping stays load-bearing and no new
+(`while IFS= read -r`) and splits it by hand with `${rest%%$'\t'*}` / `${rest#*$'\t'}` — **eight** pairs
+yielding nine fields, the ninth being the untouched remainder — which preserves empty fields exactly. No producer change, so `@tsv`'s escaping stays load-bearing and no new
 escaping surface is introduced. The comment above the loop carries the trap so the next reader does not
 reinstate it.
+
+**Plus an arity guard, because without one the new split is WORSE than the `read` it replaced on a
+short row:** the hand split duplicates the last available field into every remaining slot, where `read`
+at least left them empty — plausible data instead of missing data. Measured identically on bash 3.2.57
+and 5.2.37. It is unreachable today (`… | @tsv | awk -F'\t' '{c[NF]++}'` → nine fields on all 47 rows),
+so the guard asserts rather than trusts: count the tabs, and refuse the row with a named error and
+rc 1 if there are not exactly eight. A producer/reader drift is a programming error and must be loud.
 
 **Options considered, and why option 1.**
 1. **Split the row explicitly** rather than relying on `read` — keep `@tsv` (its escaping of embedded
@@ -15839,21 +15862,27 @@ binary the suite first asserts is absent, one WITHOUT `version_command` and one 
 so no network and no host tool is touched. It asserts the plan the operator receives, not the `read`:
 `.manual_install[] | select(.name==…) | .instructions`.
 
-RED with the final file at `681beb3`: **2 passed / 4 failed**. R1 (the no-version tool's install
+RED with the final file at `681beb3`: **2 passed / 5 failed**. R1 (the no-version tool's install
 instructions came back EMPTY) and R2 (its description came back as the base64 install blob,
 `eyJtYW51YWwiOiJCTDI1OS1JTlNUQUxM…`) are the discriminators; M0 and the MP1 setup fail because the
 marker does not exist yet. The two passes are honest-outcome controls — R0 (the resolver runs) and R3
 (the control tool WITH a version_command was never affected) — true on main by construction.
 
-GREEN **6 / 0**, one mutant: MP1 replaces the whole split block with the single collapsing
+GREEN **7 / 0**, two mutants. MP1 replaces the whole split block with the single collapsing
 `IFS=$'\t' read` line it removed, located by the loop opener and the marker, and asserts the mutation
 landed (`bash -n`, the restored line present exactly once, the marker gone). Under it R1 goes red with
-an empty instructions field, which is what proves R1 discriminates.
+an empty instructions field, which is what proves R1 discriminates. MP2 drops one element from the
+PRODUCER on a mirror so the row carries seven tabs, and asserts the resolver REFUSES it at rc 1 naming
+"malformed tool row" rather than reading a short row as plausible data — that is what makes the arity
+guard load-bearing rather than decoration.
 
 A first cut carried a seventh case asserting the description never appears as a `version` anywhere in
 the plan. It was **vacuous** — no tool in the fixture is installed, so the plan contains no `version`
 field at all and the case could not fail in either direction. Dropped rather than kept as decoration.
-All **8** unit-lane suites that drive `resolve-tools.sh` re-run green (`test-brownfield-wp10a-tool-resolution`
+Both the review's surviving mutants (deleting the sole `TOOL_VERSION_CMD=` assignment; exchanging the
+`check`/`auto` fields) pass this suite and are killed by the unit lane — this suite pins fields 1, 7, 8
+and 9, and the lane covers the rest; recorded rather than papered over. All **8** unit-lane suites that
+drive `resolve-tools.sh` re-run green (`test-brownfield-wp10a-tool-resolution`
 54/0, `test-bl235-tool-matrix-probes` 42/0); registered in the aggregator and the `tests.yml` unit lane
 (`lint-tests-registered.sh --list`: `registered`).
 

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15765,3 +15765,71 @@ caught by review, not by the lint.
 **Related:** `## BL-253:`, `## BL-254:`, `## BL-255:`, `## BL-256:` (the four that shipped),
 `## BL-257:` (filed out of BL-256's review, same wave), `## BL-231:` (#6's family),
 `## BL-181:` (#10's full-lane blind spot).
+
+## BL-259: `resolve-tools.sh` loses the install instructions for every tool that declares no `version_command` — an empty `@tsv` field collapses and shifts the row
+
+**Status:** Open
+
+**Logged:** 2026-09-10, reproducing `## BL-258:`'s lead #5, fourth atom ("the resolver's `@tsv` output
+is consumed with a shifted field index"). **The lead reproduces.** This entry is the reproduction; the
+fix is not built yet.
+
+**The defect.** `scripts/resolve-tools.sh` reads its tool rows with a nine-variable
+`while IFS=$'\t' read -r TOOL_NAME … TOOL_INSTALL_B64` whose producer is the `jq -r '… | @tsv'` at the
+matching `done < <(…)` — one loop, reader and producer paired. **Tab is an IFS *whitespace* character**,
+so bash collapses runs of tabs: an EMPTY field does not survive as an empty field, it disappears, and
+every later field shifts left one. The producer emits `(.version_command // "")` — and that `// ""` is
+itself the proof the field is optional.
+
+**Measured, both directions:**
+```
+printf 'name\tcat\t1\ttrue\tcheck\tfalse\t\tdesc\tB64DATA\n' \
+  | while IFS=$'\t' read -r a b c d e f g h i; do echo "[$g] [$h] [$i]"; done
+  -> [desc] [B64DATA] []          # empty version_command: every later field shifted
+same row with field 7 populated
+  -> [ver] [desc] [B64DATA]       # correct
+```
+
+**What the operator sees, and why nothing complains.** With the row shifted, `TOOL_VERSION_CMD` holds
+the description, `TOOL_DESCRIPTION` holds the base64 install blob, and `TOOL_INSTALL_B64` is empty.
+Then every downstream step succeeds at rc 0 while producing nothing:
+`printf '' | base64 -d` exits **0** with empty output, so the `|| echo "{}"` fallback beside it never
+fires and `TOOL_INSTALL_JSON` is the empty string; `printf '' | jq -r '.manual // "See documentation"'`
+exits **0** with NO output, so the `// "See documentation"` default never fires either and
+`INSTALL_CMD` ends up EMPTY. That empty string is what reaches the operator as
+`--arg instructions "$INSTALL_CMD"`. (The jq half is the same "jq on empty input is a silent success"
+shape recorded as `## BL-256:` residual 4.)
+
+**Blast radius — measured, not estimated.** Of 47 tools across the four catalogs, **6 declare no
+`version_command`** and are affected today:
+```
+for c in templates/tool-matrix/*.json; do jq -r --arg f "$(basename "$c")" \
+  '[.. | objects | select(has("check_command")) | select(has("version_command")|not) | .name]
+   | "\($f): \(if length==0 then "none" else join(", ") end)"' "$c"; done
+
+common.json: none
+desktop.json: Apple Developer Program (Desktop), EV Code Signing Certificate (Windows)
+mobile.json: Android Studio, Apple Developer Program, Android Keystore
+web.json: OWASP ZAP
+```
+So it does not fire on a plain web/common project, which is why it has gone unnoticed: it needs a
+mobile or desktop platform, or ZAP on web.
+
+**Fix — NOT built; the shape is a real choice and wants a decision.**
+1. **Split the row explicitly** rather than relying on `read` — keep `@tsv` (its escaping of embedded
+   tabs and newlines is load-bearing) and read one whole line, splitting on tab in a way that preserves
+   empty fields. Safest; no producer change; no new escaping surface.
+2. **Change the delimiter to a non-whitespace one** (`join("\u001f")` + `IFS=$'\x1f'`). Empty fields
+   survive because `\x1f` is not IFS whitespace — but `join` does NOT escape embedded newlines the way
+   `@tsv` does, so this trades one silent corruption for another unless the fields are sanitised.
+3. **Make the producer never emit an empty field** (a sentinel the reader converts back). Smallest
+   diff, but any sentinel can collide with a legitimate value.
+Recommendation: (1). It is the only one that adds no new failure mode.
+
+**Test it must carry.** A row with an absent `version_command` must reach the operator with the real
+install instructions, pinned end to end rather than at the `read` alone, plus a mutation proof that
+restoring the collapsing read re-opens it. The six named tools above are the fixture set.
+
+**Related:** `## BL-258:` (the lead this reproduces — strike its #5 fourth atom when this closes),
+`## BL-256:` (residual 4, the same jq-on-empty silent success), `## BL-231:` (the
+absent-vs-unreadable family).

--- a/solo-orchestrator-backlog.md
+++ b/solo-orchestrator-backlog.md
@@ -15815,7 +15815,13 @@ web.json: OWASP ZAP
 So it does not fire on a plain web/common project, which is why it has gone unnoticed: it needs a
 mobile or desktop platform, or ZAP on web.
 
-**Fix — NOT built; the shape is a real choice and wants a decision.**
+**Fix — BUILT on this branch, option 1.** `# BL-259-TSV-SPLIT`: the loop reads one whole line
+(`while IFS= read -r`) and splits it by hand with `${rest%%$'\t'*}` / `${rest#*$'\t'}`, nine times, which
+preserves empty fields exactly. No producer change, so `@tsv`'s escaping stays load-bearing and no new
+escaping surface is introduced. The comment above the loop carries the trap so the next reader does not
+reinstate it.
+
+**Options considered, and why option 1.**
 1. **Split the row explicitly** rather than relying on `read` — keep `@tsv` (its escaping of embedded
    tabs and newlines is load-bearing) and read one whole line, splitting on tab in a way that preserves
    empty fields. Safest; no producer change; no new escaping surface.
@@ -15824,11 +15830,32 @@ mobile or desktop platform, or ZAP on web.
    `@tsv` does, so this trades one silent corruption for another unless the fields are sanitised.
 3. **Make the producer never emit an empty field** (a sentinel the reader converts back). Smallest
    diff, but any sentinel can collide with a legitimate value.
-Recommendation: (1). It is the only one that adds no new failure mode.
+Chose (1): it is the only one that adds no new failure mode.
 
-**Test it must carry.** A row with an absent `version_command` must reach the operator with the real
-install instructions, pinned end to end rather than at the `read` alone, plus a mutation proof that
-restoring the collapsing read re-opens it. The six named tools above are the fixture set.
+**Build note (2026-09-10, branch `fix/bl259-tsv-empty-field-shift`).** Suite
+`tests/test-bl259-tsv-empty-field-shift.sh` drives the REAL resolver end to end against a hermetic
+fixture matrix passed with `--matrix-dir` — two manual-install tools whose `check_command` looks for a
+binary the suite first asserts is absent, one WITHOUT `version_command` and one WITH it as the control,
+so no network and no host tool is touched. It asserts the plan the operator receives, not the `read`:
+`.manual_install[] | select(.name==…) | .instructions`.
+
+RED with the final file at `681beb3`: **2 passed / 4 failed**. R1 (the no-version tool's install
+instructions came back EMPTY) and R2 (its description came back as the base64 install blob,
+`eyJtYW51YWwiOiJCTDI1OS1JTlNUQUxM…`) are the discriminators; M0 and the MP1 setup fail because the
+marker does not exist yet. The two passes are honest-outcome controls — R0 (the resolver runs) and R3
+(the control tool WITH a version_command was never affected) — true on main by construction.
+
+GREEN **6 / 0**, one mutant: MP1 replaces the whole split block with the single collapsing
+`IFS=$'\t' read` line it removed, located by the loop opener and the marker, and asserts the mutation
+landed (`bash -n`, the restored line present exactly once, the marker gone). Under it R1 goes red with
+an empty instructions field, which is what proves R1 discriminates.
+
+A first cut carried a seventh case asserting the description never appears as a `version` anywhere in
+the plan. It was **vacuous** — no tool in the fixture is installed, so the plan contains no `version`
+field at all and the case could not fail in either direction. Dropped rather than kept as decoration.
+All **8** unit-lane suites that drive `resolve-tools.sh` re-run green (`test-brownfield-wp10a-tool-resolution`
+54/0, `test-bl235-tool-matrix-probes` 42/0); registered in the aggregator and the `tests.yml` unit lane
+(`lint-tests-registered.sh --list`: `registered`).
 
 **Related:** `## BL-258:` (the lead this reproduces — strike its #5 fourth atom when this closes),
 `## BL-256:` (residual 4, the same jq-on-empty silent success), `## BL-231:` (the

--- a/tests/full-project-test-suite.sh
+++ b/tests/full-project-test-suite.sh
@@ -856,6 +856,10 @@ run_child_suite "tests/test-bl256-unearned-receipts.sh" \
   "BL-256 unearned receipts (P3 semgrep count needs a .results array; UAT attestation refused when unrecordable)" \
   "BL-256 unearned-receipt tests FAILED (run tests/test-bl256-unearned-receipts.sh for details)"
 
+run_child_suite "tests/test-bl259-tsv-empty-field-shift.sh" \
+  "BL-259: an empty @tsv field must not collapse and shift the resolver row" \
+  "BL-259 tsv-field-shift tests FAILED (run tests/test-bl259-tsv-empty-field-shift.sh for details)"
+
 # ----------------------------------------------------------------
 # TEST 0g: INTAKE WIZARD + RECONFIGURE FIELD HANDLERS
 # ----------------------------------------------------------------

--- a/tests/test-bl259-tsv-empty-field-shift.sh
+++ b/tests/test-bl259-tsv-empty-field-shift.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# tests/test-bl259-tsv-empty-field-shift.sh
+#
+# `## BL-259:` — AN EMPTY `@tsv` FIELD COLLAPSED AND SHIFTED THE WHOLE ROW.
+#
+# scripts/resolve-tools.sh read nine tab-separated fields with
+# `IFS=$'\t' read -r f1 … f9`. Tab is an IFS *whitespace* character, so bash
+# collapses runs of tabs: an EMPTY field does not arrive as an empty field, it
+# vanishes, and every later field shifts left one. `version_command` is
+# optional — the producer emits `(.version_command // "")` for it — so for the
+# six catalogued tools that omit it the base64 install blob landed in
+# TOOL_DESCRIPTION and TOOL_INSTALL_B64 arrived EMPTY. After that every step
+# succeeded at rc 0 producing nothing (`base64 -d` on empty input, then `jq` on
+# empty input), so neither the `|| echo "{}"` nor the `// "See documentation"`
+# default fired, and the operator was handed an EMPTY install instruction.
+#
+# This drives the REAL resolver against a hermetic fixture matrix — no network,
+# no host tools, a `check_command` that cannot succeed — and asserts the
+# install text and the description survive for a tool with no version_command.
+# The control is the same tool WITH one. The mutant restores the collapsing
+# read on a mirror and must re-open the defect.
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RESOLVER="$REPO_ROOT/scripts/resolve-tools.sh"
+
+PASSED=0
+FAILED=0
+pass()  { echo "  [PASS] $1"; PASSED=$((PASSED + 1)); }
+fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
+
+TOPTMP="$(mktemp -d)"
+trap 'rm -rf "$TOPTMP"' EXIT INT TERM
+newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+
+[ -f "$RESOLVER" ] || { echo "  [FAIL] setup — $RESOLVER not found"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "  [FAIL] setup — jq is required"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
+
+# Distinctive payloads: if the row shifts, these are exactly what goes missing.
+NOVER_INSTALL='BL259-INSTALL-TEXT-FOR-THE-TOOL-WITHOUT-A-VERSION-COMMAND'
+NOVER_DESC='BL259-DESCRIPTION-NO-VERSION'
+CTRL_INSTALL='BL259-INSTALL-TEXT-FOR-THE-CONTROL'
+CTRL_DESC='BL259-DESCRIPTION-CONTROL'
+
+# mk_matrix <dir> — a common.json with two manual-install tools that can never
+# be found: one WITHOUT version_command (the trigger), one WITH it (the control).
+mk_matrix() {
+  local d="$1"
+  mkdir -p "$d" || return 1
+  cat > "$d/common.json" <<MATRIX
+{
+  "schema_version": "1.0",
+  "scope": "common",
+  "description": "BL-259 fixture",
+  "tools": [
+    {
+      "name": "BL259 No Version Tool",
+      "category": "testing",
+      "description": "$NOVER_DESC",
+      "required": true,
+      "phase": 1,
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
+      "check_command": "command -v bl259_definitely_absent_binary",
+      "auto_installable": false,
+      "install": { "manual": "$NOVER_INSTALL" }
+    },
+    {
+      "name": "BL259 Control Tool",
+      "category": "testing",
+      "description": "$CTRL_DESC",
+      "required": true,
+      "phase": 1,
+      "tracks": ["light", "standard", "full"],
+      "dev_os": ["darwin", "linux"],
+      "platforms": ["all"],
+      "languages": ["all"],
+      "check_command": "command -v bl259_definitely_absent_binary",
+      "version_command": "bl259_definitely_absent_binary --version",
+      "auto_installable": false,
+      "install": { "manual": "$CTRL_INSTALL" }
+    }
+  ]
+}
+MATRIX
+  jq empty "$d/common.json" 2>/dev/null || return 1
+  # the fixture is only honest if the check_command really cannot succeed
+  if command -v bl259_definitely_absent_binary >/dev/null 2>&1; then
+    return 1
+  fi
+  return 0
+}
+
+# run_resolver <matrix-dir> [resolver] → RESOLVER_OUT, RESOLVER_RC
+run_resolver() {
+  local mdir="$1" bin="${2:-$RESOLVER}"
+  RESOLVER_OUT="$( bash "$bin" \
+    --dev-os linux --platform web --language typescript \
+    --track standard --phase 1 --matrix-dir "$mdir" 2>/dev/null )"
+  RESOLVER_RC=$?
+  return 0
+}
+
+# field_of <json> <tool-name> <field> → the manual_install record's field
+field_of() {
+  printf '%s' "$1" | jq -r --arg n "$2" --arg f "$3" \
+    '(.manual_install[] | select(.name == $n) | .[$f]) // "<<ABSENT>>"' 2>/dev/null
+}
+
+echo "=== R — the real resolver, hermetic fixture matrix ==="
+
+MX="$(newtmp)/matrix"
+if ! mk_matrix "$MX"; then
+  fail_ "R setup" "could not build the fixture matrix (or the absent binary is somehow present)"
+else
+  run_resolver "$MX"
+  if [ "$RESOLVER_RC" -ne 0 ] || [ -z "$RESOLVER_OUT" ]; then
+    fail_ "R0" "the resolver did not produce a plan (rc=$RESOLVER_RC)"
+  else
+    pass "R0 — the resolver produced a plan from the fixture matrix (rc=$RESOLVER_RC)"
+
+    # R1 — THE DISCRIMINATOR. With the row shifted this is empty.
+    got="$(field_of "$RESOLVER_OUT" "BL259 No Version Tool" instructions)"
+    if [ "$got" = "$NOVER_INSTALL" ]; then
+      pass "R1 — a tool with NO version_command keeps its install instructions"
+    else
+      fail_ "R1" "install instructions for the no-version tool are [$got], want [$NOVER_INSTALL]"
+    fi
+
+    # R2 — the same shift puts the base64 install blob into the description
+    got="$(field_of "$RESOLVER_OUT" "BL259 No Version Tool" description)"
+    if [ "$got" = "$NOVER_DESC" ]; then
+      pass "R2 — and its description is the real description, not the base64 install blob"
+    else
+      fail_ "R2" "description is [$got], want [$NOVER_DESC]"
+    fi
+
+    # R3 — the control: a tool WITH version_command was never affected
+    got="$(field_of "$RESOLVER_OUT" "BL259 Control Tool" instructions)"
+    if [ "$got" = "$CTRL_INSTALL" ]; then
+      pass "R3 — the control tool (WITH version_command) keeps its install instructions"
+    else
+      fail_ "R3" "control install instructions are [$got], want [$CTRL_INSTALL]"
+    fi
+  fi
+fi
+
+echo "=== M — mutation proof on a mirror ==="
+
+M_SPLIT="# BL-259-TSV-SPLIT"
+n="$(grep -c "${M_SPLIT}\$" "$RESOLVER" 2>/dev/null)"; case "$n" in ''|*[!0-9]*) n=0 ;; esac
+[ "$n" = "1" ] \
+  && pass "M0 — '$M_SPLIT' occurs exactly once at end-of-line in resolve-tools.sh" \
+  || fail_ "M0" "'$M_SPLIT' occurs $n times in resolve-tools.sh (need exactly 1)"
+
+# MP1 — restore the collapsing read on a mirror: R1 must go red again. The
+# whole explicit-split block is replaced by the single `IFS=$'\t' read` line
+# it replaced, located by the marker and the loop opener around it.
+MP1="$(newtmp)/fw"
+if ! mkdir -p "$MP1" || ! cp -Rp "$REPO_ROOT/scripts" "$MP1/"; then
+  fail_ "MP1 setup" "could not mirror scripts/"
+else
+  tgt="$MP1/scripts/resolve-tools.sh"; before="$(mktemp)"; cp "$tgt" "$before"
+  open_ln="$(grep -n 'while IFS= read -r _bl259_row; do' "$before" | head -1 | cut -d: -f1)"
+  mark_ln="$(grep -n "${M_SPLIT}\$" "$before" | head -1 | cut -d: -f1)"
+  if [ -z "$open_ln" ] || [ -z "$mark_ln" ] || [ "$mark_ln" -le "$open_ln" ]; then
+    fail_ "MP1 setup" "could not locate the split block (open=$open_ln mark=$mark_ln)"
+  else
+    {
+      head -n $((open_ln - 1)) "$before"
+      printf '%s\n' "while IFS=\$'\\t' read -r TOOL_NAME TOOL_CATEGORY TOOL_PHASE TOOL_REQUIRED TOOL_CHECK TOOL_AUTO TOOL_VERSION_CMD TOOL_DESCRIPTION TOOL_INSTALL_B64; do"
+      tail -n +$((mark_ln + 1)) "$before"
+    } > "$tgt"
+    if ! bash -n "$tgt" 2>/dev/null \
+       || [ "$(grep -c "IFS=\$'\\\\t' read -r TOOL_NAME" "$tgt")" -ne 1 ] \
+       || [ "$(grep -c "${M_SPLIT}\$" "$tgt")" -ne 0 ]; then
+      fail_ "MP1 setup" "the collapsing-read mutation did not apply cleanly"
+    else
+      MX2="$(newtmp)/matrix"
+      if ! mk_matrix "$MX2"; then
+        fail_ "MP1 setup" "could not build the mutant's fixture matrix"
+      else
+        run_resolver "$MX2" "$tgt"
+        got="$(field_of "$RESOLVER_OUT" "BL259 No Version Tool" instructions)"
+        if [ "$got" != "$NOVER_INSTALL" ]; then
+          pass "MP1 (MUTATION) — with the collapsing read restored, the no-version tool loses its install instructions (got [$got]): R1 is what stops it"
+        else
+          fail_ "MP1 (MUTATION)" "the collapsing read changed nothing — R1 may be passing for another reason"
+        fi
+      fi
+    fi
+  fi
+fi
+
+echo ""
+echo "Results: $PASSED passed, $FAILED failed"
+[ "$FAILED" -eq 0 ] && exit 0
+exit 1

--- a/tests/test-bl259-tsv-empty-field-shift.sh
+++ b/tests/test-bl259-tsv-empty-field-shift.sh
@@ -33,6 +33,7 @@ fail_() { echo "  [FAIL] $1 — $2"; FAILED=$((FAILED + 1)); }
 TOPTMP="$(mktemp -d)"
 trap 'rm -rf "$TOPTMP"' EXIT INT TERM
 newtmp() { mktemp -d "$TOPTMP/fixXXXXXX"; }
+_changed_lines() { local n; n=$(diff "$1" "$2" 2>/dev/null | grep -c '^[<>]'); case "$n" in ''|*[!0-9]*) n=0 ;; esac; printf '%s\n' "$n"; }
 
 [ -f "$RESOLVER" ] || { echo "  [FAIL] setup — $RESOLVER not found"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "  [FAIL] setup — jq is required"; echo ""; echo "Results: 0 passed, 1 failed"; exit 1; }
@@ -189,6 +190,42 @@ else
           pass "MP1 (MUTATION) — with the collapsing read restored, the no-version tool loses its install instructions (got [$got]): R1 is what stops it"
         else
           fail_ "MP1 (MUTATION)" "the collapsing read changed nothing — R1 may be passing for another reason"
+        fi
+      fi
+    fi
+  fi
+fi
+
+# MP2 — the arity guard. Drop one field from the PRODUCER on a mirror so the
+# row carries seven tabs instead of eight. Without the guard the hand split
+# duplicates the last available field into every remaining slot — plausible
+# data, silently. The resolver must refuse loudly instead.
+MP2="$(newtmp)/fw"
+if ! mkdir -p "$MP2" || ! cp -Rp "$REPO_ROOT/scripts" "$MP2/"; then
+  fail_ "MP2 setup" "could not mirror scripts/"
+else
+  tgt2="$MP2/scripts/resolve-tools.sh"; before2="$(mktemp)"; cp "$tgt2" "$before2"
+  # the producer's `.description,` element — one line, exactly one occurrence
+  if [ "$(grep -c '^  \.description,$' "$before2")" -ne 1 ]; then
+    fail_ "MP2 setup" "the producer's .description element is not a unique single line"
+  else
+    grep -v '^  \.description,$' "$before2" > "$tgt2"
+    if ! bash -n "$tgt2" 2>/dev/null \
+       || [ "$(grep -c '^  \.description,$' "$tgt2")" -ne 0 ] \
+       || [ "$(_changed_lines "$before2" "$tgt2")" -ne 1 ]; then
+      fail_ "MP2 setup" "the producer mutation did not apply cleanly"
+    else
+      MX3="$(newtmp)/matrix"
+      if ! mk_matrix "$MX3"; then
+        fail_ "MP2 setup" "could not build the mutant's fixture matrix"
+      else
+        MP2_ERR="$(newtmp)/err"
+        RESOLVER_OUT="$( bash "$tgt2" --dev-os linux --platform web --language typescript \
+          --track standard --phase 1 --matrix-dir "$MX3" 2>"$MP2_ERR" )"; MP2_RC=$?
+        if [ "$MP2_RC" -ne 0 ] && grep -q 'malformed tool row' "$MP2_ERR"; then
+          pass "MP2 (MUTATION) — a producer emitting one field fewer is REFUSED loudly (rc=$MP2_RC), not read as plausible data"
+        else
+          fail_ "MP2 (MUTATION)" "a short row was accepted (rc=$MP2_RC) — the arity guard is not load-bearing; stderr: $(head -1 "$MP2_ERR" 2>/dev/null)"
         fi
       fi
     fi


### PR DESCRIPTION
`## BL-258:`'s lead #5, fourth atom — "the resolver's `@tsv` output is consumed with a shifted field index" — **reproduces**, and it is worse than the lead suggested.

## The defect

`scripts/resolve-tools.sh` read nine tab-separated fields with `IFS=$'\t' read -r …`, fed by a `jq -r '… | @tsv'` producer in the same loop. **Tab is an IFS *whitespace* character**, so bash collapses runs of tabs: an empty field does not arrive empty, it vanishes, and every later field shifts left one. `version_command` is optional — the producer emits `(.version_command // "")`, which is itself proof of that — so a tool omitting it lost its install payload.

Nothing complained, because every step afterwards succeeded while producing nothing. `printf '' | base64 -d` exits 0 empty, so the `|| echo "{}"` beside it never fired. `jq` on empty input exits 0 with no output, so `// "See documentation"` never fired either. **The operator received a blank install instruction.**

The same shift also put the description into `TOOL_VERSION_CMD`, which `run_bounded_capture` **evaluates as a shell command**. On the shipped catalogue all six fail inertly (rc 2 for the three containing a parenthesis, rc 127 for the rest). But the catalogue is data and downstream projects supply their own with `--matrix-dir`, so the class is data-as-code. The fix closes that path; nothing extra was needed for it.

## Who it reached

Six of 47 catalogued tools declare no `version_command`. By their own `tracks`: **mobile** at every track, **desktop** at standard and full only, **web** at standard and full from phase 3 — that last via `OWASP ZAP`, which is `"required": true`. Common is untouched, 0 of 21.

That web case is the one to note. **A standard-track web project was losing the install text for a tool the framework marks required.** It looked harmless on the dev Mac only because ZAP's `check_command` inspects a Docker image that happens to be pulled there, so ZAP resolves to `already_installed` and never reaches the list where the damage shows. On a clean `ubuntu:24.04` with no Docker it is empty at base and correct at the fix.

## The fix — `# BL-259-TSV-SPLIT`

The row was always well-formed. `@tsv` escapes an embedded tab as a literal `\t` and a newline as `\n`, so a row is one line with exactly eight real tabs and no field contains one. `awk -F'\t'` reads it correctly; only bash's `read` does not.

So read the whole line and split it by hand — eight `${rest%%$'\t'*}` / `${rest#*$'\t'}` pairs yielding nine fields, the ninth the untouched remainder. Empty fields survive exactly. No producer change, so `@tsv`'s escaping stays load-bearing and no new escaping surface appears. Two alternatives were considered and are recorded on the entry with why neither was taken.

**Plus an arity guard**, because without one the hand split is *worse* than the `read` it replaced on a short row: it duplicates the last available field into every remaining slot, turning missing data into plausible data. Unreachable today, so it asserts rather than trusts — count the tabs, refuse at rc 1 with a named error otherwise.

## Test — `tests/test-bl259-tsv-empty-field-shift.sh`

Drives the REAL resolver against a hermetic fixture matrix passed with `--matrix-dir`: two manual-install tools whose `check_command` looks for a binary the suite asserts is absent *before* measuring, one without `version_command` and one with it as the control. No network, no host tool. It asserts the plan the operator receives, not the `read`.

**GREEN 7 / 0** on bash 3.2.57 and on 5.2.21 in `ubuntu:24.04` as a non-root user. **RED 2 / 5** at `681beb3`; the two passes are honest controls. Two mutants: MP1 restores the collapsing read, MP2 drops a field from the *producer* and asserts the guard refuses it. Both assert their mutation landed before measuring.

All 8 unit-lane suites that drive `resolve-tools.sh` green; 16/16 lints.

## Review

Two adversarial rounds, both `major_concerns`, **both on the prose, never on the code**. The code half was judged "approve on its own" in round 1 and survived round 2's attack on the new guard: 17 adversarial rows across both bash versions, four locales, invalid UTF-8, `extglob`/`nocasematch`/`GLOBIGNORE`, and 30 real-catalogue runs with zero false positives. Round 2 also proved MP2 load-bearing by deleting the guard and watching it fail.

What review caught, both times, was me. Round 1: the blast-radius line understated who is hit, the entry contradicted itself, a count was wrong, and the execution path was unrecorded. Round 2: the *corrected* blast-radius line was now wrong in the opposite direction, and the execution sentence named the wrong error class for half the cases including its own exemplar. Both folded, each re-measured rather than transcribed.

Three rounds running, the errors were in freshly-added sentences. So the entry now states the six tools' own measured `tracks` values instead of a summary of them, says outright that the line has been wrong twice in opposite directions, and drops a usage claim that cannot be measured from the repo. The final commit is documentation only and was not re-reviewed; the review record says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011sxanx6uBR9D2nKHvuAcKk
